### PR TITLE
feat(admin): per-tool cost management with markup support

### DIFF
--- a/lexwebapp/src/pages/AdminServicePricingPage.tsx
+++ b/lexwebapp/src/pages/AdminServicePricingPage.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { Tag, RefreshCw, Save, AlertCircle, CheckCircle, ChevronDown, ChevronRight } from 'lucide-react';
+import { Tag, RefreshCw, Save, AlertCircle, CheckCircle, ChevronDown, ChevronRight, Percent } from 'lucide-react';
 import { api } from '../utils/api-client';
+
+// ─── External service pricing ───────────────────────────────────────────────
 
 interface PricingEntry {
   id: string;
@@ -17,13 +19,29 @@ interface PricingEntry {
   updated_by: string | null;
 }
 
+// ─── Tool pricing ────────────────────────────────────────────────────────────
+
+interface ToolPricingEntry {
+  id: string;
+  tool_name: string;
+  service: string;
+  display_name: string;
+  base_cost_usd: number;
+  markup_percent: number;
+  is_active: boolean;
+  notes: string | null;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
 const PROVIDER_LABELS: Record<string, string> = {
   anthropic:   'Anthropic (Claude)',
   openai:      'OpenAI',
   voyageai:    'VoyageAI',
   zakononline: 'ZakonOnline API',
 };
-
 const PROVIDER_ORDER = ['anthropic', 'openai', 'voyageai', 'zakononline'];
 
 const UNIT_LABELS: Record<string, string> = {
@@ -33,6 +51,13 @@ const UNIT_LABELS: Record<string, string> = {
   per_call:             'за виклик',
 };
 
+const SERVICE_LABELS: Record<string, string> = {
+  backend:      'mcp_backend (юридичний аналіз)',
+  rada:         'mcp_rada (парламент)',
+  openreyestr:  'mcp_openreyestr (реєстр)',
+};
+const SERVICE_ORDER = ['backend', 'rada', 'openreyestr'];
+
 function formatDate(iso: string) {
   try {
     return new Date(iso).toLocaleString('uk-UA', { dateStyle: 'short', timeStyle: 'short' });
@@ -41,7 +66,13 @@ function formatDate(iso: string) {
   }
 }
 
-export function AdminServicePricingPage() {
+function fmtUsd(v: number) {
+  return v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 6 });
+}
+
+// ─── External providers tab ──────────────────────────────────────────────────
+
+function ExternalProvidersTab() {
   const [pricing, setPricing] = useState<PricingEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -52,18 +83,13 @@ export function AdminServicePricingPage() {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
 
   const load = async () => {
-    setLoading(true);
-    setError(null);
+    setLoading(true); setError(null);
     try {
       const res = await api.admin.getServicePricing();
       setPricing(res.data.pricing || []);
       const initial: typeof editValues = {};
       for (const p of res.data.pricing || []) {
-        initial[p.id] = {
-          price_usd: String(p.price_usd),
-          notes: p.notes || '',
-          is_active: p.is_active,
-        };
+        initial[p.id] = { price_usd: String(p.price_usd), notes: p.notes || '', is_active: p.is_active };
       }
       setEditValues(initial);
     } catch (e: any) {
@@ -72,7 +98,6 @@ export function AdminServicePricingPage() {
       setLoading(false);
     }
   };
-
   useEffect(() => { load(); }, []);
 
   const handleSave = async (entry: PricingEntry) => {
@@ -86,17 +111,9 @@ export function AdminServicePricingPage() {
     setSaving(prev => ({ ...prev, [entry.id]: true }));
     setErrorIds(prev => { const n = { ...prev }; delete n[entry.id]; return n; });
     try {
-      await api.admin.updateServicePricing(entry.id, {
-        price_usd: priceNum,
-        notes: vals.notes || undefined,
-        is_active: vals.is_active,
-      });
+      await api.admin.updateServicePricing(entry.id, { price_usd: priceNum, notes: vals.notes || undefined, is_active: vals.is_active });
       setSavedIds(prev => new Set([...prev, entry.id]));
-      setPricing(prev => prev.map(p =>
-        p.id === entry.id
-          ? { ...p, price_usd: priceNum, notes: vals.notes || null, is_active: vals.is_active, updated_at: new Date().toISOString() }
-          : p
-      ));
+      setPricing(prev => prev.map(p => p.id === entry.id ? { ...p, price_usd: priceNum, notes: vals.notes || null, is_active: vals.is_active, updated_at: new Date().toISOString() } : p));
       setTimeout(() => setSavedIds(prev => { const n = new Set(prev); n.delete(entry.id); return n; }), 2500);
     } catch (e: any) {
       setErrorIds(prev => ({ ...prev, [entry.id]: e?.response?.data?.error || e.message || 'Помилка збереження' }));
@@ -106,11 +123,7 @@ export function AdminServicePricingPage() {
   };
 
   const toggleCollapse = (provider: string) => {
-    setCollapsed(prev => {
-      const n = new Set(prev);
-      n.has(provider) ? n.delete(provider) : n.add(provider);
-      return n;
-    });
+    setCollapsed(prev => { const n = new Set(prev); n.has(provider) ? n.delete(provider) : n.add(provider); return n; });
   };
 
   const grouped: Record<string, PricingEntry[]> = {};
@@ -118,182 +131,431 @@ export function AdminServicePricingPage() {
     if (!grouped[p.provider]) grouped[p.provider] = [];
     grouped[p.provider].push(p);
   }
-
   const providers = PROVIDER_ORDER.filter(p => grouped[p]);
 
+  if (loading && !pricing.length) {
+    return <div className="flex items-center justify-center py-16 text-claude-subtext"><RefreshCw className="w-5 h-5 animate-spin mr-2" />Завантаження…</div>;
+  }
+  if (error) {
+    return <div className="p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2 text-sm text-red-700"><AlertCircle className="w-4 h-4 flex-shrink-0" />{error}</div>;
+  }
+
   return (
-    <div className="h-full overflow-y-auto">
-    <div className="p-6 max-w-5xl mx-auto">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-3">
-          <div className="p-2 bg-claude-accent/10 rounded-lg">
-            <Tag className="w-6 h-6 text-claude-accent" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-semibold text-claude-text font-sans">Собівартість зовнішніх сервісів</h1>
-            <p className="text-sm text-claude-subtext mt-0.5">Управління вартістю API-сервісів для обліку витрат</p>
-          </div>
-        </div>
-        <button
-          onClick={load}
-          disabled={loading}
-          className="flex items-center gap-2 px-4 py-2 bg-white border border-claude-border rounded-lg text-sm text-claude-text hover:bg-claude-bg transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-          Оновити
+    <div className="space-y-4">
+      <div className="flex justify-end">
+        <button onClick={load} disabled={loading} className="flex items-center gap-2 px-3 py-1.5 bg-white border border-claude-border rounded-lg text-sm text-claude-text hover:bg-claude-bg transition-colors disabled:opacity-50">
+          <RefreshCw className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`} />Оновити
         </button>
       </div>
-
-      {error && (
-        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2 text-sm text-red-700">
-          <AlertCircle className="w-4 h-4 flex-shrink-0" />
-          {error}
-        </div>
-      )}
-
-      {loading && !pricing.length ? (
-        <div className="flex items-center justify-center py-16 text-claude-subtext">
-          <RefreshCw className="w-5 h-5 animate-spin mr-2" />
-          Завантаження…
-        </div>
-      ) : (
-        <div className="space-y-4">
-          {providers.map(provider => {
-            const entries = grouped[provider] || [];
-            const isCollapsed = collapsed.has(provider);
-            return (
-              <div key={provider} className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
-                {/* Provider header */}
-                <button
-                  onClick={() => toggleCollapse(provider)}
-                  className="w-full flex items-center justify-between px-5 py-3 bg-claude-bg hover:bg-claude-sidebar transition-colors text-left"
-                >
-                  <span className="font-medium text-claude-text font-sans">{PROVIDER_LABELS[provider] || provider}</span>
-                  <div className="flex items-center gap-2 text-claude-subtext text-xs">
-                    <span>{entries.length} {entries.length === 1 ? 'позиція' : 'позиції'}</span>
-                    {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-                  </div>
-                </button>
-
-                {!isCollapsed && (
-                  <div className="divide-y divide-claude-border">
-                    {/* Table header */}
-                    <div className="grid grid-cols-[1fr_120px_180px_100px_80px_100px] gap-3 px-5 py-2 bg-white text-xs font-medium text-claude-subtext uppercase tracking-wide">
-                      <span>Модель / Послуга</span>
-                      <span>Одиниця</span>
-                      <span>Ціна (USD)</span>
-                      <span>Активна</span>
-                      <span>Оновлено</span>
-                      <span></span>
-                    </div>
-
-                    {entries.map(entry => {
-                      const vals = editValues[entry.id];
-                      const isSaving = saving[entry.id];
-                      const isSaved = savedIds.has(entry.id);
-                      const entryError = errorIds[entry.id];
-                      const isDirty = vals && (
-                        String(parseFloat(vals.price_usd) || 0) !== String(entry.price_usd) ||
-                        (vals.notes || '') !== (entry.notes || '') ||
-                        vals.is_active !== entry.is_active
-                      );
-
-                      return (
-                        <div
-                          key={entry.id}
-                          className={`grid grid-cols-[1fr_120px_180px_100px_80px_100px] gap-3 px-5 py-3 items-center text-sm hover:bg-claude-bg transition-colors ${!entry.is_active ? 'opacity-50' : ''}`}
-                        >
-                          {/* Name */}
-                          <div>
-                            <div className="font-medium text-claude-text">{entry.display_name}</div>
-                            {entry.notes && (
-                              <div className="text-xs text-claude-subtext mt-0.5">{entry.notes}</div>
-                            )}
-                          </div>
-
-                          {/* Unit type */}
-                          <div className="text-xs text-claude-subtext">
-                            {UNIT_LABELS[entry.unit_type] || entry.unit_type}
-                            <div className="text-claude-subtext/70">{entry.currency}</div>
-                          </div>
-
-                          {/* Price input */}
-                          <div>
-                            <div className="flex items-center gap-1">
-                              <span className="text-claude-subtext text-xs">$</span>
-                              <input
-                                type="number"
-                                min="0"
-                                step="0.00000001"
-                                value={vals?.price_usd ?? entry.price_usd}
-                                onChange={e => setEditValues(prev => ({
-                                  ...prev,
-                                  [entry.id]: { ...prev[entry.id], price_usd: e.target.value },
-                                }))}
-                                className="w-full border border-claude-border rounded-md px-2 py-1 text-sm text-claude-text bg-white focus:outline-none focus:ring-2 focus:ring-claude-accent/40 focus:border-claude-accent/60"
-                              />
-                            </div>
-                            {entryError && (
-                              <div className="text-xs text-red-500 mt-1">{entryError}</div>
-                            )}
-                          </div>
-
-                          {/* Active toggle */}
-                          <div className="flex justify-center">
-                            <button
-                              onClick={() => setEditValues(prev => ({
-                                ...prev,
-                                [entry.id]: { ...prev[entry.id], is_active: !prev[entry.id]?.is_active },
-                              }))}
-                              className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${vals?.is_active ? 'bg-claude-accent' : 'bg-claude-border'}`}
-                            >
-                              <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${vals?.is_active ? 'translate-x-4.5' : 'translate-x-0.5'}`} />
-                            </button>
-                          </div>
-
-                          {/* Updated at */}
-                          <div className="text-xs text-claude-subtext whitespace-nowrap">
-                            {formatDate(entry.updated_at)}
-                          </div>
-
-                          {/* Save button */}
-                          <div className="flex justify-end">
-                            {isSaved ? (
-                              <span className="flex items-center gap-1 text-xs text-emerald-600">
-                                <CheckCircle className="w-3.5 h-3.5" /> Збережено
-                              </span>
-                            ) : (
-                              <button
-                                onClick={() => handleSave(entry)}
-                                disabled={isSaving || !isDirty}
-                                className="flex items-center gap-1 px-2.5 py-1 text-xs bg-claude-text text-white rounded-md hover:bg-black/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-                              >
-                                {isSaving ? (
-                                  <RefreshCw className="w-3 h-3 animate-spin" />
-                                ) : (
-                                  <Save className="w-3 h-3" />
-                                )}
-                                Зберегти
-                              </button>
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
+      {providers.map(provider => {
+        const entries = grouped[provider] || [];
+        const isCollapsed = collapsed.has(provider);
+        return (
+          <div key={provider} className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
+            <button onClick={() => toggleCollapse(provider)} className="w-full flex items-center justify-between px-5 py-3 bg-claude-bg hover:bg-claude-sidebar transition-colors text-left">
+              <span className="font-medium text-claude-text font-sans">{PROVIDER_LABELS[provider] || provider}</span>
+              <div className="flex items-center gap-2 text-claude-subtext text-xs">
+                <span>{entries.length} {entries.length === 1 ? 'позиція' : 'позиції'}</span>
+                {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
               </div>
-            );
-          })}
-        </div>
-      )}
-
-      <p className="mt-6 text-xs text-claude-subtext">
+            </button>
+            {!isCollapsed && (
+              <div className="divide-y divide-claude-border">
+                <div className="grid grid-cols-[1fr_120px_180px_100px_80px_100px] gap-3 px-5 py-2 bg-white text-xs font-medium text-claude-subtext uppercase tracking-wide">
+                  <span>Модель / Послуга</span><span>Одиниця</span><span>Ціна (USD)</span><span>Активна</span><span>Оновлено</span><span></span>
+                </div>
+                {entries.map(entry => {
+                  const vals = editValues[entry.id];
+                  const isSaving = saving[entry.id];
+                  const isSaved = savedIds.has(entry.id);
+                  const entryError = errorIds[entry.id];
+                  const isDirty = vals && (
+                    String(parseFloat(vals.price_usd) || 0) !== String(entry.price_usd) ||
+                    (vals.notes || '') !== (entry.notes || '') ||
+                    vals.is_active !== entry.is_active
+                  );
+                  return (
+                    <div key={entry.id} className={`grid grid-cols-[1fr_120px_180px_100px_80px_100px] gap-3 px-5 py-3 items-center text-sm hover:bg-claude-bg transition-colors ${!entry.is_active ? 'opacity-50' : ''}`}>
+                      <div>
+                        <div className="font-medium text-claude-text">{entry.display_name}</div>
+                        {entry.notes && <div className="text-xs text-claude-subtext mt-0.5">{entry.notes}</div>}
+                      </div>
+                      <div className="text-xs text-claude-subtext">
+                        {UNIT_LABELS[entry.unit_type] || entry.unit_type}
+                        <div className="text-claude-subtext/70">{entry.currency}</div>
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-1">
+                          <span className="text-claude-subtext text-xs">$</span>
+                          <input type="number" min="0" step="0.00000001" value={vals?.price_usd ?? entry.price_usd}
+                            onChange={e => setEditValues(prev => ({ ...prev, [entry.id]: { ...prev[entry.id], price_usd: e.target.value } }))}
+                            className="w-full border border-claude-border rounded-md px-2 py-1 text-sm text-claude-text bg-white focus:outline-none focus:ring-2 focus:ring-claude-accent/40 focus:border-claude-accent/60"
+                          />
+                        </div>
+                        {entryError && <div className="text-xs text-red-500 mt-1">{entryError}</div>}
+                      </div>
+                      <div className="flex justify-center">
+                        <button onClick={() => setEditValues(prev => ({ ...prev, [entry.id]: { ...prev[entry.id], is_active: !prev[entry.id]?.is_active } }))}
+                          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${vals?.is_active ? 'bg-claude-accent' : 'bg-claude-border'}`}>
+                          <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${vals?.is_active ? 'translate-x-4.5' : 'translate-x-0.5'}`} />
+                        </button>
+                      </div>
+                      <div className="text-xs text-claude-subtext whitespace-nowrap">{formatDate(entry.updated_at)}</div>
+                      <div className="flex justify-end">
+                        {isSaved ? (
+                          <span className="flex items-center gap-1 text-xs text-emerald-600"><CheckCircle className="w-3.5 h-3.5" /> Збережено</span>
+                        ) : (
+                          <button onClick={() => handleSave(entry)} disabled={isSaving || !isDirty}
+                            className="flex items-center gap-1 px-2.5 py-1 text-xs bg-claude-text text-white rounded-md hover:bg-black/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors">
+                            {isSaving ? <RefreshCw className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />}
+                            Зберегти
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+      <p className="text-xs text-claude-subtext">
         Ціни зберігаються в таблиці <code className="font-mono bg-claude-bg px-1 rounded">service_pricing</code> та використовуються для обліку собівартості запитів.
         Значення вказуються в USD (крім ZakonOnline — в UAH).
       </p>
     </div>
+  );
+}
+
+// ─── Tool pricing tab ────────────────────────────────────────────────────────
+
+function ToolPricingTab() {
+  const [tools, setTools] = useState<ToolPricingEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [editValues, setEditValues] = useState<Record<string, { base_cost_usd: string; markup_percent: string; notes: string; is_active: boolean }>>({});
+  const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [savedNames, setSavedNames] = useState<Set<string>>(new Set());
+  const [errorNames, setErrorNames] = useState<Record<string, string>>({});
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+
+  // Bulk markup
+  const [bulkMarkup, setBulkMarkup] = useState('');
+  const [bulkService, setBulkService] = useState('');
+  const [bulkSaving, setBulkSaving] = useState(false);
+  const [bulkMsg, setBulkMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const load = async () => {
+    setLoading(true); setError(null);
+    try {
+      const res = await api.admin.getToolPricing();
+      const rows: ToolPricingEntry[] = res.data.tools || [];
+      setTools(rows);
+      const initial: typeof editValues = {};
+      for (const t of rows) {
+        initial[t.tool_name] = {
+          base_cost_usd: String(t.base_cost_usd),
+          markup_percent: String(t.markup_percent),
+          notes: t.notes || '',
+          is_active: t.is_active,
+        };
+      }
+      setEditValues(initial);
+    } catch (e: any) {
+      setError(e?.response?.data?.error || e.message || 'Помилка завантаження');
+    } finally {
+      setLoading(false);
+    }
+  };
+  useEffect(() => { load(); }, []);
+
+  const handleSave = async (tool: ToolPricingEntry) => {
+    const vals = editValues[tool.tool_name];
+    if (!vals) return;
+    const costNum = parseFloat(vals.base_cost_usd);
+    const markupNum = parseFloat(vals.markup_percent);
+    if (isNaN(costNum) || costNum < 0) {
+      setErrorNames(prev => ({ ...prev, [tool.tool_name]: 'Некоректна собівартість' }));
+      return;
+    }
+    if (isNaN(markupNum) || markupNum < -100) {
+      setErrorNames(prev => ({ ...prev, [tool.tool_name]: 'Надбавка ≥ -100%' }));
+      return;
+    }
+    setSaving(prev => ({ ...prev, [tool.tool_name]: true }));
+    setErrorNames(prev => { const n = { ...prev }; delete n[tool.tool_name]; return n; });
+    try {
+      await api.admin.updateToolPricing(tool.tool_name, {
+        base_cost_usd: costNum,
+        markup_percent: markupNum,
+        notes: vals.notes || undefined,
+        is_active: vals.is_active,
+      });
+      setSavedNames(prev => new Set([...prev, tool.tool_name]));
+      setTools(prev => prev.map(t => t.tool_name === tool.tool_name
+        ? { ...t, base_cost_usd: costNum, markup_percent: markupNum, notes: vals.notes || null, is_active: vals.is_active, updated_at: new Date().toISOString() }
+        : t
+      ));
+      setTimeout(() => setSavedNames(prev => { const n = new Set(prev); n.delete(tool.tool_name); return n; }), 2500);
+    } catch (e: any) {
+      setErrorNames(prev => ({ ...prev, [tool.tool_name]: e?.response?.data?.error || e.message || 'Помилка збереження' }));
+    } finally {
+      setSaving(prev => ({ ...prev, [tool.tool_name]: false }));
+    }
+  };
+
+  const handleBulkMarkup = async () => {
+    const pct = parseFloat(bulkMarkup);
+    if (isNaN(pct) || pct < -100) { setBulkMsg({ ok: false, text: 'Некоректне значення надбавки' }); return; }
+    setBulkSaving(true); setBulkMsg(null);
+    try {
+      const res = await api.admin.bulkToolMarkup({ markup_percent: pct, service: bulkService || undefined });
+      setBulkMsg({ ok: true, text: `Оновлено ${res.data.updated} інструментів` });
+      await load();
+    } catch (e: any) {
+      setBulkMsg({ ok: false, text: e?.response?.data?.error || e.message || 'Помилка' });
+    } finally {
+      setBulkSaving(false);
+    }
+  };
+
+  const toggleCollapse = (svc: string) => {
+    setCollapsed(prev => { const n = new Set(prev); n.has(svc) ? n.delete(svc) : n.add(svc); return n; });
+  };
+
+  const grouped: Record<string, ToolPricingEntry[]> = {};
+  for (const t of tools) {
+    if (!grouped[t.service]) grouped[t.service] = [];
+    grouped[t.service].push(t);
+  }
+  const services = SERVICE_ORDER.filter(s => grouped[s]);
+
+  if (loading && !tools.length) {
+    return <div className="flex items-center justify-center py-16 text-claude-subtext"><RefreshCw className="w-5 h-5 animate-spin mr-2" />Завантаження…</div>;
+  }
+  if (error) {
+    return <div className="p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2 text-sm text-red-700"><AlertCircle className="w-4 h-4 flex-shrink-0" />{error}</div>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Bulk markup panel */}
+      <div className="bg-white rounded-xl border border-claude-border shadow-sm p-4">
+        <div className="flex items-center gap-2 mb-3">
+          <Percent className="w-4 h-4 text-claude-accent" />
+          <span className="font-medium text-sm text-claude-text">Масова зміна надбавки</span>
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-1">
+            <input
+              type="number" step="0.01" placeholder="Надбавка, %"
+              value={bulkMarkup}
+              onChange={e => setBulkMarkup(e.target.value)}
+              className="w-36 border border-claude-border rounded-md px-2 py-1.5 text-sm text-claude-text bg-white focus:outline-none focus:ring-2 focus:ring-claude-accent/40"
+            />
+            <span className="text-claude-subtext text-sm">%</span>
+          </div>
+          <select
+            value={bulkService}
+            onChange={e => setBulkService(e.target.value)}
+            className="border border-claude-border rounded-md px-2 py-1.5 text-sm text-claude-text bg-white focus:outline-none focus:ring-2 focus:ring-claude-accent/40"
+          >
+            <option value="">Всі сервіси</option>
+            {SERVICE_ORDER.map(s => <option key={s} value={s}>{SERVICE_LABELS[s] || s}</option>)}
+          </select>
+          <button
+            onClick={handleBulkMarkup}
+            disabled={bulkSaving || bulkMarkup === ''}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-claude-text text-white rounded-md hover:bg-black/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {bulkSaving ? <RefreshCw className="w-3.5 h-3.5 animate-spin" /> : <Percent className="w-3.5 h-3.5" />}
+            Застосувати
+          </button>
+          {bulkMsg && (
+            <span className={`text-sm flex items-center gap-1 ${bulkMsg.ok ? 'text-emerald-600' : 'text-red-600'}`}>
+              {bulkMsg.ok ? <CheckCircle className="w-3.5 h-3.5" /> : <AlertCircle className="w-3.5 h-3.5" />}
+              {bulkMsg.text}
+            </span>
+          )}
+          <button onClick={load} disabled={loading} className="ml-auto flex items-center gap-1.5 px-3 py-1.5 bg-white border border-claude-border rounded-lg text-sm text-claude-text hover:bg-claude-bg transition-colors disabled:opacity-50">
+            <RefreshCw className={`w-3.5 h-3.5 ${loading ? 'animate-spin' : ''}`} />Оновити
+          </button>
+        </div>
+        <p className="mt-2 text-xs text-claude-subtext">
+          Надбавка додається до собівартості при виставленні рахунку клієнту. Від'ємне значення — знижка.
+        </p>
+      </div>
+
+      {/* Tool groups */}
+      {services.map(svc => {
+        const entries = grouped[svc] || [];
+        const isCollapsed = collapsed.has(svc);
+        const totalTools = entries.length;
+        const avgCost = entries.reduce((s, t) => s + t.base_cost_usd, 0) / (totalTools || 1);
+        return (
+          <div key={svc} className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
+            <button onClick={() => toggleCollapse(svc)} className="w-full flex items-center justify-between px-5 py-3 bg-claude-bg hover:bg-claude-sidebar transition-colors text-left">
+              <span className="font-medium text-claude-text font-sans">{SERVICE_LABELS[svc] || svc}</span>
+              <div className="flex items-center gap-3 text-claude-subtext text-xs">
+                <span>{totalTools} інструм.</span>
+                <span>Середня: ${fmtUsd(avgCost)}</span>
+                {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
+              </div>
+            </button>
+
+            {!isCollapsed && (
+              <div className="divide-y divide-claude-border">
+                {/* Table header */}
+                <div className="grid grid-cols-[1fr_160px_140px_90px_80px_90px] gap-2 px-5 py-2 bg-white text-xs font-medium text-claude-subtext uppercase tracking-wide">
+                  <span>Інструмент</span>
+                  <span>Собівартість (USD)</span>
+                  <span>Надбавка (%)</span>
+                  <span>Клієнтська ціна</span>
+                  <span>Активний</span>
+                  <span></span>
+                </div>
+
+                {entries.map(tool => {
+                  const vals = editValues[tool.tool_name];
+                  const isSaving = saving[tool.tool_name];
+                  const isSaved = savedNames.has(tool.tool_name);
+                  const toolError = errorNames[tool.tool_name];
+                  const costNum = parseFloat(vals?.base_cost_usd ?? String(tool.base_cost_usd)) || 0;
+                  const markupNum = parseFloat(vals?.markup_percent ?? String(tool.markup_percent)) || 0;
+                  const clientPrice = costNum * (1 + markupNum / 100);
+                  const isDirty = vals && (
+                    String(parseFloat(vals.base_cost_usd) || 0) !== String(tool.base_cost_usd) ||
+                    String(parseFloat(vals.markup_percent) || 0) !== String(tool.markup_percent) ||
+                    (vals.notes || '') !== (tool.notes || '') ||
+                    vals.is_active !== tool.is_active
+                  );
+
+                  return (
+                    <div key={tool.tool_name}
+                      className={`grid grid-cols-[1fr_160px_140px_90px_80px_90px] gap-2 px-5 py-3 items-center text-sm hover:bg-claude-bg transition-colors ${!tool.is_active ? 'opacity-50' : ''}`}
+                    >
+                      {/* Name */}
+                      <div>
+                        <div className="font-medium text-claude-text">{tool.display_name}</div>
+                        <div className="text-xs text-claude-subtext font-mono mt-0.5">{tool.tool_name}</div>
+                        {tool.notes && <div className="text-xs text-claude-subtext/70 mt-0.5 italic">{tool.notes}</div>}
+                        {toolError && <div className="text-xs text-red-500 mt-1">{toolError}</div>}
+                      </div>
+
+                      {/* Base cost */}
+                      <div>
+                        <div className="flex items-center gap-1">
+                          <span className="text-claude-subtext text-xs">$</span>
+                          <input
+                            type="number" min="0" step="0.000001"
+                            value={vals?.base_cost_usd ?? tool.base_cost_usd}
+                            onChange={e => setEditValues(prev => ({ ...prev, [tool.tool_name]: { ...prev[tool.tool_name], base_cost_usd: e.target.value } }))}
+                            className="w-full border border-claude-border rounded-md px-2 py-1 text-sm text-claude-text bg-white focus:outline-none focus:ring-2 focus:ring-claude-accent/40 focus:border-claude-accent/60"
+                          />
+                        </div>
+                      </div>
+
+                      {/* Markup % */}
+                      <div>
+                        <div className="flex items-center gap-1">
+                          <input
+                            type="number" step="0.01"
+                            value={vals?.markup_percent ?? tool.markup_percent}
+                            onChange={e => setEditValues(prev => ({ ...prev, [tool.tool_name]: { ...prev[tool.tool_name], markup_percent: e.target.value } }))}
+                            className="w-full border border-claude-border rounded-md px-2 py-1 text-sm text-claude-text bg-white focus:outline-none focus:ring-2 focus:ring-claude-accent/40 focus:border-claude-accent/60"
+                          />
+                          <span className="text-claude-subtext text-xs">%</span>
+                        </div>
+                      </div>
+
+                      {/* Client price (computed) */}
+                      <div className="text-sm font-medium text-claude-text text-right tabular-nums">
+                        ${fmtUsd(clientPrice)}
+                      </div>
+
+                      {/* Active toggle */}
+                      <div className="flex justify-center">
+                        <button
+                          onClick={() => setEditValues(prev => ({ ...prev, [tool.tool_name]: { ...prev[tool.tool_name], is_active: !prev[tool.tool_name]?.is_active } }))}
+                          className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${vals?.is_active ? 'bg-claude-accent' : 'bg-claude-border'}`}
+                        >
+                          <span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${vals?.is_active ? 'translate-x-4.5' : 'translate-x-0.5'}`} />
+                        </button>
+                      </div>
+
+                      {/* Save button */}
+                      <div className="flex justify-end">
+                        {isSaved ? (
+                          <span className="flex items-center gap-1 text-xs text-emerald-600"><CheckCircle className="w-3.5 h-3.5" /> Збережено</span>
+                        ) : (
+                          <button
+                            onClick={() => handleSave(tool)}
+                            disabled={isSaving || !isDirty}
+                            className="flex items-center gap-1 px-2.5 py-1 text-xs bg-claude-text text-white rounded-md hover:bg-black/80 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                          >
+                            {isSaving ? <RefreshCw className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />}
+                            Зберегти
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <p className="text-xs text-claude-subtext">
+        Дані зберігаються в таблиці <code className="font-mono bg-claude-bg px-1 rounded">tool_pricing</code>.
+        «Клієнтська ціна» розраховується як: собівартість × (1 + надбавка / 100).
+      </p>
+    </div>
+  );
+}
+
+// ─── Main page ────────────────────────────────────────────────────────────────
+
+type Tab = 'external' | 'tools';
+
+export function AdminServicePricingPage() {
+  const [activeTab, setActiveTab] = useState<Tab>('tools');
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-6 max-w-6xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6">
+          <div className="p-2 bg-claude-accent/10 rounded-lg">
+            <Tag className="w-6 h-6 text-claude-accent" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-claude-text font-sans">Собівартість сервісів</h1>
+            <p className="text-sm text-claude-subtext mt-0.5">Управління вартістю API-сервісів та MCP-інструментів</p>
+          </div>
+        </div>
+
+        {/* Tabs */}
+        <div className="flex gap-1 mb-6 bg-claude-bg rounded-lg p-1 w-fit">
+          <button
+            onClick={() => setActiveTab('tools')}
+            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${activeTab === 'tools' ? 'bg-white text-claude-text shadow-sm' : 'text-claude-subtext hover:text-claude-text'}`}
+          >
+            MCP Інструменти
+          </button>
+          <button
+            onClick={() => setActiveTab('external')}
+            className={`px-4 py-2 rounded-md text-sm font-medium transition-colors ${activeTab === 'external' ? 'bg-white text-claude-text shadow-sm' : 'text-claude-subtext hover:text-claude-text'}`}
+          >
+            Зовнішні сервіси
+          </button>
+        </div>
+
+        {activeTab === 'tools'    && <ToolPricingTab />}
+        {activeTab === 'external' && <ExternalProvidersTab />}
+      </div>
     </div>
   );
 }

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -357,11 +357,19 @@ export const api = {
     stopCourtScraper: (jobId: string) =>
       apiClient.post(`/api/admin/scrape-court-registry/${jobId}/stop`),
 
-    // Service pricing
+    // Service pricing (external providers)
     getServicePricing: () =>
       apiClient.get('/api/admin/service-pricing'),
     updateServicePricing: (id: string, data: { price_usd: number; notes?: string; is_active?: boolean }) =>
       apiClient.put(`/api/admin/service-pricing/${id}`, data),
+
+    // Tool pricing (MCP tools per-call cost)
+    getToolPricing: () =>
+      apiClient.get('/api/admin/tool-pricing'),
+    updateToolPricing: (toolName: string, data: { base_cost_usd: number; markup_percent?: number; notes?: string; is_active?: boolean }) =>
+      apiClient.put(`/api/admin/tool-pricing/${toolName}`, data),
+    bulkToolMarkup: (data: { markup_percent: number; service?: string }) =>
+      apiClient.post('/api/admin/tool-pricing/bulk-markup', data),
   },
 
   // GDPR

--- a/mcp_backend/src/migrations/053_add_tool_pricing.sql
+++ b/mcp_backend/src/migrations/053_add_tool_pricing.sql
@@ -1,0 +1,130 @@
+-- Migration 053: Add tool_pricing table for per-tool cost management
+-- Stores base cost per call and markup % for each MCP tool
+
+CREATE TABLE IF NOT EXISTS tool_pricing (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tool_name     VARCHAR(100) UNIQUE NOT NULL,
+  service       VARCHAR(50)  NOT NULL DEFAULT 'backend', -- 'backend', 'rada', 'openreyestr'
+  display_name  VARCHAR(200) NOT NULL,
+  base_cost_usd DECIMAL(14, 8) NOT NULL DEFAULT 0,
+  markup_percent DECIMAL(8, 4) NOT NULL DEFAULT 0,       -- % надбавка до ціни для клієнта
+  is_active     BOOLEAN NOT NULL DEFAULT true,
+  notes         TEXT,
+  updated_at    TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  updated_by    VARCHAR(255)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tool_pricing_service   ON tool_pricing(service);
+CREATE INDEX IF NOT EXISTS idx_tool_pricing_tool_name ON tool_pricing(tool_name);
+
+-- ============================================================
+-- Seed: Backend tools (mcp_backend, 36 основних інструментів)
+-- ============================================================
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes) VALUES
+
+-- Pipeline entry points
+('classify_intent',              'backend', 'Класифікація запиту',                     0.00200000, 'Роутинг pipeline, мінімальна вартість'),
+('retrieve_legal_sources',       'backend', 'RAG: отримання правових джерел',           0.01000000, 'Залежить від обсягу документів'),
+('analyze_legal_patterns',       'backend', 'Аналіз юридичних паттернів',               0.05000000, 'Success arguments + risk factors'),
+('validate_response',            'backend', 'Валідація відповіді (anti-hallucination)',  0.02000000, 'Trust layer, перевірка джерел'),
+
+-- Пошук судових справ
+('search_legal_precedents',      'backend', 'Пошук юридичних прецедентів',              0.06500000, 'OpenAI embeddings + ZakonOnline API'),
+('search_supreme_court_practice','backend', 'Практика Верховного Суду',                 0.10000000, 'ВП/КЦС/КГС/КАС/ККС'),
+('find_similar_fact_pattern_cases','backend','Пошук за схожими фактами',                0.06500000, 'Екстракція термінів + пошук'),
+('compare_practice_pro_contra',  'backend', 'Підбірка практики «за/проти»',             0.10000000, 'Дві лінії практики'),
+
+-- Аналіз судової практики
+('analyze_case_pattern',         'backend', 'Аналіз паттернів судової практики',        0.05000000, 'Аргументи, ризики, статистика'),
+('get_similar_reasoning',        'backend', 'Схожі судові обґрунтування',               0.02000000, 'OpenAI embeddings + Qdrant'),
+('get_citation_graph',           'backend', 'Граф цитувань між справами',               0.01000000, 'Прямі та зворотні зв''язки'),
+('check_precedent_status',       'backend', 'Перевірка статусу прецеденту',             0.01000000, 'Чинний/скасований/сумнівний'),
+
+-- Робота з документами
+('get_court_decision',           'backend', 'Завантаження рішення суду',                0.02500000, 'Секції: ФАКТИ, ОБҐРУНТУВАННЯ, РІШЕННЯ'),
+('get_case_text',                'backend', 'Отримання тексту судового рішення',        0.02500000, 'Аліас для get_court_decision'),
+('get_case_documents_chain',     'backend', 'Всі документи справи по всіх інстанціях',  0.01000000, 'Перша → Апеляція → Касація → ВП ВС'),
+('semantic_search',              'backend', 'Семантичний пошук у vault',                0.02000000, 'Qdrant векторна БД'),
+('get_related_cases',            'backend', 'Пов''язані судові справи',                 0.01500000, 'За номером справи або embeddings'),
+('extract_document_sections',    'backend', 'Вилучення структурованих секцій',          0.02000000, 'Залежить від use_llm'),
+('load_full_texts',              'backend', 'Завантаження повних текстів рішень',       0.00700000, 'PG + Redis кеш перед завантаженням'),
+('bulk_ingest_court_decisions',  'backend', 'Масове завантаження та індексація рішень', 0.05000000, 'Пошук → Scraping → Embeddings → Qdrant'),
+
+-- Підрахунки та статистика
+('count_cases_by_party',         'backend', 'Кількість справ за стороною',              0.00700000, '~$0.007 за сторінку (1000 справ)'),
+
+-- Нормативна база
+('find_relevant_law_articles',   'backend', 'Статті законів за темою',                  0.01500000, 'Legal patterns DB'),
+('search_procedural_norms',      'backend', 'Пошук процесуальних норм (ЦПК/ГПК)',       0.01500000, 'Через RADA MCP'),
+
+-- Законодавство
+('get_legislation_article',      'backend', 'Отримати статтю законодавчого акту',       0.00100000, 'Мінімальна вартість'),
+('get_legislation_section',      'backend', 'Отримати фрагмент за посиланням',          0.00100000, 'Мінімальна вартість'),
+('get_legislation_articles',     'backend', 'Кілька статей одночасно',                  0.00200000, 'Мінімальна вартість'),
+('search_legislation',           'backend', 'Семантичний пошук у законодавстві',        0.02000000, 'Векторний пошук'),
+('get_legislation_structure',    'backend', 'Структура законодавчого акту',             0.00100000, 'Мінімальна вартість'),
+
+-- Процесуальні інструменти
+('calculate_procedural_deadlines','backend','Калькулятор процесуальних строків',        0.05000000, 'ЦПК/ГПК/КПК строки'),
+('build_procedural_checklist',   'backend', 'Процесуальний чекліст',                   0.02000000, 'Шаблон + посилання на норму'),
+('calculate_monetary_claims',    'backend', 'Розрахунок грошових вимог',               0.00500000, '3% річних, інфляція, пеня'),
+
+-- Парсинг документів
+('parse_document',               'backend', 'Парсинг документу (PDF/DOCX/HTML)',        0.05000000, 'PDF текст → OCR → Vision'),
+('extract_key_clauses',          'backend', 'Вилучення ключових положень контракту',    0.06500000, 'Сторони, права, строки, штрафи'),
+('summarize_document',           'backend', 'Резюме документу',                         0.05000000, 'Quick/standard/deep рівні'),
+('compare_documents',            'backend', 'Порівняння двох документів',               0.07500000, 'Семантичне порівняння + embeddings'),
+
+-- Vault
+('store_document',               'backend', 'Збереження документу у vault',             0.00200000, 'Мінімальна вартість'),
+('get_document',                 'backend', 'Отримання документу з vault',              0.00100000, 'Мінімальна вартість'),
+('list_documents',               'backend', 'Список документів у vault',                0.00100000, 'З фільтрацією'),
+
+-- Додатковий аналіз
+('get_document_text',            'backend', 'Повний текст документу по doc_id',         0.00200000, 'Мінімальна вартість'),
+('get_case_metadata',            'backend', 'Метадані справи без повного тексту',       0.00100000, 'Мінімальна вартість'),
+('analyze_judicial_reasoning',   'backend', 'Глибокий аналіз судового обґрунтування',   0.03500000, 'Мотивировка'),
+('extract_legal_principles',     'backend', 'Вилучення правових принципів',             0.05500000, 'З масиву рішень'),
+('compare_decisions',            'backend', 'Порівняння двох або більше рішень',        0.04000000, 'Семантичне порівняння'),
+('track_precedent_evolution',    'backend', 'Еволюція прецеденту в часі',               0.05500000, 'Хронологічний аналіз'),
+('get_citation_network',         'backend', 'Мережа цитувань для набору справ',         0.10000000, 'Глибокий аналіз'),
+('batch_process_documents',      'backend', 'Пакетна обробка документів',               0.05000000, 'Парсинг, вилучення, резюме'),
+('get_judge_statistics',         'backend', 'Статистика по судді',                      0.02000000, 'Кількість справ, результати'),
+('analyze_court_trends',         'backend', 'Аналіз тенденцій судової практики',        0.08500000, 'Тренди по суду/темі/часу'),
+
+-- Головний інструмент
+('get_legal_advice',             'backend', 'Комплексний юридичний аналіз',             0.20000000, 'Найдорожчий: quick~$0.10, standard~$0.18, deep~$0.28')
+
+ON CONFLICT (tool_name) DO NOTHING;
+
+-- ============================================================
+-- Seed: RADA tools (4 інструменти)
+-- ============================================================
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes) VALUES
+('rada_search_parliament_bills',   'rada', 'Пошук законопроектів ВРУ',            0.01000000, 'Пошук по назві, статусу, автору'),
+('rada_get_deputy_info',           'rada', 'Інформація про депутата',             0.00500000, 'ФІО, фракція, комітети, голосування'),
+('rada_search_legislation_text',   'rada', 'Пошук у текстах законодавства',       0.01500000, 'Семантичний пошук RADA'),
+('rada_analyze_voting_record',     'rada', 'Аналіз протоколу голосування',        0.02000000, 'По законопроекту або депутату')
+ON CONFLICT (tool_name) DO NOTHING;
+
+-- ============================================================
+-- Seed: OpenReyestr tools (16 інструментів)
+-- ============================================================
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes) VALUES
+('openreyestr_search_entities',                'openreyestr', 'Пошук юридичних осіб',                0.00500000, 'ЄДР: назва, код, статус'),
+('openreyestr_get_entity_details',             'openreyestr', 'Деталі юридичної особи',              0.00300000, 'Повна інформація з ЄДР'),
+('openreyestr_search_beneficiaries',           'openreyestr', 'Пошук бенефіціарів',                  0.00500000, 'Кінцеві власники'),
+('openreyestr_get_by_edrpou',                  'openreyestr', 'Пошук за кодом ЄДРПОУ',              0.00300000, 'Точний пошук за кодом'),
+('openreyestr_get_statistics',                 'openreyestr', 'Статистика реєстру',                  0.00100000, 'Загальна статистика ЄДР'),
+('openreyestr_search_notaries',                'openreyestr', 'Пошук нотаріусів',                    0.00300000, 'Реєстр нотаріусів'),
+('openreyestr_search_court_experts',           'openreyestr', 'Пошук судових експертів',             0.00300000, 'Реєстр судових експертів'),
+('openreyestr_search_arbitration_managers',    'openreyestr', 'Пошук арбітражних керуючих',          0.00300000, 'Реєстр арбітражних керуючих'),
+('openreyestr_search_debtors',                 'openreyestr', 'Пошук боржників',                     0.00500000, 'Реєстр боржників'),
+('openreyestr_search_enforcement_proceedings', 'openreyestr', 'Виконавчі провадження',               0.00500000, 'Пошук по ВДВС'),
+('openreyestr_search_bankruptcy_cases',        'openreyestr', 'Справи про банкрутство',              0.00500000, 'Реєстр банкрутів'),
+('openreyestr_search_special_forms',           'openreyestr', 'Спеціальні форми власності',          0.00300000, 'Особливі форми'),
+('openreyestr_search_forensic_methods',        'openreyestr', 'Методи судової експертизи',           0.00300000, 'Словник методів'),
+('openreyestr_search_legal_acts',              'openreyestr', 'Нормативні акти реєстру',             0.00300000, 'Правові акти ЄДР'),
+('openreyestr_search_administrative_units',    'openreyestr', 'Пошук адміністративних одиниць',      0.00100000, 'КАТОТТГ класифікатор'),
+('openreyestr_search_streets',                 'openreyestr', 'Пошук вулиць',                        0.00100000, 'Класифікатор вулиць')
+ON CONFLICT (tool_name) DO NOTHING;


### PR DESCRIPTION
## Summary

- **New DB table** `tool_pricing` (migration 053) pre-seeded with all 56 MCP tools — base cost per call + markup %
- **3 new admin API endpoints**: list tools, update single tool pricing, bulk-apply markup (with optional service filter)
- **Refactored `AdminServicePricingPage`** into two tabs:
  - **MCP Інструменти** (default) — grouped by service (backend / rada / openreyestr), editable base cost & markup, real-time client price preview, bulk markup panel
  - **Зовнішні сервіси** — existing provider pricing (OpenAI, Anthropic, VoyageAI, ZakonOnline)

## Test plan

- [ ] Run migration: `cd mcp_backend && npm run migrate` — table created, 56 rows seeded
- [ ] Open admin → "Собівартість сервісів" → "MCP Інструменти" tab loads all tools
- [ ] Edit base cost or markup % for a tool → "Зберегти" saves, client price updates live
- [ ] Use bulk markup panel → changes reflected on all rows after reload
- [ ] Switch to "Зовнішні сервіси" tab — existing behavior unchanged
- [ ] `npm run build` (frontend) and `npm run build` (backend) — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-tool MCP pricing with markup so admins can control costs and client prices. Introduces a new tool_pricing table, admin APIs, and a refreshed admin UI with bulk markup.

- **New Features**
  - DB: tool_pricing table (migration 053) seeded with 56 tools across backend, rada, openreyestr (base_cost_usd, markup_percent, is_active, notes).
  - API: GET /api/admin/tool-pricing, PUT /api/admin/tool-pricing/:toolName, POST /api/admin/tool-pricing/bulk-markup (optional service filter).
  - UI: AdminServicePricingPage now has two tabs:
    - MCP Інструменти (default): group by service, edit base cost and markup, live client price preview, bulk markup panel.
    - Зовнішні сервіси: existing provider pricing UI unchanged.

- **Migration**
  - Run: cd mcp_backend && npm run migrate.
  - Rebuild: frontend and backend.
  - No breaking changes; external provider pricing flows remain the same.

<sup>Written for commit 4aa5c7df72612524a6e1aed56589938b37f0b60a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

