### PR TITLE
fix: search all courts by default on /decisions

### DIFF
--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -309,7 +309,7 @@ export class ProceduralTools extends BaseToolHandler {
     const query = typeof args.query === 'string' ? args.query.trim() : '';
     const limit = Math.min(50, Math.max(1, Number(args.limit || 10)));
     const sectionFocus = Array.isArray(args.section_focus) ? args.section_focus : undefined;
-    const courtLevel = String(args.court_level || 'SC');
+    const courtLevel = args.court_level ? String(args.court_level) : undefined;
 
     if (!query) throw new Error('query parameter is required');
 
@@ -317,7 +317,7 @@ export class ProceduralTools extends BaseToolHandler {
 
     // Build where-filters for SC instance and justice_kind (procedure type)
     const whereFilters: any[] = [
-      ...buildSupremeCourtWhereFilter(courtLevel),
+      ...(courtLevel ? buildSupremeCourtWhereFilter(courtLevel) : []),
     ];
     if (procedureCode) {
       const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
@@ -371,7 +371,7 @@ export class ProceduralTools extends BaseToolHandler {
       query,
       time_range: args.time_range,
       applied_filters: {
-        court_level: courtLevel,
+        court_level: courtLevel || 'all',
         ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
         ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
       },


### PR DESCRIPTION
## Summary
- When `court_level` is not specified, search all courts instead of only Supreme Court
- Fixes /decisions page returning 0 results for non-SC case numbers

## Test plan
- [ ] Search `369/1855/15-ц` on /decisions without filters — should return results
- [ ] Search with `court_level=SC` explicitly — should still filter to Supreme Court only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Searches on /decisions now query all courts when court_level is not provided. This fixes empty results for non–Supreme Court case numbers while preserving SC-only filtering when explicitly set.

- **Bug Fixes**
  - Remove default 'SC'; apply SC filter only if court_level is provided.
  - Set applied_filters.court_level to 'all' when unspecified.

<sup>Written for commit 8e08e32deeca443ad45b5b8126d9a7adc7817e3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

