### PR TITLE
Enforce PR workflow in CLAUDE.md and scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ When the user asks for a specific task (e.g., 'commit frontend changes'), do exa
 
 ## Git & Deployment Workflow
 
-After completing code changes, always: 1) Build and verify no errors, 2) Commit with a descriptive message, 3) Push to remote, 4) Deploy locally if requested. Do NOT over-scope commits — only stage files relevant to the current task.
+Branch `main` is protected — direct pushes are blocked for everyone (including admins). All changes must go through a Pull Request with at least 1 approving review.
+
+After completing code changes, always: 1) Build and verify no errors, 2) Create a feature branch (`git checkout -b <descriptive-name>`), 3) Commit with a descriptive message, 4) Push the branch and create a PR via `gh pr create`, 5) Deploy locally if requested. Do NOT over-scope commits — only stage files relevant to the current task. NEVER push directly to `main`.
 
 ## Local Dev Environment
 

--- a/scripts/claude/git-housekeeping.sh
+++ b/scripts/claude/git-housekeeping.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Batch git housekeeping - runs Claude in headless mode
+# Creates a feature branch, commits changes, pushes, and opens a PR (main is protected)
 cd "$(dirname "$0")/../.." || exit 1
 
-claude -p "Check for uncommitted changes, stage everything, create a descriptive commit message, and push to origin main" --allowedTools "Bash,Read,Glob"
+claude -p "Check for uncommitted changes. If there are changes: 1) Create a descriptive feature branch, 2) Stage and commit with a descriptive message, 3) Push the branch, 4) Create a PR via 'gh pr create'. NEVER push directly to main." --allowedTools "Bash,Read,Glob"


### PR DESCRIPTION
## Summary
- Update CLAUDE.md: document that `main` is protected, all changes via PR with review
- Update `scripts/claude/git-housekeeping.sh`: create branch + PR instead of direct push to main

## Test plan
- [ ] Verify Claude Code follows PR workflow in new sessions
- [ ] Run `git-housekeeping.sh` and confirm it creates a branch + PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Protects main and enforces a PR-first workflow for all changes. Updates CLAUDE.md and git-housekeeping.sh to create feature branches and open PRs via gh, never push to main.

<sup>Written for commit 616323d79b92c5719134547d9496a709e5770e83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

