### PR TITLE
fix: cost_summary type — add response_id, charged_usd, balance_usd

### DIFF
--- a/mcp_backend/src/services/conversation-service.ts
+++ b/mcp_backend/src/services/conversation-service.ts
@@ -23,7 +23,7 @@ export interface ConversationMessage {
   documents?: any[];
   tool_calls?: any[];
   cost_tracking_id?: string;
-  cost_summary?: { total_cost_usd: number; tools_used: string[] } | null;
+  cost_summary?: { total_cost_usd: number; tools_used: string[]; response_id?: string; charged_usd?: number; balance_usd?: number } | null;
   created_at: Date;
 }
 
@@ -114,7 +114,7 @@ export class ConversationService {
       documents?: any[];
       tool_calls?: any[];
       cost_tracking_id?: string;
-      cost_summary?: { total_cost_usd: number; tools_used: string[] } | null;
+      cost_summary?: { total_cost_usd: number; tools_used: string[]; response_id?: string; charged_usd?: number; balance_usd?: number } | null;
     }
   ): Promise<ConversationMessage | null> {
     // Verify ownership


### PR DESCRIPTION
## Summary
Build fix: extend `ConversationMessage.cost_summary` type in conversation-service.ts to include `response_id`, `charged_usd`, `balance_usd` fields that PRs #778 and #779 now persist.

## Test plan
- [ ] `npm run build` passes in mcp_backend
- [ ] Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)