### PR TITLE
fix: disable ZOAdapter, raise chat rate limit to 20/min

### DIFF
--- a/mcp_backend/src/adapters/zo-adapter.ts
+++ b/mcp_backend/src/adapters/zo-adapter.ts
@@ -123,7 +123,7 @@ export class ZOAdapter {
     this.apiTokens = [primaryToken, secondaryToken].filter(t => t.length > 0);
 
     if (this.apiTokens.length === 0) {
-      throw new Error('No Zakononline API tokens configured');
+      logger.warn(`ZOAdapter (${this.domainConfig.displayName}): no API tokens configured — adapter disabled`);
     }
 
     // If we have multiple tokens, prefer starting with the second one (TOKEN2)
@@ -473,6 +473,10 @@ export class ZOAdapter {
     return this.domainConfig.availableTargets;
   }
 
+  get disabled(): boolean {
+    return this.apiTokens.length === 0;
+  }
+
   private getCurrentToken(): string {
     return this.apiTokens[this.currentTokenIndex];
   }
@@ -648,6 +652,9 @@ export class ZOAdapter {
     params: any,
     maxRetries: number = 3
   ): Promise<any> {
+    if (this.disabled) {
+      throw new Error('ZOAdapter is disabled — no API tokens configured');
+    }
     this.validateEndpoint(endpoint);
     const cacheKey = this.generateCacheKey(endpoint, params);
     const cached = await this.getCached(cacheKey);

--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -91,10 +91,10 @@ export const webhookRateLimit = createRateLimiter({
   keyPrefix: 'ratelimit:webhook',
 });
 
-// Chat endpoint rate limiter (max 10 requests per minute)
+// Chat endpoint rate limiter (max 20 requests per minute)
 export const chatRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 10,
+  maxRequests: 20,
   keyPrefix: 'ratelimit:chat',
 });
 


### PR DESCRIPTION
## Summary
- ZOAdapter no longer crashes when API tokens are empty — logs warning and marks itself `disabled`
- Chat rate limit raised from 10 → 20 requests per minute
- Prepares for full removal of ZakonOnline in favour of local EDRSR database search

## Test plan
- [x] Verified prod starts with empty ZO tokens (healthy container)
- [x] ZO tool calls return clear error "ZOAdapter is disabled"
- [ ] Verify chat endpoint allows 20 req/min

🤖 Generated with [Claude Code](https://claude.com/claude-code)