### PR TITLE
fix: enqueue all court decisions without full_text

### DIFF
--- a/mcp_backend/src/scripts/bulk-scrape-enqueue.ts
+++ b/mcp_backend/src/scripts/bulk-scrape-enqueue.ts
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
     const countResult = await db.query(
       `SELECT COUNT(*) as total FROM documents
        WHERE full_text IS NULL
-         AND zakononline_id LIKE 'court_%'`
+         AND type = 'court_decision'`
     );
     const totalAvailable = parseInt(countResult.rows[0].total, 10);
     logger.info(`  Documents needing download: ${totalAvailable}`);
@@ -77,7 +77,7 @@ async function main(): Promise<void> {
       const result = await db.query(
         `SELECT zakononline_id FROM documents
          WHERE full_text IS NULL
-           AND zakononline_id LIKE 'court_%'
+           AND type = 'court_decision'
          ORDER BY zakononline_id
          OFFSET $1 LIMIT $2`,
         [offset, effectiveLimit]
@@ -85,7 +85,7 @@ async function main(): Promise<void> {
 
       if (result.rows.length === 0) break;
 
-      // Extract registry IDs (strip 'court_' prefix)
+      // Extract registry IDs (strip 'court_' prefix if present, use as-is otherwise)
       const registryIds: string[] = result.rows.map(
         (r: { zakononline_id: string }) => r.zakononline_id.replace(/^court_/, '')
       );


### PR DESCRIPTION
## Summary
- Fix `bulk-scrape-enqueue.ts` to filter on `type = 'court_decision'` instead of `zakononline_id LIKE 'court_%'`
- Captures all ~166K documents needing download, including ~33K with bare numeric IDs that were previously missed
- The existing `replace(/^court_/, '')` already handles both ID formats correctly

## Test plan
- [ ] Run `DRY_RUN=true` enqueue and verify it reports ~166K documents (not ~134K)
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes enqueue script to select court decisions by type instead of ID prefix, so we enqueue all documents missing full_text. Captures ~166K decisions, including ~33K with numeric IDs previously missed.

- **Bug Fixes**
  - Switched SQL filter from zakononline_id LIKE 'court_%' to type = 'court_decision'.
  - Updated both COUNT and SELECT queries to use the new filter.
  - Kept ID normalization: strips "court_" when present; numeric IDs pass through unchanged.

<sup>Written for commit 05591f201f32353bae52971235ab58b7038f4004. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

