### PR TITLE
feat: add document picker to consultation request modal

### DIFF
--- a/lexwebapp/src/components/consultation/ConfirmStep.tsx
+++ b/lexwebapp/src/components/consultation/ConfirmStep.tsx
@@ -1,0 +1,108 @@
+import { Loader2, FileText, File } from 'lucide-react';
+import type { CreateConsultationRequest } from '../../services/api/ConsultationService';
+import type { VaultDocument } from '../../pages/DocumentsPage/types';
+import { getFileExtension } from '../../pages/DocumentsPage/types';
+
+const TYPE_LABELS: Record<string, string> = {
+  consultation: 'Консультація',
+  representation: 'Представництво в суді',
+  document_review: 'Аналіз документів',
+};
+
+const URGENCY_LABELS: Record<string, string> = {
+  low: 'Низька',
+  normal: 'Звичайна',
+  high: 'Висока',
+  urgent: 'Термінова',
+};
+
+interface Props {
+  form: CreateConsultationRequest;
+  selectedDocIds: string[];
+  allDocs: VaultDocument[];
+  attorneyName: string;
+  consultationFee?: number;
+  onBack: () => void;
+  onSubmit: () => void;
+  submitting: boolean;
+  error: string;
+}
+
+export function ConfirmStep({ form, selectedDocIds, allDocs, attorneyName, consultationFee, onBack, onSubmit, submitting, error }: Props) {
+  const selectedDocs = allDocs.filter(d => selectedDocIds.includes(d.id));
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto p-5 space-y-4">
+        {error && (
+          <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">{error}</div>
+        )}
+
+        <div className="space-y-3">
+          <Row label="Адвокат" value={attorneyName} />
+          {consultationFee && <Row label="Вартість" value={`${consultationFee} грн`} />}
+          <Row label="Тип послуги" value={TYPE_LABELS[form.consultationType || ''] || form.consultationType || ''} />
+          <Row label="Тема" value={form.requestTitle} />
+          {form.requestDescription && (
+            <div>
+              <p className="text-xs text-gray-500 mb-1">Опис</p>
+              <p className="text-sm text-gray-800 whitespace-pre-wrap">{form.requestDescription}</p>
+            </div>
+          )}
+          <Row label="Терміновість" value={URGENCY_LABELS[form.urgency || ''] || form.urgency || ''} />
+        </div>
+
+        <div className="pt-2">
+          <p className="text-xs text-gray-500 mb-2">Документи</p>
+          {selectedDocs.length === 0 ? (
+            <p className="text-sm text-gray-400">Документи не вибрані</p>
+          ) : (
+            <div className="space-y-1">
+              {selectedDocs.map(doc => {
+                const ext = getFileExtension(doc);
+                return (
+                  <div key={doc.id} className="flex items-center gap-2 p-2 bg-gray-50 rounded text-sm">
+                    {ext === '.pdf' ? (
+                      <FileText className="w-4 h-4 text-red-500 shrink-0" />
+                    ) : (
+                      <File className="w-4 h-4 text-gray-400 shrink-0" />
+                    )}
+                    <span className="truncate">{doc.title}</span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-3 p-5 pt-3 border-t">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50"
+        >
+          Назад
+        </button>
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={submitting}
+          className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2"
+        >
+          {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+          Надіслати запит
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="text-sm font-medium text-gray-800">{value}</p>
+    </div>
+  );
+}

--- a/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
+++ b/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
@@ -3,6 +3,10 @@ import { X, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { consultationService, type CreateConsultationRequest } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
+import { StepIndicator } from '../attorney/AttorneyOnboardingModal/StepIndicator';
+import { DocumentPicker } from './DocumentPicker';
+import { ConfirmStep } from './ConfirmStep';
+import type { VaultDocument } from '../../pages/DocumentsPage/types';
 
 interface Props {
   attorneyId: string;
@@ -25,10 +29,15 @@ const URGENCY_OPTIONS = [
   { value: 'urgent', label: 'Термінова' },
 ];
 
+const STEP_TITLES = ['Деталі запиту', 'Документи', 'Підтвердження'];
+
 export function ConsultationRequestModal({ attorneyId, attorneyName, consultationFee, matterId, onClose }: Props) {
   const navigate = useNavigate();
+  const [step, setStep] = useState(1);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
+  const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
+  const [allDocs, setAllDocs] = useState<VaultDocument[]>([]);
   const [form, setForm] = useState<CreateConsultationRequest>({
     attorneyUserId: attorneyId,
     matterId: matterId || undefined,
@@ -41,16 +50,26 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
     feeType: 'fixed',
   });
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!form.requestTitle.trim()) {
-      setError('Введіть тему запиту');
-      return;
+  const handleNext = () => {
+    if (step === 1) {
+      if (!form.requestTitle.trim()) {
+        setError('Введіть тему запиту');
+        return;
+      }
+      setError('');
+      setStep(2);
     }
+  };
+
+  const handleSubmit = async () => {
     setSubmitting(true);
     setError('');
     try {
-      const consultation = await consultationService.createConsultation(form);
+      const payload: CreateConsultationRequest = {
+        ...form,
+        documentIds: selectedDocIds.length > 0 ? selectedDocIds : undefined,
+      };
+      const consultation = await consultationService.createConsultation(payload);
       onClose();
       navigate(generateRoute.consultationDetail(consultation.id));
     } catch (err: any) {
@@ -62,91 +81,124 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
-      <div className="bg-white rounded-lg max-w-lg w-full max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
-        <div className="flex items-center justify-between p-5 border-b">
-          <h2 className="text-lg font-bold">Запит на консультацію</h2>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600"><X className="w-5 h-5" /></button>
+      <div className="bg-white rounded-lg max-w-lg w-full max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+        <div className="flex items-center justify-between p-5 pb-2 border-b">
+          <div>
+            <h2 className="text-lg font-bold">{STEP_TITLES[step - 1]}</h2>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-5 space-y-4">
-          <p className="text-sm text-gray-500">
-            Адвокат: <strong>{attorneyName}</strong>
-            {consultationFee && <> | Вартість: <strong>{consultationFee} грн</strong></>}
-          </p>
+        <StepIndicator currentStep={step} totalSteps={3} />
 
-          {error && <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">{error}</div>}
+        <div className="flex-1 overflow-y-auto min-h-0">
+          {step === 1 && (
+            <div className="p-5 pt-2 space-y-4">
+              <p className="text-sm text-gray-500">
+                Адвокат: <strong>{attorneyName}</strong>
+                {consultationFee && <> | Вартість: <strong>{consultationFee} грн</strong></>}
+              </p>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Тип послуги</label>
-            <select
-              className="w-full px-3 py-2 border rounded-md text-sm bg-white"
-              value={form.consultationType}
-              onChange={e => setForm(f => ({ ...f, consultationType: e.target.value }))}
-            >
-              {CONSULTATION_TYPES.map(t => (
-                <option key={t.value} value={t.value}>{t.label}</option>
-              ))}
-            </select>
-          </div>
+              {error && <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">{error}</div>}
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Тема запиту *</label>
-            <input
-              type="text"
-              className="w-full px-3 py-2 border rounded-md text-sm"
-              placeholder="Коротко опишіть проблему"
-              value={form.requestTitle}
-              onChange={e => setForm(f => ({ ...f, requestTitle: e.target.value }))}
-            />
-          </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Тип послуги</label>
+                <select
+                  className="w-full px-3 py-2 border rounded-md text-sm bg-white"
+                  value={form.consultationType}
+                  onChange={e => setForm(f => ({ ...f, consultationType: e.target.value }))}
+                >
+                  {CONSULTATION_TYPES.map(t => (
+                    <option key={t.value} value={t.value}>{t.label}</option>
+                  ))}
+                </select>
+              </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Детальний опис</label>
-            <textarea
-              rows={4}
-              className="w-full px-3 py-2 border rounded-md text-sm"
-              placeholder="Опишіть ситуацію детальніше..."
-              value={form.requestDescription}
-              onChange={e => setForm(f => ({ ...f, requestDescription: e.target.value }))}
-            />
-          </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Тема запиту *</label>
+                <input
+                  type="text"
+                  className="w-full px-3 py-2 border rounded-md text-sm"
+                  placeholder="Коротко опишіть проблему"
+                  value={form.requestTitle}
+                  onChange={e => setForm(f => ({ ...f, requestTitle: e.target.value }))}
+                />
+              </div>
 
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Терміновість</label>
-            <select
-              className="w-full px-3 py-2 border rounded-md text-sm bg-white"
-              value={form.urgency}
-              onChange={e => setForm(f => ({ ...f, urgency: e.target.value }))}
-            >
-              {URGENCY_OPTIONS.map(u => (
-                <option key={u.value} value={u.value}>{u.label}</option>
-              ))}
-            </select>
-          </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Детальний опис</label>
+                <textarea
+                  rows={4}
+                  className="w-full px-3 py-2 border rounded-md text-sm"
+                  placeholder="Опишіть ситуацію детальніше..."
+                  value={form.requestDescription}
+                  onChange={e => setForm(f => ({ ...f, requestDescription: e.target.value }))}
+                />
+              </div>
 
-          {matterId && (
-            <div className="space-y-2">
-              <label className="flex items-center gap-2 text-sm">
-                <input type="checkbox" className="rounded" checked={form.shareDocuments} onChange={e => setForm(f => ({ ...f, shareDocuments: e.target.checked }))} />
-                Надати доступ до документів справи
-              </label>
-              <label className="flex items-center gap-2 text-sm">
-                <input type="checkbox" className="rounded" checked={form.shareConversations} onChange={e => setForm(f => ({ ...f, shareConversations: e.target.checked }))} />
-                Надати доступ до чатів справи
-              </label>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Терміновість</label>
+                <select
+                  className="w-full px-3 py-2 border rounded-md text-sm bg-white"
+                  value={form.urgency}
+                  onChange={e => setForm(f => ({ ...f, urgency: e.target.value }))}
+                >
+                  {URGENCY_OPTIONS.map(u => (
+                    <option key={u.value} value={u.value}>{u.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              {matterId && (
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 text-sm">
+                    <input type="checkbox" className="rounded" checked={form.shareDocuments} onChange={e => setForm(f => ({ ...f, shareDocuments: e.target.checked }))} />
+                    Надати доступ до документів справи
+                  </label>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input type="checkbox" className="rounded" checked={form.shareConversations} onChange={e => setForm(f => ({ ...f, shareConversations: e.target.checked }))} />
+                    Надати доступ до чатів справи
+                  </label>
+                </div>
+              )}
+
+              <div className="flex gap-3 pt-2">
+                <button type="button" onClick={onClose} className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50">
+                  Скасувати
+                </button>
+                <button type="button" onClick={handleNext} className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700">
+                  Далі
+                </button>
+              </div>
             </div>
           )}
 
-          <div className="flex gap-3 pt-2">
-            <button type="button" onClick={onClose} className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50">
-              Скасувати
-            </button>
-            <button type="submit" disabled={submitting} className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2">
-              {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-              Надіслати запит
-            </button>
-          </div>
-        </form>
+          {step === 2 && (
+            <DocumentPicker
+              selectedIds={selectedDocIds}
+              onChange={setSelectedDocIds}
+              onDocsLoaded={setAllDocs}
+              onBack={() => setStep(1)}
+              onNext={() => setStep(3)}
+            />
+          )}
+
+          {step === 3 && (
+            <ConfirmStep
+              form={form}
+              selectedDocIds={selectedDocIds}
+              allDocs={allDocs}
+              attorneyName={attorneyName}
+              consultationFee={consultationFee}
+              onBack={() => setStep(2)}
+              onSubmit={handleSubmit}
+              submitting={submitting}
+              error={error}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/lexwebapp/src/components/consultation/DocumentPicker.tsx
+++ b/lexwebapp/src/components/consultation/DocumentPicker.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect } from 'react';
+import { Search, FileText, File, Loader2 } from 'lucide-react';
+import { mcpService } from '../../services/api/MCPService';
+import type { VaultDocument } from '../../pages/DocumentsPage/types';
+import { getFileExtension } from '../../pages/DocumentsPage/types';
+
+interface Props {
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  onDocsLoaded: (docs: VaultDocument[]) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export function DocumentPicker({ selectedIds, onChange, onDocsLoaded, onBack, onNext }: Props) {
+  const [docs, setDocs] = useState<VaultDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const result = await mcpService.callTool('list_documents', {
+          limit: 50,
+          offset: 0,
+          sortBy: 'uploadedAt',
+          sortOrder: 'desc',
+        });
+        const parsed = result?.result?.content?.[0]?.text
+          ? JSON.parse(result.result.content[0].text)
+          : result?.result || result;
+        const loaded = parsed.documents || [];
+        setDocs(loaded);
+        onDocsLoaded(loaded);
+      } catch (err) {
+        console.error('Failed to load documents:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const toggle = (id: string) => {
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter(d => d !== id)
+        : [...selectedIds, id]
+    );
+  };
+
+  const q = search.toLowerCase().trim();
+  const filtered = q
+    ? docs.filter(d =>
+        d.title.toLowerCase().includes(q) ||
+        (d.metadata?.originalFilename || '').toLowerCase().includes(q)
+      )
+    : docs;
+
+  const hasSelected = selectedIds.length > 0;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-5 pb-3 space-y-3">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            className="w-full pl-9 pr-3 py-2 border rounded-md text-sm"
+            placeholder="Пошук документів..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+        </div>
+        {hasSelected && (
+          <p className="text-xs text-indigo-600">Вибрано: {selectedIds.length}</p>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 min-h-0" style={{ maxHeight: '300px' }}>
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-gray-400">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Завантаження...
+          </div>
+        ) : docs.length === 0 ? (
+          <div className="text-center py-12 text-gray-400 text-sm">
+            У вас ще немає документів
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-8 text-gray-400 text-sm">
+            Нічого не знайдено
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {filtered.map(doc => {
+              const ext = getFileExtension(doc);
+              const checked = selectedIds.includes(doc.id);
+              const date = doc.metadata?.uploadedAt
+                ? new Date(doc.metadata.uploadedAt).toLocaleDateString('uk-UA')
+                : '';
+              return (
+                <label
+                  key={doc.id}
+                  className={`flex items-center gap-3 p-2.5 rounded-lg cursor-pointer transition-colors ${
+                    checked ? 'bg-indigo-50 border border-indigo-200' : 'hover:bg-gray-50 border border-transparent'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    className="rounded text-indigo-600 shrink-0"
+                    checked={checked}
+                    onChange={() => toggle(doc.id)}
+                  />
+                  {ext === '.pdf' ? (
+                    <FileText className="w-4 h-4 text-red-500 shrink-0" />
+                  ) : (
+                    <File className="w-4 h-4 text-gray-400 shrink-0" />
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm truncate">{doc.title}</p>
+                    <p className="text-xs text-gray-400 truncate">
+                      {ext && <span className="uppercase">{ext.slice(1)}</span>}
+                      {ext && date && ' · '}
+                      {date}
+                    </p>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-3 p-5 pt-3 border-t">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50"
+        >
+          Назад
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700"
+        >
+          {hasSelected ? `Продовжити (${selectedIds.length})` : 'Пропустити'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Converts `ConsultationRequestModal` from a single-step form into a 3-step wizard (form → document picker → confirmation)
- New `DocumentPicker` component fetches vault documents via MCP `list_documents` tool, with search filter and checkbox selection
- New `ConfirmStep` component shows a read-only summary of the request including selected documents
- Sends `documentIds` in the consultation creation payload (backend already supports it)

## Test plan
- [ ] Open `/attorneys/:id`, click "Замовити консультацію"
- [ ] Fill form fields → click "Далі" → verify step 2 shows document list
- [ ] Search/filter documents, select some → click "Продовжити (N)" → verify step 3 summary
- [ ] Click "Пропустити" on step 2 → verify step 3 shows "Документи не вибрані"
- [ ] Click "Надіслати запит" → verify consultation created with `document_ids` populated
- [ ] Verify "Назад" navigation works between all steps
- [ ] `npx tsc --noEmit` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned the consultation request modal into a 3-step wizard (details → document picker → confirmation) to let users attach vault documents. The request now includes documentIds so attorneys receive relevant files.

- **New Features**
  - Added DocumentPicker that lists vault documents via MCP list_documents, with search and checkbox selection.
  - Added ConfirmStep showing a read-only summary, including selected documents and fee.
  - Added step navigation with back/skip and a StepIndicator; selections persist across steps.
  - Sends selected documentIds in the createConsultation payload.

<sup>Written for commit 30f5ebc43081ef47e5f4272613de3b28f61d2a12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

