### PR TITLE
feat: add Мої договори page (LEG-334)

### DIFF
--- a/lexwebapp/src/components/sidebar/SidebarFooter.tsx
+++ b/lexwebapp/src/components/sidebar/SidebarFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { User, LogOut, CreditCard, UsersRound, Plug } from 'lucide-react';
+import { User, LogOut, CreditCard, UsersRound, Plug, FileText } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ROUTES } from '../../router/routes';
 import type { UserRole } from '../../types/models/User';
@@ -49,6 +49,14 @@ export function SidebarFooter({
                 <span className="text-[13px] font-medium text-claude-text font-sans">Біллінг</span>
               </button>
             )}
+            <button
+              onClick={() => { onProfileMenuClick(); navigate(ROUTES.MY_CONTRACTS); }}
+              className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
+              <div className="p-1.5 bg-claude-subtext/8 rounded-lg">
+                <FileText size={16} className="text-claude-subtext" />
+              </div>
+              <span className="text-[13px] font-medium text-claude-text font-sans">Мої договори</span>
+            </button>
             <button
               onClick={() => { onProfileMenuClick(); navigate(ROUTES.MCP_CONNECT); }}
               className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -20,6 +20,7 @@ const PAGE_TITLES: Record<string, string> = {
   [ROUTES.CHAT]: 'Чат',
   [ROUTES.PROFILE]: 'Профіль',
   [ROUTES.BILLING]: 'Білінг',
+  [ROUTES.MY_CONTRACTS]: 'Мої договори',
   [ROUTES.JUDGES]: 'Судді',
   [ROUTES.LAWYERS]: 'Адвокати',
   [ROUTES.CLIENTS]: 'Клієнти',

--- a/lexwebapp/src/pages/ContractsPage/index.tsx
+++ b/lexwebapp/src/pages/ContractsPage/index.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react';
+import { FileText, ExternalLink, Calendar, Hash, Shield } from 'lucide-react';
+import { authService } from '../../services/api/AuthService';
+import showToast from '../../utils/toast';
+
+interface Contract {
+  id: string;
+  version: string;
+  contractNumber: string | null;
+  contractDate: string | null;
+  acceptedAt: string;
+  ipAddress: string | null;
+  title: string;
+  type: string;
+  url: string;
+}
+
+export function ContractsPage() {
+  const [contracts, setContracts] = useState<Contract[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    authService.getMyContracts()
+      .then(data => setContracts(data.contracts))
+      .catch(() => showToast.error('Не вдалося завантажити договори'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const formatDate = (dateStr: string) => {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('uk-UA', { day: '2-digit', month: '2-digit', year: 'numeric' });
+  };
+
+  const formatDateTime = (dateStr: string) => {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('uk-UA', {
+      day: '2-digit', month: '2-digit', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    });
+  };
+
+  const typeIcon = (type: string) => {
+    switch (type) {
+      case 'attorney_offer': return <Shield size={20} className="text-blue-600" />;
+      case 'client_offer': return <FileText size={20} className="text-emerald-600" />;
+      case 'marketplace_rules': return <FileText size={20} className="text-amber-600" />;
+      default: return <FileText size={20} className="text-claude-subtext" />;
+    }
+  };
+
+  const typeBadge = (type: string) => {
+    switch (type) {
+      case 'attorney_offer': return 'bg-blue-50 text-blue-700 border-blue-200';
+      case 'client_offer': return 'bg-emerald-50 text-emerald-700 border-emerald-200';
+      case 'marketplace_rules': return 'bg-amber-50 text-amber-700 border-amber-200';
+      default: return 'bg-gray-50 text-gray-700 border-gray-200';
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center">
+        <div className="w-8 h-8 border-3 border-claude-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="max-w-3xl mx-auto px-6 py-8">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold text-claude-text font-sans">Мої договори</h1>
+          <p className="text-sm text-claude-subtext mt-1">
+            Підписані документи з платформою
+          </p>
+        </div>
+
+        {contracts.length === 0 ? (
+          <div className="text-center py-16">
+            <FileText size={48} className="mx-auto text-claude-subtext/30 mb-4" />
+            <p className="text-claude-subtext text-[15px]">Немає підписаних договорів</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {contracts.map(contract => (
+              <div
+                key={contract.id}
+                className="bg-white border border-claude-border rounded-xl p-5 hover:shadow-sm transition-shadow"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="p-2.5 bg-claude-bg rounded-xl flex-shrink-0">
+                    {typeIcon(contract.type)}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-3 mb-2">
+                      <h3 className="text-[15px] font-semibold text-claude-text font-sans">
+                        {contract.title}
+                      </h3>
+                      <span className={`px-2 py-0.5 text-[11px] font-medium rounded-full border ${typeBadge(contract.type)}`}>
+                        v{contract.version.split('-').pop() || contract.version}
+                      </span>
+                    </div>
+
+                    <div className="flex flex-wrap gap-x-5 gap-y-1.5 text-[13px] text-claude-subtext">
+                      {contract.contractNumber && (
+                        <div className="flex items-center gap-1.5">
+                          <Hash size={13} className="text-claude-subtext/50" />
+                          <span className="font-mono">{contract.contractNumber}</span>
+                        </div>
+                      )}
+                      {contract.contractDate && (
+                        <div className="flex items-center gap-1.5">
+                          <Calendar size={13} className="text-claude-subtext/50" />
+                          <span>Дата договору: {formatDate(contract.contractDate)}</span>
+                        </div>
+                      )}
+                      <div className="flex items-center gap-1.5">
+                        <Calendar size={13} className="text-claude-subtext/50" />
+                        <span>Підписано: {formatDateTime(contract.acceptedAt)}</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <a
+                    href={contract.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex-shrink-0 p-2 text-claude-subtext hover:text-claude-accent hover:bg-claude-accent/5 rounded-lg transition-colors"
+                    title="Відкрити документ"
+                  >
+                    <ExternalLink size={16} />
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -91,6 +91,7 @@ const NewsPage = lazy(() => import('../pages/NewsPage').then(m => ({ default: m.
 
 // -- MCP Connect --
 const MCPConnectPage = lazy(() => import('../pages/MCPConnectPage').then(m => ({ default: m.MCPConnectPage })));
+const ContractsPage = lazy(() => import('../pages/ContractsPage').then(m => ({ default: m.ContractsPage })));
 
 // -- Attorney/Consultations (client-facing) --
 const AttorneySearchPage = lazy(() => import('../pages/AttorneySearchPage').then(m => ({ default: m.AttorneySearchPage })));
@@ -239,6 +240,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.MCP_CONNECT,
             element: S(MCPConnectPage),
+          },
+          {
+            path: ROUTES.MY_CONTRACTS,
+            element: S(ContractsPage),
           },
           {
             path: ROUTES.JUDGES,

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   BILLING: '/billing',
   TEAM: '/team',
   MCP_CONNECT: '/mcp-connect',
+  MY_CONTRACTS: '/my-contracts',
 
   // Legal Entities
   JUDGES: '/judges',

--- a/lexwebapp/src/services/api/AuthService.ts
+++ b/lexwebapp/src/services/api/AuthService.ts
@@ -130,6 +130,23 @@ export class AuthService extends BaseService {
     return this.request(() => this.client.post('/auth/accept-attorney-offer'));
   }
 
+  /**
+   * Get all signed contracts for current user
+   */
+  async getMyContracts(): Promise<{ contracts: Array<{
+    id: string;
+    version: string;
+    contractNumber: string | null;
+    contractDate: string | null;
+    acceptedAt: string;
+    ipAddress: string | null;
+    title: string;
+    type: string;
+    url: string;
+  }> }> {
+    return this.request(() => this.client.get('/auth/my-contracts'));
+  }
+
   // ========================================================================
   // WebAuthn (Passkeys)
   // ========================================================================

--- a/mcp_backend/src/controllers/auth.ts
+++ b/mcp_backend/src/controllers/auth.ts
@@ -268,6 +268,58 @@ export async function acceptAttorneyOffer(req: AuthenticatedRequest, res: Respon
   }
 }
 
+/**
+ * Get all contracts/acceptances for current user
+ */
+export async function getMyContracts(req: AuthenticatedRequest, res: Response): Promise<Response> {
+  try {
+    const user = req.user;
+    if (!user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+
+    const userService = getUserService();
+    const db = (userService as any).db;
+
+    const result = await db.query(
+      `SELECT id, eula_version, contract_number, contract_date, accepted_at, ip_address
+       FROM eula_acceptances
+       WHERE user_id = $1
+       ORDER BY accepted_at DESC`,
+      [user.id]
+    );
+
+    // Map eula_version to human-readable contract info
+    const versionMap: Record<string, { title: string; type: string; url: string }> = {
+      'attorney-offer-1.0': { title: 'Публічна оферта для адвокатів', type: 'attorney_offer', url: '/ua/attorney-offer' },
+      'client-offer-1.0': { title: 'Публічна оферта для клієнтів', type: 'client_offer', url: '/ua/offer' },
+      'marketplace-rules-1.0': { title: 'Правила маркетплейсу', type: 'marketplace_rules', url: '/ua/terms' },
+    };
+
+    const contracts = result.rows.map((row: any) => {
+      const meta = versionMap[row.eula_version] || {
+        title: row.eula_version,
+        type: 'unknown',
+        url: '#',
+      };
+      return {
+        id: row.id,
+        version: row.eula_version,
+        contractNumber: row.contract_number || null,
+        contractDate: row.contract_date || null,
+        acceptedAt: row.accepted_at,
+        ipAddress: row.ip_address || null,
+        ...meta,
+      };
+    });
+
+    return res.json({ contracts });
+  } catch (error: any) {
+    logger.error('Error getting user contracts:', error);
+    return res.status(500).json({ error: 'Internal server error', message: error.message });
+  }
+}
+
 export async function logout(req: AuthenticatedRequest, res: Response): Promise<Response> {
   try {
     const user = req.user;

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -201,6 +201,13 @@ router.post('/logout', authController.logout as any);
 router.post('/accept-attorney-offer', requireJWT as any, authController.acceptAttorneyOffer as any);
 
 /**
+ * @route   GET /auth/my-contracts
+ * @desc    Get all signed contracts/acceptances for current user
+ * @access  Protected (JWT required)
+ */
+router.get('/my-contracts', requireJWT as any, authController.getMyContracts as any);
+
+/**
  * @route   POST /auth/refresh
  * @desc    Refresh JWT token
  * @access  Protected (valid JWT required)


### PR DESCRIPTION
## Summary
- New `GET /auth/my-contracts` endpoint returning all signed contracts from `eula_acceptances`
- New `ContractsPage` at `/my-contracts` showing signed documents with contract number, date, version, and link to full text
- "Мої договори" menu item in sidebar profile popup (between Біллінг and MCP конект)

## Part of LEG-334
Implements the UI portion of "Архітектура договорів та система акцептів маркетплейсу" — users can now see all their signed platform contracts.

## Test plan
- [ ] Login as attorney (advocat@legal.org.ua) — should see signed attorney offer in the list
- [ ] Click profile popup → "Мої договори" → page loads
- [ ] Contract card shows number, date, version, link to document
- [ ] Users with no contracts see empty state
- [ ] Link "Відкрити документ" opens the offer page in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)