### PR TITLE
fix: route KMU RSS through backend to bypass bot protection

### DIFF
--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -270,21 +270,6 @@ location ^~ /s3/ {
 }
 
 # ==========================================
-# External RSS Proxy (KMU news)
-# ==========================================
-
-location = /proxy/kmu-rss {
-    proxy_pass https://www.kmu.gov.ua/api/rss;
-    proxy_ssl_server_name on;
-    proxy_ssl_verify off;
-    proxy_set_header Host www.kmu.gov.ua;
-    proxy_set_header Accept "application/rss+xml";
-    proxy_hide_header Access-Control-Allow-Origin;
-    add_header Access-Control-Allow-Origin "$http_origin" always;
-    proxy_cache_valid 200 10m;
-}
-
-# ==========================================
 # Static Assets (with caching)
 # ==========================================
 

--- a/lexwebapp/src/pages/NewsPage.tsx
+++ b/lexwebapp/src/pages/NewsPage.tsx
@@ -56,7 +56,10 @@ export function NewsPage() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/proxy/kmu-rss');
+      const token = localStorage.getItem('auth_token');
+      const response = await fetch('/api/proxy/kmu-rss', {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       const xml = await response.text();
       const items = parseRSS(xml);

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -2143,6 +2143,30 @@ class HTTPMCPServer {
       }
     }) as any);
 
+    // ============ KMU RSS Proxy ============
+    // GET /api/proxy/kmu-rss - Proxy KMU government news RSS feed (handles bot-protection redirects)
+    this.app.get('/api/proxy/kmu-rss', requireJWT as any, (async (_req: DualAuthRequest, res: Response) => {
+      try {
+        const KMU_RSS_URL = 'https://www.kmu.gov.ua/api/rss';
+        const headers: Record<string, string> = {
+          'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+          'Accept': 'application/rss+xml, application/xml, text/xml, */*',
+        };
+        const response = await fetch(KMU_RSS_URL, { headers, redirect: 'follow' });
+        if (!response.ok) {
+          return res.status(response.status).json({ error: `KMU RSS returned ${response.status}` });
+        }
+        const body = await response.text();
+        res.set('Content-Type', 'application/xml; charset=utf-8');
+        res.set('Cache-Control', 'public, max-age=600');
+        res.send(body);
+      } catch (error: any) {
+        logger.error('[KMU RSS Proxy] Error', { error: error.message });
+        res.status(502).json({ error: 'Failed to fetch KMU RSS feed' });
+      }
+    }) as any);
+    logger.info('KMU RSS Proxy endpoint registered at GET /api/proxy/kmu-rss');
+
     // ============ Chat Plan Review endpoint ============
     // POST /api/chat/plan - Returns execution plan for user review before running
     this.app.post('/api/chat/plan', chatRateLimit as any, requireJWT as any, (async (req: DualAuthRequest, res: Response) => {


### PR DESCRIPTION
## Summary
- KMU gov site uses ShieldSquare bot protection that returns 302 redirects to non-browser clients
- Nginx proxy can't handle the cookie-based validation dance
- Moved RSS proxy to backend Node.js endpoint (`GET /api/proxy/kmu-rss`) with browser User-Agent
- Removed unused nginx proxy location, updated frontend fetch URL

## Test plan
- [ ] Verify https://legal.org.ua/news loads government news

🤖 Generated with [Claude Code](https://claude.com/claude-code)