### PR TITLE
fix: prioritize scenario tools in filterTools cap

### DIFF
--- a/mcp_backend/src/prompts/tool-registry-catalog.ts
+++ b/mcp_backend/src/prompts/tool-registry-catalog.ts
@@ -1083,6 +1083,36 @@ export function deriveDefaultTools(catalog: ScenarioCatalogEntry[]): string[] {
     .map(([tool]) => tool);
 }
 
+/**
+ * Get prioritized tool names for a list of preferred scenario IDs.
+ * Non-optional tools from preferred scenarios come first.
+ */
+export function getScenarioPriorityTools(scenarioIds: string[]): string[] {
+  const priority: string[] = [];
+  const seen = new Set<string>();
+
+  for (const id of scenarioIds) {
+    const scenario = SCENARIO_CATALOG.find(s => s.id === id);
+    if (!scenario) continue;
+    // Non-optional tools first
+    for (const step of scenario.toolChain) {
+      if (!step.optional && !seen.has(step.tool)) {
+        seen.add(step.tool);
+        priority.push(step.tool);
+      }
+    }
+    // Then optional tools
+    for (const step of scenario.toolChain) {
+      if (step.optional && !seen.has(step.tool)) {
+        seen.add(step.tool);
+        priority.push(step.tool);
+      }
+    }
+  }
+
+  return priority;
+}
+
 // Pre-computed exports
 export const DERIVED_DOMAIN_TOOL_MAP = deriveDomainToolMap(SCENARIO_CATALOG);
 export const DERIVED_DEFAULT_TOOLS = deriveDefaultTools(SCENARIO_CATALOG);

--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -17,6 +17,8 @@ import {
   type QueryType,
   type ChatIntentClassification,
 } from '../prompts/chat-system-prompt.js';
+import { getScenarioPriorityTools } from '../prompts/tool-registry-catalog.js';
+import { QUERY_TYPE_CONFIG } from '../prompts/query-type-config.js';
 
 interface CostRecorder {
   recordStreamingCost(
@@ -227,8 +229,10 @@ export class IntentClassifier {
 
   /**
    * Filter 45+ tools to a relevant subset based on intent domains.
+   * When queryType is provided, tools from matching scenarios are prioritized
+   * so they survive the 15-tool cap.
    */
-  async filterTools(domains: string[], slots?: Record<string, any>): Promise<ToolDefinition[]> {
+  async filterTools(domains: string[], slots?: Record<string, any>, queryType?: QueryType): Promise<ToolDefinition[]> {
     const allDefs = await this.toolRegistry.getAllToolDefinitions();
 
     // Collect tool names from matching domains
@@ -261,6 +265,24 @@ export class IntentClassifier {
 
     // Filter to only tools that actually exist in the registry
     const filtered = allDefs.filter((d) => relevantNames.has(d.name));
+
+    // Build priority set from preferred scenarios for this queryType
+    const priorityTools = new Set<string>();
+    if (queryType) {
+      const config = QUERY_TYPE_CONFIG[queryType];
+      if (config?.preferredScenarios?.length) {
+        for (const tool of getScenarioPriorityTools(config.preferredScenarios)) {
+          priorityTools.add(tool);
+        }
+      }
+    }
+
+    // Sort: scenario-priority tools first, then the rest (preserving original order within each group)
+    if (priorityTools.size > 0) {
+      const priority = filtered.filter((d) => priorityTools.has(d.name));
+      const rest = filtered.filter((d) => !priorityTools.has(d.name));
+      return [...priority, ...rest].slice(0, 15);
+    }
 
     // Cap at 15 tools — modern LLMs handle 15-20 tools fine
     return filtered.slice(0, 15);

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -252,7 +252,7 @@ export class ChatService {
     requestId?: string
   ): Promise<{ plan: ExecutionPlan; planSessionId: string; queryType: QueryType } | null> {
     const classification = await this.intentClassifier.classify(query, requestId);
-    const toolDefs = await this.intentClassifier.filterTools(classification.domains, classification.slots);
+    const toolDefs = await this.intentClassifier.filterTools(classification.domains, classification.slots, classification.queryType);
     const plan = await this.generateExecutionPlan(query, classification, toolDefs, requestId);
 
     if (!plan) return null;
@@ -527,13 +527,13 @@ export class ChatService {
             planSessionId: request.planSessionId,
           });
           classification = await this.intentClassifier.classify(query, requestId);
-          toolDefs = await this.intentClassifier.filterTools(classification.domains, classification.slots);
+          toolDefs = await this.intentClassifier.filterTools(classification.domains, classification.slots, classification.queryType);
           plan = await this.generateExecutionPlan(query, classification, toolDefs, requestId);
         }
       } else {
         // Standard flow: classify + generate plan
         classification = await this.intentClassifier.classify(query, requestId);
-        toolDefs = await this.intentClassifier.filterTools(classification.domains, classification.slots);
+        toolDefs = await this.intentClassifier.filterTools(classification.domains, classification.slots, classification.queryType);
 
         // Try fast plan lookup for deterministic query types (skips LLM plan generation)
         const fastPlan = this.fastPlanLookup(classification, toolDefs);


### PR DESCRIPTION
## Summary
- `filterTools()` used naive `.slice(0, 15)` to cap tool count, which could drop query-critical tools (e.g. `search_erb_debtors` for debtor queries) when a domain like `registry` had 20+ tools
- Now accepts optional `queryType` param, uses `preferredScenarios` from `QUERY_TYPE_CONFIG` to sort scenario-specific tools first before applying the cap
- Added `getScenarioPriorityTools()` helper to `tool-registry-catalog.ts` that extracts prioritized tools from scenario definitions (non-optional first, then optional)

## Test plan
- [x] TypeScript build passes (`tsc --noEmit`)
- [x] Existing tests pass (3 pre-existing failures unrelated to this change)
- [ ] Verify debtor query "Перевір ТОВ Будівельний Альянс в реєстрі боржників" includes `search_erb_debtors` in filtered tools
- [ ] Verify registry queries with 20+ candidate tools still get scenario-relevant tools in the top 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)