### PR TITLE
fix: make procedure_code optional in court practice search

### DIFF
--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -110,7 +110,7 @@ export class ProceduralTools extends BaseToolHandler {
             section_focus: { type: 'array', items: { type: 'string', enum: Object.values(SectionType) } },
             limit: { type: 'number', default: 10 },
           },
-          required: ['procedure_code', 'query'],
+          required: ['query'],
         },
       },
       {
@@ -311,13 +311,6 @@ export class ProceduralTools extends BaseToolHandler {
     const sectionFocus = Array.isArray(args.section_focus) ? args.section_focus : undefined;
     const courtLevel = String(args.court_level || 'SC');
 
-    if (!procedureCode) {
-      const providedValue = args.procedure_code || args.code;
-      throw new Error(
-        `procedure_code must be one of: cpc, gpc, cac, crpc. ` +
-        `Received: ${providedValue ? `'${providedValue}'` : 'undefined'}.`
-      );
-    }
     if (!query) throw new Error('query parameter is required');
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
@@ -326,9 +319,11 @@ export class ProceduralTools extends BaseToolHandler {
     const whereFilters: any[] = [
       ...buildSupremeCourtWhereFilter(courtLevel),
     ];
-    const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
-    if (justiceKind !== null) {
-      whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
+    if (procedureCode) {
+      const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
+      if (justiceKind !== null) {
+        whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
+      }
     }
 
     const searchParams: any = {
@@ -372,7 +367,7 @@ export class ProceduralTools extends BaseToolHandler {
     });
 
     const payload: any = {
-      procedure_code: procedureCode,
+      procedure_code: procedureCode || 'all',
       query,
       time_range: args.time_range,
       applied_filters: {


### PR DESCRIPTION
## Summary
- Reverts `procedure_code` from required to optional in `search_supreme_court_practice` tool
- Users can now search by case number on `/decisions` without selecting a procedural code
- When no code is selected, searches across all legal areas (no `justice_kind` filter)

## Root cause
Commit `97221c1` made `procedure_code` mandatory in the backend schema, but the frontend sends it only when explicitly selected. This broke case-number-only searches.

## Test plan
- [ ] Search by case number without selecting a procedural code on https://legal.org.ua/decisions
- [ ] Search with a specific procedural code still filters correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make procedure_code optional in the Supreme Court practice search so users can search by case number on /decisions without picking a legal area. When no code is selected, the search spans all areas.

- **Bug Fixes**
  - Made procedure_code optional: removed the required schema entry and missing-code error.
  - Only apply justice_kind filter when a procedure_code is provided.
  - Set payload procedure_code to "all" when no code is passed.

<sup>Written for commit 96541ca681797e0c38d944f76b6e4880838699a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

