### PR TITLE
fix: make LOCAL_IP optional for EC2 scrapers

### DIFF
--- a/mcp_backend/src/scripts/local-slow-scraper.js
+++ b/mcp_backend/src/scripts/local-slow-scraper.js
@@ -103,8 +103,7 @@ function fetchHTML(registryId, retries = 3) {
       attempt++;
       const url = `${BASE_URL}${registryId}`;
 
-      const req = https.get(url, {
-        localAddress: LOCAL_IP,
+      const fetchOpts = {
         headers: {
           'User-Agent': randomUA(),
           'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -113,7 +112,10 @@ function fetchHTML(registryId, retries = 3) {
           'Connection': 'keep-alive',
         },
         timeout: 30000,
-      }, (res) => {
+      };
+      if (LOCAL_IP) fetchOpts.localAddress = LOCAL_IP;
+
+      const req = https.get(url, fetchOpts, (res) => {
         if (res.statusCode === 429) {
           stats.rateLimited++;
           if (attempt < retries) {


### PR DESCRIPTION
Fixes EADDRNOTAVAIL when running on EC2 without residential IP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make LOCAL_IP optional in the local-slow-scraper to prevent EADDRNOTAVAIL on EC2. We now only set https localAddress when the LOCAL_IP env var is present, allowing scrapers to run without a residential IP.

<sup>Written for commit 2ce943f3215dcf39684023a1d9e0d252dcd8427c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

