### PR TITLE
feat: document preview — PDF/DOCX thumbnails, folder & bucket fixes

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -449,17 +449,17 @@ export function DocumentsPage() {
       setPreviewLoading(true);
       setPreviewOpen(true);
       try {
-        const isImage = mimeType?.startsWith('image/');
-
-        // For images, fetch both preview URL and full_text (OCR) in parallel
+        // Fetch preview URL and full_text (OCR/parsed text) in parallel
         const [previewResp, docResp] = await Promise.all([
           api.documents.getPreviewUrl(doc.id),
-          isImage ? api.documents.getById(doc.id).catch(() => null) : Promise.resolve(null),
+          api.documents.getById(doc.id).catch(() => null),
         ]);
 
         const { previewUrl, mimeType: serverMime } = previewResp.data;
         const badge = DOC_TYPE_LABELS[doc.type] || doc.type;
         const ocrText = docResp?.data?.full_text ?? undefined;
+        const effectiveMime = serverMime || mimeType;
+        const isImagePreview = effectiveMime?.startsWith('image/');
 
         if (previewUrl) {
           setPreviewDoc({
@@ -469,8 +469,8 @@ export function DocumentsPage() {
             badge,
             content: ocrText || '',
             previewUrl,
-            mimeType: serverMime || mimeType,
-            ...(isImage ? { ocrText: ocrText || '', documentId: doc.id } : {}),
+            mimeType: effectiveMime,
+            ...(isImagePreview ? { ocrText: ocrText || '', documentId: doc.id } : {}),
           });
         } else {
           // No binary preview (vault-stored PDF/image) — load extracted text

--- a/lexwebapp/src/pages/DocumentsPage/types.ts
+++ b/lexwebapp/src/pages/DocumentsPage/types.ts
@@ -93,7 +93,11 @@ export function getFileExtension(doc: VaultDocument): string {
  */
 export function isPreviewableBinary(mimeType?: string): boolean {
   if (!mimeType) return false;
-  return mimeType.startsWith('image/') || mimeType === 'application/pdf' || mimeType.startsWith('video/');
+  return mimeType.startsWith('image/')
+    || mimeType === 'application/pdf'
+    || mimeType.startsWith('video/')
+    || mimeType === 'application/msword'
+    || mimeType === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 }
 
 const EDITABLE_MIME_TYPES = new Set([

--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -947,11 +947,12 @@ Pipeline:
         paramIndex++;
       }
 
-      // Folder path prefix filter
+      // Folder path prefix filter — match exact path OR any sub-path
       if (args.folderPath) {
-        conditions.push(`metadata::jsonb ->> 'folderPath' LIKE $${paramIndex}`);
-        params.push(args.folderPath + '%');
-        paramIndex++;
+        const cleanFolder = args.folderPath.replace(/\/+$/, '');
+        conditions.push(`(metadata::jsonb ->> 'folderPath' = $${paramIndex} OR metadata::jsonb ->> 'folderPath' LIKE $${paramIndex + 1})`);
+        params.push(cleanFolder, cleanFolder + '/%');
+        paramIndex += 2;
       }
 
       // Matter filter

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1337,9 +1337,20 @@ class HTTPMCPServer {
         const doc = result.rows[0];
 
         if (doc.storage_type === 'minio' && doc.metadata?.minioKey) {
-          const isPreviewable = doc.mime_type === 'application/pdf' || doc.mime_type?.startsWith('image/') || doc.mime_type?.startsWith('video/');
-          const url = await this.minioService.getFileUrl(userId, doc.metadata.minioKey, 3600, isPreviewable);
-          res.json({ previewUrl: url, mimeType: doc.mime_type, storageType: 'minio' });
+          const isPreviewable = doc.mime_type === 'application/pdf' || doc.mime_type?.startsWith('image/') || doc.mime_type?.startsWith('video/') || !!doc.metadata?.previewKey;
+          const bucket = doc.metadata?.minioBucket || `user-${userId}`;
+
+          // For documents with a previewKey (JPG thumbnail from PDF/DOCX), serve that instead
+          let previewUrl: string;
+          let previewMime = doc.mime_type;
+          if (doc.metadata?.previewKey) {
+            previewUrl = await this.minioService.getFileUrlFromBucket(bucket, doc.metadata.previewKey, 3600, true);
+            previewMime = 'image/jpeg';
+          } else {
+            previewUrl = await this.minioService.getFileUrlFromBucket(bucket, doc.metadata.minioKey, 3600, isPreviewable);
+          }
+
+          res.json({ previewUrl, mimeType: previewMime, storageType: 'minio' });
         } else {
           // Vault document — no binary preview, content is text
           res.json({ previewUrl: null, mimeType: doc.mime_type, storageType: doc.storage_type || 'vault' });

--- a/mcp_backend/src/services/minio-service.ts
+++ b/mcp_backend/src/services/minio-service.ts
@@ -85,6 +85,39 @@ export class MinioService {
     }
   }
 
+  async getFileUrlFromBucket(
+    bucket: string,
+    objectKey: string,
+    expirySeconds: number = 3600,
+    inline: boolean = false
+  ): Promise<string> {
+    try {
+      const respHeaders: Record<string, string> = {};
+      if (inline) {
+        respHeaders['response-content-disposition'] = 'inline';
+      }
+      let url = await this.client.presignedGetObject(bucket, objectKey, expirySeconds, respHeaders);
+
+      const publicUrl = process.env.MINIO_PUBLIC_URL;
+      if (publicUrl) {
+        const endpoint = process.env.MINIO_ENDPOINT || 'localhost';
+        const port = process.env.MINIO_PORT || '9000';
+        const useSSL = process.env.MINIO_USE_SSL === 'true';
+        const internalOrigin = `${useSSL ? 'https' : 'http'}://${endpoint}:${port}`;
+        url = url.replace(internalOrigin, publicUrl);
+      }
+
+      return url;
+    } catch (error: any) {
+      logger.error('[MinIO] Failed to generate presigned URL', {
+        bucket,
+        key: objectKey,
+        error: error.message,
+      });
+      throw error;
+    }
+  }
+
   async getFileUrl(
     userId: string,
     objectKey: string,


### PR DESCRIPTION
## Summary
- Preview endpoint uses `metadata.minioBucket` instead of deriving from userId (fixes cross-bucket access)
- Documents with `previewKey` (pre-generated JPG thumbnails from PDF/DOCX) now serve image preview + OCR text side-by-side
- Added `getFileUrlFromBucket` to MinioService for explicit bucket access
- Frontend fetches `full_text` for all previewable docs, not just images
- DOCX/DOC added to `isPreviewableBinary` for preview support
- Fixed folder path filter: exact match OR sub-path (trailing slash issue)

## Test plan
- [ ] Open a PDF document in Vault — should show JPG preview on left, text on right
- [ ] Open a DOCX document in Vault — should show JPG preview on left, text on right
- [ ] Open an image document — should show image + OCR as before
- [ ] Navigate folder structure — folders should show their documents correctly
- [ ] Verify presigned URLs work for documents in cross-user buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds JPEG thumbnail previews for PDF/DOCX with side-by-side text in the Vault preview. Also fixes cross-bucket MinIO access and folder path filtering.

- **New Features**
  - Serve previewKey JPEG thumbnails for PDF/DOCX; respond as image/jpeg.
  - Frontend fetches full_text for all previewable docs, not just images.
  - DOC and DOCX added to previewable MIME types.
  - MinioService: added getFileUrlFromBucket for explicit bucket access.

- **Bug Fixes**
  - Preview endpoint uses metadata.minioBucket (not derived from userId) to fix cross-bucket URLs.
  - Folder filter matches exact path or subpaths; handles trailing slashes correctly.

<sup>Written for commit a6d0f5203db1d621bab100e88b650accee830c09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

