### PR TITLE
fix: sidebar close button not working on desktop

### DIFF
--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -137,7 +137,7 @@ export function MainLayout() {
   return (
     <div className="flex h-screen bg-claude-bg overflow-hidden">
       {/* Sidebar */}
-      <div className={`${isSidebarOpen ? 'block' : 'hidden'} lg:block h-full`}>
+      <div className={`${isSidebarOpen ? 'block' : 'hidden'} h-full`}>
         <Sidebar
           isOpen={isSidebarOpen}
           onClose={() => setSidebarOpen(false)}


### PR DESCRIPTION
## Summary
- Removed `lg:block` class from sidebar container that was overriding `hidden` state on desktop
- The header toggle button (X / Menu) now correctly shows/hides the sidebar on all screen sizes

## Test plan
- [ ] Open https://legal.org.ua/chat on desktop
- [ ] Click X in header to close sidebar — should hide
- [ ] Click Menu in header to reopen — should show
- [ ] Mobile sidebar still works (slide in/out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)