### PR TITLE
feat: make legal.org.ua the primary domain

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -452,9 +452,9 @@ services:
 
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
-      GOOGLE_CALLBACK_URL: https://stage.legal.org.ua/auth/google/callback
-      FRONTEND_URL: https://stage.legal.org.ua
-      ALLOWED_ORIGINS: https://stage.legal.org.ua,https://stage.mcp.legal.org.ua,https://legal.org.ua,https://mcp.legal.org.ua
+      GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
+      FRONTEND_URL: https://legal.org.ua
+      ALLOWED_ORIGINS: https://legal.org.ua,https://stage.legal.org.ua,https://mcp.legal.org.ua,https://stage.mcp.legal.org.ua
       # MinIO (S3-compatible object storage)
       MINIO_ENDPOINT: minio-stage
       MINIO_PORT: 9000
@@ -632,7 +632,7 @@ services:
       dockerfile: lexwebapp/Dockerfile
       args:
         - BUILD_ENV=staging
-        - VITE_API_URL=https://stage.legal.org.ua
+        - VITE_API_URL=https://legal.org.ua
         - VITE_API_KEY=${VITE_API_KEY_STAGE:-REDACTED_SL_KEY_STAGE}
         - VITE_ENABLE_SSE_STREAMING=true
         - VITE_ENABLE_ALL_MCP_TOOLS=true


### PR DESCRIPTION
## Summary
- Switch primary domain from `stage.legal.org.ua` to `legal.org.ua`
- Update `FRONTEND_URL`, `GOOGLE_CALLBACK_URL`, `VITE_API_URL` in docker-compose.stage.yml
- `stage.legal.org.ua` remains in `ALLOWED_ORIGINS` for backward compatibility

## Prerequisites
- Google Cloud Console: added `https://legal.org.ua/auth/google/callback` to Authorized redirect URIs

## Test plan
- [ ] Merge and pull on gate server
- [ ] Rebuild `secondlayer-app-stage` and `lexwebapp-stage` containers
- [ ] Verify Google OAuth login works on `legal.org.ua`
- [ ] Verify billing balance displays correctly
- [ ] Verify `stage.legal.org.ua` still works (redirects or serves same content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the primary domain from stage.legal.org.ua to legal.org.ua. Updated GOOGLE_CALLBACK_URL, FRONTEND_URL, and VITE_API_URL; kept stage.* domains in ALLOWED_ORIGINS for backward compatibility.

- **Migration**
  - Add https://legal.org.ua/auth/google/callback in Google Cloud Console.
  - Deploy and rebuild secondlayer-app-stage and lexwebapp-stage.
  - Verify Google OAuth on legal.org.ua and that stage.legal.org.ua still works.

<sup>Written for commit ddc442132fe93f084020cfb8686221ed4a235d70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

