### PR TITLE
feat: add search history for lawyers page

### DIFF
--- a/lexwebapp/src/pages/LawyersPage/index.tsx
+++ b/lexwebapp/src/pages/LawyersPage/index.tsx
@@ -1,6 +1,6 @@
-import { useState, FormEvent } from 'react';
+import { useState, useEffect, FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import {
   Search,
   Award,
@@ -10,12 +10,17 @@ import {
   List,
   ExternalLink,
   Loader2,
+  Clock,
+  X,
+  Trash2,
 } from 'lucide-react';
-import { erauService, ERAULawyer } from '../../services/api/ERAUService';
+import { erauService, ERAULawyer, SearchHistoryEntry } from '../../services/api/ERAUService';
 import { generateRoute } from '../../router/routes';
+import { useAuth } from '../../contexts/AuthContext';
 
 export function LawyersPage() {
   const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
 
   const handleSelectLawyer = (lawyer: ERAULawyer) => {
     const name = [lawyer.surname, lawyer.firstname, lawyer.middlename].filter(Boolean).join(' ');
@@ -41,6 +46,22 @@ export function LawyersPage() {
   const [hasSearched, setHasSearched] = useState(false);
   const [viewMode, setViewMode] = useState<'comfortable' | 'compact'>('comfortable');
 
+  // History state
+  const [history, setHistory] = useState<SearchHistoryEntry[]>([]);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
+
+  // Load history on mount for authenticated users
+  useEffect(() => {
+    if (isAuthenticated) {
+      setHistoryLoading(true);
+      erauService.getSearchHistory(20).then((data) => {
+        setHistory(data);
+        setHistoryLoading(false);
+      }).catch(() => setHistoryLoading(false));
+    }
+  }, [isAuthenticated]);
+
   const handleSearch = async (e: FormEvent) => {
     e.preventDefault();
     const trimmed = searchQuery.trim();
@@ -49,16 +70,60 @@ export function LawyersPage() {
     setLoading(true);
     setError(null);
     setHasSearched(true);
+    setShowHistory(false);
 
     try {
       const data = await erauService.searchLawyers(trimmed);
       setResults(data);
+
+      // Save to history (fire-and-forget)
+      if (isAuthenticated) {
+        erauService.saveSearchHistory(trimmed, data.length).then((/* void */) => {
+          // Refresh history list
+          erauService.getSearchHistory(20).then(setHistory).catch(() => {});
+        });
+      }
     } catch (err: any) {
       setError(err?.message || 'Не вдалося виконати пошук. Спробуйте пізніше.');
       setResults([]);
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleHistoryClick = (entry: SearchHistoryEntry) => {
+    setSearchQuery(entry.query);
+    setShowHistory(false);
+    // Trigger search immediately
+    setLoading(true);
+    setError(null);
+    setHasSearched(true);
+
+    erauService.searchLawyers(entry.query).then((data) => {
+      setResults(data);
+      if (isAuthenticated) {
+        erauService.saveSearchHistory(entry.query, data.length).then(() => {
+          erauService.getSearchHistory(20).then(setHistory).catch(() => {});
+        });
+      }
+    }).catch((err: any) => {
+      setError(err?.message || 'Не вдалося виконати пошук. Спробуйте пізніше.');
+      setResults([]);
+    }).finally(() => {
+      setLoading(false);
+    });
+  };
+
+  const handleDeleteHistoryEntry = async (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    setHistory((prev) => prev.filter((h) => h.id !== id));
+    await erauService.deleteSearchHistoryEntry(id);
+  };
+
+  const handleClearHistory = async () => {
+    setHistory([]);
+    setShowHistory(false);
+    await erauService.clearSearchHistory();
   };
 
   const formatDate = (dateStr: string) => {
@@ -68,6 +133,26 @@ export function LawyersPage() {
       return d.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit', year: 'numeric' });
     } catch {
       return dateStr;
+    }
+  };
+
+  const formatHistoryDate = (dateStr: string) => {
+    if (!dateStr) return '';
+    try {
+      const d = new Date(dateStr);
+      const now = new Date();
+      const diff = now.getTime() - d.getTime();
+      const minutes = Math.floor(diff / 60000);
+      const hours = Math.floor(diff / 3600000);
+      const days = Math.floor(diff / 86400000);
+
+      if (minutes < 1) return 'щойно';
+      if (minutes < 60) return `${minutes} хв тому`;
+      if (hours < 24) return `${hours} год тому`;
+      if (days < 7) return `${days} дн тому`;
+      return d.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit' });
+    } catch {
+      return '';
     }
   };
 
@@ -125,8 +210,74 @@ export function LawyersPage() {
                 placeholder="Введіть прізвище адвоката..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
+                onFocus={() => {
+                  if (isAuthenticated && history.length > 0 && !hasSearched) {
+                    setShowHistory(true);
+                  }
+                }}
                 disabled={loading}
               />
+
+              {/* History Dropdown */}
+              <AnimatePresence>
+                {showHistory && history.length > 0 && (
+                  <motion.div
+                    initial={{ opacity: 0, y: -4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -4 }}
+                    transition={{ duration: 0.15 }}
+                    className="absolute top-full left-0 right-0 mt-2 bg-white border border-claude-border rounded-xl shadow-lg z-50 overflow-hidden"
+                  >
+                    <div className="flex items-center justify-between px-4 py-2.5 border-b border-claude-border/50">
+                      <span className="text-xs font-sans font-medium text-claude-subtext flex items-center gap-1.5">
+                        <Clock size={12} />
+                        Останні пошуки
+                      </span>
+                      <button
+                        type="button"
+                        onClick={handleClearHistory}
+                        className="text-xs text-claude-subtext hover:text-red-500 transition-colors font-sans flex items-center gap-1"
+                      >
+                        <Trash2 size={11} />
+                        Очистити
+                      </button>
+                    </div>
+                    <div className="max-h-64 overflow-y-auto">
+                      {history.map((entry) => (
+                        <button
+                          key={entry.id}
+                          type="button"
+                          onClick={() => handleHistoryClick(entry)}
+                          className="w-full flex items-center justify-between px-4 py-2.5 hover:bg-claude-bg transition-colors text-left group/item"
+                        >
+                          <div className="flex items-center gap-2.5 min-w-0">
+                            <Clock size={14} className="text-claude-subtext/50 flex-shrink-0" />
+                            <span className="text-sm font-sans text-claude-text truncate">
+                              {entry.query}
+                            </span>
+                            <span className="text-xs text-claude-subtext/60 font-sans flex-shrink-0">
+                              {entry.result_count} рез.
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-[11px] text-claude-subtext/40 font-sans">
+                              {formatHistoryDate(entry.created_at)}
+                            </span>
+                            <button
+                              type="button"
+                              onClick={(e) => handleDeleteHistoryEntry(e, entry.id)}
+                              className="opacity-0 group-hover/item:opacity-100 p-0.5 text-claude-subtext/40 hover:text-red-400 transition-all"
+                              title="Видалити"
+                            >
+                              <X size={13} />
+                            </button>
+                          </div>
+                        </button>
+                      ))}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
             </div>
 
             <button
@@ -158,6 +309,11 @@ export function LawyersPage() {
             </div>
           </form>
         </motion.div>
+
+        {/* Click-away to close history dropdown */}
+        {showHistory && (
+          <div className="fixed inset-0 z-40" onClick={() => setShowHistory(false)} />
+        )}
 
         {/* Error */}
         {error && (
@@ -236,7 +392,7 @@ export function LawyersPage() {
           </div>
         )}
 
-        {/* Empty state - before search */}
+        {/* Empty state - before search (with history) */}
         {!hasSearched && (
           <motion.div
             initial={{ opacity: 0 }}
@@ -252,6 +408,44 @@ export function LawyersPage() {
             <p className="text-claude-subtext font-sans max-w-md mx-auto">
               Введіть прізвище адвоката для пошуку в Єдиному реєстрі адвокатів України
             </p>
+
+            {/* Recent searches below empty state */}
+            {isAuthenticated && !historyLoading && history.length > 0 && (
+              <div className="mt-8 max-w-md mx-auto">
+                <div className="flex items-center justify-between mb-3">
+                  <span className="text-xs font-sans font-medium text-claude-subtext flex items-center gap-1.5">
+                    <Clock size={12} />
+                    Останні пошуки
+                  </span>
+                  <button
+                    onClick={handleClearHistory}
+                    className="text-xs text-claude-subtext hover:text-red-500 transition-colors font-sans flex items-center gap-1"
+                  >
+                    <Trash2 size={11} />
+                    Очистити
+                  </button>
+                </div>
+                <div className="flex flex-wrap gap-2 justify-center">
+                  {history.slice(0, 8).map((entry) => (
+                    <button
+                      key={entry.id}
+                      onClick={() => handleHistoryClick(entry)}
+                      className="group/chip flex items-center gap-1.5 px-3 py-1.5 bg-white border border-claude-border rounded-full text-sm font-sans text-claude-text hover:border-claude-accent hover:text-claude-accent transition-all shadow-sm"
+                    >
+                      <Clock size={12} className="text-claude-subtext/40" />
+                      {entry.query}
+                      <span className="text-[10px] text-claude-subtext/50">({entry.result_count})</span>
+                      <button
+                        onClick={(e) => handleDeleteHistoryEntry(e, entry.id)}
+                        className="opacity-0 group-hover/chip:opacity-100 ml-0.5 p-0.5 text-claude-subtext/40 hover:text-red-400 transition-all"
+                      >
+                        <X size={11} />
+                      </button>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
           </motion.div>
         )}
 

--- a/lexwebapp/src/services/api/ERAUService.ts
+++ b/lexwebapp/src/services/api/ERAUService.ts
@@ -36,6 +36,13 @@ export interface ERAUProfile {
   qualification: Array<{ year: string; status: string }>;
 }
 
+export interface SearchHistoryEntry {
+  id: string;
+  query: string;
+  result_count: number;
+  created_at: string;
+}
+
 export class ERAUService extends BaseService {
   async searchLawyers(surname: string): Promise<ERAULawyer[]> {
     try {
@@ -54,6 +61,41 @@ export class ERAUService extends BaseService {
       return response.data;
     } catch (error) {
       return this.handleError(error);
+    }
+  }
+
+  async getSearchHistory(limit = 20): Promise<SearchHistoryEntry[]> {
+    try {
+      const response = await this.client.get<SearchHistoryEntry[]>('/api/erau/search-history', {
+        params: { limit },
+      });
+      return response.data;
+    } catch {
+      return [];
+    }
+  }
+
+  async saveSearchHistory(query: string, resultCount: number): Promise<void> {
+    try {
+      await this.client.post('/api/erau/search-history', { query, resultCount });
+    } catch {
+      // silent — history is non-critical
+    }
+  }
+
+  async deleteSearchHistoryEntry(id: string): Promise<void> {
+    try {
+      await this.client.delete(`/api/erau/search-history/${id}`);
+    } catch {
+      // silent
+    }
+  }
+
+  async clearSearchHistory(): Promise<void> {
+    try {
+      await this.client.delete('/api/erau/search-history');
+    } catch {
+      // silent
     }
   }
 }

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1942,7 +1942,7 @@ class HTTPMCPServer {
 
     // ERAU proxy - Ukrainian Bar Registry (public, no auth required)
     const erauCacheService = new ERAUCacheService(this.services.db);
-    this.app.use('/api/erau', optionalJWT as any, createERAUProxyRoutes(erauCacheService));
+    this.app.use('/api/erau', optionalJWT as any, createERAUProxyRoutes(erauCacheService, this.services.db));
     logger.info('ERAU proxy routes registered at /api/erau');
 
     // Worker heartbeat (uses dualAuth so EC2 workers can auth with SECONDARY_LAYER_KEYS)

--- a/mcp_backend/src/migrations/074_search_history.sql
+++ b/mcp_backend/src/migrations/074_search_history.sql
@@ -1,0 +1,15 @@
+-- Search history for lawyers page (and potentially other search pages)
+CREATE TABLE IF NOT EXISTS search_history (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  page VARCHAR(50) NOT NULL DEFAULT 'lawyers',
+  query TEXT NOT NULL,
+  result_count INTEGER DEFAULT 0,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_search_history_user_page
+  ON search_history (user_id, page, created_at DESC);
+
+-- Prevent exact duplicate consecutive searches per user/page
+-- (keep only the latest timestamp via application logic)

--- a/mcp_backend/src/routes/erau-proxy-routes.ts
+++ b/mcp_backend/src/routes/erau-proxy-routes.ts
@@ -12,6 +12,7 @@ import { Router, Request, Response } from 'express';
 import { load } from 'cheerio';
 import { logger } from '../utils/logger.js';
 import { ERAUCacheService } from '../services/erau-cache-service.js';
+import { BaseDatabase } from '@secondlayer/shared';
 
 const ERAU_BASE_URL = 'https://erau.unba.org.ua';
 const PROFILE_REDIS_PREFIX = 'erau:profile:';
@@ -187,8 +188,113 @@ function parseERAUProfileHTML(html: string, id: string): ERAUProfile {
   };
 }
 
-export function createERAUProxyRoutes(erauCacheService?: ERAUCacheService): Router {
+export function createERAUProxyRoutes(erauCacheService?: ERAUCacheService, db?: BaseDatabase): Router {
   const router = Router();
+
+  // --- Search History endpoints ---
+
+  // GET /search-history — list recent searches for the authenticated user
+  router.get('/search-history', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId || !db) {
+        return res.json([]);
+      }
+
+      const limit = Math.min(Number(req.query.limit) || 20, 50);
+      const { rows } = await db.query(
+        `SELECT id, query, result_count, created_at
+         FROM search_history
+         WHERE user_id = $1 AND page = 'lawyers'
+         ORDER BY created_at DESC
+         LIMIT $2`,
+        [userId, limit]
+      );
+      res.json(rows);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[ERAU] Search history fetch error', { error: msg });
+      res.json([]);
+    }
+  });
+
+  // POST /search-history — save a search entry
+  router.post('/search-history', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId || !db) {
+        return res.status(200).json({ ok: true });
+      }
+
+      const { query, resultCount } = req.body;
+      if (!query || typeof query !== 'string' || query.trim().length < 2) {
+        return res.status(400).json({ error: 'query required (min 2 chars)' });
+      }
+
+      const trimmed = query.trim();
+
+      // Remove previous identical query for this user to avoid duplicates, then insert fresh
+      await db.query(
+        `DELETE FROM search_history WHERE user_id = $1 AND page = 'lawyers' AND LOWER(query) = LOWER($2)`,
+        [userId, trimmed]
+      );
+
+      const { rows } = await db.query(
+        `INSERT INTO search_history (user_id, page, query, result_count)
+         VALUES ($1, 'lawyers', $2, $3)
+         RETURNING id, query, result_count, created_at`,
+        [userId, trimmed, resultCount || 0]
+      );
+
+      res.json(rows[0]);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[ERAU] Search history save error', { error: msg });
+      res.status(200).json({ ok: true });
+    }
+  });
+
+  // DELETE /search-history/:id — delete a single history entry
+  router.delete('/search-history/:id', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId || !db) {
+        return res.status(200).json({ ok: true });
+      }
+
+      await db.query(
+        `DELETE FROM search_history WHERE id = $1 AND user_id = $2`,
+        [req.params.id, userId]
+      );
+
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[ERAU] Search history delete error', { error: msg });
+      res.status(200).json({ ok: true });
+    }
+  });
+
+  // DELETE /search-history — clear all history for authenticated user
+  router.delete('/search-history', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId || !db) {
+        return res.status(200).json({ ok: true });
+      }
+
+      await db.query(
+        `DELETE FROM search_history WHERE user_id = $1 AND page = 'lawyers'`,
+        [userId]
+      );
+
+      res.json({ ok: true });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[ERAU] Search history clear error', { error: msg });
+      res.status(200).json({ ok: true });
+    }
+  });
 
   // Profile endpoint
   router.get('/profile/:id', async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- New `search_history` DB table (migration 074) with per-user, per-page search tracking
- 4 backend endpoints under `/api/erau/search-history`: list, save, delete one, clear all
- Frontend: history dropdown on input focus, clickable chip tags on empty state, auto-save after each search
- Graceful degradation: unauthenticated users see no history, all history ops are non-blocking

## Changes
| File | What |
|------|------|
| `mcp_backend/src/migrations/074_search_history.sql` | New table + index |
| `mcp_backend/src/routes/erau-proxy-routes.ts` | 4 search-history endpoints |
| `mcp_backend/src/http-server.ts` | Pass `db` to ERAU routes |
| `lexwebapp/src/services/api/ERAUService.ts` | 4 new client methods |
| `lexwebapp/src/pages/LawyersPage/index.tsx` | History UI (dropdown + chips) |

## Test plan
- [ ] Run migration on local DB
- [ ] Search for a lawyer while authenticated — verify entry appears in history
- [ ] Focus input field — verify history dropdown shows
- [ ] Click history entry — verify it re-triggers search
- [ ] Delete individual entry via X button
- [ ] Clear all history
- [ ] Verify unauthenticated users see no history (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)