### PR TITLE
fix(prod): add Vision OCR env vars to prod containers

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -456,6 +456,10 @@ services:
       ANTHROPIC_MODEL_STANDARD: ${ANTHROPIC_MODEL_STANDARD:-claude-sonnet-4-5-20250929}
       ANTHROPIC_MODEL_DEEP: ${ANTHROPIC_MODEL_DEEP:-claude-sonnet-4-5-20250929}
 
+      # Google Cloud Vision API (OCR)
+      VISION_CREDENTIALS_PATH: /app/credentials/vision-credentials.json
+      GOOGLE_APPLICATION_CREDENTIALS: /app/credentials/vision-credentials.json
+
       # Document Service
       DOCUMENT_SERVICE_URL: http://document-service-prod:3002
 
@@ -586,6 +590,8 @@ services:
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-task-aware}
       ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN}
       ZAKONONLINE_API_TOKEN2: ${ZAKONONLINE_API_TOKEN2:-}
+      VISION_CREDENTIALS_PATH: /app/credentials/vision-credentials.json
+      GOOGLE_APPLICATION_CREDENTIALS: /app/credentials/vision-credentials.json
       FULLTEXT_STRATEGY: scrape_only
       SCRAPE_MAX_CONCURRENT: "5"
       SCRAPE_MAX_QUEUE_DEPTH: "200"


### PR DESCRIPTION
## Summary
- Add `VISION_CREDENTIALS_PATH` and `GOOGLE_APPLICATION_CREDENTIALS` env vars to `app-prod` and `document-service-prod`
- Without these, OCR was disabled (backend looked at wrong default path `/app/vision-ocr-credentials.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Google Cloud Vision OCR in production by setting the correct credentials path for app-prod and document-service-prod. Fixes OCR being disabled due to the backend reading the wrong default path.

<sup>Written for commit 9f3e0fef0a8bcf671d03cbc3d0a3e8c4a3e6f364. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

