### PR TITLE
refactor: merge document loading useEffects with debounced search

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/useDocumentData.ts
+++ b/lexwebapp/src/pages/DocumentsPage/useDocumentData.ts
@@ -82,23 +82,19 @@ export function useDocumentData(options: UseDocumentDataOptions) {
     }
   }, []);
 
-  // Load documents when deps change
+  // Load documents + folders when deps change (debounce text search)
   useEffect(() => {
-    loadDocuments();
     loadFolders(currentFolderPath);
-  }, [filterType, currentFolderPath, offset, sortBy, sortOrder]);
 
-  // Debounced text search
-  useEffect(() => {
-    if (!searchQuery.trim()) {
-      loadDocuments();
-      return;
+    if (searchQuery.trim()) {
+      const timer = setTimeout(() => {
+        loadDocuments();
+      }, 300);
+      return () => clearTimeout(timer);
     }
-    const timer = setTimeout(() => {
-      loadDocuments();
-    }, 300);
-    return () => clearTimeout(timer);
-  }, [searchQuery]);
+
+    loadDocuments();
+  }, [loadDocuments, loadFolders, filterType, currentFolderPath, offset, sortBy, sortOrder, searchQuery]);
 
   // Load stats on mount
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Combine two separate useEffects into one that handles both document loading and debounced text search
- Reduces redundant re-renders when dependencies overlap

## Test plan
- [ ] Open documents page — verify documents load
- [ ] Type in search — verify debounce works (300ms delay)
- [ ] Change folder/filter/sort — verify immediate reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)