### PR TITLE
fix: decode Cyrillic folder names in documents UI

### DIFF
--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -93,7 +93,8 @@ export function MainLayout() {
     if (location.pathname.startsWith('/documents/folders/')) {
       const folderPath = location.pathname.replace('/documents/folders/', '');
       const segments = folderPath.split('/').filter(Boolean);
-      return segments.length > 0 ? `Документи / ${segments.join(' / ')}` : 'Документи';
+      const decoded = segments.map(s => { try { return decodeURIComponent(s); } catch { return s; } });
+      return decoded.length > 0 ? `Документи / ${decoded.join(' / ')}` : 'Документи';
     }
 
     return 'SecondLayer';

--- a/lexwebapp/src/pages/DocumentsPage/FolderNavigator.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/FolderNavigator.tsx
@@ -48,7 +48,7 @@ export function FolderNavigator({
                     : 'text-claude-subtext/70 hover:text-claude-text hover:bg-claude-bg'
                 }`}
               >
-                {seg}
+                {(() => { try { return decodeURIComponent(seg); } catch { return seg; } })()}
               </button>
             </React.Fragment>
           ))}
@@ -66,7 +66,7 @@ export function FolderNavigator({
               className="flex items-center gap-2 px-3 py-2.5 bg-white border border-claude-border rounded-xl text-sm text-claude-text hover:bg-claude-bg hover:border-claude-subtext/30 transition-all active:scale-[0.98] font-sans disabled:opacity-50"
             >
               <Folder size={16} className="text-claude-subtext/50 flex-shrink-0" />
-              <span className="truncate">{folder}</span>
+              <span className="truncate">{(() => { try { return decodeURIComponent(folder); } catch { return folder; } })()}</span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Added `decodeURIComponent()` to folder name display in page header (`MainLayout.tsx`) and breadcrumbs/folder grid (`FolderNavigator.tsx`)
- Folder names like `20231201-заява-в-поліцію` were showing as `20231201-%D0%B7%D0%B0%D1%8F%D0%B2%D0%B0-...`

## Test plan
- [ ] Navigate to a folder with Cyrillic name — header and breadcrumbs should show decoded text
- [ ] Verify folder grid tiles also display decoded names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes URL-encoded Cyrillic folder names in the Documents UI so users see readable text instead of percent-encoded strings. Decodes folder path segments in the page header, breadcrumbs, and folder grid with a safe fallback.

<sup>Written for commit df20891ef4dd923cc318a657b98a7eba3d2a6b31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

