### PR TITLE
fix(webapp): fix recharts Tooltip formatter type error

### DIFF
--- a/lexwebapp/src/pages/AdminZOStatsPage.tsx
+++ b/lexwebapp/src/pages/AdminZOStatsPage.tsx
@@ -276,7 +276,7 @@ export function AdminZOStatsPage() {
                     <Tooltip
                       contentStyle={{ backgroundColor: '#1f2937', border: '1px solid #374151', borderRadius: 8 }}
                       labelStyle={{ color: '#e5e7eb', fontWeight: 600 }}
-                      formatter={(value: any, name: string | undefined) => [formatNum(Number(value)), name ?? '']}
+                      formatter={(value: any, name: any) => [formatNum(Number(value)), String(name ?? '')]}
                     />
                     <Legend wrapperStyle={{ color: '#9ca3af', fontSize: 12 }} />
                     {data.justiceKinds.map(k => (


### PR DESCRIPTION
## Summary
- Fix pre-existing TS2322 type error in AdminZOStatsPage.tsx caused by recharts v3 Tooltip formatter type change

## Test plan
- [x] `tsc --noEmit` passes
- [x] Required for prod Docker build to succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)