### PR TITLE
Cleanup profile page: Ukrainian localization, remove mocks

### DIFF
--- a/lexwebapp/src/pages/ProfilePage/BillingSection.tsx
+++ b/lexwebapp/src/pages/ProfilePage/BillingSection.tsx
@@ -6,7 +6,7 @@ export function BillingSection({ billing, stats }: BillingSectionProps) {
   return (
     <section className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm">
       <h2 className="text-xl font-serif text-claude-text mb-6">
-        Activity
+        Активність
       </h2>
       <div className="space-y-4">
         {stats.map((stat) => (
@@ -30,7 +30,7 @@ export function BillingSection({ billing, stats }: BillingSectionProps) {
         <div className="mt-6 pt-6 border-t border-claude-border/50">
           <div className="flex items-center justify-between mb-2">
             <span className="text-sm font-medium text-claude-text">
-              Monthly Spend
+              Витрати за місяць
             </span>
             <span className="text-sm text-claude-subtext">
               ${Number(billing.month_spent_usd).toFixed(2)} / ${Number(billing.monthly_limit_usd).toFixed(2)}
@@ -43,7 +43,7 @@ export function BillingSection({ billing, stats }: BillingSectionProps) {
             />
           </div>
           <p className="text-xs text-claude-subtext mt-2">
-            Daily limit: ${Number(billing.daily_limit_usd).toFixed(2)} • Today: ${Number(billing.today_spent_usd).toFixed(2)}
+            Денний ліміт: ${Number(billing.daily_limit_usd).toFixed(2)} · Сьогодні: ${Number(billing.today_spent_usd).toFixed(2)}
           </p>
         </div>
       )}

--- a/lexwebapp/src/pages/ProfilePage/EditProfileModal.tsx
+++ b/lexwebapp/src/pages/ProfilePage/EditProfileModal.tsx
@@ -37,7 +37,7 @@ export function EditProfileModal({
             onClick={(e) => e.stopPropagation()}
           >
             <div className="sticky top-0 bg-white border-b border-claude-border px-6 py-4 flex items-center justify-between z-10">
-              <h2 className="text-xl font-serif text-claude-text">Edit Profile</h2>
+              <h2 className="text-xl font-serif text-claude-text">Редагування профілю</h2>
               <button
                 onClick={handleCloseModal}
                 className="p-2 hover:bg-claude-bg rounded-lg transition-colors"
@@ -72,14 +72,14 @@ export function EditProfileModal({
                   ) : (
                     <Upload size={16} />
                   )}
-                  {isUploadingPhoto ? 'Uploading...' : 'Change Photo'}
+                  {isUploadingPhoto ? 'Завантаження...' : 'Змінити фото'}
                 </button>
               </div>
 
               {/* Name Field */}
               <div>
                 <label htmlFor="profile-name" className="block text-sm font-medium text-claude-text mb-2">
-                  Full Name
+                  Повне ім'я
                 </label>
                 <input
                   id="profile-name"
@@ -88,14 +88,14 @@ export function EditProfileModal({
                   value={editForm.name}
                   onChange={(e) => setEditForm(prev => ({ ...prev, name: e.target.value }))}
                   className="w-full px-4 py-2.5 border border-claude-border rounded-lg focus:outline-none focus:ring-2 focus:ring-claude-accent focus:border-transparent transition-all"
-                  placeholder="Enter your name"
+                  placeholder="Введіть ваше ім'я"
                 />
               </div>
 
               {/* Phone Field */}
               <div>
                 <label htmlFor="profile-phone" className="block text-sm font-medium text-claude-text mb-2">
-                  Phone Number (optional)
+                  Номер телефону (необов'язково)
                 </label>
                 <input
                   id="profile-phone"
@@ -111,14 +111,14 @@ export function EditProfileModal({
               {/* Email Field (Read-only) */}
               <div>
                 <label className="block text-sm font-medium text-claude-text mb-2">
-                  Email
+                  Електронна пошта
                 </label>
                 <div className="w-full px-4 py-2.5 border border-claude-border rounded-lg bg-claude-bg text-claude-subtext flex items-center gap-2">
                   <Mail size={16} />
                   {user?.email}
                 </div>
                 <p className="text-xs text-claude-subtext mt-1">
-                  Email cannot be changed for security reasons
+                  Email не можна змінити з міркувань безпеки
                 </p>
               </div>
             </div>
@@ -128,7 +128,7 @@ export function EditProfileModal({
                 onClick={handleCloseModal}
                 className="flex-1 px-4 py-2.5 bg-white border border-claude-border text-claude-text rounded-xl font-medium text-sm hover:bg-claude-bg transition-colors"
               >
-                Cancel
+                Скасувати
               </button>
               <button
                 onClick={handleSaveProfile}
@@ -138,12 +138,12 @@ export function EditProfileModal({
                 {isSaving ? (
                   <>
                     <Loader2 size={16} className="animate-spin" />
-                    Saving...
+                    Збереження...
                   </>
                 ) : (
                   <>
                     <Save size={16} />
-                    Save Changes
+                    Зберегти
                   </>
                 )}
               </button>

--- a/lexwebapp/src/pages/ProfilePage/ProfileHeader.tsx
+++ b/lexwebapp/src/pages/ProfilePage/ProfileHeader.tsx
@@ -4,7 +4,7 @@ import type { UseProfileReturn } from './types';
 
 type ProfileHeaderProps = Pick<
   UseProfileReturn,
-  'user' | 'isUploadingPhoto' | 'fileInputRef' | 'handlePhotoClick' | 'handleFileChange' | 'handleEditProfile' | 'handleShare'
+  'user' | 'isUploadingPhoto' | 'fileInputRef' | 'handlePhotoClick' | 'handleFileChange' | 'handleEditProfile'
 >;
 
 export function ProfileHeader({
@@ -14,7 +14,6 @@ export function ProfileHeader({
   handlePhotoClick,
   handleFileChange,
   handleEditProfile,
-  handleShare,
 }: ProfileHeaderProps) {
   return (
     <motion.div
@@ -79,7 +78,7 @@ export function ProfileHeader({
           </h1>
           <p className="text-claude-subtext mt-1 flex items-center gap-2">
             <span className="w-2 h-2 rounded-full bg-green-500" />
-            {user?.emailVerified && '✓ '}Verified • Member since {user?.createdAt ? new Date(user.createdAt).getFullYear() : new Date().getFullYear()}
+            {user?.emailVerified && '✓ '}Підтверджено · Учасник з {user?.createdAt ? new Date(user.createdAt).getFullYear() : new Date().getFullYear()} р.
           </p>
         </div>
 
@@ -88,13 +87,7 @@ export function ProfileHeader({
             onClick={handleEditProfile}
             className="flex-1 md:flex-none px-4 py-2.5 bg-claude-accent text-white rounded-xl font-medium text-sm hover:bg-[#C66345] transition-colors shadow-sm active:scale-[0.98]"
           >
-            Edit Profile
-          </button>
-          <button
-            onClick={handleShare}
-            className="flex-1 md:flex-none px-4 py-2.5 bg-white border border-claude-border text-claude-text rounded-xl font-medium text-sm hover:bg-claude-bg transition-colors active:scale-[0.98]"
-          >
-            Share
+            Редагувати
           </button>
         </div>
       </div>

--- a/lexwebapp/src/pages/ProfilePage/index.tsx
+++ b/lexwebapp/src/pages/ProfilePage/index.tsx
@@ -19,7 +19,7 @@ export function ProfilePage() {
       <div className="flex-1 h-full flex items-center justify-center bg-claude-bg">
         <div className="text-center">
           <Loader2 size={48} className="text-claude-accent animate-spin mx-auto mb-4" />
-          <p className="text-claude-text font-sans">Loading profile...</p>
+          <p className="text-claude-text font-sans">Завантаження профілю...</p>
         </div>
       </div>
     );
@@ -30,12 +30,12 @@ export function ProfilePage() {
     return (
       <div className="flex-1 h-full flex items-center justify-center bg-claude-bg">
         <div className="text-center">
-          <p className="text-claude-text font-sans mb-4">No user data available</p>
+          <p className="text-claude-text font-sans mb-4">Дані користувача недоступні</p>
           <button
             onClick={() => window.location.reload()}
             className="px-4 py-2 bg-claude-accent text-white rounded-xl font-medium hover:bg-[#C66345] transition-colors"
           >
-            Reload Page
+            Перезавантажити
           </button>
         </div>
       </div>
@@ -53,7 +53,6 @@ export function ProfilePage() {
           handlePhotoClick={profile.handlePhotoClick}
           handleFileChange={profile.handleFileChange}
           handleEditProfile={profile.handleEditProfile}
-          handleShare={profile.handleShare}
         />
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
@@ -67,18 +66,18 @@ export function ProfilePage() {
             {/* Bio Section */}
             <section className="bg-white rounded-2xl p-6 border border-claude-border shadow-sm">
               <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-serif text-claude-text">Profile Information</h2>
+                <h2 className="text-xl font-serif text-claude-text">Інформація профілю</h2>
               </div>
 
               <div className="space-y-4">
                 <div>
-                  <label className="text-sm font-medium text-claude-subtext">Email</label>
+                  <label className="text-sm font-medium text-claude-subtext">Електронна пошта</label>
                   <p className="text-claude-text mt-1 flex items-center gap-2">
                     <Mail size={16} className="text-claude-subtext" />
-                    {user?.email || 'Not available'}
+                    {user?.email || 'Недоступно'}
                     {user?.emailVerified && (
                       <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-green-50 border border-green-200 rounded-full text-xs text-green-700">
-                        ✓ Verified
+                        ✓ Підтверджено
                       </span>
                     )}
                   </p>
@@ -86,7 +85,7 @@ export function ProfilePage() {
 
                 {(user as any).phone && (
                   <div>
-                    <label className="text-sm font-medium text-claude-subtext">Phone</label>
+                    <label className="text-sm font-medium text-claude-subtext">Телефон</label>
                     <p className="text-claude-text mt-1 flex items-center gap-2">
                       <Phone size={16} className="text-claude-subtext" />
                       {(user as any).phone}
@@ -95,7 +94,7 @@ export function ProfilePage() {
                 )}
 
                 <div>
-                  <label className="text-sm font-medium text-claude-subtext">Last Login</label>
+                  <label className="text-sm font-medium text-claude-subtext">Останній вхід</label>
                   <p className="text-claude-text mt-1">
                     {user?.lastLogin ? new Date(user.lastLogin).toLocaleString('uk-UA', {
                       year: 'numeric',
@@ -103,18 +102,18 @@ export function ProfilePage() {
                       day: 'numeric',
                       hour: '2-digit',
                       minute: '2-digit'
-                    }) : 'Not available'}
+                    }) : 'Недоступно'}
                   </p>
                 </div>
 
                 <div>
-                  <label className="text-sm font-medium text-claude-subtext">Account Created</label>
+                  <label className="text-sm font-medium text-claude-subtext">Обліковий запис створено</label>
                   <p className="text-claude-text mt-1">
                     {user?.createdAt ? new Date(user.createdAt).toLocaleString('uk-UA', {
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric'
-                    }) : 'Not available'}
+                    }) : 'Недоступно'}
                   </p>
                 </div>
               </div>
@@ -130,28 +129,33 @@ export function ProfilePage() {
                     </h3>
                   </div>
                   <div className="divide-y divide-claude-border/50">
-                    {group.items.map((item) => (
-                      <button
-                        key={item.label}
-                        onClick={item.onClick}
-                        className="w-full px-6 py-4 flex items-center justify-between hover:bg-claude-bg/50 transition-colors group"
-                      >
-                        <div className="flex items-center gap-4">
-                          <div className="p-2 bg-claude-bg rounded-lg text-claude-subtext group-hover:text-claude-accent transition-colors">
-                            <item.icon size={18} />
-                          </div>
-                          <div className="text-left">
-                            <div className="text-sm font-medium text-claude-text">
-                              {item.label}
+                    {group.items.map((item) => {
+                      const Wrapper = item.onClick ? 'button' : 'div';
+                      return (
+                        <Wrapper
+                          key={item.label}
+                          onClick={item.onClick}
+                          className={`w-full px-6 py-4 flex items-center justify-between transition-colors group ${item.onClick ? 'hover:bg-claude-bg/50 cursor-pointer' : ''}`}
+                        >
+                          <div className="flex items-center gap-4">
+                            <div className={`p-2 bg-claude-bg rounded-lg text-claude-subtext ${item.onClick ? 'group-hover:text-claude-accent' : ''} transition-colors`}>
+                              <item.icon size={18} />
                             </div>
-                            <div className="text-xs text-claude-subtext">
-                              {item.value}
+                            <div className="text-left">
+                              <div className="text-sm font-medium text-claude-text">
+                                {item.label}
+                              </div>
+                              <div className="text-xs text-claude-subtext">
+                                {item.value}
+                              </div>
                             </div>
                           </div>
-                        </div>
-                        <ChevronRight size={16} className="text-claude-border group-hover:text-claude-subtext transition-colors" />
-                      </button>
-                    ))}
+                          {item.onClick && (
+                            <ChevronRight size={16} className="text-claude-border group-hover:text-claude-subtext transition-colors" />
+                          )}
+                        </Wrapper>
+                      );
+                    })}
                   </div>
                 </section>
               ))}
@@ -192,30 +196,6 @@ export function ProfilePage() {
             {/* Usage Stats */}
             <BillingSection billing={billing} stats={stats} />
 
-            {/* Pro Card */}
-            <div className="bg-gradient-to-br from-claude-text to-gray-800 rounded-2xl p-6 text-white shadow-lg relative overflow-hidden group">
-              <div className="absolute top-0 right-0 w-32 h-32 bg-white/5 rounded-full -mr-16 -mt-16 blur-2xl group-hover:bg-white/10 transition-colors duration-500" />
-
-              <div className="relative z-10">
-                <div className="inline-flex items-center gap-2 px-2.5 py-1 bg-white/10 rounded-full text-xs font-medium mb-4 border border-white/10">
-                  <span className="w-1.5 h-1.5 rounded-full bg-claude-accent" />
-                  Pro Plan
-                </div>
-                <h3 className="text-xl font-serif mb-2">
-                  Upgrade your workflow
-                </h3>
-                <p className="text-white/70 text-sm mb-6 leading-relaxed">
-                  Get access to advanced models, longer context window, and
-                  priority support.
-                </p>
-                <button
-                  onClick={() => window.location.href = '/billing'}
-                  className="w-full py-2.5 bg-white text-claude-text rounded-xl font-medium text-sm hover:bg-gray-50 transition-colors active:scale-[0.98]"
-                >
-                  Manage Subscription
-                </button>
-              </div>
-            </div>
           </motion.div>
         </div>
       </div>

--- a/lexwebapp/src/pages/ProfilePage/types.ts
+++ b/lexwebapp/src/pages/ProfilePage/types.ts
@@ -64,7 +64,6 @@ export interface UseProfileReturn {
   handleSaveProfile: () => Promise<void>;
   handlePhotoClick: () => void;
   handleFileChange: (event: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
-  handleShare: () => void;
   handleRegisterPasskey: (attachment?: 'cross-platform') => Promise<void>;
   handleDeleteCredential: (credentialId: string) => Promise<void>;
   handleCreateMcpToken: () => Promise<void>;

--- a/lexwebapp/src/pages/ProfilePage/useProfile.ts
+++ b/lexwebapp/src/pages/ProfilePage/useProfile.ts
@@ -146,27 +146,6 @@ export function useProfile(): UseProfileReturn {
     }
   };
 
-  const handleShare = () => {
-    const profileUrl = window.location.href;
-    if (navigator.share) {
-      navigator.share({
-        title: `${user!.name} - SecondLayer Profile`,
-        url: profileUrl
-      }).catch(() => {
-        copyToClipboard(profileUrl);
-      });
-    } else {
-      copyToClipboard(profileUrl);
-    }
-  };
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text).then(() => {
-      showToast.success('Посилання скопійовано');
-    }).catch(() => {
-      showToast.error('Не вдалося скопіювати посилання');
-    });
-  };
 
   const handleRegisterPasskey = async (attachment?: 'cross-platform') => {
     setIsRegisteringKey(true);
@@ -245,44 +224,44 @@ export function useProfile(): UseProfileReturn {
   };
 
   const stats = [{
-    label: 'Balance',
+    label: 'Баланс',
     value: billing ? `$${Number(billing.balance_usd).toFixed(2)}` : '—',
     icon: DollarSign
   }, {
-    label: 'Total Requests',
+    label: 'Всього запитів',
     value: billing ? String(billing.total_requests) : '—',
     icon: Activity
   }, {
-    label: 'Total Spent',
+    label: 'Всього витрачено',
     value: billing ? `$${Number(billing.total_spent_usd).toFixed(2)}` : '—',
     icon: Zap
   }];
 
   const settingsGroups = [{
-    title: 'Account',
+    title: 'Обліковий запис',
     items: [{
       icon: Mail,
-      label: 'Email',
-      value: user?.email || 'Not set'
+      label: 'Електронна пошта',
+      value: user?.email || 'Не вказано'
     }, {
       icon: Shield,
-      label: 'Authentication',
+      label: 'Автентифікація',
       value: 'Google OAuth'
     }, {
       icon: User,
-      label: 'User ID',
-      value: user?.id?.substring(0, 8) + '...' || 'N/A'
+      label: 'ID користувача',
+      value: user?.id?.substring(0, 8) + '...' || 'Н/Д'
     }]
   }, {
-    title: 'Application',
+    title: 'Додаток',
     items: [{
       icon: Settings,
-      label: 'Language',
+      label: 'Мова',
       value: 'Українська'
     }, {
       icon: CreditCard,
-      label: 'Billing',
-      value: billing ? `$${Number(billing.balance_usd).toFixed(2)} • ${billing.pricing_tier}` : 'Loading...',
+      label: 'Білінг',
+      value: billing ? `$${Number(billing.balance_usd).toFixed(2)} • ${billing.pricing_tier}` : 'Завантаження...',
       onClick: () => window.location.href = '/billing'
     }]
   }];
@@ -315,7 +294,6 @@ export function useProfile(): UseProfileReturn {
     handleSaveProfile,
     handlePhotoClick,
     handleFileChange,
-    handleShare,
     handleRegisterPasskey,
     handleDeleteCredential,
     handleCreateMcpToken,


### PR DESCRIPTION
## Summary
- Translated all profile page UI text to Ukrainian (uk-UA)
- Removed mock "Pro Plan" upgrade card that wasn't connected to any real functionality
- Removed non-functional "Share" button (no public profile pages exist)
- Non-interactive settings items now render as `<div>` instead of `<button>` for proper semantics

## What stays the same
All real functionality is preserved: profile editing, photo upload, WebAuthn passkeys, MCP token management, billing display, GDPR section.

## Test plan
- [ ] Visit /profile page — all text should be in Ukrainian
- [ ] Edit profile (name, phone, photo) works correctly
- [ ] WebAuthn key registration/deletion works
- [ ] MCP token creation/revocation works
- [ ] Billing section shows real data from API
- [ ] No "Pro Plan" card or "Share" button visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)