### PR TITLE
feat: increase global API rate limit to 300 req/min

### DIFF
--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -110,6 +110,6 @@ export const passwordResetRateLimit = createRateLimiter({
 // More specific per-endpoint limiters (auth, chat, etc.) still apply additionally.
 export const globalApiRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 120,
+  maxRequests: 300,
   keyPrefix: 'ratelimit:global-api',
 });

--- a/mcp_openreyestr/src/middleware/rate-limit.ts
+++ b/mcp_openreyestr/src/middleware/rate-limit.ts
@@ -75,7 +75,7 @@ export function createRateLimiter(options: RateLimitOptions) {
 // Global API rate limiter — baseline protection for all /api/ routes (120 req/min per IP)
 export const globalApiRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 120,
+  maxRequests: 300,
   keyPrefix: 'ratelimit:or-global-api',
 });
 

--- a/mcp_rada/src/middleware/rate-limit.ts
+++ b/mcp_rada/src/middleware/rate-limit.ts
@@ -86,6 +86,6 @@ export const webhookRateLimit = createRateLimiter({
 // Global API rate limiter — baseline protection for all /api/ routes (120 req/min per IP)
 export const globalApiRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 120,
+  maxRequests: 300,
   keyPrefix: 'ratelimit:rada-global-api',
 });


### PR DESCRIPTION
## Summary
- Increased global API rate limit from 120 to 300 requests per minute across all 3 services (backend, rada, openreyestr)

## Test plan
- [ ] Deploy to prod and verify no more 429 errors under normal usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the global API rate limit from 120 to 300 requests per minute across Backend, Rada, and OpenReyestr to reduce 429s under normal usage. Endpoint-specific limiters are unchanged; per-IP 60s window remains the same.

<sup>Written for commit cfb5667d1b58d41f366b7dbfaa1c555aaab708ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

