### PR TITLE
feat: add Terms of Service and Privacy Policy pages

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -641,7 +641,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             Продовжуючи, ви погоджуєтесь з{' '}
             <a href="/uk/offer" className="text-claude-accent hover:text-[#C66345]">Договором публічної оферти</a>{' '}
             та{' '}
-            <a href="#" className="text-claude-accent hover:text-[#C66345]">Політикою конфіденційності</a>
+            <a href="/uk/privacy" className="text-claude-accent hover:text-[#C66345]">Політикою конфіденційності</a>
           </p>
         </motion.div>
       </motion.div>

--- a/lexwebapp/src/pages/PrivacyPolicyPage.tsx
+++ b/lexwebapp/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,459 @@
+/**
+ * Privacy Policy Page
+ * Bilingual (UK/EN) with {lang} parameter: /uk/privacy or /en/privacy
+ */
+
+import { useParams, useNavigate } from 'react-router-dom';
+import { Shield, ArrowLeft, Globe } from 'lucide-react';
+
+const privacyContent = {
+  uk: {
+    title: 'ПОЛІТИКА КОНФІДЕНЦІЙНОСТІ',
+    subtitle: 'сервісу LEX AI',
+    lastUpdated: 'Останнє оновлення: 7 березня 2026 р.',
+    backLabel: 'Назад',
+    switchLang: 'English',
+    switchTo: 'en',
+    sections: [
+      {
+        heading: '',
+        content: `Товариство з обмеженою відповідальністю «Лекс ЕйАй»
+Код ЄДРПОУ: 46011385
+Місцезнаходження: 04132, Україна, м. Київ, 47-Садова, 1а
+Email: info@legal.org.ua
+Відповідальний за захист даних: info@legal.org.ua`,
+      },
+      {
+        heading: '1. Загальні положення',
+        content: `Ця Політика конфіденційності описує, як ТОВ «Лекс ЕйАй» (далі — «Компанія», «ми») збирає, обробляє, зберігає та захищає персональні дані користувачів сервісу LEX AI (далі — «Сервіс»).
+
+Компанія обробляє персональні дані відповідно до:
+— Закону України «Про захист персональних даних» (№ 2297-VI);
+— Загального регламенту захисту даних ЄС (GDPR, Регламент 2016/679) — для користувачів з ЄС/ЄЕЗ;
+— інших застосовних нормативних актів.
+
+Використовуючи Сервіс, ви підтверджуєте ознайомлення з цією Політикою та надаєте згоду на обробку ваших персональних даних у порядку, визначеному нижче.`,
+      },
+      {
+        heading: '2. Які дані ми збираємо',
+        content: `2.1. Дані, які ви надаєте безпосередньо:
+— ім'я, прізвище, email (при реєстрації);
+— фото профілю (при авторизації через Google або Дію);
+— документи, які ви завантажуєте для AI-аналізу;
+— текстові запити до AI-системи;
+— коментарі до статей блогу.
+
+2.2. Дані, які збираються автоматично:
+— IP-адреса та приблизна геолокація;
+— тип браузера та операційної системи;
+— час та тривалість сесій;
+— дії в інтерфейсі Сервісу (переглянуті сторінки, використані інструменти);
+— використання API (кількість запитів, типи інструментів).
+
+2.3. Дані від третіх сторін:
+— профіль Google (ім'я, email, фото) — при авторизації через Google OAuth;
+— дані з Дія.Підпис (ПІБ, РНОКПП) — при авторизації через Дію;
+— платіжна інформація від Monobank (статус транзакції, без номера картки).`,
+      },
+      {
+        heading: '3. Цілі обробки даних',
+        content: `Ми обробляємо персональні дані для таких цілей:
+
+3.1. Надання послуг Сервісу:
+— створення та управління обліковим записом;
+— виконання AI-аналізу завантажених документів;
+— семантичний пошук та отримання юридичної інформації;
+— зберігання документів у захищеному сховищі.
+
+3.2. Безпека та якість:
+— захист від несанкціонованого доступу;
+— моніторинг якості та продуктивності Сервісу;
+— виявлення та запобігання зловживанням.
+
+3.3. Комунікація:
+— відправлення сервісних повідомлень (підтвердження реєстрації, скидання пароля);
+— повідомлення про зміни в Умовах або Політиці.
+
+3.4. Юридичні зобов'язання:
+— виконання вимог законодавства;
+— ведення бухгалтерського обліку (дані оплат).`,
+      },
+      {
+        heading: '4. Правові підстави обробки (GDPR)',
+        content: `Для користувачів з ЄС/ЄЕЗ ми обробляємо дані на підставі:
+— Згоди (ст. 6(1)(a) GDPR) — для необов'язкових функцій та маркетингу;
+— Виконання договору (ст. 6(1)(b) GDPR) — для надання послуг Сервісу;
+— Законного інтересу (ст. 6(1)(f) GDPR) — для безпеки та покращення Сервісу;
+— Юридичного зобов'язання (ст. 6(1)(c) GDPR) — для виконання вимог законодавства.`,
+      },
+      {
+        heading: '5. Обробка документів через AI (OpenAI)',
+        content: `ВАЖЛИВО: При використанні AI-аналізу, вміст ваших документів та запити передаються до OpenAI API для обробки.
+
+Умови обробки даних через OpenAI:
+— OpenAI виступає як субобробник (sub-processor) і обробляє дані виключно за нашими інструкціями;
+— OpenAI НЕ використовує дані API для тренування своїх моделей (за замовчуванням з 1 березня 2023 р.);
+— дані зберігаються OpenAI до 30 днів виключно для моніторингу зловживань, після чого видаляються;
+— обробка регулюється Data Processing Addendum (DPA) між Компанією та OpenAI;
+— OpenAI має сертифікацію SOC 2 Type 2.
+
+Рекомендації для користувачів:
+— не завантажуйте документи з особливо чутливими персональними даними (медичні, фінансові), якщо це не є необхідним для аналізу;
+— за можливості знеособлюйте документи перед завантаженням;
+— зв'язуйтесь з нами, якщо потребуєте додаткових гарантій обробки чутливих даних.`,
+      },
+      {
+        heading: '6. Зберігання та захист даних',
+        content: `6.1. Де зберігаються дані:
+— облікові записи та метадані — PostgreSQL (зашифрований зв'язок);
+— документи — MinIO (S3-сумісне сховище з шифруванням);
+— векторні embeddings — Qdrant (для семантичного пошуку);
+— кеш сесій — Redis (дані зберігаються тимчасово).
+
+6.2. Заходи безпеки:
+— шифрування даних при передачі (TLS 1.2+);
+— автентифікація через JWT-токени;
+— рольовий контроль доступу;
+— аудит-лог з хеш-ланцюгом для відстеження доступу;
+— ізоляція даних між клієнтами (matter segregation);
+— регулярне резервне копіювання.
+
+6.3. Строки зберігання:
+— дані облікового запису — протягом дії акаунту + 30 днів після видалення;
+— завантажені документи — протягом дії акаунту, видаляються за запитом;
+— логи використання — 90 днів;
+— дані оплат — 5 років (вимога законодавства);
+— дані AI-запитів — 30 днів (abuse monitoring OpenAI).`,
+      },
+      {
+        heading: '7. Передача даних третім сторонам',
+        content: `Ми передаємо персональні дані виключно таким категоріям одержувачів:
+
+7.1. Субобробники (sub-processors):
+— OpenAI, LP (США) — AI-аналіз документів та запитів;
+— Monobank / АТ «Універсал Банк» (Україна) — обробка платежів;
+— Cloudflare, Inc. (США) — CDN та захист від DDoS;
+— Hetzner Online GmbH (Німеччина) — хостинг серверів.
+
+7.2. Державні органи:
+— на вимогу суду або органів влади відповідно до законодавства України.
+
+Ми НЕ продаємо та НЕ передаємо персональні дані для маркетингових цілей третіх сторін.
+
+Для передачі даних за межі ЄС/ЄЕЗ ми використовуємо Стандартні договірні умови (SCC) відповідно до рішення Європейської Комісії.`,
+      },
+      {
+        heading: '8. Права користувачів',
+        content: `Відповідно до законодавства та GDPR, ви маєте такі права:
+
+— Право на доступ (ст. 15 GDPR) — отримати інформацію про те, які ваші дані ми обробляємо;
+— Право на виправлення (ст. 16 GDPR) — виправити неточні дані;
+— Право на видалення (ст. 17 GDPR) — вимагати повного видалення ваших даних;
+— Право на обмеження обробки (ст. 18 GDPR) — обмежити обробку ваших даних;
+— Право на перенесення (ст. 20 GDPR) — отримати ваші дані у структурованому форматі;
+— Право на заперечення (ст. 21 GDPR) — заперечити проти обробки на підставі законного інтересу;
+— Право на відкликання згоди — в будь-який час без впливу на законність обробки до відкликання.
+
+Для реалізації цих прав:
+— Експорт даних: Профіль → Privacy & Data → Export;
+— Видалення акаунту: Профіль → Privacy & Data → Delete;
+— Інші запити: info@legal.org.ua.
+
+Ми відповідаємо на запити протягом 30 днів.
+
+Ви також маєте право подати скаргу до Уповноваженого Верховної Ради з прав людини (Україна) або до наглядового органу у вашій країні ЄС.`,
+      },
+      {
+        heading: '9. Файли cookie',
+        content: `Сервіс використовує:
+— необхідні cookie — для автентифікації та підтримки сесії (JWT-токени);
+— функціональні cookie — для збереження мовних налаштувань та преференцій інтерфейсу.
+
+Ми НЕ використовуємо рекламні або аналітичні cookie третіх сторін. Ми НЕ відстежуємо користувачів на інших веб-сайтах.`,
+      },
+      {
+        heading: '10. Захист даних дітей',
+        content: `Сервіс не призначений для осіб молодших за 18 років. Ми свідомо не збираємо персональні дані неповнолітніх. Якщо ви вважаєте, що неповнолітня особа надала нам свої дані, зв'яжіться з нами для їх видалення.`,
+      },
+      {
+        heading: '11. Зміни до Політики',
+        content: `Ми можемо оновлювати цю Політику конфіденційності. Про суттєві зміни ми повідомляємо:
+— через email, зареєстрований в обліковому записі;
+— через повідомлення в інтерфейсі Сервісу;
+— не менше ніж за 14 днів до набуття чинності.
+
+Продовження використання Сервісу після змін означає прийняття оновленої Політики.`,
+      },
+      {
+        heading: '12. Контактна інформація',
+        content: `З питань захисту персональних даних звертайтеся:
+
+ТОВ «Лекс ЕйАй»
+ЄДРПОУ: 46011385
+Адреса: 04132, Україна, м. Київ, 47-Садова, 1а
+Email: info@legal.org.ua
+Веб-сайт: https://legal.org.ua`,
+      },
+    ],
+  },
+  en: {
+    title: 'PRIVACY POLICY',
+    subtitle: 'LEX AI Platform',
+    lastUpdated: 'Last updated: March 7, 2026',
+    backLabel: 'Back',
+    switchLang: 'Українська',
+    switchTo: 'uk',
+    sections: [
+      {
+        heading: '',
+        content: `Limited Liability Company "Lex AI"
+EDRPOU Code: 46011385
+Address: 04132, Ukraine, Kyiv, 47-Sadova, 1a
+Email: info@legal.org.ua
+Data Protection Contact: info@legal.org.ua`,
+      },
+      {
+        heading: '1. Introduction',
+        content: `This Privacy Policy describes how LLC "Lex AI" (hereinafter — "Company", "we") collects, processes, stores, and protects personal data of users of the LEX AI service (hereinafter — "Service").
+
+The Company processes personal data in accordance with:
+— the Law of Ukraine "On Personal Data Protection" (No. 2297-VI);
+— the General Data Protection Regulation (GDPR, Regulation 2016/679) — for EU/EEA users;
+— other applicable regulations.
+
+By using the Service, you confirm that you have read this Policy and consent to the processing of your personal data as described below.`,
+      },
+      {
+        heading: '2. Data We Collect',
+        content: `2.1. Data you provide directly:
+— name, surname, email (during registration);
+— profile photo (when authorizing via Google or Diia);
+— documents you upload for AI analysis;
+— text queries to the AI system;
+— comments on blog articles.
+
+2.2. Data collected automatically:
+— IP address and approximate geolocation;
+— browser type and operating system;
+— session time and duration;
+— actions within the Service interface (pages viewed, tools used);
+— API usage (number of requests, tool types).
+
+2.3. Data from third parties:
+— Google profile (name, email, photo) — when authorizing via Google OAuth;
+— Diia.Signature data (full name, tax ID) — when authorizing via Diia;
+— payment information from Monobank (transaction status, without card number).`,
+      },
+      {
+        heading: '3. Purposes of Data Processing',
+        content: `We process personal data for the following purposes:
+
+3.1. Service provision:
+— creating and managing user accounts;
+— performing AI analysis of uploaded documents;
+— semantic search and retrieval of legal information;
+— storing documents in the secure vault.
+
+3.2. Security and quality:
+— protection against unauthorized access;
+— monitoring service quality and performance;
+— detecting and preventing abuse.
+
+3.3. Communication:
+— sending service notifications (registration confirmation, password reset);
+— notifying about changes to Terms or Policy.
+
+3.4. Legal obligations:
+— compliance with legal requirements;
+— accounting records (payment data).`,
+      },
+      {
+        heading: '4. Legal Basis for Processing (GDPR)',
+        content: `For EU/EEA users, we process data based on:
+— Consent (Art. 6(1)(a) GDPR) — for optional features and marketing;
+— Performance of contract (Art. 6(1)(b) GDPR) — for providing the Service;
+— Legitimate interest (Art. 6(1)(f) GDPR) — for security and Service improvement;
+— Legal obligation (Art. 6(1)(c) GDPR) — for compliance with legal requirements.`,
+      },
+      {
+        heading: '5. Document Processing via AI (OpenAI)',
+        content: `IMPORTANT: When using AI analysis, the content of your documents and queries is transmitted to the OpenAI API for processing.
+
+Terms of data processing through OpenAI:
+— OpenAI acts as a sub-processor and processes data solely according to our instructions;
+— OpenAI does NOT use API data for training its models (by default since March 1, 2023);
+— data is retained by OpenAI for up to 30 days solely for abuse monitoring, after which it is deleted;
+— processing is governed by a Data Processing Addendum (DPA) between the Company and OpenAI;
+— OpenAI holds SOC 2 Type 2 certification.
+
+Recommendations for users:
+— do not upload documents with particularly sensitive personal data (medical, financial) unless necessary for analysis;
+— anonymize documents before uploading when possible;
+— contact us if you require additional safeguards for processing sensitive data.`,
+      },
+      {
+        heading: '6. Data Storage and Security',
+        content: `6.1. Where data is stored:
+— user accounts and metadata — PostgreSQL (encrypted connections);
+— documents — MinIO (S3-compatible storage with encryption);
+— vector embeddings — Qdrant (for semantic search);
+— session cache — Redis (temporary storage).
+
+6.2. Security measures:
+— data encryption in transit (TLS 1.2+);
+— JWT token authentication;
+— role-based access control;
+— audit log with hash chain for access tracking;
+— data isolation between clients (matter segregation);
+— regular backups.
+
+6.3. Retention periods:
+— account data — duration of the account + 30 days after deletion;
+— uploaded documents — duration of the account, deleted upon request;
+— usage logs — 90 days;
+— payment data — 5 years (legal requirement);
+— AI query data — 30 days (OpenAI abuse monitoring).`,
+      },
+      {
+        heading: '7. Data Sharing with Third Parties',
+        content: `We share personal data exclusively with the following categories of recipients:
+
+7.1. Sub-processors:
+— OpenAI, LP (USA) — AI analysis of documents and queries;
+— Monobank / JSC "Universal Bank" (Ukraine) — payment processing;
+— Cloudflare, Inc. (USA) — CDN and DDoS protection;
+— Hetzner Online GmbH (Germany) — server hosting.
+
+7.2. Government authorities:
+— upon court order or lawful request in accordance with Ukrainian law.
+
+We do NOT sell or share personal data for third-party marketing purposes.
+
+For data transfers outside the EU/EEA, we use Standard Contractual Clauses (SCCs) pursuant to European Commission decisions.`,
+      },
+      {
+        heading: '8. Your Rights',
+        content: `Under applicable law and the GDPR, you have the following rights:
+
+— Right of access (Art. 15 GDPR) — obtain information about what data we process;
+— Right to rectification (Art. 16 GDPR) — correct inaccurate data;
+— Right to erasure (Art. 17 GDPR) — request complete deletion of your data;
+— Right to restriction (Art. 18 GDPR) — restrict processing of your data;
+— Right to data portability (Art. 20 GDPR) — receive your data in a structured format;
+— Right to object (Art. 21 GDPR) — object to processing based on legitimate interest;
+— Right to withdraw consent — at any time without affecting the lawfulness of prior processing.
+
+To exercise these rights:
+— Data export: Profile → Privacy & Data → Export;
+— Account deletion: Profile → Privacy & Data → Delete;
+— Other requests: info@legal.org.ua.
+
+We respond to requests within 30 days.
+
+You also have the right to lodge a complaint with the Ukrainian Parliament Commissioner for Human Rights (Ukraine) or the supervisory authority in your EU country.`,
+      },
+      {
+        heading: '9. Cookies',
+        content: `The Service uses:
+— essential cookies — for authentication and session support (JWT tokens);
+— functional cookies — for storing language settings and interface preferences.
+
+We do NOT use third-party advertising or analytics cookies. We do NOT track users across other websites.`,
+      },
+      {
+        heading: '10. Children\'s Data Protection',
+        content: `The Service is not intended for persons under the age of 18. We do not knowingly collect personal data from minors. If you believe a minor has provided us with their data, please contact us for its deletion.`,
+      },
+      {
+        heading: '11. Changes to This Policy',
+        content: `We may update this Privacy Policy. We will notify you of material changes:
+— via the email registered with your account;
+— through notifications in the Service interface;
+— at least 14 days before the changes take effect.
+
+Continued use of the Service after changes constitutes acceptance of the updated Policy.`,
+      },
+      {
+        heading: '12. Contact Information',
+        content: `For data protection inquiries, please contact:
+
+LLC "Lex AI"
+EDRPOU: 46011385
+Address: 04132, Ukraine, Kyiv, 47-Sadova, 1a
+Email: info@legal.org.ua
+Website: https://legal.org.ua`,
+      },
+    ],
+  },
+};
+
+export function PrivacyPolicyPage() {
+  const { lang } = useParams<{ lang: string }>();
+  const navigate = useNavigate();
+
+  const currentLang = lang === 'uk' || lang === 'en' ? lang : 'uk';
+  const content = privacyContent[currentLang];
+
+  const handleSwitchLang = () => {
+    navigate(`/${content.switchTo}/privacy`, { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors text-sm"
+          >
+            <ArrowLeft size={16} />
+            {content.backLabel}
+          </button>
+          <button
+            onClick={handleSwitchLang}
+            className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-gray-700"
+          >
+            <Globe size={14} />
+            {content.switchLang}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 py-8">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 md:p-12">
+          <div className="text-center mb-10">
+            <div className="flex justify-center mb-4">
+              <div className="w-14 h-14 bg-green-100 rounded-full flex items-center justify-center">
+                <Shield size={28} className="text-green-600" />
+              </div>
+            </div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">{content.title}</h1>
+            <p className="text-lg text-gray-600">{content.subtitle}</p>
+            <p className="text-sm text-gray-400 mt-2">{content.lastUpdated}</p>
+          </div>
+
+          <div className="space-y-8">
+            {content.sections.map((section, index) => (
+              <section key={index}>
+                {section.heading && (
+                  <h2 className="text-xl font-semibold text-gray-900 mb-3">
+                    {section.heading}
+                  </h2>
+                )}
+                <div className="text-gray-700 leading-relaxed whitespace-pre-line">
+                  {section.content}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </main>
+
+      <footer className="max-w-4xl mx-auto px-4 py-6 text-center">
+        <p className="text-xs text-gray-400">
+          ТОВ «Лекс ЕйАй» &copy; {new Date().getFullYear()}
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/TermsPage.tsx
+++ b/lexwebapp/src/pages/TermsPage.tsx
@@ -1,0 +1,371 @@
+/**
+ * Terms of Service Page
+ * Bilingual (UK/EN) with {lang} parameter: /uk/terms or /en/terms
+ */
+
+import { useParams, useNavigate } from 'react-router-dom';
+import { FileText, ArrowLeft, Globe } from 'lucide-react';
+
+const termsContent = {
+  uk: {
+    title: 'УМОВИ ВИКОРИСТАННЯ',
+    subtitle: 'сервісу LEX AI',
+    lastUpdated: 'Останнє оновлення: 7 березня 2026 р.',
+    backLabel: 'Назад',
+    switchLang: 'English',
+    switchTo: 'en',
+    sections: [
+      {
+        heading: '',
+        content: `Товариство з обмеженою відповідальністю «Лекс ЕйАй»
+Код ЄДРПОУ: 46011385
+Місцезнаходження: 04132, Україна, м. Київ, 47-Садова, 1а
+Email: info@legal.org.ua`,
+      },
+      {
+        heading: '1. Визначення термінів',
+        content: `«Сервіс» — програмне забезпечення LEX AI, доступне за адресою legal.org.ua, включаючи API, MCP-сервери та веб-додаток.
+«Компанія» — ТОВ «Лекс ЕйАй», оператор Сервісу.
+«Користувач» — фізична або юридична особа, яка використовує Сервіс.
+«Контент» — будь-які дані, документи, запити та результати аналізу, створені або завантажені Користувачем.
+«AI-аналіз» — автоматизована обробка юридичних документів із використанням штучного інтелекту.
+«MCP-токен» — ключ доступу для підключення зовнішніх MCP-клієнтів (Claude Desktop тощо).`,
+      },
+      {
+        heading: '2. Прийняття умов',
+        content: `Реєстрація облікового запису або використання Сервісу означає повне прийняття цих Умов використання, Політики конфіденційності та Публічної оферти. Якщо ви не погоджуєтесь з будь-яким положенням, припиніть використання Сервісу.
+
+Компанія залишає за собою право змінювати ці Умови. Про суттєві зміни Користувачі будуть повідомлені електронною поштою або через інтерфейс Сервісу не менше ніж за 14 днів до набуття чинності.`,
+      },
+      {
+        heading: '3. Опис Сервісу',
+        content: `LEX AI надає:
+— AI-аналіз юридичних документів (договорів, позовів, судових рішень);
+— семантичний пошук по судовій практиці України;
+— пошук та аналіз законодавства;
+— перевірку контрагентів у державних реєстрах (ЄДР, ЄДРСР);
+— зберігання документів у захищеному сховищі;
+— доступ до парламентських даних (законопроєкти, голосування);
+— інтеграцію через MCP-токени з Claude Desktop та іншими клієнтами.
+
+Сервіс використовує технології штучного інтелекту (OpenAI API) для обробки та аналізу юридичної інформації.`,
+      },
+      {
+        heading: '4. Обмеження відповідальності щодо AI-аналізу',
+        content: `ВАЖЛИВО: Результати AI-аналізу мають виключно інформаційний характер і НЕ є юридичною консультацією.
+
+Компанія НЕ гарантує:
+— повну точність, актуальність чи повноту результатів аналізу;
+— відповідність результатів конкретній юридичній ситуації;
+— відсутність помилок у цитуванні нормативних актів чи судових рішень.
+
+Користувач зобов'язаний самостійно перевіряти результати AI-аналізу перед використанням у юридичній практиці. Компанія не несе відповідальності за збитки, завдані внаслідок використання результатів аналізу без належної перевірки.
+
+Система включає механізми HallucinationGuard та CitationValidator для мінімізації помилок, проте вони не гарантують абсолютну точність.`,
+      },
+      {
+        heading: '5. Реєстрація та обліковий запис',
+        content: `Для використання Сервісу необхідно створити обліковий запис одним із способів:
+— реєстрація через email та пароль;
+— авторизація через Google OAuth;
+— авторизація через Дію (Дія.Підпис).
+
+Користувач зобов'язаний:
+— надавати достовірну інформацію при реєстрації;
+— забезпечити конфіденційність пароля та MCP-токенів;
+— негайно повідомити Компанію про несанкціонований доступ;
+— не передавати обліковий запис третім особам.
+
+Компанія має право заблокувати або видалити обліковий запис у разі порушення цих Умов.`,
+      },
+      {
+        heading: '6. Допустиме використання',
+        content: `Користувач зобов'язується використовувати Сервіс виключно для законних цілей. Забороняється:
+— використання для порушення прав інтелектуальної власності;
+— завантаження шкідливого програмного забезпечення;
+— спроби несанкціонованого доступу до систем або даних інших користувачів;
+— масове автоматизоване завантаження даних (scraping) без дозволу;
+— використання Сервісу для створення конкуруючих продуктів;
+— перевищення встановлених лімітів API без узгодження;
+— використання результатів аналізу для введення в оману суду чи клієнтів.`,
+      },
+      {
+        heading: '7. Інтелектуальна власність',
+        content: `Сервіс LEX AI, включаючи програмний код, дизайн, алгоритми та документацію, є інтелектуальною власністю Компанії та захищений законодавством про авторське право.
+
+Контент, завантажений Користувачем, залишається його власністю. Користувач надає Компанії обмежену ліцензію на обробку Контенту виключно для надання послуг Сервісу.
+
+Результати AI-аналізу, створені Сервісом на основі Контенту Користувача, належать Користувачу.`,
+      },
+      {
+        heading: '8. Тарифи та оплата',
+        content: `Вартість послуг визначається відповідно до обраного тарифного плану, опублікованого на сайті Сервісу.
+
+Оплата здійснюється онлайн через платіжну систему Monobank. Ціни вказуються в гривнях (UAH) з урахуванням ПДВ.
+
+Компанія залишає за собою право змінювати тарифи з попереднім повідомленням за 30 днів. Зміна тарифів не впливає на вже оплачені періоди.`,
+      },
+      {
+        heading: '9. Повернення коштів',
+        content: `Повернення коштів можливе у випадках:
+— технічної неможливості надання послуг протягом більше ніж 72 години;
+— помилкового списання коштів;
+— суттєвого зниження якості послуг, підтвердженого документально.
+
+Заява на повернення подається на info@legal.org.ua протягом 14 календарних днів з моменту виникнення підстави. Повернення здійснюється протягом 10 робочих днів.`,
+      },
+      {
+        heading: '10. Обмеження відповідальності',
+        content: `Сервіс надається «як є» (as is). Компанія не гарантує безперебійну роботу Сервісу та не несе відповідальності за:
+— тимчасову недоступність Сервісу з технічних причин;
+— втрату даних внаслідок дій третіх осіб або форс-мажорних обставин;
+— збитки, що виникли внаслідок неправильного використання Сервісу;
+— дії або рішення, прийняті на основі результатів AI-аналізу.
+
+Сукупна відповідальність Компанії обмежується сумою, сплаченою Користувачем за останні 12 місяців.`,
+      },
+      {
+        heading: '11. Припинення використання',
+        content: `Користувач може припинити використання Сервісу в будь-який час, видаливши обліковий запис через налаштування профілю або надіславши запит на info@legal.org.ua.
+
+Компанія може припинити надання послуг:
+— за 30 днів письмового повідомлення;
+— негайно — у разі суттєвого порушення цих Умов.
+
+Після припинення Компанія зберігає дані протягом 30 днів для можливості відновлення, після чого видаляє їх відповідно до Політики конфіденційності.`,
+      },
+      {
+        heading: '12. Застосовне право та вирішення спорів',
+        content: `Ці Умови регулюються законодавством України.
+
+Спори вирішуються шляхом переговорів. Якщо сторони не досягнуть згоди протягом 30 днів, спір передається на розгляд до суду за місцезнаходженням Компанії (м. Київ, Україна).
+
+Для користувачів з ЄС також застосовуються положення GDPR (Регламент ЄС 2016/679).`,
+      },
+      {
+        heading: '13. Контактна інформація',
+        content: `ТОВ «Лекс ЕйАй»
+ЄДРПОУ: 46011385
+Адреса: 04132, Україна, м. Київ, 47-Садова, 1а
+Email: info@legal.org.ua
+Веб-сайт: https://legal.org.ua`,
+      },
+    ],
+  },
+  en: {
+    title: 'TERMS OF SERVICE',
+    subtitle: 'LEX AI Platform',
+    lastUpdated: 'Last updated: March 7, 2026',
+    backLabel: 'Back',
+    switchLang: 'Українська',
+    switchTo: 'uk',
+    sections: [
+      {
+        heading: '',
+        content: `Limited Liability Company "Lex AI"
+EDRPOU Code: 46011385
+Address: 04132, Ukraine, Kyiv, 47-Sadova, 1a
+Email: info@legal.org.ua`,
+      },
+      {
+        heading: '1. Definitions',
+        content: `"Service" — the LEX AI software available at legal.org.ua, including APIs, MCP servers, and the web application.
+"Company" — LLC "Lex AI", the operator of the Service.
+"User" — any individual or legal entity using the Service.
+"Content" — any data, documents, queries, and analysis results created or uploaded by the User.
+"AI Analysis" — automated processing of legal documents using artificial intelligence.
+"MCP Token" — an access key for connecting external MCP clients (Claude Desktop, etc.).`,
+      },
+      {
+        heading: '2. Acceptance of Terms',
+        content: `By registering an account or using the Service, you fully accept these Terms of Service, the Privacy Policy, and the Public Offer. If you disagree with any provision, discontinue use of the Service.
+
+The Company reserves the right to modify these Terms. Users will be notified of material changes via email or through the Service interface at least 14 days before the changes take effect.`,
+      },
+      {
+        heading: '3. Description of the Service',
+        content: `LEX AI provides:
+— AI analysis of legal documents (contracts, claims, court decisions);
+— semantic search across Ukrainian court practice;
+— legislation search and analysis;
+— counterparty verification in state registries (EDR, EDRSR);
+— secure document storage (vault);
+— access to parliamentary data (bills, voting records);
+— integration via MCP tokens with Claude Desktop and other clients.
+
+The Service uses artificial intelligence technologies (OpenAI API) for processing and analyzing legal information.`,
+      },
+      {
+        heading: '4. AI Analysis Disclaimer',
+        content: `IMPORTANT: AI analysis results are for informational purposes only and do NOT constitute legal advice.
+
+The Company does NOT guarantee:
+— complete accuracy, currency, or completeness of analysis results;
+— suitability of results for any specific legal situation;
+— absence of errors in citations of legal acts or court decisions.
+
+The User is obligated to independently verify AI analysis results before using them in legal practice. The Company shall not be liable for damages caused by the use of analysis results without proper verification.
+
+The system includes HallucinationGuard and CitationValidator mechanisms to minimize errors; however, they do not guarantee absolute accuracy.`,
+      },
+      {
+        heading: '5. Registration and Account',
+        content: `To use the Service, you must create an account using one of the following methods:
+— registration via email and password;
+— authorization via Google OAuth;
+— authorization via Diia (Diia.Signature).
+
+The User is obligated to:
+— provide accurate information during registration;
+— maintain the confidentiality of passwords and MCP tokens;
+— immediately notify the Company of any unauthorized access;
+— not transfer the account to third parties.
+
+The Company reserves the right to block or delete an account in case of violation of these Terms.`,
+      },
+      {
+        heading: '6. Acceptable Use',
+        content: `The User agrees to use the Service exclusively for lawful purposes. The following is prohibited:
+— use for infringement of intellectual property rights;
+— uploading malicious software;
+— attempting unauthorized access to systems or data of other users;
+— mass automated data downloading (scraping) without permission;
+— using the Service to create competing products;
+— exceeding established API limits without agreement;
+— using analysis results to mislead courts or clients.`,
+      },
+      {
+        heading: '7. Intellectual Property',
+        content: `The LEX AI Service, including source code, design, algorithms, and documentation, is the intellectual property of the Company and is protected by copyright law.
+
+Content uploaded by the User remains the User's property. The User grants the Company a limited license to process the Content solely for the purpose of providing the Service.
+
+AI analysis results generated by the Service based on the User's Content belong to the User.`,
+      },
+      {
+        heading: '8. Pricing and Payment',
+        content: `The cost of services is determined by the selected plan published on the Service website.
+
+Payments are made online through the Monobank payment system. Prices are listed in Ukrainian hryvnia (UAH) inclusive of VAT.
+
+The Company reserves the right to change pricing with 30 days' prior notice. Price changes do not affect already paid periods.`,
+      },
+      {
+        heading: '9. Refunds',
+        content: `Refunds are available in the following cases:
+— technical inability to provide services for more than 72 hours;
+— erroneous charges;
+— substantial documented deterioration in service quality.
+
+Refund requests should be sent to info@legal.org.ua within 14 calendar days of the event. Refunds are processed within 10 business days.`,
+      },
+      {
+        heading: '10. Limitation of Liability',
+        content: `The Service is provided "as is." The Company does not guarantee uninterrupted operation and shall not be liable for:
+— temporary unavailability of the Service for technical reasons;
+— data loss due to actions of third parties or force majeure;
+— damages resulting from improper use of the Service;
+— actions or decisions made based on AI analysis results.
+
+The Company's aggregate liability is limited to the amount paid by the User in the preceding 12 months.`,
+      },
+      {
+        heading: '11. Termination',
+        content: `The User may discontinue use of the Service at any time by deleting their account through profile settings or by sending a request to info@legal.org.ua.
+
+The Company may terminate services:
+— with 30 days' written notice;
+— immediately — in case of material breach of these Terms.
+
+After termination, the Company retains data for 30 days for possible recovery, after which it is deleted in accordance with the Privacy Policy.`,
+      },
+      {
+        heading: '12. Governing Law and Dispute Resolution',
+        content: `These Terms are governed by the laws of Ukraine.
+
+Disputes shall be resolved through negotiation. If the parties fail to reach agreement within 30 days, the dispute shall be submitted to the court at the Company's registered address (Kyiv, Ukraine).
+
+For users within the EU, the provisions of the GDPR (EU Regulation 2016/679) also apply.`,
+      },
+      {
+        heading: '13. Contact Information',
+        content: `LLC "Lex AI"
+EDRPOU: 46011385
+Address: 04132, Ukraine, Kyiv, 47-Sadova, 1a
+Email: info@legal.org.ua
+Website: https://legal.org.ua`,
+      },
+    ],
+  },
+};
+
+export function TermsPage() {
+  const { lang } = useParams<{ lang: string }>();
+  const navigate = useNavigate();
+
+  const currentLang = lang === 'uk' || lang === 'en' ? lang : 'uk';
+  const content = termsContent[currentLang];
+
+  const handleSwitchLang = () => {
+    navigate(`/${content.switchTo}/terms`, { replace: true });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+        <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
+          <button
+            onClick={() => navigate(-1)}
+            className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors text-sm"
+          >
+            <ArrowLeft size={16} />
+            {content.backLabel}
+          </button>
+          <button
+            onClick={handleSwitchLang}
+            className="flex items-center gap-2 px-3 py-1.5 text-sm border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors text-gray-700"
+          >
+            <Globe size={14} />
+            {content.switchLang}
+          </button>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-4 py-8">
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 md:p-12">
+          <div className="text-center mb-10">
+            <div className="flex justify-center mb-4">
+              <div className="w-14 h-14 bg-blue-100 rounded-full flex items-center justify-center">
+                <FileText size={28} className="text-blue-600" />
+              </div>
+            </div>
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">{content.title}</h1>
+            <p className="text-lg text-gray-600">{content.subtitle}</p>
+            <p className="text-sm text-gray-400 mt-2">{content.lastUpdated}</p>
+          </div>
+
+          <div className="space-y-8">
+            {content.sections.map((section, index) => (
+              <section key={index}>
+                {section.heading && (
+                  <h2 className="text-xl font-semibold text-gray-900 mb-3">
+                    {section.heading}
+                  </h2>
+                )}
+                <div className="text-gray-700 leading-relaxed whitespace-pre-line">
+                  {section.content}
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+      </main>
+
+      <footer className="max-w-4xl mx-auto px-4 py-6 text-center">
+        <p className="text-xs text-gray-400">
+          ТОВ «Лекс ЕйАй» &copy; {new Date().getFullYear()}
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -35,6 +35,8 @@ const ResetPasswordPage = lazy(() => import('../pages/ResetPasswordPage').then(m
 const PaymentSuccessPage = lazy(() => import('../pages/PaymentSuccessPage').then(m => ({ default: m.PaymentSuccessPage })));
 const PaymentErrorPage = lazy(() => import('../pages/PaymentErrorPage').then(m => ({ default: m.PaymentErrorPage })));
 const OfferPage = lazy(() => import('../pages/OfferPage').then(m => ({ default: m.OfferPage })));
+const TermsPage = lazy(() => import('../pages/TermsPage').then(m => ({ default: m.TermsPage })));
+const PrivacyPolicyPage = lazy(() => import('../pages/PrivacyPolicyPage').then(m => ({ default: m.PrivacyPolicyPage })));
 const BlogPage = lazy(() => import('../pages/BlogPage').then(m => ({ default: m.BlogPage })));
 
 // -- Data Sources (country pages) --
@@ -138,6 +140,14 @@ export const router = createBrowserRouter([
   {
     path: ROUTES.OFERTA,
     element: <Navigate to="/uk/offer" replace />,
+  },
+  {
+    path: ROUTES.TERMS,
+    element: S(TermsPage),
+  },
+  {
+    path: ROUTES.PRIVACY,
+    element: S(PrivacyPolicyPage),
   },
   {
     path: ROUTES.US_DATA_SOURCES,

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -47,9 +47,11 @@ export const ROUTES = {
   PAYMENT_SUCCESS: '/payment/success',
   PAYMENT_ERROR: '/payment/error',
 
-  // Public Offer
+  // Public Offer & Legal
   OFFER: '/:lang/offer',
   OFERTA: '/oferta',
+  TERMS: '/:lang/terms',
+  PRIVACY: '/:lang/privacy',
 
   // Blog
   BLOG: '/blog',


### PR DESCRIPTION
## Summary
- Add **Terms of Service** page (`/uk/terms`, `/en/terms`) — bilingual, 13 sections covering AI disclaimer, acceptable use, IP, payments, liability
- Add **Privacy Policy** page (`/uk/privacy`, `/en/privacy`) — bilingual, 12 sections covering data collection, OpenAI sub-processing (no training on API data, 30-day abuse monitoring), GDPR rights, data retention periods, cookies, third-party sub-processors
- Fix broken privacy link on LoginPage (`href="#"` → `/uk/privacy`)
- Both pages follow the existing `OfferPage` design pattern (bilingual, same layout)

## Key Privacy Policy points
- OpenAI as sub-processor: no training on data, 30-day retention for abuse monitoring
- Sub-processors listed: OpenAI, Monobank, Cloudflare, Hetzner
- GDPR rights with instructions (Profile → Privacy & Data)
- Data retention: account+30d, logs 90d, payments 5y
- No advertising cookies, no cross-site tracking

## Test plan
- [ ] Visit `/uk/terms` and `/en/terms` — verify content renders, language switch works
- [ ] Visit `/uk/privacy` and `/en/privacy` — verify content renders, language switch works
- [ ] On `/login` — verify "Політикою конфіденційності" link navigates to `/uk/privacy`
- [ ] Back button works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)