### PR TITLE
feat: documents page UI/UX improvements (LEG-271)

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/DeleteConfirmModal.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DeleteConfirmModal.tsx
@@ -1,0 +1,63 @@
+import { motion, AnimatePresence } from 'framer-motion';
+import { Trash2, Loader2 } from 'lucide-react';
+import type { VaultDocument } from './types';
+
+interface DeleteConfirmModalProps {
+  target: VaultDocument | null;
+  deleting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DeleteConfirmModal({ target, deleting, onConfirm, onCancel }: DeleteConfirmModalProps) {
+  return (
+    <AnimatePresence>
+      {target && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => !deleting && onCancel()}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-red-50 rounded-lg">
+                <Trash2 size={20} className="text-red-500" />
+              </div>
+              <h3 className="text-lg font-semibold text-claude-text font-sans">
+                Видалити документ?
+              </h3>
+            </div>
+            <p className="text-sm text-claude-subtext/70 mb-6 font-sans">
+              Ви впевнені, що хочете видалити &laquo;{target.title}&raquo;? Документ можна буде відновити.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                disabled={deleting}
+                onClick={onCancel}
+                className="px-4 py-2 text-sm font-medium text-claude-text bg-white border border-claude-border rounded-xl hover:bg-claude-bg transition-colors font-sans disabled:opacity-50"
+              >
+                Скасувати
+              </button>
+              <button
+                disabled={deleting}
+                onClick={onConfirm}
+                className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-xl hover:bg-red-700 transition-colors font-sans disabled:opacity-50 flex items-center gap-2"
+              >
+                {deleting && <Loader2 size={14} className="animate-spin" />}
+                Видалити
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/lexwebapp/src/pages/DocumentsPage/DocumentGrid.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentGrid.tsx
@@ -1,68 +1,16 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import {
-  FileText,
-  Image,
-  Film,
-  FileSpreadsheet,
   MoreVertical,
   Eye,
   Pencil,
   Trash2,
   FolderInput,
+  AlertTriangle,
 } from 'lucide-react';
-import type { VaultDocument } from './types';
+import type { VaultDocument, SortField, SortOrder } from './types';
 import { isEditable, getFileExtension } from './types';
-
-const DOC_TYPE_LABELS: Record<string, string> = {
-  contract: 'Договір',
-  legislation: 'Законодавство',
-  court_decision: 'Судове рішення',
-  internal: 'Внутрішній',
-  other: 'Інше',
-};
-
-const DOC_TYPE_COLORS: Record<string, string> = {
-  contract: 'bg-blue-50 text-blue-700 border-blue-200',
-  legislation: 'bg-purple-50 text-purple-700 border-purple-200',
-  court_decision: 'bg-amber-50 text-amber-700 border-amber-200',
-  internal: 'bg-green-50 text-green-700 border-green-200',
-  other: 'bg-gray-50 text-gray-700 border-gray-200',
-};
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString('uk-UA', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function getFileIcon(mimeType?: string) {
-  if (!mimeType) return FileText;
-  if (mimeType.startsWith('image/')) return Image;
-  if (mimeType.startsWith('video/')) return Film;
-  if (
-    mimeType.includes('spreadsheet') ||
-    mimeType.includes('excel') ||
-    mimeType === 'text/csv'
-  )
-    return FileSpreadsheet;
-  return FileText;
-}
+import { DOC_TYPE_LABELS, DOC_TYPE_COLORS, formatDate, formatFileSize, getFileIcon } from './constants';
 
 function CardContextMenu({
   doc,
@@ -94,17 +42,21 @@ function CardContextMenu({
   return (
     <div ref={menuRef} className="relative">
       <button
-        className="p-1 text-claude-subtext/30 hover:text-claude-text transition-colors opacity-0 group-hover:opacity-100"
+        className="p-1 text-claude-subtext/30 hover:text-claude-text transition-colors sm:opacity-0 sm:group-hover:opacity-100"
         onClick={(e) => {
           e.stopPropagation();
           setOpen((v) => !v);
         }}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Дії з документом"
       >
         <MoreVertical size={14} />
       </button>
       {open && (
-        <div className="absolute right-0 top-full mt-1 z-50 w-44 bg-white border border-claude-border rounded-xl shadow-lg py-1">
+        <div className="absolute left-0 top-full mt-1 z-50 w-44 bg-white border border-claude-border rounded-xl shadow-lg py-1" role="menu">
           <button
+            role="menuitem"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-text hover:bg-claude-bg transition-colors font-sans"
             onClick={(e) => {
               e.stopPropagation();
@@ -117,6 +69,7 @@ function CardContextMenu({
           </button>
           {isEditable(doc.metadata?.mimeType) && (
             <button
+              role="menuitem"
               className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-text hover:bg-claude-bg transition-colors font-sans"
               onClick={(e) => {
                 e.stopPropagation();
@@ -129,6 +82,7 @@ function CardContextMenu({
             </button>
           )}
           <button
+            role="menuitem"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-text hover:bg-claude-bg transition-colors font-sans"
             onClick={(e) => {
               e.stopPropagation();
@@ -140,6 +94,7 @@ function CardContextMenu({
             Перемістити
           </button>
           <button
+            role="menuitem"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors font-sans"
             onClick={(e) => {
               e.stopPropagation();
@@ -156,6 +111,12 @@ function CardContextMenu({
   );
 }
 
+const SORT_OPTIONS: { value: SortField; label: string }[] = [
+  { value: 'uploadedAt', label: 'За датою' },
+  { value: 'title', label: 'За назвою' },
+  { value: 'type', label: 'За типом' },
+];
+
 interface DocumentGridProps {
   documents: VaultDocument[];
   onDocumentClick: (doc: VaultDocument) => void;
@@ -163,98 +124,165 @@ interface DocumentGridProps {
   onEdit: (doc: VaultDocument) => void;
   onDelete: (doc: VaultDocument) => void;
   onMove: (doc: VaultDocument) => void;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
+  sortBy?: SortField;
+  sortOrder?: SortOrder;
+  onSort?: (field: SortField) => void;
 }
 
-export function DocumentGrid({ documents, onDocumentClick, onView, onEdit, onDelete, onMove }: DocumentGridProps) {
+export function DocumentGrid({
+  documents,
+  onDocumentClick,
+  onView,
+  onEdit,
+  onDelete,
+  onMove,
+  selectedIds,
+  onToggleSelect,
+  sortBy,
+  sortOrder,
+  onSort,
+}: DocumentGridProps) {
+  const hasSelection = selectedIds != null && onToggleSelect != null;
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-      {documents.map((doc, index) => {
-        const Icon = getFileIcon(doc.metadata?.mimeType);
-        return (
-          <motion.div
-            key={doc.id}
-            initial={{ opacity: 0, y: 8 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: index * 0.03 }}
-            className="bg-white rounded-2xl border border-claude-border p-4 hover:shadow-md transition-all group cursor-pointer"
-            onClick={() => onDocumentClick(doc)}
-          >
-            {/* Content preview area */}
-            <div className="relative mb-3 h-24 rounded-lg bg-claude-subtext/[0.03] border border-claude-border/40 overflow-hidden">
-              {doc.text_preview ? (
-                <p className="p-2.5 text-[11px] leading-[1.4] text-claude-subtext/60 font-sans line-clamp-5 whitespace-pre-line">
-                  {doc.text_preview}
+    <div>
+      {/* Sort controls for grid view */}
+      {onSort && sortBy && (
+        <div className="flex items-center gap-2 mb-3">
+          <span className="text-xs text-claude-subtext/50 font-sans">Сортування:</span>
+          {SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => onSort(opt.value)}
+              className={`px-2.5 py-1 rounded-lg text-xs font-sans font-medium transition-colors ${
+                sortBy === opt.value
+                  ? 'bg-claude-text text-white'
+                  : 'bg-white border border-claude-border text-claude-subtext hover:bg-claude-bg'
+              }`}
+            >
+              {opt.label}
+              {sortBy === opt.value && (
+                <span className="ml-1 text-[10px]">{sortOrder === 'asc' ? '↑' : '↓'}</span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {documents.map((doc, index) => {
+          const Icon = getFileIcon(doc.metadata?.mimeType);
+          const isSelected = hasSelection && selectedIds!.has(doc.id);
+          return (
+            <motion.div
+              key={doc.id}
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: index * 0.03 }}
+              className={`bg-white rounded-2xl border p-4 hover:shadow-md transition-all group cursor-pointer ${
+                isSelected ? 'border-claude-accent bg-claude-accent/5' : 'border-claude-border'
+              }`}
+              onClick={() => onDocumentClick(doc)}
+            >
+              {/* Content preview area */}
+              <div className="relative mb-3 h-24 rounded-lg bg-claude-subtext/[0.03] border border-claude-border/40 overflow-hidden">
+                {doc.text_preview ? (
+                  <p className="p-2.5 text-[11px] leading-[1.4] text-claude-subtext/60 font-sans line-clamp-5 whitespace-pre-line">
+                    {doc.text_preview}
+                  </p>
+                ) : (
+                  <div className="flex items-center justify-center h-full">
+                    <Icon size={24} className="text-claude-subtext/20" />
+                  </div>
+                )}
+                {/* Fade out bottom */}
+                <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white to-transparent" />
+                {/* Type badge overlay */}
+                <div className="absolute top-2 right-2 flex items-center gap-1">
+                  {doc.metadata?.classificationStatus === 'needs_review' && (
+                    <span title="Потребує уваги — не вдалося класифікувати">
+                      <AlertTriangle size={12} className="text-amber-500" />
+                    </span>
+                  )}
+                  <span
+                    className={`inline-flex px-1.5 py-0.5 text-[9px] font-semibold rounded-md border ${
+                      DOC_TYPE_COLORS[doc.type] || DOC_TYPE_COLORS.other
+                    } font-sans backdrop-blur-sm`}
+                  >
+                    {DOC_TYPE_LABELS[doc.type] || doc.type}
+                  </span>
+                </div>
+                {/* Context menu overlay */}
+                <div className="absolute top-1.5 left-1.5">
+                  <CardContextMenu
+                    doc={doc}
+                    onView={onView}
+                    onEdit={onEdit}
+                    onDelete={onDelete}
+                    onMove={onMove}
+                  />
+                </div>
+                {/* Selection checkbox */}
+                {hasSelection && (
+                  <div className="absolute bottom-2 left-2">
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={(e) => {
+                        e.stopPropagation();
+                        onToggleSelect!(doc.id);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      className="rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer"
+                    />
+                  </div>
+                )}
+              </div>
+              <div className="flex items-center gap-1.5 mb-1">
+                <h4 className="text-sm font-semibold text-claude-text truncate font-sans">
+                  {doc.title}
+                </h4>
+                {(() => {
+                  const ext = getFileExtension(doc);
+                  return ext ? (
+                    <span className="text-[10px] px-1.5 py-0.5 bg-claude-subtext/8 text-claude-subtext/60 rounded font-mono flex-shrink-0 uppercase">
+                      {ext.replace('.', '')}
+                    </span>
+                  ) : null;
+                })()}
+              </div>
+              <div className="flex items-center gap-2">
+                <p className="text-xs text-claude-subtext/50 font-sans">
+                  {doc.metadata?.documentDate
+                    ? formatDate(doc.metadata.documentDate)
+                    : doc.metadata?.uploadedAt
+                    ? formatDate(doc.metadata.uploadedAt)
+                    : ''}
                 </p>
-              ) : (
-                <div className="flex items-center justify-center h-full">
-                  <Icon size={24} className="text-claude-subtext/20" />
+                {doc.metadata?.fileSize && (
+                  <span className="text-xs text-claude-subtext/40 font-sans">
+                    · {formatFileSize(doc.metadata.fileSize)}
+                  </span>
+                )}
+              </div>
+              {doc.metadata?.tags && doc.metadata.tags.length > 0 && (
+                <div className="flex gap-1 mt-2 flex-wrap">
+                  {doc.metadata.tags.slice(0, 3).map((tag: string) => (
+                    <span
+                      key={tag}
+                      className="text-[10px] px-1.5 py-0.5 bg-claude-subtext/5 text-claude-subtext/70 rounded font-sans"
+                    >
+                      {tag}
+                    </span>
+                  ))}
                 </div>
               )}
-              {/* Fade out bottom */}
-              <div className="absolute bottom-0 left-0 right-0 h-6 bg-gradient-to-t from-white to-transparent" />
-              {/* Type badge overlay */}
-              <div className="absolute top-2 right-2 flex items-center gap-1">
-                <span
-                  className={`inline-flex px-1.5 py-0.5 text-[9px] font-semibold rounded-md border ${
-                    DOC_TYPE_COLORS[doc.type] || DOC_TYPE_COLORS.other
-                  } font-sans backdrop-blur-sm`}
-                >
-                  {DOC_TYPE_LABELS[doc.type] || doc.type}
-                </span>
-              </div>
-              {/* Context menu overlay */}
-              <div className="absolute top-1.5 left-1.5">
-                <CardContextMenu
-                  doc={doc}
-                  onView={onView}
-                  onEdit={onEdit}
-                  onDelete={onDelete}
-                  onMove={onMove}
-                />
-              </div>
-            </div>
-            <div className="flex items-center gap-1.5 mb-1">
-              <h4 className="text-sm font-semibold text-claude-text truncate font-sans">
-                {doc.title}
-              </h4>
-              {(() => {
-                const ext = getFileExtension(doc);
-                return ext ? (
-                  <span className="text-[10px] px-1.5 py-0.5 bg-claude-subtext/8 text-claude-subtext/60 rounded font-mono flex-shrink-0 uppercase">
-                    {ext.replace('.', '')}
-                  </span>
-                ) : null;
-              })()}
-            </div>
-            <div className="flex items-center gap-2">
-              <p className="text-xs text-claude-subtext/50 font-sans">
-                {doc.metadata?.documentDate
-                  ? formatDate(doc.metadata.documentDate)
-                  : doc.metadata?.uploadedAt
-                  ? formatDate(doc.metadata.uploadedAt)
-                  : ''}
-              </p>
-              {doc.metadata?.fileSize && (
-                <span className="text-xs text-claude-subtext/40 font-sans">
-                  · {formatFileSize(doc.metadata.fileSize)}
-                </span>
-              )}
-            </div>
-            {doc.metadata?.tags && doc.metadata.tags.length > 0 && (
-              <div className="flex gap-1 mt-2 flex-wrap">
-                {doc.metadata.tags.slice(0, 3).map((tag: string) => (
-                  <span
-                    key={tag}
-                    className="text-[10px] px-1.5 py-0.5 bg-claude-subtext/5 text-claude-subtext/70 rounded font-sans"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            )}
-          </motion.div>
-        );
-      })}
+            </motion.div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/lexwebapp/src/pages/DocumentsPage/DocumentStatsPanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentStatsPanel.tsx
@@ -8,29 +8,7 @@ import {
   HardDrive,
 } from 'lucide-react';
 import type { DocumentStats } from './types';
-
-const DOC_TYPE_LABELS: Record<string, string> = {
-  contract: 'Договори',
-  legislation: 'Законодавство',
-  court_decision: 'Судові рішення',
-  internal: 'Внутрішні',
-  other: 'Інше',
-};
-
-const DOC_TYPE_COLORS: Record<string, string> = {
-  contract: 'bg-blue-100 text-blue-700',
-  legislation: 'bg-purple-100 text-purple-700',
-  court_decision: 'bg-amber-100 text-amber-700',
-  internal: 'bg-green-100 text-green-700',
-  other: 'bg-gray-100 text-gray-600',
-};
-
-function formatBytes(bytes: number): string {
-  if (bytes === 0) return '0 B';
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(1024));
-  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${sizes[i]}`;
-}
+import { DOC_TYPE_LABELS_PLURAL, DOC_TYPE_COLORS_SOLID, formatFileSize } from './constants';
 
 interface DocumentStatsPanelProps {
   stats: DocumentStats | null;
@@ -38,7 +16,17 @@ interface DocumentStatsPanelProps {
 }
 
 export function DocumentStatsPanel({ stats, loading }: DocumentStatsPanelProps) {
-  if (loading || !stats || stats.total === 0) return null;
+  if (loading || !stats) return null;
+
+  if (stats.total === 0) {
+    return (
+      <div className="mb-5 rounded-xl border border-claude-border bg-white p-4 text-center">
+        <p className="text-sm text-claude-subtext/60 font-sans">
+          0 документів — завантажте перший файл щоб побачити статистику
+        </p>
+      </div>
+    );
+  }
 
   const classifiedPercent = stats.total > 0
     ? Math.round((stats.classified / stats.total) * 100)
@@ -82,7 +70,7 @@ export function DocumentStatsPanel({ stats, loading }: DocumentStatsPanelProps) 
         <StatCard
           icon={<HardDrive size={14} />}
           label="Обсяг"
-          value={formatBytes(stats.totalStorageBytes)}
+          value={formatFileSize(stats.totalStorageBytes)}
           color="text-purple-600"
         />
       </div>
@@ -97,10 +85,10 @@ export function DocumentStatsPanel({ stats, loading }: DocumentStatsPanelProps) 
               <span
                 key={type}
                 className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-sans font-medium ${
-                  DOC_TYPE_COLORS[type] || DOC_TYPE_COLORS.other
+                  DOC_TYPE_COLORS_SOLID[type] || DOC_TYPE_COLORS_SOLID.other
                 }`}
               >
-                {DOC_TYPE_LABELS[type] || type}
+                {DOC_TYPE_LABELS_PLURAL[type] || type}
                 <span className="opacity-70">{count}</span>
               </span>
             ))}

--- a/lexwebapp/src/pages/DocumentsPage/DocumentTable.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentTable.tsx
@@ -1,13 +1,9 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import {
-  FileText,
   MoreVertical,
   ChevronUp,
   ChevronDown,
-  Image,
-  Film,
-  FileSpreadsheet,
   Eye,
   Pencil,
   Trash2,
@@ -16,68 +12,7 @@ import {
 } from 'lucide-react';
 import type { VaultDocument, SortField, SortOrder } from './types';
 import { isEditable, getFileExtension } from './types';
-
-const DOC_TYPE_LABELS: Record<string, string> = {
-  contract: 'Договір',
-  legislation: 'Законодавство',
-  court_decision: 'Судове рішення',
-  internal: 'Внутрішній',
-  other: 'Інше',
-};
-
-const DOC_TYPE_COLORS: Record<string, string> = {
-  contract: 'bg-blue-50 text-blue-700 border-blue-200',
-  legislation: 'bg-purple-50 text-purple-700 border-purple-200',
-  court_decision: 'bg-amber-50 text-amber-700 border-amber-200',
-  internal: 'bg-green-50 text-green-700 border-green-200',
-  other: 'bg-gray-50 text-gray-700 border-gray-200',
-};
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString('uk-UA', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return iso;
-  }
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function getFileIcon(mimeType?: string) {
-  if (!mimeType) return FileText;
-  if (mimeType.startsWith('image/')) return Image;
-  if (mimeType.startsWith('video/')) return Film;
-  if (
-    mimeType.includes('spreadsheet') ||
-    mimeType.includes('excel') ||
-    mimeType === 'text/csv'
-  )
-    return FileSpreadsheet;
-  return FileText;
-}
-
-interface DocumentTableProps {
-  documents: VaultDocument[];
-  sortBy: SortField;
-  sortOrder: SortOrder;
-  onSort: (field: SortField) => void;
-  onDocumentClick: (doc: VaultDocument) => void;
-  onView: (doc: VaultDocument) => void;
-  onEdit: (doc: VaultDocument) => void;
-  onDelete: (doc: VaultDocument) => void;
-  onMove: (doc: VaultDocument) => void;
-}
+import { DOC_TYPE_LABELS, DOC_TYPE_COLORS, formatDate, formatFileSize, getFileIcon } from './constants';
 
 function SortIcon({ field, sortBy, sortOrder }: { field: SortField; sortBy: SortField; sortOrder: SortOrder }) {
   if (field !== sortBy) {
@@ -103,10 +38,14 @@ function SortableHeader({
   onSort: (field: SortField) => void;
   className?: string;
 }) {
+  const isActive = field === sortBy;
   return (
     <th
-      className={`text-left px-5 py-3 text-[11px] font-semibold text-claude-subtext/60 uppercase tracking-wider font-sans cursor-pointer select-none hover:text-claude-text transition-colors ${className}`}
+      className={`text-left px-5 py-3 text-[11px] font-semibold uppercase tracking-wider font-sans cursor-pointer select-none transition-colors ${
+        isActive ? 'text-claude-text' : 'text-claude-subtext/60 hover:text-claude-text'
+      } ${className}`}
       onClick={() => onSort(field)}
+      aria-sort={isActive ? (sortOrder === 'asc' ? 'ascending' : 'descending') : 'none'}
     >
       <div className="flex items-center gap-1">
         {label}
@@ -146,17 +85,21 @@ function RowContextMenu({
   return (
     <div ref={menuRef} className="relative">
       <button
-        className="p-1 text-claude-subtext/30 hover:text-claude-text transition-colors opacity-0 group-hover:opacity-100"
+        className="p-1 text-claude-subtext/30 hover:text-claude-text transition-colors sm:opacity-0 sm:group-hover:opacity-100"
         onClick={(e) => {
           e.stopPropagation();
           setOpen((v) => !v);
         }}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        aria-label="Дії з документом"
       >
         <MoreVertical size={14} />
       </button>
       {open && (
-        <div className="absolute right-0 top-full mt-1 z-50 w-44 bg-white border border-claude-border rounded-xl shadow-lg py-1">
+        <div className="absolute right-0 top-full mt-1 z-50 w-44 bg-white border border-claude-border rounded-xl shadow-lg py-1" role="menu">
           <button
+            role="menuitem"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-text hover:bg-claude-bg transition-colors font-sans"
             onClick={(e) => {
               e.stopPropagation();
@@ -169,6 +112,7 @@ function RowContextMenu({
           </button>
           {isEditable(doc.metadata?.mimeType) && (
             <button
+              role="menuitem"
               className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-text hover:bg-claude-bg transition-colors font-sans"
               onClick={(e) => {
                 e.stopPropagation();
@@ -181,6 +125,7 @@ function RowContextMenu({
             </button>
           )}
           <button
+            role="menuitem"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-text hover:bg-claude-bg transition-colors font-sans"
             onClick={(e) => {
               e.stopPropagation();
@@ -192,6 +137,7 @@ function RowContextMenu({
             Перемістити
           </button>
           <button
+            role="menuitem"
             className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors font-sans"
             onClick={(e) => {
               e.stopPropagation();
@@ -208,13 +154,57 @@ function RowContextMenu({
   );
 }
 
-export function DocumentTable({ documents, sortBy, sortOrder, onSort, onDocumentClick, onView, onEdit, onDelete, onMove }: DocumentTableProps) {
+interface DocumentTableProps {
+  documents: VaultDocument[];
+  sortBy: SortField;
+  sortOrder: SortOrder;
+  onSort: (field: SortField) => void;
+  onDocumentClick: (doc: VaultDocument) => void;
+  onView: (doc: VaultDocument) => void;
+  onEdit: (doc: VaultDocument) => void;
+  onDelete: (doc: VaultDocument) => void;
+  onMove: (doc: VaultDocument) => void;
+  selectedIds?: Set<string>;
+  onToggleSelect?: (id: string) => void;
+  onToggleAll?: () => void;
+}
+
+export function DocumentTable({
+  documents,
+  sortBy,
+  sortOrder,
+  onSort,
+  onDocumentClick,
+  onView,
+  onEdit,
+  onDelete,
+  onMove,
+  selectedIds,
+  onToggleSelect,
+  onToggleAll,
+}: DocumentTableProps) {
+  const hasSelection = selectedIds != null && onToggleSelect != null;
+  const allSelected = hasSelection && documents.length > 0 && documents.every((d) => selectedIds!.has(d.id));
+  const someSelected = hasSelection && documents.some((d) => selectedIds!.has(d.id)) && !allSelected;
+
   return (
     <div className="bg-white rounded-2xl border border-claude-border shadow-sm overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full">
           <thead>
             <tr className="border-b border-claude-border/50">
+              {hasSelection && (
+                <th className="w-10 px-3 py-3">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    ref={(el) => { if (el) el.indeterminate = someSelected; }}
+                    onChange={onToggleAll}
+                    className="rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer"
+                    aria-label="Вибрати всі"
+                  />
+                </th>
+              )}
               <SortableHeader label="Назва" field="title" sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
               <SortableHeader label="Тип" field="type" sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
               <SortableHeader label="Дата" field="uploadedAt" sortBy={sortBy} sortOrder={sortOrder} onSort={onSort} />
@@ -231,15 +221,32 @@ export function DocumentTable({ documents, sortBy, sortOrder, onSort, onDocument
             {documents.map((doc, index) => {
               const Icon = getFileIcon(doc.metadata?.mimeType);
               const ext = getFileExtension(doc);
+              const isSelected = hasSelection && selectedIds!.has(doc.id);
               return (
                 <motion.tr
                   key={doc.id}
                   initial={{ opacity: 0, y: 8 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: index * 0.03 }}
-                  className="hover:bg-claude-bg/50 transition-colors group cursor-pointer"
+                  className={`hover:bg-claude-bg/50 transition-colors group cursor-pointer ${
+                    isSelected ? 'bg-claude-accent/5' : ''
+                  }`}
                   onClick={() => onDocumentClick(doc)}
                 >
+                  {hasSelection && (
+                    <td className="px-3 py-3">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={(e) => {
+                          e.stopPropagation();
+                          onToggleSelect!(doc.id);
+                        }}
+                        onClick={(e) => e.stopPropagation()}
+                        className="rounded border-claude-border text-claude-accent focus:ring-claude-accent/30 cursor-pointer"
+                      />
+                    </td>
+                  )}
                   <td className="px-5 py-3">
                     <div className="flex items-center gap-2">
                       <Icon

--- a/lexwebapp/src/pages/DocumentsPage/EditDocumentModal.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/EditDocumentModal.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useCallback, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X, Loader2, ChevronLeft, ChevronRight, Trash2 } from 'lucide-react';
+import type { VaultDocument } from './types';
+
+interface EditDocumentModalProps {
+  target: VaultDocument | null;
+  editText: string;
+  onEditTextChange: (text: string) => void;
+  editLoading: boolean;
+  editSaving: boolean;
+  onSave: () => void;
+  onClose: () => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  onDelete: () => void;
+  currentIndex: number;
+  totalCount: number;
+}
+
+export function EditDocumentModal({
+  target,
+  editText,
+  onEditTextChange,
+  editLoading,
+  editSaving,
+  onSave,
+  onClose,
+  onPrevious,
+  onNext,
+  onDelete,
+  currentIndex,
+  totalCount,
+}: EditDocumentModalProps) {
+  const [pendingDelete, setPendingDelete] = useState(false);
+
+  // Reset pending delete when target changes
+  useEffect(() => {
+    setPendingDelete(false);
+  }, [target?.id]);
+
+  const handleDeleteClick = useCallback(() => {
+    if (pendingDelete) {
+      onDelete();
+      setPendingDelete(false);
+    } else {
+      setPendingDelete(true);
+      setTimeout(() => setPendingDelete(false), 3000);
+    }
+  }, [pendingDelete, onDelete]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    if (!target) return;
+    const handleKeydown = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'TEXTAREA' || tag === 'INPUT') return;
+      if (e.key === 'ArrowLeft' && currentIndex > 0) {
+        e.preventDefault();
+        onPrevious();
+      } else if (e.key === 'ArrowRight' && currentIndex < totalCount - 1) {
+        e.preventDefault();
+        onNext();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  }, [target, currentIndex, totalCount, onPrevious, onNext, onClose]);
+
+  return (
+    <AnimatePresence>
+      {target && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => !editSaving && onClose()}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-3xl mx-4 max-h-[85vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-2 min-w-0 flex-1">
+                <button
+                  disabled={editSaving || currentIndex <= 0}
+                  onClick={onPrevious}
+                  className="p-1 text-claude-subtext hover:text-claude-text transition-colors disabled:opacity-30"
+                  title="Попередній (←)"
+                >
+                  <ChevronLeft size={18} />
+                </button>
+                <button
+                  disabled={editSaving || currentIndex >= totalCount - 1}
+                  onClick={onNext}
+                  className="p-1 text-claude-subtext hover:text-claude-text transition-colors disabled:opacity-30"
+                  title="Наступний (→)"
+                >
+                  <ChevronRight size={18} />
+                </button>
+                {totalCount > 1 && (
+                  <span className="text-[11px] text-claude-subtext font-medium tabular-nums mr-1">
+                    {currentIndex + 1} / {totalCount}
+                  </span>
+                )}
+                <h3 className="text-lg font-semibold text-claude-text font-sans truncate">
+                  Редагувати: {target.title}
+                </h3>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  onClick={handleDeleteClick}
+                  disabled={editSaving}
+                  className={`p-1 transition-colors disabled:opacity-30 ${
+                    pendingDelete
+                      ? 'text-red-500 bg-red-50 rounded-lg'
+                      : 'text-claude-subtext/40 hover:text-red-500'
+                  }`}
+                  title={pendingDelete ? 'Натисніть ще раз для підтвердження' : 'Видалити'}
+                >
+                  <Trash2 size={16} />
+                </button>
+                <button
+                  onClick={() => !editSaving && onClose()}
+                  className="p-1 text-claude-subtext/40 hover:text-claude-text transition-colors"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+            </div>
+            {editLoading ? (
+              <div className="flex-1 flex items-center justify-center py-20">
+                <Loader2 size={24} className="animate-spin text-claude-subtext/40" />
+              </div>
+            ) : (
+              <>
+                <textarea
+                  value={editText}
+                  onChange={(e) => onEditTextChange(e.target.value)}
+                  className="flex-1 min-h-[400px] w-full p-4 border border-claude-border rounded-xl text-sm text-claude-text font-mono resize-none focus:outline-none focus:border-claude-subtext/40 transition-colors"
+                  placeholder="Вміст документа..."
+                />
+                <div className="flex justify-end gap-3 mt-4">
+                  <button
+                    disabled={editSaving}
+                    onClick={onClose}
+                    className="px-4 py-2 text-sm font-medium text-claude-text bg-white border border-claude-border rounded-xl hover:bg-claude-bg transition-colors font-sans disabled:opacity-50"
+                  >
+                    Скасувати
+                  </button>
+                  <button
+                    disabled={editSaving}
+                    onClick={onSave}
+                    className="px-4 py-2 text-sm font-medium text-white bg-claude-text rounded-xl hover:bg-claude-text/90 transition-colors font-sans disabled:opacity-50 flex items-center gap-2"
+                  >
+                    {editSaving && <Loader2 size={14} className="animate-spin" />}
+                    Зберегти
+                  </button>
+                </div>
+              </>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/lexwebapp/src/pages/DocumentsPage/MoveDocumentModal.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/MoveDocumentModal.tsx
@@ -1,0 +1,234 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { FolderInput, Folder, CornerLeftUp, ChevronDown, Loader2, X, Plus } from 'lucide-react';
+import { showToast } from '../../utils/toast';
+import type { VaultDocument } from './types';
+
+interface MoveDocumentModalProps {
+  target: VaultDocument | null;
+  moveFolder: string;
+  onMoveFolderChange: (folder: string) => void;
+  moveFolders: string[];
+  moveFoldersLoading: boolean;
+  moveLoading: boolean;
+  moveBrowsePath: string;
+  onBrowse: (prefix: string) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function MoveDocumentModal({
+  target,
+  moveFolder,
+  onMoveFolderChange,
+  moveFolders,
+  moveFoldersLoading,
+  moveLoading,
+  moveBrowsePath,
+  onBrowse,
+  onConfirm,
+  onClose,
+}: MoveDocumentModalProps) {
+  const [newFolderName, setNewFolderName] = useState('');
+  const [showNewFolder, setShowNewFolder] = useState(false);
+
+  const handleCreateFolder = () => {
+    if (!newFolderName.trim()) return;
+    const sanitized = newFolderName.trim().replace(/[\/\\]/g, '-');
+    const fullPath = moveBrowsePath ? `${moveBrowsePath}${sanitized}/` : `${sanitized}/`;
+    onMoveFolderChange(fullPath);
+    setNewFolderName('');
+    setShowNewFolder(false);
+    showToast.success(`Папку «${sanitized}» буде створено при переміщенні`);
+  };
+
+  return (
+    <AnimatePresence>
+      {target && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          onClick={() => !moveLoading && onClose()}
+        >
+          <motion.div
+            initial={{ scale: 0.95, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.95, opacity: 0 }}
+            className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4 max-h-[70vh] flex flex-col"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 mb-4">
+              <div className="p-2 bg-claude-bg rounded-lg">
+                <FolderInput size={20} className="text-claude-text" />
+              </div>
+              <div className="min-w-0">
+                <h3 className="text-lg font-semibold text-claude-text font-sans">
+                  Перемістити документ
+                </h3>
+                <p className="text-xs text-claude-subtext/60 font-sans truncate">
+                  {target.title}
+                </p>
+              </div>
+            </div>
+
+            {/* Current location */}
+            <div className="text-xs text-claude-subtext/60 font-sans mb-3">
+              Поточна папка: <span className="font-medium text-claude-text">{target.metadata?.folderPath || '/ (корінь)'}</span>
+            </div>
+
+            {/* Folder browser */}
+            <div className="flex-1 overflow-y-auto border border-claude-border rounded-xl mb-4">
+              <button
+                onClick={() => {
+                  onMoveFolderChange('');
+                  onBrowse('');
+                }}
+                className={`flex items-center gap-2 w-full px-3 py-2 text-sm font-sans transition-colors ${
+                  moveFolder === '' ? 'bg-claude-accent/10 text-claude-accent font-medium' : 'text-claude-text hover:bg-claude-bg'
+                }`}
+              >
+                <CornerLeftUp size={14} className="text-claude-subtext/60" />
+                / (корінь)
+              </button>
+
+              {moveBrowsePath && (
+                <button
+                  onClick={() => {
+                    const segments = moveBrowsePath.split('/').filter(Boolean);
+                    segments.pop();
+                    const parent = segments.length ? segments.join('/') + '/' : '';
+                    onBrowse(parent);
+                  }}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-subtext hover:bg-claude-bg transition-colors font-sans border-b border-claude-border/30"
+                >
+                  <CornerLeftUp size={14} />
+                  ..
+                </button>
+              )}
+
+              {moveBrowsePath && (
+                <button
+                  onClick={() => onMoveFolderChange(moveBrowsePath)}
+                  className={`flex items-center gap-2 w-full px-3 py-2 text-sm font-sans transition-colors border-b border-claude-border/30 ${
+                    moveFolder === moveBrowsePath ? 'bg-claude-accent/10 text-claude-accent font-medium' : 'text-claude-text hover:bg-claude-bg'
+                  }`}
+                >
+                  <Folder size={14} className="text-claude-accent" />
+                  {moveBrowsePath.replace(/\/$/, '').split('/').pop()} (поточна)
+                </button>
+              )}
+
+              {moveFoldersLoading ? (
+                <div className="flex justify-center py-6">
+                  <Loader2 size={18} className="animate-spin text-claude-subtext/40" />
+                </div>
+              ) : moveFolders.length === 0 && !showNewFolder ? (
+                <div className="text-center py-4 text-xs text-claude-subtext/40 font-sans">
+                  Немає підпапок
+                </div>
+              ) : (
+                moveFolders.map((folder) => {
+                  const fullPath = moveBrowsePath ? `${moveBrowsePath}${folder}/` : `${folder}/`;
+                  return (
+                    <div key={folder} className="flex items-center border-b border-claude-border/20 last:border-0">
+                      <button
+                        onClick={() => onMoveFolderChange(fullPath)}
+                        className={`flex-1 flex items-center gap-2 px-3 py-2 text-sm font-sans transition-colors ${
+                          moveFolder === fullPath ? 'bg-claude-accent/10 text-claude-accent font-medium' : 'text-claude-text hover:bg-claude-bg'
+                        }`}
+                      >
+                        <Folder size={14} className={moveFolder === fullPath ? 'text-claude-accent' : 'text-claude-subtext/40'} />
+                        {folder}
+                      </button>
+                      <button
+                        onClick={() => onBrowse(fullPath)}
+                        className="px-2 py-2 text-claude-subtext/40 hover:text-claude-text transition-colors"
+                        title="Відкрити папку"
+                      >
+                        <ChevronDown size={14} className="rotate-[-90deg]" />
+                      </button>
+                    </div>
+                  );
+                })
+              )}
+
+              {/* Create new folder */}
+              {showNewFolder ? (
+                <div className="flex items-center gap-2 px-3 py-2 border-t border-claude-border/30">
+                  <Folder size={14} className="text-green-500 flex-shrink-0" />
+                  <input
+                    type="text"
+                    value={newFolderName}
+                    onChange={(e) => setNewFolderName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleCreateFolder();
+                      if (e.key === 'Escape') { setShowNewFolder(false); setNewFolderName(''); }
+                    }}
+                    placeholder="Назва папки..."
+                    className="flex-1 text-sm px-2 py-1 border border-claude-border rounded-lg focus:outline-none focus:border-claude-subtext/40 font-sans"
+                    autoFocus
+                  />
+                  <button
+                    onClick={handleCreateFolder}
+                    disabled={!newFolderName.trim()}
+                    className="text-xs text-green-600 hover:text-green-700 font-medium font-sans disabled:opacity-40"
+                  >
+                    OK
+                  </button>
+                  <button
+                    onClick={() => { setShowNewFolder(false); setNewFolderName(''); }}
+                    className="p-0.5 text-claude-subtext/40 hover:text-claude-text"
+                  >
+                    <X size={12} />
+                  </button>
+                </div>
+              ) : (
+                <button
+                  onClick={() => setShowNewFolder(true)}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-green-600 hover:bg-green-50 transition-colors font-sans border-t border-claude-border/30"
+                >
+                  <Plus size={14} />
+                  Створити папку
+                </button>
+              )}
+            </div>
+
+            {/* Manual input */}
+            <div className="mb-4">
+              <label className="text-xs text-claude-subtext/60 font-sans mb-1 block">
+                Або введіть шлях вручну:
+              </label>
+              <input
+                type="text"
+                value={moveFolder}
+                onChange={(e) => onMoveFolderChange(e.target.value)}
+                placeholder="наприклад: contracts/2026/"
+                className="w-full px-3 py-2 border border-claude-border rounded-xl text-sm text-claude-text font-sans focus:outline-none focus:border-claude-subtext/40 transition-colors"
+              />
+            </div>
+
+            <div className="flex justify-end gap-3">
+              <button
+                disabled={moveLoading}
+                onClick={onClose}
+                className="px-4 py-2 text-sm font-medium text-claude-text bg-white border border-claude-border rounded-xl hover:bg-claude-bg transition-colors font-sans disabled:opacity-50"
+              >
+                Скасувати
+              </button>
+              <button
+                disabled={moveLoading}
+                onClick={onConfirm}
+                className="px-4 py-2 text-sm font-medium text-white bg-claude-text rounded-xl hover:bg-claude-text/90 transition-colors font-sans disabled:opacity-50 flex items-center gap-2"
+              >
+                {moveLoading && <Loader2 size={14} className="animate-spin" />}
+                Перемістити
+              </button>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/lexwebapp/src/pages/DocumentsPage/UploadItemRow.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/UploadItemRow.tsx
@@ -7,20 +7,9 @@ import {
   Pause,
   RotateCcw,
   XCircle,
-  FileText,
-  Image,
-  Film,
-  FileSpreadsheet,
 } from 'lucide-react';
 import type { UploadItem } from '../../services/upload/UploadManager';
-
-const DOC_TYPE_LABELS: Record<string, string> = {
-  contract: 'Договір',
-  legislation: 'Законодавство',
-  court_decision: 'Судове рішення',
-  internal: 'Внутрішній',
-  other: 'Інше',
-};
+import { DOC_TYPE_LABELS, formatFileSize, getFileIcon } from './constants';
 
 const STATUS_LABELS: Record<string, string> = {
   queued: 'В черзі',
@@ -33,25 +22,6 @@ const STATUS_LABELS: Record<string, string> = {
   cancelled: 'Скасовано',
   paused: 'Пауза',
 };
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
-
-function getFileIcon(mimeType: string) {
-  if (mimeType.startsWith('image/')) return Image;
-  if (mimeType.startsWith('video/')) return Film;
-  if (
-    mimeType.includes('spreadsheet') ||
-    mimeType.includes('excel') ||
-    mimeType === 'text/csv'
-  )
-    return FileSpreadsheet;
-  return FileText;
-}
 
 interface UploadItemRowProps {
   item: UploadItem;
@@ -134,7 +104,7 @@ export function UploadItemRow({
         >
           {(Object.keys(DOC_TYPE_LABELS) as string[]).map((t) => (
             <option key={t} value={t}>
-              {DOC_TYPE_LABELS[t]}
+              {DOC_TYPE_LABELS[t as keyof typeof DOC_TYPE_LABELS]}
             </option>
           ))}
         </select>

--- a/lexwebapp/src/pages/DocumentsPage/UploadQueuePanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/UploadQueuePanel.tsx
@@ -12,23 +12,9 @@ import {
 } from 'lucide-react';
 import { useUploadStore } from '../../stores/uploadStore';
 import { UploadItemRow } from './UploadItemRow';
-
-type DocType = 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';
-
-const DOC_TYPE_LABELS: Record<DocType, string> = {
-  contract: 'Договір',
-  legislation: 'Законодавство',
-  court_decision: 'Судове рішення',
-  internal: 'Внутрішній',
-  other: 'Інше',
-};
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
-}
+import { DOC_TYPE_LABELS } from './constants';
+import { formatFileSize } from './constants';
+import type { DocType } from './types';
 
 interface UploadQueuePanelProps {
   showUploadPanel: boolean;

--- a/lexwebapp/src/pages/DocumentsPage/constants.ts
+++ b/lexwebapp/src/pages/DocumentsPage/constants.ts
@@ -1,0 +1,68 @@
+import { FileText, Image, Film, FileSpreadsheet } from 'lucide-react';
+import type { DocType } from './types';
+
+export const DOC_TYPE_LABELS: Record<DocType, string> = {
+  contract: 'Договір',
+  legislation: 'Законодавство',
+  court_decision: 'Судове рішення',
+  internal: 'Внутрішній',
+  other: 'Інше',
+};
+
+export const DOC_TYPE_LABELS_PLURAL: Record<string, string> = {
+  contract: 'Договори',
+  legislation: 'Законодавство',
+  court_decision: 'Судові рішення',
+  internal: 'Внутрішні',
+  other: 'Інше',
+};
+
+export const DOC_TYPE_COLORS: Record<string, string> = {
+  contract: 'bg-blue-50 text-blue-700 border-blue-200',
+  legislation: 'bg-purple-50 text-purple-700 border-purple-200',
+  court_decision: 'bg-amber-50 text-amber-700 border-amber-200',
+  internal: 'bg-green-50 text-green-700 border-green-200',
+  other: 'bg-gray-50 text-gray-700 border-gray-200',
+};
+
+export const DOC_TYPE_COLORS_SOLID: Record<string, string> = {
+  contract: 'bg-blue-100 text-blue-700',
+  legislation: 'bg-purple-100 text-purple-700',
+  court_decision: 'bg-amber-100 text-amber-700',
+  internal: 'bg-green-100 text-green-700',
+  other: 'bg-gray-100 text-gray-600',
+};
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+export function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString('uk-UA', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function getFileIcon(mimeType?: string) {
+  if (!mimeType) return FileText;
+  if (mimeType.startsWith('image/')) return Image;
+  if (mimeType.startsWith('video/')) return Film;
+  if (
+    mimeType.includes('spreadsheet') ||
+    mimeType.includes('excel') ||
+    mimeType === 'text/csv'
+  )
+    return FileSpreadsheet;
+  return FileText;
+}

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -14,11 +14,7 @@ import {
   List,
   Trash2,
   FolderInput,
-  Folder,
-  CornerLeftUp,
-  ChevronDown,
-  ChevronLeft,
-  ChevronRight,
+  SearchX,
 } from 'lucide-react';
 import { mcpService } from '../../services';
 import { useUploadStore } from '../../stores/uploadStore';
@@ -30,6 +26,9 @@ import { DocumentTable } from './DocumentTable';
 import { DocumentGrid } from './DocumentGrid';
 import { DocumentViewerModal } from '../../components/DocumentViewerModal';
 import { ClassificationPanel } from './ClassificationPanel';
+import { DeleteConfirmModal } from './DeleteConfirmModal';
+import { EditDocumentModal } from './EditDocumentModal';
+import { MoveDocumentModal } from './MoveDocumentModal';
 import type { VaultDocument, DocType, ViewMode, SortField, SortOrder } from './types';
 import { isPreviewableBinary } from './types';
 import { processEmlContent } from '../../utils/eml-parser';
@@ -37,17 +36,12 @@ import { useUndoStore } from '../../stores/undoStore';
 import { useUndoKeyboard } from '../../hooks/useUndoKeyboard';
 import { useDocumentData } from './useDocumentData';
 import { useDocumentActions } from './useDocumentActions';
-
-const DOC_TYPE_LABELS: Record<DocType, string> = {
-  contract: 'Договір',
-  legislation: 'Законодавство',
-  court_decision: 'Судове рішення',
-  internal: 'Внутрішній',
-  other: 'Інше',
-};
+import { DOC_TYPE_LABELS } from './constants';
 
 const ACCEPTED_TYPES =
   '.pdf,.docx,.doc,.html,.htm,.txt,.rtf,.jpg,.jpeg,.png,.bmp,.gif,.xlsx,.xls,.csv,.mp4,.mov,.avi,.mkv,.webm,.eml,.zip,.gz,.tgz,.tar';
+
+const VIEW_MODE_KEY = 'documents-view-mode';
 
 function guessMimeType(file: File): string {
   if (file.type) return file.type;
@@ -115,10 +109,16 @@ export function DocumentsPage() {
   // UI state
   const [searchQuery, setSearchQuery] = useState('');
   const [filterType, setFilterType] = useState<DocType | ''>('');
-  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const saved = localStorage.getItem(VIEW_MODE_KEY);
+    return (saved === 'grid' || saved === 'list') ? saved : 'list';
+  });
   const [offset, setOffset] = useState(0);
   const [sortBy, setSortBy] = useState<SortField>('uploadedAt');
   const [sortOrder, setSortOrder] = useState<SortOrder>('desc');
+
+  // Multi-select state
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
   // Preview state
   const [previewDoc, setPreviewDoc] = useState<{
@@ -136,10 +136,24 @@ export function DocumentsPage() {
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewIndex, setPreviewIndex] = useState<number>(-1);
 
+  // Compact upload zone
+  const [uploadZoneExpanded, setUploadZoneExpanded] = useState(false);
+
+  // Persist view mode
+  const handleSetViewMode = useCallback((mode: ViewMode) => {
+    setViewMode(mode);
+    localStorage.setItem(VIEW_MODE_KEY, mode);
+  }, []);
+
   // Reset offset when filters change
   useEffect(() => {
     setOffset(0);
   }, [filterType, currentFolderPath, searchQuery]);
+
+  // Clear selection when documents change
+  useEffect(() => {
+    setSelectedIds(new Set());
+  }, [currentFolderPath, filterType, searchQuery, offset]);
 
   // Data fetching hook
   const {
@@ -289,6 +303,7 @@ export function DocumentsPage() {
     e.preventDefault();
     e.stopPropagation();
     setIsDragOver(true);
+    setUploadZoneExpanded(true);
   };
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
@@ -353,6 +368,51 @@ export function DocumentsPage() {
       setSortOrder('desc');
     }
   };
+
+  // Multi-select handlers
+  const handleToggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleToggleAll = useCallback(() => {
+    setSelectedIds((prev) => {
+      const allSelected = documents.every((d) => prev.has(d.id));
+      if (allSelected) return new Set();
+      return new Set(documents.map((d) => d.id));
+    });
+  }, [documents]);
+
+  const handleBatchDelete = useCallback(async () => {
+    if (selectedIds.size === 0) return;
+    const count = selectedIds.size;
+    const ids = Array.from(selectedIds);
+    try {
+      await Promise.all(ids.map((id) => api.documents.delete(id)));
+      ids.forEach((id) => {
+        const doc = documents.find((d) => d.id === id);
+        if (doc) pushAction({ type: 'delete', documentId: id, documentTitle: doc.title });
+      });
+      showToast.success(`${count} документів видалено`);
+      setSelectedIds(new Set());
+      loadDocuments();
+      loadFolders(currentFolderPath);
+    } catch (err) {
+      console.error('Batch delete failed:', err);
+      showToast.error('Не вдалося видалити деякі документи');
+    }
+  }, [selectedIds, documents, pushAction, loadDocuments, loadFolders, currentFolderPath]);
+
+  const handleBatchMove = useCallback(() => {
+    if (selectedIds.size === 0) return;
+    // Use the first selected document as move target to open modal
+    const firstDoc = documents.find((d) => selectedIds.has(d.id));
+    if (firstDoc) handleMoveOpen(firstDoc);
+  }, [selectedIds, documents, handleMoveOpen]);
 
   // Document preview
   const handleDocumentClick = async (doc: VaultDocument, index?: number) => {
@@ -509,9 +569,20 @@ export function DocumentsPage() {
     }
   }, [previewIndex, documents, offset, totalDocs, sortBy, sortOrder, filterType, currentFolderPath, searchQuery]);
 
-  // Silent delete from preview modal
+  // Delete from preview modal — with double-click confirmation
+  const [previewDeletePending, setPreviewDeletePending] = useState(false);
   const handlePreviewDelete = useCallback(async () => {
     if (previewIndex < 0 || !documents[previewIndex]) return;
+
+    // First press = arm, second press = delete
+    if (!previewDeletePending) {
+      setPreviewDeletePending(true);
+      showToast.success('Натисніть Delete ще раз для підтвердження');
+      setTimeout(() => setPreviewDeletePending(false), 3000);
+      return;
+    }
+
+    setPreviewDeletePending(false);
     const doc = documents[previewIndex];
     try {
       await api.documents.delete(doc.id);
@@ -535,22 +606,20 @@ export function DocumentsPage() {
       console.error('Failed to delete document:', err);
       showToast.error('Не вдалося видалити документ');
     }
-  }, [previewIndex, documents]);
+  }, [previewIndex, documents, previewDeletePending]);
 
   // Edit navigation handlers
+  const editIndex = editTarget ? documents.findIndex((d) => d.id === editTarget.id) : -1;
+
   const handleEditPrevious = useCallback(() => {
-    if (!editTarget) return;
-    const idx = documents.findIndex((d) => d.id === editTarget.id);
-    if (idx > 0) handleEditOpen(documents[idx - 1]);
-  }, [editTarget, documents]);
+    if (editIndex > 0) handleEditOpen(documents[editIndex - 1]);
+  }, [editIndex, documents]);
 
   const handleEditNext = useCallback(() => {
-    if (!editTarget) return;
-    const idx = documents.findIndex((d) => d.id === editTarget.id);
-    if (idx < documents.length - 1) handleEditOpen(documents[idx + 1]);
-  }, [editTarget, documents]);
+    if (editIndex < documents.length - 1) handleEditOpen(documents[editIndex + 1]);
+  }, [editIndex, documents]);
 
-  // Silent delete from edit modal
+  // Delete from edit modal — with double-click confirmation
   const handleEditDelete = useCallback(async () => {
     if (!editTarget) return;
     const idx = documents.findIndex((d) => d.id === editTarget.id);
@@ -576,35 +645,32 @@ export function DocumentsPage() {
     }
   }, [editTarget, documents]);
 
-  // Keyboard navigation for edit modal
+  // Keyboard shortcut for upload (Ctrl+U)
   useEffect(() => {
-    if (!editTarget) return;
     const handleKeydown = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'TEXTAREA' || tag === 'INPUT') return;
-      const idx = documents.findIndex((d) => d.id === editTarget.id);
-      if (e.key === 'ArrowLeft' && idx > 0) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'u') {
         e.preventDefault();
-        handleEditOpen(documents[idx - 1]);
-      } else if (e.key === 'ArrowRight' && idx < documents.length - 1) {
-        e.preventDefault();
-        handleEditOpen(documents[idx + 1]);
-      } else if (e.key === 'Delete' || e.key === 'Backspace') {
-        e.preventDefault();
-        handleEditDelete();
+        handleFileSelect();
       }
     };
     window.addEventListener('keydown', handleKeydown);
     return () => window.removeEventListener('keydown', handleKeydown);
-  }, [editTarget, documents, handleEditDelete]);
+  }, []);
 
   // Pagination
   const hasMore = offset + PAGE_SIZE < totalDocs;
   const hasPrev = offset > 0;
   const isSearchActive = searchQuery.trim().length > 0;
+  const hasDocuments = documents.length > 0;
+  const showCompactUpload = hasDocuments && !uploadZoneExpanded;
 
   return (
-    <div className="flex-1 flex flex-col h-full overflow-hidden">
+    <div
+      className="flex-1 flex flex-col h-full overflow-hidden"
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       {/* Hidden file inputs */}
       <input
         ref={fileInputRef}
@@ -681,55 +747,99 @@ export function DocumentsPage() {
             )}
           </AnimatePresence>
 
-          {/* Upload Zone */}
-          <div
-            ref={dropZoneRef}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-            className={`relative rounded-2xl border-2 border-dashed p-8 mb-6 transition-all duration-300 ${
-              isDragOver
-                ? 'border-claude-accent bg-claude-accent/5 scale-[1.01]'
-                : 'border-claude-border hover:border-claude-subtext/40 bg-white'
-            }`}
-          >
-            <div className="text-center">
-              <div className="flex justify-center gap-3 mb-4">
-                <button
-                  onClick={handleFileSelect}
-                  className="inline-flex items-center gap-2 px-5 py-2.5 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all active:scale-[0.98] shadow-sm"
-                >
-                  <Upload size={16} strokeWidth={2} />
-                  Завантажити файли
-                </button>
-                <button
-                  onClick={handleFolderSelect}
-                  className="inline-flex items-center gap-2 px-5 py-2.5 bg-white border border-claude-border text-claude-text rounded-xl text-sm font-medium hover:bg-claude-bg transition-all active:scale-[0.98] shadow-sm"
-                >
-                  <FolderUp size={16} strokeWidth={2} />
-                  Завантажити папку
-                </button>
-              </div>
-              <p className="text-sm text-claude-subtext/70 font-sans">
-                Перетягніть файли або папку сюди &middot; PDF, DOCX, HTML, TXT, зображення, відео &middot; до 2 ГБ
-              </p>
-            </div>
+          {/* Upload Zone — compact when documents exist, full when empty or expanded */}
+          <div ref={dropZoneRef}>
+            {showCompactUpload ? (
+              /* Compact upload toolbar */
+              <div className={`mb-4 transition-all ${isDragOver ? 'ring-2 ring-claude-accent ring-offset-2 rounded-xl' : ''}`}>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleFileSelect}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all active:scale-[0.98] shadow-sm font-sans"
+                  >
+                    <Upload size={14} strokeWidth={2} />
+                    Завантажити
+                  </button>
+                  <button
+                    onClick={handleFolderSelect}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 bg-white border border-claude-border text-claude-subtext rounded-xl text-sm font-medium hover:bg-claude-bg transition-all active:scale-[0.98] font-sans"
+                  >
+                    <FolderUp size={14} strokeWidth={2} />
+                    Папку
+                  </button>
+                  <span className="text-xs text-claude-subtext/40 font-sans ml-1 hidden sm:inline">
+                    або перетягніть файли · Ctrl+U
+                  </span>
+                </div>
 
-            {/* Drag overlay */}
-            <AnimatePresence>
-              {isDragOver && (
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  className="absolute inset-0 flex items-center justify-center bg-claude-accent/10 rounded-2xl z-10"
-                >
-                  <div className="text-claude-accent font-semibold text-lg font-sans">
-                    Відпустіть для завантаження
+                {/* Drag overlay for compact mode */}
+                <AnimatePresence>
+                  {isDragOver && (
+                    <motion.div
+                      initial={{ opacity: 0, height: 0 }}
+                      animate={{ opacity: 1, height: 'auto' }}
+                      exit={{ opacity: 0, height: 0 }}
+                      className="mt-2 flex items-center justify-center bg-claude-accent/10 rounded-xl py-6"
+                    >
+                      <div className="text-claude-accent font-semibold text-lg font-sans">
+                        Відпустіть для завантаження
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            ) : (
+              /* Full upload zone */
+              <div
+                className={`relative rounded-2xl border-2 border-dashed p-8 mb-6 transition-all duration-300 ${
+                  isDragOver
+                    ? 'border-claude-accent bg-claude-accent/5 scale-[1.01]'
+                    : 'border-claude-border hover:border-claude-subtext/40 bg-white'
+                }`}
+                role="button"
+                aria-label="Зона завантаження файлів"
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleFileSelect(); }}
+              >
+                <div className="text-center">
+                  <div className="flex justify-center gap-3 mb-4">
+                    <button
+                      onClick={handleFileSelect}
+                      className="inline-flex items-center gap-2 px-5 py-2.5 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all active:scale-[0.98] shadow-sm"
+                    >
+                      <Upload size={16} strokeWidth={2} />
+                      Завантажити файли
+                    </button>
+                    <button
+                      onClick={handleFolderSelect}
+                      className="inline-flex items-center gap-2 px-5 py-2.5 bg-white border border-claude-border text-claude-text rounded-xl text-sm font-medium hover:bg-claude-bg transition-all active:scale-[0.98] shadow-sm"
+                    >
+                      <FolderUp size={16} strokeWidth={2} />
+                      Завантажити папку
+                    </button>
                   </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
+                  <p className="text-sm text-claude-subtext/70 font-sans">
+                    Перетягніть файли або папку сюди &middot; PDF, DOCX, HTML, TXT, зображення, відео &middot; до 2 ГБ &middot; Ctrl+U
+                  </p>
+                </div>
+
+                {/* Drag overlay */}
+                <AnimatePresence>
+                  {isDragOver && (
+                    <motion.div
+                      initial={{ opacity: 0 }}
+                      animate={{ opacity: 1 }}
+                      exit={{ opacity: 0 }}
+                      className="absolute inset-0 flex items-center justify-center bg-claude-accent/10 rounded-2xl z-10"
+                    >
+                      <div className="text-claude-accent font-semibold text-lg font-sans">
+                        Відпустіть для завантаження
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+            )}
           </div>
 
           {/* Upload Queue Panel */}
@@ -740,8 +850,6 @@ export function DocumentsPage() {
             setDefaultDocType={setDefaultDocType}
             onStartUpload={handleStartUpload}
           />
-
-          {/* Document Statistics — removed per design */}
 
           {/* Classification Panel */}
           <ClassificationPanel
@@ -782,6 +890,7 @@ export function DocumentsPage() {
               value={filterType}
               onChange={(e) => setFilterType(e.target.value as DocType | '')}
               className="px-3 py-2.5 bg-white border border-claude-border rounded-xl text-sm text-claude-text focus:outline-none focus:border-claude-subtext/40 transition-colors font-sans"
+              title="Фільтр за типом документа"
             >
               <option value="">Всі типи</option>
               {(Object.keys(DOC_TYPE_LABELS) as DocType[]).map((t) => (
@@ -794,27 +903,68 @@ export function DocumentsPage() {
             {/* View mode toggle */}
             <div className="flex border border-claude-border rounded-xl overflow-hidden">
               <button
-                onClick={() => setViewMode('list')}
+                onClick={() => handleSetViewMode('list')}
                 className={`p-2.5 transition-colors ${
                   viewMode === 'list'
                     ? 'bg-claude-text text-white'
                     : 'bg-white text-claude-subtext hover:bg-claude-bg'
                 }`}
+                title="Таблиця"
               >
                 <List size={16} />
               </button>
               <button
-                onClick={() => setViewMode('grid')}
+                onClick={() => handleSetViewMode('grid')}
                 className={`p-2.5 transition-colors ${
                   viewMode === 'grid'
                     ? 'bg-claude-text text-white'
                     : 'bg-white text-claude-subtext hover:bg-claude-bg'
                 }`}
+                title="Сітка"
               >
                 <LayoutGrid size={16} />
               </button>
             </div>
           </div>
+
+          {/* Batch actions bar */}
+          <AnimatePresence>
+            {selectedIds.size > 0 && (
+              <motion.div
+                initial={{ opacity: 0, y: -8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -8 }}
+                className="mb-4 flex items-center gap-3 px-4 py-2.5 bg-claude-accent/5 border border-claude-accent/20 rounded-xl"
+              >
+                <span className="text-sm font-medium text-claude-text font-sans">
+                  Вибрано: {selectedIds.size}
+                </span>
+                <div className="flex items-center gap-2 ml-auto">
+                  <button
+                    onClick={handleBatchMove}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-claude-border rounded-lg hover:bg-claude-bg transition-colors font-sans"
+                  >
+                    <FolderInput size={12} />
+                    Перемістити
+                  </button>
+                  <button
+                    onClick={handleBatchDelete}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors font-sans"
+                  >
+                    <Trash2 size={12} />
+                    Видалити
+                  </button>
+                  <button
+                    onClick={() => setSelectedIds(new Set())}
+                    className="p-1 text-claude-subtext/40 hover:text-claude-text transition-colors"
+                    title="Зняти виділення"
+                  >
+                    <X size={14} />
+                  </button>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
 
           {/* Folder Navigator */}
           {(currentFolderPath || folders.length > 0) && (
@@ -841,15 +991,36 @@ export function DocumentsPage() {
           {loading ? (
             <SkeletonRows />
           ) : documents.length === 0 ? (
-            <div className="text-center py-20">
-              <FileText size={48} className="mx-auto mb-4 text-claude-subtext/20" />
-              <h3 className="text-lg font-semibold text-claude-text mb-2 font-sans">
-                Немає документів
-              </h3>
-              <p className="text-sm text-claude-subtext/60 font-sans">
-                Завантажте документи за допомогою кнопок вище або перетягніть файли
-              </p>
-            </div>
+            isSearchActive ? (
+              /* Search no results */
+              <div className="text-center py-20">
+                <SearchX size={48} className="mx-auto mb-4 text-claude-subtext/20" />
+                <h3 className="text-lg font-semibold text-claude-text mb-2 font-sans">
+                  Нічого не знайдено
+                </h3>
+                <p className="text-sm text-claude-subtext/60 font-sans mb-4">
+                  За запитом «{searchQuery}» не знайдено документів
+                </p>
+                <button
+                  onClick={handleClearSearch}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-white border border-claude-border text-claude-text rounded-xl text-sm font-medium hover:bg-claude-bg transition-colors font-sans"
+                >
+                  <X size={14} />
+                  Очистити пошук
+                </button>
+              </div>
+            ) : (
+              /* Empty state */
+              <div className="text-center py-20">
+                <FileText size={48} className="mx-auto mb-4 text-claude-subtext/20" />
+                <h3 className="text-lg font-semibold text-claude-text mb-2 font-sans">
+                  Немає документів
+                </h3>
+                <p className="text-sm text-claude-subtext/60 font-sans">
+                  Завантажте документи за допомогою кнопок вище або перетягніть файли
+                </p>
+              </div>
+            )
           ) : viewMode === 'list' ? (
             <DocumentTable
               documents={documents}
@@ -861,6 +1032,9 @@ export function DocumentsPage() {
               onEdit={handleEditOpen}
               onDelete={setDeleteTarget}
               onMove={handleMoveOpen}
+              selectedIds={selectedIds}
+              onToggleSelect={handleToggleSelect}
+              onToggleAll={handleToggleAll}
             />
           ) : (
             <DocumentGrid
@@ -870,14 +1044,19 @@ export function DocumentsPage() {
               onEdit={handleEditOpen}
               onDelete={setDeleteTarget}
               onMove={handleMoveOpen}
+              selectedIds={selectedIds}
+              onToggleSelect={handleToggleSelect}
+              sortBy={sortBy}
+              sortOrder={sortOrder}
+              onSort={handleSort}
             />
           )}
 
-          {/* Pagination footer */}
-          {documents.length > 0 && !isSearchActive && (
+          {/* Pagination footer — always show when there are results */}
+          {documents.length > 0 && (hasMore || hasPrev || isSearchActive) && (
             <div className="flex items-center justify-between mt-4">
               <span className="text-xs text-claude-subtext/50 font-sans">
-                {offset + 1}–{Math.min(offset + PAGE_SIZE, totalDocs)} з {totalDocs}
+                {isSearchActive ? `Знайдено: ` : ''}{offset + 1}–{Math.min(offset + PAGE_SIZE, totalDocs)} з {totalDocs}
               </span>
               <div className="flex gap-2">
                 <button
@@ -898,11 +1077,11 @@ export function DocumentsPage() {
             </div>
           )}
 
-          {/* Search results count */}
-          {documents.length > 0 && isSearchActive && (
+          {/* Simple count when only one page */}
+          {documents.length > 0 && !hasMore && !hasPrev && !isSearchActive && (
             <div className="mt-4 text-center">
               <span className="text-xs text-claude-subtext/50 font-sans">
-                Знайдено {documents.length} документів
+                {totalDocs} документів
               </span>
             </div>
           )}
@@ -916,6 +1095,7 @@ export function DocumentsPage() {
           setPreviewOpen(false);
           setPreviewDoc(null);
           setPreviewIndex(-1);
+          setPreviewDeletePending(false);
         }}
         item={previewLoading ? {
           type: 'document',
@@ -933,306 +1113,42 @@ export function DocumentsPage() {
       />
 
       {/* Delete Confirmation Modal */}
-      <AnimatePresence>
-        {deleteTarget && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-            onClick={() => !deleting && setDeleteTarget(null)}
-          >
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 bg-red-50 rounded-lg">
-                  <Trash2 size={20} className="text-red-500" />
-                </div>
-                <h3 className="text-lg font-semibold text-claude-text font-sans">
-                  Видалити документ?
-                </h3>
-              </div>
-              <p className="text-sm text-claude-subtext/70 mb-6 font-sans">
-                Ви впевнені, що хочете видалити &laquo;{deleteTarget.title}&raquo;? Цю дію неможливо скасувати.
-              </p>
-              <div className="flex justify-end gap-3">
-                <button
-                  disabled={deleting}
-                  onClick={() => setDeleteTarget(null)}
-                  className="px-4 py-2 text-sm font-medium text-claude-text bg-white border border-claude-border rounded-xl hover:bg-claude-bg transition-colors font-sans disabled:opacity-50"
-                >
-                  Скасувати
-                </button>
-                <button
-                  disabled={deleting}
-                  onClick={handleDeleteConfirm}
-                  className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-xl hover:bg-red-700 transition-colors font-sans disabled:opacity-50 flex items-center gap-2"
-                >
-                  {deleting && <Loader2 size={14} className="animate-spin" />}
-                  Видалити
-                </button>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <DeleteConfirmModal
+        target={deleteTarget}
+        deleting={deleting}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
 
       {/* Edit Document Modal */}
-      <AnimatePresence>
-        {editTarget && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-            onClick={() => !editSaving && setEditTarget(null)}
-          >
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-3xl mx-4 max-h-[85vh] flex flex-col"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                  {(() => {
-                    const idx = documents.findIndex((d) => d.id === editTarget.id);
-                    return (
-                      <>
-                        <button
-                          disabled={editSaving || idx <= 0}
-                          onClick={handleEditPrevious}
-                          className="p-1 text-claude-subtext hover:text-claude-text transition-colors disabled:opacity-30"
-                          title="Попередній (←)"
-                        >
-                          <ChevronLeft size={18} />
-                        </button>
-                        <button
-                          disabled={editSaving || idx >= documents.length - 1}
-                          onClick={handleEditNext}
-                          className="p-1 text-claude-subtext hover:text-claude-text transition-colors disabled:opacity-30"
-                          title="Наступний (→)"
-                        >
-                          <ChevronRight size={18} />
-                        </button>
-                        {documents.length > 1 && (
-                          <span className="text-[11px] text-claude-subtext font-medium tabular-nums mr-1">
-                            {idx + 1} / {documents.length}
-                          </span>
-                        )}
-                      </>
-                    );
-                  })()}
-                  <h3 className="text-lg font-semibold text-claude-text font-sans truncate">
-                    Редагувати: {editTarget.title}
-                  </h3>
-                </div>
-                <div className="flex items-center gap-1">
-                  <button
-                    onClick={handleEditDelete}
-                    disabled={editSaving}
-                    className="p-1 text-claude-subtext/40 hover:text-red-500 transition-colors disabled:opacity-30"
-                    title="Видалити (Delete)"
-                  >
-                    <Trash2 size={16} />
-                  </button>
-                  <button
-                    onClick={() => !editSaving && setEditTarget(null)}
-                    className="p-1 text-claude-subtext/40 hover:text-claude-text transition-colors"
-                  >
-                    <X size={18} />
-                  </button>
-                </div>
-              </div>
-              {editLoading ? (
-                <div className="flex-1 flex items-center justify-center py-20">
-                  <Loader2 size={24} className="animate-spin text-claude-subtext/40" />
-                </div>
-              ) : (
-                <>
-                  <textarea
-                    value={editText}
-                    onChange={(e) => setEditText(e.target.value)}
-                    className="flex-1 min-h-[400px] w-full p-4 border border-claude-border rounded-xl text-sm text-claude-text font-mono resize-none focus:outline-none focus:border-claude-subtext/40 transition-colors"
-                    placeholder="Вміст документа..."
-                  />
-                  <div className="flex justify-end gap-3 mt-4">
-                    <button
-                      disabled={editSaving}
-                      onClick={() => setEditTarget(null)}
-                      className="px-4 py-2 text-sm font-medium text-claude-text bg-white border border-claude-border rounded-xl hover:bg-claude-bg transition-colors font-sans disabled:opacity-50"
-                    >
-                      Скасувати
-                    </button>
-                    <button
-                      disabled={editSaving}
-                      onClick={handleEditSave}
-                      className="px-4 py-2 text-sm font-medium text-white bg-claude-text rounded-xl hover:bg-claude-text/90 transition-colors font-sans disabled:opacity-50 flex items-center gap-2"
-                    >
-                      {editSaving && <Loader2 size={14} className="animate-spin" />}
-                      Зберегти
-                    </button>
-                  </div>
-                </>
-              )}
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <EditDocumentModal
+        target={editTarget}
+        editText={editText}
+        onEditTextChange={setEditText}
+        editLoading={editLoading}
+        editSaving={editSaving}
+        onSave={handleEditSave}
+        onClose={() => !editSaving && setEditTarget(null)}
+        onPrevious={handleEditPrevious}
+        onNext={handleEditNext}
+        onDelete={handleEditDelete}
+        currentIndex={editIndex}
+        totalCount={documents.length}
+      />
+
       {/* Move Document Modal */}
-      <AnimatePresence>
-        {moveTarget && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-            onClick={() => !moveLoading && setMoveTarget(null)}
-          >
-            <motion.div
-              initial={{ scale: 0.95, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              exit={{ scale: 0.95, opacity: 0 }}
-              className="bg-white rounded-2xl shadow-xl p-6 w-full max-w-md mx-4 max-h-[70vh] flex flex-col"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <div className="flex items-center gap-3 mb-4">
-                <div className="p-2 bg-claude-bg rounded-lg">
-                  <FolderInput size={20} className="text-claude-text" />
-                </div>
-                <div className="min-w-0">
-                  <h3 className="text-lg font-semibold text-claude-text font-sans">
-                    Перемістити документ
-                  </h3>
-                  <p className="text-xs text-claude-subtext/60 font-sans truncate">
-                    {moveTarget.title}
-                  </p>
-                </div>
-              </div>
-
-              {/* Current location */}
-              <div className="text-xs text-claude-subtext/60 font-sans mb-3">
-                Поточна папка: <span className="font-medium text-claude-text">{moveTarget.metadata?.folderPath || '/ (корінь)'}</span>
-              </div>
-
-              {/* Folder browser */}
-              <div className="flex-1 overflow-y-auto border border-claude-border rounded-xl mb-4">
-                <button
-                  onClick={() => {
-                    setMoveFolder('');
-                    handleMoveBrowse('');
-                  }}
-                  className={`flex items-center gap-2 w-full px-3 py-2 text-sm font-sans transition-colors ${
-                    moveFolder === '' ? 'bg-claude-accent/10 text-claude-accent font-medium' : 'text-claude-text hover:bg-claude-bg'
-                  }`}
-                >
-                  <CornerLeftUp size={14} className="text-claude-subtext/60" />
-                  / (корінь)
-                </button>
-
-                {moveBrowsePath && (
-                  <button
-                    onClick={() => {
-                      const segments = moveBrowsePath.split('/').filter(Boolean);
-                      segments.pop();
-                      const parent = segments.length ? segments.join('/') + '/' : '';
-                      handleMoveBrowse(parent);
-                    }}
-                    className="flex items-center gap-2 w-full px-3 py-2 text-sm text-claude-subtext hover:bg-claude-bg transition-colors font-sans border-b border-claude-border/30"
-                  >
-                    <CornerLeftUp size={14} />
-                    ..
-                  </button>
-                )}
-
-                {moveBrowsePath && (
-                  <button
-                    onClick={() => setMoveFolder(moveBrowsePath)}
-                    className={`flex items-center gap-2 w-full px-3 py-2 text-sm font-sans transition-colors border-b border-claude-border/30 ${
-                      moveFolder === moveBrowsePath ? 'bg-claude-accent/10 text-claude-accent font-medium' : 'text-claude-text hover:bg-claude-bg'
-                    }`}
-                  >
-                    <Folder size={14} className="text-claude-accent" />
-                    {moveBrowsePath.replace(/\/$/, '').split('/').pop()} (поточна)
-                  </button>
-                )}
-
-                {moveFoldersLoading ? (
-                  <div className="flex justify-center py-6">
-                    <Loader2 size={18} className="animate-spin text-claude-subtext/40" />
-                  </div>
-                ) : moveFolders.length === 0 ? (
-                  <div className="text-center py-4 text-xs text-claude-subtext/40 font-sans">
-                    Немає підпапок
-                  </div>
-                ) : (
-                  moveFolders.map((folder) => {
-                    const fullPath = moveBrowsePath ? `${moveBrowsePath}${folder}/` : `${folder}/`;
-                    return (
-                      <div key={folder} className="flex items-center border-b border-claude-border/20 last:border-0">
-                        <button
-                          onClick={() => setMoveFolder(fullPath)}
-                          className={`flex-1 flex items-center gap-2 px-3 py-2 text-sm font-sans transition-colors ${
-                            moveFolder === fullPath ? 'bg-claude-accent/10 text-claude-accent font-medium' : 'text-claude-text hover:bg-claude-bg'
-                          }`}
-                        >
-                          <Folder size={14} className={moveFolder === fullPath ? 'text-claude-accent' : 'text-claude-subtext/40'} />
-                          {folder}
-                        </button>
-                        <button
-                          onClick={() => handleMoveBrowse(fullPath)}
-                          className="px-2 py-2 text-claude-subtext/40 hover:text-claude-text transition-colors"
-                          title="Відкрити папку"
-                        >
-                          <ChevronDown size={14} className="rotate-[-90deg]" />
-                        </button>
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-
-              {/* Manual input */}
-              <div className="mb-4">
-                <label className="text-xs text-claude-subtext/60 font-sans mb-1 block">
-                  Або введіть шлях вручну:
-                </label>
-                <input
-                  type="text"
-                  value={moveFolder}
-                  onChange={(e) => setMoveFolder(e.target.value)}
-                  placeholder="наприклад: contracts/2026/"
-                  className="w-full px-3 py-2 border border-claude-border rounded-xl text-sm text-claude-text font-sans focus:outline-none focus:border-claude-subtext/40 transition-colors"
-                />
-              </div>
-
-              <div className="flex justify-end gap-3">
-                <button
-                  disabled={moveLoading}
-                  onClick={() => setMoveTarget(null)}
-                  className="px-4 py-2 text-sm font-medium text-claude-text bg-white border border-claude-border rounded-xl hover:bg-claude-bg transition-colors font-sans disabled:opacity-50"
-                >
-                  Скасувати
-                </button>
-                <button
-                  disabled={moveLoading}
-                  onClick={handleMoveConfirm}
-                  className="px-4 py-2 text-sm font-medium text-white bg-claude-text rounded-xl hover:bg-claude-text/90 transition-colors font-sans disabled:opacity-50 flex items-center gap-2"
-                >
-                  {moveLoading && <Loader2 size={14} className="animate-spin" />}
-                  Перемістити
-                </button>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <MoveDocumentModal
+        target={moveTarget}
+        moveFolder={moveFolder}
+        onMoveFolderChange={setMoveFolder}
+        moveFolders={moveFolders}
+        moveFoldersLoading={moveFoldersLoading}
+        moveLoading={moveLoading}
+        moveBrowsePath={moveBrowsePath}
+        onBrowse={handleMoveBrowse}
+        onConfirm={handleMoveConfirm}
+        onClose={() => !moveLoading && setMoveTarget(null)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **P0 fixes**: keyboard Delete now requires double-press confirmation; search results now paginate properly
- **P1 features**: multi-select with batch delete/move, compact upload zone (toolbar when docs exist), extracted 3 inline modals into separate components, deduplicated shared constants
- **P2 improvements**: sort controls in grid view, classification status in grid cards, persistent view mode, Ctrl+U shortcut, search "no results" empty state, inline folder creation in move modal
- **Accessibility**: role/aria attributes on context menus, sort headers, upload drop zone

## Changes
| File | Change |
|------|--------|
| `constants.ts` | New shared constants (labels, colors, formatters) |
| `DeleteConfirmModal.tsx` | Extracted from index.tsx, fixed undo text |
| `EditDocumentModal.tsx` | Extracted, double-press delete confirmation |
| `MoveDocumentModal.tsx` | Extracted, inline "Create folder" |
| `DocumentTable.tsx` | Multi-select checkboxes, a11y, shared imports |
| `DocumentGrid.tsx` | Sort controls, classification status, multi-select |
| `index.tsx` | Refactored from 1275→850 lines, compact upload zone, batch actions bar |

Resolves [LEG-271](https://linear.app/legalorgua/issue/LEG-271)

## Test plan
- [ ] Upload files via button and drag-drop — verify compact zone appears after first upload
- [ ] Search for documents — verify pagination works on results
- [ ] Press Delete key in preview modal — verify double-press required
- [ ] Select multiple documents via checkboxes — verify batch delete/move bar
- [ ] Switch between list/grid views — verify mode persists on reload
- [ ] Test grid view sort buttons
- [ ] Test "Create folder" in move dialog
- [ ] Ctrl+U shortcut opens file picker

🤖 Generated with [Claude Code](https://claude.com/claude-code)