### PR TITLE
fix: change Redis eviction policy to volatile-lru

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -104,7 +104,7 @@ services:
       - "6379:6379"  # Standard Redis port
     volumes:
       - redis_local_data:/data
-    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy volatile-lru
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -171,7 +171,7 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy volatile-lru
     healthcheck:
       test:
       - CMD

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -173,7 +173,7 @@ services:
     - "127.0.0.1:6381:6379"
     volumes:
     - redis_stage_data:/data
-    command: redis-server --appendonly yes --maxmemory 8192mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 8192mb --maxmemory-policy volatile-lru
     healthcheck:
       test:
       - CMD


### PR DESCRIPTION
## Summary
- Change Redis `maxmemory-policy` from `noeviction` to `volatile-lru` across all environments (local, stage, prod)
- `noeviction` causes write errors when Redis is full, blocking BullMQ job queues and upload sessions
- `volatile-lru` evicts only keys with TTL set, keeping persistent data safe

## Test plan
- [ ] Verify Redis starts with new policy: `docker exec redis redis-cli CONFIG GET maxmemory-policy`
- [ ] Confirm BullMQ jobs process normally under memory pressure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched Redis eviction policy from noeviction to volatile-lru in local, stage, and prod to prevent write errors at max memory and avoid BullMQ/upload stalls, while evicting only TTL-based keys.

- **Migration**
  - Restart Redis containers in each environment.
  - Verify the policy via: docker exec redis redis-cli CONFIG GET maxmemory-policy

<sup>Written for commit e3d5ae8acb03c6a2ae60ddc7541382f2e51510d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

