### PR TITLE
fix(frontend): route court decisions to Рішення tab

### DIFF
--- a/lexwebapp/src/hooks/chat/evidence/court.ts
+++ b/lexwebapp/src/hooks/chat/evidence/court.ts
@@ -10,6 +10,11 @@ const COURT_TOOLS = [
   'compare_practice_pro_contra',
   'get_court_decision',
   'count_cases_by_party',
+  'check_precedent_status',
+  'analyze_case_pattern',
+  'get_similar_reasoning',
+  'get_citation_graph',
+  'get_case_text',
 ];
 
 export function extractCourtEvidence(toolName: string, parsed: any): EvidenceResult {

--- a/lexwebapp/src/hooks/chat/useEvidenceAggregator.ts
+++ b/lexwebapp/src/hooks/chat/useEvidenceAggregator.ts
@@ -7,8 +7,11 @@ import { useMemo } from 'react';
 import { useChatStore } from '../../stores';
 import type { Decision, Citation, VaultDocument } from '../../types/models/Message';
 
-/** Only "Рішення" and "Вирок" are proper court decisions */
-const DECISION_TYPES = new Set(['Рішення', 'Вирок']);
+/** Proper court decisions — shown in the "Рішення" tab */
+const DECISION_TYPES = new Set(['Рішення', 'Вирок', 'Постанова']);
+
+/** Procedural court docs (ухвали, окремі думки) — shown in "Документи" tab */
+const PROCEDURAL_TYPES = new Set(['Ухвала', 'Окрема думка', 'Окрема ухвала']);
 
 export function useEvidenceAggregator() {
   const messages = useChatStore(state => state.messages);
@@ -23,12 +26,12 @@ export function useEvidenceAggregator() {
   }, [messages]);
 
   const decisions = useMemo(() =>
-    allDecisions.filter(d => d.documentType && DECISION_TYPES.has(d.documentType)),
+    allDecisions.filter(d => !d.documentType || DECISION_TYPES.has(d.documentType)),
     [allDecisions]
   );
 
   const otherCourtDocs = useMemo(() =>
-    allDecisions.filter(d => !d.documentType || !DECISION_TYPES.has(d.documentType)),
+    allDecisions.filter(d => d.documentType && PROCEDURAL_TYPES.has(d.documentType)),
     [allDecisions]
   );
 


### PR DESCRIPTION
## Summary
- Court decisions (Рішення, Вирок, Постанова) and unclassified court docs now correctly appear in the **Рішення** tab
- Procedural docs (Ухвала, Окрема думка) go to **Документи** tab
- Added 5 missing court tools to evidence extractor so their results appear in the right panel

## Test plan
- [ ] Search court cases → verify results appear in Рішення tab
- [ ] Verify Ухвала-type results appear in Документи tab
- [ ] Verify Норми tab still works for legislation results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes proper court decisions to the Рішення tab and procedural docs to Документи, fixing misplacement in the right panel. Adds missing court tools so more court evidence appears.

- **Bug Fixes**
  - Рішення, Вирок, Постанова → Рішення tab; unclassified decisions also default to Рішення.
  - Ухвала, Окрема думка, Окрема ухвала → Документи tab.

- **New Features**
  - Added court tools: check_precedent_status, analyze_case_pattern, get_similar_reasoning, get_citation_graph, get_case_text.

<sup>Written for commit 2c1a7d5ae8b6a14985dbac0b0870493163ba683b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

