### PR TITLE
feat: show copyable request ID in chat

### DIFF
--- a/lexwebapp/src/components/CostSummary.tsx
+++ b/lexwebapp/src/components/CostSummary.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { ChevronDown, Coins } from 'lucide-react';
+import { useState, useCallback } from 'react';
+import { ChevronDown, Coins, Copy, Check } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import type { CostSummary as CostSummaryType } from '../types/models/Message';
 import { getToolLabel } from '../hooks/chat/tool-labels';
@@ -11,7 +11,16 @@ interface CostSummaryProps {
 
 export function CostSummary({ data }: CostSummaryProps) {
   const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
   const { formatUah } = useCurrencyRate();
+
+  const copyRequestId = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!data.response_id) return;
+    navigator.clipboard.writeText(data.response_id);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [data.response_id]);
 
   const displayCostUsd = data.charged_usd != null && Number(data.charged_usd) > 0
     ? Number(data.charged_usd)
@@ -32,7 +41,14 @@ export function CostSummary({ data }: CostSummaryProps) {
             : '0.00 \u20B4'}
         </span>
         {data.response_id && (
-          <span className="text-claude-subtext/60 font-mono">#{data.response_id}</span>
+          <button
+            onClick={copyRequestId}
+            className="inline-flex items-center gap-1 text-claude-subtext/60 font-mono hover:text-claude-text transition-colors"
+            title="Копіювати request ID"
+          >
+            {data.response_id}
+            {copied ? <Check size={10} strokeWidth={2} /> : <Copy size={10} strokeWidth={2} />}
+          </button>
         )}
         <ChevronDown
           size={12}

--- a/lexwebapp/src/hooks/chat/useAIChat.ts
+++ b/lexwebapp/src/hooks/chat/useAIChat.ts
@@ -78,12 +78,6 @@ export function useAIChat(options: UseAIChatOptions = {}) {
       const controller = await mcpService.streamChat(query, history, {
         onResponseId: (data) => {
           responseIdRef.current = data.response_id;
-          addThinkingStep(assistantMessageId, {
-            id: 'response-id',
-            title: `#${data.response_id}`,
-            content: '',
-            isComplete: true,
-          });
         },
 
         onPlan: (data) => {


### PR DESCRIPTION
## Summary
- Request ID (`chat-{uuid}`) now displayed as a clickable copy button next to cost in CostSummary
- Removed redundant thinking step that duplicated the same ID
- ID can be used to search backend logs and `cost_tracking` table

## Test plan
- [ ] Send a chat message — verify request ID appears next to cost
- [ ] Click the ID — verify it copies to clipboard (icon changes to checkmark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)