### PR TITLE
fix(embeddings): use voyage-multilingual-2 as default for Ukrainian support

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -249,7 +249,7 @@ services:
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
       VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
-      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-law-2}
+      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}
 
       # Dynamic model selection (cost-optimized defaults)
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
@@ -472,7 +472,7 @@ services:
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
       VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
-      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-law-2}
+      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}
 
       # Dynamic model selection
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}

--- a/mcp_backend/src/utils/voyage-client.ts
+++ b/mcp_backend/src/utils/voyage-client.ts
@@ -1,6 +1,6 @@
 /**
  * VoyageAI embedding client using native fetch (Node 20+).
- * Supports voyage-law-2 and other Voyage embedding models.
+ * Default model: voyage-multilingual-2 (supports Ukrainian and other languages).
  */
 
 const VOYAGE_API_URL = 'https://api.voyageai.com/v1/embeddings';


### PR DESCRIPTION
## Summary

`voyage-law-2` is an English-focused model with no Ukrainian language support. The docker-compose fallback defaults were using it, which would produce poor embeddings for Ukrainian legal text if `.env.local` was absent.

Changes:
- Both `secondlayer-app-local` and `document-service-local` now default to `voyage-multilingual-2`
- Updated `voyage-client.ts` comment to reflect the actual default and language support

All defaults are now consistent across docker-compose, `embedding-service.ts`, and `model-selector.ts`.

## Test plan

- [ ] Start local stack without `VOYAGEAI_EMBEDDING_MODEL` in `.env.local` — confirm `voyage-multilingual-2` is used in logs
- [ ] Run a Ukrainian-language semantic search query — confirm relevant results are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the default Voyage embedding model to voyage-multilingual-2 to support Ukrainian and avoid poor embeddings when .env.local is missing. Align docker-compose and code defaults.

- **Bug Fixes**
  - Change docker-compose defaults to voyage-multilingual-2 for both secondlayer-app-local and document-service-local.
  - Update voyage-client.ts comment to reflect the default and multilingual support.

<sup>Written for commit 518d777836c724af618b2474663423822a539ec8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

