### PR TITLE
fix(scraper): skip DOC_FORM click when __all__ and support custom Chromium path

### DIFF
--- a/mcp_backend/src/scripts/scrape-court-registry.ts
+++ b/mcp_backend/src/scripts/scrape-court-registry.ts
@@ -439,8 +439,10 @@ async function fillSearchForm(page: Page, dateFromValue: string): Promise<void> 
   await clickMultiSelectOption(page, JUSTICE_KIND);
   await sleepWithJitter(500);
 
-  await clickMultiSelectOption(page, DOC_FORM);
-  await sleepWithJitter(500);
+  if (DOC_FORM && DOC_FORM !== '__all__') {
+    await clickMultiSelectOption(page, DOC_FORM);
+    await sleepWithJitter(500);
+  }
 
   if (SEARCH_TEXT) {
     const textInput = page.locator('input[name="SearchExpression"], textarea[name="SearchExpression"]');
@@ -801,8 +803,10 @@ async function main() {
       await processWithPool(ctx, items);
     } else {
       const proxy = process.env.SCRAPE_PROXY || process.env.HTTP_PROXY;
+      const executablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
       const launchOptions: Parameters<typeof chromium.launch>[0] = {
         headless: HEADLESS,
+        ...(executablePath && { executablePath }),
         ...(proxy && { proxy: { server: proxy } }),
       };
       const contextOptions: Parameters<import('playwright').Browser['newContext']>[0] = {


### PR DESCRIPTION
## Summary

- Guard `clickMultiSelectOption(page, DOC_FORM)` behind `DOC_FORM && DOC_FORM !== '__all__'` — prevents a crash when no document form filter is configured
- Support `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` env var passed as `executablePath` to `chromium.launch()` — allows using a system or Docker-provided Chromium binary instead of the bundled one

## Test plan

- [ ] Run scraper with `DOC_FORM` unset or set to `__all__` — confirm form fills without error
- [ ] Run scraper with a valid `DOC_FORM` value — confirm filter is still applied
- [ ] Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium` and confirm the scraper uses it (check launch logs)
- [ ] Run without `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` — confirm default Playwright Chromium is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents scraper errors when DOC_FORM is unset or set to "__all__", and adds support for using a custom Chromium binary via an env var.

- **Bug Fixes**
  - Skip DOC_FORM multi-select click unless DOC_FORM is set and not "__all__".

- **New Features**
  - Support PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to pass executablePath to chromium.launch; falls back to Playwright’s bundled Chromium when unset.

<sup>Written for commit 00aea0082baa776bc8757a61a0e4d8a9d03eda2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

