### PR TITLE
fix: reduce cadvisor stale overlay filesystem errors

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -798,6 +798,9 @@ services:
     command:
       - '-docker_only=true'
       - '-housekeeping_interval=30s'
+      - '-storage_duration=1m0s'
+      - '-event_storage_age_limit=default=0'
+      - '-event_storage_event_limit=default=0'
       - '-disable_metrics=cpu_topology,hugetlb,memory_numa,perf_event,referenced_memory,resctrl,sched,tcp,udp'
     volumes:
       - /:/rootfs:ro

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -893,6 +893,9 @@ services:
     command:
       - '-docker_only=true'
       - '-housekeeping_interval=30s'
+      - '-storage_duration=1m0s'
+      - '-event_storage_age_limit=default=0'
+      - '-event_storage_event_limit=default=0'
       - '-disable_metrics=cpu_topology,hugetlb,memory_numa,perf_event,referenced_memory,resctrl,sched,tcp,udp'
     volumes:
       - /:/rootfs:ro


### PR DESCRIPTION
## Summary
- Add `--storage_duration=1m0s` to reduce how long cAdvisor retains data for removed containers
- Add `--event_storage_age_limit=default=0` and `--event_storage_event_limit=default=0` to disable event history retention
- Applied to both prod and stage compose files
- Fixes recurring `failed to collect filesystem stats` errors from stale overlay paths after container redeploys

## Test plan
- [x] Deployed to prod — cadvisor-prod restarted healthy with clean logs
- [x] Also pruned 35.9GB of stale Docker build cache on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce cAdvisor noise from stale overlay filesystem stats after container redeploys by shortening retention and disabling event history. Added -storage_duration=1m0s and -event_storage_* limits set to 0 in prod and stage compose files to prevent recurring "failed to collect filesystem stats" errors.

<sup>Written for commit d0eb9c64303aff2d820d3ffcb09b15dc6955e6bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

