### PR TITLE
fix: attorney not seeing consultation requests

### DIFF
--- a/lexwebapp/src/components/attorney/PendingInvitationsModal.tsx
+++ b/lexwebapp/src/components/attorney/PendingInvitationsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Clock, FileText, MessageSquare } from 'lucide-react';
 import { consultationService, type Consultation } from '../../services/api/ConsultationService';
@@ -23,8 +23,15 @@ const TYPE_LABELS: Record<string, string> = {
   document_review: 'Перевірка документів',
 };
 
-export function PendingInvitationsModal({ open, consultations: initialConsultations, onClose }: PendingInvitationsModalProps) {
-  const [items, setItems] = useState<Consultation[]>(initialConsultations);
+export function PendingInvitationsModal({ open, consultations, onClose }: PendingInvitationsModalProps) {
+  const [items, setItems] = useState<Consultation[]>(consultations);
+
+  // Sync internal items state when consultations prop changes
+  useEffect(() => {
+    if (consultations.length > 0) {
+      setItems(consultations);
+    }
+  }, [consultations]);
   const [processing, setProcessing] = useState<string | null>(null);
 
   const handleAccept = async (id: string) => {

--- a/lexwebapp/src/pages/ConsultationsPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationsPage/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Loader2, CreditCard } from 'lucide-react';
 import { consultationService, type Consultation } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
@@ -17,15 +17,9 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
 
 export function ConsultationsPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-
-  // Redirect to last viewed consultation unless explicitly navigating to list
+  // Clear stale redirect so attorney always sees full list first
   useEffect(() => {
-    if (searchParams.has('list')) return;
-    const lastId = sessionStorage.getItem('lastConsultationId');
-    if (lastId) {
-      navigate(generateRoute.consultationDetail(lastId), { replace: true });
-    }
+    sessionStorage.removeItem('lastConsultationId');
   }, []);
   const [consultations, setConsultations] = useState<Consultation[]>([]);
   const [total, setTotal] = useState(0);


### PR DESCRIPTION
## Summary
- **PendingInvitationsModal** used `useState(initialConsultations)` which only captured the initial empty array — when MainLayout fetched pending data and passed it as props, the modal's internal `items` stayed `[]` and immediately self-closed
- Added `useEffect` to sync internal state when `consultations` prop changes
- Removed `ConsultationsPage` auto-redirect to last viewed consultation detail, which prevented attorneys from seeing the full list

## Test plan
- [ ] Login as client, create a consultation request for an attorney
- [ ] Login as attorney, verify the pending invitations modal appears on page load
- [ ] Accept/decline a request from the modal
- [ ] Navigate to /consultations and verify the full list renders (no redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)