### PR TITLE
fix: resolve userId extraction in API key routes for JWT auth

### DIFF
--- a/mcp_backend/src/routes/api-key-routes.ts
+++ b/mcp_backend/src/routes/api-key-routes.ts
@@ -21,6 +21,10 @@ function getStringParam(param: string | string[] | undefined): string {
   return Array.isArray(param) ? param[0] : param;
 }
 
+function getUserId(req: AuthenticatedRequest): string | undefined {
+  return req.userId || req.user?.id;
+}
+
 export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: CreditService): Router {
   const router = Router();
 
@@ -29,14 +33,15 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
    */
   router.get('/', async (req: AuthenticatedRequest, res: Response): Promise<any> => {
     try {
-      if (!req.userId) {
+      const userId = getUserId(req);
+      if (!userId) {
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'User ID not found in request',
         });
       }
 
-      const keys = await apiKeyService.listUserApiKeys(req.userId);
+      const keys = await apiKeyService.listUserApiKeys(userId);
 
       // Mask keys (show only prefix and suffix)
       const maskedKeys = keys.map((key: any) => ({
@@ -52,7 +57,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
     } catch (error: any) {
       logger.error('[ApiKeyRoutes] Error listing API keys', {
         error: error.message,
-        userId: req.userId,
+        userId: getUserId(req),
       });
       return res.status(500).json({
         error: 'Failed to list API keys',
@@ -66,7 +71,8 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
    */
   router.post('/', async (req: AuthenticatedRequest, res: Response): Promise<any> => {
     try {
-      if (!req.userId) {
+      const userId = getUserId(req);
+      if (!userId) {
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'User ID not found in request',
@@ -92,7 +98,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
       const expiresAtDate = expiresAt ? new Date(expiresAt) : undefined;
 
       const newKey = await apiKeyService.createApiKey(
-        req.userId,
+        userId,
         name.trim(),
         description?.trim(),
         expiresAtDate
@@ -107,7 +113,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
     } catch (error: any) {
       logger.error('[ApiKeyRoutes] Error creating API key', {
         error: error.message,
-        userId: req.userId,
+        userId: getUserId(req),
       });
       return res.status(500).json({
         error: 'Failed to create API key',
@@ -121,7 +127,8 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
    */
   router.delete('/:keyId', async (req: AuthenticatedRequest, res: Response): Promise<any> => {
     try {
-      if (!req.userId) {
+      const userId = getUserId(req);
+      if (!userId) {
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'User ID not found in request',
@@ -137,7 +144,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
         });
       }
 
-      const success = await apiKeyService.revokeApiKey(keyId, req.userId);
+      const success = await apiKeyService.revokeApiKey(keyId, userId);
 
       if (!success) {
         return res.status(404).json({
@@ -153,7 +160,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
     } catch (error: any) {
       logger.error('[ApiKeyRoutes] Error revoking API key', {
         error: error.message,
-        userId: req.userId,
+        userId: getUserId(req),
         keyId: req.params.keyId,
       });
       return res.status(500).json({
@@ -168,18 +175,19 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
    */
   router.get('/balance', async (req: AuthenticatedRequest, res: Response): Promise<any> => {
     try {
-      if (!req.userId) {
+      const userId = getUserId(req);
+      if (!userId) {
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'User ID not found in request',
         });
       }
 
-      const balanceStatus = await creditService.getBalanceStatus(req.userId);
+      const balanceStatus = await creditService.getBalanceStatus(userId);
 
       if (!balanceStatus) {
         // Initialize credits if not exists
-        await creditService.initializeUserCredits(req.userId, 0);
+        await creditService.initializeUserCredits(userId, 0);
 
         return res.json({
           success: true,
@@ -198,7 +206,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
     } catch (error: any) {
       logger.error('[ApiKeyRoutes] Error getting balance', {
         error: error.message,
-        userId: req.userId,
+        userId: getUserId(req),
       });
       return res.status(500).json({
         error: 'Failed to get balance',
@@ -212,7 +220,8 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
    */
   router.get('/transactions', async (req: AuthenticatedRequest, res: Response): Promise<any> => {
     try {
-      if (!req.userId) {
+      const userId = getUserId(req);
+      if (!userId) {
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'User ID not found in request',
@@ -228,7 +237,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
         });
       }
 
-      const transactions = await creditService.getTransactions(req.userId, limit);
+      const transactions = await creditService.getTransactions(userId, limit);
 
       return res.json({
         success: true,
@@ -238,7 +247,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
     } catch (error: any) {
       logger.error('[ApiKeyRoutes] Error getting transactions', {
         error: error.message,
-        userId: req.userId,
+        userId: getUserId(req),
       });
       return res.status(500).json({
         error: 'Failed to get transactions',
@@ -253,7 +262,8 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
    */
   router.post('/credits/add', async (req: AuthenticatedRequest, res: Response): Promise<any> => {
     try {
-      if (!req.userId) {
+      const userId = getUserId(req);
+      if (!userId) {
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'User ID not found in request',
@@ -270,7 +280,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
       }
 
       const result = await creditService.addCredits(
-        req.userId,
+        userId,
         amount,
         'bonus',
         'manual_grant',
@@ -287,7 +297,7 @@ export function createApiKeyRouter(apiKeyService: ApiKeyService, creditService: 
     } catch (error: any) {
       logger.error('[ApiKeyRoutes] Error adding credits', {
         error: error.message,
-        userId: req.userId,
+        userId: getUserId(req),
       });
       return res.status(500).json({
         error: 'Failed to add credits',


### PR DESCRIPTION
## Summary
- `requireJWT` middleware sets `req.user` but API key routes checked `req.userId`, causing all `/api/keys` endpoints to return 401
- Add `getUserId()` helper that checks both `req.userId` (from API key auth) and `req.user.id` (from JWT auth)
- Fixes MCP token generation from the profile page

## Test plan
- [ ] Create MCP token via profile page UI
- [ ] List tokens via `GET /api/keys`
- [ ] Revoke token via UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 401s on all /api/keys endpoints by correctly reading the user ID for both JWT and API key auth. Restores MCP token generation from the profile page.

- **Bug Fixes**
  - Added getUserId(req) to read req.userId or req.user.id.
  - Updated list/create/revoke keys, balance, transactions, and credits routes to use the resolved userId.
  - Error logs now include the resolved userId.

<sup>Written for commit 4088eb638b99cdf41c2417846cc753393bd87928. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

