### PR TITLE
feat(chat): add load/save user prompt functionality

### DIFF
--- a/lexwebapp/src/services/api/PromptService.ts
+++ b/lexwebapp/src/services/api/PromptService.ts
@@ -1,0 +1,42 @@
+/**
+ * Prompt Service - HTTP client for saved user prompts
+ */
+
+import { BaseService } from '../base/BaseService';
+
+export interface SavedPrompt {
+  id: string;
+  name: string;
+  content: string;
+  created_at: string;
+}
+
+export class PromptService extends BaseService {
+  async list(): Promise<SavedPrompt[]> {
+    try {
+      const response = await this.client.get<{ prompts: SavedPrompt[] }>('/api/prompts');
+      return response.data.prompts;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async save(name: string, content: string): Promise<SavedPrompt> {
+    try {
+      const response = await this.client.post<{ prompt: SavedPrompt }>('/api/prompts', { name, content });
+      return response.data.prompt;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    try {
+      await this.client.delete(`/api/prompts/${id}`);
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+}
+
+export const promptService = new PromptService();

--- a/mcp_backend/src/migrations/054_add_user_prompts.sql
+++ b/mcp_backend/src/migrations/054_add_user_prompts.sql
@@ -1,0 +1,23 @@
+-- Migration 054: Add user_prompts table for saved chat prompts
+
+CREATE TABLE IF NOT EXISTS user_prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id VARCHAR(255) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_prompts_user_id ON user_prompts(user_id);
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'update_user_prompts_updated_at'
+  ) THEN
+    CREATE TRIGGER update_user_prompts_updated_at
+      BEFORE UPDATE ON user_prompts
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Add `user_prompts` table (migration 054) to persist saved prompts per user
- Add `GET /api/prompts`, `POST /api/prompts`, `DELETE /api/prompts/:id` endpoints (JWT-protected)
- Add `PromptService.ts` frontend client
- Add **Load prompt** / **Save prompt** buttons below the chat input textarea
  - **Save**: enter a name → saves current input content to DB
  - **Load**: list saved prompts with name + content preview, click to insert into textarea, hover to delete

## Test plan
- [ ] Type text in chat input → "Save prompt" button becomes active → click → enter name → saved
- [ ] Click "Load prompt" → modal shows saved prompts list
- [ ] Click a prompt in the list → text populates the textarea
- [ ] Hover a prompt row → trash icon appears → click deletes it
- [ ] Run `npm run migrate` to apply migration 054
- [ ] Build passes: `npm run build` in both `mcp_backend` and `lexwebapp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds saved user prompts to the chat input so users can save, load, and delete named prompts. Persists prompts per user with JWT-protected APIs and a new DB table.

- **New Features**
  - Backend: GET /api/prompts, POST /api/prompts, DELETE /api/prompts/:id (JWT), storing in user_prompts.
  - Frontend: PromptService client and “Load prompt” / “Save prompt” UI with save modal, load list, preview, and hover delete.

- **Migration**
  - Run npm run migrate to apply migration 054.

<sup>Written for commit b481d909c4a3a12ee354f58648aa7e2caed89b72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

