### PR TITLE
feat: enriched judge profile page with ZO stats

### DIFF
--- a/lexwebapp/src/components/JudgeProfilePage.tsx
+++ b/lexwebapp/src/components/JudgeProfilePage.tsx
@@ -1,0 +1,365 @@
+import { motion } from 'framer-motion';
+import {
+  ArrowLeft,
+  Building2,
+  Calendar,
+  Scale,
+  FileText,
+  BarChart3,
+  Clock,
+  Info,
+} from 'lucide-react';
+import type { JudgeProfile } from '../services/api/JudgesService';
+
+interface JudgeProfilePageProps {
+  profile: JudgeProfile;
+  onBack: () => void;
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return '—';
+  try {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  } catch {
+    return dateStr;
+  }
+}
+
+function computeExperience(firstSeen: string | null): string | null {
+  if (!firstSeen) return null;
+  const start = new Date(firstSeen);
+  const now = new Date();
+  const years = now.getFullYear() - start.getFullYear();
+  const months = now.getMonth() - start.getMonth();
+  const totalMonths = years * 12 + months;
+  const y = Math.floor(totalMonths / 12);
+  const m = totalMonths % 12;
+  if (y === 0) return `${m} міс.`;
+  if (m === 0) return `${y} р.`;
+  return `${y} р. ${m} міс.`;
+}
+
+export function JudgeProfilePage({ profile, onBack }: JudgeProfilePageProps) {
+  const { basic, court_history, stats } = profile;
+
+  const initials = basic.full_name
+    .split(' ')
+    .map((n) => n[0])
+    .slice(0, 2)
+    .join('');
+
+  const experience = computeExperience(basic.first_seen);
+  const maxDecisions = stats
+    ? Math.max(...stats.by_justice_kind.map((s) => s.count), 1)
+    : 1;
+  const maxFormCount = stats
+    ? Math.max(...stats.by_judgment_form.map((s) => s.count), 1)
+    : 1;
+  const maxYearCount = stats
+    ? Math.max(...stats.year_activity.map((y) => y.count), 1)
+    : 1;
+
+  return (
+    <div className="flex-1 h-full overflow-y-auto bg-claude-bg p-4 md:p-8 lg:p-12">
+      <div className="max-w-4xl mx-auto space-y-8">
+        {/* Back Button */}
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 text-claude-subtext hover:text-claude-text transition-colors group"
+        >
+          <ArrowLeft
+            size={18}
+            className="group-hover:-translate-x-1 transition-transform"
+          />
+          <span className="font-sans text-sm">Назад до списку</span>
+        </button>
+
+        {/* Header Section */}
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+          className="relative bg-white rounded-2xl p-6 md:p-8 border border-claude-border shadow-sm overflow-hidden"
+        >
+          <div className="absolute top-0 left-0 w-full h-32 bg-gradient-to-r from-claude-accent/10 to-claude-bg" />
+
+          <div className="relative flex flex-col md:flex-row items-start md:items-end gap-6 pt-12">
+            <div className="w-24 h-24 md:w-32 md:h-32 rounded-full bg-claude-sidebar border-4 border-white shadow-md flex items-center justify-center text-3xl font-serif text-claude-subtext">
+              {initials}
+            </div>
+
+            <div className="flex-1 mb-2">
+              <h1 className="text-3xl md:text-4xl font-serif text-claude-text font-medium tracking-tight">
+                {basic.full_name}
+              </h1>
+              {basic.court_name && (
+                <p className="text-claude-subtext mt-1 font-sans flex items-center gap-1.5">
+                  <Building2 size={14} className="flex-shrink-0" />
+                  {basic.court_name}
+                </p>
+              )}
+              <div className="flex flex-wrap gap-2 mt-3">
+                {basic.dossier_number && (
+                  <span className="inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-claude-bg text-claude-subtext border border-claude-border">
+                    Досьє: {basic.dossier_number}
+                  </span>
+                )}
+                {experience && (
+                  <span className="inline-flex items-center px-3 py-1 rounded-lg text-sm font-medium bg-claude-accent/10 text-claude-accent border border-claude-accent/20">
+                    <Clock size={14} className="mr-1.5" />
+                    {experience}
+                  </span>
+                )}
+                {basic.first_seen && (
+                  <span className="inline-flex items-center px-3 py-1 rounded-lg text-sm text-claude-subtext bg-claude-bg border border-claude-border">
+                    <Calendar size={14} className="mr-1.5" />
+                    з {formatDate(basic.first_seen)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Court History */}
+        {court_history.length > 0 && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.1 }}
+            className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+          >
+            <h2 className="text-xl font-serif text-claude-text mb-4 flex items-center gap-2">
+              <Building2 size={20} className="text-claude-accent" />
+              Історія призначень
+            </h2>
+            <div className="relative pl-6">
+              <div className="absolute left-2 top-2 bottom-2 w-0.5 bg-claude-border" />
+              <div className="space-y-4">
+                {court_history.map((entry, i) => (
+                  <div key={i} className="relative flex items-start gap-4">
+                    <div className="absolute -left-4 top-1.5 w-3 h-3 rounded-full bg-claude-accent border-2 border-white shadow-sm" />
+                    <div className="flex-1 p-3 bg-claude-bg rounded-xl">
+                      <h3 className="font-sans font-medium text-claude-text text-sm">
+                        {entry.court_name}
+                      </h3>
+                      <p className="text-xs text-claude-subtext font-sans mt-1">
+                        {formatDate(entry.first_seen)} — {formatDate(entry.last_seen)}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </motion.div>
+        )}
+
+        {/* Stats Section */}
+        {stats ? (
+          <>
+            {/* Total Decisions */}
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.15 }}
+              className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+            >
+              <h2 className="text-xl font-serif text-claude-text mb-4 flex items-center gap-2">
+                <Scale size={20} className="text-claude-accent" />
+                Судові рішення
+              </h2>
+              <div className="text-center py-4">
+                <p className="text-5xl font-serif font-medium text-claude-text">
+                  {stats.total_decisions.toLocaleString('uk-UA')}
+                </p>
+                <p className="text-sm text-claude-subtext mt-1 font-sans">
+                  загальна кількість рішень
+                </p>
+              </div>
+            </motion.div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {/* By Justice Kind */}
+              {stats.by_justice_kind.length > 0 && (
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.5, delay: 0.2 }}
+                  className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+                >
+                  <h2 className="text-lg font-serif text-claude-text mb-4 flex items-center gap-2">
+                    <BarChart3 size={18} className="text-claude-accent" />
+                    За видом судочинства
+                  </h2>
+                  <div className="space-y-3">
+                    {stats.by_justice_kind.map((jk) => (
+                      <div key={jk.id}>
+                        <div className="flex justify-between text-sm font-sans mb-1">
+                          <span className="text-claude-text">{jk.name}</span>
+                          <span className="text-claude-subtext">{jk.count.toLocaleString('uk-UA')}</span>
+                        </div>
+                        <div className="h-2 bg-claude-bg rounded-full overflow-hidden">
+                          <motion.div
+                            initial={{ width: 0 }}
+                            animate={{ width: `${(jk.count / maxDecisions) * 100}%` }}
+                            transition={{ duration: 0.8, delay: 0.3 }}
+                            className="h-full bg-claude-accent rounded-full"
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+
+              {/* By Judgment Form */}
+              {stats.by_judgment_form.length > 0 && (
+                <motion.div
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.5, delay: 0.25 }}
+                  className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+                >
+                  <h2 className="text-lg font-serif text-claude-text mb-4 flex items-center gap-2">
+                    <FileText size={18} className="text-claude-accent" />
+                    За формою рішення
+                  </h2>
+                  <div className="space-y-3">
+                    {stats.by_judgment_form.map((jf) => (
+                      <div key={jf.id}>
+                        <div className="flex justify-between text-sm font-sans mb-1">
+                          <span className="text-claude-text">{jf.name}</span>
+                          <span className="text-claude-subtext">{jf.count.toLocaleString('uk-UA')}</span>
+                        </div>
+                        <div className="h-2 bg-claude-bg rounded-full overflow-hidden">
+                          <motion.div
+                            initial={{ width: 0 }}
+                            animate={{ width: `${(jf.count / maxFormCount) * 100}%` }}
+                            transition={{ duration: 0.8, delay: 0.3 }}
+                            className="h-full bg-claude-accent/70 rounded-full"
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </motion.div>
+              )}
+            </div>
+
+            {/* Year Activity */}
+            {stats.year_activity.length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.3 }}
+                className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+              >
+                <h2 className="text-lg font-serif text-claude-text mb-4 flex items-center gap-2">
+                  <Calendar size={18} className="text-claude-accent" />
+                  Активність за роками
+                </h2>
+                <div className="flex items-end gap-3 h-40">
+                  {stats.year_activity.map((ya) => (
+                    <div key={ya.year} className="flex-1 flex flex-col items-center gap-1">
+                      <span className="text-xs font-sans text-claude-subtext">
+                        {ya.count > 0 ? ya.count.toLocaleString('uk-UA') : '—'}
+                      </span>
+                      <motion.div
+                        initial={{ height: 0 }}
+                        animate={{
+                          height: ya.count > 0 ? `${Math.max((ya.count / maxYearCount) * 100, 4)}%` : '2%',
+                        }}
+                        transition={{ duration: 0.8, delay: 0.4 }}
+                        className={`w-full rounded-t-lg ${ya.count > 0 ? 'bg-claude-accent' : 'bg-claude-border'}`}
+                      />
+                      <span className="text-xs font-sans text-claude-subtext font-medium">
+                        {ya.year}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+
+            {/* Recent Decisions */}
+            {stats.recent_decisions.length > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, delay: 0.35 }}
+                className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+              >
+                <h2 className="text-lg font-serif text-claude-text mb-4 flex items-center gap-2">
+                  <FileText size={18} className="text-claude-accent" />
+                  Останні рішення
+                </h2>
+                <div className="space-y-3">
+                  {stats.recent_decisions.map((d) => (
+                    <div
+                      key={d.id}
+                      className="p-3 border border-claude-border/50 rounded-xl hover:bg-claude-bg/50 transition-colors"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="flex-1 min-w-0">
+                          {d.case_number && (
+                            <p className="text-sm font-medium text-claude-text font-sans truncate">
+                              {d.case_number}
+                            </p>
+                          )}
+                          {d.snippet && (
+                            <p className="text-xs text-claude-subtext font-sans mt-0.5 line-clamp-2">
+                              {d.snippet}
+                            </p>
+                          )}
+                          <div className="flex flex-wrap gap-2 mt-1.5">
+                            {d.justice_kind && (
+                              <span className="text-xs text-claude-subtext bg-claude-bg px-2 py-0.5 rounded font-sans">
+                                {d.justice_kind}
+                              </span>
+                            )}
+                            {d.doc_type && (
+                              <span className="text-xs text-claude-subtext bg-claude-bg px-2 py-0.5 rounded font-sans">
+                                {d.doc_type}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        {d.adjudication_date && (
+                          <span className="text-xs text-claude-subtext font-sans whitespace-nowrap">
+                            {formatDate(d.adjudication_date)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </motion.div>
+            )}
+          </>
+        ) : (
+          /* No ZO data fallback */
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.15 }}
+            className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm"
+          >
+            <div className="flex items-start gap-3 text-claude-subtext">
+              <Info size={20} className="flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="font-sans text-sm font-medium text-claude-text">
+                  Статистика рішень недоступна
+                </p>
+                <p className="font-sans text-sm mt-1">
+                  Не вдалося знайти цього суддю в реєстрі судових рішень ZakonOnline.
+                  Базова інформація отримана з досьє ВККС.
+                </p>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/PersonDetailPage/index.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/index.tsx
@@ -4,10 +4,11 @@
  */
 
 import { useEffect, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router-dom';
-import { PersonDetailPage as PersonDetailPageComponent } from '../../components/PersonDetailPage';
+import { useNavigate, useParams } from 'react-router-dom';
 import { LawyerProfilePage } from '../../components/LawyerProfilePage';
+import { JudgeProfilePage } from '../../components/JudgeProfilePage';
 import { erauService, ERAUProfile } from '../../services/api/ERAUService';
+import { judgesService, JudgeProfile } from '../../services/api/JudgesService';
 import { ROUTES } from '../../router/routes';
 
 interface PersonDetailPageProps {
@@ -15,16 +16,13 @@ interface PersonDetailPageProps {
 }
 
 export function PersonDetailPage({ type }: PersonDetailPageProps) {
-  const location = useLocation();
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
 
-  const [profile, setProfile] = useState<ERAUProfile | null>(null);
+  const [lawyerProfile, setLawyerProfile] = useState<ERAUProfile | null>(null);
+  const [judgeProfile, setJudgeProfile] = useState<JudgeProfile | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Get person data from location state (for judges)
-  const person = location.state?.person?.data;
 
   const handleBack = () => {
     if (type === 'judge') {
@@ -43,7 +41,7 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
 
     erauService.getProfile(id)
       .then((data) => {
-        setProfile(data);
+        setLawyerProfile(data);
       })
       .catch((err) => {
         setError(err.message || 'Не вдалося завантажити профіль адвоката');
@@ -53,44 +51,43 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
       });
   }, [type, id]);
 
-  // Lawyer view
-  if (type === 'lawyer') {
-    if (loading) {
-      return (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
-            <div className="w-8 h-8 border-2 border-claude-accent border-t-transparent rounded-full animate-spin mx-auto mb-3" />
-            <p className="text-claude-subtext">Завантаження профілю...</p>
-          </div>
-        </div>
-      );
-    }
+  // Fetch judge profile
+  useEffect(() => {
+    if (type !== 'judge' || !id) return;
 
-    if (error || !profile) {
-      return (
-        <div className="flex-1 flex items-center justify-center">
-          <div className="text-center">
-            <p className="text-claude-subtext">{error || 'Профіль не знайдено'}</p>
-            <button
-              onClick={handleBack}
-              className="mt-4 px-4 py-2 bg-claude-accent text-white rounded-lg"
-            >
-              Повернутися назад
-            </button>
-          </div>
-        </div>
-      );
-    }
+    setLoading(true);
+    setError(null);
 
-    return <LawyerProfilePage profile={profile} onBack={handleBack} />;
-  }
+    judgesService.getJudgeProfile(id)
+      .then((data) => {
+        setJudgeProfile(data);
+      })
+      .catch((err) => {
+        setError(err.message || 'Не вдалося завантажити профіль судді');
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [type, id]);
 
-  // Judge view (existing behavior)
-  if (!person) {
+  // Loading state
+  if (loading) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <div className="text-center">
-          <p className="text-claude-subtext">Завантаження...</p>
+          <div className="w-8 h-8 border-2 border-claude-accent border-t-transparent rounded-full animate-spin mx-auto mb-3" />
+          <p className="text-claude-subtext">Завантаження профілю...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-claude-subtext">{error}</p>
           <button
             onClick={handleBack}
             className="mt-4 px-4 py-2 bg-claude-accent text-white rounded-lg"
@@ -102,11 +99,43 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
     );
   }
 
-  return (
-    <PersonDetailPageComponent
-      type={type}
-      person={person}
-      onBack={handleBack}
-    />
-  );
+  // Lawyer view
+  if (type === 'lawyer') {
+    if (!lawyerProfile) {
+      return (
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-claude-subtext">Профіль не знайдено</p>
+            <button
+              onClick={handleBack}
+              className="mt-4 px-4 py-2 bg-claude-accent text-white rounded-lg"
+            >
+              Повернутися назад
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return <LawyerProfilePage profile={lawyerProfile} onBack={handleBack} />;
+  }
+
+  // Judge view
+  if (!judgeProfile) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-claude-subtext">Профіль не знайдено</p>
+          <button
+            onClick={handleBack}
+            className="mt-4 px-4 py-2 bg-claude-accent text-white rounded-lg"
+          >
+            Повернутися назад
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return <JudgeProfilePage profile={judgeProfile} onBack={handleBack} />;
 }

--- a/lexwebapp/src/services/api/JudgesService.ts
+++ b/lexwebapp/src/services/api/JudgesService.ts
@@ -22,6 +22,55 @@ export interface JudgesSearchParams {
   offset?: number;
 }
 
+export interface CourtHistoryEntry {
+  court_name: string;
+  first_seen: string;
+  last_seen: string;
+  snapshot_count: number;
+}
+
+export interface JusticeKindStat {
+  id: number;
+  name: string;
+  count: number;
+}
+
+export interface JudgmentFormStat {
+  id: number;
+  name: string;
+  count: number;
+}
+
+export interface YearActivity {
+  year: number;
+  count: number;
+}
+
+export interface RecentDecision {
+  id: number;
+  case_number: string | null;
+  adjudication_date: string | null;
+  court_name: string | null;
+  justice_kind: string | null;
+  doc_type: string | null;
+  snippet: string | null;
+}
+
+export interface JudgeStats {
+  total_decisions: number;
+  by_justice_kind: JusticeKindStat[];
+  by_judgment_form: JudgmentFormStat[];
+  year_activity: YearActivity[];
+  recent_decisions: RecentDecision[];
+}
+
+export interface JudgeProfile {
+  basic: Judge;
+  court_history: CourtHistoryEntry[];
+  zo_id: number | null;
+  stats: JudgeStats | null;
+}
+
 export class JudgesService extends BaseService {
   async getJudges(params?: JudgesSearchParams): Promise<JudgesListResponse> {
     try {
@@ -35,6 +84,15 @@ export class JudgesService extends BaseService {
   async getJudgeByDossier(dossierNumber: string): Promise<Judge> {
     try {
       const response = await this.client.get<Judge>(`/api/judges/${dossierNumber}`);
+      return response.data;
+    } catch (error) {
+      return this.handleError(error);
+    }
+  }
+
+  async getJudgeProfile(dossierNumber: string): Promise<JudgeProfile> {
+    try {
+      const response = await this.client.get<JudgeProfile>(`/api/judges/${dossierNumber}/profile`);
       return response.data;
     } catch (error) {
       return this.handleError(error);

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1883,7 +1883,7 @@ class HTTPMCPServer {
     logger.info('Matter routes registered at /api/matters');
 
     // Judges routes - search judges from VKKS data
-    const judgesService = new JudgesService(this.services.db);
+    const judgesService = new JudgesService(this.services.db, this.services.zoAdapter);
     this.app.use('/api/judges', requireJWT as any, createJudgesRoutes(judgesService));
 
     // Decisions routes - download court decision full texts from reyestr.court.gov.ua

--- a/mcp_backend/src/routes/judges-routes.ts
+++ b/mcp_backend/src/routes/judges-routes.ts
@@ -20,6 +20,21 @@ export function createJudgesRoutes(judgesService: JudgesService): Router {
     }
   });
 
+  router.get('/:dossierNumber/profile', async (req: any, res: Response) => {
+    try {
+      const { dossierNumber } = req.params;
+      const profile = await judgesService.getJudgeProfile(dossierNumber);
+      if (!profile) {
+        return res.status(404).json({ error: 'Judge not found' });
+      }
+      res.json(profile);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[Judges] profile error', { error: msg, dossier: req.params.dossierNumber });
+      res.status(500).json({ error: msg });
+    }
+  });
+
   router.get('/:dossierNumber', async (req: any, res: Response) => {
     try {
       const { dossierNumber } = req.params;

--- a/mcp_backend/src/services/judges-service.ts
+++ b/mcp_backend/src/services/judges-service.ts
@@ -1,5 +1,7 @@
 import { BaseDatabase } from '@secondlayer/shared';
 import { logger } from '../utils/logger.js';
+import { ZOAdapter } from '../adapters/zo-adapter.js';
+import { getRedisClient } from '../utils/redis-client.js';
 
 export interface JudgeRecord {
   id: number;
@@ -17,11 +19,91 @@ export interface JudgesListResult {
   total: number;
 }
 
+export interface CourtHistoryEntry {
+  court_name: string;
+  first_seen: string;
+  last_seen: string;
+  snapshot_count: number;
+}
+
+export interface JusticeKindStat {
+  id: number;
+  name: string;
+  count: number;
+}
+
+export interface JudgmentFormStat {
+  id: number;
+  name: string;
+  count: number;
+}
+
+export interface YearActivity {
+  year: number;
+  count: number;
+}
+
+export interface RecentDecision {
+  id: number;
+  case_number: string | null;
+  adjudication_date: string | null;
+  court_name: string | null;
+  justice_kind: string | null;
+  doc_type: string | null;
+  snippet: string | null;
+}
+
+export interface JudgeStats {
+  total_decisions: number;
+  by_justice_kind: JusticeKindStat[];
+  by_judgment_form: JudgmentFormStat[];
+  year_activity: YearActivity[];
+  recent_decisions: RecentDecision[];
+}
+
+export interface JudgeProfile {
+  basic: JudgeRecord;
+  court_history: CourtHistoryEntry[];
+  zo_id: number | null;
+  stats: JudgeStats | null;
+}
+
+// ZakonOnline justice_kind IDs and names
+const JUSTICE_KINDS: { id: number; name: string }[] = [
+  { id: 1, name: 'Цивільне' },
+  { id: 2, name: 'Кримінальне' },
+  { id: 3, name: 'Господарське' },
+  { id: 4, name: 'Адміністративне' },
+  { id: 5, name: 'Адмінправопорушення' },
+  { id: 10, name: 'Інше' },
+];
+
+// ZakonOnline judgment_form IDs and names
+const JUDGMENT_FORMS: { id: number; name: string }[] = [
+  { id: 1, name: 'Вирок' },
+  { id: 2, name: 'Постанова' },
+  { id: 3, name: 'Рішення' },
+  { id: 4, name: 'Ухвала' },
+  { id: 5, name: 'Окрема ухвала' },
+  { id: 6, name: 'Окрема думка' },
+  { id: 7, name: 'Додаткове рішення' },
+  { id: 8, name: 'Додатковий вирок' },
+  { id: 9, name: 'Додаткова постанова' },
+  { id: 10, name: 'Додаткова ухвала' },
+  { id: 11, name: 'Наказ' },
+  { id: 12, name: 'Судовий наказ' },
+  { id: 13, name: 'Окрема ухвала (постанова)' },
+];
+
+const CACHE_TTL = 86400; // 24 hours
+
 export class JudgesService {
   private db: BaseDatabase;
+  private zoAdapter: ZOAdapter | null;
 
-  constructor(db: BaseDatabase) {
+  constructor(db: BaseDatabase, zoAdapter?: ZOAdapter) {
     this.db = db;
+    this.zoAdapter = zoAdapter || null;
   }
 
   async getJudges(search?: string, limit = 50, offset = 0): Promise<JudgesListResult> {
@@ -62,5 +144,181 @@ export class JudgesService {
       [dossierNumber]
     );
     return result.rows[0] || null;
+  }
+
+  async getJudgeProfile(dossierNumber: string): Promise<JudgeProfile | null> {
+    // Check Redis cache first
+    const cacheKey = `judge:profile:${dossierNumber}`;
+    try {
+      const redis = await getRedisClient();
+      if (redis) {
+        const cached = await redis.get(cacheKey);
+        if (cached) {
+          logger.debug('[Judges] Cache hit for profile', { dossierNumber });
+          return JSON.parse(cached);
+        }
+      }
+    } catch (err) {
+      logger.warn('[Judges] Redis cache read failed', { error: (err as Error).message });
+    }
+
+    const pool = this.db.getPool();
+
+    // 1. Basic info from judges_current
+    const basicResult = await pool.query(
+      `SELECT id, dossier_number, full_name, gender, court_name, first_seen, last_seen, snapshot_count
+       FROM judges_current WHERE dossier_number = $1 LIMIT 1`,
+      [dossierNumber]
+    );
+    if (basicResult.rows.length === 0) return null;
+    const basic: JudgeRecord = basicResult.rows[0];
+
+    // 2. Court history from judges table (historical snapshots)
+    const historyResult = await pool.query(
+      `SELECT court_name, MIN(snapshot_date) as first_seen, MAX(snapshot_date) as last_seen, COUNT(*)::int as snapshot_count
+       FROM judges
+       WHERE dossier_number = $1 AND court_name IS NOT NULL
+       GROUP BY court_name
+       ORDER BY MIN(snapshot_date) ASC`,
+      [dossierNumber]
+    );
+    const court_history: CourtHistoryEntry[] = historyResult.rows;
+
+    // 3. Match judge to ZO dictionary
+    let zo_id: number | null = null;
+    try {
+      const dictResult = await pool.query(
+        `SELECT data FROM zo_dictionaries WHERE domain = 'court_decisions' AND dictionary_name = 'judges' LIMIT 1`
+      );
+      if (dictResult.rows.length > 0) {
+        const judges: Array<{ id: number; title: string }> = dictResult.rows[0].data;
+        const normalizedName = basic.full_name.trim().toLowerCase();
+        const match = judges.find((j) => j.title.trim().toLowerCase() === normalizedName);
+        if (match) {
+          zo_id = match.id;
+          logger.info('[Judges] ZO match found', { dossierNumber, zo_id, name: basic.full_name });
+        } else {
+          logger.info('[Judges] No ZO match for judge', { dossierNumber, name: basic.full_name });
+        }
+      }
+    } catch (err) {
+      logger.warn('[Judges] ZO dictionary lookup failed', { error: (err as Error).message });
+    }
+
+    // 4. Fetch ZO stats if we have a match and adapter
+    let stats: JudgeStats | null = null;
+    if (zo_id && this.zoAdapter) {
+      try {
+        stats = await this.fetchZoStats(zo_id);
+      } catch (err) {
+        logger.warn('[Judges] ZO stats fetch failed, returning profile without stats', {
+          dossierNumber, zo_id, error: (err as Error).message,
+        });
+      }
+    }
+
+    const profile: JudgeProfile = { basic, court_history, zo_id, stats };
+
+    // Cache result
+    try {
+      const redis = await getRedisClient();
+      if (redis) {
+        await redis.set(cacheKey, JSON.stringify(profile), { EX: CACHE_TTL });
+      }
+    } catch (err) {
+      logger.warn('[Judges] Redis cache write failed', { error: (err as Error).message });
+    }
+
+    return profile;
+  }
+
+  private async fetchZoStats(judgeId: number): Promise<JudgeStats> {
+    const adapter = this.zoAdapter!;
+    const judgeWhere = [{ field: 'judge_id', operator: '$eq', value: judgeId }];
+
+    // Batch 1: Total count + justice kind breakdown (7 calls in parallel)
+    const [totalResult, ...justiceKindResults] = await Promise.all([
+      adapter.searchCourtDecisions({ where: judgeWhere, limit: 1 }),
+      ...JUSTICE_KINDS.map((jk) =>
+        adapter.searchCourtDecisions({
+          where: [...judgeWhere, { field: 'justice_kind', operator: '$eq', value: jk.id }],
+          limit: 1,
+        })
+      ),
+    ]);
+
+    const total_decisions = totalResult.total || 0;
+
+    const by_justice_kind: JusticeKindStat[] = JUSTICE_KINDS
+      .map((jk, i) => ({
+        id: jk.id,
+        name: jk.name,
+        count: justiceKindResults[i].total || 0,
+      }))
+      .filter((s) => s.count > 0);
+
+    // Batch 2: Judgment form breakdown (13 calls in parallel)
+    const judgmentFormResults = await Promise.all(
+      JUDGMENT_FORMS.map((jf) =>
+        adapter.searchCourtDecisions({
+          where: [...judgeWhere, { field: 'judgment_form', operator: '$eq', value: jf.id }],
+          limit: 1,
+        })
+      )
+    );
+
+    const by_judgment_form: JudgmentFormStat[] = JUDGMENT_FORMS
+      .map((jf, i) => ({
+        id: jf.id,
+        name: jf.name,
+        count: judgmentFormResults[i].total || 0,
+      }))
+      .filter((s) => s.count > 0);
+
+    // Batch 3: Recent decisions + year activity (1 + 5 calls)
+    const currentYear = new Date().getFullYear();
+    const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
+
+    const [recentResult, ...yearResults] = await Promise.all([
+      adapter.searchCourtDecisions({
+        where: judgeWhere,
+        limit: 5,
+        orderBy: { field: 'adjudication_date', direction: 'desc' },
+      }),
+      ...years.map((year) =>
+        adapter.searchCourtDecisions({
+          where: [
+            ...judgeWhere,
+            { field: 'adjudication_date', operator: '>=', value: `${year}-01-01` },
+            { field: 'adjudication_date', operator: '<=', value: `${year}-12-31` },
+          ],
+          limit: 1,
+        })
+      ),
+    ]);
+
+    const recent_decisions: RecentDecision[] = (recentResult.data || []).slice(0, 5).map((d: any) => ({
+      id: d.id,
+      case_number: d.case_number || d.number || null,
+      adjudication_date: d.adjudication_date || null,
+      court_name: d.court_name || null,
+      justice_kind: d.justice_kind_name || d.justice_kind || null,
+      doc_type: d.judgment_form_name || d.judgment_form || null,
+      snippet: d.title || d.cause || null,
+    }));
+
+    const year_activity: YearActivity[] = years
+      .map((year, i) => ({
+        year,
+        count: yearResults[i].total || 0,
+      }));
+
+    return {
+      total_decisions,
+      by_justice_kind,
+      by_judgment_form,
+      year_activity,
+      recent_decisions,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded placeholder data on judge detail page (`/judges/:id`) with real data from DB + ZakonOnline API
- Backend `getJudgeProfile()` fetches basic info from `judges_current`, court history from `judges` snapshots, matches to ZO dictionary, and pulls decision stats (~26 lightweight parallel ZO API calls)
- Frontend `JudgeProfilePage` component follows `LawyerProfilePage` pattern with animated stat bars, court timeline, year activity chart, and recent decisions

## Test plan
- [ ] Navigate to /judges, search for a judge, click to open profile
- [ ] Verify basic info (name, court, dossier, experience) renders correctly
- [ ] Verify court history timeline shows entries from judges table
- [ ] Verify ZO stats (total decisions, by justice kind, by judgment form) display with bar charts
- [ ] Verify year activity chart shows last 5 years
- [ ] Verify recent decisions list shows last 5 decisions
- [ ] Test judge with no ZO match — should show basic info + "Статистика рішень недоступна" message
- [ ] Test Redis caching — second load should be instant
- [ ] Verify TypeScript compiles clean (both backend and frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enriched the judge profile page with real data and ZakonOnline stats to replace placeholders and give a complete overview, including charts and recent decisions. Added a backend profile endpoint with Redis caching to keep it fast.

- **New Features**
  - Frontend
    - New JudgeProfilePage component with animated stat bars, court timeline, year activity chart, and recent decisions.
    - PersonDetailPage loads judge data via judgesService.getJudgeProfile and shows a fallback when ZO data is missing.
  - Backend
    - New GET /api/judges/:dossierNumber/profile route.
    - JudgesService.getJudgeProfile composes:
      - Basic info from judges_current.
      - Court history from judges snapshots.
      - ZO judge match via dictionary, then lightweight parallel queries for:
        - Totals, by justice kind, by judgment form, year activity (last 5 years), recent decisions.
    - Results cached in Redis for 24h.
    - http-server wires JudgesService with zoAdapter.

<sup>Written for commit ec34768b0dc11098a0eeb5afe6ae61a9dcbc9030. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

