### PR TITLE
test(admin): fix AdminMonitoringPage tests to match current component

### DIFF
--- a/lexwebapp/src/pages/__tests__/AdminMonitoringPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/AdminMonitoringPage.test.tsx
@@ -1,269 +1,269 @@
 /**
  * AdminMonitoringPage Tests
+ * Tests for the current multi-section monitoring dashboard
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 
-// Mock api-client
+// Mock API
 const mockGetDataSources = vi.fn();
+const mockGetRecentCourtDocs = vi.fn();
+const mockGetBackfillStatus = vi.fn();
+const mockGetCourtScraperStatus = vi.fn();
+const mockGetImportSamples = vi.fn();
 
 vi.mock('../../utils/api-client', () => ({
   default: {},
   api: {
     admin: {
-      getDataSources: () => mockGetDataSources(),
+      getDataSources: (...args: any[]) => mockGetDataSources(...args),
+      getRecentCourtDocs: (...args: any[]) => mockGetRecentCourtDocs(...args),
+      runDocumentCompletenessCheck: vi.fn(),
+      startBackfillFulltext: vi.fn(),
+      getBackfillStatus: (...args: any[]) => mockGetBackfillStatus(...args),
+      stopBackfill: vi.fn(),
+      startCourtScraper: vi.fn(),
+      getCourtScraperStatus: (...args: any[]) => mockGetCourtScraperStatus(...args),
+      stopCourtScraper: vi.fn(),
+      getImportSamples: (...args: any[]) => mockGetImportSamples(...args),
+    },
+    documents: {
+      getById: vi.fn(),
     },
   },
 }));
 
 import { AdminMonitoringPage } from '../AdminMonitoringPage';
 
-const mockDataSources = {
-  backendSources: [
+const mockBackendData = {
+  tables: [
     {
-      id: 'zakononline',
-      name: 'ZakonOnline',
-      service: 'backend',
-      metrics: { calls_24h: 1250, errors_24h: 3, last_call: '2026-02-15T14:30:00Z' },
+      id: 'documents',
+      name: 'Документи ZakonOnline',
+      rows: 15240,
+      source: 'ZakonOnline — Документи',
+      sourceUrl: 'https://zakononline.com.ua',
+      updateFrequency: 'Щоденно',
+      lastUpdate: '2026-02-20T10:00:00Z',
+      lastBatchCount: 120,
     },
     {
       id: 'legislation',
-      name: 'Legislation',
-      service: 'backend',
-      metrics: { codes_count: 12, articles_count: 5191, newest_update: '2026-02-10T00:00:00Z' },
-    },
-    {
-      id: 'zo_dictionaries',
-      name: 'ZO Dictionaries',
-      service: 'backend',
-      metrics: { loaded_domains: 8, total_entries: 4500, last_update: '2026-02-12T00:00:00Z' },
+      name: 'Законодавство',
+      rows: 5191,
+      source: 'Верховна Рада — Законодавство',
+      sourceUrl: 'https://zakon.rada.gov.ua',
+      updateFrequency: 'Щомісячно',
+      lastUpdate: '2026-02-10T00:00:00Z',
+      lastBatchCount: 0,
     },
   ],
-  externalServices: [
+  dbSizeMb: 842,
+};
+
+const mockRadaData = {
+  tables: {
+    deputies: {
+      rows: 450,
+      source: 'Верховна Рада — Депутати',
+      sourceUrl: 'https://data.rada.gov.ua',
+      updateFrequency: 'Щотижнево',
+      lastUpdate: '2026-02-18T00:00:00Z',
+    },
+  },
+  dbSizeMb: 120,
+};
+
+const mockCourtDocsData = {
+  total_court_docs: 15240,
+  recent_court_docs: 350,
+  days: 30,
+  categories: [
     {
-      id: 'rada',
-      name: 'Verkhovna Rada',
-      service: 'mcp_rada',
-      healthEndpoint: '/health',
-      port: 3001,
-      dataSources: [
-        { id: 'deputies', name: 'Deputies', table: 'deputies' },
-        { id: 'bills', name: 'Bills', table: 'bills' },
-      ],
+      code: '1',
+      name: 'Цивільне судочинство',
+      total: 8000,
+      recent: 150,
+      earliest_date: '2015-01-01',
+      latest_date: '2026-02-19',
+      last_loaded_at: '2026-02-20T09:00:00Z',
+      documents: [],
     },
   ],
-  timestamp: '2026-02-15T15:00:00Z',
 };
 
 describe('AdminMonitoringPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetDataSources.mockImplementation((section?: string) => {
+      if (section === 'backend') {
+        return Promise.resolve({ data: mockBackendData });
+      }
+      if (section === 'rada') {
+        return Promise.resolve({ data: mockRadaData });
+      }
+      return Promise.resolve({ data: { tables: {}, dbSizeMb: 0 } });
+    });
+    mockGetRecentCourtDocs.mockResolvedValue({ data: mockCourtDocsData });
+    mockGetBackfillStatus.mockResolvedValue({ data: { active: false, job: null } });
+    mockGetCourtScraperStatus.mockResolvedValue({ data: { active: false, job: null } });
+    mockGetImportSamples.mockResolvedValue({
+      data: { hours: 24, samples: [], summary: { court_decisions: 0, legislation: 0, embeddings: 0, user_uploads: 0 }, timestamp: new Date().toISOString() },
+    });
   });
 
-  it('shows loading spinner initially', () => {
-    mockGetDataSources.mockReturnValue(new Promise(() => {}));
+  it('shows page header after load', async () => {
     render(<AdminMonitoringPage />);
-    expect(screen.getByText('Loading data sources...')).toBeInTheDocument();
-  });
-
-  it('renders page header and backend sources after data loads', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    render(<AdminMonitoringPage />);
-
     await waitFor(() => {
-      expect(screen.getByText('Data Sources Monitoring')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Backend Sources')).toBeInTheDocument();
-    expect(screen.getByText('ZakonOnline')).toBeInTheDocument();
-    expect(screen.getByText('Legislation')).toBeInTheDocument();
-    expect(screen.getByText('ZO Dictionaries')).toBeInTheDocument();
-  });
-
-  it('renders ZakonOnline metrics', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('ZakonOnline')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Calls (24h)')).toBeInTheDocument();
-    expect(screen.getByText('Errors (24h)')).toBeInTheDocument();
-    expect(screen.getByText('Last call')).toBeInTheDocument();
-  });
-
-  it('renders Legislation metrics', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Legislation')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Codes')).toBeInTheDocument();
-    expect(screen.getByText('Articles')).toBeInTheDocument();
-    expect(screen.getByText('Latest update')).toBeInTheDocument();
-  });
-
-  it('renders ZO Dictionaries metrics', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('ZO Dictionaries')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Loaded domains')).toBeInTheDocument();
-    expect(screen.getByText('Total entries')).toBeInTheDocument();
-  });
-
-  it('renders external services section', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Verkhovna Rada')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('port 3001')).toBeInTheDocument();
-    expect(screen.getByText('Deputies')).toBeInTheDocument();
-    expect(screen.getByText('Bills')).toBeInTheDocument();
-  });
-
-  it('shows OK status for healthy ZakonOnline', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('ZakonOnline')).toBeInTheDocument();
-    });
-
-    // ZakonOnline has 3 errors (< 10) and has last_call → healthy → "OK"
-    const okBadges = screen.getAllByText('OK');
-    expect(okBadges.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it('shows Degraded status when errors > 10', async () => {
-    const degradedData = {
-      ...mockDataSources,
-      backendSources: [
-        {
-          id: 'zakononline',
-          name: 'ZakonOnline',
-          service: 'backend',
-          metrics: { calls_24h: 100, errors_24h: 15, last_call: '2026-02-15T14:30:00Z' },
-        },
-      ],
-      externalServices: [],
-    };
-    mockGetDataSources.mockResolvedValue({ data: degradedData });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Degraded')).toBeInTheDocument();
+      expect(screen.getByText('Моніторинг джерел даних')).toBeInTheDocument();
     });
   });
 
-  it('shows Down status when legislation codes_count is 0', async () => {
-    const downData = {
-      ...mockDataSources,
-      backendSources: [
-        {
-          id: 'legislation',
-          name: 'Legislation',
-          service: 'backend',
-          metrics: { codes_count: 0, articles_count: 0, newest_update: null },
-        },
-      ],
-      externalServices: [],
-    };
-    mockGetDataSources.mockResolvedValue({ data: downData });
+  it('shows refresh button', async () => {
     render(<AdminMonitoringPage />);
-
     await waitFor(() => {
-      expect(screen.getByText('Down')).toBeInTheDocument();
+      expect(screen.getByText('Оновити')).toBeInTheDocument();
     });
   });
 
-  it('shows Down status when zo_dictionaries loaded_domains is 0', async () => {
-    const downData = {
-      ...mockDataSources,
-      backendSources: [
-        {
-          id: 'zo_dictionaries',
-          name: 'ZO Dictionaries',
-          service: 'backend',
-          metrics: { loaded_domains: 0, total_entries: 0, last_update: null },
-        },
-      ],
-      externalServices: [],
-    };
-    mockGetDataSources.mockResolvedValue({ data: downData });
+  it('shows backend section header after data loads', async () => {
     render(<AdminMonitoringPage />);
-
     await waitFor(() => {
-      expect(screen.getByText('Down')).toBeInTheDocument();
+      expect(screen.getByText('Backend (mcp_backend)')).toBeInTheDocument();
     });
   });
 
-  it('shows error state with retry button on API failure', async () => {
-    mockGetDataSources.mockRejectedValue({ message: 'Timeout' });
+  it('renders backend table rows', async () => {
     render(<AdminMonitoringPage />);
-
     await waitFor(() => {
-      expect(screen.getByText('Timeout')).toBeInTheDocument();
+      expect(screen.getByText('documents')).toBeInTheDocument();
     });
-    expect(screen.getByText('Retry')).toBeInTheDocument();
+    expect(screen.getByText('legislation')).toBeInTheDocument();
   });
 
-  it('retry button re-fetches data', async () => {
-    mockGetDataSources.mockRejectedValueOnce({ message: 'Fail' });
+  it('shows court docs section', async () => {
     render(<AdminMonitoringPage />);
-
     await waitFor(() => {
-      expect(screen.getByText('Retry')).toBeInTheDocument();
-    });
-
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
-    fireEvent.click(screen.getByText('Retry'));
-
-    await waitFor(() => {
-      expect(screen.getByText('Data Sources Monitoring')).toBeInTheDocument();
+      expect(screen.getByText('Судові рішення за видами права')).toBeInTheDocument();
     });
   });
 
-  it('refresh button re-fetches data', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
+  it('shows court doc categories', async () => {
     render(<AdminMonitoringPage />);
-
     await waitFor(() => {
-      expect(screen.getByText('Refresh')).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByText('Refresh'));
-    expect(mockGetDataSources).toHaveBeenCalledTimes(2);
-  });
-
-  it('shows server error message from response data', async () => {
-    mockGetDataSources.mockRejectedValue({
-      response: { data: { error: 'Admin access required' } },
-    });
-    render(<AdminMonitoringPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Admin access required')).toBeInTheDocument();
+      expect(screen.getByText('Цивільне судочинство')).toBeInTheDocument();
     });
   });
 
-  it('renders table names in external service data sources', async () => {
-    mockGetDataSources.mockResolvedValue({ data: mockDataSources });
+  it('shows document completeness section', async () => {
     render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Перевірка повноти документів')).toBeInTheDocument();
+    });
+  });
 
+  it('shows court scraper section', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Докачати документи з реєстру')).toBeInTheDocument();
+    });
+  });
+
+  it('shows RADA section', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('RADA Server (mcp_rada)')).toBeInTheDocument();
+    });
+  });
+
+  it('shows OpenReyestr section', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('OpenReyestr Server (mcp_openreyestr)')).toBeInTheDocument();
+    });
+  });
+
+  it('renders RADA table data', async () => {
+    render(<AdminMonitoringPage />);
     await waitFor(() => {
       expect(screen.getByText('deputies')).toBeInTheDocument();
     });
-    expect(screen.getByText('bills')).toBeInTheDocument();
+  });
+
+  it('shows error state with retry for backend section on API failure', async () => {
+    mockGetDataSources.mockImplementation((section?: string) => {
+      if (section === 'backend') return Promise.reject({ message: 'Network error', response: { data: { error: 'Network error' } } });
+      return Promise.resolve({ data: { tables: {}, dbSizeMb: 0 } });
+    });
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+    // Retry button appears
+    expect(screen.getAllByText('Повторити').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows RADA offline badge when service returns error', async () => {
+    mockGetDataSources.mockImplementation((section?: string) => {
+      if (section === 'backend') return Promise.resolve({ data: mockBackendData });
+      if (section === 'rada') return Promise.resolve({ data: { tables: {}, dbSizeMb: 0, error: 'Service unavailable' } });
+      return Promise.resolve({ data: { tables: {}, dbSizeMb: 0 } });
+    });
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('RADA Server (mcp_rada)')).toBeInTheDocument();
+    });
+    // Should show "Недоступний" for RADA
+    expect(screen.getAllByText('Недоступний').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows summary cards with totals', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Всього записів')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Backend DB')).toBeInTheDocument();
+    expect(screen.getByText('RADA DB')).toBeInTheDocument();
+    expect(screen.getByText('OpenReyestr DB')).toBeInTheDocument();
+  });
+
+  it('refresh button re-fetches all data', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText('Оновити').length).toBeGreaterThanOrEqual(1);
+    });
+    // Initial load calls getDataSources for backend/rada/openreyestr
+    const initialCalls = mockGetDataSources.mock.calls.length;
+    // Click the first "Оновити" (header refresh button)
+    fireEvent.click(screen.getAllByText('Оновити')[0]);
+    await waitFor(() => {
+      expect(mockGetDataSources.mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+  });
+
+  it('shows "Завантаження..." section loaders while fetching', () => {
+    // Don't resolve promises — keep loading
+    mockGetDataSources.mockReturnValue(new Promise(() => {}));
+    mockGetRecentCourtDocs.mockReturnValue(new Promise(() => {}));
+    render(<AdminMonitoringPage />);
+    const loaders = screen.getAllByText('Завантаження...');
+    expect(loaders.length).toBeGreaterThan(0);
+  });
+
+  it('shows dbSizeMb in backend section header', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(screen.getAllByText(/842 MB/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it('calls getDataSources for all three services on mount', async () => {
+    render(<AdminMonitoringPage />);
+    await waitFor(() => {
+      expect(mockGetDataSources).toHaveBeenCalledWith('backend');
+      expect(mockGetDataSources).toHaveBeenCalledWith('rada');
+      expect(mockGetDataSources).toHaveBeenCalledWith('openreyestr');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Rewrite `AdminMonitoringPage.test.tsx` to match the current Ukrainian multi-section dashboard (old tests were for a defunct English component)
- Add missing mocks to `AdminMonitoringBackfill.test.tsx`: `getCourtScraperStatus`, `startCourtScraper`, `stopCourtScraper`, `getImportSamples`
- Fix `startBackfill` call assertions to use `expect.objectContaining` (component now passes `concurrency`/`proxy` params alongside `justice_kind_code`/`limit`)
- Replace `getByText` with `getAllByText` where text appears in multiple elements (e.g. `'Цивільне'` in both table cell and CourtScraper `<option>`)

## Test plan
- [ ] All 35 tests in the two affected files pass
- [ ] `cd lexwebapp && npx vitest run src/pages/__tests__/AdminMonitoringPage.test.tsx src/pages/__tests__/AdminMonitoringBackfill.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update AdminMonitoringPage tests to match the current Ukrainian multi-section dashboard and fix backfill tests with proper API mocks and flexible assertions. This aligns tests with the live UI and prevents false failures when extra params are passed.

- **Refactors**
  - Rewrote AdminMonitoringPage.test.tsx for the current Ukrainian UI: multi-service sections (Backend/RADA/OpenReyestr), court docs/completeness/scraper, loaders, refresh, error states, DB sizes, and data-source calls.
  - Added missing mocks in AdminMonitoringBackfill.test.tsx: getCourtScraperStatus, startCourtScraper, stopCourtScraper, getImportSamples; also stubbed documents.getById.
  - Updated startBackfill expectations to use expect.objectContaining; replaced getByText with getAllByText for repeated strings like "Цивільне".

<sup>Written for commit 0c632271dc5c1f15c886c53881ff116e8089c347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

