### PR TITLE
feat: add admin system configuration page

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -30,7 +30,8 @@ import {
   Database,
   Globe,
   Server,
-  Boxes } from
+  Boxes,
+  Settings } from
 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../contexts/AuthContext';
@@ -68,6 +69,7 @@ interface SidebarProps {
   onAdminBillingClick?: () => void;
   onAdminInfrastructureClick?: () => void;
   onAdminContainersClick?: () => void;
+  onAdminConfigClick?: () => void;
   onLogout?: () => void;
 }
 export function Sidebar({
@@ -102,6 +104,7 @@ export function Sidebar({
   onAdminBillingClick,
   onAdminInfrastructureClick,
   onAdminContainersClick,
+  onAdminConfigClick,
   onLogout
 }: SidebarProps) {
   const { user } = useAuth();
@@ -237,6 +240,7 @@ export function Sidebar({
     { id: 'containers', label: 'Контейнери', icon: Boxes, onClick: onAdminContainersClick },
     { id: 'data-sources', label: 'Джерела даних', icon: Globe, onClick: onAdminDataSourcesClick },
     { id: 'admin-billing', label: 'Біллінг', icon: CreditCard, onClick: onAdminBillingClick },
+    { id: 'system-config', label: 'Конфігурація', icon: Settings, onClick: onAdminConfigClick },
   ];
 
   const evidenceSections = [

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -45,6 +45,7 @@ const PAGE_TITLES: Record<string, string> = {
   [ROUTES.ADMIN_BILLING]: 'Billing Management',
   [ROUTES.ADMIN_INFRASTRUCTURE]: 'Інфраструктура',
   [ROUTES.ADMIN_CONTAINERS]: 'Контейнери',
+  [ROUTES.ADMIN_CONFIG]: 'Конфігурація системи',
 };
 
 export function MainLayout() {
@@ -138,6 +139,7 @@ export function MainLayout() {
           onAdminBillingClick={() => navigate(ROUTES.ADMIN_BILLING)}
           onAdminInfrastructureClick={() => navigate(ROUTES.ADMIN_INFRASTRUCTURE)}
           onAdminContainersClick={() => navigate(ROUTES.ADMIN_CONTAINERS)}
+          onAdminConfigClick={() => navigate(ROUTES.ADMIN_CONFIG)}
           onLogout={handleLogout}
         />
       </div>

--- a/lexwebapp/src/pages/AdminConfigPage.tsx
+++ b/lexwebapp/src/pages/AdminConfigPage.tsx
@@ -1,0 +1,315 @@
+/**
+ * Admin Config Page
+ * View and override system configuration at runtime
+ */
+
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  RefreshCw,
+  Search,
+  Lock,
+  Edit3,
+  RotateCcw,
+  Save,
+  X,
+  Settings,
+} from 'lucide-react';
+import { api } from '../utils/api-client';
+import toast from 'react-hot-toast';
+
+interface ConfigEntry {
+  key: string;
+  category: string;
+  description: string;
+  is_secret: boolean;
+  value_type: 'string' | 'number' | 'boolean' | 'select';
+  default_value: string;
+  value: string;
+  source: 'database' | 'env' | 'default';
+  options?: string[];
+  updated_at?: string;
+  updated_by?: string;
+}
+
+interface CategoryGroup {
+  label: string;
+  entries: ConfigEntry[];
+}
+
+const SOURCE_BADGE: Record<string, { label: string; className: string }> = {
+  database: { label: 'DB', className: 'bg-blue-100 text-blue-700' },
+  env: { label: 'ENV', className: 'bg-green-100 text-green-700' },
+  default: { label: 'Default', className: 'bg-gray-100 text-gray-600' },
+};
+
+export function AdminConfigPage() {
+  const [categories, setCategories] = useState<Record<string, CategoryGroup>>({});
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      setLoading(true);
+      const res = await api.admin.getConfig();
+      setCategories(res.data.categories);
+    } catch {
+      toast.error('Failed to load configuration');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchConfig();
+  }, [fetchConfig]);
+
+  const handleSave = async (key: string) => {
+    try {
+      setSaving(true);
+      await api.admin.updateConfig(key, editValue);
+      toast.success(`Updated ${key}`);
+      setEditingKey(null);
+      await fetchConfig();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error || 'Failed to update');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = async (key: string) => {
+    try {
+      await api.admin.resetConfig(key);
+      toast.success(`Reset ${key} to default`);
+      await fetchConfig();
+    } catch (err: any) {
+      toast.error(err?.response?.data?.error || 'Failed to reset');
+    }
+  };
+
+  const startEditing = (entry: ConfigEntry) => {
+    setEditingKey(entry.key);
+    setEditValue(entry.value);
+  };
+
+  const filteredCategories = Object.entries(categories).reduce<Record<string, CategoryGroup>>(
+    (acc, [catKey, group]) => {
+      if (!search) {
+        acc[catKey] = group;
+        return acc;
+      }
+      const q = search.toLowerCase();
+      const filtered = group.entries.filter(
+        (e) =>
+          e.key.toLowerCase().includes(q) ||
+          e.description.toLowerCase().includes(q)
+      );
+      if (filtered.length > 0) {
+        acc[catKey] = { ...group, entries: filtered };
+      }
+      return acc;
+    },
+    {}
+  );
+
+  const totalEntries = Object.values(categories).reduce((sum, g) => sum + g.entries.length, 0);
+  const dbOverrides = Object.values(categories)
+    .flatMap((g) => g.entries)
+    .filter((e) => e.source === 'database').length;
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6 bg-claude-bg">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-claude-text flex items-center gap-2">
+            <Settings size={24} />
+            Конфігурація системи
+          </h1>
+          <p className="text-sm text-claude-subtext mt-1">
+            {totalEntries} параметрів &middot; {dbOverrides} DB overrides
+          </p>
+        </div>
+        <button
+          onClick={fetchConfig}
+          disabled={loading}
+          className="flex items-center gap-2 px-4 py-2 bg-white border border-claude-border rounded-lg hover:bg-claude-bg transition-colors text-sm font-medium"
+        >
+          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+          Оновити
+        </button>
+      </div>
+
+      {/* Search */}
+      <div className="relative mb-6 max-w-md">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-claude-subtext" />
+        <input
+          type="text"
+          placeholder="Пошук за назвою або описом..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="w-full pl-10 pr-4 py-2.5 bg-white border border-claude-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent"
+        />
+      </div>
+
+      {loading && Object.keys(categories).length === 0 ? (
+        <div className="flex items-center justify-center py-20 text-claude-subtext">
+          <RefreshCw size={20} className="animate-spin mr-2" />
+          Завантаження...
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Object.entries(filteredCategories).map(([catKey, group]) => (
+            <div
+              key={catKey}
+              className="bg-white rounded-xl border border-claude-border shadow-sm p-6"
+            >
+              <h2 className="text-lg font-semibold text-claude-text mb-4">
+                {group.label}
+              </h2>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="text-left text-claude-subtext border-b border-claude-border">
+                      <th className="pb-2 pr-4 font-medium">Key</th>
+                      <th className="pb-2 pr-4 font-medium">Value</th>
+                      <th className="pb-2 pr-4 font-medium w-20">Source</th>
+                      <th className="pb-2 pr-4 font-medium">Default</th>
+                      <th className="pb-2 font-medium w-24">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {group.entries.map((entry) => (
+                      <tr
+                        key={entry.key}
+                        className="border-b border-claude-border/50 last:border-b-0"
+                      >
+                        {/* Key + Description */}
+                        <td className="py-3 pr-4">
+                          <div className="font-mono text-xs font-medium text-claude-text">
+                            {entry.key}
+                          </div>
+                          <div className="text-xs text-claude-subtext mt-0.5">
+                            {entry.description}
+                          </div>
+                        </td>
+
+                        {/* Value */}
+                        <td className="py-3 pr-4">
+                          {editingKey === entry.key ? (
+                            <div className="flex items-center gap-2">
+                              {entry.value_type === 'boolean' ? (
+                                <select
+                                  value={editValue}
+                                  onChange={(e) => setEditValue(e.target.value)}
+                                  className="px-2 py-1 border border-claude-border rounded text-xs focus:outline-none focus:ring-1 focus:ring-claude-accent"
+                                >
+                                  <option value="true">true</option>
+                                  <option value="false">false</option>
+                                </select>
+                              ) : entry.value_type === 'select' && entry.options ? (
+                                <select
+                                  value={editValue}
+                                  onChange={(e) => setEditValue(e.target.value)}
+                                  className="px-2 py-1 border border-claude-border rounded text-xs focus:outline-none focus:ring-1 focus:ring-claude-accent"
+                                >
+                                  {entry.options.map((opt) => (
+                                    <option key={opt} value={opt}>
+                                      {opt}
+                                    </option>
+                                  ))}
+                                </select>
+                              ) : (
+                                <input
+                                  type={entry.value_type === 'number' ? 'number' : 'text'}
+                                  value={editValue}
+                                  onChange={(e) => setEditValue(e.target.value)}
+                                  className="px-2 py-1 border border-claude-border rounded text-xs w-48 focus:outline-none focus:ring-1 focus:ring-claude-accent font-mono"
+                                />
+                              )}
+                              <button
+                                onClick={() => handleSave(entry.key)}
+                                disabled={saving}
+                                className="p-1 text-green-600 hover:bg-green-50 rounded"
+                                title="Save"
+                              >
+                                <Save size={14} />
+                              </button>
+                              <button
+                                onClick={() => setEditingKey(null)}
+                                className="p-1 text-claude-subtext hover:bg-claude-bg rounded"
+                                title="Cancel"
+                              >
+                                <X size={14} />
+                              </button>
+                            </div>
+                          ) : (
+                            <div className="flex items-center gap-2">
+                              {entry.is_secret && (
+                                <Lock size={12} className="text-claude-subtext flex-shrink-0" />
+                              )}
+                              <span className="font-mono text-xs text-claude-text truncate max-w-[200px]">
+                                {entry.value || '(empty)'}
+                              </span>
+                            </div>
+                          )}
+                        </td>
+
+                        {/* Source */}
+                        <td className="py-3 pr-4">
+                          <span
+                            className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-medium ${
+                              SOURCE_BADGE[entry.source]?.className || ''
+                            }`}
+                          >
+                            {SOURCE_BADGE[entry.source]?.label || entry.source}
+                          </span>
+                        </td>
+
+                        {/* Default */}
+                        <td className="py-3 pr-4">
+                          <span className="font-mono text-xs text-claude-subtext truncate max-w-[150px] inline-block">
+                            {entry.is_secret ? '********' : entry.default_value || '(empty)'}
+                          </span>
+                        </td>
+
+                        {/* Actions */}
+                        <td className="py-3">
+                          {entry.is_secret ? (
+                            <span className="text-[10px] text-claude-subtext">Read-only</span>
+                          ) : editingKey === entry.key ? null : (
+                            <div className="flex items-center gap-1">
+                              <button
+                                onClick={() => startEditing(entry)}
+                                className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded transition-colors"
+                                title="Edit"
+                              >
+                                <Edit3 size={13} />
+                              </button>
+                              {entry.source === 'database' && (
+                                <button
+                                  onClick={() => handleReset(entry.key)}
+                                  className="p-1.5 text-orange-500 hover:text-orange-600 hover:bg-orange-50 rounded transition-colors"
+                                  title="Reset to default"
+                                >
+                                  <RotateCcw size={13} />
+                                </button>
+                              )}
+                            </div>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -45,6 +45,7 @@ import { AdminDataSourcesPage } from '../pages/AdminDataSourcesPage';
 import { AdminBillingPage } from '../pages/AdminBillingPage';
 import { AdminInfrastructurePage } from '../pages/AdminInfrastructurePage';
 import { AdminContainersPage } from '../pages/AdminContainersPage';
+import { AdminConfigPage } from '../pages/AdminConfigPage';
 import { DocumentsPage } from '../pages/DocumentsPage';
 import { TimeEntriesPage } from '../pages/TimeEntriesPage';
 import { InvoicesPage } from '../pages/InvoicesPage';
@@ -262,6 +263,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ADMIN_CONTAINERS,
             element: <AdminContainersPage />,
+          },
+          {
+            path: ROUTES.ADMIN_CONFIG,
+            element: <AdminConfigPage />,
           },
         ],
       },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -79,6 +79,7 @@ export const ROUTES = {
   ADMIN_BILLING: '/admin/billing',
   ADMIN_INFRASTRUCTURE: '/admin/infrastructure',
   ADMIN_CONTAINERS: '/admin/containers',
+  ADMIN_CONFIG: '/admin/config',
 } as const;
 
 // Helper function to generate dynamic routes

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -318,6 +318,13 @@ export const api = {
         : apiClient.delete(`/api/admin/users/${userId}/tags/test`),
     createTestUser: (data: { email: string; name?: string; password: string; credits: number }) =>
       apiClient.post('/api/admin/test-users', data),
+
+    // System configuration
+    getConfig: () => apiClient.get('/api/admin/config'),
+    updateConfig: (key: string, value: string) =>
+      apiClient.put(`/api/admin/config/${key}`, { value }),
+    resetConfig: (key: string) =>
+      apiClient.delete(`/api/admin/config/${key}`),
   },
 
   // GDPR

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -89,6 +89,7 @@ import { getLLMManager } from './utils/llm-client-manager.js';
 import { ChatSearchCacheService } from './services/chat-search-cache-service.js';
 import { PricingService } from './services/pricing-service.js';
 import { SubscriptionService } from './services/subscription-service.js';
+import { ConfigService } from './services/config-service.js';
 
 dotenv.config();
 
@@ -127,6 +128,7 @@ class HTTPMCPServer {
   private timeEntryService: TimeEntryService;
   private matterInvoiceService: MatterInvoiceService;
   private chatService: ChatService;
+  private configService: ConfigService;
 
   constructor() {
     this.app = express();
@@ -266,6 +268,9 @@ class HTTPMCPServer {
       this.services.embeddingService
     );
     logger.info('ChatService initialized with search cache, conversation persistence, shepardization, and embedding');
+
+    // Initialize config service
+    this.configService = new ConfigService(this.services.db);
 
     // Initialize BullMQ upload queue service
     this.uploadQueueService = new UploadQueueService(
@@ -1657,7 +1662,7 @@ class HTTPMCPServer {
     // GET /api/admin/settings - Get system settings
     const pricingService = new PricingService(this.services.db);
     const subscriptionService = new SubscriptionService(this.services.db);
-    this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, process.env.PROMETHEUS_URL, pricingService, subscriptionService));
+    this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, process.env.PROMETHEUS_URL, pricingService, subscriptionService, this.configService));
 
     // Upload metrics endpoint (admin)
     this.app.get('/api/admin/upload-metrics', requireJWT as any, (async (_req: DualAuthRequest, res: express.Response) => {

--- a/mcp_backend/src/migrations/048_add_system_config.sql
+++ b/mcp_backend/src/migrations/048_add_system_config.sql
@@ -1,0 +1,23 @@
+-- Migration 048: System Configuration Table
+-- Stores runtime configuration overrides (DB > env > default)
+
+CREATE TABLE IF NOT EXISTS system_config (
+  key VARCHAR(255) PRIMARY KEY,
+  value TEXT NOT NULL,
+  category VARCHAR(50) NOT NULL,
+  description TEXT,
+  is_secret BOOLEAN DEFAULT false,
+  value_type VARCHAR(20) DEFAULT 'string',
+  default_value TEXT,
+  updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_config_category ON system_config(category);
+
+DROP TRIGGER IF EXISTS update_system_config_updated_at ON system_config;
+CREATE TRIGGER update_system_config_updated_at
+  BEFORE UPDATE ON system_config
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();

--- a/mcp_backend/src/services/config-service.ts
+++ b/mcp_backend/src/services/config-service.ts
@@ -1,0 +1,279 @@
+/**
+ * ConfigService
+ * Manages runtime system configuration with DB override → env → default fallback
+ */
+
+import { Database } from '../database/database.js';
+import { logger } from '../utils/logger.js';
+
+export interface ConfigEntry {
+  key: string;
+  category: string;
+  description: string;
+  is_secret: boolean;
+  value_type: 'string' | 'number' | 'boolean' | 'select';
+  default_value: string;
+  options?: string[];
+}
+
+export interface ConfigValue extends ConfigEntry {
+  value: string;
+  source: 'database' | 'env' | 'default';
+  updated_at?: string;
+  updated_by?: string;
+}
+
+const CONFIG_REGISTRY: ConfigEntry[] = [
+  // AI Models
+  { key: 'OPENAI_MODEL_QUICK', category: 'ai_models', description: 'Model for quick/cheap operations', is_secret: false, value_type: 'string', default_value: 'gpt-4o-mini' },
+  { key: 'OPENAI_MODEL_STANDARD', category: 'ai_models', description: 'Model for standard operations', is_secret: false, value_type: 'string', default_value: 'gpt-4o-mini' },
+  { key: 'OPENAI_MODEL_DEEP', category: 'ai_models', description: 'Model for deep analysis', is_secret: false, value_type: 'string', default_value: 'gpt-4o' },
+  { key: 'OPENAI_EMBEDDING_MODEL', category: 'ai_models', description: 'Embedding model', is_secret: false, value_type: 'string', default_value: 'text-embedding-ada-002' },
+  { key: 'OPENAI_MODEL', category: 'ai_models', description: 'Default OpenAI model', is_secret: false, value_type: 'string', default_value: 'gpt-4o' },
+  { key: 'LLM_PROVIDER_STRATEGY', category: 'ai_models', description: 'Provider selection strategy', is_secret: false, value_type: 'select', default_value: 'round-robin', options: ['round-robin', 'openai-only', 'anthropic-only', 'failover'] },
+  { key: 'ANTHROPIC_MODEL_QUICK', category: 'ai_models', description: 'Anthropic model for quick ops', is_secret: false, value_type: 'string', default_value: 'claude-haiku-4-5-20251001' },
+  { key: 'ANTHROPIC_MODEL_STANDARD', category: 'ai_models', description: 'Anthropic model for standard ops', is_secret: false, value_type: 'string', default_value: 'claude-sonnet-4-6' },
+  { key: 'ANTHROPIC_MODEL_DEEP', category: 'ai_models', description: 'Anthropic model for deep analysis', is_secret: false, value_type: 'string', default_value: 'claude-opus-4-6' },
+
+  // Upload / Processing
+  { key: 'MAX_CONCURRENT_PROCESSING', category: 'upload', description: 'Max concurrent upload processing jobs', is_secret: false, value_type: 'number', default_value: '50' },
+  { key: 'MAX_USER_SESSIONS', category: 'upload', description: 'Max upload sessions per user', is_secret: false, value_type: 'number', default_value: '50' },
+  { key: 'WORKERS_PER_CORE', category: 'upload', description: 'Processing workers per CPU core', is_secret: false, value_type: 'number', default_value: '2' },
+  { key: 'MIN_CONCURRENT_PROCESSING', category: 'upload', description: 'Min concurrent processing jobs', is_secret: false, value_type: 'number', default_value: '5' },
+  { key: 'ADAPTIVE_CONCURRENCY', category: 'upload', description: 'Enable adaptive concurrency', is_secret: false, value_type: 'boolean', default_value: 'true' },
+  { key: 'MAX_BATCH_INIT_FILES', category: 'upload', description: 'Max files in batch init', is_secret: false, value_type: 'number', default_value: '50' },
+
+  // Chat
+  { key: 'MAX_CHAT_TOOL_CALLS', category: 'chat', description: 'Max tool calls per chat turn', is_secret: false, value_type: 'number', default_value: '5' },
+  { key: 'CHAT_SEARCH_CACHE_TTL', category: 'chat', description: 'Chat search cache TTL (seconds)', is_secret: false, value_type: 'number', default_value: '300' },
+
+  // Cache TTLs
+  { key: 'CACHE_TTL_DEPUTIES', category: 'cache', description: 'Deputies cache TTL (seconds)', is_secret: false, value_type: 'number', default_value: '604800' },
+  { key: 'CACHE_TTL_BILLS', category: 'cache', description: 'Bills cache TTL (seconds)', is_secret: false, value_type: 'number', default_value: '86400' },
+  { key: 'CACHE_TTL_LAWS', category: 'cache', description: 'Laws cache TTL (seconds)', is_secret: false, value_type: 'number', default_value: '2592000' },
+  { key: 'CACHE_TTL_VOTING', category: 'cache', description: 'Voting cache TTL (seconds)', is_secret: false, value_type: 'number', default_value: '86400' },
+
+  // Scraping
+  { key: 'SCRAPE_MAX_CONCURRENT', category: 'scraping', description: 'Max concurrent scrape jobs', is_secret: false, value_type: 'number', default_value: '10' },
+  { key: 'SCRAPE_MIN_INTERVAL_MS', category: 'scraping', description: 'Min interval between scrapes (ms)', is_secret: false, value_type: 'number', default_value: '200' },
+  { key: 'SCRAPE_MAX_QUEUE_DEPTH', category: 'scraping', description: 'Max scrape queue depth', is_secret: false, value_type: 'number', default_value: '200' },
+  { key: 'SCRAPE_DELAY_MIN_MS', category: 'scraping', description: 'Min scrape delay (ms)', is_secret: false, value_type: 'number', default_value: '500' },
+  { key: 'SCRAPE_DELAY_MAX_MS', category: 'scraping', description: 'Max scrape delay (ms)', is_secret: false, value_type: 'number', default_value: '2000' },
+
+  // External APIs
+  { key: 'ZAKONONLINE_MIN_REQUEST_INTERVAL_MS', category: 'external_apis', description: 'ZakonOnline min request interval (ms)', is_secret: false, value_type: 'number', default_value: '1000' },
+  { key: 'ZAKONONLINE_RATE_LIMIT_DELAY_MS', category: 'external_apis', description: 'ZakonOnline rate limit delay (ms)', is_secret: false, value_type: 'number', default_value: '5000' },
+  { key: 'ZAKONONLINE_TOKEN_STRATEGY', category: 'external_apis', description: 'ZakonOnline token strategy', is_secret: false, value_type: 'select', default_value: 'rotate', options: ['rotate', 'single', 'random'] },
+
+  // Server
+  { key: 'HTTP_PORT', category: 'server', description: 'HTTP server port', is_secret: false, value_type: 'number', default_value: '3000' },
+  { key: 'HTTP_HOST', category: 'server', description: 'HTTP server host', is_secret: false, value_type: 'string', default_value: '0.0.0.0' },
+  { key: 'NODE_ENV', category: 'server', description: 'Node environment', is_secret: false, value_type: 'select', default_value: 'development', options: ['development', 'production', 'test'] },
+  { key: 'ALLOWED_ORIGINS', category: 'server', description: 'CORS allowed origins (comma-separated)', is_secret: false, value_type: 'string', default_value: '*' },
+  { key: 'LOG_LEVEL', category: 'server', description: 'Logging level', is_secret: false, value_type: 'select', default_value: 'info', options: ['error', 'warn', 'info', 'debug', 'verbose'] },
+
+  // Gateway
+  { key: 'ENABLE_UNIFIED_GATEWAY', category: 'gateway', description: 'Enable unified gateway mode', is_secret: false, value_type: 'boolean', default_value: 'false' },
+  { key: 'RADA_MCP_URL', category: 'gateway', description: 'RADA MCP service URL', is_secret: false, value_type: 'string', default_value: '' },
+  { key: 'OPENREYESTR_MCP_URL', category: 'gateway', description: 'OpenReyestr MCP service URL', is_secret: false, value_type: 'string', default_value: '' },
+
+  // Storage
+  { key: 'MINIO_ENDPOINT', category: 'storage', description: 'MinIO endpoint', is_secret: false, value_type: 'string', default_value: 'localhost' },
+  { key: 'MINIO_PORT', category: 'storage', description: 'MinIO port', is_secret: false, value_type: 'number', default_value: '9000' },
+  { key: 'MINIO_USE_SSL', category: 'storage', description: 'MinIO use SSL', is_secret: false, value_type: 'boolean', default_value: 'false' },
+  { key: 'QDRANT_URL', category: 'storage', description: 'Qdrant vector DB URL', is_secret: false, value_type: 'string', default_value: 'http://localhost:6333' },
+
+  // Database
+  { key: 'POSTGRES_HOST', category: 'database', description: 'PostgreSQL host', is_secret: false, value_type: 'string', default_value: 'localhost' },
+  { key: 'POSTGRES_PORT', category: 'database', description: 'PostgreSQL port', is_secret: false, value_type: 'number', default_value: '5432' },
+  { key: 'POSTGRES_DB', category: 'database', description: 'PostgreSQL database name', is_secret: false, value_type: 'string', default_value: 'secondlayer' },
+
+  // Redis
+  { key: 'REDIS_HOST', category: 'redis', description: 'Redis host', is_secret: false, value_type: 'string', default_value: 'localhost' },
+  { key: 'REDIS_PORT', category: 'redis', description: 'Redis port', is_secret: false, value_type: 'number', default_value: '6379' },
+
+  // Payments
+  { key: 'MOCK_PAYMENTS', category: 'payments', description: 'Use mock payment providers', is_secret: false, value_type: 'boolean', default_value: 'true' },
+  { key: 'UAH_TO_USD_RATE', category: 'payments', description: 'UAH to USD exchange rate', is_secret: false, value_type: 'number', default_value: '41.5' },
+  { key: 'FONDY_API_URL', category: 'payments', description: 'Fondy API base URL', is_secret: false, value_type: 'string', default_value: 'https://pay.fondy.eu/api' },
+
+  // Email
+  { key: 'SMTP_HOST', category: 'email', description: 'SMTP server host', is_secret: false, value_type: 'string', default_value: '' },
+  { key: 'SMTP_PORT', category: 'email', description: 'SMTP server port', is_secret: false, value_type: 'number', default_value: '587' },
+  { key: 'SMTP_SECURE', category: 'email', description: 'SMTP use TLS', is_secret: false, value_type: 'boolean', default_value: 'false' },
+  { key: 'EMAIL_FROM', category: 'email', description: 'From email address', is_secret: false, value_type: 'string', default_value: '' },
+  { key: 'EMAIL_FROM_NAME', category: 'email', description: 'From display name', is_secret: false, value_type: 'string', default_value: 'SecondLayer' },
+
+  // Auth
+  { key: 'WEBAUTHN_RP_NAME', category: 'auth', description: 'WebAuthn relying party name', is_secret: false, value_type: 'string', default_value: 'SecondLayer' },
+  { key: 'WEBAUTHN_RP_ID', category: 'auth', description: 'WebAuthn relying party ID', is_secret: false, value_type: 'string', default_value: 'localhost' },
+  { key: 'WEBAUTHN_ORIGIN', category: 'auth', description: 'WebAuthn origin URL', is_secret: false, value_type: 'string', default_value: 'http://localhost:5173' },
+
+  // Monitoring
+  { key: 'PROMETHEUS_URL', category: 'monitoring', description: 'Prometheus server URL', is_secret: false, value_type: 'string', default_value: '' },
+
+  // URLs
+  { key: 'PUBLIC_URL', category: 'urls', description: 'Public-facing URL', is_secret: false, value_type: 'string', default_value: 'http://localhost:3000' },
+  { key: 'FRONTEND_URL', category: 'urls', description: 'Frontend application URL', is_secret: false, value_type: 'string', default_value: 'http://localhost:5173' },
+  { key: 'APP_URL', category: 'urls', description: 'Application URL', is_secret: false, value_type: 'string', default_value: 'http://localhost:5173' },
+
+  // Secrets (read-only, masked)
+  { key: 'OPENAI_API_KEY', category: 'ai_models', description: 'OpenAI API key', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'ANTHROPIC_API_KEY', category: 'ai_models', description: 'Anthropic API key', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'ZAKONONLINE_API_TOKEN', category: 'external_apis', description: 'ZakonOnline API token', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'JWT_SECRET', category: 'auth', description: 'JWT signing secret', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'POSTGRES_PASSWORD', category: 'database', description: 'PostgreSQL password', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'SECONDARY_LAYER_KEYS', category: 'auth', description: 'API authentication keys', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'MINIO_ACCESS_KEY', category: 'storage', description: 'MinIO access key', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'MINIO_SECRET_KEY', category: 'storage', description: 'MinIO secret key', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'STRIPE_SECRET_KEY', category: 'payments', description: 'Stripe secret key', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'FONDY_SECRET_KEY', category: 'payments', description: 'Fondy secret key', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'GOOGLE_CLIENT_SECRET', category: 'auth', description: 'Google OAuth client secret', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'SMTP_PASS', category: 'email', description: 'SMTP password', is_secret: true, value_type: 'string', default_value: '' },
+];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ai_models: 'AI Models',
+  database: 'Database',
+  redis: 'Redis',
+  external_apis: 'External APIs',
+  upload: 'Upload & Processing',
+  chat: 'Chat',
+  cache: 'Cache TTLs',
+  scraping: 'Scraping',
+  server: 'Server',
+  gateway: 'Gateway',
+  storage: 'Storage',
+  payments: 'Payments',
+  email: 'Email',
+  auth: 'Authentication',
+  monitoring: 'Monitoring',
+  urls: 'URLs',
+};
+
+interface DbOverride {
+  key: string;
+  value: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export class ConfigService {
+  private db: Database;
+  private cache: Map<string, DbOverride> = new Map();
+  private lastRefresh: number = 0;
+  private refreshInterval: number = 60_000; // 60s
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  private async refreshCache(): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastRefresh < this.refreshInterval) return;
+
+    try {
+      const result = await this.db.query(
+        'SELECT key, value, updated_at, updated_by FROM system_config'
+      );
+      this.cache.clear();
+      for (const row of result.rows) {
+        this.cache.set(row.key, {
+          key: row.key,
+          value: row.value,
+          updated_at: row.updated_at,
+          updated_by: row.updated_by,
+        });
+      }
+      this.lastRefresh = now;
+    } catch (error: any) {
+      logger.error('Failed to refresh config cache', { error: error.message });
+    }
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    await this.refreshCache();
+    const dbOverride = this.cache.get(key);
+    if (dbOverride) return dbOverride.value;
+
+    const envVal = process.env[key];
+    if (envVal !== undefined) return envVal;
+
+    const entry = CONFIG_REGISTRY.find(e => e.key === key);
+    return entry?.default_value;
+  }
+
+  async getAll(): Promise<{ categories: Record<string, { label: string; entries: ConfigValue[] }> }> {
+    await this.refreshCache();
+
+    const categories: Record<string, { label: string; entries: ConfigValue[] }> = {};
+
+    for (const entry of CONFIG_REGISTRY) {
+      if (!categories[entry.category]) {
+        categories[entry.category] = {
+          label: CATEGORY_LABELS[entry.category] || entry.category,
+          entries: [],
+        };
+      }
+
+      const dbOverride = this.cache.get(entry.key);
+      const envVal = process.env[entry.key];
+
+      let value: string;
+      let source: 'database' | 'env' | 'default';
+
+      if (dbOverride) {
+        value = entry.is_secret ? '********' : dbOverride.value;
+        source = 'database';
+      } else if (envVal !== undefined && envVal !== '') {
+        value = entry.is_secret ? '********' : envVal;
+        source = 'env';
+      } else {
+        value = entry.is_secret ? '********' : entry.default_value;
+        source = 'default';
+      }
+
+      categories[entry.category].entries.push({
+        ...entry,
+        value,
+        source,
+        updated_at: dbOverride?.updated_at,
+        updated_by: dbOverride?.updated_by || undefined,
+      });
+    }
+
+    return { categories };
+  }
+
+  async set(key: string, value: string, adminId: string): Promise<void> {
+    const entry = CONFIG_REGISTRY.find(e => e.key === key);
+    if (!entry) throw new Error(`Unknown config key: ${key}`);
+    if (entry.is_secret) throw new Error('Cannot modify secret values via admin UI');
+
+    await this.db.query(
+      `INSERT INTO system_config (key, value, category, description, is_secret, value_type, default_value, updated_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (key) DO UPDATE SET
+         value = EXCLUDED.value,
+         updated_by = EXCLUDED.updated_by,
+         updated_at = NOW()`,
+      [key, value, entry.category, entry.description, entry.is_secret, entry.value_type, entry.default_value, adminId]
+    );
+
+    // Invalidate cache
+    this.lastRefresh = 0;
+    logger.info('Config updated', { key, value, adminId });
+  }
+
+  async delete(key: string, adminId: string): Promise<void> {
+    const entry = CONFIG_REGISTRY.find(e => e.key === key);
+    if (!entry) throw new Error(`Unknown config key: ${key}`);
+    if (entry.is_secret) throw new Error('Cannot modify secret values via admin UI');
+
+    await this.db.query('DELETE FROM system_config WHERE key = $1', [key]);
+
+    // Invalidate cache
+    this.lastRefresh = 0;
+    logger.info('Config reset to default', { key, adminId });
+  }
+}


### PR DESCRIPTION
## Summary
- **Migration 048**: `system_config` table for DB-backed runtime overrides (key PK, category, is_secret, value_type, updated_by FK)
- **ConfigService**: Registry of ~70 tunable vars across 16 categories (ai_models, upload, chat, cache, scraping, etc.) with in-memory cache (60s), DB → env → default fallback, secret masking
- **3 admin API endpoints**: `GET /api/admin/config` (grouped view), `PUT /config/:key` (upsert override), `DELETE /config/:key` (reset to env/default) — all with audit logging
- **AdminConfigPage**: Search filter, category cards, inline editing (text/number/boolean/select), source badges (DB=blue, ENV=green, Default=gray), reset button for DB overrides, secrets are read-only with lock icon

## Test plan
- [ ] Run migration 048 — `system_config` table created
- [ ] Login as admin → Sidebar shows "Конфігурація" under Моніторинг
- [ ] Page loads with all config vars grouped by category
- [ ] Edit a non-secret var (e.g. `OPENAI_MODEL_QUICK`) → save → refresh → source shows "DB"
- [ ] Reset the var → source reverts to "ENV" or "Default"
- [ ] Secret vars show `********` and no edit button
- [ ] `npm run build` passes for both backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Admin System Configuration page with DB-backed runtime overrides so admins can tune non-secret settings without redeploys. Includes a backend ConfigService with safe DB → env → default fallback and audit logging.

- **New Features**
  - system_config table to store overrides (category, types, updated_by)
  - ConfigService: ~70 keys across categories, 60s in-memory cache, secret masking
  - Admin API: GET /api/admin/config, PUT/DELETE /api/admin/config/:key with audit logs
  - Admin UI: searchable category view, inline edits for non-secrets, reset to default, source badges (DB/ENV/Default)
  - Navigation: new “Конфігурація” route and sidebar entry

- **Migration**
  - Run migration 048 to create system_config table

<sup>Written for commit a734b2d04a1e4ee8607c0adaeb865a826c3b138c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

