### PR TITLE
feat: add undo/redo system for document management

### DIFF
--- a/lexwebapp/src/hooks/useUndoKeyboard.ts
+++ b/lexwebapp/src/hooks/useUndoKeyboard.ts
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { useUndoStore } from '../stores/undoStore';
+import { showToast } from '../utils/toast';
+
+export function useUndoKeyboard() {
+  const undo = useUndoStore((s) => s.undo);
+  const redo = useUndoStore((s) => s.redo);
+  const canUndo = useUndoStore((s) => s.canUndo);
+  const canRedo = useUndoStore((s) => s.canRedo);
+
+  useEffect(() => {
+    const handler = async (e: KeyboardEvent) => {
+      // Skip when focus is in text-editable elements (preserve native undo)
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'TEXTAREA' || tag === 'INPUT' || (e.target as HTMLElement)?.isContentEditable) {
+        return;
+      }
+
+      const isMod = e.metaKey || e.ctrlKey;
+      if (!isMod) return;
+
+      // Ctrl+Shift+Z or Cmd+Shift+Z → redo
+      if (e.key === 'z' && e.shiftKey) {
+        e.preventDefault();
+        if (!canRedo()) return;
+        try {
+          await redo();
+        } catch {
+          showToast.error('Не вдалося повторити дію');
+        }
+        return;
+      }
+
+      // Ctrl+Y / Cmd+Y → redo
+      if (e.key === 'y') {
+        e.preventDefault();
+        if (!canRedo()) return;
+        try {
+          await redo();
+        } catch {
+          showToast.error('Не вдалося повторити дію');
+        }
+        return;
+      }
+
+      // Ctrl+Z / Cmd+Z → undo
+      if (e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        if (!canUndo()) return;
+        try {
+          await undo();
+        } catch {
+          showToast.error('Не вдалося скасувати дію');
+        }
+        return;
+      }
+    };
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [undo, redo, canUndo, canRedo]);
+}

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -33,6 +33,8 @@ import { ClassificationPanel } from './ClassificationPanel';
 import { DocumentStatsPanel } from './DocumentStatsPanel';
 import type { VaultDocument, DocType, ViewMode, SortField, SortOrder, DocumentStats } from './types';
 import { isPreviewableBinary } from './types';
+import { useUndoStore } from '../../stores/undoStore';
+import { useUndoKeyboard } from '../../hooks/useUndoKeyboard';
 
 const DOC_TYPE_LABELS: Record<DocType, string> = {
   contract: 'Договір',
@@ -182,6 +184,23 @@ export function DocumentsPage() {
     dismissRecoveredSession,
     clearRecoveredSessions,
   } = useUploadStore();
+
+  // Undo/redo
+  const pushAction = useUndoStore((s) => s.pushAction);
+  const undoAction = useUndoStore((s) => s.undo);
+  const setOnActionExecuted = useUndoStore((s) => s.setOnActionExecuted);
+  const editOriginalTextRef = useRef<string>('');
+
+  useUndoKeyboard();
+
+  // Register reload callback for undo/redo
+  useEffect(() => {
+    setOnActionExecuted(() => {
+      loadDocuments();
+      loadFolders(currentFolderPath);
+    });
+    return () => setOnActionExecuted(null);
+  }, [currentFolderPath]);
 
   // Local UI state
   const [isDragOver, setIsDragOver] = useState(false);
@@ -500,8 +519,13 @@ export function DocumentsPage() {
     if (!deleteTarget) return;
     setDeleting(true);
     try {
-      await api.documents.delete(deleteTarget.id);
-      showToast.success('Документ видалено');
+      const docId = deleteTarget.id;
+      const docTitle = deleteTarget.title;
+      await api.documents.delete(docId);
+      pushAction({ type: 'delete', documentId: docId, documentTitle: docTitle });
+      showToast.undoable(`«${docTitle}» видалено`, () => {
+        undoAction().then(() => { loadDocuments(); loadFolders(currentFolderPath); });
+      });
       setDeleteTarget(null);
       loadDocuments();
       loadFolders(currentFolderPath);
@@ -520,7 +544,9 @@ export function DocumentsPage() {
     try {
       const resp = await api.documents.getById(doc.id);
       const data = resp.data;
-      setEditText(data.full_text || data.content || '');
+      const text = data.full_text || data.content || '';
+      editOriginalTextRef.current = text;
+      setEditText(text);
     } catch (err: any) {
       console.error('Failed to fetch document for editing:', err);
       showToast.error('Не вдалося завантажити документ');
@@ -536,6 +562,15 @@ export function DocumentsPage() {
     setEditSaving(true);
     try {
       await api.documents.update(editTarget.id, { full_text: editText });
+      if (editText !== editOriginalTextRef.current) {
+        pushAction({
+          type: 'edit',
+          documentId: editTarget.id,
+          documentTitle: editTarget.title,
+          previousText: editOriginalTextRef.current,
+          newText: editText,
+        });
+      }
       showToast.success('Документ збережено');
       setEditTarget(null);
       loadDocuments();
@@ -579,8 +614,19 @@ export function DocumentsPage() {
     if (!moveTarget) return;
     setMoveLoading(true);
     try {
+      const previousFolder = moveTarget.metadata?.folderPath || '';
       await api.documents.move(moveTarget.id, moveFolder);
-      showToast.success(`Документ переміщено${moveFolder ? ` до ${moveFolder}` : ' у корінь'}`);
+      pushAction({
+        type: 'move',
+        documentId: moveTarget.id,
+        documentTitle: moveTarget.title,
+        previousFolder,
+        newFolder: moveFolder,
+      });
+      showToast.undoable(
+        `Документ переміщено${moveFolder ? ` до ${moveFolder}` : ' у корінь'}`,
+        () => { undoAction().then(() => { loadDocuments(); loadFolders(currentFolderPath); }); },
+      );
       setMoveTarget(null);
       loadDocuments();
       loadFolders(currentFolderPath);
@@ -658,7 +704,10 @@ export function DocumentsPage() {
     const doc = documents[previewIndex];
     try {
       await api.documents.delete(doc.id);
-      showToast.success(`«${doc.title}» видалено`);
+      pushAction({ type: 'delete', documentId: doc.id, documentTitle: doc.title });
+      showToast.undoable(`«${doc.title}» видалено`, () => {
+        undoAction().then(() => { loadDocuments(); loadFolders(currentFolderPath); });
+      });
       const newDocs = documents.filter((_, i) => i !== previewIndex);
       setDocuments(newDocs);
       setTotalDocs((prev) => Math.max(0, prev - 1));
@@ -696,7 +745,10 @@ export function DocumentsPage() {
     const idx = documents.findIndex((d) => d.id === editTarget.id);
     try {
       await api.documents.delete(editTarget.id);
-      showToast.success(`«${editTarget.title}» видалено`);
+      pushAction({ type: 'delete', documentId: editTarget.id, documentTitle: editTarget.title });
+      showToast.undoable(`«${editTarget.title}» видалено`, () => {
+        undoAction().then(() => { loadDocuments(); loadFolders(currentFolderPath); });
+      });
       const newDocs = documents.filter((d) => d.id !== editTarget.id);
       setDocuments(newDocs);
       setTotalDocs((prev) => Math.max(0, prev - 1));

--- a/lexwebapp/src/stores/undoStore.ts
+++ b/lexwebapp/src/stores/undoStore.ts
@@ -1,0 +1,131 @@
+import { create } from 'zustand';
+import { api } from '../utils/api-client';
+
+export type UndoActionType = 'delete' | 'edit' | 'move';
+
+export interface UndoAction {
+  type: UndoActionType;
+  documentId: string;
+  documentTitle: string;
+  timestamp: number;
+  // delete: no extra data needed (restore/re-delete via API)
+  // edit: store previous and new text
+  previousText?: string;
+  newText?: string;
+  // move: store previous and new folder
+  previousFolder?: string;
+  newFolder?: string;
+}
+
+const MAX_STACK_SIZE = 50;
+const ACTION_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function pruneExpired(stack: UndoAction[]): UndoAction[] {
+  const cutoff = Date.now() - ACTION_TTL_MS;
+  return stack.filter((a) => a.timestamp > cutoff);
+}
+
+interface UndoState {
+  undoStack: UndoAction[];
+  redoStack: UndoAction[];
+  onActionExecuted: (() => void) | null;
+
+  setOnActionExecuted: (cb: (() => void) | null) => void;
+  pushAction: (action: Omit<UndoAction, 'timestamp'>) => void;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+  canUndo: () => boolean;
+  canRedo: () => boolean;
+}
+
+export const useUndoStore = create<UndoState>((set, get) => ({
+  undoStack: [],
+  redoStack: [],
+  onActionExecuted: null,
+
+  setOnActionExecuted: (cb) => set({ onActionExecuted: cb }),
+
+  pushAction: (action) => {
+    const full: UndoAction = { ...action, timestamp: Date.now() };
+    set((state) => ({
+      undoStack: pruneExpired([full, ...state.undoStack]).slice(0, MAX_STACK_SIZE),
+      redoStack: [], // clear redo on new action
+    }));
+  },
+
+  undo: async () => {
+    const { undoStack, onActionExecuted } = get();
+    const stack = pruneExpired(undoStack);
+    if (stack.length === 0) return;
+
+    const [action, ...rest] = stack;
+    set({ undoStack: rest });
+
+    try {
+      switch (action.type) {
+        case 'delete':
+          await api.documents.restore(action.documentId);
+          break;
+        case 'edit':
+          if (action.previousText !== undefined) {
+            await api.documents.update(action.documentId, { full_text: action.previousText });
+          }
+          break;
+        case 'move':
+          if (action.previousFolder !== undefined) {
+            await api.documents.move(action.documentId, action.previousFolder);
+          }
+          break;
+      }
+
+      set((state) => ({
+        redoStack: [action, ...state.redoStack].slice(0, MAX_STACK_SIZE),
+      }));
+
+      onActionExecuted?.();
+    } catch (err) {
+      // Restore the action back to undo stack on failure
+      set((state) => ({ undoStack: [action, ...state.undoStack] }));
+      throw err;
+    }
+  },
+
+  redo: async () => {
+    const { redoStack, onActionExecuted } = get();
+    if (redoStack.length === 0) return;
+
+    const [action, ...rest] = redoStack;
+    set({ redoStack: rest });
+
+    try {
+      switch (action.type) {
+        case 'delete':
+          await api.documents.delete(action.documentId);
+          break;
+        case 'edit':
+          if (action.newText !== undefined) {
+            await api.documents.update(action.documentId, { full_text: action.newText });
+          }
+          break;
+        case 'move':
+          if (action.newFolder !== undefined) {
+            await api.documents.move(action.documentId, action.newFolder);
+          }
+          break;
+      }
+
+      set((state) => ({
+        undoStack: [action, ...state.undoStack].slice(0, MAX_STACK_SIZE),
+      }));
+
+      onActionExecuted?.();
+    } catch (err) {
+      // Restore the action back to redo stack on failure
+      set((state) => ({ redoStack: [action, ...state.redoStack] }));
+      throw err;
+    }
+  },
+
+  canUndo: () => pruneExpired(get().undoStack).length > 0,
+  canRedo: () => get().redoStack.length > 0,
+}));

--- a/lexwebapp/src/utils/api-client.ts
+++ b/lexwebapp/src/utils/api-client.ts
@@ -211,6 +211,7 @@ export const api = {
       apiClient.get('/api/documents/folders', { params: { prefix } }),
     getById: (id: string) => apiClient.get(`/api/documents/${id}`),
     delete: (id: string) => apiClient.delete(`/api/documents/${id}`),
+    restore: (id: string) => apiClient.patch(`/api/documents/${id}/restore`),
     update: (id: string, data: { full_text?: string; title?: string; type?: string }) =>
       apiClient.patch(`/api/documents/${id}`, data),
     move: (id: string, folderPath: string) =>

--- a/lexwebapp/src/utils/toast.ts
+++ b/lexwebapp/src/utils/toast.ts
@@ -4,6 +4,7 @@
  */
 
 import toast from 'react-hot-toast';
+import React from 'react';
 
 const baseStyle = {
   fontFamily: 'Inter, sans-serif',
@@ -107,6 +108,35 @@ export const showToast = {
         },
       },
     });
+  },
+
+  undoable: (message: string, onUndo: () => void, duration = 5000) => {
+    return toast(
+      (t) => React.createElement('div', { style: { display: 'flex', alignItems: 'center', gap: '12px' } },
+        React.createElement('span', null, message),
+        React.createElement('button', {
+          onClick: () => { toast.dismiss(t.id); onUndo(); },
+          style: {
+            background: 'none',
+            border: '1px solid #D97757',
+            borderRadius: '6px',
+            color: '#D97757',
+            cursor: 'pointer',
+            padding: '4px 10px',
+            fontSize: '13px',
+            fontWeight: 500,
+            whiteSpace: 'nowrap' as const,
+          },
+        }, '\u0421\u043A\u0430\u0441\u0443\u0432\u0430\u0442\u0438'),
+      ),
+      {
+        duration,
+        style: {
+          ...baseStyle,
+          borderLeft: '3px solid #D97757',
+        },
+      }
+    );
   },
 
   dismiss: (toastId?: string) => {

--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -631,7 +631,7 @@ Pipeline:
       const sortOrder = args.sortOrder || 'desc';
 
       // Build SQL query with filters
-      const conditions: string[] = ['1=1'];
+      const conditions: string[] = ['1=1', 'deleted_at IS NULL'];
       const params: any[] = [];
       let paramIndex = 1;
 
@@ -765,7 +765,7 @@ Pipeline:
   }): Promise<{ folders: string[]; fileCount: number }> {
     try {
       const prefix = args.prefix || '';
-      const conditions: string[] = ["metadata::jsonb ->> 'folderPath' IS NOT NULL"];
+      const conditions: string[] = ["metadata::jsonb ->> 'folderPath' IS NOT NULL", 'deleted_at IS NULL'];
       const params: any[] = [];
       let paramIndex = 1;
 
@@ -893,7 +893,7 @@ Pipeline:
           const docsQuery = `
             SELECT id, type, title, metadata
             FROM documents
-            WHERE id = ANY($1)
+            WHERE id = ANY($1) AND deleted_at IS NULL
             ${args.userId ? 'AND user_id = $2' : ''}
           `;
           const params: any[] = args.userId ? [uniqueIds, args.userId] : [uniqueIds];

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1205,7 +1205,7 @@ class HTTPMCPServer {
         const { id } = req.params;
 
         const result = await this.services.db.query(
-          'SELECT storage_type, storage_path, mime_type, metadata FROM documents WHERE id = $1 AND user_id = $2',
+          'SELECT storage_type, storage_path, mime_type, metadata FROM documents WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL',
           [id, userId]
         );
 

--- a/mcp_backend/src/migrations/063_add_document_soft_delete.sql
+++ b/mcp_backend/src/migrations/063_add_document_soft_delete.sql
@@ -1,0 +1,27 @@
+-- Migration 063: Add soft-delete support for documents (undo/redo)
+
+-- Add deleted_at column
+DO $$ BEGIN
+  ALTER TABLE documents ADD COLUMN deleted_at TIMESTAMPTZ DEFAULT NULL;
+EXCEPTION WHEN duplicate_column THEN
+  NULL;
+END $$;
+
+-- Partial index: only non-deleted documents for user queries
+CREATE INDEX IF NOT EXISTS idx_documents_user_active
+  ON documents (user_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- Function to permanently purge soft-deleted documents older than retention_days
+CREATE OR REPLACE FUNCTION purge_soft_deleted_documents(retention_days INTEGER DEFAULT 30)
+RETURNS INTEGER AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM documents
+  WHERE deleted_at IS NOT NULL
+    AND deleted_at < NOW() - (retention_days || ' days')::INTERVAL;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;

--- a/mcp_backend/src/routes/rest-api.ts
+++ b/mcp_backend/src/routes/rest-api.ts
@@ -24,7 +24,7 @@ export function createRestAPIRouter(db: IDatabase): Router {
         res.json([]);
         return;
       }
-      const userFilter = { where: 'WHERE user_id = $1', params: [userId] };
+      const userFilter = { where: 'WHERE user_id = $1 AND deleted_at IS NULL', params: [userId] };
 
       const countResult = await db.query(
         `SELECT COUNT(*) FROM documents ${userFilter.where}`,
@@ -65,7 +65,7 @@ export function createRestAPIRouter(db: IDatabase): Router {
         return;
       }
       const result = await db.query(
-        'SELECT * FROM documents WHERE id = $1 AND user_id = $2',
+        'SELECT * FROM documents WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL',
         [id, userId]
       );
 
@@ -151,7 +151,7 @@ export function createRestAPIRouter(db: IDatabase): Router {
         res.status(401).json({ error: 'Authentication required' });
         return;
       }
-      const result = await db.query('DELETE FROM documents WHERE id = $1 AND user_id = $2 RETURNING id', [id, userId]);
+      const result = await db.query('UPDATE documents SET deleted_at = NOW() WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL RETURNING id', [id, userId]);
 
       if (result.rows.length === 0) {
         res.status(404).json({ error: 'Document not found' });
@@ -162,6 +162,34 @@ export function createRestAPIRouter(db: IDatabase): Router {
     } catch (error: any) {
       logger.error('Error deleting document:', error);
       res.status(500).json({ error: 'Failed to delete document', message: error.message });
+    }
+  }) as any);
+
+  // Restore soft-deleted document
+  router.patch('/:id/restore', (async (req: DualAuthRequest, res: Response): Promise<void> => {
+    try {
+      const { id } = req.params;
+      const userId = req.user?.id;
+
+      if (!userId) {
+        res.status(401).json({ error: 'Authentication required' });
+        return;
+      }
+
+      const result = await db.query(
+        'UPDATE documents SET deleted_at = NULL WHERE id = $1 AND user_id = $2 AND deleted_at IS NOT NULL RETURNING id',
+        [id, userId]
+      );
+
+      if (result.rows.length === 0) {
+        res.status(404).json({ error: 'Document not found or not deleted' });
+        return;
+      }
+
+      res.json(result.rows[0]);
+    } catch (error: any) {
+      logger.error('Error restoring document:', error);
+      res.status(500).json({ error: 'Failed to restore document', message: error.message });
     }
   }) as any);
 


### PR DESCRIPTION
## Summary
- Replace hard-delete with soft-delete (`deleted_at` column) so documents can be restored
- Add `PATCH /:id/restore` endpoint to un-delete documents
- Add `deleted_at IS NULL` filter to all document SELECT queries (rest-api, http-server, vault-tools)
- Add Zustand undo/redo store with 50-action stack and 10-min TTL
- Add global `Ctrl+Z` / `Ctrl+Shift+Z` / `Ctrl+Y` keyboard shortcuts (skips textarea/input)
- Add undoable toast with "Скасувати" button for delete and move actions
- Wire undo into all delete handlers (confirm dialog, preview modal, edit modal), edit save, and move confirm
- Add `purge_soft_deleted_documents(retention_days)` SQL function for future cleanup

## Test plan
- [ ] Run migration `063_add_document_soft_delete.sql`
- [ ] Delete a document → verify soft-deleted (Ctrl+Z restores it)
- [ ] Ctrl+Shift+Z re-deletes it
- [ ] Click "Скасувати" on toast → document restored
- [ ] Edit document text → save → Ctrl+Z reverts to original text
- [ ] Move document → Ctrl+Z moves back to original folder
- [ ] Verify native Ctrl+Z still works inside textarea/input
- [ ] `npx tsc --noEmit` passes for both frontend and backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds undo/redo for document actions and switches deletes to soft-delete so documents can be restored. Includes keyboard shortcuts and a restore API to reverse deletes, edits, and moves quickly.

- **New Features**
  - Soft-delete with a deleted_at column; adds PATCH /api/documents/:id/restore.
  - All document queries now exclude deleted rows (deleted_at IS NULL).
  - Undo/redo store (Zustand) with a 50-action stack and 10‑minute TTL.
  - Global shortcuts: Ctrl+Z, Ctrl+Shift+Z, Ctrl+Y (ignored in inputs/textarea/contentEditable).
  - Undoable toast for delete and move; wired into delete, edit save, and move flows.

- **Migration**
  - Run migration 063_add_document_soft_delete.sql.
  - Optional: use purge_soft_deleted_documents(retention_days) to clean up old deletes.

<sup>Written for commit d4c41f0c6953d8b52cdacb4011b0970c0ec956d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

