### PR TITLE
fix: conversation loading and auto-naming for chat sidebar

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChat.ts
+++ b/lexwebapp/src/hooks/chat/useAIChat.ts
@@ -222,11 +222,18 @@ export function useAIChat(options: UseAIChatOptions = {}) {
             completedState.syncMessage(completedMsg);
           }
 
-          if (completedState.conversationId && completedState.messages.length <= 3) {
-            const firstUserMsg = completedState.messages.find((m) => m.role === 'user');
-            if (firstUserMsg) {
-              const title = firstUserMsg.content.slice(0, 60).trim();
-              completedState.renameConversation(completedState.conversationId, title);
+          // Auto-rename conversation if it still has the default title
+          if (completedState.conversationId) {
+            const conv = completedState.conversations.find(
+              (c) => c.id === completedState.conversationId
+            );
+            const needsRename = !conv || conv.title === 'New conversation' || conv.title === 'Нова розмова';
+            if (needsRename) {
+              const firstUserMsg = completedState.messages.find((m) => m.role === 'user');
+              if (firstUserMsg) {
+                const title = firstUserMsg.content.slice(0, 60).trim();
+                completedState.renameConversation(completedState.conversationId, title);
+              }
             }
           }
 
@@ -264,6 +271,14 @@ export function useAIChat(options: UseAIChatOptions = {}) {
         },
 
         onComplete: (data) => {
+          // Pick up auto-created conversationId from backend
+          if (data.conversationId && !useChatStore.getState().conversationId) {
+            const store = useChatStore.getState();
+            useChatStore.setState({ conversationId: data.conversationId });
+            // Refresh sidebar conversation list
+            store.loadConversations();
+          }
+
           if (data.tools_used || data.total_cost_usd != null || data.charged_usd != null) {
             costSummaryRef.current = {
               ...costSummaryRef.current,
@@ -310,8 +325,10 @@ export function useAIChat(options: UseAIChatOptions = {}) {
 
       const state = useChatStore.getState();
       if (!state.conversationId && localStorage.getItem('auth_token')) {
-        await state.createConversation();
+        const title = query.slice(0, 60).trim() || undefined;
+        await state.createConversation(title);
       }
+      // syncMessage after createConversation resolves so conversationId is set
       useChatStore.getState().syncMessage(userMessage);
 
       const assistantMessageId = (Date.now() + 1).toString();

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -30,7 +30,7 @@ export interface ChatStreamCallbacks {
   onAnswerDelta?: (data: { text: string }) => void;
   onAnswer?: (data: { text: string; provider: string; model: string }) => void;
   onCitationWarning?: (data: CitationWarning) => void;
-  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string }) => void;
+  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string; conversationId?: string }) => void;
   onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
   onBudgetEscalated?: (data: { reason: string; estimatedCost: { minUsd: number; maxUsd: number } }) => void;
   onError?: (data: { message: string }) => void;

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -210,11 +210,8 @@ export const useChatStore = create<ChatState>()(
           const cached = get().conversationCache[conversationId] || [];
           const targetHasActiveStream = isStreaming && cached.some((m) => m.isStreaming);
 
-          if (cached.length > 0) {
-            set({ conversationId, messages: cached });
-          } else {
-            set({ conversationId, messages: [] });
-          }
+          // Set conversationId and show cached messages (or empty while loading)
+          set({ conversationId, messages: cached.length > 0 ? cached : [] });
 
           // Skip server fetch if the target conversation is currently being streamed
           // (stream will continue updating the restored cached messages)
@@ -248,8 +245,8 @@ export const useChatStore = create<ChatState>()(
               messages: fetchedMessages,
               conversationCache: { ...state.conversationCache, [conversationId]: fetchedMessages },
             }));
-          } catch {
-            // Keep the cached messages if server fetch fails
+          } catch (err) {
+            console.error('[ChatStore] Failed to load conversation messages', conversationId, err);
           }
         },
 

--- a/mcp_backend/src/services/conversation-service.ts
+++ b/mcp_backend/src/services/conversation-service.ts
@@ -40,7 +40,7 @@ export class ConversationService {
       `INSERT INTO conversations (id, user_id, title, client_id, matter_id)
        VALUES ($1, $2, $3, $4, $5)
        RETURNING *`,
-      [id, userId, title || 'New conversation', options?.clientId || null, options?.matterId || null]
+      [id, userId, title || 'Нова розмова', options?.clientId || null, options?.matterId || null]
     );
     return result.rows[0];
   }


### PR DESCRIPTION
## Summary
- Fix chat content not loading when selecting a conversation from sidebar (user messages weren't synced to server due to race condition with `conversationId`)
- Fix "New conversation" titles persisting in sidebar by improving auto-rename logic and passing query text as title on creation
- Pick up backend auto-created `conversationId` in `onComplete` SSE event and refresh sidebar

## Test plan
- [ ] Click on existing conversation in sidebar — messages should load
- [ ] Send a new message — conversation should appear in sidebar with the query as title
- [ ] Switch between conversations — content should update correctly
- [ ] Verify no TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conversation loading and improves auto-naming in the chat sidebar. Messages now load when switching, and new chats get a proper title from the first query.

- **Bug Fixes**
  - Wait for createConversation to finish (sets conversationId) before syncing the first user message; pass the query as the initial title.
  - Capture backend-created conversationId from SSE onComplete and refresh the sidebar.
  - Rename only if the title is default ("New conversation"/"Нова розмова"), using the first user message.
  - Show cached messages immediately when switching; log fetch errors instead of swallowing them.
  - Add conversationId to onComplete callback type; backend default title is now "Нова розмова".

<sup>Written for commit 19fc7651a09a9249dd327164ec139094320d8a51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

