### PR TITLE
fix(frontend): format court decision dates as dd.MM.yyyy

### DIFF
--- a/lexwebapp/src/components/chat/DecisionsTab.tsx
+++ b/lexwebapp/src/components/chat/DecisionsTab.tsx
@@ -7,6 +7,12 @@ import { Gavel, ChevronDown, ChevronUp } from 'lucide-react';
 import type { Decision } from '../DecisionCard';
 import { ExpandableCard, EmptyTabState } from './ExpandableCard';
 
+function formatDate(raw: string): string {
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
 const STATUS_LABELS: Record<string, string> = {
   active: 'Чинне',
   overturned: 'Скасовано',
@@ -76,7 +82,7 @@ export function DecisionsTab({ decisions, onOpenModal }: DecisionsTabProps) {
                   </div>
                 </div>
                 <div className="text-[11px] text-claude-subtext mb-2">
-                  {decision.court} {decision.date && `• ${decision.date}`}
+                  {decision.court} {decision.date && `• ${formatDate(decision.date)}`}
                 </div>
               </>
             }

--- a/lexwebapp/src/components/chat/DocumentsTab.tsx
+++ b/lexwebapp/src/components/chat/DocumentsTab.tsx
@@ -7,6 +7,12 @@ import { FileText, ChevronDown, ChevronUp } from 'lucide-react';
 import type { Decision } from '../DecisionCard';
 import { ExpandableCard, EmptyTabState } from './ExpandableCard';
 
+function formatDate(raw: string): string {
+  const d = new Date(raw);
+  if (isNaN(d.getTime())) return raw;
+  return d.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
 interface VaultDocument {
   id: string;
   title: string;
@@ -79,7 +85,7 @@ export function DocumentsTab({ otherCourtDocs, vaultDocuments, onOpenDocModal }:
                       {d.documentType}
                     </span>
                     {d.court && <span>{d.court}</span>}
-                    {d.date && <span>{d.date}</span>}
+                    {d.date && <span>{formatDate(d.date)}</span>}
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Decision dates in the right panel showed raw ISO format (e.g. `2026-02-12T00:00:00.000Z`)
- Now formatted as `12.02.2026` using Ukrainian locale in both DecisionsTab and DocumentsTab

## Test plan
- [ ] Verify decision dates display as dd.MM.yyyy in Рішення tab
- [ ] Verify dates in Документи tab also formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Format court decision and document dates as dd.MM.yyyy using the Ukrainian locale, replacing raw ISO strings in the right panel. Improves readability and consistency across the Decisions and Documents tabs.

- **Bug Fixes**
  - Apply uk-UA date formatting in DecisionsTab and DocumentsTab (dd.MM.yyyy).
  - Fallback to raw value if the date is invalid.

<sup>Written for commit 1517da85acbc0663d9edbcbd9e571adbb9c346d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

