### PR TITLE
fix(chat): use deep model for plan generation

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1025,7 +1025,7 @@ ${stepsText}
           max_tokens: 2000,
           response_format: { type: 'json_object' },
         },
-        'standard',
+        'deep',
         'openai'
       );
 


### PR DESCRIPTION
## Summary
- Switch plan generation from `standard` (gpt-5-mini) to `deep` (gpt-5.1) model
- gpt-5-mini consistently returns `{}` despite explicit instructions not to

## Test plan
- [ ] Deploy to stage and verify plan generation produces non-empty plans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch plan generation from standard (gpt-5-mini) to deep (gpt-5.1) to ensure reliable JSON output and stop empty plans. This fixes the issue where gpt-5-mini frequently returned {} despite formatting instructions.

<sup>Written for commit 634a5c1d77627b0f896474d23e7ea6c481a95a90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

