### PR TITLE
fix: self-heal — use npx for Claude Code CLI

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -154,7 +154,7 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          claude -p "$(cat <<PROMPT
+          npx -y @anthropic-ai/claude-code@latest -p "$(cat <<PROMPT
           The CI/CD build-and-test job failed. Here are the error logs:
 
           \`\`\`
@@ -533,7 +533,7 @@ jobs:
 
           git checkout -b "$BRANCH_NAME"
 
-          claude -p "$(cat <<PROMPT
+          npx -y @anthropic-ai/claude-code@latest -p "$(cat <<PROMPT
           Production deployment failed. Here are the diagnostics:
 
           === CI Run Error Log ===


### PR DESCRIPTION
## Summary
Replace bare `claude` with `npx -y @anthropic-ai/claude-code@latest` in both self-heal jobs (build + deploy). The self-hosted runner doesn't have Claude Code CLI installed globally.

## Test plan
- [ ] Trigger a build failure → self-heal job runs npx claude successfully
- [ ] No "command not found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)