### PR TITLE
fix(document-service): add VOYAGEAI_API_KEY/MODEL env vars to docker-compose

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -471,6 +471,8 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-local-dev-openai-key}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
+      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-law-2}
 
       # Dynamic model selection
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}


### PR DESCRIPTION
## Summary

- `document-service-local` was missing `VOYAGEAI_API_KEY` and `VOYAGEAI_EMBEDDING_MODEL` env vars that were added to `secondlayer-app-local` in #245
- Without these, the container crashed on startup with `VOYAGEAI_API_KEY is required`

## Test plan

- [ ] `./manage-gateway.sh start local` — confirm `document-service-local` reaches healthy state
- [ ] Check logs: no `VOYAGEAI_API_KEY is required` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add VOYAGEAI_API_KEY and VOYAGEAI_EMBEDDING_MODEL to document-service-local in docker-compose. This prevents the startup crash when VOYAGEAI_API_KEY is missing and matches the envs used in secondlayer-app-local.

- **Migration**
  - Add VOYAGEAI_API_KEY to .env.local for local runs (optional: override VOYAGEAI_EMBEDDING_MODEL; default is voyage-law-2).

<sup>Written for commit a36e0f520f2eab0d8eff9caf602fa81b065e1de5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

