### PR TITLE
fix: reduce deep budget maxTokens for GPT-5.1

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -67,7 +67,7 @@ const MAX_TOOL_CALLS = parseInt(process.env.MAX_CHAT_TOOL_CALLS || '5', 10);
 const BUDGET_LIMITS = {
   quick:    { maxResultChars: 6000,   maxContextChars: 48_000,  maxTokens: 4096,  resolutionSlice: 120 },
   standard: { maxResultChars: 8000,   maxContextChars: 64_000,  maxTokens: 4096,  resolutionSlice: 300 },
-  deep:     { maxResultChars: 40_000, maxContextChars: 100_000, maxTokens: 32000, resolutionSlice: 800 },
+  deep:     { maxResultChars: 40_000, maxContextChars: 100_000, maxTokens: 16384, resolutionSlice: 800 },
 } as const;
 type BudgetKey = keyof typeof BUDGET_LIMITS;
 


### PR DESCRIPTION
## Summary
- GPT-5.1 model supports max 16384 completion tokens, but `deep` budget in ChatService was set to 32000
- This caused `400 max_tokens is too large` errors on every deep-budget chat request
- Fixed by reducing `maxTokens` from 32000 to 16384

## Test plan
- [ ] Verify deep-budget chat requests complete without 400 errors
- [ ] Confirm response quality is not degraded at 16384 tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced deep-budget maxTokens from 32000 to 16384 to match GPT-5.1 limits and prevent "max_tokens is too large" 400 errors on deep chat requests.

<sup>Written for commit 395769340ed9caf7f106dadad8fd486b2be777e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

