### PR TITLE
feat(prod): add cAdvisor and tune OpenReyestr PostgreSQL

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -103,10 +103,11 @@ services:
     command: >-
       postgres
       -c max_connections=100
-      -c shared_buffers=1GB
-      -c effective_cache_size=3GB
+      -c shared_buffers=2GB
+      -c effective_cache_size=4GB
       -c work_mem=64MB
       -c maintenance_work_mem=512MB
+      -c wal_buffers=32MB
       -c idle_in_transaction_session_timeout=60000
       -c statement_timeout=300000
       -c lock_timeout=30000
@@ -131,9 +132,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 6G
         reservations:
-          memory: 1G
+          memory: 2G
 
   qdrant-prod:
     image: qdrant/qdrant:latest
@@ -755,6 +756,35 @@ services:
           memory: 512M
         reservations:
           memory: 128M
+
+  cadvisor-prod:
+    image: gcr.io/cadvisor/cadvisor:v0.55.1
+    container_name: cadvisor-prod
+    privileged: true
+    devices:
+      - /dev/kmsg
+    environment:
+      - DOCKER_API_VERSION=1.44
+    command:
+      - '-docker_only=true'
+      - '-housekeeping_interval=30s'
+      - '-disable_metrics=cpu_topology,hugetlb,memory_numa,perf_event,referenced_memory,resctrl,sched,tcp,udp'
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+      - /etc/machine-id:/etc/machine-id:ro
+    networks:
+      - secondlayer-prod-network
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 384M
+        reservations:
+          memory: 64M
 
 volumes:
   postgres_prod_data:

--- a/deployment/prometheus/prometheus-prod.yml
+++ b/deployment/prometheus/prometheus-prod.yml
@@ -51,6 +51,15 @@ scrape_configs:
           service: qdrant
           environment: production
 
+  # cAdvisor container metrics
+  - job_name: cadvisor
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['cadvisor-prod:8080']
+        labels:
+          service: cadvisor
+          environment: production
+
   # Prometheus self-monitoring
   - job_name: prometheus
     scrape_interval: 15s


### PR DESCRIPTION
## Summary
- Add cAdvisor container to prod for container metrics (fixes "No container metrics available" on /admin/containers)
- Tune OpenReyestr PostgreSQL for 155GB database: shared_buffers 1→2GB, effective_cache_size 3→4GB, wal_buffers 32MB
- Increase OpenReyestr PG memory limit 4→6GB (was at 63% usage)
- Increase cAdvisor memory limit to 384MB
- Add cAdvisor scrape target to Prometheus config

## Test plan
- [x] cAdvisor running on prod, 29% memory usage
- [x] OpenReyestr PG restarted with new params
- [x] All containers healthy
- [x] Prometheus scraping cAdvisor metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cAdvisor to production and tunes OpenReyestr PostgreSQL for a 155GB database to restore container metrics and improve performance. Also updates Prometheus to scrape cAdvisor.

- **New Features**
  - Add cAdvisor in prod; fixes “No container metrics available” on /admin/containers.
  - Add Prometheus scrape target (cadvisor-prod:8080) with 15s interval.
  - Limit cAdvisor memory to 384MB and disable high-cost metrics to reduce overhead.

- **Performance**
  - Tune OpenReyestr PostgreSQL: shared_buffers 2GB, effective_cache_size 4GB, wal_buffers 32MB.
  - Increase PG container memory limit to 6GB and reservation to 2GB.

<sup>Written for commit e4ce4765ea1db573525c6b0c6354777313da1b67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

