### PR TITLE
feat(chat): interactive plan review with per-step depth selection

### DIFF
--- a/lexwebapp/src/components/PlanReviewDisplay.tsx
+++ b/lexwebapp/src/components/PlanReviewDisplay.tsx
@@ -1,0 +1,202 @@
+import { useState } from 'react';
+import { Target, Zap, Search, Play } from 'lucide-react';
+import { motion } from 'framer-motion';
+import type { ExecutionPlan, PlanStep } from '../types/models/Message';
+
+interface PlanReviewDisplayProps {
+  plan: ExecutionPlan;
+  onConfirm: (approvedPlan: ExecutionPlan) => void;
+  onSkip: () => void;
+  isLoading?: boolean;
+}
+
+const TOOL_LABELS: Record<string, string> = {
+  search_legal_precedents: 'Пошук прецедентів',
+  search_supreme_court_practice: 'Практика ВС',
+  get_court_decision: 'Отримання рішення',
+  get_case_documents_chain: 'Ланцюг документів',
+  find_similar_fact_pattern_cases: 'Схожі справи',
+  compare_practice_pro_contra: 'Аналіз за і проти',
+  load_full_texts: 'Повні тексти рішень',
+  search_legislation: 'Пошук законодавства',
+  get_legislation_article: 'Стаття закону',
+  get_legislation_articles: 'Статті закону',
+  get_legislation_section: 'Розділ закону',
+  find_relevant_law_articles: 'Релевантні статті',
+  search_procedural_norms: 'Процесуальні норми',
+  semantic_search: 'Семантичний пошук',
+  openreyestr_search_entities: 'Пошук юросіб',
+  openreyestr_get_entity_details: 'Деталі юрособи',
+  openreyestr_get_by_edrpou: 'Пошук за ЄДРПОУ',
+  rada_search_parliament_bills: 'Законопроекти Ради',
+  rada_get_deputy_info: 'Інфо про депутата',
+};
+
+/** Tools that support depth differentiation (search tools with configurable limits) */
+const DEPTH_CAPABLE_TOOLS = new Set([
+  'search_legal_precedents',
+  'search_supreme_court_practice',
+  'find_similar_fact_pattern_cases',
+  'compare_practice_pro_contra',
+  'search_legislation',
+  'find_relevant_law_articles',
+  'search_procedural_norms',
+]);
+
+function getToolLabel(toolName: string): string {
+  return TOOL_LABELS[toolName] || toolName;
+}
+
+export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanReviewDisplayProps) {
+  const [steps, setSteps] = useState<PlanStep[]>(
+    plan.steps.map(s => ({ ...s, depth: s.depth || 'standard' }))
+  );
+
+  const toggleDepth = (stepId: number) => {
+    setSteps(prev =>
+      prev.map(s =>
+        s.id === stepId
+          ? { ...s, depth: s.depth === 'deep' ? 'standard' : 'deep' }
+          : s
+      )
+    );
+  };
+
+  const setAllDeep = () => {
+    setSteps(prev => prev.map(s => ({
+      ...s,
+      depth: DEPTH_CAPABLE_TOOLS.has(s.tool) ? 'deep' : s.depth,
+    })));
+  };
+
+  const setAllStandard = () => {
+    setSteps(prev => prev.map(s => ({ ...s, depth: 'standard' })));
+  };
+
+  const handleConfirm = () => {
+    onConfirm({ ...plan, steps });
+  };
+
+  const deepCount = steps.filter(s => s.depth === 'deep').length;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
+      className="my-3 border border-claude-border rounded-lg overflow-hidden bg-white"
+    >
+      {/* Header */}
+      <div className="p-3 border-b border-claude-border/30 bg-claude-bg/30">
+        <div className="flex items-center gap-2">
+          <Target size={14} className="text-claude-text flex-shrink-0" strokeWidth={2} />
+          <span className="text-[13px] text-claude-text font-medium">
+            {plan.goal}
+          </span>
+        </div>
+        <p className="text-[11px] text-claude-subtext mt-1">
+          Оберіть глибину аналізу для кожного кроку
+        </p>
+      </div>
+
+      {/* Steps */}
+      <div className="p-3 space-y-2">
+        {steps.map((step) => {
+          const isDepthCapable = DEPTH_CAPABLE_TOOLS.has(step.tool);
+          const isDeep = step.depth === 'deep';
+
+          return (
+            <div
+              key={step.id}
+              className="flex items-center justify-between gap-3 py-1.5"
+            >
+              <div className="flex items-start gap-2 flex-1 min-w-0">
+                <span className="text-[11px] text-claude-subtext/60 font-mono mt-0.5 w-4 flex-shrink-0 text-right">
+                  {step.id}
+                </span>
+                <div className="min-w-0">
+                  <span className="text-[13px] text-claude-text leading-relaxed">
+                    {step.purpose}
+                  </span>
+                  <span className="text-[11px] text-claude-subtext/60 ml-1.5">
+                    {getToolLabel(step.tool)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Depth toggle */}
+              {isDepthCapable ? (
+                <button
+                  onClick={() => toggleDepth(step.id)}
+                  className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors flex-shrink-0 ${
+                    isDeep
+                      ? 'bg-amber-100 text-amber-800 hover:bg-amber-200'
+                      : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                  }`}
+                >
+                  {isDeep ? (
+                    <>
+                      <Search size={10} strokeWidth={2.5} />
+                      Глибокий
+                    </>
+                  ) : (
+                    <>
+                      <Zap size={10} strokeWidth={2.5} />
+                      Стандартний
+                    </>
+                  )}
+                </button>
+              ) : (
+                <span className="text-[11px] text-claude-subtext/40 flex-shrink-0 px-2">
+                  фіксований
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer: bulk actions + confirm */}
+      <div className="p-3 border-t border-claude-border/30 bg-claude-bg/20 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={setAllDeep}
+            className="text-[11px] text-claude-subtext hover:text-claude-text transition-colors"
+          >
+            Усі глибокі
+          </button>
+          <span className="text-[11px] text-claude-subtext/30">|</span>
+          <button
+            onClick={setAllStandard}
+            className="text-[11px] text-claude-subtext hover:text-claude-text transition-colors"
+          >
+            Усі стандартні
+          </button>
+          {deepCount > 0 && (
+            <span className="text-[11px] text-amber-600 ml-1">
+              ({deepCount} глибоких)
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onSkip}
+            disabled={isLoading}
+            className="text-[11px] text-claude-subtext hover:text-claude-text transition-colors px-2 py-1"
+          >
+            Пропустити
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-claude-text text-white rounded-md text-[12px] font-medium hover:bg-claude-text/90 transition-colors disabled:opacity-50"
+          >
+            <Play size={11} strokeWidth={2.5} />
+            {isLoading ? 'Запуск...' : 'Почати аналіз'}
+          </button>
+        </div>
+      </div>
+    </motion.div>
+  );
+}

--- a/lexwebapp/src/hooks/useMCPTool.ts
+++ b/lexwebapp/src/hooks/useMCPTool.ts
@@ -1085,6 +1085,7 @@ export function useMCPTool(
 /**
  * useAIChat Hook
  * Calls the agentic /api/chat endpoint with SSE streaming.
+ * Supports two-phase flow: plan review → approved execution.
  * The LLM automatically selects and calls tools, then generates a synthesized answer.
  */
 export function useAIChat(options: UseMCPToolOptions = {}) {
@@ -1095,6 +1096,8 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
     setStreaming,
     setStreamController,
     setCurrentTool,
+    setPendingPlanReview,
+    setIsPlanLoading,
   } = useChatStore();
 
   const { onSuccess, onError } = options;
@@ -1112,9 +1115,17 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
   // Track response_id for request traceability
   const responseIdRef = useRef<string | null>(null);
 
-  const executeChat = useCallback(
-    async (query: string, documentIds?: string[]) => {
-      // Reset accumulators for new chat request
+  /**
+   * Internal: run the SSE chat stream (shared between direct and approved-plan flows).
+   */
+  const runChatStream = useCallback(
+    async (
+      query: string,
+      assistantMessageId: string,
+      approvedPlan?: ExecutionPlan,
+      planSessionId?: string
+    ) => {
+      // Reset accumulators
       accumulatedDecisions.current = [];
       accumulatedCitations.current = [];
       accumulatedDocuments.current = [];
@@ -1122,6 +1133,237 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
       planRef.current = null;
       costSummaryRef.current = {};
       responseIdRef.current = null;
+
+      // Build history from prior messages
+      const currentMessages = useChatStore.getState().messages;
+      const history = currentMessages
+        .filter((m) => m.id !== assistantMessageId && (m.role === 'user' || m.role === 'assistant'))
+        .slice(-6)
+        .map((m) => ({
+          role: m.role as 'user' | 'assistant',
+          content: m.content.slice(0, 1000),
+        }));
+
+      const chatConversationId = useChatStore.getState().conversationId || undefined;
+
+      const controller = await mcpService.streamChat(query, history, {
+        onResponseId: (data) => {
+          responseIdRef.current = data.response_id;
+          addThinkingStep(assistantMessageId, {
+            id: 'response-id',
+            title: `#${data.response_id}`,
+            content: '',
+            isComplete: true,
+          });
+        },
+
+        onPlan: (data) => {
+          const plan: ExecutionPlan = {
+            goal: data.goal,
+            steps: data.steps.map((s) => ({ ...s, completed: false })),
+            expected_iterations: data.expected_iterations,
+          };
+          planRef.current = plan;
+          updateMessage(assistantMessageId, { executionPlan: plan });
+
+          const planSummary = data.steps
+            .map((s) => `${s.id}. ${s.purpose}`)
+            .join('\n');
+          addThinkingStep(assistantMessageId, {
+            id: 'plan',
+            title: `Стратегія: ${data.goal}`,
+            content: planSummary,
+            isComplete: true,
+          });
+        },
+
+        onBudgetEscalated: (data) => {
+          showToast.info(
+            `Глибокий аналіз — орієнтовна вартість $${data.estimatedCost.minUsd.toFixed(2)}–$${data.estimatedCost.maxUsd.toFixed(2)}`,
+            6000
+          );
+        },
+
+        onThinking: (data) => {
+          contentRef.current = '';
+
+          if (planRef.current) {
+            const matchingStep = planRef.current.steps.find((s) => s.tool === data.tool);
+            if (matchingStep && !matchingStep.completed) {
+              matchingStep.completed = true;
+              updateMessage(assistantMessageId, {
+                executionPlan: { ...planRef.current, steps: [...planRef.current.steps] },
+              });
+            }
+          }
+
+          const costSuffix = data.cost_usd ? ` · $${data.cost_usd.toFixed(4)}` : '';
+          addThinkingStep(assistantMessageId, {
+            id: `step-${data.step}`,
+            title: (data.description || `${getToolLabel(data.tool)}`) + costSuffix,
+            content: JSON.stringify(data.params, null, 2),
+            isComplete: false,
+          });
+        },
+
+        onToolResult: (data) => {
+          const toolPreview = typeof data.result === 'string'
+            ? data.result.slice(0, 500)
+            : JSON.stringify(data.result, null, 2).slice(0, 500);
+
+          const costSuffix = data.cost_usd ? ` · $${data.cost_usd.toFixed(4)}` : '';
+          addThinkingStep(assistantMessageId, {
+            id: `result-${data.tool}`,
+            title: `${getToolLabel(data.tool)}` + costSuffix,
+            content: toolPreview,
+            isComplete: true,
+          });
+
+          const evidence = extractEvidenceFromToolResult(data.tool, data.result);
+          console.log('[AIChat] Evidence extraction', {
+            tool: data.tool,
+            decisions: evidence.decisions.length,
+            citations: evidence.citations.length,
+            documents: evidence.documents.length,
+          });
+          if (evidence.decisions.length > 0) {
+            accumulatedDecisions.current.push(...evidence.decisions);
+          }
+          if (evidence.citations.length > 0) {
+            accumulatedCitations.current.push(...evidence.citations);
+          }
+          if (evidence.documents.length > 0) {
+            accumulatedDocuments.current.push(...evidence.documents);
+          }
+
+          if (accumulatedDecisions.current.length > 0 || accumulatedCitations.current.length > 0 || accumulatedDocuments.current.length > 0) {
+            updateMessage(assistantMessageId, {
+              decisions: [...accumulatedDecisions.current],
+              citations: [...accumulatedCitations.current],
+              documents: [...accumulatedDocuments.current],
+            });
+          }
+        },
+
+        onAnswerDelta: (data) => {
+          contentRef.current += data.text;
+          updateMessage(assistantMessageId, { content: contentRef.current });
+        },
+
+        onAnswer: (data) => {
+          contentRef.current = data.text;
+
+          const answerNorms = extractNormsFromAnswer(data.text);
+          if (answerNorms.length > 0) {
+            accumulatedCitations.current.push(...answerNorms);
+          }
+
+          updateMessage(assistantMessageId, {
+            content: data.text,
+            isStreaming: false,
+            decisions: accumulatedDecisions.current.length > 0
+              ? [...accumulatedDecisions.current]
+              : undefined,
+            citations: accumulatedCitations.current.length > 0
+              ? [...accumulatedCitations.current]
+              : undefined,
+            documents: accumulatedDocuments.current.length > 0
+              ? [...accumulatedDocuments.current]
+              : undefined,
+          });
+
+          setStreaming(false);
+          setStreamController(null);
+          setCurrentTool(null);
+
+          const completedState = useChatStore.getState();
+          const completedMsg = completedState.messages.find(
+            (m) => m.id === assistantMessageId
+          );
+          if (completedMsg) {
+            completedState.syncMessage(completedMsg);
+          }
+
+          if (completedState.conversationId && completedState.messages.length <= 3) {
+            const firstUserMsg = completedState.messages.find((m) => m.role === 'user');
+            if (firstUserMsg) {
+              const title = firstUserMsg.content.slice(0, 60).trim();
+              completedState.renameConversation(completedState.conversationId, title);
+            }
+          }
+
+          onSuccess?.(data);
+        },
+
+        onCitationWarning: (data) => {
+          const currentMsg = useChatStore.getState().messages.find(
+            (m) => m.id === assistantMessageId
+          );
+          const existing = currentMsg?.citationWarnings || [];
+          updateMessage(assistantMessageId, {
+            citationWarnings: [
+              ...existing,
+              {
+                case_number: data.case_number,
+                status: data.status,
+                confidence: data.confidence,
+                message: data.message,
+              },
+            ],
+          });
+        },
+
+        onError: (error) => {
+          updateMessage(assistantMessageId, {
+            content: `Помилка: ${error.message}`,
+            isStreaming: false,
+          });
+          setStreaming(false);
+          setStreamController(null);
+          setCurrentTool(null);
+          showToast.error(error.message);
+          onError?.(new Error(error.message));
+        },
+
+        onComplete: (data) => {
+          if (data.tools_used || data.total_cost_usd != null || data.charged_usd != null) {
+            costSummaryRef.current = {
+              ...costSummaryRef.current,
+              tools_used: data.tools_used || [],
+              total_cost_usd: data.total_cost_usd || 0,
+              charged_usd: data.charged_usd || 0,
+              response_id: data.response_id || responseIdRef.current || undefined,
+            };
+            updateMessage(assistantMessageId, {
+              costSummary: costSummaryRef.current as CostSummary,
+            });
+          }
+          console.log('[AIChat] Complete', data);
+        },
+
+        onCostSummary: (data) => {
+          costSummaryRef.current = {
+            ...costSummaryRef.current,
+            charged_usd: data.charged_usd,
+            balance_usd: data.balance_usd,
+          };
+          updateMessage(assistantMessageId, {
+            costSummary: costSummaryRef.current as CostSummary,
+          });
+        },
+      }, 'standard', chatConversationId, approvedPlan, planSessionId);
+
+      setStreamController(controller);
+    },
+    [addThinkingStep, updateMessage, setStreaming, setStreamController, setCurrentTool, onSuccess, onError]
+  );
+
+  /**
+   * Phase 1: Request plan for user review, then pause.
+   * If plan generation fails or returns null (simple query), falls through to direct execution.
+   */
+  const executeChat = useCallback(
+    async (query: string, documentIds?: string[]) => {
       // 1. Add user message
       const userMessage = {
         id: Date.now().toString(),
@@ -1137,18 +1379,7 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
       }
       useChatStore.getState().syncMessage(userMessage);
 
-      // 3. Build history from prior messages
-      const currentMessages = useChatStore.getState().messages;
-      const history = currentMessages
-        .slice(0, -1) // exclude the just-added user message
-        .filter((m) => m.role === 'user' || m.role === 'assistant')
-        .slice(-6) // last 3 exchanges
-        .map((m) => ({
-          role: m.role as 'user' | 'assistant',
-          content: m.content.slice(0, 1000),
-        }));
-
-      // 4. Create placeholder assistant message
+      // 3. Create placeholder assistant message
       const assistantMessageId = (Date.now() + 1).toString();
       addMessage({
         id: assistantMessageId,
@@ -1157,233 +1388,35 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
         isStreaming: true,
         thinkingSteps: [],
       });
+
+      // 4. Request plan for review
+      setIsPlanLoading(true);
+      try {
+        const planResult = await mcpService.requestPlan(query, 'standard');
+
+        if (planResult.plan && planResult.planSessionId) {
+          // Plan received — pause and show review UI
+          setIsPlanLoading(false);
+          updateMessage(assistantMessageId, { isStreaming: false });
+          setPendingPlanReview({
+            plan: planResult.plan,
+            planSessionId: planResult.planSessionId,
+            query,
+            assistantMessageId,
+          });
+          return;
+        }
+      } catch (err) {
+        console.warn('[AIChat] Plan request failed, falling through to direct execution', err);
+      }
+
+      // No plan or plan failed → direct execution (old flow)
+      setIsPlanLoading(false);
       setStreaming(true);
       setCurrentTool('ai_chat');
 
       try {
-        const chatConversationId = useChatStore.getState().conversationId || undefined;
-        const controller = await mcpService.streamChat(query, history, {
-          onResponseId: (data) => {
-            responseIdRef.current = data.response_id;
-            addThinkingStep(assistantMessageId, {
-              id: 'response-id',
-              title: `#${data.response_id}`,
-              content: '',
-              isComplete: true,
-            });
-          },
-
-          onPlan: (data) => {
-            // Store the plan and add it to the message for UI rendering
-            const plan: ExecutionPlan = {
-              goal: data.goal,
-              steps: data.steps.map((s) => ({ ...s, completed: false })),
-              expected_iterations: data.expected_iterations,
-            };
-            planRef.current = plan;
-            updateMessage(assistantMessageId, { executionPlan: plan });
-
-            // Also add a thinking step showing the plan
-            const planSummary = data.steps
-              .map((s) => `${s.id}. ${s.purpose}`)
-              .join('\n');
-            addThinkingStep(assistantMessageId, {
-              id: 'plan',
-              title: `📋 Стратегія: ${data.goal}`,
-              content: planSummary,
-              isComplete: true,
-            });
-          },
-
-          onBudgetEscalated: (data) => {
-            showToast.info(
-              `🔬 Глибокий аналіз — орієнтовна вартість $${data.estimatedCost.minUsd.toFixed(2)}–$${data.estimatedCost.maxUsd.toFixed(2)}`,
-              6000
-            );
-          },
-
-          onThinking: (data) => {
-            // Clear partial streamed text when entering a tool-calling iteration
-            contentRef.current = '';
-
-            // Mark matching plan step as in-progress
-            if (planRef.current) {
-              const matchingStep = planRef.current.steps.find((s) => s.tool === data.tool);
-              if (matchingStep && !matchingStep.completed) {
-                matchingStep.completed = true;
-                updateMessage(assistantMessageId, {
-                  executionPlan: { ...planRef.current, steps: [...planRef.current.steps] },
-                });
-              }
-            }
-
-            const costSuffix = data.cost_usd ? ` · $${data.cost_usd.toFixed(4)}` : '';
-            addThinkingStep(assistantMessageId, {
-              id: `step-${data.step}`,
-              title: (data.description || `🔍 ${getToolLabel(data.tool)}`) + costSuffix,
-              content: JSON.stringify(data.params, null, 2),
-              isComplete: false,
-            });
-          },
-
-          onToolResult: (data) => {
-            // Update the last thinking step as complete and add result preview
-            const toolPreview = typeof data.result === 'string'
-              ? data.result.slice(0, 500)
-              : JSON.stringify(data.result, null, 2).slice(0, 500);
-
-            const costSuffix = data.cost_usd ? ` · $${data.cost_usd.toFixed(4)}` : '';
-            addThinkingStep(assistantMessageId, {
-              id: `result-${data.tool}`,
-              title: `✓ ${getToolLabel(data.tool)}` + costSuffix,
-              content: toolPreview,
-              isComplete: true,
-            });
-
-            // Extract decisions & citations from tool results
-            const evidence = extractEvidenceFromToolResult(data.tool, data.result);
-            console.log('[AIChat] Evidence extraction', {
-              tool: data.tool,
-              decisions: evidence.decisions.length,
-              citations: evidence.citations.length,
-              documents: evidence.documents.length,
-            });
-            if (evidence.decisions.length > 0) {
-              accumulatedDecisions.current.push(...evidence.decisions);
-            }
-            if (evidence.citations.length > 0) {
-              accumulatedCitations.current.push(...evidence.citations);
-            }
-            if (evidence.documents.length > 0) {
-              accumulatedDocuments.current.push(...evidence.documents);
-            }
-
-            // Update message with accumulated evidence so far (for live RightPanel updates)
-            if (accumulatedDecisions.current.length > 0 || accumulatedCitations.current.length > 0 || accumulatedDocuments.current.length > 0) {
-              updateMessage(assistantMessageId, {
-                decisions: [...accumulatedDecisions.current],
-                citations: [...accumulatedCitations.current],
-                documents: [...accumulatedDocuments.current],
-              });
-            }
-          },
-
-          onAnswerDelta: (data) => {
-            contentRef.current += data.text;
-            updateMessage(assistantMessageId, { content: contentRef.current });
-          },
-
-          onAnswer: (data) => {
-            // Reconcile with final answer text from server
-            contentRef.current = data.text;
-
-            // Extract law norm references mentioned in the answer text
-            const answerNorms = extractNormsFromAnswer(data.text);
-            if (answerNorms.length > 0) {
-              accumulatedCitations.current.push(...answerNorms);
-            }
-
-            updateMessage(assistantMessageId, {
-              content: data.text,
-              isStreaming: false,
-              decisions: accumulatedDecisions.current.length > 0
-                ? [...accumulatedDecisions.current]
-                : undefined,
-              citations: accumulatedCitations.current.length > 0
-                ? [...accumulatedCitations.current]
-                : undefined,
-              documents: accumulatedDocuments.current.length > 0
-                ? [...accumulatedDocuments.current]
-                : undefined,
-            });
-
-            setStreaming(false);
-            setStreamController(null);
-            setCurrentTool(null);
-
-            // Sync assistant message to server
-            const completedState = useChatStore.getState();
-            const completedMsg = completedState.messages.find(
-              (m) => m.id === assistantMessageId
-            );
-            if (completedMsg) {
-              completedState.syncMessage(completedMsg);
-            }
-
-            // Auto-title on first exchange
-            if (completedState.conversationId && completedState.messages.length <= 3) {
-              const firstUserMsg = completedState.messages.find((m) => m.role === 'user');
-              if (firstUserMsg) {
-                const title = firstUserMsg.content.slice(0, 60).trim();
-                completedState.renameConversation(completedState.conversationId, title);
-              }
-            }
-
-            onSuccess?.(data);
-          },
-
-          onCitationWarning: (data) => {
-            // Accumulate citation warnings on the assistant message
-            const currentMsg = useChatStore.getState().messages.find(
-              (m) => m.id === assistantMessageId
-            );
-            const existing = currentMsg?.citationWarnings || [];
-            updateMessage(assistantMessageId, {
-              citationWarnings: [
-                ...existing,
-                {
-                  case_number: data.case_number,
-                  status: data.status,
-                  confidence: data.confidence,
-                  message: data.message,
-                },
-              ],
-            });
-          },
-
-          onError: (error) => {
-            updateMessage(assistantMessageId, {
-              content: `Помилка: ${error.message}`,
-              isStreaming: false,
-            });
-            setStreaming(false);
-            setStreamController(null);
-            setCurrentTool(null);
-            showToast.error(error.message);
-            onError?.(new Error(error.message));
-          },
-
-          onComplete: (data) => {
-            // Store cost data from complete event
-            if (data.tools_used || data.total_cost_usd != null || data.charged_usd != null) {
-              costSummaryRef.current = {
-                ...costSummaryRef.current,
-                tools_used: data.tools_used || [],
-                total_cost_usd: data.total_cost_usd || 0,
-                charged_usd: data.charged_usd || 0,
-                response_id: data.response_id || responseIdRef.current || undefined,
-              };
-              updateMessage(assistantMessageId, {
-                costSummary: costSummaryRef.current as CostSummary,
-              });
-            }
-            console.log('[AIChat] Complete', data);
-          },
-
-          onCostSummary: (data) => {
-            // Merge balance info from cost_summary event
-            costSummaryRef.current = {
-              ...costSummaryRef.current,
-              charged_usd: data.charged_usd,
-              balance_usd: data.balance_usd,
-            };
-            updateMessage(assistantMessageId, {
-              costSummary: costSummaryRef.current as CostSummary,
-            });
-          },
-        }, 'standard', chatConversationId);
-
-        setStreamController(controller);
+        await runChatStream(query, assistantMessageId);
       } catch (error: any) {
         updateMessage(assistantMessageId, {
           content: `Помилка: ${error.message || 'Невідома помилка'}`,
@@ -1395,9 +1428,73 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
         onError?.(error);
       }
     },
-    [addMessage, updateMessage, addThinkingStep, setStreaming, setStreamController, setCurrentTool, onSuccess, onError]
+    [addMessage, updateMessage, setStreaming, setCurrentTool, setIsPlanLoading, setPendingPlanReview, runChatStream, onError]
   );
 
-  return { executeChat };
+  /**
+   * Phase 2: User confirmed the plan with depth choices → execute.
+   */
+  const confirmPlanAndExecute = useCallback(
+    async (approvedPlan: ExecutionPlan) => {
+      const pending = useChatStore.getState().pendingPlanReview;
+      if (!pending) return;
+
+      const { query, assistantMessageId, planSessionId } = pending;
+
+      // Clear review state, switch to streaming
+      setPendingPlanReview(null);
+      updateMessage(assistantMessageId, { isStreaming: true, content: '' });
+      setStreaming(true);
+      setCurrentTool('ai_chat');
+
+      try {
+        await runChatStream(query, assistantMessageId, approvedPlan, planSessionId);
+      } catch (error: any) {
+        updateMessage(assistantMessageId, {
+          content: `Помилка: ${error.message || 'Невідома помилка'}`,
+          isStreaming: false,
+        });
+        setStreaming(false);
+        setCurrentTool(null);
+        showToast.error(error.message || 'Невідома помилка');
+        onError?.(error);
+      }
+    },
+    [updateMessage, setStreaming, setCurrentTool, setPendingPlanReview, runChatStream, onError]
+  );
+
+  /**
+   * Skip plan review → execute with default depths (standard flow).
+   */
+  const skipPlanReview = useCallback(
+    async () => {
+      const pending = useChatStore.getState().pendingPlanReview;
+      if (!pending) return;
+
+      const { query, assistantMessageId } = pending;
+
+      // Clear review state, direct execution without approved plan
+      setPendingPlanReview(null);
+      updateMessage(assistantMessageId, { isStreaming: true, content: '' });
+      setStreaming(true);
+      setCurrentTool('ai_chat');
+
+      try {
+        await runChatStream(query, assistantMessageId);
+      } catch (error: any) {
+        updateMessage(assistantMessageId, {
+          content: `Помилка: ${error.message || 'Невідома помилка'}`,
+          isStreaming: false,
+        });
+        setStreaming(false);
+        setCurrentTool(null);
+        showToast.error(error.message || 'Невідома помилка');
+        onError?.(error);
+      }
+    },
+    [updateMessage, setStreaming, setCurrentTool, setPendingPlanReview, runChatStream, onError]
+  );
+
+  return { executeChat, confirmPlanAndExecute, skipPlanReview };
 }
 

--- a/lexwebapp/src/pages/ChatPage/index.tsx
+++ b/lexwebapp/src/pages/ChatPage/index.tsx
@@ -8,6 +8,7 @@ import { useState, useCallback } from 'react';
 import { ChatInput } from '../../components/ChatInput';
 import { MessageThread } from '../../components/MessageThread';
 import { EmptyState } from '../../components/EmptyState';
+import { PlanReviewDisplay } from '../../components/PlanReviewDisplay';
 import { useChatStore } from '../../stores';
 import { useMCPTool, useAIChat } from '../../hooks/useMCPTool';
 import showToast from '../../utils/toast';
@@ -18,7 +19,7 @@ export function ChatPage() {
   const [selectedTool, setSelectedTool] = useState(AI_CHAT_MODE);
 
   // Zustand stores
-  const { messages, isStreaming, cancelStream, removeMessage } = useChatStore();
+  const { messages, isStreaming, cancelStream, removeMessage, pendingPlanReview, isPlanLoading } = useChatStore();
 
   // MCP Tool hook (for manual tool mode)
   const { executeTool } = useMCPTool(selectedTool === AI_CHAT_MODE ? 'search_legal_precedents' : selectedTool, {
@@ -26,7 +27,7 @@ export function ChatPage() {
   });
 
   // AI Chat hook (agentic mode)
-  const { executeChat } = useAIChat();
+  const { executeChat, confirmPlanAndExecute, skipPlanReview } = useAIChat();
 
   /**
    * Parse content to tool-specific parameters
@@ -132,11 +133,24 @@ export function ChatPage() {
       ) : (
         <MessageThread messages={messages} onRegenerate={handleRegenerate} onEdit={handleEdit} />
       )}
+
+      {/* Plan review questionnaire — shown between messages and input */}
+      {pendingPlanReview && (
+        <div className="w-full max-w-3xl mx-auto px-4">
+          <PlanReviewDisplay
+            plan={pendingPlanReview.plan}
+            onConfirm={confirmPlanAndExecute}
+            onSkip={skipPlanReview}
+            isLoading={isStreaming}
+          />
+        </div>
+      )}
+
       <div className="w-full bg-gradient-to-t from-claude-bg via-claude-bg to-transparent pt-6 pb-4 z-20 border-t border-claude-border/30">
         <ChatInput
           onSend={handleSend}
-          disabled={isStreaming}
-          isStreaming={isStreaming}
+          disabled={isStreaming || isPlanLoading || !!pendingPlanReview}
+          isStreaming={isStreaming || isPlanLoading}
           onCancel={cancelStream}
           selectedTool={selectedTool}
           onToolChange={setSelectedTool}

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -119,12 +119,39 @@ export class MCPService extends BaseService {
    * Stream AI chat (agentic LLM loop with tool calling)
    * POST /api/chat → SSE events: thinking, tool_result, answer, complete
    */
+  /**
+   * Request an execution plan for user review (Phase 1 of two-phase flow).
+   * Returns plan with steps that user can mark as standard/deep.
+   */
+  async requestPlan(
+    query: string,
+    budget: string = 'standard'
+  ): Promise<{ plan: import('../../types/models/Message').ExecutionPlan | null; planSessionId: string | null }> {
+    const response = await fetch(`${this.API_URL}/chat/plan`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.getAuthToken()}`,
+      },
+      body: JSON.stringify({ query, budget }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Plan request failed: ${response.status} - ${errorText}`);
+    }
+
+    return response.json();
+  }
+
   async streamChat(
     query: string,
     history: Array<{ role: 'user' | 'assistant'; content: string }>,
     callbacks: ChatStreamCallbacks,
     budget: string = 'standard',
-    conversationId?: string
+    conversationId?: string,
+    approvedPlan?: import('../../types/models/Message').ExecutionPlan,
+    planSessionId?: string
   ): Promise<AbortController> {
     const controller = new AbortController();
 
@@ -135,7 +162,7 @@ export class MCPService extends BaseService {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.getAuthToken()}`,
         },
-        body: JSON.stringify({ query, history, budget, conversationId }),
+        body: JSON.stringify({ query, history, budget, conversationId, approvedPlan, planSessionId }),
         signal: controller.signal,
       });
 

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -5,7 +5,7 @@
 
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
-import { Message, ThinkingStep } from '../types/models';
+import { Message, ThinkingStep, ExecutionPlan } from '../types/models';
 import { api } from '../utils/api-client';
 
 interface ConversationSummary {
@@ -14,12 +14,24 @@ interface ConversationSummary {
   updated_at: string;
 }
 
+/** Pending plan awaiting user depth choices before execution */
+interface PendingPlanReview {
+  plan: ExecutionPlan;
+  planSessionId: string;
+  query: string;
+  assistantMessageId: string;
+}
+
 interface ChatState {
   // State
   messages: Message[];
   isStreaming: boolean;
   streamController: AbortController | null;
   currentTool: string | null;
+
+  // Plan review state
+  pendingPlanReview: PendingPlanReview | null;
+  isPlanLoading: boolean;
 
   // Conversation state
   conversationId: string | null;
@@ -42,6 +54,10 @@ interface ChatState {
   setStreamController: (controller: AbortController | null) => void;
   setCurrentTool: (toolName: string | null) => void;
   cancelStream: () => void;
+
+  // Plan review actions
+  setPendingPlanReview: (review: PendingPlanReview | null) => void;
+  setIsPlanLoading: (loading: boolean) => void;
 
   // Conversation actions
   loadConversations: () => Promise<void>;
@@ -67,6 +83,8 @@ export const useChatStore = create<ChatState>()(
         isStreaming: false,
         streamController: null,
         currentTool: null,
+        pendingPlanReview: null,
+        isPlanLoading: false,
         conversationId: null,
         conversations: [],
         conversationsLoading: false,
@@ -124,6 +142,10 @@ export const useChatStore = create<ChatState>()(
 
         // Set current tool being executed
         setCurrentTool: (toolName) => set({ currentTool: toolName }),
+
+        // Plan review actions
+        setPendingPlanReview: (review) => set({ pendingPlanReview: review }),
+        setIsPlanLoading: (loading) => set({ isPlanLoading: loading }),
 
         // Cancel active stream
         cancelStream: () => {

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -55,6 +55,7 @@ export interface PlanStep {
   purpose: string;
   depends_on?: number[];
   completed?: boolean;
+  depth?: 'standard' | 'deep';
 }
 
 export interface Decision {

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1760,6 +1760,41 @@ class HTTPMCPServer {
       }
     }) as any);
 
+    // ============ Chat Plan Review endpoint ============
+    // POST /api/chat/plan - Returns execution plan for user review before running
+    this.app.post('/api/chat/plan', chatRateLimit as any, requireJWT as any, (async (req: DualAuthRequest, res: Response) => {
+      const userId = req.user?.id;
+      const requestId = `plan-${uuidv4()}`;
+
+      try {
+        const { query, budget } = req.body;
+
+        if (!query || typeof query !== 'string') {
+          return res.status(400).json({ error: 'query is required' });
+        }
+
+        const result = await this.chatService.generatePlanForReview(
+          query,
+          budget || 'standard',
+          userId,
+          requestId
+        );
+
+        if (!result) {
+          return res.json({ plan: null, planSessionId: null, message: 'Simple query — no plan needed' });
+        }
+
+        res.json({
+          plan: result.plan,
+          planSessionId: result.planSessionId,
+        });
+      } catch (error: any) {
+        logger.error('[ChatPlan] Endpoint error', { error: error.message, requestId });
+        res.status(500).json({ error: 'Plan generation failed', message: error.message });
+      }
+    }) as any);
+    logger.info('Chat Plan Review endpoint registered at POST /api/chat/plan');
+
     // ============ AI Chat endpoint (agentic LLM loop with SSE) ============
     // POST /api/chat - Streams thinking steps, tool results, and final answer
     this.app.post('/api/chat', chatRateLimit as any, requireJWT as any, (async (req: DualAuthRequest, res: Response) => {
@@ -1767,7 +1802,7 @@ class HTTPMCPServer {
       const requestId = `chat-${uuidv4()}`;
 
       try {
-        const { query, history, budget, conversationId } = req.body;
+        const { query, history, budget, conversationId, approvedPlan, planSessionId } = req.body;
 
         if (!query || typeof query !== 'string') {
           return res.status(400).json({ error: 'query is required' });
@@ -1828,6 +1863,8 @@ class HTTPMCPServer {
             userId,
             requestId,
             signal: abortController.signal,
+            approvedPlan,
+            planSessionId,
           })) {
             if (abortController.signal.aborted) break;
 

--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -28,6 +28,7 @@ export interface PlanStep {
   params: Record<string, any>; // Call parameters
   purpose: string;             // Why this step (for UI, Ukrainian)
   depends_on?: number[];       // Dependencies on prior steps
+  depth?: 'standard' | 'deep'; // User-chosen analysis depth (default: standard)
 }
 
 // ============================

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -56,6 +56,19 @@ export interface ChatRequest {
   userId?: string;
   requestId?: string;
   signal?: AbortSignal;
+  /** Pre-approved plan with per-step depth choices — skips plan generation */
+  approvedPlan?: ExecutionPlan;
+  /** Session ID from a prior /api/chat/plan call — reuses cached classification */
+  planSessionId?: string;
+}
+
+/** Cached result from /api/chat/plan for reuse during execution */
+interface PlanSession {
+  classification: { domains: string[]; keywords: string; slots?: Record<string, any> };
+  toolDefs: ToolDefinition[];
+  plan: ExecutionPlan;
+  query: string;
+  createdAt: number;
 }
 
 // ============================
@@ -102,9 +115,24 @@ function toolCallHash(toolName: string, params: Record<string, any>): string {
   return `${toolName}:${hash}`;
 }
 
+/** Depth-based parameter overrides for search tools (deep = larger limits) */
+const DEPTH_OVERRIDES: Record<string, { standard: Record<string, any>; deep: Record<string, any> }> = {
+  search_legal_precedents:        { standard: { limit: 20 }, deep: { limit: 50 } },
+  search_supreme_court_practice:  { standard: { limit: 20 }, deep: { limit: 50 } },
+  find_similar_fact_pattern_cases: { standard: { limit: 10 }, deep: { limit: 30 } },
+  compare_practice_pro_contra:    { standard: { limit: 20 }, deep: { limit: 50 } },
+  search_legislation:             { standard: { limit: 10 }, deep: { limit: 30 } },
+  find_relevant_law_articles:     { standard: { limit: 10 }, deep: { limit: 25 } },
+  search_procedural_norms:        { standard: { limit: 10 }, deep: { limit: 25 } },
+};
+
+const PLAN_SESSION_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
 export class ChatService {
   /** In-memory cache: conversationId → compressed summary of older history */
   private historySummaryCache = new Map<string, { messageCount: number; summary: string }>();
+  /** In-memory cache: planSessionId → classification + plan for two-phase flow */
+  private planSessions = new Map<string, PlanSession>();
 
   constructor(
     private toolRegistry: ToolRegistry,
@@ -114,7 +142,74 @@ export class ChatService {
     private conversationService?: ConversationService,
     private shepardizationService?: ShepardizationService,
     private embeddingService?: EmbeddingService
-  ) {}
+  ) {
+    // Periodic cleanup of expired plan sessions (every 2 minutes)
+    setInterval(() => {
+      const now = Date.now();
+      for (const [id, session] of this.planSessions) {
+        if (now - session.createdAt > PLAN_SESSION_TTL_MS) {
+          this.planSessions.delete(id);
+        }
+      }
+    }, 2 * 60 * 1000);
+  }
+
+  /**
+   * Phase 1: Generate execution plan for user review.
+   * Returns plan + session ID that can be passed to chat() for execution.
+   */
+  async generatePlanForReview(
+    query: string,
+    budget: 'quick' | 'standard' | 'deep' = 'standard',
+    userId?: string,
+    requestId?: string
+  ): Promise<{ plan: ExecutionPlan; planSessionId: string } | null> {
+    const classification = await this.classifyChatIntent(query, requestId);
+    const toolDefs = await this.filterTools(classification.domains, classification.slots);
+    const plan = await this.generateExecutionPlan(query, classification, toolDefs, requestId);
+
+    if (!plan) return null;
+
+    // Assign default depth to each step
+    for (const step of plan.steps) {
+      if (!step.depth) step.depth = 'standard';
+    }
+
+    // Cache session for reuse
+    const planSessionId = `plan-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    this.planSessions.set(planSessionId, {
+      classification,
+      toolDefs,
+      plan,
+      query,
+      createdAt: Date.now(),
+    });
+
+    logger.info('[ChatService] Plan generated for review', {
+      planSessionId,
+      steps: plan.steps.length,
+      goal: plan.goal.slice(0, 100),
+    });
+
+    return { plan, planSessionId };
+  }
+
+  /**
+   * Apply user-chosen depth overrides to plan step parameters.
+   * Deep steps get larger limits for search tools.
+   */
+  private applyStepDepths(plan: ExecutionPlan): ExecutionPlan {
+    const adjustedSteps = plan.steps.map(step => {
+      const depth = step.depth || 'standard';
+      const overrides = DEPTH_OVERRIDES[step.tool];
+      if (!overrides) return step;
+      return {
+        ...step,
+        params: { ...step.params, ...overrides[depth] },
+      };
+    });
+    return { ...plan, steps: adjustedSteps };
+  }
 
   /**
    * Run the agentic chat loop. Yields ChatEvents for SSE streaming.
@@ -139,25 +234,58 @@ export class ChatService {
     }
 
     try {
-      // 1. Classify intent via LLM → filter tools
-      const classification = await this.classifyChatIntent(query, requestId);
-      const toolDefs = await this.filterTools(classification.domains, classification.slots);
+      // --- Two-phase support: reuse cached session if approvedPlan is provided ---
+      let classification: { domains: string[]; keywords: string; slots?: Record<string, any> };
+      let toolDefs: ToolDefinition[];
+      let plan: ExecutionPlan | undefined;
 
-      // 2. Generate execution plan (replaces old response template)
-      const plan = await this.generateExecutionPlan(query, classification, toolDefs, requestId);
+      if (request.approvedPlan && request.planSessionId) {
+        const session = this.planSessions.get(request.planSessionId);
+        if (session && Date.now() - session.createdAt <= PLAN_SESSION_TTL_MS) {
+          classification = session.classification;
+          toolDefs = session.toolDefs;
+          // Use the user-approved plan with depth overrides applied
+          plan = this.applyStepDepths(request.approvedPlan);
+          this.planSessions.delete(request.planSessionId);
+          logger.info('[ChatService] Using approved plan from session', {
+            planSessionId: request.planSessionId,
+            steps: plan.steps.length,
+            deepSteps: plan.steps.filter(s => s.depth === 'deep').length,
+          });
+        } else {
+          logger.warn('[ChatService] Plan session expired or not found, regenerating', {
+            planSessionId: request.planSessionId,
+          });
+          classification = await this.classifyChatIntent(query, requestId);
+          toolDefs = await this.filterTools(classification.domains, classification.slots);
+          plan = await this.generateExecutionPlan(query, classification, toolDefs, requestId);
+        }
+      } else {
+        // Standard flow: classify + generate plan
+        classification = await this.classifyChatIntent(query, requestId);
+        toolDefs = await this.filterTools(classification.domains, classification.slots);
+        plan = await this.generateExecutionPlan(query, classification, toolDefs, requestId);
+      }
 
-      // 3. Emit plan to client via SSE
+      // Emit plan to client via SSE
       if (plan) {
         yield { type: 'plan', data: plan };
       }
 
-      // 4. Budget escalation:
+      // Budget escalation:
+      //    - Any step marked "deep" by user → deep budget
       //    - Plan with >= 3 steps → deep
       //    - Complex case analysis (case_number + long query) → deep even without a plan
       //    - Court practice analysis query → deep (needs full doc content + long response)
       let effectiveBudget: BudgetKey = budget;
+      const hasDeepSteps = plan?.steps.some(s => s.depth === 'deep');
       const PRACTICE_ANALYSIS_KEYWORDS = /проаналізу|аналіз практик|судова практика|знайти справи|знайти практику|огляд практики|яка практика|як суди|позиція судів/i;
-      if (plan && plan.steps.length >= 3) {
+      if (hasDeepSteps) {
+        effectiveBudget = 'deep';
+        logger.info('[ChatService] Escalated to deep budget (user chose deep steps)', {
+          deepSteps: plan!.steps.filter(s => s.depth === 'deep').map(s => s.tool),
+        });
+      } else if (plan && plan.steps.length >= 3) {
         effectiveBudget = 'deep';
       } else if (
         !plan &&


### PR DESCRIPTION
## Summary
- Adds a two-phase chat flow: before executing the agentic loop, the system generates an execution plan and pauses for user review
- Each plan step shows a toggle between **Стандартний** and **Глибокий** analysis depth (only for search tools with configurable limits)
- Deep steps get larger search limits (e.g. 50 vs 20 for precedent searches) and auto-escalate the LLM budget to the deep tier
- New `POST /api/chat/plan` endpoint returns plan + planSessionId; existing `POST /api/chat` accepts optional `approvedPlan` with depth choices

## Changes
- **Backend**: `generatePlanForReview()` method, plan session cache (5min TTL), `applyStepDepths()` with depth overrides per tool, new `/api/chat/plan` endpoint
- **Frontend**: `PlanReviewDisplay` component with depth toggles and bulk actions, two-phase `useAIChat` hook (`executeChat` → `confirmPlanAndExecute`), `pendingPlanReview` store state
- **Types**: `PlanStep.depth?: 'standard' | 'deep'` added to both backend and frontend

## Test plan
- [ ] Send a complex query (e.g. court practice analysis) — should show plan review card before execution
- [ ] Toggle individual steps between Standard/Deep — verify UI state
- [ ] Click "Усі глибокі" / "Усі стандартні" — all depth-capable steps should switch
- [ ] Click "Почати аналіз" — verify SSE stream starts with approved depths applied
- [ ] Click "Пропустити" — verify standard execution without plan review
- [ ] Send a simple query (1-step plan or no plan) — should fall through to direct execution
- [ ] Verify plan session expiry: wait >5 min then confirm — should gracefully regenerate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a two-phase chat flow with a pre-execution plan review where users pick Standard or Deep per step. Deep steps expand search limits and auto-escalate the LLM budget, giving better control over depth, speed, and cost.

- New Features
  - Two-phase flow: POST /api/chat/plan returns plan + planSessionId → user reviews → execute; falls back to direct execution for simple queries or failures.
  - Per-step depth for search tools with bulk “all deep/standard” toggles.
  - Deep steps apply higher limits (e.g., precedents 50 vs 20) and escalate to deep budget; plan sessions cached for 5 minutes.
  - API: POST /api/chat now accepts approvedPlan and planSessionId.
  - Frontend: PlanReviewDisplay component; useAIChat adds confirmPlanAndExecute and skipPlanReview; chat store adds pendingPlanReview and isPlanLoading; input is disabled during review.
  - Types: PlanStep.depth added.

- Migration
  - No changes required for existing callers; the flow is optional and auto-fallback remains.
  - To opt in via API: call /api/chat/plan, let the user choose depths, then call /api/chat with approvedPlan and planSessionId.
  - Plan sessions expire after 5 minutes; regenerate if expired.

<sup>Written for commit 2eeec0e76da9b5fca29f4a4e7cf95b601dcec3b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

