### PR TITLE
fix: increase health endpoint rate limit to 300 req/min

### DIFF
--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -75,7 +75,7 @@ export const mcpDiscoveryRateLimit = createRateLimiter({
 
 export const healthCheckRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 60,
+  maxRequests: 300,
   keyPrefix: 'ratelimit:health',
 });
 

--- a/mcp_rada/src/middleware/rate-limit.ts
+++ b/mcp_rada/src/middleware/rate-limit.ts
@@ -73,7 +73,7 @@ export const mcpDiscoveryRateLimit = createRateLimiter({
 
 export const healthCheckRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 60,
+  maxRequests: 300,
   keyPrefix: 'ratelimit:health',
 });
 


### PR DESCRIPTION
## Summary
- Increased `/health` rate limit from 60 to 300 requests/min in `mcp_backend` and `mcp_rada`
- Prometheus scraping (every 15s) + Docker healthchecks (every 30s) + monitoring tools combined exceed the 60 req/min limit

## Test plan
- [x] Verify no more `[RateLimit] Limit exceeded` warnings for `/health` in prod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised /health rate limit to 300 req/min in mcp_backend and mcp_rada to prevent 429s caused by monitoring traffic. This accommodates Prometheus scrapes (15s), Docker healthchecks (30s), and other tools without hitting the limit.

<sup>Written for commit 925ede07ca3ef476dbd0278afc7cecc055137951. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

