### PR TITLE
fix: soften shepardization warning style

### DIFF
--- a/lexwebapp/src/components/Message.tsx
+++ b/lexwebapp/src/components/Message.tsx
@@ -292,23 +292,23 @@ export function Message({
                       transition={{ duration: 0.3, delay: idx * 0.1 }}
                       className={`flex items-start gap-3 px-4 py-3 rounded-lg border ${
                         warning.status === 'explicitly_overruled'
-                          ? 'bg-red-50 border-red-200 dark:bg-red-950/30 dark:border-red-800'
-                          : 'bg-amber-50 border-amber-200 dark:bg-amber-950/30 dark:border-amber-800'
+                          ? 'bg-orange-50/70 border-orange-200 dark:bg-orange-950/20 dark:border-orange-800/50'
+                          : 'bg-amber-50/70 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800/50'
                       }`}
                     >
-                      <span className="text-lg mt-0.5">
-                        {warning.status === 'explicitly_overruled' ? '\u26D4' : '\u26A0\uFE0F'}
+                      <span className="text-base mt-0.5 opacity-70">
+                        {warning.status === 'explicitly_overruled' ? '\u{1F4CB}' : '\u{1F4CC}'}
                       </span>
                       <div className="flex-1 min-w-0">
-                        <p className={`text-sm font-medium ${
+                        <p className={`text-sm ${
                           warning.status === 'explicitly_overruled'
-                            ? 'text-red-800 dark:text-red-300'
-                            : 'text-amber-800 dark:text-amber-300'
+                            ? 'text-orange-700 dark:text-orange-300'
+                            : 'text-amber-700 dark:text-amber-300'
                         }`}>
                           {warning.message}
                         </p>
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                          {warning.status === 'explicitly_overruled' ? 'Скасовано' : 'Змінено'} &middot; впевненість: {Math.round(warning.confidence * 100)}%
+                        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+                          {warning.status === 'explicitly_overruled' ? 'Скасовано вищою інстанцією' : 'Частково змінено'} &middot; впевненість: {Math.round(warning.confidence * 100)}%
                         </p>
                       </div>
                     </motion.div>


### PR DESCRIPTION
## Summary
- Change overruled citation warnings from red error-like style to soft orange informational
- Replace ⛔/⚠️ icons with 📋/📌 (less alarming)
- More descriptive labels: "Скасовано вищою інстанцією" / "Частково змінено"

## Test plan
- [ ] Trigger a chat that cites an overruled case — warning should appear as soft orange info box

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Softened shepardization warnings in chat: overruled and modified citations now render as soft orange/amber informational boxes instead of red error states. Replaced ⛔/⚠️ with 📋/📌 and updated labels to “Скасовано вищою інстанцією” and “Частково змінено” for clearer, less alarming messaging.

<sup>Written for commit b665ade915492cabdad6585b9d04b04aee5ba93d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

