### PR TITLE
fix(stage): suppress postgres-exporter config warning and pin plan gen to OpenAI

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -802,6 +802,9 @@ services:
     container_name: postgres-exporter-backend-stage
     environment:
       DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-stage:5432/${POSTGRES_DB:-secondlayer_stage}?sslmode=disable"
+    volumes:
+      - ./postgres_exporter.yml:/etc/postgres_exporter.yml:ro
+    command: ["--config.file=/etc/postgres_exporter.yml"]
     ports:
       - "127.0.0.1:9187:9187"
     networks:
@@ -816,6 +819,9 @@ services:
     container_name: postgres-exporter-openreyestr-stage
     environment:
       DATA_SOURCE_NAME: "postgresql://${OPENREYESTR_POSTGRES_USER:-openreyestr}:${OPENREYESTR_POSTGRES_PASSWORD}@postgres-openreyestr-stage:5432/${OPENREYESTR_POSTGRES_DB:-openreyestr_stage}?sslmode=disable"
+    volumes:
+      - ./postgres_exporter.yml:/etc/postgres_exporter.yml:ro
+    command: ["--config.file=/etc/postgres_exporter.yml"]
     ports:
       - "127.0.0.1:9188:9187"
     networks:

--- a/deployment/postgres_exporter.yml
+++ b/deployment/postgres_exporter.yml
@@ -1,0 +1,4 @@
+# postgres_exporter configuration
+# Minimal config to suppress "no such file" warning.
+# DATA_SOURCE_NAME is provided via environment variable.
+auth_modules: {}

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -879,7 +879,8 @@ ${stepsText}
           temperature: 0.1,
           response_format: { type: 'json_object' },
         },
-        'quick'
+        'quick',
+        'openai'
       );
 
       // Record plan generation LLM cost
@@ -911,6 +912,8 @@ ${stepsText}
           hasGoal: !!parsed.goal,
           hasSteps: Array.isArray(parsed.steps),
           stepsLength: parsed.steps?.length,
+          model: response.model,
+          provider: response.provider,
         });
         throw new Error('Invalid plan structure: missing goal or steps');
       }


### PR DESCRIPTION
## Summary
- Create `deployment/postgres_exporter.yml` (minimal valid config) and mount it into both postgres-exporter containers via `--config.file` flag, eliminating the repeated `"Error opening config file postgres_exporter.yml: no such file or directory"` startup warning
- Pin `ChatService` plan generation to OpenAI provider — `response_format: { type: 'json_object' }` is OpenAI-specific; when Anthropic was selected via round-robin it returned `{}`, causing repeated plan validation failures
- Add `model` and `provider` fields to the plan validation failure log for easier future diagnosis

## Test plan
- [ ] Restart postgres-exporter containers on stage — warning should be gone
- [ ] Rebuild backend image on stage — ChatService plan validation warnings should stop appearing
- [ ] Verify `/metrics` endpoint on both postgres exporters still returns valid Prometheus metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates postgres-exporter startup config warnings and fixes ChatService plan generation failures by pinning the provider to OpenAI. Adds model/provider details to plan validation logs for easier debugging.

- **Bug Fixes**
  - Mount minimal postgres_exporter.yml via --config.file for both stage exporters to remove the “no such file” warning.
  - Pin ChatService plan generation to OpenAI to support response_format: json_object and avoid empty {} responses.
  - Include model and provider fields in plan validation failure logs.

<sup>Written for commit f08e40d65888d85642e5d26ac1f86b8c4e90b2a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

