### PR TITLE
fix: skip temperature for GPT-5 models

### DIFF
--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -5,6 +5,11 @@ import { OpenAIClientManager, getOpenAIManager, CostTrackerInterface } from './o
 import { AnthropicClientManager, getAnthropicManager } from './anthropic-client';
 import { ModelSelector, LLMProvider, BudgetLevel, ModelSelection } from './model-selector';
 
+/** GPT-5 models only support temperature=1 (default) */
+function supportsTemperature(model: string): boolean {
+  return !model.startsWith('gpt-5');
+}
+
 export interface ToolDefinitionParam {
   name: string;
   description: string;
@@ -166,7 +171,7 @@ export class LLMClientManager {
       const params: OpenAI.Chat.ChatCompletionCreateParams = {
         model,
         messages: messages as OpenAI.Chat.ChatCompletionMessageParam[],
-        temperature: request.temperature ?? 0.3,
+        ...(supportsTemperature(model) ? { temperature: request.temperature ?? 0.3 } : {}),
       };
 
       if (request.max_tokens) {
@@ -395,7 +400,7 @@ export class LLMClientManager {
     const params: any = {
       model,
       messages,
-      temperature: request.temperature ?? 0.3,
+      ...(supportsTemperature(model) ? { temperature: request.temperature ?? 0.3 } : {}),
       stream: true,
       stream_options: { include_usage: true },
     };


### PR DESCRIPTION
## Summary
- GPT-5 models reject `temperature` values other than 1 (default)
- Added `supportsTemperature()` helper that checks for `gpt-5*` prefix
- Conditionally omits temperature in both streaming and non-streaming OpenAI calls
- Anthropic calls unchanged

## Test plan
- [ ] Verify chat works with gpt-5-nano, gpt-5-mini, gpt-5.1 on stage
- [ ] Verify non-GPT-5 models still get temperature=0.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip sending the temperature param to GPT-5 models to avoid API errors, since they only accept the default temperature=1. Other models continue to use the provided temperature or default to 0.3.

- **Bug Fixes**
  - Added supportsTemperature() to detect gpt-5* models and omit temperature in both streaming and non-streaming OpenAI calls.
  - Anthropic calls unchanged; non-GPT-5 models still use temperature as before.

<sup>Written for commit e8c6256a666cc94136ba2804cc2bc08031566ce8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

