### PR TITLE
chore: remove unused Anthropic API key env vars

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -181,12 +181,7 @@ services:
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
 
-      # Anthropic/Claude (optional for local dev)
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_API_KEY2: ${ANTHROPIC_API_KEY2:-}
-      # Anthropic models removed — OpenAI-only pipeline
-
-      # LLM Provider Strategy
+      # LLM Provider Strategy (OpenAI-only pipeline)
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
 
       # ZakonOnline API
@@ -338,8 +333,6 @@ services:
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # Anthropic models removed — OpenAI-only pipeline
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
       SECONDLAYER_URL: http://app-local:3000
       SECONDLAYER_API_KEY: ${SECONDARY_LAYER_KEYS:-test-key-123}
@@ -399,12 +392,7 @@ services:
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
 
-      # Anthropic (optional)
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_API_KEY2: ${ANTHROPIC_API_KEY2:-}
-      # Anthropic models removed — OpenAI-only pipeline
-
-      # LLM Provider Strategy
+      # LLM Provider Strategy (OpenAI-only pipeline)
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
 
       # Vision/OCR credentials path (inside container, always same path)

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -306,8 +306,6 @@ services:
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      # Anthropic models removed — OpenAI-only pipeline
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
       SECONDLAYER_URL: http://app-stage:3000
       SECONDLAYER_API_KEY: ${SECONDARY_LAYER_KEYS}
@@ -461,9 +459,6 @@ services:
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_API_KEY2: ${ANTHROPIC_API_KEY2:-}
-      # Anthropic models removed — OpenAI-only pipeline
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
       ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN}
       ZAKONONLINE_API_TOKEN2: ${ZAKONONLINE_API_TOKEN2:-}
@@ -602,12 +597,7 @@ services:
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
 
-      # Anthropic (optional)
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      ANTHROPIC_API_KEY2: ${ANTHROPIC_API_KEY2:-}
-      # Anthropic models removed — OpenAI-only pipeline
-
-      # LLM Provider Strategy
+      # LLM Provider Strategy (OpenAI-only pipeline)
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
 
       # Vision/OCR credentials path (inside container)


### PR DESCRIPTION
## Summary
- Remove `ANTHROPIC_API_KEY` and `ANTHROPIC_API_KEY2` from all docker-compose services (6 occurrences across local and stage)
- Pipeline is OpenAI-only; shared package already handles missing keys gracefully

## Test plan
- [ ] `docker compose -f deployment/docker-compose.stage.yml config` parses cleanly
- [ ] `docker compose -f deployment/docker-compose.local.yml config` parses cleanly
- [ ] Services start without errors (Anthropic provider logs warning and disables itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed ANTHROPIC_API_KEY and ANTHROPIC_API_KEY2 from local and stage docker-compose files to match the OpenAI-only pipeline. The shared LLM provider disables Anthropic and logs a warning when keys are absent, so services run normally without them.

<sup>Written for commit a3bf651bea91eb3797b05b9899a8e2b4dcc66fbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

