### PR TITLE
feat: rename Legal Hold to Заборона знищення, add field descriptions

### DIFF
--- a/lexwebapp/src/components/audit/AuditLogViewer.tsx
+++ b/lexwebapp/src/components/audit/AuditLogViewer.tsx
@@ -35,9 +35,9 @@ const ACTION_LABELS: Record<string, string> = {
   'matter.reopen': 'Відкрито справу повторно',
   'team.add': 'Додано учасника команди',
   'team.remove': 'Видалено учасника команди',
-  'hold.create': 'Встановлено утримання',
-  'hold.release': 'Знято утримання',
-  'hold.add_documents': 'Додано документи до утримання',
+  'hold.create': 'Встановлено заборону знищення',
+  'hold.release': 'Знято заборону знищення',
+  'hold.add_documents': 'Додано документи до заборони знищення',
   'document.upload': 'Завантажено документ',
   'document.delete': 'Видалено документ',
   'conflict_check.run': 'Перевірка конфліктів',
@@ -171,7 +171,7 @@ export function AuditLogViewer({ resourceType, resourceId, compact = false }: Au
                   : 'bg-white text-claude-text border border-claude-border hover:bg-claude-bg'
               }`}
             >
-              {type === '' ? 'Всі' : type === 'client' ? 'Клієнти' : type === 'matter' ? 'Справи' : type === 'hold' ? 'Утримання' : type === 'team' ? 'Команда' : 'Документи'}
+              {type === '' ? 'Всі' : type === 'client' ? 'Клієнти' : type === 'matter' ? 'Справи' : type === 'hold' ? 'Заборона знищення' : type === 'team' ? 'Команда' : 'Документи'}
             </button>
           ))}
         </motion.div>

--- a/lexwebapp/src/components/matters/CreateHoldModal.tsx
+++ b/lexwebapp/src/components/matters/CreateHoldModal.tsx
@@ -55,7 +55,7 @@ export function CreateHoldModal({ isOpen, onClose, matterId }: CreateHoldModalPr
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} title="Нове утримання" size="md">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Нова заборона знищення" size="md">
       <form onSubmit={handleSubmit} className="space-y-4 p-1">
         <div>
           <label className="block text-sm font-medium text-claude-text font-sans mb-1">
@@ -68,7 +68,7 @@ export function CreateHoldModal({ isOpen, onClose, matterId }: CreateHoldModalPr
             required
             value={name}
             onChange={(e) => setName(e.target.value)}
-            placeholder="Наприклад: Утримання документів для суду"
+            placeholder="Наприклад: Заборона знищення документів для суду"
             className="w-full px-3 py-2.5 bg-white border border-claude-border rounded-xl text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all font-sans text-sm"
           />
         </div>
@@ -102,7 +102,7 @@ export function CreateHoldModal({ isOpen, onClose, matterId }: CreateHoldModalPr
             name="scopeDescription"
             value={scope}
             onChange={(e) => setScope(e.target.value)}
-            placeholder="Описати документи та дані, що підлягають утриманню..."
+            placeholder="Описати документи та дані, на які поширюється заборона знищення..."
             rows={3}
             className="w-full px-3 py-2.5 bg-white border border-claude-border rounded-xl text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all resize-none font-sans text-sm"
           />

--- a/lexwebapp/src/components/matters/HoldsList.tsx
+++ b/lexwebapp/src/components/matters/HoldsList.tsx
@@ -54,7 +54,7 @@ export function HoldsList({ matterId }: HoldsListProps) {
     return (
       <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 font-sans text-sm">
         <AlertCircle size={18} />
-        Помилка завантаження утримань
+        Помилка завантаження заборон знищення
       </div>
     );
   }
@@ -67,7 +67,7 @@ export function HoldsList({ matterId }: HoldsListProps) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
-          <h3 className="text-lg font-serif text-claude-text">Утримання</h3>
+          <h3 className="text-lg font-serif text-claude-text">Заборона знищення</h3>
           {activeHolds.length > 0 && (
             <span className="px-2 py-0.5 text-xs font-medium bg-red-100 text-red-700 rounded-full">
               {activeHolds.length} активних
@@ -79,7 +79,7 @@ export function HoldsList({ matterId }: HoldsListProps) {
           className="flex items-center gap-2 px-3 py-2 bg-claude-accent text-white rounded-xl font-medium text-xs font-sans hover:bg-[#C66345] transition-colors shadow-sm"
         >
           <Plus size={14} />
-          Створити утримання
+          Створити заборону
         </button>
       </div>
 
@@ -87,7 +87,7 @@ export function HoldsList({ matterId }: HoldsListProps) {
       {holds.length === 0 ? (
         <div className="text-center py-8">
           <Shield size={24} className="mx-auto text-claude-subtext mb-2" />
-          <p className="text-claude-subtext font-sans text-sm">Утримань немає</p>
+          <p className="text-claude-subtext font-sans text-sm">Заборон знищення немає</p>
         </div>
       ) : (
         <div className="space-y-3">

--- a/lexwebapp/src/components/matters/ReleaseHoldConfirmation.tsx
+++ b/lexwebapp/src/components/matters/ReleaseHoldConfirmation.tsx
@@ -26,17 +26,17 @@ export function ReleaseHoldConfirmation({ hold, matterId, onClose }: ReleaseHold
   };
 
   return (
-    <Modal isOpen={true} onClose={onClose} title="Зняти утримання" size="sm">
+    <Modal isOpen={true} onClose={onClose} title="Зняти заборону знищення" size="sm">
       <div className="space-y-4 p-1">
         <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
           <AlertTriangle size={20} className="text-amber-600 flex-shrink-0 mt-0.5" />
           <div>
             <p className="text-sm font-medium text-amber-800 font-sans">
-              Ви впевнені, що хочете зняти утримання?
+              Ви впевнені, що хочете зняти заборону знищення?
             </p>
             <p className="text-xs text-amber-700 font-sans mt-1">
-              Утримання "{hold.hold_name}" буде знято. Документи, що знаходяться під цим
-              утриманням, більше не будуть захищені від видалення.
+              Заборону "{hold.hold_name}" буде знято. Документи, на які поширювалась ця
+              заборона, більше не будуть захищені від видалення.
             </p>
           </div>
         </div>
@@ -55,7 +55,7 @@ export function ReleaseHoldConfirmation({ hold, matterId, onClose }: ReleaseHold
             className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-amber-600 text-white rounded-xl font-medium text-sm font-sans hover:bg-amber-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {releaseHold.isPending && <Loader2 size={16} className="animate-spin" />}
-            Зняти утримання
+            Зняти заборону
           </button>
         </div>
       </div>

--- a/lexwebapp/src/pages/ClientDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ClientDetailPage/index.tsx
@@ -347,7 +347,7 @@ export function ClientDetailPage() {
                             {matter.has_legal_hold && (
                               <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
                                 <Shield size={10} />
-                                Утримання
+                                Заборона знищення
                               </span>
                             )}
                           </div>

--- a/lexwebapp/src/pages/MatterDetailPage/index.tsx
+++ b/lexwebapp/src/pages/MatterDetailPage/index.tsx
@@ -72,7 +72,7 @@ type Tab = 'overview' | 'team' | 'holds' | 'documents' | 'activity';
 const TABS: { id: Tab; label: string; icon: React.ReactNode }[] = [
   { id: 'overview', label: 'Огляд', icon: <Briefcase size={16} /> },
   { id: 'team', label: 'Команда', icon: <Users size={16} /> },
-  { id: 'holds', label: 'Утримання', icon: <Lock size={16} /> },
+  { id: 'holds', label: 'Заборона знищення', icon: <Lock size={16} /> },
   { id: 'documents', label: 'Документи', icon: <FileText size={16} /> },
   { id: 'activity', label: 'Активність', icon: <Clock size={16} /> },
 ];
@@ -176,7 +176,7 @@ export function MatterDetailPage() {
                 {matter.has_legal_hold && (
                   <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium bg-red-100 text-red-700">
                     <Shield size={12} />
-                    Утримання
+                    Заборона знищення
                   </span>
                 )}
               </div>
@@ -243,14 +243,20 @@ export function MatterDetailPage() {
                 <h2 className="text-xl font-serif text-claude-text mb-4">Деталі справи</h2>
                 <div className="space-y-4">
                   <div className="flex items-center justify-between p-3 bg-claude-bg rounded-lg">
-                    <span className="text-sm text-claude-subtext font-sans">Тип</span>
+                    <div>
+                      <span className="text-sm text-claude-subtext font-sans">Тип</span>
+                      <p className="text-[11px] text-claude-subtext/60 font-sans">Категорія юридичної роботи за цією справою</p>
+                    </div>
                     <span className="text-sm font-medium text-claude-text font-sans">
                       {MATTER_TYPE_LABELS[matter.matter_type] || matter.matter_type}
                     </span>
                   </div>
                   {matter.responsible_attorney && (
                     <div className="flex items-center justify-between p-3 bg-claude-bg rounded-lg">
-                      <span className="text-sm text-claude-subtext font-sans">Відповідальний</span>
+                      <div>
+                        <span className="text-sm text-claude-subtext font-sans">Відповідальний</span>
+                        <p className="text-[11px] text-claude-subtext/60 font-sans">Адвокат, який веде справу</p>
+                      </div>
                       <span className="text-sm font-medium text-claude-text font-sans flex items-center gap-2">
                         <User size={14} />
                         {matter.responsible_attorney}
@@ -258,7 +264,10 @@ export function MatterDetailPage() {
                     </div>
                   )}
                   <div className="flex items-center justify-between p-3 bg-claude-bg rounded-lg">
-                    <span className="text-sm text-claude-subtext font-sans">Дата відкриття</span>
+                    <div>
+                      <span className="text-sm text-claude-subtext font-sans">Дата відкриття</span>
+                      <p className="text-[11px] text-claude-subtext/60 font-sans">Коли справу було створено в системі</p>
+                    </div>
                     <span className="text-sm font-medium text-claude-text font-sans flex items-center gap-2">
                       <Calendar size={14} />
                       {new Date(matter.opened_date).toLocaleDateString('uk-UA')}
@@ -266,14 +275,20 @@ export function MatterDetailPage() {
                   </div>
                   {matter.closed_date && (
                     <div className="flex items-center justify-between p-3 bg-claude-bg rounded-lg">
-                      <span className="text-sm text-claude-subtext font-sans">Дата закриття</span>
+                      <div>
+                        <span className="text-sm text-claude-subtext font-sans">Дата закриття</span>
+                        <p className="text-[11px] text-claude-subtext/60 font-sans">Коли справу було завершено</p>
+                      </div>
                       <span className="text-sm font-medium text-claude-text font-sans">
                         {new Date(matter.closed_date).toLocaleDateString('uk-UA')}
                       </span>
                     </div>
                   )}
                   <div className="flex items-center justify-between p-3 bg-claude-bg rounded-lg">
-                    <span className="text-sm text-claude-subtext font-sans">Строк зберігання</span>
+                    <div>
+                      <span className="text-sm text-claude-subtext font-sans">Строк зберігання</span>
+                      <p className="text-[11px] text-claude-subtext/60 font-sans">Мінімальний період зберігання документів після закриття</p>
+                    </div>
                     <span className="text-sm font-medium text-claude-text font-sans">
                       {matter.retention_period_years} р.
                     </span>
@@ -289,7 +304,8 @@ export function MatterDetailPage() {
                     <div className="flex items-start gap-3">
                       <div className="p-2 bg-claude-bg rounded-lg text-claude-subtext"><Gavel size={18} /></div>
                       <div>
-                        <div className="text-xs text-claude-subtext font-sans mb-1">Суд</div>
+                        <div className="text-xs text-claude-subtext font-sans mb-0.5">Суд</div>
+                        <p className="text-[11px] text-claude-subtext/60 font-sans mb-1">Суд, в якому розглядається справа</p>
                         <p className="text-sm text-claude-text font-sans">{matter.court_name}</p>
                       </div>
                     </div>
@@ -298,7 +314,8 @@ export function MatterDetailPage() {
                     <div className="flex items-start gap-3">
                       <div className="p-2 bg-claude-bg rounded-lg text-claude-subtext"><FileText size={18} /></div>
                       <div>
-                        <div className="text-xs text-claude-subtext font-sans mb-1">Номер справи в суді</div>
+                        <div className="text-xs text-claude-subtext font-sans mb-0.5">Номер справи в суді</div>
+                        <p className="text-[11px] text-claude-subtext/60 font-sans mb-1">Єдиний унікальний номер судової справи</p>
                         <p className="text-sm text-claude-text font-sans font-mono">{matter.court_case_number}</p>
                       </div>
                     </div>
@@ -307,7 +324,8 @@ export function MatterDetailPage() {
                     <div className="flex items-start gap-3">
                       <div className="p-2 bg-claude-bg rounded-lg text-claude-subtext"><Users size={18} /></div>
                       <div>
-                        <div className="text-xs text-claude-subtext font-sans mb-1">Протилежна сторона</div>
+                        <div className="text-xs text-claude-subtext font-sans mb-0.5">Протилежна сторона</div>
+                        <p className="text-[11px] text-claude-subtext/60 font-sans mb-1">Опонент у справі (відповідач, позивач тощо)</p>
                         <p className="text-sm text-claude-text font-sans">{matter.opposing_party}</p>
                       </div>
                     </div>
@@ -316,7 +334,8 @@ export function MatterDetailPage() {
                     <div className="flex items-start gap-3">
                       <div className="p-2 bg-claude-bg rounded-lg text-claude-subtext"><Users size={18} /></div>
                       <div>
-                        <div className="text-xs text-claude-subtext font-sans mb-1">Пов'язані сторони</div>
+                        <div className="text-xs text-claude-subtext font-sans mb-0.5">Пов'язані сторони</div>
+                        <p className="text-[11px] text-claude-subtext/60 font-sans mb-1">Треті особи, свідки або інші учасники справи</p>
                         <div className="flex flex-wrap gap-1 mt-1">
                           {matter.related_parties.map((party, i) => (
                             <span key={i} className="px-2 py-0.5 bg-claude-bg rounded text-xs font-sans text-claude-text">

--- a/lexwebapp/src/pages/MattersPage/index.tsx
+++ b/lexwebapp/src/pages/MattersPage/index.tsx
@@ -82,7 +82,7 @@ export function MattersPage() {
                 Справи
               </h1>
               <p className="text-claude-subtext font-sans text-sm">
-                Управління юридичними справами та провадженнями
+                Управління юридичними справами та провадженнями. Кожна справа містить документи, команду, історію дій та заборони знищення.
               </p>
             </div>
 
@@ -206,14 +206,14 @@ export function MattersPage() {
                       <div className="flex items-start justify-between gap-4 mb-2">
                         <div>
                           <div className="flex items-center gap-2 mb-1">
-                            <span className="text-xs font-mono text-claude-subtext">{matter.matter_number}</span>
-                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusConfig.color}`}>
+                            <span className="text-xs font-mono text-claude-subtext" title="Унікальний номер справи в системі">{matter.matter_number}</span>
+                            <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${statusConfig.color}`} title="Поточний статус справи">
                               {statusConfig.label}
                             </span>
                             {matter.has_legal_hold && (
-                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">
+                              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700" title="Документи у справі захищені від видалення (Legal Hold)">
                                 <Shield size={10} />
-                                Утримання
+                                Заборона знищення
                               </span>
                             )}
                           </div>
@@ -226,18 +226,18 @@ export function MattersPage() {
                       {/* Details row */}
                       <div className="grid grid-cols-1 md:grid-cols-3 gap-3 mt-3">
                         {matter.client_name && (
-                          <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans">
+                          <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans" title="Клієнт — замовник юридичних послуг">
                             <Building2 size={14} className="flex-shrink-0" />
                             <span className="truncate">{matter.client_name}</span>
                           </div>
                         )}
                         {matter.responsible_attorney && (
-                          <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans">
+                          <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans" title="Адвокат, який веде справу">
                             <User size={14} className="flex-shrink-0" />
                             <span className="truncate">{matter.responsible_attorney}</span>
                           </div>
                         )}
-                        <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans">
+                        <div className="flex items-center gap-2 text-sm text-claude-subtext font-sans" title="Дата створення справи в системі">
                           <Calendar size={14} className="flex-shrink-0" />
                           <span>{new Date(matter.opened_date).toLocaleDateString('uk-UA')}</span>
                         </div>


### PR DESCRIPTION
## Summary
- Rename all "Утримання" → "Заборона знищення" across matters UI (detail page, list, client detail, audit log, holds list, create/release modals)
- Add Ukrainian descriptions to all fields on matter detail page (type, attorney, dates, retention, court, parties)
- Add hover tooltips to matter list card fields

## Test plan
- [ ] Open https://legal.org.ua/matters — verify "Заборона знищення" badge text
- [ ] Open a matter detail — verify field descriptions under each label
- [ ] Check "Заборона знищення" tab and create/release modals

🤖 Generated with [Claude Code](https://claude.com/claude-code)