### PR TITLE
feat: add conversation picker to consultation wizard

### DIFF
--- a/lexwebapp/src/components/consultation/ConfirmStep.tsx
+++ b/lexwebapp/src/components/consultation/ConfirmStep.tsx
@@ -1,7 +1,8 @@
-import { FileText, File } from 'lucide-react';
+import { FileText, File, MessageSquare } from 'lucide-react';
 import type { CreateConsultationRequest } from '../../services/api/ConsultationService';
 import type { VaultDocument } from '../../pages/DocumentsPage/types';
 import { getFileExtension } from '../../pages/DocumentsPage/types';
+import type { Conversation } from '../../services/api/ConversationService';
 
 const TYPE_LABELS: Record<string, string> = {
   consultation: 'Консультація',
@@ -20,14 +21,17 @@ interface Props {
   form: CreateConsultationRequest;
   selectedDocIds: string[];
   allDocs: VaultDocument[];
+  selectedConversationIds: string[];
+  allConversations: Conversation[];
   attorneyName: string;
   consultationFee?: number;
   onBack: () => void;
   onNext: () => void;
 }
 
-export function ConfirmStep({ form, selectedDocIds, allDocs, attorneyName, consultationFee, onBack, onNext }: Props) {
+export function ConfirmStep({ form, selectedDocIds, allDocs, selectedConversationIds, allConversations, attorneyName, consultationFee, onBack, onNext }: Props) {
   const selectedDocs = allDocs.filter(d => selectedDocIds.includes(d.id));
+  const selectedConvs = allConversations.filter(c => selectedConversationIds.includes(c.id));
 
   return (
     <div className="flex flex-col h-full">
@@ -44,6 +48,22 @@ export function ConfirmStep({ form, selectedDocIds, allDocs, attorneyName, consu
             </div>
           )}
           <Row label="Терміновість" value={URGENCY_LABELS[form.urgency || ''] || form.urgency || ''} />
+        </div>
+
+        <div className="pt-2">
+          <p className="text-xs text-gray-500 mb-2">Чати</p>
+          {selectedConvs.length === 0 ? (
+            <p className="text-sm text-gray-400">Чати не вибрані</p>
+          ) : (
+            <div className="space-y-1">
+              {selectedConvs.map(conv => (
+                <div key={conv.id} className="flex items-center gap-2 p-2 bg-gray-50 rounded text-sm">
+                  <MessageSquare className="w-4 h-4 text-indigo-500 shrink-0" />
+                  <span className="truncate">{conv.title || 'Без назви'}</span>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
 
         <div className="pt-2">

--- a/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
+++ b/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import { consultationService, type CreateConsultationRequest } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
 import { StepIndicator } from '../attorney/AttorneyOnboardingModal/StepIndicator';
+import { ConversationPicker } from './ConversationPicker';
 import { DocumentPicker } from './DocumentPicker';
 import { ConfirmStep } from './ConfirmStep';
 import { PaymentStep } from './PaymentStep';
 import type { VaultDocument } from '../../pages/DocumentsPage/types';
+import type { Conversation } from '../../services/api/ConversationService';
 
 interface Props {
   attorneyId: string;
@@ -30,7 +32,7 @@ const URGENCY_OPTIONS = [
   { value: 'urgent', label: 'Термінова' },
 ];
 
-const STEP_TITLES = ['Деталі запиту', 'Документи', 'Підтвердження', 'Оплата'];
+const STEP_TITLES = ['Деталі запиту', 'Чати', 'Документи', 'Підтвердження', 'Оплата'];
 
 export function ConsultationRequestModal({ attorneyId, attorneyName, consultationFee, matterId, onClose }: Props) {
   const navigate = useNavigate();
@@ -39,6 +41,8 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
   const [error, setError] = useState('');
   const [selectedDocIds, setSelectedDocIds] = useState<string[]>([]);
   const [allDocs, setAllDocs] = useState<VaultDocument[]>([]);
+  const [selectedConversationIds, setSelectedConversationIds] = useState<string[]>([]);
+  const [allConversations, setAllConversations] = useState<Conversation[]>([]);
   const [form, setForm] = useState<CreateConsultationRequest>({
     attorneyUserId: attorneyId,
     matterId: matterId || undefined,
@@ -69,6 +73,7 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
       const payload: CreateConsultationRequest = {
         ...form,
         documentIds: selectedDocIds.length > 0 ? selectedDocIds : undefined,
+        conversationIds: selectedConversationIds.length > 0 ? selectedConversationIds : undefined,
       };
       const consultation = await consultationService.createConsultation(payload);
       onClose();
@@ -92,7 +97,7 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
           </button>
         </div>
 
-        <StepIndicator currentStep={step} totalSteps={4} />
+        <StepIndicator currentStep={step} totalSteps={5} />
 
         <div className="flex-1 overflow-y-auto min-h-0">
           {step === 1 && (
@@ -177,34 +182,46 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
           )}
 
           {step === 2 && (
-            <DocumentPicker
-              selectedIds={selectedDocIds}
-              onChange={setSelectedDocIds}
-              onDocsLoaded={setAllDocs}
+            <ConversationPicker
+              selectedIds={selectedConversationIds}
+              onChange={setSelectedConversationIds}
+              onConversationsLoaded={setAllConversations}
               onBack={() => setStep(1)}
               onNext={() => setStep(3)}
             />
           )}
 
           {step === 3 && (
-            <ConfirmStep
-              form={form}
-              selectedDocIds={selectedDocIds}
-              allDocs={allDocs}
-              attorneyName={attorneyName}
-              consultationFee={consultationFee}
+            <DocumentPicker
+              selectedIds={selectedDocIds}
+              onChange={setSelectedDocIds}
+              onDocsLoaded={setAllDocs}
               onBack={() => setStep(2)}
               onNext={() => setStep(4)}
             />
           )}
 
           {step === 4 && (
+            <ConfirmStep
+              form={form}
+              selectedDocIds={selectedDocIds}
+              allDocs={allDocs}
+              selectedConversationIds={selectedConversationIds}
+              allConversations={allConversations}
+              attorneyName={attorneyName}
+              consultationFee={consultationFee}
+              onBack={() => setStep(3)}
+              onNext={() => setStep(5)}
+            />
+          )}
+
+          {step === 5 && (
             <PaymentStep
               attorneyName={attorneyName}
               consultationFee={consultationFee}
               serviceType={form.consultationType || 'consultation'}
               onPaymentComplete={handleSubmit}
-              onBack={() => setStep(3)}
+              onBack={() => setStep(4)}
               submitting={submitting}
               error={error}
             />

--- a/lexwebapp/src/components/consultation/ConversationPicker.tsx
+++ b/lexwebapp/src/components/consultation/ConversationPicker.tsx
@@ -1,0 +1,131 @@
+import { useState, useEffect } from 'react';
+import { Search, MessageSquare, Loader2 } from 'lucide-react';
+import { conversationService, type Conversation } from '../../services/api/ConversationService';
+
+interface Props {
+  selectedIds: string[];
+  onChange: (ids: string[]) => void;
+  onConversationsLoaded: (convs: Conversation[]) => void;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export function ConversationPicker({ selectedIds, onChange, onConversationsLoaded, onBack, onNext }: Props) {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const result = await conversationService.list({ limit: 50, offset: 0 });
+        const loaded = result.conversations ?? [];
+        setConversations(loaded);
+        onConversationsLoaded(loaded);
+      } catch (err) {
+        console.error('Failed to load conversations:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const toggle = (id: string) => {
+    onChange(
+      selectedIds.includes(id)
+        ? selectedIds.filter(c => c !== id)
+        : [...selectedIds, id]
+    );
+  };
+
+  const q = search.toLowerCase().trim();
+  const filtered = q
+    ? conversations.filter(c => (c.title || '').toLowerCase().includes(q))
+    : conversations;
+
+  const hasSelected = selectedIds.length > 0;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-5 pb-3 space-y-3">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <input
+            type="text"
+            className="w-full pl-9 pr-3 py-2 border rounded-md text-sm"
+            placeholder="Пошук чатів..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+        </div>
+        {hasSelected && (
+          <p className="text-xs text-indigo-600">Вибрано: {selectedIds.length}</p>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 min-h-0" style={{ maxHeight: '300px' }}>
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-gray-400">
+            <Loader2 className="w-5 h-5 animate-spin mr-2" />
+            Завантаження...
+          </div>
+        ) : conversations.length === 0 ? (
+          <div className="text-center py-12 text-gray-400 text-sm">
+            У вас ще немає чатів
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="text-center py-8 text-gray-400 text-sm">
+            Нічого не знайдено
+          </div>
+        ) : (
+          <div className="space-y-1">
+            {filtered.map(conv => {
+              const checked = selectedIds.includes(conv.id);
+              const date = conv.updated_at
+                ? new Date(conv.updated_at).toLocaleDateString('uk-UA')
+                : '';
+              return (
+                <label
+                  key={conv.id}
+                  className={`flex items-center gap-3 p-2.5 rounded-lg cursor-pointer transition-colors ${
+                    checked ? 'bg-indigo-50 border border-indigo-200' : 'hover:bg-gray-50 border border-transparent'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    className="rounded text-indigo-600 shrink-0"
+                    checked={checked}
+                    onChange={() => toggle(conv.id)}
+                  />
+                  <MessageSquare className="w-4 h-4 text-indigo-500 shrink-0" />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm truncate">{conv.title || 'Без назви'}</p>
+                    <p className="text-xs text-gray-400 truncate">{date}</p>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-3 p-5 pt-3 border-t">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50"
+        >
+          Назад
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700"
+        >
+          {hasSelected ? `Продовжити (${selectedIds.length})` : 'Пропустити'}
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a **ConversationPicker** step (step 2) to the consultation request wizard, letting clients attach AI chat conversations to give attorneys context about prior document analysis
- Wizard now has 5 steps: Details → Chats → Documents → Confirmation → Payment
- Selected conversations are shown in the confirmation step and sent as `conversationIds` in the create payload

## Test plan
- [ ] Open attorney profile → "Замовити консультацію"
- [ ] Step 1: fill details → Далі
- [ ] Step 2: see conversation list with search, select some → Далі (or Пропустити)
- [ ] Step 3: documents picker works as before
- [ ] Step 4: confirmation shows selected conversations and documents
- [ ] Step 5: payment → consultation created with `conversationIds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a ConversationPicker step to the consultation wizard so clients can attach chat conversations for attorney context. Selected chats appear in the confirmation step and are sent as conversationIds in the create payload.

- **New Features**
  - Wizard now has 5 steps: Details → Chats → Documents → Confirmation → Payment.
  - ConversationPicker with search, multi-select, and skip.
  - ConfirmStep shows selected conversations.
  - Payload includes conversationIds when creating a consultation.
  - Updated navigation and StepIndicator to reflect the new flow.

<sup>Written for commit ac530bcc6b234629bccda7b015cb95239416f888. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

