### PR TITLE
fix(ui): remove upgrade card from sidebar and simplify save prompt flow

### DIFF
--- a/lexwebapp/src/components/ChatInput.tsx
+++ b/lexwebapp/src/components/ChatInput.tsx
@@ -265,9 +265,7 @@ export function ChatInput({
   const [expandedCategory, setExpandedCategory] = useState<string | null>(null);
 
   // Prompt save/load state
-  const [showSaveModal, setShowSaveModal] = useState(false);
   const [showLoadModal, setShowLoadModal] = useState(false);
-  const [promptName, setPromptName] = useState('');
   const [savedPrompts, setSavedPrompts] = useState<SavedPrompt[]>([]);
   const [promptsLoading, setPromptsLoading] = useState(false);
   const [savingPrompt, setSavingPrompt] = useState(false);
@@ -310,13 +308,12 @@ export function ChatInput({
   };
 
   const handleSavePrompt = async () => {
-    if (!promptName.trim() || !input.trim()) return;
+    if (!input.trim()) return;
+    const autoName = input.trim().split(/\s+/).slice(0, 6).join(' ').slice(0, 60);
     setSavingPrompt(true);
     try {
-      await promptService.save(promptName.trim(), input.trim());
+      await promptService.save(autoName, input.trim());
       showToast.success('Промпт збережено');
-      setShowSaveModal(false);
-      setPromptName('');
     } catch {
       showToast.error('Не вдалося зберегти промпт');
     } finally {
@@ -462,12 +459,12 @@ export function ChatInput({
         </button>
         <button
           type="button"
-          onClick={() => { setPromptName(''); setShowSaveModal(true); }}
-          disabled={!input.trim()}
+          onClick={handleSavePrompt}
+          disabled={!input.trim() || savingPrompt}
           className="flex items-center gap-1.5 text-[13px] text-claude-subtext hover:text-claude-text transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
         >
           <Save size={14} />
-          Save prompt
+          {savingPrompt ? 'Зберігаю...' : 'Save prompt'}
         </button>
       </div>
 
@@ -540,41 +537,6 @@ export function ChatInput({
         </div>
       </div>
     </div>
-
-      {/* Save Prompt Modal */}
-      {showSaveModal && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setShowSaveModal(false)}>
-          <div className="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4 p-6" onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-[15px] font-semibold text-claude-text mb-4">Зберегти промпт</h3>
-            <input
-              autoFocus
-              type="text"
-              value={promptName}
-              onChange={(e) => setPromptName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') handleSavePrompt(); if (e.key === 'Escape') setShowSaveModal(false); }}
-              placeholder="Назва промпту..."
-              className="w-full px-3 py-2 text-[14px] border border-claude-border rounded-lg focus:outline-none focus:border-claude-subtext/50 mb-4"
-            />
-            <div className="flex justify-end gap-2">
-              <button
-                type="button"
-                onClick={() => setShowSaveModal(false)}
-                className="px-4 py-2 text-[13px] text-claude-subtext hover:text-claude-text transition-colors"
-              >
-                Скасувати
-              </button>
-              <button
-                type="button"
-                onClick={handleSavePrompt}
-                disabled={!promptName.trim() || savingPrompt}
-                className="px-4 py-2 text-[13px] bg-claude-text text-white rounded-lg disabled:opacity-40 disabled:cursor-not-allowed hover:bg-claude-text/90 transition-colors"
-              >
-                {savingPrompt ? 'Зберігаю...' : 'Зберегти'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Load Prompt Modal */}
       {showLoadModal && (

--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -425,18 +425,6 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 <NavItem icon={Zap} label="Workflows" route={null} />
               </div>
 
-              {/* Upgrade Card */}
-              <div className="px-3 py-3 border-t border-claude-border/50">
-                <div className="p-3.5 bg-gradient-to-br from-claude-subtext/5 to-claude-subtext/8 rounded-[12px] border border-claude-border">
-                  <h4 className="text-[13px] font-semibold text-claude-text mb-1 tracking-tight font-sans">Оновити до Pro</h4>
-                  <p className="text-[11px] text-claude-subtext/80 mb-3 leading-relaxed font-sans">
-                    Доступ до розширеної бази рішень та аналітики.
-                  </p>
-                  <button className="text-[12px] font-semibold text-white bg-claude-text hover:bg-claude-text/90 px-3 py-1.5 rounded-lg transition-all duration-200 w-full shadow-sm active:scale-[0.98] font-sans">
-                    Оновити
-                  </button>
-                </div>
-              </div>
             </>
           )}
 


### PR DESCRIPTION
## Summary
- Remove "Оновити до Pro" upgrade card from the left sidebar
- Simplify save prompt: auto-generates name from first 6 words of input, no modal required

## Test plan
- [ ] Verify upgrade card no longer appears in sidebar
- [ ] Verify "Save prompt" button saves immediately without showing modal
- [ ] Verify auto-generated prompt name uses first 6 words of input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Upgrade to Pro” card from the sidebar. Simplified the Save prompt flow: the button saves immediately with a saving state and auto-generates the name from the first 6 words of the input (capped at 60 characters), no modal.

<sup>Written for commit 191ee873b4ad64571ca2eee1b60122b4d76c4b8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

