### PR TITLE
feat: Nextcloud integration — MCP tools + Docker deployment

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -296,6 +296,11 @@ services:
       MINIO_USE_SSL: "false"
       MINIO_PUBLIC_URL: https://local.legal.org.ua/s3
 
+      # Nextcloud (cloud file storage)
+      NEXTCLOUD_URL: http://nextcloud-local:80
+      NEXTCLOUD_USER: ${NEXTCLOUD_USER:-admin}
+      NEXTCLOUD_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
+
       # Upload temp directory
       UPLOAD_TEMP_DIR: /app/data/uploads
 
@@ -726,6 +731,50 @@ services:
     networks:
       - secondlayer-local
 
+  # ===== Nextcloud (cloud file storage) =====
+
+  nextcloud-db-local:
+    image: postgres:15-alpine
+    container_name: nextcloud-db-local
+    environment:
+      POSTGRES_DB: ${NEXTCLOUD_DB_NAME:-nextcloud}
+      POSTGRES_USER: ${NEXTCLOUD_DB_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-nextcloud_local_pass}
+    volumes:
+      - nextcloud_db_local_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${NEXTCLOUD_DB_USER:-nextcloud}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - secondlayer-local
+
+  nextcloud-local:
+    image: nextcloud:29-apache
+    container_name: nextcloud-local
+    environment:
+      POSTGRES_HOST: nextcloud-db-local
+      POSTGRES_DB: ${NEXTCLOUD_DB_NAME:-nextcloud}
+      POSTGRES_USER: ${NEXTCLOUD_DB_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-nextcloud_local_pass}
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_USER:-admin}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
+      NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud-local localhost local.legal.org.ua"
+      OVERWRITEWEBROOT: /nextcloud
+      OVERWRITEPROTOCOL: https
+    ports:
+      - "8888:80"
+    volumes:
+      - nextcloud_local_data:/var/www/html
+    depends_on:
+      nextcloud-db-local:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - secondlayer-local
+
   # ===== Frontend (Vite dev server in Docker) =====
 
   lexwebapp-deps-local:
@@ -913,6 +962,10 @@ volumes:
   certbot_webroot:
     driver: local
   grafana_local_data:
+    driver: local
+  nextcloud_local_data:
+    driver: local
+  nextcloud_db_local_data:
     driver: local
 
 networks:

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -412,6 +412,61 @@ services:
         reservations:
           memory: 512M
 
+  # Nextcloud - cloud file storage
+  nextcloud-db-prod:
+    image: postgres:15-alpine
+    container_name: nextcloud-db-prod
+    environment:
+      POSTGRES_DB: ${NEXTCLOUD_DB_NAME:-nextcloud}
+      POSTGRES_USER: ${NEXTCLOUD_DB_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-nextcloud_prod_pass}
+    volumes:
+      - nextcloud_db_prod_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${NEXTCLOUD_DB_USER:-nextcloud}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 256M
+    networks:
+      - secondlayer-prod-network
+
+  nextcloud-prod:
+    image: nextcloud:29-apache
+    container_name: nextcloud-prod
+    environment:
+      POSTGRES_HOST: nextcloud-db-prod
+      POSTGRES_DB: ${NEXTCLOUD_DB_NAME:-nextcloud}
+      POSTGRES_USER: ${NEXTCLOUD_DB_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-nextcloud_prod_pass}
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_USER:-admin}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
+      NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud-prod localhost legal.org.ua"
+      OVERWRITEWEBROOT: /nextcloud
+      OVERWRITEPROTOCOL: https
+    ports:
+      - "127.0.0.1:8890:80"
+    volumes:
+      - nextcloud_prod_data:/var/www/html
+    depends_on:
+      nextcloud-db-prod:
+        condition: service_healthy
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+    networks:
+      - secondlayer-prod-network
+
   minio-prod:
     image: minio/minio:latest
     container_name: minio-prod
@@ -529,6 +584,11 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
       MINIO_USE_SSL: "false"
       MINIO_PUBLIC_URL: https://legal.org.ua/s3
+
+      # Nextcloud (cloud file storage)
+      NEXTCLOUD_URL: http://nextcloud-prod:80
+      NEXTCLOUD_USER: ${NEXTCLOUD_USER:-admin}
+      NEXTCLOUD_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
 
       # Upload temp
       UPLOAD_TEMP_DIR: /app/data/uploads
@@ -860,6 +920,10 @@ volumes:
   nginx_prod_logs:
     driver: local
   grafana_prod_data:
+    driver: local
+  nextcloud_prod_data:
+    driver: local
+  nextcloud_db_prod_data:
     driver: local
 
 networks:

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -414,6 +414,49 @@ services:
           memory: 512M
 
   # MinIO - S3-compatible object storage for media/large files
+  # Nextcloud - cloud file storage
+  nextcloud-db-stage:
+    image: postgres:15-alpine
+    container_name: nextcloud-db-stage
+    environment:
+      POSTGRES_DB: ${NEXTCLOUD_DB_NAME:-nextcloud}
+      POSTGRES_USER: ${NEXTCLOUD_DB_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-nextcloud_stage_pass}
+    volumes:
+      - nextcloud_db_stage_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${NEXTCLOUD_DB_USER:-nextcloud}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - secondlayer-stage-network
+
+  nextcloud-stage:
+    image: nextcloud:29-apache
+    container_name: nextcloud-stage
+    environment:
+      POSTGRES_HOST: nextcloud-db-stage
+      POSTGRES_DB: ${NEXTCLOUD_DB_NAME:-nextcloud}
+      POSTGRES_USER: ${NEXTCLOUD_DB_USER:-nextcloud}
+      POSTGRES_PASSWORD: ${NEXTCLOUD_DB_PASSWORD:-nextcloud_stage_pass}
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_USER:-admin}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
+      NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud-stage localhost stage.legal.org.ua"
+      OVERWRITEWEBROOT: /nextcloud
+      OVERWRITEPROTOCOL: https
+    ports:
+      - "127.0.0.1:8889:80"
+    volumes:
+      - nextcloud_stage_data:/var/www/html
+    depends_on:
+      nextcloud-db-stage:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - secondlayer-stage-network
+
   minio-stage:
     image: minio/minio:latest
     container_name: minio-stage
@@ -511,6 +554,11 @@ services:
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
       MINIO_USE_SSL: "false"
       MINIO_PUBLIC_URL: https://stage.legal.org.ua/s3
+
+      # Nextcloud (cloud file storage)
+      NEXTCLOUD_URL: http://nextcloud-stage:80
+      NEXTCLOUD_USER: ${NEXTCLOUD_USER:-admin}
+      NEXTCLOUD_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
 
       # Upload temp directory
       UPLOAD_TEMP_DIR: /app/data/uploads
@@ -934,6 +982,10 @@ volumes:
   nginx_stage_logs:
     driver: local
   grafana_stage_data:
+    driver: local
+  nextcloud_stage_data:
+    driver: local
+  nextcloud_db_stage_data:
     driver: local
 networks:
   secondlayer-stage-network:

--- a/deployment/nginx/includes/nextcloud-proxy.conf
+++ b/deployment/nginx/includes/nextcloud-proxy.conf
@@ -1,0 +1,13 @@
+# Nextcloud reverse proxy (cloud file storage)
+
+location ^~ /nextcloud/ {
+    proxy_pass http://nextcloud-stage:80/nextcloud/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    client_max_body_size 512M;
+}

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -233,6 +233,22 @@ location = /register {
 }
 
 # ==========================================
+# Nextcloud (cloud file storage)
+# ==========================================
+
+location ^~ /nextcloud/ {
+    proxy_pass http://nextcloud-prod:80/nextcloud/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    client_max_body_size 512M;
+}
+
+# ==========================================
 # MinIO S3 Proxy (presigned URLs)
 # ==========================================
 

--- a/deployment/nginx/includes/server-common.conf
+++ b/deployment/nginx/includes/server-common.conf
@@ -19,4 +19,5 @@ client_max_body_size 50M;
 include /etc/nginx/includes/oauth-endpoints.conf;
 include /etc/nginx/includes/mcp-endpoints.conf;
 include /etc/nginx/includes/api-endpoints.conf;
+include /etc/nginx/includes/nextcloud-proxy.conf;
 include /etc/nginx/includes/frontend-routes.conf;

--- a/deployment/nginx/local-docker.conf
+++ b/deployment/nginx/local-docker.conf
@@ -302,6 +302,22 @@ server {
     }
 
     # ==========================================
+    # Nextcloud (cloud file storage)
+    # ==========================================
+
+    location ^~ /nextcloud/ {
+        proxy_pass http://nextcloud-local:80/nextcloud/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        client_max_body_size 512M;
+    }
+
+    # ==========================================
     # MinIO S3 Proxy (presigned URLs)
     # ==========================================
 
@@ -610,6 +626,22 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection "";
         client_body_buffer_size 1m;
+    }
+
+    # ==========================================
+    # Nextcloud (cloud file storage)
+    # ==========================================
+
+    location ^~ /nextcloud/ {
+        proxy_pass http://nextcloud-local:80/nextcloud/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        client_max_body_size 512M;
     }
 
     # ==========================================

--- a/mcp_backend/src/api/tools/nextcloud-tools.ts
+++ b/mcp_backend/src/api/tools/nextcloud-tools.ts
@@ -1,0 +1,180 @@
+/**
+ * Nextcloud Tools — MCP tool handler for Nextcloud file upload & sharing
+ *
+ * 2 tools:
+ * - nextcloud_upload   — завантаження файлу в Nextcloud через WebDAV
+ * - nextcloud_share    — створення посилання для спільного доступу через OCS API
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { NextcloudService } from '../../services/nextcloud-service.js';
+import { logger } from '../../utils/logger.js';
+import fs from 'fs';
+
+export class NextcloudTools extends BaseToolHandler {
+  constructor(private nextcloudService: NextcloudService) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'nextcloud_upload',
+        description: `Завантаження файлу в хмарне сховище Nextcloud
+
+Завантажує файл у Nextcloud через WebDAV. Підтримує завантаження з base64-кодованого вмісту або з локального файлу.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            remote_path: {
+              type: 'string',
+              description: 'Шлях у Nextcloud (напр. "Documents/contracts/file.pdf")',
+            },
+            content_base64: {
+              type: 'string',
+              description: 'Вміст файлу в base64 (альтернатива local_file_path)',
+            },
+            local_file_path: {
+              type: 'string',
+              description: 'Локальний шлях до файлу (альтернатива content_base64)',
+            },
+            content_type: {
+              type: 'string',
+              default: 'application/octet-stream',
+              description: 'MIME тип файлу (напр. "application/pdf", "text/plain")',
+            },
+          },
+          required: ['remote_path'],
+        },
+      },
+      {
+        name: 'nextcloud_share',
+        description: `Створення посилання для спільного доступу до файлу в Nextcloud
+
+Створює публічне посилання або надає доступ конкретному користувачу через OCS Share API.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: {
+              type: 'string',
+              description: 'Шлях до файлу або папки у Nextcloud',
+            },
+            share_type: {
+              type: 'string',
+              enum: ['public_link', 'user'],
+              default: 'public_link',
+              description: 'Тип спільного доступу: public_link (публічне посилання) або user (конкретний користувач)',
+            },
+            share_with: {
+              type: 'string',
+              description: 'Ім\'я користувача для share_type=user',
+            },
+            password: {
+              type: 'string',
+              description: 'Пароль для захисту посилання (необов\'язково)',
+            },
+            expire_date: {
+              type: 'string',
+              description: 'Дата закінчення дії (YYYY-MM-DD)',
+            },
+            permissions: {
+              type: 'number',
+              default: 1,
+              description: 'Права доступу: 1=читання, 2=оновлення, 4=створення, 8=видалення, 16=поширення, 31=усі',
+            },
+          },
+          required: ['path'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    switch (name) {
+      case 'nextcloud_upload':
+        return this.handleUpload(args);
+      case 'nextcloud_share':
+        return this.handleShare(args);
+      default:
+        return null;
+    }
+  }
+
+  private async handleUpload(args: any): Promise<ToolResult> {
+    const remotePath = String(args.remote_path || '').trim();
+    if (!remotePath) {
+      return this.wrapError('remote_path є обов\'язковим параметром');
+    }
+
+    const contentType = args.content_type || 'application/octet-stream';
+
+    try {
+      let result;
+
+      if (args.content_base64) {
+        const buffer = Buffer.from(args.content_base64, 'base64');
+        result = await this.nextcloudService.upload(remotePath, buffer, contentType);
+      } else if (args.local_file_path) {
+        if (!fs.existsSync(args.local_file_path)) {
+          return this.wrapError(`Файл не знайдено: ${args.local_file_path}`);
+        }
+        result = await this.nextcloudService.uploadFromFile(remotePath, args.local_file_path, contentType);
+      } else {
+        return this.wrapError('Необхідно вказати content_base64 або local_file_path');
+      }
+
+      return this.wrapResponse({
+        success: true,
+        message: `Файл завантажено в Nextcloud: ${remotePath}`,
+        path: result.path,
+        size: result.size,
+        content_type: result.contentType,
+      });
+    } catch (error: any) {
+      logger.error('[NextcloudTools] Upload failed', { remotePath, error: error.message });
+      return this.wrapError(`Помилка завантаження: ${error.message}`);
+    }
+  }
+
+  private async handleShare(args: any): Promise<ToolResult> {
+    const path = String(args.path || '').trim();
+    if (!path) {
+      return this.wrapError('path є обов\'язковим параметром');
+    }
+
+    const shareTypeStr = args.share_type || 'public_link';
+    const shareType = shareTypeStr === 'user' ? 0 : 3;
+
+    if (shareType === 0 && !args.share_with) {
+      return this.wrapError('share_with є обов\'язковим для share_type=user');
+    }
+
+    try {
+      const result = await this.nextcloudService.createShare({
+        path,
+        shareType,
+        shareWith: args.share_with,
+        password: args.password,
+        expireDate: args.expire_date,
+        permissions: args.permissions ?? 1,
+      });
+
+      return this.wrapResponse({
+        success: true,
+        message: shareType === 3
+          ? `Створено публічне посилання для: ${path}`
+          : `Надано доступ користувачу ${args.share_with} до: ${path}`,
+        share_id: result.id,
+        url: result.url,
+        token: result.token,
+        path: result.path,
+        share_type: shareTypeStr,
+        permissions: result.permissions,
+        expiration: result.expiration,
+      });
+    } catch (error: any) {
+      logger.error('[NextcloudTools] Share failed', { path, error: error.message });
+      return this.wrapError(`Помилка створення спільного доступу: ${error.message}`);
+    }
+  }
+}

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -73,6 +73,8 @@ import { ServiceProxy } from './services/service-proxy.js';
 import { ServiceType } from './types/gateway.js';
 import { UploadService } from './services/upload-service.js';
 import { MinioService } from './services/minio-service.js';
+import { NextcloudService } from './services/nextcloud-service.js';
+import { NextcloudTools } from './api/tools/nextcloud-tools.js';
 import { createUploadRouter } from './routes/upload-routes.js';
 import { VaultTools } from './api/vault-tools.js';
 import { ConversationService } from './services/conversation-service.js';
@@ -285,6 +287,11 @@ class HTTPMCPServer {
     this.toolRegistry.registerHandler(new LegalActsTools(this.services.zoLegalActsAdapter));
     this.toolRegistry.registerHandler(new ECHRPracticeTools(this.services.zoECHRAdapter));
     logger.info('Core tool handlers registered with ToolRegistry');
+
+    // Initialize Nextcloud integration
+    const nextcloudService = new NextcloudService();
+    this.toolRegistry.registerHandler(new NextcloudTools(nextcloudService));
+    logger.info('Nextcloud tools registered');
 
     // Initialize upload and storage services
     this.uploadService = new UploadService(this.services.db);

--- a/mcp_backend/src/services/nextcloud-service.ts
+++ b/mcp_backend/src/services/nextcloud-service.ts
@@ -1,0 +1,187 @@
+/**
+ * Nextcloud Service — WebDAV upload + OCS Share API wrapper
+ *
+ * Reads config from env vars: NEXTCLOUD_URL, NEXTCLOUD_USER, NEXTCLOUD_PASSWORD
+ */
+
+import { logger } from '../utils/logger.js';
+
+export interface NextcloudUploadResult {
+  path: string;
+  size: number;
+  contentType: string;
+  url: string;
+}
+
+export interface NextcloudShareResult {
+  id: number;
+  url: string;
+  token: string;
+  path: string;
+  shareType: number;
+  permissions: number;
+  expiration: string | null;
+}
+
+export class NextcloudService {
+  private baseUrl: string;
+  private user: string;
+  private password: string;
+
+  constructor() {
+    this.baseUrl = (process.env.NEXTCLOUD_URL || 'http://localhost:8888').replace(/\/$/, '');
+    this.user = process.env.NEXTCLOUD_USER || 'admin';
+    this.password = process.env.NEXTCLOUD_PASSWORD || 'admin';
+
+    logger.info('[Nextcloud] Service initialized', {
+      baseUrl: this.baseUrl,
+      user: this.user,
+    });
+  }
+
+  private get authHeader(): string {
+    return 'Basic ' + Buffer.from(`${this.user}:${this.password}`).toString('base64');
+  }
+
+  private get davBaseUrl(): string {
+    return `${this.baseUrl}/remote.php/dav/files/${this.user}`;
+  }
+
+  /**
+   * Health check — GET /status.php
+   */
+  async healthCheck(): Promise<{ installed: boolean; version: string }> {
+    const res = await fetch(`${this.baseUrl}/status.php`, {
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      throw new Error(`Nextcloud health check failed: ${res.status} ${res.statusText}`);
+    }
+    return res.json() as Promise<{ installed: boolean; version: string }>;
+  }
+
+  /**
+   * Create directory via WebDAV MKCOL (recursive)
+   */
+  async mkdirp(remotePath: string): Promise<void> {
+    const parts = remotePath.replace(/^\/+/, '').split('/').filter(Boolean);
+    let current = '';
+    for (const part of parts) {
+      current += '/' + part;
+      const url = `${this.davBaseUrl}${current}`;
+      const res = await fetch(url, {
+        method: 'MKCOL',
+        headers: { Authorization: this.authHeader },
+      });
+      // 201 = created, 405 = already exists — both OK
+      if (!res.ok && res.status !== 405) {
+        const body = await res.text();
+        throw new Error(`MKCOL ${current} failed: ${res.status} ${body}`);
+      }
+    }
+  }
+
+  /**
+   * Upload file content via WebDAV PUT
+   */
+  async upload(remotePath: string, content: Buffer, contentType: string): Promise<NextcloudUploadResult> {
+    // Ensure parent directory exists
+    const dir = remotePath.substring(0, remotePath.lastIndexOf('/'));
+    if (dir) {
+      await this.mkdirp(dir);
+    }
+
+    const url = `${this.davBaseUrl}/${remotePath.replace(/^\/+/, '')}`;
+
+    const res = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        Authorization: this.authHeader,
+        'Content-Type': contentType || 'application/octet-stream',
+      },
+      body: content,
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`WebDAV PUT failed: ${res.status} ${body}`);
+    }
+
+    logger.info('[Nextcloud] File uploaded', { path: remotePath, size: content.length });
+
+    return {
+      path: remotePath,
+      size: content.length,
+      contentType,
+      url: `${this.baseUrl}/remote.php/dav/files/${this.user}/${remotePath.replace(/^\/+/, '')}`,
+    };
+  }
+
+  /**
+   * Upload from local file path
+   */
+  async uploadFromFile(remotePath: string, localFilePath: string, contentType: string): Promise<NextcloudUploadResult> {
+    const fs = await import('fs');
+    const content = fs.readFileSync(localFilePath);
+    return this.upload(remotePath, content, contentType);
+  }
+
+  /**
+   * Create share link or user share via OCS API
+   *
+   * shareType: 0 = user, 3 = public_link
+   * permissions: 1 = read, 2 = update, 4 = create, 8 = delete, 16 = share, 31 = all
+   */
+  async createShare(options: {
+    path: string;
+    shareType: number;
+    shareWith?: string;
+    password?: string;
+    expireDate?: string;
+    permissions?: number;
+  }): Promise<NextcloudShareResult> {
+    const url = `${this.baseUrl}/ocs/v2.php/apps/files_sharing/api/v1/shares`;
+
+    const body = new URLSearchParams();
+    body.append('path', options.path);
+    body.append('shareType', String(options.shareType));
+    if (options.shareWith) body.append('shareWith', options.shareWith);
+    if (options.password) body.append('password', options.password);
+    if (options.expireDate) body.append('expireDate', options.expireDate);
+    if (options.permissions !== undefined) body.append('permissions', String(options.permissions));
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: this.authHeader,
+        'OCS-APIRequest': 'true',
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`OCS share creation failed: ${res.status} ${text}`);
+    }
+
+    const json = await res.json() as any;
+    const data = json.ocs?.data;
+    if (!data) {
+      throw new Error('Unexpected OCS response: missing ocs.data');
+    }
+
+    logger.info('[Nextcloud] Share created', { path: options.path, shareType: options.shareType, id: data.id });
+
+    return {
+      id: data.id,
+      url: data.url,
+      token: data.token,
+      path: data.path,
+      shareType: data.share_type,
+      permissions: data.permissions,
+      expiration: data.expiration || null,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `NextcloudService` (WebDAV upload + OCS Share API wrapper) and `NextcloudTools` handler with 2 MCP tools: `nextcloud_upload` and `nextcloud_share`
- Add Nextcloud + Nextcloud DB containers to all 3 Docker Compose environments (local:8888, stage:8889, prod:8890)
- Add `/nextcloud/` nginx reverse proxy location blocks for all environments with 512M upload limit

## Test plan

- [ ] `cd mcp_backend && npm run build` — no TS errors
- [ ] `cd deployment && docker compose -f docker-compose.local.yml --env-file .env.local up -d nextcloud-db-local nextcloud-local` — containers start healthy
- [ ] `curl http://localhost:8888/status.php` — Nextcloud responds
- [ ] Call `POST /api/tools/nextcloud_upload` with base64 content — upload succeeds
- [ ] Call `POST /api/tools/nextcloud_share` with public_link — returns share URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)