### PR TITLE
fix: prevent UTF-8 corruption in user activity endpoint

### DIFF
--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -420,7 +420,7 @@ export function createAdminRoutes(
             ct.user_id,
             ct.id,
             ct.tool_name,
-            LEFT(COALESCE(ct.user_query, ''), 150)          AS user_query,
+            COALESCE(ct.user_query, '')                      AS user_query,
             ct.total_cost_usd::float,
             ct.execution_time_ms,
             ct.status,

--- a/mcp_backend/src/services/cost-tracker.ts
+++ b/mcp_backend/src/services/cost-tracker.ts
@@ -74,7 +74,7 @@ export class CostTracker extends BaseCostTracker {
         params.toolName,
         params.clientKey || null,
         params.userId || null,
-        params.userQuery?.replace(/[^\x09\x0A\x0D\x20-\x7E\u00A0-\uFFFF]/g, '') || '',
+        (params.userQuery?.replace(/[^\x09\x0A\x0D\x20-\x7E\u00A0-\uFFFF]/g, '') || '').substring(0, 500),
         JSON.stringify(params.queryParams),
         monthlyTotal,
         'pending',


### PR DESCRIPTION
## Summary
- Cap `user_query` to 500 chars in JS before PostgreSQL INSERT to prevent multi-byte Cyrillic character truncation
- Remove `LEFT()` in activity query SQL to avoid triggering PG encoding errors on corrupted data
- Already cleaned corrupted data on both stage (43 rows) and prod (2 rows)

## Root cause
The `ai_chat` tool was storing long Ukrainian text queries (600+ chars) that somehow got corrupted UTF-8 encoding. `LEFT()` in PostgreSQL would then fail with `invalid byte sequence for encoding "UTF8": 0xd0` when trying to process these rows.

## Test plan
- [x] Cleaned corrupted data on stage and prod databases
- [x] Verified full activity query works on both environments after data fix
- [x] TypeScript compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes UTF-8 corruption in the user activity endpoint to stop invalid byte sequence errors and preserve multi-byte text.

- **Bug Fixes**
  - Cap user_query to 500 chars before INSERT to avoid multi-byte truncation.
  - Remove LEFT() from the admin activity query to prevent PostgreSQL UTF-8 errors.
  - Cleaned corrupted rows on stage (43) and prod (2).

<sup>Written for commit d9ae5eeaef642864cdb6c33f36951c5e0bdb254e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

