### PR TITLE
fix: use BillingService (USD) instead of CreditService for chat billing

### DIFF
--- a/lexwebapp/src/components/CostSummary.tsx
+++ b/lexwebapp/src/components/CostSummary.tsx
@@ -37,8 +37,11 @@ export function CostSummary({ data }: CostSummaryProps) {
       >
         <Coins size={12} strokeWidth={2} />
         <span>
-          {data.credits_deducted} кредитів
-          {data.total_cost_usd > 0 && ` · $${data.total_cost_usd.toFixed(4)}`}
+          {data.charged_usd != null && data.charged_usd > 0
+            ? `$${data.charged_usd.toFixed(4)}`
+            : data.total_cost_usd > 0
+              ? `$${data.total_cost_usd.toFixed(4)}`
+              : '$0.00'}
         </span>
         <ChevronDown
           size={12}
@@ -77,9 +80,8 @@ export function CostSummary({ data }: CostSummaryProps) {
                 {data.total_cost_usd > 0 && (
                   <span>Вартість LLM: ${data.total_cost_usd.toFixed(4)}</span>
                 )}
-                <span>Списано: {data.credits_deducted} кредитів</span>
-                {data.new_balance_credits != null && (
-                  <span>Залишок: {data.new_balance_credits} кредитів</span>
+                {data.charged_usd != null && data.charged_usd > 0 && (
+                  <span>Списано: ${data.charged_usd.toFixed(4)}</span>
                 )}
                 {data.balance_usd != null && (
                   <span>Баланс: ${data.balance_usd.toFixed(2)}</span>

--- a/lexwebapp/src/hooks/useMCPTool.ts
+++ b/lexwebapp/src/hooks/useMCPTool.ts
@@ -1071,12 +1071,12 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
 
           onComplete: (data) => {
             // Store cost data from complete event
-            if (data.tools_used || data.total_cost_usd != null || data.credits_deducted != null) {
+            if (data.tools_used || data.total_cost_usd != null || data.charged_usd != null) {
               costSummaryRef.current = {
                 ...costSummaryRef.current,
                 tools_used: data.tools_used || [],
                 total_cost_usd: data.total_cost_usd || 0,
-                credits_deducted: data.credits_deducted || 3,
+                charged_usd: data.charged_usd || 0,
               };
               updateMessage(assistantMessageId, {
                 costSummary: costSummaryRef.current as CostSummary,
@@ -1089,8 +1089,7 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
             // Merge balance info from cost_summary event
             costSummaryRef.current = {
               ...costSummaryRef.current,
-              credits_deducted: data.credits_deducted,
-              new_balance_credits: data.new_balance_credits,
+              charged_usd: data.charged_usd,
               balance_usd: data.balance_usd,
             };
             updateMessage(assistantMessageId, {

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -36,8 +36,8 @@ export interface ChatStreamCallbacks {
   onAnswerDelta?: (data: { text: string }) => void;
   onAnswer?: (data: { text: string; provider: string; model: string }) => void;
   onCitationWarning?: (data: CitationWarning) => void;
-  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; credits_deducted?: number }) => void;
-  onCostSummary?: (data: { credits_deducted: number; new_balance_credits: number; balance_usd: number | null }) => void;
+  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number }) => void;
+  onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
   onError?: (data: { message: string }) => void;
 }
 

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -12,9 +12,12 @@ export interface CitationWarning {
 export interface CostSummary {
   tools_used: string[];
   total_cost_usd: number;
-  credits_deducted: number;
-  new_balance_credits?: number;
+  charged_usd?: number;
   balance_usd?: number | null;
+  /** @deprecated use charged_usd */
+  credits_deducted?: number;
+  /** @deprecated use balance_usd */
+  new_balance_credits?: number;
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary
- Chat endpoint was using old `CreditService` (checks `user_credits` table) instead of `BillingService` (checks `user_billing.balance_usd`), causing 402 errors for users with sufficient USD balance but 0 credits
- Replaced pre-flight check and post-execution deduction with `BillingService` methods
- Updated frontend to display USD amounts instead of "кредитів"

## Test plan
- [ ] Verify user with USD balance can send chat messages without 402
- [ ] Verify `cost_summary` SSE event returns `charged_usd` and `balance_usd`
- [ ] Verify CostSummary component displays USD amounts correctly
- [ ] Verify users with 0 USD balance still get 402 blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch chat billing to the USD-based BillingService to stop 402 errors for users who have USD balance. Updated SSE events and UI to show USD amounts instead of credits.

- **Bug Fixes**
  - Pre-flight check now uses BillingService.checkBalance with estimated USD cost.
  - Post-execution charges use BillingService.chargeUser and emit cost_summary with total_cost_usd, charged_usd, and balance_usd.
  - Frontend updates: CostSummary and hooks consume charged_usd/balance_usd and display USD amounts; credit fields deprecated.
  - Users with 0 USD balance still get a 402.

<sup>Written for commit 273b62b4ca3b13d22aa205f49816323b1c7443b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

