### PR TITLE
feat: show Мої клієнти menu only for attorneys

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -531,7 +531,9 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
               <div className="mb-6 space-y-1">
                 <NavItem icon={UserCheck} label="Адвокати" route={ROUTES.ATTORNEYS} onClick={() => handleNavigation(ROUTES.ATTORNEYS)} />
                 <NavItem icon={MessageSquare} label="Консультації" route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} />
-                <NavItem icon={UsersRound} label="Мої клієнти" route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
+                {user?.userType === 'attorney' && (
+                  <NavItem icon={UsersRound} label="Мої клієнти" route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
+                )}
               </div>
 
             </>
@@ -567,7 +569,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                   </div>
                   <span className="text-[13px] font-medium text-claude-text font-sans">Профіль</span>
                 </button>
-                {role === 'user' && (
+                {role === 'user' && user?.userType !== 'attorney' && (
                   <button
                     onClick={() => { setShowProfileMenu(false); navigate(ROUTES.ATTORNEY_PROFILE_EDIT); }}
                     className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">

--- a/lexwebapp/src/types/models/User.ts
+++ b/lexwebapp/src/types/models/User.ts
@@ -3,6 +3,7 @@
  */
 
 export type UserRole = 'user' | 'company' | 'administrator';
+export type UserType = 'individual' | 'attorney' | 'company_admin';
 
 export interface User {
   id: string;
@@ -13,6 +14,7 @@ export interface User {
   lastLogin?: string;
   createdAt?: string;
   role: UserRole;
+  userType?: UserType;
 }
 
 export interface UserProfile extends User {

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -121,6 +121,7 @@ export async function getCurrentUser(req: AuthenticatedRequest, res: Response): 
         lastLogin: user.last_login,
         createdAt: user.created_at,
         role: user.role,
+        userType: user.user_type || 'individual',
       },
     });
   } catch (error: any) {


### PR DESCRIPTION
## Summary
- Return `userType` field from `/auth/me` endpoint (from `users.user_type` column)
- Show "Мої клієнти" sidebar item only for users with `userType === 'attorney'`
- Hide "Стати адвокатом" button for users who already have attorney status

## Test plan
- [ ] Log in as a regular user (`individual`) — verify "Мої клієнти" is hidden
- [ ] Log in as an attorney user — verify "Мої клієнти" is visible
- [ ] Verify "Стати адвокатом" button hidden for attorneys, visible for regular users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show "Мої клієнти" in the sidebar only for attorney users. Hide "Стати адвокатом" for users who already have attorney status.

- **New Features**
  - /auth/me now returns userType from users.user_type (defaults to "individual").
  - Added UserType to the frontend User model.
  - Use userType to show "Мої клієнти" only for attorneys and hide "Стати адвокатом" for attorneys.

<sup>Written for commit 90bd79bb2dc91d030220918211213d9ef96dd4bc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

