### PR TITLE
feat: real-time worker stats heartbeat

### DIFF
--- a/deployment/scripts/bulk-scrape/02-launch-workers.sh
+++ b/deployment/scripts/bulk-scrape/02-launch-workers.sh
@@ -28,6 +28,8 @@ S3_BUCKET="${BULK_SCRAPE_S3_BUCKET}"
 SQS_QUEUE_URL="${BULK_SCRAPE_SQS_QUEUE_URL}"
 IAM_PROFILE="${BULK_SCRAPE_IAM_PROFILE}"
 SG_ID="${BULK_SCRAPE_SECURITY_GROUP}"
+STATS_URL="${BULK_SCRAPE_STATS_URL:-}"
+STATS_API_KEY="${BULK_SCRAPE_STATS_API_KEY:-}"
 
 PREFIX="secondlayer-bulk-scrape"
 LT_NAME="${PREFIX}-lt"
@@ -59,6 +61,8 @@ USERDATA=$(cat "$SCRIPT_DIR/worker-userdata.sh" \
   | sed "s|__SQS_QUEUE_URL__|${SQS_QUEUE_URL}|g" \
   | sed "s|__S3_BUCKET__|${S3_BUCKET}|g" \
   | sed "s|__AWS_REGION__|${REGION}|g" \
+  | sed "s|__STATS_URL__|${STATS_URL}|g" \
+  | sed "s|__STATS_API_KEY__|${STATS_API_KEY}|g" \
   | base64 -w 0)
 
 # Get latest Ubuntu 22.04 AMI

--- a/deployment/scripts/bulk-scrape/worker-scraper.js
+++ b/deployment/scripts/bulk-scrape/worker-scraper.js
@@ -14,6 +14,8 @@
  *   CONCURRENCY          - Parallel downloads per instance (default: 5)
  *   RATE_LIMIT_RPS       - Requests per second per instance (default: 2)
  *   WORKER_ID            - Unique worker identifier (default: hostname)
+ *   STATS_URL            - Backend heartbeat URL (optional, e.g. https://mcp.legal.org.ua/api/workers/heartbeat)
+ *   STATS_API_KEY        - Bearer token for heartbeat auth (optional)
  */
 
 const https = require('https');
@@ -44,6 +46,8 @@ const REGION = process.env.AWS_REGION || 'eu-central-1';
 const CONCURRENCY = parseInt(process.env.CONCURRENCY || '5', 10);
 const RATE_LIMIT_RPS = parseFloat(process.env.RATE_LIMIT_RPS || '2');
 const WORKER_ID = process.env.WORKER_ID || os.hostname();
+const STATS_URL = process.env.STATS_URL || '';
+const STATS_API_KEY = process.env.STATS_API_KEY || '';
 
 const BASE_URL = 'https://reyestr.court.gov.ua/Review/';
 
@@ -66,6 +70,53 @@ const stats = {
 };
 
 let shuttingDown = false;
+let workerPublicIp = null;
+
+// --- Stats push (heartbeat) ---
+function fetchPublicIp() {
+  return new Promise((resolve) => {
+    const req = http.get('http://169.254.169.254/latest/meta-data/public-ipv4', { timeout: 2000 }, (res) => {
+      if (res.statusCode !== 200) { res.resume(); resolve(null); return; }
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => resolve(Buffer.concat(chunks).toString().trim()));
+      res.on('error', () => resolve(null));
+    });
+    req.on('error', () => resolve(null));
+    req.on('timeout', () => { req.destroy(); resolve(null); });
+  });
+}
+
+function pushStats() {
+  if (!STATS_URL) return;
+  const uptimeS = Math.round((Date.now() - stats.startTime) / 1000);
+  const body = JSON.stringify({
+    worker_id: WORKER_ID,
+    ip: workerPublicIp,
+    received: stats.received,
+    downloaded: stats.downloaded,
+    uploaded: stats.uploaded,
+    errors: stats.errors,
+    captchas: stats.captchas,
+    rate_limited: stats.rateLimited,
+    uptime_s: uptimeS,
+  });
+
+  const url = new URL(STATS_URL);
+  const transport = url.protocol === 'https:' ? https : http;
+  const req = transport.request(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+      ...(STATS_API_KEY ? { 'Authorization': `Bearer ${STATS_API_KEY}` } : {}),
+    },
+    timeout: 5000,
+  }, (res) => { res.resume(); }); // drain response
+  req.on('error', () => {}); // silent — fire and forget
+  req.on('timeout', () => req.destroy());
+  req.end(body);
+}
 
 // --- Helpers ---
 function sleep(ms) {
@@ -343,12 +394,25 @@ async function main() {
   const sqs = new SQSClient({ region: REGION });
   const s3 = new S3Client({ region: REGION });
 
+  // Fetch public IP for heartbeat reporting
+  workerPublicIp = await fetchPublicIp();
+  if (workerPublicIp) log(`Public IP: ${workerPublicIp}`);
+
+  // Start heartbeat interval (every 10s)
+  let heartbeatInterval = null;
+  if (STATS_URL) {
+    log(`Stats push enabled: ${STATS_URL}`);
+    pushStats(); // initial push
+    heartbeatInterval = setInterval(pushStats, 10000);
+  }
+
   // Graceful shutdown
   const shutdown = () => {
     if (shuttingDown) return;
     shuttingDown = true;
     log('Shutting down gracefully...');
     logStats();
+    if (heartbeatInterval) clearInterval(heartbeatInterval);
     setTimeout(() => process.exit(0), 5000);
   };
   process.on('SIGINT', shutdown);

--- a/deployment/scripts/bulk-scrape/worker-userdata.sh
+++ b/deployment/scripts/bulk-scrape/worker-userdata.sh
@@ -43,6 +43,8 @@ export AWS_REGION="__AWS_REGION__"
 export CONCURRENCY="5"
 export RATE_LIMIT_RPS="2"
 export WORKER_ID="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
+export STATS_URL="__STATS_URL__"
+export STATS_API_KEY="__STATS_API_KEY__"
 
 # Run with restart on crash
 while true; do

--- a/lexwebapp/src/pages/admin/bulk-scrape/index.tsx
+++ b/lexwebapp/src/pages/admin/bulk-scrape/index.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { RefreshCw, Database, FileText, CheckCircle, Clock, AlertCircle, Cloud } from 'lucide-react';
+import { RefreshCw, Database, FileText, CheckCircle, Clock, AlertCircle, Cloud, Server } from 'lucide-react';
 import { api } from '../../../utils/api-client';
 import { SectionLoader, SectionError, formatNumber, formatDate } from '../monitoring/shared';
-import type { BulkScrapeStatusResponse, BulkScrapeJob, CourtBreakdown, JusticeKindBreakdown } from './types';
+import type { BulkScrapeStatusResponse, BulkScrapeJob, CourtBreakdown, JusticeKindBreakdown, WorkerStats } from './types';
 import { InfrastructureDiagram } from './InfrastructureDiagram';
 
 function StatusBadge({ status }: { status: string }) {
@@ -49,6 +49,69 @@ function duration(startedAt: string | null, completedAt: string | null): string 
   return `${Math.floor(sec / 3600)}h ${Math.floor((sec % 3600) / 60)}m`;
 }
 
+function formatUptime(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+  return `${Math.floor(seconds / 3600)}h ${Math.floor((seconds % 3600) / 60)}m`;
+}
+
+function WorkerTable({ workers }: { workers: WorkerStats[] }) {
+  const onlineCount = workers.filter(w => w.online).length;
+  return (
+    <div className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
+      <div className="px-4 py-3 border-b border-claude-border bg-gray-50 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Server size={14} className="text-purple-500" />
+          <h2 className="text-sm font-semibold text-claude-text">EC2 Workers</h2>
+        </div>
+        <span className="text-xs text-claude-subtext">{onlineCount}/{workers.length} online</span>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-claude-border bg-gray-50/50">
+              <th className="text-left px-4 py-2 text-xs font-medium text-claude-subtext"></th>
+              <th className="text-left px-4 py-2 text-xs font-medium text-claude-subtext">Worker</th>
+              <th className="text-left px-4 py-2 text-xs font-medium text-claude-subtext">IP</th>
+              <th className="text-left px-4 py-2 text-xs font-medium text-claude-subtext">Uptime</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">Recv</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">DL</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">UP</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">Err</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">CAPTCHA</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">Rate</th>
+              <th className="text-right px-4 py-2 text-xs font-medium text-claude-subtext">Last seen</th>
+            </tr>
+          </thead>
+          <tbody>
+            {workers.map((w) => (
+              <tr key={w.worker_id} className={`border-b border-claude-border/30 hover:bg-gray-50/50 ${!w.online ? 'opacity-40' : ''}`}>
+                <td className="px-4 py-2">
+                  <span className={`inline-block w-2 h-2 rounded-full ${w.online ? 'bg-green-500' : 'bg-gray-300'}`} />
+                </td>
+                <td className="px-4 py-2 font-mono text-xs text-claude-text">{w.worker_id_short}</td>
+                <td className="px-4 py-2 font-mono text-xs text-claude-subtext">{w.ip || '\u2014'}</td>
+                <td className="px-4 py-2 text-xs text-claude-subtext">{formatUptime(w.uptime_s)}</td>
+                <td className="px-4 py-2 text-right font-mono text-xs">{formatNumber(w.received)}</td>
+                <td className="px-4 py-2 text-right font-mono text-xs">{formatNumber(w.downloaded)}</td>
+                <td className="px-4 py-2 text-right font-mono text-xs text-green-700">{formatNumber(w.uploaded)}</td>
+                <td className="px-4 py-2 text-right font-mono text-xs">
+                  {w.errors > 0 ? <span className="text-red-600">{formatNumber(w.errors)}</span> : '\u2014'}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-xs">
+                  {w.captchas > 0 ? <span className="text-amber-600">{formatNumber(w.captchas)}</span> : '\u2014'}
+                </td>
+                <td className="px-4 py-2 text-right font-mono text-xs text-blue-600">{w.rate_docs_per_s.toFixed(2)}/s</td>
+                <td className="px-4 py-2 text-right text-xs text-claude-subtext">{w.last_seen_s}s ago</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
 export function AdminBulkScrapePage() {
   const [data, setData] = useState<BulkScrapeStatusResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -77,7 +140,8 @@ export function AdminBulkScrapePage() {
   useEffect(() => {
     const hasRunning = data?.jobs?.some(j => j.status === 'running') ?? false;
     const awsActive = data?.aws_pipeline?.active ?? false;
-    const shouldPoll = hasRunning || awsActive;
+    const hasWorkers = (data?.workers?.length ?? 0) > 0;
+    const shouldPoll = hasRunning || awsActive || hasWorkers;
     if (shouldPoll && !polling) {
       setPolling(true);
       intervalRef.current = setInterval(() => fetchData(true), 10000);
@@ -88,7 +152,7 @@ export function AdminBulkScrapePage() {
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, [data?.jobs, data?.aws_pipeline?.active, polling, fetchData]);
+  }, [data?.jobs, data?.aws_pipeline?.active, data?.workers?.length, polling, fetchData]);
 
   if (loading && !data) return <div className="p-6"><SectionLoader /></div>;
   if (error && !data) return <div className="p-6"><SectionError message={error} onRetry={() => fetchData()} /></div>;
@@ -96,6 +160,7 @@ export function AdminBulkScrapePage() {
   const stats = data?.stats;
   const jobs = data?.jobs ?? [];
   const awsPipeline = data?.aws_pipeline;
+  const workers = data?.workers ?? [];
   const courtBreakdown = data?.court_breakdown ?? [];
   const justiceKindBreakdown = data?.justice_kind_breakdown ?? [];
 
@@ -216,6 +281,9 @@ export function AdminBulkScrapePage() {
           )}
         </div>
       )}
+
+      {/* Worker Stats */}
+      {workers.length > 0 && <WorkerTable workers={workers} />}
 
       {/* Jobs Table */}
       {jobs.length > 0 && (
@@ -339,7 +407,7 @@ export function AdminBulkScrapePage() {
 
       {polling && (
         <div className="text-center text-xs text-claude-subtext">
-          Auto-refresh кожні 10 секунд (AWS pipeline active)
+          Auto-refresh кожні 10 секунд
         </div>
       )}
     </div>

--- a/lexwebapp/src/pages/admin/bulk-scrape/types.ts
+++ b/lexwebapp/src/pages/admin/bulk-scrape/types.ts
@@ -43,10 +43,27 @@ export interface AwsPipelineStats {
   active: boolean;
 }
 
+export interface WorkerStats {
+  worker_id: string;
+  worker_id_short: string;
+  ip: string | null;
+  uptime_s: number;
+  received: number;
+  downloaded: number;
+  uploaded: number;
+  errors: number;
+  captchas: number;
+  rate_limited: number;
+  rate_docs_per_s: number;
+  last_seen_s: number;
+  online: boolean;
+}
+
 export interface BulkScrapeStatusResponse {
   jobs: BulkScrapeJob[];
   stats: BulkScrapeStats | null;
   aws_pipeline?: AwsPipelineStats | null;
+  workers?: WorkerStats[];
   court_breakdown?: CourtBreakdown[];
   justice_kind_breakdown?: JusticeKindBreakdown[];
   message?: string;

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -33,6 +33,7 @@ import { InvoiceService } from './services/invoice-service.js';
 import { createPaymentRouter, createWebhookRouter } from './routes/payment-routes.js';
 import { createBillingRoutes } from './routes/billing-routes.js';
 import { createAdminRoutes } from './routes/admin-routes.js';
+import { createWorkerHeartbeatRoute } from './routes/worker-heartbeat-routes.js';
 import { createDecisionsRoutes } from './routes/decisions-routes.js';
 import { attachTerminalWebSocket } from './routes/terminal-routes.js';
 import { createTeamRoutes } from './routes/team-routes.js';
@@ -1853,6 +1854,9 @@ class HTTPMCPServer {
     // GET /api/admin/api-keys - List API keys
     // GET /api/admin/settings - Get system settings
     this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, this.billingService, this.userPreferencesService, this.prometheusService, this.pricingService, this.subscriptionService, this.configService));
+
+    // Worker heartbeat (uses dualAuth so EC2 workers can auth with SECONDARY_LAYER_KEYS)
+    this.app.use('/api/workers', dualAuth as any, createWorkerHeartbeatRoute());
 
     // Upload metrics endpoint (admin)
     this.app.get('/api/admin/upload-metrics', requireJWT as any, (async (_req: DualAuthRequest, res: express.Response) => {

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -21,6 +21,7 @@ import { CourtDecisionHTMLParser } from '../utils/html-parser.js';
 import { logger } from '../utils/logger.js';
 import { SQSClient, GetQueueAttributesCommand } from '@aws-sdk/client-sqs';
 import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+import { getWorkerStats } from './worker-heartbeat-routes.js';
 
 
 /**
@@ -4813,6 +4814,9 @@ export function createAdminRoutes(
         }
       }
 
+      // Worker stats from Redis heartbeats
+      const workers = await getWorkerStats();
+
       res.json({
         jobs: jobsResult.rows,
         stats: {
@@ -4823,6 +4827,7 @@ export function createAdminRoutes(
           completion_pct: totalCourt > 0 ? ((withFullText / totalCourt) * 100).toFixed(1) : '0.0',
         },
         aws_pipeline,
+        workers: workers.length > 0 ? workers : undefined,
         court_breakdown: courtBreakdownResult.rows.map((r: any) => ({
           court_name: r.court_name,
           total: parseInt(r.total_count, 10),

--- a/mcp_backend/src/routes/worker-heartbeat-routes.ts
+++ b/mcp_backend/src/routes/worker-heartbeat-routes.ts
@@ -1,0 +1,110 @@
+/**
+ * Worker Heartbeat Routes
+ * Receives stats from EC2 scrape workers and stores in Redis with TTL.
+ */
+
+import express, { Request, Response } from 'express';
+import { logger } from '../utils/logger.js';
+import { getRedisClient } from '../utils/redis-client.js';
+
+const WORKER_KEY_PREFIX = 'worker:stats:';
+const WORKER_TTL_SECONDS = 60;
+
+export function createWorkerHeartbeatRoute(): express.Router {
+  const router = express.Router();
+
+  /**
+   * POST /api/workers/heartbeat
+   * Workers push stats every 10s. Stored in Redis with 60s TTL.
+   */
+  router.post('/heartbeat', async (req: Request, res: Response) => {
+    const { worker_id, ip, received, downloaded, uploaded, errors, captchas, rate_limited, uptime_s } = req.body;
+
+    if (!worker_id) {
+      return res.status(400).json({ error: 'worker_id is required' });
+    }
+
+    try {
+      const redis = await getRedisClient();
+      if (!redis) {
+        return res.status(503).json({ error: 'Redis unavailable' });
+      }
+
+      const payload = JSON.stringify({
+        worker_id,
+        ip: ip || null,
+        received: received || 0,
+        downloaded: downloaded || 0,
+        uploaded: uploaded || 0,
+        errors: errors || 0,
+        captchas: captchas || 0,
+        rate_limited: rate_limited || 0,
+        uptime_s: uptime_s || 0,
+        last_seen: Date.now(),
+      });
+
+      await redis.set(`${WORKER_KEY_PREFIX}${worker_id}`, payload, { EX: WORKER_TTL_SECONDS });
+
+      res.json({ ok: true });
+    } catch (err: any) {
+      logger.error('Worker heartbeat failed', { error: err.message, worker_id });
+      res.status(500).json({ error: 'Failed to store heartbeat' });
+    }
+  });
+
+  return router;
+}
+
+/**
+ * Read all worker stats from Redis. Used by bulk-scrape-status endpoint.
+ */
+export async function getWorkerStats(): Promise<any[]> {
+  try {
+    const redis = await getRedisClient();
+    if (!redis) return [];
+
+    const keys = await redis.keys(`${WORKER_KEY_PREFIX}*`);
+    if (keys.length === 0) return [];
+
+    const pipeline = redis.multi();
+    for (const key of keys) {
+      pipeline.get(key);
+    }
+    const results = await pipeline.exec();
+
+    const now = Date.now();
+    const workers = [];
+
+    for (const raw of results) {
+      if (!raw || typeof raw !== 'string') continue;
+      try {
+        const data = JSON.parse(raw);
+        const lastSeenS = Math.round((now - data.last_seen) / 1000);
+        const rateDocsPerS = data.uptime_s > 0 ? (data.uploaded / data.uptime_s) : 0;
+
+        workers.push({
+          worker_id: data.worker_id,
+          worker_id_short: data.worker_id.length > 10 ? data.worker_id.slice(0, 10) : data.worker_id,
+          ip: data.ip,
+          uptime_s: data.uptime_s,
+          received: data.received,
+          downloaded: data.downloaded,
+          uploaded: data.uploaded,
+          errors: data.errors,
+          captchas: data.captchas,
+          rate_limited: data.rate_limited,
+          rate_docs_per_s: parseFloat(rateDocsPerS.toFixed(2)),
+          last_seen_s: lastSeenS,
+          online: lastSeenS < WORKER_TTL_SECONDS,
+        });
+      } catch { /* skip malformed */ }
+    }
+
+    // Sort by worker_id for stable ordering
+    workers.sort((a, b) => a.worker_id.localeCompare(b.worker_id));
+    return workers;
+  } catch (err: any) {
+    logger.warn('Failed to read worker stats from Redis', { error: err.message });
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary
- EC2 scrape workers push heartbeat stats every 10s to `POST /api/workers/heartbeat` (authenticated via `SECONDARY_LAYER_KEYS`)
- Backend stores worker stats in Redis with 60s TTL (`worker:stats:{id}`)
- `GET /api/admin/bulk-scrape-status` now includes `workers` array with per-worker metrics
- Admin bulk-scrape page shows live worker table: online dot, IP, uptime, recv/dl/up/errors/captchas, throughput rate, last seen
- Auto-polling activates when workers are online

## Test plan
- [ ] Deploy backend, `POST /api/workers/heartbeat` with test payload → 200
- [ ] Verify Redis key: `redis-cli keys 'worker:stats:*'`
- [ ] Admin page shows worker table with live data
- [ ] Workers going offline → row dims after 60s TTL expires
- [ ] Add `BULK_SCRAPE_STATS_URL` + `BULK_SCRAPE_STATS_API_KEY` to `infra-config.env`
- [ ] Cycle ASG — workers report stats on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-time heartbeat from EC2 scrape workers and shows live per-worker stats on the admin bulk-scrape page. Backend stores metrics in Redis and returns them via the bulk-scrape status API.

- **New Features**
  - Workers send stats every 10s to POST /api/workers/heartbeat (Bearer auth via SECONDARY_LAYER_KEYS).
  - Store in Redis with 60s TTL under worker:stats:{id}.
  - /api/admin/bulk-scrape-status now includes workers[] with online status, IP, uptime, counts, rate, and last seen.
  - Admin page shows a live worker table and auto-refreshes when workers are online.

- **Migration**
  - Set BULK_SCRAPE_STATS_URL and BULK_SCRAPE_STATS_API_KEY in infra-config.env.
  - Launch template passes STATS_URL and STATS_API_KEY to instances; cycle the ASG or redeploy workers.

<sup>Written for commit 393053aca806670afd873b49d5e1ea2bc32860ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

