### PR TITLE
fix: EML UTF-8 encoding for Cyrillic filenames and content

### DIFF
--- a/lexwebapp/src/utils/eml-parser.ts
+++ b/lexwebapp/src/utils/eml-parser.ts
@@ -20,15 +20,33 @@ function decodeEncodedWords(str: string): string {
   return str.replace(/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g, (_match, _charset, encoding, text) => {
     if (encoding.toUpperCase() === 'B') {
       try {
-        return atob(text);
+        const bytes = atob(text);
+        const uint8 = new Uint8Array(bytes.length);
+        for (let i = 0; i < bytes.length; i++) uint8[i] = bytes.charCodeAt(i);
+        return new TextDecoder('utf-8').decode(uint8);
       } catch {
         return text;
       }
     }
     if (encoding.toUpperCase() === 'Q') {
-      return text.replace(/_/g, ' ').replace(/=([0-9A-Fa-f]{2})/g, (_: string, hex: string) =>
-        String.fromCharCode(parseInt(hex, 16))
-      );
+      // Collect all bytes first, then decode as UTF-8 (handles multi-byte Cyrillic)
+      const withSpaces = text.replace(/_/g, ' ');
+      const bytes: number[] = [];
+      let i = 0;
+      while (i < withSpaces.length) {
+        if (withSpaces[i] === '=' && i + 2 < withSpaces.length) {
+          bytes.push(parseInt(withSpaces.substring(i + 1, i + 3), 16));
+          i += 3;
+        } else {
+          bytes.push(withSpaces.charCodeAt(i));
+          i++;
+        }
+      }
+      try {
+        return new TextDecoder('utf-8').decode(new Uint8Array(bytes));
+      } catch {
+        return text;
+      }
     }
     return text;
   });
@@ -38,9 +56,24 @@ function decodeEncodedWords(str: string): string {
  * Decode quoted-printable encoded text
  */
 function decodeQuotedPrintable(text: string): string {
-  return text
-    .replace(/=\r?\n/g, '') // soft line breaks
-    .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+  // Remove soft line breaks, then decode all =XX as raw bytes → UTF-8
+  const stripped = text.replace(/=\r?\n/g, '');
+  const bytes: number[] = [];
+  let i = 0;
+  while (i < stripped.length) {
+    if (stripped[i] === '=' && i + 2 < stripped.length && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
+      bytes.push(parseInt(stripped.substring(i + 1, i + 3), 16));
+      i += 3;
+    } else {
+      bytes.push(stripped.charCodeAt(i));
+      i++;
+    }
+  }
+  try {
+    return new TextDecoder('utf-8').decode(new Uint8Array(bytes));
+  } catch {
+    return stripped;
+  }
 }
 
 /**

--- a/mcp_backend/src/services/document-parser.ts
+++ b/mcp_backend/src/services/document-parser.ts
@@ -754,14 +754,26 @@ export class DocumentParser {
    * Decode RFC 2047 encoded words (=?charset?encoding?text?=)
    */
   private decodeEncodedWords(str: string): string {
-    return str.replace(/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g, (_match, _charset, encoding, text) => {
+    return str.replace(/=\?([^?]+)\?([BbQq])\?([^?]*)\?=/g, (_match, charset, encoding, text) => {
+      const enc = (charset || 'utf-8').toLowerCase().replace(/^(utf8|utf-8)$/, 'utf-8');
       if (encoding.toUpperCase() === 'B') {
-        try { return Buffer.from(text, 'base64').toString('utf-8'); } catch { return text; }
+        try { return Buffer.from(text, 'base64').toString(enc as BufferEncoding); } catch { return text; }
       }
       if (encoding.toUpperCase() === 'Q') {
-        return text.replace(/_/g, ' ').replace(/=([0-9A-Fa-f]{2})/g, (_: string, hex: string) =>
-          String.fromCharCode(parseInt(hex, 16))
-        );
+        // Collect all bytes first, then decode as charset (handles multi-byte UTF-8)
+        const withSpaces = text.replace(/_/g, ' ');
+        const bytes: number[] = [];
+        let i = 0;
+        while (i < withSpaces.length) {
+          if (withSpaces[i] === '=' && i + 2 < withSpaces.length) {
+            bytes.push(parseInt(withSpaces.substring(i + 1, i + 3), 16));
+            i += 3;
+          } else {
+            bytes.push(withSpaces.charCodeAt(i));
+            i++;
+          }
+        }
+        try { return Buffer.from(bytes).toString(enc as BufferEncoding); } catch { return text; }
       }
       return text;
     });
@@ -931,9 +943,20 @@ export class DocumentParser {
       } catch { return content; }
     }
     if (encoding === 'quoted-printable') {
-      return content
-        .replace(/=\r?\n/g, '')
-        .replace(/=([0-9A-Fa-f]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+      // Remove soft line breaks, then decode all =XX sequences as raw bytes → UTF-8
+      const stripped = content.replace(/=\r?\n/g, '');
+      const bytes: number[] = [];
+      let i = 0;
+      while (i < stripped.length) {
+        if (stripped[i] === '=' && i + 2 < stripped.length && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
+          bytes.push(parseInt(stripped.substring(i + 1, i + 3), 16));
+          i += 3;
+        } else {
+          bytes.push(stripped.charCodeAt(i));
+          i++;
+        }
+      }
+      try { return Buffer.from(bytes).toString('utf-8'); } catch { return stripped; }
     }
     return content;
   }


### PR DESCRIPTION
## Summary
- Attachment filenames in EML emails showing as mojibake (`Ð�Ð�Ð�Ð�Ð�Ð�` instead of Cyrillic)
- Root cause: quoted-printable and RFC 2047 Q-encoding decoded byte-by-byte with `String.fromCharCode`, which breaks multi-byte UTF-8 (Cyrillic uses 2 bytes per character)
- Fix: collect all `=XX` hex bytes into a byte array first, then decode as UTF-8 using `Buffer.from().toString('utf-8')` (backend) and `TextDecoder` (frontend)
- Fixed in both backend (`document-parser.ts`) and frontend (`eml-parser.ts`)

## Test plan
- [ ] Click EML document in `/documents/folders/20231201-заява-в-поліцію`
- [ ] Attachment filenames should display in proper Ukrainian (e.g. `ПОЗОВ КРИМІНАЛЬНИЙ ГОРЕНИЧІ.jpg`)
- [ ] Email body text with Cyrillic should render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mojibake in EML emails by correctly decoding UTF-8 for Cyrillic filenames and body text. Attachment names and message content now render as intended.

- **Bug Fixes**
  - Decode RFC 2047 Q-encoded words and quoted-printable by assembling raw bytes first, then decoding as UTF‑8 (handles multi-byte characters).
  - Respect charset for B/Q-encoded words; use TextDecoder in the frontend and Buffer in the backend.
  - Applied in lexwebapp/src/utils/eml-parser.ts and mcp_backend/src/services/document-parser.ts.

<sup>Written for commit 62875e8541c114c3dea7f6bf3de4335e8454daf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

