### PR TITLE
fix: Cloudflare maintenance — use GitHub secrets instead of symlink

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -341,16 +341,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Link Cloudflare credentials
-        run: ln -sf /home/vovkes/SecondLayer/.env.cloudflare .env.cloudflare 2>/dev/null || true
-
       - name: Enable Cloudflare maintenance page
+        env:
+          CLOUDFLARE_GLOBAL_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
         run: |
-          if [ -f deployment/maintenance/cf-maintenance.sh ] && [ -f .env.cloudflare ]; then
-            bash deployment/maintenance/cf-maintenance.sh enable prod || echo "::warning::Could not enable CF maintenance page — deploying without it"
-          else
-            echo "::warning::cf-maintenance.sh or .env.cloudflare not found — skipping maintenance page"
+          if [ -z "$CLOUDFLARE_GLOBAL_API_KEY" ] || [ -z "$CLOUDFLARE_EMAIL" ]; then
+            echo "::warning::CLOUDFLARE_GLOBAL_API_KEY or CLOUDFLARE_EMAIL secret not set — skipping maintenance page"
+            exit 0
           fi
+          cat > .env.cloudflare <<EOF
+          CLOUDFLARE_GLOBAL_API_KEY=$CLOUDFLARE_GLOBAL_API_KEY
+          CLOUDFLARE_EMAIL=$CLOUDFLARE_EMAIL
+          EOF
+          bash deployment/maintenance/cf-maintenance.sh enable prod || echo "::warning::Could not enable CF maintenance page — deploying without it"
 
       - name: Deploy changed services to prod
         env:
@@ -444,10 +448,18 @@ jobs:
 
       - name: Disable Cloudflare maintenance page
         if: always()
+        env:
+          CLOUDFLARE_GLOBAL_API_KEY: ${{ secrets.CLOUDFLARE_GLOBAL_API_KEY }}
+          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
         run: |
-          if [ -f deployment/maintenance/cf-maintenance.sh ] && [ -f .env.cloudflare ]; then
-            bash deployment/maintenance/cf-maintenance.sh disable prod || echo "::warning::Could not disable CF maintenance page — run manually"
+          if [ -z "$CLOUDFLARE_GLOBAL_API_KEY" ] || [ -z "$CLOUDFLARE_EMAIL" ]; then
+            exit 0
           fi
+          cat > .env.cloudflare <<EOF
+          CLOUDFLARE_GLOBAL_API_KEY=$CLOUDFLARE_GLOBAL_API_KEY
+          CLOUDFLARE_EMAIL=$CLOUDFLARE_EMAIL
+          EOF
+          bash deployment/maintenance/cf-maintenance.sh disable prod || echo "::warning::Could not disable CF maintenance page — run manually"
 
   # ─── Step 4b: Self-heal deploy failures ─────────────────────────────
   self-heal-deploy:


### PR DESCRIPTION
## Summary
`.env.cloudflare` symlink failed because the file doesn't exist on the stage CI runner.
Now generates `.env.cloudflare` inline from `CLOUDFLARE_GLOBAL_API_KEY` and `CLOUDFLARE_EMAIL` GitHub secrets.

**Required:** Add these secrets to the repo:
- `CLOUDFLARE_GLOBAL_API_KEY`
- `CLOUDFLARE_EMAIL`

## Test plan
- [ ] Add secrets to repo settings
- [ ] Merge → CI enables maintenance page before deploy, disables after

🤖 Generated with [Claude Code](https://claude.com/claude-code)