### PR TITLE
test: add tests for consultation chat tab feature

### DIFF
--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+// Mock AuthContext
+const mockUser = { id: 'user-1', name: 'Test User', email: 'test@test.com', role: 'user' as const };
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUser, isAuthenticated: true, token: 'fake', isLoading: false }),
+}));
+
+// Mock consultation service
+const mockGetMessages = vi.fn();
+const mockSendMessage = vi.fn();
+const mockConnectMessageStream = vi.fn();
+
+vi.mock('../../../services', () => ({
+  consultationService: {
+    getMessages: (...args: any[]) => mockGetMessages(...args),
+    sendMessage: (...args: any[]) => mockSendMessage(...args),
+    connectMessageStream: (...args: any[]) => mockConnectMessageStream(...args),
+  },
+}));
+
+import { ConsultationChatTab } from '../ConsultationChatTab';
+
+// Mock EventSource
+function createMockEventSource() {
+  const listeners: Record<string, Function[]> = {};
+  return {
+    addEventListener: vi.fn((event: string, cb: Function) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(cb);
+    }),
+    close: vi.fn(),
+    onerror: null as any,
+    _emit: (event: string, data: any) => {
+      listeners[event]?.forEach(cb => cb({ data: JSON.stringify(data) }));
+    },
+    _listeners: listeners,
+  };
+}
+
+describe('ConsultationChatTab', () => {
+  const mockOnUnreadCountChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMessages.mockResolvedValue({ messages: [], total: 0 });
+    mockConnectMessageStream.mockReturnValue(createMockEventSource());
+  });
+
+  describe('Empty state', () => {
+    it('shows "select consultation" when consultationId is null', () => {
+      render(
+        <ConsultationChatTab consultationId={null} onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+      expect(screen.getByText('Оберіть консультацію для чату')).toBeInTheDocument();
+    });
+
+    it('shows "no messages" when consultation has no messages', async () => {
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Повідомлень поки немає')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Message loading', () => {
+    it('fetches and displays messages', async () => {
+      mockGetMessages.mockResolvedValue({
+        messages: [
+          {
+            id: 'msg-1',
+            consultation_id: 'cons-1',
+            sender_id: 'user-2',
+            content: 'Привіт!',
+            message_type: 'text',
+            created_at: '2026-02-28T10:00:00Z',
+            sender_name: 'Attorney',
+          },
+          {
+            id: 'msg-2',
+            consultation_id: 'cons-1',
+            sender_id: 'user-1',
+            content: 'Добрий день',
+            message_type: 'text',
+            created_at: '2026-02-28T10:01:00Z',
+            sender_name: 'Test User',
+          },
+        ],
+        total: 2,
+      });
+
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Привіт!')).toBeInTheDocument();
+        expect(screen.getByText('Добрий день')).toBeInTheDocument();
+      });
+
+      // Other person's name shown, own name not shown
+      expect(screen.getByText('Attorney')).toBeInTheDocument();
+    });
+
+    it('resets unread count after loading', async () => {
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockOnUnreadCountChange).toHaveBeenCalledWith(0);
+      });
+    });
+  });
+
+  describe('Sending messages', () => {
+    it('sends message on Enter key and shows optimistically', async () => {
+      const user = userEvent.setup();
+      mockSendMessage.mockResolvedValue({
+        id: 'msg-new',
+        consultation_id: 'cons-1',
+        sender_id: 'user-1',
+        content: 'Test message',
+        message_type: 'text',
+        created_at: '2026-02-28T10:05:00Z',
+        sender_name: 'Test User',
+      });
+
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalled();
+      });
+
+      const input = screen.getByPlaceholderText('Написати повідомлення...');
+      await user.type(input, 'Test message{Enter}');
+
+      await waitFor(() => {
+        expect(screen.getByText('Test message')).toBeInTheDocument();
+      });
+
+      expect(mockSendMessage).toHaveBeenCalledWith('cons-1', 'Test message');
+    });
+
+    it('does not send empty messages', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalled();
+      });
+
+      const input = screen.getByPlaceholderText('Написати повідомлення...');
+      await user.type(input, '{Enter}');
+
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
+    it('restores input on send failure', async () => {
+      const user = userEvent.setup();
+      mockSendMessage.mockRejectedValue(new Error('Network error'));
+
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockGetMessages).toHaveBeenCalled();
+      });
+
+      const input = screen.getByPlaceholderText('Написати повідомлення...');
+      await user.type(input, 'Failed msg{Enter}');
+
+      await waitFor(() => {
+        expect(input).toHaveValue('Failed msg');
+      });
+    });
+  });
+
+  describe('SSE connection', () => {
+    it('connects to SSE stream when consultationId is set', async () => {
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockConnectMessageStream).toHaveBeenCalledWith('cons-1');
+      });
+    });
+
+    it('closes SSE on unmount', async () => {
+      const mockES = createMockEventSource();
+      mockConnectMessageStream.mockReturnValue(mockES);
+
+      const { unmount } = render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockConnectMessageStream).toHaveBeenCalled();
+      });
+
+      unmount();
+      expect(mockES.close).toHaveBeenCalled();
+    });
+
+    it('appends messages received via SSE', async () => {
+      const mockES = createMockEventSource();
+      mockConnectMessageStream.mockReturnValue(mockES);
+
+      render(
+        <ConsultationChatTab consultationId="cons-1" onUnreadCountChange={mockOnUnreadCountChange} />
+      );
+
+      await waitFor(() => {
+        expect(mockConnectMessageStream).toHaveBeenCalled();
+      });
+
+      // Simulate SSE message
+      mockES._emit('message', {
+        id: 'msg-sse',
+        consultation_id: 'cons-1',
+        sender_id: 'user-2',
+        content: 'SSE message',
+        message_type: 'text',
+        created_at: '2026-02-28T11:00:00Z',
+        sender_name: 'Attorney',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('SSE message')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/mcp_backend/src/routes/__tests__/consultation-routes-chat.test.ts
+++ b/mcp_backend/src/routes/__tests__/consultation-routes-chat.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Consultation Chat Routes Tests
+ *
+ * Tests SSE message stream and unread count endpoints:
+ *  - GET /api/consultations/:id/messages/stream
+ *  - GET /api/consultations/:id/messages/unread-count
+ *  - Query-param JWT token middleware
+ */
+
+import express from 'express';
+import http from 'http';
+import request from 'supertest';
+import { createConsultationRoutes } from '../consultation-routes';
+import { consultationMessageBus } from '../../services/consultation-message-bus';
+
+// ──────────────────────────────────────────────────────────────────────────
+// Mock services
+// ──────────────────────────────────────────────────────────────────────────
+
+const mockConsultationService = {
+  createConsultation: jest.fn(),
+  listConsultations: jest.fn(),
+  getConsultation: jest.fn(),
+  acceptConsultation: jest.fn(),
+  declineConsultation: jest.fn(),
+  startConsultation: jest.fn(),
+  completeConsultation: jest.fn(),
+  cancelConsultation: jest.fn(),
+  getUnseenPending: jest.fn(),
+  markViewed: jest.fn(),
+  getAttorneyClients: jest.fn(),
+  getMessages: jest.fn(),
+  sendMessage: jest.fn(),
+  submitReview: jest.fn(),
+  getUnreadCount: jest.fn(),
+};
+
+const mockPaymentService = {
+  createPayment: jest.fn(),
+  initiatePayment: jest.fn(),
+  getPaymentByConsultation: jest.fn(),
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// App factory
+// ──────────────────────────────────────────────────────────────────────────
+
+function buildApp(userId = 'user-123') {
+  const app = express();
+  app.use(express.json());
+
+  // Simulate JWT auth middleware
+  app.use((req: any, _res: any, next: any) => {
+    req.user = { id: userId, email: 'test@test.com', name: 'Test User' };
+    next();
+  });
+
+  app.use(
+    '/api/consultations',
+    createConsultationRoutes(
+      mockConsultationService as any,
+      mockPaymentService as any,
+    ),
+  );
+
+  return app;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('Consultation Chat Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /:id/messages/unread-count', () => {
+    it('returns unread count', async () => {
+      mockConsultationService.getUnreadCount.mockResolvedValue(5);
+
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/consultations/cons-1/messages/unread-count')
+        .expect(200);
+
+      expect(res.body).toEqual({ count: 5 });
+      expect(mockConsultationService.getUnreadCount).toHaveBeenCalledWith('cons-1', 'user-123');
+    });
+
+    it('returns 500 on service error', async () => {
+      mockConsultationService.getUnreadCount.mockRejectedValue(new Error('DB down'));
+
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/consultations/cons-1/messages/unread-count')
+        .expect(500);
+
+      expect(res.body.error).toBe('Failed to get unread count');
+    });
+  });
+
+  describe('Query-param token middleware', () => {
+    it('returns 401 without user even when token query param is set', async () => {
+      const app = express();
+      app.use(express.json());
+      // No auth middleware — user is not set
+      app.use('/api/consultations', createConsultationRoutes(
+        mockConsultationService as any,
+        mockPaymentService as any,
+      ));
+
+      mockConsultationService.getUnreadCount.mockResolvedValue(3);
+
+      const res = await request(app)
+        .get('/api/consultations/cons-1/messages/unread-count?token=fake-jwt')
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+  });
+
+  describe('GET /:id/messages/stream (SSE)', () => {
+    it('returns 404 when consultation not found', async () => {
+      mockConsultationService.getConsultation.mockResolvedValue(null);
+
+      const app = buildApp();
+      // Non-SSE request since consultation is not found — returns JSON 404
+      const res = await request(app)
+        .get('/api/consultations/cons-bad/messages/stream');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Consultation not found');
+    });
+
+    it('returns SSE headers, connected event, and delivers messages', (done) => {
+      mockConsultationService.getConsultation.mockResolvedValue({
+        id: 'cons-1',
+        client_user_id: 'user-123',
+        attorney_user_id: 'attorney-1',
+        status: 'in_progress',
+      });
+
+      const app = buildApp();
+      const server = http.createServer(app);
+
+      server.listen(0, () => {
+        const port = (server.address() as any).port;
+
+        // Use raw http request for SSE to avoid supertest stream issues
+        const req = http.get(`http://localhost:${port}/api/consultations/cons-1/messages/stream`, (res) => {
+          let data = '';
+
+          expect(res.headers['content-type']).toBe('text/event-stream');
+          expect(res.headers['cache-control']).toBe('no-cache');
+          expect(res.headers['x-accel-buffering']).toBe('no');
+
+          res.on('data', (chunk: Buffer) => {
+            data += chunk.toString();
+
+            if (data.includes('event: connected') && !data.includes('event: message')) {
+              // Connected event received — now publish a message
+              const msg = {
+                id: 'msg-1',
+                consultation_id: 'cons-1',
+                sender_id: 'attorney-1',
+                content: 'Hi there',
+                message_type: 'text',
+                created_at: new Date().toISOString(),
+                sender_name: 'Attorney',
+              };
+              consultationMessageBus.publish('cons-1', msg as any);
+            }
+
+            if (data.includes('event: message')) {
+              // Message received via SSE
+              expect(data).toContain('event: connected');
+              expect(data).toContain('"Hi there"');
+              req.destroy();
+              server.close(() => done());
+            }
+          });
+        });
+
+        req.on('error', () => {
+          // Expected when we destroy
+        });
+      });
+    });
+  });
+});

--- a/mcp_backend/src/services/__tests__/consultation-message-bus.test.ts
+++ b/mcp_backend/src/services/__tests__/consultation-message-bus.test.ts
@@ -1,0 +1,84 @@
+import { consultationMessageBus } from '../consultation-message-bus';
+import type { ConsultationMessage } from '../consultation-service';
+
+function makeMessage(overrides: Partial<ConsultationMessage> = {}): ConsultationMessage {
+  return {
+    id: 'msg-1',
+    consultation_id: 'cons-1',
+    sender_id: 'user-1',
+    content: 'Hello',
+    message_type: 'text',
+    created_at: new Date(),
+    sender_name: 'Test User',
+    ...overrides,
+  };
+}
+
+describe('ConsultationMessageBus', () => {
+  it('delivers messages to subscribers of the correct consultation', () => {
+    const callback = jest.fn();
+    const unsubscribe = consultationMessageBus.subscribe('cons-1', callback);
+
+    const msg = makeMessage();
+    consultationMessageBus.publish('cons-1', msg);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(msg);
+    unsubscribe();
+  });
+
+  it('does not deliver messages to subscribers of other consultations', () => {
+    const callback = jest.fn();
+    const unsubscribe = consultationMessageBus.subscribe('cons-2', callback);
+
+    consultationMessageBus.publish('cons-1', makeMessage());
+
+    expect(callback).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('supports multiple subscribers for the same consultation', () => {
+    const cb1 = jest.fn();
+    const cb2 = jest.fn();
+    const unsub1 = consultationMessageBus.subscribe('cons-3', cb1);
+    const unsub2 = consultationMessageBus.subscribe('cons-3', cb2);
+
+    const msg = makeMessage({ consultation_id: 'cons-3' });
+    consultationMessageBus.publish('cons-3', msg);
+
+    expect(cb1).toHaveBeenCalledWith(msg);
+    expect(cb2).toHaveBeenCalledWith(msg);
+    unsub1();
+    unsub2();
+  });
+
+  it('unsubscribe stops delivery', () => {
+    const callback = jest.fn();
+    const unsubscribe = consultationMessageBus.subscribe('cons-4', callback);
+
+    unsubscribe();
+    consultationMessageBus.publish('cons-4', makeMessage({ consultation_id: 'cons-4' }));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribe only removes the specific callback', () => {
+    const cb1 = jest.fn();
+    const cb2 = jest.fn();
+    const unsub1 = consultationMessageBus.subscribe('cons-5', cb1);
+    const unsub2 = consultationMessageBus.subscribe('cons-5', cb2);
+
+    unsub1();
+    consultationMessageBus.publish('cons-5', makeMessage({ consultation_id: 'cons-5' }));
+
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).toHaveBeenCalledTimes(1);
+    unsub2();
+  });
+
+  it('handles publish with no subscribers gracefully', () => {
+    expect(() => {
+      consultationMessageBus.publish('cons-no-one', makeMessage());
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 21 tests covering the consultation chat tab feature from PR #520
- Backend: message bus unit tests (6) + route integration tests with SSE streaming (5)
- Frontend: ConsultationChatTab component tests with mocked SSE and services (10)

## Test coverage
| File | Tests | Covers |
|---|---|---|
| `consultation-message-bus.test.ts` | 6 | pub/sub, unsubscribe, isolation between consultations |
| `consultation-routes-chat.test.ts` | 5 | SSE headers/events, message delivery, unread-count, 404, auth |
| `ConsultationChatTab.test.tsx` | 10 | empty states, message loading, optimistic send, send failure rollback, SSE connection/cleanup |

## Test plan
- [x] `cd mcp_backend && npx jest --no-cache src/services/__tests__/consultation-message-bus.test.ts` — 6/6
- [x] `cd mcp_backend && npx jest --no-cache src/routes/__tests__/consultation-routes-chat.test.ts` — 5/5
- [x] `cd lexwebapp && npx vitest run src/components/chat/__tests__/ConsultationChatTab.test.tsx` — 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 21 tests for the consultation chat tab across backend and frontend. Covers message bus pub/sub and unsubscribe, SSE stream headers and delivery, unread count, and UI behaviors like loading messages, optimistic send with rollback on failure, and live updates via SSE.

<sup>Written for commit eb7ae636ea61cec52dbbf787485883825ba3e9ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

