### PR TITLE
feat: auto-pagination and delete hotkey in document modals

### DIFF
--- a/lexwebapp/src/components/DocumentViewerModal.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { AnimatePresence, motion } from 'framer-motion';
-import { X, ExternalLink, Gavel, BookOpen, FileText, Copy, Check, Download, Loader2, AlertTriangle, Save, ChevronLeft, ChevronRight } from 'lucide-react';
+import { X, ExternalLink, Gavel, BookOpen, FileText, Copy, Check, Download, Loader2, AlertTriangle, Save, ChevronLeft, ChevronRight, Trash2 } from 'lucide-react';
 
 export interface DocumentViewerItem {
   type: 'decision' | 'citation' | 'document';
@@ -33,6 +33,7 @@ interface DocumentViewerModalProps {
   hasNext?: boolean;
   currentIndex?: number;
   totalCount?: number;
+  onDelete?: () => void;
 }
 
 const typeIcons = {
@@ -41,7 +42,7 @@ const typeIcons = {
   document: FileText,
 };
 
-export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMessage, onSaveOcrText, onPrevious, onNext, hasPrevious, hasNext, currentIndex, totalCount }: DocumentViewerModalProps) {
+export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMessage, onSaveOcrText, onPrevious, onNext, hasPrevious, hasNext, currentIndex, totalCount, onDelete }: DocumentViewerModalProps) {
   const [copied, setCopied] = React.useState(false);
   const [editedOcrText, setEditedOcrText] = React.useState('');
   const [ocrSaving, setOcrSaving] = React.useState(false);
@@ -93,11 +94,14 @@ export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMes
       } else if (e.key === 'ArrowRight' && !isTyping && onNext && hasNext) {
         e.preventDefault();
         onNext();
+      } else if ((e.key === 'Delete' || e.key === 'Backspace') && !isTyping && onDelete) {
+        e.preventDefault();
+        onDelete();
       }
     };
     window.addEventListener('keydown', handleKeydown);
     return () => window.removeEventListener('keydown', handleKeydown);
-  }, [isOpen, onClose, onPrevious, onNext, hasPrevious, hasNext]);
+  }, [isOpen, onClose, onPrevious, onNext, hasPrevious, hasNext, onDelete]);
 
   const handleCopy = () => {
     if (!item) return;
@@ -240,6 +244,16 @@ export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMes
                       >
                         <ExternalLink size={16} strokeWidth={2} />
                       </a>
+                    )}
+                    {onDelete && (
+                      <button
+                        onClick={onDelete}
+                        disabled={isLoading}
+                        className="p-2 text-claude-subtext hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-40"
+                        title="Видалити (Delete)"
+                      >
+                        <Trash2 size={16} strokeWidth={2} />
+                      </button>
                     )}
                     <button
                       onClick={onClose}

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -592,19 +592,73 @@ export function DocumentsPage() {
     }
   };
 
-  // Preview navigation handlers
-  const handlePreviewPrevious = useCallback(() => {
+  // Preview navigation handlers (with auto-pagination)
+  const handlePreviewPrevious = useCallback(async () => {
     if (previewIndex > 0) {
       const prevDoc = documents[previewIndex - 1];
       if (prevDoc) handleDocumentClick(prevDoc, previewIndex - 1);
+    } else if (offset > 0) {
+      // Load previous page and open last document
+      const newOffset = Math.max(0, offset - PAGE_SIZE);
+      setOffset(newOffset);
+      setPreviewLoading(true);
+      try {
+        const params: Record<string, any> = { limit: PAGE_SIZE, offset: newOffset, sortBy, sortOrder };
+        if (filterType) params.type = filterType;
+        if (currentFolderPath) params.folderPath = currentFolderPath;
+        if (searchQuery.trim()) params.query = searchQuery.trim();
+        const result = await mcpService.callTool('list_documents', params);
+        const parsed = result?.result?.content?.[0]?.text ? JSON.parse(result.result.content[0].text) : result?.result || result;
+        const newDocs: VaultDocument[] = parsed.documents || [];
+        setDocuments(newDocs);
+        setTotalDocs(parsed.total || 0);
+        if (newDocs.length > 0) {
+          const lastDoc = newDocs[newDocs.length - 1];
+          handleDocumentClick(lastDoc, newDocs.length - 1);
+        }
+      } catch (err) {
+        console.error('Failed to load previous page:', err);
+        setPreviewLoading(false);
+      }
     }
-  }, [previewIndex, documents]);
+  }, [previewIndex, documents, offset, sortBy, sortOrder, filterType, currentFolderPath, searchQuery]);
 
-  const handlePreviewNext = useCallback(() => {
+  const handlePreviewNext = useCallback(async () => {
     if (previewIndex < documents.length - 1) {
       const nextDoc = documents[previewIndex + 1];
       if (nextDoc) handleDocumentClick(nextDoc, previewIndex + 1);
+    } else if (offset + PAGE_SIZE < totalDocs) {
+      // Load next page and open first document
+      const newOffset = offset + PAGE_SIZE;
+      setOffset(newOffset);
+      setPreviewLoading(true);
+      try {
+        const params: Record<string, any> = { limit: PAGE_SIZE, offset: newOffset, sortBy, sortOrder };
+        if (filterType) params.type = filterType;
+        if (currentFolderPath) params.folderPath = currentFolderPath;
+        if (searchQuery.trim()) params.query = searchQuery.trim();
+        const result = await mcpService.callTool('list_documents', params);
+        const parsed = result?.result?.content?.[0]?.text ? JSON.parse(result.result.content[0].text) : result?.result || result;
+        const newDocs: VaultDocument[] = parsed.documents || [];
+        setDocuments(newDocs);
+        setTotalDocs(parsed.total || 0);
+        if (newDocs.length > 0) {
+          handleDocumentClick(newDocs[0], 0);
+        }
+      } catch (err) {
+        console.error('Failed to load next page:', err);
+        setPreviewLoading(false);
+      }
     }
+  }, [previewIndex, documents, offset, totalDocs, sortBy, sortOrder, filterType, currentFolderPath, searchQuery]);
+
+  // Delete from preview modal — opens delete confirmation
+  const handlePreviewDelete = useCallback(() => {
+    if (previewIndex < 0 || !documents[previewIndex]) return;
+    const doc = documents[previewIndex];
+    setPreviewOpen(false);
+    setPreviewDoc(null);
+    setDeleteTarget(doc);
   }, [previewIndex, documents]);
 
   // Edit navigation handlers
@@ -620,6 +674,13 @@ export function DocumentsPage() {
     if (idx < documents.length - 1) handleEditOpen(documents[idx + 1]);
   }, [editTarget, documents]);
 
+  // Delete from edit modal — opens delete confirmation
+  const handleEditDelete = useCallback(() => {
+    if (!editTarget) return;
+    setEditTarget(null);
+    setDeleteTarget(editTarget);
+  }, [editTarget]);
+
   // Keyboard navigation for edit modal
   useEffect(() => {
     if (!editTarget) return;
@@ -633,11 +694,14 @@ export function DocumentsPage() {
       } else if (e.key === 'ArrowRight' && idx < documents.length - 1) {
         e.preventDefault();
         handleEditOpen(documents[idx + 1]);
+      } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        e.preventDefault();
+        handleEditDelete();
       }
     };
     window.addEventListener('keydown', handleKeydown);
     return () => window.removeEventListener('keydown', handleKeydown);
-  }, [editTarget, documents]);
+  }, [editTarget, documents, handleEditDelete]);
 
   // Pagination
   const hasMore = offset + PAGE_SIZE < totalDocs;
@@ -967,10 +1031,11 @@ export function DocumentsPage() {
         onSaveOcrText={handleSaveOcrText}
         onPrevious={handlePreviewPrevious}
         onNext={handlePreviewNext}
-        hasPrevious={previewIndex > 0}
-        hasNext={previewIndex < documents.length - 1}
-        currentIndex={previewIndex}
-        totalCount={documents.length}
+        hasPrevious={previewIndex > 0 || offset > 0}
+        hasNext={previewIndex < documents.length - 1 || offset + PAGE_SIZE < totalDocs}
+        currentIndex={offset + previewIndex}
+        totalCount={totalDocs}
+        onDelete={handlePreviewDelete}
       />
 
       {/* Delete Confirmation Modal */}
@@ -1074,12 +1139,22 @@ export function DocumentsPage() {
                     Редагувати: {editTarget.title}
                   </h3>
                 </div>
-                <button
-                  onClick={() => !editSaving && setEditTarget(null)}
-                  className="p-1 text-claude-subtext/40 hover:text-claude-text transition-colors"
-                >
-                  <X size={18} />
-                </button>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={handleEditDelete}
+                    disabled={editSaving}
+                    className="p-1 text-claude-subtext/40 hover:text-red-500 transition-colors disabled:opacity-30"
+                    title="Видалити (Delete)"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                  <button
+                    onClick={() => !editSaving && setEditTarget(null)}
+                    className="p-1 text-claude-subtext/40 hover:text-claude-text transition-colors"
+                  >
+                    <X size={18} />
+                  </button>
+                </div>
               </div>
               {editLoading ? (
                 <div className="flex-1 flex items-center justify-center py-20">


### PR DESCRIPTION
## Summary
- Arrow left/right auto-loads next/prev page when reaching boundary of current page
- Delete/Backspace key opens delete confirmation from preview and edit modals
- Trash button added to both modal toolbars
- Counter shows global position across pages (e.g. "51 / 234")

## Test plan
- [ ] Navigate to last doc on page, press → — should load next page and show first doc
- [ ] Navigate to first doc on page, press ← — should load prev page and show last doc
- [ ] Press Delete/Backspace in preview modal — should close modal and open delete confirmation
- [ ] Press Delete/Backspace in edit modal — same behavior
- [ ] Click trash icon in preview/edit modal toolbar
- [ ] Verify Delete/Backspace don't trigger when typing in textarea

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds keyboard navigation and delete hotkeys to document preview and edit modals, with auto-pagination at list edges and a global position counter. Also raises the health check rate limit to prevent 429s during monitoring.

- New Features
  - Arrow keys navigate in preview and edit modals; hotkeys are ignored while typing.
  - Auto-pagination loads next/prev page when reaching the first/last item.
  - Toolbar trash button and Delete/Backspace open the delete confirmation.
  - Global counter shows position across all pages (e.g., 51 / 234).

- Bug Fixes
  - Increase health endpoint rate limit from 60 to 300 req/min to avoid 429s from Prometheus and Docker health checks.

<sup>Written for commit 9fb144da843c96e2d52af0aa936f2317e68d99cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

