### PR TITLE
feat: add mock Monobank payment step to consultation request

### DIFF
--- a/lexwebapp/src/components/consultation/ConfirmStep.tsx
+++ b/lexwebapp/src/components/consultation/ConfirmStep.tsx
@@ -1,4 +1,4 @@
-import { Loader2, FileText, File } from 'lucide-react';
+import { FileText, File } from 'lucide-react';
 import type { CreateConsultationRequest } from '../../services/api/ConsultationService';
 import type { VaultDocument } from '../../pages/DocumentsPage/types';
 import { getFileExtension } from '../../pages/DocumentsPage/types';
@@ -23,21 +23,15 @@ interface Props {
   attorneyName: string;
   consultationFee?: number;
   onBack: () => void;
-  onSubmit: () => void;
-  submitting: boolean;
-  error: string;
+  onNext: () => void;
 }
 
-export function ConfirmStep({ form, selectedDocIds, allDocs, attorneyName, consultationFee, onBack, onSubmit, submitting, error }: Props) {
+export function ConfirmStep({ form, selectedDocIds, allDocs, attorneyName, consultationFee, onBack, onNext }: Props) {
   const selectedDocs = allDocs.filter(d => selectedDocIds.includes(d.id));
 
   return (
     <div className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto p-5 space-y-4">
-        {error && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">{error}</div>
-        )}
-
         <div className="space-y-3">
           <Row label="Адвокат" value={attorneyName} />
           {consultationFee && <Row label="Вартість" value={`${consultationFee} грн`} />}
@@ -86,12 +80,10 @@ export function ConfirmStep({ form, selectedDocIds, allDocs, attorneyName, consu
         </button>
         <button
           type="button"
-          onClick={onSubmit}
-          disabled={submitting}
-          className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2"
+          onClick={onNext}
+          className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700 flex items-center justify-center gap-2"
         >
-          {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-          Надіслати запит
+          Далі до оплати
         </button>
       </div>
     </div>

--- a/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
+++ b/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
-import { X, Loader2 } from 'lucide-react';
+import { X } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { consultationService, type CreateConsultationRequest } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
 import { StepIndicator } from '../attorney/AttorneyOnboardingModal/StepIndicator';
 import { DocumentPicker } from './DocumentPicker';
 import { ConfirmStep } from './ConfirmStep';
+import { PaymentStep } from './PaymentStep';
 import type { VaultDocument } from '../../pages/DocumentsPage/types';
 
 interface Props {
@@ -29,7 +30,7 @@ const URGENCY_OPTIONS = [
   { value: 'urgent', label: 'Термінова' },
 ];
 
-const STEP_TITLES = ['Деталі запиту', 'Документи', 'Підтвердження'];
+const STEP_TITLES = ['Деталі запиту', 'Документи', 'Підтвердження', 'Оплата'];
 
 export function ConsultationRequestModal({ attorneyId, attorneyName, consultationFee, matterId, onClose }: Props) {
   const navigate = useNavigate();
@@ -91,7 +92,7 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
           </button>
         </div>
 
-        <StepIndicator currentStep={step} totalSteps={3} />
+        <StepIndicator currentStep={step} totalSteps={4} />
 
         <div className="flex-1 overflow-y-auto min-h-0">
           {step === 1 && (
@@ -193,7 +194,17 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
               attorneyName={attorneyName}
               consultationFee={consultationFee}
               onBack={() => setStep(2)}
-              onSubmit={handleSubmit}
+              onNext={() => setStep(4)}
+            />
+          )}
+
+          {step === 4 && (
+            <PaymentStep
+              attorneyName={attorneyName}
+              consultationFee={consultationFee}
+              serviceType={form.consultationType || 'consultation'}
+              onPaymentComplete={handleSubmit}
+              onBack={() => setStep(3)}
               submitting={submitting}
               error={error}
             />

--- a/lexwebapp/src/components/consultation/PaymentStep.tsx
+++ b/lexwebapp/src/components/consultation/PaymentStep.tsx
@@ -1,0 +1,126 @@
+import { useState, useEffect } from 'react';
+import { CheckCircle, Loader2, CreditCard } from 'lucide-react';
+
+interface Props {
+  attorneyName: string;
+  consultationFee?: number;
+  serviceType: string;
+  onPaymentComplete: () => void;
+  onBack: () => void;
+  submitting: boolean;
+  error: string;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  consultation: 'Консультація',
+  representation: 'Представництво в суді',
+  document_review: 'Аналіз документів',
+};
+
+export function PaymentStep({ attorneyName, consultationFee, serviceType, onPaymentComplete, onBack, submitting, error }: Props) {
+  const [paying, setPaying] = useState(false);
+  const [paid, setPaid] = useState(false);
+  const isFree = !consultationFee || consultationFee === 0;
+
+  useEffect(() => {
+    if (isFree) {
+      onPaymentComplete();
+    }
+  }, [isFree, onPaymentComplete]);
+
+  const handlePay = () => {
+    setPaying(true);
+    setTimeout(() => {
+      setPaying(false);
+      setPaid(true);
+      setTimeout(() => {
+        onPaymentComplete();
+      }, 1000);
+    }, 2000);
+  };
+
+  if (isFree) {
+    return (
+      <div className="flex flex-col items-center justify-center p-8 gap-3">
+        <Loader2 className="w-6 h-6 animate-spin text-indigo-600" />
+        <p className="text-sm text-gray-500">Безкоштовно — створюємо запит...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto p-5 space-y-5">
+        {error && (
+          <div className="p-3 bg-red-50 border border-red-200 rounded text-red-700 text-sm">{error}</div>
+        )}
+
+        <div className="bg-gray-50 rounded-lg p-4 space-y-2">
+          <p className="text-xs text-gray-500 uppercase tracking-wide">Замовлення</p>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Адвокат</span>
+            <span className="font-medium text-gray-800">{attorneyName}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span className="text-gray-600">Послуга</span>
+            <span className="font-medium text-gray-800">{TYPE_LABELS[serviceType] || serviceType}</span>
+          </div>
+          <div className="border-t pt-2 mt-2 flex justify-between">
+            <span className="text-sm font-medium text-gray-700">До сплати</span>
+            <span className="text-lg font-bold text-gray-900">{consultationFee} грн</span>
+          </div>
+        </div>
+
+        {paid ? (
+          <div className="flex flex-col items-center gap-3 py-4">
+            <CheckCircle className="w-12 h-12 text-green-500" />
+            <p className="text-sm font-medium text-green-700">Оплату успішно здійснено</p>
+            {submitting && (
+              <div className="flex items-center gap-2 text-sm text-gray-500">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Створюємо запит...
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <button
+              type="button"
+              onClick={handlePay}
+              disabled={paying}
+              className="w-full py-3 rounded-lg text-sm font-medium flex items-center justify-center gap-2 transition-colors disabled:opacity-70"
+              style={{ backgroundColor: '#000000', color: '#FFFFFF' }}
+            >
+              {paying ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Обробка платежу...
+                </>
+              ) : (
+                <>
+                  <CreditCard className="w-4 h-4" />
+                  Сплатити через Monobank
+                </>
+              )}
+            </button>
+            <p className="text-xs text-center text-gray-400">
+              Тестовий режим — реальна оплата не відбувається
+            </p>
+          </div>
+        )}
+      </div>
+
+      {!paid && !paying && (
+        <div className="flex gap-3 p-5 pt-3 border-t">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50"
+          >
+            Назад
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a 4th step (Payment) to the consultation request modal with a mock Monobank payment widget
- Confirm step now shows "Далі до оплати" and navigates to payment instead of submitting directly
- Payment step shows order summary, simulates a 2-second payment, then auto-submits the consultation request
- Free consultations (fee=0) skip payment and auto-proceed

## Test plan
- [ ] Open attorney detail page → click "Замовити консультацію"
- [ ] Fill details → attach docs → confirm → verify 4-step indicator
- [ ] On payment step, verify order summary and "Сплатити через Monobank" button
- [ ] Click pay → verify 2s loading → green checkmark → consultation created
- [ ] Verify "Назад" button returns to confirm step
- [ ] Test with consultationFee=0 → should auto-proceed without payment UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 4th “Оплата” step with a mock Monobank payment to the consultation request flow. Confirm now routes to payment; after a 2s simulated payment we auto-submit, and free consultations skip payment.

- New Features
  - Added PaymentStep with order summary (attorney, service label, amount) and a Monobank-style pay button; shows success and submission states.
  - Updated flow: step titles/indicator now 4 steps; ConfirmStep swaps “Надіслати запит” for “Далі до оплати” (onNext).
  - Free consultations (fee=0) auto-submit without showing payment UI.
  - Back from payment to confirm; error messages surface on the payment step.

<sup>Written for commit 477c7485d9513b041fa01a18b964c0203517fd25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

