### PR TITLE
feat: Ishihara-style banners for lawyer profiles

### DIFF
--- a/lexwebapp/src/components/IshiharaBanner.tsx
+++ b/lexwebapp/src/components/IshiharaBanner.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useRef, useState } from 'react';
+
+const BANNER_WIDTH = 800;
+const BANNER_HEIGHT = 200;
+const MIN_RADIUS = 4;
+const MAX_RADIUS = 18;
+const GRID_STEP = 12;
+
+function seededRandom(seed: number): () => number {
+  return function () {
+    seed |= 0;
+    seed = (seed + 0x6D2B79F5) | 0;
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashString(str: string): number {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+
+function generatePalette(baseHue: number, rand: () => number): string[] {
+  const colors: string[] = [];
+  for (let i = 0; i < 15; i++) {
+    const h = (baseHue + (rand() - 0.5) * 30) % 360;
+    const s = 45 + rand() * 30;
+    const l = 35 + rand() * 25;
+    colors.push(`hsl(${h.toFixed(0)}, ${s.toFixed(0)}%, ${l.toFixed(0)}%)`);
+  }
+  return colors;
+}
+
+function getUserPalettes(rand: () => number): { bg: string[]; text: string[] } {
+  const bgHue = rand() * 360;
+  const textHue = (bgHue + 120 + rand() * 120) % 360;
+  return {
+    bg: generatePalette(bgHue, rand),
+    text: generatePalette(textHue, rand),
+  };
+}
+
+function createTextMask(name: string, width: number, height: number): boolean[][] {
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d')!;
+
+  const displayName = name.length > 20 ? name.substring(0, 20) : name;
+  const fontSize = Math.min(72, Math.max(36, Math.floor(600 / Math.max(displayName.length, 1))));
+
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, width, height);
+
+  ctx.fillStyle = 'white';
+  ctx.font = `bold ${fontSize}px Arial, Helvetica, sans-serif`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(displayName, width / 2, height / 2);
+
+  const imageData = ctx.getImageData(0, 0, width, height);
+  const mask: boolean[][] = [];
+  for (let y = 0; y < height; y++) {
+    mask[y] = [];
+    for (let x = 0; x < width; x++) {
+      const idx = (y * width + x) * 4;
+      mask[y][x] = imageData.data[idx] > 128;
+    }
+  }
+  return mask;
+}
+
+function generateCircles(seed: string, name: string): string {
+  const rand = seededRandom(hashString(seed));
+  const { bg: bgPalette, text: textPalette } = getUserPalettes(rand);
+  const textMask = createTextMask(name, BANNER_WIDTH, BANNER_HEIGHT);
+
+  const circles: string[] = [];
+
+  for (let gy = MIN_RADIUS; gy < BANNER_HEIGHT - MIN_RADIUS; gy += GRID_STEP) {
+    for (let gx = MIN_RADIUS; gx < BANNER_WIDTH - MIN_RADIUS; gx += GRID_STEP) {
+      const x = gx + (rand() - 0.5) * GRID_STEP * 0.8;
+      const y = gy + (rand() - 0.5) * GRID_STEP * 0.8;
+      const r = MIN_RADIUS + rand() * (MAX_RADIUS - MIN_RADIUS);
+
+      const mx = Math.round(Math.min(Math.max(x, 0), BANNER_WIDTH - 1));
+      const my = Math.round(Math.min(Math.max(y, 0), BANNER_HEIGHT - 1));
+      const isText = textMask[my]?.[mx] ?? false;
+
+      const palette = isText ? textPalette : bgPalette;
+      const color = palette[Math.floor(rand() * palette.length)];
+      const opacity = 0.7 + rand() * 0.3;
+
+      circles.push(
+        `<circle cx="${x.toFixed(1)}" cy="${y.toFixed(1)}" r="${r.toFixed(1)}" fill="${color}" opacity="${opacity.toFixed(2)}"/>`
+      );
+    }
+  }
+
+  return `<svg width="${BANNER_WIDTH}" height="${BANNER_HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+  <rect width="${BANNER_WIDTH}" height="${BANNER_HEIGHT}" fill="#1a1a2e"/>
+  ${circles.join('\n  ')}
+</svg>`;
+}
+
+interface IshiharaBannerProps {
+  seed: string;
+  name: string;
+  className?: string;
+}
+
+export function IshiharaBanner({ seed, name, className = '' }: IshiharaBannerProps) {
+  const [svgDataUrl, setSvgDataUrl] = useState<string | null>(null);
+  const generatedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const key = `${seed}:${name}`;
+    if (generatedRef.current === key) return;
+    generatedRef.current = key;
+
+    const svg = generateCircles(seed, name);
+    const encoded = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`;
+    setSvgDataUrl(encoded);
+  }, [seed, name]);
+
+  if (!svgDataUrl) {
+    return <div className={`bg-gradient-to-r from-claude-accent/10 to-claude-bg ${className}`} />;
+  }
+
+  return (
+    <img
+      src={svgDataUrl}
+      alt=""
+      className={`object-cover ${className}`}
+    />
+  );
+}

--- a/lexwebapp/src/pages/PersonDetailPage/LawyerProfile.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/LawyerProfile.tsx
@@ -13,6 +13,7 @@ import {
   GraduationCap,
 } from 'lucide-react';
 import { ERAUProfile } from '../../services/api/ERAUService';
+import { IshiharaBanner } from '../../components/IshiharaBanner';
 
 interface LawyerProfilePageProps {
   profile: ERAUProfile;
@@ -54,7 +55,11 @@ export function LawyerProfilePage({ profile, onBack }: LawyerProfilePageProps) {
           transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
           className="relative bg-white rounded-2xl p-6 md:p-8 border border-claude-border shadow-sm overflow-hidden"
         >
-          <div className="absolute top-0 left-0 w-full h-32 bg-gradient-to-r from-claude-accent/10 to-claude-bg" />
+          <IshiharaBanner
+            seed={String(profile.id)}
+            name={profile.fullName}
+            className="absolute top-0 left-0 w-full h-32"
+          />
 
           <div className="relative flex flex-col md:flex-row items-start md:items-end gap-6 pt-12">
             <div className="w-24 h-24 md:w-32 md:h-32 rounded-full bg-claude-sidebar border-4 border-white shadow-md flex items-center justify-center text-3xl font-serif text-claude-subtext">


### PR DESCRIPTION
## Summary
- New reusable `IshiharaBanner` component — generates Ishihara-style dot banners client-side using seeded PRNG + canvas text mask (same visual style as server-side user banners)
- Replaced static gradient on lawyer profile pages with unique per-lawyer banners based on ERAU ID
- No server storage needed — banners are deterministic and generated on render

## Test plan
- [ ] Open a lawyer profile page (e.g. `/lawyers/9078`) and verify the Ishihara banner renders with the lawyer's name hidden in dots
- [ ] Verify different lawyers get different color palettes
- [ ] Verify the banner is responsive and covers the header area

🤖 Generated with [Claude Code](https://claude.com/claude-code)