### PR TITLE
perf: remove admin manualChunks and drop unused html2canvas

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -29,7 +29,6 @@
     "docx": "^9.5.3",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.34.0",
-    "html2canvas": "^1.4.1",
     "jspdf": "^4.2.0",
     "lucide-react": "0.574.0",
     "react": "^19.2.4",

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -19,29 +19,6 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: mode === 'staging' ? 'dist-staging' : 'dist',
       sourcemap: mode === 'staging' || mode === 'development',
-      rollupOptions: {
-        output: {
-          manualChunks: {
-            'admin': [
-              './src/pages/AdminOverviewPage.tsx',
-              './src/pages/AdminMonitoringPage.tsx',
-              './src/pages/AdminUsersPage.tsx',
-              './src/pages/AdminCostsPage.tsx',
-              './src/pages/AdminDataSourcesPage.tsx',
-              './src/pages/AdminBillingPage.tsx',
-              './src/pages/AdminInfrastructurePage.tsx',
-              './src/pages/AdminContainersPage.tsx',
-              './src/pages/AdminConfigPage.tsx',
-              './src/pages/AdminDBComparePage.tsx',
-              './src/pages/AdminServicePricingPage.tsx',
-              './src/pages/AdminTerminalPage.tsx',
-              './src/pages/AdminZOStatsPage.tsx',
-              './src/pages/AdminUserActivityPage.tsx',
-              './src/pages/AdminBulkScrapePage.tsx',
-            ],
-          },
-        },
-      },
     },
     server: {
       host: true,


### PR DESCRIPTION
## Summary
- Remove `manualChunks` config from `vite.config.ts` that bundled all 15 admin pages into a single ~1,306KB chunk, defeating the lazy loading introduced in PR #588
- Remove unused `html2canvas` dependency (zero imports in `src/`)
- Each admin page now gets its own chunk (30-190KB), loaded on demand via `React.lazy()`

## Test plan
- [ ] `npx tsc --noEmit` — no new type errors
- [ ] `npm run build` — verify admin pages are separate chunks in output
- [ ] Navigate to admin pages — each loads independently
- [ ] Verify non-admin pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the manualChunks config in vite.config.ts that forced all 15 admin pages into a single ~1.3MB bundle, restoring per-page code splitting and lazy loading. Also removed the unused html2canvas dependency.

<sup>Written for commit 2647b81a9ee09be14ac925f78aec9dbcbbdcf935. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

