### PR TITLE
fix: enforce JSON response format for GPT-5 structured prompts

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -654,6 +654,7 @@ ${stepsText}
           ],
           max_tokens: 300,
           temperature: 0.1,
+          response_format: { type: 'json_object' },
         },
         'quick'
       );
@@ -754,6 +755,7 @@ ${stepsText}
           ],
           max_tokens: 800,
           temperature: 0.1,
+          response_format: { type: 'json_object' },
         },
         'quick'
       );


### PR DESCRIPTION
## Summary
- Added `response_format: { type: 'json_object' }` to intent classification and plan generation LLM calls
- GPT-5-nano was sometimes returning non-JSON, causing fallback to keyword matching

## Test plan
- [ ] Verify intent classification returns valid JSON on stage
- [ ] Verify plan generation returns valid JSON with goal/steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces JSON responses from GPT-5 for intent classification and plan generation by setting response_format to json_object. Prevents non-JSON outputs that triggered keyword fallbacks and parsing errors.

- **Bug Fixes**
  - Added response_format: { type: 'json_object' } to classification and plan generation calls in chat-service.ts.
  - Stabilizes structured parsing and removes fallback paths in these flows.

<sup>Written for commit ad335afd57cb3c9061ab5c61eebc3a52a3659afd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

