### PR TITLE
fix: EML documents not displaying (raw MIME in full_text)

### DIFF
--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -571,12 +571,39 @@ Pipeline:
         return null;
       }
 
+      let content = doc.full_text || '';
+
+      // If full_text is raw EML with MIME attachments, re-parse to extract just the text
+      const docMeta = typeof doc.metadata === 'string' ? JSON.parse(doc.metadata) : doc.metadata || {};
+      const mimeType = (doc as any).mime_type || docMeta.mimeType;
+      if (mimeType === 'message/rfc822' && content.length > 0) {
+        const first500 = content.substring(0, 500);
+        const looksRawEml = /^(From|Subject|Date|MIME-Version|Content-Type):\s/mi.test(first500) &&
+          (/boundary=/i.test(first500) || /Content-Type:\s*multipart/i.test(first500));
+        if (looksRawEml) {
+          try {
+            const parsed = await this.documentParser.parseEML(Buffer.from(content, 'utf-8'));
+            content = parsed.text;
+            logger.info('[Vault] Re-parsed raw EML full_text', {
+              documentId: args.documentId,
+              originalLen: doc.full_text!.length,
+              parsedLen: content.length,
+            });
+          } catch (err: any) {
+            logger.warn('[Vault] Failed to re-parse EML, returning raw', {
+              documentId: args.documentId,
+              error: err.message,
+            });
+          }
+        }
+      }
+
       const result: VaultDocument = {
         id: doc.id!,
         title: doc.title || 'Untitled',
         type: doc.type as any,
-        content: doc.full_text || '',
-        metadata: typeof doc.metadata === 'string' ? JSON.parse(doc.metadata) : doc.metadata || {},
+        content,
+        metadata: docMeta,
       };
 
       // Include sections if requested


### PR DESCRIPTION
## Summary
- EML documents in `20231201-заява-в-поліцію` folder weren't displaying when clicked
- Root cause: `full_text` stored raw EML with base64-encoded attachments (2.8MB), returned as-is to frontend
- Fix: `get_document` now detects raw EML content and re-parses it server-side using `DocumentParser.parseEML()`, returning only clean text headers + body

## Test plan
- [ ] Navigate to `/documents/folders/20231201-заява-в-поліцію`
- [ ] Click an EML document — should display email headers and body text
- [ ] Non-EML documents in the same folder should be unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes EML documents failing to display by detecting raw EML in full_text and re-parsing server-side to return clean headers and body text. This prevents sending large raw MIME data to the frontend and restores proper rendering.

- **Bug Fixes**
  - Detect message/rfc822 via mime_type/metadata and simple EML heuristics.
  - Re-parse with DocumentParser.parseEML and set content to parsed text; fall back to raw on errors with a warning.
  - Non-EML documents are unchanged.

<sup>Written for commit d32144d8ed7085116af8f12c37b14dfab700361a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

