### PR TITLE
fix: migration 065 safety for missing pricing_tiers table

### DIFF
--- a/mcp_backend/src/migrations/065_add_attorney_pricing_tier.sql
+++ b/mcp_backend/src/migrations/065_add_attorney_pricing_tier.sql
@@ -10,28 +10,32 @@ EXCEPTION WHEN undefined_table THEN
   RAISE NOTICE 'user_billing table does not exist, skipping constraint update';
 END $$;
 
--- 2. Insert attorney tier into pricing_tiers (DB-backed config)
-INSERT INTO pricing_tiers (tier_key, markup_percentage, description, features, monthly_price_usd, annual_price_usd, trial_days, is_active, display_name, display_order)
-VALUES (
-  'attorney',
-  30,
-  'Attorney tier - 30% markup with higher limits for legal professionals',
-  '["Legal consultations management", "Advanced legal document analysis", "Court practice deep search", "Priority support (12h response)", "Higher daily/monthly limits ($50/$500)"]',
-  49,
-  490,
-  14,
-  true,
-  'Attorney',
-  2
-)
-ON CONFLICT (tier_key) DO UPDATE SET
-  markup_percentage = EXCLUDED.markup_percentage,
-  description = EXCLUDED.description,
-  features = EXCLUDED.features,
-  monthly_price_usd = EXCLUDED.monthly_price_usd,
-  annual_price_usd = EXCLUDED.annual_price_usd,
-  trial_days = EXCLUDED.trial_days,
-  is_active = EXCLUDED.is_active,
-  display_name = EXCLUDED.display_name,
-  display_order = EXCLUDED.display_order,
-  updated_at = NOW();
+-- 2. Insert attorney tier into pricing_tiers (DB-backed config) if table exists
+DO $$ BEGIN
+  INSERT INTO pricing_tiers (tier_key, markup_percentage, description, features, monthly_price_usd, annual_price_usd, trial_days, is_active, display_name, display_order)
+  VALUES (
+    'attorney',
+    30,
+    'Attorney tier - 30% markup with higher limits for legal professionals',
+    '["Legal consultations management", "Advanced legal document analysis", "Court practice deep search", "Priority support (12h response)", "Higher daily/monthly limits ($50/$500)"]',
+    49,
+    490,
+    14,
+    true,
+    'Attorney',
+    2
+  )
+  ON CONFLICT (tier_key) DO UPDATE SET
+    markup_percentage = EXCLUDED.markup_percentage,
+    description = EXCLUDED.description,
+    features = EXCLUDED.features,
+    monthly_price_usd = EXCLUDED.monthly_price_usd,
+    annual_price_usd = EXCLUDED.annual_price_usd,
+    trial_days = EXCLUDED.trial_days,
+    is_active = EXCLUDED.is_active,
+    display_name = EXCLUDED.display_name,
+    display_order = EXCLUDED.display_order,
+    updated_at = NOW();
+EXCEPTION WHEN undefined_table THEN
+  RAISE NOTICE 'pricing_tiers table does not exist, skipping tier insert (fallback config used)';
+END $$;


### PR DESCRIPTION
## Summary
- Wrap `pricing_tiers` INSERT in DO block with EXCEPTION handler for environments where the table doesn't exist

## Test plan
- [x] Verified on prod — constraint already applied, INSERT safely skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new “attorney” pricing tier and auto-assign it when creating an attorney profile. Also makes migration 065 safe to run on environments missing pricing_tiers by skipping cleanly.

- **New Features**
  - Add “attorney” tier to PricingService fallback config (30% markup, active, $49/mo).
  - Auto-assign “attorney” tier in user_billing when an admin creates an attorney profile.
  - Allow “attorney” in tier validation for admin routes.
  - Show “attorney” tier in Admin Users and Activity pages with distinct colors.

- **Migration**
  - Update user_billing check constraint to include “attorney”.
  - Insert or update the “attorney” row in pricing_tiers.
  - Wrap both in DO blocks with EXCEPTION handling to skip if tables are missing. No manual action required.

<sup>Written for commit 9dfb517906a540ad4117f151a2c155fc082c5185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

