### PR TITLE
feat: add PG Monitoring admin page for EDRSR fulltext tracking

### DIFF
--- a/lexwebapp/src/components/sidebar/nav-config.ts
+++ b/lexwebapp/src/components/sidebar/nav-config.ts
@@ -3,7 +3,7 @@ import {
   Bell, FileCode, BarChart3, Vote, History, Newspaper,
   Clock, FileText, Search, Activity, Database, Users, DollarSign,
   Server, Boxes, Globe, CreditCard, Settings, Terminal, Tag, Zap,
-  Layers,
+  Layers, HardDrive,
 } from 'lucide-react';
 import { ROUTES } from '../../router/routes';
 
@@ -56,4 +56,5 @@ export const monitoringSections = [
   { id: 'zo-stats', label: 'Статистика рішень', icon: BarChart3, route: ROUTES.ADMIN_ZO_STATS },
   { id: 'user-activity', label: 'Активність юзерів', icon: Zap, route: ROUTES.ADMIN_USER_ACTIVITY },
   { id: 'bulk-scrape', label: 'Пайплайн збору', icon: Database, route: ROUTES.ADMIN_BULK_SCRAPE },
+  { id: 'pg-monitoring', label: 'PG Моніторинг', icon: HardDrive, route: ROUTES.ADMIN_PG_MONITORING },
 ];

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -52,6 +52,7 @@ const PAGE_TITLES: Record<string, string> = {
   [ROUTES.ADMIN_TERMINAL]: 'Admin Terminal',
   [ROUTES.ADMIN_BULK_SCRAPE]: 'Пайплайн збору даних',
   [ROUTES.ADMIN_OPEN_DATA_CATALOG]: 'Каталог OpenData',
+  [ROUTES.ADMIN_PG_MONITORING]: 'PG Моніторинг',
   [ROUTES.ATTORNEY_CLIENTS]: 'Мої клієнти',
 };
 

--- a/lexwebapp/src/pages/AdminPGMonitoringPage.tsx
+++ b/lexwebapp/src/pages/AdminPGMonitoringPage.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, Database, AlertCircle } from 'lucide-react';
+import { adminApi } from '../utils/api/admin';
+
+interface YearRow {
+  year: number | null;
+  total: number;
+  with_fulltext: number;
+}
+
+interface EnvStats {
+  byYear: YearRow[];
+  totalDocuments: number;
+  totalFulltext: number;
+  standaloneFulltext: number;
+  timestamp: string;
+}
+
+interface PGMonitoringData {
+  local: EnvStats | null;
+  stage: EnvStats | null;
+  prod: EnvStats | null;
+  timestamp: string;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('uk-UA');
+}
+
+function EdrsrTable({ data, label }: { data: EnvStats; label: string }) {
+  const rows = data.byYear.filter(r => r.year !== null && r.year > 1990 && r.year < 2100);
+  const nullRow = data.byYear.find(r => r.year === null);
+
+  const totalWithFt = rows.reduce((s, r) => s + r.with_fulltext, 0) + (nullRow?.with_fulltext || 0);
+  const totalDocs = rows.reduce((s, r) => s + r.total, 0) + (nullRow?.total || 0);
+
+  return (
+    <div className="flex-1 min-w-[400px]">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-claude-text-primary flex items-center gap-2">
+          <Database className="w-5 h-5 text-claude-accent" />
+          {label}
+        </h3>
+        <span className="text-xs text-claude-text-secondary">
+          {new Date(data.timestamp).toLocaleTimeString('uk-UA')}
+        </span>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 mb-4">
+        <div className="bg-claude-bg-secondary rounded-lg p-3 border border-claude-border">
+          <div className="text-xs text-claude-text-secondary">Метаданих</div>
+          <div className="text-xl font-bold text-claude-text-primary">{formatNumber(data.totalDocuments)}</div>
+        </div>
+        <div className="bg-claude-bg-secondary rounded-lg p-3 border border-claude-border">
+          <div className="text-xs text-claude-text-secondary">З fulltext</div>
+          <div className="text-xl font-bold text-emerald-400">{formatNumber(data.totalFulltext)}</div>
+        </div>
+        <div className="bg-claude-bg-secondary rounded-lg p-3 border border-claude-border">
+          <div className="text-xs text-claude-text-secondary">Покриття</div>
+          <div className="text-xl font-bold text-amber-400">
+            {totalDocs > 0 ? ((totalWithFt / totalDocs) * 100).toFixed(1) : '0'}%
+          </div>
+        </div>
+      </div>
+
+      <div className="border border-claude-border rounded-lg overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="bg-claude-bg-secondary border-b border-claude-border">
+              <th className="px-4 py-2.5 text-left text-sm font-semibold text-claude-text-primary">Рік</th>
+              <th className="px-4 py-2.5 text-right text-sm font-semibold text-claude-text-primary">Метаданих</th>
+              <th className="px-4 py-2.5 text-right text-sm font-semibold text-claude-text-primary">З fulltext</th>
+              <th className="px-4 py-2.5 text-right text-sm font-semibold text-claude-text-primary">%</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => {
+              const pct = row.total > 0 ? (row.with_fulltext / row.total) * 100 : 0;
+              return (
+                <tr key={row.year} className="border-b border-claude-border/50 hover:bg-claude-bg-secondary/50 transition-colors">
+                  <td className="px-4 py-2 text-sm font-medium text-claude-text-primary">{row.year}</td>
+                  <td className="px-4 py-2 text-sm text-right text-claude-text-secondary font-mono">
+                    {formatNumber(row.total)}
+                  </td>
+                  <td className="px-4 py-2 text-sm text-right font-mono">
+                    <span className={row.with_fulltext > 0 ? 'text-emerald-400' : 'text-claude-text-secondary'}>
+                      {formatNumber(row.with_fulltext)}
+                    </span>
+                  </td>
+                  <td className="px-4 py-2 text-sm text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <div className="w-16 h-1.5 bg-claude-bg-tertiary rounded-full overflow-hidden">
+                        <div
+                          className="h-full rounded-full transition-all"
+                          style={{
+                            width: `${Math.min(pct, 100)}%`,
+                            backgroundColor: pct > 50 ? '#34d399' : pct > 10 ? '#fbbf24' : '#6b7280',
+                          }}
+                        />
+                      </div>
+                      <span className="text-claude-text-secondary font-mono w-12 text-right">
+                        {pct > 0 ? pct.toFixed(1) : '0'}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+            {nullRow && (
+              <tr className="border-b border-claude-border/50 hover:bg-claude-bg-secondary/50">
+                <td className="px-4 py-2 text-sm font-medium text-claude-text-secondary italic">без дати</td>
+                <td className="px-4 py-2 text-sm text-right text-claude-text-secondary font-mono">
+                  {formatNumber(nullRow.total)}
+                </td>
+                <td className="px-4 py-2 text-sm text-right font-mono text-claude-text-secondary">
+                  {formatNumber(nullRow.with_fulltext)}
+                </td>
+                <td className="px-4 py-2 text-sm text-right text-claude-text-secondary">—</td>
+              </tr>
+            )}
+            {data.standaloneFulltext > 0 && (
+              <tr className="hover:bg-claude-bg-secondary/50">
+                <td className="px-4 py-2 text-sm font-medium text-amber-400 italic">fulltext без метаданих</td>
+                <td className="px-4 py-2 text-sm text-right text-claude-text-secondary font-mono">—</td>
+                <td className="px-4 py-2 text-sm text-right font-mono text-amber-400">
+                  {formatNumber(data.standaloneFulltext)}
+                </td>
+                <td className="px-4 py-2 text-sm text-right text-claude-text-secondary">—</td>
+              </tr>
+            )}
+          </tbody>
+          <tfoot>
+            <tr className="bg-claude-bg-secondary border-t border-claude-border">
+              <td className="px-4 py-2.5 text-sm font-bold text-claude-text-primary">Всього</td>
+              <td className="px-4 py-2.5 text-sm text-right font-bold text-claude-text-primary font-mono">
+                {formatNumber(totalDocs)}
+              </td>
+              <td className="px-4 py-2.5 text-sm text-right font-bold text-emerald-400 font-mono">
+                {formatNumber(totalWithFt)}
+              </td>
+              <td className="px-4 py-2.5 text-sm text-right font-bold text-claude-text-primary font-mono">
+                {totalDocs > 0 ? ((totalWithFt / totalDocs) * 100).toFixed(1) : '0'}%
+              </td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export function AdminPGMonitoringPage() {
+  const [data, setData] = useState<PGMonitoringData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setError(null);
+      const resp = await adminApi.getPGMonitoring();
+      setData(resp.data);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Не вдалося завантажити дані';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    if (!autoRefresh) return;
+    const interval = setInterval(fetchData, 30000);
+    return () => clearInterval(interval);
+  }, [autoRefresh, fetchData]);
+
+  return (
+    <div className="p-6 max-w-[1600px] mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-claude-text-primary">PG Моніторинг</h1>
+          <p className="text-sm text-claude-text-secondary mt-1">
+            ЄДРСР: метадані та повні тексти рішень по роках
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <label className="flex items-center gap-2 text-sm text-claude-text-secondary cursor-pointer">
+            <input
+              type="checkbox"
+              checked={autoRefresh}
+              onChange={(e) => setAutoRefresh(e.target.checked)}
+              className="rounded border-claude-border bg-claude-bg-secondary"
+            />
+            Авто-оновлення (30с)
+          </label>
+          <button
+            onClick={() => { setLoading(true); fetchData(); }}
+            disabled={loading}
+            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-claude-bg-secondary border border-claude-border rounded-lg hover:bg-claude-bg-tertiary transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+            Оновити
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center gap-2 text-red-400 text-sm">
+          <AlertCircle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {loading && !data ? (
+        <div className="flex items-center justify-center py-20">
+          <div className="w-8 h-8 border-4 border-claude-accent border-t-transparent rounded-full animate-spin" />
+        </div>
+      ) : data ? (
+        <div className="flex flex-wrap gap-6">
+          {data.prod && <EdrsrTable data={data.prod} label="Production" />}
+          {data.stage && <EdrsrTable data={data.stage} label="Stage" />}
+          {data.local && <EdrsrTable data={data.local} label="Local" />}
+          {!data.prod && !data.stage && !data.local && (
+            <div className="text-claude-text-secondary text-sm py-10 text-center w-full">
+              Немає даних з жодного середовища
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -114,6 +114,7 @@ const AdminZOStatsPage = lazy(() => import('../pages/AdminZOStatsPage').then(m =
 const AdminUserActivityPage = lazy(() => import('../pages/AdminUserActivityPage').then(m => ({ default: m.AdminUserActivityPage })));
 const AdminBulkScrapePage = lazy(() => import('../pages/AdminBulkScrapePage').then(m => ({ default: m.AdminBulkScrapePage })));
 const AdminOpenDataCatalogPage = lazy(() => import('../pages/AdminOpenDataCatalogPage').then(m => ({ default: m.AdminOpenDataCatalogPage })));
+const AdminPGMonitoringPage = lazy(() => import('../pages/AdminPGMonitoringPage').then(m => ({ default: m.AdminPGMonitoringPage })));
 
 export const router = createBrowserRouter([
   {
@@ -398,6 +399,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ADMIN_OPEN_DATA_CATALOG,
             element: S(AdminOpenDataCatalogPage),
+          },
+          {
+            path: ROUTES.ADMIN_PG_MONITORING,
+            element: S(AdminPGMonitoringPage),
           },
         ],
       },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -113,6 +113,7 @@ export const ROUTES = {
   ADMIN_ZO_STATS: '/admin/zo-stats',
   ADMIN_BULK_SCRAPE: '/admin/bulk-scrape',
   ADMIN_OPEN_DATA_CATALOG: '/admin/open-data-catalog',
+  ADMIN_PG_MONITORING: '/admin/pg-monitoring',
 } as const;
 
 // Helper function to generate dynamic routes

--- a/lexwebapp/src/utils/api/admin.ts
+++ b/lexwebapp/src/utils/api/admin.ts
@@ -181,4 +181,8 @@ export const adminApi = {
     apiClient.put(`/api/admin/users/${userId}/attorney-profile`, data),
   deleteAttorneyProfile: (userId: string) =>
     apiClient.delete(`/api/admin/users/${userId}/attorney-profile`),
+
+  // PG Monitoring — EDRSR stats
+  getPGMonitoring: () =>
+    apiClient.get('/api/admin/pg-monitoring'),
 };

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -2881,6 +2881,79 @@ class HTTPMCPServer {
       }
     }) as any);
 
+    // Internal EDRSR stats endpoint (used by pg-monitoring cross-env queries)
+    this.app.get('/api/internal/edrsr-stats', dualAuth as any, (async (_req: DualAuthRequest, res: Response) => {
+      try {
+        // Check if tables exist
+        const tablesExist = await this.services.db.query(`
+          SELECT
+            EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='edrsr_documents') AS has_docs,
+            EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='edrsr_fulltext') AS has_ft
+        `);
+        const { has_docs, has_ft } = tablesExist.rows[0];
+
+        let edrsrByYear: Array<{ year: number | null; total: number; with_fulltext: number }> = [];
+
+        if (has_docs && has_ft) {
+          const result = await this.services.db.query(`
+            SELECT
+              EXTRACT(YEAR FROM e.adjudication_date)::int AS year,
+              COUNT(*)::int AS total,
+              COUNT(f.doc_id)::int AS with_fulltext
+            FROM edrsr_documents e
+            LEFT JOIN edrsr_fulltext f ON f.doc_id = e.doc_id
+            GROUP BY year
+            ORDER BY year NULLS LAST
+          `);
+          edrsrByYear = result.rows;
+        } else if (has_docs) {
+          const result = await this.services.db.query(`
+            SELECT
+              EXTRACT(YEAR FROM adjudication_date)::int AS year,
+              COUNT(*)::int AS total,
+              0 AS with_fulltext
+            FROM edrsr_documents
+            GROUP BY year
+            ORDER BY year NULLS LAST
+          `);
+          edrsrByYear = result.rows;
+        }
+
+        // Also get standalone fulltext records not in edrsr_documents
+        let standaloneFulltext = 0;
+        if (has_ft) {
+          const ftOnly = await this.services.db.query(`
+            SELECT COUNT(*)::int AS cnt FROM edrsr_fulltext f
+            WHERE NOT EXISTS (SELECT 1 FROM edrsr_documents e WHERE e.doc_id = f.doc_id)
+          `);
+          standaloneFulltext = ftOnly.rows[0]?.cnt || 0;
+        }
+
+        // Get total counts
+        let totalDocs = 0;
+        let totalFulltext = 0;
+        if (has_docs) {
+          const r = await this.services.db.query('SELECT COUNT(*)::int AS cnt FROM edrsr_documents');
+          totalDocs = r.rows[0]?.cnt || 0;
+        }
+        if (has_ft) {
+          const r = await this.services.db.query('SELECT COUNT(*)::int AS cnt FROM edrsr_fulltext');
+          totalFulltext = r.rows[0]?.cnt || 0;
+        }
+
+        res.json({
+          byYear: edrsrByYear,
+          totalDocuments: totalDocs,
+          totalFulltext: totalFulltext,
+          standaloneFulltext,
+          timestamp: new Date().toISOString(),
+        });
+      } catch (error: any) {
+        logger.error('internal/edrsr-stats failed', { error: error.message });
+        res.status(500).json({ error: 'Failed to collect EDRSR stats' });
+      }
+    }) as any);
+
     // User prompts (save/load)
     this.app.get('/api/prompts', requireJWT as any, (async (req: DualAuthRequest, res: Response) => {
       try {

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -5078,5 +5078,111 @@ export function createAdminRoutes(
     }
   }) as any);
 
+  // ========================================
+  // PG MONITORING — EDRSR stats (prod + stage)
+  // ========================================
+  router.get('/pg-monitoring', async (req: Request, res: Response) => {
+    try {
+      // Fetch local EDRSR stats
+      const tablesExist = await db.query(`
+        SELECT
+          EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='edrsr_documents') AS has_docs,
+          EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name='edrsr_fulltext') AS has_ft
+      `);
+      const { has_docs, has_ft } = tablesExist.rows[0];
+
+      let localByYear: Array<{ year: number | null; total: number; with_fulltext: number }> = [];
+
+      if (has_docs && has_ft) {
+        const result = await db.query(`
+          SELECT
+            EXTRACT(YEAR FROM e.adjudication_date)::int AS year,
+            COUNT(*)::int AS total,
+            COUNT(f.doc_id)::int AS with_fulltext
+          FROM edrsr_documents e
+          LEFT JOIN edrsr_fulltext f ON f.doc_id = e.doc_id
+          GROUP BY year
+          ORDER BY year NULLS LAST
+        `);
+        localByYear = result.rows;
+      } else if (has_docs) {
+        const result = await db.query(`
+          SELECT
+            EXTRACT(YEAR FROM adjudication_date)::int AS year,
+            COUNT(*)::int AS total,
+            0 AS with_fulltext
+          FROM edrsr_documents
+          GROUP BY year
+          ORDER BY year NULLS LAST
+        `);
+        localByYear = result.rows;
+      }
+
+      let localStandaloneFulltext = 0;
+      if (has_ft && has_docs) {
+        const ftOnly = await db.query(`
+          SELECT COUNT(*)::int AS cnt FROM edrsr_fulltext f
+          WHERE NOT EXISTS (SELECT 1 FROM edrsr_documents e WHERE e.doc_id = f.doc_id)
+        `);
+        localStandaloneFulltext = ftOnly.rows[0]?.cnt || 0;
+      }
+
+      let totalDocs = 0;
+      let totalFulltext = 0;
+      if (has_docs) {
+        const r = await db.query('SELECT COUNT(*)::int AS cnt FROM edrsr_documents');
+        totalDocs = r.rows[0]?.cnt || 0;
+      }
+      if (has_ft) {
+        const r = await db.query('SELECT COUNT(*)::int AS cnt FROM edrsr_fulltext');
+        totalFulltext = r.rows[0]?.cnt || 0;
+      }
+
+      const localData = {
+        byYear: localByYear,
+        totalDocuments: totalDocs,
+        totalFulltext: totalFulltext,
+        standaloneFulltext: localStandaloneFulltext,
+        timestamp: new Date().toISOString(),
+      };
+
+      // Fetch remote env stats
+      const stageBackendUrl = process.env.STAGE_BACKEND_URL || 'https://stage.legal.org.ua';
+      const stageApiKey = process.env.STAGE_API_KEY ||
+        process.env.SECONDARY_LAYER_KEYS?.split(',')[0]?.trim() || '';
+      const prodBackendUrl = process.env.PROD_BACKEND_URL || 'https://mcp.legal.org.ua';
+      const prodApiKey = process.env.PROD_API_KEY ||
+        process.env.SECONDARY_LAYER_KEYS?.split(',')[0]?.trim() || '';
+
+      const fetchRemote = async (url: string, apiKey: string) => {
+        try {
+          const resp = await axios.get(`${url}/api/internal/edrsr-stats`, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+            timeout: 30000,
+          });
+          return resp.data;
+        } catch (err: any) {
+          logger.warn('pg-monitoring: failed to fetch remote EDRSR stats', { url, error: err.message });
+          return null;
+        }
+      };
+
+      const [stageData, prodData] = await Promise.all([
+        fetchRemote(stageBackendUrl, stageApiKey),
+        fetchRemote(prodBackendUrl, prodApiKey),
+      ]);
+
+      return res.json({
+        local: localData,
+        stage: stageData,
+        prod: prodData,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (error: any) {
+      logger.error('pg-monitoring failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to fetch PG monitoring data' });
+    }
+  });
+
   return router;
 }

--- a/scripts/edrsr/import-edrsr-fulltext-metadata-prod.sh
+++ b/scripts/edrsr/import-edrsr-fulltext-metadata-prod.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# Import ЄДРСР metadata for doc_ids that exist in edrsr_fulltext but NOT in edrsr_documents
+# Targets prod: downloads 2013+2014 from data.gov.ua, filters for matching doc_ids, imports in parallel
+# Usage: ./import-edrsr-fulltext-metadata-prod.sh [CONTAINER] [THREADS]
+
+set -euo pipefail
+
+CONTAINER="${1:-secondlayer-postgres-prod}"
+THREADS="${2:-100}"
+PGUSER="secondlayer"
+PGDATABASE="secondlayer_prod"
+
+run_psql() {
+  docker exec -i "$CONTAINER" psql -U "$PGUSER" -d "$PGDATABASE" -v ON_ERROR_STOP=1 "$@"
+}
+
+# --- Step 0: Get doc_id range from edrsr_fulltext that's missing from edrsr_documents ---
+echo "=== Fetching fulltext doc_id range ==="
+RANGE=$(run_psql -Atc "SELECT MIN(doc_id) || ',' || MAX(doc_id) FROM edrsr_fulltext WHERE NOT EXISTS (SELECT 1 FROM edrsr_documents e WHERE e.doc_id = edrsr_fulltext.doc_id) LIMIT 1;" 2>/dev/null || true)
+
+if [ -z "$RANGE" ] || [ "$RANGE" = "," ]; then
+  # Fallback: just get full range from edrsr_fulltext
+  RANGE=$(run_psql -Atc "SELECT MIN(doc_id) || ',' || MAX(doc_id) FROM edrsr_fulltext;")
+fi
+
+MIN_ID=$(echo "$RANGE" | cut -d',' -f1)
+MAX_ID=$(echo "$RANGE" | cut -d',' -f2)
+TOTAL_FT=$(run_psql -Atc "SELECT COUNT(*) FROM edrsr_fulltext;")
+
+echo "  Fulltext doc_id range: $MIN_ID – $MAX_ID ($TOTAL_FT records)"
+echo "  Container: $CONTAINER, DB: $PGDATABASE, Threads: $THREADS"
+echo ""
+
+# Years to download (2013 covers ~36M doc_ids, 2014 covers up to ~42M+)
+declare -A URLS
+URLS[2013]="https://data.gov.ua/dataset/3bc24b95-1f9e-41d6-bffa-c57088474e4a/resource/19eadafb-552b-4eef-89d6-bd17bec95575/download/edrsr_data_2013.zip"
+URLS[2014]="https://data.gov.ua/dataset/e5c3c05a-61f5-4422-a41b-82dff1f71856/resource/7fb5d7cf-19b8-487f-9b6a-de1a17abbc91/download/edrsr_data_2014.zip"
+
+import_chunk() {
+  local chunk_file="$1"
+  local container="$2"
+  local pguser="$3"
+  local pgdb="$4"
+  local chunk_name=$(basename "$chunk_file")
+  local lines=$(wc -l < "$chunk_file")
+  echo "  [$chunk_name] $lines rows..."
+  docker exec -i "$container" psql -U "$pguser" -d "$pgdb" -v ON_ERROR_STOP=1 \
+    -c "COPY edrsr_documents(doc_id, court_code, judgment_code, justice_kind, category_code, cause_num, adjudication_date, receipt_date, judge, doc_url, status, date_publ) FROM STDIN WITH (FORMAT csv, DELIMITER E'\\t', QUOTE '\"', NULL '');" < "$chunk_file"
+  echo "  [$chunk_name] Done"
+}
+export -f import_chunk
+
+# --- Step 1: Export existing doc_ids from edrsr_documents in the target range ---
+echo "=== Exporting existing doc_ids to avoid duplicates ==="
+EXISTING_FILE="/tmp/edrsr_existing_docids.txt"
+run_psql -Atc "SELECT doc_id FROM edrsr_documents WHERE doc_id BETWEEN $MIN_ID AND $MAX_ID ORDER BY doc_id;" > "$EXISTING_FILE"
+EXISTING_COUNT=$(wc -l < "$EXISTING_FILE")
+echo "  Already in edrsr_documents: $EXISTING_COUNT doc_ids in range $MIN_ID–$MAX_ID"
+
+# --- Step 2: Export fulltext doc_ids ---
+echo "=== Exporting fulltext doc_ids ==="
+FT_IDS_FILE="/tmp/edrsr_fulltext_docids.txt"
+run_psql -Atc "SELECT doc_id FROM edrsr_fulltext ORDER BY doc_id;" > "$FT_IDS_FILE"
+FT_COUNT=$(wc -l < "$FT_IDS_FILE")
+echo "  Fulltext doc_ids: $FT_COUNT"
+
+TOTAL_IMPORTED=0
+
+for YEAR in 2013 2014; do
+  echo ""
+  echo "========================================"
+  echo "=== ЄДРСР $YEAR ==="
+  echo "========================================"
+
+  ZIP_FILE="/tmp/edrsr_data_${YEAR}.zip"
+  WORK_DIR="/tmp/edrsr_import_ft_${YEAR}_$$"
+  URL="${URLS[$YEAR]}"
+
+  # Download
+  if [ -f "$ZIP_FILE" ]; then
+    echo "[DL] Already exists: $ZIP_FILE ($(du -h "$ZIP_FILE" | cut -f1))"
+  else
+    echo "[DL] Downloading edrsr_data_${YEAR}.zip..."
+    wget -q --show-progress -O "$ZIP_FILE" "$URL"
+    echo "[DL] Done: $(du -h "$ZIP_FILE" | cut -f1)"
+  fi
+
+  # Extract
+  echo "[EX] Extracting..."
+  mkdir -p "$WORK_DIR"
+  unzip -o "$ZIP_FILE" -d "$WORK_DIR" > /dev/null
+  echo "[EX] Files: $(ls "$WORK_DIR"/*.csv | wc -l) CSV files"
+
+  # Filter documents.csv: keep only rows where doc_id is in fulltext range
+  DOC_FILE="$WORK_DIR/documents.csv"
+  FILTERED_FILE="$WORK_DIR/filtered_docs.csv"
+
+  TOTAL_LINES=$(($(wc -l < "$DOC_FILE") - 1))
+  echo "[FLT] Total in $YEAR dump: $TOTAL_LINES documents"
+  echo "[FLT] Filtering for doc_id $MIN_ID–$MAX_ID..."
+
+  # Use awk to filter: field 1 (doc_id) must be in range AND exist in fulltext
+  # For speed, just filter by range first, then intersect with fulltext ids
+  tail -n +2 "$DOC_FILE" | awk -F'\t' -v min="$MIN_ID" -v max="$MAX_ID" '$1 >= min && $1 <= max' > "$WORK_DIR/range_filtered.csv"
+  RANGE_COUNT=$(wc -l < "$WORK_DIR/range_filtered.csv")
+  echo "[FLT] In doc_id range: $RANGE_COUNT"
+
+  if [ "$RANGE_COUNT" -eq 0 ]; then
+    echo "[SKIP] No matching doc_ids in $YEAR dump"
+    rm -rf "$WORK_DIR"
+    continue
+  fi
+
+  # Now intersect with fulltext doc_ids (only import rows that have fulltext)
+  # Extract doc_ids from filtered, sort, intersect with fulltext ids
+  cut -f1 "$WORK_DIR/range_filtered.csv" | sort -n > "$WORK_DIR/range_docids.txt"
+  comm -12 "$WORK_DIR/range_docids.txt" "$FT_IDS_FILE" > "$WORK_DIR/matching_docids.txt"
+  MATCH_COUNT=$(wc -l < "$WORK_DIR/matching_docids.txt")
+  echo "[FLT] Matching fulltext doc_ids: $MATCH_COUNT"
+
+  if [ "$MATCH_COUNT" -eq 0 ]; then
+    echo "[SKIP] No fulltext matches in $YEAR dump"
+    rm -rf "$WORK_DIR"
+    continue
+  fi
+
+  # Remove already-existing doc_ids
+  if [ "$EXISTING_COUNT" -gt 0 ]; then
+    comm -23 "$WORK_DIR/matching_docids.txt" "$EXISTING_FILE" > "$WORK_DIR/new_docids.txt"
+  else
+    cp "$WORK_DIR/matching_docids.txt" "$WORK_DIR/new_docids.txt"
+  fi
+  NEW_COUNT=$(wc -l < "$WORK_DIR/new_docids.txt")
+  echo "[FLT] New doc_ids to import (not yet in edrsr_documents): $NEW_COUNT"
+
+  if [ "$NEW_COUNT" -eq 0 ]; then
+    echo "[SKIP] All matching doc_ids already in edrsr_documents"
+    rm -rf "$WORK_DIR"
+    continue
+  fi
+
+  # Filter the actual CSV rows to only include new doc_ids
+  # Load new_docids into awk for fast lookup
+  awk -F'\t' 'NR==FNR{ids[$1]=1; next} $1 in ids' "$WORK_DIR/new_docids.txt" "$WORK_DIR/range_filtered.csv" > "$FILTERED_FILE"
+  IMPORT_COUNT=$(wc -l < "$FILTERED_FILE")
+  echo "[IMP] Importing $IMPORT_COUNT documents in $THREADS threads..."
+
+  # Split and parallel import
+  CHUNK_SIZE=$(( (IMPORT_COUNT + THREADS - 1) / THREADS ))
+  [ "$CHUNK_SIZE" -lt 1 ] && CHUNK_SIZE=1
+
+  split -l "$CHUNK_SIZE" -d -a 3 "$FILTERED_FILE" "$WORK_DIR/chunk_"
+
+  PIDS=()
+  for chunk in "$WORK_DIR"/chunk_*; do
+    import_chunk "$chunk" "$CONTAINER" "$PGUSER" "$PGDATABASE" &
+    PIDS+=($!)
+    if [ ${#PIDS[@]} -ge "$THREADS" ]; then
+      wait "${PIDS[0]}"
+      PIDS=("${PIDS[@]:1}")
+    fi
+  done
+  wait
+
+  TOTAL_IMPORTED=$((TOTAL_IMPORTED + IMPORT_COUNT))
+  echo "[OK] $YEAR done: $IMPORT_COUNT docs imported (running total: $TOTAL_IMPORTED)"
+
+  # Cleanup work dir (keep ZIP for reuse)
+  rm -rf "$WORK_DIR"
+done
+
+# Cleanup temp files
+rm -f "$EXISTING_FILE" "$FT_IDS_FILE"
+
+echo ""
+echo "=== Verification ==="
+run_psql -c "SELECT 'edrsr_documents' AS tbl, COUNT(*) FROM edrsr_documents;"
+run_psql -c "SELECT 'matched' AS status, COUNT(*) FROM edrsr_fulltext f WHERE EXISTS (SELECT 1 FROM edrsr_documents e WHERE e.doc_id = f.doc_id);"
+run_psql -c "SELECT 'unmatched' AS status, COUNT(*) FROM edrsr_fulltext f WHERE NOT EXISTS (SELECT 1 FROM edrsr_documents e WHERE e.doc_id = f.doc_id);"
+
+echo ""
+echo "=== Done! Total imported: $TOTAL_IMPORTED ==="


### PR DESCRIPTION
## Summary
- New admin page **PG Моніторинг** showing EDRSR metadata + fulltext stats by year for prod, stage, and local environments
- Backend endpoints: `GET /api/admin/pg-monitoring` (admin) + `GET /api/internal/edrsr-stats` (cross-env)
- Auto-refresh every 30s with KPI cards (total metadata, fulltext count, coverage %), progress bars per year
- Included EDRSR fulltext metadata import script (`scripts/edrsr/import-edrsr-fulltext-metadata-prod.sh`) for bulk loading from data.gov.ua

## Test plan
- [ ] Navigate to Admin → PG Моніторинг
- [ ] Verify prod and stage tables load with year-by-year data
- [ ] Check auto-refresh toggles on/off
- [ ] Verify new years appearing in DB show up automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)