### PR TITLE
fix: return full text in court decision viewer

### DIFF
--- a/lexwebapp/src/components/RightPanel.tsx
+++ b/lexwebapp/src/components/RightPanel.tsx
@@ -41,6 +41,9 @@ const SECTION_TYPE_LABELS: Record<string, string> = {
   COURT_REASONING: 'Мотивувальна частина',
   DECISION: 'Резолютивна частина',
   DISSENT: 'Окрема думка',
+  AMOUNTS: 'Суми та компенсації',
+  CLAIMS: 'Позовні вимоги',
+  LAW_REFERENCES: 'Посилання на закон',
 };
 
 interface RightPanelProps {
@@ -107,15 +110,17 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
         const result = await mcpService.callTool('get_court_decision', params);
         const parsed = parseToolResult(result);
 
-        if (parsed?.sections && Array.isArray(parsed.sections) && parsed.sections.length > 0) {
-          const fullText = parsed.sections
+        if (parsed?.full_text && typeof parsed.full_text === 'string') {
+          setViewerItem(prev => prev ? { ...prev, content: parsed.full_text } : prev);
+        } else if (parsed?.sections && Array.isArray(parsed.sections) && parsed.sections.length > 0) {
+          const sectionsText = parsed.sections
             .map((s: any) => {
               const label = SECTION_TYPE_LABELS[s.type] || s.type;
               return `## ${label}\n\n${s.text}`;
             })
             .join('\n\n---\n\n');
 
-          setViewerItem(prev => prev ? { ...prev, content: fullText } : prev);
+          setViewerItem(prev => prev ? { ...prev, content: sectionsText } : prev);
         }
       } catch (err: any) {
         console.error('Failed to fetch full decision text:', err);

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -341,6 +341,7 @@ export class CourtDecisionTools extends BaseToolHandler {
       url,
       depth,
       sections: sections.slice(0, depth),
+      full_text: fullText || undefined,
       full_text_length: fullText.length,
     };
 


### PR DESCRIPTION
## Summary
- **Backend**: Added `full_text` to `get_court_decision` response payload — previously only returned sectioned snippets sliced by `depth`
- **Frontend**: Prefers `full_text` for display; falls back to sections only if unavailable. Added missing section type labels (AMOUNTS, CLAIMS, LAW_REFERENCES)

## Problem
Court decision viewer showed fragmented "AMOUNTS" headers with ~200-char monetary regex context windows instead of the full document text. The `SemanticSectionizer` creates these small AMOUNTS sections around `грн`/`гривень` matches, and with `depth: 5` the response was dominated by these fragments.

## Test plan
- [ ] Open a court decision in the right panel — should show continuous full text
- [ ] Verify no "AMOUNTS" raw headers appear
- [ ] Rebuild Docker images and test on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the full court decision text in the viewer instead of fragmented section snippets. Backend now returns full_text, and the UI prefers it, falling back to labeled sections only if needed.

- **Bug Fixes**
  - API: get_court_decision now includes full_text (with full_text_length); sections still sliced by depth.
  - UI: render full_text when present; otherwise show concatenated sections.
  - UI: added labels for AMOUNTS, CLAIMS, LAW_REFERENCES.

<sup>Written for commit f3d08e13dc8b31f5ca73f11e6e37341999664e42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

