### PR TITLE
fix(chat): remove double billing charge and persist documents in right panel

### DIFF
--- a/mcp_backend/src/migrations/050_add_documents_to_conversation_messages.sql
+++ b/mcp_backend/src/migrations/050_add_documents_to_conversation_messages.sql
@@ -1,0 +1,5 @@
+-- Migration 050: Add documents column to conversation_messages
+-- Documents (vault files etc.) shown in right panel, analogous to decisions/citations
+
+ALTER TABLE conversation_messages
+  ADD COLUMN IF NOT EXISTS documents jsonb;

--- a/mcp_backend/src/routes/conversation-routes.ts
+++ b/mcp_backend/src/routes/conversation-routes.ts
@@ -97,7 +97,7 @@ export function createConversationRouter(conversationService: ConversationServic
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'User not authenticated' });
 
-      const { role, content, thinking_steps, decisions, citations, tool_calls, cost_tracking_id } = req.body;
+      const { role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id } = req.body;
       if (!role || !content) return res.status(400).json({ error: 'role and content required' });
 
       const message = await conversationService.addMessage(req.params.id as string, userId, {
@@ -106,6 +106,7 @@ export function createConversationRouter(conversationService: ConversationServic
         thinking_steps,
         decisions,
         citations,
+        documents,
         tool_calls,
         cost_tracking_id,
       });

--- a/mcp_backend/src/services/conversation-service.ts
+++ b/mcp_backend/src/services/conversation-service.ts
@@ -20,6 +20,7 @@ export interface ConversationMessage {
   thinking_steps?: any[];
   decisions?: any[];
   citations?: any[];
+  documents?: any[];
   tool_calls?: any[];
   cost_tracking_id?: string;
   created_at: Date;
@@ -98,6 +99,7 @@ export class ConversationService {
       thinking_steps?: any[];
       decisions?: any[];
       citations?: any[];
+      documents?: any[];
       tool_calls?: any[];
       cost_tracking_id?: string;
     }
@@ -109,8 +111,8 @@ export class ConversationService {
     const id = uuidv4();
     const result = await this.db.query(
       `INSERT INTO conversation_messages
-         (id, conversation_id, role, content, thinking_steps, decisions, citations, tool_calls, cost_tracking_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         (id, conversation_id, role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
        RETURNING *`,
       [
         id,
@@ -120,6 +122,7 @@ export class ConversationService {
         message.thinking_steps ? JSON.stringify(message.thinking_steps) : null,
         message.decisions ? JSON.stringify(message.decisions) : null,
         message.citations ? JSON.stringify(message.citations) : null,
+        message.documents ? JSON.stringify(message.documents) : null,
         message.tool_calls ? JSON.stringify(message.tool_calls) : null,
         message.cost_tracking_id || null,
       ]


### PR DESCRIPTION
## Summary

- **Double billing charge fixed**: Chat SSE route was calling `billingService.chargeUser()` _after_ `CostTracker.onTrackingComplete()` had already charged the user automatically. Each chat request was deducting cost twice (confirmed in stage logs: two `User charged with markup` entries per request). The duplicate `chargeUser()` call is removed; the route now only emits a `cost_summary` SSE event with the current balance from `getBillingSummary()`.
- **Documents not shown in right panel after reload**: The `documents` field (vault/uploaded files displayed in the right panel) was being sent by the frontend `syncMessage()` but was never extracted in `conversation-routes.ts`, never saved in `conversation-service.ts`, and the `conversation_messages` table had no `documents` column. Added migration 050, updated the service and route to persist and return `documents` alongside `decisions` and `citations`.

## Test plan

- [ ] Make a chat request as `test_user@legal.org.ua` — verify only one `User charged with markup` log entry per request
- [ ] Verify `cost_summary` SSE event still reaches the frontend with correct balance
- [ ] Upload a document / get tool results with documents, reload the page — documents should still appear in the right panel
- [ ] Run migration 050 on stage: `ALTER TABLE conversation_messages ADD COLUMN IF NOT EXISTS documents jsonb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double billing on chat requests and persists documents in conversation messages so right-panel files survive reloads.

- **Bug Fixes**
  - Removed duplicate post-chat charge; the route now only emits a cost_summary using the current balance from getBillingSummary.
  - Added documents to message handling and storage so uploaded/tool-generated files reappear after reload.

- **Migration**
  - Run migration 050: ALTER TABLE conversation_messages ADD COLUMN IF NOT EXISTS documents jsonb.

<sup>Written for commit f6523f084aab609086ba217c48e66e6ea049207c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

