### PR TITLE
fix: attorney page crash on non-numeric average_rating

### DIFF
--- a/lexwebapp/src/pages/AttorneyDetailPage/index.tsx
+++ b/lexwebapp/src/pages/AttorneyDetailPage/index.tsx
@@ -79,7 +79,7 @@ export function AttorneyDetailPage() {
                 <Star key={i} className={`w-5 h-5 ${i <= Math.round(attorney.average_rating) ? 'text-yellow-400 fill-yellow-400' : 'text-gray-200'}`} />
               ))}
               <span className="text-sm text-gray-500 ml-2">
-                {attorney.average_rating.toFixed(1)} ({attorney.rating_count} відгуків)
+                {Number(attorney.average_rating || 0).toFixed(1)} ({attorney.rating_count} відгуків)
               </span>
             </div>
           </div>

--- a/lexwebapp/src/pages/AttorneySearchPage/index.tsx
+++ b/lexwebapp/src/pages/AttorneySearchPage/index.tsx
@@ -214,7 +214,7 @@ function AttorneyCard({ attorney, onClick }: { attorney: AttorneyProfile; onClic
           />
         ))}
         <span className="text-xs text-gray-500 ml-1">
-          {attorney.average_rating.toFixed(1)} ({attorney.rating_count})
+          {Number(attorney.average_rating || 0).toFixed(1)} ({attorney.rating_count})
         </span>
       </div>
 


### PR DESCRIPTION
## Summary
- `average_rating` from API can be a string or null, causing `.toFixed()` to throw `TypeError`
- Wrap with `Number(... || 0)` in both `AttorneySearchPage` and `AttorneyDetailPage`

## Test plan
- [ ] Open https://legal.org.ua/attorneys — page loads without crash
- [ ] Attorney cards display rating correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on Attorney Search and Detail pages when the API returns average_rating as a string or null. We now coerce the value with Number(... || 0) before calling toFixed, so pages load and ratings render reliably.

<sup>Written for commit 0381670aff4e9ff4ad8f87ebf5fb279e0f070d4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

