### PR TITLE
fix: add appellate and first instance court filtering

### DIFF
--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -232,12 +232,18 @@ export function mapProcedureCodeToJusticeKind(code: string | null): number | nul
 }
 
 /**
- * Build where-filter conditions for Supreme Court instance filtering.
- * instance_code=1 corresponds to cassation courts (Верховний Суд).
+ * Build where-filter conditions for court instance filtering.
+ * instance_code: 1=cassation (ВС), 2=appellate, 3=first instance
  */
 export function buildSupremeCourtWhereFilter(courtLevel: string): any[] {
   if (courtLevel === 'SC' || courtLevel === 'GrandChamber') {
     return [{ field: 'instance_code', operator: '=', value: 1 }];
+  }
+  if (courtLevel === 'AC') {
+    return [{ field: 'instance_code', operator: '=', value: 2 }];
+  }
+  if (courtLevel === 'FC') {
+    return [{ field: 'instance_code', operator: '=', value: 3 }];
   }
   return [];
 }


### PR DESCRIPTION
## Summary
- Extend `buildSupremeCourtWhereFilter` in tool-utils to support `AC` (appellate, instance_code=2) and `FC` (first instance, instance_code=3)
- Previously only `SC`/`GrandChamber` (instance_code=1) was supported

## Test plan
- [ ] Verify `court_level=AC` filters to appellate court decisions
- [ ] Verify `court_level=FC` filters to first instance decisions
- [ ] Verify existing SC/GrandChamber filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated buildSupremeCourtWhereFilter to support appellate (AC → instance_code=2) and first instance (FC → instance_code=3) filtering alongside existing SC/GrandChamber (1).
Queries using court_level=AC or court_level=FC now return the correct decisions.

<sup>Written for commit 45272185ce417765f733daa1e51f50e321cf7cea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

