### PR TITLE
fix(deploy): route app-prod and document-service through pgbouncer

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -445,8 +445,8 @@ services:
       HTTP_PORT: ${HTTP_PORT:-3000}
       HTTP_HOST: 0.0.0.0
       JWT_SECRET: ${JWT_SECRET}
-      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
-      POSTGRES_HOST: postgres-prod
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@pgbouncer-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: pgbouncer-prod
       POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -530,7 +530,7 @@ services:
     ports:
     - "127.0.0.1:3007:3000"
     depends_on:
-      postgres-prod:
+      pgbouncer-prod:
         condition: service_healthy
       qdrant-prod:
         condition: service_healthy
@@ -578,7 +578,7 @@ services:
         max-size: "50m"
         max-file: "10"
     depends_on:
-      postgres-prod:
+      pgbouncer-prod:
         condition: service_healthy
       qdrant-prod:
         condition: service_started
@@ -590,8 +590,8 @@ services:
       PORT: 3002
       HTTP_PORT: 3002
       HTTP_HOST: 0.0.0.0
-      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
-      POSTGRES_HOST: postgres-prod
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@pgbouncer-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: pgbouncer-prod
       POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
## Summary
- `app-prod` and `document-service-prod` were connecting directly to `postgres-prod`, bypassing pgbouncer
- Switched `POSTGRES_HOST` and `DATABASE_URL` to `pgbouncer-prod` for both services
- Updated `depends_on` from `postgres-prod` to `pgbouncer-prod`
- Migrations and seeds remain on direct postgres (advisory locks need session mode)

## Test plan
- [ ] Restart app-prod and document-service-prod
- [ ] Verify `docker logs secondlayer-pgbouncer-prod` shows actual queries flowing (`xacts/s > 0`)
- [ ] Verify app health: `curl localhost:3007/health`
- [ ] Test a chat query to confirm DB access works through pgbouncer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route app-prod and document-service-prod through pgbouncer-prod instead of connecting directly to postgres-prod to enable connection pooling and improve stability. Migrations and seeds still run directly against postgres because they need session mode.

<sup>Written for commit d6fc9c7f93e426654f5667f6fd5071846dca8ee1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

