### PR TITLE
fix(sidebar): navigate to chat on conversation switch; toast for unimplemented menu items

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useState, useRef } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { ROUTES } from '../router/routes';
+import showToast from '../utils/toast';
 import {
   Plus,
   MessageSquare,
@@ -115,6 +118,8 @@ export function Sidebar({
   onAdminTerminalClick,
   onLogout
 }: SidebarProps) {
+  const navigate = useNavigate();
+  const location = useLocation();
   const { user } = useAuth();
   const role: UserRole = user?.role || 'user';
   const [showProfileMenu, setShowProfileMenu] = useState(false);
@@ -440,6 +445,9 @@ export function Sidebar({
                       }`}
                       onClick={() => {
                         switchConversation(conv.id);
+                        if (location.pathname !== ROUTES.CHAT) {
+                          navigate(ROUTES.CHAT);
+                        }
                         if (window.innerWidth < 1024) onClose();
                       }}
                     >
@@ -522,6 +530,8 @@ export function Sidebar({
                     if (section.onClick) {
                       section.onClick();
                       if (window.innerWidth < 1024) onClose();
+                    } else {
+                      showToast.info('Скоро буде доступно');
                     }
                   }}
                   className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center justify-between group">
@@ -573,6 +583,8 @@ export function Sidebar({
                     if (section.onClick) {
                       section.onClick();
                       if (window.innerWidth < 1024) onClose();
+                    } else {
+                      showToast.info('Скоро буде доступно');
                     }
                   }}
                   className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">


### PR DESCRIPTION
## Summary
- Clicking a conversation in the sidebar now navigates to `/chat` if the user is on a different page (billing, documents, etc.) — previously it only updated the store silently
- Menu items without onClick handlers (Джерела права, Нормативні акти, Коментарі та практика, Перевірка актуальності) now show "Скоро буде доступно" toast instead of doing nothing

## Test plan
- [ ] Navigate to /billing, then click a conversation in the sidebar → should navigate to /chat and show the conversation
- [ ] Click "Джерела права", "Нормативні акти", "Коментарі та практика", "Перевірка актуальності" → should show toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking a conversation in the sidebar now redirects to Chat when you're on another page, so switching works consistently. Unimplemented menu items now show a “Скоро буде доступно” toast instead of doing nothing.

- **Bug Fixes**
  - Navigate to /chat when selecting a conversation outside the chat page.

- **New Features**
  - Show “Скоро буде доступно” toast for menu items without handlers: Джерела права, Нормативні акти, Коментарі та практика, Перевірка актуальності.

<sup>Written for commit 0b12a2a74a3899563c0f86b86cd23786d5e9c95f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

