### PR TITLE
feat: extract and store EML attachments as separate documents

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -335,7 +335,7 @@ export function DocumentsPage() {
         .map((file) => ({
           file,
           mimeType: guessMimeType(file),
-          relativePath: (file as any).webkitRelativePath || file.name,
+          relativePath: (file as any).webkitRelativePath || currentFolderPath || '',
           docType: defaultDocType,
         }));
 
@@ -343,7 +343,7 @@ export function DocumentsPage() {
       addFiles(newItems);
       setShowUploadPanel(true);
     },
-    [defaultDocType, addFiles]
+    [defaultDocType, addFiles, currentFolderPath]
   );
 
   const handleFileSelect = () => fileInputRef.current?.click();

--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -1,13 +1,16 @@
-import { DocumentParser, ParsedDocument } from '../services/document-parser.js';
+import { DocumentParser, ParsedDocument, EmlAttachment } from '../services/document-parser.js';
 import { SemanticSectionizer } from '../services/semantic-sectionizer.js';
 import { LegalPatternStore } from '../services/legal-pattern-store.js';
 import type { IEmbeddingPort } from '../domain/ports/index.js';
 import { DocumentService, Document } from '../services/document-service.js';
+import { MinioService } from '../services/minio-service.js';
 import { MetadataExtractor } from '../services/metadata-extractor.js';
+import { UploadService } from '../services/upload-service.js';
 import { logger } from '../utils/logger.js';
 import { v4 as uuidv4 } from 'uuid';
 import { DocumentSection } from '../types/index.js';
 import fs from 'fs/promises';
+import path from 'path';
 import { BaseToolHandler, ToolDefinition, ToolResult } from './base-tool-handler.js';
 
 /**
@@ -58,6 +61,8 @@ export interface SemanticSearchResult {
 }
 
 export class VaultTools extends BaseToolHandler {
+  private minioService?: MinioService;
+
   constructor(
     private documentParser: DocumentParser,
     private sectionizer: SemanticSectionizer,
@@ -67,6 +72,10 @@ export class VaultTools extends BaseToolHandler {
     private metadataExtractor: MetadataExtractor
   ) {
     super();
+  }
+
+  setMinioService(minioService: MinioService): void {
+    this.minioService = minioService;
   }
 
   getToolDefinitions() {
@@ -270,6 +279,7 @@ Pipeline:
     type: 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';
     metadata?: any;
     userId?: string;
+    skipAttachmentExtraction?: boolean;
   }): Promise<VaultDocument> {
     const fileBuffer = await fs.readFile(args.filePath);
     const fileBase64 = fileBuffer.toString('base64');
@@ -281,6 +291,7 @@ Pipeline:
       type: args.type,
       metadata: args.metadata,
       userId: args.userId,
+      skipAttachmentExtraction: args.skipAttachmentExtraction,
     });
   }
 
@@ -301,6 +312,7 @@ Pipeline:
     type: 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';
     metadata?: any;
     userId?: string;
+    skipAttachmentExtraction?: boolean;
   }): Promise<VaultDocument> {
     const startTime = Date.now();
     const documentId = uuidv4();
@@ -517,6 +529,17 @@ Pipeline:
         await this.documentService.saveSections(documentId, sections);
       }
 
+      // Step 6: Extract and store EML attachments as separate documents
+      if (parsed.attachments && parsed.attachments.length > 0 && !args.skipAttachmentExtraction) {
+        await this.processEmlAttachments(
+          parsed.attachments,
+          documentId,
+          args.title,
+          args.metadata,
+          args.userId
+        );
+      }
+
       const duration = Date.now() - startTime;
       logger.info('[Vault] Document stored successfully', {
         documentId,
@@ -544,6 +567,131 @@ Pipeline:
         stack: error.stack,
       });
       throw new Error(`Failed to store document: ${error.message}`);
+    }
+  }
+
+  /**
+   * Process EML attachments: store document types via vault pipeline, binary types via MinIO
+   */
+  private async processEmlAttachments(
+    attachments: EmlAttachment[],
+    parentDocumentId: string,
+    emlTitle: string,
+    parentMetadata: any,
+    userId?: string
+  ): Promise<void> {
+    // Compute subfolder: strip .eml extension from title
+    const baseName = emlTitle.replace(/\.eml$/i, '');
+    const parentFolder = parentMetadata?.folderPath || '';
+    const attachmentFolder = parentFolder
+      ? `${parentFolder.replace(/\/$/, '')}/${baseName}/`
+      : `${baseName}/`;
+
+    const tempDir = '/tmp/eml-attachments';
+    await fs.mkdir(tempDir, { recursive: true });
+
+    logger.info('[Vault] Processing EML attachments', {
+      parentDocumentId,
+      attachmentCount: attachments.length,
+      attachmentFolder,
+    });
+
+    for (const attachment of attachments) {
+      const tempPath = path.join(tempDir, `${uuidv4()}-${attachment.filename}`);
+
+      try {
+        await fs.writeFile(tempPath, attachment.data);
+
+        const isDocumentType = UploadService.isDocumentType(attachment.mimeType);
+
+        if (isDocumentType) {
+          // Route through vault pipeline (parse, section, embed)
+          const result = await this.storeDocumentFromPath({
+            filePath: tempPath,
+            mimeType: attachment.mimeType,
+            title: attachment.filename.replace(/\.[^/.]+$/, ''),
+            type: 'other',
+            metadata: {
+              ...parentMetadata,
+              folderPath: attachmentFolder,
+              parentDocumentId,
+              extractedFrom: emlTitle,
+              originalFilename: attachment.filename,
+            },
+            userId,
+            skipAttachmentExtraction: true,
+          });
+
+          logger.info('[Vault] EML attachment stored via vault', {
+            parentDocumentId,
+            attachmentDocId: result.id,
+            filename: attachment.filename,
+          });
+        } else if (this.minioService && userId) {
+          // Route binary files to MinIO
+          const objectKey = MinioService.generateObjectKey(attachment.filename);
+          const minioResult = await this.minioService.uploadFile(
+            userId,
+            objectKey,
+            tempPath,
+            attachment.mimeType
+          );
+
+          const documentId = uuidv4();
+          const storagePath = `${minioResult.bucket}/${minioResult.key}`;
+
+          // Save metadata record in documents table
+          await this.documentService['db'].query(
+            `INSERT INTO documents
+              (id, zakononline_id, type, title, metadata, storage_type, storage_path, file_size, mime_type, user_id)
+             VALUES ($1, $2, $3, $4, $5, 'minio', $6, $7, $8, $9)`,
+            [
+              documentId,
+              documentId,
+              'other',
+              attachment.filename.replace(/\.[^/.]+$/, ''),
+              JSON.stringify({
+                ...parentMetadata,
+                folderPath: attachmentFolder,
+                parentDocumentId,
+                extractedFrom: emlTitle,
+                originalFilename: attachment.filename,
+                fileSize: attachment.data.length,
+                mimeType: attachment.mimeType,
+                uploadedAt: new Date().toISOString(),
+                minioEtag: minioResult.etag,
+                minioBucket: minioResult.bucket,
+                minioKey: minioResult.key,
+              }),
+              storagePath,
+              attachment.data.length,
+              attachment.mimeType,
+              userId,
+            ]
+          );
+
+          logger.info('[Vault] EML attachment stored via MinIO', {
+            parentDocumentId,
+            attachmentDocId: documentId,
+            filename: attachment.filename,
+            bucket: minioResult.bucket,
+          });
+        } else {
+          logger.warn('[Vault] Cannot store binary EML attachment — MinIO not configured or no userId', {
+            parentDocumentId,
+            filename: attachment.filename,
+            mimeType: attachment.mimeType,
+          });
+        }
+      } catch (err: any) {
+        logger.error('[Vault] Failed to store EML attachment', {
+          parentDocumentId,
+          filename: attachment.filename,
+          error: err.message,
+        });
+      } finally {
+        await fs.unlink(tempPath).catch(() => {});
+      }
     }
   }
 
@@ -827,10 +975,21 @@ Pipeline:
       const folderSet = new Set<string>();
       let fileCount = 0;
 
+      // Skip folderPath values that look like bare file names (no slash, has extension)
+      const FILE_EXT_RE = /\.[a-zA-Z0-9]{1,10}$/;
+
       for (const p of allPaths) {
+        // Skip entries that are just a filename (e.g. "contract.pdf") rather than a real folder
+        if (!p.includes('/') && FILE_EXT_RE.test(p)) {
+          continue;
+        }
         const segments = p.split('/').filter(Boolean);
         if (segments.length > prefixDepth) {
-          folderSet.add(segments[prefixDepth]);
+          const candidate = segments[prefixDepth];
+          // Also skip segment-level entries that look like filenames
+          if (!FILE_EXT_RE.test(candidate)) {
+            folderSet.add(candidate);
+          }
         }
         // Count files at exactly the current prefix level
         if (segments.length === prefixDepth || (prefix && p === prefix)) {

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -289,6 +289,7 @@ class HTTPMCPServer {
       this.services.documentService,
       metadataExtractor
     );
+    this.vaultTools.setMinioService(this.minioService);
     this.toolRegistry.registerHandler(this.vaultTools);
     this.conversationService = new ConversationService(this.services.db);
     this.gdprService = new GdprService(this.services.db, this.minioService, this.services.embeddingService);

--- a/mcp_backend/src/services/document-parser.ts
+++ b/mcp_backend/src/services/document-parser.ts
@@ -17,6 +17,12 @@ import { promisify } from 'util';
 
 const execAsync = promisify(exec);
 
+export interface EmlAttachment {
+  filename: string;
+  mimeType: string;
+  data: Buffer;
+}
+
 export interface ParsedDocument {
   text: string;
   metadata: {
@@ -33,6 +39,7 @@ export interface ParsedDocument {
     text: string;
     confidence?: number;
   }>;
+  attachments?: EmlAttachment[];
 }
 
 export class DocumentParser {
@@ -818,7 +825,8 @@ export class DocumentParser {
 
     let textBody = '';
     let htmlBody = '';
-    const attachments: string[] = [];
+    const attachmentNames: string[] = [];
+    const attachmentBuffers: EmlAttachment[] = [];
 
     if (contentType.toLowerCase().includes('multipart')) {
       // Extract boundary
@@ -828,7 +836,7 @@ export class DocumentParser {
         this.extractMimeParts(bodySection, boundaryMatch[1], (ct, content) => {
           if (ct.startsWith('text/plain') && !textBody) textBody = content;
           else if (ct.startsWith('text/html') && !htmlBody) htmlBody = content;
-        }, attachments);
+        }, attachmentNames, attachmentBuffers);
       }
     } else if (contentType.toLowerCase().includes('text/html')) {
       htmlBody = this.decodeMimeContent(bodySection, transferEncoding);
@@ -861,9 +869,9 @@ export class DocumentParser {
     }
     if (body) lines.push(body);
 
-    if (attachments.length > 0) {
-      lines.push('', `Attachments (${attachments.length}):`);
-      for (const att of attachments) lines.push(`- ${att}`);
+    if (attachmentNames.length > 0) {
+      lines.push('', `Attachments (${attachmentNames.length}):`);
+      for (const att of attachmentNames) lines.push(`- ${att}`);
     }
 
     const text = lines.join('\n');
@@ -871,7 +879,7 @@ export class DocumentParser {
       throw new Error('EML file contains no extractable text');
     }
 
-    logger.info('EML parsed', { textLength: text.length, attachments: attachments.length });
+    logger.info('EML parsed', { textLength: text.length, attachments: attachmentNames.length, attachmentBuffers: attachmentBuffers.length });
 
     return {
       text,
@@ -880,17 +888,19 @@ export class DocumentParser {
         mimeType: 'message/rfc822',
         title: subject || undefined,
       },
+      ...(attachmentBuffers.length > 0 ? { attachments: attachmentBuffers } : {}),
     };
   }
 
   /**
-   * Recursively extract text parts from multipart MIME
+   * Recursively extract text parts and binary attachments from multipart MIME
    */
   private extractMimeParts(
     body: string,
     boundary: string,
     onText: (contentType: string, content: string) => void,
-    attachments: string[]
+    attachmentNames: string[],
+    attachmentBuffers?: EmlAttachment[]
   ): void {
     const escaped = boundary.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const parts = body.split(new RegExp(`--${escaped}(?:--)?`));
@@ -912,7 +922,7 @@ export class DocumentParser {
       if (ct.startsWith('multipart/')) {
         const nestedBoundary = partHeaders.match(/boundary="?([^";\s]+)"?/i);
         if (nestedBoundary) {
-          this.extractMimeParts(partBody, nestedBoundary[1], onText, attachments);
+          this.extractMimeParts(partBody, nestedBoundary[1], onText, attachmentNames, attachmentBuffers);
         }
         continue;
       }
@@ -920,10 +930,48 @@ export class DocumentParser {
       const encMatch = partHeaders.match(/Content-Transfer-Encoding:\s*(\S+)/i);
       const enc = encMatch ? encMatch[1].trim().toLowerCase() : '7bit';
 
-      // Check for attachments
-      if (/Content-Disposition:\s*attachment/i.test(partHeaders)) {
-        const nameMatch = partHeaders.match(/filename="?([^";\r\n]+)"?/i);
-        if (nameMatch) attachments.push(this.decodeEncodedWords(nameMatch[1].trim()));
+      // Check for explicit attachments
+      const isAttachment = /Content-Disposition:\s*attachment/i.test(partHeaders);
+      // Check for inline with Content-ID (embedded images)
+      const isInline = /Content-Disposition:\s*inline/i.test(partHeaders) && /Content-ID:/i.test(partHeaders);
+
+      if (isAttachment || (isInline && !ct.startsWith('text/'))) {
+        const nameMatch = partHeaders.match(/filename="?([^";\r\n]+)"?/i) ||
+                          partHeaders.match(/name="?([^";\r\n]+)"?/i);
+        const filename = nameMatch ? this.decodeEncodedWords(nameMatch[1].trim()) : `attachment-${attachmentNames.length + 1}`;
+        attachmentNames.push(filename);
+
+        // Decode binary data if collecting attachments
+        if (attachmentBuffers) {
+          try {
+            let data: Buffer;
+            if (enc === 'base64') {
+              data = Buffer.from(partBody.replace(/\s/g, ''), 'base64');
+            } else if (enc === 'quoted-printable') {
+              const stripped = partBody.replace(/=\r?\n/g, '');
+              const bytes: number[] = [];
+              let i = 0;
+              while (i < stripped.length) {
+                if (stripped[i] === '=' && i + 2 < stripped.length && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
+                  bytes.push(parseInt(stripped.substring(i + 1, i + 3), 16));
+                  i += 3;
+                } else {
+                  bytes.push(stripped.charCodeAt(i));
+                  i++;
+                }
+              }
+              data = Buffer.from(bytes);
+            } else {
+              data = Buffer.from(partBody, 'binary');
+            }
+
+            if (data.length > 0) {
+              attachmentBuffers.push({ filename, mimeType: ct, data });
+            }
+          } catch (err: any) {
+            logger.warn('Failed to decode EML attachment', { filename, encoding: enc, error: err.message });
+          }
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary
- EML attachments (images, PDFs, etc.) are now extracted and saved as individual documents in a subfolder named after the EML file
- Document-type attachments (PDF/DOCX/HTML/TXT/RTF) go through the full vault pipeline (parse → section → embed)
- Binary attachments (images, etc.) are uploaded to MinIO with proper DB records
- `skipAttachmentExtraction` flag prevents infinite recursion on nested EMLs
- Folder listing now filters bare filenames from appearing as folders
- Fixed drag-and-drop upload folder path assignment

## Changes
- `document-parser.ts`: Added `EmlAttachment` interface, extended `ParsedDocument`, modified `extractMimeParts()` to decode and collect binary attachment data
- `vault-tools.ts`: Added `processEmlAttachments()` method, `setMinioService()`, `skipAttachmentExtraction` flag, folder listing filename filter
- `http-server.ts`: Wire up `minioService` to `VaultTools`
- `DocumentsPage/index.tsx`: Use `currentFolderPath` for drag-and-drop uploads

## Test plan
- [ ] Upload an EML with image attachments — verify subfolder appears with individual files
- [ ] Upload an EML with PDF attachment — verify PDF is parsed and searchable
- [ ] Upload a nested EML (EML with EML attachment) — verify no infinite recursion
- [ ] Verify `npx tsc --noEmit` passes (confirmed locally)
- [ ] Verify folder listing doesn't show bare filenames as folders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts attachments from uploaded EML files and stores them as separate documents in a subfolder named after the EML. Document-type attachments go through the vault pipeline; binaries are uploaded to MinIO for correct storage and metadata.

- New Features
  - Extract and store EML attachments as individual documents under an EML-named subfolder, with parent and original filename metadata.
  - Route PDFs/DOCX/HTML/TXT/RTF through parse → section → embed; upload other binaries to MinIO with DB records.
  - Add skipAttachmentExtraction to prevent recursion on nested EMLs and wire MinIO into VaultTools.

- Bug Fixes
  - Use currentFolderPath for drag-and-drop uploads so files land in the correct folder.
  - Hide bare filenames from folder listings so they don’t show up as folders.

<sup>Written for commit 832367227e2e3bcbab44794fc6d4cfebbddad835. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

