### PR TITLE
fix(admin): fix Cost by Model zeros and add VoyageAI tracking

### DIFF
--- a/lexwebapp/src/pages/AdminCostsPage.tsx
+++ b/lexwebapp/src/pages/AdminCostsPage.tsx
@@ -16,6 +16,7 @@ import {
   Globe,
   Zap,
   Server,
+  Layers,
 } from 'lucide-react';
 import {
   AreaChart,
@@ -41,6 +42,7 @@ interface CostBreakdown {
     anthropic_cost_usd: number;
     zakononline_cost_usd: number;
     secondlayer_cost_usd: number;
+    voyage_cost_usd: number;
     total_cost_usd: number;
     total_requests: number;
   };
@@ -64,6 +66,7 @@ interface CostBreakdown {
     anthropic: number;
     zakononline: number;
     secondlayer: number;
+    voyage: number;
   }>;
 }
 
@@ -135,6 +138,7 @@ const COLORS = {
 const PROVIDER_COLORS: Record<string, string> = {
   OpenAI: COLORS.emerald,
   Anthropic: COLORS.purple,
+  VoyageAI: COLORS.cyan,
   ZakonOnline: COLORS.amber,
   'SecondLayer API': COLORS.blue,
 };
@@ -332,6 +336,7 @@ export function AdminCostsPage() {
     date: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
     OpenAI: d.openai,
     Anthropic: d.anthropic,
+    VoyageAI: d.voyage,
     ZakonOnline: d.zakononline,
     SecondLayer: d.secondlayer,
   }));
@@ -388,13 +393,13 @@ export function AdminCostsPage() {
 
       {/* KPI Cards */}
       {costLoading && !costData ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
-          {Array.from({ length: 5 }).map((_, i) => (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mb-6">
+          {Array.from({ length: 6 }).map((_, i) => (
             <div key={i} className="bg-white rounded-xl border border-claude-border p-5 shadow-sm animate-pulse h-28" />
           ))}
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mb-6">
           <KPICard
             label="Total Cost"
             value={formatUSD(costData?.totals.total_cost_usd)}
@@ -414,6 +419,12 @@ export function AdminCostsPage() {
             value={formatUSD(costData?.totals.anthropic_cost_usd)}
             icon={Zap}
             color="bg-purple-50 text-purple-600"
+          />
+          <KPICard
+            label="VoyageAI"
+            value={formatUSD(costData?.totals.voyage_cost_usd)}
+            icon={Layers}
+            color="bg-cyan-50 text-cyan-600"
           />
           <KPICard
             label="ZakonOnline"
@@ -474,6 +485,14 @@ export function AdminCostsPage() {
                     stackId="1"
                     stroke={COLORS.purple}
                     fill={COLORS.purple}
+                    fillOpacity={0.7}
+                  />
+                  <Area
+                    type="monotone"
+                    dataKey="VoyageAI"
+                    stackId="1"
+                    stroke={COLORS.cyan}
+                    fill={COLORS.cyan}
                     fillOpacity={0.7}
                   />
                   <Area

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -166,6 +166,13 @@ class HTTPMCPServer {
     this.invoiceService = new InvoiceService();
     this.costTracker.setBillingService(this.billingService);
 
+    // Register VoyageAI token usage callback on EmbeddingService
+    this.services.embeddingService.setTokenUsageCallback((tokens, model, task) => {
+      this.costTracker.recordVoyageCall({ model, totalTokens: tokens, task }).catch((err) => {
+        logger.warn('Failed to record VoyageAI tokens in monthly stats', { error: err.message });
+      });
+    });
+
     // Initialize Phase 2 billing services (API keys & credits)
     this.apiKeyService = new ApiKeyService(this.services.db.getPool());
     this.creditService = new CreditService(this.services.db.getPool());

--- a/mcp_backend/src/migrations/051_add_voyage_cost_tracking.sql
+++ b/mcp_backend/src/migrations/051_add_voyage_cost_tracking.sql
@@ -1,0 +1,12 @@
+-- Migration 051: Add VoyageAI cost tracking to cost_tracking and monthly_api_usage
+
+-- Add VoyageAI columns to cost_tracking
+ALTER TABLE cost_tracking
+  ADD COLUMN IF NOT EXISTS voyage_cost_usd DECIMAL(12,8) DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS voyage_total_tokens INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS voyage_calls JSONB DEFAULT '[]'::jsonb;
+
+-- Add VoyageAI columns to monthly_api_usage
+ALTER TABLE monthly_api_usage
+  ADD COLUMN IF NOT EXISTS voyage_total_tokens INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS voyage_total_cost_usd DECIMAL(12,8) DEFAULT 0;

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -22,6 +22,14 @@ export interface AnthropicCallRecord {
   timestamp: string;
 }
 
+export interface VoyageCallRecord {
+  model: string;
+  total_tokens: number;
+  cost_usd: number;
+  task: string;
+  timestamp: string;
+}
+
 export interface ZOCallRecord {
   endpoint: string;
   timestamp: string;


### PR DESCRIPTION
## Summary

- **Fix zeros in Cost by Model**: SQL query was reading `elem->>'cost'` and `elem->>'tokens'` from the JSONB `openai_calls`/`anthropic_calls` arrays, but the actual stored field names are `cost_usd` and `total_tokens` (per `OpenAICallRecord`/`AnthropicCallRecord` types) — causing all per-model costs to show as $0
- **Add VoyageAI cost tracking**: VoyageAI is used for all embeddings but was not tracked anywhere; now writes to `monthly_api_usage` via a global callback on `EmbeddingService`, and appears in the admin panel

## Changes

- `mcp_backend/src/migrations/051_add_voyage_cost_tracking.sql` — new columns on `cost_tracking` and `monthly_api_usage`
- `VoyageAIClient` — `generateEmbeddingsBatchWithUsage()` returns token counts from API response
- `EmbeddingService` — `setTokenUsageCallback()` hook; `generateEmbedding/Batch` now fire the callback with token count
- `BaseCostTracker` — `recordVoyageCall()` with pricing table per model; `requestId` optional (always writes monthly aggregate, also writes per-request if ID provided)
- `http-server.ts` — register global VoyageAI callback after CostTracker init
- `admin-routes.ts` — fix field names in `by_model` SQL; add VoyageAI to totals/by_provider/by_model/daily
- `AdminCostsPage.tsx` — VoyageAI KPI card, daily chart Area, provider colors

## Test plan

- [ ] Deploy locally: `./deployment/manage-gateway.sh deploy local`
- [ ] Run migration: `docker exec secondlayer-backend-local npm run migrate`
- [ ] Open `/admin/costs` — Cost by Model should now show real costs (non-zero) for OpenAI/Anthropic models
- [ ] Make a few search requests to generate embeddings, then check VoyageAI KPI card shows non-zero cost
- [ ] Verify 7d / 30d / 90d period switching still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes $0 values in Admin Costs “Cost by Model” and adds full VoyageAI embedding cost tracking across backend and UI.

- **Bug Fixes**
  - Corrected admin SQL to use cost_usd and total_tokens fields, restoring per-model costs and tokens.

- **New Features**
  - Track VoyageAI embedding usage: client returns token counts, EmbeddingService emits a callback, and CostTracker records per-request (when available) and monthly aggregates.
  - Admin API now includes VoyageAI in totals, by_provider, by_model (with monthly fallback), and daily; total_cost_usd now includes VoyageAI.
  - Admin UI adds a VoyageAI KPI card and a cyan area in the daily cost chart.
  - DB migration adds VoyageAI columns to cost_tracking and monthly_api_usage.

<sup>Written for commit 8f922edeb0f3beba215655cef2fa2f84a4dd2910. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

