### PR TITLE
fix(deploy): fix cAdvisor container metrics for Docker 27+ (API v1.44+)

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -796,13 +796,17 @@ services:
     restart: unless-stopped
 
   cadvisor-local:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor-local
     privileged: true
     devices:
       - /dev/kmsg
     environment:
       - DOCKER_API_VERSION=1.44
+    command:
+      - '-docker_only=true'
+      - '-housekeeping_interval=30s'
+      - '-disable_metrics=cpu_topology,hugetlb,memory_numa,perf_event,referenced_memory,resctrl,sched,tcp,udp'
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -850,12 +850,24 @@ services:
     restart: unless-stopped
 
   cadvisor-stage:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor-stage
+    privileged: true
+    devices:
+      - /dev/kmsg
+    environment:
+      - DOCKER_API_VERSION=1.44
+    command:
+      - '-docker_only=true'
+      - '-housekeeping_interval=30s'
+      - '-disable_metrics=cpu_topology,hugetlb,memory_numa,perf_event,referenced_memory,resctrl,sched,tcp,udp'
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
       - /sys:/sys:ro
       - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /etc/machine-id:/etc/machine-id:ro
     networks:
       - secondlayer-stage-network
     restart: unless-stopped


### PR DESCRIPTION
## Problem
`/admin/containers` page showed no container data. cAdvisor v0.49.1 used Docker client that negotiates API version starting at v1.41, but Docker 27+ requires minimum v1.44. Docker factory registration failed silently, cAdvisor fell back to containerd which lacks the `name` label — making all Prometheus queries with `name=~".+"` return 0 results.

## Fix
- **Upgrade cAdvisor v0.49.1 → v0.55.1** — supports Docker API 1.44+, Docker factory registers successfully
- **`-docker_only=true`** — use Docker API (includes `name` label per container)
- **`-housekeeping_interval=30s`** — reduce CPU overhead (default was 1s)
- **`-disable_metrics=...`** — disable unused metrics
- **Stage**: add missing `privileged: true`, `devices: [/dev/kmsg]`, full volume mounts (`/:/rootfs:ro`, `/var/run:/var/run:ro`, etc.), `DOCKER_API_VERSION=1.44`

## Verified
Prometheus now returns 17 container metrics with `name` labels (minio-local, grafana-local, nginx-local, etc.)

## Test plan
- [ ] Open `/admin/containers` — container cards appear with CPU/memory bars
- [ ] 1h/6h/24h time range selectors work
- [ ] Charts show per-container CPU and memory history

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing container metrics on Docker 27+ by upgrading cAdvisor to v0.55.1 and enabling Docker-only mode. Restores container name labels so /admin/containers shows data again, with lower CPU overhead.

- **Bug Fixes**
  - Upgrade cAdvisor v0.49.1 → v0.55.1 (supports Docker API ≥ v1.44)
  - Use Docker-only mode and set DOCKER_API_VERSION=1.44 to restore name labels
  - Add privileged, /dev/kmsg, and full mounts on stage; align local and stage configs
  - Set housekeeping_interval=30s and disable unused metrics to cut CPU usage

<sup>Written for commit bf9f61f419c827a75ec44b8cb23cab3da685be3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

