### PR TITLE
fix: backfill-fulltext GET route not found

### DIFF
--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -1892,6 +1892,30 @@ export function createAdminRoutes(
   });
 
   /**
+   * GET /api/admin/backfill-fulltext
+   * Get latest/active backfill job status (convenience)
+   * NOTE: must be registered BEFORE the :jobId route to avoid parameter capture
+   */
+  router.get('/backfill-fulltext', (_req: Request, res: Response) => {
+    // Find the most recent job
+    let latest: BackfillJob | null = null;
+    for (const job of backfillJobs.values()) {
+      if (!latest || job.started_at > latest.started_at) {
+        latest = job;
+      }
+    }
+
+    if (!latest) {
+      return res.json({ active: false, job: null });
+    }
+
+    res.json({
+      active: latest.status === 'running' || latest.status === 'queued',
+      job: latest,
+    });
+  });
+
+  /**
    * GET /api/admin/backfill-fulltext/:jobId
    * Get backfill job status
    */
@@ -1922,29 +1946,6 @@ export function createAdminRoutes(
 
     job.stop_requested = true;
     res.json({ message: 'Stop requested', job_id: jobId });
-  });
-
-  /**
-   * GET /api/admin/backfill-fulltext
-   * Get latest/active backfill job status (convenience)
-   */
-  router.get('/backfill-fulltext', (_req: Request, res: Response) => {
-    // Find the most recent job
-    let latest: BackfillJob | null = null;
-    for (const job of backfillJobs.values()) {
-      if (!latest || job.started_at > latest.started_at) {
-        latest = job;
-      }
-    }
-
-    if (!latest) {
-      return res.json({ active: false, job: null });
-    }
-
-    res.json({
-      active: latest.status === 'running' || latest.status === 'queued',
-      job: latest,
-    });
   });
 
   // ========================================


### PR DESCRIPTION
## Summary
- Reorders Express routes so `GET /api/admin/backfill-fulltext` (latest job) is registered **before** `GET /api/admin/backfill-fulltext/:jobId`
- Previously the parameterized route captured the bare path, treating it as a jobId lookup and returning 404

## Test plan
- [x] All 15 backend tests pass
- [ ] Verify `GET /api/admin/backfill-fulltext` returns `{ active: false, job: null }` when no jobs exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 404s for GET /api/admin/backfill-fulltext by registering it before GET /api/admin/backfill-fulltext/:jobId. Express no longer captures the bare path as a jobId, so the latest-job endpoint now responds correctly (returns { active: false, job: null } when no jobs exist).

<sup>Written for commit d9a8b18afe7e50e43bf00961e5724ffce2ceefd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

