### PR TITLE
fix: add scrollable wrappers to attorney & consultation pages

### DIFF
--- a/lexwebapp/src/pages/AttorneyDetailPage/index.tsx
+++ b/lexwebapp/src/pages/AttorneyDetailPage/index.tsx
@@ -58,6 +58,7 @@ export function AttorneyDetailPage() {
   }
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-4xl mx-auto p-6">
       <button onClick={() => navigate(-1)} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-6">
         <ArrowLeft className="w-4 h-4" /> Назад
@@ -211,6 +212,7 @@ export function AttorneyDetailPage() {
           onClose={() => setShowRequestModal(false)}
         />
       )}
+    </div>
     </div>
   );
 }

--- a/lexwebapp/src/pages/AttorneyProfilePage/index.tsx
+++ b/lexwebapp/src/pages/AttorneyProfilePage/index.tsx
@@ -103,6 +103,7 @@ export function AttorneyProfilePage() {
   }
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-3xl mx-auto p-6">
       <AttorneyOnboardingModal
         open={showOnboarding}
@@ -253,6 +254,7 @@ export function AttorneyProfilePage() {
           {isNew ? 'Створити профіль' : 'Зберегти зміни'}
         </button>
       </form>
+    </div>
     </div>
   );
 }

--- a/lexwebapp/src/pages/AttorneySearchPage/index.tsx
+++ b/lexwebapp/src/pages/AttorneySearchPage/index.tsx
@@ -60,6 +60,7 @@ export function AttorneySearchPage() {
   };
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-7xl mx-auto p-6">
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-3">
@@ -182,6 +183,7 @@ export function AttorneySearchPage() {
           )}
         </>
       )}
+    </div>
     </div>
   );
 }

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -128,6 +128,7 @@ export function ConsultationDetailPage() {
   const isTerminal = ['cancelled', 'declined', 'disputed'].includes(consultation.status);
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-4xl mx-auto p-6">
       <button onClick={() => navigate(-1)} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-6">
         <ArrowLeft className="w-4 h-4" /> Назад до консультацій
@@ -310,6 +311,7 @@ export function ConsultationDetailPage() {
           </div>
         </div>
       )}
+    </div>
     </div>
   );
 }

--- a/lexwebapp/src/pages/ConsultationsPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationsPage/index.tsx
@@ -39,6 +39,7 @@ export function ConsultationsPage() {
   }, [role, statusFilter]);
 
   return (
+    <div className="h-full overflow-y-auto">
     <div className="max-w-5xl mx-auto p-6">
       <div className="flex items-center gap-3 mb-8">
         <MessageSquare className="w-7 h-7 text-indigo-600" />
@@ -120,6 +121,7 @@ export function ConsultationsPage() {
           })}
         </div>
       )}
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `h-full overflow-y-auto` wrapper to AttorneyProfilePage, AttorneySearchPage, AttorneyDetailPage, ConsultationsPage, ConsultationDetailPage
- MainLayout uses `overflow-hidden` on the content area, so pages with long content need their own scroll container
- Without this, page content is clipped and users cannot scroll to reach the save button or bottom sections

## Test plan
- [ ] `/attorney/profile` — full form is scrollable, save button reachable
- [ ] `/attorneys` — search results list scrolls
- [ ] `/attorneys/:id` — detail page scrolls
- [ ] `/consultations` — list scrolls
- [ ] `/consultations/:id` — detail page with messages scrolls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added h-full overflow-y-auto wrappers to AttorneyProfilePage, AttorneySearchPage, AttorneyDetailPage, ConsultationsPage, and ConsultationDetailPage to fix clipped content caused by MainLayout’s overflow-hidden. Long forms and lists now scroll, so users can reach bottom sections and save buttons.

<sup>Written for commit f550f3aa84cffd4496a8192b20bb9867441081ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

