### PR TITLE
fix(chat): strengthen plan generation prompt and increase token limit

### DIFF
--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -47,6 +47,8 @@ export function buildPlanGenerationMessages(
 ): Array<{ role: 'system' | 'user'; content: string }> {
   const systemMessage = `You are a plan generator for SecondLayer legal AI assistant. Output ONLY valid JSON — no markdown, no comments, no extra text.
 
+CRITICAL: You MUST ALWAYS return a plan with at least 1 step. NEVER return an empty object {}. Every user query needs at least one tool call.
+
 ## Rules
 1. Max 5 steps
 2. Use ONLY tools from the user's tool list

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1022,8 +1022,7 @@ ${stepsText}
       const response = await llm.chatCompletion(
         {
           messages: planMessages,
-          max_tokens: 800,
-          temperature: 0.1,
+          max_tokens: 2000,
           response_format: { type: 'json_object' },
         },
         'standard',
@@ -1052,8 +1051,12 @@ ${stepsText}
 
       const parsed = JSON.parse(jsonMatch[0]);
 
-      // Empty object means model decided no plan is needed (simple/conversational query)
+      // Empty object — model failed to generate a plan despite instructions
       if (Object.keys(parsed).length === 0) {
+        logger.warn('[ChatService] Plan generation returned empty object, model did not follow instructions', {
+          model: response.model,
+          query: query.slice(0, 200),
+        });
         return undefined;
       }
 


### PR DESCRIPTION
## Summary
- Added explicit `CRITICAL` instruction to plan generation prompt to never return empty `{}` objects
- Increased `max_tokens` from 800 to 2000 to prevent truncation of complex plans
- Added warning log when model returns empty object despite instructions

## Context
GPT-5-mini was consistently returning `{}` for plan generation, causing the plan review feature to always fall through to "Simple query — no plan needed". The model needs stronger instruction and more room for output.

## Test plan
- [ ] Deploy to stage
- [ ] Test `POST /api/chat/plan` with a complex legal query
- [ ] Verify non-null plan with steps is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens plan generation to stop empty JSON plans and prevent truncation. Restores plan review by enforcing at least one step and allowing longer responses.

- **Bug Fixes**
  - Added CRITICAL prompt instruction to always return a plan with at least one step; never {}
  - Increased plan generation max_tokens to 2000 (from 800)
  - Added warning log when an empty object is returned, including model and query snippet

<sup>Written for commit 03954f433b279d0266f7ca5e0302158c41f16012. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

