### PR TITLE
Add Ishihara-style profile banner generation

### DIFF
--- a/lexwebapp/src/pages/ProfilePage/ProfileHeader.tsx
+++ b/lexwebapp/src/pages/ProfilePage/ProfileHeader.tsx
@@ -23,7 +23,11 @@ export function ProfileHeader({
       transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
       className="relative bg-white rounded-2xl p-6 md:p-8 border border-claude-border shadow-sm overflow-hidden"
     >
-      <div className="absolute top-0 left-0 w-full h-32 bg-gradient-to-r from-claude-accent/10 to-claude-bg" />
+      {user?.banner ? (
+        <img src={user.banner} alt="" className="absolute top-0 left-0 w-full h-32 object-cover" />
+      ) : (
+        <div className="absolute top-0 left-0 w-full h-32 bg-gradient-to-r from-claude-accent/10 to-claude-bg" />
+      )}
 
       <div className="relative flex flex-col md:flex-row items-start md:items-end gap-6 pt-12">
         <div className="relative group">

--- a/lexwebapp/src/types/models/User.ts
+++ b/lexwebapp/src/types/models/User.ts
@@ -10,6 +10,7 @@ export interface User {
   email: string;
   name: string;
   picture?: string;
+  banner?: string;
   emailVerified?: boolean;
   lastLogin?: string;
   createdAt?: string;

--- a/mcp_backend/src/config/passport.ts
+++ b/mcp_backend/src/config/passport.ts
@@ -7,7 +7,15 @@ import passport from 'passport';
 import { Strategy as GoogleStrategy } from 'passport-google-oauth20';
 import { Database } from '../database/database.js';
 import { UserService } from '../services/user-service.js';
+import { BannerService } from '../services/banner-service.js';
 import { logger } from '../utils/logger.js';
+
+let passportBannerService: BannerService | null = null;
+
+/** Set the banner service for passport. Call from composition root. */
+export function setPassportBannerService(svc: BannerService): void {
+  passportBannerService = svc;
+}
 
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID || '';
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET || '';
@@ -83,6 +91,13 @@ export function configurePassport(db: Database): typeof passport {
 
           await userService.updateLastLogin(user.id);
           logger.info('New Google user created', { userId: user.id, email });
+
+          // Generate banner (fire and forget)
+          if (passportBannerService) {
+            passportBannerService.generateBanner(user.id, user.name || user.email).catch((err) => {
+              logger.error('[Banner] Async generation failed for OAuth user', { userId: user.id, error: err.message });
+            });
+          }
 
           return done(null, user);
         } catch (error: any) {

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -13,11 +13,13 @@ import { logger } from '../utils/logger.js';
 import { getUserService, getWebAuthnService } from '../middleware/dual-auth.js';
 import { EmailService } from '../services/email-service.js';
 import { MinioService } from '../services/minio-service.js';
+import { BannerService } from '../services/banner-service.js';
 import type { ICachePort } from '../domain/ports/index.js';
 
 let authCache: ICachePort | null = null;
 let authEmailService: EmailService | null = null;
 let authMinioService: MinioService | null = null;
+let authBannerService: BannerService | null = null;
 
 const AVATAR_BUCKET = 'avatars';
 const AVATAR_MAX_SIZE = 512; // px
@@ -41,6 +43,22 @@ export function setAuthEmailService(svc: EmailService): void {
 /** Set the MinIO service for avatar storage. Call from composition root. */
 export function setAuthMinioService(svc: MinioService): void {
   authMinioService = svc;
+}
+
+/** Set the banner service for profile banner generation. Call from composition root. */
+export function setAuthBannerService(svc: BannerService): void {
+  authBannerService = svc;
+}
+
+/**
+ * Fire-and-forget banner generation for a new user.
+ * Logs errors but never throws.
+ */
+function generateBannerAsync(userId: string, name: string): void {
+  if (!authBannerService) return;
+  authBannerService.generateBanner(userId, name).catch((err) => {
+    logger.error('[Banner] Async generation failed', { userId, error: err.message });
+  });
 }
 
 const JWT_SECRET = process.env.JWT_SECRET || 'change-this-secret-in-production';
@@ -134,6 +152,7 @@ export async function getCurrentUser(req: AuthenticatedRequest, res: Response): 
         email: user.email,
         name: user.name,
         picture: user.picture,
+        banner: user.banner || null,
         emailVerified: user.email_verified,
         lastLogin: user.last_login,
         createdAt: user.created_at,
@@ -419,6 +438,7 @@ export async function loginWithPassword(req: Request, res: Response): Promise<Re
         email: user.email,
         name: user.name,
         picture: user.picture,
+        banner: user.banner || null,
         emailVerified: user.email_verified,
         lastLogin: user.last_login,
         createdAt: user.created_at,
@@ -500,6 +520,9 @@ export async function registerWithPassword(req: Request, res: Response): Promise
 
     // Create user
     const user = await userService.createUserWithPassword({ email, password, name });
+
+    // Generate banner (fire and forget)
+    generateBannerAsync(user.id, user.name || user.email);
 
     // Create verification token and send email
     const verificationToken = await userService.createVerificationToken(user.id);
@@ -804,6 +827,7 @@ export async function webauthnAuthVerify(req: Request, res: Response): Promise<R
         email: user.email,
         name: user.name,
         picture: user.picture,
+        banner: user.banner || null,
         emailVerified: user.email_verified,
         lastLogin: user.last_login,
         createdAt: user.created_at,
@@ -1023,5 +1047,68 @@ export async function getAvatar(req: Request, res: Response): Promise<void> {
       logger.error('[Avatar] Serve failed:', error);
       res.status(500).json({ error: 'Internal server error' });
     }
+  }
+}
+
+// ============================================================================
+// Banner (Ishihara-style) Endpoints
+// ============================================================================
+
+/**
+ * Serve user banner from MinIO
+ * Public endpoint - serves banner by userId with caching headers
+ */
+export async function getBanner(req: Request, res: Response): Promise<void> {
+  try {
+    const userId = req.params.userId as string;
+    if (!userId) {
+      res.status(400).json({ error: 'Bad Request', message: 'User ID is required' });
+      return;
+    }
+
+    if (!authBannerService) {
+      res.status(503).json({ error: 'Service Unavailable' });
+      return;
+    }
+
+    const stream = await authBannerService.getBannerStream(userId);
+    if (!stream) {
+      res.status(404).json({ error: 'Not Found', message: 'Банер не знайдено' });
+      return;
+    }
+
+    res.setHeader('Content-Type', 'image/webp');
+    res.setHeader('Cache-Control', 'public, max-age=86400, stale-while-revalidate=604800');
+    stream.pipe(res);
+  } catch (error: any) {
+    logger.error('[Banner] Serve failed:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+/**
+ * Regenerate banner for the current user
+ * Protected route - requires JWT
+ */
+export async function regenerateBanner(req: AuthenticatedRequest, res: Response): Promise<Response> {
+  try {
+    const user = req.user;
+    if (!user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    if (!authBannerService) {
+      return res.status(503).json({ error: 'Service Unavailable', message: 'Banner service not configured' });
+    }
+
+    const bannerPath = await authBannerService.generateBanner(user.id, user.name || 'User');
+
+    return res.json({
+      success: true,
+      banner: bannerPath,
+    });
+  } catch (error: any) {
+    logger.error('[Banner] Regeneration failed:', error);
+    return res.status(500).json({ error: 'Internal server error', message: error.message });
   }
 }

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -7,7 +7,9 @@ import { logger } from './utils/logger.js';
 import { dualAuth, requireJWT, optionalJWT, initializeDualAuth, initializeWebAuthn, AuthenticatedRequest as DualAuthRequest } from './middleware/dual-auth.js';
 import { configurePassport } from './config/passport.js';
 import authRouter from './routes/auth.js';
-import { setAuthCache, setAuthEmailService, setAuthMinioService } from './controllers/auth.js';
+import { setAuthCache, setAuthEmailService, setAuthMinioService, setAuthBannerService } from './controllers/auth.js';
+import { BannerService } from './services/banner-service.js';
+import { setPassportBannerService } from './config/passport.js';
 import { createBackendCoreServices, BackendCoreServices } from './factories/core-services.js';
 import { DocumentAnalysisTools } from './api/document-analysis-tools.js';
 import { BatchDocumentTools } from './api/batch-document-tools.js';
@@ -310,7 +312,10 @@ class HTTPMCPServer {
     this.conversationService = new ConversationService(this.services.db);
     this.gdprService = new GdprService(this.services.db, this.minioService, this.services.embeddingService);
     setAuthMinioService(this.minioService);
-    logger.info('Upload and MinIO services initialized');
+    const bannerService = new BannerService(this.minioService, this.services.db);
+    setAuthBannerService(bannerService);
+    setPassportBannerService(bannerService);
+    logger.info('Upload, MinIO, and Banner services initialized');
     logger.info('Conversation and GDPR services initialized');
 
     // Initialize Client-Matter segregation services

--- a/mcp_backend/src/migrations/073_add_user_banner.sql
+++ b/mcp_backend/src/migrations/073_add_user_banner.sql
@@ -1,0 +1,4 @@
+-- Migration: 073_add_user_banner
+-- Add banner column to users table for Ishihara-style profile banners
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS banner VARCHAR(500);

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -155,6 +155,20 @@ router.post('/avatar', requireJWT as any, avatarUpload.single('avatar'), authCon
  */
 router.get('/avatar/:userId', authController.getAvatar as any);
 
+/**
+ * @route   GET /auth/banner/:userId
+ * @desc    Serve user banner image (Ishihara-style)
+ * @access  Public (cached)
+ */
+router.get('/banner/:userId', authController.getBanner as any);
+
+/**
+ * @route   POST /auth/banner/regenerate
+ * @desc    Regenerate banner for current user
+ * @access  Protected (JWT required)
+ */
+router.post('/banner/regenerate', requireJWT as any, authController.regenerateBanner as any);
+
 // ============================================================================
 // WebAuthn (Passkeys) Routes
 // ============================================================================

--- a/mcp_backend/src/scripts/generate-banners.ts
+++ b/mcp_backend/src/scripts/generate-banners.ts
@@ -1,0 +1,58 @@
+/**
+ * Generate Ishihara-style banners for all users without banners
+ * Usage: npx tsx src/scripts/generate-banners.ts
+ */
+
+import { Database } from '../database/database.js';
+import { MinioService } from '../services/minio-service.js';
+import { BannerService } from '../services/banner-service.js';
+import { logger } from '../utils/logger.js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+async function generateBanners() {
+  const db = new Database();
+  const minioService = new MinioService();
+  const bannerService = new BannerService(minioService, db);
+
+  try {
+    await db.connect();
+    console.log('\n========================================');
+    console.log('Generate User Banners');
+    console.log('========================================\n');
+
+    // Find all users without banners
+    const result = await db.query(
+      'SELECT id, name, email FROM users WHERE banner IS NULL'
+    );
+
+    const users = result.rows;
+    console.log(`Found ${users.length} users without banners\n`);
+
+    let success = 0;
+    let failed = 0;
+
+    for (const user of users) {
+      try {
+        const displayName = user.name || user.email;
+        await bannerService.generateBanner(user.id, displayName);
+        success++;
+        console.log(`  [OK] ${user.email} (${displayName})`);
+      } catch (err: any) {
+        failed++;
+        console.error(`  [FAIL] ${user.email}: ${err.message}`);
+      }
+    }
+
+    console.log(`\nDone: ${success} generated, ${failed} failed`);
+  } catch (error) {
+    logger.error('Failed to generate banners:', error);
+    console.error('Error:', error);
+    process.exit(1);
+  } finally {
+    await db.close();
+  }
+}
+
+generateBanners();

--- a/mcp_backend/src/services/banner-service.ts
+++ b/mcp_backend/src/services/banner-service.ts
@@ -1,0 +1,226 @@
+/**
+ * Banner Service
+ * Generates Ishihara-style color blindness test banners where the user's name
+ * is hidden within colored dots.
+ */
+
+import sharp from 'sharp';
+import { logger } from '../utils/logger.js';
+import { MinioService } from './minio-service.js';
+import type { IDatabase } from '../domain/ports/index.js';
+
+const BANNER_WIDTH = 800;
+const BANNER_HEIGHT = 200;
+const BANNER_BUCKET = 'banners';
+const BANNER_QUALITY = 85;
+
+// Circle size range
+const MIN_RADIUS = 4;
+const MAX_RADIUS = 18;
+
+// Color palettes for Ishihara effect
+const BACKGROUND_COLORS = [
+  '#2E8B57', '#3CB371', '#66CDAA', '#8FBC8F', '#20B2AA',
+  '#2E9959', '#4CAF6E', '#5BB882', '#3DA06B', '#48B577',
+  '#279E5E', '#55C285', '#6ECE9A', '#459F6E', '#38A863',
+];
+
+const TEXT_COLORS = [
+  '#CD5C5C', '#E9967A', '#FA8072', '#F08080', '#DC143C',
+  '#D96B6B', '#E8826E', '#F4907A', '#E07474', '#D45858',
+  '#C94E4E', '#D77165', '#EB8B78', '#CE6262', '#DB6F5F',
+];
+
+/**
+ * Simple seeded PRNG (mulberry32)
+ */
+function seededRandom(seed: number): () => number {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Hash a string to a numeric seed
+ */
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+/**
+ * Check if a point falls within rendered text using a bitmap approach.
+ * We render the text onto a small canvas via sharp and sample pixel values.
+ */
+async function createTextMask(name: string, width: number, height: number): Promise<boolean[][]> {
+  const displayName = name.length > 20 ? name.substring(0, 20) : name;
+  const fontSize = Math.min(72, Math.max(36, Math.floor(600 / Math.max(displayName.length, 1))));
+
+  // Create SVG with just the text (white text on black background)
+  const textSvg = `<svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
+    <rect width="${width}" height="${height}" fill="black"/>
+    <text x="${width / 2}" y="${height / 2 + fontSize / 3}"
+          font-family="Arial, Helvetica, sans-serif"
+          font-size="${fontSize}" font-weight="bold"
+          fill="white" text-anchor="middle">${escapeXml(displayName)}</text>
+  </svg>`;
+
+  // Render to raw pixels
+  const { data, info } = await sharp(Buffer.from(textSvg))
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+
+  // Build 2D boolean mask (true = inside text)
+  const mask: boolean[][] = [];
+  for (let y = 0; y < info.height; y++) {
+    mask[y] = [];
+    for (let x = 0; x < info.width; x++) {
+      const idx = (y * info.width + x) * info.channels;
+      // White pixels (text) have high values
+      mask[y][x] = data[idx] > 128;
+    }
+  }
+
+  return mask;
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Generate Ishihara-style SVG banner
+ */
+async function generateIshiharaSvg(userId: string, name: string): Promise<string> {
+  const rand = seededRandom(hashString(userId));
+  const textMask = await createTextMask(name, BANNER_WIDTH, BANNER_HEIGHT);
+
+  const circles: string[] = [];
+
+  // Generate packed circle positions
+  const gridStep = 12; // spacing between circle center candidates
+  for (let gy = MIN_RADIUS; gy < BANNER_HEIGHT - MIN_RADIUS; gy += gridStep) {
+    for (let gx = MIN_RADIUS; gx < BANNER_WIDTH - MIN_RADIUS; gx += gridStep) {
+      // Jitter position
+      const x = gx + (rand() - 0.5) * gridStep * 0.8;
+      const y = gy + (rand() - 0.5) * gridStep * 0.8;
+
+      // Random radius
+      const r = MIN_RADIUS + rand() * (MAX_RADIUS - MIN_RADIUS);
+
+      // Check if center is inside text
+      const mx = Math.round(Math.min(Math.max(x, 0), BANNER_WIDTH - 1));
+      const my = Math.round(Math.min(Math.max(y, 0), BANNER_HEIGHT - 1));
+      const isText = textMask[my]?.[mx] ?? false;
+
+      // Pick color from appropriate palette
+      const palette = isText ? TEXT_COLORS : BACKGROUND_COLORS;
+      const color = palette[Math.floor(rand() * palette.length)];
+
+      // Slight opacity variation for organic feel
+      const opacity = 0.7 + rand() * 0.3;
+
+      circles.push(
+        `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="${r.toFixed(1)}" fill="${color}" opacity="${opacity.toFixed(2)}"/>`
+      );
+    }
+  }
+
+  return `<svg width="${BANNER_WIDTH}" height="${BANNER_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="${BANNER_WIDTH}" height="${BANNER_HEIGHT}" fill="#1a1a2e"/>
+  ${circles.join('\n  ')}
+</svg>`;
+}
+
+export class BannerService {
+  private minioService: MinioService;
+  private db: IDatabase;
+
+  constructor(minioService: MinioService, db: IDatabase) {
+    this.minioService = minioService;
+    this.db = db;
+  }
+
+  private async ensureBannerBucket(): Promise<void> {
+    const client = (this.minioService as any).client;
+    const exists = await client.bucketExists(BANNER_BUCKET);
+    if (!exists) {
+      await client.makeBucket(BANNER_BUCKET);
+      const policy = JSON.stringify({
+        Version: '2012-10-17',
+        Statement: [{
+          Effect: 'Allow',
+          Principal: { AWS: ['*'] },
+          Action: ['s3:GetObject'],
+          Resource: [`arn:aws:s3:::${BANNER_BUCKET}/*`],
+        }],
+      });
+      await client.setBucketPolicy(BANNER_BUCKET, policy);
+      logger.info('[Banner] Created banners bucket with public read policy');
+    }
+  }
+
+  /**
+   * Generate an Ishihara-style banner for a user and store it in MinIO.
+   * Returns the banner path.
+   */
+  async generateBanner(userId: string, name: string): Promise<string> {
+    const displayName = name || 'User';
+
+    // Generate SVG
+    const svg = await generateIshiharaSvg(userId, displayName);
+
+    // Convert SVG to WebP via sharp
+    const webpBuffer = await sharp(Buffer.from(svg))
+      .webp({ quality: BANNER_QUALITY })
+      .toBuffer();
+
+    // Upload to MinIO
+    await this.ensureBannerBucket();
+    const objectKey = `${userId}.webp`;
+    const client = (this.minioService as any).client;
+    await client.putObject(BANNER_BUCKET, objectKey, webpBuffer, webpBuffer.length, {
+      'Content-Type': 'image/webp',
+      'Cache-Control': 'public, max-age=86400',
+    });
+
+    // Store path in DB
+    const bannerPath = `/auth/banner/${userId}`;
+    await this.db.query(
+      'UPDATE users SET banner = $1 WHERE id = $2',
+      [bannerPath, userId]
+    );
+
+    logger.info('[Banner] Generated banner', { userId, size: webpBuffer.length });
+    return bannerPath;
+  }
+
+  /**
+   * Serve banner from MinIO. Returns a readable stream or null if not found.
+   */
+  async getBannerStream(userId: string): Promise<NodeJS.ReadableStream | null> {
+    try {
+      const client = (this.minioService as any).client;
+      return await client.getObject(BANNER_BUCKET, `${userId}.webp`);
+    } catch (error: any) {
+      if (error.code === 'NoSuchKey' || error.code === 'NoSuchBucket') {
+        return null;
+      }
+      throw error;
+    }
+  }
+}

--- a/mcp_backend/src/services/user-service.ts
+++ b/mcp_backend/src/services/user-service.ts
@@ -14,6 +14,7 @@ export interface User {
   email: string;
   name?: string;
   picture?: string;
+  banner?: string;
   email_verified: boolean;
   locale?: string;
   last_login?: Date;


### PR DESCRIPTION
## Summary
- Generates unique Ishihara color blindness test-style banners per user — name hidden in colored dots (red/orange text on green/teal background)
- Deterministic output seeded from userId; SVG rendered to WebP via `sharp` and stored in MinIO `banners` bucket
- Auto-generates on user creation (password registration + OAuth), served via `GET /auth/banner/:userId` with cache headers
- Frontend `ProfileHeader` displays banner image with gradient fallback for users without banners

## New files
- `mcp_backend/src/services/banner-service.ts` — core generation logic
- `mcp_backend/src/migrations/073_add_user_banner.sql` — `banner` column on `users`
- `mcp_backend/src/scripts/generate-banners.ts` — backfill script for existing users

## Test plan
- [ ] Run migration 073 to add banner column
- [ ] Register a new user → verify banner appears in MinIO `banners` bucket
- [ ] Visit profile page → see Ishihara banner instead of gradient
- [ ] Run `npx tsx src/scripts/generate-banners.ts` → existing users get banners
- [ ] `GET /auth/banner/:userId` returns WebP with cache headers
- [ ] `POST /auth/banner/regenerate` (with JWT) regenerates the banner
- [ ] Verify TypeScript builds clean (`tsc --noEmit` in both backend and frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)