### PR TITLE
fix: use correct Vite build mode for production

### DIFF
--- a/lexwebapp/Dockerfile
+++ b/lexwebapp/Dockerfile
@@ -34,14 +34,18 @@ ENV VITE_SHOW_TOOL_SELECTOR=$VITE_SHOW_TOOL_SELECTOR
 ENV VITE_ENABLE_THINKING_STEPS=$VITE_ENABLE_THINKING_STEPS
 ENV VITE_AUTO_EXPAND_THINKING=$VITE_AUTO_EXPAND_THINKING
 
-# Build the application for staging
-RUN npm run build:staging
+# Build the application using the correct mode and normalize output to /app/lexwebapp/dist
+RUN if [ "$BUILD_ENV" = "production" ]; then \
+      npm run build; \
+    else \
+      npm run build:staging && mv dist-staging dist; \
+    fi
 
 # Stage 2: Serve with nginx
 FROM nginx:alpine
 
-# Copy built assets from builder stage (staging build outputs to dist-staging)
-COPY --from=builder /app/lexwebapp/dist-staging /usr/share/nginx/html
+# Copy built assets from builder stage
+COPY --from=builder /app/lexwebapp/dist /usr/share/nginx/html
 
 # Copy custom nginx configuration
 COPY lexwebapp/nginx.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- Dockerfile was hardcoded to `npm run build:staging` for all environments
- Production builds were running with `--mode staging` — source maps enabled, wrong output dir name
- Now respects `BUILD_ENV` arg: `production` runs `npm run build`, `staging` runs `npm run build:staging`
- Output is always normalized to `dist/` for the nginx COPY stage

## Test plan
- [ ] Build stage image — verify `vite build --mode staging` in logs
- [ ] Build prod image — verify `vite build` (no --mode staging) in logs, no source maps in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)