### PR TITLE
fix: use ECDSA + SHA256 base64 for Diia requestId hashing

### DIFF
--- a/mcp_backend/src/services/diia-service.ts
+++ b/mcp_backend/src/services/diia-service.ts
@@ -196,8 +196,9 @@ export class DiiaService {
     const token = await this.getSessionToken();
 
     const requestId = crypto.randomUUID();
-    // SDK hashes requestId with SHA256 before sending to Diia
-    const hashedRequestId = crypto.createHash('sha256').update(requestId).digest('hex');
+    // ECDSA algorithm: hash requestId with SHA256 → base64 (44 chars)
+    // DSTU (default) would require ГОСТ 34.311 via IIT library — use ECDSA instead
+    const hashedRequestId = crypto.createHash('sha256').update(requestId).digest('base64');
 
     const response = await fetch(
       `${DIIA_BASE_URL}/api/v2/acquirers/branch/${branchId}/offer-request/dynamic`,
@@ -207,7 +208,7 @@ export class DiiaService {
           'Authorization': `Bearer ${token}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ offerId, requestId: hashedRequestId }),
+        body: JSON.stringify({ offerId, requestId: hashedRequestId, signAlgo: 'ECDSA' }),
       }
     );
 


### PR DESCRIPTION
## Summary
- Per official Дія.Підпис docs (section 4.2.3.4): DSTU requires ГОСТ 34.311 → base64 (IIT library), ECDSA requires SHA256 → base64
- Previous code used `SHA256 → hex` which is incorrect for both algorithms
- Switch to ECDSA with `SHA256 → base64` to avoid IIT library dependency

## Pending (requires Дія support)
- [ ] Enable `diiaId: auth` scope for test acquirer `acquirer_1356` on `api2s`
- [ ] Register endpoint `https://stage.legal.org.ua/auth/diia/callback` with Дія staff

🤖 Generated with [Claude Code](https://claude.com/claude-code)