### PR TITLE
feat: cache & persist ЄРАУ data on every external lookup

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -36,6 +36,7 @@ import { createAdminRoutes } from './routes/admin-routes.js';
 import { createWorkerHeartbeatRoute } from './routes/worker-heartbeat-routes.js';
 import { createDecisionsRoutes } from './routes/decisions-routes.js';
 import { createERAUProxyRoutes } from './routes/erau-proxy-routes.js';
+import { ERAUCacheService } from './services/erau-cache-service.js';
 import { attachTerminalWebSocket } from './routes/terminal-routes.js';
 import { createTeamRoutes } from './routes/team-routes.js';
 import { createTeamService } from './services/team-service.js';
@@ -1884,7 +1885,8 @@ class HTTPMCPServer {
     logger.info('Decisions routes registered at /api/decisions');
 
     // ERAU proxy - Ukrainian Bar Registry (public, no auth required)
-    this.app.use('/api/erau', optionalJWT as any, createERAUProxyRoutes());
+    const erauCacheService = new ERAUCacheService(this.services.db);
+    this.app.use('/api/erau', optionalJWT as any, createERAUProxyRoutes(erauCacheService));
     logger.info('ERAU proxy routes registered at /api/erau');
 
     // Worker heartbeat (uses dualAuth so EC2 workers can auth with SECONDARY_LAYER_KEYS)

--- a/mcp_backend/src/migrations/067_erau_lawyers_cache.sql
+++ b/mcp_backend/src/migrations/067_erau_lawyers_cache.sql
@@ -1,0 +1,21 @@
+-- Migration 067: ERAU lawyers cache table
+-- Caches results from the Ukrainian Bar Registry (ЄРАУ) to reduce external API calls
+-- and provide fallback when the external service is unavailable.
+
+CREATE TABLE IF NOT EXISTS erau_lawyers (
+  id SERIAL PRIMARY KEY,
+  erau_id INTEGER NOT NULL,
+  surname VARCHAR(255) NOT NULL,
+  firstname VARCHAR(255) NOT NULL,
+  middlename VARCHAR(255),
+  racalc VARCHAR(255),
+  certnum VARCHAR(100),
+  certat VARCHAR(100),
+  certcalc VARCHAR(255),
+  fetched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_erau_lawyers_erau_id UNIQUE (erau_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_erau_lawyers_surname ON erau_lawyers (LOWER(surname));
+CREATE INDEX IF NOT EXISTS idx_erau_lawyers_certnum ON erau_lawyers (certnum);

--- a/mcp_backend/src/routes/erau-proxy-routes.ts
+++ b/mcp_backend/src/routes/erau-proxy-routes.ts
@@ -3,14 +3,18 @@
  *
  * Proxies requests to the Ukrainian Bar Registry (Єдиний реєстр адвокатів України)
  * at https://erau.unba.org.ua/search
+ *
+ * Cache-through: Redis → PG → external API. On success, results are persisted
+ * to PG and cached in Redis so repeat searches avoid external calls.
  */
 
 import { Router, Request, Response } from 'express';
 import { logger } from '../utils/logger.js';
+import { ERAUCacheService } from '../services/erau-cache-service.js';
 
 const ERAU_BASE_URL = 'https://erau.unba.org.ua';
 
-export function createERAUProxyRoutes(): Router {
+export function createERAUProxyRoutes(erauCacheService?: ERAUCacheService): Router {
   const router = Router();
 
   router.get('/search', async (req: Request, res: Response) => {
@@ -20,32 +24,76 @@ export function createERAUProxyRoutes(): Router {
         return res.status(400).json({ error: 'surname query parameter required (min 2 characters)' });
       }
 
-      const url = `${ERAU_BASE_URL}/search?surname=${encodeURIComponent(surname.trim())}`;
-      logger.info(`[ERAU] Proxying search for surname="${surname.trim()}"`);
+      const trimmed = surname.trim();
 
-      const response = await fetch(url, {
-        headers: {
-          'Accept': 'application/json',
-          'User-Agent': 'SecondLayer/1.0',
-        },
-        signal: AbortSignal.timeout(15000),
-      });
-
-      if (!response.ok) {
-        logger.warn(`[ERAU] Upstream returned ${response.status}`);
-        return res.status(502).json({ error: `ERAU returned status ${response.status}` });
+      // 1. Check cache (Redis → PG)
+      if (erauCacheService) {
+        const cached = await erauCacheService.getBySurname(trimmed);
+        if (cached && cached.length > 0) {
+          logger.info(`[ERAU] Serving ${cached.length} cached results for "${trimmed}"`);
+          return res.json(cached);
+        }
       }
 
-      const data = await response.json() as any;
-      // ERAU returns { items: [...], total: "N" } — unwrap to array for frontend
-      const items = Array.isArray(data) ? data : (data.items || []);
+      // 2. Fetch from external API
+      const url = `${ERAU_BASE_URL}/search?surname=${encodeURIComponent(trimmed)}`;
+      logger.info(`[ERAU] Proxying search for surname="${trimmed}"`);
+
+      let items: any[];
+      try {
+        const response = await fetch(url, {
+          headers: {
+            'Accept': 'application/json',
+            'User-Agent': 'SecondLayer/1.0',
+          },
+          signal: AbortSignal.timeout(15000),
+        });
+
+        if (!response.ok) {
+          logger.warn(`[ERAU] Upstream returned ${response.status}`);
+          // Fallback to PG on upstream error
+          if (erauCacheService) {
+            const fallback = await erauCacheService.getBySurname(trimmed);
+            if (fallback && fallback.length > 0) {
+              logger.info(`[ERAU] Serving ${fallback.length} PG fallback results for "${trimmed}"`);
+              return res.json(fallback);
+            }
+          }
+          return res.status(502).json({ error: `ERAU returned status ${response.status}` });
+        }
+
+        const data = await response.json() as any;
+        items = Array.isArray(data) ? data : (data.items || []);
+      } catch (fetchErr: unknown) {
+        const msg = fetchErr instanceof Error ? fetchErr.message : String(fetchErr);
+        logger.error('[ERAU] External API error', { error: msg });
+
+        // Fallback to PG on network/timeout errors
+        if (erauCacheService) {
+          const fallback = await erauCacheService.getBySurname(trimmed);
+          if (fallback && fallback.length > 0) {
+            logger.info(`[ERAU] Serving ${fallback.length} PG fallback results after external failure for "${trimmed}"`);
+            return res.json(fallback);
+          }
+        }
+
+        if (msg.includes('timeout') || msg.includes('abort')) {
+          return res.status(504).json({ error: 'ERAU request timed out' });
+        }
+        return res.status(502).json({ error: 'Failed to reach ERAU registry' });
+      }
+
+      // 3. Cache results (fire-and-forget)
+      if (erauCacheService && items.length > 0) {
+        erauCacheService.cacheResults(trimmed, items).catch((err) => {
+          logger.warn('[ERAU] Background cache write failed', { error: err.message });
+        });
+      }
+
       res.json(items);
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       logger.error('[ERAU] Proxy error', { error: msg });
-      if (msg.includes('timeout') || msg.includes('abort')) {
-        return res.status(504).json({ error: 'ERAU request timed out' });
-      }
       res.status(502).json({ error: 'Failed to reach ERAU registry' });
     }
   });

--- a/mcp_backend/src/services/erau-cache-service.ts
+++ b/mcp_backend/src/services/erau-cache-service.ts
@@ -1,0 +1,112 @@
+import { BaseDatabase } from '@secondlayer/shared';
+import { logger } from '../utils/logger.js';
+import { getRedisClient } from '../utils/redis-client.js';
+
+export interface ERAULawyer {
+  id: number;
+  surname: string;
+  firstname: string;
+  middlename?: string;
+  racalc?: string;
+  certnum?: string;
+  certat?: string;
+  certcalc?: string;
+}
+
+const REDIS_PREFIX = 'erau:search:';
+const REDIS_TTL = 86400; // 24 hours
+
+export class ERAUCacheService {
+  constructor(private db: BaseDatabase) {}
+
+  async getBySurname(surname: string): Promise<ERAULawyer[] | null> {
+    const key = this.redisKey(surname);
+
+    // 1. Try Redis
+    try {
+      const redis = await getRedisClient();
+      if (redis) {
+        const cached = await redis.get(key);
+        if (cached) {
+          logger.info(`[ERAU Cache] Redis hit for "${surname}"`);
+          return JSON.parse(cached);
+        }
+      }
+    } catch (err: any) {
+      logger.warn('[ERAU Cache] Redis read error', { error: err.message });
+    }
+
+    // 2. Try PG
+    try {
+      const result = await this.db.query(
+        'SELECT erau_id AS id, surname, firstname, middlename, racalc, certnum, certat, certcalc FROM erau_lawyers WHERE LOWER(surname) = LOWER($1)',
+        [surname.trim()]
+      );
+      if (result.rows.length > 0) {
+        logger.info(`[ERAU Cache] PG hit for "${surname}" (${result.rows.length} rows)`);
+        const lawyers: ERAULawyer[] = result.rows;
+        // Repopulate Redis
+        this.setRedis(key, lawyers).catch(() => {});
+        return lawyers;
+      }
+    } catch (err: any) {
+      logger.warn('[ERAU Cache] PG read error', { error: err.message });
+    }
+
+    return null;
+  }
+
+  async cacheResults(surname: string, lawyers: ERAULawyer[]): Promise<void> {
+    if (!lawyers.length) return;
+
+    // Upsert into PG
+    try {
+      const values: any[] = [];
+      const placeholders: string[] = [];
+      let idx = 1;
+
+      for (const l of lawyers) {
+        placeholders.push(`($${idx}, $${idx + 1}, $${idx + 2}, $${idx + 3}, $${idx + 4}, $${idx + 5}, $${idx + 6}, $${idx + 7})`);
+        values.push(l.id, l.surname, l.firstname, l.middlename || null, l.racalc || null, l.certnum || null, l.certat || null, l.certcalc || null);
+        idx += 8;
+      }
+
+      await this.db.query(
+        `INSERT INTO erau_lawyers (erau_id, surname, firstname, middlename, racalc, certnum, certat, certcalc)
+         VALUES ${placeholders.join(', ')}
+         ON CONFLICT (erau_id) DO UPDATE SET
+           surname = EXCLUDED.surname,
+           firstname = EXCLUDED.firstname,
+           middlename = EXCLUDED.middlename,
+           racalc = EXCLUDED.racalc,
+           certnum = EXCLUDED.certnum,
+           certat = EXCLUDED.certat,
+           certcalc = EXCLUDED.certcalc,
+           updated_at = NOW()`,
+        values
+      );
+      logger.info(`[ERAU Cache] Upserted ${lawyers.length} lawyers for "${surname}"`);
+    } catch (err: any) {
+      logger.warn('[ERAU Cache] PG upsert error', { error: err.message });
+    }
+
+    // Set Redis
+    const key = this.redisKey(surname);
+    await this.setRedis(key, lawyers).catch(() => {});
+  }
+
+  private redisKey(surname: string): string {
+    return `${REDIS_PREFIX}${surname.trim().toLowerCase()}`;
+  }
+
+  private async setRedis(key: string, data: ERAULawyer[]): Promise<void> {
+    try {
+      const redis = await getRedisClient();
+      if (redis) {
+        await redis.set(key, JSON.stringify(data), { EX: REDIS_TTL });
+      }
+    } catch (err: any) {
+      logger.warn('[ERAU Cache] Redis write error', { error: err.message });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `erau_lawyers` PG table (migration 067) to persist lawyer records from ЄРАУ
- Add `ERAUCacheService` with Redis (24h TTL) → PG → null lookup chain
- Modify ЄРАУ proxy route to cache-through: serve from cache on hit, persist on external success, fallback to PG when external API fails

## Test plan
- [ ] `npm run migrate` — table created without errors
- [ ] Search a surname → external API hit, results returned, PG rows + Redis key populated
- [ ] Repeat same search → served from Redis, no external call (check logs)
- [ ] Clear Redis key → search again → served from PG, Redis repopulated
- [ ] Simulate external failure → fallback to PG if data exists
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cache-through layer for ERAU search to reduce external calls and improve reliability during outages. Results are cached in Redis for 24 hours and persisted to PostgreSQL for fallback.

- **New Features**
  - Added erau_lawyers table (migration 067) with indexes and unique erau_id.
  - Implemented ERAUCacheService (Redis → PG → external) and TTL of 24h.
  - Updated /api/erau/search to serve from cache, persist on success, and fall back to PG on upstream errors.

- **Migration**
  - Run npm run migrate to create the erau_lawyers table (067).

<sup>Written for commit b7041777e9ad2c49a5d3f867d0a7e7fc441c1656. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

