### PR TITLE
fix: inject charset=utf-8 for downloaded court HTML

### DIFF
--- a/mcp_backend/src/services/reyestr-download-service.ts
+++ b/mcp_backend/src/services/reyestr-download-service.ts
@@ -228,7 +228,10 @@ export class ReyestrDownloadService {
         await new Promise(resolve => setTimeout(resolve, 2000));
       }
 
-      return await tab.content();
+      let html = await tab.content();
+      // Fix encoding: reyestr puts <meta charset> inside <body>, move it to <head>
+      html = html.replace(/<head><\/head>/, '<head><meta charset="utf-8"></head>');
+      return html;
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
       logger.error(`[ReyestrDownload] Download error for ${docId}: ${msg}`);


### PR DESCRIPTION
## Summary
- Fix garbled Cyrillic in court decisions downloaded from reyestr.court.gov.ua
- The print version has `<meta charset>` in `<body>` with empty `<head>`, causing encoding misdetection
- Inject `<meta charset="utf-8">` into `<head>` after download

## Test plan
- [ ] Download a court decision and verify Cyrillic text displays correctly
- [ ] Verify the `<head>` tag contains the charset meta

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix garbled Cyrillic in downloaded court decision HTML by declaring UTF-8 in the head. When reyestr.court.gov.ua print pages put the charset meta in the body and leave an empty head, we inject <meta charset="utf-8"> into <head>.

<sup>Written for commit 354a6b52e24b017d878d63265582ee388868f49e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

