### PR TITLE
fix(deploy): set Redis eviction policy to noeviction

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -171,7 +171,7 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy volatile-lru
+    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy noeviction
     healthcheck:
       test:
       - CMD


### PR DESCRIPTION
## Summary
- Changed Redis `maxmemory-policy` from `volatile-lru` to `noeviction` in prod
- Eliminates `IMPORTANT! Eviction policy is volatile-lru. It should be "noeviction"` warnings on every app startup

## Test plan
- [ ] Restart redis-prod
- [ ] Verify no eviction policy warnings in app-prod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch prod apps to use pgbouncer with SCRAM auth and set Redis eviction policy to noeviction. This aligns prod config with app expectations and removes Redis startup warnings.

- **Bug Fixes**
  - Set Redis maxmemory-policy to noeviction to stop eviction and remove startup warnings.

- **Refactors**
  - Route app-prod and document-service-prod through pgbouncer-prod; update DATABASE_URL and depends_on to pgbouncer.
  - Enable SCRAM by setting pgbouncer AUTH_TYPE=scram-sha-256 (PG15). Migrations/seeds remain on direct Postgres.

<sup>Written for commit d71e46045556351ad4a66c94eb6be372d22c848c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

