### PR TITLE
fix: increase upload chunk rate limit to 500/min

### DIFF
--- a/mcp_backend/src/middleware/upload-rate-limit.ts
+++ b/mcp_backend/src/middleware/upload-rate-limit.ts
@@ -82,9 +82,9 @@ export const uploadBatchInitRateLimit = createUserRateLimiter({
   keyPrefix: 'ratelimit:upload-init-batch',
 });
 
-// 200 chunk uploads per minute per user
+// 500 chunk uploads per minute per user
 export const uploadChunkRateLimit = createUserRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 200,
+  maxRequests: 500,
   keyPrefix: 'ratelimit:upload-chunk',
 });


### PR DESCRIPTION
## Summary
- Increased `uploadChunkRateLimit` from 200 to 500 chunks per minute per user
- Users uploading many files were hitting 429 errors (100+ rate limit warnings from a single user in 20 seconds on prod)

## Test plan
- [x] TypeScript build passes
- [ ] Deploy to prod and verify no more excessive 429s during bulk uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased upload chunk rate limit from 200 to 500 per minute per user to prevent 429 errors during bulk uploads. This reduces unnecessary throttling for high-volume file uploads while maintaining per-user safeguards.

<sup>Written for commit 83d34f89eeea09deab28450aec4827a7ef588a37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

