### PR TITLE
chore: rename local nginx config and improve smoke tests + catalog page

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -782,7 +782,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/localdev-docker.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/local-docker.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/certs:/etc/nginx/certs:ro
       - certbot_webroot:/var/www/certbot:ro
     depends_on:

--- a/deployment/lib/smoke-test.sh
+++ b/deployment/lib/smoke-test.sh
@@ -116,25 +116,35 @@ check_http_health() {
 
     case $env in
         local)
-            local urls=("https://local.legal.org.ua/health")
-            for url in "${urls[@]}"; do
+            # Primary: test directly via nginx on :80 (bypasses DNS/SSL issues)
+            local domains=("local.legal.org.ua")
+            for domain in "${domains[@]}"; do
                 local attempt=1
                 local passed=false
                 while [ $attempt -le $SMOKE_TEST_RETRIES ]; do
-                    if curl -skf --max-time 10 "$url" > /dev/null 2>&1; then
-                        smoke_record "HTTP health ($url)" "pass" ""
+                    if curl -sf --max-time 10 -H "Host: ${domain}" http://localhost:80/health > /dev/null 2>&1; then
+                        smoke_record "HTTP health direct ($domain)" "pass" ""
                         passed=true
                         break
                     fi
                     if [ $attempt -lt $SMOKE_TEST_RETRIES ]; then
-                        print_msg "$YELLOW" "  Health check attempt $attempt failed for $url, retrying in ${SMOKE_TEST_RETRY_DELAY}s..."
+                        print_msg "$YELLOW" "  Direct health check attempt $attempt failed for $domain, retrying in ${SMOKE_TEST_RETRY_DELAY}s..."
                         sleep "$SMOKE_TEST_RETRY_DELAY"
                     fi
                     attempt=$((attempt + 1))
                 done
                 if [ "$passed" = false ]; then
-                    smoke_record "HTTP health ($url)" "fail" "No response after $SMOKE_TEST_RETRIES attempts"
+                    smoke_record "HTTP health direct ($domain)" "fail" "No response on localhost:80 after $SMOKE_TEST_RETRIES attempts"
                     all_passed=false
+                fi
+            done
+
+            # Secondary: check public HTTPS URL — informational only
+            for domain in "${domains[@]}"; do
+                if curl -skf --max-time 10 "https://${domain}/health" > /dev/null 2>&1; then
+                    smoke_record "HTTP health public ($domain)" "pass" ""
+                else
+                    smoke_record "HTTP health public ($domain)" "warn" "Not reachable via public URL (DNS/SSL may not be configured)"
                 fi
             done
             ;;
@@ -217,26 +227,31 @@ check_http_health() {
 check_frontend_health() {
     local env=$1
 
-    local urls=()
     case $env in
         local)
-            urls=("https://local.legal.org.ua")
+            # Test frontend directly via nginx on :80
+            local domain="local.legal.org.ua"
+            if curl -sf --max-time 10 -H "Host: ${domain}" http://localhost:80/ > /dev/null 2>&1; then
+                smoke_record "Frontend direct ($domain)" "pass" ""
+            else
+                smoke_record "Frontend direct ($domain)" "warn" "Not responding on localhost:80"
+            fi
             ;;
-        prod|production)
-            urls=("https://legal.org.ua" "https://mcp.legal.org.ua")
-            ;;
-        stage|staging)
-            urls=("https://stage.legal.org.ua")
+        prod|production|stage|staging)
+            local urls=()
+            case $env in
+                prod|production) urls=("https://legal.org.ua" "https://mcp.legal.org.ua") ;;
+                stage|staging)   urls=("https://stage.legal.org.ua") ;;
+            esac
+            for url in "${urls[@]}"; do
+                if curl -skf --max-time 10 "$url" > /dev/null 2>&1; then
+                    smoke_record "Frontend ($url)" "pass" ""
+                else
+                    smoke_record "Frontend ($url)" "warn" "Not responding (may need DNS propagation)"
+                fi
+            done
             ;;
     esac
-
-    for url in "${urls[@]}"; do
-        if curl -skf --max-time 10 "$url" > /dev/null 2>&1; then
-            smoke_record "Frontend ($url)" "pass" ""
-        else
-            smoke_record "Frontend ($url)" "warn" "Not responding (may need DNS propagation)"
-        fi
-    done
 }
 
 # Check database connectivity via container exec

--- a/deployment/nginx/local-docker.conf
+++ b/deployment/nginx/local-docker.conf
@@ -27,8 +27,8 @@ server {
     listen [::]:80;
     server_name local.legal.org.ua local.mcp.legal.org.ua usa.legal.org.ua uk.legal.org.ua de.legal.org.ua fr.legal.org.ua nl.legal.org.ua ee.legal.org.ua eu.legal.org.ua ua.legal.org.ua;
 
-    access_log /var/log/nginx/localdev-access.log;
-    error_log /var/log/nginx/localdev-error.log;
+    access_log /var/log/nginx/local-access.log;
+    error_log /var/log/nginx/local-error.log;
 
     client_max_body_size 50M;
 
@@ -343,8 +343,8 @@ server {
     ssl_certificate_key /etc/nginx/certs/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
 
-    access_log /var/log/nginx/localdev-ssl-access.log;
-    error_log /var/log/nginx/localdev-ssl-error.log;
+    access_log /var/log/nginx/local-ssl-access.log;
+    error_log /var/log/nginx/local-ssl-error.log;
 
     client_max_body_size 50M;
 

--- a/lexwebapp/package-lock.json
+++ b/lexwebapp/package-lock.json
@@ -21,7 +21,6 @@
         "docx": "^9.5.3",
         "file-saver": "^2.0.5",
         "framer-motion": "^12.34.0",
-        "html2canvas": "^1.4.1",
         "jspdf": "^4.2.0",
         "lucide-react": "0.574.0",
         "react": "^19.2.4",
@@ -82,6 +81,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1276,6 +1276,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1297,6 +1298,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1306,12 +1308,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1322,6 +1326,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1335,6 +1340,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1344,6 +1350,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2199,6 +2206,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -2771,12 +2779,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2790,6 +2800,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/aria-query": {
@@ -2888,6 +2899,7 @@
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
       "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -2916,6 +2928,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2938,6 +2951,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2997,6 +3011,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3107,6 +3122,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3131,6 +3147,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3180,6 +3197,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3243,6 +3261,7 @@
       "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
       "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
       }
@@ -3608,12 +3627,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/docx": {
@@ -4142,6 +4163,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4158,6 +4180,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4195,6 +4218,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4229,6 +4253,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4356,6 +4381,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4426,6 +4452,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4602,6 +4629,7 @@
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
@@ -4739,6 +4767,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4751,6 +4780,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4776,6 +4806,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4785,6 +4816,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4807,6 +4839,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4864,6 +4897,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -5036,6 +5070,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5048,6 +5083,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -5427,6 +5463,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5999,6 +6036,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -6096,6 +6134,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -6107,6 +6146,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6139,6 +6179,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6148,6 +6189,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6157,6 +6199,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6291,6 +6334,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -6311,12 +6355,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -6329,6 +6375,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6338,6 +6385,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -6347,6 +6395,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6375,6 +6424,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -6392,6 +6442,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6417,6 +6468,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6459,6 +6511,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6484,6 +6537,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6497,6 +6551,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6580,6 +6635,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6752,6 +6808,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6776,6 +6833,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -6936,6 +6994,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -6956,6 +7015,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7021,6 +7081,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7148,6 +7209,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7245,6 +7307,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -7267,6 +7330,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7296,6 +7360,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -7334,6 +7399,7 @@
       "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
       "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "utrie": "^1.0.2"
       }
@@ -7342,6 +7408,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -7351,6 +7418,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -7386,6 +7454,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -7402,6 +7471,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -7419,6 +7489,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7461,6 +7532,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -7542,6 +7614,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -7741,6 +7814,7 @@
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
       "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
       }

--- a/lexwebapp/src/pages/AdminOpenDataCatalogPage.tsx
+++ b/lexwebapp/src/pages/AdminOpenDataCatalogPage.tsx
@@ -9,10 +9,15 @@ import {
   ExternalLink, Search, ChevronDown, ChevronUp,
   Scale, BookOpen, Building2, Database, Landmark, Shield,
   CheckCircle2, Clock, Microscope, CalendarClock,
-  FileSpreadsheet, Globe, Code, FileText,
+  FileSpreadsheet, Globe, Code, FileText, Link2, HardDrive, Timer,
 } from 'lucide-react';
 
 type IntegrationStatus = 'integrated' | 'in_progress' | 'researched' | 'planned';
+
+interface DataLink {
+  label: string;
+  url: string;
+}
 
 interface OpenDataSource {
   name: string;
@@ -28,6 +33,9 @@ interface OpenDataSource {
   notes?: string;
   apiAvailable?: boolean;
   updateFrequency?: string;
+  dataUrls?: DataLink[];
+  volume?: string;
+  integrationEta?: string;
 }
 
 interface SourceDomain {
@@ -71,6 +79,10 @@ const domains: SourceDomain[] = [
         linearTasks: ['LEG-210', 'LEG-212'],
         updateFrequency: 'Щоденно',
         notes: 'Імпорт метаданих завершено на проді. Довідники: 843 суди, 4106 категорій, 5 видів судочинства.',
+        dataUrls: [
+          { label: 'Набір даних (CSV/ZIP)', url: 'https://data.gov.ua/dataset/d9ad7a57-96ab-4e42-b8bc-3b9dbb949e13' },
+        ],
+        volume: '~50 GB (щоденні ZIP-дампи CSV, 8.8M записів)',
       },
       {
         name: 'Court Decisions Registry',
@@ -82,6 +94,10 @@ const domains: SourceDomain[] = [
         formats: ['HTML'],
         linearTasks: ['LEG-91', 'LEG-53', 'LEG-76'],
         notes: 'Document-service offload, semaphore (max 10), rate limiter (200ms). Admin control panel для управління скрапером.',
+        dataUrls: [
+          { label: 'Пошук рішень', url: 'https://reyestr.court.gov.ua/' },
+        ],
+        volume: '100M+ рішень, ~500 GB повних текстів (HTML)',
       },
       {
         name: 'Court Statistics',
@@ -94,6 +110,11 @@ const domains: SourceDomain[] = [
         linearTasks: ['LEG-209'],
         updateFrequency: 'Щоквартально',
         notes: 'URL-патерн передбачуваний, можна автоматизувати. Дані по кожному суду — можна збагатити профіль судді.',
+        dataUrls: [
+          { label: 'Статистичні форми', url: 'https://court.gov.ua/inshe/sudova_statystyka/' },
+        ],
+        volume: '~300 XLS файлів, ~150 MB',
+        integrationEta: '1–2 тижні (парсинг XLS + ETL)',
       },
       {
         name: 'Judiciary Open Data Portal',
@@ -105,6 +126,10 @@ const domains: SourceDomain[] = [
         formats: ['XLS', 'XLSX', 'CSV', 'JSON'],
         linearTasks: ['LEG-47', 'LEG-112'],
         notes: 'Покриває 7 категорій: ЄДРСР (25), статистика (197), кримінальна (22), закупівлі (103), ПІ запити (302), нормативні акти (21), судочинство (126).',
+        dataUrls: [
+          { label: 'Портал відкритих даних', url: 'https://court.gov.ua/opendata/' },
+        ],
+        volume: '814 наборів, ~2 GB (XLS/CSV/JSON)',
       },
       {
         name: 'Register of Debtors',
@@ -115,6 +140,10 @@ const domains: SourceDomain[] = [
         formats: ['API', 'XML'],
         linearTasks: ['LEG-48', 'LEG-105'],
         notes: 'Інтегровано через OpenReyestr MCP tools.',
+        dataUrls: [
+          { label: 'Пошук боржників', url: 'https://erb.minjust.gov.ua/' },
+        ],
+        volume: '~2M записів (виконавчі провадження)',
       },
       {
         name: 'Court Cases Bulk Loader',
@@ -125,6 +154,10 @@ const domains: SourceDomain[] = [
         formats: ['API', 'JSON'],
         linearTasks: ['LEG-43', 'LEG-31'],
         notes: 'Поступово замінюється безкоштовними дампами ЄДРСР з data.gov.ua.',
+        dataUrls: [
+          { label: 'ZakonOnline API', url: 'https://zakononline.com.ua/' },
+        ],
+        volume: '~1M рішень завантажено, ~20 GB текстів',
       },
     ],
   },
@@ -136,23 +169,39 @@ const domains: SourceDomain[] = [
         name: 'Supreme Court Open Data',
         nameUa: 'Відкриті дані Верховного Суду',
         url: 'https://supreme.court.gov.ua/',
-        description: 'Відкриті дані Верховного Суду України: правові позиції, огляди практики, статистика касаційних проваджень.',
+        description: 'Відкриті дані ВС: правові позиції (so.supreme.court.gov.ua/digests), щомісячні огляди 4 касаційних судів (КАС/КГС/ККС/КЦС), дайджести ВП ВС, тематичні аналізи, статистика.',
         status: 'researched',
-        formats: ['HTML', 'JSON'],
+        datasets: '9 наборів на data.gov.ua + 200+ PDF оглядів',
+        formats: ['HTML', 'JSON', 'PDF', 'XLSX'],
         linearTasks: ['LEG-211'],
-        notes: 'Дослідження джерела в рамках OpenData проєкту.',
+        notes: 'Портал правових позицій має JSON-метадані з PDF-посиланнями. 4 касаційні суди публікують щомісячні огляди з 2018 р. data.gov.ua має 9 адмін-наборів (структура, звіти, акти). CC BY-SA 4.0.',
+        dataUrls: [
+          { label: 'Правові позиції (дайджести)', url: 'https://so.supreme.court.gov.ua/digests' },
+          { label: 'Аналіз судової практики', url: 'https://supreme.court.gov.ua/supreme/pokazniki-diyalnosti/analiz/' },
+          { label: 'data.gov.ua (9 наборів)', url: 'https://data.gov.ua/organization/verkhovnyi-sud' },
+          { label: 'Огляди касаційних судів', url: 'https://supreme.court.gov.ua/supreme/pres-centr/info_anons_daidgest_oglyad/' },
+        ],
+        volume: '200+ PDF (огляди 2018–2026), 9 XLSX наборів, ~500 MB',
+        integrationEta: '2–3 тижні (парсинг PDF + JSON-метадані)',
       },
       {
         name: 'VKKS — High Qualification Commission of Judges',
         nameUa: 'ВККС — Вища кваліфікаційна комісія суддів',
-        url: 'https://new.vkksu.gov.ua/rubric/vidkryti-dani',
-        description: 'Відкриті дані ВККС: результати кваліфікаційного оцінювання суддів, рішення щодо кандидатів, дисциплінарні провадження.',
+        url: 'https://data.gov.ua/organization/vyshcha-kvalifikatsiina-komisiia-suddiv-ukrayiny',
+        description: 'Відкриті дані ВККС: результати кваліфікаційного оцінювання, рішення, список суддів (~4820), вакансії, рейтинг кандидатів, декларації доброчесності.',
         status: 'researched',
-        datasets: '8 наборів на data.gov.ua',
-        formats: ['XLS', 'XLSX', 'CSV'],
+        datasets: '19 наборів, 311+ ресурсів на data.gov.ua',
+        formats: ['XLSX', '7Z', 'ZIP', 'CSV'],
         linearTasks: ['LEG-213'],
         apiAvailable: false,
-        notes: 'Оцінка пріоритетності: VERY HIGH. Дані можна зв\'язати з профілями суддів.',
+        notes: 'Пріоритет: VERY HIGH. Рішення ВККС: 139 файлів (541 MB). Список суддів: 86 снапшотів (~4820 суддів). Офіційний сайт vkksu.gov.ua/rubric/vidkryti-dani повертає 403.',
+        dataUrls: [
+          { label: 'data.gov.ua (19 наборів)', url: 'https://data.gov.ua/organization/vyshcha-kvalifikatsiina-komisiia-suddiv-ukrayiny' },
+          { label: 'Рішення ВККС (541 MB)', url: 'https://data.gov.ua/dataset/832a5ac3-ad33-40bc-9d03-f51103aa4b2f' },
+          { label: 'Список суддів (86 файлів)', url: 'https://data.gov.ua/dataset/354d406b-53cc-4788-a384-78b9abaf2ea0' },
+        ],
+        volume: '~600 MB (рішення 541 MB + судді 57 MB)',
+        integrationEta: '1–2 тижні (імпорт XLSX + зв\'язка з профілями суддів)',
       },
       {
         name: 'HACC — High Anti-Corruption Court',
@@ -162,18 +211,31 @@ const domains: SourceDomain[] = [
         status: 'researched',
         formats: ['HTML'],
         linearTasks: ['LEG-213'],
-        notes: 'Розглядається в рамках додаткових джерел судової системи.',
+        notes: 'Розглядається в рамках додаткових джерел судової системи. Рішення ВАКС також доступні в ЄДРСР.',
+        dataUrls: [
+          { label: 'Офіційний сайт ВАКС', url: 'https://hcac.court.gov.ua/' },
+        ],
+        volume: '~5,000 рішень (HTML-скрапінг)',
+        integrationEta: '1 тиждень (рішення вже в ЄДРСР)',
       },
       {
         name: 'HCJ — High Council of Justice',
         nameUa: 'ВРП — Вища рада правосуддя',
         url: 'https://hcj.gov.ua/page/vidkryti-dani',
-        description: 'Реєстр судових справ, дисциплінарні справи суддів, рішення ВРП, скарги на суддів.',
+        description: 'Рішення ВРП, дисциплінарна відповідальність суддів, відсторонення, звільнення, реєстр втручань у діяльність суддів, конкурсні комісії.',
         status: 'researched',
-        datasets: '6 наборів на data.gov.ua',
-        formats: ['XLS', 'CSV'],
+        datasets: '22 набори на data.gov.ua',
+        formats: ['JSON', 'XLSX', 'CSV', 'ZIP'],
         linearTasks: ['LEG-213'],
-        notes: 'Пріоритет: HIGH. Дані доповнюють профіль судді — дисциплінарна історія.',
+        notes: 'Пріоритет: HIGH. Рішення ВРП: 16,533 з поіменним голосуванням (350 MB). Дисципліна: 934 записи (JSON, оновлення 2022). Втручання: 2,637 записів (JSON). Доповнює профіль судді.',
+        dataUrls: [
+          { label: 'data.gov.ua (22 набори)', url: 'https://data.gov.ua/organization/vyshcha-rada-pravosuddia' },
+          { label: 'Рішення ВРП (350 MB)', url: 'https://data.gov.ua/dataset/16a4fb23-e65d-4a4a-956d-32f5f2d14dd4' },
+          { label: 'Дисциплінарна відповідальність', url: 'https://data.gov.ua/dataset/305877d5-f250-4849-a1b7-96d2344fea4e' },
+          { label: 'Реєстр втручань (2637)', url: 'https://data.gov.ua/dataset/a1eaafbc-241d-4099-a752-e99b95ec492c' },
+        ],
+        volume: '22 набори, ~460 MB (рішення 350 MB + інші JSON/XLSX)',
+        integrationEta: '1–2 тижні (JSON-набори — легко парсити)',
       },
       {
         name: 'KDKP — Council of Prosecutors Discipline',
@@ -183,7 +245,12 @@ const domains: SourceDomain[] = [
         status: 'researched',
         formats: ['HTML'],
         linearTasks: ['LEG-213'],
-        notes: 'Дані для розширення охоплення правоохоронної системи.',
+        notes: 'Дані для розширення охоплення правоохоронної системи. Немає API або структурованих даних на data.gov.ua.',
+        dataUrls: [
+          { label: 'Офіційний сайт КДКП', url: 'https://kdkp.gov.ua/' },
+        ],
+        volume: '~500 рішень (HTML-скрапінг)',
+        integrationEta: '1 тиждень (скрапер + парсинг HTML)',
       },
     ],
   },
@@ -203,6 +270,12 @@ const domains: SourceDomain[] = [
         apiAvailable: true,
         updateFrequency: 'Щоденно (deputies 7d, bills 1d, laws 30d cache)',
         notes: 'Інтегровано: deputies, bills, factions, voting, cron sync. Категорії: депутати (179), порядок денний (140), пленарні (115), законопроекти (66), НПБ (61), фінанси (62).',
+        dataUrls: [
+          { label: 'API документація', url: 'https://data.rada.gov.ua/open/main/api' },
+          { label: 'Депутати', url: 'https://data.rada.gov.ua/open/data/mps-sklikanna' },
+          { label: 'Законопроекти', url: 'https://data.rada.gov.ua/open/data/bills_main-sklikanna' },
+        ],
+        volume: '633 наборів, ~2 GB (JSON/XML)',
       },
       {
         name: 'Legislation of Ukraine',
@@ -215,6 +288,10 @@ const domains: SourceDomain[] = [
         linearTasks: ['LEG-106', 'LEG-59', 'LEG-43'],
         apiAvailable: true,
         notes: 'Aliases: constitution, цивільний кодекс, кримінальний кодекс тощо. Секціонування: статті/частини/глави. TCC legislation loader з bylaws та military law.',
+        dataUrls: [
+          { label: 'Пошук законодавства', url: 'https://zakon.rada.gov.ua/laws/main' },
+        ],
+        volume: '12 кодексів (5191 стаття), ~500 MB повних текстів',
       },
       {
         name: 'Draft Legislation System',
@@ -225,6 +302,10 @@ const domains: SourceDomain[] = [
         formats: ['HTML', 'API'],
         linearTasks: ['LEG-99'],
         notes: 'Bills sync з active API endpoint, incremental mode поки не реалізовано (LEG-54).',
+        dataUrls: [
+          { label: 'Пошук законопроектів', url: 'https://itd.rada.gov.ua/billInfo/Bills/CardBillSearch' },
+        ],
+        volume: '~30,000 законопроектів (HTML/API)',
       },
     ],
   },
@@ -235,13 +316,18 @@ const domains: SourceDomain[] = [
       {
         name: 'Legal Entities Registry',
         nameUa: 'Єдиний державний реєстр юридичних осіб, ФОП та ГО',
-        url: 'https://data.gov.ua/dataset/1c7f3815-3259-45e0-bdf1-64dca07ddc10',
+        url: 'https://data.gov.ua/dataset/03cc1239-3988-4451-aa0d-aadb77448714',
         description: 'Реєстр усіх юридичних осіб та ФОП України. EDRPOU import pipeline: validation, resume, diff-based updates.',
         status: 'integrated',
-        formats: ['XML', 'CSV', 'ZIP'],
+        formats: ['ZIP', 'XML'],
         linearTasks: ['LEG-105', 'LEG-48', 'LEG-56'],
         apiAvailable: true,
-        notes: '14 MCP tools для всіх таблиць OpenReyestr. tsvector FTS замість ILIKE. pg_class.reltuples для instant stats.',
+        notes: '14 MCP tools для всіх таблиць OpenReyestr. tsvector FTS замість ILIKE. UO.zip (359 MB) + FOP.zip (508 MB) + FSU.zip.',
+        dataUrls: [
+          { label: 'Набір даних (ЄДР)', url: 'https://data.gov.ua/dataset/03cc1239-3988-4451-aa0d-aadb77448714' },
+          { label: 'UO.zip (359 MB)', url: 'https://data.gov.ua/dataset/03cc1239-3988-4451-aa0d-aadb77448714/resource/d40cc921-39bb-44fd-be06-dc02589f45c6/download/uo.zip' },
+        ],
+        volume: '~1.8M юридичних осіб, ~868 MB (ZIP/XML)',
       },
       {
         name: 'Beneficiaries Registry',
@@ -251,6 +337,10 @@ const domains: SourceDomain[] = [
         status: 'integrated',
         formats: ['XML', 'CSV'],
         linearTasks: ['LEG-48'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/af0f5e2c-d5a4-4c83-b6a9-0ce5a8a7c579' },
+        ],
+        volume: '~800K записів, ~500 MB',
       },
       {
         name: 'Notary Registry',
@@ -260,6 +350,10 @@ const domains: SourceDomain[] = [
         status: 'integrated',
         formats: ['XML', 'CSV'],
         linearTasks: ['LEG-27', 'LEG-57'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/1603f092-68b3-4c25-afef-8632aed79daf' },
+        ],
+        volume: '~8,000 нотаріусів, ~5 MB',
       },
       {
         name: 'Forensic Experts Registry',
@@ -269,6 +363,10 @@ const domains: SourceDomain[] = [
         status: 'integrated',
         formats: ['XML', 'CSV'],
         linearTasks: ['LEG-27', 'LEG-57'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/0a556891-d6ef-4a5f-a182-caac2f7aa9c9' },
+        ],
+        volume: '~12,000 експертів, ~8 MB',
       },
       {
         name: 'Arbitration Managers Registry',
@@ -278,62 +376,95 @@ const domains: SourceDomain[] = [
         status: 'integrated',
         formats: ['XML', 'CSV'],
         linearTasks: ['LEG-27', 'LEG-57'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/78531b7b-e0b1-489f-9924-64144faa7abd' },
+        ],
+        volume: '~1,500 керуючих, ~2 MB',
       },
       {
         name: 'Advocates Registry',
         nameUa: 'Єдиний реєстр адвокатів України (ЄРАУ)',
-        url: 'https://data.gov.ua/dataset/0f420daa-efa9-44c1-a3c0-43f1feae55d8',
+        url: 'https://data.gov.ua/dataset/e1af20b8-c80b-4f2c-bf82-566567ef936e',
         description: 'Повний реєстр адвокатів України з інформацією про свідоцтва, статус, регіон діяльності.',
         status: 'integrated',
-        formats: ['CSV', 'XML'],
+        formats: ['JSON', 'CSV'],
         linearTasks: ['LEG-27', 'LEG-57'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/e1af20b8-c80b-4f2c-bf82-566567ef936e' },
+          { label: 'register-2026-01-27.json (215 MB)', url: 'https://data.gov.ua/dataset/e1af20b8-c80b-4f2c-bf82-566567ef936e/resource/94f6f8b4-8800-4220-8b6d-8769bae283bb/download/register-2026-01-27.json' },
+        ],
+        volume: '~65,000 адвокатів, ~215 MB (JSON)',
       },
       {
         name: 'Appraisers Registry',
         nameUa: 'Реєстр оцінювачів',
-        url: 'https://data.gov.ua/dataset/appraisers',
-        description: 'Реєстр суб\'єктів оціночної діяльності.',
+        url: 'https://data.gov.ua/dataset/23490f8d-d11d-409a-9ead-5c9ca2b1d7f4',
+        description: 'Реєстр суб\'єктів оціночної діяльності. Щотижневі снапшоти з 2018 року.',
         status: 'integrated',
-        formats: ['CSV', 'XML'],
+        formats: ['CSV', 'XLSX'],
         linearTasks: ['LEG-27', 'LEG-57'],
+        dataUrls: [
+          { label: 'Набір даних (763 ресурси)', url: 'https://data.gov.ua/dataset/23490f8d-d11d-409a-9ead-5c9ca2b1d7f4' },
+        ],
+        volume: '~5,000 оцінювачів, ~1 MB (CSV щотижня)',
       },
       {
         name: 'Enforcement Proceedings',
         nameUa: 'Реєстр виконавчих проваджень',
-        url: 'https://data.gov.ua/dataset/enforcement',
+        url: 'https://data.gov.ua/dataset/783b9b50-faba-4cc9-a393-60485e395b1d',
         description: 'Відомості про виконавчі провадження від Державної виконавчої служби.',
         status: 'integrated',
-        formats: ['CSV', 'XML'],
+        formats: ['CSV', 'ZIP'],
         linearTasks: ['LEG-48'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/783b9b50-faba-4cc9-a393-60485e395b1d' },
+          { label: '29-ex_csv_erb.zip (678 MB)', url: 'https://data.gov.ua/dataset/783b9b50-faba-4cc9-a393-60485e395b1d/resource/e6ea76c1-01f4-4bd0-a282-7d92d6ecc2a1/download/29-ex_csv_erb.zip' },
+        ],
+        volume: '~3M проваджень, ~678 MB (ZIP/CSV)',
       },
       {
         name: 'NAIS Legal Acts (EDRNPA)',
         nameUa: 'Нормативно-правові акти (ЕДРНПА)',
-        url: 'https://data.gov.ua/dataset/legal_acts',
-        description: 'Єдиний державний реєстр нормативно-правових актів. Custom EDRNPA parser для multi-section XML.',
+        url: 'https://data.gov.ua/dataset/b22d184c-4826-4e1d-8577-972effc5700c',
+        description: 'Єдиний державний реєстр нормативно-правових актів. Щотижневий ZIP-дамп ~566 MB.',
         status: 'planned',
-        formats: ['XML'],
+        formats: ['ZIP', 'XML'],
         linearTasks: ['LEG-37', 'LEG-57'],
-        notes: 'Домен повертає 403 з data.gov.ua. Потрібно знайти альтернативний endpoint.',
+        notes: 'URL оновлено — набір доступний на data.gov.ua. Щотижневе оновлення.',
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/b22d184c-4826-4e1d-8577-972effc5700c' },
+          { label: '25-edrnpa.zip (566 MB)', url: 'https://data.gov.ua/dataset/b22d184c-4826-4e1d-8577-972effc5700c/resource/5616dd04-949a-489c-8efc-54004293b238/download/25-edrnpa.zip' },
+        ],
+        volume: '~100,000 НПА, ~566 MB (ZIP/XML)',
+        integrationEta: '2–3 тижні (після вирішення проблеми доступу)',
       },
       {
         name: 'FOP (Individual Entrepreneurs)',
         nameUa: 'Реєстр фізичних осіб-підприємців',
-        url: 'https://data.gov.ua/dataset/fop',
+        url: 'https://data.gov.ua/dataset/03cc1239-3988-4451-aa0d-aadb77448714',
         description: 'Повний реєстр ФОП. Паралельний імпорт (streaming + 10 workers), але поки без incremental updates.',
         status: 'integrated',
-        formats: ['XML', 'CSV'],
+        formats: ['ZIP', 'XML'],
         linearTasks: ['LEG-56'],
-        notes: 'Повний ре-імпорт кожного разу. Потрібен hash-based dedup та COPY оптимізація.',
+        notes: 'Повний ре-імпорт кожного разу. FOP.zip (508 MB) + UO.zip (359 MB) + FSU.zip (65 KB). XSD-схеми додаються.',
+        dataUrls: [
+          { label: 'Набір даних (ЄДР)', url: 'https://data.gov.ua/dataset/03cc1239-3988-4451-aa0d-aadb77448714' },
+          { label: 'FOP.zip (508 MB)', url: 'https://data.gov.ua/dataset/03cc1239-3988-4451-aa0d-aadb77448714/resource/c262938f-cce7-4489-a805-2fd7c5a44e0b/download/fop.zip' },
+        ],
+        volume: '~2M ФОП, ~508 MB ZIP (XML windows-1251)',
       },
       {
         name: 'Administrative Units & Streets',
         nameUa: 'Адміністративно-територіальні одиниці та вулиці',
-        url: 'https://data.gov.ua/dataset/admin-units',
-        description: 'Довідник АТО та вулиць України. Додано до OpenReyestr stats endpoint.',
+        url: 'https://data.gov.ua/dataset/2f4beef4-6bba-43d3-9e9e-120c696f1123',
+        description: 'Кодифікатор КАТОТТГ (замінив КОАТУУ). Адміністративно-територіальні одиниці України.',
         status: 'integrated',
-        formats: ['CSV', 'XML'],
+        formats: ['XLSX'],
         linearTasks: ['LEG-48'],
+        dataUrls: [
+          { label: 'КАТОТТГ (XLSX)', url: 'https://data.gov.ua/dataset/2f4beef4-6bba-43d3-9e9e-120c696f1123' },
+        ],
+        volume: '~1.4 MB (XLSX кодифікатор)',
       },
     ],
   },
@@ -345,13 +476,18 @@ const domains: SourceDomain[] = [
         name: 'data.gov.ua',
         nameUa: 'Єдиний державний вебпортал відкритих даних',
         url: 'https://data.gov.ua/',
-        description: 'Центральний портал відкритих даних України з 80,000+ наборами від усіх державних органів. 3-тє місце в Європі (97% зрілості).',
+        description: 'Центральний портал відкритих даних України. CKAN v2.7.2 з повним API. 11,689 розпорядників.',
         status: 'integrated',
-        datasets: '80,000+ наборів',
-        formats: ['CSV', 'XLSX', 'XLS', 'JSON', 'XML', 'ZIP'],
+        datasets: '39,612 наборів, 330,845 ресурсів',
+        formats: ['XLS', 'XLSX', 'CSV', 'JSON', 'XML', 'ZIP'],
         linearTasks: ['LEG-47', 'LEG-112'],
         apiAvailable: true,
-        notes: 'Розподіл форматів: XLSX (16173), CSV (12179), XLS (6992), DOCX (2007), ZIP (1999), JSON (1714), XML (1682), PDF (1521).',
+        notes: 'Розподіл ресурсів: XLS (152K), XLSX (103K), CSV (39K), ZIP (39K), JSON (17K), PDF (14K), XML (14K). Ліміт API: 1000 rows/запит. Без rate limiting.',
+        dataUrls: [
+          { label: 'Каталог наборів', url: 'https://data.gov.ua/dataset' },
+          { label: 'CKAN API v3', url: 'https://data.gov.ua/api/3/' },
+        ],
+        volume: '39,612 наборів, 330,845 файлів',
       },
       {
         name: 'Diia Open Data',
@@ -361,6 +497,11 @@ const domains: SourceDomain[] = [
         status: 'researched',
         formats: ['JSON', 'API'],
         linearTasks: ['LEG-47'],
+        dataUrls: [
+          { label: 'Портал Дія', url: 'https://diia.data.gov.ua/' },
+        ],
+        volume: 'Агрегатор — посилання на data.gov.ua наборі',
+        integrationEta: '1 тиждень (аналіз унікальних наборів)',
       },
     ],
   },
@@ -372,11 +513,18 @@ const domains: SourceDomain[] = [
         name: 'NAZK Asset Declarations',
         nameUa: 'НАЗК — Реєстр декларацій',
         url: 'https://public.nazk.gov.ua/',
-        description: 'Єдиний державний реєстр декларацій осіб, уповноважених на виконання функцій держави. Є API.',
+        description: 'Єдиний державний реєстр декларацій осіб, уповноважених на виконання функцій держави. Публічний API v2 з пошуком, фільтрацією по типу, року, даті.',
         status: 'researched',
         formats: ['API', 'JSON'],
         linearTasks: ['LEG-47'],
         apiAvailable: true,
+        dataUrls: [
+          { label: 'API v2 документація', url: 'https://public.nazk.gov.ua/public_api' },
+          { label: 'Статистика', url: 'https://public.nazk.gov.ua/documents/stats' },
+          { label: 'Пошук декларацій', url: 'https://public.nazk.gov.ua/' },
+        ],
+        volume: '9.8M документів (декларації 2015–2026)',
+        integrationEta: '2–3 тижні (API v2, пагінація до 100 сторінок)',
       },
       {
         name: 'Corruption Offenders Registry',
@@ -386,6 +534,11 @@ const domains: SourceDomain[] = [
         status: 'researched',
         formats: ['CSV', 'JSON'],
         linearTasks: ['LEG-47'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/1b80e5ef-3c57-4090-8c4f-cda687f67721' },
+        ],
+        volume: '~15,000 записів, ~5 MB',
+        integrationEta: '2–3 дні (простий CSV імпорт)',
       },
       {
         name: 'Lustration Registry',
@@ -395,6 +548,11 @@ const domains: SourceDomain[] = [
         status: 'researched',
         formats: ['CSV'],
         linearTasks: ['LEG-47'],
+        dataUrls: [
+          { label: 'Набір даних', url: 'https://data.gov.ua/dataset/8faa71c1-3a54-45e8-8f6e-06c92b1ff8bc' },
+        ],
+        volume: '~1,000 записів, ~500 KB',
+        integrationEta: '1–2 дні (простий CSV імпорт)',
       },
     ],
   },
@@ -411,6 +569,12 @@ const domains: SourceDomain[] = [
         formats: ['API', 'JSON'],
         linearTasks: ['LEG-47'],
         apiAvailable: true,
+        dataUrls: [
+          { label: 'API (OCDS)', url: 'https://public-api.prozorro.gov.ua/' },
+          { label: 'Пошук тендерів', url: 'https://prozorro.gov.ua/search' },
+        ],
+        volume: '~10M тендерів, десятки GB (OCDS JSON)',
+        integrationEta: '3–4 тижні (великий обсяг, OCDS парсинг)',
       },
       {
         name: 'E-Data / Spending.gov.ua',
@@ -421,6 +585,12 @@ const domains: SourceDomain[] = [
         formats: ['API', 'JSON', 'CSV'],
         linearTasks: ['LEG-47'],
         apiAvailable: true,
+        dataUrls: [
+          { label: 'Портал Є-Data', url: 'https://spending.gov.ua/' },
+          { label: 'API транзакцій', url: 'https://api.spending.gov.ua/' },
+        ],
+        volume: 'Мільйони транзакцій, десятки GB',
+        integrationEta: '2–3 тижні (API + агрегація)',
       },
       {
         name: 'SETAM — Seized Property Auctions',
@@ -430,6 +600,11 @@ const domains: SourceDomain[] = [
         status: 'researched',
         formats: ['HTML', 'API'],
         linearTasks: ['LEG-47'],
+        dataUrls: [
+          { label: 'Пошук аукціонів', url: 'https://setam.net.ua/auctions' },
+        ],
+        volume: '~100,000 лотів, ~500 MB',
+        integrationEta: '1–2 тижні (API/скрапінг)',
       },
     ],
   },
@@ -615,7 +790,41 @@ export function AdminOpenDataCatalogPage() {
                               API
                             </span>
                           )}
+                          {source.volume && (
+                            <span className="flex items-center gap-1">
+                              <HardDrive size={11} className="text-claude-subtext/50" />
+                              {source.volume}
+                            </span>
+                          )}
+                          {source.integrationEta && (
+                            <span className="flex items-center gap-1 text-orange-600 font-medium">
+                              <Timer size={11} />
+                              ETA: {source.integrationEta}
+                            </span>
+                          )}
                         </div>
+
+                        {/* Data links */}
+                        {source.dataUrls && source.dataUrls.length > 0 && (
+                          <div className="flex flex-wrap items-center gap-1.5 mt-2">
+                            <span className="flex items-center gap-1 text-[11px] text-claude-subtext/60 mr-1">
+                              <Link2 size={11} />
+                              Дані:
+                            </span>
+                            {source.dataUrls.map(dl => (
+                              <a
+                                key={dl.url}
+                                href={dl.url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-sky-50 text-sky-700 hover:bg-sky-100 transition-colors font-medium"
+                              >
+                                {dl.label}
+                                <ExternalLink size={9} className="opacity-40" />
+                              </a>
+                            ))}
+                          </div>
+                        )}
 
                         {/* Formats */}
                         <div className="flex flex-wrap items-center gap-1.5 mt-2">


### PR DESCRIPTION
## Summary
- Rename `localdev-docker.conf` → `local-docker.conf` for consistency with other config naming
- Update smoke tests to test directly via `localhost:80` instead of public HTTPS URLs (bypasses DNS/SSL issues for local dev)
- Add data URLs, volume, and integration ETA fields to OpenData catalog page

## Test plan
- [ ] `docker compose -f docker-compose.local.yml --env-file .env.local up -d` starts nginx with renamed config
- [ ] Smoke tests pass for local environment
- [ ] OpenData catalog page renders new fields correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes local nginx config naming and makes local smoke tests more reliable by targeting localhost:80. Enhances the OpenData catalog with data links, dataset volumes, and ETA fields to improve discovery and planning.

- **New Features**
  - Smoke tests now hit http://localhost:80 with Host headers; public HTTPS checks are informational to avoid DNS/SSL noise in local.
  - OpenData catalog: added dataUrls, volume, and integrationEta fields with UI badges; populated for key sources.

- **Refactors**
  - Renamed nginx config localdev-docker.conf → local-docker.conf and updated docker-compose mount and log filenames.

<sup>Written for commit a03f89dd20b6cce3dafdfe54bfd626aacc8a073c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

