### PR TITLE
fix: strict user isolation for vault documents

### DIFF
--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -591,9 +591,9 @@ Pipeline:
       const params: any[] = [];
       let paramIndex = 1;
 
-      // User isolation: show own + public documents
+      // User isolation: show only own documents
       if (args.userId) {
-        conditions.push(`(user_id = $${paramIndex} OR user_id IS NULL)`);
+        conditions.push(`user_id = $${paramIndex}`);
         params.push(args.userId);
         paramIndex++;
       }
@@ -702,7 +702,7 @@ Pipeline:
       let paramIndex = 1;
 
       if (args.userId) {
-        conditions.push(`(user_id = $${paramIndex} OR user_id IS NULL)`);
+        conditions.push(`user_id = $${paramIndex}`);
         params.push(args.userId);
         paramIndex++;
       }
@@ -819,7 +819,7 @@ Pipeline:
             SELECT id, type, title, metadata
             FROM documents
             WHERE id = ANY($1)
-            ${args.userId ? 'AND (user_id = $2 OR user_id IS NULL)' : ''}
+            ${args.userId ? 'AND user_id = $2' : ''}
           `;
           const params: any[] = args.userId ? [uniqueIds, args.userId] : [uniqueIds];
           const docsResult = await this.documentService['db'].query(docsQuery, params);

--- a/mcp_backend/src/routes/rest-api.ts
+++ b/mcp_backend/src/routes/rest-api.ts
@@ -19,7 +19,7 @@ export function createRestAPIRouter(db: Database): Router {
       const offset = start;
 
       const userFilter = userId
-        ? { where: 'WHERE (user_id = $1 OR user_id IS NULL)', params: [userId] }
+        ? { where: 'WHERE user_id = $1', params: [userId] }
         : { where: '', params: [] };
 
       const countResult = await db.query(
@@ -58,7 +58,7 @@ export function createRestAPIRouter(db: Database): Router {
 
       const result = userId
         ? await db.query(
-            'SELECT * FROM documents WHERE id = $1 AND (user_id = $2 OR user_id IS NULL)',
+            'SELECT * FROM documents WHERE id = $1 AND user_id = $2',
             [id, userId]
           )
         : await db.query('SELECT * FROM documents WHERE id = $1', [id]);
@@ -112,7 +112,7 @@ export function createRestAPIRouter(db: Database): Router {
       }
 
       // Only allow updating own documents (or public if no userId)
-      const ownerCheck = userId ? ` AND (user_id = '${userId}' OR user_id IS NULL)` : '';
+      const ownerCheck = userId ? ` AND user_id = '${userId}'` : '';
       const result = await db.query(
         `UPDATE documents SET ${setClause}, updated_at = NOW() WHERE id = $1${ownerCheck} RETURNING *`,
         values

--- a/mcp_backend/src/services/document-service.ts
+++ b/mcp_backend/src/services/document-service.ts
@@ -311,7 +311,7 @@ export class DocumentService {
   ): Promise<{ documents: Document[]; total: number }> {
     const limit = options.limit || 20;
     const offset = options.offset || 0;
-    const conditions = ['(user_id = $1 OR user_id IS NULL)'];
+    const conditions = ['user_id = $1'];
     const params: any[] = [userId];
     let paramIndex = 2;
 
@@ -351,7 +351,7 @@ export class DocumentService {
    */
   async getDocumentForUser(id: string, userId: string): Promise<Document | null> {
     const result = await this.db.query(
-      `SELECT * FROM documents WHERE id = $1 AND (user_id = $2 OR user_id IS NULL)`,
+      `SELECT * FROM documents WHERE id = $1 AND user_id = $2`,
       [id, userId]
     );
     return result.rows[0] || null;


### PR DESCRIPTION
## Summary
- Remove `OR user_id IS NULL` from all document listing/retrieval queries
- Users now only see documents they personally uploaded, not all ownerless documents
- Affects: vault-tools (list, folders, semantic search), document-service, REST API

## Prod cleanup done
- Deleted 166,904 user-uploaded documents and 470,641 related sections from prod DB

## Test plan
- [ ] Upload a document as user A, verify only user A sees it
- [ ] Verify user B sees empty documents list
- [ ] Verify system court decisions (user_id IS NULL) are not shown in vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict per-user isolation in the vault so users only see and edit documents they uploaded. Ownerless/system documents are no longer visible in user-facing lists, detail, updates, or search.

- **Bug Fixes**
  - Removed OR user_id IS NULL from all document list/retrieve/update queries in vault-tools, document-service, and REST API.
  - Applies to lists, folders, semantic search, get-by-id, and updates; now require user_id = current user.
  - Production cleanup: deleted 166,904 user-uploaded documents and 470,641 related sections.

<sup>Written for commit 2a75c548a179ddc6bd28bf169ca820b4b6140347. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

