### PR TITLE
feat(deploy): add persistent logging to app containers

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -277,6 +277,11 @@ services:
     image: rada-mcp-prod:latest
     container_name: rada-mcp-app-prod
     command: ["node", "--max-old-space-size=1536", "dist/http-server.js"]
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     depends_on:
       rada-migrate-prod:
         condition: service_completed_successfully
@@ -351,6 +356,11 @@ services:
     image: openreyestr-app-prod:latest
     container_name: openreyestr-app-prod
     command: ["node", "dist/http-server.js"]
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       NODE_ENV: production
       HTTP_PORT: 3005
@@ -425,6 +435,11 @@ services:
     - node
     - --max-old-space-size=3072
     - dist/http-server.js
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "10"
     environment:
       NODE_ENV: production
       HTTP_PORT: ${HTTP_PORT:-3000}
@@ -557,6 +572,11 @@ services:
     image: document-service-prod:latest
     container_name: document-service-prod
     command: ["node", "--max-old-space-size=2048", "--expose-gc", "dist/document-service.js"]
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "10"
     depends_on:
       postgres-prod:
         condition: service_healthy
@@ -672,6 +692,11 @@ services:
   nginx-prod:
     image: nginx:alpine
     container_name: nginx-prod
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     ports:
       - "80:80"
       - "443:443"

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -282,6 +282,11 @@ services:
     image: rada-mcp:latest
     container_name: rada-mcp-app-stage
     command: ["node", "--max-old-space-size=3072", "dist/http-server.js"]
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     depends_on:
       rada-migrate-stage:
         condition: service_completed_successfully
@@ -359,6 +364,11 @@ services:
     image: openreyestr-app:latest
     container_name: openreyestr-app-stage
     command: ["node", "dist/http-server.js"]
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     environment:
       NODE_ENV: staging
       HTTP_PORT: 3005
@@ -433,6 +443,11 @@ services:
       dockerfile: deployment/Dockerfile.mono-backend
     image: secondlayer-app:latest
     container_name: secondlayer-app-stage
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "10"
     command:
     - node
     - --max-old-space-size=8192
@@ -557,6 +572,11 @@ services:
     image: document-service:latest
     container_name: document-service-stage
     command: ["node", "--max-old-space-size=5120", "--expose-gc", "dist/document-service.js"]
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "10"
     depends_on:
       postgres-stage:
         condition: service_healthy
@@ -709,6 +729,11 @@ services:
   nginx-stage:
     image: nginx:alpine
     container_name: nginx-stage
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "5"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Summary
- Add `json-file` logging driver with rotation to all app services (stage + prod)
- Logs now persist across container recreation during deploys
- Backend/doc-service: 500MB cap (10x50MB), others: 250MB cap (5x50MB)

## Test plan
- [ ] Deploy, check `docker logs` shows entries from before deploy
- [ ] Verify log rotation works under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add persistent Docker logging with json-file rotation to all app services in stage and prod so logs survive container recreation during deploys. Improves observability across deploys.

- **New Features**
  - Use json-file logging with rotation (50MB per file). Backend and document-service: 10 files (500MB). Others: 5 files (250MB).
  - Applied to backend, document-service, rada-mcp, openreyestr, secondlayer app, and nginx on both environments.

<sup>Written for commit 63e447b36946fba0a0b704181a5489ad4c3e141f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

