### PR TITLE
feat: DocumentPicker — select all, pagination, platform styling

### DIFF
--- a/lexwebapp/src/components/consultation/DocumentPicker.tsx
+++ b/lexwebapp/src/components/consultation/DocumentPicker.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Search, FileText, File, Loader2 } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { Search, FileText, File, Loader2, CheckSquare, Square, ChevronDown } from 'lucide-react';
 import { mcpService } from '../../services/api/MCPService';
 import type { VaultDocument } from '../../pages/DocumentsPage/types';
 import { getFileExtension } from '../../pages/DocumentsPage/types';
@@ -12,34 +12,50 @@ interface Props {
   onNext: () => void;
 }
 
+const PAGE_SIZE = 100;
+
 export function DocumentPicker({ selectedIds, onChange, onDocsLoaded, onBack, onNext }: Props) {
   const [docs, setDocs] = useState<VaultDocument[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [search, setSearch] = useState('');
+  const [hasMore, setHasMore] = useState(false);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const loadDocs = useCallback(async (offset: number, append: boolean) => {
+    try {
+      const result = await mcpService.callTool('list_documents', {
+        limit: PAGE_SIZE,
+        offset,
+        sortBy: 'uploadedAt',
+        sortOrder: 'desc',
+      });
+      const parsed = result?.result?.content?.[0]?.text
+        ? JSON.parse(result.result.content[0].text)
+        : result?.result || result;
+      const loaded: VaultDocument[] = parsed.documents || [];
+      const total = parsed.total ?? parsed.totalCount ?? 0;
+
+      const updated = append ? [...docs, ...loaded] : loaded;
+      setDocs(updated);
+      setTotalCount(total);
+      setHasMore(updated.length < total);
+      onDocsLoaded(updated);
+    } catch (err) {
+      console.error('Failed to load documents:', err);
+    }
+  }, [docs, onDocsLoaded]);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const result = await mcpService.callTool('list_documents', {
-          limit: 50,
-          offset: 0,
-          sortBy: 'uploadedAt',
-          sortOrder: 'desc',
-        });
-        const parsed = result?.result?.content?.[0]?.text
-          ? JSON.parse(result.result.content[0].text)
-          : result?.result || result;
-        const loaded = parsed.documents || [];
-        setDocs(loaded);
-        onDocsLoaded(loaded);
-      } catch (err) {
-        console.error('Failed to load documents:', err);
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
+    setLoading(true);
+    loadDocs(0, false).finally(() => setLoading(false));
   }, []);
+
+  const loadMore = async () => {
+    setLoadingMore(true);
+    await loadDocs(docs.length, true);
+    setLoadingMore(false);
+  };
 
   const toggle = (id: string) => {
     onChange(
@@ -57,38 +73,66 @@ export function DocumentPicker({ selectedIds, onChange, onDocsLoaded, onBack, on
       )
     : docs;
 
+  const allFilteredSelected = filtered.length > 0 && filtered.every(d => selectedIds.includes(d.id));
+
+  const toggleAll = () => {
+    if (allFilteredSelected) {
+      // Deselect all filtered
+      const filteredIds = new Set(filtered.map(d => d.id));
+      onChange(selectedIds.filter(id => !filteredIds.has(id)));
+    } else {
+      // Select all filtered (merge with existing selection)
+      const existing = new Set(selectedIds);
+      const merged = [...selectedIds, ...filtered.filter(d => !existing.has(d.id)).map(d => d.id)];
+      onChange(merged);
+    }
+  };
+
   const hasSelected = selectedIds.length > 0;
 
   return (
     <div className="flex flex-col h-full">
       <div className="p-5 pb-3 space-y-3">
         <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-claude-subtext" />
           <input
             type="text"
-            className="w-full pl-9 pr-3 py-2 border rounded-md text-sm"
+            className="w-full pl-9 pr-3 py-2 border border-claude-border rounded-lg text-sm text-claude-text bg-white focus:outline-none focus:border-claude-subtext/40 transition-colors"
             placeholder="Пошук документів..."
             value={search}
             onChange={e => setSearch(e.target.value)}
           />
         </div>
-        {hasSelected && (
-          <p className="text-xs text-indigo-600">Вибрано: {selectedIds.length}</p>
-        )}
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={toggleAll}
+            disabled={filtered.length === 0}
+            className="flex items-center gap-1.5 text-xs text-claude-subtext hover:text-claude-text transition-colors disabled:opacity-40"
+          >
+            {allFilteredSelected ? <CheckSquare size={14} /> : <Square size={14} />}
+            {allFilteredSelected ? 'Зняти вибір' : `Вибрати все (${filtered.length})`}
+          </button>
+          {hasSelected && (
+            <span className="text-xs text-claude-accent font-medium">
+              Вибрано: {selectedIds.length}{totalCount > 0 ? ` / ${totalCount}` : ''}
+            </span>
+          )}
+        </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-5 min-h-0" style={{ maxHeight: '300px' }}>
+      <div className="flex-1 overflow-y-auto px-5 min-h-0" style={{ maxHeight: '350px' }}>
         {loading ? (
-          <div className="flex items-center justify-center py-12 text-gray-400">
+          <div className="flex items-center justify-center py-12 text-claude-subtext">
             <Loader2 className="w-5 h-5 animate-spin mr-2" />
             Завантаження...
           </div>
         ) : docs.length === 0 ? (
-          <div className="text-center py-12 text-gray-400 text-sm">
+          <div className="text-center py-12 text-claude-subtext text-sm">
             У вас ще немає документів
           </div>
         ) : filtered.length === 0 ? (
-          <div className="text-center py-8 text-gray-400 text-sm">
+          <div className="text-center py-8 text-claude-subtext text-sm">
             Нічого не знайдено
           </div>
         ) : (
@@ -103,23 +147,23 @@ export function DocumentPicker({ selectedIds, onChange, onDocsLoaded, onBack, on
                 <label
                   key={doc.id}
                   className={`flex items-center gap-3 p-2.5 rounded-lg cursor-pointer transition-colors ${
-                    checked ? 'bg-indigo-50 border border-indigo-200' : 'hover:bg-gray-50 border border-transparent'
+                    checked ? 'bg-claude-accent/5 border border-claude-accent/20' : 'hover:bg-claude-bg border border-transparent'
                   }`}
                 >
                   <input
                     type="checkbox"
-                    className="rounded text-indigo-600 shrink-0"
+                    className="rounded text-claude-accent shrink-0"
                     checked={checked}
                     onChange={() => toggle(doc.id)}
                   />
                   {ext === '.pdf' ? (
                     <FileText className="w-4 h-4 text-red-500 shrink-0" />
                   ) : (
-                    <File className="w-4 h-4 text-gray-400 shrink-0" />
+                    <File className="w-4 h-4 text-claude-subtext shrink-0" />
                   )}
                   <div className="min-w-0 flex-1">
-                    <p className="text-sm truncate">{doc.title}</p>
-                    <p className="text-xs text-gray-400 truncate">
+                    <p className="text-sm text-claude-text truncate">{doc.title}</p>
+                    <p className="text-xs text-claude-subtext truncate">
                       {ext && <span className="uppercase">{ext.slice(1)}</span>}
                       {ext && date && ' · '}
                       {date}
@@ -128,22 +172,39 @@ export function DocumentPicker({ selectedIds, onChange, onDocsLoaded, onBack, on
                 </label>
               );
             })}
+
+            {/* Load More */}
+            {hasMore && (
+              <button
+                type="button"
+                onClick={loadMore}
+                disabled={loadingMore}
+                className="w-full flex items-center justify-center gap-2 py-3 text-sm text-claude-subtext hover:text-claude-text transition-colors"
+              >
+                {loadingMore ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <ChevronDown size={14} />
+                )}
+                {loadingMore ? 'Завантаження...' : `Завантажити ще (${docs.length} / ${totalCount})`}
+              </button>
+            )}
           </div>
         )}
       </div>
 
-      <div className="flex gap-3 p-5 pt-3 border-t">
+      <div className="flex gap-3 p-5 pt-3 border-t border-claude-border">
         <button
           type="button"
           onClick={onBack}
-          className="flex-1 py-2.5 border rounded-lg text-sm hover:bg-gray-50"
+          className="flex-1 py-2.5 border border-claude-border rounded-lg text-sm text-claude-text hover:bg-claude-bg transition-colors"
         >
           Назад
         </button>
         <button
           type="button"
           onClick={onNext}
-          className="flex-1 py-2.5 bg-indigo-600 text-white rounded-lg text-sm hover:bg-indigo-700"
+          className="flex-1 py-2.5 bg-claude-accent text-white rounded-lg text-sm hover:bg-claude-accent/90 transition-colors"
         >
           {hasSelected ? `Продовжити (${selectedIds.length})` : 'Пропустити'}
         </button>


### PR DESCRIPTION
## Summary
- **Select all** button — selects/deselects all visible (filtered) documents at once
- **Pagination** — loads 100 docs per page with "Завантажити ще" (previously hardcoded limit=50)
- Shows count: "Вибрано: N / total"
- Platform design system: claude-accent, claude-border, claude-subtext

Fixes: user with 1100+ documents couldn't select them all when sharing with attorney.

## Test plan
- [ ] Open consultation request → document step → see "Вибрати все" button
- [ ] Click "Вибрати все" — all visible docs selected
- [ ] Scroll down → "Завантажити ще" loads next 100
- [ ] Search filter + "Вибрати все" selects only filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)