### PR TITLE
fix(db): resolve PG type mismatch in precedent_status query

### DIFF
--- a/mcp_backend/src/services/shepardization-service.ts
+++ b/mcp_backend/src/services/shepardization-service.ts
@@ -397,8 +397,8 @@ export class ShepardizationService {
     try {
       await this.db.query(
         `INSERT INTO precedent_status (case_id, case_number, target_doc_id, status, confidence, affecting_decisions, check_source, last_checked, ttl_expires_at)
-         SELECT id, $1, $2, $3, $4, $5::jsonb, $6, NOW(), NOW() + INTERVAL '7 days'
-         FROM documents WHERE metadata->>'case_number' = $1 LIMIT 1
+         SELECT id, $1::varchar(100), $2, $3, $4, $5::jsonb, $6, NOW(), NOW() + INTERVAL '7 days'
+         FROM documents WHERE metadata->>'case_number' = $1::text LIMIT 1
          ON CONFLICT (case_id) DO UPDATE SET
            case_number = EXCLUDED.case_number,
            target_doc_id = EXCLUDED.target_doc_id,


### PR DESCRIPTION
## Summary
- Fixed PostgreSQL `inconsistent types deduced for parameter $1` error in `shepardization-service.ts`
- The `$1` parameter was used in both `SELECT` (mapped to `VARCHAR(100)` column) and `WHERE metadata->>'case_number'` (returns `TEXT`), causing PG to fail with conflicting type inference
- Added explicit casts: `$1::varchar(100)` in SELECT and `$1::text` in WHERE to resolve the ambiguity
- This error was firing ~30+ times in recent logs on stage

## Test plan
- [ ] Deploy to stage and verify no more `inconsistent types` errors in PG logs
- [ ] Test shepardization tool to confirm precedent status caching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a PostgreSQL type mismatch in the precedent_status INSERT…SELECT by explicitly casting the case_number parameter, preventing the “inconsistent types deduced for parameter $1” error and stabilizing shepardization writes.

- **Bug Fixes**
  - Cast $1 to varchar(100) in the SELECT list to match case_number.
  - Cast $1 to text in the WHERE clause comparing metadata->>'case_number'.

<sup>Written for commit 4f54b57567265ed2a335e46294b721d5e28e5b41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

