### PR TITLE
feat(infra): dedicated terminal-service container (Debian) for admin shell

### DIFF
--- a/deployment/Dockerfile.terminal-service
+++ b/deployment/Dockerfile.terminal-service
@@ -1,0 +1,18 @@
+FROM node:20-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sudo git curl wget vim nano jq \
+    postgresql-client redis-tools \
+    python3 make g++ \
+    htop procps ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY terminal-service/package.json ./
+RUN npm install
+
+COPY terminal-service/server.js ./
+
+WORKDIR /workspace
+EXPOSE 3010
+CMD ["node", "/app/server.js"]

--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -312,6 +312,9 @@ services:
       ADMIN_USER_EMAIL: ${ADMIN_USER_EMAIL:-admin@legal.org.ua}
       ADMIN_USER_PASSWORD: ${ADMIN_USER_PASSWORD:-admin123456}
 
+      # Terminal service (dedicated Debian container for admin shell)
+      TERMINAL_SERVICE_URL: ws://terminal-service-local:3010
+
     ports:
       - "3000:3000"  # Standard backend port
 
@@ -648,6 +651,56 @@ services:
         reservations:
           cpus: '0.25'
           memory: 256M
+
+  # ===== Terminal Service (Debian shell for admins) =====
+
+  terminal-service-local:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.terminal-service
+    image: terminal-service:latest
+    container_name: terminal-service-local
+    restart: unless-stopped
+    networks:
+      - secondlayer-local
+    environment:
+      TERMINAL_CWD: /workspace/mcp_backend
+      MAX_SESSIONS: "10"
+      NODE_ENV: development
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD:-local_dev_password}@postgres-local:5432/${POSTGRES_DB:-secondlayer_local}
+      POSTGRES_HOST: postgres-local
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-local_dev_password}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_local}
+      REDIS_URL: redis://redis-local:6379
+      REDIS_HOST: redis-local
+      REDIS_PORT: 6379
+      QDRANT_URL: http://qdrant-local:6333
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
+      OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
+      OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
+      ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN:-}
+      SECONDARY_LAYER_KEYS: ${SECONDARY_LAYER_KEYS:-local-dev-key}
+      JWT_SECRET: ${JWT_SECRET:-local-dev-jwt-secret-change-in-production}
+      LOG_LEVEL: debug
+    volumes:
+      - ../:/workspace
+    depends_on:
+      postgres-local:
+        condition: service_healthy
+      redis-local:
+        condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+    # NO ports exposed — only accessible via Docker internal network
 
   # MinIO - S3-compatible object storage for media/large files
   minio-local:

--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -486,11 +486,11 @@ deploy_local() {
         print_msg "$BLUE" "Stopping app containers (keeping databases running)..."
         $compose_cmd $compose_args stop \
             app-local rada-mcp-app-local app-openreyestr-local \
-            document-service-local nginx-local lexwebapp-local lexwebapp-deps-local \
+            document-service-local terminal-service-local nginx-local lexwebapp-local lexwebapp-deps-local \
             2>/dev/null || true
         $compose_cmd $compose_args rm -f \
             app-local rada-mcp-app-local app-openreyestr-local \
-            document-service-local nginx-local lexwebapp-local lexwebapp-deps-local \
+            document-service-local terminal-service-local nginx-local lexwebapp-local lexwebapp-deps-local \
             migrate-local rada-migrate-local migrate-openreyestr-local \
             rada-db-init-local \
             2>/dev/null || true
@@ -516,6 +516,7 @@ deploy_local() {
             rada-migrate-local \
             migrate-openreyestr-local \
             document-service-local \
+            terminal-service-local \
             lexwebapp-local \
             nginx-local
 
@@ -539,7 +540,7 @@ deploy_local() {
         print_msg "$BLUE" "Installing frontend dependencies..."
         $compose_cmd $compose_args up lexwebapp-deps-local
         print_msg "$BLUE" "Starting application services..."
-        $compose_cmd $compose_args up -d app-local rada-mcp-app-local app-openreyestr-local document-service-local lexwebapp-local nginx-local
+        $compose_cmd $compose_args up -d app-local rada-mcp-app-local app-openreyestr-local document-service-local terminal-service-local lexwebapp-local nginx-local
 
         # Step 9: Start monitoring services
         print_msg "$BLUE" "Starting monitoring services..."

--- a/terminal-service/package.json
+++ b/terminal-service/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "terminal-service",
+  "version": "1.0.0",
+  "main": "server.js",
+  "dependencies": {
+    "node-pty": "^1.0.0",
+    "ws": "^8.18.0"
+  }
+}

--- a/terminal-service/server.js
+++ b/terminal-service/server.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const http = require('http');
+const { WebSocketServer } = require('ws');
+const pty = require('node-pty');
+
+const PORT = parseInt(process.env.TERMINAL_PORT || '3010', 10);
+const CWD = process.env.TERMINAL_CWD || '/workspace/mcp_backend';
+const MAX_SESSIONS = parseInt(process.env.MAX_SESSIONS || '10', 10);
+
+let activeSessions = 0;
+
+// Build env for bash: pass all container env vars through
+function buildEnv() {
+  const env = Object.assign({}, process.env);
+  env.TERM = 'xterm-256color';
+  env.COLORTERM = 'truecolor';
+  return env;
+}
+
+const httpServer = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok', sessions: activeSessions, maxSessions: MAX_SESSIONS }));
+    return;
+  }
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+const wss = new WebSocketServer({ server: httpServer });
+
+wss.on('connection', (ws) => {
+  if (activeSessions >= MAX_SESSIONS) {
+    ws.send(JSON.stringify({ type: 'error', data: `Max ${MAX_SESSIONS} sessions reached` }));
+    ws.close(4029, 'Too many sessions');
+    return;
+  }
+
+  activeSessions++;
+  console.log(`[terminal-service] Session opened. Active: ${activeSessions}`);
+
+  let cols = 120;
+  let rows = 30;
+
+  const ptyProcess = pty.spawn('bash', [], {
+    name: 'xterm-256color',
+    cols,
+    rows,
+    cwd: CWD,
+    env: buildEnv(),
+  });
+
+  ptyProcess.onData((data) => {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify({ type: 'output', data }));
+    }
+  });
+
+  ptyProcess.onExit(({ exitCode }) => {
+    if (ws.readyState === ws.OPEN) {
+      ws.send(JSON.stringify({ type: 'exit', exitCode }));
+      ws.close();
+    }
+  });
+
+  ws.on('message', (raw) => {
+    try {
+      const msg = JSON.parse(raw.toString());
+      if (msg.type === 'input' && typeof msg.data === 'string') {
+        ptyProcess.write(msg.data);
+      } else if (msg.type === 'resize') {
+        const newCols = Math.max(1, Math.min(500, parseInt(msg.cols, 10) || 80));
+        const newRows = Math.max(1, Math.min(200, parseInt(msg.rows, 10) || 24));
+        ptyProcess.resize(newCols, newRows);
+      }
+    } catch {
+      // ignore malformed messages
+    }
+  });
+
+  ws.on('close', () => {
+    activeSessions--;
+    console.log(`[terminal-service] Session closed. Active: ${activeSessions}`);
+    try { ptyProcess.kill(); } catch { /* already dead */ }
+  });
+
+  ws.on('error', (err) => {
+    console.error('[terminal-service] WebSocket error:', err.message);
+  });
+});
+
+httpServer.listen(PORT, '0.0.0.0', () => {
+  console.log(`[terminal-service] Terminal service on port ${PORT}`);
+  console.log(`[terminal-service] Default CWD: ${CWD}, Max sessions: ${MAX_SESSIONS}`);
+});


### PR DESCRIPTION
## Summary

- Adds a dedicated `terminal-service` Debian Bookworm container that owns the PTY + bash, isolating it from the backend process
- Backend (`mcp_backend`) keeps JWT auth + session tracking and **proxies** the WebSocket to `terminal-service-local:3010` via Docker internal network
- Falls back to direct node-pty if `TERMINAL_SERVICE_URL` is not set (stage compatibility)

## Architecture

```
Browser (xterm.js) → nginx → mcp_backend:3000 (JWT auth) → terminal-service-local:3010 (bash, Debian, apt)
```

## What's included

- `terminal-service/server.js` — standalone WS server, bash via node-pty, full env vars (DB, Redis, OpenAI, etc.) passed to shell
- `deployment/Dockerfile.terminal-service` — `node:20-bookworm-slim` + `postgresql-client redis-tools sudo git curl vim jq htop`
- `deployment/docker-compose.local.yml` — `terminal-service-local` service (no exposed ports) + `TERMINAL_SERVICE_URL` in `app-local`
- `deployment/manage-gateway.sh` — terminal-service-local added to build/stop/start commands
- `mcp_backend/src/routes/terminal-routes.ts` — proxy mode when env set, direct PTY fallback otherwise

## Test plan

- [ ] `./manage-gateway.sh deploy local` — all containers healthy including `terminal-service-local`
- [ ] Open `/admin/terminal` as admin → bash prompt at `/workspace/mcp_backend`
- [ ] `sudo apt install -y wget` → installs successfully
- [ ] `node -e "console.log(process.env.DATABASE_URL)"` → shows DB connection string
- [ ] `redis-cli -h $REDIS_HOST ping` → PONG
- [ ] Kill terminal session → backend stays up (process isolation confirmed)

Linear: LEG-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated Debian-based terminal-service for the admin shell and proxies terminal WebSockets from the backend, isolating the PTY from the app. Addresses LEG-86 by enabling apt tools while keeping JWT auth and session tracking in the backend.

- New Features
  - Dedicated terminal-service container (Debian Bookworm) running bash via node-pty with full env passthrough.
  - Backend proxies terminal WebSocket to TERMINAL_SERVICE_URL; falls back to direct node-pty if unset.
  - docker-compose.local adds terminal-service-local on the internal network only (no exposed ports).
  - manage-gateway updates to build/start/stop the terminal-service.

- Migration
  - Local: use TERMINAL_SERVICE_URL=ws://terminal-service-local:3010 (pre-set in compose) and run ./manage-gateway.sh deploy local.
  - Access via /admin/terminal as an admin; no external ports required.
  - Envs without TERMINAL_SERVICE_URL keep current behavior.

<sup>Written for commit 93189a4ef961b02a6a7d0694930c6c7b78b83de8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

