### PR TITLE
fix: add missing route constants breaking prod build

### DIFF
--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -11,6 +11,10 @@ export const ROUTES = {
   HOME: '/',
   CHAT: '/chat',
 
+  // Referral
+  REFERRAL: '/referral',
+  REFERRAL_LANDING: '/r/:code',
+
   // Profile & Settings
   PROFILE: '/profile',
   BILLING: '/billing',
@@ -51,6 +55,7 @@ export const ROUTES = {
   // Public Offer & Legal
   OFFER: '/:lang/offer',
   ATTORNEY_OFFER: '/:lang/attorney-offer',
+  MARKETPLACE_RULES: '/:lang/marketplace-rules',
   OFERTA: '/oferta',
   TERMS: '/:lang/terms',
   PRIVACY: '/:lang/privacy',


### PR DESCRIPTION
## Summary
- `MARKETPLACE_RULES`, `REFERRAL`, `REFERRAL_LANDING` constants were missing from committed `routes.ts` but referenced in `router/index.tsx`
- This caused TypeScript compilation failure during Docker build on prod

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)