### PR TITLE
fix(security): remove hardcoded JWT tokens from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ redis_data/
 # Scratch/temp notes with credentials
 1
 
+# MCP client configs (may contain tokens)
+config/jan-chat-mcp-config.json
+
 # Claude Code
 .claude/
 

--- a/docs/api/MCP_CLIENT_CONFIG.md
+++ b/docs/api/MCP_CLIENT_CONFIG.md
@@ -66,7 +66,7 @@ SECONDARY_LAYER_KEYS=test-key-123,dev-key-456,YOUR_API_KEY_PROD
 Your configuration had:
 ```json
 {
-  "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+  "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
 }
 ```
 

--- a/docs/archived/legacy-2026/backend/CLAUDE_DESKTOP_CONFIG.md
+++ b/docs/archived/legacy-2026/backend/CLAUDE_DESKTOP_CONFIG.md
@@ -18,7 +18,7 @@ Since Claude Desktop requires a `command` field, we use a local stdio proxy that
       ],
       "env": {
         "MCP_REMOTE_URL": "https://mcp.legal.org.ua",
-        "MCP_JWT_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+        "MCP_JWT_TOKEN": "YOUR_JWT_TOKEN_HERE"
       }
     }
   }
@@ -70,7 +70,7 @@ Some newer versions of Claude Desktop may support direct SSE connections. If so,
     "SecondLayerMCP": {
       "url": "https://mcp.legal.org.ua/v1/sse",
       "headers": {
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+        "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
       },
       "transport": "sse"
     }

--- a/docs/archived/legacy-2026/backend/JWT_AUTH_SETUP.md
+++ b/docs/archived/legacy-2026/backend/JWT_AUTH_SETUP.md
@@ -12,7 +12,7 @@ Your SecondLayer MCP server at `https://mcp.legal.org.ua/v1/sse` now requires JW
 **Expires:** January 18, 2027 (365 days)
 **Token:**
 ```
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw
+YOUR_JWT_TOKEN_HERE
 ```
 
 ---
@@ -29,7 +29,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc
     "SecondLayerMCP": {
       "url": "https://mcp.legal.org.ua/v1/sse",
       "headers": {
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+        "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
       }
     }
   }

--- a/docs/backend/CLAUDE_DESKTOP_CONFIG.md
+++ b/docs/backend/CLAUDE_DESKTOP_CONFIG.md
@@ -18,7 +18,7 @@ Since Claude Desktop requires a `command` field, we use a local stdio proxy that
       ],
       "env": {
         "MCP_REMOTE_URL": "https://mcp.legal.org.ua",
-        "MCP_JWT_TOKEN": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+        "MCP_JWT_TOKEN": "YOUR_JWT_TOKEN_HERE"
       }
     }
   }
@@ -70,7 +70,7 @@ Some newer versions of Claude Desktop may support direct SSE connections. If so,
     "SecondLayerMCP": {
       "url": "https://mcp.legal.org.ua/v1/sse",
       "headers": {
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+        "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
       },
       "transport": "sse"
     }

--- a/docs/backend/JWT_AUTH_SETUP.md
+++ b/docs/backend/JWT_AUTH_SETUP.md
@@ -12,7 +12,7 @@ Your SecondLayer MCP server at `https://mcp.legal.org.ua/v1/sse` now requires JW
 **Expires:** January 18, 2027 (365 days)
 **Token:**
 ```
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw
+YOUR_JWT_TOKEN_HERE
 ```
 
 ---
@@ -29,7 +29,7 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc
     "SecondLayerMCP": {
       "url": "https://mcp.legal.org.ua/v1/sse",
       "headers": {
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+        "Authorization": "Bearer YOUR_JWT_TOKEN_HERE"
       }
     }
   }

--- a/mcp_backend/scripts/mcp-remote-client.js
+++ b/mcp_backend/scripts/mcp-remote-client.js
@@ -10,7 +10,11 @@ const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
 const { SSEClientTransport } = require('@modelcontextprotocol/sdk/client/sse.js');
 
 const REMOTE_URL = process.env.MCP_REMOTE_URL || 'https://mcp.legal.org.ua/v1/sse';
-const JWT_TOKEN = process.env.MCP_JWT_TOKEN || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw';
+const JWT_TOKEN = process.env.MCP_JWT_TOKEN;
+if (!JWT_TOKEN) {
+  console.error('Error: MCP_JWT_TOKEN environment variable is required. Generate one with: npx tsx scripts/generate-jwt-token.ts');
+  process.exit(1);
+}
 
 async function main() {
   try {

--- a/mcp_backend/scripts/mcp-remote-wrapper.sh
+++ b/mcp_backend/scripts/mcp-remote-wrapper.sh
@@ -4,8 +4,8 @@
 # Connects to remote SSE MCP server via local stdio
 
 # Configuration
-REMOTE_URL="https://mcp.legal.org.ua/v1/sse"
-JWT_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw"
+REMOTE_URL="${MCP_REMOTE_URL:-https://mcp.legal.org.ua/v1/sse}"
+JWT_TOKEN="${MCP_JWT_TOKEN:?Error: MCP_JWT_TOKEN environment variable is required. Generate one with: npx tsx scripts/generate-jwt-token.ts}"
 
 # Use npx to run the MCP client proxy
 # This requires @modelcontextprotocol/sdk to be installed

--- a/mcp_backend/scripts/mcp-stdio-proxy.js
+++ b/mcp_backend/scripts/mcp-stdio-proxy.js
@@ -12,7 +12,11 @@ const readline = require('readline');
 
 // Configuration
 const REMOTE_URL = process.env.MCP_REMOTE_URL || 'https://mcp.legal.org.ua';
-const JWT_TOKEN = process.env.MCP_JWT_TOKEN || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCIsImlhdCI6MTc2ODc2NDIxOSwiZXhwIjoxODAwMzAwMjE5LCJpc3MiOiJzZWNvbmRsYXllci1tY3AifQ.r8VbMPM6bLxQjnLIlqUMW8sTIs-Zw_K-KqAgI8WQvEw';
+const JWT_TOKEN = process.env.MCP_JWT_TOKEN;
+if (!JWT_TOKEN) {
+  console.error('Error: MCP_JWT_TOKEN environment variable is required. Generate one with: npx tsx scripts/generate-jwt-token.ts');
+  process.exit(1);
+}
 
 const api = axios.create({
   baseURL: REMOTE_URL,

--- a/scripts/testing/phase1-time-billing-tests.sh
+++ b/scripts/testing/phase1-time-billing-tests.sh
@@ -7,7 +7,7 @@
 set -euo pipefail
 
 BASE_URL="http://localhost:3000"
-JWT="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiIxMTExMTExMS0xMTExLTExMTEtMTExMS0xMTExMTExMTExMTEiLCJlbWFpbCI6InRlc3RAbGVnYWwub3JnLnVhIiwibmFtZSI6IlRlc3QgQXR0b3JuZXkiLCJpc0FkbWluIjp0cnVlLCJpYXQiOjE3NzA4NjY2MTEsImV4cCI6MTc3MDk1MzAxMX0.3j44FzCNN11Zo3xnYInX73AxxZWstl2tmkmContRmiQ"
+JWT="${TEST_JWT_TOKEN:?Error: TEST_JWT_TOKEN environment variable is required. Generate one with: cd mcp_backend && npx tsx scripts/generate-jwt-token.ts test-user 30d}"
 USER_ID="11111111-1111-1111-1111-111111111111"
 MATTER_A="44444444-4444-4444-4444-444444444444"
 MATTER_B="55555555-5555-5555-5555-555555555555"


### PR DESCRIPTION
## Summary

- **Removed hardcoded JWT tokens** (valid until Jan 2027) from 3 MCP proxy scripts — now require `MCP_JWT_TOKEN` env var with fail-fast error
- **Replaced real tokens** with `YOUR_JWT_TOKEN_HERE` placeholders in 5 documentation files
- **Replaced hardcoded test JWT** in `phase1-time-billing-tests.sh` with required `TEST_JWT_TOKEN` env var
- **Added** `config/jan-chat-mcp-config.json` to `.gitignore`

## Action required after merge

Rotate `JWT_SECRET` on the server to invalidate the compromised token that remains in git history.

## Test plan

- [ ] Verify MCP proxy scripts fail with clear error when `MCP_JWT_TOKEN` is not set
- [ ] Verify scripts work when `MCP_JWT_TOKEN` is provided
- [ ] Verify no real JWT tokens remain in tracked files (`grep -r "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjbGF1ZGUtZGVza3RvcCI"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed hardcoded JWT tokens from MCP proxy scripts, tests, and docs to prevent secret leaks. Scripts now require env vars and fail fast if missing; added .gitignore for MCP client config and replaced docs with placeholders.

- **Migration**
  - Rotate JWT_SECRET on the server to revoke the token exposed in git history.
  - Set required env vars: MCP_JWT_TOKEN for MCP proxies; TEST_JWT_TOKEN for scripts/testing/phase1-time-billing-tests.sh. Generate tokens with: npx tsx scripts/generate-jwt-token.ts

<sup>Written for commit 7c79ee4772ccf995e64930fb4207b61349a20f38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

