### PR TITLE
feat: save chat request_id in conversations for log traceability

### DIFF
--- a/mcp_backend/src/migrations/076_conversations_request_id.sql
+++ b/mcp_backend/src/migrations/076_conversations_request_id.sql
@@ -1,0 +1,7 @@
+-- Add request_id column to conversations for frontend chat ID tracking
+-- The request_id (e.g. "chat-{uuid}") is shown in the UI as #chat-xxx
+-- and allows easy log correlation between frontend and backend
+
+ALTER TABLE conversations ADD COLUMN IF NOT EXISTS request_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_conversations_request_id ON conversations(request_id) WHERE request_id IS NOT NULL;

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -273,7 +273,7 @@ export class ChatService {
     if (this.conversationService && request.userId && !request.conversationId) {
       try {
         const titlePreview = query.slice(0, 80) || 'New conversation';
-        const conv = await this.conversationService.createConversation(request.userId, titlePreview);
+        const conv = await this.conversationService.createConversation(request.userId, titlePreview, { requestId });
         request.conversationId = conv.id;
         logger.info('[ChatService] Auto-created conversation for request without conversationId', {
           conversationId: conv.id,
@@ -283,6 +283,9 @@ export class ChatService {
       } catch (e) {
         logger.warn('[ChatService] Failed to auto-create conversation', { error: (e as Error).message });
       }
+    } else if (this.conversationService && request.conversationId && requestId) {
+      // Link request_id to existing conversation for log traceability
+      this.conversationService.updateRequestId(request.conversationId, requestId).catch(() => {});
     }
 
     // Create cost tracking record if requestId provided

--- a/mcp_backend/src/services/conversation-service.ts
+++ b/mcp_backend/src/services/conversation-service.ts
@@ -33,16 +33,23 @@ export class ConversationService {
   async createConversation(
     userId: string,
     title?: string,
-    options?: { clientId?: string; matterId?: string }
+    options?: { clientId?: string; matterId?: string; requestId?: string }
   ): Promise<Conversation> {
     const id = uuidv4();
     const result = await this.db.query(
-      `INSERT INTO conversations (id, user_id, title, client_id, matter_id)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO conversations (id, user_id, title, client_id, matter_id, request_id)
+       VALUES ($1, $2, $3, $4, $5, $6)
        RETURNING *`,
-      [id, userId, title || 'Нова розмова', options?.clientId || null, options?.matterId || null]
+      [id, userId, title || 'Нова розмова', options?.clientId || null, options?.matterId || null, options?.requestId || null]
     );
     return result.rows[0];
+  }
+
+  async updateRequestId(conversationId: string, requestId: string): Promise<void> {
+    await this.db.query(
+      'UPDATE conversations SET request_id = $1 WHERE id = $2',
+      [requestId, conversationId]
+    );
   }
 
   async listConversations(


### PR DESCRIPTION
## Summary
- Add `request_id` column to `conversations` table — stores the `#chat-xxx` ID shown in frontend UI
- Saved immediately at conversation creation, not at the end of the request
- Also updates `request_id` on existing conversations when continuing a chat session
- Enables easy DB lookups by the chat ID visible in the UI

## Test plan
- [ ] Deploy and verify migration runs
- [ ] Send a chat message and check `SELECT request_id FROM conversations ORDER BY created_at DESC LIMIT 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)