### PR TITLE
feat(admin): add import samples section to monitoring dashboard

### DIFF
--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -325,6 +325,9 @@ export const api = {
     createTestUser: (data: { email: string; name?: string; password: string; credits: number }) =>
       apiClient.post('/api/admin/test-users', data),
 
+    getImportSamples: (hours: number = 24, limit: number = 5) =>
+      apiClient.get('/api/admin/import-samples', { params: { hours, limit } }),
+
     // System configuration
     getConfig: () => apiClient.get('/api/admin/config'),
     updateConfig: (key: string, value: string) =>


### PR DESCRIPTION
## Summary

Add functionality for admins to view sample data from recent script uploads on the admin monitoring dashboard.

## Changes

### Backend (mcp_backend)
- New endpoint `GET /api/admin/import-samples` returning sample records from recent imports
- Supports query params: `hours` (1-168, default 24) and `limit` (1-10, default 5)
- Returns samples from 5 data sources:
  - **Court decisions** - from load-* scripts (commercial, criminal, civil, debt cases)
  - **Legislation** - from sync scripts
  - **Embedding chunks** - from document processing
  - **User uploads** - documents uploaded by users
  - **ZO dictionaries** - from sync-dictionaries script

### Frontend (lexwebapp)
- New `ImportSamplesSection` component with:
  - Time range selector (1 hour to 1 week)
  - Summary cards showing counts per data type
  - Expandable source cards showing sample records
- New API client method `api.admin.getImportSamples(hours, limit)`
- Added section to AdminMonitoringPage

## Screenshots

The new section appears below "Перевірка повноти документів" and includes:
- Time period selector dropdown
- 4 summary cards (court decisions, legislation, embeddings, user uploads)
- Expandable cards per data source showing actual sample records

## Testing

1. Navigate to `/admin/monitoring`
2. Scroll to "Зразки даних з останніх завантажень" section
3. Select different time periods to see samples
4. Click on source headers to expand/collapse sample records

## Related

Admin request to monitor recent script upload data samples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an “Import samples” section to the admin monitoring dashboard to preview recent data from script uploads. Adds a new backend endpoint and a simple UI with time range selection and expandable source cards.

- **New Features**
  - Backend: GET /api/admin/import-samples with hours (1–168, default 24) and limit (1–10, default 5). Returns grouped samples and summary counts for court decisions, legislation, embedding chunks, user uploads, and ZO dictionaries.
  - Frontend: ImportSamplesSection on AdminMonitoringPage with a time range selector, refresh, summary cards, and expandable source cards. Uses api.admin.getImportSamples(hours, limit).

<sup>Written for commit b5de934a009fce04474cc4ae736f419405a0bce5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

