### PR TITLE
feat: remember last viewed consultation on navigation

### DIFF
--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { ArrowLeft, Loader2, Send, Star, CreditCard, CheckCircle, XCircle, Play, MessageSquare } from 'lucide-react';
 import { consultationService, type Consultation, type ConsultationMessage } from '../../services/api/ConsultationService';
 import { useAuth } from '../../contexts/AuthContext';
@@ -40,12 +40,16 @@ export function ConsultationDetailPage() {
       setMessages(m.messages);
     } catch {
       setConsultation(null);
+      sessionStorage.removeItem('lastConsultationId');
     } finally {
       setLoading(false);
     }
   };
 
-  useEffect(() => { load(); }, [id]);
+  useEffect(() => {
+    load();
+    if (id) sessionStorage.setItem('lastConsultationId', id);
+  }, [id]);
   useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' }); }, [messages]);
 
   const handleAction = async (action: string) => {
@@ -119,7 +123,7 @@ export function ConsultationDetailPage() {
     return (
       <div className="max-w-4xl mx-auto p-6 text-center py-20">
         <h2 className="text-xl text-gray-600">Консультацію не знайдено</h2>
-        <button onClick={() => navigate(-1)} className="mt-4 text-indigo-600 hover:underline">Назад</button>
+        <Link to="/consultations?list" className="mt-4 text-indigo-600 hover:underline">Назад</Link>
       </div>
     );
   }
@@ -130,9 +134,9 @@ export function ConsultationDetailPage() {
   return (
     <div className="h-full overflow-y-auto">
     <div className="max-w-4xl mx-auto p-6">
-      <button onClick={() => navigate(-1)} className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-6">
+      <Link to="/consultations?list" className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-6">
         <ArrowLeft className="w-4 h-4" /> Назад до консультацій
-      </button>
+      </Link>
 
       <div className="bg-white border rounded-lg p-6 mb-6">
         <h1 className="text-xl font-bold text-gray-900 mb-2">{consultation.request_title}</h1>

--- a/lexwebapp/src/pages/ConsultationsPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationsPage/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Loader2, CreditCard } from 'lucide-react';
 import { consultationService, type Consultation } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
@@ -17,6 +17,16 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
 
 export function ConsultationsPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Redirect to last viewed consultation unless explicitly navigating to list
+  useEffect(() => {
+    if (searchParams.has('list')) return;
+    const lastId = sessionStorage.getItem('lastConsultationId');
+    if (lastId) {
+      navigate(generateRoute.consultationDetail(lastId), { replace: true });
+    }
+  }, []);
   const [consultations, setConsultations] = useState<Consultation[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- When a lawyer navigates away from consultations and returns via sidebar, the app auto-redirects to the last viewed consultation detail page
- "Назад до консультацій" back button explicitly shows the full consultation list (via `?list` param)
- Last viewed consultation ID stored in `sessionStorage` — cleared if consultation not found

## Test plan
- [ ] Open a consultation detail page, navigate to another section (e.g. Chat), click "Консультації" in sidebar → should open the last viewed consultation
- [ ] Click "Назад до консультацій" → should show the full list (no redirect)
- [ ] Open a consultation that doesn't exist → should clear saved state, back button shows list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-opens the last viewed consultation when returning to Consultations; the “Back to consultations” link now always shows the full list.

- **New Features**
  - Store last consultation ID in sessionStorage and clear it if the consultation is missing.
  - Redirect from /consultations to the saved consultation unless the URL includes ?list.
  - Update “Back to consultations” to link to /consultations?list.

<sup>Written for commit 53788705863bd627d77da90d2775b4909018e333. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

