### PR TITLE
fix: prevent stale chunk errors after deploy

### DIFF
--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -293,4 +293,9 @@ location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header Connection "";
+
+    # Prevent caching index.html so browsers always get fresh chunk references after deploy
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+    add_header Pragma "no-cache";
+    add_header Expires "0";
 }

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -19,8 +19,8 @@ import { LoginPage } from '../pages/LoginPage';
 function lazyWithRetry(factory: () => Promise<any>) {
   return lazy(() =>
     factory().catch(() => {
-      // Chunk not found (stale hash after deploy) — reload once to get new manifest
-      const key = 'chunk-reload';
+      // Chunk not found (stale hash after deploy) — reload once per page path
+      const key = `chunk-reload:${window.location.pathname}`;
       if (!sessionStorage.getItem(key)) {
         sessionStorage.setItem(key, '1');
         window.location.reload();


### PR DESCRIPTION
## Summary
- **Per-path retry key**: `lazyWithRetry` now uses `chunk-reload:{pathname}` instead of a global key, so each page gets its own auto-reload attempt when a stale chunk is detected
- **No-cache for index.html**: Nginx SPA fallback (`location /`) now sends `Cache-Control: no-cache` headers so browsers always fetch fresh HTML with correct chunk hashes after deploy

## Context
Users hitting `https://legal.org.ua/workflows` got `Failed to fetch dynamically imported module: index-CUdZgxSR.js` because the old chunk was deleted after deploy but the browser served cached `index.html` referencing it.

## Test plan
- [ ] Deploy to stage and verify `/workflows` loads without stale chunk errors
- [ ] Hard-refresh prod after deploy and confirm no chunk errors
- [ ] Visit multiple pages after a deploy to verify per-path retry works

🤖 Generated with [Claude Code](https://claude.com/claude-code)