### PR TITLE
feat: show credit costs per tool call and summary in chat UI

### DIFF
--- a/lexwebapp/src/components/CostSummary.tsx
+++ b/lexwebapp/src/components/CostSummary.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react';
+import { ChevronDown, Coins } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import type { CostSummary as CostSummaryType } from '../types/models/Message';
+
+const TOOL_LABELS: Record<string, string> = {
+  search_legal_precedents: 'Пошук прецедентів',
+  search_supreme_court_practice: 'Практика ВС',
+  get_court_decision: 'Отримання рішення',
+  get_case_documents_chain: 'Ланцюг документів',
+  find_similar_fact_pattern_cases: 'Схожі справи',
+  compare_practice_pro_contra: 'Аналіз за і проти',
+  search_legislation: 'Пошук законодавства',
+  get_legislation_article: 'Стаття закону',
+  semantic_search: 'Семантичний пошук',
+  openreyestr_search_entities: 'Пошук юросіб',
+  openreyestr_get_by_edrpou: 'Пошук за ЄДРПОУ',
+  rada_search_parliament_bills: 'Законопроекти Ради',
+};
+
+function getToolLabel(name: string): string {
+  return TOOL_LABELS[name] || name;
+}
+
+interface CostSummaryProps {
+  data: CostSummaryType;
+}
+
+export function CostSummary({ data }: CostSummaryProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="mt-3">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1.5 text-[12px] text-claude-subtext hover:text-claude-text transition-colors"
+      >
+        <Coins size={12} strokeWidth={2} />
+        <span>
+          {data.credits_deducted} кредитів
+          {data.total_cost_usd > 0 && ` · $${data.total_cost_usd.toFixed(4)}`}
+        </span>
+        <ChevronDown
+          size={12}
+          className={`transition-transform ${expanded ? 'rotate-180' : ''}`}
+          strokeWidth={2}
+        />
+      </button>
+
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: 'auto' }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="mt-2 px-3 py-2.5 rounded-lg border border-claude-border/50 bg-claude-bg/40 text-[12px] text-claude-subtext space-y-1.5">
+              {/* Tools used */}
+              {data.tools_used.length > 0 && (
+                <div className="flex flex-wrap gap-1">
+                  <span className="font-medium text-claude-text">Інструменти:</span>
+                  {data.tools_used.map((tool) => (
+                    <span
+                      key={tool}
+                      className="px-1.5 py-0.5 rounded bg-claude-subtext/8 text-[11px]"
+                    >
+                      {getToolLabel(tool)}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Cost breakdown */}
+              <div className="flex items-center gap-3 flex-wrap">
+                {data.total_cost_usd > 0 && (
+                  <span>Вартість LLM: ${data.total_cost_usd.toFixed(4)}</span>
+                )}
+                <span>Списано: {data.credits_deducted} кредитів</span>
+                {data.new_balance_credits != null && (
+                  <span>Залишок: {data.new_balance_credits} кредитів</span>
+                )}
+                {data.balance_usd != null && (
+                  <span>Баланс: ${data.balance_usd.toFixed(2)}</span>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/lexwebapp/src/components/Message.tsx
+++ b/lexwebapp/src/components/Message.tsx
@@ -8,8 +8,9 @@ import { AnalyticsBlock } from './AnalyticsBlock';
 import { ThinkingSteps } from './ThinkingSteps';
 import { PlanDisplay } from './PlanDisplay';
 import { DocumentTemplate } from './DocumentTemplate';
+import { CostSummary } from './CostSummary';
 import showToast from '../utils/toast';
-import type { ExecutionPlan, CitationWarning } from '../types/models/Message';
+import type { ExecutionPlan, CitationWarning, CostSummary as CostSummaryType } from '../types/models/Message';
 
 export type MessageRole = 'user' | 'assistant';
 export interface MessageProps {
@@ -43,6 +44,7 @@ export interface MessageProps {
   }>;
   executionPlan?: ExecutionPlan;
   citationWarnings?: CitationWarning[];
+  costSummary?: CostSummaryType;
   onRegenerate?: () => void;
 }
 
@@ -95,6 +97,7 @@ export function Message({
   thinkingSteps,
   executionPlan,
   citationWarnings,
+  costSummary,
   onRegenerate
 }: MessageProps) {
   const isUser = role === 'user';
@@ -368,6 +371,11 @@ export function Message({
 
               {/* Analytics Block */}
               {analytics && <AnalyticsBlock data={analytics} />}
+
+              {/* Cost Summary */}
+              {costSummary && !isStreaming && (
+                <CostSummary data={costSummary} />
+              )}
 
               {/* Actions */}
               {!isStreaming && content && <div className="flex items-center gap-1 pt-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -31,12 +31,13 @@ export interface CitationWarning {
 
 export interface ChatStreamCallbacks {
   onPlan?: (data: { goal: string; steps: Array<{ id: number; tool: string; params: Record<string, any>; purpose: string; depends_on?: number[] }>; expected_iterations: number }) => void;
-  onThinking?: (data: { step: number; tool: string; params: any; description?: string }) => void;
-  onToolResult?: (data: { tool: string; result: any }) => void;
+  onThinking?: (data: { step: number; tool: string; params: any; description?: string; cost_usd?: number }) => void;
+  onToolResult?: (data: { tool: string; result: any; cost_usd?: number }) => void;
   onAnswerDelta?: (data: { text: string }) => void;
   onAnswer?: (data: { text: string; provider: string; model: string }) => void;
   onCitationWarning?: (data: CitationWarning) => void;
-  onComplete?: (data: { iterations: number; elapsed_ms: number }) => void;
+  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; credits_deducted?: number }) => void;
+  onCostSummary?: (data: { credits_deducted: number; new_balance_credits: number; balance_usd: number | null }) => void;
   onError?: (data: { message: string }) => void;
 }
 
@@ -206,6 +207,9 @@ export class MCPService extends BaseService {
                       break;
                     case 'complete':
                       callbacks.onComplete?.(data);
+                      break;
+                    case 'cost_summary':
+                      callbacks.onCostSummary?.(data);
                       break;
                     case 'error':
                       callbacks.onError?.(data);

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -9,6 +9,14 @@ export interface CitationWarning {
   message: string;
 }
 
+export interface CostSummary {
+  tools_used: string[];
+  total_cost_usd: number;
+  credits_deducted: number;
+  new_balance_credits?: number;
+  balance_usd?: number | null;
+}
+
 export interface Message {
   id: string;
   role: 'user' | 'assistant';
@@ -20,6 +28,7 @@ export interface Message {
   citations?: Citation[];
   documents?: VaultDocument[];
   citationWarnings?: CitationWarning[];
+  costSummary?: CostSummary;
 }
 
 export interface ThinkingStep {


### PR DESCRIPTION
## Summary
- Backend emits `cost_usd` in `thinking` and `tool_result` SSE events, plus `tools_used`/`total_cost_usd`/`credits_deducted` in `complete` event
- New `cost_summary` SSE event sent after credit deduction with balance info (credits + USD)
- Frontend displays per-step USD cost (e.g. `· $0.0023`) in thinking step titles
- New collapsible `CostSummary` component below assistant messages showing tools used, LLM cost, credits deducted, and remaining balance

## Test plan
- [ ] Send a chat message and verify thinking steps show `· $X.XXXX` cost suffix
- [ ] Verify collapsible cost summary appears below the assistant answer
- [ ] Expand cost summary — check tools list, LLM cost, credits deducted, balance
- [ ] Check SSE stream in DevTools Network tab for `cost_summary` event
- [ ] Verify backend builds: `cd mcp_backend && npm run build`
- [ ] Verify frontend builds: `cd lexwebapp && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-call USD costs and a collapsible cost summary to the chat, so users see LLM spend, credits deducted, and remaining balance after each reply.

- **New Features**
  - Backend SSE: adds cost_usd to thinking/tool_result; includes tools_used, total_cost_usd, credits_deducted in complete; emits cost_summary after credit deduction with new_balance_credits and balance_usd.
  - Frontend UI: shows per-step cost suffix in thinking titles (e.g., · $0.0023); adds CostSummary under assistant messages with tools used, LLM cost, credits deducted, and balances; renders after streaming completes.
  - Client updates: Message model extended with costSummary; stream handlers process new fields and cost_summary event; hook aggregates and updates cost data.

<sup>Written for commit e41f8f6f9382e463d6c4d969c9a2d11b0b242f84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

