### PR TITLE
feat(frontend): show right panel on all routes + auto-populate from chat store

### DIFF
--- a/lexwebapp/src/components/DocumentViewerModal.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { AnimatePresence, motion } from 'framer-motion';
-import { X, ExternalLink, Gavel, BookOpen, FileText, Copy, Check } from 'lucide-react';
+import { X, ExternalLink, Gavel, BookOpen, FileText, Copy, Check, Download } from 'lucide-react';
 
 interface DocumentViewerItem {
   type: 'decision' | 'citation' | 'document';
@@ -51,6 +51,17 @@ export function DocumentViewerModal({ isOpen, onClose, item }: DocumentViewerMod
     navigator.clipboard.writeText(item.content);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleSave = () => {
+    if (!item) return;
+    const blob = new Blob([item.content], { type: 'text/plain;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${item.title.replace(/[^\wа-яА-ЯёЁa-zA-Z0-9]/g, '_')}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
   };
 
   if (!item) return null;
@@ -131,6 +142,13 @@ export function DocumentViewerModal({ isOpen, onClose, item }: DocumentViewerMod
                       title="Копіювати"
                     >
                       {copied ? <Check size={16} strokeWidth={2} /> : <Copy size={16} strokeWidth={2} />}
+                    </button>
+                    <button
+                      onClick={handleSave}
+                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all"
+                      title="Зберегти як .txt"
+                    >
+                      <Download size={16} strokeWidth={2} />
                     </button>
                     {item.externalUrl && (
                       <a

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -100,9 +100,6 @@ export function MainLayout() {
 
   const pageTitle = getPageTitle();
 
-  // Hide right panel on admin routes
-  const isAdminRoute = location.pathname.startsWith('/admin');
-
   return (
     <div className="flex h-screen bg-claude-bg overflow-hidden">
       {/* Sidebar */}
@@ -171,21 +168,19 @@ export function MainLayout() {
             </h1>
           </div>
 
-          {/* Right: Toggle right panel button (hidden on admin routes) */}
+          {/* Right: Toggle right panel button */}
           <div className="flex items-center justify-end gap-2 w-[200px]">
-            {!isAdminRoute && (
-              <button
-                onClick={toggleRightPanel}
-                className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-lg transition-all duration-200"
-                title={isRightPanelOpen ? 'Сховати панель' : 'Показати панель'}
-              >
-                {isRightPanelOpen ? (
-                  <X size={18} strokeWidth={2} />
-                ) : (
-                  <PanelRightOpen size={18} strokeWidth={2} />
-                )}
-              </button>
-            )}
+            <button
+              onClick={toggleRightPanel}
+              className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-lg transition-all duration-200"
+              title={isRightPanelOpen ? 'Сховати панель' : 'Показати панель'}
+            >
+              {isRightPanelOpen ? (
+                <X size={18} strokeWidth={2} />
+              ) : (
+                <PanelRightOpen size={18} strokeWidth={2} />
+              )}
+            </button>
           </div>
         </header>
 
@@ -214,14 +209,12 @@ export function MainLayout() {
               />
             )}
           </div>
-          {!isAdminRoute && (
-            <button
-              onClick={() => useUIStore.getState().setRightPanelOpen(true)}
-              className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-lg transition-all duration-200"
-            >
-              <PanelRightOpen size={20} strokeWidth={2} />
-            </button>
-          )}
+          <button
+            onClick={() => useUIStore.getState().setRightPanelOpen(true)}
+            className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-lg transition-all duration-200"
+          >
+            <PanelRightOpen size={20} strokeWidth={2} />
+          </button>
         </header>
 
         {/* Main Content Area - Outlet renders child routes */}
@@ -230,15 +223,13 @@ export function MainLayout() {
         </div>
       </main>
 
-      {/* Right Panel (hidden on admin routes) */}
-      {!isAdminRoute && (
-        <div className={`${isRightPanelOpen ? 'block' : 'hidden'}`} style={{ width: isRightPanelOpen ? rightPanelWidth : 0 }}>
-          <RightPanel
-            isOpen={isRightPanelOpen}
-            onClose={() => useUIStore.getState().setRightPanelOpen(false)}
-          />
-        </div>
-      )}
+      {/* Right Panel */}
+      <div className={`${isRightPanelOpen ? 'block' : 'hidden'}`} style={{ width: isRightPanelOpen ? rightPanelWidth : 0 }}>
+        <RightPanel
+          isOpen={isRightPanelOpen}
+          onClose={() => useUIStore.getState().setRightPanelOpen(false)}
+        />
+      </div>
 
       {/* Time Tracker Widget */}
       <TimeTrackerWidget />


### PR DESCRIPTION
## Summary

- Removes `isAdminRoute` guard from `MainLayout` — the panel toggle button and `<RightPanel>` now render on all pages including `/admin/*`
- `RightPanel` subscribes to `useChatStore` and aggregates `decisions`, `citations`, and `documents` from all messages with deduplication by `id`, so it updates in real time during streaming
- `DocumentViewerModal` gains a **Зберегти** (Download) button that saves the displayed content as a `.txt` file

## Test plan

- [ ] Open `/chat`, send a query → right panel populates with decisions/norms in real time
- [ ] Navigate to `/admin/overview` → panel toggle visible in header, panel opens with accumulated chat evidence
- [ ] Click "Повний вигляд" on any card → modal opens with Download button; clicking it downloads a `.txt` file
- [ ] Mobile: panel opens as overlay with backdrop, close button works
- [ ] `cd lexwebapp && npm run build` — clean build, no TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the right panel on all routes and auto-populate it with decisions, citations, and documents from the chat store. Adds a Download button to the document viewer.

- **New Features**
  - Panel toggle and RightPanel are now visible on admin routes.
  - RightPanel aggregates evidence from useChatStore across all messages, deduplicates by id, and updates in real time.
  - DocumentViewerModal adds “Зберегти” to save the current content as a .txt file.

- **Refactors**
  - Removed the isAdminRoute guard in MainLayout; the panel and toggle always render.
  - RightPanel no longer receives decisions/citations/documents as props; it reads them from the store.

<sup>Written for commit 1100cf679ea99daa0a536864800a78323ff2616a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

