### PR TITLE
fix: legal pages lang prefix uk→ua, back button to home

### DIFF
--- a/lexwebapp/src/components/LegalPageLayout.tsx
+++ b/lexwebapp/src/components/LegalPageLayout.tsx
@@ -21,18 +21,18 @@ export function LegalPageLayout({
   const { lang } = useParams<{ lang: string }>();
   const navigate = useNavigate();
 
-  const currentLang = lang === 'uk' || lang === 'en' ? lang : 'uk';
-  const content = currentLang === 'uk' ? contentUk : contentEn;
-  const switchTo = currentLang === 'uk' ? 'en' : 'uk';
-  const switchLabel = currentLang === 'uk' ? 'English' : 'Українська';
-  const backLabel = currentLang === 'uk' ? 'Назад' : 'Back';
+  const currentLang = lang === 'ua' || lang === 'en' ? lang : 'ua';
+  const content = currentLang === 'ua' ? contentUk : contentEn;
+  const switchTo = currentLang === 'ua' ? 'en' : 'ua';
+  const switchLabel = currentLang === 'ua' ? 'English' : 'Українська';
+  const backLabel = currentLang === 'ua' ? 'Назад' : 'Back';
 
   return (
     <div className="min-h-screen bg-gray-50">
       <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
         <div className="max-w-4xl mx-auto px-4 py-4 flex items-center justify-between">
           <button
-            onClick={() => navigate(-1)}
+            onClick={() => navigate('/')}
             className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors text-sm"
           >
             <ArrowLeft size={16} />

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -399,21 +399,21 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               <label className="flex items-start gap-2.5 cursor-pointer">
                 <input type="checkbox" checked={acceptedTerms} onChange={(e) => setAcceptedTerms(e.target.checked)} className="mt-0.5 w-4 h-4 rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer" />
                 <span className="text-xs text-claude-subtext font-sans leading-relaxed">
-                  <a href="/uk/terms" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Умови використання</a>
+                  <a href="/ua/terms" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Умови використання</a>
                   {' '}та{' '}
-                  <a href="/uk/offer" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Публічну оферту</a>
+                  <a href="/ua/offer" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Публічну оферту</a>
                 </span>
               </label>
               <label className="flex items-start gap-2.5 cursor-pointer">
                 <input type="checkbox" checked={acceptedPrivacy} onChange={(e) => setAcceptedPrivacy(e.target.checked)} className="mt-0.5 w-4 h-4 rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer" />
                 <span className="text-xs text-claude-subtext font-sans leading-relaxed">
-                  <a href="/uk/privacy" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Політику конфіденційності</a>
+                  <a href="/ua/privacy" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Політику конфіденційності</a>
                 </span>
               </label>
               <label className="flex items-start gap-2.5 cursor-pointer">
                 <input type="checkbox" checked={acceptedDpa} onChange={(e) => setAcceptedDpa(e.target.checked)} className="mt-0.5 w-4 h-4 rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer" />
                 <span className="text-xs text-claude-subtext font-sans leading-relaxed">
-                  <a href="/uk/dpa" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Угоду про обробку даних (DPA)</a>
+                  <a href="/ua/dpa" target="_blank" rel="noopener noreferrer" className="text-claude-accent hover:text-[#C66345] underline" onClick={(e) => e.stopPropagation()}>Угоду про обробку даних (DPA)</a>
                 </span>
               </label>
             </div>
@@ -693,13 +693,13 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
         {/* Footer */}
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.55 }} className="text-center mt-3 text-xs text-claude-subtext font-sans">
           <p>
-            <a href="/uk/terms" className="text-claude-accent hover:text-[#C66345]">Умови використання</a>
+            <a href="/ua/terms" className="text-claude-accent hover:text-[#C66345]">Умови використання</a>
             {' · '}
-            <a href="/uk/offer" className="text-claude-accent hover:text-[#C66345]">Оферта</a>
+            <a href="/ua/offer" className="text-claude-accent hover:text-[#C66345]">Оферта</a>
             {' · '}
-            <a href="/uk/privacy" className="text-claude-accent hover:text-[#C66345]">Конфіденційність</a>
+            <a href="/ua/privacy" className="text-claude-accent hover:text-[#C66345]">Конфіденційність</a>
             {' · '}
-            <a href="/uk/dpa" className="text-claude-accent hover:text-[#C66345]">DPA</a>
+            <a href="/ua/dpa" className="text-claude-accent hover:text-[#C66345]">DPA</a>
           </p>
         </motion.div>
       </motion.div>

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -140,7 +140,7 @@ export const router = createBrowserRouter([
   },
   {
     path: ROUTES.OFERTA,
-    element: <Navigate to="/uk/offer" replace />,
+    element: <Navigate to="/ua/offer" replace />,
   },
   {
     path: ROUTES.TERMS,


### PR DESCRIPTION
## Summary
- Change URL language prefix from `/uk/` to `/ua/` (uk = United Kingdom, ua = Ukraine)
- Fix back button on legal pages to navigate to `/` (home) instead of `navigate(-1)`

## Test plan
- [ ] Verify `/ua/terms`, `/ua/offer`, `/ua/privacy`, `/ua/dpa` work
- [ ] Verify `/en/terms` etc. still work
- [ ] Verify language switcher toggles between `/ua/` and `/en/`
- [ ] Verify back button goes to home page
- [ ] Verify login page links point to `/ua/` URLs

Generated with [Claude Code](https://claude.com/claude-code)