### PR TITLE
feat: contract acceptance system with version tracking (LEG-334)

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -93,6 +93,8 @@ import { ConflictCheckService } from './services/conflict-check-service.js';
 import { LegalHoldService } from './services/legal-hold-service.js';
 import { initializeMatterAccess } from './middleware/matter-access.js';
 import { createMatterRoutes } from './routes/matter-routes.js';
+import { ContractService } from './services/contract-service.js';
+import { createContractRoutes } from './routes/contract-routes.js';
 import { UploadRecoveryService } from './services/upload-recovery-service.js';
 import { UploadQueueService } from './services/upload-queue-service.js';
 import { getUploadProcessingMetrics } from './routes/upload-routes.js';
@@ -164,6 +166,7 @@ class HTTPMCPServer {
   private gdprService: GdprService;
   private auditService: AuditService;
   private matterService: MatterService;
+  private contractService: ContractService;
   private conflictCheckService: ConflictCheckService;
   private legalHoldService: LegalHoldService;
   private uploadRecoveryService: UploadRecoveryService;
@@ -343,6 +346,7 @@ class HTTPMCPServer {
     // Initialize Client-Matter segregation services
     this.auditService = new AuditService(this.services.db);
     this.matterService = new MatterService(this.services.db, this.auditService);
+    this.contractService = new ContractService(this.services.db);
     this.conflictCheckService = new ConflictCheckService(this.services.db, this.auditService);
     this.legalHoldService = new LegalHoldService(this.services.db, this.auditService);
     initializeMatterAccess(this.matterService);
@@ -1999,6 +2003,10 @@ class HTTPMCPServer {
       this.matterService, this.conflictCheckService, this.legalHoldService, this.auditService
     ));
     logger.info('Matter routes registered at /api/matters');
+
+    // Contract acceptance routes
+    this.app.use('/api/contracts', requireJWT as any, createContractRoutes(this.contractService));
+    logger.info('Contract routes registered at /api/contracts');
 
     // Judges routes - search judges from VKKS data
     const judgesService = new JudgesService(this.services.db, this.services.zoAdapter);

--- a/mcp_backend/src/migrations/078_contract_acceptance_system.sql
+++ b/mcp_backend/src/migrations/078_contract_acceptance_system.sql
@@ -1,0 +1,62 @@
+-- Migration: Contract acceptance system
+-- Date: 2026-03-14
+-- Description: Add eula_type and document_version columns to eula_acceptances,
+--              create per-type contract sequences, backfill existing data
+
+-- Add new columns
+ALTER TABLE eula_acceptances
+  ADD COLUMN IF NOT EXISTS eula_type VARCHAR(30) DEFAULT 'offer',
+  ADD COLUMN IF NOT EXISTS document_version VARCHAR(20);
+
+-- Create sequences for each contract type
+CREATE SEQUENCE IF NOT EXISTS client_offer_contract_seq START 1;
+CREATE SEQUENCE IF NOT EXISTS marketplace_rules_contract_seq START 1;
+-- attorney_offer_contract_seq already exists from migration 077
+
+-- Backfill eula_type from existing eula_version strings
+DO $$
+BEGIN
+  UPDATE eula_acceptances
+    SET eula_type = 'attorney_offer'
+    WHERE eula_version LIKE 'attorney-offer%'
+      AND (eula_type IS NULL OR eula_type = 'offer');
+
+  UPDATE eula_acceptances
+    SET eula_type = 'offer'
+    WHERE eula_version LIKE 'client-offer%'
+      AND (eula_type IS NULL OR eula_type = 'offer');
+
+  UPDATE eula_acceptances
+    SET eula_type = 'marketplace_rules'
+    WHERE eula_version LIKE 'marketplace-rules%'
+      AND (eula_type IS NULL OR eula_type = 'offer');
+END $$;
+
+-- Backfill document_version from eula_version (extract version number after last dash)
+DO $$
+BEGIN
+  UPDATE eula_acceptances
+    SET document_version = regexp_replace(eula_version, '^.*-(\d+\.\d+)$', '\1')
+    WHERE document_version IS NULL
+      AND eula_version ~ '-\d+\.\d+$';
+END $$;
+
+-- Unique constraint: one acceptance per (user, type, version)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'uq_eula_user_type_version'
+  ) THEN
+    ALTER TABLE eula_acceptances
+      ADD CONSTRAINT uq_eula_user_type_version UNIQUE (user_id, eula_type, document_version);
+  END IF;
+EXCEPTION WHEN duplicate_table THEN
+  NULL;
+END $$;
+
+-- Index for efficient lookups
+CREATE INDEX IF NOT EXISTS idx_eula_acceptances_type_version
+  ON eula_acceptances(user_id, eula_type, document_version);
+
+COMMENT ON COLUMN eula_acceptances.eula_type IS 'Contract type: offer, attorney_offer, marketplace_rules';
+COMMENT ON COLUMN eula_acceptances.document_version IS 'Document content version; version bump requires re-acceptance';

--- a/mcp_backend/src/routes/contract-routes.ts
+++ b/mcp_backend/src/routes/contract-routes.ts
@@ -1,0 +1,87 @@
+import { Router, Response } from 'express';
+import { AuthenticatedRequest as JWTRequest } from '../middleware/dual-auth.js';
+import { ContractService, ContractType } from '../services/contract-service.js';
+import { logger } from '../utils/logger.js';
+
+const VALID_TYPES: ContractType[] = ['offer', 'attorney_offer', 'marketplace_rules'];
+
+export function createContractRoutes(contractService: ContractService): Router {
+  const router = Router();
+
+  // POST / — Accept a contract
+  router.post('/', (async (req: JWTRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const { eulaType, documentVersion } = req.body;
+
+      if (!eulaType || !VALID_TYPES.includes(eulaType)) {
+        return res.status(400).json({ error: 'Невірний тип договору. Допустимі: offer, attorney_offer, marketplace_rules' });
+      }
+      if (!documentVersion || typeof documentVersion !== 'string') {
+        return res.status(400).json({ error: 'documentVersion є обов\'язковим' });
+      }
+
+      const ipAddress = (req.ip || req.headers['x-forwarded-for'] || 'unknown') as string;
+      const userAgent = (req.headers['user-agent'] || 'unknown') as string;
+
+      const result = await contractService.acceptContract(userId, eulaType, documentVersion, ipAddress, userAgent);
+
+      return res.json({ success: true, ...result });
+    } catch (error: any) {
+      logger.error('[ContractRoutes] Accept contract failed', { error: error.message });
+      return res.status(500).json({ error: 'Внутрішня помилка сервера' });
+    }
+  }) as any);
+
+  // GET / — List user's contracts
+  router.get('/', (async (req: JWTRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const contracts = await contractService.getContracts(userId);
+      return res.json({ contracts });
+    } catch (error: any) {
+      logger.error('[ContractRoutes] List contracts failed', { error: error.message });
+      return res.status(500).json({ error: 'Внутрішня помилка сервера' });
+    }
+  }) as any);
+
+  // GET /status — Check version status
+  router.get('/status', (async (req: JWTRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const checksParam = req.query.checks as string;
+      if (!checksParam) {
+        return res.status(400).json({ error: 'Параметр checks є обов\'язковим. Формат: type:version,type:version' });
+      }
+
+      const checks = checksParam.split(',').map((item) => {
+        const [eulaType, currentVersion] = item.trim().split(':');
+        return { eulaType: eulaType as ContractType, currentVersion };
+      });
+
+      // Validate
+      for (const check of checks) {
+        if (!VALID_TYPES.includes(check.eulaType)) {
+          return res.status(400).json({ error: `Невірний тип: ${check.eulaType}` });
+        }
+        if (!check.currentVersion) {
+          return res.status(400).json({ error: `Відсутня версія для ${check.eulaType}` });
+        }
+      }
+
+      const statuses = await contractService.checkVersionStatus(userId, checks);
+      return res.json({ statuses });
+    } catch (error: any) {
+      logger.error('[ContractRoutes] Check version status failed', { error: error.message });
+      return res.status(500).json({ error: 'Внутрішня помилка сервера' });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/contract-service.ts
+++ b/mcp_backend/src/services/contract-service.ts
@@ -1,0 +1,148 @@
+import type { IDatabase } from '../domain/ports/index.js';
+import { logger } from '../utils/logger.js';
+
+export type ContractType = 'offer' | 'attorney_offer' | 'marketplace_rules';
+
+export interface ContractAcceptance {
+  id: string;
+  userId: string;
+  eulaType: ContractType;
+  documentVersion: string;
+  contractNumber: string | null;
+  contractDate: string | null;
+  acceptedAt: string;
+  ipAddress: string | null;
+  eulaVersion: string | null;
+}
+
+export interface ContractVersionStatus {
+  eulaType: ContractType;
+  currentVersion: string;
+  acceptedVersion: string | null;
+  needsReAcceptance: boolean;
+  contractNumber: string | null;
+}
+
+const CONTRACT_PREFIX: Record<ContractType, string> = {
+  offer: 'C',
+  attorney_offer: 'A',
+  marketplace_rules: 'M',
+};
+
+const CONTRACT_SEQUENCE: Record<ContractType, string> = {
+  offer: 'client_offer_contract_seq',
+  attorney_offer: 'attorney_offer_contract_seq',
+  marketplace_rules: 'marketplace_rules_contract_seq',
+};
+
+export class ContractService {
+  constructor(private db: IDatabase) {}
+
+  async acceptContract(
+    userId: string,
+    eulaType: ContractType,
+    documentVersion: string,
+    ipAddress: string,
+    userAgent: string,
+  ): Promise<{ contractNumber: string; contractDate: string }> {
+    // Check if already accepted this exact (user, type, version)
+    const existing = await this.db.query(
+      `SELECT contract_number, contract_date FROM eula_acceptances
+       WHERE user_id = $1 AND eula_type = $2 AND document_version = $3
+       LIMIT 1`,
+      [userId, eulaType, documentVersion],
+    );
+
+    if (existing.rows.length > 0 && existing.rows[0].contract_number) {
+      return {
+        contractNumber: existing.rows[0].contract_number,
+        contractDate: existing.rows[0].contract_date,
+      };
+    }
+
+    // Generate contract number
+    const year = new Date().getFullYear();
+    const prefix = CONTRACT_PREFIX[eulaType];
+    const sequence = CONTRACT_SEQUENCE[eulaType];
+    const seqResult = await this.db.query(`SELECT nextval('${sequence}') AS seq`);
+    const seq = String(seqResult.rows[0].seq).padStart(5, '0');
+    const contractNumber = `${prefix}-${year}-${seq}`;
+    const contractDate = new Date().toISOString().split('T')[0];
+
+    // Build eula_version string for backward compat
+    const eulaVersionMap: Record<ContractType, string> = {
+      offer: `client-offer-${documentVersion}`,
+      attorney_offer: `attorney-offer-${documentVersion}`,
+      marketplace_rules: `marketplace-rules-${documentVersion}`,
+    };
+
+    await this.db.query(
+      `INSERT INTO eula_acceptances (user_id, eula_version, eula_type, document_version, ip_address, user_agent, contract_number, contract_date)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       ON CONFLICT (user_id, eula_type, document_version) DO NOTHING`,
+      [userId, eulaVersionMap[eulaType], eulaType, documentVersion, ipAddress, userAgent, contractNumber, contractDate],
+    );
+
+    logger.info('Contract accepted', { userId, eulaType, documentVersion, contractNumber });
+
+    return { contractNumber, contractDate };
+  }
+
+  async getContracts(userId: string): Promise<ContractAcceptance[]> {
+    const result = await this.db.query(
+      `SELECT id, user_id, eula_type, document_version, contract_number, contract_date, accepted_at, ip_address, eula_version
+       FROM eula_acceptances
+       WHERE user_id = $1
+       ORDER BY accepted_at DESC`,
+      [userId],
+    );
+
+    return result.rows.map((row: any) => ({
+      id: row.id,
+      userId: row.user_id,
+      eulaType: row.eula_type || 'offer',
+      documentVersion: row.document_version,
+      contractNumber: row.contract_number,
+      contractDate: row.contract_date,
+      acceptedAt: row.accepted_at,
+      ipAddress: row.ip_address,
+      eulaVersion: row.eula_version,
+    }));
+  }
+
+  async checkVersionStatus(
+    userId: string,
+    checks: { eulaType: ContractType; currentVersion: string }[],
+  ): Promise<ContractVersionStatus[]> {
+    if (checks.length === 0) return [];
+
+    // Get latest acceptance per type for this user
+    const types = checks.map((c) => c.eulaType);
+    const result = await this.db.query(
+      `SELECT DISTINCT ON (eula_type) eula_type, document_version, contract_number
+       FROM eula_acceptances
+       WHERE user_id = $1 AND eula_type = ANY($2)
+       ORDER BY eula_type, accepted_at DESC`,
+      [userId, types],
+    );
+
+    const acceptedMap = new Map<string, { version: string; contractNumber: string | null }>();
+    for (const row of result.rows) {
+      acceptedMap.set(row.eula_type, {
+        version: row.document_version,
+        contractNumber: row.contract_number,
+      });
+    }
+
+    return checks.map((check) => {
+      const accepted = acceptedMap.get(check.eulaType);
+      return {
+        eulaType: check.eulaType,
+        currentVersion: check.currentVersion,
+        acceptedVersion: accepted?.version || null,
+        needsReAcceptance: !accepted || accepted.version !== check.currentVersion,
+        contractNumber: accepted?.contractNumber || null,
+      };
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Add migration 078: `eula_type` + `document_version` columns on `eula_acceptances`, per-type contract sequences, backfill existing data
- Add `ContractService` with `acceptContract()`, `getContracts()`, `checkVersionStatus()` — generates contract numbers (C-/A-/M- prefixes)
- Add contract API routes: `POST /api/contracts`, `GET /api/contracts`, `GET /api/contracts/status`
- Integrate into `http-server.ts` with requireJWT auth

## Test plan
- [ ] Run migration 078 on local DB
- [ ] `POST /api/contracts` with `{ eulaType: 'offer', documentVersion: '1.0' }` → returns `C-2026-00001`
- [ ] `GET /api/contracts` → lists all user contracts
- [ ] `GET /api/contracts/status?checks=offer:1.0` → `needsReAcceptance: false`
- [ ] Change version to `1.1` → `needsReAcceptance: true`
- [ ] Duplicate acceptance returns existing contract number (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)