### PR TITLE
fix: bump fast-xml-parser to >=5.3.6 (CVE-2026-26278)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1467,24 +1467,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "mcp_openreyestr/node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "mcp_openreyestr/node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -9112,9 +9094,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.5.tgz",
-      "integrity": "sha512-JeaA2Vm9ffQKp9VjvfzObuMCjUYAp5WDYhRYL5LrBPY/jUDlUtOvDfot0vKSkB9tuX885BDHjtw4fZadD95wnA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "postcss": "^8.4.49",
     "esbuild": ">=0.25.0",
 "minio": {
-      "fast-xml-parser": ">=5.3.4"
+      "fast-xml-parser": ">=5.3.6"
     },
     "ajv": ">=8.18.0"
   }


### PR DESCRIPTION
## Summary
- Bumps `fast-xml-parser` override in root `package.json` from `>=5.3.4` to `>=5.3.6`
- Resolves [Dependabot alert #73](https://github.com/overthelex/secondlayer/security/dependabot/73) — **High severity** DoS via unlimited XML entity expansion in DOCTYPE parsing
- Both direct (`mcp_openreyestr`) and transitive (`minio` → `mcp_backend`) dependencies now resolve to `5.3.6`

## Test plan
- [x] `npm ls fast-xml-parser` shows `5.3.6` for all instances
- [ ] Verify Docker builds succeed with updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade fast-xml-parser to >=5.3.6 to fix CVE-2026-26278 (DoS via XML entity expansion). All direct and transitive installs now resolve to 5.3.6, addressing Dependabot alert #73.

- **Dependencies**
  - Add root override for fast-xml-parser >=5.3.6 (covers minio’s transitive dep and mcp_openreyestr).
  - Update lockfile so all instances resolve to 5.3.6.

<sup>Written for commit 813a3e977bfc6e066a37bbbbfb9513dea237de1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

