### PR TITLE
fix(deploy): bust Docker cache for lexwebapp on every new commit

### DIFF
--- a/lexwebapp/Dockerfile
+++ b/lexwebapp/Dockerfile
@@ -10,6 +10,9 @@ COPY lexwebapp/package.json lexwebapp/package-lock.json* ./
 # Install dependencies directly in lexwebapp
 RUN npm install --legacy-peer-deps
 
+# Cache-bust: copy git HEAD ref so Docker invalidates cache on every new commit
+COPY .git/HEAD .git/HEAD
+
 # Accept build arguments
 ARG BUILD_ENV=staging
 ARG VITE_API_URL=https://stage.legal.org.ua/api


### PR DESCRIPTION
## Summary
- Adds `COPY .git/HEAD .git/HEAD` to `lexwebapp/Dockerfile` before the source copy step
- Docker BuildKit invalidates the cache on every new git commit, preventing stale cached builds from being deployed
- Root cause of the recurring issue where stage showed old UI after deployment

## Test plan
- [ ] Deploy to stage and verify the new JS bundle filenames change after each deployment
- [ ] Confirm new frontend code (norms fix, structured blocks) appears immediately after `manage-gateway deploy stage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bust Docker cache for lexwebapp so every new commit triggers a fresh build. Prevents stale frontend bundles from being deployed to stage.

- **Bug Fixes**
  - Copy .git/HEAD before the source copy step in lexwebapp/Dockerfile.
  - Forces BuildKit to invalidate the cache on each commit, ensuring new UI assets are built and deployed.

<sup>Written for commit 9b99f24c65c7cde00fb9a910a1a92b39f60eda1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

