### PR TITLE
fix: exclude already-processed docs from classification queue

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/ClassificationPanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/ClassificationPanel.tsx
@@ -29,7 +29,7 @@ export function ClassificationPanel({ stats, onComplete }: ClassificationPanelPr
   const [showSettings, setShowSettings] = useState(false);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const unclassifiedCount = stats ? stats.unclassified + stats.needsReview : 0;
+  const unclassifiedCount = stats ? stats.unclassified : 0;
 
   // Poll job status
   const pollJob = useCallback(async (jobId: string) => {

--- a/mcp_backend/src/services/document-classification-service.ts
+++ b/mcp_backend/src/services/document-classification-service.ts
@@ -85,13 +85,13 @@ export class DocumentClassificationService {
                ORDER BY created_at DESC`;
       params = [userId, documentIds];
     } else {
-      // Get docs that have no tags or type is 'other' (unclassified)
+      // Get docs that haven't been classified yet (exclude already processed)
       query = `SELECT id, title, full_text, type, metadata
                FROM documents
                WHERE user_id = $1
+                 AND deleted_at IS NULL
                  AND (
-                   type = 'other'
-                   OR metadata->>'classificationStatus' IS NULL
+                   metadata->>'classificationStatus' IS NULL
                    OR metadata->>'classificationStatus' = 'pending'
                  )
                ORDER BY created_at DESC`;
@@ -446,8 +446,7 @@ export class DocumentClassificationService {
        WHERE user_id = $1
          AND deleted_at IS NULL
          AND (
-           type = 'other'
-           OR metadata->>'classificationStatus' IS NULL
+           metadata->>'classificationStatus' IS NULL
            OR metadata->>'classificationStatus' = 'pending'
          )`,
       [userId]


### PR DESCRIPTION
## Summary
- Removed `type = 'other'` condition from classification and dismiss queries — documents already processed (needs_review/classified/dismissed) were being re-selected for classification
- Frontend classification count now shows only truly unclassified documents, not needs_review ones

## Test plan
- [ ] Upload documents, run classification
- [ ] Verify documents that fail classification (short text, LLM error) are not offered again
- [ ] Verify "dismiss" only affects unclassified docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)