### PR TITLE
fix: remove hardcoded OpenAI in chat, add Anthropic direct provider

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1076,10 +1076,8 @@ export class ChatService {
         {
           messages: planMessages,
           max_tokens: 2000,
-          response_format: { type: 'json_object' },
         },
-        'deep',
-        'openai'
+        'deep'
       );
 
       // Record plan generation LLM cost
@@ -1144,7 +1142,7 @@ export class ChatService {
       };
 
       logger.info('[ChatService] Execution plan generated', {
-        provider: 'openai',
+        provider: response.provider,
         elapsed_ms: elapsed,
         steps: plan.steps.length,
         goal: plan.goal.slice(0, 100),

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -27,6 +27,10 @@ export class ModelSelector {
   private static readonly BEDROCK_STANDARD = process.env.BEDROCK_MODEL_STANDARD || 'eu.anthropic.claude-sonnet-4-6';
   private static readonly BEDROCK_DEEP = process.env.BEDROCK_MODEL_DEEP || 'eu.anthropic.claude-opus-4-6-v1';
 
+  private static readonly ANTHROPIC_QUICK = process.env.ANTHROPIC_MODEL_QUICK || 'claude-haiku-4-5-20251001';
+  private static readonly ANTHROPIC_STANDARD = process.env.ANTHROPIC_MODEL_STANDARD || 'claude-sonnet-4-6-20250514';
+  private static readonly ANTHROPIC_DEEP = process.env.ANTHROPIC_MODEL_DEEP || 'claude-opus-4-6-20250602';
+
   private static readonly SINGLE_MODEL = process.env.OPENAI_MODEL;
 
   static getEmbeddingModel(): string {
@@ -85,6 +89,14 @@ export class ModelSelector {
       }[budget];
     }
 
+    if (effectiveProvider === 'anthropic') {
+      return {
+        quick: this.ANTHROPIC_QUICK,
+        standard: this.ANTHROPIC_STANDARD,
+        deep: this.ANTHROPIC_DEEP,
+      }[budget];
+    }
+
     return {
       quick: this.OPENAI_QUICK,
       standard: this.OPENAI_STANDARD,
@@ -101,6 +113,10 @@ export class ModelSelector {
 
     if (process.env.OPENAI_API_KEY) {
       providers.push('openai');
+    }
+
+    if (process.env.ANTHROPIC_API_KEY) {
+      providers.push('anthropic');
     }
 
     return providers;


### PR DESCRIPTION
## Summary
- ChatService plan generation was hardcoded to `'openai'` provider — when OpenAI returns 429 (quota exceeded), Bedrock fallback couldn't activate
- Removed `response_format: json_object` from plan generation (unsupported by Bedrock Claude Converse API)
- Added Anthropic as direct provider in `ModelSelector.getAvailableProviders()` (was missing despite `ANTHROPIC_API_KEY` being configured)

## Test plan
- [ ] Deploy to prod and verify chat works with Bedrock Claude models
- [ ] Verify plan generation falls back to Bedrock when OpenAI is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)