### PR TITLE
fix: replace vulnerable xlsx with exceljs

### DIFF
--- a/scripts/judges/load-judges-vkks.js
+++ b/scripts/judges/load-judges-vkks.js
@@ -16,7 +16,7 @@
 
 const https = require('https');
 const http = require('http');
-const XLSX = require('xlsx');
+const ExcelJS = require('exceljs');
 const { Pool } = require('pg');
 const path = require('path');
 const fs = require('fs');
@@ -107,10 +107,15 @@ function detectLayout(rows) {
 }
 
 // --- Parse XLSX buffer into judge records ---
-function parseXlsx(buffer, snapshotDate, resourceName) {
-  const wb = XLSX.read(buffer, { type: 'buffer' });
-  const ws = wb.Sheets[wb.SheetNames[0]];
-  const rows = XLSX.utils.sheet_to_json(ws, { header: 1 });
+async function parseXlsx(buffer, snapshotDate, resourceName) {
+  const workbook = new ExcelJS.Workbook();
+  await workbook.xlsx.load(buffer);
+  const ws = workbook.worksheets[0];
+
+  const rows = [];
+  ws.eachRow((row) => {
+    rows.push(row.values.slice(1)); // row.values is 1-indexed, slice to make 0-indexed
+  });
 
   const layout = detectLayout(rows);
   const judges = [];
@@ -173,7 +178,7 @@ async function processResource(resource, index, total) {
   }
 
   try {
-    const judges = parseXlsx(buffer, snapshotDate, resource.name);
+    const judges = await parseXlsx(buffer, snapshotDate, resource.name);
     return { snapshotDate, judges, resourceId: resource.id };
   } catch (err) {
     console.error(`  [${index + 1}/${total}] PARSE ERROR: ${resource.name} — ${err.message}`);
@@ -339,7 +344,7 @@ async function buildCurrentTable(pool) {
 }
 
 // --- Load from cached downloads (offline mode) ---
-function loadFromCache() {
+async function loadFromCache() {
   const files = fs.readdirSync(DOWNLOAD_DIR).filter(f => f.endsWith('.xlsx')).sort();
   console.log(`Loading ${files.length} cached files from ${DOWNLOAD_DIR}`);
   const results = [];
@@ -349,7 +354,7 @@ function loadFromCache() {
     const filePath = path.join(DOWNLOAD_DIR, file);
     const buffer = fs.readFileSync(filePath);
     try {
-      const judges = parseXlsx(buffer, snapshotDate, file);
+      const judges = await parseXlsx(buffer, snapshotDate, file);
       console.log(`  [${i + 1}/${files.length}] ${file}: ${judges.length} judges`);
       results.push({ snapshotDate, judges, resourceId: file });
     } catch (err) {
@@ -386,7 +391,7 @@ async function main() {
       results = await parallelMap(resources, processResource, CONCURRENCY);
     } catch (err) {
       console.log(`API unreachable (${err.message}), using ${cachedFiles.length} cached files...`);
-      results = loadFromCache();
+      results = await loadFromCache();
     }
   } else {
     let resources = await fetchResourceList();

--- a/scripts/judges/package.json
+++ b/scripts/judges/package.json
@@ -12,6 +12,6 @@
   "type": "commonjs",
   "dependencies": {
     "pg": "^8.19.0",
-    "xlsx": "^0.18.5"
+    "exceljs": "^4.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replaced `xlsx` (SheetJS) with `exceljs` in `scripts/judges/` — xlsx has 2 high-severity CVEs with no patched version
- Updated `load-judges-vkks.js` to use exceljs async API
- Resolves dependabot alerts #122, #123

## Test plan
- [ ] Verify `node -c scripts/judges/load-judges-vkks.js` passes syntax check
- [ ] Run script against cached XLSX files to confirm parsing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced vulnerable xlsx with exceljs in the judges import script to fix two high‑severity CVEs while keeping XLSX parsing. Resolves dependabot alerts #122 and #123.

- **Dependencies**
  - Removed xlsx; added exceljs ^4.4.0 in scripts/judges.

- **Refactors**
  - Made parseXlsx async with ExcelJS and updated callers (processResource, loadFromCache, main) to await.
  - Adjusted row extraction for ExcelJS’s 1‑indexed values.

<sup>Written for commit 8032600f51c10c6b0387d37a2a9cbb81272f49d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

