### PR TITLE
fix: use max_completion_tokens for GPT-5 models

### DIFF
--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -170,7 +170,7 @@ export class LLMClientManager {
       };
 
       if (request.max_tokens) {
-        params.max_tokens = request.max_tokens;
+        params.max_completion_tokens = request.max_tokens;
       }
 
       if (request.response_format?.type === 'json_object' && ModelSelector.supportsJsonMode(model)) {
@@ -401,7 +401,7 @@ export class LLMClientManager {
     };
 
     if (request.max_tokens) {
-      params.max_tokens = request.max_tokens;
+      params.max_completion_tokens = request.max_tokens;
     }
 
     if (request.response_format?.type === 'json_object' && ModelSelector.supportsJsonMode(model)) {


### PR DESCRIPTION
## Summary
- GPT-5 models reject `max_tokens` parameter, requiring `max_completion_tokens` instead
- Updated both streaming and non-streaming OpenAI calls in `LLMClientManager`
- Anthropic calls unchanged (they still use `max_tokens`)

## Test plan
- [ ] Verify chat requests work with gpt-5-nano, gpt-5-mini, gpt-5.1
- [ ] Verify no regressions on non-streaming tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch OpenAI GPT-5 calls to use max_completion_tokens instead of max_tokens to prevent rejected requests. Applies to both streaming and non-streaming paths in LLMClientManager; Anthropic calls remain unchanged.

<sup>Written for commit 217c756b98ea8bd4d6afa7a700c4b8e8a406a7e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

