### PR TITLE
fix(deploy): correct VITE_API_URL for stage frontend

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -663,7 +663,7 @@ services:
       dockerfile: lexwebapp/Dockerfile
       args:
         - BUILD_ENV=staging
-        - VITE_API_URL=https://legal.org.ua
+        - VITE_API_URL=https://stage.legal.org.ua
         - VITE_API_KEY=${VITE_API_KEY_STAGE:-REDACTED_SL_KEY_STAGE}
         - VITE_ENABLE_SSE_STREAMING=true
         - VITE_ENABLE_ALL_MCP_TOOLS=true


### PR DESCRIPTION
## Summary
- Stage frontend was built with `VITE_API_URL=https://legal.org.ua` (production) instead of `https://stage.legal.org.ua`
- This caused all API calls to fail with "Network error" / "Помилка входу" on stage

## Test plan
- [ ] Deploy to stage and verify login works
- [ ] Verify API calls go to stage.legal.org.ua, not legal.org.ua

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected VITE_API_URL for the stage frontend to point to https://stage.legal.org.ua instead of production. This fixes network errors and restores login and API calls on stage.

<sup>Written for commit 44fe7a704e2eacfe753e3dc229fb57a0ee41e951. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

