### PR TITLE
debug: chat switch logging for prod

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -227,11 +227,17 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   };
 
   const handleSwitchConversation = async (convId: string) => {
-    if (switchingId) return;
+    console.log('[Sidebar] handleSwitchConversation called', { convId, switchingId, activeConversationId });
+    if (switchingId) {
+      console.warn('[Sidebar] blocked by switchingId', switchingId);
+      return;
+    }
     setSwitchingId(convId);
     try {
       await switchConversation(convId);
       if (location.pathname !== ROUTES.CHAT) navigate(ROUTES.CHAT);
+    } catch (err) {
+      console.error('[Sidebar] switchConversation error', err);
     } finally {
       setSwitchingId(null);
       if (window.innerWidth < 1024) onClose();

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -196,7 +196,10 @@ export const useChatStore = create<ChatState>()(
 
         // Switch to existing conversation
         switchConversation: async (conversationId: string) => {
-          if (!isAuthenticated()) return;
+          if (!isAuthenticated()) {
+            console.warn('[ChatStore] switchConversation blocked: not authenticated (no auth_token in localStorage)');
+            return;
+          }
           const { conversationId: currentId, messages, isStreaming } = get();
 
           // Save current conversation messages to cache before switching


### PR DESCRIPTION
Temporary debug logging

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add temporary console logging around conversation switching to debug a production issue where clicking a conversation sometimes does nothing. Logs start, blocked-by-switchingId, missing auth, and errors; behavior is unchanged.

<sup>Written for commit d215680e007baa6f9f0c28dc975566cad49378d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

