### PR TITLE
fix: blog banner gradient fallback for missing images

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -115,11 +115,15 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
         </div>
 
         {/* Banner */}
-        <img
-          src={`/blog-banners/${article.id}.png`}
-          alt={article.title}
-          className="w-full h-48 sm:h-64 object-cover"
-        />
+        <div className="relative w-full h-48 sm:h-64 overflow-hidden">
+          <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
+          <img
+            src={`/blog-banners/${article.id}.png`}
+            alt={article.title}
+            className="relative w-full h-full object-cover"
+            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+          />
+        </div>
 
         {/* Modal content */}
         <div className="px-6 sm:px-8 py-6 sm:py-8">

--- a/lexwebapp/src/pages/BlogPage/index.tsx
+++ b/lexwebapp/src/pages/BlogPage/index.tsx
@@ -124,11 +124,15 @@ export function BlogPage() {
               className="bg-white rounded-2xl border border-claude-border overflow-hidden hover:shadow-lg hover:border-claude-accent/30 transition-all cursor-pointer group"
               onClick={() => setSelectedArticle(article)}
             >
-              <img
-                src={`/blog-banners/${article.id}.png`}
-                alt={article.title}
-                className="w-full h-40 sm:h-48 object-cover"
-              />
+              <div className="relative w-full h-40 sm:h-48 overflow-hidden">
+                <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
+                <img
+                  src={`/blog-banners/${article.id}.png`}
+                  alt={article.title}
+                  className="relative w-full h-full object-cover"
+                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                />
+              </div>
               <div className="p-6 sm:p-8">
               <div className="flex items-start gap-4">
                 <div className={`flex-shrink-0 w-10 h-10 rounded-xl flex items-center justify-center ${


### PR DESCRIPTION
## Summary
- Add gradient background behind blog banner images
- When image fails to load (`onError`), hide the broken `<img>` and show category-colored gradient
- Tech articles: blue gradient, Legal articles: amber gradient
- Fixes broken image icons for 5 new articles that don't have banners yet

## Test plan
- [ ] Verify existing articles still show their banner images
- [ ] Verify new articles show gradient instead of broken image

🤖 Generated with [Claude Code](https://claude.com/claude-code)