### PR TITLE
fix(shepardization): validate UUID format before documents.id query

### DIFF
--- a/mcp_backend/src/services/shepardization-service.ts
+++ b/mcp_backend/src/services/shepardization-service.ts
@@ -301,17 +301,20 @@ export class ShepardizationService {
       return identifier;
     }
 
-    // Try UUID lookup in documents table
-    try {
-      const result = await this.db.query(
-        `SELECT metadata->>'case_number' as case_number FROM documents WHERE id = $1 LIMIT 1`,
-        [identifier]
-      );
-      if (result.rows.length > 0 && result.rows[0].case_number) {
-        return result.rows[0].case_number;
+    // Try UUID lookup in documents table (only if identifier looks like a UUID)
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (uuidRegex.test(identifier)) {
+      try {
+        const result = await this.db.query(
+          `SELECT metadata->>'case_number' as case_number FROM documents WHERE id = $1 LIMIT 1`,
+          [identifier]
+        );
+        if (result.rows.length > 0 && result.rows[0].case_number) {
+          return result.rows[0].case_number;
+        }
+      } catch {
+        // Not a valid UUID, ignore
       }
-    } catch {
-      // Not a valid UUID, ignore
     }
 
     // Try zakononline_id lookup


### PR DESCRIPTION
## Summary
- Numeric ZakonOnline IDs (e.g. `114118466`) were being passed directly to `WHERE id = $1` on `documents` table which has UUID primary key, causing PostgreSQL `22P02` cast errors on every shepardization run
- Added UUID regex validation before attempting the UUID lookup — non-UUID identifiers now skip straight to `zakononline_id` lookup

## Test plan
- [ ] Deploy to stage and verify no more `22P02` errors in logs during chat sessions with citation verification
- [ ] Confirm shepardization still resolves case numbers correctly via UUID, zakononline_id, and direct case number paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent PostgreSQL 22P02 errors by validating UUID identifiers before querying documents.id in shepardization. Non-UUID inputs now skip to the zakononline_id lookup.

- **Bug Fixes**
  - Add UUID regex guard before documents.id query.
  - Avoid cast errors with numeric ZakonOnline IDs.
  - Preserve normal resolution for valid UUIDs.

<sup>Written for commit 24f769eec1ea5838a5dff5fa6adcd28dce08535c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

