### PR TITLE
feat: add Login with Diia (Дія) authentication

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -15,6 +15,7 @@ import {
   EyeOff,
   User,
   BookOpen,
+  X,
 } from 'lucide-react';
 import { startAuthentication } from '@simplewebauthn/browser';
 import { useAuth } from '../../contexts/AuthContext';
@@ -57,6 +58,9 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const [error, setError] = useState<string | null>(null);
   const [showForgotPassword, setShowForgotPassword] = useState(false);
   const [showGDPR, setShowGDPR] = useState(false);
+  const [diiaDeeplink, setDiiaDeeplink] = useState<string | null>(null);
+  const [diiaSessionId, setDiiaSessionId] = useState<string | null>(null);
+  const diiaPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
@@ -79,24 +83,34 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
     }
   }, []);
 
-  // Handle OAuth callback on mount
+  // Handle OAuth callback on mount (Google + Diia)
   useEffect(() => {
     const handleOAuthCallback = async () => {
       const urlParams = new URLSearchParams(window.location.search);
       const token = urlParams.get('token');
       const oauthError = urlParams.get('error');
+      const diiaDeeplinkParam = urlParams.get('diia_deeplink');
+      const diiaSessionParam = urlParams.get('diia_session');
+
+      // Handle Diia QR deeplink — show the QR modal
+      if (diiaDeeplinkParam && diiaSessionParam) {
+        setDiiaDeeplink(diiaDeeplinkParam);
+        setDiiaSessionId(diiaSessionParam);
+        window.history.replaceState({}, '', window.location.pathname);
+        return;
+      }
 
       if (oauthError) {
-        if (oauthError === 'oauth_failed') {
-          setError('Google authentication failed. Please try again.');
-          showToast.error('Google authentication failed');
-        } else if (oauthError === 'server_error') {
-          setError('Server error occurred. Please try again later.');
-          showToast.error('Server error occurred');
-        } else {
-          setError('Authentication failed. Please try again.');
-          showToast.error('Authentication failed');
-        }
+        const errorMap: Record<string, string> = {
+          oauth_failed: 'Помилка автентифікації через Google. Спробуйте ще раз.',
+          server_error: 'Помилка сервера. Спробуйте пізніше.',
+          diia_not_configured: 'Дія авторизацію ще не налаштовано.',
+          diia_failed: 'Помилка автентифікації через Дію. Спробуйте ще раз.',
+          diia_no_result: 'Не отримано дані від Дії. Спробуйте ще раз.',
+        };
+        const msg = errorMap[oauthError] || 'Помилка автентифікації. Спробуйте ще раз.';
+        setError(msg);
+        showToast.error(msg);
         window.history.replaceState({}, '', window.location.pathname);
         return;
       }
@@ -123,6 +137,39 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
     handleOAuthCallback();
   }, [login, onLoginSuccess]);
 
+  // Poll Diia session status when QR modal is open
+  useEffect(() => {
+    if (!diiaSessionId) return;
+
+    diiaPollingRef.current = setInterval(async () => {
+      try {
+        const resp = await fetch(`${BASE_URL}/auth/diia/status/${diiaSessionId}`);
+        if (!resp.ok) return;
+        const data = await resp.json();
+
+        if (data.status === 'complete' && data.token) {
+          clearInterval(diiaPollingRef.current!);
+          setDiiaDeeplink(null);
+          setDiiaSessionId(null);
+          await login(data.token);
+          if (onLoginSuccess) onLoginSuccess();
+          navigate(getReturnUrl(), { replace: true });
+        } else if (data.status === 'expired') {
+          clearInterval(diiaPollingRef.current!);
+          setDiiaDeeplink(null);
+          setDiiaSessionId(null);
+          setError('Сесія Дії закінчилась. Спробуйте ще раз.');
+        }
+      } catch {
+        // ignore polling errors
+      }
+    }, 3000);
+
+    return () => {
+      if (diiaPollingRef.current) clearInterval(diiaPollingRef.current);
+    };
+  }, [diiaSessionId]);
+
   // Redirect if already authenticated
   useEffect(() => {
     if (isAuthenticated && !isLoading) {
@@ -134,6 +181,11 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const handleGoogleAuth = () => {
     setError(null);
     window.location.href = `${window.location.origin}/auth/google`;
+  };
+
+  const handleDiiaAuth = () => {
+    setError(null);
+    window.location.href = `${window.location.origin}/auth/diia`;
   };
 
   const handlePasswordChange = (value: string) => {
@@ -304,6 +356,22 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               {isLogin ? 'Оберіть зручний спосіб входу' : 'Створіть акаунт для початку роботи'}
             </p>
           </div>
+
+          {/* Diia Auth Button */}
+          <motion.button
+            whileHover={{ scale: 1.02 }}
+            whileTap={{ scale: 0.98 }}
+            onClick={handleDiiaAuth}
+            className="w-full flex items-center justify-center gap-3 px-4 py-3.5 bg-[#1A4DC2] hover:bg-[#1540A8] text-white rounded-xl font-medium transition-all shadow-sm mb-3 font-sans"
+          >
+            {/* Official Diia logo */}
+            <svg width="22" height="22" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <rect width="32" height="32" rx="6" fill="white" fillOpacity="0.15"/>
+              <path d="M8 7h7.5C19.09 7 22 9.91 22 13.5S19.09 20 15.5 20H11v5H8V7zm3 3v7h4.5c1.93 0 3.5-1.57 3.5-3.5S17.43 10 15.5 10H11z" fill="white"/>
+              <path d="M23 7h3v18h-3V7z" fill="white"/>
+            </svg>
+            {isLogin ? 'Увійти через Дію' : 'Зареєструватися через Дію'}
+          </motion.button>
 
           {/* Google Auth Button */}
           <motion.button
@@ -569,6 +637,72 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       {/* GDPR Info Modal */}
       <AnimatePresence>
         {showGDPR && <GDPRModal onClose={() => setShowGDPR(false)} />}
+      </AnimatePresence>
+
+      {/* Diia QR Modal */}
+      <AnimatePresence>
+        {diiaDeeplink && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+            onClick={() => { setDiiaDeeplink(null); setDiiaSessionId(null); }}
+          >
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.95, opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              onClick={(e) => e.stopPropagation()}
+              className="bg-white rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center"
+            >
+              <button
+                onClick={() => { setDiiaDeeplink(null); setDiiaSessionId(null); }}
+                className="absolute top-4 right-4 text-claude-subtext hover:text-claude-text"
+              >
+                <X size={20} />
+              </button>
+
+              {/* Diia logo */}
+              <div className="w-16 h-16 bg-[#1A4DC2] rounded-2xl flex items-center justify-center mx-auto mb-4">
+                <svg width="36" height="36" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M8 7h7.5C19.09 7 22 9.91 22 13.5S19.09 20 15.5 20H11v5H8V7zm3 3v7h4.5c1.93 0 3.5-1.57 3.5-3.5S17.43 10 15.5 10H11z" fill="white"/>
+                  <path d="M23 7h3v18h-3V7z" fill="white"/>
+                </svg>
+              </div>
+
+              <h2 className="text-xl font-medium text-claude-text mb-1 font-sans">Вхід через Дію</h2>
+              <p className="text-sm text-claude-subtext mb-6 font-sans">
+                Відкрийте застосунок Дія та відскануйте QR-код або натисніть кнопку нижче
+              </p>
+
+              {/* QR code placeholder — real QR from deeplink */}
+              <div className="bg-claude-bg rounded-xl p-4 mb-6 flex items-center justify-center">
+                <img
+                  src={`https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encodeURIComponent(diiaDeeplink)}`}
+                  alt="Diia QR code"
+                  className="w-44 h-44"
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.display = 'none';
+                  }}
+                />
+              </div>
+
+              <a
+                href={diiaDeeplink}
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-[#1A4DC2] hover:bg-[#1540A8] text-white rounded-xl font-medium transition-colors font-sans mb-3"
+              >
+                Відкрити в застосунку Дія
+              </a>
+
+              <p className="text-xs text-claude-subtext font-sans flex items-center justify-center gap-2">
+                <Loader2 size={12} className="animate-spin" />
+                Очікування автентифікації…
+              </p>
+            </motion.div>
+          </motion.div>
+        )}
       </AnimatePresence>
     </div>
   );

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -8,6 +8,7 @@ import jwt from 'jsonwebtoken';
 import passport from 'passport';
 import bcrypt from 'bcryptjs';
 import sharp from 'sharp';
+import crypto from 'crypto';
 import { User } from '../services/user-service.js';
 import { logger } from '../utils/logger.js';
 import { getUserService, getWebAuthnService } from '../middleware/dual-auth.js';
@@ -15,6 +16,7 @@ import { EmailService } from '../services/email-service.js';
 import { MinioService } from '../services/minio-service.js';
 import { BannerService } from '../services/banner-service.js';
 import type { ICachePort } from '../domain/ports/index.js';
+import { getDiiaService } from '../services/diia-service.js';
 
 let authCache: ICachePort | null = null;
 let authEmailService: EmailService | null = null;
@@ -1111,4 +1113,170 @@ export async function regenerateBanner(req: AuthenticatedRequest, res: Response)
     logger.error('[Banner] Regeneration failed:', error);
     return res.status(500).json({ error: 'Internal server error', message: error.message });
   }
+}
+
+// ============================================================================
+// Diia Auth Controllers
+// ============================================================================
+
+const DIIA_SESSION_TTL = 600; // 10 minutes
+
+/**
+ * GET /auth/diia
+ * Initiates Diia authentication flow.
+ * Calls Diia Business API to get a deeplink/QR session, stores pending session in Redis,
+ * then redirects frontend to /login with Diia params so it can show the QR modal.
+ */
+export async function diiaAuthInit(req: Request, res: Response): Promise<void> {
+  try {
+    const diiaService = getDiiaService();
+
+    if (!diiaService.isConfigured()) {
+      const frontendUrl = (() => {
+        const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+        const host = req.headers['x-forwarded-host'] || req.headers.host;
+        return `${protocol}://${host}`;
+      })();
+      res.redirect(`${frontendUrl}/login?error=diia_not_configured`);
+      return;
+    }
+
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+    const host = req.headers['x-forwarded-host'] || req.headers.host;
+    const baseUrl = `${protocol}://${host}`;
+    const callbackUrl = `${baseUrl}/auth/diia/callback`;
+
+    const session = await diiaService.initAuthSession(callbackUrl);
+
+    const sessionId = session.requestId || crypto.randomUUID();
+
+    // Store pending session in Redis
+    if (authCache) {
+      await authCache.set(
+        `diia:session:${sessionId}`,
+        JSON.stringify({ status: 'pending', requestId: session.requestId }),
+        DIIA_SESSION_TTL
+      );
+    }
+
+    // Redirect frontend to login page with Diia deeplink params (for QR modal)
+    const params = new URLSearchParams({
+      diia_session: sessionId,
+      diia_deeplink: session.deepLink,
+    });
+    res.redirect(`${baseUrl}/login?${params.toString()}`);
+  } catch (error: any) {
+    logger.error('[Diia] Auth init failed:', error);
+    const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+    const host = req.headers['x-forwarded-host'] || req.headers.host;
+    res.redirect(`${protocol}://${host}/login?error=diia_failed`);
+  }
+}
+
+/**
+ * GET /auth/diia/callback
+ * Diia redirects the user here after they complete authentication in the app.
+ * The requestId is passed as a query param; we fetch the auth result from Diia.
+ */
+export async function diiaAuthCallback(req: Request, res: Response): Promise<void> {
+  const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  const frontendUrl = `${protocol}://${host}`;
+
+  try {
+    const { requestId } = req.query as Record<string, string>;
+
+    if (!requestId) {
+      res.redirect(`${frontendUrl}/login?error=diia_no_request`);
+      return;
+    }
+
+    const diiaService = getDiiaService();
+    const userInfo = await diiaService.getAuthResult(requestId);
+
+    if (!userInfo) {
+      res.redirect(`${frontendUrl}/login?error=diia_no_result`);
+      return;
+    }
+
+    const userService = getUserService();
+    if (!userService) {
+      res.redirect(`${frontendUrl}/login?error=server_error`);
+      return;
+    }
+
+    // Build an email from RNOKPP if no email provided
+    const email = userInfo.email || `diia_${userInfo.rnokpp || requestId}@diia.gov.ua`;
+    const name = [userInfo.lastName, userInfo.firstName, userInfo.middleName]
+      .filter(Boolean)
+      .join(' ') || 'Diia User';
+
+    // Find or create user
+    let user = await userService.findByEmail(email);
+    if (!user) {
+      user = await userService.createUser({
+        googleId: '',       // no Google ID for Diia users
+        email,
+        name,
+        emailVerified: true, // Diia-verified identity
+      });
+      logger.info('[Diia] Created new user from Diia auth', { userId: user.id, email });
+
+      // Generate banner async
+      generateBannerAsync(user.id, name);
+    } else {
+      await userService.updateLastLogin(user.id);
+      logger.info('[Diia] Existing user logged in via Diia', { userId: user.id, email });
+    }
+
+    // Mark session as complete in Redis
+    if (authCache) {
+      await authCache.set(
+        `diia:session:${requestId}`,
+        JSON.stringify({ status: 'complete', userId: user.id }),
+        DIIA_SESSION_TTL
+      );
+    }
+
+    const token = generateToken(user);
+    res.redirect(`${frontendUrl}/login?token=${token}`);
+  } catch (error: any) {
+    logger.error('[Diia] Auth callback failed:', error);
+    res.redirect(`${frontendUrl}/login?error=diia_failed`);
+  }
+}
+
+/**
+ * GET /auth/diia/status/:sessionId
+ * Frontend polls this to check if the Diia auth session has completed.
+ * Returns { status: 'pending' | 'complete', token? }.
+ */
+export async function diiaAuthStatus(req: Request, res: Response): Promise<Response> {
+  const { sessionId } = req.params;
+
+  if (!authCache) {
+    return res.status(503).json({ error: 'Cache unavailable' });
+  }
+
+  const raw = await authCache.get(`diia:session:${sessionId}`);
+  if (!raw) {
+    return res.status(404).json({ status: 'expired' });
+  }
+
+  const session = JSON.parse(raw) as { status: string; userId?: string };
+
+  if (session.status === 'complete' && session.userId) {
+    const userService = getUserService();
+    if (!userService) return res.status(503).json({ error: 'Service unavailable' });
+
+    const user = await userService.findById(session.userId);
+    if (!user) return res.status(404).json({ status: 'expired' });
+
+    // Consume the session
+    await authCache.del(`diia:session:${sessionId}`);
+    const token = generateToken(user);
+    return res.json({ status: 'complete', token });
+  }
+
+  return res.json({ status: session.status });
 }

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -7,6 +7,7 @@ import { Router } from 'express';
 import passport from 'passport';
 import multer from 'multer';
 import * as authController from '../controllers/auth.js';
+import { getDiiaService } from '../services/diia-service.js';
 import { authRateLimit, passwordResetRateLimit } from '../middleware/rate-limit.js';
 import { requireJWT } from '../middleware/dual-auth.js';
 
@@ -100,6 +101,43 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
   });
   router.get('/google/callback', (_req, res) => {
     res.status(501).json({ error: 'Google OAuth is not configured' });
+  });
+}
+
+/**
+ * Diia (Дія) OAuth routes.
+ * Only registered when DIIA_AUTH_ACQUIRER_TOKEN is set.
+ */
+if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
+  /**
+   * @route   GET /auth/diia
+   * @desc    Initiate Diia auth flow — calls Diia Business API, returns deeplink for QR
+   * @access  Public
+   */
+  router.get('/diia', authController.diiaAuthInit as any);
+
+  /**
+   * @route   GET /auth/diia/callback
+   * @desc    Diia redirects here after user authenticates in the app
+   * @access  Public
+   */
+  router.get('/diia/callback', authController.diiaAuthCallback as any);
+
+  /**
+   * @route   GET /auth/diia/status/:sessionId
+   * @desc    Poll for Diia auth session completion
+   * @access  Public
+   */
+  router.get('/diia/status/:sessionId', authController.diiaAuthStatus as any);
+} else {
+  router.get('/diia', (_req, res) => {
+    res.status(501).json({ error: 'Diia auth is not configured' });
+  });
+  router.get('/diia/callback', (_req, res) => {
+    res.status(501).json({ error: 'Diia auth is not configured' });
+  });
+  router.get('/diia/status/:sessionId', (_req, res) => {
+    res.status(501).json({ error: 'Diia auth is not configured' });
   });
 }
 

--- a/mcp_backend/src/services/diia-service.ts
+++ b/mcp_backend/src/services/diia-service.ts
@@ -1,0 +1,219 @@
+/**
+ * Diia Service
+ * Integration with Ukrainian government's Diia Business API for user authentication.
+ * Docs: https://api2t.diia.gov.ua (test) / https://api2.diia.gov.ua (prod)
+ */
+
+import { logger } from '../utils/logger.js';
+
+const DIIA_BASE_URL = process.env.DIIA_BASE_URL || 'https://api2t.diia.gov.ua';
+const DIIA_AUTH_ACQUIRER_TOKEN = process.env.DIIA_AUTH_ACQUIRER_TOKEN || '';
+
+interface DiiaSessionResponse {
+  token: string;
+}
+
+interface DiiaBranch {
+  id: string;
+  name: string;
+  customFullName?: string;
+  customAddress?: string;
+  offerRequestType?: string;
+}
+
+interface DiiaOffer {
+  id: string;
+  name: string;
+  returnLink?: string;
+  shareAttributes?: string[];
+}
+
+interface DiiaAuthLink {
+  deepLink: string;
+  barcode: string;
+  requestId: string;
+}
+
+export interface DiiaUserInfo {
+  rnokpp?: string;    // IPN / tax number
+  firstName?: string;
+  lastName?: string;
+  middleName?: string;
+  email?: string;
+  phoneNumber?: string;
+  birthDate?: string;
+}
+
+export class DiiaService {
+  private tokenCache: { token: string; expiresAt: number } | null = null;
+
+  /**
+   * Get Bearer token for Diia API using Basic auth (acquirer credentials).
+   * Token is cached until close to expiry.
+   */
+  async getAcquirerToken(): Promise<string> {
+    if (this.tokenCache && Date.now() < this.tokenCache.expiresAt) {
+      return this.tokenCache.token;
+    }
+
+    if (!DIIA_AUTH_ACQUIRER_TOKEN) {
+      throw new Error('DIIA_AUTH_ACQUIRER_TOKEN is not configured');
+    }
+
+    const response = await fetch(`${DIIA_BASE_URL}/api/v1/auth/acquirer/session`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${DIIA_AUTH_ACQUIRER_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Diia auth session failed: ${response.status} ${body}`);
+    }
+
+    const data = await response.json() as DiiaSessionResponse;
+
+    // Cache for 23 hours (tokens typically valid 24h)
+    this.tokenCache = {
+      token: data.token,
+      expiresAt: Date.now() + 23 * 60 * 60 * 1000,
+    };
+
+    logger.info('[Diia] Acquirer session token obtained');
+    return data.token;
+  }
+
+  /**
+   * Get list of configured branches for this acquirer.
+   */
+  async getBranches(): Promise<DiiaBranch[]> {
+    const token = await this.getAcquirerToken();
+
+    const response = await fetch(`${DIIA_BASE_URL}/api/v2/acquirer/branches`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Diia branches request failed: ${response.status} ${body}`);
+    }
+
+    const data = await response.json() as { branches: DiiaBranch[] };
+    return data.branches || [];
+  }
+
+  /**
+   * Get offers for a specific branch.
+   */
+  async getBranchOffers(branchId: string): Promise<DiiaOffer[]> {
+    const token = await this.getAcquirerToken();
+
+    const response = await fetch(`${DIIA_BASE_URL}/api/v1/acquirer/branch/${branchId}/offers`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Diia offers request failed: ${response.status} ${body}`);
+    }
+
+    const data = await response.json() as { offers: DiiaOffer[] };
+    return data.offers || [];
+  }
+
+  /**
+   * Create an auth sharing link (deeplink + QR barcode) for a given branch/offer.
+   * The returnUrl is where Diia redirects after the user authenticates.
+   */
+  async createAuthLink(branchId: string, offerId: string, returnUrl: string): Promise<DiiaAuthLink> {
+    const token = await this.getAcquirerToken();
+
+    const response = await fetch(
+      `${DIIA_BASE_URL}/api/v2/acquirer/branch/${branchId}/offer/${offerId}/sharing-link`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ returnLink: returnUrl }),
+      }
+    );
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Diia sharing link creation failed: ${response.status} ${body}`);
+    }
+
+    return await response.json() as DiiaAuthLink;
+  }
+
+  /**
+   * Initialize a Diia auth session.
+   * Discovers the first available branch and offer, then creates an auth deeplink.
+   * Returns the deeplink, barcode, and requestId for tracking.
+   */
+  async initAuthSession(returnUrl: string): Promise<DiiaAuthLink & { branchId: string; offerId: string }> {
+    const branches = await this.getBranches();
+
+    if (!branches.length) {
+      throw new Error('No Diia branches configured for this acquirer. Please set up a branch in the Diia Business Cabinet.');
+    }
+
+    const branch = branches[0];
+    logger.info('[Diia] Using branch', { branchId: branch.id, name: branch.name });
+
+    const offers = await this.getBranchOffers(branch.id);
+
+    if (!offers.length) {
+      throw new Error('No Diia offers configured for branch ' + branch.id);
+    }
+
+    const offer = offers[0];
+    logger.info('[Diia] Using offer', { offerId: offer.id, name: offer.name });
+
+    const link = await this.createAuthLink(branch.id, offer.id, returnUrl);
+
+    return { ...link, branchId: branch.id, offerId: offer.id };
+  }
+
+  /**
+   * Verify a Diia auth result by requestId.
+   * Called after the user returns from the Diia app.
+   */
+  async getAuthResult(requestId: string): Promise<DiiaUserInfo | null> {
+    const token = await this.getAcquirerToken();
+
+    const response = await fetch(`${DIIA_BASE_URL}/api/v1/acquirer/document-request/${requestId}`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Diia auth result fetch failed: ${response.status} ${body}`);
+    }
+
+    return await response.json() as DiiaUserInfo;
+  }
+
+  /** Whether Diia is configured (tokens present). */
+  isConfigured(): boolean {
+    return Boolean(DIIA_AUTH_ACQUIRER_TOKEN);
+  }
+}
+
+// Singleton
+let diiaServiceInstance: DiiaService | null = null;
+
+export function getDiiaService(): DiiaService {
+  if (!diiaServiceInstance) {
+    diiaServiceInstance = new DiiaService();
+  }
+  return diiaServiceInstance;
+}


### PR DESCRIPTION
## Summary
- Add "Увійти через Дію" button above Google OAuth on the login page
- Backend `DiiaService` integrates with Diia Business API (test env: `api2t.diia.gov.ua`): acquirer session token → branches → offers → auth deeplink
- Routes: `GET /auth/diia` (init), `GET /auth/diia/callback` (Diia redirect), `GET /auth/diia/status/:sessionId` (polling)
- Frontend shows QR-code modal (via external QR API) + "Відкрити в застосунку Дія" deeplink; polls `/auth/diia/status` every 3s and auto-completes login
- Credentials added to `.env.prod` (`DIIA_BASE_URL`, `DIIA_ACQUIRER_TOKEN`, `DIIA_AUTH_ACQUIRER_TOKEN`)
- Routes only activate when `DIIA_AUTH_ACQUIRER_TOKEN` env var is set (graceful degradation)

## Test plan
- [ ] Login page shows both Diia and Google buttons
- [ ] Clicking Diia button redirects to `/auth/diia` → backend calls Diia API → returns deeplink → shows QR modal
- [ ] QR modal shows QR code and "Відкрити в застосунку Дія" deeplink
- [ ] After Diia authentication, user is logged in automatically
- [ ] Error cases (Diia not configured, session expired) show Ukrainian error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)