### PR TITLE
feat(frontend): URL-based folder navigation in Vault

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -40,10 +40,13 @@ import {
   Search,
   Archive,
   Zap,
+  Folder,
+  FolderOpen,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../contexts/AuthContext';
 import { useChatStore } from '../stores/chatStore';
+import { api } from '../utils/api-client';
 import type { UserRole } from '../types/models/User';
 
 interface SidebarProps {
@@ -143,7 +146,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   // Compute which section IDs are actually rendered (for toggle-all)
   const renderedSectionIds = useMemo(() => {
     if (role === 'administrator') return ['monitoring'];
-    const ids = ['research', 'legislation'];
+    const ids = ['research', 'legislation', 'vault'];
     if (conversations.length > 0) ids.push('conversations');
     if (role !== 'user') ids.push('matters');
     return ids;
@@ -169,11 +172,29 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
 
   const allCollapsed = renderedSectionIds.length > 0 && renderedSectionIds.every(id => collapsedSections.has(id));
 
+  const [vaultFolders, setVaultFolders] = useState<string[]>([]);
+  const [vaultFoldersLoaded, setVaultFoldersLoaded] = useState(false);
+
   const profileMenuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     loadConversations();
   }, []);
+
+  // Load top-level vault folders when vault section is expanded
+  useEffect(() => {
+    if (!collapsedSections.has('vault') && !vaultFoldersLoaded) {
+      api.documents.getFolders()
+        .then((resp) => {
+          setVaultFolders(resp.data.folders || []);
+          setVaultFoldersLoaded(true);
+        })
+        .catch(() => {
+          setVaultFolders([]);
+          setVaultFoldersLoaded(true);
+        });
+    }
+  }, [collapsedSections, vaultFoldersLoaded]);
 
   // Listen for navigation events from NavItem (to close mobile sidebar)
   useEffect(() => {
@@ -407,10 +428,32 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 ))}
               </Section>
 
-              {/* Vault — top-level link */}
-              <div className="mb-2">
-                <NavItem icon={Archive} label="Vault" route={ROUTES.DOCUMENTS} onClick={() => handleNavigation(ROUTES.DOCUMENTS)} />
-              </div>
+              {/* Vault — documents & folders */}
+              <Section id="vault" title="Vault" collapsed={collapsedSections.has('vault')} onToggle={toggleSection}>
+                <NavItem icon={Archive} label="Всі документи" route={ROUTES.DOCUMENTS} onClick={() => handleNavigation(ROUTES.DOCUMENTS)} />
+                {vaultFolders.map((folder) => {
+                  const folderRoute = `/documents/folders/${folder}`;
+                  const isActive = location.pathname === folderRoute || location.pathname.startsWith(folderRoute + '/');
+                  return (
+                    <button
+                      key={folder}
+                      onClick={() => handleNavigation(folderRoute)}
+                      className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${
+                        isActive
+                          ? 'bg-claude-accent/10 text-claude-accent'
+                          : 'text-claude-text hover:bg-claude-subtext/8'
+                      }`}
+                    >
+                      {isActive ? (
+                        <FolderOpen size={15} strokeWidth={2} className="text-claude-accent flex-shrink-0" />
+                      ) : (
+                        <Folder size={15} strokeWidth={2} className="text-claude-subtext/60 group-hover:text-claude-text transition-colors duration-200 flex-shrink-0" />
+                      )}
+                      <span className="truncate font-medium tracking-tight font-sans">{folder}</span>
+                    </button>
+                  );
+                })}
+              </Section>
 
               {/* Matters — company/lawyer only */}
               {role !== 'user' && (

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -90,6 +90,11 @@ export function MainLayout() {
     if (location.pathname.startsWith('/matters/')) {
       return 'Деталі справи';
     }
+    if (location.pathname.startsWith('/documents/folders/')) {
+      const folderPath = location.pathname.replace('/documents/folders/', '');
+      const segments = folderPath.split('/').filter(Boolean);
+      return segments.length > 0 ? `Документи / ${segments.join(' / ')}` : 'Документи';
+    }
 
     return 'SecondLayer';
   };

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Upload,
@@ -84,6 +85,17 @@ function SkeletonRows() {
 }
 
 export function DocumentsPage() {
+  const navigate = useNavigate();
+  const params = useParams();
+
+  // Derive folder path from URL: /documents/folders/a/b → "a/b/"
+  const currentFolderPath = useMemo(() => {
+    const wildcard = params['*'] || '';
+    if (!wildcard) return '';
+    // Ensure trailing slash for consistency
+    return wildcard.endsWith('/') ? wildcard : wildcard + '/';
+  }, [params]);
+
   // Document list state
   const [documents, setDocuments] = useState<VaultDocument[]>([]);
   const [totalDocs, setTotalDocs] = useState(0);
@@ -107,9 +119,19 @@ export function DocumentsPage() {
   const [previewLoading, setPreviewLoading] = useState(false);
 
   // Folder navigation state
-  const [currentFolderPath, setCurrentFolderPath] = useState('');
   const [folders, setFolders] = useState<string[]>([]);
   const [foldersLoading, setFoldersLoading] = useState(false);
+
+  // Navigation helpers
+  const navigateToFolder = useCallback((folderPath: string) => {
+    if (!folderPath) {
+      navigate('/documents');
+    } else {
+      // Strip trailing slash for clean URLs
+      const cleanPath = folderPath.replace(/\/+$/, '');
+      navigate(`/documents/folders/${cleanPath}`);
+    }
+  }, [navigate]);
 
   // Upload state from Zustand store
   const {
@@ -587,13 +609,13 @@ export function DocumentsPage() {
                 const newPath = currentFolderPath
                   ? `${currentFolderPath}${folderName}/`
                   : `${folderName}/`;
-                setCurrentFolderPath(newPath);
+                navigateToFolder(newPath);
               }}
-              onReset={() => setCurrentFolderPath('')}
+              onReset={() => navigateToFolder('')}
               onBreadcrumbClick={(depth) => {
                 const segments = currentFolderPath.split('/').filter(Boolean);
                 const newPath = segments.slice(0, depth).join('/') + '/';
-                setCurrentFolderPath(newPath);
+                navigateToFolder(newPath);
               }}
               loading={foldersLoading}
             />

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -198,6 +198,10 @@ export const router = createBrowserRouter([
             element: <DocumentsPage />,
           },
           {
+            path: ROUTES.DOCUMENTS_FOLDER,
+            element: <DocumentsPage />,
+          },
+          {
             path: ROUTES.CASE_ANALYSIS,
             element: <CaseAnalysisPage />,
           },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -36,6 +36,7 @@ export const ROUTES = {
 
   // Documents
   DOCUMENTS: '/documents',
+  DOCUMENTS_FOLDER: '/documents/folders/*',
 
   // Cases & Decisions
   CASE_ANALYSIS: '/case-analysis',


### PR DESCRIPTION
## Summary
- Folder paths are now URL-based (`/documents/folders/path/to/folder`), enabling bookmarking and browser back/forward navigation
- Sidebar Vault section expanded from a single link to a collapsible section showing top-level folders with active state highlighting
- Dynamic page title in header shows folder breadcrumb path

## Test plan
- [ ] Navigate to `/documents` — shows all documents as before
- [ ] Click a folder in FolderNavigator — URL updates to `/documents/folders/<name>`
- [ ] Browser back/forward buttons navigate between folders
- [ ] Sidebar Vault section expands to show top-level folders
- [ ] Clicking a sidebar folder navigates and highlights it
- [ ] Breadcrumb clicks in FolderNavigator update URL correctly
- [ ] Page title in header shows folder path for nested folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made Vault folder navigation URL-based (/documents/folders/...), so folders can be bookmarked and browser back/forward works. The sidebar now shows top-level folders, and the header displays a breadcrumb.

- **New Features**
  - Added /documents/folders/* route; DocumentsPage reads folder from URL and updates it on navigation and breadcrumb clicks.
  - Sidebar Vault expanded to a collapsible list of top-level folders (loaded on expand) with active highlighting and an “Всі документи” link.
  - Dynamic page title shows "Документи / ..." based on the current folder path.

<sup>Written for commit ccc5ceaa17fd266d7b02ab0b6b96829cfa7a3903. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

