### PR TITLE
feat(frontend): load full court decision text in modal viewer

### DIFF
--- a/lexwebapp/src/components/DecisionCard.tsx
+++ b/lexwebapp/src/components/DecisionCard.tsx
@@ -11,6 +11,7 @@ export interface Decision {
   status: 'active' | 'overturned' | 'modified';
   documentType?: string;
   externalUrl?: string;
+  docId?: string;
 }
 interface DecisionCardProps {
   decision: Decision;

--- a/lexwebapp/src/components/DocumentViewerModal.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { AnimatePresence, motion } from 'framer-motion';
-import { X, ExternalLink, Gavel, BookOpen, FileText, Copy, Check, Download } from 'lucide-react';
+import { X, ExternalLink, Gavel, BookOpen, FileText, Copy, Check, Download, Loader2 } from 'lucide-react';
 
 export interface DocumentViewerItem {
   type: 'decision' | 'citation' | 'document';
@@ -18,6 +18,7 @@ interface DocumentViewerModalProps {
   isOpen: boolean;
   onClose: () => void;
   item: DocumentViewerItem | null;
+  isLoading?: boolean;
 }
 
 const typeIcons = {
@@ -26,7 +27,7 @@ const typeIcons = {
   document: FileText,
 };
 
-export function DocumentViewerModal({ isOpen, onClose, item }: DocumentViewerModalProps) {
+export function DocumentViewerModal({ isOpen, onClose, item, isLoading }: DocumentViewerModalProps) {
   const [copied, setCopied] = React.useState(false);
 
   React.useEffect(() => {
@@ -138,14 +139,16 @@ export function DocumentViewerModal({ isOpen, onClose, item }: DocumentViewerMod
                   <div className="flex items-center gap-1 flex-shrink-0 ml-4">
                     <button
                       onClick={handleCopy}
-                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all"
+                      disabled={isLoading}
+                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all disabled:opacity-40"
                       title="Копіювати"
                     >
                       {copied ? <Check size={16} strokeWidth={2} /> : <Copy size={16} strokeWidth={2} />}
                     </button>
                     <button
                       onClick={handleSave}
-                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all"
+                      disabled={isLoading}
+                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all disabled:opacity-40"
                       title="Зберегти як .txt"
                     >
                       <Download size={16} strokeWidth={2} />
@@ -172,9 +175,16 @@ export function DocumentViewerModal({ isOpen, onClose, item }: DocumentViewerMod
 
                 {/* Content — Markdown rendered */}
                 <div className="flex-1 overflow-y-auto px-6 py-5">
-                  <div className="prose prose-sm max-w-none prose-headings:text-claude-text prose-p:text-claude-text prose-p:leading-relaxed prose-a:text-blue-600 prose-strong:text-claude-text prose-code:text-[13px] prose-code:bg-claude-bg prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-pre:bg-claude-bg prose-pre:border prose-pre:border-claude-border prose-blockquote:border-claude-border prose-blockquote:text-claude-subtext">
-                    <ReactMarkdown>{item.content}</ReactMarkdown>
-                  </div>
+                  {isLoading ? (
+                    <div className="flex flex-col items-center justify-center py-16 text-claude-subtext">
+                      <Loader2 size={28} className="animate-spin mb-3" strokeWidth={2} />
+                      <p className="text-[13px]">Завантаження повного тексту...</p>
+                    </div>
+                  ) : (
+                    <div className="prose prose-sm max-w-none prose-headings:text-claude-text prose-p:text-claude-text prose-p:leading-relaxed prose-a:text-blue-600 prose-strong:text-claude-text prose-code:text-[13px] prose-code:bg-claude-bg prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-pre:bg-claude-bg prose-pre:border prose-pre:border-claude-border prose-blockquote:border-claude-border prose-blockquote:text-claude-subtext">
+                      <ReactMarkdown>{item.content}</ReactMarkdown>
+                    </div>
+                  )}
                 </div>
               </motion.div>
             </div>

--- a/lexwebapp/src/components/RightPanel.tsx
+++ b/lexwebapp/src/components/RightPanel.tsx
@@ -8,6 +8,7 @@ import { useEvidenceAggregator } from '../hooks/chat/useEvidenceAggregator';
 import { DecisionsTab } from './chat/DecisionsTab';
 import { RegulationsTab } from './chat/RegulationsTab';
 import { DocumentsTab } from './chat/DocumentsTab';
+import { mcpService } from '../services/api/MCPService';
 
 interface DocumentViewerItem {
   type: 'decision' | 'citation' | 'document';
@@ -32,6 +33,14 @@ const DOC_TYPE_LABELS: Record<string, string> = {
   court_decision: 'Судове рішення',
   internal: 'Внутрішній',
   other: 'Інше',
+};
+
+const SECTION_TYPE_LABELS: Record<string, string> = {
+  HEADER: 'Заголовок',
+  FACTS: 'Обставини справи',
+  COURT_REASONING: 'Мотивувальна частина',
+  DECISION: 'Резолютивна частина',
+  DISSENT: 'Окрема думка',
 };
 
 interface RightPanelProps {
@@ -66,8 +75,10 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
   // --- Viewer modal state ---
   const [viewerItem, setViewerItem] = useState<DocumentViewerItem | null>(null);
   const [isViewerOpen, setIsViewerOpen] = useState(false);
+  const [isViewerLoading, setIsViewerLoading] = useState(false);
 
-  const openDecisionModal = (d: Decision) => {
+  const openDecisionModal = async (d: Decision) => {
+    // Open modal immediately with summary while loading
     setViewerItem({
       type: 'decision',
       title: d.number,
@@ -76,8 +87,41 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
       badgeVariant: d.status as 'active' | 'overturned' | 'modified',
       content: d.summary || 'Немає тексту рішення.',
       relevance: d.relevance,
+      externalUrl: d.externalUrl,
     });
     setIsViewerOpen(true);
+
+    // Try to fetch full text if we have a docId or case number
+    const docId = d.docId;
+    const caseNumber = d.number !== 'N/A' ? d.number : undefined;
+
+    if (docId || caseNumber) {
+      setIsViewerLoading(true);
+      try {
+        const params: Record<string, any> = { depth: 5 };
+        if (docId) params.doc_id = docId;
+        else if (caseNumber) params.case_number = caseNumber;
+
+        const result = await mcpService.callTool('get_court_decision', params);
+        const parsed = parseToolResult(result);
+
+        if (parsed?.sections && Array.isArray(parsed.sections) && parsed.sections.length > 0) {
+          const fullText = parsed.sections
+            .map((s: any) => {
+              const label = SECTION_TYPE_LABELS[s.type] || s.type;
+              return `## ${label}\n\n${s.text}`;
+            })
+            .join('\n\n---\n\n');
+
+          setViewerItem(prev => prev ? { ...prev, content: fullText } : prev);
+        }
+      } catch (err) {
+        console.error('Failed to fetch full decision text:', err);
+        // Keep showing the summary — no need to show error
+      } finally {
+        setIsViewerLoading(false);
+      }
+    }
   };
 
   const openCitationModal = (c: { text: string; source: string }) => {
@@ -231,6 +275,20 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
       isOpen={isViewerOpen}
       onClose={() => setIsViewerOpen(false)}
       item={viewerItem}
+      isLoading={isViewerLoading}
     />
   </>;
+}
+
+/** Parse MCP tool result wrapper to get the inner JSON payload */
+function parseToolResult(data: any): any {
+  try {
+    if (data?.result?.content?.[0]?.text) {
+      return JSON.parse(data.result.content[0].text);
+    }
+    if (data?.result) return data.result;
+    return data;
+  } catch {
+    return data;
+  }
 }

--- a/lexwebapp/src/components/chat/ExpandableCard.tsx
+++ b/lexwebapp/src/components/chat/ExpandableCard.tsx
@@ -102,17 +102,14 @@ export function ExpandableCard({
                     Повний вигляд
                   </button>
                 )}
-                {externalUrl && (
-                  <a
-                    href={externalUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
+                {externalUrl && onOpenModal && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onOpenModal(); }}
                     className="flex items-center gap-1 text-[10px] text-claude-subtext hover:text-claude-text px-2 py-1 rounded-md hover:bg-claude-bg transition-colors"
                   >
                     <ExternalLink size={11} />
                     Відкрити
-                  </a>
+                  </button>
                 )}
               </div>
             </div>

--- a/lexwebapp/src/hooks/chat/evidence/court.ts
+++ b/lexwebapp/src/hooks/chat/evidence/court.ts
@@ -36,6 +36,7 @@ export function extractCourtEvidence(toolName: string, parsed: any): EvidenceRes
       status: 'active',
       documentType: classifyDocumentType(sc),
       externalUrl: courtDocUrl(sc.doc_id),
+      docId: sc.doc_id ? String(sc.doc_id) : undefined,
     });
   }
 
@@ -57,6 +58,7 @@ export function extractCourtEvidence(toolName: string, parsed: any): EvidenceRes
       status: 'active',
       documentType: classifyDocumentType(c),
       externalUrl: courtDocUrl(c.doc_id),
+      docId: c.doc_id ? String(c.doc_id) : undefined,
     });
   }
 
@@ -78,6 +80,7 @@ export function extractCourtEvidence(toolName: string, parsed: any): EvidenceRes
       status: 'active',
       documentType: classifyDocumentType(doc),
       externalUrl: courtDocUrl(doc.doc_id),
+      docId: doc.doc_id ? String(doc.doc_id) : undefined,
     });
   }
 
@@ -94,6 +97,7 @@ export function extractCourtEvidence(toolName: string, parsed: any): EvidenceRes
       status: 'active',
       documentType: classifyDocumentType(c),
       externalUrl: courtDocUrl(c.doc_id),
+      docId: c.doc_id ? String(c.doc_id) : undefined,
     });
   }
 
@@ -109,6 +113,7 @@ export function extractCourtEvidence(toolName: string, parsed: any): EvidenceRes
       relevance: 100,
       status: 'active',
       externalUrl: courtDocUrl(parsed.doc_id),
+      docId: parsed.doc_id ? String(parsed.doc_id) : undefined,
     });
   }
 

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -68,6 +68,7 @@ export interface Decision {
   status: 'active' | 'overturned' | 'modified';
   documentType?: string;
   externalUrl?: string;
+  docId?: string;
 }
 
 export interface Citation {


### PR DESCRIPTION
## Summary
- **"Повний вигляд"** and **"Відкрити"** buttons on court decision cards now fetch the full decision text via `get_court_decision` (depth=5) and render all sections as markdown in the modal
- Modal shows a loading spinner while fetching, with the summary visible as a fallback
- `docId` is preserved through the evidence extraction pipeline so the modal can fetch by document ID

## Test plan
- [ ] Trigger a court decision search in chat (e.g. ask about a court case)
- [ ] In the Рішення tab, expand a card and click "Повний вигляд" — verify the modal loads full text with section headers
- [ ] Click "Відкрити" — verify it also opens the modal with full text (not an external link)
- [ ] Verify the loading spinner appears briefly while fetching
- [ ] Verify the external link icon in the modal header still opens the court registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load the full court decision text in the modal viewer with structured sections and a clear loading state. Clicking “Повний вигляд” or “Відкрити” now shows the complete document, not just the summary.

- **New Features**
  - Fetches full text via get_court_decision (depth=5) using docId or case number.
  - Renders sections (facts, reasoning, decision, dissent) as markdown with headers.
  - Shows a spinner while loading; keeps the summary visible; disables copy/save until ready.
  - “Відкрити” opens the modal instead of a new tab; the external link icon in the modal header still links to the registry.
  - Preserves docId across evidence extraction and types to enable reliable fetching.

<sup>Written for commit a1bb6d0a7e807da0e01322a477a791d9aa861553. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

