### PR TITLE
fix(ui): filter right panel Decisions tab to court decisions only

### DIFF
--- a/lexwebapp/src/components/RightPanel.tsx
+++ b/lexwebapp/src/components/RightPanel.tsx
@@ -77,15 +77,15 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
     });
   }, [messages]);
 
-  // Only proper court decisions (Рішення/Постанова or no documentType = from search results)
+  // Only proper court decisions (Рішення/Постанова) with explicit documentType
   const decisions = useMemo(() =>
-    allDecisions.filter(d => !d.documentType || DECISION_TYPES.has(d.documentType)),
+    allDecisions.filter(d => d.documentType && DECISION_TYPES.has(d.documentType)),
     [allDecisions]
   );
 
-  // Other court documents (Ухвала, Окрема думка, etc.) — shown in documents tab
+  // Everything else (Ухвала, Окрема думка, untyped results, etc.) — shown in documents tab
   const otherCourtDocs = useMemo(() =>
-    allDecisions.filter(d => d.documentType && !DECISION_TYPES.has(d.documentType)),
+    allDecisions.filter(d => !d.documentType || !DECISION_TYPES.has(d.documentType)),
     [allDecisions]
   );
 


### PR DESCRIPTION
## Summary
- Only show Рішення and Постанова (with explicit `documentType`) in the Decisions tab
- Move ухвали, окремі думки, and untyped search results to the Documents tab
- Aligns tab content with user expectations — Decisions = court decisions on the merits

## Test plan
- [ ] Run a search that returns mixed document types (рішення, ухвала, окрема думка)
- [ ] Verify Decisions tab shows only Рішення/Постанова
- [ ] Verify Documents tab shows ухвали, окремі думки, and untyped results
- [ ] Check tab badge counts match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters the Right Panel Decisions tab to only show court decisions on the merits: Рішення and Постанова with an explicit documentType. All other types (ухвала, окрема думка) and untyped results now appear in Documents, making tabs and badge counts accurate.

<sup>Written for commit bed1196b1bddf1ea13fb18132ba0abae6058e115. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

