### PR TITLE
fix: update Matter type for related_parties objects

### DIFF
--- a/lexwebapp/src/types/models/Matter.ts
+++ b/lexwebapp/src/types/models/Matter.ts
@@ -26,7 +26,7 @@ export interface Matter {
   opposing_party: string | null;
   court_case_number: string | null;
   court_name: string | null;
-  related_parties: string[] | null;
+  related_parties: Array<string | { inn?: string; name?: string; role?: string }> | null;
   retention_period_years: number;
   has_legal_hold: boolean;
   metadata: Record<string, any>;


### PR DESCRIPTION
## Summary
- Follow-up to #689 — fix TS build error by updating `related_parties` type from `string[]` to `Array<string | {inn?, name?, role?}>`

## Test plan
- [ ] Docker build succeeds (tsc --noEmit passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)