### PR TITLE
feat: increase global API rate limit from 300 to 900 req/min

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -539,7 +539,7 @@ class HTTPMCPServer {
     // Our custom Redis-backed limiters still apply per-route for finer control.
     this.app.use(rateLimit({
       windowMs: 60 * 1000,
-      max: 300,
+      max: 900,
       standardHeaders: true,
       legacyHeaders: false,
       message: { error: 'Too Many Requests', code: 'RATE_LIMIT_EXCEEDED' },

--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -110,6 +110,6 @@ export const passwordResetRateLimit = createRateLimiter({
 // More specific per-endpoint limiters (auth, chat, etc.) still apply additionally.
 export const globalApiRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 300,
+  maxRequests: 900,
   keyPrefix: 'ratelimit:global-api',
 });


### PR DESCRIPTION
## Summary
- Increase global rate limit from 300 to 900 req/min (3x) to handle document preview requests for users with many documents

## Test plan
- [ ] Verify rate limiting still works at 900 req/min threshold
- [ ] Verify document previews load without 429 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the global API rate limit from 300 to 900 requests/minute to reduce 429s during document preview bursts and high-volume usage. Per-route Redis-backed limiters remain unchanged and still apply.

<sup>Written for commit 66bce3c82ac17ca47821b908ebb1c7cba9d4d2a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

