### PR TITLE
fix: add missing columns to cost_tracking table

### DIFF
--- a/mcp_backend/src/migrations/010_fix_cost_tracking_schema.sql
+++ b/mcp_backend/src/migrations/010_fix_cost_tracking_schema.sql
@@ -1,0 +1,45 @@
+-- Migration 010: Fix cost_tracking schema - add missing columns
+-- Ensures cost_tracking table has all required columns for current code
+
+-- Add missing columns from original schema
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS total_cost_usd DECIMAL(10, 6) DEFAULT 0.00;
+
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS openai_total_tokens INTEGER DEFAULT 0;
+
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS openai_prompt_tokens INTEGER DEFAULT 0;
+
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS openai_completion_tokens INTEGER DEFAULT 0;
+
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS openai_calls JSONB DEFAULT '[]';
+
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS execution_time_ms INTEGER;
+
+-- Rename duration_ms to execution_time_ms if it exists
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'cost_tracking' AND column_name = 'duration_ms'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'cost_tracking' AND column_name = 'execution_time_ms'
+  ) THEN
+    ALTER TABLE cost_tracking RENAME COLUMN duration_ms TO execution_time_ms;
+  END IF;
+END $$;
+
+-- Update total_cost_usd based on individual cost components
+UPDATE cost_tracking
+SET total_cost_usd = COALESCE(openai_cost_usd, 0) +
+                     COALESCE(zakononline_cost_usd, 0) +
+                     COALESCE(secondlayer_cost_usd, 0)
+WHERE total_cost_usd = 0;
+
+-- Add index for total_cost_usd
+CREATE INDEX IF NOT EXISTS idx_cost_tracking_total_cost ON cost_tracking(total_cost_usd);


### PR DESCRIPTION
# PR #1: Fix cost tracking database schema

## 🐛 Problem

The cost tracking system was failing with database errors:
```
column "total_cost_usd" of relation "cost_tracking" does not exist
```

Code referenced columns that didn't exist in the database schema, causing all API requests to fail when trying to record cost tracking data.

## ✅ Solution

Added migration `010_fix_cost_tracking_schema.sql` that adds all missing columns:

- `total_cost_usd` - Aggregate cost across all providers (OpenAI, ZakonOnline, SecondLayer)
- `openai_total_tokens` - Total token count for OpenAI API calls
- `openai_prompt_tokens` - Prompt token count
- `openai_completion_tokens` - Completion token count
- `openai_calls` - JSONB array storing individual API call details
- `execution_time_ms` - Request execution time (renamed from `duration_ms`)

Also adds index on `total_cost_usd` for query performance.

## 📊 Changes

- **Files changed:** 1
- **Lines added:** 45

### Migration file:
- `mcp_backend/src/migrations/010_fix_cost_tracking_schema.sql`

## ✅ Testing

Verified migration:
1. Applied migration to PostgreSQL database
2. Made test API call to `/api/tools/classify_intent`
3. Confirmed cost tracking data saved successfully
4. Verified all columns populated correctly

## 📝 Related Issues

Fixes cost tracking failures that prevented recording API usage metrics and costs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost tracking failures by adding missing columns to the cost_tracking table and renaming duration_ms to execution_time_ms. Restores API cost logging and adds an index on total_cost_usd for faster queries.

- **Migration**
  - Add columns: total_cost_usd, openai_total_tokens, openai_prompt_tokens, openai_completion_tokens, openai_calls, execution_time_ms
  - Rename duration_ms to execution_time_ms when present
  - Backfill total_cost_usd from provider cost columns when zero
  - Create index on total_cost_usd

<sup>Written for commit e833ddef31f8724fe31bc261d5e1ca52892ba2bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

