### PR TITLE
fix: translate AI footer links to Ukrainian on login page

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -805,9 +805,9 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             {' · '}
             <a href="/ua/dpa" className="text-claude-accent hover:text-[#C66345]">DPA</a>
             {' · '}
-            <a href="/ua/ai-usage" className="text-claude-accent hover:text-[#C66345]">AI Policy</a>
+            <a href="/ua/ai-usage" className="text-claude-accent hover:text-[#C66345]">Політика AI</a>
             {' · '}
-            <a href="/ua/ai-transparency" className="text-claude-accent hover:text-[#C66345]">AI Transparency</a>
+            <a href="/ua/ai-transparency" className="text-claude-accent hover:text-[#C66345]">Прозорість AI</a>
           </p>
         </motion.div>
       </motion.div>


### PR DESCRIPTION
## Summary
- Translated "AI Policy" → "Політика AI" and "AI Transparency" → "Прозорість AI" in login page footer

## Test plan
- [ ] Verify login page footer shows Ukrainian link names

🤖 Generated with [Claude Code](https://claude.com/claude-code)