### PR TITLE
fix: rewrite MinIO presigned URLs to public endpoint

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -514,6 +514,7 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
       MINIO_USE_SSL: "false"
+      MINIO_PUBLIC_URL: https://legal.org.ua/s3
 
       # Upload temp
       UPLOAD_TEMP_DIR: /app/data/uploads

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -510,6 +510,7 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
       MINIO_USE_SSL: "false"
+      MINIO_PUBLIC_URL: https://stage.legal.org.ua/s3
 
       # Upload temp directory
       UPLOAD_TEMP_DIR: /app/data/uploads

--- a/deployment/nginx/includes/api-endpoints.conf
+++ b/deployment/nginx/includes/api-endpoints.conf
@@ -56,6 +56,18 @@ location /api {
 }
 
 # ==========================================
+# MinIO S3 Proxy (presigned URLs)
+# ==========================================
+
+location /s3/ {
+    proxy_pass http://minio-stage:9000/;
+    proxy_http_version 1.1;
+    proxy_set_header Host minio-stage:9000;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+}
+
+# ==========================================
 # Webhook Routes (Stripe, Fondy)
 # ==========================================
 

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -135,6 +135,18 @@ location = /.well-known/oauth-authorization-server {
 }
 
 # ==========================================
+# MinIO S3 Proxy (presigned URLs)
+# ==========================================
+
+location /s3/ {
+    proxy_pass http://minio-prod:9000/;
+    proxy_http_version 1.1;
+    proxy_set_header Host minio-prod:9000;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+}
+
+# ==========================================
 # Static Assets (with caching)
 # ==========================================
 


### PR DESCRIPTION
## Summary
- MinIO presigned URLs contained Docker-internal hostnames (`minio-prod:9000`, `minio-stage:9000`) which browsers cannot resolve, causing `ERR_NAME_NOT_RESOLVED` for uploaded files
- Added nginx `/s3/` reverse proxy location blocks for both prod and stage
- Added `MINIO_PUBLIC_URL` env var to docker-compose so the existing rewrite logic in `MinioService.getFileUrl()` activates

## Test plan
- [ ] Deploy to stage: rebuild nginx-stage and app-stage containers
- [ ] Upload a file and verify the presigned URL uses `https://stage.legal.org.ua/s3/...` instead of `minio-stage:9000`
- [ ] Verify uploaded images/files load correctly in the browser
- [ ] Deploy to prod and repeat verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken MinIO presigned URLs by rewriting them to a public /s3 endpoint, so browsers can load uploaded files without DNS errors. Applies to both stage and prod.

- **Bug Fixes**
  - Added Nginx /s3 reverse proxy to minio-stage:9000 and minio-prod:9000.
  - Set MINIO_PUBLIC_URL in stage/prod compose to enable URL rewrite in MinioService.getFileUrl().

- **Migration**
  - Rebuild and deploy nginx and app containers in stage, then prod.
  - Upload a file and confirm the URL uses https://stage.legal.org.ua/s3/... or https://legal.org.ua/s3/... and loads in the browser.

<sup>Written for commit eb4e650ae5616803574833488c7941a3054b66ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

