### PR TITLE
fix: Google OAuth redirect_uri mismatch on prod

### DIFF
--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -70,6 +70,9 @@ router.post('/reset-password', authRateLimit as any, authController.resetPasswor
  * The redirect URI must also be registered in Google Cloud Console.
  */
 function getCallbackURL(req: any): string {
+  if (process.env.GOOGLE_CALLBACK_URL) {
+    return process.env.GOOGLE_CALLBACK_URL;
+  }
   const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
   const host = req.headers['x-forwarded-host'] || req.headers.host;
   return `${protocol}://${host}/auth/google/callback`;


### PR DESCRIPTION
## Summary
- Google OAuth fails with `redirect_uri_mismatch` because the dynamically built callback URL uses `http://` instead of `https://`
- Root cause: ALB sends `X-Forwarded-Proto: https` but nginx overwrites it with `$scheme` (http) when proxying to backend
- Fix: prioritize `GOOGLE_CALLBACK_URL` env var (already set to `https://legal.org.ua/auth/google/callback` in `.env.prod`)

## Test plan
- [ ] Deploy to prod and verify Google OAuth login works
- [ ] Verify stage OAuth still works (stage also has `GOOGLE_CALLBACK_URL` set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)