### PR TITLE
fix: show matters section for all user roles

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -147,9 +147,8 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   // Compute which section IDs are actually rendered (for toggle-all)
   const renderedSectionIds = useMemo(() => {
     if (role === 'administrator') return ['monitoring'];
-    const ids = ['research', 'legislation', 'vault'];
+    const ids = ['research', 'legislation', 'vault', 'matters'];
     if (conversations.length > 0) ids.push('conversations');
-    if (role !== 'user') ids.push('matters');
     return ids;
   }, [role, conversations.length]);
 
@@ -516,14 +515,12 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 })}
               </Section>
 
-              {/* Matters — company/lawyer only */}
-              {role !== 'user' && (
-                <Section id="matters" title="Справи" collapsed={collapsedSections.has('matters')} onToggle={toggleSection}>
-                  {mattersSections.map((s) => (
-                    <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
-                  ))}
-                </Section>
-              )}
+              {/* Matters */}
+              <Section id="matters" title="Справи" collapsed={collapsedSections.has('matters')} onToggle={toggleSection}>
+                {mattersSections.map((s) => (
+                  <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
+                ))}
+              </Section>
 
               {/* Workflows — institutional analysis */}
               <div className="mb-6">


### PR DESCRIPTION
## Summary
- Remove `role !== 'user'` gate on the Matters sidebar section
- All authenticated users can now see Справи (Clients, Matters, Time Entries, Invoices, Case Analysis)

## Test plan
- [ ] Login as `user` role → verify "Справи" section visible in sidebar
- [ ] Click "Справи" → verify matters list loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the “Справи” (Matters) sidebar section visible to all authenticated users, including role "user". This fixes hidden access for users with assigned matters and keeps collapse/toggle behavior consistent.

- **Bug Fixes**
  - Always render the Matters section (removed role !== 'user' check).
  - Added "matters" to renderedSectionIds for proper toggle/collapse.

<sup>Written for commit df58c0eb84bf8e727a35f583f2f2c5dae69fb3f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

