### PR TITLE
feat(chat): add response_id tracking to SSE pipeline

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1800,7 +1800,7 @@ class HTTPMCPServer {
         res.setHeader('Connection', 'keep-alive');
         res.setHeader('X-Accel-Buffering', 'no');
 
-        // Emit response_id as the very first SSE event so the client can track it
+        // Emit response_id as the very first SSE event for request traceability
         res.write(`event: response_id\n`);
         res.write(`data: ${JSON.stringify({ response_id: requestId })}\n\n`);
 
@@ -1834,7 +1834,6 @@ class HTTPMCPServer {
             if (event.type === 'complete') {
               chatCompleted = true;
               chatTotalCostUsd = event.data?.total_cost_usd || 0;
-              // Inject response_id into the complete event
               event.data.response_id = requestId;
             }
 


### PR DESCRIPTION
## Summary
- Each `/api/chat` request now emits `response_id` as the very first SSE event
- `response_id` is also injected into the `complete` event data
- Frontend displays the ID as the first thinking step (`#chat-xxx`) and next to the cost badge in CostSummary

## Changed files
- `mcp_backend/src/http-server.ts` — emit `response_id` SSE event, inject into `complete`
- `lexwebapp/src/services/api/MCPService.ts` — add `onResponseId` callback + SSE dispatcher
- `lexwebapp/src/types/models/Message.ts` — add `response_id` to `CostSummary` type
- `lexwebapp/src/hooks/useMCPTool.ts` — handle `onResponseId`, store in ref + costSummary
- `lexwebapp/src/components/CostSummary.tsx` — render `#response_id` next to cost

## Test plan
- [ ] Send a chat request and verify `#chat-xxx` appears as first thinking step
- [ ] Verify response_id shows next to cost amount after response completes
- [ ] Verify response_id matches between thinking step and cost badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add response_id tracking to the chat SSE flow for request traceability. The server emits response_id first and includes it in complete; the UI shows it in the first thinking step and next to the cost badge.

- **New Features**
  - Backend: Emit response_id (existing requestId) as the first SSE event and inject it into the complete event.
  - Frontend: Add onResponseId callback, store the id during the stream, include it in CostSummary, and render #response_id in the thinking step and CostSummary badge.

<sup>Written for commit 05bc7901fc770d52270229fd47038178d32e79e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

