### PR TITLE
fix(chat): use standard model for plan generation

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1026,7 +1026,7 @@ ${stepsText}
           temperature: 0.1,
           response_format: { type: 'json_object' },
         },
-        'quick',
+        'standard',
         'openai'
       );
 


### PR DESCRIPTION
## Summary
- Switch plan generation from `quick` (gpt-5-nano) to `standard` (gpt-5-mini)
- gpt-5-nano frequently returns `{}` for complex queries, skipping the plan review questionnaire
- gpt-5-mini has 1M context window and produces stable JSON plans
- Cost increase: ~$0.004 per plan (negligible)

## Test plan
- [ ] Send complex query to `/api/chat/plan` — should return non-null plan with steps
- [ ] Verify plan review UI appears in frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched plan generation from quick (gpt-5-nano) to standard (gpt-5-mini) to stop empty JSON plans on complex queries and ensure the plan review UI appears. gpt-5-mini’s 1M context produces stable JSON; cost impact is ~$0.004 per plan.

<sup>Written for commit e77131573485a67505ffcc7205c7857a02fa9988. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

