### PR TITLE
fix(lexwebapp): move hooks before early returns in MatterDetailPage

### DIFF
--- a/lexwebapp/src/pages/MatterDetailPage/index.tsx
+++ b/lexwebapp/src/pages/MatterDetailPage/index.tsx
@@ -81,6 +81,14 @@ export function MatterDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: matter, isLoading, error } = useMatter(id || '');
+  const { matterDetailTab, setMatterDetailTab } = useClientMatterStore();
+  const closeMatter = useCloseMatter();
+  const { data: teamData } = useMatterTeam(matter?.id || '');
+  const { data: clientData } = useClient(matter?.client_id || '');
+  const removeTeamMember = useRemoveTeamMember();
+  const addTeamMember = useAddTeamMember();
+  const [addMemberId, setAddMemberId] = useState('');
+  const [addMemberRole, setAddMemberRole] = useState<MatterTeamRole>('associate');
 
   const onBack = () => {
     navigate(ROUTES.MATTERS);
@@ -109,16 +117,6 @@ export function MatterDetailPage() {
       </div>
     );
   }
-  const { matterDetailTab, setMatterDetailTab } = useClientMatterStore();
-  const closeMatter = useCloseMatter();
-
-  const { data: teamData } = useMatterTeam(matter.id);
-  const { data: clientData } = useClient(matter.client_id);
-  const removeTeamMember = useRemoveTeamMember();
-  const addTeamMember = useAddTeamMember();
-
-  const [addMemberId, setAddMemberId] = useState('');
-  const [addMemberRole, setAddMemberRole] = useState<MatterTeamRole>('associate');
 
   const team = teamData?.members || [];
   const statusConfig = STATUS_CONFIG[matter.status] || STATUS_CONFIG.open;


### PR DESCRIPTION
## Summary
- Fix React error #310 ("Rendered more hooks than during the previous render") on MatterDetailPage
- Hooks (`useClientMatterStore`, `useCloseMatter`, `useMatterTeam`, `useClient`, `useRemoveTeamMember`, `useAddTeamMember`, `useState`) were called **after** early returns for loading/error states, violating React Rules of Hooks
- Moved all hooks before the conditional returns, using optional chaining (`matter?.id || ''`)

## Test plan
- [ ] Navigate to `/matters` and click on any matter — page should render without error
- [ ] Verify loading spinner shows while data is fetching
- [ ] Verify error state shows correctly for invalid matter IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)