### PR TITLE
fix(deploy): add -d flag to pgbouncer healthcheck

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -59,7 +59,7 @@ services:
       postgres-prod:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -h localhost -p 5432 -U ${POSTGRES_USER:-secondlayer}"]
+      test: ["CMD-SHELL", "pg_isready -h localhost -p 5432 -U ${POSTGRES_USER:-secondlayer} -d ${POSTGRES_DB:-secondlayer_prod}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary
- PgBouncer healthcheck used `pg_isready` without `-d` flag, defaulting to `db=secondlayer` (same as username)
- PgBouncer only has `secondlayer_prod` configured, so every healthcheck failed
- This caused `(nodb)/secondlayer login attempt` log spam every 10s and 0 queries passing through

## Test plan
- [ ] Deploy to prod, restart pgbouncer-prod
- [ ] Verify `docker logs secondlayer-pgbouncer-prod` no longer shows `(nodb)` login attempts
- [ ] Verify healthcheck passes: `docker inspect --format='{{.State.Health.Status}}' secondlayer-pgbouncer-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add -d to pg_isready in the prod PgBouncer healthcheck to target ${POSTGRES_DB:-secondlayer_prod}, fixing failing health checks, stopping “(nodb)/secondlayer” login spam, and restoring query flow.

<sup>Written for commit 7e400f5f934ea325340e8b32886c5b81f312fe43. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

