### PR TITLE
fix: strip LLM artifacts from search queries

### DIFF
--- a/mcp_backend/src/adapters/zo-adapter.ts
+++ b/mcp_backend/src/adapters/zo-adapter.ts
@@ -43,14 +43,25 @@ interface ZOSearchResponse {
 
 /**
  * Sanitize search query for ZakonOnline sph04 Sphinx mode.
- * Strips characters that act as syntax operators (parentheses, etc.)
- * and collapses resulting whitespace.
+ * Strips LLM artifacts (```json blocks, "search_query": prefix)
+ * and characters that act as syntax operators.
  */
 function sanitizeSearchQuery(query: string): string {
-  return query
-    .replace(/[(){}[\]]/g, ' ')
-    .replace(/\s{2,}/g, ' ')
-    .trim();
+  let q = query;
+
+  // Strip markdown code block wrappers: ```json ... ``` or ``` ... ```
+  q = q.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/g, '');
+
+  // Strip JSON-style "search_query": prefix (with or without quotes around key)
+  q = q.replace(/^["']?search_query["']?\s*:\s*/i, '');
+
+  // Strip remaining Sphinx-breaking chars: brackets
+  q = q.replace(/[(){}[\]]/g, ' ');
+
+  // Collapse whitespace
+  q = q.replace(/\s{2,}/g, ' ').trim();
+
+  return q;
 }
 
 export class ZOAdapter {

--- a/mcp_backend/src/services/query-planner.ts
+++ b/mcp_backend/src/services/query-planner.ts
@@ -463,6 +463,9 @@ export class QueryPlanner {
 
       let content = response.content || userQuery;
       
+      // Strip markdown code block wrappers before JSON parse
+      content = content.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/g, '').trim();
+
       // If JSON mode, extract search_query field
       if (content.includes('{')) {
         try {
@@ -471,7 +474,11 @@ export class QueryPlanner {
             content = parsed.search_query;
           }
         } catch {
-          // Not JSON, use as is
+          // Not valid JSON — try to extract "search_query": "value" with regex
+          const match = content.match(/["']?search_query["']?\s*:\s*"([^"]+)"/i);
+          if (match) {
+            content = match[1];
+          }
         }
       }
       


### PR DESCRIPTION
## Summary
- **ZOAdapter**: sanitize \`\`\`json blocks and \`"search_query":\` prefix from LLM-generated queries before sending to ZakonOnline Sphinx
- **QueryPlanner**: strip markdown code blocks before JSON parse, add regex fallback for extracting search_query

## Test plan
- [ ] Chat query that triggers court search — verify no Sphinx syntax errors in logs
- [ ] Verify search results return correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)