### PR TITLE
feat: document management via chat (delete, rename, tag, move)

### DIFF
--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -265,6 +265,76 @@ Pipeline:
           required: ['query'],
         },
       },
+      {
+        name: 'delete_document',
+        description: `Видалити документ з Vault (soft-delete).
+
+Видаляє документ, його векторні ембеддінги та файл з MinIO (якщо є).
+Потрібно знати ID документа — спочатку використай list_documents для пошуку.
+
+Приклади:
+- "Видали документ договір оренди" → спочатку list_documents(query="договір оренди"), потім delete_document(documentId=...)`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            documentId: {
+              type: 'string',
+              description: 'UUID документа в vault',
+            },
+          },
+          required: ['documentId'],
+        },
+      },
+      {
+        name: 'update_document',
+        description: `Оновити метадані документа в Vault.
+
+Можна змінити:
+- title — назву документа
+- tags — масив тегів
+- type — тип документа (contract, legislation, court_decision, internal, other)
+- category — категорію
+- folderPath — шлях до папки
+
+Потрібно знати ID документа — спочатку використай list_documents для пошуку.
+
+Приклади:
+- "Переименуй документ на 'Новий договір'" → list_documents → update_document(title="Новий договір")
+- "Додай тег 'оренда'" → list_documents → update_document(tags=["оренда"])
+- "Перенеси в папку Contracts" → list_documents → update_document(folderPath="/Contracts")`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            documentId: {
+              type: 'string',
+              description: 'UUID документа в vault',
+            },
+            title: {
+              type: 'string',
+              description: 'Нова назва документа',
+            },
+            tags: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Нові теги (замінюють існуючі)',
+            },
+            type: {
+              type: 'string',
+              enum: ['contract', 'legislation', 'court_decision', 'internal', 'other'],
+              description: 'Новий тип документа',
+            },
+            category: {
+              type: 'string',
+              description: 'Нова категорія',
+            },
+            folderPath: {
+              type: 'string',
+              description: 'Новий шлях до папки',
+            },
+          },
+          required: ['documentId'],
+        },
+      },
     ];
   }
 
@@ -1349,6 +1419,162 @@ Pipeline:
     }
   }
 
+  /**
+   * Delete document (soft-delete) with cleanup of vectors and MinIO
+   */
+  async deleteDocument(args: {
+    documentId: string;
+    userId?: string;
+  }): Promise<{ deleted: boolean; title?: string; error?: string }> {
+    try {
+      logger.info('[Vault] delete_document started', { documentId: args.documentId, userId: args.userId });
+
+      if (!args.userId) {
+        return { deleted: false, error: 'Authentication required' };
+      }
+
+      // Verify ownership and get doc info
+      const docResult = await this.documentService['db'].query(
+        `SELECT id, title, storage_type, storage_path, user_id, metadata
+         FROM documents WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+        [args.documentId, args.userId]
+      );
+
+      if (docResult.rows.length === 0) {
+        return { deleted: false, error: 'Document not found or access denied' };
+      }
+
+      const doc = docResult.rows[0];
+
+      // Soft-delete the document
+      await this.documentService['db'].query(
+        `UPDATE documents SET deleted_at = NOW(), updated_at = NOW() WHERE id = $1`,
+        [args.documentId]
+      );
+
+      // Cleanup Qdrant vectors
+      try {
+        await this.embeddingService.deleteByDocId(args.documentId);
+        logger.info('[Vault] Vectors deleted for document', { documentId: args.documentId });
+      } catch (err: any) {
+        logger.warn('[Vault] Failed to delete vectors', { documentId: args.documentId, error: err.message });
+      }
+
+      // Cleanup MinIO object if stored there
+      if (doc.storage_type === 'minio' && doc.storage_path && this.minioService) {
+        try {
+          const meta = typeof doc.metadata === 'string' ? JSON.parse(doc.metadata) : doc.metadata || {};
+          const objectKey = meta.minioKey || doc.storage_path.split('/').pop();
+          if (objectKey) {
+            await this.minioService.deleteFile(args.userId, objectKey);
+            logger.info('[Vault] MinIO object deleted', { documentId: args.documentId, objectKey });
+          }
+        } catch (err: any) {
+          logger.warn('[Vault] Failed to delete MinIO object', { documentId: args.documentId, error: err.message });
+        }
+      }
+
+      logger.info('[Vault] delete_document completed', { documentId: args.documentId, title: doc.title });
+      return { deleted: true, title: doc.title };
+    } catch (error: any) {
+      logger.error('[Vault] delete_document failed', { documentId: args.documentId, error: error.message });
+      return { deleted: false, error: error.message };
+    }
+  }
+
+  /**
+   * Update document metadata
+   */
+  async updateDocument(args: {
+    documentId: string;
+    userId?: string;
+    title?: string;
+    tags?: string[];
+    type?: string;
+    category?: string;
+    folderPath?: string;
+  }): Promise<{ updated: boolean; document?: { id: string; title: string; type: string; metadata: any }; error?: string }> {
+    try {
+      logger.info('[Vault] update_document started', args);
+
+      if (!args.userId) {
+        return { updated: false, error: 'Authentication required' };
+      }
+
+      // Verify ownership
+      const docResult = await this.documentService['db'].query(
+        `SELECT id, title, type, metadata FROM documents WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+        [args.documentId, args.userId]
+      );
+
+      if (docResult.rows.length === 0) {
+        return { updated: false, error: 'Document not found or access denied' };
+      }
+
+      const doc = docResult.rows[0];
+      const currentMeta = typeof doc.metadata === 'string' ? JSON.parse(doc.metadata) : doc.metadata || {};
+
+      // Build dynamic SET clause
+      const setClauses: string[] = ['updated_at = NOW()'];
+      const params: any[] = [];
+      let paramIdx = 1;
+
+      if (args.title !== undefined) {
+        setClauses.push(`title = $${paramIdx++}`);
+        params.push(args.title);
+      }
+
+      if (args.type !== undefined) {
+        setClauses.push(`type = $${paramIdx++}`);
+        params.push(args.type);
+      }
+
+      // Merge metadata fields: tags, category, folderPath
+      const metaUpdates: Record<string, any> = {};
+      if (args.tags !== undefined) metaUpdates.tags = args.tags;
+      if (args.category !== undefined) metaUpdates.category = args.category;
+      if (args.folderPath !== undefined) metaUpdates.folderPath = args.folderPath;
+
+      if (Object.keys(metaUpdates).length > 0) {
+        const mergedMeta = { ...currentMeta, ...metaUpdates };
+        setClauses.push(`metadata = $${paramIdx++}`);
+        params.push(JSON.stringify(mergedMeta));
+      }
+
+      // Add WHERE params
+      params.push(args.documentId);
+      params.push(args.userId);
+
+      await this.documentService['db'].query(
+        `UPDATE documents SET ${setClauses.join(', ')} WHERE id = $${paramIdx++} AND user_id = $${paramIdx++} AND deleted_at IS NULL`,
+        params
+      );
+
+      // Fetch updated doc
+      const updated = await this.documentService['db'].query(
+        `SELECT id, title, type, metadata FROM documents WHERE id = $1`,
+        [args.documentId]
+      );
+
+      const updatedDoc = updated.rows[0];
+      const updatedMeta = typeof updatedDoc.metadata === 'string' ? JSON.parse(updatedDoc.metadata) : updatedDoc.metadata || {};
+
+      logger.info('[Vault] update_document completed', { documentId: args.documentId });
+      return {
+        updated: true,
+        document: {
+          id: updatedDoc.id,
+          title: updatedDoc.title,
+          type: updatedDoc.type,
+          metadata: updatedMeta,
+        },
+      };
+    } catch (error: any) {
+      logger.error('[Vault] update_document failed', { documentId: args.documentId, error: error.message });
+      return { updated: false, error: error.message };
+    }
+  }
+
   async executeTool(name: string, args: any): Promise<ToolResult | null> {
     switch (name) {
       case 'store_document':
@@ -1359,6 +1585,10 @@ Pipeline:
         return this.wrapResponse(await this.listDocuments(args));
       case 'semantic_search':
         return this.wrapResponse(await this.semanticSearch(args));
+      case 'delete_document':
+        return this.wrapResponse(await this.deleteDocument(args));
+      case 'update_document':
+        return this.wrapResponse(await this.updateDocument(args));
       default:
         return null;
     }

--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -89,7 +89,7 @@ export function buildPlanGenerationMessages(
       legal_consultation: '11. queryType=legal_consultation: combine legislation + practice search tools',
       registry_lookup: '11. queryType=registry_lookup: start with openreyestr_get_by_edrpou or openreyestr_search_entities, max 3 steps',
       parliament_query: '11. queryType=parliament_query: use rada_ tools, max 2 steps',
-      document_query: '11. queryType=document_query: use list_documents or semantic_search, max 2 steps',
+      document_query: '11. queryType=document_query: use list_documents, semantic_search, delete_document, or update_document, max 3 steps. For delete/update by name: first list_documents to find the doc, then delete_document/update_document with the ID',
       document_drafting: '11. queryType=document_drafting: first find_relevant_law_articles for legal basis, then generate document',
       comparative_analysis: '11. queryType=comparative_analysis: search each competing approach separately with pro/contra, include legislation',
       due_diligence: '11. queryType=due_diligence: start with registry lookup, add debtors/bankruptcy/enforcement checks, then court cases',
@@ -540,6 +540,8 @@ export const CHAT_INTENT_CLASSIFICATION_PROMPT = `Ти — класифікат�
 - list_documents — список документів користувача (завантажені файли, VAULT)
 - list_folders — список папок у сховищі
 - semantic_search — семантичний пошук по завантажених документах
+- delete_document — видалити документ (видали, удали файл)
+- update_document — оновити метадані (переименуй, додай тег, перенеси в папку)
 
 ### legal_advice — Комплексна юридична консультація
 Використовуй цей домен, коли потрібні одночасно і судова практика, і законодавство.

--- a/mcp_backend/src/prompts/tool-registry-catalog.ts
+++ b/mcp_backend/src/prompts/tool-registry-catalog.ts
@@ -708,6 +708,48 @@ export const SCENARIO_CATALOG: ScenarioCatalogEntry[] = [
     ],
   },
 
+  {
+    id: 'document_delete',
+    label: 'Видалення документа з Vault',
+    domains: ['documents'],
+    exampleQueries: [
+      'Видали документ "договір оренди"',
+      'Удали файл про земельну ділянку',
+      'Delete document with name...',
+    ],
+    dataSources: [
+      { name: 'PostgreSQL', provides: 'документ для видалення' },
+    ],
+    toolChain: [
+      { tool: 'list_documents', purpose: 'знайти документ за назвою/ключовими словами' },
+      { tool: 'delete_document', purpose: 'видалити документ за ID' },
+    ],
+    responseTemplate: [
+      { heading: 'Результат', instruction: 'підтвердження видалення з назвою документа' },
+    ],
+  },
+
+  {
+    id: 'document_update',
+    label: 'Оновлення метаданих документа',
+    domains: ['documents'],
+    exampleQueries: [
+      'Переименуй документ на "Новий договір"',
+      'Додай тег "оренда" до документа',
+      'Перенеси документ в папку Contracts',
+    ],
+    dataSources: [
+      { name: 'PostgreSQL', provides: 'документ для оновлення' },
+    ],
+    toolChain: [
+      { tool: 'list_documents', purpose: 'знайти документ за назвою/ключовими словами' },
+      { tool: 'update_document', purpose: 'оновити метадані документа (назва, теги, тип, категорія, папка)' },
+    ],
+    responseTemplate: [
+      { heading: 'Результат', instruction: 'підтвердження оновлення з новими даними' },
+    ],
+  },
+
   // ─────────────── Composite (4) ───────────────
 
   {

--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -116,7 +116,7 @@ export class IntentClassifier {
       }
 
       // Safety net for documents/vault queries
-      const documentsKeywords = ['vault', 'сховищ', 'завантажив', 'завантажені', 'мої документи', 'мої файли', 'загрузил', 'зарузил', 'загруженн', 'зберіг', 'збережені', 'uploaded', 'my documents', 'my files'];
+      const documentsKeywords = ['vault', 'сховищ', 'завантажив', 'завантажені', 'мої документи', 'мої файли', 'загрузил', 'зарузил', 'загруженн', 'зберіг', 'збережені', 'uploaded', 'my documents', 'my files', 'видали', 'видалити', 'удали', 'удалить', 'delete', 'перейменуй', 'переименуй', 'rename', 'перенеси', 'move', 'папк', 'тег', 'tag', 'позначк'];
       const hasDocumentsKeyword = documentsKeywords.some(kw => lowerQuery.includes(kw));
       if (hasDocumentsKeyword && !domains.includes('documents')) {
         domains.push('documents');

--- a/mcp_backend/src/services/workflow-executor-service.ts
+++ b/mcp_backend/src/services/workflow-executor-service.ts
@@ -82,7 +82,7 @@ export class WorkflowExecutorService {
 
         try {
           // Inject userId for vault tools
-          const VAULT_TOOLS = new Set(['store_document', 'get_document', 'list_documents', 'semantic_search', 'list_folders']);
+          const VAULT_TOOLS = new Set(['store_document', 'get_document', 'list_documents', 'semantic_search', 'list_folders', 'delete_document', 'update_document']);
           const toolArgs = VAULT_TOOLS.has(step.tool)
             ? { ...step.params, userId }
             : step.params;


### PR DESCRIPTION
## Summary
- Added `delete_document` and `update_document` MCP tools to VaultTools so users can manage documents entirely from chat
- Chat pipeline updated: intent classifier keywords, system prompt domains, plan rules, and tool-registry-catalog scenarios
- VAULT_TOOLS sets updated across all 4 injection points for userId isolation

## How it works
- "видали документ X" → `list_documents(query="X")` → `delete_document(id)` (soft-delete + Qdrant + MinIO cleanup)
- "переименуй X на Y" → `list_documents(query="X")` → `update_document(id, title="Y")`
- "додай тег 'оренда' до X" → `list_documents` → `update_document(id, tags=["оренда"])`
- "перенеси X в папку Contracts" → `list_documents` → `update_document(id, folderPath="/Contracts")`

## Test plan
- [ ] Build passes (`npm run build` in mcp_backend — verified locally)
- [ ] "які документи я завантажив?" → existing list works (regression)
- [ ] "видали документ [name]" → lists then deletes
- [ ] "переименуй [name] на [new name]" → lists then updates title
- [ ] "додай тег 'оренда' до документа [name]" → lists then updates tags
- [ ] "перенеси документ [name] в папку Contracts" → lists then updates folderPath

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add chat-based document management to Vault: delete, rename, tag, and move documents. Introduces delete_document and update_document tools with user-scoped execution and Qdrant/MinIO cleanup.

- **New Features**
  - Tools: delete_document (soft-delete + vector and MinIO cleanup) and update_document (title, tags, type, category, folderPath).
  - Chat pipeline: updated document_query plan rules, intent keywords, and tool-registry scenarios; workflow now injects userId for the new tools.

<sup>Written for commit 3846304b7e9838e3db19c1ef7f8775d4cb694769. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

