### PR TITLE
refactor: rename local domain to local.legal.org.ua

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -65,13 +65,13 @@ RADA_API_KEY=test-key-123
 # Google OAuth (Optional - get from https://console.cloud.google.com/)
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-GOOGLE_CALLBACK_URL=https://localdev.legal.org.ua/auth/google/callback
+GOOGLE_CALLBACK_URL=https://local.legal.org.ua/auth/google/callback
 
 # =============================================================================
 # CORS & Frontend Configuration
 # =============================================================================
-FRONTEND_URL=https://localdev.legal.org.ua
-ALLOWED_ORIGINS=https://localdev.legal.org.ua,http://localhost:5173,http://localhost:3000
+FRONTEND_URL=https://local.legal.org.ua
+ALLOWED_ORIGINS=https://local.legal.org.ua,http://localhost:5173,http://localhost:3000
 
 # =============================================================================
 # Redis Configuration
@@ -118,7 +118,7 @@ ADMIN_EMAIL=grafana@legal.org.ua
 # =============================================================================
 # Frontend Build Configuration
 # =============================================================================
-VITE_API_URL=https://localdev.legal.org.ua
+VITE_API_URL=https://local.legal.org.ua
 
 # =============================================================================
 # Unified Gateway (disabled for local — each service on its own port)

--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -277,16 +277,16 @@ services:
       STAGE_API_KEY: ${STAGE_API_KEY:-}
 
       # WebAuthn / FIDO2
-      WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-localdev.legal.org.ua}
+      WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-local.legal.org.ua}
       WEBAUTHN_RP_NAME: ${WEBAUTHN_RP_NAME:-SecondLayer Legal}
-      WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN:-https://localdev.legal.org.ua}
+      WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN:-https://local.legal.org.ua}
 
       # OAuth (optional for local - can use API keys instead)
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      GOOGLE_CALLBACK_URL: ${GOOGLE_CALLBACK_URL:-https://localdev.legal.org.ua/auth/google/callback}
-      FRONTEND_URL: ${FRONTEND_URL:-https://localdev.legal.org.ua}
-      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://localdev.legal.org.ua,https://usa.legal.org.ua,https://uk.legal.org.ua,https://de.legal.org.ua,https://fr.legal.org.ua,https://nl.legal.org.ua,https://ee.legal.org.ua,https://eu.legal.org.ua,https://ua.legal.org.ua,http://localhost:5173,http://localhost:3000}
+      GOOGLE_CALLBACK_URL: ${GOOGLE_CALLBACK_URL:-https://local.legal.org.ua/auth/google/callback}
+      FRONTEND_URL: ${FRONTEND_URL:-https://local.legal.org.ua}
+      ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://local.legal.org.ua,https://usa.legal.org.ua,https://uk.legal.org.ua,https://de.legal.org.ua,https://fr.legal.org.ua,https://nl.legal.org.ua,https://ee.legal.org.ua,https://eu.legal.org.ua,https://ua.legal.org.ua,http://localhost:5173,http://localhost:3000}
 
       # MinIO (S3-compatible object storage)
       MINIO_ENDPOINT: minio-local
@@ -294,7 +294,7 @@ services:
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
       MINIO_USE_SSL: "false"
-      MINIO_PUBLIC_URL: https://localdev.legal.org.ua/s3
+      MINIO_PUBLIC_URL: https://local.legal.org.ua/s3
 
       # Upload temp directory
       UPLOAD_TEMP_DIR: /app/data/uploads
@@ -748,7 +748,7 @@ services:
     environment:
       NODE_ENV: development
       DOCKER_ENV: "true"
-      VITE_API_URL: ${VITE_API_URL:-https://localdev.legal.org.ua}
+      VITE_API_URL: ${VITE_API_URL:-https://local.legal.org.ua}
     volumes:
       - ../lexwebapp:/app
       - lexwebapp_node_modules:/app/node_modules

--- a/deployment/lib/smoke-test.sh
+++ b/deployment/lib/smoke-test.sh
@@ -116,7 +116,7 @@ check_http_health() {
 
     case $env in
         local)
-            local urls=("https://localdev.legal.org.ua/health")
+            local urls=("https://local.legal.org.ua/health")
             for url in "${urls[@]}"; do
                 local attempt=1
                 local passed=false
@@ -220,7 +220,7 @@ check_frontend_health() {
     local urls=()
     case $env in
         local)
-            urls=("https://localdev.legal.org.ua")
+            urls=("https://local.legal.org.ua")
             ;;
         prod|production)
             urls=("https://legal.org.ua" "https://mcp.legal.org.ua")

--- a/deployment/maintenance/cf-maintenance.sh
+++ b/deployment/maintenance/cf-maintenance.sh
@@ -63,8 +63,8 @@ STAGE_PATTERNS=(
     "stage.legal.org.ua/*"
 )
 LOCAL_PATTERNS=(
-    "localdev.legal.org.ua/*"
-    "localdev.mcp.legal.org.ua/*"
+    "local.legal.org.ua/*"
+    "local.mcp.legal.org.ua/*"
 )
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -377,7 +377,7 @@ case "$CMD" in
         echo "Usage: $0 <enable|disable|status|setup> [local|stage]"
         echo ""
         echo "  setup           — deploy worker script to Cloudflare (first-time)"
-        echo "  enable [env]    — activate maintenance page (stage: all domains, local: localdev only)"
+        echo "  enable [env]    — activate maintenance page (stage: all domains, local: local only)"
         echo "  disable [env]   — deactivate maintenance page"
         echo "  status          — show current maintenance routes"
         exit 1

--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -142,7 +142,7 @@ Environments:
                     Domains: legal.org.ua, mcp.legal.org.ua
   stage             Staging -> gate.lexapp.co.ua (Cloudflare proxy)
                     Domains: stage.legal.org.ua, legal.org.ua, mcp.legal.org.ua
-  local             Local development (localdev.legal.org.ua) -> localhost
+  local             Local development (local.legal.org.ua) -> localhost
 
 Deployment Targets:
   - Prod:  Deploys to AWS EC2 (18.192.189.254), serves legal.org.ua via nginx + Cloudflare
@@ -233,11 +233,11 @@ start_env() {
             $compose_cmd $local_compose_args up -d --build
 
             # Open browser (nginx + Vite run inside Docker now)
-            print_msg "$BLUE" "Opening https://localdev.legal.org.ua ..."
+            print_msg "$BLUE" "Opening https://local.legal.org.ua ..."
             if command -v xdg-open &> /dev/null; then
-                xdg-open "https://localdev.legal.org.ua" 2>/dev/null &
+                xdg-open "https://local.legal.org.ua" 2>/dev/null &
             elif command -v open &> /dev/null; then
-                open "https://localdev.legal.org.ua" 2>/dev/null &
+                open "https://local.legal.org.ua" 2>/dev/null &
             fi
             ;;
         *)
@@ -496,8 +496,8 @@ check_health() {
     curl -sf --max-time 5 http://localhost:3000/health > /dev/null && print_msg "$GREEN" "  Backend (localhost:3000): healthy" || print_msg "$RED" "  Backend (localhost:3000): unhealthy"
     docker ps --filter "name=nginx-local" --format '{{.Status}}' 2>/dev/null | grep -qi "up" && print_msg "$GREEN" "  Nginx: running" || print_msg "$RED" "  Nginx: stopped"
     docker ps --filter "name=lexwebapp-local" --format '{{.Status}}' 2>/dev/null | grep -qi "up" && print_msg "$GREEN" "  Vite (Docker): running" || print_msg "$RED" "  Vite (Docker): stopped"
-    curl -sf --max-time 10 https://localdev.legal.org.ua/ > /dev/null && print_msg "$GREEN" "  Frontend (localdev HTTPS): healthy" || print_msg "$RED" "  Frontend (localdev HTTPS): unhealthy"
-    curl -sf --max-time 10 https://localdev.mcp.legal.org.ua/health > /dev/null && print_msg "$GREEN" "  MCP SSE (localdev.mcp HTTPS): healthy" || print_msg "$RED" "  MCP SSE (localdev.mcp HTTPS): unhealthy"
+    curl -sf --max-time 10 https://local.legal.org.ua/ > /dev/null && print_msg "$GREEN" "  Frontend (local HTTPS): healthy" || print_msg "$RED" "  Frontend (local HTTPS): unhealthy"
+    curl -sf --max-time 10 https://local.mcp.legal.org.ua/health > /dev/null && print_msg "$GREEN" "  MCP SSE (local.mcp HTTPS): healthy" || print_msg "$RED" "  MCP SSE (local.mcp HTTPS): unhealthy"
 
     echo ""
 }
@@ -506,8 +506,8 @@ check_health() {
 # Manage Let's Encrypt certificates for local environment
 ensure_letsencrypt_certs() {
     local certs_dir="$SCRIPT_DIR/nginx/certs"
-    local le_dir="/etc/letsencrypt/live/localdev.legal.org.ua"
-    local domains="-d localdev.legal.org.ua -d localdev.mcp.legal.org.ua"
+    local le_dir="/etc/letsencrypt/live/local.legal.org.ua"
+    local domains="-d local.legal.org.ua -d local.mcp.legal.org.ua"
     local compose_cmd=$(get_compose_cmd)
     local compose_args="$1"
 
@@ -682,11 +682,11 @@ deploy_local() {
     fi
 
     # Phase 5: Open browser (nginx + Vite run inside Docker now)
-    print_msg "$BLUE" "Opening https://localdev.legal.org.ua ..."
+    print_msg "$BLUE" "Opening https://local.legal.org.ua ..."
     if command -v xdg-open &> /dev/null; then
-        xdg-open "https://localdev.legal.org.ua" 2>/dev/null &
+        xdg-open "https://local.legal.org.ua" 2>/dev/null &
     elif command -v open &> /dev/null; then
-        open "https://localdev.legal.org.ua" 2>/dev/null &
+        open "https://local.legal.org.ua" 2>/dev/null &
     fi
 
     # Phase 6: Report

--- a/deployment/nginx/localdev-docker.conf
+++ b/deployment/nginx/localdev-docker.conf
@@ -25,7 +25,7 @@ upstream local_frontend {
 server {
     listen 80;
     listen [::]:80;
-    server_name localdev.legal.org.ua localdev.mcp.legal.org.ua usa.legal.org.ua uk.legal.org.ua de.legal.org.ua fr.legal.org.ua nl.legal.org.ua ee.legal.org.ua eu.legal.org.ua ua.legal.org.ua;
+    server_name local.legal.org.ua local.mcp.legal.org.ua usa.legal.org.ua uk.legal.org.ua de.legal.org.ua fr.legal.org.ua nl.legal.org.ua ee.legal.org.ua eu.legal.org.ua ua.legal.org.ua;
 
     access_log /var/log/nginx/localdev-access.log;
     error_log /var/log/nginx/localdev-error.log;
@@ -336,7 +336,7 @@ server {
     listen 443 ssl;
     listen [::]:443 ssl;
     http2 on;
-    server_name localdev.legal.org.ua localdev.mcp.legal.org.ua usa.legal.org.ua uk.legal.org.ua de.legal.org.ua fr.legal.org.ua nl.legal.org.ua ee.legal.org.ua eu.legal.org.ua ua.legal.org.ua;
+    server_name local.legal.org.ua local.mcp.legal.org.ua usa.legal.org.ua uk.legal.org.ua de.legal.org.ua fr.legal.org.ua nl.legal.org.ua ee.legal.org.ua eu.legal.org.ua ua.legal.org.ua;
 
     # SSL (Let's Encrypt)
     ssl_certificate /etc/nginx/certs/fullchain.pem;

--- a/deployment/nginx/localdev.legal.org.ua.conf
+++ b/deployment/nginx/localdev.legal.org.ua.conf
@@ -1,13 +1,13 @@
-# Local Development Nginx Configuration for localdev.legal.org.ua
+# Local Development Nginx Configuration for local.legal.org.ua
 # Standalone config (no includes) — routes to local backend (port 3000) and Vite dev server (port 5173)
 #
 # Prerequisites:
-#   1. localdev.legal.org.ua resolves via DNS (or /etc/hosts)
+#   1. local.legal.org.ua resolves via DNS (or /etc/hosts)
 #   2. Backend running on port 3000 (Docker or npm)
 #   3. Vite dev server running on port 5173 (npm run dev)
 #
 # Installation:
-#   sudo ln -sf /home/vovkes/SecondLayer/deployment/nginx/localdev.legal.org.ua.conf /etc/nginx/sites-enabled/
+#   sudo ln -sf /home/vovkes/SecondLayer/deployment/nginx/local.legal.org.ua.conf /etc/nginx/sites-enabled/
 #   sudo nginx -t && sudo systemctl reload nginx
 
 # WebSocket upgrade map (for Vite HMR)
@@ -26,11 +26,11 @@ upstream local_mcp_backend {
 server {
     listen 80;
     listen [::]:80;
-    server_name localdev.legal.org.ua;
+    server_name local.legal.org.ua;
 
     # Logging
-    access_log /var/log/nginx/localdev.legal.org.ua-access.log;
-    error_log /var/log/nginx/localdev.legal.org.ua-error.log;
+    access_log /var/log/nginx/local.legal.org.ua-access.log;
+    error_log /var/log/nginx/local.legal.org.ua-error.log;
 
     # Settings
     client_max_body_size 50M;
@@ -314,16 +314,16 @@ server {
 server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
-    server_name localdev.legal.org.ua;
+    server_name local.legal.org.ua;
 
     # SSL (mkcert local CA)
-    ssl_certificate /home/vovkes/SecondLayer/deployment/nginx/certs/localdev.legal.org.ua+2.pem;
-    ssl_certificate_key /home/vovkes/SecondLayer/deployment/nginx/certs/localdev.legal.org.ua+2-key.pem;
+    ssl_certificate /home/vovkes/SecondLayer/deployment/nginx/certs/local.legal.org.ua+2.pem;
+    ssl_certificate_key /home/vovkes/SecondLayer/deployment/nginx/certs/local.legal.org.ua+2-key.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
 
     # Logging
-    access_log /var/log/nginx/localdev.legal.org.ua-ssl-access.log;
-    error_log /var/log/nginx/localdev.legal.org.ua-ssl-error.log;
+    access_log /var/log/nginx/local.legal.org.ua-ssl-access.log;
+    error_log /var/log/nginx/local.legal.org.ua-ssl-error.log;
 
     # Settings
     client_max_body_size 50M;

--- a/deployment/wireguard/tinyproxy.conf
+++ b/deployment/wireguard/tinyproxy.conf
@@ -1,4 +1,4 @@
-# tinyproxy config for developer machine (localdev.legal.org.ua)
+# tinyproxy config for developer machine (local.legal.org.ua)
 # Install: sudo apt-get install -y tinyproxy
 #          sudo cp tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 #          sudo systemctl enable --now tinyproxy

--- a/deployment/wireguard/wg1-localdev.conf
+++ b/deployment/wireguard/wg1-localdev.conf
@@ -1,5 +1,5 @@
 # WireGuard config for localdev (local developer machine)
-# Node: localdev.legal.org.ua
+# Node: local.legal.org.ua
 # WG IP: 10.149.22.181/32
 # Install: sudo cp wg1-localdev.conf /etc/wireguard/wg1.conf
 #          sudo systemctl enable --now wg-quick@wg1

--- a/deployment/wireguard/wg1-stage.conf
+++ b/deployment/wireguard/wg1-stage.conf
@@ -17,7 +17,7 @@ Endpoint = 178.162.234.145:51820
 PersistentKeepalive = 25
 
 [Peer]
-# localdev.legal.org.ua (developer machine)
+# local.legal.org.ua (developer machine)
 PublicKey = 5l/HsPNNxbD6mvpKWJkDq589+V5aGH3Nch1ATG9BIXI=
 AllowedIPs = 10.149.22.181/32
 Endpoint = 134.249.53.181:44082

--- a/lexwebapp/src/pages/admin/monitoring/CourtDataMapSection.tsx
+++ b/lexwebapp/src/pages/admin/monitoring/CourtDataMapSection.tsx
@@ -310,7 +310,7 @@ export function CourtDataMapSection() {
               >
                 <option value="none">Без проксі (Direct)</option>
                 <option value="mail">Проксі: mail.legal.org.ua</option>
-                <option value="localdev">Проксі: localdev.legal.org.ua</option>
+                <option value="localdev">Проксі: local.legal.org.ua</option>
               </select>
             </div>
           </div>

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -7,8 +7,8 @@ import path from 'path'
 export default defineConfig(({ mode }) => {
   const isDocker = !!process.env.DOCKER_ENV
   const certsDir = path.resolve(__dirname, 'certs')
-  const certFile = path.join(certsDir, 'localdev.legal.org.ua+2.pem')
-  const keyFile = path.join(certsDir, 'localdev.legal.org.ua+2-key.pem')
+  const certFile = path.join(certsDir, 'local.legal.org.ua+2.pem')
+  const keyFile = path.join(certsDir, 'local.legal.org.ua+2-key.pem')
   const hasLocalCerts = !isDocker && fs.existsSync(certFile) && fs.existsSync(keyFile)
 
   return {
@@ -22,7 +22,7 @@ export default defineConfig(({ mode }) => {
     },
     server: {
       host: true,
-      allowedHosts: ['localdev.legal.org.ua', 'usa.legal.org.ua', 'uk.legal.org.ua', 'de.legal.org.ua', 'fr.legal.org.ua', 'nl.legal.org.ua', 'ee.legal.org.ua', 'eu.legal.org.ua', 'ua.legal.org.ua'],
+      allowedHosts: ['local.legal.org.ua', 'usa.legal.org.ua', 'uk.legal.org.ua', 'de.legal.org.ua', 'fr.legal.org.ua', 'nl.legal.org.ua', 'ee.legal.org.ua', 'eu.legal.org.ua', 'ua.legal.org.ua'],
       ...(hasLocalCerts && {
         https: {
           cert: fs.readFileSync(certFile),
@@ -30,7 +30,7 @@ export default defineConfig(({ mode }) => {
         },
       }),
       hmr: {
-        host: 'localdev.legal.org.ua',
+        host: 'local.legal.org.ua',
         ...(isDocker ? { clientPort: 443, protocol: 'wss' } : { port: 5173, protocol: 'wss' }),
       },
       watch: isDocker ? {


### PR DESCRIPTION
## Summary
- Renamed local development domain from `localdev.legal.org.ua` to `local.legal.org.ua` across all deployment configs
- Updated nginx configs, docker-compose, smoke tests, maintenance scripts, vite config, and frontend components (12 files)

## Test plan
- [ ] Verify DNS record `local.legal.org.ua` resolves correctly
- [ ] Renew Let's Encrypt certificate for new domain (`local.legal.org.ua` + `local.mcp.legal.org.ua`)
- [ ] Run `manage-gateway.sh deploy local` and confirm all services start
- [ ] Verify HTTPS access at `https://local.legal.org.ua`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the local dev domain from localdev.legal.org.ua to local.legal.org.ua across configs and app. This aligns HTTPS, WebAuthn, CORS, and health checks with the new domain.

- **Refactors**
  - Updated env, Docker Compose, and Vite to use local.legal.org.ua (FRONTEND_URL, ALLOWED_ORIGINS, VITE_API_URL).
  - Switched WEBAUTHN_RP_ID/ORIGIN and Google OAuth callback to the new domain.
  - Updated nginx server_name and cert paths; adjusted MinIO public URL.
  - Updated smoke tests, gateway scripts, Cloudflare maintenance routes, and WireGuard comments.

- **Migration**
  - Ensure DNS resolves for local.legal.org.ua.
  - Renew Let's Encrypt certs for local.legal.org.ua and local.mcp.legal.org.ua.
  - Run: manage-gateway.sh deploy local.
  - Verify HTTPS at https://local.legal.org.ua.

<sup>Written for commit 3b3f7c4417240dd3a85088ccbe510d24820f7344. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

