### PR TITLE
Fix PR #177 review issues (P2 items)

### DIFF
--- a/mcp_backend/src/services/court-registry-metrics.ts
+++ b/mcp_backend/src/services/court-registry-metrics.ts
@@ -1,33 +1,30 @@
 /**
- * Prometheus metrics for court registry scraping (LEG-53).
- * Script does not expose HTTP /metrics; counters are for logging/debug. Pushgateway can be added later.
+ * Simple counters for court registry scraping (LEG-53).
+ * No prom-client dependency — the scraper is a standalone script
+ * that does not expose /metrics. Values are used for logging and alerts only.
  */
 
-import { Registry, Counter, Gauge } from 'prom-client';
+class SimpleCounter {
+  private value = 0;
+  inc(_labels?: Record<string, string>): void {
+    this.value++;
+  }
+  get(): number {
+    return this.value;
+  }
+}
 
-const registry = new Registry();
+class SimpleGauge {
+  private value = 0;
+  set(v: number): void {
+    this.value = v;
+  }
+  get(): number {
+    return this.value;
+  }
+}
 
-export const courtRegistryScrapeTotal = new Counter({
-  name: 'court_registry_scrape_total',
-  help: 'Total documents scraped from court registry',
-  labelNames: ['status'],
-  registers: [registry],
-});
-
-export const courtRegistryScrapeSuccessRate = new Gauge({
-  name: 'court_registry_scrape_success_rate',
-  help: 'Success rate of last scrape run',
-  registers: [registry],
-});
-
-export const courtRegistryCaptchaCount = new Counter({
-  name: 'court_registry_captcha_total',
-  help: 'Total CAPTCHAs encountered',
-  registers: [registry],
-});
-
-export const courtRegistryBlockCount = new Counter({
-  name: 'court_registry_block_total',
-  help: 'Total access blocks encountered',
-  registers: [registry],
-});
+export const courtRegistryScrapeTotal = new SimpleCounter();
+export const courtRegistryScrapeSuccessRate = new SimpleGauge();
+export const courtRegistryCaptchaCount = new SimpleCounter();
+export const courtRegistryBlockCount = new SimpleCounter();

--- a/mcp_backend/src/services/court-registry-scrape-service.ts
+++ b/mcp_backend/src/services/court-registry-scrape-service.ts
@@ -88,25 +88,6 @@ export class CourtRegistryScrapeService {
     return this.mapCheckpoint(r.rows[0]);
   }
 
-  async enqueueUrls(
-    checkpointId: string,
-    items: { docId: string; url: string; pageNumber: number }[]
-  ): Promise<number> {
-    if (items.length === 0) return 0;
-    const docIds = items.map((i) => i.docId);
-    const urls = items.map((i) => i.url);
-    const pageNumbers = items.map((i) => i.pageNumber);
-    const res = await this.db.query(
-      `INSERT INTO court_registry_scrape_queue (doc_id, url, page_number, checkpoint_id, status)
-       SELECT unnest($1::varchar[]), unnest($2::text[]), unnest($3::int[]), $4::uuid, 'pending'
-       ON CONFLICT (doc_id) DO NOTHING`,
-      [docIds, urls, pageNumbers, checkpointId]
-    );
-    return res.rowCount ?? 0;
-  }
-
-  /** Queue methods (getNextBatch, markCompleted, markFailed) reserved for future discovery/extraction mode. */
-
   async recordStats(
     runId: string,
     checkpointId: string | null,


### PR DESCRIPTION
## Summary
- **Simplify `page.evaluate` cast**: replaced `globalThis as unknown as ...` with string-form `page.evaluate()` to avoid TS needing `dom` lib
- **Replace dead Prometheus metrics**: `court-registry-metrics.ts` now uses simple counter/gauge classes instead of `prom-client` (script doesn't expose `/metrics`)
- **Remove unused `court_registry_scrape_queue` table**: dropped CREATE TABLE + 3 indexes + trigger from migration, removed `enqueueUrls()` from scrape service
- **Fix resume CAPTCHA off-by-one**: when `goToNextPage()` returns CAPTCHA/block, browser is on page `i` not `i+1`; now saves checkpoint as failed and throws (consistent with initial search CAPTCHA handling)

Skipped items (by design):
- **P2 #2 UA rotation**: requires new context per page, not critical
- **P3 #6 hashConfig comment**: already documented
- **P3 #7 npm script**: already exists

## Test plan
- [x] `npm run build` compiles without errors
- [ ] Run `PROCESS_ONLY=true MAX_DOCS=5 npm run scrape:court` to verify metrics imports work
- [ ] Verify migration runs clean on fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes P2 review items from PR #177 for LEG-53. Cleans up unused code, simplifies browser evaluation, and fixes resume CAPTCHA handling to save the correct checkpoint and stop the run.

- **Bug Fixes**
  - Resume: when goToNextPage hits CAPTCHA/block, mark page i as failed and throw (was off by one).

- **Refactors**
  - Use string-form page.evaluate to access document without TS dom lib.
  - Replace prom-client metrics with simple in-memory counters/gauge for logging/alerts.
  - Remove unused court_registry_scrape_queue table, related indexes/trigger in migration, and the enqueueUrls method.

<sup>Written for commit c88ae3459587266b2b6c6b700fca65a75a3acc70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

