### PR TITLE
feat: add EDRSR scenarios to query-type-config and evidence extractor

### DIFF
--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -24,7 +24,7 @@ export const QUERY_TYPE_CONFIG: Record<QueryType, QueryTypeConfig> = {
   case_lookup: {
     defaultBudget: 'standard',
     requiresGrounding: true,
-    preferredScenarios: ['specific_case_lookup', 'case_chain_analysis', 'comprehensive_case_analysis'],
+    preferredScenarios: ['specific_case_lookup', 'case_chain_analysis', 'comprehensive_case_analysis', 'edrsr_case_search'],
     groundingNote: 'Відповідь МУСИТЬ містити дані з результатів інструментів (номер справи, суд, дата, резолютивна частина). Не вигадуй деталі справи.',
     thinkingPrefix: 'Шукаю справу в реєстрі',
   },
@@ -112,7 +112,7 @@ export const QUERY_TYPE_CONFIG: Record<QueryType, QueryTypeConfig> = {
   institutional_analysis: {
     defaultBudget: 'deep',
     requiresGrounding: true,
-    preferredScenarios: ['court_practice_search', 'practice_pro_contra', 'supreme_court_practice'],
+    preferredScenarios: ['edrsr_judge_analysis', 'edrsr_case_search', 'court_practice_search', 'practice_pro_contra', 'supreme_court_practice'],
     groundingNote: 'Запит потребує глибокого інституційного аналізу. Система згенерує набір робочих процесів (workflows) для поетапного виконання.',
     thinkingPrefix: 'Генерую план глибокого аналізу',
   },

--- a/mcp_backend/src/services/evidence-extractor.ts
+++ b/mcp_backend/src/services/evidence-extractor.ts
@@ -101,6 +101,8 @@ export function extractFromToolResult(
     'compare_practice_pro_contra',
     'get_court_decision',
     'count_cases_by_party',
+    'search_edrsr_decisions',
+    'get_edrsr_decision_fulltext',
   ];
   if (courtTools.some((t) => toolName.includes(t) || toolName === t)) {
     // source_case (single)


### PR DESCRIPTION
## Summary
- Add `edrsr_case_search` to `case_lookup` preferred scenarios for local DB search before ZO API
- Add `edrsr_judge_analysis` and `edrsr_case_search` to `institutional_analysis` preferred scenarios
- Register `search_edrsr_decisions` and `get_edrsr_decision_fulltext` as court tools in evidence extractor

## Test plan
- [ ] Backend builds successfully
- [ ] EDRSR tools appear in filtered tools for case_lookup and institutional_analysis queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)