### PR TITLE
fix: reload chat messages on navigation return

### DIFF
--- a/lexwebapp/src/components/ChatLayout.tsx
+++ b/lexwebapp/src/components/ChatLayout.tsx
@@ -91,7 +91,14 @@ export function ChatLayout() {
   const [messagingClientIds, setMessagingClientIds] = useState<string[]>([]);
 
   // Use Zustand store for messages and streaming state
-  const { messages, isStreaming, cancelStream, removeMessage } = useChatStore();
+  const { messages, isStreaming, cancelStream, removeMessage, conversationId, switchConversation } = useChatStore();
+
+  // Reload messages from server when returning to chat view with an active conversation
+  React.useEffect(() => {
+    if (currentView === 'chat' && conversationId && !isStreaming && messages.length === 0) {
+      switchConversation(conversationId);
+    }
+  }, [currentView, conversationId]);
 
   // Aggregate evidence from ALL messages in the current chat (deduplicated)
   const allDecisions = React.useMemo(() => {

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -198,7 +198,10 @@ export const useChatStore = create<ChatState>()(
               currentSessionId: null,
             });
           } catch {
-            // fallback: do nothing
+            // Keep conversationId set but preserve existing messages if API fails
+            if (get().conversationId !== conversationId) {
+              set({ conversationId, currentSessionId: null });
+            }
           }
         },
 


### PR DESCRIPTION
## Summary
- Fix: messages disappear when user navigates away from chat and returns
- Add auto-reload from server when returning to chat view with empty messages
- Improve error handling in `switchConversation` to not silently lose state

## Test plan
- [ ] Start a chat conversation, navigate to another menu item, return — messages should reload
- [ ] Verify streaming chat still works normally
- [ ] Verify switching between conversations in sidebar works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disappearing chat messages when navigating away and back to a conversation. Automatically reloads messages on return and preserves conversation selection on API errors.

- **Bug Fixes**
  - Reload messages when returning to chat with an active conversation and an empty message list.
  - Preserve conversationId and existing messages if switchConversation fails, avoiding silent state loss.

<sup>Written for commit 1662f5b12a21bb7e349403998476ac5618b64732. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

