### PR TITLE
feat(admin): one-time password reset for users + fix deploy seed

### DIFF
--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -325,6 +325,8 @@ export const api = {
         : apiClient.delete(`/api/admin/users/${userId}/tags/test`),
     createTestUser: (data: { email: string; name?: string; password: string; credits: number }) =>
       apiClient.post('/api/admin/test-users', data),
+    resetUserPassword: (id: string) =>
+      apiClient.post(`/api/admin/users/${id}/reset-password`),
 
     getImportSamples: (hours: number = 24, limit: number = 5) =>
       apiClient.get('/api/admin/import-samples', { params: { hours, limit } }),

--- a/mcp_backend/src/scripts/seed-admin-user.ts
+++ b/mcp_backend/src/scripts/seed-admin-user.ts
@@ -62,7 +62,6 @@ async function seedAdminUser(db: Database, admin: AdminEntry) {
     `INSERT INTO users (email, name, password_hash, email_verified, role, is_admin)
      VALUES ($1, $2, $3, TRUE, 'administrator', TRUE)
      ON CONFLICT (email) DO UPDATE SET
-       password_hash = $3,
        role = 'administrator',
        is_admin = TRUE,
        updated_at = CURRENT_TIMESTAMP


### PR DESCRIPTION
## Summary
- Admin can generate a new secure password for any user via the key icon in the users table
- Password shown **once only** in a modal (like API key reveal) — only bcrypt hash stored, no copy button
- Confirm dialog warns admin before generating; result modal requires explicit dismiss
- Fix `seed-admin-user.ts`: `ON CONFLICT` no longer overwrites `password_hash`, so passwords changed via admin panel survive redeployments (local + stage)

## Security
- 16-char random password from URL-safe charset (letters + digits + symbols), using `crypto.randomBytes`
- bcrypt cost factor 12
- `failed_login_attempts` and `locked_until` reset on password change
- Admin action logged via `logAdminAction`

## Test plan
- [ ] Click key icon on a user row → confirm modal appears with user email
- [ ] Click "Generate" → result modal shows password in monospace, no copy button
- [ ] Dismiss → password gone, not retrievable from UI
- [ ] Verify user can log in with new password
- [ ] Redeploy locally → manually-reset admin password is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-time admin password reset with a secure, randomly generated password that’s shown once. Also ensures admin-set passwords aren’t overwritten on redeploy.

- **New Features**
  - Key icon in the users table opens a confirm modal to generate a new password.
  - POST /api/admin/users/:id/reset-password creates a 16-char password via crypto.randomBytes; bcrypt cost 12; only the hash is stored.
  - Result modal reveals the password once, with explicit dismiss; no copy button.
  - Resets failed_login_attempts and locked_until; action is logged with logAdminAction.

- **Bug Fixes**
  - seed-admin-user.ts no longer overwrites password_hash on ON CONFLICT, preserving manual admin password changes across deployments.

<sup>Written for commit 8564c15539b831b7a54c1d35a3ae44f5b1c551f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

