### PR TITLE
feat: silent delete from document modals

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -652,13 +652,29 @@ export function DocumentsPage() {
     }
   }, [previewIndex, documents, offset, totalDocs, sortBy, sortOrder, filterType, currentFolderPath, searchQuery]);
 
-  // Delete from preview modal — opens delete confirmation
-  const handlePreviewDelete = useCallback(() => {
+  // Silent delete from preview modal — removes doc and navigates to next
+  const handlePreviewDelete = useCallback(async () => {
     if (previewIndex < 0 || !documents[previewIndex]) return;
     const doc = documents[previewIndex];
-    setPreviewOpen(false);
-    setPreviewDoc(null);
-    setDeleteTarget(doc);
+    try {
+      await api.documents.delete(doc.id);
+      showToast.success(`«${doc.title}» видалено`);
+      const newDocs = documents.filter((_, i) => i !== previewIndex);
+      setDocuments(newDocs);
+      setTotalDocs((prev) => Math.max(0, prev - 1));
+      if (newDocs.length === 0) {
+        setPreviewOpen(false);
+        setPreviewDoc(null);
+        setPreviewIndex(-1);
+      } else if (previewIndex < newDocs.length) {
+        handleDocumentClick(newDocs[previewIndex], previewIndex);
+      } else {
+        handleDocumentClick(newDocs[newDocs.length - 1], newDocs.length - 1);
+      }
+    } catch (err: any) {
+      console.error('Failed to delete document:', err);
+      showToast.error('Не вдалося видалити документ');
+    }
   }, [previewIndex, documents]);
 
   // Edit navigation handlers
@@ -674,12 +690,28 @@ export function DocumentsPage() {
     if (idx < documents.length - 1) handleEditOpen(documents[idx + 1]);
   }, [editTarget, documents]);
 
-  // Delete from edit modal — opens delete confirmation
-  const handleEditDelete = useCallback(() => {
+  // Silent delete from edit modal — removes doc and navigates to next
+  const handleEditDelete = useCallback(async () => {
     if (!editTarget) return;
-    setEditTarget(null);
-    setDeleteTarget(editTarget);
-  }, [editTarget]);
+    const idx = documents.findIndex((d) => d.id === editTarget.id);
+    try {
+      await api.documents.delete(editTarget.id);
+      showToast.success(`«${editTarget.title}» видалено`);
+      const newDocs = documents.filter((d) => d.id !== editTarget.id);
+      setDocuments(newDocs);
+      setTotalDocs((prev) => Math.max(0, prev - 1));
+      if (newDocs.length === 0) {
+        setEditTarget(null);
+      } else if (idx < newDocs.length) {
+        handleEditOpen(newDocs[idx]);
+      } else {
+        handleEditOpen(newDocs[newDocs.length - 1]);
+      }
+    } catch (err: any) {
+      console.error('Failed to delete document:', err);
+      showToast.error('Не вдалося видалити документ');
+    }
+  }, [editTarget, documents]);
 
   // Keyboard navigation for edit modal
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Delete/Backspace silently removes document and shows toast instead of confirmation dialog
- Auto-navigates to next document after deletion without interrupting viewing flow
- Same behavior in both preview and edit modals

## Test plan
- [ ] Press Delete in preview modal — doc removed, toast shown, next doc displayed
- [ ] Delete last doc in list — navigates to previous doc
- [ ] Delete only doc — modal closes
- [ ] Same behavior in edit modal
- [ ] Trash icon button works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instantly deletes documents from preview and edit modals with a toast and automatic navigation, removing the confirmation dialog. Keeps the viewing flow uninterrupted.

- **New Features**
  - Delete/Backspace and trash icon now delete immediately in both modals.
  - Shows success toast on delete and error toast on failure.
  - Auto-navigates to the next doc; goes to previous if last; closes modal if none.
  - Updates the document list and total count in place.

<sup>Written for commit 6d08d8241ec5382b295a0ea2fe973a29301c3fff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

