### PR TITLE
fix(sidebar): highlight active route in all menu sections

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -482,7 +482,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                       showToast.info('Скоро буде доступно');
                     }
                   }}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center justify-between group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center justify-between group ${section.route && location.pathname === section.route ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                     <div className="flex items-center gap-3 min-w-0">
                       <section.icon
                       size={15}
@@ -532,7 +532,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                       showToast.info('Скоро буде доступно');
                     }
                   }}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${section.route && location.pathname === section.route ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                     <section.icon
                     size={15}
                     strokeWidth={2}
@@ -575,7 +575,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                       showToast.info('Скоро буде доступно');
                     }
                   }}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${section.route && location.pathname === section.route ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                     <section.icon
                     size={15}
                     strokeWidth={2}
@@ -610,7 +610,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
               <div className="space-y-0.5">
                 <button
                   onClick={() => handleNavigation(ROUTES.BILLING)}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${location.pathname === ROUTES.BILLING ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                   <CreditCard
                     size={15}
                     strokeWidth={2}
@@ -622,7 +622,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 {role === 'company' && (
                 <button
                   onClick={() => handleNavigation(ROUTES.TEAM)}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${location.pathname === ROUTES.TEAM ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                   <UsersRound
                     size={15}
                     strokeWidth={2}
@@ -657,7 +657,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
               <div className="space-y-0.5">
                 <button
                   onClick={() => handleNavigation(ROUTES.JUDGES)}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${location.pathname === ROUTES.JUDGES ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                   <Scale
                     size={15}
                     strokeWidth={2}
@@ -668,7 +668,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 </button>
                 <button
                   onClick={() => handleNavigation(ROUTES.LAWYERS)}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${location.pathname === ROUTES.LAWYERS ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                   <Briefcase
                     size={15}
                     strokeWidth={2}
@@ -708,7 +708,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                       handleNavigation(section.route);
                     }
                   }}
-                  className="w-full text-left px-3 py-2 rounded-lg text-[13px] text-claude-text hover:bg-claude-subtext/8 transition-all duration-200 flex items-center gap-3 group">
+                  className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${section.route && location.pathname === section.route ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
                     <section.icon
                     size={15}
                     strokeWidth={2}


### PR DESCRIPTION
## Summary

- Active route highlighting (orange `bg-claude-accent/10`) was previously only applied to the active conversation in the РОЗМОВИ section
- Extended active state detection to all sidebar navigation sections: Контекст роботи, Доказова база, Законодавство, Фінанси, Учасники процесу, Моніторинг
- Inactive items retain the existing grey `hover:bg-claude-subtext/8` hover style

## Test plan

- [ ] Navigate to any page (e.g. Billing, Judges, Decisions Search) and verify the corresponding sidebar item is highlighted in orange
- [ ] Verify non-active items still show grey on hover
- [ ] Verify РОЗМОВИ active conversation highlight is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Highlight the active route across all sidebar sections with the orange accent, so the current location is clear everywhere. Previously, only the active conversation was highlighted.

- **Bug Fixes**
  - Apply bg-claude-accent/10 and text-claude-accent when the current route matches the item in all sections (Контекст роботи, Доказова база, Законодавство, Фінанси, Учасники процесу, Моніторинг).
  - Inactive items keep text-claude-text + hover:bg-claude-subtext/8; the РОЗМОВИ active conversation highlight remains unchanged.

<sup>Written for commit 1e7fb515f7fbbf1391944049852b995ac7f36036. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

