### PR TITLE
fix(sidebar): await switchConversation before navigating to ensure chat updates

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -443,11 +443,9 @@ export function Sidebar({
                           ? 'bg-claude-accent/10 text-claude-accent'
                           : 'text-claude-text hover:bg-claude-subtext/8'
                       }`}
-                      onClick={() => {
-                        switchConversation(conv.id);
-                        if (location.pathname !== ROUTES.CHAT) {
-                          navigate(ROUTES.CHAT);
-                        }
+                      onClick={async () => {
+                        await switchConversation(conv.id);
+                        navigate(ROUTES.CHAT);
                         if (window.innerWidth < 1024) onClose();
                       }}
                     >


### PR DESCRIPTION
## Summary

- Make conversation click handler `async` and `await switchConversation()` so the Zustand store is fully updated with new messages before React Router triggers a re-render
- Remove the `if (location.pathname !== ROUTES.CHAT)` condition — `navigate(ROUTES.CHAT)` now always fires, forcing the `<Outlet>` to re-render and `ChatPage` to read the updated messages regardless of which page the user is on

## Root cause

The previous fix (#293) added navigation only when coming from another page. When already on `/chat`, only `switchConversation` was called (async, no await) with no navigation — so `ChatPage` stayed mounted but received no signal to re-render. The Zustand `persist + devtools` subscription was not reliably triggering re-renders in this scenario.

## Test plan

- [ ] Open the chat page with an existing conversation visible
- [ ] Click a different conversation in the sidebar — content should switch immediately
- [ ] Click back and forth between multiple conversations — each switch should update the chat content
- [ ] Navigate to another page (e.g. Судді), click a conversation — should navigate to `/chat` and show the correct content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar conversation switching so the chat updates immediately and reliably. The click now awaits the store update and always navigates to /chat to trigger a re-render.

- **Bug Fixes**
  - Make onClick async and await switchConversation before navigation.
  - Always call navigate(ROUTES.CHAT); remove pathname check to force ChatPage re-render.

<sup>Written for commit 1e8c2b86dab0f35f25e9a2d423f733002968a44c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

