### PR TITLE
fix(chat): restore thinking steps and cost summary when switching conversations

### DIFF
--- a/lexwebapp/src/services/api/ConversationService.ts
+++ b/lexwebapp/src/services/api/ConversationService.ts
@@ -86,6 +86,7 @@ export class ConversationService extends BaseService {
       citations?: any[];
       tool_calls?: any[];
       cost_tracking_id?: string;
+      cost_summary?: any;
     }
   ): Promise<ConversationMessage> {
     try {

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -177,10 +177,20 @@ export const useChatStore = create<ChatState>()(
               id: m.id,
               role: m.role,
               content: m.content,
-              thinkingSteps: m.thinking_steps,
+              thinkingSteps: Array.isArray(m.thinking_steps)
+                ? m.thinking_steps.map((s: any, i: number) => ({
+                    id: `step-${i}`,
+                    title: `✓ ${s.tool || 'tool'}`,
+                    content: typeof s.result === 'string'
+                      ? s.result.slice(0, 500)
+                      : JSON.stringify(s.result, null, 2).slice(0, 500),
+                    isComplete: true,
+                  }))
+                : undefined,
               decisions: m.decisions,
               citations: m.citations,
               documents: m.documents,
+              costSummary: m.cost_summary ?? undefined,
             }));
             set({
               conversationId,
@@ -248,6 +258,7 @@ export const useChatStore = create<ChatState>()(
               decisions: message.decisions,
               citations: message.citations,
               documents: message.documents,
+              cost_summary: message.costSummary,
             })
             .catch(() => {
               // Silent fail - localStorage backup remains

--- a/mcp_backend/src/migrations/052_add_cost_summary_to_messages.sql
+++ b/mcp_backend/src/migrations/052_add_cost_summary_to_messages.sql
@@ -1,0 +1,5 @@
+-- Add cost_summary JSONB column to conversation_messages
+-- Stores { total_cost_usd, tools_used } for display when loading conversation history
+
+ALTER TABLE conversation_messages
+  ADD COLUMN IF NOT EXISTS cost_summary JSONB;

--- a/mcp_backend/src/routes/conversation-routes.ts
+++ b/mcp_backend/src/routes/conversation-routes.ts
@@ -97,7 +97,7 @@ export function createConversationRouter(conversationService: ConversationServic
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'User not authenticated' });
 
-      const { role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id } = req.body;
+      const { role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id, cost_summary } = req.body;
       if (!role || !content) return res.status(400).json({ error: 'role and content required' });
 
       const message = await conversationService.addMessage(req.params.id as string, userId, {
@@ -109,6 +109,7 @@ export function createConversationRouter(conversationService: ConversationServic
         documents,
         tool_calls,
         cost_tracking_id,
+        cost_summary,
       });
 
       if (!message) return res.status(404).json({ error: 'Conversation not found' });

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -523,6 +523,7 @@ export class ChatService {
             content: fullAnswerText,
             tool_calls: collectedToolCalls.length > 0 ? collectedToolCalls : undefined,
             thinking_steps: collectedThinkingSteps.length > 0 ? collectedThinkingSteps : undefined,
+            cost_summary: totalCostUsd > 0 ? { total_cost_usd: totalCostUsd, tools_used: toolsUsed } : undefined,
           });
         } catch (e) {
           logger.warn('[ChatService] Failed to persist messages', { error: (e as Error).message });

--- a/mcp_backend/src/services/conversation-service.ts
+++ b/mcp_backend/src/services/conversation-service.ts
@@ -23,6 +23,7 @@ export interface ConversationMessage {
   documents?: any[];
   tool_calls?: any[];
   cost_tracking_id?: string;
+  cost_summary?: { total_cost_usd: number; tools_used: string[] } | null;
   created_at: Date;
 }
 
@@ -102,6 +103,7 @@ export class ConversationService {
       documents?: any[];
       tool_calls?: any[];
       cost_tracking_id?: string;
+      cost_summary?: { total_cost_usd: number; tools_used: string[] } | null;
     }
   ): Promise<ConversationMessage | null> {
     // Verify ownership
@@ -111,8 +113,8 @@ export class ConversationService {
     const id = uuidv4();
     const result = await this.db.query(
       `INSERT INTO conversation_messages
-         (id, conversation_id, role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         (id, conversation_id, role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id, cost_summary)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
       [
         id,
@@ -125,6 +127,7 @@ export class ConversationService {
         message.documents ? JSON.stringify(message.documents) : null,
         message.tool_calls ? JSON.stringify(message.tool_calls) : null,
         message.cost_tracking_id || null,
+        message.cost_summary ? JSON.stringify(message.cost_summary) : null,
       ]
     );
 


### PR DESCRIPTION
## Summary
- Thinking steps disappeared when switching conversations because the DB format `[{tool, params, result}]` was passed directly to the component which expects `[{id, title, content, isComplete}]` — now transformed on load
- Cost summary disappeared because it was never persisted to DB — added `cost_summary JSONB` column (migration 052), backend now saves `{total_cost_usd, tools_used}` with each assistant message, frontend loads and displays it on conversation switch

## Test plan
- [ ] Start a new AI chat with a query that triggers tool calls — verify thinking steps and cost appear
- [ ] Switch to a different conversation and back — verify thinking steps and cost are still visible
- [ ] Deploy to stage and run migration: `manage-gateway.sh deploy stage` (migration runs automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores thinking steps and cost summary when switching conversations. Maps DB thinking_steps to the UI format and persists a cost_summary for assistant messages so both display reliably.

- **Bug Fixes**
  - Transform thinking_steps from [{tool, params, result}] to [{id, title, content, isComplete}] on conversation load.
  - Persist and return cost_summary ({total_cost_usd, tools_used}) for assistant messages; include in frontend sync payload.
  - Load and display cost summary and steps after switching conversations.

- **Migration**
  - Add cost_summary JSONB column to conversation_messages (migration 052). No manual steps required.

<sup>Written for commit ca8582709933bfb6a103b2361a2f9e32c3d79e04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

