### PR TITLE
feat: add attorney pricing tier

### DIFF
--- a/lexwebapp/src/pages/AdminUserActivityPage.tsx
+++ b/lexwebapp/src/pages/AdminUserActivityPage.tsx
@@ -68,6 +68,7 @@ const TIER_COLORS: Record<string, string> = {
   startup: 'bg-blue-100 text-blue-700',
   business: 'bg-purple-100 text-purple-700',
   enterprise: 'bg-amber-100 text-amber-700',
+  attorney: 'bg-orange-100 text-orange-700',
   internal: 'bg-green-100 text-green-700',
 };
 

--- a/lexwebapp/src/pages/AdminUsersPage.tsx
+++ b/lexwebapp/src/pages/AdminUsersPage.tsx
@@ -51,7 +51,7 @@ interface Pagination {
   total: number;
 }
 
-const TIERS = ['free', 'startup', 'business', 'enterprise', 'internal'];
+const TIERS = ['free', 'startup', 'attorney', 'business', 'enterprise', 'internal'];
 const PAGE_SIZE = 50;
 
 const SPECIALIZATIONS = [

--- a/lexwebapp/src/pages/admin/costs/constants.ts
+++ b/lexwebapp/src/pages/admin/costs/constants.ts
@@ -25,6 +25,7 @@ export const TIER_COLORS: Record<string, string> = {
   startup: '#60a5fa',
   business: '#a78bfa',
   enterprise: '#f59e0b',
+  attorney: '#f97316',
   internal: '#34d399',
 };
 

--- a/mcp_backend/src/migrations/065_add_attorney_pricing_tier.sql
+++ b/mcp_backend/src/migrations/065_add_attorney_pricing_tier.sql
@@ -1,0 +1,37 @@
+-- Migration 065: Add 'attorney' pricing tier
+-- Adds attorney tier with 30% markup, higher daily/monthly limits
+
+-- 1. Update the check constraint on user_billing to include 'attorney'
+DO $$ BEGIN
+  ALTER TABLE user_billing DROP CONSTRAINT IF EXISTS check_pricing_tier;
+  ALTER TABLE user_billing ADD CONSTRAINT check_pricing_tier
+    CHECK (pricing_tier IN ('free', 'startup', 'business', 'enterprise', 'internal', 'attorney'));
+EXCEPTION WHEN undefined_table THEN
+  RAISE NOTICE 'user_billing table does not exist, skipping constraint update';
+END $$;
+
+-- 2. Insert attorney tier into pricing_tiers (DB-backed config)
+INSERT INTO pricing_tiers (tier_key, markup_percentage, description, features, monthly_price_usd, annual_price_usd, trial_days, is_active, display_name, display_order)
+VALUES (
+  'attorney',
+  30,
+  'Attorney tier - 30% markup with higher limits for legal professionals',
+  '["Legal consultations management", "Advanced legal document analysis", "Court practice deep search", "Priority support (12h response)", "Higher daily/monthly limits ($50/$500)"]',
+  49,
+  490,
+  14,
+  true,
+  'Attorney',
+  2
+)
+ON CONFLICT (tier_key) DO UPDATE SET
+  markup_percentage = EXCLUDED.markup_percentage,
+  description = EXCLUDED.description,
+  features = EXCLUDED.features,
+  monthly_price_usd = EXCLUDED.monthly_price_usd,
+  annual_price_usd = EXCLUDED.annual_price_usd,
+  trial_days = EXCLUDED.trial_days,
+  is_active = EXCLUDED.is_active,
+  display_name = EXCLUDED.display_name,
+  display_order = EXCLUDED.display_order,
+  updated_at = NOW();

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -546,7 +546,7 @@ export function createAdminRoutes(
       const userId = getStringParam(req.params.userId);
       const { tier } = req.body;
 
-      if (!['free', 'startup', 'business', 'enterprise', 'internal'].includes(tier)) {
+      if (!['free', 'startup', 'business', 'enterprise', 'internal', 'attorney'].includes(tier)) {
         return res.status(400).json({ error: 'Invalid pricing tier' });
       }
 
@@ -4958,8 +4958,14 @@ export function createAdminRoutes(
         ]
       );
 
-      // Set user_type to attorney
+      // Set user_type to attorney and assign attorney pricing tier
       await db.query(`UPDATE users SET user_type = 'attorney' WHERE id = $1`, [userId]);
+      await db.query(
+        `INSERT INTO user_billing (user_id, pricing_tier)
+         VALUES ($1, 'attorney')
+         ON CONFLICT (user_id) DO UPDATE SET pricing_tier = 'attorney', updated_at = NOW()`,
+        [userId]
+      );
 
       await logAdminAction(adminId, 'create_attorney_profile', userId, id, { email: userCheck.rows[0].email }, req);
       logger.info('Admin created attorney profile', { adminId, userId, profileId: id });

--- a/mcp_backend/src/services/pricing-service.ts
+++ b/mcp_backend/src/services/pricing-service.ts
@@ -14,7 +14,7 @@
 import type { IDatabase } from '../domain/ports/index.js';
 import { logger } from '../utils/logger.js';
 
-export type PricingTier = 'free' | 'startup' | 'business' | 'enterprise' | 'internal';
+export type PricingTier = 'free' | 'startup' | 'business' | 'enterprise' | 'internal' | 'attorney';
 
 export interface PricingConfig {
   tier: PricingTier;
@@ -120,6 +120,24 @@ export class PricingService {
       is_active: true,
       display_name: 'Enterprise',
       display_order: 3,
+    },
+    attorney: {
+      tier: 'attorney',
+      markup_percentage: 30,
+      description: 'Attorney tier - 30% markup with higher limits for legal professionals',
+      features: [
+        'Legal consultations management',
+        'Advanced legal document analysis',
+        'Court practice deep search',
+        'Priority support (12h response)',
+        'Higher daily/monthly limits ($50/$500)',
+      ],
+      monthly_price_usd: 49,
+      annual_price_usd: 490,
+      trial_days: 14,
+      is_active: true,
+      display_name: 'Attorney',
+      display_order: 2,
     },
     internal: {
       tier: 'internal',


### PR DESCRIPTION
## Summary
- Add dedicated `attorney` pricing tier with 30% markup, $49/mo, $490/yr, 14-day trial
- DB migration (065) adds tier to `check_pricing_tier` constraint and inserts into `pricing_tiers`
- Auto-assigns attorney tier when admin creates an attorney profile (upserts `user_billing`)
- Frontend: orange color badge in admin costs dashboard, activity page, and users page filter

## Test plan
- [ ] Run migration 065 on DB — verify `pricing_tiers` has attorney row
- [ ] Create attorney profile via admin → verify `user_billing.pricing_tier = 'attorney'`
- [ ] Change tier to `attorney` via admin users page → verify it persists
- [ ] Check admin costs dashboard shows orange for attorney tier
- [ ] Verify Олександр Рябчук gets attorney tier after profile creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Attorney pricing tier and wires it through backend and admin UI. Creating an attorney profile now auto-assigns this tier.

- **New Features**
  - Pricing: 30% markup, $49/mo, $490/yr, 14-day trial, higher daily/monthly limits.
  - Backend: pricing-service and tier validation updated; admin route sets/accepts 'attorney'.
  - Admin UI: orange tier badge in costs and activity; users page filter includes 'attorney'.

- **Migration**
  - Run migration 065 to update the user_billing tier constraint and upsert the 'attorney' row in pricing_tiers.

<sup>Written for commit 225e675a64fab9e6cfb43fcf340c21bf2f402915. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

