### PR TITLE
fix: upload rate limit + PDF parsing crash on prod

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -607,12 +607,16 @@ class HTTPMCPServer {
 
     // Global rate limiter (express-rate-limit) — recognised by CodeQL as proper rate limiting.
     // Our custom Redis-backed limiters still apply per-route for finer control.
+    // Upload routes are excluded — they have their own per-user Redis-backed limits
+    // (upload-rate-limit.ts) and the global IP-based limit blocks bulk folder uploads
+    // through Cloudflare (all requests arrive from the same CF edge IP).
     this.app.use(rateLimit({
       windowMs: 60 * 1000,
       max: 900,
       standardHeaders: true,
       legacyHeaders: false,
       message: { error: 'Too Many Requests', code: 'RATE_LIMIT_EXCEEDED' },
+      skip: (req) => req.path.startsWith('/upload'),
     }));
 
     // Monobank webhooks need raw body BEFORE json parsing for signature verification

--- a/mcp_backend/src/services/document-parser.ts
+++ b/mcp_backend/src/services/document-parser.ts
@@ -159,6 +159,17 @@ export class DocumentParser {
             body: `<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
 <body>
+<script>
+// Polyfill Map.prototype.getOrInsertComputed (TC39 Stage 3) — required by pdfjs-dist ≥5.x
+if (!Map.prototype.getOrInsertComputed) {
+  Map.prototype.getOrInsertComputed = function(key, callbackFn) {
+    if (this.has(key)) return this.get(key);
+    const value = callbackFn(key);
+    this.set(key, value);
+    return value;
+  };
+}
+</script>
 <script type="module">
 import { getDocument, GlobalWorkerOptions } from './pdf.min.mjs';
 GlobalWorkerOptions.workerSrc = './pdf.worker.min.mjs';
@@ -257,6 +268,17 @@ window.extractText = async function(base64Data, maxPages) {
             body: `<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
 <body><div id="container"></div>
+<script>
+// Polyfill Map.prototype.getOrInsertComputed (TC39 Stage 3) — required by pdfjs-dist ≥5.x
+if (!Map.prototype.getOrInsertComputed) {
+  Map.prototype.getOrInsertComputed = function(key, callbackFn) {
+    if (this.has(key)) return this.get(key);
+    const value = callbackFn(key);
+    this.set(key, value);
+    return value;
+  };
+}
+</script>
 <script type="module">
 import { getDocument, GlobalWorkerOptions } from './pdf.min.mjs';
 GlobalWorkerOptions.workerSrc = './pdf.worker.min.mjs';


### PR DESCRIPTION
## Summary
- **Rate limit**: exclude `/upload/*` from global `express-rate-limit` (900/min per IP). Bulk folder uploads through Cloudflare hit this limit instantly — all requests arrive from the same CF edge IP (`172.64.198.70`). Upload routes already have per-user Redis-backed rate limits (`upload-rate-limit.ts`).
- **PDF parsing**: add `Map.prototype.getOrInsertComputed` polyfill for Playwright's Chromium. pdfjs-dist 5.x uses this TC39 Stage 3 API in `getOptionalContentConfig()`, crashing with `TypeError: this[#Ar].getOrInsertComputed is not a function`.

## Test plan
- [ ] Upload 100+ files in a folder — no 429 errors from global rate limiter
- [ ] Upload a PDF file — parses successfully without `getOrInsertComputed` error
- [ ] Non-upload API routes still rate-limited at 900/min

🤖 Generated with [Claude Code](https://claude.com/claude-code)