### PR TITLE
fix(backend): persist chat results on client disconnect

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -658,9 +658,19 @@ export class ChatService {
         },
       };
 
-      // Server-side message persistence — skip if client disconnected (aborted)
-      if (this.conversationService && request.conversationId && request.userId && !signal?.aborted) {
+      // Server-side message persistence — always persist if we have any data,
+      // even if client disconnected (user may have refreshed or navigated away).
+      const hasData = fullAnswerText || collectedThinkingSteps.length > 0 || collectedToolCalls.length > 0;
+      if (this.conversationService && request.conversationId && request.userId && hasData) {
         try {
+          if (signal?.aborted) {
+            logger.info('[ChatService] Client disconnected but persisting partial results', {
+              conversationId: request.conversationId,
+              hadAnswer: !!fullAnswerText,
+              toolCallsCount: collectedToolCalls.length,
+            });
+          }
+
           await this.conversationService.addMessage(request.conversationId, request.userId, {
             role: 'user',
             content: request.query,
@@ -670,9 +680,13 @@ export class ChatService {
             ? extractAllEvidence(collectedThinkingSteps, fullAnswerText)
             : undefined;
 
+          const contentToSave = fullAnswerText || (collectedThinkingSteps.length > 0
+            ? '[Відповідь не завершена — клієнт від\'єднався під час генерації]'
+            : '');
+
           await this.conversationService.addMessage(request.conversationId, request.userId, {
             role: 'assistant',
-            content: fullAnswerText,
+            content: contentToSave,
             tool_calls: collectedToolCalls.length > 0 ? collectedToolCalls : undefined,
             thinking_steps: collectedThinkingSteps.length > 0 ? collectedThinkingSteps : undefined,
             decisions: evidence?.decisions && evidence.decisions.length > 0 ? evidence.decisions : undefined,
@@ -683,13 +697,6 @@ export class ChatService {
         } catch (e) {
           logger.warn('[ChatService] Failed to persist messages', { error: (e as Error).message });
         }
-      } else if (signal?.aborted) {
-        logger.info('[ChatService] Skipping message persistence — client disconnected', {
-          conversationId: request.conversationId,
-          userId: request.userId,
-          hadAnswer: !!fullAnswerText,
-          toolCallsCount: collectedToolCalls.length,
-        });
       }
     } catch (err: any) {
       logger.error('[ChatService] Error in agentic loop', { error: err.message, stack: err.stack });


### PR DESCRIPTION
## Summary
- ChatService skipped `addMessage` when `signal.aborted` was true (user refreshed/navigated away mid-stream)
- Now always persists if there's any data — tool results, partial answer, or evidence
- Partial answers get a placeholder message if LLM didn't finish

## Test plan
- [ ] Start a deep chat query, reload page mid-stream
- [ ] Navigate back — verify partial results and evidence appear in right panel
- [ ] Complete query normally — verify full persistence still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist chat results even when the client disconnects mid-stream, so partial answers, tool results, and evidence are saved and visible after reload.

- **Bug Fixes**
  - Always persist user/assistant messages if any data exists, even when signal.aborted.
  - Save a placeholder assistant message when the LLM stops early; include tool calls, thinking steps, and extracted evidence.

<sup>Written for commit 774d892169c5f23631fe3ce2293c091a307086f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

