### PR TITLE
feat: blog page i18n — UK/EN/RU localization

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -12,6 +12,8 @@ import {
 } from 'lucide-react';
 import type { Article } from './articles';
 import { CommentSection } from './CommentSection';
+import { useLocaleStore } from '../../stores/localeStore';
+import { getBlogUI } from './blog-i18n';
 
 interface ArticleModalProps {
   article: Article;
@@ -20,6 +22,8 @@ interface ArticleModalProps {
 
 export function ArticleModal({ article, onClose }: ArticleModalProps) {
   const [copied, setCopied] = useState(false);
+  const language = useLocaleStore((s) => s.language);
+  const ui = getBlogUI(language);
 
   const getArticleUrl = () =>
     `${window.location.origin}/blog?article=${article.id}`;
@@ -80,28 +84,28 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
             <button
               onClick={(e) => { e.stopPropagation(); shareOnLinkedIn(); }}
               className="w-8 h-8 flex items-center justify-center rounded-lg text-[#0A66C2] bg-[#0A66C2]/10 hover:bg-[#0A66C2]/20 transition-colors"
-              title="Поділитися в LinkedIn"
+              title={ui.shareLinkedIn}
             >
               <Linkedin size={15} />
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); shareOnX(); }}
               className="w-8 h-8 flex items-center justify-center rounded-lg text-claude-text bg-claude-bg hover:bg-claude-border transition-colors"
-              title="Поділитися в X"
+              title={ui.shareX}
             >
               <Twitter size={15} />
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); shareOnFacebook(); }}
               className="w-8 h-8 flex items-center justify-center rounded-lg text-[#1877F2] bg-[#1877F2]/10 hover:bg-[#1877F2]/20 transition-colors"
-              title="Поділитися у Facebook"
+              title={ui.shareFacebook}
             >
               <Facebook size={15} />
             </button>
             <button
               onClick={(e) => { e.stopPropagation(); copyLink(); }}
               className="w-8 h-8 flex items-center justify-center rounded-lg text-claude-subtext bg-claude-bg hover:bg-claude-border transition-colors"
-              title="Копіювати посилання"
+              title={ui.copyLink}
             >
               {copied ? <Check size={15} className="text-green-600" /> : <Link2 size={15} />}
             </button>
@@ -165,7 +169,7 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
           {/* Share footer */}
           <div className="mt-6 p-4 bg-claude-bg rounded-xl flex flex-col sm:flex-row items-center justify-between gap-4">
             <p className="text-sm text-claude-subtext font-sans">
-              Поділитися цією статтею:
+              {ui.shareArticle}
             </p>
             <div className="flex items-center gap-2">
               <button
@@ -194,7 +198,7 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
                 className="flex items-center gap-2 px-4 py-2.5 bg-white border border-claude-border text-claude-text rounded-xl text-sm font-sans font-medium hover:bg-claude-bg transition-colors"
               >
                 {copied ? <Check size={16} className="text-green-600" /> : <Link2 size={16} />}
-                {copied ? 'Скопійовано!' : 'Копіювати посилання'}
+                {copied ? ui.copied : ui.copyLink}
               </button>
             </div>
           </div>

--- a/lexwebapp/src/pages/BlogPage/CommentSection.tsx
+++ b/lexwebapp/src/pages/BlogPage/CommentSection.tsx
@@ -7,6 +7,8 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { blogService, type BlogComment } from '../../services/blog-service';
+import { useLocaleStore } from '../../stores/localeStore';
+import { getBlogUI } from './blog-i18n';
 
 interface CommentSectionProps {
   articleId: string;
@@ -14,6 +16,8 @@ interface CommentSectionProps {
 
 export function CommentSection({ articleId }: CommentSectionProps) {
   const { user, isAuthenticated } = useAuth();
+  const language = useLocaleStore((s) => s.language);
+  const ui = getBlogUI(language);
   const [comments, setComments] = useState<BlogComment[]>([]);
   const [commentText, setCommentText] = useState('');
   const [commentsLoading, setCommentsLoading] = useState(false);
@@ -64,7 +68,7 @@ export function CommentSection({ articleId }: CommentSectionProps) {
       <div className="flex items-center gap-2 mb-6">
         <MessageSquare size={18} className="text-claude-accent" />
         <h3 className="text-base font-sans font-medium text-claude-text">
-          Коментарі {comments.length > 0 && <span className="text-claude-subtext font-normal">({comments.length})</span>}
+          {ui.comments} {comments.length > 0 && <span className="text-claude-subtext font-normal">({comments.length})</span>}
         </h3>
       </div>
 
@@ -84,7 +88,7 @@ export function CommentSection({ articleId }: CommentSectionProps) {
               value={commentText}
               onChange={(e) => setCommentText(e.target.value)}
               onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSubmitComment()}
-              placeholder="Написати коментар..."
+              placeholder={ui.writeComment}
               maxLength={2000}
               className="flex-1 px-4 py-2.5 bg-white border border-claude-border rounded-xl text-sm text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all font-sans"
             />
@@ -103,16 +107,16 @@ export function CommentSection({ articleId }: CommentSectionProps) {
           className="flex items-center justify-center gap-2 mb-6 px-4 py-3 bg-claude-bg border border-claude-border rounded-xl text-sm text-claude-subtext hover:text-claude-text hover:border-claude-accent/30 transition-all font-sans"
         >
           <LogIn size={16} />
-          Увійдіть, щоб залишити коментар
+          {ui.loginToComment}
         </a>
       )}
 
       {/* Comments list */}
       {commentsLoading ? (
-        <div className="text-center py-6 text-sm text-claude-subtext font-sans">Завантаження...</div>
+        <div className="text-center py-6 text-sm text-claude-subtext font-sans">{ui.loading}</div>
       ) : comments.length === 0 ? (
         <div className="text-center py-6 text-sm text-claude-subtext font-sans">
-          Поки немає коментарів. Будьте першим!
+          {ui.noComments}
         </div>
       ) : (
         <div className="space-y-4">
@@ -130,10 +134,10 @@ export function CommentSection({ articleId }: CommentSectionProps) {
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium text-claude-text font-sans">
-                    {comment.user_name || 'Анонім'}
+                    {comment.user_name || ui.anonymous}
                   </span>
                   <span className="text-xs text-claude-subtext/60 font-sans">
-                    {new Date(comment.created_at).toLocaleDateString('uk-UA', {
+                    {new Date(comment.created_at).toLocaleDateString(language === 'uk' ? 'uk-UA' : language === 'ru' ? 'ru-RU' : 'en-US', {
                       day: 'numeric', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit',
                     })}
                   </span>
@@ -141,7 +145,7 @@ export function CommentSection({ articleId }: CommentSectionProps) {
                     <button
                       onClick={() => handleDeleteComment(comment.id)}
                       className="opacity-0 group-hover:opacity-100 text-claude-subtext/40 hover:text-red-500 transition-all ml-auto"
-                      title="Видалити"
+                      title={ui.delete}
                     >
                       <Trash2 size={14} />
                     </button>

--- a/lexwebapp/src/pages/BlogPage/blog-i18n.ts
+++ b/lexwebapp/src/pages/BlogPage/blog-i18n.ts
@@ -1,0 +1,152 @@
+/**
+ * Blog page UI translations
+ */
+import type { AppLanguage } from '../../stores/localeStore';
+import type { Article, TranslationMap } from './articles';
+
+interface BlogUIStringsMap {
+  tryLexAi: string;
+  read: string;
+  login: string;
+  all: string;
+  tech: string;
+  forLawyers: string;
+  dataSources: string;
+  heroTitle: string;
+  heroSubtitle: string;
+  footerDescription: string;
+  shareArticle: string;
+  copyLink: string;
+  copied: string;
+  shareLinkedIn: string;
+  shareX: string;
+  shareFacebook: string;
+  comments: string;
+  writeComment: string;
+  loginToComment: string;
+  loading: string;
+  noComments: string;
+  anonymous: string;
+  delete: string;
+}
+
+const uiStrings: Record<AppLanguage, BlogUIStringsMap> = {
+  uk: {
+    tryLexAi: 'Спробувати LEX AI',
+    read: 'Читати',
+    login: 'Увійти',
+    all: 'Всі',
+    tech: 'Tech',
+    forLawyers: 'Для юристів',
+    dataSources: 'Джерела даних',
+    heroTitle: 'LEX AI Blog',
+    heroSubtitle: 'Як ми будуємо AI-платформу для юридичної аналітики. Технічні інсайти для розробників та практичні кейси для юристів.',
+    footerDescription: 'LEX AI — AI-powered legal research platform',
+    shareArticle: 'Поділитися цією статтею:',
+    copyLink: 'Копіювати посилання',
+    copied: 'Скопійовано!',
+    shareLinkedIn: 'Поділитися в LinkedIn',
+    shareX: 'Поділитися в X',
+    shareFacebook: 'Поділитися у Facebook',
+    comments: 'Коментарі',
+    writeComment: 'Написати коментар...',
+    loginToComment: 'Увійдіть, щоб залишити коментар',
+    loading: 'Завантаження...',
+    noComments: 'Поки немає коментарів. Будьте першим!',
+    anonymous: 'Анонім',
+    delete: 'Видалити',
+  },
+  en: {
+    tryLexAi: 'Try LEX AI',
+    read: 'Read',
+    login: 'Sign In',
+    all: 'All',
+    tech: 'Tech',
+    forLawyers: 'For Lawyers',
+    dataSources: 'Data Sources',
+    heroTitle: 'LEX AI Blog',
+    heroSubtitle: 'How we build an AI platform for legal analytics. Technical insights for developers and practical cases for lawyers.',
+    footerDescription: 'LEX AI — AI-powered legal research platform',
+    shareArticle: 'Share this article:',
+    copyLink: 'Copy link',
+    copied: 'Copied!',
+    shareLinkedIn: 'Share on LinkedIn',
+    shareX: 'Share on X',
+    shareFacebook: 'Share on Facebook',
+    comments: 'Comments',
+    writeComment: 'Write a comment...',
+    loginToComment: 'Sign in to leave a comment',
+    loading: 'Loading...',
+    noComments: 'No comments yet. Be the first!',
+    anonymous: 'Anonymous',
+    delete: 'Delete',
+  },
+  ru: {
+    tryLexAi: 'Попробовать LEX AI',
+    read: 'Читать',
+    login: 'Войти',
+    all: 'Все',
+    tech: 'Tech',
+    forLawyers: 'Для юристов',
+    dataSources: 'Источники данных',
+    heroTitle: 'LEX AI Blog',
+    heroSubtitle: 'Как мы строим AI-платформу для юридической аналитики. Технические инсайты для разработчиков и практические кейсы для юристов.',
+    footerDescription: 'LEX AI — AI-powered legal research platform',
+    shareArticle: 'Поделиться этой статьёй:',
+    copyLink: 'Копировать ссылку',
+    copied: 'Скопировано!',
+    shareLinkedIn: 'Поделиться в LinkedIn',
+    shareX: 'Поделиться в X',
+    shareFacebook: 'Поделиться в Facebook',
+    comments: 'Комментарии',
+    writeComment: 'Написать комментарий...',
+    loginToComment: 'Войдите, чтобы оставить комментарий',
+    loading: 'Загрузка...',
+    noComments: 'Пока нет комментариев. Будьте первым!',
+    anonymous: 'Аноним',
+    delete: 'Удалить',
+  },
+};
+
+export type BlogUIStrings = BlogUIStringsMap;
+
+export function getBlogUI(lang: AppLanguage): BlogUIStrings {
+  return uiStrings[lang] || uiStrings.uk;
+}
+
+/**
+ * Get a localized version of an article.
+ * Falls back to original (Ukrainian) if translation is not available.
+ */
+export function getLocalizedArticle(
+  article: Article,
+  lang: AppLanguage,
+  translationMaps: Partial<Record<AppLanguage, TranslationMap>>
+): Article {
+  if (lang === 'uk') return article;
+
+  const map = translationMaps[lang];
+  if (!map) return article;
+
+  const translation = map[article.id];
+  if (!translation) return article;
+
+  return {
+    ...article,
+    title: translation.title,
+    punchline: translation.punchline,
+    readTime: translation.readTime,
+    content: translation.content,
+  };
+}
+
+/**
+ * Get all articles localized to the given language.
+ */
+export function getLocalizedArticles(
+  allArticles: Article[],
+  lang: AppLanguage,
+  translationMaps: Partial<Record<AppLanguage, TranslationMap>>
+): Article[] {
+  return allArticles.map(a => getLocalizedArticle(a, lang, translationMaps));
+}

--- a/lexwebapp/src/pages/BlogPage/index.tsx
+++ b/lexwebapp/src/pages/BlogPage/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
@@ -9,28 +9,40 @@ import {
   Scale,
 } from 'lucide-react';
 import { articles, type Article } from './articles';
+import { enTranslations } from './articles-en';
+import { ruTranslations } from './articles-ru';
 import { ArticleModal } from './ArticleModal';
+import { useLocaleStore } from '../../stores/localeStore';
+import { getBlogUI, getLocalizedArticles } from './blog-i18n';
+
+const translationMaps = { en: enTranslations, ru: ruTranslations };
 
 export function BlogPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
   const [filter, setFilter] = useState<'all' | 'tech' | 'legal'>('all');
+  const language = useLocaleStore((s) => s.language);
+  const ui = getBlogUI(language);
+  const localizedArticles = useMemo(
+    () => getLocalizedArticles(articles, language, translationMaps),
+    [language]
+  );
 
   // Auto-open article from ?article= query param (used after login redirect)
   useEffect(() => {
     const articleId = searchParams.get('article');
     if (articleId && !selectedArticle) {
-      const found = articles.find((a) => a.id === articleId);
+      const found = localizedArticles.find((a) => a.id === articleId);
       if (found) {
         setSelectedArticle(found);
         searchParams.delete('article');
         setSearchParams(searchParams, { replace: true });
       }
     }
-  }, [searchParams]);
+  }, [searchParams, localizedArticles]);
 
-  const sorted = [...articles].sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
+  const sorted = [...localizedArticles].sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime());
   const filtered = filter === 'all' ? sorted : sorted.filter(a => a.category === filter);
 
   return (
@@ -56,7 +68,7 @@ export function BlogPage() {
             href="/login"
             className="px-4 py-2 bg-claude-accent text-white rounded-xl text-sm font-medium font-sans hover:bg-[#C66345] transition-colors"
           >
-            Спробувати LEX AI
+            {ui.tryLexAi}
           </a>
         </div>
       </header>
@@ -77,8 +89,7 @@ export function BlogPage() {
             transition={{ delay: 0.1 }}
             className="text-claude-subtext font-sans max-w-2xl mx-auto"
           >
-            Як ми будуємо AI-платформу для юридичної аналітики.
-            Технічні інсайти для розробників та практичні кейси для юристів.
+            {ui.heroSubtitle}
           </motion.p>
 
           {/* Filter tabs */}
@@ -89,9 +100,9 @@ export function BlogPage() {
             className="flex justify-center gap-2 mt-8"
           >
             {([
-              { key: 'all', label: 'Всі', count: articles.length },
-              { key: 'tech', label: 'Tech', count: articles.filter(a => a.category === 'tech').length },
-              { key: 'legal', label: 'Для юристів', count: articles.filter(a => a.category === 'legal').length },
+              { key: 'all', label: ui.all, count: localizedArticles.length },
+              { key: 'tech', label: ui.tech, count: localizedArticles.filter(a => a.category === 'tech').length },
+              { key: 'legal', label: ui.forLawyers, count: localizedArticles.filter(a => a.category === 'legal').length },
             ] as const).map(tab => (
               <button
                 key={tab.key}
@@ -170,7 +181,7 @@ export function BlogPage() {
                     ))}
                     <div className="flex-1" />
                     <span className="text-sm text-claude-accent font-sans font-medium flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                      Читати <ChevronRight size={14} />
+                      {ui.read} <ChevronRight size={14} />
                     </span>
                   </div>
                 </div>
@@ -186,12 +197,12 @@ export function BlogPage() {
         <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <img src="/Image.jpg" alt="Lex" className="h-8 w-auto" />
-            <span className="text-sm text-claude-subtext font-sans">LEX AI — AI-powered legal research platform</span>
+            <span className="text-sm text-claude-subtext font-sans">{ui.footerDescription}</span>
           </div>
           <div className="flex items-center gap-4 text-sm text-claude-subtext font-sans">
-            <a href="/login" className="hover:text-claude-accent transition-colors">Увійти</a>
+            <a href="/login" className="hover:text-claude-accent transition-colors">{ui.login}</a>
             <span className="text-claude-border">|</span>
-            <a href="/ua/data-sources" className="hover:text-claude-accent transition-colors">Джерела даних</a>
+            <a href="/ua/data-sources" className="hover:text-claude-accent transition-colors">{ui.dataSources}</a>
           </div>
         </div>
       </footer>

--- a/lexwebapp/src/stores/localeStore.ts
+++ b/lexwebapp/src/stores/localeStore.ts
@@ -7,7 +7,7 @@
 import { create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 
-export type AppLanguage = 'uk' | 'en';
+export type AppLanguage = 'uk' | 'en' | 'ru';
 export type AppCurrency = 'UAH' | 'USD' | 'EUR';
 export type AppCountry = 'UA' | 'US' | 'GB' | 'DE' | 'FR' | 'NL' | 'EE' | 'OTHER';
 
@@ -41,6 +41,11 @@ function getDefaultsForCountry(countryCode: string): {
   // Ukrainian-speaking countries
   if (code === 'UA') {
     return { language: 'uk', currency: 'UAH', country: 'UA' };
+  }
+
+  // Russian-speaking countries
+  if (['RU', 'BY', 'KZ'].includes(code)) {
+    return { language: 'ru', currency: 'USD', country: 'OTHER' };
   }
 
   // Euro zone


### PR DESCRIPTION
## Summary
- Extract all hardcoded Ukrainian UI strings from BlogPage, ArticleModal, and CommentSection into `blog-i18n.ts`
- Add Russian (`ru`) locale support to `AppLanguage` type in localeStore
- Auto-detect RU/BY/KZ countries → default to Russian language
- All blog UI elements (share buttons, comments, filters, footer) now respect user's language setting

## Test plan
- [ ] Verify blog page renders correctly in Ukrainian (default)
- [ ] Switch language to English — all UI strings update
- [ ] Switch language to Russian — all UI strings update
- [ ] Verify article content localization uses articles-en/articles-ru translations
- [ ] Verify comment section respects locale for date formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)