### PR TITLE
feat: resizable right panel with inline document expansion

### DIFF
--- a/lexwebapp/src/components/ChatLayout.tsx
+++ b/lexwebapp/src/components/ChatLayout.tsx
@@ -5,7 +5,7 @@ import { ChatInput } from './ChatInput';
 import { MessageThread } from './MessageThread';
 import { EmptyState } from './EmptyState';
 import { ProfilePage } from './ProfilePage';
-import { useChatStore } from '../stores';
+import { useChatStore, useUIStore } from '../stores';
 import { useMCPTool, useAIChat } from '../hooks/useMCPTool';
 import showToast from '../utils/toast';
 import { JudgesPage } from './JudgesPage';
@@ -81,6 +81,7 @@ export function ChatLayout() {
   const { logout } = useAuth();
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
   const [isRightPanelOpen, setIsRightPanelOpen] = useState(true);
+  const { rightPanelWidth } = useUIStore();
   const [selectedTool, setSelectedTool] = useState('ai_chat');
   const [currentView, setCurrentView] = useState<ViewState>('chat');
   const [selectedPerson, setSelectedPerson] = useState<SelectedPerson | null>(
@@ -594,7 +595,7 @@ export function ChatLayout() {
       </main>
 
       {/* Right Panel */}
-      <div className={`${isRightPanelOpen ? 'block' : 'hidden'}`}>
+      <div className={`${isRightPanelOpen ? 'block' : 'hidden'}`} style={{ width: isRightPanelOpen ? rightPanelWidth : 0 }}>
         <RightPanel
           isOpen={isRightPanelOpen}
           onClose={() => setIsRightPanelOpen(false)}

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -56,6 +56,7 @@ export function MainLayout() {
   const {
     isSidebarOpen,
     isRightPanelOpen,
+    rightPanelWidth,
     toggleSidebar,
     toggleRightPanel,
     setSidebarOpen,
@@ -227,7 +228,7 @@ export function MainLayout() {
 
       {/* Right Panel (hidden on admin routes) */}
       {!isAdminRoute && (
-        <div className={`${isRightPanelOpen ? 'block' : 'hidden'}`}>
+        <div className={`${isRightPanelOpen ? 'block' : 'hidden'}`} style={{ width: isRightPanelOpen ? rightPanelWidth : 0 }}>
           <RightPanel
             isOpen={isRightPanelOpen}
             onClose={() => useUIStore.getState().setRightPanelOpen(false)}

--- a/lexwebapp/src/stores/uiStore.ts
+++ b/lexwebapp/src/stores/uiStore.ts
@@ -16,6 +16,8 @@ interface UIState {
   isRightPanelOpen: boolean;
   toggleRightPanel: () => void;
   setRightPanelOpen: (isOpen: boolean) => void;
+  rightPanelWidth: number;
+  setRightPanelWidth: (width: number) => void;
 
   // Modals
   openModals: Set<string>;
@@ -48,6 +50,8 @@ export const useUIStore = create<UIState>()(
         toggleRightPanel: () =>
           set((state) => ({ isRightPanelOpen: !state.isRightPanelOpen })),
         setRightPanelOpen: (isOpen) => set({ isRightPanelOpen: isOpen }),
+        rightPanelWidth: 400,
+        setRightPanelWidth: (width) => set({ rightPanelWidth: Math.min(800, Math.max(320, width)) }),
 
         // Modals
         openModals: new Set(),
@@ -81,6 +85,7 @@ export const useUIStore = create<UIState>()(
           // Persist sidebar, panel, and theme preferences
           isSidebarOpen: state.isSidebarOpen,
           isRightPanelOpen: state.isRightPanelOpen,
+          rightPanelWidth: state.rightPanelWidth,
           theme: state.theme,
         }),
       }


### PR DESCRIPTION
## Summary
- **Resizable panel**: Drag left edge to resize between 320-800px; width persisted in localStorage via `uiStore`
- **Inline expansion**: Click any card to expand content inline with markdown rendering, copy button, and "full view" modal link — no more modal-only reading
- **3 tabs**: Dropped Verification tab; kept Decisions, Regulations, Documents

## Files changed
- `lexwebapp/src/stores/uiStore.ts` — added `rightPanelWidth` state + setter
- `lexwebapp/src/components/RightPanel.tsx` — full rewrite (resize handle, inline expand, 3 tabs)
- `lexwebapp/src/components/ChatLayout.tsx` — dynamic panel width from store
- `lexwebapp/src/layouts/MainLayout.tsx` — dynamic panel width from store

## Test plan
- [ ] Drag panel edge — width changes smoothly, persists on reload
- [ ] Click card — expands inline with full content, click again collapses
- [ ] "Повний вигляд" button opens existing DocumentViewerModal
- [ ] Copy button copies content to clipboard
- [ ] Send chat query — panel auto-opens with results in correct tabs
- [ ] Mobile view — panel slides in/out correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a resizable right panel and inline content expansion for decisions, regulations, and documents, replacing the fixed 360px panel and modal-only reading. This improves readability and control, with the panel width saved between sessions.

- **New Features**
  - Drag to resize the right panel (320–800px); width is persisted via uiStore/localStorage.
  - Cards expand inline with Markdown rendering, a copy button, and a “Full view” link to the existing modal.
  - Simplified tabs to Decisions, Regulations, Documents (removed Verification).

- **Refactors**
  - Rewrote RightPanel with a resize handle and inline expansion; animations via framer-motion.
  - ChatLayout/MainLayout now read panel width from uiStore.
  - uiStore adds rightPanelWidth with clamped setter.

<sup>Written for commit 0e82b0d3e4b77d342768e7dbac810d92e07b1289. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

