### PR TITLE
fix(chat): auto-switch RightPanel to Норми tab when citations arrive

### DIFF
--- a/lexwebapp/src/hooks/useMCPTool.ts
+++ b/lexwebapp/src/hooks/useMCPTool.ts
@@ -234,7 +234,9 @@ function extractEvidenceFromToolResult(
   const legislationTools = [
     'search_legislation',
     'get_legislation_article',
+    'get_legislation_articles',
     'get_legislation_section',
+    'find_relevant_law_articles',
   ];
   if (legislationTools.some((t) => toolName.includes(t) || toolName === t)) {
     // Single article result
@@ -264,6 +266,21 @@ function extractEvidenceFromToolResult(
           text: a.full_text || a.text || a.content || '',
           source: `Стаття ${a.article_number || ''}`,
         });
+      }
+    }
+
+    // find_relevant_law_articles — returns array of string article refs or objects
+    if (toolName === 'find_relevant_law_articles') {
+      const refs = parsed.relevant_articles || parsed.articles || (Array.isArray(parsed) ? parsed : []);
+      for (const r of refs) {
+        if (typeof r === 'string') {
+          citations.push({ text: r, source: r });
+        } else if (r?.article || r?.reference || r?.norm) {
+          citations.push({
+            text: r.text || r.content || r.description || r.article || r.reference || r.norm || '',
+            source: r.article || r.reference || r.norm || r.title || 'Норма',
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

When the AI responds to a legislation query (calls `search_legislation`, `get_legislation_article`, etc.), it correctly extracts citation norms and stores them on the message. However, the RightPanel always defaulted to the **Рішення** tab — so users never saw the populated **Норми** tab unless they clicked it manually.

The deployment was confirmed correct (all code from PRs #270/#272/#274 is live). The issue was purely UX.

## Fix

### `RightPanel.tsx`
- Added `userSelectedTab` ref to track manual vs auto tab selection
- `useEffect` auto-switches to `'regulations'` when citations arrive and decisions are empty
- `useEffect` auto-switches back to `'decisions'` when decisions arrive  
- Manual tab clicks set `userSelectedTab.current = true` to prevent further auto-switching
- Resets when conversation is cleared (messages.length === 0)

### `useMCPTool.ts`
- Added `get_legislation_articles` and `find_relevant_law_articles` to `legislationTools` extraction list
- Added handler for `find_relevant_law_articles` results (string refs and object arrays)

## Test plan
- [ ] Ask a legislation question (e.g. "що таке договір за ЦКУ?") → RightPanel should auto-switch to Норми tab
- [ ] Ask a court case question → RightPanel should show Рішення tab
- [ ] Manually click Рішення tab during a legislation query → should stay on Рішення (no auto-switch)
- [ ] Start new conversation → tab resets to default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically switches the RightPanel to the Норми tab when legislation citations arrive (and no decisions), so users immediately see norms. Also extracts citations from new legislation tools to populate the tab reliably.

- **Bug Fixes**
  - Auto-switch to Норми when citations arrive and decisions are empty; switch back to Рішення when decisions appear.
  - Manual tab clicks disable further auto-switching; resets on new conversation.
  - Parse citations from get_legislation_articles and find_relevant_law_articles (supports string refs and object arrays).

<sup>Written for commit 42f669976c6668398107cea04fa673f8436523df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

