### PR TITLE
fix: add KMU RSS proxy to prod nginx config

### DIFF
--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -270,6 +270,21 @@ location ^~ /s3/ {
 }
 
 # ==========================================
+# External RSS Proxy (KMU news)
+# ==========================================
+
+location = /proxy/kmu-rss {
+    proxy_pass https://www.kmu.gov.ua/api/rss;
+    proxy_ssl_server_name on;
+    proxy_ssl_verify off;
+    proxy_set_header Host www.kmu.gov.ua;
+    proxy_set_header Accept "application/rss+xml";
+    proxy_hide_header Access-Control-Allow-Origin;
+    add_header Access-Control-Allow-Origin "$http_origin" always;
+    proxy_cache_valid 200 10m;
+}
+
+# ==========================================
 # Static Assets (with caching)
 # ==========================================
 


### PR DESCRIPTION
## Summary
- Added missing `/proxy/kmu-rss` location block to prod nginx config
- The /news page was failing because this proxy was only configured for local dev

## Test plan
- [ ] Verify https://legal.org.ua/news loads KMU news feed

🤖 Generated with [Claude Code](https://claude.com/claude-code)