### PR TITLE
fix: require authenticated userId for all vault access

### DIFF
--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -591,12 +591,13 @@ Pipeline:
       const params: any[] = [];
       let paramIndex = 1;
 
-      // User isolation: show only own documents
-      if (args.userId) {
-        conditions.push(`user_id = $${paramIndex}`);
-        params.push(args.userId);
-        paramIndex++;
+      // User isolation: require userId, return empty if not authenticated
+      if (!args.userId) {
+        return { documents: [], total: 0 };
       }
+      conditions.push(`user_id = $${paramIndex}`);
+      params.push(args.userId);
+      paramIndex++;
 
       if (args.type) {
         conditions.push(`type = $${paramIndex}`);
@@ -701,11 +702,13 @@ Pipeline:
       const params: any[] = [];
       let paramIndex = 1;
 
-      if (args.userId) {
-        conditions.push(`user_id = $${paramIndex}`);
-        params.push(args.userId);
-        paramIndex++;
+      // Require userId for folder listing
+      if (!args.userId) {
+        return { folders: [], fileCount: 0 };
       }
+      conditions.push(`user_id = $${paramIndex}`);
+      params.push(args.userId);
+      paramIndex++;
 
       if (prefix) {
         conditions.push(`metadata::jsonb ->> 'folderPath' LIKE $${paramIndex}`);
@@ -789,6 +792,11 @@ Pipeline:
         type: args.type,
         limit: args.limit,
       });
+
+      // Require userId for semantic search
+      if (!args.userId) {
+        return [];
+      }
 
       const limit = args.limit || 10;
       const threshold = args.threshold || 0.7;

--- a/mcp_backend/src/routes/rest-api.ts
+++ b/mcp_backend/src/routes/rest-api.ts
@@ -18,9 +18,13 @@ export function createRestAPIRouter(db: Database): Router {
       const limit = end - start;
       const offset = start;
 
-      const userFilter = userId
-        ? { where: 'WHERE user_id = $1', params: [userId] }
-        : { where: '', params: [] };
+      if (!userId) {
+        res.setHeader('X-Total-Count', '0');
+        res.setHeader('Access-Control-Expose-Headers', 'X-Total-Count');
+        res.json([]);
+        return;
+      }
+      const userFilter = { where: 'WHERE user_id = $1', params: [userId] };
 
       const countResult = await db.query(
         `SELECT COUNT(*) FROM documents ${userFilter.where}`,
@@ -56,12 +60,14 @@ export function createRestAPIRouter(db: Database): Router {
       const { id } = req.params;
       const userId = req.user?.id;
 
-      const result = userId
-        ? await db.query(
-            'SELECT * FROM documents WHERE id = $1 AND user_id = $2',
-            [id, userId]
-          )
-        : await db.query('SELECT * FROM documents WHERE id = $1', [id]);
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+      const result = await db.query(
+        'SELECT * FROM documents WHERE id = $1 AND user_id = $2',
+        [id, userId]
+      );
 
       if (result.rows.length === 0) {
         res.status(404).json({ error: 'Document not found' });
@@ -112,7 +118,11 @@ export function createRestAPIRouter(db: Database): Router {
       }
 
       // Only allow updating own documents (or public if no userId)
-      const ownerCheck = userId ? ` AND user_id = '${userId}'` : '';
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+      const ownerCheck = ` AND user_id = '${userId}'`;
       const result = await db.query(
         `UPDATE documents SET ${setClause}, updated_at = NOW() WHERE id = $1${ownerCheck} RETURNING *`,
         values
@@ -137,9 +147,11 @@ export function createRestAPIRouter(db: Database): Router {
       const userId = req.user?.id;
 
       // Only allow deleting own documents
-      const result = userId
-        ? await db.query('DELETE FROM documents WHERE id = $1 AND user_id = $2 RETURNING id', [id, userId])
-        : await db.query('DELETE FROM documents WHERE id = $1 RETURNING id', [id]);
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+      const result = await db.query('DELETE FROM documents WHERE id = $1 AND user_id = $2 RETURNING id', [id, userId]);
 
       if (result.rows.length === 0) {
         res.status(404).json({ error: 'Document not found' });


### PR DESCRIPTION
## Summary
- Return empty results when no userId present (API-key-only requests)
- Return 401 for REST endpoints without authentication
- Prevents unauthenticated access to any vault documents

## Test plan
- [ ] API key auth returns empty document list
- [ ] JWT-authenticated user sees only own documents
- [ ] Unauthenticated REST calls get 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an authenticated userId for all vault access. Unauthenticated requests now return empty results or 401 to prevent data exposure from API-key-only calls.

- **Bug Fixes**
  - Vault tools: require userId; return empty documents, folders, and semantic search results when missing.
  - REST API: require auth; list returns [] with X-Total-Count=0 if no userId, and GET/UPDATE/DELETE return 401 and enforce user_id checks.

<sup>Written for commit 280acce98d99e91c211530a4fa6719a82dfc2406. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

