### PR TITLE
fix(admin): correct embedding_chunks query in import-samples

### DIFF
--- a/lexwebapp/src/pages/AdminMonitoringPage.tsx
+++ b/lexwebapp/src/pages/AdminMonitoringPage.tsx
@@ -166,10 +166,9 @@ interface ImportSample {
     rada_id?: string;
     status?: string;
     effective_date?: string;
-    document_id?: string;
+    document_section_id?: string;
+    vector_id?: string;
     document_title?: string;
-    section_index?: number;
-    token_count?: number;
     user_email?: string;
     user_name?: string;
     name?: string;
@@ -1044,8 +1043,8 @@ function ImportSamplesSection() {
                             {record.type && <span className="text-green-600">{record.type}</span>}
                             {record.rada_id && <span className="font-mono">ID: {record.rada_id}</span>}
                             {record.status && <span className="text-orange-600">{record.status}</span>}
-                            {record.section_index !== undefined && <span>Секція {record.section_index}</span>}
-                            {record.token_count !== undefined && <span className="font-mono">{record.token_count} токенів</span>}
+                            {record.vector_id && <span className="font-mono text-xs">{record.vector_id.substring(0, 20)}...</span>}
+                            {record.document_section_id && <span className="text-gray-500">Секція</span>}
                             {record.user_email && <span>{record.user_email}</span>}
                             {record.user_name && <span>{record.user_name}</span>}
                             {record.domain && <span className="text-gray-500">{record.domain}</span>}

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -3268,11 +3268,11 @@ export function createAdminRoutes(
       // 3. Embedding chunks (from processing)
       const embeddings = await db.query(`
         SELECT 
-          ec.id, ec.document_id, ec.section_index,
-          ec.token_count, ec.created_at,
-          d.title as document_title
+          ec.id, ec.document_section_id, ec.vector_id,
+          ec.created_at, d.title as document_title
         FROM embedding_chunks ec
-        LEFT JOIN documents d ON d.id = ec.document_id
+        LEFT JOIN document_sections ds ON ds.id = ec.document_section_id
+        LEFT JOIN documents d ON d.id = ds.document_id
         WHERE ec.created_at >= NOW() - $1::integer * INTERVAL '1 hour'
         ORDER BY ec.created_at DESC
         LIMIT $2
@@ -3286,10 +3286,9 @@ export function createAdminRoutes(
           last_import: embeddings.rows[0]?.created_at,
           records: embeddings.rows.map((r: any) => ({
             id: r.id,
-            document_id: r.document_id,
+            document_section_id: r.document_section_id,
+            vector_id: r.vector_id,
             document_title: r.document_title?.substring(0, 100),
-            section_index: r.section_index,
-            token_count: r.token_count,
             created_at: r.created_at,
           })),
         });


### PR DESCRIPTION
## Summary

Fix 500 error on `/api/admin/import-samples` endpoint caused by incorrect column names in embedding_chunks query.

## Problem

Error: `column ec.document_id does not exist`

The SQL query was referencing columns that don't exist in the `embedding_chunks` table:
- `document_id` → should use `document_section_id` with join through document_sections
- `section_index` → doesn't exist
- `token_count` → doesn't exist

## Changes

### Backend (mcp_backend)
- Fix query to use correct column `document_section_id`
- Join through `document_sections` table to get to documents
- Use existing `vector_id` column instead of non-existent fields

### Frontend (lexwebapp)
- Update ImportSample interface fields
- Replace `document_id`, `section_index`, `token_count` with `document_section_id`, `vector_id`
- Update display component accordingly

## Testing

1. Navigate to `/admin/monitoring`
2. Scroll to "Зразки даних з останніх завантажень" section
3. Endpoint should return 200 with sample data instead of 500 error

## Related

Follow-up fix for import-samples endpoint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 500 on /api/admin/import-samples by correcting the embedding_chunks query and aligning the admin UI with the actual schema.

- **Bug Fixes**
  - Backend: query now uses document_section_id and vector_id; joins via document_sections to get document_title.
  - Frontend: ImportSample fields updated (document_section_id, vector_id); removed document_id, section_index, token_count; display shows a short vector_id and a section label.
  - Result: endpoint returns 200 with sample data.

<sup>Written for commit 0e898e33de3004dde22877a8356b4c5d7608bd29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

