### PR TITLE
feat: LLM document classification with progress UI and stats

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/ClassificationPanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/ClassificationPanel.tsx
@@ -1,0 +1,294 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  Sparkles,
+  Loader2,
+  CheckCircle,
+  AlertTriangle,
+  X,
+  Play,
+  Square,
+  Settings2,
+} from 'lucide-react';
+import { api } from '../../utils/api-client';
+import toast from 'react-hot-toast';
+import type { ClassificationJob, DocumentStats } from './types';
+
+interface ClassificationPanelProps {
+  stats: DocumentStats | null;
+  onComplete: () => void;
+}
+
+const CONCURRENCY_OPTIONS = [1, 2, 3, 5, 8, 10];
+
+export function ClassificationPanel({ stats, onComplete }: ClassificationPanelProps) {
+  const [job, setJob] = useState<ClassificationJob | null>(null);
+  const [concurrency, setConcurrency] = useState(3);
+  const [starting, setStarting] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const unclassifiedCount = stats ? stats.unclassified + stats.needsReview : 0;
+
+  // Poll job status
+  const pollJob = useCallback(async (jobId: string) => {
+    try {
+      const resp = await api.documents.getClassificationJob(jobId);
+      const jobData = resp.data as ClassificationJob;
+      setJob(jobData);
+
+      if (jobData.status !== 'running') {
+        if (pollRef.current) {
+          clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+        onComplete();
+        if (jobData.status === 'completed') {
+          toast.success(
+            `Класифікацію завершено: ${jobData.completed} з ${jobData.total} документів`
+          );
+        }
+      }
+    } catch {
+      // Job may have expired from memory
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      setJob(null);
+    }
+  }, [onComplete]);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, []);
+
+  const handleStart = async () => {
+    setStarting(true);
+    try {
+      const resp = await api.documents.startClassification({ concurrency });
+      const jobData = resp.data as ClassificationJob;
+      setJob(jobData);
+
+      if (jobData.total === 0) {
+        toast.success('Всі документи вже класифіковані');
+        setStarting(false);
+        return;
+      }
+
+      // Start polling
+      pollRef.current = setInterval(() => pollJob(jobData.jobId), 1500);
+    } catch (err: any) {
+      toast.error('Не вдалося запустити класифікацію');
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!job) return;
+    try {
+      await api.documents.cancelClassification(job.jobId);
+      toast.success('Класифікацію скасовано');
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      setJob((prev) => prev ? { ...prev, status: 'cancelled' } : null);
+      onComplete();
+    } catch {
+      toast.error('Не вдалося скасувати');
+    }
+  };
+
+  const handleDismiss = () => {
+    setJob(null);
+  };
+
+  if (unclassifiedCount === 0 && !job) return null;
+
+  const isRunning = job?.status === 'running';
+  const progress = job && job.total > 0
+    ? ((job.completed + job.failed) / job.total) * 100
+    : 0;
+
+  return (
+    <div className="mb-5">
+      <AnimatePresence mode="wait">
+        {/* Running or completed job */}
+        {job && (
+          <motion.div
+            key="job"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            className={`rounded-xl border p-4 ${
+              job.status === 'completed'
+                ? 'bg-green-50 border-green-200'
+                : job.status === 'cancelled'
+                ? 'bg-gray-50 border-gray-200'
+                : 'bg-blue-50 border-blue-200'
+            }`}
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                {isRunning ? (
+                  <Loader2 size={16} className="text-blue-500 animate-spin" />
+                ) : job.status === 'completed' ? (
+                  <CheckCircle size={16} className="text-green-500" />
+                ) : (
+                  <AlertTriangle size={16} className="text-gray-500" />
+                )}
+                <span className="text-sm font-semibold font-sans text-claude-text">
+                  {isRunning
+                    ? 'Класифікація документів...'
+                    : job.status === 'completed'
+                    ? 'Класифікацію завершено'
+                    : 'Класифікацію скасовано'}
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {job.totalCostUsd > 0 && (
+                  <span className="text-xs text-claude-subtext/60 font-sans">
+                    ${job.totalCostUsd.toFixed(4)}
+                  </span>
+                )}
+                {isRunning ? (
+                  <button
+                    onClick={handleCancel}
+                    className="p-1 text-red-400 hover:text-red-600 transition-colors"
+                    title="Скасувати"
+                  >
+                    <Square size={14} />
+                  </button>
+                ) : (
+                  <button
+                    onClick={handleDismiss}
+                    className="p-1 text-claude-subtext/40 hover:text-claude-text transition-colors"
+                  >
+                    <X size={14} />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Progress bar */}
+            <div className="w-full bg-white/60 rounded-full h-2 mb-2">
+              <motion.div
+                className={`h-2 rounded-full ${
+                  job.status === 'completed'
+                    ? 'bg-green-400'
+                    : job.status === 'cancelled'
+                    ? 'bg-gray-400'
+                    : 'bg-blue-400'
+                }`}
+                initial={{ width: 0 }}
+                animate={{ width: `${progress}%` }}
+                transition={{ duration: 0.3 }}
+              />
+            </div>
+
+            <div className="flex items-center justify-between text-xs text-claude-subtext/60 font-sans">
+              <span>
+                {job.completed + job.failed} / {job.total}
+                {job.failed > 0 && (
+                  <span className="text-amber-600 ml-1">
+                    ({job.failed} потребують уваги)
+                  </span>
+                )}
+              </span>
+              <span>{Math.round(progress)}%</span>
+            </div>
+          </motion.div>
+        )}
+
+        {/* Start classification prompt */}
+        {!job && unclassifiedCount > 0 && (
+          <motion.div
+            key="prompt"
+            initial={{ opacity: 0, y: -8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            className="rounded-xl border border-amber-200 bg-amber-50 p-4"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <Sparkles size={16} className="text-amber-500" />
+                <span className="text-sm font-sans text-claude-text">
+                  <strong>{unclassifiedCount}</strong> документів без класифікації
+                </span>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {/* Concurrency settings */}
+                <button
+                  onClick={() => setShowSettings(!showSettings)}
+                  className={`p-1.5 rounded-lg transition-colors ${
+                    showSettings
+                      ? 'bg-amber-200 text-amber-700'
+                      : 'text-amber-500 hover:bg-amber-100'
+                  }`}
+                  title="Налаштування"
+                >
+                  <Settings2 size={14} />
+                </button>
+
+                <button
+                  onClick={handleStart}
+                  disabled={starting}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-amber-500 text-white rounded-lg text-xs font-medium hover:bg-amber-600 transition-colors disabled:opacity-50 font-sans"
+                >
+                  {starting ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : (
+                    <Play size={12} />
+                  )}
+                  Класифікувати
+                </button>
+              </div>
+            </div>
+
+            {/* Settings dropdown */}
+            <AnimatePresence>
+              {showSettings && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  className="mt-3 pt-3 border-t border-amber-200"
+                >
+                  <div className="flex items-center gap-3">
+                    <label className="text-xs text-claude-subtext/70 font-sans whitespace-nowrap">
+                      Одночасно документів:
+                    </label>
+                    <div className="flex gap-1">
+                      {CONCURRENCY_OPTIONS.map((n) => (
+                        <button
+                          key={n}
+                          onClick={() => setConcurrency(n)}
+                          className={`px-2 py-1 rounded text-xs font-sans font-medium transition-colors ${
+                            concurrency === n
+                              ? 'bg-amber-500 text-white'
+                              : 'bg-white text-claude-subtext border border-amber-200 hover:bg-amber-100'
+                          }`}
+                        >
+                          {n}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <p className="text-xs text-claude-subtext/50 mt-2 font-sans">
+                    Використовується модель gpt-5-nano (~$0.0001 за документ). Аналізується перші 2000 символів тексту.
+                  </p>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/DocumentsPage/DocumentStatsPanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentStatsPanel.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import {
+  FileText,
+  CheckCircle,
+  AlertTriangle,
+  HelpCircle,
+  DollarSign,
+  HardDrive,
+} from 'lucide-react';
+import type { DocumentStats } from './types';
+
+const DOC_TYPE_LABELS: Record<string, string> = {
+  contract: 'Договори',
+  legislation: 'Законодавство',
+  court_decision: 'Судові рішення',
+  internal: 'Внутрішні',
+  other: 'Інше',
+};
+
+const DOC_TYPE_COLORS: Record<string, string> = {
+  contract: 'bg-blue-100 text-blue-700',
+  legislation: 'bg-purple-100 text-purple-700',
+  court_decision: 'bg-amber-100 text-amber-700',
+  internal: 'bg-green-100 text-green-700',
+  other: 'bg-gray-100 text-gray-600',
+};
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`;
+}
+
+interface DocumentStatsPanelProps {
+  stats: DocumentStats | null;
+  loading: boolean;
+}
+
+export function DocumentStatsPanel({ stats, loading }: DocumentStatsPanelProps) {
+  if (loading || !stats || stats.total === 0) return null;
+
+  const classifiedPercent = stats.total > 0
+    ? Math.round((stats.classified / stats.total) * 100)
+    : 0;
+
+  return (
+    <div className="mb-5 rounded-xl border border-claude-border bg-white p-4">
+      {/* Top row: key metrics */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-3">
+        <StatCard
+          icon={<FileText size={14} />}
+          label="Всього"
+          value={stats.total}
+          color="text-claude-text"
+        />
+        <StatCard
+          icon={<CheckCircle size={14} />}
+          label="Класифіковано"
+          value={stats.classified}
+          color="text-green-600"
+          subtext={`${classifiedPercent}%`}
+        />
+        <StatCard
+          icon={<AlertTriangle size={14} />}
+          label="Потр. уваги"
+          value={stats.needsReview}
+          color="text-amber-600"
+        />
+        <StatCard
+          icon={<HelpCircle size={14} />}
+          label="Не класифіковано"
+          value={stats.unclassified}
+          color="text-gray-500"
+        />
+        <StatCard
+          icon={<DollarSign size={14} />}
+          label="Витрати"
+          value={`$${stats.totalClassificationCostUsd.toFixed(4)}`}
+          color="text-blue-600"
+        />
+        <StatCard
+          icon={<HardDrive size={14} />}
+          label="Обсяг"
+          value={formatBytes(stats.totalStorageBytes)}
+          color="text-purple-600"
+        />
+      </div>
+
+      {/* Type distribution */}
+      {stats.total > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {Object.entries(stats.byType)
+            .filter(([, count]) => count > 0)
+            .sort(([, a], [, b]) => b - a)
+            .map(([type, count]) => (
+              <span
+                key={type}
+                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-sans font-medium ${
+                  DOC_TYPE_COLORS[type] || DOC_TYPE_COLORS.other
+                }`}
+              >
+                {DOC_TYPE_LABELS[type] || type}
+                <span className="opacity-70">{count}</span>
+              </span>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  color,
+  subtext,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string | number;
+  color: string;
+  subtext?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className={`${color} opacity-60`}>{icon}</div>
+      <div>
+        <div className={`text-sm font-semibold font-sans ${color}`}>
+          {value}
+          {subtext && (
+            <span className="text-xs font-normal text-claude-subtext/50 ml-1">{subtext}</span>
+          )}
+        </div>
+        <div className="text-[10px] text-claude-subtext/50 font-sans leading-tight">{label}</div>
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/DocumentsPage/DocumentTable.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentTable.tsx
@@ -11,6 +11,7 @@ import {
   Eye,
   Pencil,
   Trash2,
+  AlertTriangle,
 } from 'lucide-react';
 import type { VaultDocument, SortField, SortOrder } from './types';
 import { isEditable } from './types';
@@ -224,7 +225,7 @@ export function DocumentTable({ documents, sortBy, sortOrder, onSort, onDocument
                   onClick={() => onDocumentClick(doc)}
                 >
                   <td className="px-5 py-3">
-                    <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2">
                       <Icon
                         size={16}
                         className="text-claude-subtext/40 flex-shrink-0"
@@ -232,6 +233,11 @@ export function DocumentTable({ documents, sortBy, sortOrder, onSort, onDocument
                       <span className="text-sm font-medium text-claude-text truncate max-w-[300px] font-sans">
                         {doc.title}
                       </span>
+                      {doc.metadata?.classificationStatus === 'needs_review' && (
+                        <span className="flex-shrink-0" title="Потребує уваги — не вдалося класифікувати">
+                          <AlertTriangle size={12} className="text-amber-500" />
+                        </span>
+                      )}
                     </div>
                   </td>
                   <td className="px-5 py-3">

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -23,7 +23,9 @@ import { UploadQueuePanel } from './UploadQueuePanel';
 import { DocumentTable } from './DocumentTable';
 import { DocumentGrid } from './DocumentGrid';
 import { DocumentViewerModal } from '../../components/DocumentViewerModal';
-import type { VaultDocument, DocType, ViewMode, SortField, SortOrder } from './types';
+import { ClassificationPanel } from './ClassificationPanel';
+import { DocumentStatsPanel } from './DocumentStatsPanel';
+import type { VaultDocument, DocType, ViewMode, SortField, SortOrder, DocumentStats } from './types';
 
 const DOC_TYPE_LABELS: Record<DocType, string> = {
   contract: 'Договір',
@@ -128,6 +130,10 @@ export function DocumentsPage() {
   const [editText, setEditText] = useState('');
   const [editLoading, setEditLoading] = useState(false);
   const [editSaving, setEditSaving] = useState(false);
+
+  // Document statistics state
+  const [docStats, setDocStats] = useState<DocumentStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
 
   // Folder navigation state
   const [folders, setFolders] = useState<string[]>([]);
@@ -245,6 +251,29 @@ export function DocumentsPage() {
       setFoldersLoading(false);
     }
   };
+
+  const loadStats = async () => {
+    setStatsLoading(true);
+    try {
+      const resp = await api.documents.getStats();
+      setDocStats(resp.data);
+    } catch (err: any) {
+      console.error('Failed to load document stats:', err);
+    } finally {
+      setStatsLoading(false);
+    }
+  };
+
+  // Load stats on mount and when docs change
+  useEffect(() => {
+    loadStats();
+  }, []);
+
+  useEffect(() => {
+    if (completedFiles > 0 && !isUploading) {
+      loadStats();
+    }
+  }, [completedFiles, isUploading]);
 
   // File selection handlers
   const handleFilesSelected = useCallback(
@@ -596,6 +625,18 @@ export function DocumentsPage() {
             defaultDocType={defaultDocType}
             setDefaultDocType={setDefaultDocType}
             onStartUpload={handleStartUpload}
+          />
+
+          {/* Document Statistics */}
+          <DocumentStatsPanel stats={docStats} loading={statsLoading} />
+
+          {/* Classification Panel */}
+          <ClassificationPanel
+            stats={docStats}
+            onComplete={() => {
+              loadDocuments();
+              loadStats();
+            }}
           />
 
           {/* Search and Filters */}

--- a/lexwebapp/src/pages/DocumentsPage/types.ts
+++ b/lexwebapp/src/pages/DocumentsPage/types.ts
@@ -15,7 +15,34 @@ export interface VaultDocument {
     parties?: string[];
     documentSubtype?: string;
     jurisdiction?: string;
+    classificationStatus?: 'classified' | 'needs_review' | 'pending';
+    classificationConfidence?: number;
+    classifiedAt?: string;
   };
+}
+
+export interface DocumentStats {
+  total: number;
+  classified: number;
+  needsReview: number;
+  unclassified: number;
+  byType: Record<string, number>;
+  totalClassificationCostUsd: number;
+  totalUploadSessions: number;
+  totalStorageBytes: number;
+}
+
+export interface ClassificationJob {
+  jobId: string;
+  userId: string;
+  total: number;
+  completed: number;
+  failed: number;
+  inProgress: number;
+  status: 'running' | 'completed' | 'cancelled';
+  totalCostUsd: number;
+  startedAt: string;
+  completedAt?: string;
 }
 
 export type DocType = 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -221,6 +221,13 @@ export const api = {
     delete: (id: string) => apiClient.delete(`/api/documents/${id}`),
     update: (id: string, data: { full_text?: string; title?: string; type?: string }) =>
       apiClient.patch(`/api/documents/${id}`, data),
+    getStats: () => apiClient.get('/api/documents/stats'),
+    startClassification: (params: { concurrency?: number; documentIds?: string[] }) =>
+      apiClient.post('/api/documents/classify', params),
+    getClassificationJob: (jobId: string) =>
+      apiClient.get(`/api/documents/classify/${jobId}`),
+    cancelClassification: (jobId: string) =>
+      apiClient.post(`/api/documents/classify/${jobId}/cancel`),
   },
 
   // Admin

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -102,6 +102,8 @@ import { WebAuthnService } from './services/webauthn-service.js';
 import { setRateLimitCache } from './middleware/rate-limit.js';
 import { setUploadRateLimitCache } from './middleware/upload-rate-limit.js';
 import { ConfigService } from './services/config-service.js';
+import { DocumentClassificationService } from './services/document-classification-service.js';
+import { createClassificationRoutes } from './routes/classification-routes.js';
 
 dotenv.config();
 
@@ -146,6 +148,7 @@ class HTTPMCPServer {
   private chatService: ChatService;
   private chatSearchCache: ChatSearchCacheService;
   private configService: ConfigService;
+  private classificationService: DocumentClassificationService;
 
   constructor() {
     this.app = express();
@@ -308,6 +311,13 @@ class HTTPMCPServer {
 
     // Initialize config service
     this.configService = new ConfigService(this.services.db);
+
+    // Initialize document classification service
+    this.classificationService = new DocumentClassificationService(
+      this.services.db,
+      llmAdapter,
+      this.costTracker
+    );
 
     // Initialize BullMQ upload queue service
     this.uploadQueueService = new UploadQueueService(
@@ -1145,6 +1155,19 @@ class HTTPMCPServer {
     // OAuth 2.0 routes for ChatGPT integration (public)
     this.app.use('/oauth', createOAuthRouter(this.oauthService));
     logger.info('OAuth 2.0 routes registered at /oauth');
+
+    // Document classification & stats endpoints - must come before /api/documents generic REST route
+    this.app.use('/api/documents/classify', requireJWT as any, createClassificationRoutes(this.classificationService));
+    this.app.get('/api/documents/stats', requireJWT as any, (async (req: DualAuthRequest, res: Response) => {
+      try {
+        const userId = req.user!.id;
+        const stats = await this.classificationService.getUserDocumentStats(userId);
+        res.json(stats);
+      } catch (error: any) {
+        logger.error('Failed to get document stats', { error: error.message });
+        res.status(500).json({ error: 'Failed to get stats', message: error.message });
+      }
+    }) as any);
 
     // Document folders endpoint - must come before /api/documents generic REST route
     this.app.get('/api/documents/folders', requireJWT as any, (async (req: DualAuthRequest, res: Response) => {

--- a/mcp_backend/src/routes/classification-routes.ts
+++ b/mcp_backend/src/routes/classification-routes.ts
@@ -1,0 +1,94 @@
+import { Router, Request, Response } from 'express';
+import { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+import { DocumentClassificationService } from '../services/document-classification-service.js';
+import { logger } from '../utils/logger.js';
+
+export function createClassificationRoutes(
+  classificationService: DocumentClassificationService
+): Router {
+  const router = Router();
+
+  // POST /api/documents/classify — Start batch classification
+  router.post('/', (async (req: DualAuthRequest, res: Response): Promise<void> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const { concurrency = 3, documentIds } = req.body;
+      const clampedConcurrency = Math.min(Math.max(1, concurrency), 10);
+
+      const job = await classificationService.startClassification(
+        userId,
+        clampedConcurrency,
+        documentIds
+      );
+
+      res.status(202).json(job);
+    } catch (error: any) {
+      logger.error('Failed to start classification', { error: error.message });
+      res.status(500).json({ error: 'Failed to start classification', message: error.message });
+    }
+  }) as any);
+
+  // GET /api/documents/classify/:jobId — Get job status
+  router.get('/:jobId', (async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const jobId = req.params.jobId as string;
+      const job = classificationService.getJobStatus(jobId);
+      if (!job) {
+        res.status(404).json({ error: 'Job not found' });
+        return;
+      }
+
+      if (job.userId !== userId) {
+        res.status(403).json({ error: 'Access denied' });
+        return;
+      }
+
+      res.json(job);
+    } catch (error: any) {
+      logger.error('Failed to get classification status', { error: error.message });
+      res.status(500).json({ error: 'Failed to get status', message: error.message });
+    }
+  }) as any);
+
+  // POST /api/documents/classify/:jobId/cancel — Cancel job
+  router.post('/:jobId/cancel', (async (req: Request, res: Response): Promise<void> => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const jobId = req.params.jobId as string;
+      const job = classificationService.getJobStatus(jobId);
+      if (!job) {
+        res.status(404).json({ error: 'Job not found' });
+        return;
+      }
+
+      if (job.userId !== userId) {
+        res.status(403).json({ error: 'Access denied' });
+        return;
+      }
+
+      const cancelled = classificationService.cancelJob(jobId);
+      res.json({ cancelled });
+    } catch (error: any) {
+      logger.error('Failed to cancel classification', { error: error.message });
+      res.status(500).json({ error: 'Failed to cancel', message: error.message });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/document-classification-service.ts
+++ b/mcp_backend/src/services/document-classification-service.ts
@@ -1,0 +1,482 @@
+import { logger } from '../utils/logger.js';
+import type { ILLMPort, IDatabase } from '../domain/ports/index.js';
+import { CostTracker } from './cost-tracker.js';
+import { v4 as uuidv4 } from 'uuid';
+
+export interface ClassificationResult {
+  documentId: string;
+  type: string;
+  tags: string[];
+  documentSubtype: string | null;
+  confidence: number;
+  status: 'classified' | 'needs_review' | 'failed';
+  error?: string;
+}
+
+export interface ClassificationJobStatus {
+  jobId: string;
+  userId: string;
+  total: number;
+  completed: number;
+  failed: number;
+  inProgress: number;
+  status: 'running' | 'completed' | 'cancelled';
+  results: ClassificationResult[];
+  totalCostUsd: number;
+  startedAt: string;
+  completedAt?: string;
+}
+
+const VALID_TYPES = ['contract', 'legislation', 'court_decision', 'internal', 'other'] as const;
+
+const CLASSIFICATION_PROMPT = `Ти — юридичний класифікатор документів. Проаналізуй наданий фрагмент тексту документа і визначи його тип та теги.
+
+Доступні типи документів:
+- "contract" — договори, угоди, контракти, додаткові угоди
+- "legislation" — закони, кодекси, постанови КМУ, укази, накази міністерств
+- "court_decision" — судові рішення, ухвали, постанови судів, вироки
+- "internal" — внутрішні документи: службові записки, протоколи, акти, довідки
+- "other" — якщо документ не підходить під жоден тип
+
+Поверни JSON:
+{
+  "type": "один з: contract, legislation, court_decision, internal, other",
+  "tags": ["до 5 тегів українською що описують зміст документа"],
+  "documentSubtype": "конкретний підтип (наприклад: договір оренди, позовна заява, ухвала, наказ тощо) або null",
+  "confidence": 0.0-1.0
+}
+
+Якщо текст занадто короткий, нечитабельний або не вдається визначити тип — встанови type="other" і confidence < 0.3.
+Відповідай ТІЛЬКИ валідним JSON без markdown.`;
+
+// Max chars to send to LLM for classification
+const TEXT_SNIPPET_LENGTH = 2000;
+
+// In-memory job tracking
+const activeJobs = new Map<string, ClassificationJobStatus>();
+
+export class DocumentClassificationService {
+  constructor(
+    private readonly db: IDatabase,
+    private readonly llm: ILLMPort,
+    private readonly costTracker: CostTracker
+  ) {}
+
+  /**
+   * Start batch classification of user's unclassified documents.
+   */
+  async startClassification(
+    userId: string,
+    concurrency: number = 3,
+    documentIds?: string[]
+  ): Promise<ClassificationJobStatus> {
+    const jobId = uuidv4();
+
+    // Get documents to classify
+    let query: string;
+    let params: any[];
+
+    if (documentIds && documentIds.length > 0) {
+      query = `SELECT id, title, full_text, type, metadata
+               FROM documents
+               WHERE user_id = $1 AND id = ANY($2)
+               ORDER BY created_at DESC`;
+      params = [userId, documentIds];
+    } else {
+      // Get docs that have no tags or type is 'other' (unclassified)
+      query = `SELECT id, title, full_text, type, metadata
+               FROM documents
+               WHERE user_id = $1
+                 AND (
+                   type = 'other'
+                   OR metadata->>'classificationStatus' IS NULL
+                   OR metadata->>'classificationStatus' = 'pending'
+                 )
+               ORDER BY created_at DESC`;
+      params = [userId];
+    }
+
+    const result = await this.db.query(query, params);
+    const docs = result.rows;
+
+    if (docs.length === 0) {
+      const status: ClassificationJobStatus = {
+        jobId,
+        userId,
+        total: 0,
+        completed: 0,
+        failed: 0,
+        inProgress: 0,
+        status: 'completed',
+        results: [],
+        totalCostUsd: 0,
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+      };
+      return status;
+    }
+
+    const jobStatus: ClassificationJobStatus = {
+      jobId,
+      userId,
+      total: docs.length,
+      completed: 0,
+      failed: 0,
+      inProgress: 0,
+      status: 'running',
+      results: [],
+      totalCostUsd: 0,
+      startedAt: new Date().toISOString(),
+    };
+
+    activeJobs.set(jobId, jobStatus);
+
+    // Run classification in background with concurrency control
+    this.processDocuments(jobId, userId, docs, concurrency).catch((err) => {
+      logger.error('[Classification] Batch processing error', { jobId, error: err.message });
+      const job = activeJobs.get(jobId);
+      if (job) {
+        job.status = 'completed';
+        job.completedAt = new Date().toISOString();
+      }
+    });
+
+    return jobStatus;
+  }
+
+  private async processDocuments(
+    jobId: string,
+    userId: string,
+    docs: any[],
+    concurrency: number
+  ): Promise<void> {
+    const semaphore = { active: 0 };
+    const queue = [...docs];
+
+    const processNext = async (): Promise<void> => {
+      const job = activeJobs.get(jobId);
+      if (!job || job.status === 'cancelled') return;
+
+      const doc = queue.shift();
+      if (!doc) return;
+
+      semaphore.active++;
+      job.inProgress = semaphore.active;
+
+      try {
+        const result = await this.classifySingleDocument(jobId, userId, doc);
+        job.results.push(result);
+
+        if (result.status === 'failed') {
+          job.failed++;
+        } else {
+          job.completed++;
+        }
+      } catch (err: any) {
+        job.failed++;
+        job.results.push({
+          documentId: doc.id,
+          type: 'other',
+          tags: [],
+          documentSubtype: null,
+          confidence: 0,
+          status: 'failed',
+          error: err.message,
+        });
+      } finally {
+        semaphore.active--;
+        job.inProgress = semaphore.active;
+      }
+    };
+
+    // Process with concurrency limit
+    const workers: Promise<void>[] = [];
+    for (let i = 0; i < Math.min(concurrency, docs.length); i++) {
+      workers.push(
+        (async () => {
+          while (queue.length > 0) {
+            const job = activeJobs.get(jobId);
+            if (!job || job.status === 'cancelled') break;
+            await processNext();
+          }
+        })()
+      );
+    }
+
+    await Promise.all(workers);
+
+    const job = activeJobs.get(jobId);
+    if (job && job.status !== 'cancelled') {
+      job.status = 'completed';
+      job.completedAt = new Date().toISOString();
+      job.inProgress = 0;
+    }
+  }
+
+  private async classifySingleDocument(
+    jobId: string,
+    userId: string,
+    doc: any
+  ): Promise<ClassificationResult> {
+    const requestId = uuidv4();
+    const startTime = Date.now();
+    const text = doc.full_text || '';
+    const snippet = text.slice(0, TEXT_SNIPPET_LENGTH);
+
+    if (!snippet || snippet.trim().length < 20) {
+      // Mark as needs_review — text too short for classification
+      await this.updateDocumentClassification(doc.id, userId, {
+        type: 'other',
+        tags: [],
+        documentSubtype: null,
+        confidence: 0,
+        classificationStatus: 'needs_review',
+      });
+
+      return {
+        documentId: doc.id,
+        type: 'other',
+        tags: [],
+        documentSubtype: null,
+        confidence: 0,
+        status: 'needs_review',
+        error: 'Text too short for classification',
+      };
+    }
+
+    // Track cost
+    await this.costTracker.createTrackingRecord({
+      requestId,
+      toolName: 'document_classify',
+      userId,
+      userQuery: `Classify: ${doc.title?.slice(0, 100) || 'untitled'}`,
+      queryParams: { documentId: doc.id, snippetLength: snippet.length },
+    });
+
+    try {
+      const response = await this.llm.chatCompletion(
+        {
+          messages: [
+            { role: 'system', content: CLASSIFICATION_PROMPT },
+            {
+              role: 'user',
+              content: `Назва: ${doc.title || 'Без назви'}\nПоточний тип: ${doc.type}\n\nТекст:\n${snippet}`,
+            },
+          ],
+          temperature: 0.1,
+          max_tokens: 300,
+          response_format: { type: 'json_object' },
+        },
+        'quick'
+      );
+
+      const raw = response.content?.trim();
+      if (!raw) {
+        throw new Error('LLM returned empty content');
+      }
+
+      const parsed = JSON.parse(raw);
+
+      const classifiedType = VALID_TYPES.includes(parsed.type) ? parsed.type : 'other';
+      const tags = Array.isArray(parsed.tags) ? parsed.tags.slice(0, 5) : [];
+      const documentSubtype = parsed.documentSubtype || null;
+      const confidence = typeof parsed.confidence === 'number'
+        ? Math.min(1, Math.max(0, parsed.confidence))
+        : 0.5;
+
+      const status: 'classified' | 'needs_review' = confidence >= 0.3 ? 'classified' : 'needs_review';
+
+      // Update document in DB
+      await this.updateDocumentClassification(doc.id, userId, {
+        type: classifiedType,
+        tags,
+        documentSubtype,
+        confidence,
+        classificationStatus: status,
+      });
+
+      // Record cost (estimate for quick tier)
+      const tokenEstimate = Math.ceil(snippet.length / 4) + 150;
+      const outputTokens = 100;
+      const costUsd = (tokenEstimate * 0.10 + outputTokens * 0.40) / 1_000_000;
+      await this.costTracker.recordOpenAICall({
+        requestId,
+        model: 'gpt-5-nano',
+        promptTokens: tokenEstimate,
+        completionTokens: outputTokens,
+        totalTokens: tokenEstimate + outputTokens,
+        costUsd,
+        task: 'document_classify',
+      });
+
+      await this.costTracker.completeTrackingRecord({
+        requestId,
+        executionTimeMs: Date.now() - startTime,
+        status: 'completed',
+      }).catch(() => { /* best-effort */ });
+
+      // Accumulate cost in job
+      const job = activeJobs.get(jobId);
+      if (job) {
+        // Quick tier cost: $0.10/1M input, $0.40/1M output
+        const costUsd = (tokenEstimate * 0.10 + outputTokens * 0.40) / 1_000_000;
+        job.totalCostUsd += costUsd;
+      }
+
+      return {
+        documentId: doc.id,
+        type: classifiedType,
+        tags,
+        documentSubtype,
+        confidence,
+        status,
+      };
+    } catch (err: any) {
+      await this.costTracker.completeTrackingRecord({
+        requestId,
+        executionTimeMs: 0,
+        status: 'failed',
+        errorMessage: err.message,
+      }).catch(() => { /* best-effort */ });
+
+      // Mark as needs_review
+      await this.updateDocumentClassification(doc.id, userId, {
+        type: doc.type || 'other',
+        tags: [],
+        documentSubtype: null,
+        confidence: 0,
+        classificationStatus: 'needs_review',
+      });
+
+      return {
+        documentId: doc.id,
+        type: doc.type || 'other',
+        tags: [],
+        documentSubtype: null,
+        confidence: 0,
+        status: 'failed',
+        error: err.message,
+      };
+    }
+  }
+
+  private async updateDocumentClassification(
+    docId: string,
+    userId: string,
+    data: {
+      type: string;
+      tags: string[];
+      documentSubtype: string | null;
+      confidence: number;
+      classificationStatus: string;
+    }
+  ): Promise<void> {
+    await this.db.query(
+      `UPDATE documents
+       SET type = $1,
+           metadata = COALESCE(metadata, '{}'::jsonb)
+             || jsonb_build_object(
+               'tags', $2::jsonb,
+               'documentSubtype', $3::text,
+               'classificationConfidence', $4::numeric,
+               'classificationStatus', $5::text,
+               'classifiedAt', $6::text
+             ),
+           updated_at = NOW()
+       WHERE id = $7 AND user_id = $8`,
+      [
+        data.type,
+        JSON.stringify(data.tags),
+        data.documentSubtype,
+        data.confidence,
+        data.classificationStatus,
+        new Date().toISOString(),
+        docId,
+        userId,
+      ]
+    );
+  }
+
+  /**
+   * Get status of a classification job.
+   */
+  getJobStatus(jobId: string): ClassificationJobStatus | null {
+    return activeJobs.get(jobId) || null;
+  }
+
+  /**
+   * Cancel a running classification job.
+   */
+  cancelJob(jobId: string): boolean {
+    const job = activeJobs.get(jobId);
+    if (!job || job.status !== 'running') return false;
+    job.status = 'cancelled';
+    job.completedAt = new Date().toISOString();
+    return true;
+  }
+
+  /**
+   * Get document statistics for a user.
+   */
+  async getUserDocumentStats(userId: string): Promise<{
+    total: number;
+    classified: number;
+    needsReview: number;
+    unclassified: number;
+    byType: Record<string, number>;
+    totalClassificationCostUsd: number;
+    totalUploadSessions: number;
+    totalStorageBytes: number;
+  }> {
+    const [statsResult, costResult, uploadResult] = await Promise.all([
+      this.db.query(
+        `SELECT
+           COUNT(*) as total,
+           COUNT(*) FILTER (WHERE metadata->>'classificationStatus' = 'classified') as classified,
+           COUNT(*) FILTER (WHERE metadata->>'classificationStatus' = 'needs_review') as needs_review,
+           COUNT(*) FILTER (WHERE metadata->>'classificationStatus' IS NULL OR metadata->>'classificationStatus' = 'pending') as unclassified,
+           COUNT(*) FILTER (WHERE type = 'contract') as type_contract,
+           COUNT(*) FILTER (WHERE type = 'legislation') as type_legislation,
+           COUNT(*) FILTER (WHERE type = 'court_decision') as type_court_decision,
+           COUNT(*) FILTER (WHERE type = 'internal') as type_internal,
+           COUNT(*) FILTER (WHERE type = 'other') as type_other
+         FROM documents
+         WHERE user_id = $1`,
+        [userId]
+      ),
+      this.db.query(
+        `SELECT COALESCE(SUM(total_cost_usd), 0) as total_cost
+         FROM cost_tracking
+         WHERE user_id = $1 AND tool_name IN ('document_classify', 'store_document')`,
+        [userId]
+      ),
+      this.db.query(
+        `SELECT COUNT(*) as total_sessions, COALESCE(SUM(file_size), 0) as total_bytes
+         FROM upload_sessions
+         WHERE user_id = $1 AND status = 'completed'`,
+        [userId]
+      ),
+    ]);
+
+    const s = statsResult.rows[0];
+    const c = costResult.rows[0];
+    const u = uploadResult.rows[0];
+
+    return {
+      total: parseInt(s.total) || 0,
+      classified: parseInt(s.classified) || 0,
+      needsReview: parseInt(s.needs_review) || 0,
+      unclassified: parseInt(s.unclassified) || 0,
+      byType: {
+        contract: parseInt(s.type_contract) || 0,
+        legislation: parseInt(s.type_legislation) || 0,
+        court_decision: parseInt(s.type_court_decision) || 0,
+        internal: parseInt(s.type_internal) || 0,
+        other: parseInt(s.type_other) || 0,
+      },
+      totalClassificationCostUsd: parseFloat(c.total_cost) || 0,
+      totalUploadSessions: parseInt(u.total_sessions) || 0,
+      totalStorageBytes: parseInt(u.total_bytes) || 0,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Batch document classification using cheap LLM model (gpt-5-nano, ~$0.0001 per doc)
- Sends only **top 2000 chars** of document text — enough to determine type without sending full content
- User-configurable concurrency (1–10 parallel requests to LLM)
- Full cost tracking per classification call (`document_classify` tool in `cost_tracking` table)
- Documents with confidence < 0.3 or empty text marked as `needs_review`

## Backend
- **`DocumentClassificationService`** — semaphore-based batch processor with in-memory job tracking
- **Routes**: `POST /api/documents/classify`, `GET /classify/:jobId`, `POST /classify/:jobId/cancel`
- **`GET /api/documents/stats`** — aggregated user stats (total, classified, needs_review, by type, costs, storage)
- Updates `documents.metadata` with `classificationStatus`, `tags`, `classificationConfidence`, `classifiedAt`

## Frontend (`/documents` page)
- **ClassificationPanel**: amber banner showing unclassified count, concurrency selector, start/cancel buttons, animated progress bar with live cost display
- **DocumentStatsPanel**: 6-metric dashboard (total, classified, needs review, unclassified, costs, storage) + type distribution badges
- **DocumentTable**: warning triangle icon on documents with `needs_review` status
- **API client**: 4 new methods (`getStats`, `startClassification`, `getClassificationJob`, `cancelClassification`)

## Test plan
- [ ] Upload several documents with type `other`
- [ ] Verify ClassificationPanel shows "N документів без класифікації"
- [ ] Click settings gear → select concurrency
- [ ] Click "Класифікувати" → verify progress bar animates
- [ ] Verify documents get updated type and tags after completion
- [ ] Verify StatsPanel shows correct counts and cost
- [ ] Verify `needs_review` icon appears on unrecognizable documents
- [ ] Test cancel mid-classification
- [ ] Check `cost_tracking` table has `document_classify` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds batch document classification powered by gpt-5-nano with a live progress UI and per-user stats. Documents are tagged and typed automatically, while costs are tracked and visible.

- New Features
  - Batch classify documents using gpt-5-nano; sends first 2000 chars; concurrency configurable (1–10); confidence < 0.3 or empty text → needs_review.
  - Cost tracking per classification call (tool: document_classify); in-memory job tracking with cancel support.
  - Endpoints: POST /api/documents/classify, GET /api/documents/classify/:jobId, POST /api/documents/classify/:jobId/cancel, GET /api/documents/stats.
  - Documents updated with metadata: classificationStatus, tags, classificationConfidence, classifiedAt.
  - UI: ClassificationPanel (banner, concurrency selector, start/cancel, progress, live cost); DocumentStatsPanel (totals, needs review, unclassified, cost, storage, type badges); warning icon on needs_review rows.
  - API client: getStats, startClassification, getClassificationJob, cancelClassification.

<sup>Written for commit a350d39591ccf5b46d29251b287c6e8d867184a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

