### PR TITLE
feat: add supreme court judges reference table (migration 069)

### DIFF
--- a/mcp_backend/src/migrations/069_supreme_court_judges.sql
+++ b/mcp_backend/src/migrations/069_supreme_court_judges.sql
@@ -1,0 +1,29 @@
+-- Supreme Court judges reference table
+-- Source: https://court.gov.ua/storage/portal/supreme/vidkr_dany/21_10_2024_suddi_VS.xlsx
+
+CREATE TABLE IF NOT EXISTS supreme_court_judges (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  full_name TEXT NOT NULL,
+  surname VARCHAR(100) NOT NULL,
+  first_name VARCHAR(100) NOT NULL,
+  patronymic VARCHAR(100),
+  position TEXT NOT NULL,
+  court VARCHAR(100) NOT NULL,
+  is_active BOOLEAN DEFAULT TRUE,
+  source_date DATE DEFAULT '2024-10-21',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_scj_surname ON supreme_court_judges(surname);
+CREATE INDEX IF NOT EXISTS idx_scj_court ON supreme_court_judges(court);
+CREATE INDEX IF NOT EXISTS idx_scj_active ON supreme_court_judges(is_active);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scj_fullname_court ON supreme_court_judges(full_name, court);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_supreme_court_judges_updated_at') THEN
+        CREATE TRIGGER update_supreme_court_judges_updated_at BEFORE UPDATE ON supreme_court_judges
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Adds migration `069_supreme_court_judges.sql` with reference table for 153 Supreme Court judges
- Columns: full_name, surname, first_name, patronymic, position, court, is_active
- Source: court.gov.ua open data (2024-10-21 snapshot)
- Indexes on surname, court, is_active + unique on (full_name, court)

## Test plan
- [ ] Verify migration runs idempotently
- [ ] Confirm 153 judges loaded correctly
- [ ] Check indexes created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add migration 069 to create a Supreme Court judges reference table with key indexes and an updated_at trigger. Prepares the schema for loading court.gov.ua data from 2024‑10‑21.

- **New Features**
  - New table: supreme_court_judges (id, full_name, surname, first_name, patronymic, position, court, is_active, source_date, timestamps).
  - Indexes: surname, court, is_active; unique on (full_name, court).
  - Trigger: update_updated_at_column() on UPDATE.
  - Defaults: uuid_generate_v4() for id, source_date=2024‑10‑21.

- **Migration**
  - Requires uuid-ossp extension and update_updated_at_column() function.
  - Run migration 069 and verify table and indexes exist.

<sup>Written for commit 985866065b4e79cf3b591e1f25cdee8c9bd50f83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

