### PR TITLE
feat: update referral program — 20% per payment + equity share + crypto UI

### DIFF
--- a/lexwebapp/src/pages/ReferralPage/index.tsx
+++ b/lexwebapp/src/pages/ReferralPage/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Copy, Check, UserPlus, Gift, Users } from 'lucide-react';
+import { Copy, Check, UserPlus, Gift, Users, TrendingUp, Award, DollarSign, Hash } from 'lucide-react';
 import { ReferralService, ReferralStats, ReferralEntry } from '../../services/api/ReferralService';
 import { showToast } from '../../utils/toast';
 
@@ -64,33 +64,83 @@ export function ReferralPage() {
         Реферальна програма
       </h1>
 
-      {/* Referral Link */}
-      <div className="bg-white rounded-xl border border-claude-border p-6 mb-6">
-        <h2 className="text-sm font-semibold text-claude-subtext mb-3 uppercase tracking-wide">
-          Ваше реферальне посилання
-        </h2>
-        <div className="flex items-center gap-2">
-          <input
-            type="text"
-            readOnly
-            value={referralLink}
-            className="flex-1 px-4 py-2.5 bg-claude-bg rounded-lg border border-claude-border text-sm text-claude-text font-mono"
-          />
+      {/* Referral Code — crypto style */}
+      <div className="bg-gray-950 rounded-xl border border-gray-800 p-6 mb-6">
+        <div className="flex items-center gap-2 mb-4">
+          <Hash size={14} className="text-emerald-400" />
+          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-widest">
+            Ваш реферальний код
+          </h2>
+        </div>
+        <div className="bg-gray-900 rounded-lg border border-gray-800 px-4 py-3 mb-3 flex items-center justify-between gap-3">
+          <code className="text-emerald-400 text-sm font-mono tracking-wider break-all select-all">
+            {stats?.referralCode ?? '—'}
+          </code>
           <button
             onClick={handleCopy}
-            className="flex items-center gap-2 px-4 py-2.5 bg-claude-accent text-white rounded-lg hover:bg-claude-accent/90 transition-colors text-sm font-medium"
+            className="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-md hover:bg-emerald-500/20 transition-colors text-xs font-mono"
           >
-            {copied ? <Check size={16} /> : <Copy size={16} />}
-            {copied ? 'Скопійовано' : 'Копіювати'}
+            {copied ? <Check size={12} /> : <Copy size={12} />}
+            {copied ? 'OK' : 'COPY'}
           </button>
         </div>
-        <p className="text-xs text-claude-subtext mt-3">
-          Поділіться цим посиланням з друзями. Коли вони зареєструються та поповнять баланс, ви отримаєте 20% від їх першого поповнення.
+        <div className="bg-gray-900 rounded-lg border border-gray-800 px-4 py-3 flex items-center justify-between gap-3">
+          <span className="text-gray-500 text-xs font-mono truncate">{referralLink}</span>
+          <button
+            onClick={async () => {
+              if (!referralLink) return;
+              try {
+                await navigator.clipboard.writeText(referralLink);
+                showToast.success('Посилання скопійовано');
+              } catch {
+                showToast.error('Не вдалося скопіювати');
+              }
+            }}
+            className="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-gray-800 text-gray-400 border border-gray-700 rounded-md hover:bg-gray-700 transition-colors text-xs font-mono"
+          >
+            <Copy size={12} />
+            LINK
+          </button>
+        </div>
+        <p className="text-xs text-gray-500 mt-3">
+          Поділіться кодом або посиланням з колегами. Ви отримуватимете до 20% від кожного платежу запрошеного клієнта.
         </p>
       </div>
 
+      {/* Program Terms */}
+      <div className="bg-gradient-to-br from-amber-50 to-orange-50 rounded-xl border border-amber-200 p-6 mb-6">
+        <h2 className="text-sm font-semibold text-amber-900 mb-4 uppercase tracking-wide flex items-center gap-2">
+          <Award size={16} />
+          Умови реферальної програми
+        </h2>
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center">
+              <TrendingUp size={16} className="text-amber-700" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-claude-text">До 20% від кожного платежу</h3>
+              <p className="text-xs text-claude-subtext mt-1">
+                Ви отримуєте до 20% реферальної винагороди з кожного платежу клієнта, якого ви привели на платформу. Винагорода нараховується постійно, поки клієнт залишається активним.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center">
+              <Award size={16} className="text-amber-700" />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-claude-text">Equity Share для топ-рефералів</h3>
+              <p className="text-xs text-claude-subtext mt-1">
+                Якщо за 3 місяці ви запросите 10+ клієнтів, кожен з яких платить від $500/міс — вся сума виплачених вам реферальних відсотків додатково конвертується в equity share компанії.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {/* Stats */}
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <div className="bg-white rounded-xl border border-claude-border p-5">
           <div className="flex items-center gap-2 text-claude-subtext mb-2">
             <Users size={16} />
@@ -98,6 +148,15 @@ export function ReferralPage() {
           </div>
           <div className="text-2xl font-bold text-claude-text">
             {stats?.totalReferrals ?? 0}
+          </div>
+        </div>
+        <div className="bg-white rounded-xl border border-claude-border p-5">
+          <div className="flex items-center gap-2 text-claude-subtext mb-2">
+            <DollarSign size={16} />
+            <span className="text-xs font-semibold uppercase tracking-wide">Оплачено рефералами</span>
+          </div>
+          <div className="text-2xl font-bold text-claude-text">
+            ${referrals.reduce((sum, r) => sum + (r.totalPaidUsd ?? 0), 0).toFixed(2)}
           </div>
         </div>
         <div className="bg-white rounded-xl border border-claude-border p-5">
@@ -137,6 +196,7 @@ export function ReferralPage() {
                   <th className="px-6 py-3 text-left font-semibold">Користувач</th>
                   <th className="px-6 py-3 text-left font-semibold">Дата реєстрації</th>
                   <th className="px-6 py-3 text-left font-semibold">Статус</th>
+                  <th className="px-6 py-3 text-right font-semibold">Оплачено</th>
                   <th className="px-6 py-3 text-right font-semibold">Винагорода</th>
                 </tr>
               </thead>
@@ -164,6 +224,11 @@ export function ReferralPage() {
                           Зареєстрований
                         </span>
                       )}
+                    </td>
+                    <td className="px-6 py-3 text-right text-claude-subtext font-mono text-xs">
+                      {(r.totalPaidUsd ?? 0) > 0
+                        ? `$${r.totalPaidUsd.toFixed(2)}`
+                        : '—'}
                     </td>
                     <td className="px-6 py-3 text-right font-medium text-claude-text">
                       {r.rewardAmountUsd > 0

--- a/lexwebapp/src/services/api/ReferralService.ts
+++ b/lexwebapp/src/services/api/ReferralService.ts
@@ -20,6 +20,7 @@ export interface ReferralEntry {
   hasToppedUp: boolean;
   rewardAmountUsd: number;
   rewardAmountUah: number;
+  totalPaidUsd: number;
 }
 
 export class ReferralService extends BaseService {


### PR DESCRIPTION
## Summary
- Реферальна винагорода тепер до 20% від **кожного** платежу клієнта (замість лише першого поповнення)
- Equity share для топ-рефералів: 10+ клієнтів за 3 місяці з оплатою від $500/міс
- Реферальний код відображається у крипто-стилі (темний фон, моноширинний шрифт, окремі кнопки копіювання коду та посилання)
- Нова картка «Оплачено рефералами» + колонка «Оплачено» у таблиці рефералів

## Test plan
- [ ] Перевірити відображення реферального коду в крипто-стилі
- [ ] Перевірити копіювання коду та посилання окремими кнопками
- [ ] Перевірити нову картку статистики «Оплачено рефералами»
- [ ] Перевірити колонку «Оплачено» у таблиці рефералів

🤖 Generated with [Claude Code](https://claude.com/claude-code)