### PR TITLE
fix: show extracted text for vault-stored PDFs

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -473,14 +473,30 @@ export function DocumentsPage() {
             ...(isImage ? { ocrText: ocrText || '', documentId: doc.id } : {}),
           });
         } else {
-          // Fallback to text content if no preview URL
-          setPreviewDoc({
-            type: 'document',
-            title: doc.title,
-            subtitle: doc.metadata?.uploadedAt ? `Завантажено: ${new Date(doc.metadata.uploadedAt).toLocaleDateString('uk-UA')}` : undefined,
-            badge,
-            content: 'Попередній перегляд недоступний для цього файлу.',
-          });
+          // No binary preview (vault-stored PDF/image) — load extracted text
+          try {
+            const result = await mcpService.callTool('get_document', { documentId: doc.id });
+            const parsed = result?.result?.content?.[0]?.text
+              ? JSON.parse(result.result.content[0].text)
+              : result?.result || result;
+            const rawContent = parsed.content || parsed.text || parsed.sections?.map((s: any) => s.content).join('\n\n') || 'Вміст недоступний';
+            const content = processEmlContent(rawContent);
+            setPreviewDoc({
+              type: 'document',
+              title: doc.title,
+              subtitle: doc.metadata?.uploadedAt ? `Завантажено: ${new Date(doc.metadata.uploadedAt).toLocaleDateString('uk-UA')}` : undefined,
+              badge,
+              content,
+            });
+          } catch {
+            setPreviewDoc({
+              type: 'document',
+              title: doc.title,
+              subtitle: doc.metadata?.uploadedAt ? `Завантажено: ${new Date(doc.metadata.uploadedAt).toLocaleDateString('uk-UA')}` : undefined,
+              badge,
+              content: 'Попередній перегляд недоступний для цього файлу.',
+            });
+          }
         }
       } catch (err: any) {
         console.error('Failed to fetch preview URL:', err);


### PR DESCRIPTION
## Summary
- PDFs uploaded via vault pipeline have text extracted but no binary in MinIO
- Preview endpoint returns `previewUrl: null` → showed "Попередній перегляд недоступний"
- Now falls back to loading extracted text via `get_document` MCP tool

## Test plan
- [ ] Open a vault-stored PDF document → should show extracted text instead of "unavailable"
- [ ] MinIO-stored images/PDFs still show binary preview as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show extracted text in the document preview for vault-stored PDFs when no binary preview is available. Replaces the “Preview unavailable” message; MinIO-stored files still show the binary preview.

- **Bug Fixes**
  - When previewUrl is null, fetch extracted text via the get_document MCP tool and render it.
  - Preserve existing behavior for MinIO-stored images/PDFs.

<sup>Written for commit a63ccbe119881aa6d44546adbfe0dd41099c2c03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

