### PR TITLE
feat: require legal consent checkboxes during registration

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -59,6 +59,9 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const [error, setError] = useState<string | null>(null);
   const [showForgotPassword, setShowForgotPassword] = useState(false);
   const [showGDPR, setShowGDPR] = useState(false);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [acceptedPrivacy, setAcceptedPrivacy] = useState(false);
+  const [acceptedDpa, setAcceptedDpa] = useState(false);
   const [diiaDeeplink, setDiiaDeeplink] = useState<string | null>(null);
   const [diiaSessionId, setDiiaSessionId] = useState<string | null>(null);
   const diiaPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -181,18 +184,38 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   }, [isAuthenticated, isLoading, onLoginSuccess, navigate]);
 
   const handleSSOAuth = () => {
+    if (!isLogin && !allConsentsAccepted) {
+      setError('Для реєстрації необхідно прийняти всі документи');
+      return;
+    }
     setError(null);
     window.location.href = `${window.location.origin}/auth/oidc`;
   };
 
   const handleGoogleAuth = () => {
+    if (!isLogin && !allConsentsAccepted) {
+      setError('Для реєстрації необхідно прийняти всі документи');
+      return;
+    }
     setError(null);
     window.location.href = `${window.location.origin}/auth/google`;
   };
 
   const handleDiiaAuth = () => {
+    if (!isLogin && !allConsentsAccepted) {
+      setError('Для реєстрації необхідно прийняти всі документи');
+      return;
+    }
     setError(null);
     window.location.href = `${window.location.origin}/auth/diia`;
+  };
+
+  const allConsentsAccepted = acceptedTerms && acceptedPrivacy && acceptedDpa;
+
+  const resetConsents = () => {
+    setAcceptedTerms(false);
+    setAcceptedPrivacy(false);
+    setAcceptedDpa(false);
   };
 
   const handlePasswordChange = (value: string) => {
@@ -238,6 +261,11 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
     } else {
       if (!email || !password) {
         setError('Please fill in email and password');
+        return;
+      }
+
+      if (!allConsentsAccepted) {
+        setError('Для реєстрації необхідно прийняти всі документи');
         return;
       }
 
@@ -363,6 +391,33 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               {isLogin ? 'Оберіть зручний спосіб входу' : 'Створіть акаунт для початку роботи'}
             </p>
           </div>
+
+          {/* Legal consent checkboxes (Registration only — above all auth methods) */}
+          {!isLogin && (
+            <div className="space-y-2.5 mb-6 p-4 bg-claude-bg/50 rounded-xl border border-claude-border/50">
+              <p className="text-xs font-medium text-claude-text font-sans mb-2">Для реєстрації необхідно прийняти:</p>
+              <label className="flex items-start gap-2.5 cursor-pointer">
+                <input type="checkbox" checked={acceptedTerms} onChange={(e) => setAcceptedTerms(e.target.checked)} className="mt-0.5 w-4 h-4 rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer" />
+                <span className="text-xs text-claude-subtext font-sans leading-relaxed">
+                  <a href="/uk/terms" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Умови використання</a>
+                  {' '}та{' '}
+                  <a href="/uk/offer" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Публічну оферту</a>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 cursor-pointer">
+                <input type="checkbox" checked={acceptedPrivacy} onChange={(e) => setAcceptedPrivacy(e.target.checked)} className="mt-0.5 w-4 h-4 rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer" />
+                <span className="text-xs text-claude-subtext font-sans leading-relaxed">
+                  <a href="/uk/privacy" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Політику конфіденційності</a>
+                </span>
+              </label>
+              <label className="flex items-start gap-2.5 cursor-pointer">
+                <input type="checkbox" checked={acceptedDpa} onChange={(e) => setAcceptedDpa(e.target.checked)} className="mt-0.5 w-4 h-4 rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer" />
+                <span className="text-xs text-claude-subtext font-sans leading-relaxed">
+                  <a href="/uk/dpa" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Угоду про обробку даних (DPA)</a>
+                </span>
+              </label>
+            </div>
+          )}
 
           {/* SSO Auth Button */}
           <motion.button
@@ -510,7 +565,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                   </div>
                 )}
 
-                <motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} type="submit" disabled={isLoading} className="w-full flex items-center justify-center gap-2 px-4 py-3.5 bg-black text-white rounded-xl font-medium hover:bg-gray-800 transition-colors shadow-sm font-sans disabled:opacity-50">
+                <motion.button whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }} type="submit" disabled={isLoading || (!isLogin && !allConsentsAccepted)} className="w-full flex items-center justify-center gap-2 px-4 py-3.5 bg-black text-white rounded-xl font-medium hover:bg-gray-800 transition-colors shadow-sm font-sans disabled:opacity-50">
                   {isLoading ? (
                     <Loader2 size={18} className="animate-spin" />
                   ) : (
@@ -561,7 +616,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.4 }} className="text-center mt-6">
           <p className="text-claude-subtext font-sans text-sm">
             {isLogin ? 'Немає акаунту?' : 'Вже є акаунт?'}{' '}
-            <button onClick={() => { setIsLogin(!isLogin); setError(null); setPassword(''); }} className="text-claude-accent hover:text-[#C66345] font-medium">
+            <button onClick={() => { setIsLogin(!isLogin); setError(null); setPassword(''); resetConsents(); }} className="text-claude-accent hover:text-[#C66345] font-medium">
               {isLogin ? 'Зареєструватися' : 'Увійти'}
             </button>
           </p>
@@ -638,10 +693,13 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
         {/* Footer */}
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.55 }} className="text-center mt-3 text-xs text-claude-subtext font-sans">
           <p>
-            Продовжуючи, ви погоджуєтесь з{' '}
-            <a href="/uk/offer" className="text-claude-accent hover:text-[#C66345]">Договором публічної оферти</a>{' '}
-            та{' '}
-            <a href="/uk/privacy" className="text-claude-accent hover:text-[#C66345]">Політикою конфіденційності</a>
+            <a href="/uk/terms" className="text-claude-accent hover:text-[#C66345]">Умови використання</a>
+            {' · '}
+            <a href="/uk/offer" className="text-claude-accent hover:text-[#C66345]">Оферта</a>
+            {' · '}
+            <a href="/uk/privacy" className="text-claude-accent hover:text-[#C66345]">Конфіденційність</a>
+            {' · '}
+            <a href="/uk/dpa" className="text-claude-accent hover:text-[#C66345]">DPA</a>
           </p>
         </motion.div>
       </motion.div>


### PR DESCRIPTION
## Summary
- Add **3 consent checkboxes** that appear when user switches to registration mode
- All checkboxes must be accepted before registration is allowed
- Works for all auth methods: SSO, Diia, Google OAuth, email/password

## Consent checkboxes
1. **Умови використання** (`/uk/terms`) та **Публічна оферта** (`/uk/offer`)
2. **Політика конфіденційності** (`/uk/privacy`)
3. **Угода про обробку даних (DPA)** (`/uk/dpa`)

## Behavior
- Checkboxes appear in a styled block above OAuth buttons in registration mode
- Register button is `disabled` until all 3 are checked
- OAuth buttons (SSO, Diia, Google) show error if consents not accepted
- Checkboxes reset when switching between login/register
- Document links open in new tab
- Footer updated with links to all 4 legal documents

## Test plan
- [ ] Login mode — no checkboxes visible, login works as before
- [ ] Switch to registration — checkboxes appear
- [ ] Try register with password without checking all boxes — button disabled
- [ ] Try Google/SSO/Diia without checking — error message shown
- [ ] Check all 3 boxes — registration proceeds normally
- [ ] Switch back to login — checkboxes disappear
- [ ] Footer links work: Умови, Оферта, Конфіденційність, DPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)