### PR TITLE
fix(admin): correct column names in import-samples endpoint

### DIFF
--- a/lexwebapp/src/pages/AdminMonitoringPage.tsx
+++ b/lexwebapp/src/pages/AdminMonitoringPage.tsx
@@ -154,7 +154,7 @@ interface ImportSample {
   source_name: string;
   count: number;
   last_import: string;
-  records: Array<{
+    records: Array<{
     id: string;
     title?: string;
     court?: string;
@@ -163,7 +163,7 @@ interface ImportSample {
     justice_kind?: string;
     date?: string;
     type?: string;
-    number?: string;
+    rada_id?: string;
     status?: string;
     effective_date?: string;
     document_id?: string;
@@ -1042,7 +1042,7 @@ function ImportSamplesSection() {
                             {record.category && <span className="text-blue-600">{record.category}</span>}
                             {record.justice_kind && <span className="text-purple-600">Вид: {record.justice_kind}</span>}
                             {record.type && <span className="text-green-600">{record.type}</span>}
-                            {record.number && <span className="font-mono">№{record.number}</span>}
+                            {record.rada_id && <span className="font-mono">ID: {record.rada_id}</span>}
                             {record.status && <span className="text-orange-600">{record.status}</span>}
                             {record.section_index !== undefined && <span>Секція {record.section_index}</span>}
                             {record.token_count !== undefined && <span className="font-mono">{record.token_count} токенів</span>}

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -3238,7 +3238,7 @@ export function createAdminRoutes(
       // 2. Legislation (from sync scripts)
       const legislation = await db.query(`
         SELECT 
-          id, title, legislation_type, number, status,
+          id, title, type, rada_id, status,
           effective_date, created_at, updated_at
         FROM legislation
         WHERE created_at >= NOW() - $1::integer * INTERVAL '1 hour'
@@ -3256,8 +3256,8 @@ export function createAdminRoutes(
           records: legislation.rows.map((r: any) => ({
             id: r.id,
             title: r.title?.substring(0, 150),
-            type: r.legislation_type,
-            number: r.number,
+            type: r.type,
+            rada_id: r.rada_id,
             status: r.status,
             effective_date: r.effective_date,
             created_at: r.created_at,


### PR DESCRIPTION
## Summary

Fix 500 error on `/api/admin/import-samples` endpoint caused by incorrect column names.

## Problem

Error: `column "legislation_type" does not exist`

The SQL query was referencing columns that don't exist in the `legislation` table schema:
- `legislation_type` → should be `type`
- `number` → should be `rada_id`

## Changes

### Backend (mcp_backend)
- Fix column name `legislation_type` → `type` in legislation query
- Fix column name `number` → `rada_id` in legislation query
- Update record mapping to use correct field names

### Frontend (lexwebapp)
- Update ImportSample interface: add `rada_id`, remove `number`
- Update display component to show `rada_id` instead of `number`

## Testing

1. Navigate to `/admin/monitoring`
2. Scroll to "Зразки даних з останніх завантажень" section
3. Endpoint should return 200 with sample data instead of 500 error

## Related

Fixes import-samples 500 error

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 500 error on /api/admin/import-samples by correcting legislation column names and aligning the UI to use rada_id.

- **Bug Fixes**
  - Backend: change legislation_type → type and number → rada_id in query and record mapping.
  - Frontend: update ImportSample interface and display to use rada_id instead of number.

<sup>Written for commit a3b3fe302728c28ef07b377746ef47a723c58086. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

