### PR TITLE
fix: self-healing CI/CD — Bedrock Sonnet 4.6, PR flow, loop guard

### DIFF
--- a/.github/workflows/ci-local-deploy.yml.disabled
+++ b/.github/workflows/ci-local-deploy.yml.disabled
@@ -11,6 +11,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 concurrency:
   group: deploy-local-to-prod
   cancel-in-progress: false
@@ -182,13 +186,17 @@ jobs:
       needs.detect-changes.outputs.has_changes == 'true' &&
       contains(needs.*.result, 'failure')
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      GH_TOKEN: ${{ secrets.CI_AUTOFIX_TOKEN }}
+      CLAUDE_CODE_USE_BEDROCK: '1'
+      CLAUDE_CODE_BEDROCK_MODEL: anthropic.claude-sonnet-4-6
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: eu-central-1
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
-          token: ${{ secrets.CI_AUTOFIX_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Guard against infinite loops
         id: guard
@@ -542,15 +550,19 @@ jobs:
       always() &&
       needs.deploy-prod.result == 'failure'
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_USE_BEDROCK: '1'
+      CLAUDE_CODE_BEDROCK_MODEL: anthropic.claude-sonnet-4-6
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: eu-central-1
       PROD_SERVER: '18.192.189.254'
       PROD_USER: 'ubuntu'
-      GH_TOKEN: ${{ secrets.CI_AUTOFIX_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
-          token: ${{ secrets.CI_AUTOFIX_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Guard against infinite loops
         id: guard

--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -109,7 +109,11 @@ jobs:
       always() &&
       needs.build-and-test.result == 'failure'
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_USE_BEDROCK: '1'
+      CLAUDE_CODE_BEDROCK_MODEL: anthropic.claude-sonnet-4-6
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: eu-central-1
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
@@ -431,7 +435,11 @@ jobs:
       always() &&
       needs.deploy-prod.result == 'failure'
     env:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      CLAUDE_CODE_USE_BEDROCK: '1'
+      CLAUDE_CODE_BEDROCK_MODEL: anthropic.claude-sonnet-4-6
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: eu-central-1
       PROD_SERVER: '18.192.189.254'
       PROD_USER: 'ubuntu'
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- **PR flow**: self-heal jobs now create a branch + PR instead of pushing directly to protected `main`
- **AWS Bedrock**: replaced `ANTHROPIC_API_KEY` with Bedrock Sonnet 4.6 (5x cheaper than Opus)
- **Loop guard**: checks last 5 commits for `[ci-autofix]` (not just last 1)
- **No prod SSH**: `self-heal-deploy` no longer has SSH access to production — code-only fixes
- **No PAT needed**: uses `GITHUB_TOKEN` with `permissions: contents/pull-requests: write`

## Changes
- `.github/workflows/ci-stage-deploy.yml` — active workflow
- `.github/workflows/ci-local-deploy.yml.disabled` — local workflow (disabled)

## AWS setup done
- IAM user `ci-autofix-bot` with Bedrock-only access (Sonnet 4.6)
- GitHub secrets `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` added

## Test plan
- [ ] Trigger a build failure on a test branch to verify self-heal creates PR
- [ ] Verify Bedrock credentials work with `claude` CLI
- [ ] Confirm loop guard skips when `[ci-autofix]` found in recent commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)