### PR TITLE
fix(deploy): fix logs stage SSH and add cadvisor to monitoring startup

### DIFF
--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -233,7 +233,8 @@ show_logs() {
 
     case $env in
         stage|staging)
-            $compose_cmd -f docker-compose.stage.yml --env-file .env.stage logs -f --tail=100
+            ssh ${DEPLOY_USER}@${STAGE_SERVER} \
+                "cd ${REMOTE_PATH} && docker compose -f docker-compose.stage.yml --env-file .env.stage logs -f --tail=100"
             ;;
         local)
             if [ -f ".env.local" ]; then
@@ -498,6 +499,7 @@ deploy_local() {
             prometheus-local \
             grafana-local \
             redis-exporter-local \
+            cadvisor-local \
             2>/dev/null || echo "  (some monitoring services may not exist)"
     ) || deploy_exit=$?
 
@@ -699,6 +701,7 @@ deploy_to_server() {
             postgres-exporter-openreyestr \
             redis-exporter \
             node-exporter \
+            cadvisor-stage \
             2>/dev/null || echo "  (some monitoring services may not exist in this environment)"
 
         # Step 10: Verify all domains respond


### PR DESCRIPTION
## Summary
- `logs stage` now SSHes to `gate.lexapp.co.ua` instead of running `docker compose logs` locally (stage containers only exist on the remote server — local command showed nothing)
- `cadvisor-local` and `cadvisor-stage` added to monitoring startup steps in `deploy_local` and `deploy_to_server` (services were defined in compose files but never started during deployment)

## Test plan
- [ ] `./manage-gateway.sh logs local` — shows logs from all local containers
- [ ] `./manage-gateway.sh logs stage` — SSHes to gate and streams stage logs
- [ ] `./manage-gateway.sh deploy local` — cadvisor-local starts in monitoring step
- [ ] `./manage-gateway.sh deploy stage` — cadvisor-stage starts in monitoring step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stage log streaming by SSHing to gate.lexapp.co.ua and ensures cAdvisor starts with monitoring in both local and stage deployments.

- **Bug Fixes**
  - Stage logs now stream via SSH to the remote server instead of running locally.
  - Added cadvisor-local and cadvisor-stage to monitoring startup in deploy_local and deploy_to_server.

<sup>Written for commit 3ec567b49a6fbdf05ffcf7f9c9fd21c5cf70be6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

