### PR TITLE
feat: resizable document viewer modal

### DIFF
--- a/lexwebapp/src/components/DocumentViewerModal/ImageOcrViewer.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/ImageOcrViewer.tsx
@@ -44,7 +44,7 @@ export function ImageOcrViewer({ item, onSaveOcrText }: ImageOcrViewerProps) {
   };
 
   return (
-    <div className="flex gap-4 h-[70vh]">
+    <div className="flex gap-4 h-full">
       {/* Left: Image preview with zoom/crop/follow */}
       <div className="flex-1 min-w-0">
         <ImageViewer

--- a/lexwebapp/src/components/DocumentViewerModal/MediaViewer.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/MediaViewer.tsx
@@ -7,7 +7,7 @@ interface MediaViewerProps {
 
 export function ImageOnlyViewer({ item }: MediaViewerProps) {
   return (
-    <div className="h-[70vh]">
+    <div className="h-full">
       <ImageViewer
         src={item.previewUrl!}
         alt={item.title}
@@ -20,7 +20,7 @@ export function PdfViewer({ item }: MediaViewerProps) {
   return (
     <iframe
       src={item.previewUrl!}
-      className="w-full h-[70vh] rounded-lg border border-claude-border"
+      className="w-full h-full rounded-lg border border-claude-border"
       title={item.title}
     />
   );
@@ -28,11 +28,11 @@ export function PdfViewer({ item }: MediaViewerProps) {
 
 export function VideoViewer({ item }: MediaViewerProps) {
   return (
-    <div className="flex items-center justify-center">
+    <div className="flex items-center justify-center h-full">
       <video
         src={item.previewUrl!}
         controls
-        className="max-w-full max-h-[70vh] rounded-lg"
+        className="max-w-full max-h-full rounded-lg"
       />
     </div>
   );

--- a/lexwebapp/src/components/DocumentViewerModal/index.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/index.tsx
@@ -112,7 +112,8 @@ export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMes
                 animate={{ opacity: 1, scale: 1, y: 0 }}
                 exit={{ opacity: 0, scale: 0.95, y: 20 }}
                 transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
-                className={`bg-white rounded-xl shadow-2xl w-full max-h-[85vh] flex flex-col ${isImageWithOcr ? 'max-w-6xl' : 'max-w-3xl'}`}
+                className={`bg-white rounded-xl shadow-2xl flex flex-col resize overflow-hidden ${isImageWithOcr ? 'w-[90vw] h-[90vh]' : 'w-[48rem] h-[85vh]'}`}
+                style={{ minWidth: '24rem', minHeight: '20rem', maxWidth: '98vw', maxHeight: '96vh' }}
                 onClick={(e) => e.stopPropagation()}
               >
                 {/* Header */}
@@ -212,7 +213,7 @@ export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMes
                 </div>
 
                 {/* Content — binary preview or Markdown rendered */}
-                <div className="flex-1 overflow-y-auto px-6 py-5">
+                <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
                   <ContentRenderer
                     item={item}
                     isLoading={isLoading}


### PR DESCRIPTION
## Summary
- Modal window on /documents page is now resizable — drag the bottom-right corner
- Image/PDF/video content fills the resized area instead of fixed 70vh
- Default: 90vw×90vh for image+OCR, 48rem×85vh for text documents
- Min: 24rem×20rem, Max: 98vw×96vh

## Test plan
- [ ] Open image document — modal shows resize handle at bottom-right corner
- [ ] Drag to resize — image fills available space
- [ ] Open PDF — iframe fills resized modal
- [ ] Open text document — content scrolls within resized area

🤖 Generated with [Claude Code](https://claude.com/claude-code)