### PR TITLE
fix: cAdvisor local monitoring config

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -792,10 +792,18 @@ services:
   cadvisor-local:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: cadvisor-local
+    privileged: true
+    devices:
+      - /dev/kmsg
+    environment:
+      - DOCKER_API_VERSION=1.44
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /etc/machine-id:/etc/machine-id:ro
     networks:
       - secondlayer-local
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `privileged: true` and `/dev/kmsg` device — required for cgroup access on Linux
- Set `DOCKER_API_VERSION=1.44` — cAdvisor's embedded Docker client was using 1.41, which is below the daemon's minimum (1.44), causing the Docker container factory to fail and no container metrics to be collected
- Replace `/var/run/docker.sock` with `/var/run:/var/run:ro` for full Docker runtime socket directory access
- Add `/:/rootfs:ro` and `/dev/disk/:/dev/disk:ro` mounts for accurate filesystem and disk I/O metrics
- Mount `/etc/machine-id:/etc/machine-id:ro` to resolve system UUID warning on startup

## Test plan
- [ ] `docker compose -f docker-compose.local.yml up -d --force-recreate cadvisor-local`
- [ ] `docker logs cadvisor-local` — verify no Docker factory registration error
- [ ] Check Prometheus target `cadvisor-local:8080` is up and scraping container metrics
- [ ] Verify container metrics appear in Grafana infrastructure dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cAdvisor local monitoring config to restore Docker container metrics and accurate filesystem/disk stats. Aligns the Docker API version and grants required cgroup access so the Docker factory registers successfully.

- **Bug Fixes**
  - Set DOCKER_API_VERSION=1.44 to match the daemon and prevent factory registration failure.
  - Enable privileged mode and mount /dev/kmsg for cgroup access.
  - Replace /var/run/docker.sock with /var/run:ro for full runtime socket directory access.
  - Mount /, /dev/disk, and /etc/machine-id for accurate metrics and to remove the system UUID warning.

- **Migration**
  - Recreate the service: docker compose -f docker-compose.local.yml up -d --force-recreate cadvisor-local.
  - Check logs: no Docker factory registration error.
  - Confirm Prometheus target cadvisor-local:8080 is up and metrics appear in Grafana.

<sup>Written for commit 178e814454bcd16605dd844aeb67df805bb0b9c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

