### PR TITLE
feat: attorney pending invitations modal + My Clients page

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -534,6 +534,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
               <div className="mb-6 space-y-1">
                 <NavItem icon={UserCheck} label="Адвокати" route={ROUTES.ATTORNEYS} onClick={() => handleNavigation(ROUTES.ATTORNEYS)} />
                 <NavItem icon={MessageSquare} label="Консультації" route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} />
+                <NavItem icon={UsersRound} label="Мої клієнти" route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
               </div>
 
             </>

--- a/lexwebapp/src/components/attorney/PendingInvitationsModal.tsx
+++ b/lexwebapp/src/components/attorney/PendingInvitationsModal.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Clock, FileText, MessageSquare } from 'lucide-react';
+import { consultationService, type Consultation } from '../../services/api/ConsultationService';
+import showToast from '../../utils/toast';
+
+interface PendingInvitationsModalProps {
+  open: boolean;
+  consultations: Consultation[];
+  onClose: (remainingIds: string[]) => void;
+}
+
+const URGENCY_LABELS: Record<string, { label: string; color: string }> = {
+  low: { label: 'Низька', color: 'text-gray-500 bg-gray-50' },
+  normal: { label: 'Звичайна', color: 'text-blue-600 bg-blue-50' },
+  high: { label: 'Висока', color: 'text-orange-600 bg-orange-50' },
+  urgent: { label: 'Термінова', color: 'text-red-600 bg-red-50' },
+};
+
+const TYPE_LABELS: Record<string, string> = {
+  consultation: 'Консультація',
+  representation: 'Представництво',
+  document_review: 'Перевірка документів',
+};
+
+export function PendingInvitationsModal({ open, consultations: initialConsultations, onClose }: PendingInvitationsModalProps) {
+  const [items, setItems] = useState<Consultation[]>(initialConsultations);
+  const [processing, setProcessing] = useState<string | null>(null);
+
+  const handleAccept = async (id: string) => {
+    setProcessing(id);
+    try {
+      await consultationService.acceptConsultation(id);
+      setItems(prev => prev.filter(c => c.id !== id));
+      showToast.success('Запит прийнято');
+    } catch {
+      showToast.error('Не вдалося прийняти запит');
+    } finally {
+      setProcessing(null);
+    }
+  };
+
+  const handleDecline = async (id: string) => {
+    setProcessing(id);
+    try {
+      await consultationService.declineConsultation(id);
+      setItems(prev => prev.filter(c => c.id !== id));
+      showToast.success('Запит відхилено');
+    } catch {
+      showToast.error('Не вдалося відхилити запит');
+    } finally {
+      setProcessing(null);
+    }
+  };
+
+  const handleClose = () => {
+    const remainingIds = items.map(c => c.id);
+    onClose(remainingIds);
+  };
+
+  if (items.length === 0 && open) {
+    handleClose();
+    return null;
+  }
+
+  return (
+    <AnimatePresence>
+      {open && items.length > 0 && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[60] flex items-center justify-center p-4"
+          onClick={handleClose}
+        >
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+            className="bg-white rounded-2xl shadow-2xl w-full max-w-lg max-h-[85vh] flex flex-col"
+            onClick={e => e.stopPropagation()}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+              <div>
+                <h2 className="text-[16px] font-semibold text-gray-900">Нові запити</h2>
+                <p className="text-[13px] text-gray-500 mt-0.5">
+                  {items.length} {items.length === 1 ? 'новий запит' : items.length < 5 ? 'нових запити' : 'нових запитів'}
+                </p>
+              </div>
+              <button
+                onClick={handleClose}
+                className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            {/* List */}
+            <div className="flex-1 overflow-y-auto px-6 py-3 space-y-3">
+              {items.map(consultation => {
+                const urgency = URGENCY_LABELS[consultation.urgency] || URGENCY_LABELS.normal;
+                const isProcessing = processing === consultation.id;
+
+                return (
+                  <motion.div
+                    key={consultation.id}
+                    layout
+                    initial={{ opacity: 1, height: 'auto' }}
+                    exit={{ opacity: 0, height: 0 }}
+                    className="border border-gray-200 rounded-xl p-4 hover:border-gray-300 transition-colors"
+                  >
+                    <div className="flex items-start justify-between gap-3 mb-2">
+                      <h3 className="text-[14px] font-medium text-gray-900 line-clamp-2">
+                        {consultation.request_title}
+                      </h3>
+                      <span className={`text-[11px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap ${urgency.color}`}>
+                        {urgency.label}
+                      </span>
+                    </div>
+
+                    <div className="flex items-center gap-3 text-[12px] text-gray-500 mb-3">
+                      <span className="flex items-center gap-1">
+                        <MessageSquare size={12} />
+                        {consultation.client_name}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <FileText size={12} />
+                        {TYPE_LABELS[consultation.consultation_type] || consultation.consultation_type}
+                      </span>
+                      <span className="flex items-center gap-1">
+                        <Clock size={12} />
+                        {new Date(consultation.created_at).toLocaleDateString('uk-UA')}
+                      </span>
+                    </div>
+
+                    {consultation.request_description && (
+                      <p className="text-[12px] text-gray-500 mb-3 line-clamp-2">
+                        {consultation.request_description}
+                      </p>
+                    )}
+
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleAccept(consultation.id)}
+                        disabled={isProcessing}
+                        className="flex-1 px-3 py-2 text-[13px] font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 rounded-lg transition-colors"
+                      >
+                        {isProcessing ? '...' : 'Прийняти'}
+                      </button>
+                      <button
+                        onClick={() => handleDecline(consultation.id)}
+                        disabled={isProcessing}
+                        className="flex-1 px-3 py-2 text-[13px] font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 rounded-lg transition-colors"
+                      >
+                        Відхилити
+                      </button>
+                    </div>
+                  </motion.div>
+                );
+              })}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -3,14 +3,17 @@
  * Common layout structure with sidebar, header, and content area
  */
 
+import { useState, useEffect, useCallback } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 import { X, Menu, PanelRightOpen } from 'lucide-react';
 import { Sidebar } from '../components/Sidebar';
 import { RightPanel } from '../components/RightPanel';
 import { TimeTrackerWidget } from '../components/time/TimeTrackerWidget';
+import { PendingInvitationsModal } from '../components/attorney/PendingInvitationsModal';
 import { useAuth } from '../contexts/AuthContext';
 import { useUIStore } from '../stores';
 import { ROUTES } from '../router/routes';
+import { consultationService, type Consultation } from '../services/api/ConsultationService';
 
 // Map routes to page titles
 const PAGE_TITLES: Record<string, string> = {
@@ -47,11 +50,39 @@ const PAGE_TITLES: Record<string, string> = {
   [ROUTES.ADMIN_CONFIG]: 'Конфігурація системи',
   [ROUTES.ADMIN_TERMINAL]: 'Admin Terminal',
   [ROUTES.ADMIN_BULK_SCRAPE]: 'Пайплайн збору даних',
+  [ROUTES.ATTORNEY_CLIENTS]: 'Мої клієнти',
 };
+
+const SESSION_KEY = 'pending_invitations_dismissed';
 
 export function MainLayout() {
   const location = useLocation();
-  const { logout } = useAuth();
+  const { logout, user } = useAuth();
+  const [pendingConsultations, setPendingConsultations] = useState<Consultation[]>([]);
+  const [showInvitationsModal, setShowInvitationsModal] = useState(false);
+
+  // Fetch unseen pending consultations for attorneys
+  useEffect(() => {
+    if (!user?.id) return;
+    if (sessionStorage.getItem(SESSION_KEY)) return;
+
+    consultationService.getUnseenPending()
+      .then(data => {
+        if (data.count > 0) {
+          setPendingConsultations(data.consultations);
+          setShowInvitationsModal(true);
+        }
+      })
+      .catch(() => {});
+  }, [user?.id]);
+
+  const handleInvitationsClose = useCallback((remainingIds: string[]) => {
+    if (remainingIds.length > 0) {
+      consultationService.markViewed(remainingIds).catch(() => {});
+    }
+    setShowInvitationsModal(false);
+    sessionStorage.setItem(SESSION_KEY, '1');
+  }, []);
 
   // Use UI store for sidebar and panel state
   const {
@@ -203,6 +234,13 @@ export function MainLayout() {
 
       {/* Time Tracker Widget */}
       <TimeTrackerWidget />
+
+      {/* Pending Invitations Modal for attorneys */}
+      <PendingInvitationsModal
+        open={showInvitationsModal}
+        consultations={pendingConsultations}
+        onClose={handleInvitationsClose}
+      />
     </div>
   );
 }

--- a/lexwebapp/src/pages/AttorneyClientsPage/index.tsx
+++ b/lexwebapp/src/pages/AttorneyClientsPage/index.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Users, MessageSquare, Clock, Search } from 'lucide-react';
+import { consultationService, type AttorneyClient } from '../../services/api/ConsultationService';
+import { ROUTES } from '../../router/routes';
+
+export function AttorneyClientsPage() {
+  const navigate = useNavigate();
+  const [clients, setClients] = useState<AttorneyClient[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    consultationService.getMyClients()
+      .then(data => setClients(data.clients))
+      .catch(() => setClients([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filtered = search
+    ? clients.filter(c =>
+        c.client_name.toLowerCase().includes(search.toLowerCase()) ||
+        c.client_email.toLowerCase().includes(search.toLowerCase())
+      )
+    : clients;
+
+  const handleClientClick = (clientUserId: string) => {
+    navigate(`${ROUTES.CONSULTATIONS}?clientId=${clientUserId}`);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="w-6 h-6 border-2 border-claude-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto p-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-xl font-semibold text-gray-900">Мої клієнти</h1>
+            <p className="text-[13px] text-gray-500 mt-1">
+              {clients.length} {clients.length === 1 ? 'клієнт' : clients.length < 5 ? 'клієнти' : 'клієнтів'}
+            </p>
+          </div>
+        </div>
+
+        {/* Search */}
+        {clients.length > 0 && (
+          <div className="relative mb-4">
+            <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Пошук клієнтів..."
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              className="w-full pl-10 pr-4 py-2.5 text-[13px] bg-white border border-gray-200 rounded-xl focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all"
+            />
+          </div>
+        )}
+
+        {/* Empty state */}
+        {clients.length === 0 && (
+          <div className="text-center py-16">
+            <Users size={48} className="mx-auto text-gray-300 mb-4" />
+            <h3 className="text-[15px] font-medium text-gray-600 mb-1">Поки немає клієнтів</h3>
+            <p className="text-[13px] text-gray-400">Клієнти з'являться після прийняття запитів на консультації</p>
+          </div>
+        )}
+
+        {/* Client list */}
+        <div className="space-y-2">
+          {filtered.map(client => (
+            <button
+              key={client.client_user_id}
+              onClick={() => handleClientClick(client.client_user_id)}
+              className="w-full text-left bg-white border border-gray-200 rounded-xl p-4 hover:border-gray-300 hover:shadow-sm transition-all group"
+            >
+              <div className="flex items-center gap-4">
+                {/* Avatar */}
+                {client.client_picture ? (
+                  <img src={client.client_picture} alt={client.client_name} className="w-10 h-10 rounded-full object-cover" />
+                ) : (
+                  <div className="w-10 h-10 rounded-full bg-claude-accent/10 flex items-center justify-center text-claude-accent text-[13px] font-semibold">
+                    {client.client_name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2)}
+                  </div>
+                )}
+
+                {/* Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="text-[14px] font-medium text-gray-900 group-hover:text-claude-accent transition-colors">
+                    {client.client_name}
+                  </div>
+                  <div className="text-[12px] text-gray-500 truncate">{client.client_email}</div>
+                </div>
+
+                {/* Stats */}
+                <div className="flex items-center gap-4 text-[12px] text-gray-500">
+                  <span className="flex items-center gap-1" title="Всього консультацій">
+                    <MessageSquare size={14} />
+                    {client.total_consultations}
+                  </span>
+                  {Number(client.active_consultations) > 0 && (
+                    <span className="flex items-center gap-1 text-green-600" title="Активних">
+                      <Users size={14} />
+                      {client.active_consultations}
+                    </span>
+                  )}
+                  <span className="flex items-center gap-1" title="Остання консультація">
+                    <Clock size={14} />
+                    {new Date(client.last_consultation_at).toLocaleDateString('uk-UA')}
+                  </span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+
+        {filtered.length === 0 && clients.length > 0 && (
+          <div className="text-center py-8">
+            <p className="text-[13px] text-gray-400">Нічого не знайдено</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -73,6 +73,7 @@ import { AttorneyDetailPage } from '../pages/AttorneyDetailPage';
 import { AttorneyProfilePage } from '../pages/AttorneyProfilePage';
 import { ConsultationsPage } from '../pages/ConsultationsPage';
 import { ConsultationDetailPage } from '../pages/ConsultationDetailPage';
+import { AttorneyClientsPage } from '../pages/AttorneyClientsPage';
 
 export const router = createBrowserRouter([
   {
@@ -264,6 +265,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ATTORNEY_PROFILE_EDIT,
             element: <AttorneyProfilePage />,
+          },
+          {
+            path: ROUTES.ATTORNEY_CLIENTS,
+            element: <AttorneyClientsPage />,
           },
           {
             path: ROUTES.CONSULTATIONS,

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -78,6 +78,7 @@ export const ROUTES = {
   ATTORNEYS: '/attorneys',
   ATTORNEY_DETAIL: '/attorneys/:id',
   ATTORNEY_PROFILE_EDIT: '/attorney/profile',
+  ATTORNEY_CLIENTS: '/attorney/clients',
   CONSULTATIONS: '/consultations',
   CONSULTATION_DETAIL: '/consultations/:id',
 

--- a/lexwebapp/src/services/api/ConsultationService.ts
+++ b/lexwebapp/src/services/api/ConsultationService.ts
@@ -200,6 +200,42 @@ export class ConsultationService extends BaseService {
       return this.handleError(error);
     }
   }
+
+  async getUnseenPending(): Promise<{ consultations: Consultation[]; count: number }> {
+    try {
+      const response = await this.client.get('/api/consultations/pending-unseen');
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async markViewed(ids: string[]): Promise<void> {
+    try {
+      await this.client.put('/api/consultations/mark-viewed', { ids });
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async getMyClients(): Promise<{ clients: AttorneyClient[] }> {
+    try {
+      const response = await this.client.get('/api/consultations/my-clients');
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+}
+
+export interface AttorneyClient {
+  client_user_id: string;
+  client_name: string;
+  client_email: string;
+  client_picture?: string;
+  total_consultations: number;
+  active_consultations: number;
+  last_consultation_at: string;
 }
 
 export const consultationService = new ConsultationService();

--- a/mcp_backend/src/migrations/068_consultation_viewed_at.sql
+++ b/mcp_backend/src/migrations/068_consultation_viewed_at.sql
@@ -1,0 +1,4 @@
+-- Migration 068: Add viewed_at column to consultations
+-- NULL = unseen by attorney. Set when attorney views/dismisses the modal.
+
+ALTER TABLE consultations ADD COLUMN IF NOT EXISTS viewed_at TIMESTAMPTZ;

--- a/mcp_backend/src/routes/consultation-routes.ts
+++ b/mcp_backend/src/routes/consultation-routes.ts
@@ -39,6 +39,44 @@ export function createConsultationRoutes(
     }
   }) as any);
 
+  // GET /api/consultations/pending-unseen — unseen pending requests for attorney
+  router.get('/pending-unseen', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      const result = await consultationService.getUnseenPending(req.user.id);
+      res.json(result);
+    } catch (error: any) {
+      logger.error('Failed to get unseen pending consultations', { error: error.message });
+      res.status(500).json({ error: 'Failed to get unseen pending consultations' });
+    }
+  }) as any);
+
+  // PUT /api/consultations/mark-viewed — mark consultations as viewed
+  router.put('/mark-viewed', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      const { ids } = req.body;
+      if (!Array.isArray(ids)) return res.status(400).json({ error: 'ids must be an array' });
+      await consultationService.markViewed(ids, req.user.id);
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('Failed to mark consultations as viewed', { error: error.message });
+      res.status(500).json({ error: 'Failed to mark as viewed' });
+    }
+  }) as any);
+
+  // GET /api/consultations/my-clients — attorney's client list with stats
+  router.get('/my-clients', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      const clients = await consultationService.getAttorneyClients(req.user.id);
+      res.json({ clients });
+    } catch (error: any) {
+      logger.error('Failed to get attorney clients', { error: error.message });
+      res.status(500).json({ error: 'Failed to get clients' });
+    }
+  }) as any);
+
   // GET /api/consultations/:id — get detail
   router.get('/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {

--- a/mcp_backend/src/services/consultation-service.ts
+++ b/mcp_backend/src/services/consultation-service.ts
@@ -375,6 +375,53 @@ export class ConsultationService {
     return result.rows[0];
   }
 
+  // ─── Unseen / Viewed ─────────────────────────────────────
+
+  async getUnseenPending(attorneyUserId: string): Promise<{ consultations: Consultation[]; count: number }> {
+    const result = await this.db.query(
+      `SELECT c.*,
+              cu.name as client_name,
+              au.name as attorney_name,
+              m.matter_name
+       FROM consultations c
+       JOIN users cu ON cu.id = c.client_user_id
+       JOIN users au ON au.id = c.attorney_user_id
+       LEFT JOIN matters m ON m.id = c.matter_id
+       WHERE c.attorney_user_id = $1 AND c.status = 'pending' AND c.viewed_at IS NULL
+       ORDER BY c.created_at DESC`,
+      [attorneyUserId]
+    );
+    return { consultations: result.rows, count: result.rows.length };
+  }
+
+  async markViewed(ids: string[], attorneyUserId: string): Promise<void> {
+    if (ids.length === 0) return;
+    await this.db.query(
+      `UPDATE consultations SET viewed_at = NOW() WHERE id = ANY($1) AND attorney_user_id = $2`,
+      [ids, attorneyUserId]
+    );
+  }
+
+  async getAttorneyClients(attorneyUserId: string): Promise<any[]> {
+    const result = await this.db.query(
+      `SELECT
+         c.client_user_id,
+         cu.name as client_name,
+         cu.email as client_email,
+         cu.picture as client_picture,
+         COUNT(*) as total_consultations,
+         COUNT(*) FILTER (WHERE c.status IN ('pending','accepted','paid','in_progress')) as active_consultations,
+         MAX(c.created_at) as last_consultation_at
+       FROM consultations c
+       JOIN users cu ON cu.id = c.client_user_id
+       WHERE c.attorney_user_id = $1 AND c.status NOT IN ('declined','cancelled')
+       GROUP BY c.client_user_id, cu.name, cu.email, cu.picture
+       ORDER BY MAX(c.created_at) DESC`,
+      [attorneyUserId]
+    );
+    return result.rows;
+  }
+
   // ─── Messaging ─────────────────────────────────────────
 
   async sendMessage(consultationId: string, senderId: string, content: string, messageType?: string): Promise<ConsultationMessage> {


### PR DESCRIPTION
## Summary
- **Migration 068**: adds `viewed_at` column to `consultations` table (NULL = unseen by attorney)
- **Backend**: 3 new methods (`getUnseenPending`, `markViewed`, `getAttorneyClients`) + 3 new routes (`/pending-unseen`, `/mark-viewed`, `/my-clients`)
- **PendingInvitationsModal**: Framer Motion modal shown on attorney login with unseen pending requests — accept/decline inline, marks remaining as viewed on dismiss, sessionStorage prevents re-showing
- **AttorneyClientsPage** (`/attorney/clients`): lists distinct clients with avatar, total/active consultation counts, last date; search filter; click navigates to filtered consultations
- **Sidebar**: "Мої клієнти" link added in attorney section
- **MainLayout**: mounts modal + page title mapping

## Test plan
- [ ] Run migration 068 on dev DB
- [ ] Attorney login → modal appears with unseen pending requests
- [ ] Accept a request → removed from list, toast shown
- [ ] Decline a request → removed from list
- [ ] Close modal → remaining marked as viewed, doesn't reappear same session
- [ ] New unseen request arrives → modal reappears on next session
- [ ] Navigate to `/attorney/clients` → see client list with stats
- [ ] Click client → navigates to consultations filtered by that client
- [ ] Both `tsc --noEmit` pass for backend and frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a modal with unseen pending consultation requests when an attorney logs in and adds a “My Clients” page with client stats. Adds a viewed_at field and new API endpoints to support this flow.

- **New Features**
  - Modal on login lists unseen pending requests; accept/decline inline; dismiss marks the rest as viewed; shown once per session.
  - “Мої клієнти” page (/attorney/clients): distinct clients with avatar, total/active counts, last date, and search; click opens consultations filtered by client.
  - Sidebar link added in the attorney section; routes and page title mapping updated.
  - APIs: GET /api/consultations/pending-unseen, PUT /api/consultations/mark-viewed, GET /api/consultations/my-clients.

- **Migration**
  - Add consultations.viewed_at TIMESTAMPTZ (NULL = unseen) to track when pending requests are viewed.

<sup>Written for commit 42325e2408ab344d38f5b842a648dd59ad9b9e30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

