### PR TITLE
fix(llm): skip temperature param for models that only support default (gpt-5, gpt-4.1, o-series)

### DIFF
--- a/mcp_backend/src/api/document-analysis-tools.ts
+++ b/mcp_backend/src/api/document-analysis-tools.ts
@@ -250,7 +250,7 @@ ${args.documentText.slice(0, 15000)}`;
             { role: 'system', content: 'Ты юридический эксперт по анализу контрактов.' },
             { role: 'user', content: prompt },
           ],
-          temperature: 0.1,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.1 } : {}),
           response_format: { type: 'json_object' },
         });
       });
@@ -328,7 +328,7 @@ ${args.documentText.slice(0, 20000)}`;
             { role: 'system', content: systemPrompt },
             { role: 'user', content: userPrompt },
           ],
-          temperature: 0.2,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.2 } : {}),
           response_format: { type: 'json_object' },
         });
       });
@@ -415,7 +415,7 @@ ${changesText}
             { role: 'system', content: 'Ты юридический аналитик.' },
             { role: 'user', content: summaryPrompt },
           ],
-          temperature: 0.2,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.2 } : {}),
         });
       });
 

--- a/mcp_backend/src/services/due-diligence-service.ts
+++ b/mcp_backend/src/services/due-diligence-service.ts
@@ -367,7 +367,7 @@ ${fullText.slice(0, 8000)}`;
             },
             { role: 'user', content: prompt },
           ],
-          temperature: 0.1,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.1 } : {}),
           response_format: { type: 'json_object' },
         });
       });
@@ -646,7 +646,7 @@ ${criticalFindings}
             },
             { role: 'user', content: prompt },
           ],
-          temperature: 0.2,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.2 } : {}),
           response_format: { type: 'json_object' },
         });
       });

--- a/mcp_backend/src/services/legislation-classifier.ts
+++ b/mcp_backend/src/services/legislation-classifier.ts
@@ -143,7 +143,7 @@ ${availableCodes}
           { role: 'system', content: systemPrompt },
           { role: 'user', content: query },
         ],
-        temperature: 0.2, // Низкая температура для более детерминированных результатов
+        ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.2 } : {}),
         max_completion_tokens: 300,
       };
 

--- a/mcp_backend/src/services/query-planner.ts
+++ b/mcp_backend/src/services/query-planner.ts
@@ -70,7 +70,7 @@ export class QueryPlanner {
               content: query,
             },
           ],
-          temperature: 0.3,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.3 } : {}),
           max_completion_tokens: 500,
         };
 
@@ -458,7 +458,7 @@ export class QueryPlanner {
               content: userQuery,
             },
           ],
-          temperature: 0.2,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.2 } : {}),
           max_completion_tokens: 100,
         };
 

--- a/mcp_backend/src/services/semantic-sectionizer.ts
+++ b/mcp_backend/src/services/semantic-sectionizer.ts
@@ -234,7 +234,7 @@ export class SemanticSectionizer {
             content: text.substring(0, 8000), // Limit to avoid token limits
           },
         ],
-          temperature: 0.2,
+          ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.2 } : {}),
           max_completion_tokens: 2000,
           response_format: { type: 'json_object' },
         });

--- a/mcp_backend/src/utils/html-parser.ts
+++ b/mcp_backend/src/utils/html-parser.ts
@@ -235,7 +235,7 @@ export async function extractSearchTermsWithAI(text: string): Promise<{
             content: `Проаналізуй це судове рішення:\n\n${analysisText}`,
           },
         ],
-        temperature: 0.3,
+        ...(ModelSelector.supportsTemperature(model) ? { temperature: 0.3 } : {}),
         max_completion_tokens: 500,
         response_format: { type: 'json_object' },
       });

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -241,6 +241,33 @@ export class ModelSelector {
     return jsonModeModels.includes(model);
   }
 
+  /**
+   * Returns true if the model accepts a custom temperature parameter.
+   * Reasoning models (o1, o3, o4-mini, gpt-5 family) only support temperature=1 (default)
+   * and will return a 400 error if any other value is passed.
+   */
+  static supportsTemperature(model: string): boolean {
+    const noTemperatureModels = [
+      // GPT-5 family — only default temperature supported
+      'gpt-5',
+      'gpt-5.1',
+      'gpt-5-mini',
+      'gpt-5-nano',
+      // GPT-4.1 family
+      'gpt-4.1',
+      'gpt-4.1-mini',
+      'gpt-4.1-nano',
+      // OpenAI reasoning/o-series models
+      'o1',
+      'o1-mini',
+      'o1-preview',
+      'o3',
+      'o3-mini',
+      'o4-mini',
+    ];
+    return !noTemperatureModels.includes(model);
+  }
+
   static logUsage(params: {
     model: string;
     budget: 'quick' | 'standard' | 'deep';


### PR DESCRIPTION
## Summary
- GPT-5 and GPT-4.1 family models return `400 Unsupported value: 'temperature'` when any value other than the default (1) is passed
- Added `ModelSelector.supportsTemperature(model)` to shared package covering gpt-5, gpt-5.1, gpt-5-mini, gpt-5-nano, gpt-4.1 family, and o-series reasoning models
- All 8 direct `client.chat.completions.create()` call sites now use `...(ModelSelector.supportsTemperature(model) ? { temperature: X } : {})` spread pattern
- Files going through `LLMManager.chatCompletion/chatCompletionStream` were already safe (handled internally)

## Test plan
- [ ] Verify `LegislationClassifier` no longer errors with 400 on legislation queries
- [ ] Verify `QueryPlanner` classification and search query optimization work
- [ ] Deploy to stage: `manage-gateway.sh deploy stage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip passing temperature to models that only support the default to prevent 400 errors on GPT-5, GPT-4.1, and o-series calls. Adds a supportsTemperature helper and updates all direct chat completion calls accordingly.

- **Bug Fixes**
  - Added ModelSelector.supportsTemperature for gpt-5 family, gpt-4.1 family, and o-series reasoning models.
  - Updated all eight direct client.chat.completions.create call sites to conditionally include temperature; LLMManager paths were already safe.

<sup>Written for commit d695b5bed57b66c81606a2e4c39ff2050e79b6f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

