### PR TITLE
feat: enable attorney search and consultations for users

### DIFF
--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -18,7 +18,7 @@ import { Section } from './Section';
 import { SidebarFooter } from './SidebarFooter';
 import {
   researchSections, legislationSections, getMattersSections,
-  externalSourcesSections, monitoringSections,
+  attorneyClientSections, externalSourcesSections, monitoringSections,
 } from './nav-config';
 
 interface SidebarProps {
@@ -40,7 +40,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   const [editTitle, setEditTitle] = useState('');
   const [switchingId, setSwitchingId] = useState<string | null>(null);
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
-    new Set(['conversations', 'research', 'legislation', 'vault', 'matters', 'external-sources', 'monitoring'])
+    new Set(['conversations', 'research', 'legislation', 'vault', 'matters', 'attorneys', 'external-sources', 'monitoring'])
   );
   const [vaultFolders, setVaultFolders] = useState<string[]>([]);
   const [vaultFoldersLoaded, setVaultFoldersLoaded] = useState(false);
@@ -57,7 +57,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
 
   const renderedSectionIds = useMemo(() => {
     if (role === 'administrator') return ['external-sources', 'monitoring'];
-    const ids = ['research', 'legislation', 'vault', 'matters'];
+    const ids = ['research', 'legislation', 'vault', 'matters', 'attorneys'];
     if (conversations.length > 0) ids.push('conversations');
     return ids;
   }, [role, conversations.length]);
@@ -287,11 +287,17 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 ))}
               </Section>
 
+              {!isAttorney && (
+                <Section id="attorneys" title="Адвокати" collapsed={collapsedSections.has('attorneys')} onToggle={toggleSection}>
+                  {attorneyClientSections.map((s) => (
+                    <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
+                  ))}
+                </Section>
+              )}
+
               <div className="mb-6">
                 <NavItem icon={Zap} label="Workflows" route={ROUTES.WORKFLOWS} onClick={() => handleNavigation(ROUTES.WORKFLOWS)} />
               </div>
-
-              {/* Attorney section hidden — feature not ready for production */}
             </>
           )}
 

--- a/lexwebapp/src/components/sidebar/nav-config.ts
+++ b/lexwebapp/src/components/sidebar/nav-config.ts
@@ -36,6 +36,11 @@ export function getMattersSections(isAttorney: boolean) {
   ];
 }
 
+export const attorneyClientSections = [
+  { id: 'attorney-search', label: 'Знайти адвоката', icon: Search, route: ROUTES.ATTORNEYS },
+  { id: 'my-consultations', label: 'Мої консультації', icon: Briefcase, route: ROUTES.CONSULTATIONS },
+];
+
 export const externalSourcesSections = [
   { id: 'ext-monitoring', label: 'Моніторинг', icon: Database, route: ROUTES.ADMIN_MONITORING },
   { id: 'ext-data-sources', label: 'Джерела даних', icon: Globe, route: ROUTES.ADMIN_DATA_SOURCES },

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -92,7 +92,11 @@ const NewsPage = lazy(() => import('../pages/NewsPage').then(m => ({ default: m.
 // -- MCP Connect --
 const MCPConnectPage = lazy(() => import('../pages/MCPConnectPage').then(m => ({ default: m.MCPConnectPage })));
 
-// -- Attorney/Consultations (hidden — feature not ready for production) --
+// -- Attorney/Consultations (client-facing) --
+const AttorneySearchPage = lazy(() => import('../pages/AttorneySearchPage').then(m => ({ default: m.AttorneySearchPage })));
+const AttorneyDetailPage = lazy(() => import('../pages/AttorneyDetailPage').then(m => ({ default: m.AttorneyDetailPage })));
+const ConsultationsPage = lazy(() => import('../pages/ConsultationsPage').then(m => ({ default: m.ConsultationsPage })));
+const ConsultationDetailPage = lazy(() => import('../pages/ConsultationDetailPage').then(m => ({ default: m.ConsultationDetailPage })));
 
 // -- Workflows --
 const WorkflowsPage = lazy(() => import('../pages/WorkflowsPage').then(m => ({ default: m.WorkflowsPage })));
@@ -332,7 +336,22 @@ export const router = createBrowserRouter([
             path: ROUTES.COURT_PRACTICE_ANALYSIS,
             element: S(CourtPracticeAnalysisPage),
           },
-          /* Attorney/Consultation routes hidden — feature not ready for production */
+          {
+            path: ROUTES.ATTORNEYS,
+            element: S(AttorneySearchPage),
+          },
+          {
+            path: ROUTES.ATTORNEY_DETAIL,
+            element: S(AttorneyDetailPage),
+          },
+          {
+            path: ROUTES.CONSULTATIONS,
+            element: S(ConsultationsPage),
+          },
+          {
+            path: ROUTES.CONSULTATION_DETAIL,
+            element: S(ConsultationDetailPage),
+          },
           {
             path: ROUTES.WORKFLOWS,
             element: S(WorkflowsPage),


### PR DESCRIPTION
## Summary
- Unhide attorney/consultation routes (`/attorneys`, `/attorneys/:id`, `/consultations`, `/consultations/:id`)
- Add "Адвокати" sidebar section for regular users with "Знайти адвоката" and "Мої консультації" menu items
- Section is hidden for users who are already attorneys (they have their own menu)

## Test plan
- [ ] Login as regular user (e.g. shepherdvovkes@gmail.com) — verify "Адвокати" section appears in sidebar
- [ ] Click "Знайти адвоката" — verify AttorneySearchPage loads at `/attorneys`
- [ ] Click "Мої консультації" — verify ConsultationsPage loads at `/consultations`
- [ ] Login as attorney user — verify "Адвокати" section is NOT shown (attorneys have Time Entries/Invoices instead)
- [ ] Login as admin — verify no attorney section shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)