### PR TITLE
feat(admin): add service pricing management page

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   FileCode,
   DollarSign,
   CreditCard,
+  Tag,
   UsersRound,
   Trash2,
   Edit3,
@@ -71,6 +72,7 @@ interface SidebarProps {
   onAdminContainersClick?: () => void;
   onAdminConfigClick?: () => void;
   onAdminDBCompareClick?: () => void;
+  onAdminServicePricingClick?: () => void;
   onLogout?: () => void;
 }
 export function Sidebar({
@@ -107,6 +109,7 @@ export function Sidebar({
   onAdminContainersClick,
   onAdminConfigClick,
   onAdminDBCompareClick,
+  onAdminServicePricingClick,
   onLogout
 }: SidebarProps) {
   const { user } = useAuth();
@@ -244,6 +247,7 @@ export function Sidebar({
     { id: 'admin-billing', label: 'Біллінг', icon: CreditCard, onClick: onAdminBillingClick },
     { id: 'system-config', label: 'Конфігурація', icon: Settings, onClick: onAdminConfigClick },
     { id: 'db-compare', label: 'Порівняння БД', icon: Database, onClick: onAdminDBCompareClick },
+    { id: 'service-pricing', label: 'Собівартість сервісів', icon: Tag, onClick: onAdminServicePricingClick },
   ];
 
   const evidenceSections = [

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -141,6 +141,7 @@ export function MainLayout() {
           onAdminContainersClick={() => navigate(ROUTES.ADMIN_CONTAINERS)}
           onAdminConfigClick={() => navigate(ROUTES.ADMIN_CONFIG)}
           onAdminDBCompareClick={() => navigate(ROUTES.ADMIN_DB_COMPARE)}
+          onAdminServicePricingClick={() => navigate(ROUTES.ADMIN_SERVICE_PRICING)}
           onLogout={handleLogout}
         />
       </div>

--- a/lexwebapp/src/pages/AdminServicePricingPage.tsx
+++ b/lexwebapp/src/pages/AdminServicePricingPage.tsx
@@ -1,0 +1,297 @@
+import React, { useEffect, useState } from 'react';
+import { Tag, RefreshCw, Save, AlertCircle, CheckCircle, ChevronDown, ChevronRight } from 'lucide-react';
+import { api } from '../utils/api-client';
+
+interface PricingEntry {
+  id: string;
+  provider: string;
+  model: string;
+  display_name: string;
+  unit_type: string;
+  price_usd: number;
+  currency: string;
+  sort_order: number;
+  notes: string | null;
+  is_active: boolean;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic:   'Anthropic (Claude)',
+  openai:      'OpenAI',
+  voyageai:    'VoyageAI',
+  zakononline: 'ZakonOnline API',
+};
+
+const PROVIDER_ORDER = ['anthropic', 'openai', 'voyageai', 'zakononline'];
+
+const UNIT_LABELS: Record<string, string> = {
+  per_1m_input_tokens:  'за 1M вхідних токенів',
+  per_1m_output_tokens: 'за 1M вихідних токенів',
+  per_1m_tokens:        'за 1M токенів',
+  per_call:             'за виклик',
+};
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleString('uk-UA', { dateStyle: 'short', timeStyle: 'short' });
+  } catch {
+    return iso;
+  }
+}
+
+export function AdminServicePricingPage() {
+  const [pricing, setPricing] = useState<PricingEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editValues, setEditValues] = useState<Record<string, { price_usd: string; notes: string; is_active: boolean }>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [savedIds, setSavedIds] = useState<Set<string>>(new Set());
+  const [errorIds, setErrorIds] = useState<Record<string, string>>({});
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  const load = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.admin.getServicePricing();
+      setPricing(res.data.pricing || []);
+      const initial: typeof editValues = {};
+      for (const p of res.data.pricing || []) {
+        initial[p.id] = {
+          price_usd: String(p.price_usd),
+          notes: p.notes || '',
+          is_active: p.is_active,
+        };
+      }
+      setEditValues(initial);
+    } catch (e: any) {
+      setError(e?.response?.data?.error || e.message || 'Помилка завантаження');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const handleSave = async (entry: PricingEntry) => {
+    const vals = editValues[entry.id];
+    if (!vals) return;
+    const priceNum = parseFloat(vals.price_usd);
+    if (isNaN(priceNum) || priceNum < 0) {
+      setErrorIds(prev => ({ ...prev, [entry.id]: 'Некоректна ціна' }));
+      return;
+    }
+    setSaving(prev => ({ ...prev, [entry.id]: true }));
+    setErrorIds(prev => { const n = { ...prev }; delete n[entry.id]; return n; });
+    try {
+      await api.admin.updateServicePricing(entry.id, {
+        price_usd: priceNum,
+        notes: vals.notes || undefined,
+        is_active: vals.is_active,
+      });
+      setSavedIds(prev => new Set([...prev, entry.id]));
+      setPricing(prev => prev.map(p =>
+        p.id === entry.id
+          ? { ...p, price_usd: priceNum, notes: vals.notes || null, is_active: vals.is_active, updated_at: new Date().toISOString() }
+          : p
+      ));
+      setTimeout(() => setSavedIds(prev => { const n = new Set(prev); n.delete(entry.id); return n; }), 2500);
+    } catch (e: any) {
+      setErrorIds(prev => ({ ...prev, [entry.id]: e?.response?.data?.error || e.message || 'Помилка збереження' }));
+    } finally {
+      setSaving(prev => ({ ...prev, [entry.id]: false }));
+    }
+  };
+
+  const toggleCollapse = (provider: string) => {
+    setCollapsed(prev => {
+      const n = new Set(prev);
+      n.has(provider) ? n.delete(provider) : n.add(provider);
+      return n;
+    });
+  };
+
+  const grouped: Record<string, PricingEntry[]> = {};
+  for (const p of pricing) {
+    if (!grouped[p.provider]) grouped[p.provider] = [];
+    grouped[p.provider].push(p);
+  }
+
+  const providers = PROVIDER_ORDER.filter(p => grouped[p]);
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-indigo-100 rounded-lg">
+            <Tag className="w-6 h-6 text-indigo-600" />
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">Собівартість зовнішніх сервісів</h1>
+            <p className="text-sm text-gray-500 mt-0.5">Управління вартістю API-сервісів для обліку витрат</p>
+          </div>
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="flex items-center gap-2 px-3 py-2 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Оновити
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2 text-sm text-red-700">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {loading && !pricing.length ? (
+        <div className="flex items-center justify-center py-16 text-gray-400">
+          <RefreshCw className="w-5 h-5 animate-spin mr-2" />
+          Завантаження…
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {providers.map(provider => {
+            const entries = grouped[provider] || [];
+            const isCollapsed = collapsed.has(provider);
+            return (
+              <div key={provider} className="border border-gray-200 rounded-xl overflow-hidden">
+                {/* Provider header */}
+                <button
+                  onClick={() => toggleCollapse(provider)}
+                  className="w-full flex items-center justify-between px-5 py-3 bg-gray-50 hover:bg-gray-100 transition-colors text-left"
+                >
+                  <span className="font-medium text-gray-800">{PROVIDER_LABELS[provider] || provider}</span>
+                  <div className="flex items-center gap-2 text-gray-400 text-xs">
+                    <span>{entries.length} {entries.length === 1 ? 'позиція' : 'позиції'}</span>
+                    {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+                  </div>
+                </button>
+
+                {!isCollapsed && (
+                  <div className="divide-y divide-gray-100">
+                    {/* Table header */}
+                    <div className="grid grid-cols-[1fr_120px_180px_100px_80px_100px] gap-3 px-5 py-2 bg-white text-xs font-medium text-gray-400 uppercase tracking-wide">
+                      <span>Модель / Послуга</span>
+                      <span>Одиниця</span>
+                      <span>Ціна (USD)</span>
+                      <span>Активна</span>
+                      <span>Оновлено</span>
+                      <span></span>
+                    </div>
+
+                    {entries.map(entry => {
+                      const vals = editValues[entry.id];
+                      const isSaving = saving[entry.id];
+                      const isSaved = savedIds.has(entry.id);
+                      const entryError = errorIds[entry.id];
+                      const isDirty = vals && (
+                        String(parseFloat(vals.price_usd) || 0) !== String(entry.price_usd) ||
+                        (vals.notes || '') !== (entry.notes || '') ||
+                        vals.is_active !== entry.is_active
+                      );
+
+                      return (
+                        <div
+                          key={entry.id}
+                          className={`grid grid-cols-[1fr_120px_180px_100px_80px_100px] gap-3 px-5 py-3 items-center text-sm hover:bg-gray-50 transition-colors ${!entry.is_active ? 'opacity-50' : ''}`}
+                        >
+                          {/* Name */}
+                          <div>
+                            <div className="font-medium text-gray-800">{entry.display_name}</div>
+                            {entry.notes && (
+                              <div className="text-xs text-gray-400 mt-0.5">{entry.notes}</div>
+                            )}
+                          </div>
+
+                          {/* Unit type */}
+                          <div className="text-xs text-gray-500">
+                            {UNIT_LABELS[entry.unit_type] || entry.unit_type}
+                            <div className="text-gray-400">{entry.currency}</div>
+                          </div>
+
+                          {/* Price input */}
+                          <div>
+                            <div className="flex items-center gap-1">
+                              <span className="text-gray-400 text-xs">$</span>
+                              <input
+                                type="number"
+                                min="0"
+                                step="0.00000001"
+                                value={vals?.price_usd ?? entry.price_usd}
+                                onChange={e => setEditValues(prev => ({
+                                  ...prev,
+                                  [entry.id]: { ...prev[entry.id], price_usd: e.target.value },
+                                }))}
+                                className="w-full border border-gray-200 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:border-transparent"
+                              />
+                            </div>
+                            {entryError && (
+                              <div className="text-xs text-red-500 mt-1">{entryError}</div>
+                            )}
+                          </div>
+
+                          {/* Active toggle */}
+                          <div className="flex justify-center">
+                            <button
+                              onClick={() => setEditValues(prev => ({
+                                ...prev,
+                                [entry.id]: { ...prev[entry.id], is_active: !prev[entry.id]?.is_active },
+                              }))}
+                              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${vals?.is_active ? 'bg-indigo-500' : 'bg-gray-300'}`}
+                            >
+                              <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${vals?.is_active ? 'translate-x-4.5' : 'translate-x-0.5'}`} />
+                            </button>
+                          </div>
+
+                          {/* Updated at */}
+                          <div className="text-xs text-gray-400 whitespace-nowrap">
+                            {formatDate(entry.updated_at)}
+                          </div>
+
+                          {/* Save button */}
+                          <div className="flex justify-end">
+                            {isSaved ? (
+                              <span className="flex items-center gap-1 text-xs text-green-600">
+                                <CheckCircle className="w-3.5 h-3.5" /> Збережено
+                              </span>
+                            ) : (
+                              <button
+                                onClick={() => handleSave(entry)}
+                                disabled={isSaving || !isDirty}
+                                className="flex items-center gap-1 px-2.5 py-1 text-xs bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                              >
+                                {isSaving ? (
+                                  <RefreshCw className="w-3 h-3 animate-spin" />
+                                ) : (
+                                  <Save className="w-3 h-3" />
+                                )}
+                                Зберегти
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="mt-6 text-xs text-gray-400">
+        Ціни зберігаються в таблиці <code className="font-mono bg-gray-100 px-1 rounded">service_pricing</code> та використовуються для обліку собівартості запитів.
+        Значення вказуються в USD (крім ZakonOnline — в UAH).
+      </p>
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -47,6 +47,7 @@ import { AdminInfrastructurePage } from '../pages/AdminInfrastructurePage';
 import { AdminContainersPage } from '../pages/AdminContainersPage';
 import { AdminConfigPage } from '../pages/AdminConfigPage';
 import { AdminDBComparePage } from '../pages/AdminDBComparePage';
+import { AdminServicePricingPage } from '../pages/AdminServicePricingPage';
 import { DocumentsPage } from '../pages/DocumentsPage';
 import { TimeEntriesPage } from '../pages/TimeEntriesPage';
 import { InvoicesPage } from '../pages/InvoicesPage';
@@ -272,6 +273,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ADMIN_DB_COMPARE,
             element: <AdminDBComparePage />,
+          },
+          {
+            path: ROUTES.ADMIN_SERVICE_PRICING,
+            element: <AdminServicePricingPage />,
           },
         ],
       },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -81,6 +81,7 @@ export const ROUTES = {
   ADMIN_CONTAINERS: '/admin/containers',
   ADMIN_CONFIG: '/admin/config',
   ADMIN_DB_COMPARE: '/admin/db-compare',
+  ADMIN_SERVICE_PRICING: '/admin/service-pricing',
 } as const;
 
 // Helper function to generate dynamic routes

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -354,6 +354,12 @@ export const api = {
         : apiClient.get('/api/admin/scrape-court-registry'),
     stopCourtScraper: (jobId: string) =>
       apiClient.post(`/api/admin/scrape-court-registry/${jobId}/stop`),
+
+    // Service pricing
+    getServicePricing: () =>
+      apiClient.get('/api/admin/service-pricing'),
+    updateServicePricing: (id: string, data: { price_usd: number; notes?: string; is_active?: boolean }) =>
+      apiClient.put(`/api/admin/service-pricing/${id}`, data),
   },
 
   // GDPR

--- a/mcp_backend/src/migrations/049_add_service_pricing.sql
+++ b/mcp_backend/src/migrations/049_add_service_pricing.sql
@@ -1,0 +1,79 @@
+-- Migration 049: Add service_pricing table for external service cost management
+-- Stores per-unit costs for all external services (Anthropic, OpenAI, VoyageAI, ZakonOnline)
+
+CREATE TABLE IF NOT EXISTS service_pricing (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider VARCHAR(50) NOT NULL,        -- 'anthropic', 'openai', 'voyageai', 'zakononline'
+  model VARCHAR(100) NOT NULL,          -- model/service identifier
+  display_name VARCHAR(200) NOT NULL,   -- human-readable label
+  unit_type VARCHAR(50) NOT NULL,       -- 'per_1m_input_tokens', 'per_1m_output_tokens', 'per_1m_tokens', 'per_call'
+  price_usd DECIMAL(14, 8) NOT NULL DEFAULT 0,
+  currency VARCHAR(10) NOT NULL DEFAULT 'USD',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  notes TEXT,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_by VARCHAR(255),
+  UNIQUE(provider, model, unit_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_service_pricing_provider ON service_pricing(provider);
+CREATE INDEX IF NOT EXISTS idx_service_pricing_active ON service_pricing(is_active);
+
+-- ----------------------------------------------------------------
+-- Default pricing data
+-- ----------------------------------------------------------------
+
+-- OpenAI models (USD per 1M tokens)
+INSERT INTO service_pricing (provider, model, display_name, unit_type, price_usd, currency, sort_order, notes) VALUES
+  ('openai', 'gpt-4o',               'GPT-4o',                'per_1m_input_tokens',  2.50,  'USD', 10, 'Ціна за 1M вхідних токенів'),
+  ('openai', 'gpt-4o',               'GPT-4o',                'per_1m_output_tokens', 10.00, 'USD', 11, 'Ціна за 1M вихідних токенів'),
+  ('openai', 'gpt-4o-mini',          'GPT-4o Mini',           'per_1m_input_tokens',  0.15,  'USD', 20, 'Ціна за 1M вхідних токенів'),
+  ('openai', 'gpt-4o-mini',          'GPT-4o Mini',           'per_1m_output_tokens', 0.60,  'USD', 21, 'Ціна за 1M вихідних токенів'),
+  ('openai', 'gpt-4o-2024-08-06',    'GPT-4o (2024-08-06)',   'per_1m_input_tokens',  2.50,  'USD', 30, 'Ціна за 1M вхідних токенів'),
+  ('openai', 'gpt-4o-2024-08-06',    'GPT-4o (2024-08-06)',   'per_1m_output_tokens', 10.00, 'USD', 31, 'Ціна за 1M вихідних токенів'),
+  ('openai', 'text-embedding-ada-002','Text Embedding Ada 002','per_1m_tokens',        0.10,  'USD', 40, 'Ціна за 1M токенів ембедінгу')
+ON CONFLICT (provider, model, unit_type) DO NOTHING;
+
+-- VoyageAI models (USD per 1M tokens)
+INSERT INTO service_pricing (provider, model, display_name, unit_type, price_usd, currency, sort_order, notes) VALUES
+  ('voyageai', 'voyage-multilingual-2', 'Voyage Multilingual 2', 'per_1m_tokens', 0.06, 'USD', 10, 'Ціна за 1M токенів (багатомовний ембедінг)'),
+  ('voyageai', 'voyage-3',              'Voyage 3',              'per_1m_tokens', 0.06, 'USD', 20, 'Ціна за 1M токенів'),
+  ('voyageai', 'voyage-3-lite',         'Voyage 3 Lite',         'per_1m_tokens', 0.02, 'USD', 30, 'Ціна за 1M токенів')
+ON CONFLICT (provider, model, unit_type) DO NOTHING;
+
+-- Anthropic models (USD per 1M tokens)
+INSERT INTO service_pricing (provider, model, display_name, unit_type, price_usd, currency, sort_order, notes) VALUES
+  ('anthropic', 'claude-opus-4-20250514',   'Claude Opus 4 (2025-05-14)', 'per_1m_input_tokens',  15.00, 'USD', 10, NULL),
+  ('anthropic', 'claude-opus-4-20250514',   'Claude Opus 4 (2025-05-14)', 'per_1m_output_tokens', 75.00, 'USD', 11, NULL),
+  ('anthropic', 'claude-opus-4.5',          'Claude Opus 4.5',            'per_1m_input_tokens',   5.00, 'USD', 20, NULL),
+  ('anthropic', 'claude-opus-4.5',          'Claude Opus 4.5',            'per_1m_output_tokens', 25.00, 'USD', 21, NULL),
+  ('anthropic', 'claude-opus-4',            'Claude Opus 4',              'per_1m_input_tokens',  15.00, 'USD', 30, NULL),
+  ('anthropic', 'claude-opus-4',            'Claude Opus 4',              'per_1m_output_tokens', 75.00, 'USD', 31, NULL),
+  ('anthropic', 'claude-sonnet-4-20250514', 'Claude Sonnet 4 (2025-05-14)','per_1m_input_tokens',  3.00, 'USD', 40, NULL),
+  ('anthropic', 'claude-sonnet-4-20250514', 'Claude Sonnet 4 (2025-05-14)','per_1m_output_tokens',15.00, 'USD', 41, NULL),
+  ('anthropic', 'claude-sonnet-4.5',        'Claude Sonnet 4.5',          'per_1m_input_tokens',   3.00, 'USD', 50, NULL),
+  ('anthropic', 'claude-sonnet-4.5',        'Claude Sonnet 4.5',          'per_1m_output_tokens', 15.00, 'USD', 51, NULL),
+  ('anthropic', 'claude-sonnet-4',          'Claude Sonnet 4',            'per_1m_input_tokens',   3.00, 'USD', 60, NULL),
+  ('anthropic', 'claude-sonnet-4',          'Claude Sonnet 4',            'per_1m_output_tokens', 15.00, 'USD', 61, NULL),
+  ('anthropic', 'claude-sonnet-3.7',        'Claude Sonnet 3.7',          'per_1m_input_tokens',   3.00, 'USD', 70, NULL),
+  ('anthropic', 'claude-sonnet-3.7',        'Claude Sonnet 3.7',          'per_1m_output_tokens', 15.00, 'USD', 71, NULL),
+  ('anthropic', 'claude-haiku-4-5-20251001','Claude Haiku 4.5 (2025-10-01)','per_1m_input_tokens', 1.00, 'USD', 80, NULL),
+  ('anthropic', 'claude-haiku-4-5-20251001','Claude Haiku 4.5 (2025-10-01)','per_1m_output_tokens',5.00, 'USD', 81, NULL),
+  ('anthropic', 'claude-haiku-4.5',         'Claude Haiku 4.5',           'per_1m_input_tokens',   1.00, 'USD', 82, NULL),
+  ('anthropic', 'claude-haiku-4.5',         'Claude Haiku 4.5',           'per_1m_output_tokens',  5.00, 'USD', 83, NULL),
+  ('anthropic', 'claude-haiku-3.5',         'Claude Haiku 3.5',           'per_1m_input_tokens',   0.80, 'USD', 90, NULL),
+  ('anthropic', 'claude-haiku-3.5',         'Claude Haiku 3.5',           'per_1m_output_tokens',  4.00, 'USD', 91, NULL),
+  ('anthropic', 'claude-haiku-3',           'Claude Haiku 3',             'per_1m_input_tokens',   0.25, 'USD', 100, NULL),
+  ('anthropic', 'claude-haiku-3',           'Claude Haiku 3',             'per_1m_output_tokens',  1.25, 'USD', 101, NULL)
+ON CONFLICT (provider, model, unit_type) DO NOTHING;
+
+-- ZakonOnline API (UAH per call, tiered pricing)
+-- Tier thresholds per calendar month
+INSERT INTO service_pricing (provider, model, display_name, unit_type, price_usd, currency, sort_order, notes) VALUES
+  ('zakononline', 'api_tier_1', 'API до 10 000 запитів/міс',    'per_call', 0.00714, 'UAH', 10, 'Перші 9 999 запитів на місяць'),
+  ('zakononline', 'api_tier_2', 'API 10 000–19 999 запитів/міс','per_call', 0.00690, 'UAH', 20, '10 000–19 999 запитів на місяць'),
+  ('zakononline', 'api_tier_3', 'API 20 000–29 999 запитів/міс','per_call', 0.00667, 'UAH', 30, '20 000–29 999 запитів на місяць'),
+  ('zakononline', 'api_tier_4', 'API 30 000–49 999 запитів/міс','per_call', 0.00643, 'UAH', 40, '30 000–49 999 запитів на місяць'),
+  ('zakononline', 'api_tier_5', 'API 50 000+ запитів/міс',      'per_call', 0.00238, 'UAH', 50, '50 000 та більше запитів на місяць')
+ON CONFLICT (provider, model, unit_type) DO NOTHING;


### PR DESCRIPTION
## Summary

- Новий пункт **«Собівартість сервісів»** у меню МОНІТОРИНГ адмін-панелі
- Таблиця `service_pricing` у PostgreSQL зберігає собівартість усіх зовнішніх API
- Попередньо заповнена даними зі всіх моделей, які вже є в `model-selector.ts`

## Що додано

**БД (migration 049)**
- Таблиця `service_pricing` (provider, model, display_name, unit_type, price_usd, currency, notes, is_active, updated_at, updated_by)
- Default-записи для: Anthropic (15+ Claude-моделей), OpenAI (GPT-4o, GPT-4o-mini, Ada-002), VoyageAI (voyage-multilingual-2 та ін.), ZakonOnline (5 тарифних тирів)

**Backend**
- `GET /api/admin/service-pricing` — отримати всі записи, згруповані по провайдеру
- `PUT /api/admin/service-pricing/:id` — оновити ціну/нотатки/активність конкретного запису

**Frontend**
- `AdminServicePricingPage.tsx` — таблиця по провайдерах з inline-редагуванням цін, перемикачем активності та кнопкою збереження з фідбеком
- Новий пункт меню «Собівартість сервісів» (іконка Tag) у MONITORING sidebar
- Route `/admin/service-pricing` підключений

## Test plan

- [ ] Запустити `npm run migrate` у `mcp_backend` — таблиця та default-дані мають з'явитися
- [ ] Відкрити адмін-панель → МОНІТОРИНГ → «Собівартість сервісів»
- [ ] Перевірити що всі провайдери та моделі відображаються
- [ ] Змінити ціну будь-якого рядка та натиснути «Зберегти» — дані мають зберігатися в БД
- [ ] Перевірити що `GET /api/admin/service-pricing` повертає актуальні значення

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin page to manage per‑unit costs for external services. Includes a new database table and APIs so admins can view, edit, and activate/deactivate pricing for Anthropic, OpenAI, VoyageAI, and ZakonOnline.

- **New Features**
  - New MONITORING menu item “Собівартість сервісів” → /admin/service-pricing
  - AdminServicePricingPage: grouped by provider, inline price editing, active toggle, per‑row save with feedback
  - Endpoints: GET /api/admin/service-pricing, PUT /api/admin/service-pricing/:id
  - API client helpers added; routing and sidebar wired up

- **Migration**
  - Migration 049 creates service_pricing (provider, model, display_name, unit_type, price_usd, currency, sort_order, notes, is_active, updated_at, updated_by) and seeds defaults for Anthropic (Claude), OpenAI (gpt‑4o, gpt‑4o‑mini, Ada‑002), VoyageAI (voyage‑multilingual‑2, voyage‑3, voyage‑3‑lite), and ZakonOnline tiers
  - Run mcp_backend migration, then open the new admin page to manage pricing

<sup>Written for commit c1c34ee9406ecd5168890c152cd8197f7e6cc3a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

