### PR TITLE
chore: remove AWS Startups badge from login page

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -761,28 +761,6 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           </div>
         </motion.button>
 
-        {/* AWS Startups Logo */}
-        <div className="text-center mt-6">
-          <motion.a
-            href="https://aws.amazon.com/startups/showcase/startup-details/aa3724a2-2ad3-429d-a762-4415407bbd86"
-            target="_blank"
-            rel="noopener noreferrer"
-            initial={{ scale: 0.9, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={{ duration: 0.5, delay: 0.5 }}
-            whileHover={{ scale: 1.03 }}
-            whileTap={{ scale: 0.97 }}
-            className="inline-flex flex-col items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
-          >
-            <span className="text-[10px] text-claude-subtext tracking-wide uppercase">Backed by AWS Activate</span>
-            <img
-              src="/aws.starups_dark.svg"
-              alt="Backed by AWS Activate — LexApp отримав підтримку від AWS Activate для розвитку масштабованої AI-інфраструктури та обробки великих масивів правових даних"
-              className="h-8 w-auto"
-            />
-          </motion.a>
-        </div>
-
         {/* Blog Link */}
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.5 }} className="text-center mt-5">
           <a href="/blog" className="inline-flex items-center gap-2 px-4 py-2.5 bg-white/60 border border-claude-border hover:border-claude-accent/30 hover:bg-white rounded-xl text-sm text-claude-subtext hover:text-claude-text transition-all font-sans">


### PR DESCRIPTION
## Summary
- Remove AWS Startups logo, link, and "Backed by AWS Activate" text from login page

## Test plan
- [ ] Verify login page renders without AWS badge
- [ ] Confirm no layout shift or spacing issues


🤖 Generated with [Claude Code](https://claude.com/claude-code)