### PR TITLE
feat(embeddings): switch from OpenAI to VoyageAI embeddings

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -248,6 +248,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-local-dev-openai-key}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
+      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-law-2}
 
       # Dynamic model selection (cost-optimized defaults)
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}

--- a/mcp_backend/src/utils/voyage-client.ts
+++ b/mcp_backend/src/utils/voyage-client.ts
@@ -1,0 +1,86 @@
+/**
+ * VoyageAI embedding client using native fetch (Node 20+).
+ * Supports voyage-law-2 and other Voyage embedding models.
+ */
+
+const VOYAGE_API_URL = 'https://api.voyageai.com/v1/embeddings';
+const MAX_RETRIES = 3;
+const BATCH_SIZE = 50; // VoyageAI supports up to 128, use 50 to match existing pattern
+
+interface VoyageEmbeddingResponse {
+  object: string;
+  data: Array<{ object: string; embedding: number[]; index: number }>;
+  model: string;
+  usage: { total_tokens: number };
+}
+
+export class VoyageAIClient {
+  constructor(private apiKey: string) {
+    if (!apiKey) {
+      throw new Error('VOYAGEAI_API_KEY is required');
+    }
+  }
+
+  async generateEmbedding(text: string, model: string = 'voyage-multilingual-2'): Promise<number[]> {
+    const results = await this.generateEmbeddingsBatch([text], model);
+    return results[0];
+  }
+
+  async generateEmbeddingsBatch(texts: string[], model: string = 'voyage-multilingual-2'): Promise<number[][]> {
+    const allEmbeddings: number[][] = [];
+
+    for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+      const batch = texts.slice(i, i + BATCH_SIZE);
+      const embeddings = await this._embedBatchWithRetry(batch, model);
+      allEmbeddings.push(...embeddings);
+    }
+
+    return allEmbeddings;
+  }
+
+  private async _embedBatchWithRetry(texts: string[], model: string): Promise<number[][]> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        return await this._embedBatch(texts, model);
+      } catch (err: any) {
+        lastError = err;
+
+        if (err.status === 429) {
+          // Rate limited — exponential backoff
+          const delay = Math.pow(2, attempt) * 1000;
+          await new Promise((r) => setTimeout(r, delay));
+          continue;
+        }
+
+        // Non-retryable error
+        throw err;
+      }
+    }
+
+    throw lastError ?? new Error('VoyageAI: max retries exceeded');
+  }
+
+  private async _embedBatch(texts: string[], model: string): Promise<number[][]> {
+    const response = await fetch(VOYAGE_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({ input: texts, model }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      const err: any = new Error(`VoyageAI API error ${response.status}: ${body}`);
+      err.status = response.status;
+      throw err;
+    }
+
+    const data = (await response.json()) as VoyageEmbeddingResponse;
+    // Sort by index to ensure order is preserved
+    return data.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
+  }
+}

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -15,7 +15,7 @@ export interface ModelSelection {
  * Supports multiple LLM providers (OpenAI, Anthropic) with automatic fallback
  */
 export class ModelSelector {
-  private static readonly DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
+  private static readonly DEFAULT_EMBEDDING_MODEL = 'voyage-multilingual-2';
 
   private static readonly PROVIDER_STRATEGY = process.env.LLM_PROVIDER_STRATEGY || 'openai-first';
 
@@ -26,8 +26,7 @@ export class ModelSelector {
   private static readonly SINGLE_MODEL = process.env.OPENAI_MODEL;
 
   static getEmbeddingModel(): string {
-    const model = process.env.OPENAI_EMBEDDING_MODEL || this.DEFAULT_EMBEDDING_MODEL;
-    return model;
+    return process.env.VOYAGEAI_EMBEDDING_MODEL || this.DEFAULT_EMBEDDING_MODEL;
   }
 
   /**
@@ -100,10 +99,14 @@ export class ModelSelector {
       // Legacy
       'gpt-4-turbo': { input: 10.00, output: 30.00 },
       'gpt-4': { input: 30.00, output: 60.00 },
-      // Embeddings
+      // Embeddings (OpenAI)
       'text-embedding-ada-002': { input: 0.10, output: 0 },
       'text-embedding-3-small': { input: 0.02, output: 0 },
       'text-embedding-3-large': { input: 0.13, output: 0 },
+      // Embeddings (VoyageAI)
+      'voyage-multilingual-2': { input: 0.06, output: 0 },
+      'voyage-law-2': { input: 0.12, output: 0 },
+      'voyage-3-large': { input: 0.18, output: 0 },
       // Claude (historical — kept for cost tracking of past usage)
       'claude-opus-4-20250514': { input: 15.00, output: 75.00 },
       'claude-opus-4.5': { input: 5.00, output: 25.00 },
@@ -153,10 +156,14 @@ export class ModelSelector {
       // Legacy
       'gpt-4-turbo': { input: 10.00, output: 30.00 },
       'gpt-4': { input: 30.00, output: 60.00 },
-      // Embeddings
+      // Embeddings (OpenAI)
       'text-embedding-ada-002': { input: 0.10, output: 0 },
       'text-embedding-3-small': { input: 0.02, output: 0 },
       'text-embedding-3-large': { input: 0.13, output: 0 },
+      // Embeddings (VoyageAI)
+      'voyage-multilingual-2': { input: 0.06, output: 0 },
+      'voyage-law-2': { input: 0.12, output: 0 },
+      'voyage-3-large': { input: 0.18, output: 0 },
       // Claude (historical — kept for cost tracking of past usage)
       'claude-opus-4-20250514': { input: 15.00, output: 75.00 },
       'claude-opus-4.5': { input: 5.00, output: 25.00 },


### PR DESCRIPTION
## Summary

- Adds `VoyageAIClient` (`mcp_backend/src/utils/voyage-client.ts`) — native fetch-based client with batching (50 texts/req) and exponential backoff on rate limits
- `EmbeddingService` now uses VoyageAI instead of OpenAI; embedding dimension updated to 1024 (voyage-multilingual-2); auto-detects and recreates Qdrant collection on dimension mismatch
- `ModelSelector.getEmbeddingModel()` reads `VOYAGEAI_EMBEDDING_MODEL` env var; pricing tables extended with voyage-multilingual-2, voyage-law-2, voyage-3-large
- `docker-compose.local.yml` gains `VOYAGEAI_API_KEY` and `VOYAGEAI_EMBEDDING_MODEL` env vars (default: `voyage-law-2`)

## Test plan

- [ ] Set `VOYAGEAI_API_KEY` in `.env` and start local stack with `./manage-gateway.sh start local`
- [ ] Trigger an embedding via semantic search tool — confirm no errors and Qdrant collection uses dimension 1024
- [ ] Test with existing 1536-dim collection: verify auto-delete + recreate warning in logs
- [ ] Verify batch embedding path (index multiple documents)
- [ ] Confirm cost tracking records `voyage-multilingual-2` or `voyage-law-2` in `cost_tracking` table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches embeddings from OpenAI to VoyageAI. Uses 1024‑dim vectors and auto-recreates the Qdrant collection if the stored dimension doesn’t match.

- **New Features**
  - Added VoyageAIClient with native fetch, batching (50 inputs), and exponential backoff on 429s.
  - EmbeddingService now calls VoyageAI for single and batch embeddings.
  - ModelSelector reads VOYAGEAI_EMBEDDING_MODEL and adds pricing for voyage-multilingual-2, voyage-law-2, voyage-3-large.
  - docker-compose.local adds VOYAGEAI_API_KEY and VOYAGEAI_EMBEDDING_MODEL (default: voyage-law-2).

- **Migration**
  - Set VOYAGEAI_API_KEY and optionally VOYAGEAI_EMBEDDING_MODEL in the environment.
  - On first run, the Qdrant collection may be deleted and recreated if it was 1536‑dim; new dimension is 1024.

<sup>Written for commit 9582e226bcb2ced2f70bc992ef25d4c524069bd2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

