### PR TITLE
feat(admin): animate map cells while scraper job is running

### DIFF
--- a/lexwebapp/src/pages/AdminMonitoringPage.tsx
+++ b/lexwebapp/src/pages/AdminMonitoringPage.tsx
@@ -770,6 +770,21 @@ function CourtDataMapSection() {
   const sortedYears = Object.keys(periodsByYear).sort();
   const activeCount = jobs.filter(j => j.status === 'running' || j.status === 'queued').length;
 
+  // Build set of cell keys that have active (running/queued) jobs → used for blink animation
+  const activeCellKeys = React.useMemo(() => {
+    const keys = new Set<string>();
+    for (const job of jobs) {
+      if (job.status !== 'running' && job.status !== 'queued') continue;
+      // date_from format: dd.mm.yyyy → convert to YYYY-MM
+      const parts = job.date_from.split('.');
+      if (parts.length === 3) {
+        const period = `${parts[2]}-${parts[1]}`;
+        keys.add(`${job.justice_kind_id}-${period}`);
+      }
+    }
+    return keys;
+  }, [jobs]);
+
   return (
     <div className="space-y-4">
       {/* Coverage Map Card */}
@@ -845,12 +860,15 @@ function CourtDataMapSection() {
                   </div>
                   {mapData.periods.map(period => {
                     const count = mapData.cells[jk]?.[period] ?? 0;
+                    const isActive = activeCellKeys.has(`${jk}-${period}`);
                     return (
                       <div
                         key={period}
                         onClick={() => handleCellClick(jk, period)}
                         title={`${mapData.kind_labels[jk] || jk} · ${period}: ${count.toLocaleString('uk')} документів\nКлік — запустити батч`}
                         className={`w-[16px] h-[16px] mr-[2px] rounded-[2px] cursor-pointer hover:ring-2 hover:ring-blue-400 hover:ring-offset-0 transition-all ${
+                          isActive ? 'animate-pulse ring-2 ring-amber-400 ring-offset-0' : ''
+                        } ${
                           count === 0 ? 'bg-gray-100 hover:bg-gray-200' :
                           count < 50 ? 'bg-sky-100' :
                           count < 200 ? 'bg-sky-300' :


### PR DESCRIPTION
## Summary
- Cells on the coverage heat map now pulse with an amber ring (`animate-pulse ring-2 ring-amber-400`) while their corresponding scraper job is `running` or `queued`
- Active cell keys are derived from job `date_from` + `justice_kind_id`, recomputed whenever the jobs list updates (every 2.5s poll)
- Animation disappears automatically once the job completes or fails

## Test plan
- [ ] Start a court scraper batch and verify the corresponding map cell blinks with amber ring
- [ ] Verify the animation stops after the job completes/fails
- [ ] Verify no visual regressions on cells without active jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a pulse animation with an amber ring to coverage map cells while their scraper job is running or queued. This makes it clear which period and justice kind are currently being processed.

- **New Features**
  - Marks active cells using justice_kind_id + period derived from job date_from (dd.mm.yyyy → YYYY-MM).
  - Active set recalculates on each jobs poll (~2.5s); animation stops when the job finishes or fails.

<sup>Written for commit 01ed45b96e41855a7259a439e34702220dc7f707. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

