### PR TITLE
fix: display plan step and workflow costs in UAH

### DIFF
--- a/lexwebapp/src/components/PlanReviewDisplay.tsx
+++ b/lexwebapp/src/components/PlanReviewDisplay.tsx
@@ -3,6 +3,7 @@ import { Target, Zap, Search, Play } from 'lucide-react';
 import { motion } from 'framer-motion';
 import type { ExecutionPlan, PlanStep } from '../types/models/Message';
 import { getToolLabel } from '../hooks/chat/tool-labels';
+import { useCurrencyRate } from '../hooks/useCurrencyRate';
 
 interface PlanReviewDisplayProps {
   plan: ExecutionPlan;
@@ -49,12 +50,8 @@ function getStepCost(step: PlanStep): number {
   return costs[depth];
 }
 
-function formatCost(usd: number): string {
-  if (usd < 0.001) return '<$0.001';
-  return `$${usd.toFixed(3)}`;
-}
-
 export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanReviewDisplayProps) {
+  const { formatUah } = useCurrencyRate();
   const [steps, setSteps] = useState<PlanStep[]>(
     // Use recommendedDepth from backend (LLM-chosen) as the default
     plan.steps.map(s => ({
@@ -147,7 +144,7 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
               {/* Cost + Depth toggle */}
               <div className="flex items-center gap-2 flex-shrink-0">
                 <span className="text-[10px] text-claude-subtext/50 font-mono tabular-nums w-[50px] text-right">
-                  {formatCost(cost)}
+                  {formatUah(cost)}
                 </span>
 
                 {isDepthCapable ? (
@@ -205,7 +202,7 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
           )}
           <span className="text-[11px] text-claude-subtext/30 ml-1">|</span>
           <span className="text-[11px] text-claude-subtext font-mono tabular-nums">
-            ~{formatCost(totalCost)}
+            ~{formatUah(totalCost)}
           </span>
         </div>
 

--- a/lexwebapp/src/pages/WorkflowSetDetailPage/WorkflowCard.tsx
+++ b/lexwebapp/src/pages/WorkflowSetDetailPage/WorkflowCard.tsx
@@ -5,6 +5,7 @@
 import { useState } from 'react';
 import { Play, Square, ChevronDown, ChevronRight, CheckCircle, AlertCircle, Clock, Loader2 } from 'lucide-react';
 import type { Workflow } from '../../types/models/Workflow';
+import { useCurrencyRate } from '../../hooks/useCurrencyRate';
 
 interface WorkflowCardProps {
   workflow: Workflow;
@@ -23,6 +24,7 @@ const STATUS_BADGES: Record<string, { label: string; color: string; icon: typeof
 
 export function WorkflowCard({ workflow, onExecute, onCancel, isExecuting }: WorkflowCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const { formatUah } = useCurrencyRate();
   const status = STATUS_BADGES[workflow.status] || STATUS_BADGES.pending;
   const StatusIcon = status.icon;
 
@@ -77,7 +79,7 @@ export function WorkflowCard({ workflow, onExecute, onCancel, isExecuting }: Wor
         {/* Cost */}
         {workflow.cost_usd > 0 && (
           <div className="text-xs text-gray-400 mb-3">
-            Вартість: ${workflow.cost_usd.toFixed(4)}
+            Вартість: {formatUah(workflow.cost_usd)}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- **PlanReviewDisplay**: replaced local `formatCost()` (which used `$` sign) with `formatUah()` from `useCurrencyRate` hook
- **WorkflowCard**: replaced inline `$${cost.toFixed(4)}` with `formatUah(cost)`

Both components now display costs in UAH (₴) consistent with thinking steps and CostSummary.

## Test plan
- [ ] Open chat, ask a legal question that triggers plan review — verify step costs show in ₴
- [ ] Check workflow detail page — verify workflow cost shows in ₴

🤖 Generated with [Claude Code](https://claude.com/claude-code)