### PR TITLE
fix: show insufficient balance error in chat with topup link

### DIFF
--- a/lexwebapp/src/components/message/MarkdownContent.tsx
+++ b/lexwebapp/src/components/message/MarkdownContent.tsx
@@ -110,6 +110,10 @@ export const MarkdownContent = React.memo(function MarkdownContent({ content, is
           </button>
         );
       }
+      // Internal links (starting with /) navigate in the same tab
+      if (href?.startsWith('/')) {
+        return <a href={href} className="text-claude-accent font-medium underline decoration-claude-accent/50 hover:decoration-claude-accent">{children}</a>;
+      }
       return <a href={href} className="text-claude-text underline decoration-claude-subtext/30 hover:decoration-claude-text" target="_blank" rel="noopener noreferrer">{children}</a>;
     },
     table: ({ children }: any) => (

--- a/lexwebapp/src/hooks/chat/chat-error-utils.ts
+++ b/lexwebapp/src/hooks/chat/chat-error-utils.ts
@@ -13,7 +13,7 @@ import { getErrorMessage } from '../../utils/errors';
  */
 export function handleStreamError(
   assistantMessageId: string,
-  error: { message: string },
+  error: { message?: string; code?: string; current_balance_usd?: number },
   deps: {
     updateMessage: ReturnType<typeof useChatStore.getState>['updateMessage'];
     setStreaming: ReturnType<typeof useChatStore.getState>['setStreaming'];
@@ -24,16 +24,31 @@ export function handleStreamError(
 ) {
   const { updateMessage, setStreaming, setStreamController, setCurrentTool, onError } = deps;
 
+  let content: string;
+  let toastMessage: string;
+
+  if (error.code === 'INSUFFICIENT_BALANCE') {
+    const balance = error.current_balance_usd != null
+      ? `$${error.current_balance_usd.toFixed(2)}`
+      : '';
+    content = `⚠️ **Недостатньо коштів на балансі**${balance ? ` (поточний баланс: ${balance})` : ''}.\n\nДля продовження роботи, будь ласка, [поповніть баланс](/billing).`;
+    toastMessage = 'Недостатньо коштів на балансі';
+  } else {
+    const msg = error.message || 'Невідома помилка';
+    content = `Помилка: ${msg}`;
+    toastMessage = msg;
+  }
+
   updateMessage(assistantMessageId, {
-    content: `Помилка: ${error.message}`,
+    content,
     isStreaming: false,
   });
   setStreaming(false);
   setStreamController(null);
   setCurrentTool(null);
-  showToast.error(error.message);
+  showToast.error(toastMessage);
 
-  onError?.(new Error(error.message));
+  onError?.(new Error(toastMessage));
 }
 
 /**

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -39,7 +39,7 @@ export interface ChatStreamCallbacks {
   onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string; conversationId?: string }) => void;
   onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
   onBudgetEscalated?: (data: { reason: string; estimatedCost: { minUsd: number; maxUsd: number } }) => void;
-  onError?: (data: { message: string }) => void;
+  onError?: (data: { message?: string; code?: string; current_balance_usd?: number }) => void;
 }
 
 export class MCPService extends BaseService {
@@ -237,7 +237,7 @@ export class MCPService extends BaseService {
       case 'complete': callbacks.onComplete?.(data as Parameters<NonNullable<ChatStreamCallbacks['onComplete']>>[0]); break;
       case 'cost_summary': callbacks.onCostSummary?.(data as Parameters<NonNullable<ChatStreamCallbacks['onCostSummary']>>[0]); break;
       case 'budget_escalated': callbacks.onBudgetEscalated?.(data as Parameters<NonNullable<ChatStreamCallbacks['onBudgetEscalated']>>[0]); break;
-      case 'error': callbacks.onError?.(data as { message: string }); break;
+      case 'error': callbacks.onError?.(data as { message?: string; code?: string; current_balance_usd?: number }); break;
     }
   }
 

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -2291,6 +2291,7 @@ class HTTPMCPServer {
               res.write(`event: error\n`);
               res.write(`data: ${JSON.stringify({
                 error: 'Insufficient balance',
+                message: `Недостатньо коштів на балансі. Поточний баланс: $${balanceCheck.currentBalance.toFixed(2)}. Поповніть баланс для продовження роботи.`,
                 code: 'INSUFFICIENT_BALANCE',
                 required_usd: estimatedCost.total_estimated_cost_usd,
                 current_balance_usd: balanceCheck.currentBalance,


### PR DESCRIPTION
## Summary
- Backend `/api/chat` SSE error event now includes Ukrainian `message` field with current balance info
- Frontend `handleStreamError` detects `INSUFFICIENT_BALANCE` code and shows formatted message with clickable `/billing` link in the chat bubble
- Internal markdown links (`/billing`, `/profile`, etc.) now navigate in the same tab instead of opening a new one

## Test plan
- [ ] Send a chat message with a user that has insufficient balance
- [ ] Verify error appears in chat with balance amount and clickable "поповніть баланс" link
- [ ] Click the link — should navigate to /billing in the same tab
- [ ] Verify normal errors still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)