### PR TITLE
feat: inline SSO login form via Authentik Flow Executor

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -62,6 +62,11 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const [acceptedTerms, setAcceptedTerms] = useState(false);
   const [acceptedPrivacy, setAcceptedPrivacy] = useState(false);
   const [acceptedDpa, setAcceptedDpa] = useState(false);
+  const [showSSOForm, setShowSSOForm] = useState(false);
+  const [ssoEmail, setSsoEmail] = useState('');
+  const [ssoPassword, setSsoPassword] = useState('');
+  const [showSSOPassword, setShowSSOPassword] = useState(false);
+  const [ssoLoading, setSsoLoading] = useState(false);
   const [diiaDeeplink, setDiiaDeeplink] = useState<string | null>(null);
   const [diiaSessionId, setDiiaSessionId] = useState<string | null>(null);
   const diiaPollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -189,7 +194,41 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       return;
     }
     setError(null);
-    window.location.href = `${window.location.origin}/auth/oidc`;
+    setShowSSOForm(!showSSOForm);
+  };
+
+  const handleSSOLogin = async () => {
+    setError(null);
+
+    if (!ssoEmail || !ssoPassword) {
+      setError('Введіть email та пароль SSO');
+      return;
+    }
+
+    setSsoLoading(true);
+
+    try {
+      const response = await fetch(`${BASE_URL}/auth/oidc/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: ssoEmail, password: ssoPassword }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) throw new Error(data.message || 'SSO login failed');
+
+      await login(data.token);
+      showToast.success('Вхід через SSO виконано успішно!');
+      if (onLoginSuccess) onLoginSuccess();
+      navigate(getReturnUrl(), { replace: true });
+    } catch (err: unknown) {
+      console.error('SSO login failed:', err);
+      const msg = err instanceof Error ? err.message : 'Помилка автентифікації через SSO';
+      setError(msg);
+      showToast.error('Помилка SSO');
+    } finally {
+      setSsoLoading(false);
+    }
   };
 
   const handleGoogleAuth = () => {
@@ -419,16 +458,81 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             </div>
           )}
 
-          {/* SSO Auth Button */}
+          {/* SSO Auth Button + Expandable Form */}
           <motion.button
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
             onClick={handleSSOAuth}
-            className="w-full flex items-center justify-center gap-3 px-4 py-3.5 bg-gradient-to-r from-[#fd4b2d] to-[#e0422a] hover:from-[#e0422a] hover:to-[#c93a25] text-white rounded-xl font-medium transition-all shadow-sm mb-3 font-sans"
+            className={`w-full flex items-center justify-center gap-3 px-4 py-3.5 bg-gradient-to-r from-[#fd4b2d] to-[#e0422a] hover:from-[#e0422a] hover:to-[#c93a25] text-white font-medium transition-all shadow-sm font-sans ${showSSOForm ? 'rounded-t-xl' : 'rounded-xl mb-3'}`}
           >
             <ShieldCheck size={20} />
             {isLogin ? 'Увійти через SSO' : 'Зареєструватися через SSO'}
           </motion.button>
+
+          <AnimatePresence>
+            {showSSOForm && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
+                className="overflow-hidden mb-3"
+              >
+                <div className="bg-red-50/50 border border-t-0 border-red-200/30 rounded-b-xl p-4 space-y-3">
+                  <div>
+                    <div className="relative">
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <Mail size={16} className="text-claude-subtext" />
+                      </div>
+                      <input
+                        type="email"
+                        value={ssoEmail}
+                        onChange={(e) => setSsoEmail(e.target.value)}
+                        placeholder="SSO email"
+                        autoComplete="username"
+                        className="block w-full pl-9 pr-4 py-2.5 bg-white border border-claude-border rounded-lg text-sm text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-red-400/20 focus:border-red-400 transition-all font-sans"
+                      />
+                    </div>
+                  </div>
+                  <div>
+                    <div className="relative">
+                      <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                        <Lock size={16} className="text-claude-subtext" />
+                      </div>
+                      <input
+                        type={showSSOPassword ? 'text' : 'password'}
+                        value={ssoPassword}
+                        onChange={(e) => setSsoPassword(e.target.value)}
+                        placeholder="SSO пароль"
+                        autoComplete="current-password"
+                        onKeyDown={(e) => { if (e.key === 'Enter') handleSSOLogin(); }}
+                        className="block w-full pl-9 pr-10 py-2.5 bg-white border border-claude-border rounded-lg text-sm text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-red-400/20 focus:border-red-400 transition-all font-sans"
+                      />
+                      <button type="button" onClick={() => setShowSSOPassword(!showSSOPassword)} className="absolute inset-y-0 right-0 pr-3 flex items-center text-claude-subtext hover:text-claude-text transition-colors">
+                        {showSSOPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+                      </button>
+                    </div>
+                  </div>
+                  <motion.button
+                    whileHover={{ scale: 1.02 }}
+                    whileTap={{ scale: 0.98 }}
+                    onClick={handleSSOLogin}
+                    disabled={ssoLoading}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-gradient-to-r from-[#fd4b2d] to-[#e0422a] hover:from-[#e0422a] hover:to-[#c93a25] text-white rounded-lg font-medium text-sm transition-all shadow-sm font-sans disabled:opacity-50"
+                  >
+                    {ssoLoading ? (
+                      <Loader2 size={16} className="animate-spin" />
+                    ) : (
+                      <>
+                        <ArrowRight size={16} />
+                        Увійти
+                      </>
+                    )}
+                  </motion.button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* Diia Auth Button */}
           <motion.button

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -1216,6 +1216,70 @@ export async function oidcAuthCallback(req: Request, res: Response): Promise<voi
   }
 }
 
+/**
+ * POST /auth/oidc/login
+ * SSO login with email/password via Authentik ROPC grant.
+ * Frontend collects credentials in our UI, backend authenticates against Authentik.
+ */
+export async function oidcLoginWithPassword(req: Request, res: Response): Promise<void> {
+  try {
+    const { email, password } = req.body;
+
+    if (!email || !password) {
+      res.status(400).json({ message: 'Email та пароль обов\'язкові' });
+      return;
+    }
+
+    if (!oidcService.isOidcConfigured()) {
+      res.status(501).json({ message: 'SSO не налаштовано' });
+      return;
+    }
+
+    const userInfo = await oidcService.loginWithCredentials(email, password);
+    const userService = getUserService();
+
+    // Find or create user
+    let user = await userService.findByEmail(userInfo.email);
+
+    if (user) {
+      await userService.updateLastLogin(user.id);
+      logger.info('[OIDC] Existing user logged in via SSO (ROPC)', {
+        userId: user.id,
+        email: user.email,
+      });
+    } else {
+      user = await userService.createUser({
+        googleId: '',
+        email: userInfo.email,
+        name: userInfo.name || userInfo.email.split('@')[0],
+        picture: userInfo.picture,
+        emailVerified: userInfo.email_verified ?? true,
+      });
+      await userService.updateLastLogin(user.id);
+      logger.info('[OIDC] New user created via SSO (ROPC)', {
+        userId: user.id,
+        email: user.email,
+      });
+
+      generateBannerAsync(user.id, user.name || user.email);
+    }
+
+    const token = generateToken(user);
+    res.json({ token, user: { id: user.id, email: user.email, name: user.name, picture: user.picture } });
+  } catch (error: any) {
+    logger.error('[OIDC] ROPC login failed:', error);
+
+    // Map errors to user-friendly messages
+    const msg = error.message?.includes('invalid_grant')
+      ? 'Невірний email або пароль'
+      : error.message?.includes('Unexpected flow stage')
+        ? 'Непідтримуваний крок автентифікації (можливо, потрібна MFA)'
+        : 'Помилка автентифікації через SSO';
+
+    res.status(401).json({ message: msg });
+  }
+}
+
 // ============================================================================
 // Diia Auth Controllers
 // ============================================================================

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -119,11 +119,15 @@ if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
 if (process.env.OIDC_DISCOVERY_URL && process.env.OIDC_CLIENT_ID) {
   router.get('/oidc', authController.oidcAuthInit as any);
   router.get('/oidc/callback', authController.oidcAuthCallback as any);
+  router.post('/oidc/login', authRateLimit as any, authController.oidcLoginWithPassword as any);
 } else {
   router.get('/oidc', (_req, res) => {
     res.status(501).json({ error: 'OIDC/SSO is not configured' });
   });
   router.get('/oidc/callback', (_req, res) => {
+    res.status(501).json({ error: 'OIDC/SSO is not configured' });
+  });
+  router.post('/oidc/login', (_req, res) => {
     res.status(501).json({ error: 'OIDC/SSO is not configured' });
   });
 }

--- a/mcp_backend/src/services/oidc-service.ts
+++ b/mcp_backend/src/services/oidc-service.ts
@@ -89,6 +89,121 @@ export interface OidcUserInfo {
   email_verified?: boolean;
 }
 
+const AUTHENTIK_API_URL = process.env.AUTHENTIK_API_URL || '';
+const AUTHENTIK_AUTH_FLOW_SLUG = process.env.AUTHENTIK_AUTH_FLOW_SLUG || 'default-authentication-flow';
+
+/**
+ * Authenticate user via Authentik Flow Executor API (headless).
+ * Executes the authentication flow step by step:
+ * 1. GET flow → ak-stage-identification
+ * 2. POST uid_field → ak-stage-password
+ * 3. POST password → xak-flow-redirect (success)
+ * Then fetches user info from the Authentik session.
+ */
+export async function loginWithCredentials(
+  username: string,
+  password: string
+): Promise<OidcUserInfo> {
+  if (!AUTHENTIK_API_URL) {
+    throw new Error('AUTHENTIK_API_URL is not configured');
+  }
+
+  const flowUrl = `${AUTHENTIK_API_URL}/api/v3/flows/executor/${AUTHENTIK_AUTH_FLOW_SLUG}/`;
+
+  // We need to track cookies (authentik_session) across requests
+  let sessionCookie = '';
+
+  const fetchWithCookies = async (url: string, options: RequestInit = {}): Promise<any> => {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(options.headers as Record<string, string> || {}),
+    };
+    if (sessionCookie) {
+      headers['Cookie'] = sessionCookie;
+    }
+
+    const resp = await fetch(url, { ...options, headers, redirect: 'manual' });
+
+    // Capture set-cookie header
+    const setCookie = resp.headers.get('set-cookie');
+    if (setCookie) {
+      const match = setCookie.match(/authentik_session=([^;]+)/);
+      if (match) {
+        sessionCookie = `authentik_session=${match[1]}`;
+      }
+    }
+
+    const text = await resp.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      throw new Error(`Unexpected response from Authentik: ${text.substring(0, 200)}`);
+    }
+  };
+
+  // Step 1: GET flow — get identification stage
+  const step1 = await fetchWithCookies(flowUrl);
+
+  if (step1.component !== 'ak-stage-identification') {
+    logger.error('[OIDC] Unexpected flow stage', { component: step1.component });
+    throw new Error(`Unexpected flow stage: ${step1.component}`);
+  }
+
+  // Step 2: POST identification (email/username)
+  const step2 = await fetchWithCookies(flowUrl, {
+    method: 'POST',
+    body: JSON.stringify({ component: 'ak-stage-identification', uid_field: username }),
+  });
+
+  if (step2.component === 'ak-stage-access-denied') {
+    throw new Error('invalid_grant: user not found');
+  }
+
+  if (step2.component !== 'ak-stage-password') {
+    logger.error('[OIDC] Unexpected flow stage after identification', { component: step2.component });
+    throw new Error(`Unexpected flow stage: ${step2.component}`);
+  }
+
+  // Step 3: POST password
+  const step3 = await fetchWithCookies(flowUrl, {
+    method: 'POST',
+    body: JSON.stringify({ component: 'ak-stage-password', password }),
+  });
+
+  if (step3.component === 'ak-stage-access-denied') {
+    throw new Error('invalid_grant: invalid password');
+  }
+
+  if (step3.component !== 'xak-flow-redirect') {
+    // Could be MFA or other stage — not supported yet
+    logger.error('[OIDC] Unexpected flow stage after password', { component: step3.component });
+    throw new Error(`Unexpected flow stage: ${step3.component}`);
+  }
+
+  // Step 4: Get user info from session
+  const userInfoResp = await fetchWithCookies(`${AUTHENTIK_API_URL}/api/v3/core/users/me/`);
+
+  const user = userInfoResp.user || userInfoResp;
+  const userInfo: OidcUserInfo = {
+    sub: String(user.pk || user.uid || ''),
+    email: user.email || '',
+    name: user.name || undefined,
+    picture: user.avatar || undefined,
+    email_verified: true,
+  };
+
+  if (!userInfo.email) {
+    throw new Error('No email returned from Authentik');
+  }
+
+  logger.info('[OIDC] User authenticated via Flow Executor', {
+    sub: userInfo.sub,
+    email: userInfo.email,
+  });
+
+  return userInfo;
+}
+
 /**
  * Handle callback from Authentik.
  * Exchanges authorization code for tokens, returns user info.


### PR DESCRIPTION
## Summary
- SSO button now expands an inline email/password form instead of redirecting to Authentik login page
- Backend authenticates via Authentik Flow Executor API (headless) — works out of the box, no special Authentik config needed
- Replaces ROPC grant approach which only works with Authentik app passwords

## Test plan
- [ ] Click SSO button — form expands with email/password fields
- [ ] Enter valid SSO credentials — user authenticated, JWT returned
- [ ] Enter invalid credentials — error message shown
- [ ] Existing OIDC redirect flow (GET /auth/oidc) still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)