### PR TITLE
fix: version display — fetch git tags on prod

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -365,8 +365,12 @@ jobs:
 
           echo "=== Deploying to production (from stage) ==="
 
-          # Pull latest code
-          $SSH_CMD "git -C ${REMOTE_REPO} fetch origin main && git -C ${REMOTE_REPO} reset --hard origin/main"
+          # Pull latest code and tags
+          $SSH_CMD "git -C ${REMOTE_REPO} fetch origin main --tags && git -C ${REMOTE_REPO} reset --hard origin/main"
+
+          # Write VERSION file for frontend build
+          LATEST_TAG=$(git tag -l "v*" --sort=-version:refname | head -1)
+          $SSH_CMD "echo '${LATEST_TAG:-dev}' > ${REMOTE_REPO}/VERSION"
 
           # Build dist on prod
           $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix packages/shared install && npm --prefix packages/shared run build"

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -22,7 +22,9 @@ export default defineConfig(({ mode }) => {
     define: {
       'import.meta.env.VITE_BUILD_TIME': JSON.stringify(new Date().toISOString()),
       'import.meta.env.VITE_APP_VERSION': JSON.stringify(
-        (() => { try { return execSync('git describe --tags --abbrev=0 2>/dev/null').toString().trim(); } catch { return 'dev'; } })()
+        process.env.APP_VERSION ||
+        (() => { try { return execSync('git tag -l "v*" --sort=-version:refname 2>/dev/null').toString().trim().split('\n')[0]; } catch { return ''; } })() ||
+        (() => { try { return fs.readFileSync(path.resolve(__dirname, '..', 'VERSION'), 'utf8').trim(); } catch { return 'dev'; } })()
       ),
     },
     build: {


### PR DESCRIPTION
## Summary
- CI fetches `--tags` on prod so `git tag -l "v*"` works
- Writes `VERSION` file to repo root as fallback
- `vite.config.ts` tries: `APP_VERSION` env → git tags → `VERSION` file → `'dev'`

## Test plan
- [ ] Deploy → sidebar shows version like `v1.8.0` instead of `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)