### PR TITLE
fix: correct infrastructure config issues from PR #218

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -20,10 +20,9 @@ services:
       -c checkpoint_completion_target=0.9
       -c wal_level=minimal
       -c max_wal_senders=0
-      -c idle_in_transaction_session_timeout=30000
-      -c idle_session_timeout=300000
-      -c statement_timeout=60000
-      -c lock_timeout=10000
+      -c idle_in_transaction_session_timeout=60000
+      -c statement_timeout=300000
+      -c lock_timeout=30000
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-local_dev_password}
@@ -105,7 +104,7 @@ services:
       - "6379:6379"  # Standard Redis port
     volumes:
       - redis_local_data:/data
-    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy volatile-lru
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -10,10 +10,9 @@ services:
       -c work_mem=128MB
       -c maintenance_work_mem=2GB
       -c wal_buffers=64MB
-      -c idle_in_transaction_session_timeout=30000
-      -c idle_session_timeout=300000
-      -c statement_timeout=60000
-      -c lock_timeout=10000
+      -c idle_in_transaction_session_timeout=60000
+      -c statement_timeout=300000
+      -c lock_timeout=30000
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -112,10 +111,9 @@ services:
       -c effective_cache_size=6GB
       -c work_mem=128MB
       -c maintenance_work_mem=1GB
-      -c idle_in_transaction_session_timeout=30000
-      -c idle_session_timeout=300000
-      -c statement_timeout=60000
-      -c lock_timeout=10000
+      -c idle_in_transaction_session_timeout=60000
+      -c statement_timeout=300000
+      -c lock_timeout=30000
     environment:
       POSTGRES_USER: ${OPENREYESTR_POSTGRES_USER:-openreyestr}
       POSTGRES_PASSWORD: ${OPENREYESTR_POSTGRES_PASSWORD}
@@ -176,7 +174,7 @@ services:
     - "127.0.0.1:6381:6379"
     volumes:
     - redis_stage_data:/data
-    command: redis-server --appendonly yes --maxmemory 8192mb --maxmemory-policy allkeys-lru
+    command: redis-server --appendonly yes --maxmemory 8192mb --maxmemory-policy volatile-lru
     healthcheck:
       test:
       - CMD
@@ -447,8 +445,8 @@ services:
       HTTP_PORT: ${HTTP_PORT:-3000}
       HTTP_HOST: 0.0.0.0
       JWT_SECRET: ${JWT_SECRET}
-      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-stage:5432/${POSTGRES_DB:-secondlayer_stage}
-      POSTGRES_HOST: postgres-stage
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@pgbouncer-stage:5432/${POSTGRES_DB:-secondlayer_stage}
+      POSTGRES_HOST: pgbouncer-stage
       POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -520,7 +518,7 @@ services:
     ports:
     - "127.0.0.1:3004:3000"
     depends_on:
-      postgres-stage:
+      pgbouncer-stage:
         condition: service_healthy
       qdrant-stage:
         condition: service_healthy
@@ -579,8 +577,8 @@ services:
       HTTP_HOST: 0.0.0.0
 
       # Database
-      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-stage:5432/${POSTGRES_DB:-secondlayer_stage}
-      POSTGRES_HOST: postgres-stage
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@pgbouncer-stage:5432/${POSTGRES_DB:-secondlayer_stage}
+      POSTGRES_HOST: pgbouncer-stage
       POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/deployment/prometheus/rules/alert-rules.yml
+++ b/deployment/prometheus/rules/alert-rules.yml
@@ -29,16 +29,16 @@ groups:
           description: "Redis memory usage is at {{ $value | humanizePercentage }}."
 
       - alert: RedisEvictedKeys
-        expr: rate(redis_evicted_keys_total[5m]) > 0
+        expr: rate(redis_evicted_keys_total[5m]) > 10
         for: 5m
         labels:
-          severity: critical
+          severity: warning
         annotations:
           summary: "Redis evicting keys"
           description: "Redis is evicting keys due to memory pressure. Rate: {{ $value }}/s"
 
       - alert: PgCacheHitLow
-        expr: pg_stat_database_blks_hit / (pg_stat_database_blks_hit + pg_stat_database_blks_read) < 0.95
+        expr: (pg_stat_database_blks_hit + pg_stat_database_blks_read) > 0 and pg_stat_database_blks_hit / (pg_stat_database_blks_hit + pg_stat_database_blks_read) < 0.95
         for: 10m
         labels:
           severity: critical

--- a/lexwebapp/src/pages/AdminInfrastructurePage.tsx
+++ b/lexwebapp/src/pages/AdminInfrastructurePage.tsx
@@ -179,7 +179,7 @@ function generateRecommendations(data: any): Recommendation[] {
       recommendations.push({
         severity: 'warning',
         title: 'Redis Key Evictions',
-        description: `Redis is evicting keys. Increase maxmemory or switch to allkeys-lru eviction policy.`,
+        description: `Redis is evicting keys (volatile-lru policy). Consider increasing maxmemory or reviewing TTL coverage on cached keys.`,
       });
     }
   }


### PR DESCRIPTION
## Summary
- **PG timeouts**: `statement_timeout` 60s→300s (migrations/bulk ops were at risk), `idle_in_transaction` 30s→60s, `lock_timeout` 10s→30s, removed `idle_session_timeout` (redundant with PgBouncer)
- **PgBouncer**: Route `app-stage` and `document-service-stage` through `pgbouncer-stage` (was added but unused). Migrations/seed still connect directly to postgres (DDL incompatible with transaction pooling)
- **Redis**: `allkeys-lru` → `volatile-lru` — prevents eviction of BullMQ jobs and upload sessions that lack TTL
- **Alerts**: Fix `PgCacheHitLow` division-by-zero; downgrade `RedisEvictedKeys` to warning with >10/s threshold (was critical at any rate)
- **Frontend**: Update recommendation text to match new `volatile-lru` policy

## Test plan
- [ ] Verify `docker compose -f deployment/docker-compose.stage.yml config` parses without errors
- [ ] Verify `app-stage` connects through pgbouncer on deploy
- [ ] Verify migrations still run directly against postgres (not pgbouncer)
- [ ] Confirm Redis eviction policy via `redis-cli CONFIG GET maxmemory-policy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes staging infrastructure misconfigurations from #218: adjusts Postgres timeouts, routes stage apps through PgBouncer, switches Redis to volatile-lru, and corrects alerting/UI. This reduces failed migrations, prevents Redis job loss, and improves signal quality.

- **Bug Fixes**
  - Postgres: statement_timeout 60s→300s, idle_in_transaction 30s→60s, lock_timeout 10s→30s; removed idle_session_timeout.
  - PgBouncer: route app-stage and document-service through pgbouncer-stage; keep migrations/seeds direct to Postgres.
  - Redis: allkeys-lru→volatile-lru to avoid evicting BullMQ jobs and upload sessions without TTLs.
  - Monitoring/UI: guard PgCacheHitLow against divide-by-zero; RedisEvictedKeys is warning at >10/s; update admin page text to reflect volatile-lru.

<sup>Written for commit 9acfe1025e197d3ed45157b516c14a0f389200f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

