### PR TITLE
feat: server-side evidence extraction with frontend fallback

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -140,12 +140,14 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             isComplete: true,
           });
 
-          const evidence = extractEvidenceFromToolResult(data.tool, data.result);
+          // Use server-side evidence if available, fall back to client-side extraction
+          const evidence = data.evidence || extractEvidenceFromToolResult(data.tool, data.result);
           console.log('[AIChat] Evidence extraction', {
             tool: data.tool,
             decisions: evidence.decisions.length,
             citations: evidence.citations.length,
             documents: evidence.documents.length,
+            source: data.evidence ? 'server' : 'client',
           });
           if (evidence.decisions.length > 0) {
             accumulatedDecisions.current.push(...evidence.decisions);
@@ -184,7 +186,8 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
           }
           contentRef.current = data.text;
 
-          const answerNorms = extractNormsFromAnswer(data.text);
+          // Use server-side norms if available, fall back to client-side extraction
+          const answerNorms = data.norms || extractNormsFromAnswer(data.text);
           if (answerNorms.length > 0) {
             const existingSources = new Set(
               accumulatedCitations.current.map(c => c.source.toLowerCase().replace(/\s+/g, ' ').trim())
@@ -226,6 +229,19 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
           autoTitleConversation();
 
           onSuccess?.(data);
+        },
+
+        onEvidenceUpdate: (data) => {
+          // Server sends cumulative deduplicated evidence — use directly
+          updateMessage(assistantMessageId, {
+            decisions: data.decisions.length > 0 ? data.decisions : undefined,
+            citations: data.citations.length > 0 ? data.citations : undefined,
+            documents: data.documents.length > 0 ? data.documents : undefined,
+          });
+          // Sync refs to keep local accumulators in sync
+          accumulatedDecisions.current = [...data.decisions];
+          accumulatedCitations.current = [...data.citations];
+          accumulatedDocuments.current = [...data.documents];
         },
 
         onCitationWarning: (data) => {

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -19,13 +19,22 @@ export interface CitationWarning {
   message: string;
 }
 
+import type { Decision, Citation, VaultDocument } from '../../types/models/Message';
+
+export interface EvidenceEnvelope {
+  decisions: Decision[];
+  citations: Citation[];
+  documents: VaultDocument[];
+}
+
 export interface ChatStreamCallbacks {
   onResponseId?: (data: { response_id: string }) => void;
   onPlan?: (data: { goal: string; steps: Array<{ id: number; tool: string; params: Record<string, unknown>; purpose: string; depends_on?: number[] }>; expected_iterations: number }) => void;
   onThinking?: (data: { step: number; tool: string; params: Record<string, unknown>; description?: string; cost_usd?: number }) => void;
-  onToolResult?: (data: { tool: string; result: unknown; cost_usd?: number }) => void;
+  onToolResult?: (data: { tool: string; result: unknown; evidence?: EvidenceEnvelope; cost_usd?: number }) => void;
   onAnswerDelta?: (data: { text: string }) => void;
-  onAnswer?: (data: { text: string; provider: string; model: string }) => void;
+  onAnswer?: (data: { text: string; provider: string; model: string; norms?: Array<{ text: string; source: string }> }) => void;
+  onEvidenceUpdate?: (data: EvidenceEnvelope) => void;
   onCitationWarning?: (data: CitationWarning) => void;
   onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string; conversationId?: string }) => void;
   onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
@@ -222,7 +231,8 @@ export class MCPService extends BaseService {
       case 'thinking': callbacks.onThinking?.(data as Parameters<NonNullable<ChatStreamCallbacks['onThinking']>>[0]); break;
       case 'tool_result': callbacks.onToolResult?.(data as Parameters<NonNullable<ChatStreamCallbacks['onToolResult']>>[0]); break;
       case 'answer_delta': callbacks.onAnswerDelta?.(data as { text: string }); break;
-      case 'answer': callbacks.onAnswer?.(data as { text: string; provider: string; model: string }); break;
+      case 'answer': callbacks.onAnswer?.(data as Parameters<NonNullable<ChatStreamCallbacks['onAnswer']>>[0]); break;
+      case 'evidence_update': callbacks.onEvidenceUpdate?.(data as EvidenceEnvelope); break;
       case 'citation_warning': callbacks.onCitationWarning?.(data as CitationWarning); break;
       case 'complete': callbacks.onComplete?.(data as Parameters<NonNullable<ChatStreamCallbacks['onComplete']>>[0]); break;
       case 'cost_summary': callbacks.onCostSummary?.(data as Parameters<NonNullable<ChatStreamCallbacks['onCostSummary']>>[0]); break;

--- a/mcp_backend/src/services/evidence-extractor.ts
+++ b/mcp_backend/src/services/evidence-extractor.ts
@@ -4,40 +4,14 @@
  * Mirrors the frontend extractEvidenceFromToolResult() logic so that
  * decisions, citations, and documents are persisted in conversation_messages
  * and survive page reloads.
+ *
+ * Types are imported from @secondlayer/shared — single source of truth.
  */
 
-// ── Types (lightweight — match what frontend expects) ────────────────
+import type { Decision, Citation, VaultDocument, ExtractedEvidence } from '@secondlayer/shared';
 
-export interface Decision {
-  id: string;
-  number: string;
-  court: string;
-  date: string;
-  summary: string;
-  relevance: number;
-  status: string;
-  documentType?: string;
-  externalUrl?: string;
-}
-
-export interface Citation {
-  text: string;
-  source: string;
-}
-
-export interface VaultDocument {
-  id: string;
-  title: string;
-  type: string;
-  uploadedAt?: string;
-  metadata?: Record<string, any>;
-}
-
-export interface ExtractedEvidence {
-  decisions: Decision[];
-  citations: Citation[];
-  documents: VaultDocument[];
-}
+// Re-export for consumers that import from this file
+export type { Decision, Citation, VaultDocument, ExtractedEvidence };
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -93,7 +67,7 @@ function classifyDocumentType(item: any): string {
 
 // ── Single tool result extraction ────────────────────────────────────
 
-function extractFromToolResult(
+export function extractFromToolResult(
   toolName: string,
   rawResult: any,
 ): ExtractedEvidence {
@@ -577,7 +551,7 @@ function extractFromToolResult(
 
 // ── Norm extraction from answer text ─────────────────────────────────
 
-function extractNormsFromAnswer(answerText: string): Citation[] {
+export function extractNormsFromAnswer(answerText: string): Citation[] {
   const norms: Citation[] = [];
   const seen = new Set<string>();
 

--- a/packages/shared/src/types/evidence.ts
+++ b/packages/shared/src/types/evidence.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared evidence types — single source of truth for backend and frontend.
+ * Backend extracts evidence from tool results and sends it via SSE.
+ * Frontend uses these types for rendering in the evidence panel.
+ */
+
+export interface Decision {
+  id: string;
+  number: string;
+  court: string;
+  date: string;
+  summary: string;
+  relevance: number;
+  status: string;
+  documentType?: string;
+  externalUrl?: string;
+}
+
+export interface Citation {
+  text: string;
+  source: string;
+}
+
+export interface VaultDocument {
+  id: string;
+  title: string;
+  type: string;
+  uploadedAt?: string;
+  metadata?: Record<string, any>;
+}
+
+export interface ExtractedEvidence {
+  decisions: Decision[];
+  citations: Citation[];
+  documents: VaultDocument[];
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './cost';
+export * from './evidence';
 export * from './http';


### PR DESCRIPTION
## Summary
- **Phase 1**: Backend includes extracted `evidence` in `tool_result` SSE events, eliminating frontend's need to parse 45 tool response schemas across 12 files
- **Phase 2**: Backend includes extracted `norms` (legal article references) in `answer` SSE events, replacing 300+ lines of client-side regex
- **Phase 3**: New `evidence_update` SSE event sends cumulative deduplicated evidence after each tool call, simplifying frontend accumulation logic
- Shared types (`Decision`, `Citation`, `VaultDocument`, `ExtractedEvidence`) in `@secondlayer/shared` — single source of truth
- All changes are backward-compatible: frontend falls back to client-side extraction if server fields are absent

## Test plan
- [ ] Open chat, ask a legal question → verify evidence panel shows decisions/citations without errors
- [ ] Compare evidence panel output with current production behavior (should be identical)
- [ ] Check browser console for `source: 'server'` in evidence extraction logs
- [ ] Test with older backend (no `evidence` field) → frontend should fall back to `source: 'client'`
- [ ] Verify `evidence_update` events appear in SSE stream (Network tab)
- [ ] After verification in prod — follow-up PR to remove 12 frontend evidence files

🤖 Generated with [Claude Code](https://claude.com/claude-code)