### PR TITLE
fix: use ^~ on /s3/ nginx location to prevent static asset regex override

### DIFF
--- a/deployment/nginx/includes/api-endpoints.conf
+++ b/deployment/nginx/includes/api-endpoints.conf
@@ -59,7 +59,7 @@ location /api {
 # MinIO S3 Proxy (presigned URLs)
 # ==========================================
 
-location /s3/ {
+location ^~ /s3/ {
     proxy_pass http://minio-stage:9000/;
     proxy_http_version 1.1;
     proxy_set_header Host minio-stage:9000;

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -138,7 +138,7 @@ location = /.well-known/oauth-authorization-server {
 # MinIO S3 Proxy (presigned URLs)
 # ==========================================
 
-location /s3/ {
+location ^~ /s3/ {
     proxy_pass http://minio-prod:9000/;
     proxy_http_version 1.1;
     proxy_set_header Host minio-prod:9000;

--- a/deployment/nginx/localdev-docker.conf
+++ b/deployment/nginx/localdev-docker.conf
@@ -305,7 +305,7 @@ server {
     # MinIO S3 Proxy (presigned URLs)
     # ==========================================
 
-    location /s3/ {
+    location ^~ /s3/ {
         proxy_pass http://minio-local:9000/;
         proxy_http_version 1.1;
         proxy_set_header Host minio-local:9000;
@@ -616,7 +616,7 @@ server {
     # MinIO S3 Proxy (presigned URLs)
     # ==========================================
 
-    location /s3/ {
+    location ^~ /s3/ {
         proxy_pass http://minio-local:9000/;
         proxy_http_version 1.1;
         proxy_set_header Host minio-local:9000;

--- a/deployment/nginx/localdev.legal.org.ua.conf
+++ b/deployment/nginx/localdev.legal.org.ua.conf
@@ -284,7 +284,7 @@ server {
     # MinIO S3 Proxy (presigned URLs)
     # ==========================================
 
-    location /s3/ {
+    location ^~ /s3/ {
         proxy_pass http://127.0.0.1:9000/;
         proxy_http_version 1.1;
         proxy_set_header Host minio-local:9000;
@@ -573,7 +573,7 @@ server {
     # MinIO S3 Proxy (presigned URLs)
     # ==========================================
 
-    location /s3/ {
+    location ^~ /s3/ {
         proxy_pass http://127.0.0.1:9000/;
         proxy_http_version 1.1;
         proxy_set_header Host minio-local:9000;


### PR DESCRIPTION
## Summary
- `/s3/` presigned URLs for images (`.jpg`, `.png`, etc.) were matched by the static assets regex `~* \.(jpg|png|...)$` and proxied to the frontend instead of MinIO, causing 404s
- Added `^~` modifier to all `/s3/` location blocks to give them priority over regex matches

## Test plan
- [ ] Verify images load on /documents page after nginx restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give the /s3/ Nginx location priority using the ^~ modifier so presigned URLs are not matched by the static asset regex. This fixes 404s by ensuring /s3/ requests proxy to MinIO across prod, stage, and local configs.

<sup>Written for commit 4cc0d16ace95b175f4435481d51ac996d09696f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

