### PR TITLE
fix(stage): point stage URLs to stage.legal.org.ua

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -486,9 +486,9 @@ services:
 
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET}
-      GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
-      FRONTEND_URL: https://legal.org.ua
-      ALLOWED_ORIGINS: https://legal.org.ua,https://stage.legal.org.ua,https://mcp.legal.org.ua,https://stage.mcp.legal.org.ua
+      GOOGLE_CALLBACK_URL: ${GOOGLE_CALLBACK_URL:-https://stage.legal.org.ua/auth/google/callback}
+      FRONTEND_URL: ${FRONTEND_URL:-https://stage.legal.org.ua}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://stage.legal.org.ua,https://stage.mcp.legal.org.ua,https://legal.org.ua}
       # MinIO (S3-compatible object storage)
       MINIO_ENDPOINT: minio-stage
       MINIO_PORT: 9000
@@ -663,7 +663,7 @@ services:
       dockerfile: lexwebapp/Dockerfile
       args:
         - BUILD_ENV=staging
-        - VITE_API_URL=https://legal.org.ua
+        - VITE_API_URL=https://stage.legal.org.ua
         - VITE_API_KEY=${VITE_API_KEY_STAGE:-REDACTED_SL_KEY_STAGE}
         - VITE_ENABLE_SSE_STREAMING=true
         - VITE_ENABLE_ALL_MCP_TOOLS=true


### PR DESCRIPTION
## Summary
- Fix `VITE_API_URL` from `https://legal.org.ua` → `https://stage.legal.org.ua` (frontend was calling prod API)
- Fix hardcoded `FRONTEND_URL`, `GOOGLE_CALLBACK_URL`, `ALLOWED_ORIGINS` in app-stage to use env vars with stage defaults
- This caused Google OAuth on stage to redirect users to prod after login

## Test plan
- [ ] Rebuild lexwebapp-stage (VITE_API_URL baked at build time)
- [ ] Restart app-stage to pick up new env vars
- [ ] Google OAuth on stage.legal.org.ua redirects back to stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point staging to stage.legal.org.ua so the stage frontend and backend stop calling prod. Fixes Google OAuth on stage to return to stage, not prod.

- **Bug Fixes**
  - Set VITE_API_URL to https://stage.legal.org.ua in the staging web build.
  - Use env vars for GOOGLE_CALLBACK_URL, FRONTEND_URL, and ALLOWED_ORIGINS with stage defaults.

- **Migration**
  - Rebuild lexwebapp-stage (VITE_API_URL is build-time).
  - Restart app-stage to load new env vars.
  - Verify Google OAuth on stage.legal.org.ua redirects back to stage.

<sup>Written for commit 45d9f0cace12b1f1c1d13744f74572ca320be3f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

