### PR TITLE
fix: correct URL pathname parsing in PDF route handler

### DIFF
--- a/mcp_backend/src/services/document-parser.ts
+++ b/mcp_backend/src/services/document-parser.ts
@@ -136,7 +136,8 @@ export class DocumentParser {
       // Serve pdf.js files via route interception (avoids file:// CORS issues with ESM workers)
       await context.route('http://pdfrender/**', async (route) => {
         const url = new URL(route.request().url());
-        const filePath = url.pathname.replace('/pdfrender/', '');
+        // hostname is 'pdfrender', pathname is '/render.html' or '/pdf.min.mjs' etc.
+        const filePath = url.pathname.slice(1);
 
         if (filePath === 'render.html') {
           await route.fulfill({


### PR DESCRIPTION
## Summary
- Fix bug where `url.pathname.replace('/pdfrender/', '')` did nothing because `pdfrender` is the hostname, not part of the path
- Use `url.pathname.slice(1)` to correctly strip the leading slash
- Tested: 2-page Ukrainian legal PDF successfully OCR'd via Playwright + pdf.js + Google Vision

## Test plan
- [x] Uploaded scanned PDF (Свідоцтво про хворобу) — Ukrainian text extracted correctly
- [x] 2 pages detected, OCR'd in ~38 seconds
- [x] Docker build successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected URL pathname parsing in the PDF route handler so pdf.js assets under http://pdfrender/** are served correctly. This fixes broken asset loading and restores OCR flows using Playwright + pdf.js.

- **Bug Fixes**
  - Use url.pathname.slice(1) to strip the leading slash; the previous replace('/pdfrender/', '') didn’t match because ‘pdfrender’ is the hostname.

<sup>Written for commit 73749062380331a27564499b6fbbddf326b01c5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

