### PR TITLE
feat: prod scaling + switch Bedrock defaults to Claude models

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -58,10 +58,10 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-secondlayer}:${POSTGRES_PASSWORD:-}@postgres-prod:5432/${POSTGRES_DB:-secondlayer_prod}
       AUTH_TYPE: scram-sha-256
       POOL_MODE: transaction
-      MAX_CLIENT_CONN: 300
-      DEFAULT_POOL_SIZE: 30
-      MIN_POOL_SIZE: 5
-      RESERVE_POOL_SIZE: 5
+      MAX_CLIENT_CONN: 500
+      DEFAULT_POOL_SIZE: 50
+      MIN_POOL_SIZE: 10
+      RESERVE_POOL_SIZE: 10
       RESERVE_POOL_TIMEOUT: 5
       SERVER_ROUND_ROBIN: 1
       TZ: Europe/Kiev
@@ -180,7 +180,7 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 1536mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 2048mb --maxmemory-policy noeviction
     healthcheck:
       test:
       - CMD
@@ -498,7 +498,7 @@ services:
     container_name: secondlayer-app-prod
     command:
     - node
-    - --max-old-space-size=3072
+    - --max-old-space-size=6144
     - dist/http-server.js
     logging:
       driver: json-file
@@ -649,11 +649,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
-          memory: 4G
+          cpus: '3'
+          memory: 8G
         reservations:
-          cpus: '0.5'
-          memory: 2G
+          cpus: '1'
+          memory: 4G
 
   document-service-prod:
     build:

--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -24,10 +24,10 @@ STAGE_USER="vovkes"
 STAGE_REMOTE_PATH="/home/vovkes/SecondLayer/deployment"
 DEPLOY_USER="$STAGE_USER"  # Default for lib scripts; overridden per-env in deploy
 
-PROD_SERVER="gate.lexapp.co.ua"   # Temporarily on gate server (AWS suspended)
-PROD_USER="vovkes"
-PROD_SSH_KEY=""
-PROD_REMOTE_PATH="/home/vovkes/SecondLayer/deployment"
+PROD_SERVER="18.192.189.254"      # AWS EC2 (eu-central-1)
+PROD_USER="ubuntu"
+PROD_SSH_KEY="$HOME/.ssh/secondlayer-prod.pem"
+PROD_REMOTE_PATH="/home/ubuntu/SecondLayer/deployment"
 
 NO_CACHE=""  # Set to "--no-cache" via --no-cache flag
 
@@ -36,7 +36,7 @@ get_ssh_cmd() {
     local env=$1
     case $env in
         prod|production)
-            echo "ssh ${PROD_USER}@${PROD_SERVER}"
+            echo "ssh -i ${PROD_SSH_KEY} ${PROD_USER}@${PROD_SERVER}"
             ;;
         stage|staging)
             echo "ssh ${STAGE_USER}@${STAGE_SERVER}"
@@ -49,7 +49,7 @@ get_scp_cmd() {
     local env=$1
     case $env in
         prod|production)
-            echo "scp"
+            echo "scp -i ${PROD_SSH_KEY}"
             ;;
         stage|staging)
             echo "scp"
@@ -138,14 +138,14 @@ Commands:
   clean <env>       Clean environment data (USE WITH CAUTION!)
 
 Environments:
-  prod              Production -> gate.lexapp.co.ua (temporarily on gate server)
+  prod              Production -> 18.192.189.254 (AWS EC2)
                     Domains: legal.org.ua, mcp.legal.org.ua
   stage             Staging -> gate.lexapp.co.ua (Cloudflare proxy)
                     Domains: stage.legal.org.ua, legal.org.ua, mcp.legal.org.ua
   local             Local development (local.legal.org.ua) -> localhost
 
 Deployment Targets:
-  - Prod:  Deploys to gate.lexapp.co.ua (temporarily, AWS suspended), serves legal.org.ua via Cloudflare
+  - Prod:  Deploys to 18.192.189.254 (AWS EC2), serves legal.org.ua via Cloudflare
   - Stage: Deploys to gate.lexapp.co.ua, serves all 3 domains via nginx + Cloudflare
   - Local: Full rebuild on localhost (pull, rebuild --no-cache, migrate)
 

--- a/mcp_backend/src/middleware/upload-rate-limit.ts
+++ b/mcp_backend/src/middleware/upload-rate-limit.ts
@@ -67,24 +67,24 @@ function createUserRateLimiter(options: UserRateLimitOptions) {
   };
 }
 
-// 200 init requests per minute per user (generous — session quota is the real abuse protection)
+// 500 init requests per minute per user (generous — session quota is the real abuse protection)
 export const uploadInitRateLimit = createUserRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 200,
+  maxRequests: 500,
   keyPrefix: 'ratelimit:upload-init',
 });
 
-// 500 batch-init requests per minute per user (each batch handles up to 500 files;
+// 1000 batch-init requests per minute per user (each batch handles up to 2000 files;
 // retries on failure consume this budget quickly). Session quota provides the real abuse protection.
 export const uploadBatchInitRateLimit = createUserRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 500,
+  maxRequests: 1000,
   keyPrefix: 'ratelimit:upload-init-batch',
 });
 
-// 500 chunk uploads per minute per user
+// 1500 chunk uploads per minute per user (100 users × 5 files × 10 chunks = 5000 chunks/min total)
 export const uploadChunkRateLimit = createUserRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 500,
+  maxRequests: 1500,
   keyPrefix: 'ratelimit:upload-chunk',
 });

--- a/mcp_backend/src/routes/upload-routes.ts
+++ b/mcp_backend/src/routes/upload-routes.ts
@@ -54,11 +54,11 @@ const upload = multer({
   },
 });
 
-// Per-user concurrent session quota (raised from 50: folders can have 1000+ files)
-const MAX_USER_SESSIONS = parseInt(process.env.MAX_USER_SESSIONS || '500', 10);
+// Per-user concurrent session quota (raised for 100 concurrent users with large folder uploads)
+const MAX_USER_SESSIONS = parseInt(process.env.MAX_USER_SESSIONS || '1000', 10);
 
 // Semaphore to limit concurrent file processing (DB pool, OpenAI rate limits)
-const MAX_CONCURRENT_PROCESSING = parseInt(process.env.MAX_CONCURRENT_PROCESSING || '50', 10);
+const MAX_CONCURRENT_PROCESSING = parseInt(process.env.MAX_CONCURRENT_PROCESSING || '100', 10);
 let activeProcessing = 0;
 
 // Fair processing queue: round-robin per user instead of global FIFO

--- a/mcp_backend/src/services/cpu-adaptive-manager.ts
+++ b/mcp_backend/src/services/cpu-adaptive-manager.ts
@@ -40,9 +40,9 @@ export class CpuAdaptiveManager {
     this.onConcurrencyChange = onConcurrencyChange;
     this.cpuCount = os.cpus().length;
 
-    this.workersPerCore = parseInt(process.env.WORKERS_PER_CORE || '4', 10);
-    this.minConcurrency = parseInt(process.env.MIN_CONCURRENT_PROCESSING || '2', 10);
-    this.maxConcurrency = parseInt(process.env.MAX_CONCURRENT_PROCESSING || '50', 10);
+    this.workersPerCore = parseInt(process.env.WORKERS_PER_CORE || '8', 10);
+    this.minConcurrency = parseInt(process.env.MIN_CONCURRENT_PROCESSING || '5', 10);
+    this.maxConcurrency = parseInt(process.env.MAX_CONCURRENT_PROCESSING || '100', 10);
     this.currentConcurrency = initialConcurrency;
 
     logger.info('[CpuAdaptive] Initialized', {

--- a/mcp_backend/src/services/upload-queue-service.ts
+++ b/mcp_backend/src/services/upload-queue-service.ts
@@ -36,7 +36,7 @@ export interface UploadQueueMetrics {
 }
 
 const QUEUE_NAME = 'upload-processing';
-const DEFAULT_CONCURRENCY = parseInt(process.env.MAX_CONCURRENT_PROCESSING || '50', 10);
+const DEFAULT_CONCURRENCY = parseInt(process.env.MAX_CONCURRENT_PROCESSING || '100', 10);
 
 export class UploadQueueService {
   private queue: Queue;
@@ -100,8 +100,8 @@ export class UploadQueueService {
         connection,
         concurrency,
         limiter: {
-          max: 10,
-          duration: 5000, // Max 10 jobs started per 5 seconds — prevents OpenAI API burst
+          max: 40,
+          duration: 5000, // Max 40 jobs started per 5 seconds — Bedrock has no strict RPM limits
         },
       }
     );

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -23,9 +23,9 @@ export class ModelSelector {
   private static readonly OPENAI_STANDARD = process.env.OPENAI_MODEL_STANDARD || 'gpt-5-mini';
   private static readonly OPENAI_DEEP = process.env.OPENAI_MODEL_DEEP || 'gpt-5.1';
 
-  private static readonly BEDROCK_QUICK = process.env.BEDROCK_MODEL_QUICK || 'eu.amazon.nova-micro-v1:0';
-  private static readonly BEDROCK_STANDARD = process.env.BEDROCK_MODEL_STANDARD || 'eu.amazon.nova-lite-v1:0';
-  private static readonly BEDROCK_DEEP = process.env.BEDROCK_MODEL_DEEP || 'eu.amazon.nova-pro-v1:0';
+  private static readonly BEDROCK_QUICK = process.env.BEDROCK_MODEL_QUICK || 'eu.anthropic.claude-haiku-4-5-20251001-v1:0';
+  private static readonly BEDROCK_STANDARD = process.env.BEDROCK_MODEL_STANDARD || 'eu.anthropic.claude-sonnet-4-6';
+  private static readonly BEDROCK_DEEP = process.env.BEDROCK_MODEL_DEEP || 'eu.anthropic.claude-opus-4-6-v1';
 
   private static readonly SINGLE_MODEL = process.env.OPENAI_MODEL;
 
@@ -108,6 +108,7 @@ export class ModelSelector {
 
   private static normalizeModelId(model: string): string {
     // Strip regional prefix (e.g. "eu.amazon.nova-micro-v1:0" → "amazon.nova-micro-v1:0")
+    // Also handles "eu.anthropic.claude-haiku-4-5-20251001-v1:0" → "anthropic.claude-haiku-4-5-20251001-v1:0"
     return model.replace(/^(eu|us|global)\./, '');
   }
 
@@ -159,6 +160,13 @@ export class ModelSelector {
       'claude-opus': { input: 5.00, output: 25.00 },
       'claude-sonnet': { input: 3.00, output: 15.00 },
       'claude-haiku': { input: 1.00, output: 5.00 },
+      // AWS Bedrock — Anthropic Claude
+      'anthropic.claude-haiku-4-5-20251001-v1:0': { input: 1.00, output: 5.00 },
+      'anthropic.claude-sonnet-4-6': { input: 3.00, output: 15.00 },
+      'anthropic.claude-opus-4-6-v1': { input: 15.00, output: 75.00 },
+      'anthropic.claude-sonnet-4-20250514-v1:0': { input: 3.00, output: 15.00 },
+      'anthropic.claude-sonnet-4-5-20250929-v1:0': { input: 3.00, output: 15.00 },
+      'anthropic.claude-opus-4-5-20251101-v1:0': { input: 15.00, output: 75.00 },
       // AWS Bedrock — Amazon Nova
       'amazon.nova-micro-v1:0': { input: 0.035, output: 0.14 },
       'amazon.nova-lite-v1:0': { input: 0.06, output: 0.24 },
@@ -246,6 +254,13 @@ export class ModelSelector {
       'claude-opus': { input: 5.00, output: 25.00 },
       'claude-sonnet': { input: 3.00, output: 15.00 },
       'claude-haiku': { input: 1.00, output: 5.00 },
+      // AWS Bedrock — Anthropic Claude
+      'anthropic.claude-haiku-4-5-20251001-v1:0': { input: 1.00, output: 5.00 },
+      'anthropic.claude-sonnet-4-6': { input: 3.00, output: 15.00 },
+      'anthropic.claude-opus-4-6-v1': { input: 15.00, output: 75.00 },
+      'anthropic.claude-sonnet-4-20250514-v1:0': { input: 3.00, output: 15.00 },
+      'anthropic.claude-sonnet-4-5-20250929-v1:0': { input: 3.00, output: 15.00 },
+      'anthropic.claude-opus-4-5-20251101-v1:0': { input: 15.00, output: 75.00 },
       // AWS Bedrock — Amazon Nova
       'amazon.nova-micro-v1:0': { input: 0.035, output: 0.14 },
       'amazon.nova-lite-v1:0': { input: 0.06, output: 0.24 },
@@ -307,8 +322,9 @@ export class ModelSelector {
   }
 
   static supportsJsonMode(model: string): boolean {
-    // Nova models support JSON via system prompt instructions, not response_format
+    // Bedrock Converse API doesn't support response_format — JSON via prompt instructions
     if (model.includes('amazon.nova')) return false;
+    if (model.includes('anthropic.claude')) return false;
 
     const jsonModeModels = [
       'gpt-5.1',


### PR DESCRIPTION
## Summary
- **Prod resource scaling**: app 3 CPU/8GB (was 2/4G), 6GB heap, PgBouncer 500 max conn / 50 pool, Redis 2048mb
- **Bedrock model switch**: defaults from Amazon Nova to Claude (Haiku 4.5 / Sonnet 4.6 / Opus 4.6) with pricing
- **Upload scaling**: rate limits and concurrency raised for 100 concurrent users, BullMQ 40 jobs/5s
- **Prod deploy target**: manage-gateway.sh updated to AWS EC2 (18.192.189.254)

## Test plan
- [ ] Verify build passes
- [ ] Deploy to prod with --no-cache
- [ ] Check container health and logs
- [ ] Verify chat pipeline works with Bedrock Claude models

🤖 Generated with [Claude Code](https://claude.com/claude-code)