### PR TITLE
fix(backend): pin openid-client to v5.x (revert breaking v6 upgrade)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -93,7 +93,7 @@
     "node-pty": "^1.1.0",
     "nodemailer": "^8.0.1",
     "openai": "^6.25.0",
-    "openid-client": "^6.8.2",
+    "openid-client": "^5.7.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
     "pdf-parse": "^2.4.5",


### PR DESCRIPTION
## Summary
- Pin openid-client to ^5.7.1 — the v6 upgrade (#678) broke oidc-service.ts (removed Issuer/Client/generators exports)

## Test plan
- [x] Backend `tsc --noEmit` passes with v5
- [x] Required for prod Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)