### PR TITLE
feat: add ERB debtors + NBU banks MCP tools

### DIFF
--- a/mcp_backend/src/api/tools/state-registry-tools.ts
+++ b/mcp_backend/src/api/tools/state-registry-tools.ts
@@ -1,0 +1,242 @@
+/**
+ * State Registry Tools - ERB (Єдиний реєстр боржників) + NBU bank registry
+ *
+ * 2 tools:
+ * - search_erb_debtors — пошук у Єдиному реєстрі боржників (Мін'юст)
+ * - search_nbu_banks — пошук банків з ліцензією НБУ
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+export class StateRegistryTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'search_erb_debtors',
+        description: `Пошук у Єдиному реєстрі боржників (Міністерство юстиції України)
+
+Реєстр містить 10+ млн записів про боржників з відкритими виконавчими провадженнями.
+Пошук за кодом ЄДРПОУ, ПІБ боржника або номером виконавчого провадження.
+Джерело: data.gov.ua / erb.minjust.gov.ua`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            debtor_name: {
+              type: 'string',
+              description: 'ПІБ фізичної особи або назва юридичної особи (пошук по вхожденню)',
+            },
+            debtor_code: {
+              type: 'string',
+              description: 'Код ЄДРПОУ юридичної особи',
+            },
+            vp_ordernum: {
+              type: 'string',
+              description: 'Номер виконавчого провадження',
+            },
+            vd_cat: {
+              type: 'string',
+              description: 'Категорія стягнення (наприклад: "стягнення коштів", "аліменти")',
+            },
+            limit: {
+              type: 'number',
+              default: 20,
+              maximum: 100,
+              description: 'Максимальна кількість результатів (за замовчуванням 20)',
+            },
+          },
+          required: [],
+        },
+      },
+      {
+        name: 'search_nbu_banks',
+        description: `Пошук банків з ліцензією Національного банку України
+
+Реєстр містить усі банки України з банківською ліцензією НБУ (60 банків).
+Пошук за назвою, кодом ЄДРПОУ або статусом. Включає дату ліцензії, адресу, телефон, сайт.
+Джерело: bank.gov.ua (Open Data API)`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Назва банку або частина назви (пошук по вхожденню)',
+            },
+            edrpou: {
+              type: 'string',
+              description: 'Код ЄДРПОУ банку',
+            },
+            status: {
+              type: 'string',
+              enum: ['Нормальний', 'Неплатоспроможний', 'В стані ліквідації'],
+              description: 'Статус банку',
+            },
+          },
+          required: [],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    switch (name) {
+      case 'search_erb_debtors':
+        return await this.searchErbDebtors(args);
+      case 'search_nbu_banks':
+        return await this.searchNbuBanks(args);
+      default:
+        return null;
+    }
+  }
+
+  private async searchErbDebtors(args: any): Promise<ToolResult> {
+    const debtorName = args.debtor_name?.trim();
+    const debtorCode = args.debtor_code?.trim();
+    const vpOrdernum = args.vp_ordernum?.trim();
+    const vdCat = args.vd_cat?.trim();
+    const limit = Math.min(Number(args.limit) || 20, 100);
+
+    if (!debtorName && !debtorCode && !vpOrdernum) {
+      return this.wrapError('Потрібно вказати хоча б один параметр: debtor_name, debtor_code або vp_ordernum');
+    }
+
+    logger.info('[MCP Tool] search_erb_debtors', { debtorName, debtorCode, vpOrdernum, limit });
+
+    try {
+      const conditions: string[] = [];
+      const params: any[] = [];
+      let paramIdx = 1;
+
+      if (debtorCode) {
+        conditions.push(`debtor_code = $${paramIdx++}`);
+        params.push(debtorCode);
+      }
+
+      if (vpOrdernum) {
+        conditions.push(`vp_ordernum = $${paramIdx++}`);
+        params.push(vpOrdernum);
+      }
+
+      if (debtorName) {
+        conditions.push(`debtor_name ILIKE $${paramIdx++}`);
+        params.push(`%${debtorName}%`);
+      }
+
+      if (vdCat) {
+        conditions.push(`vd_cat ILIKE $${paramIdx++}`);
+        params.push(`%${vdCat}%`);
+      }
+
+      const countQuery = `SELECT count(*) AS total FROM erb_debtors WHERE ${conditions.join(' AND ')}`;
+      const countResult = await this.db.query(countQuery, params);
+      const total = parseInt(countResult.rows[0].total, 10);
+
+      params.push(limit);
+      const dataQuery = `
+        SELECT debtor_name, debtor_birthdate, debtor_code, publisher, org_name,
+               org_phone_num, emp_full_fio, emp_phone_num, email_addr, vp_ordernum, vd_cat
+        FROM erb_debtors
+        WHERE ${conditions.join(' AND ')}
+        ORDER BY id DESC
+        LIMIT $${paramIdx}
+      `;
+      const result = await this.db.query(dataQuery, params);
+
+      return this.wrapResponse({
+        source: 'Єдиний реєстр боржників (Мін\'юст, data.gov.ua)',
+        total_found: total,
+        returned: result.rows.length,
+        limit,
+        debtors: result.rows.map((r: any) => ({
+          debtor_name: r.debtor_name,
+          debtor_birthdate: r.debtor_birthdate || null,
+          debtor_code: r.debtor_code || null,
+          publisher: r.publisher,
+          org_name: r.org_name,
+          org_phone: r.org_phone_num || null,
+          executor: r.emp_full_fio || null,
+          executor_phone: r.emp_phone_num || null,
+          executor_email: r.email_addr || null,
+          vp_number: r.vp_ordernum,
+          category: r.vd_cat,
+        })),
+      });
+    } catch (error: any) {
+      logger.error('[MCP Tool] search_erb_debtors failed', { error: error.message });
+      return this.wrapError(`Помилка пошуку в реєстрі боржників: ${error.message}`);
+    }
+  }
+
+  private async searchNbuBanks(args: any): Promise<ToolResult> {
+    const query = args.query?.trim();
+    const edrpou = args.edrpou?.trim();
+    const status = args.status?.trim();
+
+    logger.info('[MCP Tool] search_nbu_banks', { query, edrpou, status });
+
+    try {
+      const conditions: string[] = [];
+      const params: any[] = [];
+      let paramIdx = 1;
+
+      if (edrpou) {
+        conditions.push(`kod_edrpou = $${paramIdx++}`);
+        params.push(edrpou);
+      }
+
+      if (query) {
+        conditions.push(`(shortname ILIKE $${paramIdx} OR fullname ILIKE $${paramIdx})`);
+        params.push(`%${query}%`);
+        paramIdx++;
+      }
+
+      if (status) {
+        conditions.push(`n_stan = $${paramIdx++}`);
+        params.push(status);
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+      const dataQuery = `
+        SELECT shortname, fullname, kod_edrpou, n_stan, d_open, d_close,
+               num_lic, dt_lic, n_pr_lic, n_obl, np, adress, p_ind,
+               telefon, website, name_e, shortname_en, glmfo, idnbu
+        FROM nbu_banks
+        ${whereClause}
+        ORDER BY shortname
+      `;
+      const result = await this.db.query(dataQuery, params);
+
+      return this.wrapResponse({
+        source: 'Державний реєстр банків НБУ (bank.gov.ua)',
+        total_found: result.rows.length,
+        banks: result.rows.map((r: any) => ({
+          name: r.shortname,
+          full_name: r.fullname,
+          name_en: r.shortname_en || null,
+          edrpou: r.kod_edrpou,
+          status: r.n_stan,
+          opened: r.d_open,
+          closed: r.d_close || null,
+          license_number: r.num_lic,
+          license_date: r.dt_lic,
+          license_status: r.n_pr_lic,
+          region: r.n_obl,
+          city: r.np,
+          address: r.adress,
+          postal_code: r.p_ind,
+          phone: r.telefon,
+          website: r.website || null,
+          glmfo: r.glmfo,
+          nbu_id: r.idnbu,
+        })),
+      });
+    } catch (error: any) {
+      logger.error('[MCP Tool] search_nbu_banks failed', { error: error.message });
+      return this.wrapError(`Помилка пошуку в реєстрі банків: ${error.message}`);
+    }
+  }
+}

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -79,6 +79,7 @@ import { UploadService } from './services/upload-service.js';
 import { MinioService } from './services/minio-service.js';
 import { NextcloudService } from './services/nextcloud-service.js';
 import { NextcloudTools } from './api/tools/nextcloud-tools.js';
+import { StateRegistryTools } from './api/tools/state-registry-tools.js';
 import { createUploadRouter } from './routes/upload-routes.js';
 import { VaultTools } from './api/vault-tools.js';
 import { ConversationService } from './services/conversation-service.js';
@@ -308,6 +309,7 @@ class HTTPMCPServer {
     ));
     this.toolRegistry.registerHandler(new LegalActsTools(this.services.zoLegalActsAdapter));
     this.toolRegistry.registerHandler(new ECHRPracticeTools(this.services.zoECHRAdapter));
+    this.toolRegistry.registerHandler(new StateRegistryTools(this.services.db));
     logger.info('Core tool handlers registered with ToolRegistry');
 
     // Initialize Nextcloud integration

--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -89,7 +89,7 @@ export function buildPlanGenerationMessages(
       practice_analysis: '11. queryType=practice_analysis: use 5-10 search_legal_precedents calls with different queries and limit=50, then include legislation lookups',
       legislation_lookup: '11. queryType=legislation_lookup: start with get_legislation_article or search_legislation, max 2 steps',
       legal_consultation: '11. queryType=legal_consultation: combine legislation + practice search tools',
-      registry_lookup: '11. queryType=registry_lookup: start with openreyestr_get_by_edrpou or openreyestr_search_entities, max 3 steps',
+      registry_lookup: '11. queryType=registry_lookup: start with openreyestr_get_by_edrpou or openreyestr_search_entities. For debtors/enforcement proceedings use search_erb_debtors (10M+ records from Minjust). For bank info use search_nbu_banks. Max 3 steps',
       parliament_query: '11. queryType=parliament_query: use rada_ tools, max 2 steps',
       document_query: '11. queryType=document_query: ALWAYS start with list_documents(query="", limit=50) to get ALL user documents. Then use semantic_search for content-relevant fragments. For analysis: also use get_document to read full text of relevant docs. For delete/update by name: first list_documents to find the doc, then delete_document/update_document with the ID. Max 5 steps.',
       document_drafting: '11. queryType=document_drafting: first find_relevant_law_articles for legal basis, then generate document',
@@ -532,7 +532,7 @@ export const CHAT_INTENT_CLASSIFICATION_PROMPT = `Ти — класифікат�
 - find_relevant_law_articles — знайти статті за описом ситуації
 - search_procedural_norms — пошук процесуальних норм
 
-### registry — Державні реєстри (OpenReyestr / data.gov.ua / НАІС)
+### registry — Державні реєстри (OpenReyestr / data.gov.ua / НАІС / НБУ / Мін'юст)
 - openreyestr_search_entities — пошук юридичних осіб за назвою
 - openreyestr_get_entity_details — деталі юридичної особи
 - openreyestr_search_beneficiaries — пошук бенефіціарів
@@ -548,6 +548,8 @@ export const CHAT_INTENT_CLASSIFICATION_PROMPT = `Ти — класифікат�
 - openreyestr_search_administrative_units — адмін. устрій (КОАТУУ)
 - openreyestr_search_streets — вулиці
 - openreyestr_search_special_forms — спец. бланки нотаріусів
+- search_erb_debtors — Єдиний реєстр боржників (Мін'юст, 10M+ записів, виконавчі провадження)
+- search_nbu_banks — реєстр банків з ліцензією НБУ (60 банків, ліцензії, адреси, статус)
 
 ### parliament — Парламентські дані (Verkhovna Rada Open Data)
 - rada_search_parliament_bills — пошук законопроєктів

--- a/mcp_backend/src/prompts/tool-registry-catalog.ts
+++ b/mcp_backend/src/prompts/tool-registry-catalog.ts
@@ -474,18 +474,22 @@ export const SCENARIO_CATALOG: ScenarioCatalogEntry[] = [
     exampleQueries: [
       'Чи є борги у ТОВ "Приклад"?',
       'Перевірити боржника Іванов Іван Іванович',
+      'Виконавчі провадження по ЄДРПОУ 12345678',
     ],
     dataSources: [
+      { name: 'ERB (Мін\'юст)', provides: 'Єдиний реєстр боржників (10M+ записів)' },
       { name: 'OpenReyestr', provides: 'реєстр боржників' },
     ],
     toolChain: [
-      { tool: 'openreyestr_search_debtors', purpose: 'пошук у реєстрі боржників' },
+      { tool: 'search_erb_debtors', purpose: 'пошук у Єдиному реєстрі боржників Мін\'юсту (основне джерело, 10M+ записів)' },
+      { tool: 'openreyestr_search_debtors', purpose: 'додатковий пошук боржників (OpenReyestr)', optional: true },
     ],
     responseTemplate: [
       { heading: 'Боржник', instruction: 'назва/ПІБ боржника' },
-      { heading: 'Сума боргу', instruction: 'розмір заборгованості' },
-      { heading: 'Стягувач', instruction: 'хто стягує борг' },
-      { heading: 'Стан провадження', instruction: 'статус виконавчого провадження' },
+      { heading: 'Код ЄДРПОУ', instruction: 'ідентифікаційний код (якщо є)', optional: true },
+      { heading: 'Виконавче провадження', instruction: 'номер ВП та категорія стягнення' },
+      { heading: 'Орган стягнення', instruction: 'суд або орган, що видав документ' },
+      { heading: 'Виконавець', instruction: 'ПІБ та контакти державного/приватного виконавця' },
     ],
   },
 
@@ -520,10 +524,12 @@ export const SCENARIO_CATALOG: ScenarioCatalogEntry[] = [
       'Статус виконавчого провадження №12345',
     ],
     dataSources: [
+      { name: 'ERB (Мін\'юст)', provides: 'Єдиний реєстр боржників (виконавчі провадження)' },
       { name: 'OpenReyestr', provides: 'реєстр виконавчих проваджень' },
     ],
     toolChain: [
-      { tool: 'openreyestr_search_enforcement_proceedings', purpose: 'пошук виконавчих проваджень' },
+      { tool: 'search_erb_debtors', purpose: 'пошук у Єдиному реєстрі боржників за номером ВП або ПІБ' },
+      { tool: 'openreyestr_search_enforcement_proceedings', purpose: 'додатковий пошук виконавчих проваджень', optional: true },
     ],
     responseTemplate: [
       { heading: 'Номер провадження', instruction: 'номер та дата відкриття' },
@@ -553,6 +559,30 @@ export const SCENARIO_CATALOG: ScenarioCatalogEntry[] = [
       { heading: 'Список знайдених', instruction: 'ПІБ, район діяльності' },
       { heading: 'Контакти', instruction: 'адреса, телефон' },
       { heading: 'Спеціалізація', instruction: 'вид діяльності або спеціальність' },
+    ],
+  },
+
+  {
+    id: 'nbu_bank_search',
+    label: 'Пошук банків з ліцензією НБУ',
+    domains: ['registry'],
+    exampleQueries: [
+      'Чи має банк "Приватбанк" ліцензію НБУ?',
+      'Які банки мають статус "Неплатоспроможний"?',
+      'Інформація про банк з ЄДРПОУ 14360570',
+      'Список усіх банків України',
+    ],
+    dataSources: [
+      { name: 'НБУ (bank.gov.ua)', provides: 'реєстр банків з банківською ліцензією' },
+    ],
+    toolChain: [
+      { tool: 'search_nbu_banks', purpose: 'пошук банків у реєстрі НБУ' },
+    ],
+    responseTemplate: [
+      { heading: 'Банк', instruction: 'назва та ЄДРПОУ' },
+      { heading: 'Статус', instruction: 'нормальний / неплатоспроможний / ліквідація' },
+      { heading: 'Ліцензія', instruction: 'номер та дата ліцензії' },
+      { heading: 'Контакти', instruction: 'адреса, телефон, сайт' },
     ],
   },
 


### PR DESCRIPTION
## Summary
- New `search_erb_debtors` tool — queries 10.3M records from Єдиний реєстр боржників (Minjust, data.gov.ua) by debtor name, EDRPOU code, or enforcement proceedings number
- New `search_nbu_banks` tool — queries 60 licensed Ukrainian banks from NBU registry (bank.gov.ua) by name, EDRPOU, or status
- Both tools registered in ToolRegistry, chat system prompt, and scenario catalog for automatic intent routing from chat

## Data sources
| Table | Records | Source | Updated |
|-------|---------|--------|---------|
| `erb_debtors` | 10,335,177 | data.gov.ua (ERB ZIP) | 2026-03-09 |
| `nbu_banks` | 60 | bank.gov.ua JSON API | 2026-03-10 |

Tables already imported on prod (`secondlayer_prod` DB).

## Test plan
- [ ] Build passes (`tsc --noEmit`)
- [ ] Deploy to prod and rebuild backend container
- [ ] Test via chat: "Чи є борги у ТОВ Приклад?" → should use `search_erb_debtors`
- [ ] Test via chat: "Чи має ПриватБанк ліцензію НБУ?" → should use `search_nbu_banks`
- [ ] Test direct API: `POST /api/tools/search_erb_debtors` with `{"debtor_code": "20793942"}`
- [ ] Test direct API: `POST /api/tools/search_nbu_banks` with `{"query": "Приват"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)