### PR TITLE
fix: render related_parties objects on matter detail page

### DIFF
--- a/lexwebapp/src/pages/MatterDetailPage/index.tsx
+++ b/lexwebapp/src/pages/MatterDetailPage/index.tsx
@@ -319,7 +319,11 @@ export function MatterDetailPage() {
                         <div className="text-xs text-claude-subtext font-sans mb-1">Пов'язані сторони</div>
                         <div className="flex flex-wrap gap-1 mt-1">
                           {matter.related_parties.map((party, i) => (
-                            <span key={i} className="px-2 py-0.5 bg-claude-bg rounded text-xs font-sans text-claude-text">{party}</span>
+                            <span key={i} className="px-2 py-0.5 bg-claude-bg rounded text-xs font-sans text-claude-text">
+                              {typeof party === 'object' && party !== null
+                                ? [party.name, party.role, party.inn].filter(Boolean).join(' — ')
+                                : String(party)}
+                            </span>
                           ))}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- Fix React error #31 on `/matters/:id` page — `related_parties` JSONB array can contain objects with `{inn, name, role}` keys, not just strings
- Objects are now rendered as `name — role — inn` instead of being passed directly as JSX children

## Test plan
- [ ] Open https://legal.org.ua/matters/c0a4f871-395e-497e-a42b-129e80895d48
- [ ] Verify matter detail page loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)