### PR TITLE
fix: enable vertical scrolling on workflow pages

### DIFF
--- a/lexwebapp/src/pages/WorkflowSetDetailPage/index.tsx
+++ b/lexwebapp/src/pages/WorkflowSetDetailPage/index.tsx
@@ -81,6 +81,7 @@ export function WorkflowSetDetailPage() {
   const pendingCount = activeWorkflowSet.workflows?.filter((w) => w.status === 'pending').length || 0;
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-6xl mx-auto p-6">
       {/* Back button */}
       <button
@@ -141,6 +142,7 @@ export function WorkflowSetDetailPage() {
           />
         ))}
       </div>
+    </div>
     </div>
   );
 }

--- a/lexwebapp/src/pages/WorkflowsPage/index.tsx
+++ b/lexwebapp/src/pages/WorkflowsPage/index.tsx
@@ -31,6 +31,7 @@ export function WorkflowsPage() {
   };
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-6xl mx-auto p-6">
       <div className="flex items-center gap-3 mb-8">
         <Zap className="w-7 h-7 text-indigo-600" />
@@ -99,6 +100,7 @@ export function WorkflowsPage() {
           })}
         </div>
       )}
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Workflow pages (list + detail) were not scrollable because MainLayout's content area uses `overflow-hidden`
- Wrapped both `WorkflowsPage` and `WorkflowSetDetailPage` in `h-full overflow-y-auto` containers

## Test plan
- [ ] Open /workflows with enough workflow sets to overflow viewport — verify page scrolls
- [ ] Open /workflows/:id with multiple workflow cards — verify page scrolls
- [ ] Expand workflow cards and verify nested scroll (results `max-h-60`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable vertical scrolling on the workflows list and detail pages so long content is visible, without affecting nested scroll areas. Wrap page content in h-full overflow-y-auto to counter MainLayout’s overflow-hidden.

<sup>Written for commit df19f54f5375fa587894685de076332c26c2680d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

