### PR TITLE
fix(deploy): apply --no-cache to all app containers in deploy_local

### DIFF
--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -294,19 +294,19 @@ build_images() {
 
     # Build backend (from root context with mono Dockerfile)
     print_msg "$BLUE" "Building backend image..."
-    docker build -f deployment/Dockerfile.mono-backend -t secondlayer-app:latest .
+    docker build $NO_CACHE -f deployment/Dockerfile.mono-backend -t secondlayer-app:latest .
 
     # Build RADA MCP (from root context with mono Dockerfile)
     print_msg "$BLUE" "Building RADA MCP image..."
-    docker build -f deployment/Dockerfile.mono-rada -t rada-mcp:latest .
+    docker build $NO_CACHE -f deployment/Dockerfile.mono-rada -t rada-mcp:latest .
 
     # Build OpenReyestr MCP (from root context with mono Dockerfile)
     print_msg "$BLUE" "Building OpenReyestr MCP image..."
-    docker build -f deployment/Dockerfile.mono-openreyestr -t openreyestr-app:latest .
+    docker build $NO_CACHE -f deployment/Dockerfile.mono-openreyestr -t openreyestr-app:latest .
 
     # Build frontend (Dockerfile expects context=repo root)
     print_msg "$BLUE" "Building frontend image..."
-    docker build -f lexwebapp/Dockerfile -t lexwebapp-lexwebapp:latest .
+    docker build $NO_CACHE -f lexwebapp/Dockerfile -t lexwebapp-lexwebapp:latest .
 
     cd deployment
     print_msg "$GREEN" "Images built successfully"
@@ -459,7 +459,16 @@ deploy_local() {
         else
             print_msg "$BLUE" "Building all images (cached)..."
         fi
-        $compose_cmd $compose_args build $NO_CACHE migrate-local rada-migrate-local migrate-openreyestr-local document-service-local
+        $compose_cmd $compose_args build $NO_CACHE \
+            app-local \
+            rada-mcp-app-local \
+            app-openreyestr-local \
+            migrate-local \
+            rada-migrate-local \
+            migrate-openreyestr-local \
+            document-service-local \
+            lexwebapp-local \
+            nginx-local
 
         # Step 5: Ensure infrastructure services are running
         print_msg "$BLUE" "Ensuring infrastructure services are running..."


### PR DESCRIPTION
## Summary

- `deploy_local` теперь собирает все app-контейнеры (`app-local`, `rada-mcp-app-local`, `app-openreyestr-local`, `lexwebapp-local`, `nginx-local`) вместе с migrate-контейнерами — флаг `--no-cache` применяется ко всем образам
- `build_images` теперь передаёт `$NO_CACHE` во все четыре `docker build` команды

## Root cause

`deploy_local` вызывал `build` только для migrate/document-service контейнеров, а app-контейнеры запускал через `up -d` без `--build`. В результате `--no-cache` не пересобирал основные образы приложения.

## Test plan

- [ ] `./manage-gateway.sh deploy local --no-cache` пересобирает все образы без кэша
- [ ] `./manage-gateway.sh deploy local` использует кэш (без `--no-cache`)
- [ ] `./manage-gateway.sh build --no-cache` пересобирает все standalone образы

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure deploy_local honors --no-cache for all app and migrate containers to avoid stale images. Also propagate NO_CACHE to all docker builds in build_images.

- **Bug Fixes**
  - deploy_local now builds with --no-cache for: app-local, rada-mcp-app-local, app-openreyestr-local, lexwebapp-local, nginx-local, and all migrate/document services.
  - build_images passes $NO_CACHE to backend, RADA MCP, OpenReyestr MCP, and frontend docker builds.

<sup>Written for commit 3a177e9be404fb169de277c4c27d4f285feef6c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

