### PR TITLE
fix: remove Клієнти from attorney sidebar

### DIFF
--- a/lexwebapp/src/components/Sidebar.tsx
+++ b/lexwebapp/src/components/Sidebar.tsx
@@ -259,9 +259,6 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   // Matters section — company/lawyer roles only
   const isAttorney = user?.userType === 'attorney';
   const mattersSections = [
-    ...(isAttorney ? [
-      { id: 'clients', label: 'Клієнти', icon: Users, route: ROUTES.CLIENTS },
-    ] : []),
     { id: 'matters', label: 'Справи', icon: Briefcase, route: ROUTES.MATTERS },
     ...(isAttorney ? [
       { id: 'time-entries', label: 'Time Entries', icon: Clock, route: ROUTES.TIME_ENTRIES },


### PR DESCRIPTION
## Summary
- Removed "Клієнти" menu item from the Matters section in the sidebar for attorneys
- Already deployed to prod

## Test plan
- [x] Deployed and verified on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Клієнти" (Clients) item from the Matters section in the sidebar for attorney users to clean up navigation.

<sup>Written for commit faeaad72277764d0c7c808b64fceca2d2da81e5c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

