### PR TITLE
fix(security): fast-xml-parser override in mcp_backend for Docker

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -124,5 +124,10 @@
     "ts-jest": "^29.1.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "minio": {
+      "fast-xml-parser": ">=5.3.7"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Docker Dockerfile.mono-backend installs mcp_backend deps in isolation
- Root package.json override doesn't apply inside Docker
- Added `overrides` to `mcp_backend/package.json` directly

## Test plan
- [ ] `docker exec secondlayer-app-stage node -e "console.log(require('fast-xml-parser/package.json').version)"` returns 5.3.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Docker builds of mcp_backend use fast-xml-parser >=5.3.7 by adding a local dependency override. Fixes a security gap where the root-level override wasn’t applied inside the container.

- **Dependencies**
  - Added an overrides block in mcp_backend/package.json to enforce fast-xml-parser >=5.3.7 via the minio dependency.

<sup>Written for commit 49d4de570ad0caf118b62feaeacc615ded99e048. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

