### PR TITLE
fix(frontend): deduplicate norms in right panel

### DIFF
--- a/lexwebapp/src/components/RightPanel.tsx
+++ b/lexwebapp/src/components/RightPanel.tsx
@@ -89,10 +89,15 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
     [allDecisions]
   );
 
-  const citations = useMemo(() =>
-    messages.flatMap(m => m.citations ?? []),
-    [messages]
-  );
+  const citations = useMemo(() => {
+    const seen = new Set<string>();
+    return messages.flatMap(m => m.citations ?? []).filter(c => {
+      const key = c.source.toLowerCase().replace(/\s+/g, ' ').trim();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }, [messages]);
 
   const vaultDocuments = useMemo(() => {
     const seen = new Set<string>();

--- a/lexwebapp/src/hooks/useMCPTool.ts
+++ b/lexwebapp/src/hooks/useMCPTool.ts
@@ -1281,7 +1281,17 @@ export function useAIChat(options: UseMCPToolOptions = {}) {
 
           const answerNorms = extractNormsFromAnswer(data.text);
           if (answerNorms.length > 0) {
-            accumulatedCitations.current.push(...answerNorms);
+            // Deduplicate: skip answer-extracted norms that already exist from tool results
+            const existingSources = new Set(
+              accumulatedCitations.current.map(c => c.source.toLowerCase().replace(/\s+/g, ' ').trim())
+            );
+            const newNorms = answerNorms.filter(n => {
+              const key = n.source.toLowerCase().replace(/\s+/g, ' ').trim();
+              return !existingSources.has(key);
+            });
+            if (newNorms.length > 0) {
+              accumulatedCitations.current.push(...newNorms);
+            }
           }
 
           updateMessage(assistantMessageId, {


### PR DESCRIPTION
## Summary
- Deduplicate citations in the Норми tab by `source` key (same pattern as decisions/documents)
- Skip answer-extracted norms (regex from AI text) when a tool-extracted norm with the same source already exists, preventing duplicate cards with inferior content

## Test plan
- [ ] Send a chat query that triggers legislation tools (e.g. "ст. 509 ЦКУ")
- [ ] Verify no duplicate norm cards appear in the right panel Норми tab
- [ ] Verify tool-extracted norms (with full article text) take priority over regex-extracted ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates norms in the right panel and chat pipeline to remove duplicate cards and prefer tool-extracted norms. Users see cleaner results with full article text when available.

- **Bug Fixes**
  - RightPanel: deduplicate citations by normalized source to prevent duplicate norm cards.
  - Chat pipeline: skip answer-extracted norms when a tool-extracted norm with the same source already exists.

<sup>Written for commit 8140c45d6423e8fdc0a59022d195336f169699bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

