### PR TITLE
fix: align referral page with platform design system

### DIFF
--- a/lexwebapp/src/pages/ReferralPage/index.tsx
+++ b/lexwebapp/src/pages/ReferralPage/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import { Copy, Check, UserPlus, Gift, Users, TrendingUp, Award, DollarSign, Hash } from 'lucide-react';
+import { Copy, Check, UserPlus, Gift, Users, TrendingUp, Award, DollarSign, Link2 } from 'lucide-react';
 import { ReferralService, ReferralStats, ReferralEntry } from '../../services/api/ReferralService';
 import { showToast } from '../../utils/toast';
 
@@ -14,7 +14,8 @@ export function ReferralPage() {
   const [stats, setStats] = useState<ReferralStats | null>(null);
   const [referrals, setReferrals] = useState<ReferralEntry[]>([]);
   const [loading, setLoading] = useState(true);
-  const [copied, setCopied] = useState(false);
+  const [copiedCode, setCopiedCode] = useState(false);
+  const [copiedLink, setCopiedLink] = useState(false);
 
   useEffect(() => {
     async function load() {
@@ -37,13 +38,25 @@ export function ReferralPage() {
 
   const referralLink = stats ? `${window.location.origin}/r/${stats.referralCode}` : '';
 
-  const handleCopy = async () => {
+  const handleCopyCode = async () => {
+    if (!stats?.referralCode) return;
+    try {
+      await navigator.clipboard.writeText(stats.referralCode);
+      setCopiedCode(true);
+      showToast.success('Код скопійовано');
+      setTimeout(() => setCopiedCode(false), 2000);
+    } catch {
+      showToast.error('Не вдалося скопіювати');
+    }
+  };
+
+  const handleCopyLink = async () => {
     if (!referralLink) return;
     try {
       await navigator.clipboard.writeText(referralLink);
-      setCopied(true);
+      setCopiedLink(true);
       showToast.success('Посилання скопійовано');
-      setTimeout(() => setCopied(false), 2000);
+      setTimeout(() => setCopiedLink(false), 2000);
     } catch {
       showToast.error('Не вдалося скопіювати');
     }
@@ -58,80 +71,94 @@ export function ReferralPage() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto px-4 py-8">
-      <h1 className="text-2xl font-bold text-claude-text mb-6 font-sans flex items-center gap-2">
-        <UserPlus size={24} />
-        Реферальна програма
-      </h1>
+    <div className="max-w-4xl mx-auto px-4 py-8 md:px-8 lg:px-12">
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl md:text-4xl font-serif text-claude-text font-medium tracking-tight mb-2">
+          Реферальна програма
+        </h1>
+        <p className="text-sm text-claude-subtext">
+          Запрошуйте колег та отримуйте винагороду за кожного активного клієнта
+        </p>
+      </div>
 
-      {/* Referral Code — crypto style */}
-      <div className="bg-gray-950 rounded-xl border border-gray-800 p-6 mb-6">
+      {/* Referral Code */}
+      <div className="bg-white rounded-xl border border-claude-border p-6 mb-6">
         <div className="flex items-center gap-2 mb-4">
-          <Hash size={14} className="text-emerald-400" />
-          <h2 className="text-xs font-semibold text-gray-400 uppercase tracking-widest">
-            Ваш реферальний код
+          <div className="p-2 bg-claude-accent/10 rounded-lg">
+            <Link2 size={16} className="text-claude-accent" />
+          </div>
+          <h2 className="text-sm font-semibold text-claude-text uppercase tracking-wide">
+            Ваше реферальне посилання
           </h2>
         </div>
-        <div className="bg-gray-900 rounded-lg border border-gray-800 px-4 py-3 mb-3 flex items-center justify-between gap-3">
-          <code className="text-emerald-400 text-sm font-mono tracking-wider break-all select-all">
-            {stats?.referralCode ?? '—'}
-          </code>
-          <button
-            onClick={handleCopy}
-            className="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 rounded-md hover:bg-emerald-500/20 transition-colors text-xs font-mono"
-          >
-            {copied ? <Check size={12} /> : <Copy size={12} />}
-            {copied ? 'OK' : 'COPY'}
-          </button>
+
+        <div className="space-y-3">
+          {/* Code */}
+          <div className="flex items-center gap-3">
+            <div className="flex-1 bg-claude-bg rounded-lg border border-claude-border px-4 py-2.5">
+              <span className="text-sm font-mono text-claude-text tracking-wider select-all">
+                {stats?.referralCode ?? '—'}
+              </span>
+            </div>
+            <button
+              onClick={handleCopyCode}
+              className="flex-shrink-0 flex items-center gap-1.5 px-4 py-2.5 bg-claude-accent text-white rounded-lg hover:bg-claude-accent/90 transition-colors text-xs font-medium"
+            >
+              {copiedCode ? <Check size={14} /> : <Copy size={14} />}
+              {copiedCode ? 'Скопійовано' : 'Копіювати'}
+            </button>
+          </div>
+
+          {/* Full link */}
+          <div className="flex items-center gap-3">
+            <div className="flex-1 bg-claude-bg rounded-lg border border-claude-border px-4 py-2.5 overflow-hidden">
+              <span className="text-xs text-claude-subtext truncate block select-all">{referralLink}</span>
+            </div>
+            <button
+              onClick={handleCopyLink}
+              className="flex-shrink-0 flex items-center gap-1.5 px-4 py-2.5 border border-claude-border text-claude-text rounded-lg hover:bg-claude-bg transition-colors text-xs font-medium"
+            >
+              {copiedLink ? <Check size={14} /> : <Copy size={14} />}
+              Посилання
+            </button>
+          </div>
         </div>
-        <div className="bg-gray-900 rounded-lg border border-gray-800 px-4 py-3 flex items-center justify-between gap-3">
-          <span className="text-gray-500 text-xs font-mono truncate">{referralLink}</span>
-          <button
-            onClick={async () => {
-              if (!referralLink) return;
-              try {
-                await navigator.clipboard.writeText(referralLink);
-                showToast.success('Посилання скопійовано');
-              } catch {
-                showToast.error('Не вдалося скопіювати');
-              }
-            }}
-            className="flex-shrink-0 flex items-center gap-1.5 px-3 py-1.5 bg-gray-800 text-gray-400 border border-gray-700 rounded-md hover:bg-gray-700 transition-colors text-xs font-mono"
-          >
-            <Copy size={12} />
-            LINK
-          </button>
-        </div>
-        <p className="text-xs text-gray-500 mt-3">
+
+        <p className="text-xs text-claude-subtext mt-4">
           Поділіться кодом або посиланням з колегами. Ви отримуватимете до 20% від кожного платежу запрошеного клієнта.
         </p>
       </div>
 
       {/* Program Terms */}
-      <div className="bg-gradient-to-br from-amber-50 to-orange-50 rounded-xl border border-amber-200 p-6 mb-6">
-        <h2 className="text-sm font-semibold text-amber-900 mb-4 uppercase tracking-wide flex items-center gap-2">
-          <Award size={16} />
-          Умови реферальної програми
-        </h2>
+      <div className="bg-white rounded-xl border border-claude-border p-6 mb-6">
+        <div className="flex items-center gap-2 mb-5">
+          <div className="p-2 bg-claude-accent/10 rounded-lg">
+            <Award size={16} className="text-claude-accent" />
+          </div>
+          <h2 className="text-sm font-semibold text-claude-text uppercase tracking-wide">
+            Умови програми
+          </h2>
+        </div>
         <div className="space-y-4">
           <div className="flex items-start gap-3">
-            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center">
-              <TrendingUp size={16} className="text-amber-700" />
+            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-claude-accent/10 flex items-center justify-center">
+              <TrendingUp size={16} className="text-claude-accent" />
             </div>
             <div>
-              <h3 className="text-sm font-semibold text-claude-text">До 20% від кожного платежу</h3>
-              <p className="text-xs text-claude-subtext mt-1">
+              <h3 className="text-sm font-serif font-medium text-claude-text">До 20% від кожного платежу</h3>
+              <p className="text-xs text-claude-subtext mt-1 leading-relaxed">
                 Ви отримуєте до 20% реферальної винагороди з кожного платежу клієнта, якого ви привели на платформу. Винагорода нараховується постійно, поки клієнт залишається активним.
               </p>
             </div>
           </div>
           <div className="flex items-start gap-3">
-            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center">
-              <Award size={16} className="text-amber-700" />
+            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-claude-accent/10 flex items-center justify-center">
+              <Award size={16} className="text-claude-accent" />
             </div>
             <div>
-              <h3 className="text-sm font-semibold text-claude-text">Equity Share для топ-рефералів</h3>
-              <p className="text-xs text-claude-subtext mt-1">
+              <h3 className="text-sm font-serif font-medium text-claude-text">Equity Share для топ-рефералів</h3>
+              <p className="text-xs text-claude-subtext mt-1 leading-relaxed">
                 Якщо за 3 місяці ви запросите 10+ клієнтів, кожен з яких платить від $500/міс — вся сума виплачених вам реферальних відсотків додатково конвертується в equity share компанії.
               </p>
             </div>
@@ -141,58 +168,43 @@ export function ReferralPage() {
 
       {/* Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        <div className="bg-white rounded-xl border border-claude-border p-5">
-          <div className="flex items-center gap-2 text-claude-subtext mb-2">
-            <Users size={16} />
-            <span className="text-xs font-semibold uppercase tracking-wide">Запрошено</span>
+        {[
+          { icon: Users, label: 'Запрошено', value: String(stats?.totalReferrals ?? 0) },
+          { icon: DollarSign, label: 'Оплачено рефералами', value: `$${referrals.reduce((sum, r) => sum + (r.totalPaidUsd ?? 0), 0).toFixed(2)}` },
+          { icon: Gift, label: 'Зароблено (USD)', value: `$${(stats?.totalEarnedUsd ?? 0).toFixed(2)}` },
+          { icon: Gift, label: 'Зароблено (UAH)', value: `₴${(stats?.totalEarnedUah ?? 0).toFixed(2)}` },
+        ].map(({ icon: Icon, label, value }) => (
+          <div key={label} className="bg-white rounded-xl border border-claude-border p-5 hover:shadow-md hover:border-claude-subtext/30 transition-all">
+            <div className="flex items-center gap-2 text-claude-subtext mb-2">
+              <Icon size={16} strokeWidth={2} />
+              <span className="text-[11px] font-semibold uppercase tracking-wide">{label}</span>
+            </div>
+            <div className="text-2xl font-serif font-medium text-claude-text">
+              {value}
+            </div>
           </div>
-          <div className="text-2xl font-bold text-claude-text">
-            {stats?.totalReferrals ?? 0}
-          </div>
-        </div>
-        <div className="bg-white rounded-xl border border-claude-border p-5">
-          <div className="flex items-center gap-2 text-claude-subtext mb-2">
-            <DollarSign size={16} />
-            <span className="text-xs font-semibold uppercase tracking-wide">Оплачено рефералами</span>
-          </div>
-          <div className="text-2xl font-bold text-claude-text">
-            ${referrals.reduce((sum, r) => sum + (r.totalPaidUsd ?? 0), 0).toFixed(2)}
-          </div>
-        </div>
-        <div className="bg-white rounded-xl border border-claude-border p-5">
-          <div className="flex items-center gap-2 text-claude-subtext mb-2">
-            <Gift size={16} />
-            <span className="text-xs font-semibold uppercase tracking-wide">Зароблено (USD)</span>
-          </div>
-          <div className="text-2xl font-bold text-claude-text">
-            ${(stats?.totalEarnedUsd ?? 0).toFixed(2)}
-          </div>
-        </div>
-        <div className="bg-white rounded-xl border border-claude-border p-5">
-          <div className="flex items-center gap-2 text-claude-subtext mb-2">
-            <Gift size={16} />
-            <span className="text-xs font-semibold uppercase tracking-wide">Зароблено (UAH)</span>
-          </div>
-          <div className="text-2xl font-bold text-claude-text">
-            ₴{(stats?.totalEarnedUah ?? 0).toFixed(2)}
-          </div>
-        </div>
+        ))}
       </div>
 
       {/* Referrals Table */}
       <div className="bg-white rounded-xl border border-claude-border overflow-hidden">
         <div className="px-6 py-4 border-b border-claude-border">
-          <h2 className="text-sm font-semibold text-claude-text">Мої реферали</h2>
+          <h2 className="text-base font-serif font-medium text-claude-text">Мої реферали</h2>
         </div>
         {referrals.length === 0 ? (
-          <div className="px-6 py-12 text-center text-claude-subtext text-sm">
-            Поки що немає рефералів. Поділіться посиланням, щоб запросити друзів!
+          <div className="px-6 py-16 text-center">
+            <div className="w-16 h-16 bg-claude-accent/10 rounded-2xl flex items-center justify-center mx-auto mb-4">
+              <UserPlus size={24} className="text-claude-accent" />
+            </div>
+            <p className="text-sm text-claude-subtext">
+              Поки що немає рефералів. Поділіться посиланням, щоб запросити друзів!
+            </p>
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="bg-claude-bg text-claude-subtext text-xs uppercase tracking-wide">
+                <tr className="bg-claude-bg text-claude-subtext text-[11px] uppercase tracking-wide">
                   <th className="px-6 py-3 text-left font-semibold">Користувач</th>
                   <th className="px-6 py-3 text-left font-semibold">Дата реєстрації</th>
                   <th className="px-6 py-3 text-left font-semibold">Статус</th>
@@ -204,23 +216,23 @@ export function ReferralPage() {
                 {referrals.map((r) => (
                   <tr key={r.referredId} className="hover:bg-claude-bg/50 transition-colors">
                     <td className="px-6 py-3">
-                      <div className="font-medium text-claude-text">
+                      <div className="font-medium text-claude-text text-sm">
                         {r.referredName || r.referredEmail}
                       </div>
                       {r.referredName && (
                         <div className="text-xs text-claude-subtext">{r.referredEmail}</div>
                       )}
                     </td>
-                    <td className="px-6 py-3 text-claude-subtext">
+                    <td className="px-6 py-3 text-claude-subtext text-sm">
                       {new Date(r.registeredAt).toLocaleDateString('uk-UA')}
                     </td>
                     <td className="px-6 py-3">
                       {r.hasToppedUp ? (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-emerald-50 text-emerald-700 border border-emerald-200">
                           Поповнив баланс
                         </span>
                       ) : (
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-claude-bg text-claude-subtext border border-claude-border">
                           Зареєстрований
                         </span>
                       )}
@@ -230,7 +242,7 @@ export function ReferralPage() {
                         ? `$${r.totalPaidUsd.toFixed(2)}`
                         : '—'}
                     </td>
-                    <td className="px-6 py-3 text-right font-medium text-claude-text">
+                    <td className="px-6 py-3 text-right font-medium text-claude-text text-sm">
                       {r.rewardAmountUsd > 0
                         ? `$${r.rewardAmountUsd.toFixed(2)}`
                         : '—'}


### PR DESCRIPTION
## Summary
Redesign referral page to match the platform's design system:
- White cards with `claude-border` instead of dark crypto theme (`bg-gray-950`)
- Serif headings (`font-serif font-medium`) matching HistoryPage, CaseAnalysis
- `claude-accent` for icons/CTAs instead of emerald/amber
- Wider layout (`max-w-4xl`) with responsive padding
- Hover effects on stats cards
- Consistent badge, empty state, and typography patterns

## Test plan
- [ ] Visit /referral — light theme, serif headings, warm accent colors
- [ ] Copy code/link buttons work
- [ ] Stats cards have hover shadow
- [ ] Empty state shows icon + message
- [ ] Mobile responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)