### PR TITLE
infra(prod): add AWS production environment

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1,0 +1,777 @@
+services:
+  postgres-prod:
+    image: postgres:15-alpine
+    container_name: secondlayer-postgres-prod
+    command: >-
+      postgres
+      -c max_connections=300
+      -c shared_buffers=2GB
+      -c effective_cache_size=6GB
+      -c work_mem=64MB
+      -c maintenance_work_mem=512MB
+      -c wal_buffers=32MB
+      -c idle_in_transaction_session_timeout=60000
+      -c statement_timeout=300000
+      -c lock_timeout=30000
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      TZ: Europe/Kiev
+    ports:
+    - "127.0.0.1:5438:5432"
+    volumes:
+    - postgres_prod_data:/var/lib/postgresql/data
+    healthcheck:
+      test:
+      - CMD-SHELL
+      - pg_isready -U ${POSTGRES_USER:-secondlayer} -d ${POSTGRES_DB:-secondlayer_prod}
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+    - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 2G
+
+  pgbouncer-prod:
+    image: edoburu/pgbouncer:latest
+    container_name: secondlayer-pgbouncer-prod
+    ports:
+    - "127.0.0.1:5439:5432"
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POOL_MODE: transaction
+      MAX_CLIENT_CONN: 300
+      DEFAULT_POOL_SIZE: 30
+      MIN_POOL_SIZE: 5
+      RESERVE_POOL_SIZE: 5
+      RESERVE_POOL_TIMEOUT: 5
+      SERVER_ROUND_ROBIN: 1
+      TZ: Europe/Kiev
+    depends_on:
+      postgres-prod:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -h localhost -p 5432 -U ${POSTGRES_USER:-secondlayer}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+    - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 128M
+
+  rada-db-init-prod:
+    image: postgres:15-alpine
+    container_name: rada-db-init-prod
+    depends_on:
+      postgres-prod:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: "5432"
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      RADA_POSTGRES_USER: ${RADA_POSTGRES_USER:-rada_mcp}
+      RADA_POSTGRES_PASSWORD: ${RADA_POSTGRES_PASSWORD}
+      RADA_POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
+      TZ: Europe/Kiev
+    volumes:
+      - ./scripts/rada-db-init.sh:/scripts/rada-db-init.sh:ro
+    command: ["sh", "/scripts/rada-db-init.sh"]
+    restart: "no"
+    networks:
+      - secondlayer-prod-network
+
+  postgres-openreyestr-prod:
+    image: mcvovkes/openreyestr-db:latest
+    container_name: openreyestr-postgres-prod
+    shm_size: '2g'
+    command: >-
+      postgres
+      -c max_connections=100
+      -c shared_buffers=1GB
+      -c effective_cache_size=3GB
+      -c work_mem=64MB
+      -c maintenance_work_mem=512MB
+      -c idle_in_transaction_session_timeout=60000
+      -c statement_timeout=300000
+      -c lock_timeout=30000
+    environment:
+      POSTGRES_USER: ${OPENREYESTR_POSTGRES_USER:-openreyestr}
+      POSTGRES_PASSWORD: ${OPENREYESTR_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${OPENREYESTR_POSTGRES_DB:-openreyestr_prod}
+      TZ: Europe/Kiev
+    ports:
+      - "127.0.0.1:5440:5432"
+    volumes:
+      - postgres_openreyestr_prod_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${OPENREYESTR_POSTGRES_USER:-openreyestr} -d ${OPENREYESTR_POSTGRES_DB:-openreyestr_prod}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 120s
+    restart: unless-stopped
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 1G
+
+  qdrant-prod:
+    image: qdrant/qdrant:latest
+    container_name: secondlayer-qdrant-prod
+    ports:
+    - "127.0.0.1:6339:6333"
+    - "127.0.0.1:6340:6334"
+    volumes:
+    - qdrant_prod_data:/qdrant/storage
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/6333'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    restart: unless-stopped
+    networks:
+    - secondlayer-prod-network
+    environment:
+      TZ: Europe/Kiev
+      QDRANT__STORAGE__OPTIMIZERS__MEMMAP_THRESHOLD_KB: "1048576"
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 1G
+
+  redis-prod:
+    image: redis:7-alpine
+    container_name: secondlayer-redis-prod
+    ports:
+    - "127.0.0.1:6383:6379"
+    volumes:
+    - redis_prod_data:/data
+    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy volatile-lru
+    healthcheck:
+      test:
+      - CMD
+      - redis-cli
+      - ping
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+    restart: unless-stopped
+    networks:
+    - secondlayer-prod-network
+    environment:
+      TZ: Europe/Kiev
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 1G
+
+  migrate-prod:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.mono-backend
+    image: secondlayer-app-prod:latest
+    container_name: secondlayer-migrate-prod
+    depends_on:
+      postgres-prod:
+        condition: service_healthy
+      redis-prod:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      NODE_ENV: production
+      TZ: Europe/Kiev
+    working_dir: /app/mcp_backend
+    command:
+    - node
+    - dist/migrations/migrate.js
+    restart: 'no'
+    networks:
+    - secondlayer-prod-network
+
+  seed-admin-prod:
+    image: secondlayer-app-prod:latest
+    container_name: secondlayer-seed-admin-prod
+    depends_on:
+      migrate-prod:
+        condition: service_completed_successfully
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      ADMIN_USERS: ${ADMIN_USERS}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      NODE_ENV: production
+      TZ: Europe/Kiev
+    working_dir: /app/mcp_backend
+    command: ["node", "dist/scripts/seed-admin-user.js"]
+    restart: "no"
+    networks:
+      - secondlayer-prod-network
+
+  rada-migrate-prod:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.mono-rada
+    image: rada-mcp-prod:latest
+    container_name: rada-mcp-migrate-prod
+    depends_on:
+      rada-db-init-prod:
+        condition: service_completed_successfully
+      redis-prod:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${RADA_POSTGRES_USER:-rada_mcp}
+      POSTGRES_PASSWORD: ${RADA_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
+      REDIS_URL: redis://redis-prod:6379
+      REDIS_HOST: redis-prod
+      REDIS_PORT: 6379
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      NODE_ENV: production
+      TZ: Europe/Kiev
+    command: ["node", "dist/migrations/migrate.js"]
+    restart: "no"
+    networks:
+      - secondlayer-prod-network
+
+  rada-mcp-app-prod:
+    image: rada-mcp-prod:latest
+    container_name: rada-mcp-app-prod
+    command: ["node", "--max-old-space-size=1536", "dist/http-server.js"]
+    depends_on:
+      rada-migrate-prod:
+        condition: service_completed_successfully
+      redis-prod:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      HTTP_PORT: 3001
+      HTTP_HOST: 0.0.0.0
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${RADA_POSTGRES_USER:-rada_mcp}
+      POSTGRES_PASSWORD: ${RADA_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
+      REDIS_URL: redis://redis-prod:6379
+      REDIS_HOST: redis-prod
+      REDIS_PORT: 6379
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
+      OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
+      OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
+      LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-task-aware}
+      SECONDLAYER_URL: http://app-prod:3000
+      SECONDLAYER_API_KEY: ${SECONDARY_LAYER_KEYS}
+      RADA_API_KEYS: ${RADA_API_KEYS}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://legal.org.ua}
+      TZ: Europe/Kiev
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+
+  migrate-openreyestr-prod:
+    image: openreyestr-app-prod:latest
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.mono-openreyestr
+    container_name: openreyestr-migrate-prod
+    depends_on:
+      postgres-openreyestr-prod:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${OPENREYESTR_POSTGRES_USER:-openreyestr}:${OPENREYESTR_POSTGRES_PASSWORD}@postgres-openreyestr-prod:5432/${OPENREYESTR_POSTGRES_DB:-openreyestr_prod}
+      POSTGRES_HOST: postgres-openreyestr-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${OPENREYESTR_POSTGRES_USER:-openreyestr}
+      POSTGRES_PASSWORD: ${OPENREYESTR_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${OPENREYESTR_POSTGRES_DB:-openreyestr_prod}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      NODE_ENV: production
+      TZ: Europe/Kiev
+    command: ["node", "dist/migrations/migrate.js"]
+    restart: "no"
+    networks:
+      - secondlayer-prod-network
+
+  app-openreyestr-prod:
+    image: openreyestr-app-prod:latest
+    container_name: openreyestr-app-prod
+    command: ["node", "dist/http-server.js"]
+    environment:
+      NODE_ENV: production
+      HTTP_PORT: 3005
+      HTTP_HOST: 0.0.0.0
+      DATABASE_URL: postgresql://${OPENREYESTR_POSTGRES_USER:-openreyestr}:${OPENREYESTR_POSTGRES_PASSWORD}@postgres-openreyestr-prod:5432/${OPENREYESTR_POSTGRES_DB:-openreyestr_prod}
+      POSTGRES_HOST: postgres-openreyestr-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${OPENREYESTR_POSTGRES_USER:-openreyestr}
+      POSTGRES_PASSWORD: ${OPENREYESTR_POSTGRES_PASSWORD}
+      POSTGRES_DB: ${OPENREYESTR_POSTGRES_DB:-openreyestr_prod}
+      OPENREYESTR_API_KEYS: ${OPENREYESTR_API_KEYS}
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
+      OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
+      OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
+      SECONDLAYER_URL: http://app-prod:3000
+      SECONDLAYER_API_KEY: ${SECONDARY_LAYER_KEYS}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      NODE_OPTIONS: --max-old-space-size=1536
+      TZ: Europe/Kiev
+    depends_on:
+      postgres-openreyestr-prod:
+        condition: service_healthy
+      migrate-openreyestr-prod:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3005/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+
+  minio-prod:
+    image: minio/minio:latest
+    container_name: minio-prod
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-minioadmin}
+      MINIO_PROMETHEUS_AUTH_TYPE: public
+      TZ: Europe/Kiev
+    ports:
+      - "127.0.0.1:9006:9000"
+      - "127.0.0.1:9007:9001"
+    volumes:
+      - minio_prod_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+    networks:
+      - secondlayer-prod-network
+
+  app-prod:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.mono-backend
+    image: secondlayer-app-prod:latest
+    container_name: secondlayer-app-prod
+    command:
+    - node
+    - --max-old-space-size=3072
+    - dist/http-server.js
+    environment:
+      NODE_ENV: production
+      HTTP_PORT: ${HTTP_PORT:-3000}
+      HTTP_HOST: 0.0.0.0
+      JWT_SECRET: ${JWT_SECRET}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      QDRANT_URL: http://qdrant-prod:6333
+      REDIS_URL: redis://redis-prod:6379
+      REDIS_HOST: redis-prod
+      REDIS_PORT: 6379
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
+      OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
+      OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
+      LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-task-aware}
+      VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY}
+      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}
+      ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN}
+      ZAKONONLINE_API_TOKEN2: ${ZAKONONLINE_API_TOKEN2:-}
+      SECONDARY_LAYER_KEYS: ${SECONDARY_LAYER_KEYS}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      ANTHROPIC_MODEL_QUICK: ${ANTHROPIC_MODEL_QUICK:-claude-haiku-4-5-20251001}
+      ANTHROPIC_MODEL_STANDARD: ${ANTHROPIC_MODEL_STANDARD:-claude-sonnet-4-5-20250929}
+      ANTHROPIC_MODEL_DEEP: ${ANTHROPIC_MODEL_DEEP:-claude-sonnet-4-5-20250929}
+
+      # Document Service
+      DOCUMENT_SERVICE_URL: http://document-service-prod:3002
+
+      # Unified Gateway
+      ENABLE_UNIFIED_GATEWAY: "true"
+      RADA_MCP_URL: http://rada-mcp-app-prod:3001
+      RADA_API_KEY: ${RADA_API_KEY}
+      OPENREYESTR_MCP_URL: http://app-openreyestr-prod:3005
+      OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY}
+
+      # WebAuthn / FIDO2
+      WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-legal.org.ua}
+      WEBAUTHN_RP_NAME: ${WEBAUTHN_RP_NAME:-SecondLayer Legal}
+      WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN:-https://legal.org.ua}
+
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
+      GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
+      FRONTEND_URL: https://legal.org.ua
+      ALLOWED_ORIGINS: https://legal.org.ua,https://mcp.legal.org.ua
+
+      # MinIO
+      MINIO_ENDPOINT: minio-prod
+      MINIO_PORT: 9000
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
+      MINIO_USE_SSL: "false"
+
+      # Upload temp
+      UPLOAD_TEMP_DIR: /app/data/uploads
+
+      # Email
+      SMTP_HOST: mail.lexapp.co.ua
+      SMTP_PORT: "587"
+      SMTP_SECURE: "false"
+      EMAIL_FROM: noreply@legal.org.ua
+      EMAIL_FROM_NAME: SecondLayer Legal Platform
+
+      # Prometheus
+      PROMETHEUS_URL: http://prometheus-prod:9090
+
+      # Payment gateways
+      FONDY_MERCHANT_ID: ${FONDY_MERCHANT_ID}
+      FONDY_PAYMENT_KEY: ${FONDY_PAYMENT_KEY}
+      FONDY_CREDIT_PRIVATE_KEY: ${FONDY_CREDIT_PRIVATE_KEY}
+      NOWPAYMENTS_API_KEY: ${NOWPAYMENTS_API_KEY}
+      NOWPAYMENTS_IPN_SECRET: ${NOWPAYMENTS_IPN_SECRET}
+      NOWPAYMENTS_PUBLIC_KEY: ${NOWPAYMENTS_PUBLIC_KEY}
+
+      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      TZ: Europe/Kiev
+    ports:
+    - "127.0.0.1:3007:3000"
+    depends_on:
+      postgres-prod:
+        condition: service_healthy
+      qdrant-prod:
+        condition: service_healthy
+      redis-prod:
+        condition: service_healthy
+      migrate-prod:
+        condition: service_completed_successfully
+    volumes:
+    - app_prod_data:/app/data
+    - app_prod_logs:/app/logs
+    - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
+    healthcheck:
+      test:
+      - CMD
+      - wget
+      - --spider
+      - -q
+      - http://127.0.0.1:3000/health
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+    networks:
+    - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 2G
+
+  document-service-prod:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.document-service
+    image: document-service-prod:latest
+    container_name: document-service-prod
+    command: ["node", "--max-old-space-size=2048", "--expose-gc", "dist/document-service.js"]
+    depends_on:
+      postgres-prod:
+        condition: service_healthy
+      qdrant-prod:
+        condition: service_started
+      redis-prod:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      DOCUMENT_SERVICE_PORT: 3002
+      PORT: 3002
+      HTTP_PORT: 3002
+      HTTP_HOST: 0.0.0.0
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: postgres-prod
+      POSTGRES_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
+      QDRANT_URL: http://qdrant-prod:6333
+      REDIS_URL: redis://redis-prod:6379
+      REDIS_HOST: redis-prod
+      REDIS_PORT: 6379
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
+      OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
+      VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY}
+      VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}
+      OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
+      OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
+      OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
+      LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-task-aware}
+      ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN}
+      ZAKONONLINE_API_TOKEN2: ${ZAKONONLINE_API_TOKEN2:-}
+      FULLTEXT_STRATEGY: scrape_only
+      SCRAPE_MAX_CONCURRENT: "5"
+      SCRAPE_MAX_QUEUE_DEPTH: "200"
+      SCRAPE_SKIP_EMBEDDINGS: "true"
+      SECONDARY_LAYER_KEYS: ${SECONDARY_LAYER_KEYS}
+      JWT_SECRET: ${JWT_SECRET}
+      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://legal.org.ua}
+      TZ: Europe/Kiev
+    ports:
+      - "127.0.0.1:3008:3002"
+    volumes:
+      - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3002/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 3G
+        reservations:
+          cpus: '0.25'
+          memory: 512M
+
+  lexwebapp-prod:
+    build:
+      context: ..
+      dockerfile: lexwebapp/Dockerfile
+      args:
+        - BUILD_ENV=production
+        - VITE_API_URL=https://legal.org.ua
+        - VITE_API_KEY=${VITE_API_KEY_PROD:-REDACTED_SL_KEY_PROD}
+        - VITE_ENABLE_SSE_STREAMING=true
+        - VITE_ENABLE_ALL_MCP_TOOLS=true
+        - VITE_SHOW_TOOL_SELECTOR=true
+        - VITE_ENABLE_THINKING_STEPS=true
+        - VITE_AUTO_EXPAND_THINKING=true
+        - GIT_SHA=${GIT_SHA:-unknown}
+    image: lexwebapp-prod:latest
+    container_name: lexwebapp-prod
+    ports:
+    - "127.0.0.1:8093:80"
+    environment:
+    - NODE_ENV=production
+    - TZ=Europe/Kiev
+    networks:
+    - secondlayer-prod-network
+    restart: unless-stopped
+    depends_on:
+      - app-prod
+    healthcheck:
+      test:
+      - CMD
+      - sh
+      - -c
+      - wget --quiet --tries=1 --spider http://127.0.0.1/ || exit 1
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+
+  nginx-prod:
+    image: nginx:alpine
+    container_name: nginx-prod
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/prod.legal.org.ua.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/includes/ssl-common.conf:/etc/nginx/includes/ssl-common.conf:ro
+      - ./nginx/includes/prod-server-common.conf:/etc/nginx/includes/prod-server-common.conf:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
+      - /var/www/html:/var/www/html:ro
+      - nginx_prod_logs:/var/log/nginx
+    depends_on:
+      app-prod:
+        condition: service_healthy
+      lexwebapp-prod:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nginx -t 2>/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+
+  # Minimal monitoring
+  prometheus-prod:
+    image: prom/prometheus:v2.48.0
+    container_name: prometheus-prod
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.enable-lifecycle'
+    volumes:
+      - ./prometheus/prometheus-prod.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/rules:/etc/prometheus/rules:ro
+      - prometheus_prod_data:/prometheus
+    ports:
+      - "127.0.0.1:9091:9090"
+    networks:
+      - secondlayer-prod-network
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 256M
+
+  grafana-prod:
+    image: grafana/grafana:10.2.3
+    container_name: grafana-prod
+    environment:
+      - GF_SERVER_ROOT_URL=https://grafana-prod.legal.org.ua
+      - GF_SERVER_SERVE_FROM_SUB_PATH=false
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - PROMETHEUS_HOST=prometheus-prod
+    volumes:
+      - grafana_prod_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "127.0.0.1:3101:3000"
+    networks:
+      - secondlayer-prod-network
+    restart: unless-stopped
+    depends_on:
+      - prometheus-prod
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
+volumes:
+  postgres_prod_data:
+    driver: local
+  postgres_openreyestr_prod_data:
+    driver: local
+  qdrant_prod_data:
+    driver: local
+  redis_prod_data:
+    driver: local
+  app_prod_data:
+    driver: local
+  app_prod_logs:
+    driver: local
+  minio_prod_data:
+    driver: local
+  prometheus_prod_data:
+    driver: local
+  nginx_prod_logs:
+    driver: local
+  grafana_prod_data:
+    driver: local
+
+networks:
+  secondlayer-prod-network:
+    driver: bridge

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -1,0 +1,161 @@
+# Shared server block settings for production (legal.org.ua)
+
+# Security Headers
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://legal.org.ua https://accounts.google.com https://cloudflareinsights.com https://api.stripe.com wss://legal.org.ua; frame-src 'self' https://accounts.google.com https://js.stripe.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';" always;
+
+# Logging
+access_log /var/log/nginx/legal.org.ua-access.log;
+error_log /var/log/nginx/legal.org.ua-error.log;
+
+# Settings
+client_max_body_size 50M;
+
+# ==========================================
+# Authentication Routes
+# ==========================================
+
+location /auth {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+}
+
+# ==========================================
+# WebSocket - Admin Terminal
+# ==========================================
+
+location /api/admin/terminal {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+}
+
+# ==========================================
+# REST API Routes
+# ==========================================
+
+location /api {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+
+    # SSE support
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 86400s;
+}
+
+# ==========================================
+# Webhook Routes (Stripe, Fondy)
+# ==========================================
+
+location /webhooks {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    client_body_buffer_size 1m;
+}
+
+# ==========================================
+# MCP SSE Endpoints
+# ==========================================
+
+location /sse {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 86400s;
+    chunked_transfer_encoding on;
+}
+
+location /messages {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_read_timeout 86400s;
+}
+
+# ==========================================
+# OAuth Discovery
+# ==========================================
+
+location = /.well-known/openid-configuration {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+}
+
+location = /.well-known/oauth-authorization-server {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+}
+
+# ==========================================
+# Static Assets (with caching)
+# ==========================================
+
+location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    proxy_pass http://prod_frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    expires 7d;
+    add_header Cache-Control "public";
+}
+
+# ==========================================
+# SPA Frontend (default fallback)
+# ==========================================
+
+location / {
+    proxy_pass http://prod_frontend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+}

--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -1,0 +1,62 @@
+# Nginx Configuration for legal.org.ua (Production)
+# Runs as a Docker container (nginx-prod) in docker-compose.prod.yml
+
+# Upstreams (Docker service names)
+upstream prod_mcp_backend {
+    server app-prod:3000;
+    keepalive 128;
+}
+
+upstream prod_frontend {
+    server lexwebapp-prod:80;
+    keepalive 32;
+}
+
+# HTTP - redirect to HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name legal.org.ua mcp.legal.org.ua;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS - legal.org.ua (main production)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+    include /etc/nginx/includes/prod-server-common.conf;
+}
+
+# HTTPS - mcp.legal.org.ua (MCP endpoints)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name mcp.legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+    include /etc/nginx/includes/prod-server-common.conf;
+}
+
+# WebSocket upgrade map
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    '' close;
+}

--- a/deployment/prometheus/prometheus-prod.yml
+++ b/deployment/prometheus/prometheus-prod.yml
@@ -1,0 +1,58 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  # Node.js application services
+  - job_name: mcp_backend
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['app-prod:3000']
+        labels:
+          service: mcp_backend
+          environment: production
+
+  - job_name: mcp_rada
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['rada-mcp-app-prod:3001']
+        labels:
+          service: mcp_rada
+          environment: production
+
+  - job_name: mcp_openreyestr
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['app-openreyestr-prod:3005']
+        labels:
+          service: mcp_openreyestr
+          environment: production
+
+  # MinIO S3 storage
+  - job_name: minio
+    scrape_interval: 30s
+    metrics_path: /minio/v2/metrics/cluster
+    static_configs:
+      - targets: ['minio-prod:9000']
+        labels:
+          service: minio
+          environment: production
+
+  # Qdrant vector database
+  - job_name: qdrant
+    scrape_interval: 30s
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['qdrant-prod:6333']
+        labels:
+          service: qdrant
+          environment: production
+
+  # Prometheus self-monitoring
+  - job_name: prometheus
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- Add `docker-compose.prod.yml` — full production stack for AWS EC2 t3.xlarge (16GB)
- Add `nginx/prod.legal.org.ua.conf` + `prod-server-common.conf` — production nginx routing
- Add `prometheus-prod.yml` — production monitoring config
- Memory-optimized for 16GB (vs 64GB+ stage): PG 4GB, Qdrant 2GB, Redis 1.5GB, Backend 4GB

## Infrastructure
- **Server**: AWS EC2 `t3.xlarge` (4 vCPU, 16GB) — `18.192.189.254`
- **Region**: eu-central-1 (Frankfurt)
- **SSL**: Cloudflare Origin CA (wildcard, valid to 2041)
- **DNS**: legal.org.ua + mcp.legal.org.ua → Cloudflare proxy → EC2
- **14 containers**: all healthy and running

## Test plan
- [x] All 14 containers healthy
- [x] Backend health check passes (PG, Redis, Qdrant, MinIO)
- [x] Frontend served at https://legal.org.ua
- [x] SSL via Cloudflare Origin CA working
- [x] OpenReyestr DB loaded with state register data
- [ ] Google OAuth flow (may need redirect URI update in Google Console)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up the AWS production environment for legal.org.ua with Docker Compose, Nginx, and Prometheus, tuned for an EC2 t3.xlarge (16GB). This delivers a full prod stack behind Cloudflare with SSL, security headers, health checks, and basic monitoring.

- New Features
  - Added docker-compose.prod.yml for the full prod stack (Postgres, Redis, Qdrant, MinIO, backend, document service, Rada/OpenReyestr services, frontend, Nginx, Prometheus, Grafana) with memory limits optimized for 16GB (e.g., PG 4GB, Qdrant 2GB, Redis 1.5GB, backend 4GB).
  - Added production Nginx config for legal.org.ua and mcp.legal.org.ua with Cloudflare Origin CA SSL, CSP/security headers, SSE/WebSocket proxying, and SPA/static routing.
  - Added Prometheus config scraping backend, Rada, OpenReyestr, Qdrant, and MinIO; Grafana included in compose.
  - Set prod domains, CORS, and Google OAuth callback to https://legal.org.ua/auth/google/callback.

- Migration
  - Update Google OAuth redirect URI in Google Cloud Console to https://legal.org.ua/auth/google/callback.
  - Configure required env vars (e.g., POSTGRES_PASSWORD, RADA_POSTGRES_PASSWORD, OPENREYESTR_POSTGRES_PASSWORD, OPENAI_API_KEY, JWT_SECRET, SMTP, payment keys).
  - Ensure certificates are present at /etc/letsencrypt on the host (Cloudflare Origin CA) and DNS points to the EC2 instance via Cloudflare.

<sup>Written for commit fef7fad2237495feca81ef2c32a53445145a9ff8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

