### PR TITLE
fix: improve ERAU practice address parsing

### DIFF
--- a/mcp_backend/src/routes/erau-proxy-routes.ts
+++ b/mcp_backend/src/routes/erau-proxy-routes.ts
@@ -134,11 +134,12 @@ function parseERAUProfileHTML(html: string, id: string): ERAUProfile {
     if (!practiceType) {
       practiceType = extract(/(Індивідуальна адвокатська діяльність|Адвокатське бюро|Адвокатське об'єднання)/i);
     }
-    // Practice address: after "Адреса:"
-    const pAddrMatch = ps.match(/Адреса:<\/div>\s*<div[^>]*>([\s\S]*?)<\/div>/i);
+    // Practice address: after "Адреса:" in type-info div, value in next text-info div
+    const pAddrMatch = ps.match(/Адреса:[\s\S]*?<\/div>\s*<div[^>]*class="text-info[^>]*>([\s\S]*?)<\/div>/i);
     practiceAddress = pAddrMatch ? clean(pAddrMatch[1]) : null;
-    // Practice phone
-    const pPhoneMatch = ps.match(/href="tel:([^"]+)"/i);
+    // Practice phone: tel: link inside practice section
+    const pPhoneMatch = ps.match(/Мобільний[\s\S]*?href="tel:([^"]+)"/i)
+      || ps.match(/href="tel:([^"]+)"/i);
     practicePhone = pPhoneMatch ? clean(pPhoneMatch[1]) : null;
   }
 


### PR DESCRIPTION
## Summary
- Fix practice address extraction using class-based text-info selector
- Fix practice phone extraction with fallback patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed parsing of ERAU practice address and phone so values are reliably extracted from profile HTML.

- **Bug Fixes**
  - Address: read the value from the next text-info div after "Адреса:" using a class-based selector.
  - Phone: match the mobile tel link first, then fall back to any tel link within the practice section.

<sup>Written for commit 3f475b7fa03eb3bbcd28bbe1cfe66f1bd5009022. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

