### PR TITLE
fix(nginx): enable WebSocket for admin terminal endpoint

### DIFF
--- a/deployment/nginx/includes/api-endpoints.conf
+++ b/deployment/nginx/includes/api-endpoints.conf
@@ -16,6 +16,24 @@ location /auth {
 }
 
 # ==========================================
+# WebSocket - Admin Terminal
+# Must be before the general /api block (nginx uses most specific match)
+# ==========================================
+
+location /api/admin/terminal {
+    proxy_pass http://stage_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
+# ==========================================
 # REST API Routes
 # ==========================================
 


### PR DESCRIPTION
## Summary

- The admin terminal (`/admin/terminal`) uses WebSocket (`wss://`) but nginx was stripping the `Upgrade` header via `proxy_set_header Connection ""` in the general `/api` location block
- Added a specific `/api/admin/terminal` location block with `Upgrade`/`Connection` WebSocket headers before the general `/api` block
- Nginx uses longest-prefix matching so this more specific block takes priority

## Test plan

- [ ] Open `/admin/terminal` — WebSocket connects without error
- [ ] Terminal commands execute normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable WebSocket for the admin terminal by adding a dedicated nginx location for /api/admin/terminal that preserves Upgrade and Connection headers. This fixes failed upgrades caused by the general /api block and allows the terminal to connect.

- **Bug Fixes**
  - Add /api/admin/terminal location using HTTP/1.1 and forwarding Upgrade/Connection headers.
  - Place it before the general /api block so longest-prefix matching takes priority.

<sup>Written for commit 3a393b9c943de307202af6319f767fcd46dfd316. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

