### PR TITLE
fix: add started_at/completed_at to workflows migration

### DIFF
--- a/mcp_backend/src/migrations/062_add_workflows.sql
+++ b/mcp_backend/src/migrations/062_add_workflows.sql
@@ -30,6 +30,8 @@ CREATE TABLE IF NOT EXISTS workflows (
     results JSONB DEFAULT NULL,
     error_message TEXT,
     cost_usd NUMERIC(10, 6) DEFAULT 0,
+    started_at TIMESTAMPTZ,
+    completed_at TIMESTAMPTZ,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );


### PR DESCRIPTION
## Summary
- Adds `started_at` and `completed_at` TIMESTAMPTZ columns to the `workflows` table in migration 062
- These columns are used by `WorkflowExecutorService` to track workflow execution timing but were missing from the original migration

## Test plan
- [ ] Run migration against local DB: `cd mcp_backend && npm run migrate`
- [ ] Verify columns exist: `\d workflows` in psql
- [ ] Execute a workflow and confirm timestamps are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added started_at and completed_at TIMESTAMPTZ columns to the workflows table to track execution timing and align the schema with WorkflowExecutorService.

- **Migration**
  - Run: cd mcp_backend && npm run migrate
  - Verify columns: \d workflows
  - Execute a workflow to confirm timestamps are populated

<sup>Written for commit cc446cd830a1641594653594c84c88a727f81dc1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

