### PR TITLE
feat: code splitting & lazy loading for router pages

### DIFF
--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -1,8 +1,10 @@
 /**
  * Router Configuration
  * Defines all application routes and their structure
+ * Uses React.lazy() for code splitting — each page loads on demand
  */
 
+import { Suspense, lazy } from 'react';
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { ROUTES } from './routes';
 import { AuthGuard } from './guards/AuthGuard';
@@ -10,70 +12,102 @@ import { AuthGuard } from './guards/AuthGuard';
 // Layouts
 import { MainLayout } from '../layouts/MainLayout';
 
-// Pages
+// Auth — static import (first page users see)
 import { LoginPage } from '../components/LoginPage';
-import { VerifyEmailPage } from '../components/VerifyEmailPage';
-import { ResetPasswordPage } from '../components/ResetPasswordPage';
-import { ChatPage } from '../pages/ChatPage';
-import { ProfilePage } from '../components/ProfilePage';
-import { BillingDashboard } from '../components/BillingDashboard';
-import { TeamPage } from '../components/team/TeamPage';
-import { JudgesPage } from '../pages/JudgesPage';
-import { LawyersPage } from '../pages/LawyersPage';
-import { ClientsPage } from '../pages/ClientsPage';
-import { HistoryPage } from '../components/HistoryPage';
-import { DecisionsSearchPage } from '../components/DecisionsSearchPage';
-import { PersonDetailPage } from '../pages/PersonDetailPage';
-import { ClientDetailPage } from '../pages/ClientDetailPage';
-import { ClientMessagingPage } from '../pages/ClientMessagingPage';
-import { MattersPage } from '../pages/MattersPage';
-import { MatterDetailPage } from '../pages/MatterDetailPage';
-import { CaseAnalysisPage } from '../components/CaseAnalysisPage';
-import { LegislationMonitoringPage } from '../components/LegislationMonitoringPage';
-import { CourtPracticeAnalysisPage } from '../components/CourtPracticeAnalysisPage';
-import { LegalInitiativesPage } from '../components/LegalInitiativesPage';
-import { LegislationStatisticsPage } from '../components/LegislationStatisticsPage';
-import { VotingAnalysisPage } from '../components/VotingAnalysisPage';
-import { LegalCodesLibraryPage } from '../components/LegalCodesLibraryPage';
-import { HistoricalAnalysisPage } from '../components/HistoricalAnalysisPage';
-import { AdminMonitoringPage } from '../pages/AdminMonitoringPage';
-import { AdminOverviewPage } from '../pages/AdminOverviewPage';
-import { AdminUsersPage } from '../pages/AdminUsersPage';
-import { AdminCostsPage } from '../pages/AdminCostsPage';
-import { AdminDataSourcesPage } from '../pages/AdminDataSourcesPage';
-import { AdminBillingPage } from '../pages/AdminBillingPage';
-import { AdminInfrastructurePage } from '../pages/AdminInfrastructurePage';
-import { AdminContainersPage } from '../pages/AdminContainersPage';
-import { AdminConfigPage } from '../pages/AdminConfigPage';
-import { AdminDBComparePage } from '../pages/AdminDBComparePage';
-import { AdminServicePricingPage } from '../pages/AdminServicePricingPage';
-import { AdminTerminalPage } from '../pages/AdminTerminalPage';
-import { AdminZOStatsPage } from '../pages/AdminZOStatsPage';
-import { AdminUserActivityPage } from '../pages/AdminUserActivityPage';
-import { AdminBulkScrapePage } from '../pages/AdminBulkScrapePage';
-import { DocumentsPage } from '../pages/DocumentsPage';
-import { TimeEntriesPage } from '../pages/TimeEntriesPage';
-import { InvoicesPage } from '../pages/InvoicesPage';
-import { PaymentSuccessPage } from '../pages/PaymentSuccessPage';
-import { PaymentErrorPage } from '../pages/PaymentErrorPage';
-import { OfferPage } from '../pages/OfferPage';
-import { USDataSourcesPage } from '../pages/USDataSourcesPage';
-import { UKDataSourcesPage } from '../pages/UKDataSourcesPage';
-import { DEDataSourcesPage } from '../pages/DEDataSourcesPage';
-import { FRDataSourcesPage } from '../pages/FRDataSourcesPage';
-import { NLDataSourcesPage } from '../pages/NLDataSourcesPage';
-import { EEDataSourcesPage } from '../pages/EEDataSourcesPage';
-import { UADataSourcesPage } from '../pages/UADataSourcesPage';
-import { EUComparisonPage } from '../pages/EUComparisonPage';
-import { BlogPage } from '../pages/BlogPage';
-import { WorkflowsPage } from '../pages/WorkflowsPage';
-import { WorkflowSetDetailPage } from '../pages/WorkflowSetDetailPage';
-import { AttorneySearchPage } from '../pages/AttorneySearchPage';
-import { AttorneyDetailPage } from '../pages/AttorneyDetailPage';
-import { AttorneyProfilePage } from '../pages/AttorneyProfilePage';
-import { ConsultationsPage } from '../pages/ConsultationsPage';
-import { ConsultationDetailPage } from '../pages/ConsultationDetailPage';
-import { AttorneyClientsPage } from '../pages/AttorneyClientsPage';
+
+// Loading spinner for lazy-loaded pages
+const PageLoader = () => (
+  <div className="min-h-screen flex items-center justify-center bg-claude-bg">
+    <div className="w-10 h-10 border-4 border-claude-accent border-t-transparent rounded-full animate-spin" />
+  </div>
+);
+
+// Helper to wrap lazy component in Suspense
+const S = (Component: React.LazyExoticComponent<React.ComponentType<any>>, props?: Record<string, any>) => (
+  <Suspense fallback={<PageLoader />}>
+    <Component {...props} />
+  </Suspense>
+);
+
+// -- Public pages --
+const VerifyEmailPage = lazy(() => import('../components/VerifyEmailPage').then(m => ({ default: m.VerifyEmailPage })));
+const ResetPasswordPage = lazy(() => import('../components/ResetPasswordPage').then(m => ({ default: m.ResetPasswordPage })));
+const PaymentSuccessPage = lazy(() => import('../pages/PaymentSuccessPage').then(m => ({ default: m.PaymentSuccessPage })));
+const PaymentErrorPage = lazy(() => import('../pages/PaymentErrorPage').then(m => ({ default: m.PaymentErrorPage })));
+const OfferPage = lazy(() => import('../pages/OfferPage').then(m => ({ default: m.OfferPage })));
+const BlogPage = lazy(() => import('../pages/BlogPage').then(m => ({ default: m.BlogPage })));
+
+// -- Data Sources (country pages) --
+const USDataSourcesPage = lazy(() => import('../pages/USDataSourcesPage').then(m => ({ default: m.USDataSourcesPage })));
+const UKDataSourcesPage = lazy(() => import('../pages/UKDataSourcesPage').then(m => ({ default: m.UKDataSourcesPage })));
+const DEDataSourcesPage = lazy(() => import('../pages/DEDataSourcesPage').then(m => ({ default: m.DEDataSourcesPage })));
+const FRDataSourcesPage = lazy(() => import('../pages/FRDataSourcesPage').then(m => ({ default: m.FRDataSourcesPage })));
+const NLDataSourcesPage = lazy(() => import('../pages/NLDataSourcesPage').then(m => ({ default: m.NLDataSourcesPage })));
+const EEDataSourcesPage = lazy(() => import('../pages/EEDataSourcesPage').then(m => ({ default: m.EEDataSourcesPage })));
+const UADataSourcesPage = lazy(() => import('../pages/UADataSourcesPage').then(m => ({ default: m.UADataSourcesPage })));
+const EUComparisonPage = lazy(() => import('../pages/EUComparisonPage').then(m => ({ default: m.EUComparisonPage })));
+
+// -- Core app pages --
+const ChatPage = lazy(() => import('../pages/ChatPage').then(m => ({ default: m.ChatPage })));
+const ProfilePage = lazy(() => import('../components/ProfilePage').then(m => ({ default: m.ProfilePage })));
+const BillingDashboard = lazy(() => import('../components/BillingDashboard').then(m => ({ default: m.BillingDashboard })));
+const TeamPage = lazy(() => import('../components/team/TeamPage').then(m => ({ default: m.TeamPage })));
+const DocumentsPage = lazy(() => import('../pages/DocumentsPage').then(m => ({ default: m.DocumentsPage })));
+const HistoryPage = lazy(() => import('../components/HistoryPage').then(m => ({ default: m.HistoryPage })));
+
+// -- Legal entities --
+const JudgesPage = lazy(() => import('../pages/JudgesPage').then(m => ({ default: m.JudgesPage })));
+const LawyersPage = lazy(() => import('../pages/LawyersPage').then(m => ({ default: m.LawyersPage })));
+const ClientsPage = lazy(() => import('../pages/ClientsPage').then(m => ({ default: m.ClientsPage })));
+const PersonDetailPage = lazy(() => import('../pages/PersonDetailPage').then(m => ({ default: m.PersonDetailPage })));
+const ClientDetailPage = lazy(() => import('../pages/ClientDetailPage').then(m => ({ default: m.ClientDetailPage })));
+const ClientMessagingPage = lazy(() => import('../pages/ClientMessagingPage').then(m => ({ default: m.ClientMessagingPage })));
+
+// -- Matters & Time --
+const MattersPage = lazy(() => import('../pages/MattersPage').then(m => ({ default: m.MattersPage })));
+const MatterDetailPage = lazy(() => import('../pages/MatterDetailPage').then(m => ({ default: m.MatterDetailPage })));
+const TimeEntriesPage = lazy(() => import('../pages/TimeEntriesPage').then(m => ({ default: m.TimeEntriesPage })));
+const InvoicesPage = lazy(() => import('../pages/InvoicesPage').then(m => ({ default: m.InvoicesPage })));
+
+// -- Legal analysis --
+const CaseAnalysisPage = lazy(() => import('../components/CaseAnalysisPage').then(m => ({ default: m.CaseAnalysisPage })));
+const DecisionsSearchPage = lazy(() => import('../components/DecisionsSearchPage').then(m => ({ default: m.DecisionsSearchPage })));
+const LegislationMonitoringPage = lazy(() => import('../components/LegislationMonitoringPage').then(m => ({ default: m.LegislationMonitoringPage })));
+const CourtPracticeAnalysisPage = lazy(() => import('../components/CourtPracticeAnalysisPage').then(m => ({ default: m.CourtPracticeAnalysisPage })));
+const LegalInitiativesPage = lazy(() => import('../components/LegalInitiativesPage').then(m => ({ default: m.LegalInitiativesPage })));
+const LegislationStatisticsPage = lazy(() => import('../components/LegislationStatisticsPage').then(m => ({ default: m.LegislationStatisticsPage })));
+const VotingAnalysisPage = lazy(() => import('../components/VotingAnalysisPage').then(m => ({ default: m.VotingAnalysisPage })));
+const LegalCodesLibraryPage = lazy(() => import('../components/LegalCodesLibraryPage').then(m => ({ default: m.LegalCodesLibraryPage })));
+const HistoricalAnalysisPage = lazy(() => import('../components/HistoricalAnalysisPage').then(m => ({ default: m.HistoricalAnalysisPage })));
+
+// -- Attorney/Consultations --
+const AttorneySearchPage = lazy(() => import('../pages/AttorneySearchPage').then(m => ({ default: m.AttorneySearchPage })));
+const AttorneyDetailPage = lazy(() => import('../pages/AttorneyDetailPage').then(m => ({ default: m.AttorneyDetailPage })));
+const AttorneyProfilePage = lazy(() => import('../pages/AttorneyProfilePage').then(m => ({ default: m.AttorneyProfilePage })));
+const ConsultationsPage = lazy(() => import('../pages/ConsultationsPage').then(m => ({ default: m.ConsultationsPage })));
+const ConsultationDetailPage = lazy(() => import('../pages/ConsultationDetailPage').then(m => ({ default: m.ConsultationDetailPage })));
+const AttorneyClientsPage = lazy(() => import('../pages/AttorneyClientsPage').then(m => ({ default: m.AttorneyClientsPage })));
+
+// -- Workflows --
+const WorkflowsPage = lazy(() => import('../pages/WorkflowsPage').then(m => ({ default: m.WorkflowsPage })));
+const WorkflowSetDetailPage = lazy(() => import('../pages/WorkflowSetDetailPage').then(m => ({ default: m.WorkflowSetDetailPage })));
+
+// -- Admin --
+const AdminOverviewPage = lazy(() => import('../pages/AdminOverviewPage').then(m => ({ default: m.AdminOverviewPage })));
+const AdminMonitoringPage = lazy(() => import('../pages/AdminMonitoringPage').then(m => ({ default: m.AdminMonitoringPage })));
+const AdminUsersPage = lazy(() => import('../pages/AdminUsersPage').then(m => ({ default: m.AdminUsersPage })));
+const AdminCostsPage = lazy(() => import('../pages/AdminCostsPage').then(m => ({ default: m.AdminCostsPage })));
+const AdminDataSourcesPage = lazy(() => import('../pages/AdminDataSourcesPage').then(m => ({ default: m.AdminDataSourcesPage })));
+const AdminBillingPage = lazy(() => import('../pages/AdminBillingPage').then(m => ({ default: m.AdminBillingPage })));
+const AdminInfrastructurePage = lazy(() => import('../pages/AdminInfrastructurePage').then(m => ({ default: m.AdminInfrastructurePage })));
+const AdminContainersPage = lazy(() => import('../pages/AdminContainersPage').then(m => ({ default: m.AdminContainersPage })));
+const AdminConfigPage = lazy(() => import('../pages/AdminConfigPage').then(m => ({ default: m.AdminConfigPage })));
+const AdminDBComparePage = lazy(() => import('../pages/AdminDBComparePage').then(m => ({ default: m.AdminDBComparePage })));
+const AdminServicePricingPage = lazy(() => import('../pages/AdminServicePricingPage').then(m => ({ default: m.AdminServicePricingPage })));
+const AdminTerminalPage = lazy(() => import('../pages/AdminTerminalPage').then(m => ({ default: m.AdminTerminalPage })));
+const AdminZOStatsPage = lazy(() => import('../pages/AdminZOStatsPage').then(m => ({ default: m.AdminZOStatsPage })));
+const AdminUserActivityPage = lazy(() => import('../pages/AdminUserActivityPage').then(m => ({ default: m.AdminUserActivityPage })));
+const AdminBulkScrapePage = lazy(() => import('../pages/AdminBulkScrapePage').then(m => ({ default: m.AdminBulkScrapePage })));
 
 export const router = createBrowserRouter([
   {
@@ -82,59 +116,59 @@ export const router = createBrowserRouter([
   },
   {
     path: '/verify-email',
-    element: <VerifyEmailPage />,
+    element: S(VerifyEmailPage),
   },
   {
     path: '/reset-password',
-    element: <ResetPasswordPage />,
+    element: S(ResetPasswordPage),
   },
   {
     path: ROUTES.PAYMENT_SUCCESS,
-    element: <PaymentSuccessPage />,
+    element: S(PaymentSuccessPage),
   },
   {
     path: ROUTES.PAYMENT_ERROR,
-    element: <PaymentErrorPage />,
+    element: S(PaymentErrorPage),
   },
   {
     path: ROUTES.OFFER,
-    element: <OfferPage />,
+    element: S(OfferPage),
   },
   {
     path: ROUTES.US_DATA_SOURCES,
-    element: <USDataSourcesPage />,
+    element: S(USDataSourcesPage),
   },
   {
     path: ROUTES.UK_DATA_SOURCES,
-    element: <UKDataSourcesPage />,
+    element: S(UKDataSourcesPage),
   },
   {
     path: ROUTES.DE_DATA_SOURCES,
-    element: <DEDataSourcesPage />,
+    element: S(DEDataSourcesPage),
   },
   {
     path: ROUTES.FR_DATA_SOURCES,
-    element: <FRDataSourcesPage />,
+    element: S(FRDataSourcesPage),
   },
   {
     path: ROUTES.NL_DATA_SOURCES,
-    element: <NLDataSourcesPage />,
+    element: S(NLDataSourcesPage),
   },
   {
     path: ROUTES.EE_DATA_SOURCES,
-    element: <EEDataSourcesPage />,
+    element: S(EEDataSourcesPage),
   },
   {
     path: ROUTES.UA_DATA_SOURCES,
-    element: <UADataSourcesPage />,
+    element: S(UADataSourcesPage),
   },
   {
     path: ROUTES.EU_COMPARISON,
-    element: <EUComparisonPage />,
+    element: S(EUComparisonPage),
   },
   {
     path: ROUTES.BLOG,
-    element: <BlogPage />,
+    element: S(BlogPage),
   },
   {
     element: <AuthGuard />,
@@ -148,203 +182,203 @@ export const router = createBrowserRouter([
           },
           {
             path: ROUTES.CHAT,
-            element: <ChatPage />,
+            element: S(ChatPage),
           },
           {
             path: ROUTES.PROFILE,
-            element: <ProfilePage />,
+            element: S(ProfilePage),
           },
           {
             path: ROUTES.BILLING,
-            element: <BillingDashboard />,
+            element: S(BillingDashboard),
           },
           {
             path: ROUTES.TEAM,
-            element: <TeamPage />,
+            element: S(TeamPage),
           },
           {
             path: ROUTES.JUDGES,
-            element: <JudgesPage />,
+            element: S(JudgesPage),
           },
           {
             path: ROUTES.JUDGE_DETAIL,
-            element: <PersonDetailPage type="judge" />,
+            element: S(PersonDetailPage, { type: 'judge' }),
           },
           {
             path: ROUTES.LAWYERS,
-            element: <LawyersPage />,
+            element: S(LawyersPage),
           },
           {
             path: ROUTES.LAWYER_DETAIL,
-            element: <PersonDetailPage type="lawyer" />,
+            element: S(PersonDetailPage, { type: 'lawyer' }),
           },
           {
             path: ROUTES.CLIENTS,
-            element: <ClientsPage />,
+            element: S(ClientsPage),
           },
           {
             path: ROUTES.CLIENT_DETAIL,
-            element: <ClientDetailPage />,
+            element: S(ClientDetailPage),
           },
           {
             path: ROUTES.CLIENT_MESSAGING,
-            element: <ClientMessagingPage />,
+            element: S(ClientMessagingPage),
           },
           {
             path: ROUTES.MATTERS,
-            element: <MattersPage />,
+            element: S(MattersPage),
           },
           {
             path: ROUTES.MATTER_DETAIL,
-            element: <MatterDetailPage />,
+            element: S(MatterDetailPage),
           },
           {
             path: ROUTES.TIME_ENTRIES,
-            element: <TimeEntriesPage />,
+            element: S(TimeEntriesPage),
           },
           {
             path: ROUTES.INVOICES,
-            element: <InvoicesPage />,
+            element: S(InvoicesPage),
           },
           {
             path: ROUTES.DOCUMENTS,
-            element: <DocumentsPage />,
+            element: S(DocumentsPage),
           },
           {
             path: ROUTES.DOCUMENTS_FOLDER,
-            element: <DocumentsPage />,
+            element: S(DocumentsPage),
           },
           {
             path: ROUTES.CASE_ANALYSIS,
-            element: <CaseAnalysisPage />,
+            element: S(CaseAnalysisPage),
           },
           {
             path: ROUTES.DECISIONS_SEARCH,
-            element: <DecisionsSearchPage />,
+            element: S(DecisionsSearchPage),
           },
           {
             path: ROUTES.HISTORY,
-            element: <HistoryPage />,
+            element: S(HistoryPage),
           },
           {
             path: ROUTES.LEGISLATION_MONITORING,
-            element: <LegislationMonitoringPage />,
+            element: S(LegislationMonitoringPage),
           },
           {
             path: ROUTES.LEGISLATION_STATISTICS,
-            element: <LegislationStatisticsPage />,
+            element: S(LegislationStatisticsPage),
           },
           {
             path: ROUTES.LEGAL_INITIATIVES,
-            element: <LegalInitiativesPage />,
+            element: S(LegalInitiativesPage),
           },
           {
             path: ROUTES.LEGAL_CODES_LIBRARY,
-            element: <LegalCodesLibraryPage />,
+            element: S(LegalCodesLibraryPage),
           },
           {
             path: ROUTES.VOTING_ANALYSIS,
-            element: <VotingAnalysisPage />,
+            element: S(VotingAnalysisPage),
           },
           {
             path: ROUTES.HISTORICAL_ANALYSIS,
-            element: <HistoricalAnalysisPage />,
+            element: S(HistoricalAnalysisPage),
           },
           {
             path: ROUTES.COURT_PRACTICE_ANALYSIS,
-            element: <CourtPracticeAnalysisPage />,
+            element: S(CourtPracticeAnalysisPage),
           },
           {
             path: ROUTES.ATTORNEYS,
-            element: <AttorneySearchPage />,
+            element: S(AttorneySearchPage),
           },
           {
             path: ROUTES.ATTORNEY_DETAIL,
-            element: <AttorneyDetailPage />,
+            element: S(AttorneyDetailPage),
           },
           {
             path: ROUTES.ATTORNEY_PROFILE_EDIT,
-            element: <AttorneyProfilePage />,
+            element: S(AttorneyProfilePage),
           },
           {
             path: ROUTES.ATTORNEY_CLIENTS,
-            element: <AttorneyClientsPage />,
+            element: S(AttorneyClientsPage),
           },
           {
             path: ROUTES.CONSULTATIONS,
-            element: <ConsultationsPage />,
+            element: S(ConsultationsPage),
           },
           {
             path: ROUTES.CONSULTATION_DETAIL,
-            element: <ConsultationDetailPage />,
+            element: S(ConsultationDetailPage),
           },
           {
             path: ROUTES.WORKFLOWS,
-            element: <WorkflowsPage />,
+            element: S(WorkflowsPage),
           },
           {
             path: ROUTES.WORKFLOW_SET_DETAIL,
-            element: <WorkflowSetDetailPage />,
+            element: S(WorkflowSetDetailPage),
           },
           {
             path: ROUTES.ADMIN_OVERVIEW,
-            element: <AdminOverviewPage />,
+            element: S(AdminOverviewPage),
           },
           {
             path: ROUTES.ADMIN_MONITORING,
-            element: <AdminMonitoringPage />,
+            element: S(AdminMonitoringPage),
           },
           {
             path: ROUTES.ADMIN_USERS,
-            element: <AdminUsersPage />,
+            element: S(AdminUsersPage),
           },
           {
             path: ROUTES.ADMIN_COSTS,
-            element: <AdminCostsPage />,
+            element: S(AdminCostsPage),
           },
           {
             path: ROUTES.ADMIN_DATA_SOURCES,
-            element: <AdminDataSourcesPage />,
+            element: S(AdminDataSourcesPage),
           },
           {
             path: ROUTES.ADMIN_BILLING,
-            element: <AdminBillingPage />,
+            element: S(AdminBillingPage),
           },
           {
             path: ROUTES.ADMIN_INFRASTRUCTURE,
-            element: <AdminInfrastructurePage />,
+            element: S(AdminInfrastructurePage),
           },
           {
             path: ROUTES.ADMIN_CONTAINERS,
-            element: <AdminContainersPage />,
+            element: S(AdminContainersPage),
           },
           {
             path: ROUTES.ADMIN_CONFIG,
-            element: <AdminConfigPage />,
+            element: S(AdminConfigPage),
           },
           {
             path: ROUTES.ADMIN_DB_COMPARE,
-            element: <AdminDBComparePage />,
+            element: S(AdminDBComparePage),
           },
           {
             path: ROUTES.ADMIN_SERVICE_PRICING,
-            element: <AdminServicePricingPage />,
+            element: S(AdminServicePricingPage),
           },
           {
             path: ROUTES.ADMIN_TERMINAL,
-            element: <AdminTerminalPage />,
+            element: S(AdminTerminalPage),
           },
           {
             path: ROUTES.ADMIN_ZO_STATS,
-            element: <AdminZOStatsPage />,
+            element: S(AdminZOStatsPage),
           },
           {
             path: ROUTES.ADMIN_USER_ACTIVITY,
-            element: <AdminUserActivityPage />,
+            element: S(AdminUserActivityPage),
           },
           {
             path: ROUTES.ADMIN_BULK_SCRAPE,
-            element: <AdminBulkScrapePage />,
+            element: S(AdminBulkScrapePage),
           },
         ],
       },

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -19,6 +19,29 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: mode === 'staging' ? 'dist-staging' : 'dist',
       sourcemap: mode === 'staging' || mode === 'development',
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            'admin': [
+              './src/pages/AdminOverviewPage.tsx',
+              './src/pages/AdminMonitoringPage.tsx',
+              './src/pages/AdminUsersPage.tsx',
+              './src/pages/AdminCostsPage.tsx',
+              './src/pages/AdminDataSourcesPage.tsx',
+              './src/pages/AdminBillingPage.tsx',
+              './src/pages/AdminInfrastructurePage.tsx',
+              './src/pages/AdminContainersPage.tsx',
+              './src/pages/AdminConfigPage.tsx',
+              './src/pages/AdminDBComparePage.tsx',
+              './src/pages/AdminServicePricingPage.tsx',
+              './src/pages/AdminTerminalPage.tsx',
+              './src/pages/AdminZOStatsPage.tsx',
+              './src/pages/AdminUserActivityPage.tsx',
+              './src/pages/AdminBulkScrapePage.tsx',
+            ],
+          },
+        },
+      },
     },
     server: {
       host: true,


### PR DESCRIPTION
## Summary
- Replaced 63 static page imports in `lexwebapp/src/router/index.tsx` with `React.lazy()` for on-demand chunk loading
- Only `LoginPage` remains a static import (first page users see)
- Added `PageLoader` spinner component and `S()` Suspense wrapper helper
- Grouped all 15 admin pages into a single `admin` manual chunk in `vite.config.ts`

## Test plan
- [ ] `npx tsc --noEmit` passes (no new type errors)
- [ ] `npm run build` succeeds, output shows separate chunks per page
- [ ] Admin pages grouped into single `admin-*.js` chunk
- [ ] All routes load correctly in dev mode
- [ ] Network tab shows chunks loading on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the router to lazy-loaded pages with React.lazy and Suspense to reduce the initial bundle and load routes on demand. Added a shared loader and grouped all admin routes into one Vite chunk.

- **Refactors**
  - Replaced 63 static page imports with React.lazy; each page loads on navigation.
  - Added PageLoader spinner and S() helper for Suspense fallbacks.
  - Kept LoginPage as a static import (entry screen).
  - Configured Vite manualChunks to bundle 15 admin pages into a single admin-*.js chunk.

<sup>Written for commit 5d8293fcfaf6ad4a658600e95494f94c285d1581. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

