### PR TITLE
fix(a11y): associate labels with form fields and add missing id/name attrs

### DIFF
--- a/lexwebapp/src/components/billing/TopUpTab.tsx
+++ b/lexwebapp/src/components/billing/TopUpTab.tsx
@@ -644,10 +644,10 @@ export function TopUpTab({ initialAmount }: TopUpTabProps) {
           ))}
         </div>
         <div>
-          <label className="block text-sm font-medium text-claude-text mb-2">Інша сума</label>
+          <label htmlFor="topup-custom-amount" className="block text-sm font-medium text-claude-text mb-2">Інша сума</label>
           <div className="relative">
             <span className="absolute left-3 top-1/2 transform -translate-y-1/2 text-claude-subtext font-medium">{currencySymbol}</span>
-            <input type="number" min="1" step="0.01"
+            <input id="topup-custom-amount" name="customAmount" type="number" min="1" step="0.01"
               value={customAmount} onChange={(e) => { setCustomAmount(e.target.value); const p = parseFloat(e.target.value); if (!isNaN(p) && p > 0) setAmount(p); }}
               placeholder="25.00"
               className="w-full pl-8 pr-4 py-3 border border-claude-border rounded-lg focus:outline-none focus:ring-2 focus:ring-claude-accent/20" />

--- a/lexwebapp/src/components/ui/Input/Input.tsx
+++ b/lexwebapp/src/components/ui/Input/Input.tsx
@@ -24,6 +24,8 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     },
     ref
   ) => {
+    const inputId = props.id || (label ? `input-${label.toLowerCase().replace(/\s+/g, '-')}` : undefined);
+
     const inputClasses = getInputClasses({
       size,
       variant,
@@ -39,7 +41,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className={containerClasses}>
         {label && (
-          <label className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 mb-1">
             {label}
           </label>
         )}
@@ -53,6 +55,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
 
           <input
             ref={ref}
+            id={inputId}
             className={inputClasses}
             disabled={disabled}
             {...props}

--- a/lexwebapp/src/pages/AdminBillingPage.tsx
+++ b/lexwebapp/src/pages/AdminBillingPage.tsx
@@ -518,23 +518,23 @@ function OrganizationsTab() {
             <h3 className="text-lg font-semibold mb-4">Edit: {editingOrg.name}</h3>
             <div className="space-y-3">
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Plan</label>
-                <input className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.plan || ''} onChange={(e) => setEditingOrg({ ...editingOrg, plan: e.target.value })} />
+                <label htmlFor="edit-org-plan" className="block text-xs text-gray-500 mb-1">Plan</label>
+                <input id="edit-org-plan" name="plan" className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.plan || ''} onChange={(e) => setEditingOrg({ ...editingOrg, plan: e.target.value })} />
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Max Members</label>
-                <input type="number" className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.max_members} onChange={(e) => setEditingOrg({ ...editingOrg, max_members: Number(e.target.value) })} />
+                <label htmlFor="edit-org-max-members" className="block text-xs text-gray-500 mb-1">Max Members</label>
+                <input id="edit-org-max-members" name="maxMembers" type="number" className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.max_members} onChange={(e) => setEditingOrg({ ...editingOrg, max_members: Number(e.target.value) })} />
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Billing Tier</label>
-                <select className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.billing_tier_key || ''} onChange={(e) => setEditingOrg({ ...editingOrg, billing_tier_key: e.target.value || null })}>
+                <label htmlFor="edit-org-billing-tier" className="block text-xs text-gray-500 mb-1">Billing Tier</label>
+                <select id="edit-org-billing-tier" name="billingTier" className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.billing_tier_key || ''} onChange={(e) => setEditingOrg({ ...editingOrg, billing_tier_key: e.target.value || null })}>
                   <option value="">None</option>
                   {tiers.map(t => <option key={t.id} value={t.tier_key}>{t.display_name}</option>)}
                 </select>
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Billing Email</label>
-                <input className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.billing_email || ''} onChange={(e) => setEditingOrg({ ...editingOrg, billing_email: e.target.value || null })} />
+                <label htmlFor="edit-org-billing-email" className="block text-xs text-gray-500 mb-1">Billing Email</label>
+                <input id="edit-org-billing-email" name="billingEmail" className="w-full border rounded-lg px-3 py-2 text-sm" value={editingOrg.billing_email || ''} onChange={(e) => setEditingOrg({ ...editingOrg, billing_email: e.target.value || null })} />
               </div>
             </div>
             <div className="flex justify-end gap-2 mt-4">
@@ -708,37 +708,37 @@ function SubscriptionsTab() {
             <h3 className="text-lg font-semibold mb-4">Create Subscription</h3>
             <div className="space-y-3">
               <div>
-                <label className="block text-xs text-gray-500 mb-1">User ID (leave empty for org)</label>
-                <input className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.user_id} onChange={(e) => setCreateForm({ ...createForm, user_id: e.target.value })} placeholder="UUID" />
+                <label htmlFor="create-sub-user-id" className="block text-xs text-gray-500 mb-1">User ID (leave empty for org)</label>
+                <input id="create-sub-user-id" name="userId" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.user_id} onChange={(e) => setCreateForm({ ...createForm, user_id: e.target.value })} placeholder="UUID" />
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Organization ID (leave empty for user)</label>
-                <input className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.organization_id} onChange={(e) => setCreateForm({ ...createForm, organization_id: e.target.value })} placeholder="UUID" />
+                <label htmlFor="create-sub-org-id" className="block text-xs text-gray-500 mb-1">Organization ID (leave empty for user)</label>
+                <input id="create-sub-org-id" name="organizationId" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.organization_id} onChange={(e) => setCreateForm({ ...createForm, organization_id: e.target.value })} placeholder="UUID" />
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Tier</label>
-                <select className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.tier_key} onChange={(e) => setCreateForm({ ...createForm, tier_key: e.target.value })}>
+                <label htmlFor="create-sub-tier" className="block text-xs text-gray-500 mb-1">Tier</label>
+                <select id="create-sub-tier" name="tier" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.tier_key} onChange={(e) => setCreateForm({ ...createForm, tier_key: e.target.value })}>
                   <option value="">Select tier</option>
                   {tiers.map(t => <option key={t.id} value={t.tier_key}>{t.display_name}</option>)}
                 </select>
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">Billing Cycle</label>
-                  <select className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.billing_cycle} onChange={(e) => setCreateForm({ ...createForm, billing_cycle: e.target.value })}>
+                  <label htmlFor="create-sub-billing-cycle" className="block text-xs text-gray-500 mb-1">Billing Cycle</label>
+                  <select id="create-sub-billing-cycle" name="billingCycle" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.billing_cycle} onChange={(e) => setCreateForm({ ...createForm, billing_cycle: e.target.value })}>
                     <option value="monthly">Monthly</option>
                     <option value="quarterly">Quarterly</option>
                     <option value="annual">Annual</option>
                   </select>
                 </div>
                 <div>
-                  <label className="block text-xs text-gray-500 mb-1">Price (USD)</label>
-                  <input type="number" step="0.01" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.price_usd} onChange={(e) => setCreateForm({ ...createForm, price_usd: Number(e.target.value) })} />
+                  <label htmlFor="create-sub-price" className="block text-xs text-gray-500 mb-1">Price (USD)</label>
+                  <input id="create-sub-price" name="priceUsd" type="number" step="0.01" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.price_usd} onChange={(e) => setCreateForm({ ...createForm, price_usd: Number(e.target.value) })} />
                 </div>
               </div>
               <div>
-                <label className="block text-xs text-gray-500 mb-1">Trial Ends At (optional)</label>
-                <input type="date" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.trial_ends_at} onChange={(e) => setCreateForm({ ...createForm, trial_ends_at: e.target.value })} />
+                <label htmlFor="create-sub-trial-ends" className="block text-xs text-gray-500 mb-1">Trial Ends At (optional)</label>
+                <input id="create-sub-trial-ends" name="trialEndsAt" type="date" className="w-full border rounded-lg px-3 py-2 text-sm" value={createForm.trial_ends_at} onChange={(e) => setCreateForm({ ...createForm, trial_ends_at: e.target.value })} />
               </div>
             </div>
             <div className="flex justify-end gap-2 mt-4">
@@ -755,8 +755,8 @@ function SubscriptionsTab() {
           <div className="bg-white rounded-xl shadow-xl p-6 w-full max-w-sm" onClick={(e) => e.stopPropagation()}>
             <h3 className="text-lg font-semibold mb-3">Cancel Subscription</h3>
             <div>
-              <label className="block text-xs text-gray-500 mb-1">Reason</label>
-              <textarea className="w-full border rounded-lg px-3 py-2 text-sm" rows={3} value={cancelReason} onChange={(e) => setCancelReason(e.target.value)} placeholder="Reason for cancellation..." />
+              <label htmlFor="cancel-sub-reason" className="block text-xs text-gray-500 mb-1">Reason</label>
+              <textarea id="cancel-sub-reason" name="cancelReason" className="w-full border rounded-lg px-3 py-2 text-sm" rows={3} value={cancelReason} onChange={(e) => setCancelReason(e.target.value)} placeholder="Reason for cancellation..." />
             </div>
             <div className="flex justify-end gap-2 mt-4">
               <button onClick={() => setCancelModal(null)} className="px-4 py-2 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">Back</button>


### PR DESCRIPTION
## Summary

- **Input component**: derive `inputId` from `props.id` or label text; bind `htmlFor` on label and `id` on input so they're always associated
- **TopUpTab**: add `id`/`name` to the custom amount input, add `htmlFor` to its label
- **AdminBillingPage**: add `id`/`name`/`htmlFor` to all inputs, selects, and textareas in the Edit Org, Create Subscription, and Cancel Subscription modals

Fixes browser console warnings seen on stage:
- _"A form field element should have an id or name attribute"_ (4 violations)
- _"No label associated with a form field"_ (3 violations)

## Test plan

- [ ] Open Admin Billing page → Edit an org → verify no accessibility warnings in DevTools console
- [ ] Open Create Subscription modal → verify no warnings
- [ ] Open Cancel Subscription modal → verify no warnings
- [ ] Open Billing → Top Up tab → verify custom amount field has no warnings
- [ ] Confirm Input component with a `label` prop properly associates label↔input (click label focuses input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Associated labels with their form fields and added missing id/name attributes across billing pages to improve accessibility and clear DevTools warnings.

- **Bug Fixes**
  - Input: auto-derive an id from props.id or label text; bind label htmlFor to input id.
  - TopUpTab: add id/name to custom amount input and link its label.
  - AdminBillingPage: add id/name/htmlFor to inputs, selects, and textarea in Edit Org, Create Subscription, and Cancel Subscription modals.

<sup>Written for commit 4e6ff9fdbbce304cf6a4e69b4247a327c6b68e2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

