### PR TITLE
fix: crypto payment providers not visible for tagged users

### DIFF
--- a/mcp_backend/src/routes/payment-routes.ts
+++ b/mcp_backend/src/routes/payment-routes.ts
@@ -30,7 +30,7 @@ export function createPaymentRouter(
 
   router.get('/available-providers', async (req: any, res: Response) => {
     try {
-      const userId = req.user.userId;
+      const userId = req.user?.userId || req.user?.id;
       const tagResult = await db.query('SELECT 1 FROM user_tags WHERE user_id = $1 AND tag = $2', [userId, 'crypto']);
       const hasCryptoTag = tagResult.rows.length > 0;
       return res.json({
@@ -54,8 +54,8 @@ export function createPaymentRouter(
    */
   router.post('/stripe/create', async (req: any, res: Response) => {
     try {
-      const userId = req.user.userId;
-      const email = req.user.email;
+      const userId = req.user?.userId || req.user?.id;
+      const email = req.user?.email;
       const { amount_usd, metadata } = req.body;
 
       if (!amount_usd || typeof amount_usd !== 'number') {
@@ -91,8 +91,8 @@ export function createPaymentRouter(
    */
   router.post('/fondy/create', async (req: any, res: Response) => {
     try {
-      const userId = req.user.userId;
-      const email = req.user.email;
+      const userId = req.user?.userId || req.user?.id;
+      const email = req.user?.email;
       const { amount_uah } = req.body;
 
       if (!amount_uah || typeof amount_uah !== 'number') {
@@ -128,8 +128,8 @@ export function createPaymentRouter(
 
   router.post('/metamask/create', cryptoTagRequired, async (req: any, res: Response) => {
     try {
-      const userId = req.user.userId;
-      const email = req.user.email;
+      const userId = req.user?.userId || req.user?.id;
+      const email = req.user?.email;
       const { amount_usd, network, token } = req.body;
       if (!amount_usd || typeof amount_usd !== 'number') {
         return res.status(400).json({ error: 'Invalid request', message: 'amount_usd is required and must be a number' });
@@ -161,8 +161,8 @@ export function createPaymentRouter(
 
   router.post('/binance-pay/create', cryptoTagRequired, async (req: any, res: Response) => {
     try {
-      const userId = req.user.userId;
-      const email = req.user.email;
+      const userId = req.user?.userId || req.user?.id;
+      const email = req.user?.email;
       const { amount_usd } = req.body;
       if (!amount_usd || typeof amount_usd !== 'number') {
         return res.status(400).json({ error: 'Invalid request', message: 'amount_usd is required and must be a number' });


### PR DESCRIPTION
## Summary
- Fixed `req.user.userId` → `req.user?.userId || req.user?.id` in all payment route handlers
- `requireJWT` middleware sets `req.user` from DB `User` record which has `.id`, not `.userId`
- This caused the crypto tag lookup in `/available-providers` to always return `false`, hiding MetaMask and Binance Pay even for users with the `crypto` tag assigned

## Test plan
- [ ] Assign `crypto` tag to a test user via admin panel
- [ ] Open billing Top-Up modal as that user — verify MetaMask and Binance Pay buttons appear
- [ ] Remove `crypto` tag — verify crypto options disappear
- [ ] Test Stripe/Fondy payment creation still works (userId correctly resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crypto payment providers not showing for users with the crypto tag by correctly resolving the user ID from req.user.id or req.user.userId. MetaMask and Binance Pay now appear when expected, without affecting Stripe/Fondy flows.

- **Bug Fixes**
  - Use req.user?.userId || req.user?.id for all payment routes and /available-providers.
  - Aligns with requireJWT, which provides req.user.id; the crypto tag lookup now works.

<sup>Written for commit 39535828b9fb4d5a6b5b43cf2fc03db5b753d7a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

