### PR TITLE
fix: remove duplicate chat message persistence

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChat.ts
+++ b/lexwebapp/src/hooks/chat/useAIChat.ts
@@ -211,13 +211,9 @@ export function useAIChat(options: UseAIChatOptions = {}) {
           setStreamController(null);
           setCurrentTool(null);
 
+          // Server-side persistence handles saving assistant messages
+          // (chat-service.ts saves with full tool_calls/cost_summary data)
           const completedState = useChatStore.getState();
-          const completedMsg = completedState.messages.find(
-            (m) => m.id === assistantMessageId
-          );
-          if (completedMsg) {
-            completedState.syncMessage(completedMsg);
-          }
 
           // Auto-rename conversation if it still has the default title
           if (completedState.conversationId) {
@@ -325,8 +321,8 @@ export function useAIChat(options: UseAIChatOptions = {}) {
         const title = query.slice(0, 60).trim() || undefined;
         await state.createConversation(title);
       }
-      // syncMessage after createConversation resolves so conversationId is set
-      useChatStore.getState().syncMessage(userMessage);
+      // Server-side persistence handles saving user messages
+      // (chat-service.ts saves both user and assistant messages)
 
       const assistantMessageId = (Date.now() + 1).toString();
       addMessage({


### PR DESCRIPTION
## Summary
- Frontend `syncMessage` in `useAIChat.ts` was creating duplicate DB entries since server-side persistence was added in `774d892` (Feb 24)
- Removed 2 `syncMessage` calls from `useAIChat` (AI chat path); kept them in `useMCPTool` (manual tool calls where backend doesn't persist)
- Cleaned up 75 duplicate messages on prod (174 → 99, 0 duplicate groups remaining)

## Root cause
- Commit `774d892` added server-side message persistence in `chat-service.ts` (saves user + assistant with full `tool_calls`/`cost_summary`)
- Frontend `syncMessage` was never removed, causing double writes for every AI chat message
- Some conversations had up to 5x duplicate user messages

## Test plan
- [ ] Send AI chat message, verify single user + assistant message in DB
- [ ] Manual MCP tool call still persists correctly via `syncMessage`
- [ ] Verify `tool_calls` and `cost_summary` present on assistant messages (server-side data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)