### PR TITLE
fix: worker heartbeat route order before catch-all /api

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1844,6 +1844,11 @@ class HTTPMCPServer {
     this.app.use('/api/decisions', requireJWT as any, createDecisionsRoutes(this.services.reyestrDownloadService));
     logger.info('Decisions routes registered at /api/decisions');
 
+    // Worker heartbeat (uses dualAuth so EC2 workers can auth with SECONDARY_LAYER_KEYS)
+    // MUST be before the catch-all /api workflow routes
+    this.app.use('/api/workers', dualAuth as any, createWorkerHeartbeatRoute());
+    logger.info('Worker heartbeat routes registered at /api/workers');
+
     // Workflow routes - workflow sets, workflow execution, cancellation
     this.app.use('/api', requireJWT as any, createWorkflowRoutes(this.workflowService, this.workflowExecutorService));
     logger.info('Workflow routes registered at /api/workflow-sets, /api/workflows');
@@ -1881,9 +1886,6 @@ class HTTPMCPServer {
     // GET /api/admin/api-keys - List API keys
     // GET /api/admin/settings - Get system settings
     this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, this.billingService, this.userPreferencesService, this.prometheusService, this.pricingService, this.subscriptionService, this.configService));
-
-    // Worker heartbeat (uses dualAuth so EC2 workers can auth with SECONDARY_LAYER_KEYS)
-    this.app.use('/api/workers', dualAuth as any, createWorkerHeartbeatRoute());
 
     // Upload metrics endpoint (admin)
     this.app.get('/api/admin/upload-metrics', requireJWT as any, (async (_req: DualAuthRequest, res: express.Response) => {


### PR DESCRIPTION
## Summary
- Move `/api/workers` route registration before the catch-all `/api` workflow route
- Fixes API key auth being rejected by `requireJWT` instead of using `dualAuth`

## Test plan
- [ ] POST to /api/workers/heartbeat with API key returns `{"ok":true}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved /api/workers route registration before the catch-all /api routes so the worker heartbeat uses dualAuth, fixing rejected API key auth by requireJWT. This restores successful API key heartbeats at /api/workers/heartbeat.

<sup>Written for commit 28cc563831c43a2e16f511f525571c535189868c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

