### PR TITLE
fix: prevent MCP content blocks from crashing React rendering

### DIFF
--- a/lexwebapp/src/components/chat/RegulationsTab.tsx
+++ b/lexwebapp/src/components/chat/RegulationsTab.tsx
@@ -37,6 +37,8 @@ export function RegulationsTab({ citations, onOpenModal }: RegulationsTabProps) 
       {citations.map((citation, idx) => {
         const cardId = `citation-${idx}`;
         const isExpanded = expandedCards.has(cardId);
+        // Safeguard: citation.text may arrive as an object/array from MCP content blocks
+        const safeText = typeof citation.text === 'string' ? citation.text : JSON.stringify(citation.text);
 
         return (
           <ExpandableCard
@@ -46,7 +48,7 @@ export function RegulationsTab({ citations, onOpenModal }: RegulationsTabProps) 
             icon={BookOpen}
             isExpanded={isExpanded}
             onToggle={() => toggleCard(cardId)}
-            content={citation.text || 'Немає тексту.'}
+            content={safeText || 'Немає тексту.'}
             onOpenModal={() => onOpenModal(citation)}
             header={
               <div className="flex items-start gap-2.5">
@@ -66,7 +68,7 @@ export function RegulationsTab({ citations, onOpenModal }: RegulationsTabProps) 
             preview={
               <div className="ml-[30px]">
                 <p className="text-[11px] text-claude-subtext leading-relaxed line-clamp-3">
-                  {citation.text}
+                  {safeText}
                 </p>
               </div>
             }

--- a/mcp_backend/src/services/evidence-extractor.ts
+++ b/mcp_backend/src/services/evidence-extractor.ts
@@ -17,16 +17,30 @@ export type { Decision, Citation, VaultDocument, ExtractedEvidence };
 
 function parseToolResultContent(result: any): any {
   if (!result) return null;
-  try {
-    if (result.content && Array.isArray(result.content)) {
-      const textBlock = result.content.find((b: any) => b.type === 'text');
-      if (textBlock?.text) {
-        return JSON.parse(textBlock.text);
-      }
+
+  // Extract text from MCP content blocks first
+  let rawText: string | undefined;
+  if (result.content && Array.isArray(result.content)) {
+    const textBlock = result.content.find((b: any) => b.type === 'text');
+    if (textBlock?.text) {
+      rawText = textBlock.text;
     }
+  }
+
+  if (rawText) {
+    try {
+      return JSON.parse(rawText);
+    } catch {
+      // Text is not JSON — return it as a plain-text wrapper, NOT the original
+      // ToolResult (which has content: [{type, text}] that breaks React rendering)
+      return { text: rawText };
+    }
+  }
+
+  try {
     return typeof result === 'string' ? JSON.parse(result) : result;
   } catch {
-    return result;
+    return { text: String(result) };
   }
 }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `parseToolResultContent()` in `evidence-extractor.ts` returned the raw `ToolResult` object (with `content: [{type, text}]`) when `JSON.parse` failed on non-JSON tool output. This MCP content array leaked into `citation.text`, causing React error #31 when rendered in `RegulationsTab`.
- **Backend fix**: Return `{text: rawText}` on parse failure instead of the original ToolResult
- **Frontend fix**: Add safeguard in `RegulationsTab` to stringify non-string citation text

## Test plan
- [ ] Send a chat query that triggers legislation tools (e.g. "Які умови для бронювання?")
- [ ] Verify no React error #31 in the browser console
- [ ] Verify legislation citations appear correctly in the right panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)