### PR TITLE
fix: translate judges page from Russian to Ukrainian

### DIFF
--- a/lexwebapp/src/components/JudgesPage.tsx
+++ b/lexwebapp/src/components/JudgesPage.tsx
@@ -22,39 +22,39 @@ interface Judge {
 const judgesData: Judge[] = [
 {
   id: '1',
-  name: 'Иванов Петр Сергеевич',
-  court: 'Верховный Суд КГС',
+  name: 'Іванов Петро Сергійович',
+  court: 'Верховний Суд КЦС',
   cases: 156,
   approvalRate: 68,
-  avgDuration: '4.5 мес.',
-  specialization: 'Банкротство'
+  avgDuration: '4.5 міс.',
+  specialization: 'Банкрутство'
 },
 {
   id: '2',
-  name: 'Петрова Анна Викторовна',
-  court: 'Арбитражный суд г. Москвы',
+  name: 'Петрова Анна Вікторівна',
+  court: 'Господарський суд м. Києва',
   cases: 203,
   approvalRate: 72,
-  avgDuration: '3.2 мес.',
-  specialization: 'Корпоративные споры'
+  avgDuration: '3.2 міс.',
+  specialization: 'Корпоративні спори'
 },
 {
   id: '3',
-  name: 'Сидоров Михаил Александрович',
-  court: 'Девятый арбитражный апелляционный суд',
+  name: 'Сидоренко Михайло Олександрович',
+  court: 'Північний апеляційний господарський суд',
   cases: 89,
   approvalRate: 65,
-  avgDuration: '2.8 мес.',
-  specialization: 'Недвижимость'
+  avgDuration: '2.8 міс.',
+  specialization: 'Нерухомість'
 },
 {
   id: '4',
-  name: 'Кузнецова Елена Дмитриевна',
-  court: 'Арбитражный суд Московской области',
+  name: 'Кузнецова Олена Дмитрівна',
+  court: 'Господарський суд Київської області',
   cases: 142,
   approvalRate: 59,
-  avgDuration: '5.1 мес.',
-  specialization: 'Налоговые споры'
+  avgDuration: '5.1 міс.',
+  specialization: 'Податкові спори'
 }];
 
 interface JudgesPageProps {
@@ -92,17 +92,17 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
           <div className="flex flex-col md:flex-row md:items-end justify-between gap-4">
             <div>
               <h1 className="text-3xl md:text-4xl font-serif text-claude-text font-medium tracking-tight mb-2">
-                Судьи
+                Судді
               </h1>
               <p className="text-claude-subtext font-sans">
-                Поиск и аналитика по судебному корпусу
+                Пошук та аналітика по суддівському корпусу
               </p>
             </div>
 
             <div className="flex items-center gap-2 text-sm text-claude-subtext bg-white px-3 py-1.5 rounded-lg border border-claude-border shadow-sm">
               <Scale size={16} />
               <span className="font-sans">
-                {judgesData.length} судей в базе
+                {judgesData.length} суддів у базі
               </span>
             </div>
           </div>
@@ -116,7 +116,7 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
               <input
                 type="text"
                 className="block w-full pl-11 pr-4 py-4 bg-white border border-claude-border rounded-xl text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all shadow-sm font-sans"
-                placeholder="Поиск по фамилии судьи или названию суда..."
+                placeholder="Пошук за прізвищем судді або назвою суду..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)} />
 
@@ -127,14 +127,14 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
               <button
                 onClick={() => setViewMode('comfortable')}
                 className={`p-2 rounded-lg transition-colors ${viewMode === 'comfortable' ? 'bg-claude-accent text-white' : 'text-claude-subtext hover:text-claude-text'}`}
-                title="Комфортный вид">
+                title="Зручний вигляд">
 
                 <LayoutGrid size={18} />
               </button>
               <button
                 onClick={() => setViewMode('compact')}
                 className={`p-2 rounded-lg transition-colors ${viewMode === 'compact' ? 'bg-claude-accent text-white' : 'text-claude-subtext hover:text-claude-text'}`}
-                title="Компактный вид">
+                title="Компактний вигляд">
 
                 <List size={18} />
               </button>
@@ -207,7 +207,7 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
                   className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}>
 
                     <Gavel size={viewMode === 'compact' ? 10 : 12} />
-                    <span>Дел</span>
+                    <span>Справ</span>
                   </div>
                   <div
                   className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-base' : 'text-lg'}`}>
@@ -220,7 +220,7 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
                   className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}>
 
                     <Percent size={viewMode === 'compact' ? 10 : 12} />
-                    <span>Удовл.</span>
+                    <span>Задов.</span>
                   </div>
                   <div
                   className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-base' : 'text-lg'}`}>
@@ -233,7 +233,7 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
                   className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}>
 
                     <Clock size={viewMode === 'compact' ? 10 : 12} />
-                    <span>Срок</span>
+                    <span>Строк</span>
                   </div>
                   <div
                   className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-base' : 'text-lg'}`}>
@@ -260,11 +260,11 @@ export function JudgesPage({ onSelectJudge }: JudgesPageProps) {
               <Search size={24} />
             </div>
             <h3 className="text-lg font-serif text-claude-text mb-2">
-              Ничего не найдено
+              Нічого не знайдено
             </h3>
             <p className="text-claude-subtext font-sans max-w-md mx-auto">
-              Попробуйте изменить параметры поиска или проверить написание
-              фамилии
+              Спробуйте змінити параметри пошуку або перевірити написання
+              прізвища
             </p>
           </motion.div>
         }

--- a/lexwebapp/src/components/PersonDetailPage.tsx
+++ b/lexwebapp/src/components/PersonDetailPage.tsx
@@ -39,7 +39,7 @@ export function PersonDetailPage({
             size={18}
             className="group-hover:-translate-x-1 transition-transform" />
 
-          <span className="font-sans text-sm">Назад к списку</span>
+          <span className="font-sans text-sm">Назад до списку</span>
         </button>
 
         {/* Header Section */}
@@ -101,23 +101,23 @@ export function PersonDetailPage({
             className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm">
 
             <h2 className="text-xl font-serif text-claude-text mb-4">
-              Контактная информация
+              Контактна інформація
             </h2>
             <div className="space-y-3">
               <div className="flex items-center gap-3 text-claude-subtext">
                 <Mail size={18} className="flex-shrink-0" />
                 <span className="font-sans text-sm">
-                  {person.name.toLowerCase().replace(/\s+/g, '.')}@example.ru
+                  {person.name.toLowerCase().replace(/\s+/g, '.')}@example.ua
                 </span>
               </div>
               <div className="flex items-center gap-3 text-claude-subtext">
                 <Phone size={18} className="flex-shrink-0" />
-                <span className="font-sans text-sm">+7 (495) 123-45-67</span>
+                <span className="font-sans text-sm">+380 (44) 123-45-67</span>
               </div>
               <div className="flex items-center gap-3 text-claude-subtext">
                 <MapPin size={18} className="flex-shrink-0" />
                 <span className="font-sans text-sm">
-                  г. Москва, ул. Примерная, д. 1
+                  м. Київ, вул. Хрещатик, 1
                 </span>
               </div>
             </div>
@@ -146,7 +146,7 @@ export function PersonDetailPage({
               <div>
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-claude-subtext font-sans">
-                    Всего дел
+                    Всього справ
                   </span>
                   <span className="font-serif font-medium text-claude-text">
                     {person.cases}
@@ -156,7 +156,7 @@ export function PersonDetailPage({
               <div>
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-claude-subtext font-sans">
-                    {isJudge ? 'Удовлетворение' : 'Успешность'}
+                    {isJudge ? 'Задоволення' : 'Успішність'}
                   </span>
                   <span className="font-serif font-medium text-claude-text">
                     {person.successRate}%
@@ -174,10 +174,10 @@ export function PersonDetailPage({
               <div>
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-claude-subtext font-sans">
-                    Средняя длительность
+                    Середня тривалість
                   </span>
                   <span className="font-serif font-medium text-claude-text">
-                    4.2 мес.
+                    4.2 міс.
                   </span>
                 </div>
               </div>
@@ -201,7 +201,7 @@ export function PersonDetailPage({
             className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm md:col-span-2">
 
             <h2 className="text-xl font-serif text-claude-text mb-4">
-              {isJudge ? 'Судебная практика' : 'Профессиональный опыт'}
+              {isJudge ? 'Судова практика' : 'Професійний досвід'}
             </h2>
             <div className="space-y-4">
               <div className="flex items-start gap-4 p-4 bg-claude-bg rounded-xl">
@@ -210,10 +210,10 @@ export function PersonDetailPage({
                 </div>
                 <div>
                   <h3 className="font-serif font-medium text-claude-text mb-1">
-                    {isJudge ? 'Категории дел' : 'Специализация'}
+                    {isJudge ? 'Категорії справ' : 'Спеціалізація'}
                   </h3>
                   <p className="text-sm text-claude-subtext font-sans">
-                    {person.specialization}, корпоративные споры, договорное
+                    {person.specialization}, корпоративні спори, договірне
                     право
                   </p>
                 </div>
@@ -225,12 +225,12 @@ export function PersonDetailPage({
                 </div>
                 <div>
                   <h3 className="font-serif font-medium text-claude-text mb-1">
-                    {isJudge ? 'Наиболее цитируемые решения' : 'Достижения'}
+                    {isJudge ? 'Найбільш цитовані рішення' : 'Досягнення'}
                   </h3>
                   <p className="text-sm text-claude-subtext font-sans">
                     {isJudge ?
-                    'Постановление от 15.03.2023 по делу №А40-12345/23, Определение от 22.06.2023' :
-                    'Победа в 85% арбитражных споров, успешное представительство в ВС РФ'}
+                    'Постанова від 15.03.2023 у справі №910/12345/23, Ухвала від 22.06.2023' :
+                    'Перемога у 85% господарських спорів, успішне представництво у ВС'}
                   </p>
                 </div>
               </div>
@@ -241,12 +241,12 @@ export function PersonDetailPage({
                 </div>
                 <div>
                   <h3 className="font-serif font-medium text-claude-text mb-1">
-                    {isJudge ? 'Тенденции' : 'Подход к делам'}
+                    {isJudge ? 'Тенденції' : 'Підхід до справ'}
                   </h3>
                   <p className="text-sm text-claude-subtext font-sans">
                     {isJudge ?
-                    'Последний год: более строгий подход к оценке доказательств, частое применение ст. 333 ГК РФ' :
-                    'Агрессивная процессуальная тактика, упор на формальные нарушения, эффективное использование сроков'}
+                    'Останній рік: більш суворий підхід до оцінки доказів, часте застосування ст. 551 ЦК України' :
+                    'Агресивна процесуальна тактика, акцент на формальних порушеннях, ефективне використання строків'}
                   </p>
                 </div>
               </div>
@@ -270,7 +270,7 @@ export function PersonDetailPage({
             className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm md:col-span-2">
 
             <h2 className="text-xl font-serif text-claude-text mb-4">
-              Последние дела
+              Останні справи
             </h2>
             <div className="space-y-3">
               {[1, 2, 3].map((i) =>
@@ -282,7 +282,7 @@ export function PersonDetailPage({
                     <FileText size={16} className="text-claude-subtext" />
                     <div>
                       <div className="font-medium text-claude-text font-sans text-sm">
-                        Дело №А40-{12345 + i}/2024
+                        Справа №910/{12345 + i}/24
                       </div>
                       <div className="text-xs text-claude-subtext font-sans">
                         {person.specialization}
@@ -290,7 +290,7 @@ export function PersonDetailPage({
                     </div>
                   </div>
                   <div className="text-xs text-claude-subtext font-sans">
-                    {new Date(2024, 0, 15 - i).toLocaleDateString('ru-RU')}
+                    {new Date(2024, 0, 15 - i).toLocaleDateString('uk-UA')}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Translated all UI text on JudgesPage and PersonDetailPage from Russian to Ukrainian
- Updated mock data: judge names, court names (Ukrainian courts like Верховний Суд КЦС, Господарський суд м. Києва), specializations
- Updated contact info (Ukrainian phone format +380, Kyiv address, .ua domain)
- Changed date locale from `ru-RU` to `uk-UA` and case number format to Ukrainian convention (№910/...)
- Updated legal references from Russian law (ст. 333 ГК РФ) to Ukrainian (ст. 551 ЦК України)

## Test plan
- [ ] Open /judges page — verify all text is in Ukrainian
- [ ] Click on a judge card — verify detail page is in Ukrainian
- [ ] Test search filter with Ukrainian text
- [ ] Verify compact/comfortable view modes still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated JudgesPage and PersonDetailPage to Ukrainian and localized the UI. Updated mock data (UA names, courts, specializations), contact info (+380, Kyiv, .ua), case number format (№910/.../24), date locale (uk-UA), and legal references to Ukrainian law (ст. 551 ЦК України).

<sup>Written for commit 5f3ddf8c8ebb33e99686afaafcfe3f0ab1753340. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

