### PR TITLE
feat: add backfill configuration panel

### DIFF
--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -248,7 +248,7 @@ export const api = {
       apiClient.get('/api/admin/court-documents/recent', { params: { days, limit } }),
     runDocumentCompletenessCheck: () =>
       apiClient.post('/api/admin/document-completeness-check'),
-    startBackfillFulltext: (params?: { justice_kind_code?: string; limit?: number }) =>
+    startBackfillFulltext: (params?: { justice_kind_code?: string; limit?: number; concurrency?: number; proxy?: string }) =>
       apiClient.post('/api/admin/backfill-fulltext', params),
     getBackfillStatus: (jobId?: string) =>
       jobId


### PR DESCRIPTION
## Summary
- Add configurable concurrency (1-10 threads) for parallel downloads
- Add document limit setting (1-1000)
- Add justice kind selection dropdown
- Add proxy selection (none / mail server on port 8888)
- Display current config (threads, proxy) in progress bar

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backfill configuration panel to Admin Monitoring so admins can choose justice kind, document limit, concurrency, and proxy. Backend now runs downloads in parallel batches with optional HTTP proxy, and the progress bar shows the active settings.

- **New Features**
  - UI: Backfill panel with justice kind selector, limit (1–1000), concurrency slider (1–10), and proxy (none/mail:8888); hidden while a job is running.
  - Backend: /api/admin/backfill-fulltext accepts concurrency and proxy, clamps values, processes docs in parallel batches with a 1s delay, and supports HTTP proxy for axios.
  - Status/UX: Progress bar shows thread count and proxy; job status includes concurrency and proxy.
  - Client: startBackfillFulltext request type extended with concurrency and proxy.

<sup>Written for commit 1518b91488cd6a41c76e8612c5835a6e1c3e9c88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

