### PR TITLE
fix: increase blog banner height to prevent text clipping

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -115,7 +115,7 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
         </div>
 
         {/* Banner */}
-        <div className="relative w-full h-48 sm:h-64 overflow-hidden">
+        <div className="relative w-full h-56 sm:h-72 overflow-hidden">
           <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
           <img
             src={`/blog-banners/${article.id}.png`}

--- a/lexwebapp/src/pages/BlogPage/index.tsx
+++ b/lexwebapp/src/pages/BlogPage/index.tsx
@@ -124,7 +124,7 @@ export function BlogPage() {
               className="bg-white rounded-2xl border border-claude-border overflow-hidden hover:shadow-lg hover:border-claude-accent/30 transition-all cursor-pointer group"
               onClick={() => setSelectedArticle(article)}
             >
-              <div className="relative w-full h-40 sm:h-48 overflow-hidden">
+              <div className="relative w-full h-48 sm:h-56 overflow-hidden">
                 <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
                 <img
                   src={`/blog-banners/${article.id}.png`}


### PR DESCRIPTION
## Summary
- Increase banner container height on blog cards (`h-48 sm:h-56`) and article modal (`h-56 sm:h-72`) to prevent bottom text clipping

## Test plan
- [ ] Verify banner text fully visible on /blog page
- [ ] Verify banner in article modal shows complete text

🤖 Generated with [Claude Code](https://claude.com/claude-code)