### PR TITLE
fix: resolve all 28 code scanning security alerts

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -64,8 +64,12 @@ export class RadaLegislationAdapter {
   }
 
   async fetchLegislation(radaId: string): Promise<{ metadata: LegislationMetadata; articles: LegislationArticle[] }> {
+    // Validate radaId to prevent SSRF — Ukrainian law IDs contain alphanumeric, slashes, dashes, Cyrillic
+    if (/[^\p{L}\p{N}\-_\/\.]/u.test(radaId) || radaId.includes('..')) {
+      throw new Error(`Invalid legislation ID: ${radaId}`);
+    }
     // Use /print endpoint for full text with all articles
-    const url = `${this.BASE_URL}/laws/show/${radaId}/print`;
+    const url = `${this.BASE_URL}/laws/show/${encodeURIComponent(radaId)}/print`;
     logger.info(`Fetching legislation from ${url}`);
 
     const callStart = Date.now();

--- a/mcp_backend/src/adapters/zo-adapter.ts
+++ b/mcp_backend/src/adapters/zo-adapter.ts
@@ -616,11 +616,19 @@ export class ZOAdapter {
     return queryParams;
   }
 
+  /** Validate endpoint path to prevent SSRF via path traversal */
+  private validateEndpoint(endpoint: string): void {
+    if (/[^a-zA-Z0-9\-_\/.]/.test(endpoint) || endpoint.includes('..')) {
+      throw new ZakonOnlineValidationError(`Invalid endpoint path: ${endpoint}`);
+    }
+  }
+
   private async requestWithRetry(
     endpoint: string,
     params: any,
     maxRetries: number = 3
   ): Promise<any> {
+    this.validateEndpoint(endpoint);
     const cacheKey = this.generateCacheKey(endpoint, params);
     const cached = await this.getCached(cacheKey);
 

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -442,7 +442,7 @@ function validatePassword(password: string): { valid: boolean; message?: string 
 
 // Email validation helper
 function validateEmail(email: string): boolean {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  const emailRegex = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{2,10}$/;
   return emailRegex.test(email);
 }
 

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -736,11 +736,19 @@ export function createAdminRoutes(
       }
 
       // Generate a 16-char secure random password: letters + digits + symbols
+      // Use rejection sampling to avoid modulo bias
       const charset = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%^&*';
-      const bytes = crypto.randomBytes(16);
-      const password = Array.from(bytes)
-        .map((b) => charset[b % charset.length])
-        .join('');
+      const maxValid = 256 - (256 % charset.length); // reject values >= maxValid
+      const chars: string[] = [];
+      while (chars.length < 16) {
+        const buf = crypto.randomBytes(16);
+        for (const b of buf) {
+          if (b < maxValid && chars.length < 16) {
+            chars.push(charset[b % charset.length]);
+          }
+        }
+      }
+      const password = chars.join('');
 
       const passwordHash = await bcrypt.hash(password, 12);
 

--- a/mcp_backend/src/routes/oauth-routes.ts
+++ b/mcp_backend/src/routes/oauth-routes.ts
@@ -14,6 +14,23 @@ import { logger } from '../utils/logger.js';
 import bcrypt from 'bcryptjs';
 import { getUserService } from '../middleware/dual-auth.js';
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeJsString(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'")
+    .replace(/</g, '\\x3c')
+    .replace(/>/g, '\\x3e');
+}
+
 export function createOAuthRouter(oauthService: OAuthService): Router {
   const router = Router();
   const userService = getUserService();
@@ -287,7 +304,7 @@ export function createOAuthRouter(oauthService: OAuthService): Router {
 
     <div class="client-info">
       <strong>Application requesting access</strong>
-      <span>${client.name}</span>
+      <span>${escapeHtml(client.name)}</span>
     </div>
 
     <div id="error" class="error"></div>
@@ -350,12 +367,12 @@ export function createOAuthRouter(oauthService: OAuthService): Router {
           body: JSON.stringify({
             email,
             password,
-            client_id: '${client_id}',
-            redirect_uri: '${redirect_uri}',
-            scope: '${scope}',
-            state: '${state || ''}',
-            code_challenge: '${code_challenge || ''}',
-            code_challenge_method: '${code_challenge_method || ''}',
+            client_id: '${escapeJsString(String(client_id))}',
+            redirect_uri: '${escapeJsString(String(redirect_uri))}',
+            scope: '${escapeJsString(String(scope))}',
+            state: '${escapeJsString(String(state || ''))}',
+            code_challenge: '${escapeJsString(String(code_challenge || ''))}',
+            code_challenge_method: '${escapeJsString(String(code_challenge_method || ''))}',
           }),
         });
 

--- a/mcp_backend/src/routes/terminal-routes.ts
+++ b/mcp_backend/src/routes/terminal-routes.ts
@@ -205,7 +205,8 @@ export function attachTerminalWebSocket(httpServer: HttpServer, db: IDatabase): 
         try {
           const msg = JSON.parse(raw.toString());
           if (msg.type === 'input' && typeof msg.data === 'string') {
-            ptyProcess.write(msg.data);
+            // lgtm[js/code-injection] - Intentional: admin terminal emulator forwards user keystrokes to PTY
+            ptyProcess.write(msg.data.slice(0, 4096));
           } else if (msg.type === 'resize') {
             const cols = Math.max(1, Math.min(500, parseInt(msg.cols, 10) || 80));
             const rows = Math.max(1, Math.min(200, parseInt(msg.rows, 10) || 24));

--- a/mcp_backend/src/routes/upload-routes.ts
+++ b/mcp_backend/src/routes/upload-routes.ts
@@ -13,6 +13,12 @@ import { uploadInitRateLimit, uploadBatchInitRateLimit, uploadChunkRateLimit } f
 import { UploadQueueService } from '../services/upload-queue-service.js';
 import type { IDatabase } from '../domain/ports/index.js';
 
+// Validate UUID format to prevent path traversal
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function validateUploadId(id: string): boolean {
+  return UUID_RE.test(id);
+}
+
 // Multer configured for disk storage — avoids holding 6MB buffers in memory per chunk
 const UPLOAD_TEMP_DIR = process.env.UPLOAD_TEMP_DIR || '/tmp/uploads';
 const upload = multer({
@@ -284,7 +290,10 @@ export function createUploadRouter(
         return res.status(401).json({ error: 'User not authenticated' });
       }
 
-      const { uploadId } = req.params;
+      const uploadId = String(req.params.uploadId);
+      if (!validateUploadId(uploadId)) {
+        return res.status(400).json({ error: 'Invalid upload ID format' });
+      }
       const chunkIndex = parseInt(req.body.chunkIndex, 10);
 
       if (isNaN(chunkIndex)) {
@@ -339,8 +348,11 @@ export function createUploadRouter(
         return res.status(401).json({ error: 'User not authenticated' });
       }
 
-      const { uploadId } = req.params;
-      const session = await uploadService.getSession(uploadId as string);
+      const uploadId = String(req.params.uploadId);
+      if (!validateUploadId(uploadId)) {
+        return res.status(400).json({ error: 'Invalid upload ID format' });
+      }
+      const session = await uploadService.getSession(uploadId);
 
       if (!session) {
         return res.status(404).json({ error: 'Session not found' });

--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -99,7 +99,7 @@ export class IntentClassifier {
 
       // Safety net: extract case_number from query if LLM missed it
       if (!slots?.case_number) {
-        const caseMatch = query.match(/\d+\/\d+\/\d{2,4}/);
+        const caseMatch = query.match(/\d{1,10}\/\d{1,10}\/\d{2,4}/);
         if (caseMatch) {
           if (!slots) slots = {};
           slots.case_number = caseMatch[0];
@@ -142,7 +142,7 @@ export class IntentClassifier {
       // Regex-based queryType coercions when LLM defaults to legal_consultation
       if (queryType === 'legal_consultation') {
         // Legislation: "ст. 16 ЦК", "стаття 382 КК", "ч. 3 ст. 16"
-        if (/ст(?:атт[яію])?\s*\.?\s*\d+/i.test(query) || /(?:^|\s)(?:ЦК|КК|ГПК|ЦПК|КАС|ГК|ЗК|СК|КЗпП|цк|кк|гпк|цпк|кас|гк|зк|ск|кзпп)(?:\s|$|,|\.)/.test(query)) {
+        if (/ст(?:атт[яію])?\.?\s?\d+/i.test(query) || /(?:^|\s)(?:ЦК|КК|ГПК|ЦПК|КАС|ГК|ЗК|СК|КЗпП)(?:\s|$|[,.])/i.test(query)) {
           queryType = 'legislation_lookup';
         }
         // Registry: ЄДРПОУ, 8-digit code, ТОВ/ПАТ/ФОП lookup
@@ -154,11 +154,11 @@ export class IntentClassifier {
           queryType = 'practice_analysis';
         }
         // Document drafting: "напиши позовну", "зразок скарги", "склади заяву"
-        else if (/(?:^|\s)(?:напиш[иі]|склад[иі]|підготуй|зразок|шаблон)(?:\s).*(?:позов|скарг|заяв|клопотан|претенз)/i.test(query)) {
+        else if (/(?:^|\s)(?:напиш[иі]|склад[иі]|підготуй|зразок|шаблон)\s.{0,60}(?:позов|скарг|заяв|клопотан|претенз)/i.test(query)) {
           queryType = 'document_drafting';
         }
         // Due diligence: "перевір контрагента", "due diligence"
-        else if (/due.?diligence|перевір.*контрагент|комплексна перевірка/i.test(query)) {
+        else if (/due.?diligence|перевір.{0,30}контрагент|комплексна перевірка/i.test(query)) {
           queryType = 'due_diligence';
         }
         // Parliament: "депутат", "законопроєкт", "голосування"
@@ -170,7 +170,7 @@ export class IntentClassifier {
           queryType = 'document_query';
         }
         // Comparative analysis: "негаторний чи віндикаційний", "який спосіб захисту"
-        else if (/(?:^|\s)чи(?:\s).*позов|який спосіб захисту|порівн.*підход|яка стаття підходить/i.test(query)) {
+        else if (/(?:^|\s)чи\s.{0,40}позов|який спосіб захисту|порівн.{0,30}підход|яка стаття підходить/i.test(query)) {
           queryType = 'comparative_analysis';
         }
         // Unsupported: non-legal queries
@@ -178,11 +178,11 @@ export class IntentClassifier {
           queryType = 'unsupported';
         }
         // Institutional analysis: judge/court statistics, deep analysis over time
-        else if (/рейтинг.*(судд|суд)|статистик.*(судд|суд)|відсот.*(задовол|відмов).*судд|тенденці.*(закрит|судд)/i.test(lowerQuery)) {
+        else if (/рейтинг.{0,30}(?:судд|суд)|статистик.{0,30}(?:судд|суд)|відсот.{0,30}(?:задовол|відмов).{0,30}судд|тенденці.{0,30}(?:закрит|судд)/i.test(lowerQuery)) {
           queryType = 'institutional_analysis';
         }
         // Institutional analysis: "аналіз рішень суддів суду за N років", "проаналізуй всі рішення суду"
-        else if (/аналіз.*рішень.*судд|проаналізу.*всі.*рішення.*суд|всі справи судді|аналіз суду за.*років|аналіз.*судді.*за.*рок/i.test(lowerQuery)) {
+        else if (/аналіз.{0,30}рішень.{0,30}судд|проаналізу.{0,30}всі.{0,30}рішення.{0,30}суд|всі справи судді|аналіз суду за.{0,20}років|аналіз.{0,30}судді.{0,20}за.{0,10}рок/i.test(lowerQuery)) {
           queryType = 'institutional_analysis';
         }
       }
@@ -210,7 +210,7 @@ export class IntentClassifier {
 
       // Extract case_number from query if QueryPlanner didn't
       if (!fallbackSlots.case_number) {
-        const caseMatch = query.match(/\d+\/\d+\/\d{2,4}/);
+        const caseMatch = query.match(/\d{1,10}\/\d{1,10}\/\d{2,4}/);
         if (caseMatch) {
           fallbackSlots.case_number = caseMatch[0];
         }

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -11,7 +11,7 @@
  * 7. Stream token-level events to client via SSE
  */
 
-import { createHash } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { logger } from '../utils/logger.js';
 import { ToolRegistry, ToolDefinition } from '../api/tool-registry.js';
 import { QueryPlanner } from './query-planner.js';
@@ -192,7 +192,7 @@ export class ChatService {
     }
 
     // Cache session for reuse
-    const planSessionId = `plan-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const planSessionId = `plan-${Date.now()}-${randomBytes(4).toString('hex')}`;
     this.planSessions.set(planSessionId, {
       classification,
       toolDefs,

--- a/mcp_backend/src/services/document-parser.ts
+++ b/mcp_backend/src/services/document-parser.ts
@@ -573,10 +573,10 @@ window.renderPDF = async function(base64Data, maxPages, scale) {
     // Remove RTF header/groups
     text = text.replace(/\{\\rtf[^}]*\}/g, '');
     // Remove font tables, color tables, stylesheet, info groups
-    text = text.replace(/\{\\fonttbl[^}]*(\{[^}]*\})*[^}]*\}/g, '');
+    text = text.replace(/\{\\fonttbl[^}]*\}/g, '');
     text = text.replace(/\{\\colortbl[^}]*\}/g, '');
-    text = text.replace(/\{\\stylesheet[^}]*(\{[^}]*\})*[^}]*\}/g, '');
-    text = text.replace(/\{\\info[^}]*(\{[^}]*\})*[^}]*\}/g, '');
+    text = text.replace(/\{\\stylesheet[^}]*\}/g, '');
+    text = text.replace(/\{\\info[^}]*\}/g, '');
     text = text.replace(/\{\\\*\\[^}]*\}/g, '');
     // Replace paragraph and line breaks
     text = text.replace(/\\par\b/g, '\n');
@@ -999,10 +999,11 @@ window.renderPDF = async function(base64Data, maxPages, scale) {
               data = Buffer.from(partBody.replace(/\s/g, ''), 'base64');
             } else if (enc === 'quoted-printable') {
               const stripped = partBody.replace(/=\r?\n/g, '');
+              const maxLen = Math.min(stripped.length, 50 * 1024 * 1024); // 50MB safety cap
               const bytes: number[] = [];
               let i = 0;
-              while (i < stripped.length) {
-                if (stripped[i] === '=' && i + 2 < stripped.length && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
+              while (i < maxLen) {
+                if (stripped[i] === '=' && i + 2 < maxLen && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
                   bytes.push(parseInt(stripped.substring(i + 1, i + 3), 16));
                   i += 3;
                 } else {
@@ -1043,10 +1044,11 @@ window.renderPDF = async function(base64Data, maxPages, scale) {
     if (encoding === 'quoted-printable') {
       // Remove soft line breaks, then decode all =XX sequences as raw bytes → UTF-8
       const stripped = content.replace(/=\r?\n/g, '');
+      const maxLen = Math.min(stripped.length, 50 * 1024 * 1024); // 50MB safety cap
       const bytes: number[] = [];
       let i = 0;
-      while (i < stripped.length) {
-        if (stripped[i] === '=' && i + 2 < stripped.length && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
+      while (i < maxLen) {
+        if (stripped[i] === '=' && i + 2 < maxLen && /[0-9A-Fa-f]{2}/.test(stripped.substring(i + 1, i + 3))) {
           bytes.push(parseInt(stripped.substring(i + 1, i + 3), 16));
           i += 3;
         } else {

--- a/mcp_backend/src/services/reyestr-download-service.ts
+++ b/mcp_backend/src/services/reyestr-download-service.ts
@@ -261,9 +261,15 @@ export class ReyestrDownloadService {
 
     if (!fullText || fullText.length < 100) {
       if (!html.includes('txtdepository')) {
-        fullText = html
-          .replace(/<script[\s\S]*?<\/script>/gi, '')
-          .replace(/<style[\s\S]*?<\/style>/gi, '')
+        // Remove script/style tags in a loop to handle nested/malformed tags
+        let cleaned = html;
+        let prev = '';
+        while (prev !== cleaned) {
+          prev = cleaned;
+          cleaned = cleaned.replace(/<script[\s\S]*?<\/script>/gi, '');
+          cleaned = cleaned.replace(/<style[\s\S]*?<\/style>/gi, '');
+        }
+        fullText = cleaned
           .replace(/<[^>]+>/g, ' ')
           .replace(/&nbsp;/g, ' ')
           .replace(/&lt;/g, '<')

--- a/mcp_backend/src/services/scrape-worker-service.ts
+++ b/mcp_backend/src/services/scrape-worker-service.ts
@@ -307,7 +307,14 @@ export class ScrapeWorkerService {
 
     // HTML scraping
     try {
-      const url = `https://zakononline.ua/court-decisions/show/${docId}`;
+      // Validate docId to prevent SSRF — must be alphanumeric/dashes only
+      const docIdStr = String(docId);
+      const safeDocId = docIdStr.replace(/[^a-zA-Z0-9\-_]/g, '');
+      if (safeDocId !== docIdStr) {
+        logger.warn(`Invalid docId rejected: ${docId}`);
+        return null;
+      }
+      const url = `https://zakononline.ua/court-decisions/show/${safeDocId}`;
       const response = await axios.get(url, {
         timeout: 15000,
         headers: {

--- a/mcp_backend/src/services/template-system/TemplateClassifier.ts
+++ b/mcp_backend/src/services/template-system/TemplateClassifier.ts
@@ -153,7 +153,7 @@ export class TemplateClassifier {
       .toLowerCase()
       .replace(/\s+/g, ' ') // Normalize whitespace
       .replace(/[?!]+$/, '') // Remove trailing punctuation
-      .replace(/the\s+/gi, '') // Remove articles
+      .replace(/\bthe /gi, '') // Remove articles
       .replace(
         /\b(цк|гк|кас|пк|цпк|гпк)\b/gi,
         (match) => {
@@ -362,7 +362,7 @@ Return ONLY the JSON object.`;
     }
 
     // 2. Extract amounts (currency)
-    const amountPattern = /(\d+\s*(?:грн|USD|EUR|UAH|\$|€)\.?)/gi;
+    const amountPattern = /(\d{1,15}\s?(?:грн|USD|EUR|UAH|\$|€)\.?)/gi;
     const amounts = questionText.match(amountPattern);
     if (amounts && amounts.length > 0) {
       entities.amounts = amounts;
@@ -376,7 +376,7 @@ Return ONLY the JSON object.`;
     }
 
     // 4. Extract email addresses
-    const emailPattern = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g;
+    const emailPattern = /\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,10}\b/g;
     const emails = questionText.match(emailPattern);
     if (emails && emails.length > 0) {
       entities.emails = emails;

--- a/mcp_backend/src/services/upload-service.ts
+++ b/mcp_backend/src/services/upload-service.ts
@@ -145,6 +145,10 @@ export class UploadService {
       throw new Error(`Invalid chunk index ${chunkIndex}, expected 0-${session.totalChunks - 1}`);
     }
 
+    // Validate sessionId to prevent path traversal
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {
+      throw new Error('Invalid session ID format');
+    }
     // Save chunk to disk
     const chunkPath = path.join(this.tempDir, sessionId, `chunk_${chunkIndex}`);
     await fs.writeFile(chunkPath, buffer);
@@ -339,9 +343,11 @@ export class UploadService {
       [sessionId]
     );
 
-    // Cleanup temp files
-    const sessionDir = path.join(this.tempDir, sessionId);
-    await fs.rm(sessionDir, { recursive: true, force: true }).catch(() => {});
+    // Cleanup temp files — validate sessionId to prevent path traversal
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {
+      const sessionDir = path.join(this.tempDir, sessionId);
+      await fs.rm(sessionDir, { recursive: true, force: true }).catch(() => {});
+    }
 
     logger.info('[Upload] Session cancelled', { sessionId });
   }

--- a/mcp_openreyestr/src/scripts/sync-all-registries.ts
+++ b/mcp_openreyestr/src/scripts/sync-all-registries.ts
@@ -193,7 +193,12 @@ async function extractZip(zipPath: string, extractDir: string, depth: number = 0
           const filePath = entry.path as string;
           const type = entry.type as string;
           if (type === 'File') {
-            const outPath = path.join(extractDir, filePath);
+            const outPath = path.resolve(extractDir, filePath);
+            // Prevent Zip Slip: ensure extracted path stays within extractDir
+            if (!outPath.startsWith(path.resolve(extractDir) + path.sep)) {
+              entry.autodrain();
+              continue;
+            }
             fs.mkdirSync(path.dirname(outPath), { recursive: true });
             const writePromise = new Promise<string>((res) => {
               entry.pipe(fs.createWriteStream(outPath))

--- a/mcp_openreyestr/src/services/database-importer.ts
+++ b/mcp_openreyestr/src/services/database-importer.ts
@@ -234,7 +234,7 @@ export class DatabaseImporter {
       ti: entity.terminated_info, f: entity.founders?.length,
       b: entity.beneficiaries?.length, sg: entity.signers?.length,
     });
-    return createHash('md5').update(data).digest('hex');
+    return createHash('sha256').update(data).digest('hex').slice(0, 32);
   }
 
   private computeFOPHash(entity: ParsedFOPEntity): string {
@@ -242,7 +242,7 @@ export class DatabaseImporter {
       n: entity.name, s: entity.stan, f: entity.farmer, em: entity.estate_manager,
       r: entity.registration, ti: entity.terminated_info,
     });
-    return createHash('md5').update(data).digest('hex');
+    return createHash('sha256').update(data).digest('hex').slice(0, 32);
   }
 
   private computeFSUHash(entity: ParsedFSUEntity): string {
@@ -251,7 +251,7 @@ export class DatabaseImporter {
       tb: entity.type_branch, s: entity.stan, r: entity.registration,
       ti: entity.terminated_info, f: entity.founders?.length,
     });
-    return createHash('md5').update(data).digest('hex');
+    return createHash('sha256').update(data).digest('hex').slice(0, 32);
   }
 
   // --- Single entity importers with multi-row INSERTs for related tables ---

--- a/mcp_rada/src/adapters/zakon-rada-adapter.ts
+++ b/mcp_rada/src/adapters/zakon-rada-adapter.ts
@@ -67,7 +67,11 @@ export class ZakonRadaAdapter {
     await this.waitForRateLimit();
 
     const lawNumber = this.resolveLawNumber(lawIdentifier);
-    const endpoint = `/laws/show/${lawNumber}`;
+    // Validate lawNumber to prevent SSRF — Ukrainian law numbers contain Cyrillic, digits, slashes, dashes
+    if (/[^\p{L}\p{N}\-_\/\.]/u.test(lawNumber) || lawNumber.includes('..')) {
+      throw new Error(`Invalid law number: ${lawNumber}`);
+    }
+    const endpoint = `/laws/show/${encodeURIComponent(lawNumber)}`;
     logger.info('Fetching law text', { lawIdentifier, lawNumber });
 
     try {


### PR DESCRIPTION
## Summary
Fixes all 28 open GitHub code scanning alerts across 17 files:

- **Critical (4)**: SSRF in zo-adapter, scrape-worker, rada adapters — added path validation
- **Critical (1)**: Code injection in admin terminal — added input length cap + suppression comment (intentional PTY)
- **High (1)**: XSS in OAuth authorize form — escape HTML/JS in template interpolations
- **High (5)**: Path injection in upload routes/service — UUID format validation
- **High (1)**: Zip Slip in sync-all-registries — path traversal check
- **High (2)**: Loop bound injection in document-parser — max length safety cap
- **High (11)**: Polynomial ReDoS in chat-intent-classifier, TemplateClassifier, document-parser, auth — bounded quantifiers
- **High (1)**: Insecure randomness in chat-service — use crypto.randomBytes
- **High (1)**: Biased crypto random in admin-routes — rejection sampling
- **High (1)**: Weak crypto (MD5) in database-importer — replaced with SHA-256
- **High (2)**: Incomplete sanitization in reyestr-download-service — loop-based tag removal

## Test plan
- [x] TypeScript compiles cleanly (mcp_backend, mcp_rada)
- [ ] Verify OAuth login flow still works
- [ ] Verify upload chunk/complete flow
- [ ] Verify court decision scraping
- [ ] Run code scanning workflow to confirm alerts resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all 28 GitHub code scanning security alerts across 17 files to harden auth, uploads, scrapers, and classifiers. Prevents SSRF, XSS, path traversal, ReDoS, and weak/biased randomness.

- **Bug Fixes**
  - Validate and encode paths in Rada/ZO adapters and scrape worker to block SSRF.
  - Escape HTML/JS in OAuth authorize page to prevent XSS.
  - Enforce UUID format for upload IDs and cleanup; add Zip Slip check in registry sync.
  - Bound regex quantifiers and tighten patterns; add 50MB caps in quoted-printable decoding; safer RTF/HTML tag removal loops.
  - Use crypto.randomBytes for IDs and rejection sampling for password generation.
  - Replace MD5 with SHA-256 (32-hex) in database importer.
  - Cap PTY input to 4KB in admin terminal to limit injection surface.

<sup>Written for commit d8130396880d7e76ac6128c19d7f523e0fddffe2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

