### PR TITLE
fix(deploy): route app-prod through pgbouncer with SCRAM auth

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -47,6 +47,7 @@ services:
     - "127.0.0.1:5439:5432"
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      AUTH_TYPE: scram-sha-256
       POOL_MODE: transaction
       MAX_CLIENT_CONN: 300
       DEFAULT_POOL_SIZE: 30
@@ -445,8 +446,8 @@ services:
       HTTP_PORT: ${HTTP_PORT:-3000}
       HTTP_HOST: 0.0.0.0
       JWT_SECRET: ${JWT_SECRET}
-      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
-      POSTGRES_HOST: postgres-prod
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@pgbouncer-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: pgbouncer-prod
       POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -530,7 +531,7 @@ services:
     ports:
     - "127.0.0.1:3007:3000"
     depends_on:
-      postgres-prod:
+      pgbouncer-prod:
         condition: service_healthy
       qdrant-prod:
         condition: service_healthy
@@ -578,7 +579,7 @@ services:
         max-size: "50m"
         max-file: "10"
     depends_on:
-      postgres-prod:
+      pgbouncer-prod:
         condition: service_healthy
       qdrant-prod:
         condition: service_started
@@ -590,8 +591,8 @@ services:
       PORT: 3002
       HTTP_PORT: 3002
       HTTP_HOST: 0.0.0.0
-      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
-      POSTGRES_HOST: postgres-prod
+      DATABASE_URL: postgresql://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD}@pgbouncer-prod:5432/${POSTGRES_DB:-secondlayer_prod}
+      POSTGRES_HOST: pgbouncer-prod
       POSTGRES_PORT: 5432
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}


### PR DESCRIPTION
## Summary
- Switch `app-prod` and `document-service-prod` to connect via `pgbouncer-prod`
- Add `AUTH_TYPE=scram-sha-256` (PG15 requires SCRAM, MD5 causes `wrong password type`)
- Migrations and seeds remain on direct postgres (advisory locks need session mode)

## Test plan
- [ ] Restart pgbouncer-prod, app-prod, document-service-prod
- [ ] Verify pgbouncer logs show queries flowing (`xacts/s > 0`)
- [ ] Verify app health: `curl localhost:3007/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route app-prod and document-service-prod through pgbouncer-prod with SCRAM (scram-sha-256) auth to support Postgres 15 and enable transaction pooling. Migrations and seeds continue to use direct Postgres because advisory locks need session mode.

- **Migration**
  - Restart pgbouncer-prod, app-prod, document-service-prod
  - Verify pgbouncer logs show traffic (xacts/s > 0)
  - Check app health: curl localhost:3007/health

<sup>Written for commit 17a365be37881c48ac437bb5746663c625c53ab5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

