### PR TITLE
feat: add marketplace rules links for clients and attorneys

### DIFF
--- a/lexwebapp/src/pages/AttorneyProfilePage/index.tsx
+++ b/lexwebapp/src/pages/AttorneyProfilePage/index.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
-import { Loader2, Save, User } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Loader2, Save, User, BookOpen } from 'lucide-react';
 import { attorneyService, type AttorneyProfile } from '../../services/api/AttorneyService';
 import { AttorneyOnboardingModal } from '../../components/attorney/AttorneyOnboardingModal';
 import { getErrorMessage } from '../../utils/errors';
+import { useLocaleStore } from '../../stores/localeStore';
 
 const SPECIALIZATIONS = [
   { value: 'criminal', label: 'Кримінальне' },
@@ -25,6 +27,7 @@ const COURT_TYPES = [
 ];
 
 export function AttorneyProfilePage() {
+  const lang = useLocaleStore(s => s.language === 'en' ? 'en' : 'uk');
   const [profile, setProfile] = useState<Partial<AttorneyProfile>>({
     specializations: [],
     court_types: [],
@@ -118,6 +121,19 @@ export function AttorneyProfilePage() {
           {isNew ? 'Створити профіль адвоката' : 'Мій профіль адвоката'}
         </h1>
       </div>
+
+      <Link
+        to={`/${lang}/marketplace-rules`}
+        target="_blank"
+        className="flex items-center gap-3 mb-6 p-4 bg-emerald-50 border border-emerald-200 rounded-lg hover:bg-emerald-100 transition-colors group"
+      >
+        <BookOpen className="w-5 h-5 text-emerald-600 shrink-0" />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-emerald-800">Правила маркетплейсу юридичних консультацій</p>
+          <p className="text-xs text-emerald-600 mt-0.5">Ознайомтесь з правилами роботи маркетплейсу, комісією, ескроу та порядком виплат</p>
+        </div>
+        <span className="text-emerald-500 text-xs shrink-0 group-hover:underline">Відкрити →</span>
+      </Link>
 
       {error && <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>}
       {success && <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg text-green-700 text-sm">{success}</div>}

--- a/lexwebapp/src/pages/AttorneySearchPage/index.tsx
+++ b/lexwebapp/src/pages/AttorneySearchPage/index.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Search, Filter, Star, MapPin, Briefcase, Loader2, Scale } from 'lucide-react';
+import { useNavigate, Link } from 'react-router-dom';
+import { Search, Filter, Star, MapPin, Briefcase, Loader2, Scale, BookOpen } from 'lucide-react';
 import { attorneyService, type AttorneyProfile, type AttorneySearchParams } from '../../services/api/AttorneyService';
 import { generateRoute } from '../../router/routes';
 import { getErrorMessage } from '../../utils/errors';
+import { useLocaleStore } from '../../stores/localeStore';
 
 const SPECIALIZATIONS = [
   { value: 'criminal', label: 'Кримінальне' },
@@ -26,6 +27,7 @@ const SORT_OPTIONS = [
 
 export function AttorneySearchPage() {
   const navigate = useNavigate();
+  const lang = useLocaleStore(s => s.language === 'en' ? 'en' : 'uk');
   const [attorneys, setAttorneys] = useState<AttorneyProfile[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -76,6 +78,19 @@ export function AttorneySearchPage() {
           Фільтри
         </button>
       </div>
+
+      <Link
+        to={`/${lang}/marketplace-rules`}
+        target="_blank"
+        className="flex items-center gap-3 mb-6 p-4 bg-emerald-50 border border-emerald-200 rounded-lg hover:bg-emerald-100 transition-colors group"
+      >
+        <BookOpen className="w-5 h-5 text-emerald-600 shrink-0" />
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-emerald-800">Правила маркетплейсу юридичних консультацій</p>
+          <p className="text-xs text-emerald-600 mt-0.5">Ознайомтесь з умовами замовлення консультацій, оплати та захисту ваших прав як клієнта</p>
+        </div>
+        <span className="text-emerald-500 text-xs shrink-0 group-hover:underline">Відкрити →</span>
+      </Link>
 
       {showFilters && (
         <div className="mb-6 p-4 bg-gray-50 rounded-lg border grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -36,6 +36,7 @@ const PaymentSuccessPage = lazy(() => import('../pages/PaymentSuccessPage').then
 const PaymentErrorPage = lazy(() => import('../pages/PaymentErrorPage').then(m => ({ default: m.PaymentErrorPage })));
 const OfferPage = lazy(() => import('../pages/OfferPage').then(m => ({ default: m.OfferPage })));
 const AttorneyOfferPage = lazy(() => import('../pages/AttorneyOfferPage').then(m => ({ default: m.AttorneyOfferPage })));
+const MarketplaceRulesPage = lazy(() => import('../pages/MarketplaceRulesPage').then(m => ({ default: m.MarketplaceRulesPage })));
 const TermsPage = lazy(() => import('../pages/TermsPage').then(m => ({ default: m.TermsPage })));
 const PrivacyPolicyPage = lazy(() => import('../pages/PrivacyPolicyPage').then(m => ({ default: m.PrivacyPolicyPage })));
 const DpaPage = lazy(() => import('../pages/DpaPage').then(m => ({ default: m.DpaPage })));
@@ -96,6 +97,8 @@ const ContractsPage = lazy(() => import('../pages/ContractsPage').then(m => ({ d
 // -- Attorney/Consultations (client-facing) --
 const AttorneySearchPage = lazy(() => import('../pages/AttorneySearchPage').then(m => ({ default: m.AttorneySearchPage })));
 const AttorneyDetailPage = lazy(() => import('../pages/AttorneyDetailPage').then(m => ({ default: m.AttorneyDetailPage })));
+const AttorneyProfilePage = lazy(() => import('../pages/AttorneyProfilePage').then(m => ({ default: m.AttorneyProfilePage })));
+const AttorneyClientsPage = lazy(() => import('../pages/AttorneyClientsPage').then(m => ({ default: m.AttorneyClientsPage })));
 const ConsultationsPage = lazy(() => import('../pages/ConsultationsPage').then(m => ({ default: m.ConsultationsPage })));
 const ConsultationDetailPage = lazy(() => import('../pages/ConsultationDetailPage').then(m => ({ default: m.ConsultationDetailPage })));
 
@@ -150,6 +153,10 @@ export const router = createBrowserRouter([
   {
     path: ROUTES.ATTORNEY_OFFER,
     element: S(AttorneyOfferPage),
+  },
+  {
+    path: ROUTES.MARKETPLACE_RULES,
+    element: S(MarketplaceRulesPage),
   },
   {
     path: ROUTES.OFERTA,
@@ -348,6 +355,14 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ATTORNEY_DETAIL,
             element: S(AttorneyDetailPage),
+          },
+          {
+            path: ROUTES.ATTORNEY_PROFILE_EDIT,
+            element: S(AttorneyProfilePage),
+          },
+          {
+            path: ROUTES.ATTORNEY_CLIENTS,
+            element: S(AttorneyClientsPage),
           },
           {
             path: ROUTES.CONSULTATIONS,


### PR DESCRIPTION
## Summary
- Added marketplace rules banner on **AttorneySearchPage** (for clients choosing an attorney) — links to `/uk/marketplace-rules`
- Added marketplace rules banner on **AttorneyProfilePage** (for attorneys managing their profile) — links to `/uk/marketplace-rules`
- Registered missing `AttorneyProfilePage` (`/attorney/profile`) and `AttorneyClientsPage` (`/attorney/clients`) routes in the router

## Test plan
- [ ] Open /attorneys — verify green "Правила маркетплейсу" banner appears above filters
- [ ] Click banner — opens marketplace rules in new tab
- [ ] Open /attorney/profile — verify green banner appears above the form
- [ ] Verify both links respect locale (uk/en)

🤖 Generated with [Claude Code](https://claude.com/claude-code)