### PR TITLE
fix: redirect to blog article after login from comment prompt

### DIFF
--- a/lexwebapp/src/components/LoginPage.tsx
+++ b/lexwebapp/src/components/LoginPage.tsx
@@ -64,6 +64,25 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
 
+  // Determine post-login redirect: returnUrl param → sessionStorage → /chat
+  const getReturnUrl = (): string => {
+    const saved = sessionStorage.getItem('login_return_url');
+    if (saved) {
+      sessionStorage.removeItem('login_return_url');
+      return saved;
+    }
+    return '/chat';
+  };
+
+  // Save returnUrl from query params to sessionStorage (survives OAuth redirect)
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const returnUrl = urlParams.get('returnUrl');
+    if (returnUrl) {
+      sessionStorage.setItem('login_return_url', returnUrl);
+    }
+  }, []);
+
   // Handle OAuth callback on mount
   useEffect(() => {
     const handleOAuthCallback = async () => {
@@ -105,8 +124,8 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             onLoginSuccess();
           }
 
-          // Navigate to chat after successful login
-          navigate('/chat', { replace: true });
+          // Navigate to return URL or chat after successful login
+          navigate(getReturnUrl(), { replace: true });
         } catch (err: any) {
           console.error('Login failed:', err);
           setError('Не вдалося завершити вхід. Спробуйте ще раз.');
@@ -126,7 +145,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       if (onLoginSuccess) {
         onLoginSuccess();
       }
-      navigate('/chat', { replace: true });
+      navigate(getReturnUrl(), { replace: true });
     }
   }, [isAuthenticated, isLoading, onLoginSuccess, navigate]);
 
@@ -176,7 +195,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           onLoginSuccess();
         }
 
-        navigate('/chat', { replace: true });
+        navigate(getReturnUrl(), { replace: true });
       } catch (err: any) {
         console.error('Password login failed:', err);
         setError(err.message || 'Login failed. Please check your credentials.');

--- a/lexwebapp/src/pages/BlogPage.tsx
+++ b/lexwebapp/src/pages/BlogPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
@@ -714,10 +714,25 @@ AI не вирішує, яку стратегію обрати. Він дає ю
 
 export function BlogPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { user, isAuthenticated } = useAuth();
   const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
   const [copied, setCopied] = useState(false);
   const [filter, setFilter] = useState<'all' | 'tech' | 'legal'>('all');
+
+  // Auto-open article from ?article= query param (used after login redirect)
+  useEffect(() => {
+    const articleId = searchParams.get('article');
+    if (articleId && !selectedArticle) {
+      const found = articles.find((a) => a.id === articleId);
+      if (found) {
+        setSelectedArticle(found);
+        // Clean the query param from URL
+        searchParams.delete('article');
+        setSearchParams(searchParams, { replace: true });
+      }
+    }
+  }, [searchParams]);
 
   // Comments state
   const [comments, setComments] = useState<BlogComment[]>([]);
@@ -1093,7 +1108,7 @@ export function BlogPage() {
                     </div>
                   ) : (
                     <a
-                      href="/login"
+                      href={`/login?returnUrl=${encodeURIComponent('/blog?article=' + selectedArticle.id)}`}
                       className="flex items-center justify-center gap-2 mb-6 px-4 py-3 bg-claude-bg border border-claude-border rounded-xl text-sm text-claude-subtext hover:text-claude-text hover:border-claude-accent/30 transition-all font-sans"
                     >
                       <LogIn size={16} />


### PR DESCRIPTION
## Summary
- When a user clicks "login to comment" on a blog article, after authentication they are now redirected back to the same article (with comment input ready), instead of always landing on `/chat`
- Login from the `/login` page directly still redirects to `/chat` as before
- Uses `sessionStorage` to preserve `returnUrl` across the Google OAuth redirect flow

## Changes
- **BlogPage.tsx**: Login link now includes `returnUrl=/blog?article={id}`; on mount, reads `?article=` param to auto-open the article
- **LoginPage.tsx**: Saves `returnUrl` query param to `sessionStorage` before OAuth; reads it back after successful login (Google OAuth, password, or already-authenticated redirect)

## Test plan
- [ ] Open a blog article as unauthenticated user
- [ ] Click "Увійдіть, щоб залишити коментар"
- [ ] Verify redirect URL contains `returnUrl=/blog?article=...`
- [ ] Complete Google login
- [ ] Verify you land back on the blog with the article open and comment input visible
- [ ] Login from `/login` directly (no returnUrl) → should still go to `/chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes login-to-comment on blog so users return to the same article with the comment box open instead of landing on /chat. Direct login from /login still goes to /chat when no returnUrl is provided.

- **Bug Fixes**
  - BlogPage: add returnUrl with article ID to the login link; auto-open the article from ?article= after redirect and then remove the param.
  - LoginPage: store returnUrl in sessionStorage to survive OAuth; redirect to it after successful login (OAuth, password, or already authenticated), falling back to /chat.

<sup>Written for commit 3fc2c9a5d67034fa23d7d668b46f0f584f6896d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

