### PR TITLE
fix(backend): sanitize ZO search queries to strip parentheses

### DIFF
--- a/mcp_backend/src/adapters/zo-adapter.ts
+++ b/mcp_backend/src/adapters/zo-adapter.ts
@@ -42,6 +42,18 @@ interface ZOSearchResponse {
   meta?: any;
 }
 
+/**
+ * Sanitize search query for ZakonOnline sph04 Sphinx mode.
+ * Strips characters that act as syntax operators (parentheses, etc.)
+ * and collapses resulting whitespace.
+ */
+function sanitizeSearchQuery(query: string): string {
+  return query
+    .replace(/[(){}[\]]/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
 export class ZOAdapter {
   private client: AxiosInstance;
   private redis: ReturnType<typeof createClient> | null = null;
@@ -758,10 +770,11 @@ export class ZOAdapter {
     }
 
     // Add search query if provided (from meta.search or meta.query)
+    // Sanitize to strip chars that break sph04 Sphinx parser (e.g. parentheses)
     if (params.meta?.search) {
-      apiParams.search = params.meta.search;
+      apiParams.search = sanitizeSearchQuery(params.meta.search);
     } else if (params.meta?.query) {
-      apiParams.search = params.meta.query;
+      apiParams.search = sanitizeSearchQuery(params.meta.query);
     }
 
     // Convert where array to API format (only if non-empty)
@@ -1557,11 +1570,11 @@ export class ZOAdapter {
       mode: params.mode || 'sph04',
     };
 
-    // Add search query
+    // Add search query — sanitize for sph04 Sphinx parser
     if (params.meta?.search) {
-      apiParams.search = params.meta.search;
+      apiParams.search = sanitizeSearchQuery(params.meta.search);
     } else if (params.meta?.query) {
-      apiParams.search = params.meta.query;
+      apiParams.search = sanitizeSearchQuery(params.meta.query);
     }
 
     // Add where conditions


### PR DESCRIPTION
## Summary
- ZakonOnline sph04 Sphinx parser returns 503 when search queries contain parentheses (e.g. `зайнятої (захопленої)`)
- Added `sanitizeSearchQuery()` helper that strips `(){}[]` and collapses whitespace before sending to ZO API
- Applied in both `searchCourtDecisions()` and `getSearchMetadata()`

## Test plan
- [ ] Search for court decisions with parentheses in query text
- [ ] Verify no 503 errors in logs after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitize ZakonOnline sph04 search queries by stripping brackets and collapsing whitespace to prevent 503 errors when queries include parentheses. Applied in both searchCourtDecisions and getSearchMetadata before calling the ZO API.

<sup>Written for commit d0c0d6c7208aa6953ff347a05690edf095eb457c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

