### PR TITLE
feat: add multi-step execution plan for chat pipeline

### DIFF
--- a/lexwebapp/src/components/Message.tsx
+++ b/lexwebapp/src/components/Message.tsx
@@ -6,8 +6,10 @@ import remarkGfm from 'remark-gfm';
 import { DecisionCard, Decision } from './DecisionCard';
 import { AnalyticsBlock } from './AnalyticsBlock';
 import { ThinkingSteps } from './ThinkingSteps';
+import { PlanDisplay } from './PlanDisplay';
 import { DocumentTemplate } from './DocumentTemplate';
 import showToast from '../utils/toast';
+import type { ExecutionPlan } from '../types/models/Message';
 
 export type MessageRole = 'user' | 'assistant';
 export interface MessageProps {
@@ -39,6 +41,7 @@ export interface MessageProps {
     content?: string;
     isComplete: boolean;
   }>;
+  executionPlan?: ExecutionPlan;
   onRegenerate?: () => void;
 }
 
@@ -89,6 +92,7 @@ export function Message({
   citations,
   documents,
   thinkingSteps,
+  executionPlan,
   onRegenerate
 }: MessageProps) {
   const isUser = role === 'user';
@@ -150,6 +154,9 @@ export function Message({
 
             {/* Content */}
             <div className="flex-1 min-w-0 space-y-4">
+              {/* Execution Plan */}
+              {executionPlan && <PlanDisplay plan={executionPlan} />}
+
               {/* Thinking Steps */}
               {thinkingSteps && thinkingSteps.length > 0 && <div>
                   <button onClick={() => setShowThinking(!showThinking)} className="flex items-center gap-2 text-[13px] text-claude-subtext hover:text-claude-text transition-colors mb-2">

--- a/lexwebapp/src/components/PlanDisplay.tsx
+++ b/lexwebapp/src/components/PlanDisplay.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { ChevronDown, CheckCircle2, Circle, Target } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import type { ExecutionPlan } from '../types/models/Message';
+
+interface PlanDisplayProps {
+  plan: ExecutionPlan;
+}
+
+export function PlanDisplay({ plan }: PlanDisplayProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const completedCount = plan.steps.filter((s) => s.completed).length;
+  const totalCount = plan.steps.length;
+
+  return (
+    <div className="my-3 border border-claude-border/50 rounded-lg overflow-hidden bg-white/50">
+      {/* Header */}
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="w-full flex items-center justify-between p-3 hover:bg-claude-bg/50 transition-colors text-left"
+      >
+        <div className="flex items-center gap-2.5 flex-1 min-w-0">
+          <Target size={14} className="text-claude-text flex-shrink-0" strokeWidth={2} />
+          <span className="text-[13px] text-claude-text font-medium truncate">
+            {plan.goal}
+          </span>
+          <span className="text-[11px] text-claude-subtext flex-shrink-0">
+            {completedCount}/{totalCount}
+          </span>
+        </div>
+        <ChevronDown
+          size={14}
+          className={`text-claude-subtext transition-transform flex-shrink-0 ${isExpanded ? 'rotate-180' : ''}`}
+          strokeWidth={2}
+        />
+      </button>
+
+      {/* Steps */}
+      <AnimatePresence>
+        {isExpanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="border-t border-claude-border/30"
+          >
+            <div className="p-3 space-y-2">
+              {plan.steps.map((step) => (
+                <div
+                  key={step.id}
+                  className="flex items-start gap-2.5"
+                >
+                  {step.completed ? (
+                    <CheckCircle2
+                      size={14}
+                      className="text-green-600 flex-shrink-0 mt-0.5"
+                      strokeWidth={2}
+                    />
+                  ) : (
+                    <Circle
+                      size={14}
+                      className="text-claude-subtext/40 flex-shrink-0 mt-0.5"
+                      strokeWidth={2}
+                    />
+                  )}
+                  <div className="min-w-0">
+                    <span
+                      className={`text-[13px] leading-relaxed ${
+                        step.completed
+                          ? 'text-claude-subtext line-through'
+                          : 'text-claude-text'
+                      }`}
+                    >
+                      {step.purpose}
+                    </span>
+                    <span className="text-[11px] text-claude-subtext/60 ml-1.5">
+                      {step.tool}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -22,6 +22,7 @@ import {
 import { StreamingCallbacks } from '../../types/api/sse';
 
 export interface ChatStreamCallbacks {
+  onPlan?: (data: { goal: string; steps: Array<{ id: number; tool: string; params: Record<string, any>; purpose: string; depends_on?: number[] }>; expected_iterations: number }) => void;
   onThinking?: (data: { step: number; tool: string; params: any }) => void;
   onToolResult?: (data: { tool: string; result: any }) => void;
   onAnswerDelta?: (data: { text: string }) => void;
@@ -176,6 +177,9 @@ export class MCPService extends BaseService {
                 try {
                   const data = JSON.parse(currentData);
                   switch (currentEvent) {
+                    case 'plan':
+                      callbacks.onPlan?.(data);
+                      break;
                     case 'thinking':
                       callbacks.onThinking?.(data);
                       break;

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -8,6 +8,7 @@ export interface Message {
   content: string;
   isStreaming?: boolean;
   thinkingSteps?: ThinkingStep[];
+  executionPlan?: ExecutionPlan;
   decisions?: Decision[];
   citations?: Citation[];
   documents?: VaultDocument[];
@@ -18,6 +19,21 @@ export interface ThinkingStep {
   title: string;
   content: string;
   isComplete: boolean;
+}
+
+export interface ExecutionPlan {
+  goal: string;
+  steps: PlanStep[];
+  expected_iterations: number;
+}
+
+export interface PlanStep {
+  id: number;
+  tool: string;
+  params: Record<string, any>;
+  purpose: string;
+  depends_on?: number[];
+  completed?: boolean;
 }
 
 export interface Decision {


### PR DESCRIPTION
## Summary
- Replace unstructured Anthropic pre-analysis (`generateResponseTemplate`) with structured `generateExecutionPlan()` that produces a JSON plan of tool calls before the agentic loop
- New SSE `plan` event streams the execution plan to the frontend before tool execution begins
- Frontend shows a collapsible PlanDisplay component with goal, numbered steps, and real-time progress (checkmarks as steps complete)
- Budget escalation now based on plan complexity (>= 3 steps → deep) instead of always escalating when a template exists, saving tokens on simple queries

## Changes

### Backend (`mcp_backend`)
- `prompts/chat-system-prompt.ts`: Add `ExecutionPlan`/`PlanStep` types, `buildPlanGenerationPrompt()` function
- `services/chat-service.ts`: Replace `generateResponseTemplate()` with `generateExecutionPlan()`, emit `plan` SSE event, inject structured plan into system prompt

### Frontend (`lexwebapp`)
- `types/models/Message.ts`: Add `ExecutionPlan`, `PlanStep` interfaces
- `services/api/MCPService.ts`: Add `onPlan` callback to `ChatStreamCallbacks`, handle `plan` SSE event
- `hooks/useMCPTool.ts`: Track plan in `useAIChat`, mark steps as completed on `onThinking` events
- `components/PlanDisplay.tsx`: New component — collapsible plan with goal, step progress, tool names
- `components/Message.tsx`: Render `PlanDisplay` above `ThinkingSteps`

## Test plan
- [ ] Simple query ("Що каже стаття 16 ЦК?") → plan with 1 step, no budget escalation
- [ ] Medium query ("Судова практика по ст. 625 ЦК") → plan with 2-3 steps
- [ ] Complex query ("Проаналізуй справу 922/989/18 через усі інстанції") → plan with 4-5 steps, deep budget
- [ ] Plan generation failure → graceful fallback to agentic loop without plan
- [ ] Verify SSE event order: `plan` → `thinking` → `tool_result` → `answer` → `complete`
- [ ] PlanDisplay renders with goal and steps, steps get checkmarks as tools execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a structured multi-step execution plan for each chat and streams it to the UI before tool calls. This makes the agent’s strategy visible and only escalates budget for complex tasks.

- **New Features**
  - Backend: generates a JSON execution plan (generateExecutionPlan), emits a 'plan' SSE event, injects the plan into the system prompt, and escalates budget only when the plan has 3+ steps.
  - Frontend: handles the 'plan' SSE via onPlan, displays a collapsible PlanDisplay with goal and step progress, and marks steps complete as tools execute.

<sup>Written for commit 7e62058a5d7ba3a5774df369abd603a8ee4dc633. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

