### PR TITLE
feat(deploy): show branded maintenance page via Cloudflare Workers during redeploy

### DIFF
--- a/deployment/maintenance/cf-maintenance.sh
+++ b/deployment/maintenance/cf-maintenance.sh
@@ -1,0 +1,338 @@
+#!/bin/bash
+##############################################################################
+# Cloudflare Maintenance Mode — SecondLayer
+#
+# Toggles a branded "We'll be right back" page on Cloudflare edge
+# by creating/deleting Worker Routes that point to a resident Worker script.
+#
+# Usage:
+#   cf-maintenance.sh enable    # activate maintenance page on all domains
+#   cf-maintenance.sh disable   # deactivate maintenance page
+#   cf-maintenance.sh status    # show current routes
+#   cf-maintenance.sh setup     # first-time: deploy worker + show zone info
+#
+# Reads credentials from: <repo-root>/.env.cloudflare
+##############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Colours ──────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+BLUE='\033[0;34m'; CYAN='\033[0;36m'; NC='\033[0m'
+log()  { echo -e "${BLUE}[cf-maintenance]${NC} $*"; }
+ok()   { echo -e "${GREEN}[cf-maintenance]${NC} $*"; }
+warn() { echo -e "${YELLOW}[cf-maintenance]${NC} $*"; }
+err()  { echo -e "${RED}[cf-maintenance]${NC} $*" >&2; }
+
+# ── Load .env.cloudflare ─────────────────────────────────────────────────────
+CF_ENV_FILE="$REPO_ROOT/.env.cloudflare"
+if [ ! -f "$CF_ENV_FILE" ]; then
+    err ".env.cloudflare not found at $CF_ENV_FILE"
+    exit 1
+fi
+
+# Export vars from file (skip comments and blank lines)
+set -a
+# shellcheck disable=SC1090
+source <(grep -v '^\s*#' "$CF_ENV_FILE" | grep -v '^\s*$')
+set +a
+
+if [ -z "${CLOUDFLARE_GLOBAL_API_KEY:-}" ] || [ -z "${CLOUDFLARE_EMAIL:-}" ]; then
+    err "CLOUDFLARE_GLOBAL_API_KEY and CLOUDFLARE_EMAIL must be set in $CF_ENV_FILE"
+    exit 1
+fi
+
+# ── Config ────────────────────────────────────────────────────────────────────
+CF_API="https://api.cloudflare.com/client/v4"
+WORKER_NAME="secondlayer-maintenance"
+WORKER_FILE="$SCRIPT_DIR/maintenance-worker.js"
+
+# Primary zone (all subdomains live here)
+PRIMARY_DOMAIN="legal.org.ua"
+
+# Patterns to intercept during maintenance
+# Add/remove entries as needed
+MAINTENANCE_PATTERNS=(
+    "legal.org.ua/*"
+    "stage.legal.org.ua/*"
+    "mcp.legal.org.ua/*"
+    "localdev.legal.org.ua/*"
+)
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+cf_get() {
+    local path=$1
+    curl -sf \
+        -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+        -H "X-Auth-Key: $CLOUDFLARE_GLOBAL_API_KEY" \
+        -H "Content-Type: application/json" \
+        "${CF_API}${path}"
+}
+
+cf_post() {
+    local path=$1; local data=$2
+    curl -sf -X POST \
+        -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+        -H "X-Auth-Key: $CLOUDFLARE_GLOBAL_API_KEY" \
+        -H "Content-Type: application/json" \
+        -d "$data" \
+        "${CF_API}${path}"
+}
+
+cf_put_file() {
+    local path=$1; local file=$2
+    curl -sf -X PUT \
+        -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+        -H "X-Auth-Key: $CLOUDFLARE_GLOBAL_API_KEY" \
+        -H "Content-Type: application/javascript" \
+        --data-binary @"$file" \
+        "${CF_API}${path}"
+}
+
+cf_delete() {
+    local path=$1
+    curl -sf -X DELETE \
+        -H "X-Auth-Email: $CLOUDFLARE_EMAIL" \
+        -H "X-Auth-Key: $CLOUDFLARE_GLOBAL_API_KEY" \
+        "${CF_API}${path}"
+}
+
+check_success() {
+    local resp=$1; local label=${2:-"operation"}
+    local success
+    success=$(echo "$resp" | python3 -c \
+        "import sys,json; d=json.load(sys.stdin); print(str(d.get('success',False)).lower())" 2>/dev/null || echo "false")
+    if [ "$success" != "true" ]; then
+        local errors
+        errors=$(echo "$resp" | python3 -c \
+            "import sys,json; d=json.load(sys.stdin); print('; '.join(e.get('message','?') for e in d.get('errors',[])))" 2>/dev/null || echo "unknown")
+        err "$label failed: $errors"
+        return 1
+    fi
+    return 0
+}
+
+# ── Get account ID ────────────────────────────────────────────────────────────
+get_account_id() {
+    local resp
+    resp=$(cf_get "/accounts?per_page=1")
+    python3 -c \
+        "import sys,json; d=json.load(sys.stdin); print(d['result'][0]['id'])" <<< "$resp"
+}
+
+# ── Get zone ID for PRIMARY_DOMAIN ────────────────────────────────────────────
+get_zone_id() {
+    local resp
+    resp=$(cf_get "/zones?name=${PRIMARY_DOMAIN}&status=active")
+    local zone_id
+    zone_id=$(python3 -c \
+        "import sys,json; d=json.load(sys.stdin); r=d.get('result',[]); print(r[0]['id'] if r else '')" <<< "$resp")
+    if [ -z "$zone_id" ]; then
+        err "Zone for ${PRIMARY_DOMAIN} not found or not active in this CF account"
+        exit 1
+    fi
+    echo "$zone_id"
+}
+
+# ── Deploy Worker script ──────────────────────────────────────────────────────
+deploy_worker() {
+    local account_id=$1
+    if [ ! -f "$WORKER_FILE" ]; then
+        err "Worker file not found: $WORKER_FILE"
+        exit 1
+    fi
+    log "Uploading Worker '${WORKER_NAME}' to Cloudflare..."
+    local resp
+    resp=$(cf_put_file "/accounts/${account_id}/workers/scripts/${WORKER_NAME}" "$WORKER_FILE")
+    if check_success "$resp" "Worker upload"; then
+        ok "Worker '${WORKER_NAME}' deployed"
+    else
+        exit 1
+    fi
+}
+
+# ── List current maintenance routes ──────────────────────────────────────────
+list_routes() {
+    local zone_id=$1
+    local resp
+    resp=$(cf_get "/zones/${zone_id}/workers/routes")
+    python3 - <<PYEOF "$resp"
+import sys, json
+data = json.loads(sys.argv[1])
+routes = [r for r in data.get('result', []) if r.get('script') == '${WORKER_NAME}']
+if not routes:
+    print("  (no active maintenance routes)")
+else:
+    for r in routes:
+        print(f"  {r['id']}  {r['pattern']}")
+PYEOF
+}
+
+# ── Enable: create routes for all patterns ────────────────────────────────────
+enable_maintenance() {
+    log "Enabling Cloudflare maintenance mode..."
+
+    local account_id zone_id
+    account_id=$(get_account_id)
+    zone_id=$(get_zone_id)
+
+    # Ensure Worker is deployed/up-to-date
+    deploy_worker "$account_id"
+
+    # Get existing routes to avoid duplicates
+    local existing
+    existing=$(cf_get "/zones/${zone_id}/workers/routes")
+    local existing_patterns
+    existing_patterns=$(python3 -c \
+        "import sys,json; d=json.load(sys.stdin); print('\n'.join(r['pattern'] for r in d.get('result',[]) if r.get('script')=='${WORKER_NAME}'))" <<< "$existing")
+
+    local created=0 skipped=0
+
+    for pattern in "${MAINTENANCE_PATTERNS[@]}"; do
+        if echo "$existing_patterns" | grep -qxF "$pattern" 2>/dev/null; then
+            warn "Route already active: $pattern"
+            ((skipped++)) || true
+            continue
+        fi
+
+        local resp
+        resp=$(cf_post "/zones/${zone_id}/workers/routes" \
+            "{\"pattern\": \"${pattern}\", \"script\": \"${WORKER_NAME}\"}")
+
+        local success
+        success=$(python3 -c \
+            "import sys,json; d=json.load(sys.stdin); print(str(d.get('success',False)).lower())" <<< "$resp" 2>/dev/null || echo "false")
+
+        if [ "$success" = "true" ]; then
+            local route_id
+            route_id=$(python3 -c \
+                "import sys,json; d=json.load(sys.stdin); print(d['result']['id'])" <<< "$resp" 2>/dev/null || echo "?")
+            ok "  Route created: $pattern  (id: $route_id)"
+            ((created++)) || true
+        else
+            # Non-fatal: some patterns (e.g. localdev) may not be CF-proxied
+            local errmsg
+            errmsg=$(python3 -c \
+                "import sys,json; d=json.load(sys.stdin); print('; '.join(e.get('message','?') for e in d.get('errors',[])))" <<< "$resp" 2>/dev/null || echo "unknown")
+            warn "  Skipped $pattern: $errmsg"
+        fi
+    done
+
+    ok "Maintenance mode ENABLED (created: $created, skipped/failed: $skipped / $((${#MAINTENANCE_PATTERNS[@]} - created - skipped)) )"
+    echo ""
+    echo -e "${CYAN}Active routes:${NC}"
+    list_routes "$zone_id"
+}
+
+# ── Disable: delete all maintenance routes ────────────────────────────────────
+disable_maintenance() {
+    log "Disabling Cloudflare maintenance mode..."
+
+    local zone_id
+    zone_id=$(get_zone_id)
+
+    local routes_resp
+    routes_resp=$(cf_get "/zones/${zone_id}/workers/routes")
+
+    local route_ids
+    route_ids=$(python3 -c \
+        "import sys,json; d=json.load(sys.stdin); [print(r['id']) for r in d.get('result',[]) if r.get('script')=='${WORKER_NAME}']" \
+        <<< "$routes_resp")
+
+    if [ -z "$route_ids" ]; then
+        ok "No active maintenance routes found — site already live"
+        return 0
+    fi
+
+    local deleted=0
+    while IFS= read -r route_id; do
+        [ -z "$route_id" ] && continue
+        local resp
+        resp=$(cf_delete "/zones/${zone_id}/workers/routes/${route_id}")
+        local success
+        success=$(python3 -c \
+            "import sys,json; d=json.load(sys.stdin); print(str(d.get('success',False)).lower())" <<< "$resp" 2>/dev/null || echo "false")
+        if [ "$success" = "true" ]; then
+            ok "  Deleted route: $route_id"
+            ((deleted++)) || true
+        else
+            warn "  Could not delete route $route_id (may already be gone)"
+        fi
+    done <<< "$route_ids"
+
+    ok "Maintenance mode DISABLED (removed $deleted route(s)) — site is LIVE"
+}
+
+# ── Status ────────────────────────────────────────────────────────────────────
+show_status() {
+    log "Checking Cloudflare maintenance status..."
+    local zone_id
+    zone_id=$(get_zone_id)
+
+    local routes_resp
+    routes_resp=$(cf_get "/zones/${zone_id}/workers/routes")
+
+    local count
+    count=$(python3 -c \
+        "import sys,json; d=json.load(sys.stdin); print(len([r for r in d.get('result',[]) if r.get('script')=='${WORKER_NAME}']))" \
+        <<< "$routes_resp")
+
+    if [ "$count" -gt 0 ]; then
+        warn "MAINTENANCE MODE IS ACTIVE ($count route(s))"
+    else
+        ok "Site is LIVE — no active maintenance routes"
+    fi
+    echo ""
+    echo -e "${CYAN}Maintenance Worker routes (script='${WORKER_NAME}'):${NC}"
+    list_routes "$zone_id"
+
+    echo ""
+    echo -e "${CYAN}All Worker routes in zone:${NC}"
+    python3 - <<PYEOF "$routes_resp"
+import sys, json
+data = json.loads(sys.argv[1])
+routes = data.get('result', [])
+if not routes:
+    print("  (none)")
+for r in routes:
+    print(f"  {r.get('id','-')[:12]}  {r['pattern']:40s}  script={r.get('script','—')}")
+PYEOF
+}
+
+# ── Setup (first-time) ────────────────────────────────────────────────────────
+run_setup() {
+    log "Running first-time setup..."
+    local account_id zone_id
+    account_id=$(get_account_id)
+    zone_id=$(get_zone_id)
+
+    ok "Account ID : $account_id"
+    ok "Zone ID    : $zone_id  ($PRIMARY_DOMAIN)"
+
+    deploy_worker "$account_id"
+
+    ok ""
+    ok "Setup complete. Run './cf-maintenance.sh enable' before a deploy,"
+    ok "and './cf-maintenance.sh disable' after."
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+CMD="${1:-}"
+case "$CMD" in
+    enable)   enable_maintenance  ;;
+    disable)  disable_maintenance ;;
+    status)   show_status         ;;
+    setup)    run_setup           ;;
+    *)
+        echo "Usage: $0 <enable|disable|status|setup>"
+        echo ""
+        echo "  setup    — deploy worker script to Cloudflare (first-time)"
+        echo "  enable   — activate maintenance page on all domains"
+        echo "  disable  — deactivate maintenance page, site goes live"
+        echo "  status   — show current maintenance routes"
+        exit 1
+        ;;
+esac

--- a/deployment/maintenance/maintenance-worker.js
+++ b/deployment/maintenance/maintenance-worker.js
@@ -1,0 +1,184 @@
+/**
+ * SecondLayer Maintenance Mode Worker
+ * Served by Cloudflare edge during backend redeployment.
+ * Returns HTTP 503 with a branded bilingual maintenance page.
+ */
+
+const MAINTENANCE_HTML = `<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="60">
+  <title>SecondLayer — Технічне обслуговування / Maintenance</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:ital,wght@0,400;0,600;1,400&family=Inter:wght@400;500&display=swap" rel="stylesheet">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+      min-height: 100vh;
+      background: #F5F5F0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      color: #2D2D2D;
+    }
+
+    .container {
+      text-align: center;
+      padding: 3rem 2rem;
+      max-width: 540px;
+      width: 100%;
+    }
+
+    .logo-wrap {
+      margin: 0 auto 2rem;
+      width: 88px;
+      height: 88px;
+      animation: breathe 3.5s ease-in-out infinite;
+    }
+
+    @keyframes breathe {
+      0%, 100% { transform: scale(1);   opacity: 1;    }
+      50%       { transform: scale(.96); opacity: .75; }
+    }
+
+    .brand {
+      font-family: 'Crimson Pro', Georgia, 'Times New Roman', serif;
+      font-size: 1.5rem;
+      font-weight: 600;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: #2D2D2D;
+      margin-bottom: 2rem;
+    }
+    .brand em { color: #D97757; font-style: normal; }
+
+    .divider {
+      width: 44px;
+      height: 2px;
+      background: linear-gradient(90deg, #D97757, #E8A07D);
+      margin: 0 auto 2.25rem;
+      border-radius: 2px;
+    }
+
+    .msg-en {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 2.4rem;
+      font-weight: 600;
+      line-height: 1.15;
+      color: #2D2D2D;
+      margin-bottom: .6rem;
+    }
+
+    .msg-uk {
+      font-family: 'Crimson Pro', Georgia, serif;
+      font-size: 1.9rem;
+      font-weight: 400;
+      font-style: italic;
+      line-height: 1.25;
+      color: #6B6B6B;
+      margin-bottom: 2.25rem;
+    }
+
+    .sub {
+      font-size: .875rem;
+      color: #888;
+      line-height: 1.8;
+    }
+
+    .dots {
+      display: inline-flex;
+      gap: 7px;
+      margin-top: 2.5rem;
+    }
+    .dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: #D97757;
+      animation: bounce 1.5s ease-in-out infinite;
+    }
+    .dot:nth-child(2) { animation-delay: .22s; }
+    .dot:nth-child(3) { animation-delay: .44s; }
+
+    @keyframes bounce {
+      0%, 80%, 100% { transform: scale(.55); opacity: .35; }
+      40%           { transform: scale(1);   opacity: 1;   }
+    }
+
+    @media (max-width: 480px) {
+      .msg-en { font-size: 1.9rem; }
+      .msg-uk { font-size: 1.5rem; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+
+    <!-- Scales of Justice icon (inline SVG, no external deps) -->
+    <svg class="logo-wrap" viewBox="0 0 88 88" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="SecondLayer">
+      <!-- Background circle -->
+      <circle cx="44" cy="44" r="42" fill="#EDECEA" stroke="#E0DDD9" stroke-width="1.5"/>
+
+      <!-- Pole -->
+      <rect x="42.5" y="20" width="3" height="42" rx="1.5" fill="#2D2D2D"/>
+
+      <!-- Pivot cap -->
+      <circle cx="44" cy="20" r="4" fill="#D97757"/>
+
+      <!-- Horizontal beam -->
+      <rect x="18" y="31" width="52" height="3" rx="1.5" fill="#2D2D2D"/>
+
+      <!-- Left suspension line -->
+      <line x1="24" y1="34" x2="24" y2="44" stroke="#2D2D2D" stroke-width="1.8" stroke-linecap="round"/>
+      <!-- Right suspension line (slightly shorter → right pan higher) -->
+      <line x1="64" y1="34" x2="64" y2="41" stroke="#2D2D2D" stroke-width="1.8" stroke-linecap="round"/>
+
+      <!-- Left pan (lower) -->
+      <path d="M 16 46 Q 24 54 32 46" stroke="#D97757" stroke-width="2.2" fill="none" stroke-linecap="round"/>
+      <!-- Right pan (higher) -->
+      <path d="M 56 43 Q 64 51 72 43" stroke="#2D2D2D" stroke-width="2.2" fill="none" stroke-linecap="round" opacity=".55"/>
+
+      <!-- Base foot -->
+      <rect x="34" y="62" width="20" height="3.5" rx="1.75" fill="#2D2D2D"/>
+      <rect x="29" y="65.5" width="30" height="2.5" rx="1.25" fill="#2D2D2D"/>
+    </svg>
+
+    <div class="brand">Second<em>Layer</em></div>
+    <div class="divider"></div>
+
+    <div class="msg-en">We'll be right back!</div>
+    <div class="msg-uk">Ми незабаром повернемося!</div>
+
+    <p class="sub">
+      Scheduled system update in progress.<br>
+      Виконується планове оновлення системи.
+    </p>
+
+    <div class="dots">
+      <div class="dot"></div>
+      <div class="dot"></div>
+      <div class="dot"></div>
+    </div>
+
+  </div>
+</body>
+</html>`;
+
+addEventListener('fetch', event => {
+  event.respondWith(
+    new Response(MAINTENANCE_HTML, {
+      status: 503,
+      headers: {
+        'Content-Type':  'text/html; charset=UTF-8',
+        'Retry-After':   '300',
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'X-Robots-Tag':  'noindex, nofollow',
+      },
+    })
+  );
+});


### PR DESCRIPTION
## Summary

- **Cloudflare Worker** (`deployment/maintenance/maintenance-worker.js`) — self-contained 503 page served from Cloudflare edge while backend is being redeployed. Bilingual (English + Ukrainian), SecondLayer brand colours (`#F5F5F0` bg, `#D97757` accent), inline SVG scales-of-justice logo, animated bounce dots, auto-refreshes every 60 s.
- **Toggle script** (`deployment/maintenance/cf-maintenance.sh`) — uses CF Global API Key from `.env.cloudflare` to deploy the Worker and create/delete Worker Routes for `legal.org.ua`, `stage.legal.org.ua`, `mcp.legal.org.ua`, `localdev.legal.org.ua`. Commands: `setup | enable | disable | status`. Non-Cloudflare-proxied routes (e.g. `localdev`) produce a warning but do not abort.
- **`manage-gateway.sh` integration** — `enable_cf_maintenance()` is called after backup (Phase 2b, before containers stop); `disable_cf_maintenance()` is called once services are back up, in both the success path and both rollback paths, for both `stage` and `local` deploy flows.

## First-time setup (run once on the ops machine)
```bash
cd deployment
./maintenance/cf-maintenance.sh setup   # deploys Worker to CF account
```

## Test plan
- [ ] Run `./maintenance/cf-maintenance.sh setup` — confirm Worker appears in CF dashboard
- [ ] Run `./maintenance/cf-maintenance.sh enable` — visit `https://stage.legal.org.ua`, confirm 503 maintenance page appears with bilingual text and logo
- [ ] Run `./maintenance/cf-maintenance.sh disable` — confirm site loads normally
- [ ] Run `./maintenance/cf-maintenance.sh status` — shows active/inactive state
- [ ] Trigger `./manage-gateway.sh deploy stage` — observe maintenance page activate/deactivate automatically around the deploy window

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Cloudflare Worker-based maintenance mode that shows a branded bilingual 503 page during redeploys. Automatically toggled by the deploy scripts to give users a clear “we’ll be right back” experience.

- **New Features**
  - Cloudflare Worker returns a 503 maintenance page (EN/UK), brand colors, inline SVG, auto-refresh every 60s.
  - cf-maintenance.sh to setup/enable/disable/status; uses .env.cloudflare; toggles Worker Routes for legal.org.ua, stage, mcp, and localdev.
  - manage-gateway.sh enables maintenance after backup and disables when services are back, including rollback paths for local and stage.

- **Migration**
  - Add CLOUDFLARE_GLOBAL_API_KEY and CLOUDFLARE_EMAIL to .env.cloudflare.
  - Run deployment/maintenance/cf-maintenance.sh setup once to upload the Worker.

<sup>Written for commit 6050df1d6981ca13075fa85574f00f7fe43ca40b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

