### PR TITLE
fix(security): update fast-xml-parser to 5.3.7 (critical + high CVE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "cli-table3": "^0.6.3",
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
+        "fast-xml-parser": "^5.3.7",
         "ora": "^9.3.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -37,8 +38,6 @@
       "version": "0.0.1",
       "dependencies": {
         "@simplewebauthn/browser": "^13.2.2",
-        "@stripe/react-stripe-js": "^5.6.0",
-        "@stripe/stripe-js": "^8.7.0",
         "@tailwindcss/typography": "^0.5.19",
         "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-query-devtools": "^5.91.3",
@@ -524,7 +523,6 @@
         "playwright": "^1.58.0",
         "prom-client": "^15.1.3",
         "redis": "^5.11.0",
-        "stripe": "^20.3.1",
         "uuid": "^13.0.0",
         "winston": "^3.11.0",
         "word-extractor": "^1.0.4",
@@ -4475,25 +4473,6 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
-    },
-    "node_modules/@stripe/react-stripe-js": {
-      "version": "5.6.0",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "@stripe/stripe-js": ">=8.0.0 <9.0.0",
-        "react": ">=16.8.0 <20.0.0",
-        "react-dom": ">=16.8.0 <20.0.0"
-      }
-    },
-    "node_modules/@stripe/stripe-js": {
-      "version": "8.7.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.16"
-      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.18",
@@ -8764,9 +8743,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.7.tgz",
+      "integrity": "sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==",
       "funding": [
         {
           "type": "github",
@@ -11360,6 +11339,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -11902,16 +11882,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
       }
     },
     "node_modules/lop": {
@@ -14234,19 +14204,6 @@
         "node": "^16 || ^18 || >=20"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
-    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -15502,23 +15459,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stripe": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/stripe/-/stripe-20.3.1.tgz",
-      "integrity": "sha512-k990yOT5G5rhX3XluRPw5Y8RLdJDW4dzQ29wWT66piHrbnM2KyamJ1dKgPsw4HzGHRWjDiSSdcI2WdxQUPV3aQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@types/node": ">=16"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        }
       }
     },
     "node_modules/strnum": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "cli-table3": "^0.6.3",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
+    "fast-xml-parser": "^5.3.7",
     "ora": "^9.3.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -46,7 +47,7 @@
     "postcss": "^8.4.49",
     "esbuild": ">=0.25.0",
     "minio": {
-      "fast-xml-parser": ">=5.3.6"
+      "fast-xml-parser": ">=5.3.7"
     },
     "ajv": ">=8.18.0",
     "minimatch": ">=10.2.1",


### PR DESCRIPTION
## Summary
- Fixes Dependabot alerts #84 (high) and #86 (critical) for `fast-xml-parser`
- Bumped override to `>=5.3.7` and added as devDependency to force resolution
- Dependency of `minio@8.0.6` and `openreyestr-mcp`

## Test plan
- [ ] `npm ls fast-xml-parser` shows 5.3.7 everywhere
- [ ] `npm audit` shows no critical/high vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update fast-xml-parser to 5.3.7 to fix one critical and one high CVE. Forces all transitive consumers (e.g., minio) to use the patched version.

- **Dependencies**
  - Added fast-xml-parser ^5.3.7 as a direct dependency to force resolution.
  - Updated minio override to fast-xml-parser >=5.3.7.
  - Refreshed lockfile to ensure 5.3.7 is resolved across the tree.

<sup>Written for commit ac373cacd8ef4364eced4e21e8bebd297016f877. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

