### PR TITLE
fix(infra): increase openreyestr-postgres memory limit to 16G and fix revenue accounting

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -134,10 +134,10 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 4G
+          memory: 16G
         reservations:
           cpus: '0.5'
-          memory: 2G
+          memory: 4G
 
   qdrant-stage:
     image: qdrant/qdrant:latest

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -362,6 +362,14 @@ export const api = {
       apiClient.get('/api/admin/service-pricing'),
     updateServicePricing: (id: string, data: { price_usd: number; notes?: string; is_active?: boolean }) =>
       apiClient.put(`/api/admin/service-pricing/${id}`, data),
+
+    // Tool pricing
+    getToolPricing: () =>
+      apiClient.get('/api/admin/tool-pricing'),
+    updateToolPricing: (toolName: string, data: { base_cost_usd?: number; markup_percent?: number; notes?: string; is_active?: boolean }) =>
+      apiClient.put(`/api/admin/tool-pricing/${toolName}`, data),
+    bulkMarkupToolPricing: (data: { markup_percent: number; service?: string }) =>
+      apiClient.post('/api/admin/tool-pricing/bulk-markup', data),
   },
 
   // GDPR


### PR DESCRIPTION
## Summary
- Raise `openreyestr-postgres-stage` memory limit from 4G → 16G (reservation 2G → 4G) to support 145GB database page cache without OOM pressure
- Fix admin revenue queries to only count charged requests (`base_cost_usd IS NOT NULL`)
- Fix profit/cost breakdown in revenue chart using `markup_amount_usd` and `base_cost_usd`
- Add tool pricing API methods (`getToolPricing`, `updateToolPricing`, `bulkMarkupToolPricing`) to api-client

## Test plan
- [ ] Verify `openreyestr-postgres-stage` memory usage stays below 80% of container limit after deploy
- [ ] Check admin dashboard revenue/profit numbers reflect only charged requests
- [ ] Confirm tool pricing API endpoints respond correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased openreyestr-postgres-stage memory to 16G to avoid OOM and support a larger DB page cache. Fixed admin revenue accounting and added tool pricing API endpoints.

- **Bug Fixes**
  - Revenue queries and charts only count charged requests (base_cost_usd IS NOT NULL).
  - Profit and cost use markup_amount_usd and base_cost_usd.

- **New Features**
  - Tool pricing API in api-client: getToolPricing, updateToolPricing, bulkMarkupToolPricing.

<sup>Written for commit 2951fceff4d6400316908fe470aea72f4f77e29d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

