### PR TITLE
fix: set VITE_API_URL in local CI frontend steps

### DIFF
--- a/.github/workflows/ci-local-deploy.yml.disabled
+++ b/.github/workflows/ci-local-deploy.yml.disabled
@@ -1,0 +1,424 @@
+##############################################################################
+# Pipeline 1: Local CI/CD
+# - Runs on self-hosted runner (local dev machine)
+# - Builds and tests all changed services in local Docker environment
+# - Deploys ONLY changed services to production
+# - Triggered on merge to main
+##############################################################################
+name: 'CI/CD: Local Build → Prod Deploy'
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: deploy-local-to-prod
+  cancel-in-progress: false
+
+jobs:
+  # ─── Step 1: Detect what changed ─────────────────────────────────────
+  detect-changes:
+    name: Detect Changes
+    runs-on: [self-hosted, local]
+    outputs:
+      shared: ${{ steps.changes.outputs.shared }}
+      backend: ${{ steps.changes.outputs.backend }}
+      rada: ${{ steps.changes.outputs.rada }}
+      openreyestr: ${{ steps.changes.outputs.openreyestr }}
+      frontend: ${{ steps.changes.outputs.frontend }}
+      deployment: ${{ steps.changes.outputs.deployment }}
+      any_backend: ${{ steps.changes.outputs.any_backend }}
+      services_to_build: ${{ steps.changes.outputs.services_to_build }}
+      services_to_deploy: ${{ steps.changes.outputs.services_to_deploy }}
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        uses: ./.github/actions/detect-changes
+
+      - name: Check if any services need deploy
+        id: check
+        run: |
+          SERVICES='${{ steps.changes.outputs.services_to_build }}'
+          if [ "$SERVICES" = '[]' ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No services changed — skipping build/test/deploy"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ─── Step 2: Build shared package ────────────────────────────────────
+  build-shared:
+    name: Build Shared Package
+    runs-on: [self-hosted, local]
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: packages/shared/package-lock.json
+
+      - name: Install & build shared
+        run: |
+          cd packages/shared
+          npm ci
+          npm run build
+
+  # ─── Step 3: Test changed services (parallel) ───────────────────────
+  test-backend:
+    name: Test Backend
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, build-shared]
+    if: needs.detect-changes.outputs.backend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build shared
+        run: cd packages/shared && npm ci && npm run build
+
+      - name: Install & build backend
+        run: cd mcp_backend && npm ci && npm run build
+
+      - name: Run backend tests
+        run: cd mcp_backend && npm test
+        env:
+          NODE_ENV: test
+
+  test-rada:
+    name: Test RADA
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, build-shared]
+    if: needs.detect-changes.outputs.rada == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build shared
+        run: cd packages/shared && npm ci && npm run build
+
+      - name: Install & build RADA
+        run: cd mcp_rada && npm ci && npm run build
+
+      - name: Run RADA tests
+        run: cd mcp_rada && npm test
+        env:
+          NODE_ENV: test
+
+  test-openreyestr:
+    name: Test OpenReyestr
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, build-shared]
+    if: needs.detect-changes.outputs.openreyestr == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build shared
+        run: cd packages/shared && npm ci && npm run build
+
+      - name: Install & build OpenReyestr
+        run: cd mcp_openreyestr && npm ci && npm run build
+
+      - name: Run OpenReyestr tests
+        run: cd mcp_openreyestr && npm test
+        env:
+          NODE_ENV: test
+
+  test-frontend:
+    name: Test Frontend
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, build-shared]
+    if: needs.detect-changes.outputs.frontend == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install & test frontend
+        run: |
+          cd lexwebapp
+          npm ci
+          npm test
+        env:
+          VITE_API_URL: http://localhost:3000
+
+      - name: Build frontend (production)
+        run: cd lexwebapp && npm run build
+        env:
+          VITE_API_URL: http://localhost:3000
+
+  # ─── Step 4: Build Docker images locally ─────────────────────────────
+  build-docker:
+    name: Build Docker Images
+    runs-on: [self-hosted, local]
+    needs:
+      - detect-changes
+      - test-backend
+      - test-rada
+      - test-openreyestr
+      - test-frontend
+    # Run if all completed tests passed (skipped counts as success)
+    if: |
+      always() &&
+      needs.detect-changes.outputs.has_changes == 'true' &&
+      !contains(needs.*.result, 'failure')
+    env:
+      GIT_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Pre-build dist (shared + services)
+        env:
+          BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+          RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+          OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+        run: |
+          npm --prefix packages/shared install && npm --prefix packages/shared run build
+
+          if [ "$BACKEND_CHANGED" = "true" ]; then
+            npm --prefix mcp_backend install && npm --prefix mcp_backend run build
+          fi
+          if [ "$RADA_CHANGED" = "true" ]; then
+            npm --prefix mcp_rada install && npm --prefix mcp_rada run build
+          fi
+          if [ "$OPENREYESTR_CHANGED" = "true" ]; then
+            npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build
+          fi
+
+      - name: Build backend image
+        if: needs.detect-changes.outputs.backend == 'true'
+        run: |
+          docker build -f deployment/Dockerfile.mono-backend \
+            -t secondlayer-app:"$GIT_SHA" -t secondlayer-app:latest .
+
+      - name: Build RADA image
+        if: needs.detect-changes.outputs.rada == 'true'
+        run: |
+          docker build -f deployment/Dockerfile.mono-rada \
+            -t rada-mcp:"$GIT_SHA" -t rada-mcp:latest .
+
+      - name: Build OpenReyestr image
+        if: needs.detect-changes.outputs.openreyestr == 'true'
+        run: |
+          docker build -f deployment/Dockerfile.mono-openreyestr \
+            -t openreyestr-app:"$GIT_SHA" -t openreyestr-app:latest .
+
+      - name: Build frontend image
+        if: needs.detect-changes.outputs.frontend == 'true'
+        run: |
+          docker build -f lexwebapp/Dockerfile \
+            -t lexwebapp-lexwebapp:"$GIT_SHA" -t lexwebapp-lexwebapp:latest .
+
+  # ─── Step 5: Integration test with local Docker stack ────────────────
+  integration-test:
+    name: Integration Test (Local Docker)
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, build-docker]
+    if: |
+      always() &&
+      needs.build-docker.result == 'success'
+    env:
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start local stack for smoke test
+        working-directory: deployment
+        run: |
+          if [ -f ".env.local" ]; then
+            ENV_ARGS="--env-file .env.local"
+          else
+            ENV_ARGS=""
+          fi
+          DC="docker compose -f docker-compose.local.yml $ENV_ARGS"
+
+          # Ensure infra is running
+          $DC up -d postgres-local redis-local qdrant-local minio-local postgres-openreyestr-local
+          sleep 10
+
+          # Run migrations
+          $DC up migrate-local || true
+          $DC up rada-db-init-local || true
+          $DC up rada-migrate-local migrate-openreyestr-local || true
+
+          # Start only changed services + nginx
+          SERVICES="nginx-local"
+          [ "$BACKEND_CHANGED" = "true" ] && SERVICES="$SERVICES app-local document-service-local"
+          [ "$RADA_CHANGED" = "true" ] && SERVICES="$SERVICES rada-mcp-app-local"
+          [ "$OPENREYESTR_CHANGED" = "true" ] && SERVICES="$SERVICES app-openreyestr-local"
+          [ "$FRONTEND_CHANGED" = "true" ] && SERVICES="$SERVICES lexwebapp-local"
+
+          $DC up -d $SERVICES
+
+      - name: Wait for services to stabilize
+        run: sleep 20
+
+      - name: Health checks
+        run: |
+          FAILED=false
+          check_health() {
+            local name=$1 url=$2
+            for i in 1 2 3; do
+              if curl -sf --max-time 10 "$url" > /dev/null; then
+                echo "$name: OK"
+                return 0
+              fi
+              sleep 5
+            done
+            echo "::error::$name health check failed"
+            FAILED=true
+          }
+
+          [ "$BACKEND_CHANGED" = "true" ] && check_health "Backend" "http://localhost:3000/health"
+          [ "$RADA_CHANGED" = "true" ] && check_health "RADA" "http://localhost:3001/health"
+          [ "$OPENREYESTR_CHANGED" = "true" ] && check_health "OpenReyestr" "http://localhost:3004/health"
+
+          if [ "$FAILED" = "true" ]; then exit 1; fi
+
+  # ─── Step 6: Deploy to production ───────────────────────────────────
+  deploy-prod:
+    name: Deploy to Production
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, integration-test]
+    if: |
+      always() &&
+      needs.integration-test.result == 'success'
+    environment: production
+    env:
+      PROD_SERVER: '18.192.189.254'
+      PROD_USER: 'ubuntu'
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Deploy changed services to prod
+        env:
+          PROD_SSH_KEY_PATH: ${{ secrets.PROD_SSH_KEY_PATH }}
+        run: |
+          SSH_CMD="ssh -i $PROD_SSH_KEY_PATH -o StrictHostKeyChecking=no ${PROD_USER}@${PROD_SERVER}"
+          REMOTE_REPO="/home/${PROD_USER}/SecondLayer"
+
+          echo "=== Deploying to production ==="
+
+          # Step 1: Pull latest code
+          $SSH_CMD "git -C ${REMOTE_REPO} fetch origin main && git -C ${REMOTE_REPO} reset --hard origin/main"
+
+          # Step 2: Build dist on prod
+          $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix packages/shared install && npm --prefix packages/shared run build"
+
+          [ "$BACKEND_CHANGED" = "true" ] && \
+            $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_backend install && npm --prefix mcp_backend run build"
+          [ "$RADA_CHANGED" = "true" ] && \
+            $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_rada install && npm --prefix mcp_rada run build"
+          [ "$OPENREYESTR_CHANGED" = "true" ] && \
+            $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build"
+
+          # Step 3: Selective stop/build/migrate/start on prod
+          $SSH_CMD bash << DEPLOY_SCRIPT
+            set -e
+            cd ${REMOTE_REPO}/deployment
+            DC="docker compose -f docker-compose.prod.yml --env-file .env.prod"
+
+            STOP="" BUILD="" START=""
+
+            if [ "${BACKEND_CHANGED}" = "true" ]; then
+              STOP="\$STOP app-prod document-service-prod"
+              BUILD="\$BUILD app-prod document-service-prod migrate-prod"
+              START="\$START app-prod document-service-prod"
+            fi
+            if [ "${RADA_CHANGED}" = "true" ]; then
+              STOP="\$STOP rada-mcp-app-prod"
+              BUILD="\$BUILD rada-mcp-app-prod rada-db-init-prod rada-migrate-prod"
+              START="\$START rada-mcp-app-prod"
+            fi
+            if [ "${OPENREYESTR_CHANGED}" = "true" ]; then
+              STOP="\$STOP app-openreyestr-prod"
+              BUILD="\$BUILD app-openreyestr-prod migrate-openreyestr-prod"
+              START="\$START app-openreyestr-prod"
+            fi
+            if [ "${FRONTEND_CHANGED}" = "true" ]; then
+              STOP="\$STOP lexwebapp-prod"
+              BUILD="\$BUILD lexwebapp-prod"
+              START="\$START lexwebapp-prod"
+            fi
+
+            [ -n "\$STOP" ] && \$DC stop \$STOP 2>/dev/null || true
+            [ -n "\$STOP" ] && \$DC rm -f \$STOP 2>/dev/null || true
+            [ -n "\$BUILD" ] && \$DC build \$BUILD
+
+            # Migrations
+            [ "${BACKEND_CHANGED}" = "true" ] && \$DC up migrate-prod || true
+            [ "${RADA_CHANGED}" = "true" ] && { \$DC up rada-db-init-prod || true; \$DC up rada-migrate-prod || true; }
+            [ "${OPENREYESTR_CHANGED}" = "true" ] && \$DC up migrate-openreyestr-prod || true
+
+            [ -n "\$START" ] && \$DC up -d \$START
+
+            # Restart nginx to pick up new upstream IPs
+            \$DC restart nginx-prod
+            docker image prune -f
+          DEPLOY_SCRIPT
+
+      - name: Prod health check
+        env:
+          PROD_SSH_KEY_PATH: ${{ secrets.PROD_SSH_KEY_PATH }}
+        run: |
+          SSH_CMD="ssh -i $PROD_SSH_KEY_PATH -o StrictHostKeyChecking=no ${PROD_USER}@${PROD_SERVER}"
+          sleep 15
+
+          for i in 1 2 3 4 5; do
+            if $SSH_CMD "curl -sf --max-time 10 http://localhost:3007/health"; then
+              echo "Production backend: healthy"
+              break
+            fi
+            [ $i -eq 5 ] && echo "::error::Production health check failed" && exit 1
+            sleep 10
+          done
+
+          # Public domain check
+          for i in 1 2 3; do
+            if curl -sf --max-time 15 "https://legal.org.ua/health"; then
+              echo "Production (public): healthy"
+              break
+            fi
+            [ $i -eq 3 ] && echo "::warning::Public health check timed out — may be Cloudflare cache"
+            sleep 5
+          done
+
+      - name: Tag successful deploy
+        run: |
+          TAG="deploy-prod-$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA:0:7}"
+          git tag "$TAG"
+          git push origin "$TAG"


### PR DESCRIPTION
## Summary
- Set `VITE_API_URL=http://localhost:3000` in both test and build frontend steps in the local CI workflow
- Mirrors the fix from #759 for the stage pipeline
- Workflow remains `.disabled` — not triggered

## Test plan
- [ ] Workflow file syntax is valid
- [ ] Will be verified when local CI is re-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)