### PR TITLE
feat: add judges_current table (migration 070)

### DIFF
--- a/mcp_backend/src/migrations/070_judges_current.sql
+++ b/mcp_backend/src/migrations/070_judges_current.sql
@@ -1,0 +1,30 @@
+-- Current judges registry from VKKSU open data
+-- Source: https://data.gov.ua/dataset/354d406b-53cc-4788-a384-78b9abaf2ea0
+-- Data as of: 2026-02-23
+-- Table already exists from earlier migration; this ensures indexes and trigger
+
+CREATE TABLE IF NOT EXISTS judges_current (
+  id SERIAL PRIMARY KEY,
+  dossier_number VARCHAR(50),
+  full_name VARCHAR(500) NOT NULL,
+  gender VARCHAR(10),
+  court_name VARCHAR(500),
+  first_seen DATE,
+  last_seen DATE,
+  snapshot_count INTEGER DEFAULT 1,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(full_name, court_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_jc_court ON judges_current(court_name);
+CREATE INDEX IF NOT EXISTS idx_jc_dossier ON judges_current(dossier_number);
+CREATE INDEX IF NOT EXISTS idx_jc_fullname ON judges_current(full_name);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_judges_current_updated_at') THEN
+        CREATE TRIGGER update_judges_current_updated_at BEFORE UPDATE ON judges_current
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Adds migration `070_judges_current.sql` — denormalized current judges view
- Built from VKKS weekly snapshots: dossier_number, full_name, gender, court_name, first_seen, last_seen, snapshot_count
- Indexes on court_name, dossier_number, full_name
- Unique constraint on (full_name, court_name)

## Test plan
- [ ] Verify migration runs idempotently
- [ ] Confirm table structure matches `load-judges-vkks.js` expectations
- [ ] Check unique constraint works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add migration 070 to create the judges_current table as a denormalized registry of current judges from VKKSU weekly snapshots. Includes indexes, a uniqueness constraint, and an update trigger for fast lookups and reliable timestamps.

- **New Features**
  - Create judges_current with fields: dossier_number, full_name, gender, court_name, first_seen, last_seen, snapshot_count, created_at, updated_at.
  - Enforce uniqueness on (full_name, court_name); add indexes on court_name, dossier_number, full_name.
  - Add BEFORE UPDATE trigger to maintain updated_at (only if missing).
  - Uses IF NOT EXISTS to run idempotently.

<sup>Written for commit 90f0b8233c4e8f96007dbf0cbb129fe3177b7dfc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

