### PR TITLE
fix: metadata extraction JSON parsing + empty embedding guard

### DIFF
--- a/mcp_backend/src/services/embedding-service.ts
+++ b/mcp_backend/src/services/embedding-service.ts
@@ -83,10 +83,17 @@ export class EmbeddingService implements IEmbeddingPort {
   }
 
   async generateEmbeddingsBatch(texts: string[], task: string = 'batch_embedding'): Promise<number[][]> {
+    // Filter out empty strings — VoyageAI rejects them with 400
+    const filtered = texts.filter(t => t && t.trim().length > 0);
+    if (filtered.length === 0) {
+      return texts.map(() => []);
+    }
     try {
-      const result = await this.voyageClient.generateEmbeddingsBatchWithUsage(texts, VOYAGE_MODEL);
+      const result = await this.voyageClient.generateEmbeddingsBatchWithUsage(filtered, VOYAGE_MODEL);
       this.tokenUsageCallback?.(result.totalTokens, result.model, task);
-      return result.embeddings;
+      // Map back: empty inputs get empty embeddings, non-empty get real ones
+      let idx = 0;
+      return texts.map(t => (t && t.trim().length > 0) ? result.embeddings[idx++] : []);
     } catch (error) {
       logger.error('Batch embedding generation error:', error);
       throw error;

--- a/mcp_backend/src/services/metadata-extractor.ts
+++ b/mcp_backend/src/services/metadata-extractor.ts
@@ -73,10 +73,15 @@ export class MetadataExtractor {
       );
 
       rawContent = response.content;
-      const raw = rawContent?.trim();
+      let raw = rawContent?.trim();
       if (!raw) {
         logger.warn('[MetadataExtractor] LLM returned empty content', { title, docType });
         return EMPTY_METADATA;
+      }
+
+      // Strip markdown code blocks (```json ... ```) — some LLMs ignore response_format
+      if (raw.startsWith('```')) {
+        raw = raw.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
       }
 
       const parsed = JSON.parse(raw);


### PR DESCRIPTION
## Summary
- **MetadataExtractor**: strip ` ```json ` markdown code blocks from LLM response before JSON.parse(). Bedrock Haiku ignores `response_format: json_object` and wraps output in markdown fences, causing 985/1100 documents to get `null` documentSubtype → "потребують уваги" in UI.
- **EmbeddingService**: filter empty strings from batch before sending to VoyageAI API (rejects with 400). Documents with no extractable text now skip embedding gracefully.

## Test plan
- [ ] Upload a document — metadata extraction succeeds, documentSubtype populated
- [ ] Upload an empty DOCX — no VoyageAI 400 error, document stored with empty embedding
- [ ] Re-classify existing 985 documents with null subtype

🤖 Generated with [Claude Code](https://claude.com/claude-code)