### PR TITLE
fix: remove stale MCPService.parseBackendResponse tests

### DIFF
--- a/lexwebapp/src/services/api/__tests__/MCPService.test.ts
+++ b/lexwebapp/src/services/api/__tests__/MCPService.test.ts
@@ -206,56 +206,5 @@ describe('MCPService', () => {
     });
   });
 
-  describe('parseBackendResponse', () => {
-    it('should parse nested JSON response', () => {
-      const response = {
-        result: {
-          content: [
-            {
-              text: JSON.stringify({ answer: 'Test' }),
-            },
-          ],
-        },
-      };
-
-      // Access private method via any
-      const parsed = (mcpService as any).parseBackendResponse(response);
-
-      expect(parsed).toEqual({ answer: 'Test' });
-    });
-
-    it('should handle direct result format', () => {
-      const response = {
-        result: { answer: 'Test' },
-      };
-
-      const parsed = (mcpService as any).parseBackendResponse(response);
-
-      expect(parsed).toEqual({ answer: 'Test' });
-    });
-
-    it('should handle plain response', () => {
-      const response = { answer: 'Test' };
-
-      const parsed = (mcpService as any).parseBackendResponse(response);
-
-      expect(parsed).toEqual({ answer: 'Test' });
-    });
-
-    it('should handle JSON parse errors', () => {
-      const response = {
-        result: {
-          content: [
-            {
-              text: 'invalid json',
-            },
-          ],
-        },
-      };
-
-      const parsed = (mcpService as any).parseBackendResponse(response);
-
-      expect(parsed).toEqual(response);
-    });
-  });
+  // parseBackendResponse was moved to response-transformers.ts — tests are in that module
 });


### PR DESCRIPTION
## Summary
- Remove 4 stale tests for `parseBackendResponse` that was moved to `response-transformers.ts`
- Tests were calling `(mcpService as any).parseBackendResponse()` which no longer exists
- This was the last CI blocker — all 180 frontend tests now pass

## Test plan
- [x] Full test suite passes locally (12/12 files, 180/180 tests)
- [ ] CI pipeline passes on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)