### PR TITLE
docs: add --env-file requirement for docker compose

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - After making code changes, always rebuild Docker images before testing (`docker compose build <service>` then `docker compose up -d`). Never test against stale containers.
 - Local dev runs in Docker. Do NOT attempt to restart backend processes directly — always use docker compose commands.
+- Compose files have NO `env_file:` directives — secrets are injected via shell env substitution. **Always pass `--env-file`**:
+  - Local: `docker compose -f docker-compose.local.yml --env-file .env.local up -d`
+  - Stage: `docker compose -f docker-compose.stage.yml --env-file .env.stage up -d`
+  - Prod: `docker compose -f docker-compose.prod.yml --env-file .env.prod up -d`
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- Documents that docker compose files require explicit `--env-file` flag for each environment
- Without it, secrets like `OPENAI_API_KEY`, `SECONDARY_LAYER_KEYS`, `VOYAGEAI_API_KEY` get empty values and backend crashes

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented that all docker compose commands must include the --env-file flag per environment, since compose files use shell env substitution and don’t define env_file. This prevents empty secrets (e.g., OPENAI_API_KEY, SECONDARY_LAYER_KEYS, VOYAGEAI_API_KEY) that can crash the backend.

<sup>Written for commit e1bd7bf5ffdae7353f9e256ce846dae756547c72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

