### PR TITLE
fix: wire up non-functional buttons on legislation library page

### DIFF
--- a/lexwebapp/src/components/LegalCodesLibraryPage.tsx
+++ b/lexwebapp/src/components/LegalCodesLibraryPage.tsx
@@ -187,6 +187,65 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
   const [showComment, setShowComment] = useState(false);
   const [commentText, setCommentText] = useState('');
 
+  // Global search from listing page
+  const [globalSearchResults, setGlobalSearchResults] = useState<SearchResult[]>([]);
+  const [globalSearchLoading, setGlobalSearchLoading] = useState(false);
+  const [globalSearchTotal, setGlobalSearchTotal] = useState(0);
+  const [showAllCategories, setShowAllCategories] = useState(false);
+
+  const handleGlobalSearch = useCallback(async (query?: string) => {
+    const q = (query || searchQuery).trim();
+    if (!q) return;
+    setGlobalSearchLoading(true);
+    setGlobalSearchResults([]);
+    setGlobalSearchTotal(0);
+    try {
+      const result = await mcpService.callTool('search_legislation', { query: q, limit: 20 });
+      const data = parseToolResult(result);
+      setGlobalSearchResults(data.articles || []);
+      setGlobalSearchTotal(data.total_found || 0);
+    } catch (err: any) {
+      showToast.error(err.message || 'Помилка пошуку');
+    } finally {
+      setGlobalSearchLoading(false);
+    }
+  }, [searchQuery]);
+
+  const handlePopularQuery = useCallback((query: string) => {
+    setSearchQuery(query);
+    handleGlobalSearch(query);
+  }, [handleGlobalSearch]);
+
+  const handleDownloadCode = useCallback(async (codeNumber: string, codeName: string) => {
+    showToast.info('Завантаження структури...');
+    try {
+      const result = await mcpService.callTool('get_legislation_structure', { rada_id: codeNumber });
+      const data = parseToolResult(result);
+      if (data.error) {
+        showToast.error(data.error);
+        return;
+      }
+      const articles = data.articles_summary || [];
+      let content = `${data.title || codeName}\n№ ${codeNumber}\n\nЗМІСТ\n\n`;
+      content += articles.map((a: TOCArticleEntry) => `Стаття ${a.article_number}. ${a.title}`).join('\n');
+      const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${codeName.replace(/\s+/g, '_')}_зміст.txt`;
+      a.click();
+      URL.revokeObjectURL(url);
+      showToast.success('Завантажено');
+    } catch (err: any) {
+      showToast.error(err.message || 'Не вдалося завантажити');
+    }
+  }, []);
+
+  const handleCategorySearch = useCallback((category: string) => {
+    setSearchQuery(category);
+    handleGlobalSearch(category);
+  }, [handleGlobalSearch]);
+
   // All articles list for prev/next navigation
   const allArticles = legislationData?.articles_summary || [];
 
@@ -831,26 +890,81 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
                   type="text"
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
+                  onKeyDown={(e) => e.key === 'Enter' && handleGlobalSearch()}
                   placeholder="Введіть назву кодексу або закону..."
                   className="block w-full pl-11 pr-4 py-3 bg-white border border-claude-border rounded-xl text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all shadow-sm font-sans"
                 />
               </div>
-              <button className="px-6 py-3 bg-claude-accent text-white rounded-xl font-medium hover:bg-[#C66345] transition-colors shadow-sm font-sans">
+              <button
+                onClick={() => handleGlobalSearch()}
+                disabled={globalSearchLoading || !searchQuery.trim()}
+                className="px-6 py-3 bg-claude-accent text-white rounded-xl font-medium hover:bg-[#C66345] transition-colors shadow-sm font-sans disabled:opacity-50 flex items-center gap-2"
+              >
+                {globalSearchLoading && <Loader2 size={16} className="animate-spin" />}
                 Пошук
               </button>
             </div>
             <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans">
               <span>Популярні запити:</span>
-              {['конституція', 'цпк', 'цк', 'кк', 'зку'].map((query) => (
+              {['конституція', 'цпк', 'цк', 'кк', 'зку'].map((q) => (
                 <button
-                  key={query}
+                  key={q}
+                  onClick={() => handlePopularQuery(q)}
                   className="text-claude-accent hover:text-[#C66345] font-medium"
                 >
-                  {query}
+                  {q}
                 </button>
               ))}
             </div>
           </div>
+
+          {/* Global Search Results */}
+          {globalSearchResults.length > 0 && (
+            <div className="bg-white rounded-2xl border border-claude-border shadow-sm p-6 mb-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-sans text-claude-text font-medium flex items-center gap-2">
+                  <Search size={20} />
+                  Результати пошуку ({globalSearchTotal})
+                </h3>
+                <button
+                  onClick={() => { setGlobalSearchResults([]); setGlobalSearchTotal(0); setSearchQuery(''); }}
+                  className="p-1.5 text-claude-subtext hover:text-claude-text transition-colors"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+              <div className="space-y-2 max-h-96 overflow-y-auto">
+                {globalSearchResults.map((result, index) => (
+                  <div
+                    key={index}
+                    className="p-3 bg-claude-bg rounded-lg border border-claude-border hover:border-claude-accent/30 transition-colors"
+                  >
+                    <p className="text-sm font-medium text-claude-text font-sans mb-1">
+                      Ст. {result.article_number}. {result.title}
+                    </p>
+                    <p className="text-sm text-claude-subtext font-sans mb-2 line-clamp-2">
+                      {result.full_text}
+                    </p>
+                    <button
+                      onClick={() => {
+                        setSelectedCode(result.rada_id);
+                        setTimeout(() => fetchArticle(result.article_number), 500);
+                      }}
+                      className="text-xs text-claude-accent hover:text-[#C66345] font-sans font-medium"
+                    >
+                      Перейти до статті &rarr;
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {!globalSearchLoading && searchQuery && globalSearchResults.length === 0 && globalSearchTotal === 0 && (
+            <div className="bg-white rounded-2xl border border-claude-border shadow-sm p-6 mb-6 text-center">
+              <p className="text-sm text-claude-subtext font-sans">Нічого не знайдено за запитом «{searchQuery}»</p>
+            </div>
+          )}
 
           {/* Main Codes */}
           <div className="mb-6">
@@ -881,7 +995,11 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
                     >
                       Відкрити
                     </button>
-                    <button className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-colors">
+                    <button
+                      onClick={() => handleDownloadCode(code.number, code.name)}
+                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-colors"
+                      title="Завантажити зміст"
+                    >
                       <Download size={18} />
                     </button>
                   </div>
@@ -915,7 +1033,11 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
                     >
                       Відкрити
                     </button>
-                    <button className="p-1.5 text-claude-subtext hover:text-claude-text transition-colors">
+                    <button
+                      onClick={() => handleDownloadCode(code.number, code.name)}
+                      className="p-1.5 text-claude-subtext hover:text-claude-text transition-colors"
+                      title="Завантажити зміст"
+                    >
                       <Download size={16} />
                     </button>
                   </div>
@@ -941,7 +1063,11 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
                 >
                   Відкрити
                 </button>
-                <button className="p-1.5 text-claude-subtext hover:text-claude-text transition-colors">
+                <button
+                  onClick={() => handleDownloadCode('254к/96-вр', 'Конституція_України')}
+                  className="p-1.5 text-claude-subtext hover:text-claude-text transition-colors"
+                  title="Завантажити зміст"
+                >
                   <Download size={16} />
                 </button>
               </div>
@@ -955,9 +1081,10 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
               Категорії законів
             </h2>
             <div className="flex flex-wrap gap-2">
-              {categories.map((category, index) => (
+              {(showAllCategories ? categories : categories.slice(0, 7)).map((category, index) => (
                 <motion.button
                   key={category}
+                  onClick={() => handleCategorySearch(category)}
                   initial={{ opacity: 0, scale: 0.9 }}
                   animate={{ opacity: 1, scale: 1 }}
                   transition={{ delay: index * 0.03 }}
@@ -966,9 +1093,14 @@ export function LegalCodesLibraryPage({ onBack }: LegalCodesLibraryPageProps) {
                   {category}
                 </motion.button>
               ))}
-              <button className="px-4 py-2 bg-claude-bg hover:bg-claude-border border border-claude-border rounded-xl text-sm font-medium font-sans text-claude-subtext hover:text-claude-text transition-all">
-                Показати всі (47)
-              </button>
+              {!showAllCategories && (
+                <button
+                  onClick={() => setShowAllCategories(true)}
+                  className="px-4 py-2 bg-claude-bg hover:bg-claude-border border border-claude-border rounded-xl text-sm font-medium font-sans text-claude-subtext hover:text-claude-text transition-all"
+                >
+                  Показати всі ({categories.length})
+                </button>
+              )}
             </div>
           </div>
         </motion.div>

--- a/lexwebapp/src/components/__tests__/LegalCodesLibraryPage.test.tsx
+++ b/lexwebapp/src/components/__tests__/LegalCodesLibraryPage.test.tsx
@@ -1,0 +1,567 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+// Mock framer-motion — filter must be inline in factory since vi.mock is hoisted
+vi.mock('framer-motion', () => {
+  const filter = (props: any) => {
+    const { initial, animate, exit, transition, whileHover, whileTap, ...rest } = props;
+    return rest;
+  };
+  return {
+    motion: {
+      div: React.forwardRef(({ children, ...props }: any, ref: any) => (
+        <div ref={ref} {...filter(props)}>{children}</div>
+      )),
+      button: React.forwardRef(({ children, ...props }: any, ref: any) => (
+        <button ref={ref} {...filter(props)}>{children}</button>
+      )),
+    },
+    AnimatePresence: ({ children }: any) => <>{children}</>,
+  };
+});
+
+// Mock toast
+vi.mock('../../utils/toast', () => ({
+  showToast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+// Mock mcpService
+const mockCallTool = vi.fn();
+vi.mock('../../services', () => ({
+  mcpService: {
+    callTool: (...args: any[]) => mockCallTool(...args),
+  },
+}));
+
+import { LegalCodesLibraryPage } from '../LegalCodesLibraryPage';
+import { showToast } from '../../utils/toast';
+
+function makeToolResult(data: any) {
+  return { result: { content: [{ text: JSON.stringify(data) }] } };
+}
+
+describe('LegalCodesLibraryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('Library listing', () => {
+    it('renders main codes grid', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByText('Цивільний кодекс')).toBeInTheDocument();
+      expect(screen.getByText('Кримінальний кодекс')).toBeInTheDocument();
+      expect(screen.getByText('Господарський кодекс')).toBeInTheDocument();
+      expect(screen.getByText('Податковий кодекс')).toBeInTheDocument();
+    });
+
+    it('renders procedural codes section', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByText('Процесуальні кодекси')).toBeInTheDocument();
+      expect(screen.getByText(/Цивільний процесуальний кодекс/)).toBeInTheDocument();
+      expect(screen.getByText(/Господарський процесуальний кодекс/)).toBeInTheDocument();
+    });
+
+    it('renders constitutional acts section', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByText('Конституційні акти')).toBeInTheDocument();
+      expect(screen.getByText(/Конституція України/)).toBeInTheDocument();
+    });
+
+    it('renders categories section', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByText('Категорії законів')).toBeInTheDocument();
+      expect(screen.getByText('Банківське')).toBeInTheDocument();
+      expect(screen.getByText('Митне')).toBeInTheDocument();
+    });
+
+    it('renders search input and button', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByPlaceholderText('Введіть назву кодексу або закону...')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Пошук/ })).toBeInTheDocument();
+    });
+
+    it('renders popular queries', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByText('конституція')).toBeInTheDocument();
+      expect(screen.getByText('цпк')).toBeInTheDocument();
+      expect(screen.getByText('цк')).toBeInTheDocument();
+    });
+  });
+
+  describe('Global search', () => {
+    it('calls search_legislation on search button click', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(makeToolResult({ articles: [], total_found: 0 }));
+
+      render(<LegalCodesLibraryPage />);
+
+      const input = screen.getByPlaceholderText('Введіть назву кодексу або закону...');
+      await user.type(input, 'цивільний кодекс');
+
+      const searchBtn = screen.getByRole('button', { name: /Пошук/ });
+      await user.click(searchBtn);
+
+      expect(mockCallTool).toHaveBeenCalledWith('search_legislation', {
+        query: 'цивільний кодекс',
+        limit: 20,
+      });
+    });
+
+    it('calls search_legislation on Enter key', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(makeToolResult({ articles: [], total_found: 0 }));
+
+      render(<LegalCodesLibraryPage />);
+
+      const input = screen.getByPlaceholderText('Введіть назву кодексу або закону...');
+      await user.type(input, 'стаття 12{enter}');
+
+      expect(mockCallTool).toHaveBeenCalledWith('search_legislation', {
+        query: 'стаття 12',
+        limit: 20,
+      });
+    });
+
+    it('displays search results', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          articles: [
+            { rada_id: '435-15', article_number: '12', title: 'Тестова стаття', full_text: 'Текст статті' },
+          ],
+          total_found: 1,
+        })
+      );
+
+      render(<LegalCodesLibraryPage />);
+
+      const input = screen.getByPlaceholderText('Введіть назву кодексу або закону...');
+      await user.type(input, 'тест{enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/Результати пошуку/)).toBeInTheDocument();
+        expect(screen.getByText('Ст. 12. Тестова стаття')).toBeInTheDocument();
+      });
+    });
+
+    it('shows "nothing found" message for empty results', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(makeToolResult({ articles: [], total_found: 0 }));
+
+      render(<LegalCodesLibraryPage />);
+
+      const input = screen.getByPlaceholderText('Введіть назву кодексу або закону...');
+      await user.type(input, 'неіснуючий запит{enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText(/Нічого не знайдено/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows error toast on search failure', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockRejectedValue(new Error('Network error'));
+
+      render(<LegalCodesLibraryPage />);
+
+      const input = screen.getByPlaceholderText('Введіть назву кодексу або закону...');
+      await user.type(input, 'тест{enter}');
+
+      await waitFor(() => {
+        expect(showToast.error).toHaveBeenCalledWith('Network error');
+      });
+    });
+
+    it('search button is disabled when input is empty', () => {
+      render(<LegalCodesLibraryPage />);
+      const searchBtn = screen.getByRole('button', { name: /Пошук/ });
+      expect(searchBtn).toBeDisabled();
+    });
+  });
+
+  describe('Popular queries', () => {
+    it('triggers search on popular query click', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(makeToolResult({ articles: [], total_found: 0 }));
+
+      render(<LegalCodesLibraryPage />);
+      await user.click(screen.getByText('конституція'));
+
+      expect(mockCallTool).toHaveBeenCalledWith('search_legislation', {
+        query: 'конституція',
+        limit: 20,
+      });
+    });
+
+    it('sets input value when popular query is clicked', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(makeToolResult({ articles: [], total_found: 0 }));
+
+      render(<LegalCodesLibraryPage />);
+      await user.click(screen.getByText('цпк'));
+
+      const input = screen.getByPlaceholderText('Введіть назву кодексу або закону...') as HTMLInputElement;
+      expect(input.value).toBe('цпк');
+    });
+  });
+
+  describe('Open code', () => {
+    it('opens code viewer when "Відкрити" is clicked on main code', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          rada_id: '435-15',
+          title: 'Цивільний кодекс України',
+          total_articles: 1308,
+          table_of_contents: [],
+          articles_summary: [],
+        })
+      );
+
+      render(<LegalCodesLibraryPage />);
+
+      const openBtns = screen.getAllByText('Відкрити');
+      await user.click(openBtns[0]);
+
+      expect(mockCallTool).toHaveBeenCalledWith('get_legislation_structure', { rada_id: '435-15' });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Цивільний кодекс України/)).toBeInTheDocument();
+      });
+    });
+
+    it('opens procedural code when clicked', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          rada_id: '1618-15',
+          title: 'Цивільний процесуальний кодекс України',
+          total_articles: 500,
+          table_of_contents: [],
+          articles_summary: [],
+        })
+      );
+
+      render(<LegalCodesLibraryPage />);
+
+      const openBtns = screen.getAllByText('Відкрити');
+      // main codes = 8, procedural starts at index 8
+      await user.click(openBtns[8]);
+
+      expect(mockCallTool).toHaveBeenCalledWith('get_legislation_structure', { rada_id: '1618-15' });
+    });
+  });
+
+  describe('Download code', () => {
+    let originalCreateObjectURL: typeof URL.createObjectURL;
+    let originalRevokeObjectURL: typeof URL.revokeObjectURL;
+
+    beforeEach(() => {
+      originalCreateObjectURL = URL.createObjectURL;
+      originalRevokeObjectURL = URL.revokeObjectURL;
+      URL.createObjectURL = vi.fn().mockReturnValue('blob:test');
+      URL.revokeObjectURL = vi.fn();
+    });
+
+    afterEach(() => {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    });
+
+    it('calls get_legislation_structure and triggers download', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          title: 'Цивільний кодекс України',
+          articles_summary: [
+            { article_number: '1', title: 'Стаття 1' },
+            { article_number: '2', title: 'Стаття 2' },
+          ],
+        })
+      );
+
+      const clickMock = vi.fn();
+      const originalCreateElement = document.createElement.bind(document);
+      vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+        if (tag === 'a') {
+          const el = originalCreateElement('a');
+          el.click = clickMock;
+          return el;
+        }
+        return originalCreateElement(tag);
+      });
+
+      render(<LegalCodesLibraryPage />);
+
+      const downloadBtns = screen.getAllByTitle('Завантажити зміст');
+      await user.click(downloadBtns[0]);
+
+      await waitFor(() => {
+        expect(mockCallTool).toHaveBeenCalledWith('get_legislation_structure', { rada_id: '435-15' });
+        expect(showToast.success).toHaveBeenCalledWith('Завантажено');
+        expect(clickMock).toHaveBeenCalled();
+      });
+
+      vi.restoreAllMocks();
+    });
+
+    it('shows error toast on download failure', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockRejectedValue(new Error('Download failed'));
+
+      render(<LegalCodesLibraryPage />);
+
+      const downloadBtns = screen.getAllByTitle('Завантажити зміст');
+      await user.click(downloadBtns[0]);
+
+      await waitFor(() => {
+        expect(showToast.error).toHaveBeenCalledWith('Download failed');
+      });
+    });
+  });
+
+  describe('Category buttons', () => {
+    it('triggers search when category is clicked', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(makeToolResult({ articles: [], total_found: 0 }));
+
+      render(<LegalCodesLibraryPage />);
+      await user.click(screen.getByText('Банківське'));
+
+      expect(mockCallTool).toHaveBeenCalledWith('search_legislation', {
+        query: 'Банківське',
+        limit: 20,
+      });
+    });
+
+    it('renders all categories', () => {
+      render(<LegalCodesLibraryPage />);
+      expect(screen.getByText('Банківське')).toBeInTheDocument();
+      expect(screen.getByText('Про нотаріат')).toBeInTheDocument();
+    });
+  });
+
+  describe('Code viewer', () => {
+    async function openCodeViewer() {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          rada_id: '435-15',
+          title: 'Цивільний кодекс України',
+          total_articles: 3,
+          table_of_contents: [
+            {
+              type: 'section',
+              number: '1',
+              articles: [
+                { article_number: '1', title: 'Перша стаття' },
+                { article_number: '2', title: 'Друга стаття' },
+              ],
+            },
+          ],
+          articles_summary: [
+            { article_number: '1', title: 'Перша стаття' },
+            { article_number: '2', title: 'Друга стаття' },
+            { article_number: '3', title: 'Третя стаття' },
+          ],
+        })
+      );
+
+      render(<LegalCodesLibraryPage />);
+      const openBtns = screen.getAllByText('Відкрити');
+      await user.click(openBtns[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Цивільний кодекс України/)).toBeInTheDocument();
+      });
+
+      return user;
+    }
+
+    it('shows table of contents with sections', async () => {
+      await openCodeViewer();
+      expect(screen.getByText('ЗМІСТ')).toBeInTheDocument();
+      expect(screen.getByText('3 статей')).toBeInTheDocument();
+    });
+
+    it('loads article when clicked in TOC', async () => {
+      const user = await openCodeViewer();
+
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          rada_id: '435-15',
+          article_number: '1',
+          title: 'Перша стаття',
+          full_text: 'Текст першої статті',
+          url: 'https://example.com/article/1',
+        })
+      );
+
+      // Section "Розділ 1" is auto-expanded (top 2 sections expanded by default)
+      // Find and click an article in the TOC
+      const articleBtns = screen.getAllByRole('button').filter(
+        btn => btn.textContent?.includes('Ст. 1. Перша стаття')
+      );
+      await user.click(articleBtns[0]);
+
+      expect(mockCallTool).toHaveBeenCalledWith('get_legislation_article', {
+        rada_id: '435-15',
+        article_number: '1',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Текст першої статті')).toBeInTheDocument();
+      });
+    });
+
+    it('navigates back to listing on back button', async () => {
+      const user = await openCodeViewer();
+
+      const buttons = screen.getAllByRole('button');
+      // First button in viewer header is the back button
+      await user.click(buttons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('Бібліотека кодексів і законів України')).toBeInTheDocument();
+      });
+    });
+
+    it('shows placeholder text when no article is selected', async () => {
+      await openCodeViewer();
+      expect(screen.getByText('Оберіть статтю зі змісту')).toBeInTheDocument();
+    });
+  });
+
+  describe('Article actions', () => {
+    async function openArticle() {
+      const user = userEvent.setup();
+
+      // First call: get_legislation_structure
+      mockCallTool.mockResolvedValueOnce(
+        makeToolResult({
+          rada_id: '435-15',
+          title: 'Цивільний кодекс України',
+          total_articles: 2,
+          table_of_contents: [
+            { article_number: '1', title: 'Перша стаття' },
+            { article_number: '2', title: 'Друга стаття' },
+          ],
+          articles_summary: [
+            { article_number: '1', title: 'Перша стаття' },
+            { article_number: '2', title: 'Друга стаття' },
+          ],
+        })
+      );
+
+      render(<LegalCodesLibraryPage />);
+      const openBtns = screen.getAllByText('Відкрити');
+      await user.click(openBtns[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText('ЗМІСТ')).toBeInTheDocument();
+      });
+
+      // Second call: get_legislation_article
+      mockCallTool.mockResolvedValueOnce(
+        makeToolResult({
+          rada_id: '435-15',
+          article_number: '1',
+          title: 'Перша стаття',
+          full_text: 'Текст першої статті для копіювання',
+          url: 'https://example.com/article/1',
+        })
+      );
+
+      const articleBtn = screen.getByText(/Ст\. 1\. Перша стаття/);
+      await user.click(articleBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText('Текст першої статті для копіювання')).toBeInTheDocument();
+      });
+
+      return user;
+    }
+
+    it('copies article text to clipboard', async () => {
+      const user = await openArticle();
+
+      const writeTextMock = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+
+      await user.click(screen.getByText('Копіювати'));
+
+      expect(writeTextMock).toHaveBeenCalledWith(
+        expect.stringContaining('Текст першої статті для копіювання')
+      );
+    });
+
+    it('copies article link to clipboard', async () => {
+      const user = await openArticle();
+
+      const writeTextMock = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: writeTextMock },
+        writable: true,
+        configurable: true,
+      });
+
+      await user.click(screen.getByText('Посилання'));
+
+      expect(writeTextMock).toHaveBeenCalledWith('https://example.com/article/1');
+    });
+
+    it('toggles comment panel', async () => {
+      const user = await openArticle();
+
+      await user.click(screen.getByText('Коментар'));
+
+      expect(screen.getByPlaceholderText('Додати нотатку до статті...')).toBeInTheDocument();
+    });
+
+    it('shows prev/next article navigation', async () => {
+      await openArticle();
+
+      expect(screen.getByText('1 / 2')).toBeInTheDocument();
+      expect(screen.getByText('Ст. 2')).toBeInTheDocument();
+    });
+  });
+
+  describe('Favorites', () => {
+    it('toggles favorite for a code', async () => {
+      const user = userEvent.setup();
+      mockCallTool.mockResolvedValue(
+        makeToolResult({
+          rada_id: '435-15',
+          title: 'Цивільний кодекс України',
+          total_articles: 0,
+          table_of_contents: [],
+          articles_summary: [],
+        })
+      );
+
+      render(<LegalCodesLibraryPage />);
+      const openBtns = screen.getAllByText('Відкрити');
+      await user.click(openBtns[0]);
+
+      await waitFor(() => {
+        expect(screen.getByTitle('В обране')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByTitle('В обране'));
+
+      const stored = localStorage.getItem('legislation_favorites');
+      expect(stored).toContain('435-15');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Wired up 7 groups of non-functional buttons on `/legislation/library`: search button, Enter key search, popular query tags, download buttons (main codes, procedural codes, Constitution), and category filter buttons
- Added global search results panel with dismiss functionality and "nothing found" state
- Added 29 Vitest tests covering all button interactions, search, download, TOC navigation, clipboard, comments, favorites

## Test plan
- [x] `npx vitest run src/components/__tests__/LegalCodesLibraryPage.test.tsx` — 29/29 passing
- [x] `npx tsc --noEmit` — clean build
- [ ] Manual: click "Пошук" button with query → results appear
- [ ] Manual: click popular query tag → search triggers
- [ ] Manual: click download icon on code card → .txt file downloads
- [ ] Manual: click category button → search triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired up all buttons on the legislation library page and added a simple search results panel. Search, tags, categories, and downloads now work with clear states and quick navigation to articles.

- **Bug Fixes**
  - Search button and Enter now call search_legislation.
  - Popular query tags and category chips trigger searches.
  - Download icons fetch code structure and download TOC as .txt (main, procedural, Constitution).

- **New Features**
  - Global search results panel with dismiss and “nothing found” state.
  - Loading and disabled states on the search button.
  - Jump from a result to its article; “Show all” toggle for categories.

<sup>Written for commit c6eac2e24f4f5955ec993163640cd740b97b2f44. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

