### PR TITLE
feat: add blog comments with DB storage and JWT auth

### DIFF
--- a/lexwebapp/src/pages/BlogPage.tsx
+++ b/lexwebapp/src/pages/BlogPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
@@ -14,7 +14,13 @@ import {
   Cpu,
   Scale,
   X,
+  MessageSquare,
+  Send,
+  Trash2,
+  LogIn,
 } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { blogService, type BlogComment } from '../services/blog-service';
 
 // ── Article data ──────────────────────────────────────────────
 
@@ -708,9 +714,61 @@ AI не вирішує, яку стратегію обрати. Він дає ю
 
 export function BlogPage() {
   const navigate = useNavigate();
+  const { user, isAuthenticated } = useAuth();
   const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
   const [copied, setCopied] = useState(false);
   const [filter, setFilter] = useState<'all' | 'tech' | 'legal'>('all');
+
+  // Comments state
+  const [comments, setComments] = useState<BlogComment[]>([]);
+  const [commentText, setCommentText] = useState('');
+  const [commentsLoading, setCommentsLoading] = useState(false);
+  const [commentSubmitting, setCommentSubmitting] = useState(false);
+
+  const loadComments = useCallback(async (articleId: string) => {
+    setCommentsLoading(true);
+    try {
+      const data = await blogService.getComments(articleId);
+      setComments(data);
+    } catch {
+      setComments([]);
+    } finally {
+      setCommentsLoading(false);
+    }
+  }, []);
+
+  // Load comments when article is selected
+  useEffect(() => {
+    if (selectedArticle) {
+      loadComments(selectedArticle.id);
+      setCommentText('');
+    } else {
+      setComments([]);
+    }
+  }, [selectedArticle, loadComments]);
+
+  const handleSubmitComment = async () => {
+    if (!selectedArticle || !commentText.trim() || commentSubmitting) return;
+    setCommentSubmitting(true);
+    try {
+      const newComment = await blogService.postComment(selectedArticle.id, commentText.trim());
+      setComments(prev => [newComment, ...prev]);
+      setCommentText('');
+    } catch {
+      // handled silently
+    } finally {
+      setCommentSubmitting(false);
+    }
+  };
+
+  const handleDeleteComment = async (commentId: number) => {
+    try {
+      await blogService.deleteComment(commentId);
+      setComments(prev => prev.filter(c => c.id !== commentId));
+    } catch {
+      // handled silently
+    }
+  };
 
   const filtered = filter === 'all' ? articles : articles.filter(a => a.category === filter);
 
@@ -993,6 +1051,102 @@ export function BlogPage() {
                       {copied ? 'Скопійовано' : 'Копіювати'}
                     </button>
                   </div>
+                </div>
+
+                {/* ── Comments Section ── */}
+                <div className="mt-8 pt-6 border-t border-claude-border">
+                  <div className="flex items-center gap-2 mb-6">
+                    <MessageSquare size={18} className="text-claude-accent" />
+                    <h3 className="text-base font-sans font-medium text-claude-text">
+                      Коментарі {comments.length > 0 && <span className="text-claude-subtext font-normal">({comments.length})</span>}
+                    </h3>
+                  </div>
+
+                  {/* Comment input */}
+                  {isAuthenticated ? (
+                    <div className="flex gap-3 mb-6">
+                      <div className="flex-shrink-0 w-9 h-9 rounded-full bg-claude-accent/10 flex items-center justify-center overflow-hidden">
+                        {user?.picture ? (
+                          <img src={user.picture} alt="" className="w-full h-full object-cover" />
+                        ) : (
+                          <span className="text-sm font-medium text-claude-accent">{(user?.name || user?.email || '?')[0].toUpperCase()}</span>
+                        )}
+                      </div>
+                      <div className="flex-1 flex gap-2">
+                        <input
+                          type="text"
+                          value={commentText}
+                          onChange={(e) => setCommentText(e.target.value)}
+                          onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSubmitComment()}
+                          placeholder="Написати коментар..."
+                          maxLength={2000}
+                          className="flex-1 px-4 py-2.5 bg-white border border-claude-border rounded-xl text-sm text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all font-sans"
+                        />
+                        <button
+                          onClick={handleSubmitComment}
+                          disabled={!commentText.trim() || commentSubmitting}
+                          className="px-3 py-2.5 bg-claude-accent text-white rounded-xl hover:bg-[#C66345] transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                        >
+                          <Send size={16} />
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <a
+                      href="/login"
+                      className="flex items-center justify-center gap-2 mb-6 px-4 py-3 bg-claude-bg border border-claude-border rounded-xl text-sm text-claude-subtext hover:text-claude-text hover:border-claude-accent/30 transition-all font-sans"
+                    >
+                      <LogIn size={16} />
+                      Увійдіть, щоб залишити коментар
+                    </a>
+                  )}
+
+                  {/* Comments list */}
+                  {commentsLoading ? (
+                    <div className="text-center py-6 text-sm text-claude-subtext font-sans">Завантаження...</div>
+                  ) : comments.length === 0 ? (
+                    <div className="text-center py-6 text-sm text-claude-subtext font-sans">
+                      Поки немає коментарів. Будьте першим!
+                    </div>
+                  ) : (
+                    <div className="space-y-4">
+                      {comments.map((comment) => (
+                        <div key={comment.id} className="flex gap-3 group">
+                          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-claude-accent/10 flex items-center justify-center overflow-hidden">
+                            {comment.user_picture ? (
+                              <img src={comment.user_picture} alt="" className="w-full h-full object-cover" />
+                            ) : (
+                              <span className="text-xs font-medium text-claude-accent">
+                                {(comment.user_name || '?')[0].toUpperCase()}
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className="text-sm font-medium text-claude-text font-sans">
+                                {comment.user_name || 'Анонім'}
+                              </span>
+                              <span className="text-xs text-claude-subtext/60 font-sans">
+                                {new Date(comment.created_at).toLocaleDateString('uk-UA', {
+                                  day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit',
+                                })}
+                              </span>
+                              {isAuthenticated && user?.id === comment.user_id && (
+                                <button
+                                  onClick={() => handleDeleteComment(comment.id)}
+                                  className="opacity-0 group-hover:opacity-100 text-claude-subtext/40 hover:text-red-500 transition-all ml-auto"
+                                  title="Видалити"
+                                >
+                                  <Trash2 size={14} />
+                                </button>
+                              )}
+                            </div>
+                            <p className="text-sm text-claude-text font-sans mt-1 leading-relaxed">{comment.content}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
             </motion.div>

--- a/lexwebapp/src/services/blog-service.ts
+++ b/lexwebapp/src/services/blog-service.ts
@@ -1,0 +1,29 @@
+import apiClient from '../utils/api-client';
+
+export interface BlogComment {
+  id: number;
+  article_id: string;
+  user_id: string;
+  user_name: string | null;
+  user_picture: string | null;
+  content: string;
+  created_at: string;
+}
+
+class BlogService {
+  async getComments(articleId: string): Promise<BlogComment[]> {
+    const response = await apiClient.get<{ comments: BlogComment[] }>(`/api/blog/comments/${articleId}`);
+    return response.data.comments;
+  }
+
+  async postComment(articleId: string, content: string): Promise<BlogComment> {
+    const response = await apiClient.post<{ comment: BlogComment }>(`/api/blog/comments/${articleId}`, { content });
+    return response.data.comment;
+  }
+
+  async deleteComment(commentId: number): Promise<void> {
+    await apiClient.delete(`/api/blog/comments/${commentId}`);
+  }
+}
+
+export const blogService = new BlogService();

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -75,6 +75,7 @@ import { ConversationService } from './services/conversation-service.js';
 import { GdprService } from './services/gdpr-service.js';
 import { createConversationRouter } from './routes/conversation-routes.js';
 import { createGdprRouter } from './routes/gdpr-routes.js';
+import { createBlogCommentsRouter } from './routes/blog-comments.js';
 import { AuditService } from './services/audit-service.js';
 import { MatterService } from './services/matter-service.js';
 import { ConflictCheckService } from './services/conflict-check-service.js';
@@ -1650,6 +1651,10 @@ class HTTPMCPServer {
     // Conversation routes - server-side chat persistence
     this.app.use('/api/conversations', requireJWT as any, createConversationRouter(this.conversationService));
     logger.info('Conversation routes registered at /api/conversations');
+
+    // Blog comments - GET is public, POST/DELETE require JWT (checked inside handler)
+    this.app.use('/api/blog', optionalJWT as any, createBlogCommentsRouter(this.services.db.getPool()));
+    logger.info('Blog comments routes registered at /api/blog/comments');
 
     // GDPR routes - data export and deletion
     this.app.use('/api/gdpr', requireJWT as any, createGdprRouter(this.gdprService));

--- a/mcp_backend/src/migrations/058_blog_comments.sql
+++ b/mcp_backend/src/migrations/058_blog_comments.sql
@@ -1,0 +1,20 @@
+-- Migration 058: Blog comments
+-- Stores user comments on blog articles
+-- Date: 2026-02-26
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS blog_comments (
+  id          SERIAL PRIMARY KEY,
+  article_id  TEXT NOT NULL,
+  user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  user_name   TEXT,
+  user_picture TEXT,
+  content     TEXT NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_blog_comments_article ON blog_comments(article_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_blog_comments_user    ON blog_comments(user_id);
+
+COMMIT;

--- a/mcp_backend/src/routes/blog-comments.ts
+++ b/mcp_backend/src/routes/blog-comments.ts
@@ -1,0 +1,92 @@
+import { Router, Response } from 'express';
+import { Pool } from 'pg';
+
+interface AuthenticatedRequest {
+  user?: { id: string; name?: string; picture?: string };
+  body: any;
+  params: any;
+  query: any;
+}
+
+export function createBlogCommentsRouter(pool: Pool): Router {
+  const router = Router();
+
+  // GET /api/blog/comments/:articleId — public, no auth required
+  router.get('/comments/:articleId', (async (req: any, res: Response): Promise<any> => {
+    try {
+      const { articleId } = req.params;
+      const result = await pool.query(
+        `SELECT id, article_id, user_id, user_name, user_picture, content, created_at
+         FROM blog_comments
+         WHERE article_id = $1
+         ORDER BY created_at DESC`,
+        [articleId]
+      );
+      res.json({ comments: result.rows });
+    } catch (error: any) {
+      console.error('Failed to fetch comments:', error.message);
+      res.status(500).json({ error: 'Failed to fetch comments' });
+    }
+  }) as any);
+
+  // POST /api/blog/comments/:articleId — requires JWT
+  router.post('/comments/:articleId', (async (req: AuthenticatedRequest & any, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const { articleId } = req.params;
+      const { content } = req.body;
+
+      if (!content || typeof content !== 'string' || content.trim().length === 0) {
+        return res.status(400).json({ error: 'Comment content is required' });
+      }
+
+      if (content.length > 2000) {
+        return res.status(400).json({ error: 'Comment too long (max 2000 characters)' });
+      }
+
+      const result = await pool.query(
+        `INSERT INTO blog_comments (article_id, user_id, user_name, user_picture, content)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING id, article_id, user_id, user_name, user_picture, content, created_at`,
+        [articleId, userId, req.user?.name || null, req.user?.picture || null, content.trim()]
+      );
+
+      res.status(201).json({ comment: result.rows[0] });
+    } catch (error: any) {
+      console.error('Failed to create comment:', error.message);
+      res.status(500).json({ error: 'Failed to create comment' });
+    }
+  }) as any);
+
+  // DELETE /api/blog/comments/:commentId — owner or admin only
+  router.delete('/comments/:commentId', (async (req: AuthenticatedRequest & any, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+
+      const { commentId } = req.params;
+
+      const result = await pool.query(
+        `DELETE FROM blog_comments WHERE id = $1 AND user_id = $2 RETURNING id`,
+        [commentId, userId]
+      );
+
+      if (result.rowCount === 0) {
+        return res.status(404).json({ error: 'Comment not found or not owned by you' });
+      }
+
+      res.json({ deleted: true });
+    } catch (error: any) {
+      console.error('Failed to delete comment:', error.message);
+      res.status(500).json({ error: 'Failed to delete comment' });
+    }
+  }) as any);
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Migration 058: `blog_comments` table (article_id, user_id, user_name, user_picture, content, created_at)
- Backend routes at `/api/blog/comments/:articleId` — GET is public, POST/DELETE require JWT
- Frontend `blog-service.ts` with apiClient for auth headers
- Comment section in article modal: auth-gated input, avatar, timestamp, delete own comments

## Test plan
- [ ] Open http://localhost/blog → click article → scroll to comments
- [ ] Without login: see "Увійдіть, щоб залишити коментар" link
- [ ] Login → return to blog → post a comment → verify it appears
- [ ] Hover own comment → delete button appears → delete works
- [ ] `curl http://localhost/api/blog/comments/round-robin-llm` returns comments array
- [ ] Verify migration ran: `SELECT * FROM blog_comments;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds blog comments with a new DB table and API. Guests can read; signed-in users can post and delete their own comments.

- **New Features**
  - Backend: /api/blog/comments routes (GET public; POST/DELETE with JWT), content validation (≤2000 chars), owner-only delete.
  - Frontend: blog-service.ts and a comment section in the article modal with auth-gated input, avatar, and timestamps.

- **Migration**
  - Adds blog_comments table (id, article_id, user_id, user_name, user_picture, content, created_at) with indexes on article_id and user_id.
  - Run migration 058.

<sup>Written for commit cdf3509cb111bb7cf891207791308415b0aada8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

