### PR TITLE
fix: repair CI test failures — env, error handling, jsdom

### DIFF
--- a/lexwebapp/src/__tests__/setup.ts
+++ b/lexwebapp/src/__tests__/setup.ts
@@ -13,12 +13,15 @@ afterEach(() => {
 });
 
 // Mock environment variables
-vi.stubEnv('VITE_API_URL', 'https://test.example.com');
+vi.stubEnv('VITE_API_URL', 'http://localhost:3000');
 vi.stubEnv('VITE_API_KEY', 'test-key-123');
 vi.stubEnv('VITE_ENABLE_SSE_STREAMING', 'true');
 
 // Mock fetch globally
 global.fetch = vi.fn();
+
+// Mock scrollIntoView (not available in jsdom)
+Element.prototype.scrollIntoView = vi.fn();
 
 // Mock AbortController if not available
 if (typeof AbortController === 'undefined') {

--- a/lexwebapp/src/pages/__tests__/AdminMonitoringBackfill.test.tsx
+++ b/lexwebapp/src/pages/__tests__/AdminMonitoringBackfill.test.tsx
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { AxiosError } from 'axios';
 
 // Mock timers for polling
 vi.useFakeTimers({ shouldAdvanceTime: true });
@@ -266,9 +267,10 @@ describe('Document Completeness & Backfill', () => {
     });
 
     it('handles 429 error for completeness check', async () => {
-      mockRunCompletenessCheck.mockRejectedValue({
-        response: { status: 429, data: { error: 'Ліміт вичерпано: 5/5 перевірок сьогодні' } },
-      });
+      const axiosErr = new AxiosError('Request failed', '429', undefined, undefined, {
+        status: 429, data: { error: 'Ліміт вичерпано: 5/5 перевірок сьогодні' },
+      } as any);
+      mockRunCompletenessCheck.mockRejectedValue(axiosErr);
       render(<AdminMonitoringPage />);
 
       await waitFor(() => {
@@ -364,9 +366,10 @@ describe('Document Completeness & Backfill', () => {
 
     it('handles 409 conflict (already running) by fetching status', async () => {
       mockRunCompletenessCheck.mockResolvedValue({ data: mockCompletenessResult });
-      mockStartBackfill.mockRejectedValue({
-        response: { status: 409, data: { error: 'Backfill вже виконується', job_id: 'backfill-existing' } },
-      });
+      const conflict409 = new AxiosError('Conflict', '409', undefined, undefined, {
+        status: 409, data: { error: 'Backfill вже виконується', job_id: 'backfill-existing' },
+      } as any);
+      mockStartBackfill.mockRejectedValue(conflict409);
       mockGetBackfillStatus
         .mockResolvedValueOnce({ data: { active: false, job: null } }) // initial mount
         .mockResolvedValue({ data: mockBackfillJobRunning }); // after 409

--- a/lexwebapp/src/utils/errors.ts
+++ b/lexwebapp/src/utils/errors.ts
@@ -16,6 +16,19 @@ export function getErrorMessage(error: unknown): string {
   if (typeof error === 'string') {
     return error;
   }
+  if (typeof error === 'object' && error !== null) {
+    const obj = error as Record<string, unknown>;
+    // Extract from response.data (axios-like error shape without isAxiosError)
+    if (obj.response && typeof obj.response === 'object') {
+      const resp = obj.response as Record<string, unknown>;
+      if (resp.data && typeof resp.data === 'object') {
+        const data = resp.data as Record<string, unknown>;
+        if (typeof data.message === 'string') return data.message;
+        if (typeof data.error === 'string') return data.error;
+      }
+    }
+    if (typeof obj.message === 'string') return obj.message;
+  }
   return 'Невідома помилка';
 }
 


### PR DESCRIPTION
## Summary
- Fix root cause of `VITE_API_URL` test failures: test setup was stubbing `test.example.com` which is not in the allow-list. Changed to `http://localhost:3000`
- Fix `getErrorMessage()` to extract error messages from plain objects (non-AxiosError catch values with `message` or `response.data.error`)
- Fix `AdminMonitoringBackfill` test mocks to use proper `AxiosError` instances so `axios.isAxiosError()` checks pass
- Add `Element.prototype.scrollIntoView` mock for jsdom (fixes ConsultationChatTab error)

## Root cause
Tests were throwing plain objects `{ message: 'Server down' }` instead of `AxiosError` instances. `getErrorMessage()` only handled `AxiosError`, `Error`, and `string` — plain objects fell through to "Невідома помилка".

## Test plan
- [x] All 6 previously failing test files pass locally (90/90 tests)
- [x] 1 pre-existing MCPService test failure is unrelated (broken before these changes)
- [ ] CI pipeline passes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)