### PR TITLE
feat: show real ERAU profile data on /lawyers/:id

### DIFF
--- a/lexwebapp/src/components/LawyerProfilePage.tsx
+++ b/lexwebapp/src/components/LawyerProfilePage.tsx
@@ -1,0 +1,272 @@
+import { motion } from 'framer-motion';
+import {
+  ArrowLeft,
+  Mail,
+  Phone,
+  MapPin,
+  Award,
+  FileText,
+  Building2,
+  ExternalLink,
+  CheckCircle2,
+  XCircle,
+  GraduationCap,
+} from 'lucide-react';
+import { ERAUProfile } from '../services/api/ERAUService';
+
+interface LawyerProfilePageProps {
+  profile: ERAUProfile;
+  onBack: () => void;
+}
+
+const ERAU_BASE_URL = 'https://erau.unba.org.ua/profile';
+
+export function LawyerProfilePage({ profile, onBack }: LawyerProfilePageProps) {
+  const initials = profile.fullName
+    .split(' ')
+    .map((n) => n[0])
+    .slice(0, 2)
+    .join('');
+
+  const hasContacts = profile.contacts.address || profile.contacts.phone || profile.contacts.email;
+  const hasCertificate = profile.certificate.number || profile.certificate.date;
+  const hasPractice = profile.practiceForm.type;
+
+  return (
+    <div className="flex-1 h-full overflow-y-auto bg-claude-bg p-4 md:p-8 lg:p-12">
+      <div className="max-w-4xl mx-auto space-y-8">
+        {/* Back Button */}
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-claude-subtext hover:text-claude-text transition-colors group"
+        >
+          <ArrowLeft
+            size={18}
+            className="group-hover:-translate-x-1 transition-transform"
+          />
+          <span className="font-sans text-sm">Назад до списку</span>
+        </button>
+
+        {/* Header Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+          className="relative bg-white rounded-2xl p-6 md:p-8 border border-claude-border shadow-sm overflow-hidden"
+        >
+          <div className="absolute top-0 left-0 w-full h-32 bg-gradient-to-r from-claude-accent/10 to-claude-bg" />
+
+          <div className="relative flex flex-col md:flex-row items-start md:items-end gap-6 pt-12">
+            <div className="w-24 h-24 md:w-32 md:h-32 rounded-full bg-claude-sidebar border-4 border-white shadow-md flex items-center justify-center text-3xl font-serif text-claude-subtext">
+              {initials}
+            </div>
+
+            <div className="flex-1 mb-2">
+              <h1 className="text-3xl md:text-4xl font-serif text-claude-text font-medium tracking-tight">
+                {profile.fullName}
+              </h1>
+              {profile.council && (
+                <p className="text-claude-subtext mt-1 font-sans">
+                  {profile.council}
+                </p>
+              )}
+              {profile.experience && (
+                <div className="mt-3 inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-claude-accent/10 text-claude-accent border border-claude-accent/20">
+                  Стаж: {profile.experience}
+                </div>
+              )}
+            </div>
+
+            <a
+              href={`${ERAU_BASE_URL}/${profile.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-sm text-claude-subtext hover:text-claude-accent transition-colors font-sans"
+            >
+              <ExternalLink size={14} />
+              ЄРАУ
+            </a>
+          </div>
+        </motion.div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {/* Certificate Info */}
+          {hasCertificate && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.1 }}
+              className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+            >
+              <h2 className="text-xl font-serif text-claude-text mb-4 flex items-center gap-2">
+                <FileText size={20} className="text-claude-accent" />
+                Свідоцтво
+              </h2>
+              <div className="space-y-3">
+                {profile.certificate.number && (
+                  <div className="flex justify-between">
+                    <span className="text-sm text-claude-subtext font-sans">Номер</span>
+                    <span className="text-sm font-medium text-claude-text font-sans">
+                      {profile.certificate.number}
+                    </span>
+                  </div>
+                )}
+                {profile.certificate.date && (
+                  <div className="flex justify-between">
+                    <span className="text-sm text-claude-subtext font-sans">Дата видачі</span>
+                    <span className="text-sm font-medium text-claude-text font-sans">
+                      {profile.certificate.date}
+                    </span>
+                  </div>
+                )}
+                {profile.certificate.issuedBy && (
+                  <div>
+                    <span className="text-sm text-claude-subtext font-sans block mb-1">Орган видачі</span>
+                    <span className="text-sm text-claude-text font-sans">
+                      {profile.certificate.issuedBy}
+                    </span>
+                  </div>
+                )}
+                {profile.certificate.decisionNumber && (
+                  <div className="flex justify-between">
+                    <span className="text-sm text-claude-subtext font-sans">Рішення</span>
+                    <span className="text-sm font-medium text-claude-text font-sans">
+                      {profile.certificate.decisionNumber}
+                    </span>
+                  </div>
+                )}
+                {profile.certificate.decisionDate && (
+                  <div className="flex justify-between">
+                    <span className="text-sm text-claude-subtext font-sans">Дата рішення</span>
+                    <span className="text-sm font-medium text-claude-text font-sans">
+                      {profile.certificate.decisionDate}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          )}
+
+          {/* Contact Information */}
+          {hasContacts && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.15 }}
+              className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+            >
+              <h2 className="text-xl font-serif text-claude-text mb-4">
+                Контактна інформація
+              </h2>
+              <div className="space-y-3">
+                {profile.contacts.address && (
+                  <div className="flex items-start gap-3 text-claude-subtext">
+                    <MapPin size={18} className="flex-shrink-0 mt-0.5" />
+                    <span className="font-sans text-sm">{profile.contacts.address}</span>
+                  </div>
+                )}
+                {profile.contacts.phone && (
+                  <div className="flex items-center gap-3 text-claude-subtext">
+                    <Phone size={18} className="flex-shrink-0" />
+                    <a
+                      href={`tel:${profile.contacts.phone}`}
+                      className="font-sans text-sm hover:text-claude-accent transition-colors"
+                    >
+                      {profile.contacts.phone}
+                    </a>
+                  </div>
+                )}
+                {profile.contacts.email && (
+                  <div className="flex items-center gap-3 text-claude-subtext">
+                    <Mail size={18} className="flex-shrink-0" />
+                    <a
+                      href={`mailto:${profile.contacts.email}`}
+                      className="font-sans text-sm hover:text-claude-accent transition-colors"
+                    >
+                      {profile.contacts.email}
+                    </a>
+                  </div>
+                )}
+              </div>
+            </motion.div>
+          )}
+
+          {/* Practice Form */}
+          {hasPractice && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.2 }}
+              className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+            >
+              <h2 className="text-xl font-serif text-claude-text mb-4 flex items-center gap-2">
+                <Building2 size={20} className="text-claude-accent" />
+                Форма діяльності
+              </h2>
+              <div className="space-y-3">
+                <div className="flex items-start gap-4 p-3 bg-claude-bg rounded-xl">
+                  <div className="p-2 bg-white rounded-lg text-claude-accent">
+                    <Award size={20} />
+                  </div>
+                  <div>
+                    <h3 className="font-serif font-medium text-claude-text text-sm">
+                      {profile.practiceForm.type}
+                    </h3>
+                    {profile.practiceForm.address && (
+                      <p className="text-xs text-claude-subtext font-sans mt-1">
+                        {profile.practiceForm.address}
+                      </p>
+                    )}
+                    {profile.practiceForm.phone && (
+                      <p className="text-xs text-claude-subtext font-sans mt-1">
+                        {profile.practiceForm.phone}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </motion.div>
+          )}
+
+          {/* Qualification */}
+          {profile.qualification.length > 0 && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.25 }}
+              className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+            >
+              <h2 className="text-xl font-serif text-claude-text mb-4 flex items-center gap-2">
+                <GraduationCap size={20} className="text-claude-accent" />
+                Підвищення кваліфікації
+              </h2>
+              <div className="space-y-2">
+                {profile.qualification.map((q, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between p-3 border border-claude-border/50 rounded-lg"
+                  >
+                    <span className="text-sm font-medium text-claude-text font-sans">
+                      {q.year} рік
+                    </span>
+                    <span className={`flex items-center gap-1.5 text-sm font-sans ${
+                      q.status.toLowerCase().includes('виконано') && !q.status.toLowerCase().includes('не')
+                        ? 'text-green-600'
+                        : 'text-red-500'
+                    }`}>
+                      {q.status.toLowerCase().includes('виконано') && !q.status.toLowerCase().includes('не')
+                        ? <CheckCircle2 size={14} />
+                        : <XCircle size={14} />
+                      }
+                      {q.status}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/PersonDetailPage/index.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/index.tsx
@@ -3,8 +3,11 @@
  * Displays details for a judge or lawyer
  */
 
+import { useEffect, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { PersonDetailPage as PersonDetailPageComponent } from '../../components/PersonDetailPage';
+import { LawyerProfilePage } from '../../components/LawyerProfilePage';
+import { erauService, ERAUProfile } from '../../services/api/ERAUService';
 import { ROUTES } from '../../router/routes';
 
 interface PersonDetailPageProps {
@@ -14,9 +17,13 @@ interface PersonDetailPageProps {
 export function PersonDetailPage({ type }: PersonDetailPageProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const { id: _id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id: string }>();
 
-  // Get person data from location state or fetch it based on ID
+  const [profile, setProfile] = useState<ERAUProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Get person data from location state (for judges)
   const person = location.state?.person?.data;
 
   const handleBack = () => {
@@ -27,7 +34,58 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
     }
   };
 
-  // If no person data in state, could fetch it here based on ID
+  // Fetch ERAU profile for lawyers
+  useEffect(() => {
+    if (type !== 'lawyer' || !id) return;
+
+    setLoading(true);
+    setError(null);
+
+    erauService.getProfile(id)
+      .then((data) => {
+        setProfile(data);
+      })
+      .catch((err) => {
+        setError(err.message || 'Не вдалося завантажити профіль адвоката');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [type, id]);
+
+  // Lawyer view
+  if (type === 'lawyer') {
+    if (loading) {
+      return (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <div className="w-8 h-8 border-2 border-claude-accent border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+            <p className="text-claude-subtext">Завантаження профілю...</p>
+          </div>
+        </div>
+      );
+    }
+
+    if (error || !profile) {
+      return (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-claude-subtext">{error || 'Профіль не знайдено'}</p>
+            <button
+              onClick={handleBack}
+              className="mt-4 px-4 py-2 bg-claude-accent text-white rounded-lg"
+            >
+              Повернутися назад
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return <LawyerProfilePage profile={profile} onBack={handleBack} />;
+  }
+
+  // Judge view (existing behavior)
   if (!person) {
     return (
       <div className="flex-1 flex items-center justify-center">

--- a/lexwebapp/src/services/api/ERAUService.ts
+++ b/lexwebapp/src/services/api/ERAUService.ts
@@ -11,12 +11,46 @@ export interface ERAULawyer {
   certcalc: string;
 }
 
+export interface ERAUProfile {
+  id: string;
+  fullName: string;
+  council: string | null;
+  certificate: {
+    number: string | null;
+    date: string | null;
+    issuedBy: string | null;
+    decisionNumber: string | null;
+    decisionDate: string | null;
+  };
+  experience: string | null;
+  contacts: {
+    address: string | null;
+    phone: string | null;
+    email: string | null;
+  };
+  practiceForm: {
+    type: string | null;
+    address: string | null;
+    phone: string | null;
+  };
+  qualification: Array<{ year: string; status: string }>;
+}
+
 export class ERAUService extends BaseService {
   async searchLawyers(surname: string): Promise<ERAULawyer[]> {
     try {
       const response = await this.client.get<ERAULawyer[]>('/api/erau/search', {
         params: { surname },
       });
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async getProfile(id: string): Promise<ERAUProfile> {
+    try {
+      const response = await this.client.get<ERAUProfile>(`/api/erau/profile/${id}`);
       return response.data;
     } catch (error) {
       return this.handleError(error);

--- a/mcp_backend/src/routes/erau-proxy-routes.ts
+++ b/mcp_backend/src/routes/erau-proxy-routes.ts
@@ -13,9 +13,180 @@ import { logger } from '../utils/logger.js';
 import { ERAUCacheService } from '../services/erau-cache-service.js';
 
 const ERAU_BASE_URL = 'https://erau.unba.org.ua';
+const PROFILE_REDIS_PREFIX = 'erau:profile:';
+const PROFILE_REDIS_TTL = 86400; // 24 hours
+
+export interface ERAUProfile {
+  id: string;
+  fullName: string;
+  council: string | null;
+  certificate: {
+    number: string | null;
+    date: string | null;
+    issuedBy: string | null;
+    decisionNumber: string | null;
+    decisionDate: string | null;
+  };
+  experience: string | null;
+  contacts: {
+    address: string | null;
+    phone: string | null;
+    email: string | null;
+  };
+  practiceForm: {
+    type: string | null;
+    address: string | null;
+    phone: string | null;
+  };
+  qualification: Array<{ year: string; status: string }>;
+}
+
+function parseERAUProfileHTML(html: string, id: string): ERAUProfile {
+  const extract = (pattern: RegExp): string | null => {
+    const m = html.match(pattern);
+    return m ? m[1].trim() : null;
+  };
+
+  // Name: first <h1> tag
+  const fullName = extract(/<h1[^>]*>([\s\S]*?)<\/h1>/) || '';
+
+  // Council: text after "Обліковується у:" section
+  const council = extract(/<h2[^>]*>[\s\S]*?Обліковується[\s\S]*?<\/h2>[\s\S]*?<h3[^>]*>([\s\S]*?)<\/h3>/);
+
+  // Certificate fields
+  const certNumber = extract(/№\s*Свідоцтва:?\s*<\/strong>\s*([\s\S]*?)(?:<|$)/i)
+    || extract(/№\s*Свідоцтва:?\s*([\d\S]+)/i);
+  const certDate = extract(/Дата видачі свідоцтва:?\s*<\/strong>\s*([\s\S]*?)(?:<|$)/i);
+  const issuedBy = extract(/Орган,?\s*що видав свідоцтво:?\s*<\/strong>\s*([\s\S]*?)(?:<|$)/i);
+  const decisionNumber = extract(/Номер рішення:?\s*<\/strong>\s*([\s\S]*?)(?:<|$)/i);
+  const decisionDate = extract(/Дата прийняття рішення:?\s*<\/strong>\s*([\s\S]*?)(?:<|$)/i);
+
+  // Experience
+  const experience = extract(/Загальний стаж:?\s*<\/strong>\s*([\s\S]*?)(?:<|$)/i)
+    || extract(/стаж[^<]*?(\d+\s*(?:рок|років|р\.)[\s\S]*?)(?:<|$)/i);
+
+  // Contacts
+  const address = extract(/Адреса основна:?\s*<\/strong>\s*([\s\S]*?)(?:<\/|<strong|<h)/i);
+  const phone = extract(/href="tel:([^"]+)"/i);
+  const email = extract(/href="mailto:([^"]+)"/i);
+
+  // Practice form
+  const practiceType = extract(/Форма здійснення[\s\S]*?<h3[^>]*>([\s\S]*?)<\/h3>/i)
+    || extract(/(Індивідуальна адвокатська діяльність|Адвокатське бюро|Адвокатське об'єднання)/i);
+  const practiceAddress = extract(/Адреса здійснення діяльності:?\s*<\/strong>\s*([\s\S]*?)(?:<\/|<strong|<h)/i);
+  const practicePhone = extract(/Телефон(?:\s*(?:робочий|офісу))?:?\s*<\/strong>\s*[\s\S]*?href="tel:([^"]+)"/i);
+
+  // Qualification - collect year/status pairs
+  const qualification: Array<{ year: string; status: string }> = [];
+  const qualSection = html.match(/Підвищення кваліфікації[\s\S]*?(?:<\/(?:div|section|table)>)/i);
+  if (qualSection) {
+    const yearMatches = qualSection[0].matchAll(/(\d{4})\s*(?:рік|р\.?)[\s\S]*?(Виконано|Не виконано|В процесі|зараховано|не зараховано)/gi);
+    for (const m of yearMatches) {
+      qualification.push({ year: m[1], status: m[2] });
+    }
+  }
+
+  const clean = (s: string | null): string | null => {
+    if (!s) return null;
+    return s.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim() || null;
+  };
+
+  return {
+    id,
+    fullName: clean(fullName) || '',
+    council: clean(council),
+    certificate: {
+      number: clean(certNumber),
+      date: clean(certDate),
+      issuedBy: clean(issuedBy),
+      decisionNumber: clean(decisionNumber),
+      decisionDate: clean(decisionDate),
+    },
+    experience: clean(experience),
+    contacts: {
+      address: clean(address),
+      phone: clean(phone),
+      email: clean(email),
+    },
+    practiceForm: {
+      type: clean(practiceType),
+      address: clean(practiceAddress),
+      phone: clean(practicePhone),
+    },
+    qualification,
+  };
+}
 
 export function createERAUProxyRoutes(erauCacheService?: ERAUCacheService): Router {
   const router = Router();
+
+  // Profile endpoint
+  router.get('/profile/:id', async (req: Request, res: Response) => {
+    try {
+      const id = req.params.id as string;
+      if (!id || !/^\d+$/.test(id)) {
+        return res.status(400).json({ error: 'Invalid profile ID' });
+      }
+
+      // 1. Check Redis cache
+      const redisKey = `${PROFILE_REDIS_PREFIX}${id}`;
+      try {
+        const { getRedisClient } = await import('../utils/redis-client.js');
+        const redis = await getRedisClient();
+        if (redis) {
+          const cached = await redis.get(redisKey);
+          if (cached) {
+            logger.info(`[ERAU] Profile cache hit for id=${id}`);
+            return res.json(JSON.parse(cached));
+          }
+        }
+      } catch (err: any) {
+        logger.warn('[ERAU] Redis read error for profile', { error: err.message });
+      }
+
+      // 2. Fetch from ERAU
+      const url = `${ERAU_BASE_URL}/profile/${id}`;
+      logger.info(`[ERAU] Fetching profile id=${id}`);
+
+      const response = await fetch(url, {
+        headers: {
+          'Accept': 'text/html',
+          'User-Agent': 'SecondLayer/1.0',
+        },
+        signal: AbortSignal.timeout(15000),
+      });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          return res.status(404).json({ error: 'Profile not found' });
+        }
+        return res.status(502).json({ error: `ERAU returned status ${response.status}` });
+      }
+
+      const html = await response.text();
+      const profile = parseERAUProfileHTML(html, id);
+
+      // 3. Cache in Redis (fire-and-forget)
+      try {
+        const { getRedisClient } = await import('../utils/redis-client.js');
+        const redis = await getRedisClient();
+        if (redis) {
+          await redis.set(redisKey, JSON.stringify(profile), { EX: PROFILE_REDIS_TTL });
+        }
+      } catch (err: any) {
+        logger.warn('[ERAU] Redis write error for profile', { error: err.message });
+      }
+
+      res.json(profile);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[ERAU] Profile fetch error', { error: msg });
+      if (msg.includes('timeout') || msg.includes('abort')) {
+        return res.status(504).json({ error: 'ERAU request timed out' });
+      }
+      res.status(502).json({ error: 'Failed to fetch ERAU profile' });
+    }
+  });
 
   router.get('/search', async (req: Request, res: Response) => {
     try {


### PR DESCRIPTION
## Summary
- Add `GET /api/erau/profile/:id` backend endpoint that fetches and parses lawyer profiles from ERAU HTML with Redis caching (24h TTL)
- Add `ERAUProfile` interface and `getProfile()` method to frontend ERAUService
- New `LawyerProfilePage` component displaying real profile data: name, council, certificate, contacts, practice form, qualification
- `/lawyers/:id` page now fetches real data on mount instead of showing hardcoded placeholders

## Test plan
- [ ] Search "Сацюк" on /lawyers, click result → /lawyers/36388
- [ ] Verify profile data matches https://erau.unba.org.ua/profile/36388
- [ ] Verify loading state shows while fetching
- [ ] Verify error state shows for invalid IDs
- [ ] Verify Redis caching (second load should be instant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Display real ERAU lawyer profiles on /lawyers/:id using a new backend endpoint with 24h Redis caching. The page now fetches and renders actual profile data with loading and error states.

- **New Features**
  - Backend: GET /api/erau/profile/:id fetches ERAU HTML, parses fields, and caches in Redis (24h TTL).
  - Frontend: ERAUProfile interface and erauService.getProfile(id) to load data.
  - UI: New LawyerProfilePage shows name, council, certificate, contacts, practice form, and qualification.
  - PersonDetailPage: Fetches by id for lawyers, shows loading/error, and links to the ERAU profile.

<sup>Written for commit b83a2a8a7635e45e9e1395be53ba5970ca1d0c19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

