### PR TITLE
feat: auto-provision Nextcloud accounts for new users

### DIFF
--- a/mcp_backend/src/config/passport.ts
+++ b/mcp_backend/src/config/passport.ts
@@ -10,6 +10,7 @@ import { UserService } from '../services/user-service.js';
 import { BannerService } from '../services/banner-service.js';
 import { logger } from '../utils/logger.js';
 import { provisionAuthentikUser } from '../services/authentik-service.js';
+import { provisionNextcloudUser } from '../services/nextcloud-provisioning.js';
 
 let passportBannerService: BannerService | null = null;
 
@@ -93,8 +94,9 @@ export function configurePassport(db: Database): typeof passport {
           await userService.updateLastLogin(user.id);
           logger.info('New Google user created', { userId: user.id, email });
 
-          // Provision in Authentik for Nextcloud SSO access (fire and forget)
+          // Provision in Authentik and Nextcloud (fire and forget)
           provisionAuthentikUser({ email, name }).catch(() => {});
+          provisionNextcloudUser({ email, name }).catch(() => {});
 
           // Generate banner (fire and forget)
           if (passportBannerService) {

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -19,6 +19,7 @@ import type { ICachePort } from '../domain/ports/index.js';
 import { getDiiaService } from '../services/diia-service.js';
 import * as oidcService from '../services/oidc-service.js';
 import { provisionAuthentikUser } from '../services/authentik-service.js';
+import { provisionNextcloudUser } from '../services/nextcloud-provisioning.js';
 
 let authCache: ICachePort | null = null;
 let authEmailService: EmailService | null = null;
@@ -528,8 +529,9 @@ export async function registerWithPassword(req: Request, res: Response): Promise
     // Generate banner (fire and forget)
     generateBannerAsync(user.id, user.name || user.email);
 
-    // Provision user in Authentik for Nextcloud SSO access (fire and forget)
+    // Provision user in Authentik and Nextcloud (fire and forget)
     provisionAuthentikUser({ email, name, password }).catch(() => {});
+    provisionNextcloudUser({ email, name, password }).catch(() => {});
 
     // Create verification token and send email
     const verificationToken = await userService.createVerificationToken(user.id);
@@ -1199,8 +1201,9 @@ export async function oidcAuthCallback(req: Request, res: Response): Promise<voi
         email: user.email,
       });
 
-      // Generate banner (fire and forget)
+      // Generate banner and provision Nextcloud (fire and forget)
       generateBannerAsync(user.id, user.name || user.email);
+      provisionNextcloudUser({ email: userInfo.email, name: userInfo.name }).catch(() => {});
     }
 
     // Generate JWT token
@@ -1262,6 +1265,7 @@ export async function oidcLoginWithPassword(req: Request, res: Response): Promis
       });
 
       generateBannerAsync(user.id, user.name || user.email);
+      provisionNextcloudUser({ email: userInfo.email, name: userInfo.name }).catch(() => {});
     }
 
     const token = generateToken(user);
@@ -1390,6 +1394,7 @@ export async function diiaAuthCallback(req: Request, res: Response): Promise<Res
       logger.info('[Diia] Created user from webhook', { userId: user.id, traceId });
       generateBannerAsync(user.id, name);
       provisionAuthentikUser({ email, name }).catch(() => {});
+      provisionNextcloudUser({ email, name }).catch(() => {});
     } else {
       await userService.updateLastLogin(user.id);
       logger.info('[Diia] Existing user webhook auth', { userId: user.id, traceId });

--- a/mcp_backend/src/services/nextcloud-provisioning.ts
+++ b/mcp_backend/src/services/nextcloud-provisioning.ts
@@ -1,0 +1,141 @@
+/**
+ * Nextcloud User Provisioning Service
+ * Auto-creates personal Nextcloud accounts for users when they register/login.
+ * Uses Nextcloud OCS Provisioning API with admin credentials.
+ */
+
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+
+const NEXTCLOUD_URL = (process.env.NEXTCLOUD_URL || '').replace(/\/$/, '');
+const NEXTCLOUD_USER = process.env.NEXTCLOUD_USER || 'admin';
+const NEXTCLOUD_PASSWORD = process.env.NEXTCLOUD_PASSWORD || 'admin';
+
+interface ProvisionNextcloudData {
+  email: string;
+  name?: string;
+  password?: string;
+}
+
+/**
+ * Check if Nextcloud provisioning is configured
+ */
+export function isNextcloudConfigured(): boolean {
+  return !!NEXTCLOUD_URL;
+}
+
+/**
+ * Make an authenticated OCS API request to Nextcloud
+ */
+async function nextcloudOcs(path: string, options: RequestInit = {}): Promise<any> {
+  const url = `${NEXTCLOUD_URL}${path}`;
+  const auth = 'Basic ' + Buffer.from(`${NEXTCLOUD_USER}:${NEXTCLOUD_PASSWORD}`).toString('base64');
+
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Authorization': auth,
+      'OCS-APIRequest': 'true',
+      'Accept': 'application/json',
+      ...options.headers,
+    },
+  });
+
+  const text = await res.text();
+  try {
+    return { status: res.status, data: JSON.parse(text) };
+  } catch {
+    return { status: res.status, data: text };
+  }
+}
+
+/**
+ * Generate a Nextcloud-safe username from email.
+ * Nextcloud usernames: lowercase, alphanumeric + dots/hyphens/underscores.
+ */
+function emailToUsername(email: string): string {
+  return email.split('@')[0]
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]/g, '_')
+    .substring(0, 64);
+}
+
+/**
+ * Check if a Nextcloud user already exists
+ */
+async function findNextcloudUser(username: string): Promise<boolean> {
+  const result = await nextcloudOcs(`/ocs/v1.php/cloud/users/${encodeURIComponent(username)}`, {
+    method: 'GET',
+  });
+
+  // 200 with statuscode=100 = user exists, 404 or statuscode=404 = not found
+  return result.status === 200 && result.data?.ocs?.meta?.statuscode === 100;
+}
+
+/**
+ * Create a user in Nextcloud via OCS Provisioning API
+ */
+async function createNextcloudUser(
+  username: string,
+  data: ProvisionNextcloudData
+): Promise<void> {
+  const password = data.password || crypto.randomBytes(24).toString('base64url');
+
+  const body = new URLSearchParams();
+  body.append('userid', username);
+  body.append('password', password);
+  body.append('email', data.email);
+  if (data.name) {
+    body.append('displayName', data.name);
+  }
+
+  const result = await nextcloudOcs('/ocs/v1.php/cloud/users', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+
+  const statuscode = result.data?.ocs?.meta?.statuscode;
+  if (statuscode !== 100) {
+    const msg = result.data?.ocs?.meta?.message || JSON.stringify(result.data);
+    throw new Error(`OCS create user failed (statuscode=${statuscode}): ${msg}`);
+  }
+}
+
+/**
+ * Provision a Nextcloud account for a user (fire-and-forget safe).
+ * Checks if user already exists by username to avoid duplicates.
+ */
+export async function provisionNextcloudUser(data: ProvisionNextcloudData): Promise<void> {
+  if (!isNextcloudConfigured()) {
+    logger.debug('[Nextcloud] Provisioning skipped — not configured');
+    return;
+  }
+
+  try {
+    const username = emailToUsername(data.email);
+
+    // Check if user already exists
+    const exists = await findNextcloudUser(username);
+    if (exists) {
+      logger.info('[Nextcloud] User already exists, skipping provisioning', {
+        email: data.email,
+        username,
+      });
+      return;
+    }
+
+    // Create user
+    await createNextcloudUser(username, data);
+    logger.info('[Nextcloud] User provisioned successfully', {
+      email: data.email,
+      username,
+    });
+  } catch (error: any) {
+    // Non-fatal: log and continue — user can still use lexwebapp
+    logger.error('[Nextcloud] User provisioning failed', {
+      email: data.email,
+      error: error.message,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- New `nextcloud-provisioning.ts` service creates Nextcloud accounts via OCS Provisioning API
- Hooks into all auth flows: password registration, Google OAuth, OIDC SSO, Diia
- Fire-and-forget — Nextcloud failures don't block user registration
- Username derived from email prefix (lowercase, sanitized)

## Test plan
- [ ] Register new user with password — Nextcloud account created
- [ ] Login via Google (new user) — Nextcloud account created
- [ ] Login via SSO (new user) — Nextcloud account created
- [ ] Existing user login — skips provisioning (no duplicate)
- [ ] Nextcloud down — user registration still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)