### PR TITLE
fix: PG Monitoring 500 — shared memory exhaustion

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -28,6 +28,7 @@ services:
       TZ: Europe/Kiev
     ports:
     - "127.0.0.1:5438:5432"
+    shm_size: '2g'
     volumes:
     - postgres_prod_data:/var/lib/postgresql/data
     healthcheck:

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -5094,24 +5094,39 @@ export function createAdminRoutes(
       let localByYear: Array<{ year: number | null; total: number; with_fulltext: number }> = [];
 
       if (has_docs) {
-        const query = has_ft
-          ? `SELECT
+        // Two separate queries to avoid massive LEFT JOIN that exhausts shared memory
+        const docsResult = await db.query(`
+          SELECT
+            EXTRACT(YEAR FROM adjudication_date)::int AS year,
+            COUNT(*)::int AS total
+          FROM edrsr_documents
+          GROUP BY year
+          ORDER BY year NULLS LAST
+        `);
+
+        if (has_ft) {
+          const ftResult = await db.query(`
+            SELECT
               EXTRACT(YEAR FROM d.adjudication_date)::int AS year,
-              COUNT(*)::int AS total,
-              COUNT(f.doc_id)::int AS with_fulltext
-            FROM edrsr_documents d
-            LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+              COUNT(*)::int AS with_fulltext
+            FROM edrsr_fulltext f
+            JOIN edrsr_documents d ON d.doc_id = f.doc_id
             GROUP BY year
-            ORDER BY year NULLS LAST`
-          : `SELECT
-              EXTRACT(YEAR FROM adjudication_date)::int AS year,
-              COUNT(*)::int AS total,
-              0 AS with_fulltext
-            FROM edrsr_documents
-            GROUP BY year
-            ORDER BY year NULLS LAST`;
-        const result = await db.query(query);
-        localByYear = result.rows;
+            ORDER BY year NULLS LAST
+          `);
+          const ftMap = new Map(ftResult.rows.map((r: any) => [r.year, r.with_fulltext]));
+          localByYear = docsResult.rows.map((r: any) => ({
+            year: r.year,
+            total: r.total,
+            with_fulltext: ftMap.get(r.year) || 0,
+          }));
+        } else {
+          localByYear = docsResult.rows.map((r: any) => ({
+            year: r.year,
+            total: r.total,
+            with_fulltext: 0,
+          }));
+        }
       }
 
       let localStandaloneFulltext = 0;


### PR DESCRIPTION
## Summary
- Split massive LEFT JOIN (45M × 4.8M rows) into two separate COUNT queries merged in Node.js — eliminates `/dev/shm` exhaustion
- Added `shm_size: 2g` to `postgres-prod` Docker container as safety net

## Test plan
- [ ] Verify `/admin/pg-monitoring` returns 200 on prod after deploy
- [ ] Confirm yearly breakdown data matches previous results
- [ ] Restart postgres-prod container to apply shm_size

🤖 Generated with [Claude Code](https://claude.com/claude-code)