### PR TITLE
feat: court registry scraper — admin UI + backend API

### DIFF
--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -7,8 +7,7 @@
 import express, { Request, Response } from 'express';
 import axios from 'axios';
 import { spawn } from 'child_process';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
+import { join } from 'path';
 import { Database } from '../database/database.js';
 import { BillingService } from '../services/billing-service.js';
 import { UserPreferencesService } from '../services/user-preferences-service.js';
@@ -20,7 +19,6 @@ import { ConfigService } from '../services/config-service.js';
 import { CourtDecisionHTMLParser } from '../utils/html-parser.js';
 import { logger } from '../utils/logger.js';
 
-const _adminRoutesDir = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Helper to ensure param is a string (Express can return string | string[])
@@ -2151,7 +2149,7 @@ export function createAdminRoutes(
     res.json({ job_id: jobId, status: 'queued', message: 'Скрапер запущено' });
 
     // Spawn scraper as child process
-    const scriptPath = join(_adminRoutesDir, '..', 'scripts', 'scrape-court-registry.js');
+    const scriptPath = join(process.cwd(), 'dist', 'scripts', 'scrape-court-registry.js');
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       JUSTICE_KIND: job.justice_kind,


### PR DESCRIPTION
## Summary

- **Backend**: new `/api/admin/scrape-court-registry` endpoints (POST start, GET status, POST stop) — spawns `scrape-court-registry.js` as headless Playwright child process, parses stdout for live progress
- **Frontend**: `CourtScraperSection` component on `/admin/monitoring` — justice kind, doc form, date range, max docs, concurrency, proxy selector; live stats (pages / downloaded / saved_to_db / skipped / errors) + log tail
- **Scraper fixes**: detect server overload via missing `txtdepository`; click "Версія для друку" before saving HTML; regex-based text extraction for print-version pages (avoids cheerio UTF-8 encoding issues with charset-less HTML)

## Test plan

- [ ] Open `/admin/monitoring` → section "Докачати документи з реєстру" is visible
- [ ] Select "Кримінальне", all forms, date 01.01.2015, 100 docs, 2 threads, Mail proxy → click "Завантажити документи"
- [ ] Progress panel appears with live counters and log tail
- [ ] Stop button terminates the job cleanly
- [ ] After completion, verify docs in DB: `SELECT COUNT(*) FROM documents WHERE zakononline_id LIKE 'court_%'`
- [ ] Check `full_text` is readable Cyrillic (not garbled encoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin UI and backend API to run and monitor the court registry scraper with live progress and controls. Also fixes scraper reliability and script path resolution for production builds.

- **New Features**
  - Admin API: POST start, GET status, POST stop for `/api/admin/scrape-court-registry`.
  - Spawns the scraper as a headless Playwright child process and streams progress.
  - Admin monitoring UI section with controls: justice kind, form, date range, max docs, concurrency, proxy.
  - Live stats (pages, downloaded, saved_to_db, skipped, errors) and log tail, with a clean stop button.

- **Bug Fixes**
  - Detect server overload via missing `txtdepository`.
  - Click “Версія для друку” before saving HTML.
  - Use regex-based text extraction for print pages to avoid UTF-8 issues.
  - Resolve scraper script via `process.cwd()/dist/scripts/scrape-court-registry.js` instead of `import.meta.url`.

<sup>Written for commit 359073b4c75a2ea0fc8bfd16f4ece79193f70696. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

