### PR TITLE
feat: auto-create matter from upload with LLM naming (LEG-355)

### DIFF
--- a/lexwebapp/src/services/api/MatterService.ts
+++ b/lexwebapp/src/services/api/MatterService.ts
@@ -151,6 +151,12 @@ export class MatterService extends BaseService {
   async validateAuditChain(): Promise<AuditValidationResult> {
     return this.request(() => this.client.get<AuditValidationResult>('/api/matters/audit/validate'));
   }
+
+  // ─── Auto-create from upload ──────────────────────────────
+
+  async autoCreateFromUpload(documentIds: string[]): Promise<{ matter: Matter; description: string; documentsAssigned: number }> {
+    return this.request(() => this.client.post('/api/matters/auto-create-from-upload', { documentIds }));
+  }
 }
 
 // Export singleton instance

--- a/lexwebapp/src/stores/uploadStore.ts
+++ b/lexwebapp/src/stores/uploadStore.ts
@@ -10,6 +10,8 @@ import {
   UploadEvent,
 } from '../services/upload/UploadManager';
 import { uploadService, ActiveSession } from '../services/api/UploadService';
+import { matterService } from '../services/api/MatterService';
+import { showToast } from '../utils/toast';
 
 export interface RecoveredSession {
   uploadId: string;
@@ -87,6 +89,19 @@ export const useUploadStore = create<UploadState>((set) => {
     const sync = syncFromManager(uploadManager);
     if (event.type === 'all-completed') {
       set({ ...sync, isUploading: false });
+
+      // Auto-create matter from completed uploads (fire-and-forget)
+      const completedItems = sync.items.filter(i => i.status === 'completed' && i.documentId);
+      if (completedItems.length >= 3) {
+        const documentIds = completedItems.map(i => i.documentId!);
+        matterService.autoCreateFromUpload(documentIds).then(result => {
+          showToast.success(
+            `Створено справу "${result.matter.matter_name}" (${result.documentsAssigned} документів)`
+          );
+        }).catch(err => {
+          console.warn('[UploadStore] Auto-create matter failed (non-critical)', err);
+        });
+      }
     } else if (event.type === 'throttle-changed') {
       set({
         ...sync,

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -2035,7 +2035,8 @@ class HTTPMCPServer {
 
     // Client-Matter segregation routes (matters, clients, legal holds, audit)
     this.app.use('/api/matters', requireJWT as any, createMatterRoutes(
-      this.matterService, this.conflictCheckService, this.legalHoldService, this.auditService
+      this.matterService, this.conflictCheckService, this.legalHoldService, this.auditService,
+      this.services.db, llmAdapter
     ));
     logger.info('Matter routes registered at /api/matters');
 

--- a/mcp_backend/src/routes/matter-routes.ts
+++ b/mcp_backend/src/routes/matter-routes.ts
@@ -4,13 +4,16 @@ import { MatterService } from '../services/matter-service.js';
 import { ConflictCheckService } from '../services/conflict-check-service.js';
 import { LegalHoldService } from '../services/legal-hold-service.js';
 import { AuditService } from '../services/audit-service.js';
+import type { IDatabase, ILLMPort } from '../domain/ports/index.js';
 import { logger } from '../utils/logger.js';
 
 export function createMatterRoutes(
   matterService: MatterService,
   conflictCheckService: ConflictCheckService,
   legalHoldService: LegalHoldService,
-  auditService: AuditService
+  auditService: AuditService,
+  db?: IDatabase,
+  llm?: ILLMPort
 ): Router {
   const router = Router();
 
@@ -440,6 +443,142 @@ export function createMatterRoutes(
       res.json(result);
     } catch (error: any) {
       logger.error('[MatterRoutes] Validate audit chain failed', { error: error.message });
+      res.status(500).json({ error: error.message });
+    }
+  }) as any);
+
+  // POST /auto-create-from-upload — Auto-create matter from uploaded documents using LLM
+  router.post('/auto-create-from-upload', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const { documentIds } = req.body;
+      if (!Array.isArray(documentIds) || documentIds.length === 0) {
+        return res.status(400).json({ error: 'documentIds array is required' });
+      }
+
+      if (!db || !llm) {
+        return res.status(503).json({ error: 'Auto-create not available — LLM or DB not configured' });
+      }
+
+      // 1. Fetch document texts (first 5 docs, first 2000 chars each)
+      const docResult = await db.query(
+        `SELECT id, title, LEFT(full_text, 2000) as snippet, mime_type,
+                metadata->>'folderPath' as folder_path,
+                metadata->>'originalFilename' as original_filename
+         FROM documents
+         WHERE id = ANY($1) AND user_id = $2
+         ORDER BY created_at ASC
+         LIMIT 5`,
+        [documentIds, userId]
+      );
+
+      if (docResult.rows.length === 0) {
+        return res.status(404).json({ error: 'No documents found for this user' });
+      }
+
+      // 2. Build context for LLM
+      const docSummaries = docResult.rows.map((d: any) => {
+        const name = d.original_filename || d.title;
+        const text = d.snippet || '(без тексту)';
+        return `Файл: ${name}\n${text.slice(0, 500)}`;
+      }).join('\n---\n');
+
+      const totalDocs = documentIds.length;
+      const folderName = docResult.rows[0]?.folder_path?.split('/')[0] || '';
+
+      // 3. Call LLM to generate matter details
+      const llmResponse = await llm.chatCompletion(
+        {
+          messages: [
+            {
+              role: 'system',
+              content: `Ти — юридичний асистент. На основі завантажених документів користувача створи дані для юридичної справи.
+Відповідай ТІЛЬКИ валідним JSON (без markdown):
+{
+  "matterName": "коротка назва справи українською (до 100 символів), що відображає суть",
+  "matterType": "тип справи (наприклад: цивільна, господарська, адміністративна, кримінальна, сімейна, трудова, нерухомість, корпоративна)",
+  "description": "короткий опис справи (2-3 речення) на основі документів",
+  "opposingParty": "протилежна сторона якщо визначається з документів, або null",
+  "courtName": "суд якщо згадується в документах, або null",
+  "courtCaseNumber": "номер справи якщо згадується, або null"
+}`,
+            },
+            {
+              role: 'user',
+              content: `Завантажено ${totalDocs} документів${folderName ? ` з папки "${folderName}"` : ''}.\n\nПерші документи:\n${docSummaries}`,
+            },
+          ],
+          temperature: 0.1,
+          max_tokens: 1024,
+          response_format: { type: 'json_object' },
+        },
+        'quick'
+      );
+
+      let matterData: any = {};
+      try {
+        let raw = llmResponse.content?.trim() || '{}';
+        if (raw.startsWith('```')) {
+          raw = raw.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+        }
+        matterData = JSON.parse(raw);
+      } catch {
+        matterData = {
+          matterName: folderName || `Справа від ${new Date().toLocaleDateString('uk-UA')}`,
+          matterType: 'цивільна',
+          description: `Автоматично створена справа з ${totalDocs} документів`,
+        };
+      }
+
+      // 4. Ensure org + client exist
+      const orgId = await matterService.ensureUserOrg(userId);
+
+      // Get or create default client for this user
+      let clientId: string;
+      const existingClients = await matterService.listClients(orgId, {});
+      if (existingClients.clients.length > 0) {
+        clientId = existingClients.clients[0].id;
+      } else {
+        const userResult = await db.query('SELECT name, email FROM users WHERE id = $1', [userId]);
+        const userName = userResult.rows[0]?.name || 'Клієнт';
+        const client = await matterService.createClient(orgId, {
+          clientName: userName,
+          clientType: 'individual',
+          contactEmail: userResult.rows[0]?.email,
+        }, userId);
+        clientId = client.id;
+      }
+
+      // 5. Create matter
+      const matter = await matterService.createMatter({
+        clientId,
+        matterName: matterData.matterName || `Справа від ${new Date().toLocaleDateString('uk-UA')}`,
+        matterType: matterData.matterType || undefined,
+        opposingParty: matterData.opposingParty || undefined,
+        courtCaseNumber: matterData.courtCaseNumber || undefined,
+        courtName: matterData.courtName || undefined,
+        metadata: { autoCreated: true, description: matterData.description, documentCount: totalDocs },
+      }, userId);
+
+      // 6. Assign all documents to matter
+      await matterService.assignDocumentsToMatter(matter.id, documentIds, userId);
+
+      logger.info('[MatterRoutes] Auto-created matter from upload', {
+        matterId: matter.id,
+        matterName: matter.matter_name,
+        documentCount: totalDocs,
+        userId,
+      });
+
+      res.status(201).json({
+        matter,
+        description: matterData.description,
+        documentsAssigned: totalDocs,
+      });
+    } catch (error: any) {
+      logger.error('[MatterRoutes] Auto-create matter failed', { error: error.message });
       res.status(500).json({ error: error.message });
     }
   }) as any);


### PR DESCRIPTION
## Summary
Implements LEG-355: auto-create matter when documents are uploaded.

**Backend** (`POST /api/matters/auto-create-from-upload`):
- Reads first 5 document texts (2000 chars each)
- Calls Bedrock LLM to generate: matter name, type, description, opposing party, court
- Creates org/client if needed, creates matter, assigns all documents
- Falls back to date-based name if LLM fails

**Frontend** (uploadStore):
- After `all-completed` with 3+ files → auto-calls the endpoint
- Shows toast: "Створено справу [LLM-generated name] (N документів)"
- Non-blocking (fire-and-forget)

Closes LEG-355

## Test plan
- [ ] Upload 3+ documents → toast appears with auto-generated matter name
- [ ] Navigate to /matters → new matter visible with documents assigned
- [ ] Matter name reflects document content (e.g. "Справа Худика — підвал на Толстого 23")
- [ ] Upload 1-2 files → no auto-creation (threshold not met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)