### PR TITLE
fix: enable Express trust proxy behind nginx

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -176,6 +176,7 @@ class HTTPMCPServer {
 
   constructor() {
     this.app = express();
+    this.app.set('trust proxy', 1);
 
     // Initialize core services via factory
     this.services = createBackendCoreServices();

--- a/mcp_backend/src/sse-server.ts
+++ b/mcp_backend/src/sse-server.ts
@@ -36,6 +36,7 @@ class SSEServer {
 
   constructor() {
     this.app = express();
+    this.app.set('trust proxy', 1);
 
     // Initialize core services via factory
     this.services = createBackendCoreServices();


### PR DESCRIPTION
## Summary
- Set `trust proxy` to `1` on both HTTP and SSE Express servers
- Fixes `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` warning from `express-rate-limit` when running behind nginx

## Test plan
- [ ] Deploy to prod and verify warning is gone from logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Express trust proxy (1 hop) on the HTTP and SSE servers to correctly read X-Forwarded-For behind nginx. Fixes express-rate-limit’s ERR_ERL_UNEXPECTED_X_FORWARDED_FOR and stops noisy log warnings.

<sup>Written for commit 546fc0375dca5ed0706d19a414b641a69b14c0de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

