### PR TITLE
fix(frontend): coerce cost fields to Number before toFixed in CostSummary

### DIFF
--- a/lexwebapp/src/components/CostSummary.tsx
+++ b/lexwebapp/src/components/CostSummary.tsx
@@ -37,10 +37,10 @@ export function CostSummary({ data }: CostSummaryProps) {
       >
         <Coins size={12} strokeWidth={2} />
         <span>
-          {data.charged_usd != null && data.charged_usd > 0
-            ? `$${data.charged_usd.toFixed(4)}`
-            : data.total_cost_usd > 0
-              ? `$${data.total_cost_usd.toFixed(4)}`
+          {data.charged_usd != null && Number(data.charged_usd) > 0
+            ? `$${Number(data.charged_usd).toFixed(4)}`
+            : Number(data.total_cost_usd) > 0
+              ? `$${Number(data.total_cost_usd).toFixed(4)}`
               : '$0.00'}
         </span>
         <ChevronDown
@@ -77,14 +77,14 @@ export function CostSummary({ data }: CostSummaryProps) {
 
               {/* Cost breakdown */}
               <div className="flex items-center gap-3 flex-wrap">
-                {data.total_cost_usd > 0 && (
-                  <span>Вартість LLM: ${data.total_cost_usd.toFixed(4)}</span>
+                {Number(data.total_cost_usd) > 0 && (
+                  <span>Вартість LLM: ${Number(data.total_cost_usd).toFixed(4)}</span>
                 )}
-                {data.charged_usd != null && data.charged_usd > 0 && (
-                  <span>Списано: ${data.charged_usd.toFixed(4)}</span>
+                {data.charged_usd != null && Number(data.charged_usd) > 0 && (
+                  <span>Списано: ${Number(data.charged_usd).toFixed(4)}</span>
                 )}
                 {data.balance_usd != null && (
-                  <span>Баланс: ${data.balance_usd.toFixed(2)}</span>
+                  <span>Баланс: ${Number(data.balance_usd).toFixed(2)}</span>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- `balance_usd`, `charged_usd`, and `total_cost_usd` arrive as strings from the API (PostgreSQL `NUMERIC` columns serialize as strings in JSON)
- Calling `.toFixed()` on a string throws `TypeError: data.balance_usd.toFixed is not a function`
- Wraps all cost field usages with `Number()` to coerce safely before calling `.toFixed()`

## Test plan
- [ ] Open chat, generate a response
- [ ] Click the cost amount (e.g. `$0.0056`) at the bottom of the message
- [ ] Verify the breakdown expands without errors
- [ ] Verify balance, LLM cost, and charged amounts display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CostSummary crashing when cost fields arrive as strings by coercing them to Number before using toFixed. Cost amounts now render correctly and the breakdown opens without errors.

- **Bug Fixes**
  - Coerce balance_usd, charged_usd, and total_cost_usd with Number() for comparisons and formatting.
  - Prevent TypeError from toFixed on strings; values display correctly in the header and breakdown.

<sup>Written for commit 8610a6ff1be67823733fe13f90634f3c01a8ee5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

