### PR TITLE
fix: prevent blog banner text from being cropped

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -120,7 +120,7 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
           <img
             src={`/blog-banners/${article.id}.png`}
             alt={article.title}
-            className="relative w-full h-full object-cover"
+            className="relative w-full h-full object-cover object-top"
             onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
           />
         </div>

--- a/lexwebapp/src/pages/BlogPage/index.tsx
+++ b/lexwebapp/src/pages/BlogPage/index.tsx
@@ -129,7 +129,7 @@ export function BlogPage() {
                 <img
                   src={`/blog-banners/${article.id}.png`}
                   alt={article.title}
-                  className="relative w-full h-full object-cover"
+                  className="relative w-full h-full object-cover object-top"
                   onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
                 />
               </div>


### PR DESCRIPTION
## Summary
- Add `object-top` to blog banner images so title text stays visible in the fixed-height container
- Applied to both blog page cards and article modal

## Test plan
- [ ] Open /blog and verify banner text is fully visible on new articles
- [ ] Open an article modal and verify banner displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)