### PR TITLE
feat: tariff upgrade cost calculation + remove Fondy

### DIFF
--- a/lexwebapp/src/components/BillingDashboard.tsx
+++ b/lexwebapp/src/components/BillingDashboard.tsx
@@ -32,6 +32,20 @@ export function BillingDashboard({ onBack, initialTab = 'overview' }: BillingDas
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<BillingTab>(initialTab);
   const [showTopUpModal, setShowTopUpModal] = useState(false);
+  const [topUpAmount, setTopUpAmount] = useState<number | undefined>();
+  const [upgradeTier, setUpgradeTier] = useState<string | undefined>();
+
+  const handleUpgradeTopUp = (amount: number, targetTier: string) => {
+    setTopUpAmount(amount);
+    setUpgradeTier(targetTier);
+    setShowTopUpModal(true);
+  };
+
+  const handleCloseTopUp = () => {
+    setShowTopUpModal(false);
+    setTopUpAmount(undefined);
+    setUpgradeTier(undefined);
+  };
 
   const handleBack = () => {
     if (onBack) {
@@ -111,7 +125,7 @@ export function BillingDashboard({ onBack, initialTab = 'overview' }: BillingDas
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.2 }}>
             {activeTab === 'overview' && <OverviewTab onTopUp={() => setShowTopUpModal(true)} />}
-            {activeTab === 'tariffs' && <TariffsTab />}
+            {activeTab === 'tariffs' && <TariffsTab onUpgradeTopUp={handleUpgradeTopUp} />}
             {activeTab === 'history' && <HistoryTab />}
             {activeTab === 'analytics' && <AnalyticsTab />}
             {activeTab === 'settings' && <SettingsTab />}
@@ -122,7 +136,9 @@ export function BillingDashboard({ onBack, initialTab = 'overview' }: BillingDas
       {/* Top-Up Modal */}
       <TopUpModal
         isOpen={showTopUpModal}
-        onClose={() => setShowTopUpModal(false)}
+        onClose={handleCloseTopUp}
+        initialAmount={topUpAmount}
+        upgradeTier={upgradeTier}
       />
     </div>
   );

--- a/lexwebapp/src/components/billing/PaymentsTab.tsx
+++ b/lexwebapp/src/components/billing/PaymentsTab.tsx
@@ -23,7 +23,7 @@ import showToast from '../../utils/toast';
 
 interface PaymentMethod {
   id: string;
-  provider: 'stripe' | 'fondy';
+  provider: 'stripe' | 'metamask' | 'binance_pay';
   cardLast4: string;
   cardBrand: string;
   cardBank: string;
@@ -228,7 +228,7 @@ export function PaymentsTab() {
             animate={{ opacity: 1, height: 'auto' }}
             className="mb-6 p-4 bg-claude-bg border border-claude-border rounded-lg">
             <p className="text-sm text-claude-subtext mb-4">
-              Для додавання картки скористайтесь вкладкою "Поповнення" — картка буде збережена автоматично під час першої оплати через Stripe або Fondy.
+              Для додавання картки скористайтесь вкладкою "Поповнення" — картка буде збережена автоматично під час першої оплати через Stripe.
             </p>
             <button
               onClick={() => setShowAddPayment(false)}
@@ -263,14 +263,14 @@ export function PaymentsTab() {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-4 flex-1">
                     <div className="text-4xl font-bold text-claude-accent/30">
-                      {method.provider === 'stripe' ? '💳' : '🏦'}
+                      {method.provider === 'stripe' ? '💳' : method.provider === 'metamask' ? '🦊' : '🟡'}
                     </div>
                     <div className="flex-1">
                       <p className="font-semibold text-claude-text">
                         {method.cardBrand} •••• {method.cardLast4}
                       </p>
                       <p className="text-sm text-claude-subtext">
-                        {method.cardBank} • {method.provider === 'stripe' ? 'Stripe' : 'Fondy'}
+                        {method.cardBank} • {method.provider === 'stripe' ? 'Stripe' : method.provider === 'metamask' ? 'MetaMask' : 'Binance Pay'}
                       </p>
                     </div>
                   </div>
@@ -417,7 +417,7 @@ export function PaymentsTab() {
             <Inbox size={40} className="text-claude-subtext mx-auto mb-3" />
             <p className="text-claude-subtext">Оплат ще не було</p>
             <p className="text-xs text-claude-subtext mt-1">
-              Тут з'являться ваші поповнення після оплати через Stripe або Fondy
+              Тут з'являться ваші поповнення після оплати
             </p>
           </div>
         ) : (

--- a/lexwebapp/src/components/billing/SettingsTab.tsx
+++ b/lexwebapp/src/components/billing/SettingsTab.tsx
@@ -36,7 +36,7 @@ import { useAuth } from '../../contexts/AuthContext';
 
 interface PaymentMethod {
   id: string;
-  provider: 'stripe' | 'fondy';
+  provider: 'stripe' | 'metamask' | 'binance_pay';
   cardLast4: string;
   cardBrand: string;
   cardBank: string;
@@ -354,7 +354,7 @@ export function SettingsTab() {
         {showAddPayment && (
           <div className="mb-4 p-4 bg-claude-bg border border-claude-border rounded-lg">
             <p className="text-sm text-claude-subtext mb-3">
-              Для додавання картки скористайтесь кнопкою "Поповнити баланс" на вкладці Огляд — картка буде збережена автоматично під час першої оплати через Stripe або Fondy.
+              Для додавання картки скористайтесь кнопкою "Поповнити баланс" на вкладці Огляд — картка буде збережена автоматично під час першої оплати через Stripe.
             </p>
             <button
               onClick={() => setShowAddPayment(false)}
@@ -384,13 +384,13 @@ export function SettingsTab() {
                 }`}>
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-3 flex-1">
-                    <span className="text-2xl">{method.provider === 'stripe' ? '💳' : '🏦'}</span>
+                    <span className="text-2xl">{method.provider === 'stripe' ? '💳' : method.provider === 'metamask' ? '🦊' : '🟡'}</span>
                     <div>
                       <p className="font-semibold text-claude-text text-sm">
                         {method.cardBrand} •••• {method.cardLast4}
                       </p>
                       <p className="text-xs text-claude-subtext">
-                        {method.cardBank} · {method.provider === 'stripe' ? 'Stripe' : 'Fondy'}
+                        {method.cardBank} · {method.provider === 'stripe' ? 'Stripe' : method.provider === 'metamask' ? 'MetaMask' : 'Binance Pay'}
                       </p>
                     </div>
                   </div>

--- a/lexwebapp/src/components/billing/TopUpModal.tsx
+++ b/lexwebapp/src/components/billing/TopUpModal.tsx
@@ -12,9 +12,11 @@ interface TopUpModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSuccess?: () => void;
+  initialAmount?: number;
+  upgradeTier?: string;
 }
 
-export function TopUpModal({ isOpen, onClose, onSuccess }: TopUpModalProps) {
+export function TopUpModal({ isOpen, onClose, onSuccess, initialAmount, upgradeTier }: TopUpModalProps) {
   // Close on Escape key
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -50,7 +52,14 @@ export function TopUpModal({ isOpen, onClose, onSuccess }: TopUpModalProps) {
             className="relative w-full max-w-3xl my-8 mx-4 bg-claude-bg rounded-2xl shadow-2xl">
             {/* Header */}
             <div className="flex items-center justify-between px-6 py-4 border-b border-claude-border bg-white rounded-t-2xl">
-              <h2 className="text-xl font-semibold text-claude-text">Поповнити баланс</h2>
+              <div>
+                <h2 className="text-xl font-semibold text-claude-text">Поповнити баланс</h2>
+                {upgradeTier && (
+                  <p className="text-sm text-claude-subtext mt-0.5">
+                    Для переходу на тариф <strong>{upgradeTier.charAt(0).toUpperCase() + upgradeTier.slice(1)}</strong> необхідно поповнити баланс на <strong>${initialAmount?.toFixed(2)}</strong>
+                  </p>
+                )}
+              </div>
               <button
                 onClick={onClose}
                 className="p-2 hover:bg-claude-bg rounded-lg transition-colors">
@@ -60,7 +69,7 @@ export function TopUpModal({ isOpen, onClose, onSuccess }: TopUpModalProps) {
 
             {/* Content */}
             <div className="p-6">
-              <TopUpTab />
+              <TopUpTab initialAmount={initialAmount} />
             </div>
           </motion.div>
         </motion.div>

--- a/lexwebapp/src/hooks/queries/useBilling.ts
+++ b/lexwebapp/src/hooks/queries/useBilling.ts
@@ -86,21 +86,6 @@ export function useCreateStripePayment() {
 }
 
 /**
- * Create Fondy payment
- */
-export function useCreateFondyPayment() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (amount: number) => billingService.createFondyPayment(amount),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: queryKeys.billing.balance });
-      queryClient.invalidateQueries({ queryKey: queryKeys.billing.transactions() });
-    },
-  });
-}
-
-/**
  * Send test email
  */
 export function useSendTestEmail() {

--- a/lexwebapp/src/services/api/BillingService.ts
+++ b/lexwebapp/src/services/api/BillingService.ts
@@ -95,33 +95,10 @@ export class BillingService extends BaseService {
   }
 
   /**
-   * Create Fondy payment
-   */
-  async createFondyPayment(amount_uah: number): Promise<PaymentIntent> {
-    try {
-      const response = await this.client.post<CreatePaymentResponse>(
-        '/api/billing/payment/fondy/create',
-        { amount_uah }
-      );
-
-      return {
-        id: response.data.payment_id,
-        amount: amount_uah,
-        currency: 'UAH',
-        status: response.data.status,
-        provider: 'fondy',
-        createdAt: new Date().toISOString(),
-      };
-    } catch (error) {
-      return this.handleError(error);
-    }
-  }
-
-  /**
    * Get payment status
    */
   async getPaymentStatus(
-    provider: 'stripe' | 'fondy',
+    provider: string,
     paymentId: string
   ): Promise<any> {
     try {

--- a/lexwebapp/src/types/api/requests.ts
+++ b/lexwebapp/src/types/api/requests.ts
@@ -38,8 +38,7 @@ export interface UpdateBillingSettingsRequest {
 
 export interface CreatePaymentRequest {
   amount_usd?: number;
-  amount_uah?: number;
-  provider: 'stripe' | 'fondy';
+  provider: 'stripe' | 'metamask' | 'binance_pay';
   metadata?: Record<string, any>;
 }
 

--- a/lexwebapp/src/types/models/Billing.ts
+++ b/lexwebapp/src/types/models/Billing.ts
@@ -44,6 +44,6 @@ export interface PaymentIntent {
   amount: number;
   currency: 'USD' | 'UAH';
   status: 'pending' | 'succeeded' | 'failed';
-  provider: 'stripe' | 'fondy';
+  provider: 'stripe' | 'metamask' | 'binance_pay';
   createdAt: string;
 }

--- a/lexwebapp/src/types/models/Team.ts
+++ b/lexwebapp/src/types/models/Team.ts
@@ -64,7 +64,7 @@ export interface UsageChartData {
 
 export interface PaymentMethod {
   id: string;
-  provider: 'stripe' | 'fondy';
+  provider: 'stripe' | 'metamask' | 'binance_pay';
   cardLast4: string;
   cardBrand: string;
   cardBank: string;

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -158,8 +158,6 @@ export const api = {
   payment: {
     createStripe: (data: { amount_usd: number; metadata?: any }) =>
       apiClient.post('/api/billing/payment/stripe/create', data),
-    createFondy: (data: { amount_uah: number }) =>
-      apiClient.post('/api/billing/payment/fondy/create', data),
     createMetaMask: (data: { amount_usd: number; network: string; token: string }) =>
       apiClient.post('/api/billing/payment/metamask/create', data),
     verifyMetaMask: (data: { paymentIntentId: string; txHash: string }) =>

--- a/lexwebapp/src/utils/invoice-generator.ts
+++ b/lexwebapp/src/utils/invoice-generator.ts
@@ -207,7 +207,7 @@ export function generateMockInvoices(count: number = 10): InvoiceData[] {
   const invoices: InvoiceData[] = [];
   const today = new Date();
 
-  const paymentMethods = ['Stripe', 'Fondy', 'Manual', 'Wire Transfer'];
+  const paymentMethods = ['Stripe', 'MetaMask', 'Binance Pay', 'Wire Transfer'];
   const statuses: ('paid' | 'pending' | 'overdue')[] = ['paid', 'paid', 'paid', 'pending'];
 
   for (let i = 0; i < count; i++) {


### PR DESCRIPTION
## Summary
- **Tariff upgrade calculates cost**: clicking upgrade now shows the price difference (e.g. "Перейти за $70/міс") and opens the TopUp modal with the pre-filled amount and target tier info
- **Fondy payment provider removed**: only 3 methods remain — Stripe, MetaMask, Binance Pay
- Downgrade still applies directly without payment

## Changed files (13)
- `TariffsTab.tsx` — upgrade cost calculation, CTA text with price, `onUpgradeTopUp` callback
- `BillingDashboard.tsx` — passes upgrade amount/tier to TopUpModal
- `TopUpModal.tsx` — accepts `initialAmount` and `upgradeTier`, shows context header
- `TopUpTab.tsx` — removed Fondy provider/form, accepts `initialAmount` prop
- `PaymentsTab.tsx`, `SettingsTab.tsx` — updated provider types and UI text
- `api-client.ts`, `BillingService.ts`, `useBilling.ts` — removed Fondy API methods/hooks
- `Billing.ts`, `requests.ts`, `Team.ts` — updated provider type unions
- `invoice-generator.ts` — updated mock payment methods

## Test plan
- [ ] Open Tariffs tab, verify upgrade buttons show price difference
- [ ] Click upgrade on a higher tier — TopUp modal opens with correct amount
- [ ] Verify downgrade works directly without TopUp modal
- [ ] Verify TopUp tab shows only 3 payment methods (Stripe, MetaMask, Binance Pay)
- [ ] Verify no Fondy references visible in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the exact cost to upgrade a tariff and pre-fills the Top Up flow with that amount. Removes Fondy across the app; payments now support Stripe, MetaMask, and Binance Pay only.

- New Features
  - Tariff cards show upgrade price difference (e.g., “Перейти за $70/міс”).
  - Upgrade opens Top Up modal with pre-filled amount and target tier context.
  - Downgrades apply immediately without payment.

- Refactors
  - Removed Fondy from UI, hooks, services, API client, and types.
  - Updated provider unions and labels to: 'stripe' | 'metamask' | 'binance_pay'.
  - Simplified Top Up amounts to USD; cleaned provider selection UI and copy.

<sup>Written for commit 36838c5e0f32dfa377a57e943f64778e7e3c673d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

