### PR TITLE
feat: gpt-4.1 for deep budget + OpenAI streaming key rotation

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -67,7 +67,7 @@ const MAX_TOOL_CALLS = parseInt(process.env.MAX_CHAT_TOOL_CALLS || '5', 10);
 const BUDGET_LIMITS = {
   quick:    { maxResultChars: 6000,   maxContextChars: 48_000,  maxTokens: 4096,  resolutionSlice: 120 },
   standard: { maxResultChars: 8000,   maxContextChars: 64_000,  maxTokens: 4096,  resolutionSlice: 300 },
-  deep:     { maxResultChars: 40_000, maxContextChars: 100_000, maxTokens: 16384, resolutionSlice: 800 },
+  deep:     { maxResultChars: 40_000, maxContextChars: 100_000, maxTokens: 32000, resolutionSlice: 800 },
 } as const;
 type BudgetKey = keyof typeof BUDGET_LIMITS;
 

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -21,7 +21,7 @@ export class ModelSelector {
 
   private static readonly OPENAI_QUICK = process.env.OPENAI_MODEL_QUICK || 'gpt-4o-mini';
   private static readonly OPENAI_STANDARD = process.env.OPENAI_MODEL_STANDARD || 'gpt-4o-mini';
-  private static readonly OPENAI_DEEP = process.env.OPENAI_MODEL_DEEP || 'gpt-4o';
+  private static readonly OPENAI_DEEP = process.env.OPENAI_MODEL_DEEP || 'gpt-4.1';
 
   private static readonly ANTHROPIC_QUICK = process.env.ANTHROPIC_MODEL_QUICK || 'claude-haiku-4-5-20251001';
   private static readonly ANTHROPIC_STANDARD = process.env.ANTHROPIC_MODEL_STANDARD || 'claude-sonnet-4-20250514';
@@ -172,6 +172,9 @@ export class ModelSelector {
 
   static estimateCost(model: string, tokens: number): number {
     const costPer1M: Record<string, { input: number; output: number }> = {
+      'gpt-4.1': { input: 2.00, output: 8.00 },
+      'gpt-4.1-mini': { input: 0.40, output: 1.60 },
+      'gpt-4.1-nano': { input: 0.10, output: 0.40 },
       'gpt-4o': { input: 2.50, output: 10.00 },
       'gpt-4o-mini': { input: 0.15, output: 0.60 },
       'gpt-4o-2024-08-06': { input: 2.50, output: 10.00 },
@@ -212,6 +215,9 @@ export class ModelSelector {
     completionTokens: number
   ): number {
     const costPer1M: Record<string, { input: number; output: number }> = {
+      'gpt-4.1': { input: 2.00, output: 8.00 },
+      'gpt-4.1-mini': { input: 0.40, output: 1.60 },
+      'gpt-4.1-nano': { input: 0.10, output: 0.40 },
       'gpt-4o': { input: 2.50, output: 10.00 },
       'gpt-4o-mini': { input: 0.15, output: 0.60 },
       'gpt-4o-2024-08-06': { input: 2.50, output: 10.00 },
@@ -273,6 +279,9 @@ export class ModelSelector {
 
   static supportsJsonMode(model: string): boolean {
     const jsonModeModels = [
+      'gpt-4.1',
+      'gpt-4.1-mini',
+      'gpt-4.1-nano',
       'gpt-4-turbo',
       'gpt-4-turbo-preview',
       'gpt-4-1106-preview',

--- a/packages/shared/src/utils/openai-client.ts
+++ b/packages/shared/src/utils/openai-client.ts
@@ -50,6 +50,10 @@ export class OpenAIClientManager {
     return this.clients.length > 0;
   }
 
+  getClientCount(): number {
+    return this.clients.length;
+  }
+
   getClient(): OpenAI {
     if (this.clients.length === 0) {
       throw new Error('No OpenAI API keys configured');


### PR DESCRIPTION
## Summary
- **gpt-4.1 as default deep model**: 1M context, 32K output (vs gpt-4o 128K/16K), $2/$8 per 1M tokens (20% cheaper), better instruction following — fixes issue where LLM truncated 29-document chronology tables
- **Deep maxTokens: 16K → 32K**: leverages gpt-4.1's larger output capacity for comprehensive legal analysis
- **OpenAI streaming key rotation**: on 429/401/403, rotates to `OPENAI_API_KEY2` and retries before falling back to Anthropic (previously only non-streaming calls had this)
- Added gpt-4.1/4.1-mini/4.1-nano to pricing tables and JSON mode support

## Test plan
- [ ] Verify deep analysis query (922/989/18) produces full 29-row chronology table
- [ ] Confirm gpt-4.1 is selected for deep budget in logs
- [ ] Simulate 429 on primary OpenAI key — should rotate to secondary key
- [ ] Verify cost tracking records correct gpt-4.1 pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the deep budget to gpt-4.1 and raises output to 32K, improving long-form results and lowering cost. Adds OpenAI streaming key rotation to reduce failures on rate/auth errors.

- **New Features**
  - Deep budget now defaults to gpt-4.1 (1M context, 32K output, $2/$8 per 1M); fixes truncated 29-row chronology tables.
  - Deep maxTokens increased from 16K to 32K.
  - Streaming requests rotate from OPENAI_API_KEY to OPENAI_API_KEY2 on 429/401/403 before falling back to Anthropic.
  - Added gpt-4.1/4.1-mini/4.1-nano to pricing and JSON mode support.

- **Migration**
  - Set OPENAI_API_KEY2 to enable streaming key rotation.
  - To keep using gpt-4o for deep, set OPENAI_MODEL_DEEP=gpt-4o.

<sup>Written for commit b77f1ae3a0adc01604621f88fde3a1c22d42aec8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

