### PR TITLE
fix: handle empty LLM response in MetadataExtractor

### DIFF
--- a/mcp_backend/src/services/metadata-extractor.ts
+++ b/mcp_backend/src/services/metadata-extractor.ts
@@ -38,6 +38,7 @@ export class MetadataExtractor {
     }
 
     const snippet = text.slice(0, 4000);
+    let rawContent: string | undefined;
 
     try {
       if (!this.llm) {
@@ -71,7 +72,14 @@ export class MetadataExtractor {
         'quick'
       );
 
-      const parsed = JSON.parse(response.content);
+      rawContent = response.content;
+      const raw = rawContent?.trim();
+      if (!raw) {
+        logger.warn('[MetadataExtractor] LLM returned empty content', { title, docType });
+        return EMPTY_METADATA;
+      }
+
+      const parsed = JSON.parse(raw);
 
       const result: ExtractedMetadata = {
         documentDate: parsed.documentDate || null,
@@ -94,6 +102,7 @@ export class MetadataExtractor {
       logger.warn('[MetadataExtractor] Extraction failed, using defaults', {
         title,
         error: error.message,
+        ...(error.message?.includes('JSON') ? { rawContentPreview: rawContent?.slice(0, 200) } : {}),
       });
       return EMPTY_METADATA;
     }


### PR DESCRIPTION
## Summary
- Fixes `Unexpected end of JSON input` errors in MetadataExtractor when OpenAI returns empty content
- Adds empty-content check before `JSON.parse` — returns `EMPTY_METADATA` gracefully instead of crashing
- Adds diagnostic logging (first 200 chars of raw LLM response) on JSON parse failures for future debugging

## Context
Production logs show 5 MetadataExtractor failures per vault upload batch, all with `Unexpected end of JSON input`. Root cause: `llm-client-manager.ts` converts null/undefined content to `''`, and `JSON.parse('')` throws.

## Test plan
- [x] TypeScript build passes (`tsc --noEmit`)
- [ ] Deploy to prod and verify no more `Unexpected end of JSON input` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented JSON parse crashes in MetadataExtractor when the LLM returns empty content by guarding before parse and returning EMPTY_METADATA. Added warn-level logging with a 200-char raw response preview to debug failures, reducing "Unexpected end of JSON input" errors in production.

<sup>Written for commit 6b318c74acf72336703a21dcc708321d01e47303. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

