### PR TITLE
fix: escalate due_diligence to institutional_analysis for deep investigations

### DIFF
--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -112,7 +112,7 @@ export const QUERY_TYPE_CONFIG: Record<QueryType, QueryTypeConfig> = {
   institutional_analysis: {
     defaultBudget: 'deep',
     requiresGrounding: true,
-    preferredScenarios: ['edrsr_judge_analysis', 'edrsr_case_search', 'court_practice_search', 'practice_pro_contra', 'supreme_court_practice'],
+    preferredScenarios: ['edrsr_judge_analysis', 'edrsr_case_search', 'court_practice_search', 'practice_pro_contra', 'supreme_court_practice', 'due_diligence_check', 'entity_search_name', 'beneficiary_search'],
     groundingNote: 'Запит потребує глибокого інституційного аналізу. Система згенерує набір робочих процесів (workflows) для поетапного виконання.',
     thinkingPrefix: 'Генерую план глибокого аналізу',
   },

--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -189,6 +189,17 @@ export class IntentClassifier {
         }
       }
 
+      // Escalate due_diligence → institutional_analysis for long-period investigations
+      // Queries spanning 5+ years, mentioning corruption schemes, or requesting deep investigation
+      // of affiliated persons need workflow-based multi-step analysis, not a single agentic loop
+      if (queryType === 'due_diligence') {
+        const hasLongPeriod = /(?:\d{2,})\s*(?:років|рок|лет|year)|за\s+(?:весь\s+)?(?:час|період|історі)/i.test(query);
+        const isDeepInvestigation = /корупц|розслідуван|афілі.{0,30}(?:персон|осіб|чиновник|судд|адвокат|нотаріус)|схем.{0,20}(?:присво|виведен|захоплен)/i.test(query);
+        if (hasLongPeriod || isDeepInvestigation) {
+          queryType = 'institutional_analysis';
+        }
+      }
+
       let unsupportedReason = queryType === 'unsupported' && typeof parsed.unsupportedReason === 'string'
         ? parsed.unsupportedReason
         : undefined;


### PR DESCRIPTION
## Summary
- Escalate `due_diligence` → `institutional_analysis` when query spans long periods (10+ years) or involves corruption/affiliated persons investigation
- Add registry scenarios to `institutional_analysis.preferredScenarios` so OpenReyestr tools are available in workflows
- Root cause: "Амальтея Стар за 20 лет" ran as single agentic loop instead of generating multi-step investigation workflows

## Test plan
- [ ] Query "перевірити компанію за 20 років" → queryType = institutional_analysis, workflows generated
- [ ] Query "корупційна схема присвоєння" → escalated to institutional_analysis
- [ ] Simple "перевірити контрагента ТОВ" → stays as due_diligence (no escalation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)