### PR TITLE
fix: correct column rename logic in migration 010

### DIFF
--- a/mcp_backend/src/migrations/010_fix_cost_tracking_schema.sql
+++ b/mcp_backend/src/migrations/010_fix_cost_tracking_schema.sql
@@ -17,10 +17,8 @@ ADD COLUMN IF NOT EXISTS openai_completion_tokens INTEGER DEFAULT 0;
 ALTER TABLE cost_tracking
 ADD COLUMN IF NOT EXISTS openai_calls JSONB DEFAULT '[]';
 
-ALTER TABLE cost_tracking
-ADD COLUMN IF NOT EXISTS execution_time_ms INTEGER;
-
 -- Rename duration_ms to execution_time_ms if it exists
+-- IMPORTANT: Must run BEFORE adding execution_time_ms column
 DO $$
 BEGIN
   IF EXISTS (
@@ -33,6 +31,10 @@ BEGIN
     ALTER TABLE cost_tracking RENAME COLUMN duration_ms TO execution_time_ms;
   END IF;
 END $$;
+
+-- Add execution_time_ms if it still doesn't exist (when duration_ms didn't exist)
+ALTER TABLE cost_tracking
+ADD COLUMN IF NOT EXISTS execution_time_ms INTEGER;
 
 -- Update total_cost_usd based on individual cost components
 UPDATE cost_tracking


### PR DESCRIPTION
Fix logic bug where execution_time_ms column was created BEFORE attempting to rename duration_ms, causing the rename condition to always be FALSE.

The rename block checks "execution_time_ms doesn't exist", but it was created on the previous line, so the condition was always false.

Solution: Move the ADD COLUMN statement AFTER the DO block so:
1. First try to rename duration_ms → execution_time_ms (if duration_ms exists)
2. Then add execution_time_ms if it still doesn't exist (when duration_ms didn't exist)

This ensures the rename works correctly for databases that have the old duration_ms column.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the column rename in migration 010 by moving execution_time_ms creation after the rename block, so duration_ms is correctly renamed when present. Ensures databases with the old column migrate cleanly without losing data.

- **Bug Fixes**
  - Run the DO block to rename duration_ms → execution_time_ms before adding the new column.
  - Add execution_time_ms only if it still doesn’t exist after the rename.

<sup>Written for commit 1f404ce0c69324ef8fa79b0bee1f1c1e61f681c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

