### PR TITLE
fix(legislation): sort articles numerically instead of lexicographically

### DIFF
--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -407,7 +407,7 @@ export class LegislationService {
              'section_number', la.section_number,
              'chapter_number', la.chapter_number,
              'byte_size', la.byte_size
-           ) ORDER BY la.article_number
+           ) ORDER BY (regexp_match(la.article_number, '^\d+'))[1]::integer NULLS LAST, la.article_number
          ) as articles
        FROM legislation l
        LEFT JOIN legislation_articles la ON l.id = la.legislation_id AND la.is_current = true


### PR DESCRIPTION
## Summary
- Article list in `/legislation/library` was showing articles in lexicographic order (1, 10, 100, 1000...) instead of numeric order (1, 2, 3...)
- Root cause: `article_number` column is `VARCHAR(50)`, so `ORDER BY la.article_number` sorted as strings
- Fix: extract leading integer via `regexp_match` and cast to `integer` for correct numeric ordering; non-numeric identifiers fall back to string sort

## Test plan
- [ ] Open `/legislation/library`, select Цивільний кодекс — articles should now show 1, 2, 3... not 1, 10, 100...
- [ ] Verify other codes (Кримінальний, Господарський) also sort correctly
- [ ] Confirm non-numeric article identifiers still appear (NULLS LAST fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed article sorting in the legislation library to order numerically (1, 2, 3…) instead of lexicographically (1, 10, 100…). Non-numeric IDs still appear and are placed after numbered articles.

- **Bug Fixes**
  - Order by the leading integer extracted from article_number (regexp_match → integer) with NULLS LAST; use article_number as a tie-breaker.

<sup>Written for commit f3d3b5261f8e8ae310bfc4a139978bd1fa14c4c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

