### PR TITLE
fix: profile page USD→UAH + NaN spending values

### DIFF
--- a/lexwebapp/src/components/billing/LimitsTab.tsx
+++ b/lexwebapp/src/components/billing/LimitsTab.tsx
@@ -87,8 +87,8 @@ export function LimitsTab() {
       });
 
       const b = balanceRes.data;
-      const dailySpent = parseFloat(b.today_spent_usd || b.today_spending_usd || '0') || 0;
-      const monthlySpent = parseFloat(b.month_spent_usd || b.monthly_spending_usd || '0') || 0;
+      const dailySpent = parseFloat(b.today_spending_usd || '0') || 0;
+      const monthlySpent = parseFloat(b.monthly_spending_usd || '0') || 0;
       const dailyLimit = parseFloat(b.daily_limit_usd || s.daily_limit_usd || '50') || 50;
       const monthlyLimit = parseFloat(b.monthly_limit_usd || s.monthly_limit_usd || '1000') || 1000;
 

--- a/lexwebapp/src/components/billing/SettingsTab.tsx
+++ b/lexwebapp/src/components/billing/SettingsTab.tsx
@@ -198,8 +198,8 @@ export function SettingsTab() {
 
       // Usage from balance
       const b = balanceRes.data;
-      const dailySpent = parseFloat(b.today_spent_usd || b.today_spending_usd || '0') || 0;
-      const monthlySpent = parseFloat(b.month_spent_usd || b.monthly_spending_usd || '0') || 0;
+      const dailySpent = parseFloat(b.today_spending_usd || '0') || 0;
+      const monthlySpent = parseFloat(b.monthly_spending_usd || '0') || 0;
       const dailyLimit = parseFloat(b.daily_limit_usd || s.daily_limit_usd || '50') || 50;
       const monthlyLimit = parseFloat(b.monthly_limit_usd || s.monthly_limit_usd || '1000') || 1000;
 

--- a/lexwebapp/src/pages/AdminUserActivityPage.tsx
+++ b/lexwebapp/src/pages/AdminUserActivityPage.tsx
@@ -8,7 +8,7 @@ import {
   RefreshCw,
   Clock,
   Users,
-  DollarSign,
+  Banknote,
   Activity,
   ChevronDown,
   ChevronRight,
@@ -21,6 +21,7 @@ import {
   WifiOff,
 } from 'lucide-react';
 import { api } from '../utils/api-client';
+import { useCurrencyRate } from '../hooks/useCurrencyRate';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -154,7 +155,7 @@ function StatusDot({ status }: { status: string | null }) {
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
 
-function RequestRow({ req }: { req: RecentRequest }) {
+function RequestRow({ req, formatUah }: { req: RecentRequest; formatUah: (usd: number) => string }) {
   return (
     <div className="flex items-start gap-3 py-2 px-3 rounded-lg hover:bg-slate-50 transition-colors">
       <StatusDot status={req.status} />
@@ -173,7 +174,7 @@ function RequestRow({ req }: { req: RecentRequest }) {
           )}
           {req.total_cost_usd > 0 && (
             <span className="text-xs text-slate-400">
-              ${req.total_cost_usd.toFixed(4)}
+              {formatUah(req.total_cost_usd)}
             </span>
           )}
         </div>
@@ -194,10 +195,12 @@ function UserCard({
   user,
   expanded,
   onToggle,
+  formatUah,
 }: {
   user: UserActivity;
   expanded: boolean;
   onToggle: () => void;
+  formatUah: (usd: number) => string;
 }) {
   const ago = timeAgo(user.last_request_at);
   const isRecent = Date.now() - new Date(user.last_request_at).getTime() < 15 * 60_000;
@@ -261,7 +264,7 @@ function UserCard({
           </div>
           <div>
             <div className="text-sm font-semibold text-slate-800">
-              ${user.cost_in_period.toFixed(3)}
+              {formatUah(user.cost_in_period)}
             </div>
             <div className="text-xs text-slate-400">витрати</div>
           </div>
@@ -283,7 +286,7 @@ function UserCard({
       <div className="sm:hidden flex gap-3 px-4 pb-2 text-xs text-slate-500">
         <span>{user.requests_in_period} запитів</span>
         <span>•</span>
-        <span>${user.cost_in_period.toFixed(3)}</span>
+        <span>{formatUah(user.cost_in_period)}</span>
         <span>•</span>
         <span className={isRecent ? 'text-green-600' : ''}>{ago}</span>
       </div>
@@ -296,7 +299,7 @@ function UserCard({
               Останні дії
             </span>
             <span className="text-xs text-slate-400">
-              Баланс: ${user.balance_usd.toFixed(2)}
+              Баланс: {formatUah(user.balance_usd)}
             </span>
           </div>
           {user.recent_requests.length === 0 ? (
@@ -304,7 +307,7 @@ function UserCard({
           ) : (
             <div className="px-2 pb-2 space-y-0.5">
               {user.recent_requests.map((req) => (
-                <RequestRow key={req.id} req={req} />
+                <RequestRow key={req.id} req={req} formatUah={formatUah} />
               ))}
             </div>
           )}
@@ -325,6 +328,7 @@ function UserCard({
 // ─── Main page ────────────────────────────────────────────────────────────────
 
 export function AdminUserActivityPage() {
+  const { formatUah } = useCurrencyRate();
   const [users, setUsers] = useState<UserActivity[]>([]);
   const [stats, setStats] = useState<ActivityStats | null>(null);
   const [hours, setHours] = useState(24);
@@ -467,13 +471,13 @@ export function AdminUserActivityPage() {
           </div>
           <div className="bg-white border border-slate-200 rounded-xl p-4 shadow-sm">
             <div className="flex items-center gap-2 mb-1">
-              <DollarSign size={16} className="text-green-500" />
+              <Banknote size={16} className="text-green-500" />
               <span className="text-xs text-slate-500 font-medium uppercase tracking-wide">
                 Витрати
               </span>
             </div>
             <div className="text-2xl font-bold text-slate-900">
-              ${stats.total_cost.toFixed(4)}
+              {formatUah(stats.total_cost)}
             </div>
             <div className="text-xs text-slate-400">загальна вартість API</div>
           </div>
@@ -555,6 +559,7 @@ export function AdminUserActivityPage() {
                   user={user}
                   expanded={expandedId === user.id}
                   onToggle={() => handleToggle(user.id)}
+                  formatUah={formatUah}
                 />
               ))}
             </div>

--- a/lexwebapp/src/pages/ProfilePage/BillingSection.tsx
+++ b/lexwebapp/src/pages/ProfilePage/BillingSection.tsx
@@ -36,17 +36,17 @@ export function BillingSection({ billing, stats }: BillingSectionProps) {
               Витрати за місяць
             </span>
             <span className="text-sm text-claude-subtext">
-              {formatUah(Number(billing.month_spent_usd))} / {formatUah(Number(billing.monthly_limit_usd))}
+              {formatUah(Number(billing.monthly_spending_usd))} / {formatUah(Number(billing.monthly_limit_usd))}
             </span>
           </div>
           <div className="h-2 w-full bg-claude-bg rounded-full overflow-hidden">
             <div
               className="h-full bg-claude-accent rounded-full transition-all"
-              style={{ width: `${Math.min(100, (Number(billing.month_spent_usd) / Number(billing.monthly_limit_usd)) * 100)}%` }}
+              style={{ width: `${Math.min(100, (Number(billing.monthly_spending_usd) / Number(billing.monthly_limit_usd)) * 100)}%` }}
             />
           </div>
           <p className="text-xs text-claude-subtext mt-2">
-            Денний ліміт: {formatUah(Number(billing.daily_limit_usd))} · Сьогодні: {formatUah(Number(billing.today_spent_usd))}
+            Денний ліміт: {formatUah(Number(billing.daily_limit_usd))} · Сьогодні: {formatUah(Number(billing.today_spending_usd))}
           </p>
         </div>
       )}

--- a/lexwebapp/src/pages/ProfilePage/useProfile.ts
+++ b/lexwebapp/src/pages/ProfilePage/useProfile.ts
@@ -1,15 +1,17 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
-import { DollarSign, Activity, Zap, Mail, Shield, User, Settings, CreditCard } from 'lucide-react';
+import { Banknote, Activity, Zap, Mail, Shield, User, Settings, CreditCard } from 'lucide-react';
 import { startRegistration } from '@simplewebauthn/browser';
 import { useAuth } from '../../contexts/AuthContext';
 import { authService, billingService } from '../../services';
 import { api } from '../../utils/api-client';
 import { BillingBalance } from '../../types/models';
 import showToast from '../../utils/toast';
+import { useCurrencyRate } from '../../hooks/useCurrencyRate';
 import type { EditFormState, UseProfileReturn } from './types';
 
 export function useProfile(): UseProfileReturn {
   const { user, isLoading, updateUser } = useAuth();
+  const { formatUah } = useCurrencyRate();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [isUploadingPhoto, setIsUploadingPhoto] = useState(false);
@@ -225,15 +227,15 @@ export function useProfile(): UseProfileReturn {
 
   const stats = [{
     label: 'Баланс',
-    value: billing ? `$${Number(billing.balance_usd).toFixed(2)}` : '—',
-    icon: DollarSign
+    value: billing ? formatUah(Number(billing.balance_usd)) : '—',
+    icon: Banknote
   }, {
     label: 'Всього запитів',
     value: billing ? String(billing.total_requests) : '—',
     icon: Activity
   }, {
     label: 'Всього витрачено',
-    value: billing ? `$${Number(billing.total_spent_usd).toFixed(2)}` : '—',
+    value: billing ? formatUah(Number(billing.total_spent_usd)) : '—',
     icon: Zap
   }];
 
@@ -261,7 +263,7 @@ export function useProfile(): UseProfileReturn {
     }, {
       icon: CreditCard,
       label: 'Білінг',
-      value: billing ? `$${Number(billing.balance_usd).toFixed(2)} • ${billing.pricing_tier}` : 'Завантаження...',
+      value: billing ? `${formatUah(Number(billing.balance_usd))} • ${billing.pricing_tier}` : 'Завантаження...',
       onClick: () => window.location.href = '/billing'
     }]
   }];

--- a/lexwebapp/src/types/models/Billing.ts
+++ b/lexwebapp/src/types/models/Billing.ts
@@ -17,8 +17,8 @@ export interface BillingBalance {
   daily_limit_usd: number;
   monthly_limit_usd: number;
   pricing_tier: string;
-  today_spent_usd: number;
-  month_spent_usd: number;
+  today_spending_usd: number;
+  monthly_spending_usd: number;
   last_request_at?: string;
 }
 


### PR DESCRIPTION
## Summary
- **Profile page**: Balance and "Всього витрачено" showed `$97.64` / `$2.36` instead of UAH — now uses `formatUah()`
- **NaN fix**: "Витрати за місяць" and "Сьогодні" showed `NaN ₴` because API returns `today_spending_usd` / `monthly_spending_usd` but frontend expected `today_spent_usd` / `month_spent_usd` — aligned `BillingBalance` interface to match actual API response
- **Admin activity page**: All cost displays converted from `$X.XXX` to UAH format, `DollarSign` → `Banknote` icon

## Test plan
- [ ] Open profile page — verify balance shows in ₴, not $
- [ ] Check "Витрати за місяць" and "Сьогодні" are numbers, not NaN
- [ ] Open admin activity page — verify costs show in ₴
- [ ] Check billing/limits and settings tabs still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)