### PR TITLE
fix(db-compare): use API key for stage calls instead of JWT forwarding

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -272,6 +272,7 @@ services:
       OPENREYESTR_MCP_URL: ${OPENREYESTR_MCP_URL:-http://openreyestr-app-local:3004}
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-test-key-123}
       STAGE_BACKEND_URL: ${STAGE_BACKEND_URL:-https://stage.legal.org.ua}
+      STAGE_API_KEY: ${STAGE_API_KEY:-}
 
       # WebAuthn / FIDO2
       WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-localdev.legal.org.ua}

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -3606,13 +3606,14 @@ export function createAdminRoutes(
         return res.json({ local: localData });
       }
 
-      // Fetch stage data by calling the same endpoint on stage backend
+      // Fetch stage data via internal endpoint (API key auth, avoids JWT cross-env issue)
       const stageBackendUrl = process.env.STAGE_BACKEND_URL || 'https://stage.legal.org.ua';
-      const authHeader = req.headers.authorization || '';
+      const stageApiKey = process.env.STAGE_API_KEY ||
+        process.env.SECONDARY_LAYER_KEYS?.split(',')[0]?.trim() || '';
       let stageData: any = null;
       try {
-        const stageResp = await axios.get(`${stageBackendUrl}/api/admin/db-compare?local_only=true`, {
-          headers: { Authorization: authHeader },
+        const stageResp = await axios.get(`${stageBackendUrl}/api/internal/db-stats`, {
+          headers: { Authorization: `Bearer ${stageApiKey}` },
           timeout: 20000,
         });
         stageData = stageResp.data?.local || null;


### PR DESCRIPTION
## Problem

`/admin/db-compare` showed «Stage недоступний» because the local backend forwarded the user's JWT to `stage.legal.org.ua/api/admin/db-compare?local_only=true`. Local and stage use different `JWT_SECRET`, so stage always returned 401.

## Solution

- Add `/api/internal/db-stats` endpoint with `dualAuth` (accepts API keys) that returns local stats for openreyestr, rada, and main backend tables
- Update the `db-compare` handler to call `/api/internal/db-stats` on stage using `STAGE_API_KEY` env var (API key auth) instead of forwarding the user's JWT
- Add `STAGE_API_KEY` to `docker-compose.local.yml`

## Test plan
- [ ] Deploy to stage (`./manage-gateway.sh deploy stage`)
- [ ] Open `https://localdev.legal.org.ua/admin/db-compare`
- [ ] Verify green banner «Stage підключено. Порівняння актуальне.»
- [ ] Verify stage column shows row counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stage connectivity in /admin/db-compare by switching to API key auth instead of forwarding the user’s JWT. The comparison now loads and shows stage DB stats without 401 errors.

- **Bug Fixes**
  - Added /api/internal/db-stats (dualAuth) to return local DB stats.
  - Updated db-compare to call stage’s /api/internal/db-stats with STAGE_API_KEY.
  - Added STAGE_API_KEY to docker-compose.local.yml.

<sup>Written for commit f1e500e9e489ac321f13dbfbd047a3e129097394. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

