### PR TITLE
fix(chat): allow scrolling up during streaming (LEG-150)

### DIFF
--- a/lexwebapp/src/components/MessageThread.tsx
+++ b/lexwebapp/src/components/MessageThread.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { Message, MessageProps } from './Message';
 
 interface MessageThreadProps {
@@ -7,20 +7,34 @@ interface MessageThreadProps {
   onEdit?: (messageId: string, newContent: string) => void;
 }
 
+const SCROLL_THRESHOLD = 100;
+
 export function MessageThread({
   messages,
   onRegenerate,
   onEdit,
 }: MessageThreadProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const userScrolledUp = useRef(false);
+
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    userScrolledUp.current = distanceFromBottom > SCROLL_THRESHOLD;
+  }, []);
+
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'end'
-    });
+    if (!userScrolledUp.current) {
+      bottomRef.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end'
+      });
+    }
   }, [messages]);
 
-  return <div className="flex-1 overflow-y-auto scroll-smooth">
+  return <div ref={containerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto scroll-smooth">
       <div className="flex flex-col">
         <div className="h-4 md:h-6" />
         {messages.map((message, idx) => {


### PR DESCRIPTION
## Summary
- Track user scroll position in `MessageThread` during SSE streaming
- Auto-scroll to bottom only when user hasn't manually scrolled up (>100px from bottom)
- Auto-scroll resumes when user scrolls back to the bottom

## Test plan
- [ ] Start a chat query that triggers streaming response
- [ ] While response is streaming, scroll up — verify it stays in place
- [ ] Scroll back to bottom — verify auto-scroll resumes
- [ ] Send a new message without scrolling — verify normal auto-scroll works

Closes LEG-150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat auto-scroll during streaming so users can scroll up without being snapped back to the bottom. Auto-scroll resumes when the user returns to the bottom. Addresses LEG-150.

- **Bug Fixes**
  - Track scroll position in MessageThread via container onScroll.
  - Stop auto-scroll when user is >100px from bottom.
  - Resume auto-scroll once the user returns to the bottom.

<sup>Written for commit 2fe2e544ba0cf77a08a0f91fd10fb065e7a67326. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

