### PR TITLE
feat(admin): add delete button for finished scraper/backfill jobs

### DIFF
--- a/lexwebapp/src/pages/AdminMonitoringPage.tsx
+++ b/lexwebapp/src/pages/AdminMonitoringPage.tsx
@@ -501,7 +501,7 @@ function completenessBg(pct: number): string {
   return 'bg-red-50';
 }
 
-function BackfillProgress({ job, onStop, onRefresh }: { job: BackfillJob; onStop: () => void; onRefresh: () => void }) {
+function BackfillProgress({ job, onStop, onRefresh, onDelete }: { job: BackfillJob; onStop: () => void; onRefresh: () => void; onDelete: () => void }) {
   const isActive = job.status === 'running' || job.status === 'queued';
   const progressPct = job.total > 0 ? Math.round((job.processed / job.total) * 100) : 0;
 
@@ -533,12 +533,21 @@ function BackfillProgress({ job, onStop, onRefresh }: { job: BackfillJob; onStop
             </button>
           )}
           {!isActive && (
-            <button
-              onClick={onRefresh}
-              className="text-xs text-blue-600 hover:underline"
-            >
-              Приховати
-            </button>
+            <>
+              <button
+                onClick={onDelete}
+                className="flex items-center gap-1 px-2 py-1 text-xs text-gray-500 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors"
+                title="Видалити задачу"
+              >
+                <X size={10} /> Видалити
+              </button>
+              <button
+                onClick={onRefresh}
+                className="text-xs text-blue-600 hover:underline"
+              >
+                Приховати
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -597,7 +606,7 @@ const DOC_FORMS = [
 
 const MONTHS_SHORT = ['С','Л','Б','К','Т','Ч','Л','С','В','Ж','Л','Г'];
 
-function ScraperJobCard({ job, onStop }: { job: ScraperJob; onStop: (id: string) => void }) {
+function ScraperJobCard({ job, onStop, onDelete }: { job: ScraperJob; onStop: (id: string) => void; onDelete: (id: string) => void }) {
   const isActive = job.status === 'running' || job.status === 'queued';
   const [logsOpen, setLogsOpen] = useState(false);
   return (
@@ -629,6 +638,15 @@ function ScraperJobCard({ job, onStop }: { job: ScraperJob; onStop: (id: string)
               className="flex items-center gap-1 px-2 py-0.5 text-[10px] text-red-700 bg-red-100 border border-red-200 rounded hover:bg-red-200 transition-colors"
             >
               <Square size={9} /> Стоп
+            </button>
+          )}
+          {!isActive && (
+            <button
+              onClick={() => onDelete(job.job_id)}
+              className="flex items-center gap-1 px-2 py-0.5 text-[10px] text-gray-500 bg-gray-100 border border-gray-200 rounded hover:bg-gray-200 transition-colors"
+              title="Видалити задачу"
+            >
+              <X size={9} /> Видалити
             </button>
           )}
           {job.current_logs && job.current_logs.length > 0 && (
@@ -731,6 +749,10 @@ function CourtDataMapSection() {
 
   const handleStop = async (jobId: string) => {
     try { await api.admin.stopCourtScraper(jobId); await loadJobs(); } catch { /* ignore */ }
+  };
+
+  const handleDelete = async (jobId: string) => {
+    try { await api.admin.deleteCourtScraperJob(jobId); await loadJobs(); } catch { /* ignore */ }
   };
 
   // Group periods by year for header rendering
@@ -958,7 +980,7 @@ function CourtDataMapSection() {
             </button>
           </div>
           {jobs.slice(0, 10).map(job => (
-            <ScraperJobCard key={job.job_id} job={job} onStop={handleStop} />
+            <ScraperJobCard key={job.job_id} job={job} onStop={handleStop} onDelete={handleDelete} />
           ))}
         </div>
       )}
@@ -1081,6 +1103,15 @@ function DocumentCompletenessSection() {
     } catch { /* ignore */ }
   };
 
+  const deleteBackfill = async () => {
+    if (!backfillJob) return;
+    try {
+      await api.admin.deleteBackfillJob(backfillJob.job_id);
+      setBackfillJob(null);
+      stopPolling();
+    } catch { /* ignore */ }
+  };
+
   const isBackfillActive = backfillJob && (backfillJob.status === 'running' || backfillJob.status === 'queued');
 
   const displayData = backfillJob?.completeness ?? result;
@@ -1188,6 +1219,7 @@ function DocumentCompletenessSection() {
           job={backfillJob}
           onStop={stopBackfill}
           onRefresh={() => setBackfillJob(null)}
+          onDelete={deleteBackfill}
         />
       )}
 

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -263,6 +263,8 @@ export const api = {
         : apiClient.get('/api/admin/backfill-fulltext'),
     stopBackfill: (jobId: string) =>
       apiClient.post(`/api/admin/backfill-fulltext/${jobId}/stop`),
+    deleteBackfillJob: (jobId: string) =>
+      apiClient.delete(`/api/admin/backfill-fulltext/${jobId}`),
     getTrafficMetrics: (range: string = '1h') =>
       apiClient.get('/api/admin/metrics/traffic', { params: { range } }),
     getLatencyMetrics: (range: string = '1h') =>
@@ -362,6 +364,8 @@ export const api = {
         : apiClient.get('/api/admin/scrape-court-registry'),
     stopCourtScraper: (jobId: string) =>
       apiClient.post(`/api/admin/scrape-court-registry/${jobId}/stop`),
+    deleteCourtScraperJob: (jobId: string) =>
+      apiClient.delete(`/api/admin/scrape-court-registry/${jobId}`),
     getAllScraperJobs: () =>
       apiClient.get('/api/admin/scrape-court-registry/all'),
     getRegistryCoverageMap: (years?: number) =>

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -2393,6 +2393,27 @@ export function createAdminRoutes(
     res.json({ message: 'Stop requested', job_id: jobId });
   });
 
+  /**
+   * DELETE /api/admin/backfill-fulltext/:jobId
+   * Delete a finished backfill job (cannot delete active jobs)
+   */
+  router.delete('/backfill-fulltext/:jobId', async (req: Request, res: Response) => {
+    const jobId = getStringParam(req.params.jobId);
+    if (!jobId) return res.status(400).json({ error: 'Job ID required' });
+
+    const job = backfillJobs.get(jobId);
+    if (job && (job.status === 'running' || job.status === 'queued')) {
+      return res.status(409).json({ error: 'Cannot delete a running job. Stop it first.' });
+    }
+
+    backfillJobs.delete(jobId);
+    try {
+      await db.query(`DELETE FROM scraper_jobs WHERE job_id = $1`, [jobId]);
+    } catch { /* non-critical */ }
+
+    res.json({ message: 'Job deleted', job_id: jobId });
+  });
+
   // ========================================
   // REGISTRY COVERAGE MAP (temporal density of downloaded court docs)
   // ========================================
@@ -2694,6 +2715,27 @@ export function createAdminRoutes(
       try { process.kill(job.pid, 'SIGTERM'); } catch { /* already dead */ }
     }
     res.json({ message: 'Stop requested', job_id: jobId });
+  });
+
+  /**
+   * DELETE /api/admin/scrape-court-registry/:jobId
+   * Delete a finished scraper job (cannot delete active jobs)
+   */
+  router.delete('/scrape-court-registry/:jobId', async (req: Request, res: Response) => {
+    const jobId = getStringParam(req.params.jobId);
+    if (!jobId) return res.status(400).json({ error: 'Job ID required' });
+
+    const job = scraperJobs.get(jobId);
+    if (job && (job.status === 'running' || job.status === 'queued')) {
+      return res.status(409).json({ error: 'Cannot delete a running job. Stop it first.' });
+    }
+
+    scraperJobs.delete(jobId);
+    try {
+      await db.query(`DELETE FROM scraper_jobs WHERE job_id = $1`, [jobId]);
+    } catch { /* non-critical */ }
+
+    res.json({ message: 'Job deleted', job_id: jobId });
   });
 
   // ========================================


### PR DESCRIPTION
## Summary

- Add `DELETE /api/admin/scrape-court-registry/:jobId` and `DELETE /api/admin/backfill-fulltext/:jobId` endpoints
- Both endpoints: remove from in-memory Map + DELETE from `scraper_jobs` table; return 409 if job is still active
- Add `deleteCourtScraperJob()` / `deleteBackfillJob()` to API client
- Add "Видалити" button in `ScraperJobCard` and `BackfillProgress` for non-active jobs

## Test plan
- [ ] Start a scraper batch, let it finish/stop — "Видалити" button should appear
- [ ] Click "Видалити" — card disappears from UI and row is removed from `scraper_jobs` table
- [ ] Cannot delete a running job (button hidden while active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add delete actions for finished scraper and backfill jobs in Admin to clean up old entries from UI and DB. Adds backend DELETE endpoints, client methods, and UI buttons; active jobs cannot be deleted.

- **New Features**
  - Backend: DELETE /api/admin/scrape-court-registry/:jobId and /api/admin/backfill-fulltext/:jobId; remove from in-memory maps and scraper_jobs; return 409 if running.
  - API client: deleteCourtScraperJob(jobId) and deleteBackfillJob(jobId).
  - Frontend: "Видалити" button on finished/failed/stopped jobs; hidden while running; removes card on delete.

<sup>Written for commit ba886c52b802c04aefabafd5e0f76d729b593c1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

