### PR TITLE
fix: set VITE_API_URL in CI frontend test step

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -103,6 +103,8 @@ jobs:
           cd lexwebapp && npm ci
           npm test
           npm run build
+        env:
+          VITE_API_URL: https://stage.legal.org.ua
 
   # ─── Step 3: Deploy to stage & integration test ─────────────────────
   stage-deploy-and-test:


### PR DESCRIPTION
## Summary
- CI frontend tests fail because `VITE_API_URL` defaults to `https://test.example.com` which is not in the allow-list
- Set `VITE_API_URL=https://stage.legal.org.ua` in the "Test frontend" step env

## Test plan
- [ ] CI pipeline passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)