### PR TITLE
fix: chat switch crash on undefined thinking_step result

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -227,17 +227,11 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   };
 
   const handleSwitchConversation = async (convId: string) => {
-    console.log('[Sidebar] handleSwitchConversation called', { convId, switchingId, activeConversationId });
-    if (switchingId) {
-      console.warn('[Sidebar] blocked by switchingId', switchingId);
-      return;
-    }
+    if (switchingId) return;
     setSwitchingId(convId);
     try {
       await switchConversation(convId);
       if (location.pathname !== ROUTES.CHAT) navigate(ROUTES.CHAT);
-    } catch (err) {
-      console.error('[Sidebar] switchConversation error', err);
     } finally {
       setSwitchingId(null);
       if (window.innerWidth < 1024) onClose();

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -196,10 +196,7 @@ export const useChatStore = create<ChatState>()(
 
         // Switch to existing conversation
         switchConversation: async (conversationId: string) => {
-          if (!isAuthenticated()) {
-            console.warn('[ChatStore] switchConversation blocked: not authenticated (no auth_token in localStorage)');
-            return;
-          }
+          if (!isAuthenticated()) return;
           const { conversationId: currentId, messages, isStreaming } = get();
 
           // Save current conversation messages to cache before switching
@@ -235,7 +232,7 @@ export const useChatStore = create<ChatState>()(
                     title: `✓ ${s.tool || 'tool'}`,
                     content: typeof s.result === 'string'
                       ? s.result.slice(0, 500)
-                      : JSON.stringify(s.result, null, 2).slice(0, 500),
+                      : (JSON.stringify(s.result ?? '', null, 2) || '').slice(0, 500),
                     isComplete: true,
                   }))
                 : undefined,


### PR DESCRIPTION
## Summary
- `s.result` in stored `thinking_steps` can be `undefined`
- `JSON.stringify(undefined)` returns `undefined` (not a string), so `.slice(0, 500)` throws `TypeError: Cannot read properties of undefined (reading 'slice')`
- This crashed `switchConversation` silently (caught by catch block), making it look like "nothing happens" when clicking conversations

## Root cause
Conversation messages saved with thinking_steps where some steps have no `result` field.

## Fix
`JSON.stringify(s.result ?? '', null, 2)` — fallback to empty string when result is undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when switching conversations caused by undefined thinking step results, restoring reliable chat switching. Also cleans up debug logging and removes a redundant catch.

- **Bug Fixes**
  - Safely stringify thinking step results with a fallback: JSON.stringify(s.result ?? '', null, 2).slice(0, 500) to avoid TypeError.
  - Removed noisy logs and redundant catch in Sidebar and auth check; kept early returns to prevent double switches.

<sup>Written for commit 7d3b9b80ed3c25ba50cd960bec9889ecc2bdb1ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

