### PR TITLE
fix(admin): fix ZO stats API call in AdminZOStatsPage

### DIFF
--- a/lexwebapp/src/pages/AdminZOStatsPage.tsx
+++ b/lexwebapp/src/pages/AdminZOStatsPage.tsx
@@ -104,13 +104,12 @@ export function AdminZOStatsPage() {
     setError(null);
     setData(null);
     try {
-      const params = new URLSearchParams({
-        yearFrom: String(yearFrom),
-        yearTo:   String(yearTo),
+      const resp = await api.admin.getZOStats({
+        yearFrom,
+        yearTo,
         justiceKind: selectedKinds.join(','),
       });
-      const resp = await api.get<ZOStatsResponse>(`/api/admin/zo-stats?${params}`);
-      setData(resp.data);
+      setData(resp.data as ZOStatsResponse);
     } catch (err: any) {
       const msg = err?.response?.data?.error || err?.message || 'Помилка запиту';
       setError(msg);

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -265,6 +265,8 @@ export const api = {
       apiClient.get('/api/admin/metrics/services'),
     getSystemMetrics: () =>
       apiClient.get('/api/admin/metrics/system'),
+    getZOStats: (params: { yearFrom: number; yearTo: number; justiceKind?: string }) =>
+      apiClient.get('/api/admin/zo-stats', { params }),
 
     // Billing management
     getBillingTiers: () =>


### PR DESCRIPTION
## Summary

- Fixes a runtime error where `api.get()` was called but doesn't exist on the `api` object
- Added `getZOStats()` method to `api.admin` in `api-client.ts`
- Updated `AdminZOStatsPage` to use `api.admin.getZOStats()`

## Test plan

- [ ] Navigate to `/admin/zo-stats`, click "Перерахувати" — data loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the admin ZO stats page and backend endpoint, and fixes the page’s API call so recalculation works without errors.

- **New Features**
  - Admin page at /admin/zo-stats with filters and a bar chart of yearly court decision counts by proceeding type.
  - Backend GET /api/admin/zo-stats (yearFrom, yearTo, justiceKind) returning per-year totals, justice kind breakdown, and judgment form breakdown when a single kind is selected.
  - Sidebar and router entries to access the page.

- **Bug Fixes**
  - Switched AdminZOStatsPage to api.admin.getZOStats(), removing the invalid api.get() call.
  - Sends params via axios { params } (numbers for yearFrom/yearTo and comma-joined justiceKind) and handles typed response to prevent runtime errors.

<sup>Written for commit dc02fd7fdf861be4ab1cdbf3d800dc5ab970e4a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

