### PR TITLE
fix: prevent duplicate consultation creation

### DIFF
--- a/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
+++ b/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
@@ -67,6 +67,7 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
   };
 
   const handleSubmit = async () => {
+    if (submitting) return;
     setSubmitting(true);
     setError('');
     try {

--- a/lexwebapp/src/components/consultation/PaymentStep.tsx
+++ b/lexwebapp/src/components/consultation/PaymentStep.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { CheckCircle, Loader2, CreditCard } from 'lucide-react';
 
 interface Props {
@@ -21,12 +21,14 @@ export function PaymentStep({ attorneyName, consultationFee, serviceType, onPaym
   const [paying, setPaying] = useState(false);
   const [paid, setPaid] = useState(false);
   const isFree = !consultationFee || consultationFee === 0;
+  const submittedRef = useRef(false);
 
   useEffect(() => {
-    if (isFree) {
+    if (isFree && !submittedRef.current) {
+      submittedRef.current = true;
       onPaymentComplete();
     }
-  }, [isFree, onPaymentComplete]);
+  }, [isFree]);
 
   const handlePay = () => {
     setPaying(true);


### PR DESCRIPTION
## Summary
- Fixed `PaymentStep` useEffect firing twice for free consultations (unstable `onPaymentComplete` callback ref + React 18 strict mode)
- Added `useRef` guard so the submit fires exactly once
- Added `submitting` guard in `handleSubmit` as secondary protection
- Deleted duplicate consultation record from prod DB

## Root cause
`useEffect([isFree, onPaymentComplete])` — `onPaymentComplete` is `handleSubmit` which gets a new reference on every render, re-triggering the effect.

## Test plan
- [ ] Create a free consultation → verify only 1 record created
- [ ] Create a paid consultation → verify payment flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate consultation creation for free consultations by making the PaymentStep auto-complete run only once and adding a submit guard. Paid consultation flow remains unchanged.

- **Bug Fixes**
  - Guarded PaymentStep useEffect with a ref and removed unstable onPaymentComplete from deps to avoid double runs in React 18 Strict Mode.
  - Added a submitting check in ConsultationRequestModal.handleSubmit to block repeated submissions.

<sup>Written for commit 788c5eec40272124eb3362d0292d974313236bc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

