### PR TITLE
fix: change prod Redis eviction policy to volatile-lru

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -171,7 +171,7 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy volatile-lru
     healthcheck:
       test:
       - CMD


### PR DESCRIPTION
## Summary
- Changed Redis `maxmemory-policy` from `noeviction` to `volatile-lru` in prod compose
- `noeviction` returns errors on writes when memory limit is reached; `volatile-lru` evicts keys with TTL instead
- Aligns prod behavior with stage environment

## Test plan
- [ ] Deploy to prod and verify Redis accepts writes under memory pressure
- [ ] Confirm cache keys with TTL are evicted properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch prod Redis eviction policy to volatile-lru to prevent write errors when memory is full. This evicts TTL keys and matches stage configuration.

<sup>Written for commit b2669f54762b3ab647d2891ebc7038877fea8dcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

