### PR TITLE
feat: assign unique contract number and date to attorney offer

### DIFF
--- a/lexwebapp/src/components/attorney/AttorneyOfferModal.tsx
+++ b/lexwebapp/src/components/attorney/AttorneyOfferModal.tsx
@@ -42,9 +42,16 @@ export const AttorneyOfferModal: React.FC<AttorneyOfferModalProps> = ({
   const handleAccept = async () => {
     setIsSubmitting(true);
     try {
-      await authService.acceptAttorneyOffer();
-      updateUser({ attorneyOfferAccepted: true });
-      toast.success(lang === 'uk' ? 'Оферту прийнято!' : 'Offer accepted!');
+      const result = await authService.acceptAttorneyOffer();
+      updateUser({
+        attorneyOfferAccepted: true,
+        attorneyContractNumber: result.contractNumber,
+        attorneyContractDate: result.contractDate,
+      });
+      const contractInfo = result.contractNumber
+        ? ` ${lang === 'uk' ? 'Договір' : 'Contract'} №${result.contractNumber} ${lang === 'uk' ? 'від' : 'dated'} ${result.contractDate}`
+        : '';
+      toast.success((lang === 'uk' ? 'Оферту прийнято!' : 'Offer accepted!') + contractInfo);
       onAccepted();
     } catch (error: any) {
       toast.error(error.message || 'Помилка при прийнятті оферти');

--- a/lexwebapp/src/services/api/AuthService.ts
+++ b/lexwebapp/src/services/api/AuthService.ts
@@ -126,7 +126,7 @@ export class AuthService extends BaseService {
   /**
    * Accept attorney offer
    */
-  async acceptAttorneyOffer(): Promise<{ success: boolean; message: string }> {
+  async acceptAttorneyOffer(): Promise<{ success: boolean; message: string; contractNumber?: string; contractDate?: string }> {
     return this.request(() => this.client.post('/auth/accept-attorney-offer'));
   }
 

--- a/lexwebapp/src/types/models/User.ts
+++ b/lexwebapp/src/types/models/User.ts
@@ -17,6 +17,8 @@ export interface User {
   role: UserRole;
   userType?: UserType;
   attorneyOfferAccepted?: boolean;
+  attorneyContractNumber?: string;
+  attorneyContractDate?: string;
 }
 
 export interface UserProfile extends User {

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -152,15 +152,21 @@ export async function getCurrentUser(req: AuthenticatedRequest, res: Response): 
 
     // Check attorney offer acceptance for attorney users
     let attorneyOfferAccepted = false;
+    let attorneyContractNumber: string | null = null;
+    let attorneyContractDate: string | null = null;
     if (user.user_type === 'attorney') {
       try {
         const userService = getUserService();
         const db = (userService as any).db;
         const result = await db.query(
-          `SELECT 1 FROM eula_acceptances WHERE user_id = $1 AND eula_version = $2 LIMIT 1`,
+          `SELECT contract_number, contract_date FROM eula_acceptances WHERE user_id = $1 AND eula_version = $2 LIMIT 1`,
           [user.id, 'attorney-offer-1.0']
         );
         attorneyOfferAccepted = result.rows.length > 0;
+        if (result.rows.length > 0) {
+          attorneyContractNumber = result.rows[0].contract_number;
+          attorneyContractDate = result.rows[0].contract_date;
+        }
       } catch (err: any) {
         logger.warn('Failed to check attorney offer acceptance', { userId: user.id, error: err.message });
       }
@@ -179,7 +185,11 @@ export async function getCurrentUser(req: AuthenticatedRequest, res: Response): 
         createdAt: user.created_at,
         role: user.role,
         userType: user.user_type || 'individual',
-        ...(user.user_type === 'attorney' && { attorneyOfferAccepted }),
+        ...(user.user_type === 'attorney' && {
+          attorneyOfferAccepted,
+          ...(attorneyContractNumber && { attorneyContractNumber }),
+          ...(attorneyContractDate && { attorneyContractDate }),
+        }),
       },
     });
   } catch (error: any) {
@@ -214,21 +224,44 @@ export async function acceptAttorneyOffer(req: AuthenticatedRequest, res: Respon
     const userService = getUserService();
     const db = (userService as any).db;
 
+    // Check if already accepted
+    const existing = await db.query(
+      `SELECT contract_number, contract_date FROM eula_acceptances WHERE user_id = $1 AND eula_version = $2 LIMIT 1`,
+      [user.id, 'attorney-offer-1.0']
+    );
+
+    if (existing.rows.length > 0) {
+      return res.json({
+        success: true,
+        message: 'Оферту вже прийнято',
+        contractNumber: existing.rows[0].contract_number,
+        contractDate: existing.rows[0].contract_date,
+      });
+    }
+
+    // Generate unique contract number: OFFER-YYYY-NNNN
+    const year = new Date().getFullYear();
+    const seqResult = await db.query(`SELECT nextval('attorney_offer_contract_seq') AS seq`);
+    const seq = String(seqResult.rows[0].seq).padStart(4, '0');
+    const contractNumber = `OFFER-${year}-${seq}`;
+    const contractDate = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+
     await db.query(
-      `INSERT INTO eula_acceptances (user_id, eula_version, ip_address, user_agent)
-       VALUES ($1, $2, $3, $4)
-       ON CONFLICT (user_id, eula_version) DO NOTHING`,
+      `INSERT INTO eula_acceptances (user_id, eula_version, ip_address, user_agent, contract_number, contract_date)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
       [
         user.id,
         'attorney-offer-1.0',
         req.ip || req.headers['x-forwarded-for'] || 'unknown',
         req.headers['user-agent'] || 'unknown',
+        contractNumber,
+        contractDate,
       ]
     );
 
-    logger.info('Attorney accepted offer', { userId: user.id, email: user.email });
+    logger.info('Attorney accepted offer', { userId: user.id, email: user.email, contractNumber });
 
-    return res.json({ success: true, message: 'Оферту прийнято' });
+    return res.json({ success: true, message: 'Оферту прийнято', contractNumber, contractDate });
   } catch (error: any) {
     logger.error('Error accepting attorney offer:', error);
     return res.status(500).json({ error: 'Internal server error', message: error.message });

--- a/mcp_backend/src/migrations/077_attorney_offer_contract_number.sql
+++ b/mcp_backend/src/migrations/077_attorney_offer_contract_number.sql
@@ -1,0 +1,17 @@
+-- Migration: Add contract number and date to attorney offer acceptances
+-- Date: 2026-03-12
+-- Description: Each signed attorney offer gets a unique contract number and date
+
+ALTER TABLE eula_acceptances
+  ADD COLUMN IF NOT EXISTS contract_number VARCHAR(30),
+  ADD COLUMN IF NOT EXISTS contract_date DATE;
+
+-- Unique contract number
+CREATE UNIQUE INDEX IF NOT EXISTS idx_eula_acceptances_contract_number
+  ON eula_acceptances(contract_number) WHERE contract_number IS NOT NULL;
+
+-- Sequence for contract numbering within a year
+CREATE SEQUENCE IF NOT EXISTS attorney_offer_contract_seq START 1;
+
+COMMENT ON COLUMN eula_acceptances.contract_number IS 'Unique contract number, format: OFFER-YYYY-NNNN';
+COMMENT ON COLUMN eula_acceptances.contract_date IS 'Date the contract was signed';


### PR DESCRIPTION
## Summary
- При підписанні публічної оферти адвокатом присвоюється унікальний номер договору формату `OFFER-YYYY-NNNN` та дата підписання
- Номер та дата зберігаються в `eula_acceptances` (нова міграція 077)
- Бекенд повертає `contractNumber` і `contractDate` при прийнятті та в `/auth/me`
- Фронтенд показує номер договору в тост-повідомленні після підписання

## Test plan
- [ ] Запустити міграцію 077 на базі
- [ ] Підписати оферту адвокатом — перевірити що номер і дата повертаються
- [ ] Перевірити `/auth/me` — повинен повертати `attorneyContractNumber` і `attorneyContractDate`
- [ ] Повторний виклик `accept-attorney-offer` повертає існуючий номер

🤖 Generated with [Claude Code](https://claude.com/claude-code)