### PR TITLE
fix(sidebar): wire up 3 placeholder menu items to existing routes

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -232,19 +232,19 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
     id: 'regulations',
     label: 'Нормативні акти',
     icon: BookOpen,
-    route: null,
+    route: ROUTES.LEGAL_CODES_LIBRARY,
   },
   {
     id: 'commentary',
     label: 'Коментарі та практика',
     icon: MessageSquare,
-    route: null,
+    route: ROUTES.COURT_PRACTICE_ANALYSIS,
   },
   {
     id: 'verification',
     label: 'Перевірка актуальності',
     icon: CheckCircle,
-    route: null,
+    route: ROUTES.LEGISLATION_MONITORING,
   }];
 
   const legislativeSections = [


### PR DESCRIPTION
## Summary
- **Нормативні акти** → `/legislation/library` (Кодекси та закони)
- **Коментарі та практика** → `/analysis/court-practice`
- **Перевірка актуальності** → `/legislation/monitoring`

Previously all three showed a "Скоро буде доступно" toast on click.

## Test plan
- [ ] Click "Нормативні акти" in sidebar → navigates to legislation library page
- [ ] Click "Коментарі та практика" → navigates to court practice analysis page
- [ ] Click "Перевірка актуальності" → navigates to legislation monitoring page
- [ ] Active route highlighting works for all three items

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired up three sidebar menu items to their existing routes, replacing the “Скоро буде доступно” toast. This restores navigation and active-state highlighting for these entries.

- **Bug Fixes**
  - Нормативні акти → /legislation/library
  - Коментарі та практика → /analysis/court-practice
  - Перевірка актуальності → /legislation/monitoring

<sup>Written for commit cd2c67411031e4926c423f1d9191a3208526e3d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

