### PR TITLE
fix: require procedure_code in court practice search tools

### DIFF
--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -40,9 +40,9 @@ import {
  */
 function extractCourtFromTitle(title?: string): string {
   if (!title) return '';
-  // Match court name patterns: cassation, appellate, district, and other courts
-  const match = title.match(/(?:Касаційний \S+ суд|Велика палата Верховного Суду|Верховний Суд|[А-ЯІЇЄҐа-яіїєґ'\- ]+(?:апеляційний|окружний|районний|міський|господарський) суд[а-яіїєґ]*)/i);
-  return match ? match[0].trim() : '';
+  // Court name is typically the last part of the title after the case number
+  const match = title.match(/(?:Касаційний \S+ суд|Велика палата Верховного Суду|Верховний Суд)/i);
+  return match ? match[0] : '';
 }
 
 export class ProceduralTools extends BaseToolHandler {
@@ -94,11 +94,11 @@ export class ProceduralTools extends BaseToolHandler {
       },
       {
         name: 'search_supreme_court_practice',
-        description: `Пошук судових рішень (всі суди або фільтр за рівнем: ВС, апеляція, перша інстанція)`,
+        description: `Поиск практики Верховного Суду (в т.ч. ВП/КЦС/КГС/КАС/ККС) с краткими выдержками`,
         inputSchema: {
           type: 'object',
           properties: {
-            procedure_code: { type: 'string', enum: ['cpc', 'gpc', 'cac', 'crpc'], description: 'Procedure code filter. Omit for all types.' },
+            procedure_code: { type: 'string', enum: ['cpc', 'gpc', 'cac', 'crpc'] },
             query: { type: 'string' },
             time_range: {
               oneOf: [
@@ -106,11 +106,11 @@ export class ProceduralTools extends BaseToolHandler {
                 { type: 'object', properties: { from: { type: 'string' }, to: { type: 'string' } } },
               ],
             },
-            court_level: { type: 'string', enum: ['SC', 'GrandChamber', 'AC', 'FC'], description: 'Court level filter. SC=Supreme Court, AC=Appellate, FC=First instance. Omit for all courts.' },
+            court_level: { type: 'string', enum: ['SC', 'GrandChamber'], default: 'SC' },
             section_focus: { type: 'array', items: { type: 'string', enum: Object.values(SectionType) } },
             limit: { type: 'number', default: 10 },
           },
-          required: ['query'],
+          required: ['procedure_code', 'query'],
         },
       },
       {
@@ -129,16 +129,16 @@ export class ProceduralTools extends BaseToolHandler {
             },
             limit: { type: 'number', default: 7 },
           },
-          required: ['query'],
+          required: ['procedure_code', 'query'],
         },
       },
       {
         name: 'find_similar_fact_pattern_cases',
-        description: `Поиск дел по "похожим фактам" (приближенно: извлечение ключевых терминов + поиск). procedure_code optional — omit to search all procedure types.`,
+        description: `Поиск дел по "похожим фактам" (приближенно: извлечение ключевых терминов + поиск)`,
         inputSchema: {
           type: 'object',
           properties: {
-            procedure_code: { type: 'string', enum: ['cpc', 'gpc', 'cac', 'crpc'], description: 'Optional. Omit to search all procedure types.' },
+            procedure_code: { type: 'string', enum: ['cpc', 'gpc', 'cac', 'crpc'] },
             facts_text: { type: 'string' },
             time_range: {
               oneOf: [
@@ -148,7 +148,7 @@ export class ProceduralTools extends BaseToolHandler {
             },
             limit: { type: 'number', default: 10 },
           },
-          required: ['facts_text'],
+          required: ['procedure_code', 'facts_text'],
         },
       },
       {
@@ -305,12 +305,19 @@ export class ProceduralTools extends BaseToolHandler {
   }
 
   private async searchSupremeCourtPractice(args: any): Promise<ToolResult> {
-    const procedureCode = mapProcedureCodeToShort(args.procedure_code || args.code) || null;
+    const procedureCode = mapProcedureCodeToShort(args.procedure_code || args.code);
     const query = typeof args.query === 'string' ? args.query.trim() : '';
     const limit = Math.min(50, Math.max(1, Number(args.limit || 10)));
     const sectionFocus = Array.isArray(args.section_focus) ? args.section_focus : undefined;
-    const courtLevel = args.court_level ? String(args.court_level) : '';
+    const courtLevel = String(args.court_level || 'SC');
 
+    if (!procedureCode) {
+      const providedValue = args.procedure_code || args.code;
+      throw new Error(
+        `procedure_code must be one of: cpc, gpc, cac, crpc. ` +
+        `Received: ${providedValue ? `'${providedValue}'` : 'undefined'}.`
+      );
+    }
     if (!query) throw new Error('query parameter is required');
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
@@ -319,7 +326,7 @@ export class ProceduralTools extends BaseToolHandler {
     const whereFilters: any[] = [
       ...buildSupremeCourtWhereFilter(courtLevel),
     ];
-    const justiceKind = procedureCode ? mapProcedureCodeToJusticeKind(procedureCode) : null;
+    const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
     if (justiceKind !== null) {
       whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
     }
@@ -385,6 +392,7 @@ export class ProceduralTools extends BaseToolHandler {
     const procedureCode = mapProcedureCodeToShort(args.procedure_code || args.code);
     const query = typeof args.query === 'string' ? args.query.trim() : '';
     const limit = Math.min(20, Math.max(1, Number(args.limit || 7)));
+    if (!procedureCode) throw new Error('procedure_code must be one of: cpc, gpc, cac, crpc');
     if (!query) throw new Error('query parameter is required');
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
@@ -393,7 +401,7 @@ export class ProceduralTools extends BaseToolHandler {
     const whereFilters: any[] = [
       ...buildSupremeCourtWhereFilter('SC'),
     ];
-    const justiceKind = procedureCode ? mapProcedureCodeToJusticeKind(procedureCode) : null;
+    const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
     if (justiceKind !== null) {
       whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
     }
@@ -448,6 +456,13 @@ export class ProceduralTools extends BaseToolHandler {
     const procedureCode = mapProcedureCodeToShort(args.procedure_code || args.code);
     const factsText = typeof args.facts_text === 'string' ? args.facts_text.trim() : '';
     const limit = Math.min(20, Math.max(1, Number(args.limit || 10)));
+    if (!procedureCode) {
+      const providedValue = args.procedure_code || args.code;
+      throw new Error(
+        `procedure_code must be one of: cpc, gpc, cac, crpc. ` +
+        `Received: ${providedValue ? `'${providedValue}'` : 'undefined'}.`
+      );
+    }
     if (!factsText) throw new Error('facts_text parameter is required');
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
@@ -461,7 +476,7 @@ export class ProceduralTools extends BaseToolHandler {
     const whereFilters: any[] = [
       ...buildSupremeCourtWhereFilter('SC'),
     ];
-    const justiceKind = procedureCode ? mapProcedureCodeToJusticeKind(procedureCode) : null;
+    const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
     if (justiceKind !== null) {
       whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
     }
@@ -522,9 +537,7 @@ export class ProceduralTools extends BaseToolHandler {
     const practiceUseCourtPractice = args.practice_use_court_practice !== false;
     const practiceCaseMapMax = Math.min(30, Math.max(0, Number(args.practice_case_map_max || 8)));
 
-    if (!procedureCode) {
-      return this.wrapResponse({ error: 'procedure_code is required for deadline calculation. Must be one of: cpc (цивільний), gpc (господарський), cac (адміністративний), crpc (кримінальний). Please specify the procedure code and try again.' });
-    }
+    if (!procedureCode) throw new Error('procedure_code must be one of: cpc, gpc, cac, crpc');
     if (!eventDate) throw new Error('event_date parameter is required (YYYY-MM-DD)');
     if (!appealType) throw new Error('appeal_type parameter is required');
 
@@ -917,9 +930,7 @@ export class ProceduralTools extends BaseToolHandler {
     const stage = String(args.stage || '').trim().toLowerCase();
     const caseCategory = typeof args.case_category === 'string' ? args.case_category.trim() : undefined;
 
-    if (!procedureCode) {
-      return this.wrapResponse({ error: 'procedure_code is required for procedural checklist. Must be one of: cpc (цивільний), gpc (господарський), cac (адміністративний), crpc (кримінальний). Please specify the procedure code and try again.' });
-    }
+    if (!procedureCode) throw new Error('procedure_code must be one of: cpc, gpc, cac, crpc');
     if (!stage) throw new Error('stage parameter is required');
 
     const stageKey = stage.includes('апел') ? 'апеляція'


### PR DESCRIPTION
## Summary
- Make `procedure_code` required for `search_supreme_court_practice`, `analyze_legal_positions`, and `find_similar_fact_pattern_cases`
- Simplify `court_level` enum to `SC`/`GrandChamber` (remove AC/FC which aren't Supreme Court)
- Improve error messages with consistent `throw new Error` instead of `wrapResponse({ error })`
- Simplify `extractCourtFromTitle` regex

## Test plan
- [ ] Verify tools reject calls without `procedure_code` with clear error
- [ ] Verify SC practice search returns correct results with `procedure_code=cpc`
- [ ] Verify deadline calculator and procedural checklist still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make procedure_code mandatory in Supreme Court practice tools to avoid broad, irrelevant searches. Also simplify court_level options and standardize error handling.

- **Bug Fixes**
  - Require procedure_code for search_supreme_court_practice, analyze_legal_positions, and find_similar_fact_pattern_cases.
  - Restrict court_level to SC or GrandChamber (default SC).
  - Replace wrapResponse({ error }) with throw new Error across tools, including deadline calculator and procedural checklist.
  - Simplify extractCourtFromTitle to match only Supreme Court variants.

- **Migration**
  - Always pass procedure_code: one of cpc, gpc, cac, crpc.
  - Update clients to handle thrown errors instead of wrapped error responses.
  - If sending court_level, use SC or GrandChamber only.

<sup>Written for commit 97221c1cf02df8233f67219623691fa079a3f475. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

