### PR TITLE
fix(chat): replace max_tokens with max_completion_tokens and remove duplicate results in chat

### DIFF
--- a/lexwebapp/src/components/Message.tsx
+++ b/lexwebapp/src/components/Message.tsx
@@ -3,7 +3,7 @@ import { Copy, RotateCw, Star, ThumbsUp, ThumbsDown, ChevronDown } from 'lucide-
 import { motion, AnimatePresence } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { DecisionCard, Decision } from './DecisionCard';
+import type { Decision } from './DecisionCard';
 import { AnalyticsBlock } from './AnalyticsBlock';
 import { ThinkingSteps } from './ThinkingSteps';
 import { PlanDisplay } from './PlanDisplay';
@@ -315,59 +315,6 @@ export function Message({
                   ))}
                 </div>
               )}
-
-              {/* Citations */}
-              {citations && citations.length > 0 && <div className="space-y-3 mt-5">
-                  {citations.map((citation, idx) => <motion.div key={idx} initial={{
-              opacity: 0,
-              x: -10
-            }} animate={{
-              opacity: 1,
-              x: 0
-            }} transition={{
-              duration: 0.3,
-              delay: idx * 0.1
-            }} className="bg-claude-bg/80 backdrop-blur-sm border-l-4 border-claude-text/20 pl-5 pr-4 py-4 rounded-r-xl shadow-sm">
-                      <div className="flex items-start gap-4">
-                        <div className="text-5xl leading-none text-claude-subtext/20 font-serif select-none -mt-2">
-                          &ldquo;
-                        </div>
-                        <div className="flex-1 -mt-1">
-                          <p className="font-sans text-[15px] text-claude-text italic leading-relaxed mb-2">
-                            {citation.text}
-                          </p>
-                          <p className="text-[12px] text-claude-subtext font-semibold">
-                            — {citation.source}
-                          </p>
-                        </div>
-                      </div>
-                    </motion.div>)}
-                </div>}
-
-              {/* Decision Cards */}
-              {decisions && decisions.length > 0 && <div className="mt-5 space-y-3">
-                  <div className="flex items-center gap-2 text-[13px] font-semibold text-claude-text">
-                    <div className="w-1 h-4 bg-claude-subtext/40 rounded-full" />
-                    Релевантні судові рішення
-                    <span className="text-[11px] font-semibold text-claude-subtext bg-claude-subtext/8 px-2 py-0.5 rounded-full">
-                      {decisions.length}
-                    </span>
-                  </div>
-                  <div className="grid gap-3">
-                    {decisions.map((decision, idx) => <motion.div key={decision.id} initial={{
-                opacity: 0,
-                y: 10
-              }} animate={{
-                opacity: 1,
-                y: 0
-              }} transition={{
-                duration: 0.3,
-                delay: idx * 0.1
-              }}>
-                        <DecisionCard decision={decision} />
-                      </motion.div>)}
-                  </div>
-                </div>}
 
               {/* Analytics Block */}
               {analytics && <AnalyticsBlock data={analytics} />}

--- a/mcp_backend/src/services/legislation-classifier.ts
+++ b/mcp_backend/src/services/legislation-classifier.ts
@@ -144,7 +144,7 @@ ${availableCodes}
           { role: 'user', content: query },
         ],
         temperature: 0.2, // Низкая температура для более детерминированных результатов
-        max_tokens: 300,
+        max_completion_tokens: 300,
       };
 
       if (supportsJsonMode) {

--- a/mcp_backend/src/services/query-planner.ts
+++ b/mcp_backend/src/services/query-planner.ts
@@ -71,7 +71,7 @@ export class QueryPlanner {
             },
           ],
           temperature: 0.3,
-          max_tokens: 500,
+          max_completion_tokens: 500,
         };
 
         if (supportsJsonMode) {
@@ -459,7 +459,7 @@ export class QueryPlanner {
             },
           ],
           temperature: 0.2,
-          max_tokens: 100,
+          max_completion_tokens: 100,
         };
 
         if (supportsJsonMode) {

--- a/mcp_backend/src/services/semantic-sectionizer.ts
+++ b/mcp_backend/src/services/semantic-sectionizer.ts
@@ -235,7 +235,7 @@ export class SemanticSectionizer {
           },
         ],
           temperature: 0.2,
-          max_tokens: 2000,
+          max_completion_tokens: 2000,
           response_format: { type: 'json_object' },
         });
       });

--- a/mcp_backend/src/services/template-system/TemplateClassifier.ts
+++ b/mcp_backend/src/services/template-system/TemplateClassifier.ts
@@ -95,7 +95,7 @@ export class TemplateClassifier {
             },
           ],
           temperature: 0.3,
-          max_tokens: 500,
+          max_completion_tokens: 500,
         });
       });
 

--- a/mcp_backend/src/utils/html-parser.ts
+++ b/mcp_backend/src/utils/html-parser.ts
@@ -236,7 +236,7 @@ export async function extractSearchTermsWithAI(text: string): Promise<{
           },
         ],
         temperature: 0.3,
-        max_tokens: 500,
+        max_completion_tokens: 500,
         response_format: { type: 'json_object' },
       });
     });


### PR DESCRIPTION
## Summary

- **Backend**: Replace deprecated `max_tokens` with `max_completion_tokens` in all direct OpenAI API calls (`semantic-sectionizer`, `query-planner`, `legislation-classifier`, `TemplateClassifier`, `html-parser`). Newer OpenAI models (`gpt-5.1`, `gpt-5-mini`) reject `max_tokens` with HTTP 400 — this was causing `LLM-assisted extraction error` on stage.
- **Frontend**: Remove Decision Cards and Citations rendering from `Message.tsx`. These were being rendered both in the chat window AND in the RightPanel, which was redundant. Now they only appear in the RightPanel as intended.

## Test plan

- [ ] Make a chat query on stage that triggers document analysis (e.g. load full texts) — no more 400 errors in logs
- [ ] Verify court decisions and citations appear only in the right panel, not duplicated in the chat message body
- [ ] Confirm the `isRawJsonContent` guard still shows "Результати відображені на панелі праворуч." when LLM returns raw JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 400 errors from newer OpenAI models by switching to max_completion_tokens and removes duplicate results from the chat UI. This stabilizes document analysis and keeps decision data in the RightPanel only.

- **Bug Fixes**
  - Backend: Replaced max_tokens with max_completion_tokens in semantic-sectionizer, query-planner, legislation-classifier, TemplateClassifier, and html-parser to stop 400s on gpt-5.1/gpt-5-mini.
  - Frontend: Removed Decision Cards and Citations from Message.tsx to prevent duplicates; they now render only in the RightPanel.

<sup>Written for commit 1665c682bd8a00cc8e2499ae7a2e5fbf7fc2a207. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

