### PR TITLE
fix: change prod Redis eviction policy from noeviction to volatile-lru

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -171,7 +171,7 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy volatile-lru
     healthcheck:
       test:
       - CMD


### PR DESCRIPTION
## Summary
- Changes prod Redis `maxmemory-policy` from `noeviction` to `volatile-lru`
- With `noeviction`, Redis returns errors when memory is full instead of evicting stale cache keys
- `volatile-lru` evicts least-recently-used keys that have a TTL set, keeping persistent data safe

## Context
- Current prod Redis: 42.81MB / 1.5GB — not critical yet, but will fail hard when full
- All our cache keys use TTL, so `volatile-lru` is the correct policy

## Test plan
- [x] Verified prod Redis currently uses `noeviction`
- [ ] After deploy: `docker exec secondlayer-redis-prod redis-cli CONFIG GET maxmemory-policy` should return `volatile-lru`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch prod Redis eviction policy from noeviction to volatile-lru to avoid write errors at the memory limit. Now Redis evicts least-used keys with TTL and leaves persistent data untouched.

- **Migration**
  - After deploy: docker exec secondlayer-redis-prod redis-cli CONFIG GET maxmemory-policy should return volatile-lru

<sup>Written for commit b2669f54762b3ab647d2891ebc7038877fea8dcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

