### PR TITLE
feat(documents): remove stats panel, add text preview to grid cards

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/DocumentGrid.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentGrid.tsx
@@ -179,18 +179,31 @@ export function DocumentGrid({ documents, onDocumentClick, onView, onEdit, onDel
             className="bg-white rounded-2xl border border-claude-border p-4 hover:shadow-md transition-all group cursor-pointer"
             onClick={() => onDocumentClick(doc)}
           >
-            <div className="flex items-start justify-between mb-3">
-              <div className="p-2 bg-claude-subtext/5 rounded-lg">
-                <Icon size={20} className="text-claude-subtext/50" />
-              </div>
-              <div className="flex items-center gap-1">
+            {/* Content preview area */}
+            <div className="relative mb-3 h-24 rounded-lg bg-claude-subtext/[0.03] border border-claude-border/40 overflow-hidden">
+              {doc.text_preview ? (
+                <p className="p-2.5 text-[11px] leading-[1.4] text-claude-subtext/60 font-sans line-clamp-5 whitespace-pre-line">
+                  {doc.text_preview}
+                </p>
+              ) : (
+                <div className="flex items-center justify-center h-full">
+                  <Icon size={24} className="text-claude-subtext/20" />
+                </div>
+              )}
+              {/* Fade out bottom */}
+              <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white to-transparent" />
+              {/* Type badge overlay */}
+              <div className="absolute top-2 right-2 flex items-center gap-1">
                 <span
-                  className={`inline-flex px-2 py-0.5 text-[10px] font-semibold rounded-md border ${
+                  className={`inline-flex px-1.5 py-0.5 text-[9px] font-semibold rounded-md border ${
                     DOC_TYPE_COLORS[doc.type] || DOC_TYPE_COLORS.other
-                  } font-sans`}
+                  } font-sans backdrop-blur-sm`}
                 >
                   {DOC_TYPE_LABELS[doc.type] || doc.type}
                 </span>
+              </div>
+              {/* Context menu overlay */}
+              <div className="absolute top-1.5 left-1.5">
                 <CardContextMenu
                   doc={doc}
                   onView={onView}

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -30,7 +30,6 @@ import { DocumentTable } from './DocumentTable';
 import { DocumentGrid } from './DocumentGrid';
 import { DocumentViewerModal } from '../../components/DocumentViewerModal';
 import { ClassificationPanel } from './ClassificationPanel';
-import { DocumentStatsPanel } from './DocumentStatsPanel';
 import type { VaultDocument, DocType, ViewMode, SortField, SortOrder } from './types';
 import { isPreviewableBinary } from './types';
 import { processEmlContent } from '../../utils/eml-parser';
@@ -152,7 +151,6 @@ export function DocumentsPage() {
     folders,
     foldersLoading,
     docStats,
-    statsLoading,
     loadDocuments,
     loadFolders,
     loadStats,
@@ -743,8 +741,7 @@ export function DocumentsPage() {
             onStartUpload={handleStartUpload}
           />
 
-          {/* Document Statistics */}
-          <DocumentStatsPanel stats={docStats} loading={statsLoading} />
+          {/* Document Statistics — removed per design */}
 
           {/* Classification Panel */}
           <ClassificationPanel

--- a/lexwebapp/src/pages/DocumentsPage/types.ts
+++ b/lexwebapp/src/pages/DocumentsPage/types.ts
@@ -4,6 +4,7 @@ export interface VaultDocument {
   type: 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';
   storage_type?: 'vault' | 'minio';
   mime_type?: string;
+  text_preview?: string;
   metadata: {
     uploadedAt: string;
     uploadedBy?: string;

--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -994,7 +994,8 @@ Pipeline:
       }
 
       const query = `
-        SELECT id, type, title, metadata, storage_type, mime_type, created_at, updated_at
+        SELECT id, type, title, metadata, storage_type, mime_type, created_at, updated_at,
+               LEFT(full_text, 200) AS text_preview
         FROM documents
         WHERE ${whereClause}
         ORDER BY ${orderClause}
@@ -1017,6 +1018,7 @@ Pipeline:
         storage_type: row.storage_type || 'vault',
         mime_type: row.mime_type || null,
         content: '', // Don't include full content in list
+        text_preview: row.text_preview || '',
         metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata || {},
       }));
 


### PR DESCRIPTION
## Summary
- Remove `DocumentStatsPanel` block (total/classified/costs/storage stats + category badges) from `/documents` page
- Add `text_preview` field to `list_documents` API — returns first 200 chars of `full_text`
- Display text content thumbnail in grid view cards with fade-out gradient and type badge overlay

## Test plan
- [ ] Open `/documents`, verify stats panel is gone
- [ ] Switch to grid view, verify cards show text preview snippet
- [ ] Documents without text show file type icon placeholder
- [ ] List view unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)