### PR TITLE
fix: persist response_id in cost_summary for reload

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -2414,6 +2414,7 @@ class HTTPMCPServer {
               total_cost_usd: chatTotalCostUsd,
               charged_usd: chargedUsd,
               balance_usd: summary?.balance_usd ?? 0,
+              response_id: requestId,
             };
             res.write(`event: cost_summary\n`);
             res.write(`data: ${JSON.stringify({

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1309,7 +1309,7 @@ export class ChatService {
             decisions: evidence?.decisions && evidence.decisions.length > 0 ? evidence.decisions : undefined,
             citations: evidence?.citations && evidence.citations.length > 0 ? evidence.citations : undefined,
             documents: evidence?.documents && evidence.documents.length > 0 ? evidence.documents : undefined,
-            cost_summary: totalCostUsd > 0 ? { total_cost_usd: totalCostUsd, tools_used: toolsUsed } : undefined,
+            cost_summary: totalCostUsd > 0 ? { total_cost_usd: totalCostUsd, tools_used: toolsUsed, response_id: requestId } : undefined,
           });
         } catch (e) {
           logger.warn('[ChatService] Failed to persist messages', { error: (e as Error).message });


### PR DESCRIPTION
## Summary
- `response_id` was only sent via SSE but never saved to `conversation_messages.cost_summary`
- On Shift+Ctrl+R it disappeared from chat UI
- Now persisted in both initial save (chat-service.ts) and post-billing UPDATE (http-server.ts)

## Test plan
- [ ] Send chat message — response_id shown in cost footer
- [ ] Hard refresh (Shift+Ctrl+R) — response_id still visible
- [ ] Switch conversations — response_id preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)