### PR TITLE
fix: pass APP_VERSION through Docker build for version display

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -386,6 +386,7 @@ jobs:
           $SSH_CMD bash << DEPLOY_SCRIPT
             set -e
             cd ${REMOTE_REPO}/deployment
+            export APP_VERSION=\$(cat ${REMOTE_REPO}/VERSION 2>/dev/null || echo 'dev')
             DC="docker compose -f docker-compose.prod.yml --env-file .env.prod"
 
             STOP="" BUILD="" START=""

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -761,6 +761,7 @@ services:
         - VITE_ENABLE_THINKING_STEPS=true
         - VITE_AUTO_EXPAND_THINKING=true
         - GIT_SHA=${GIT_SHA:-unknown}
+        - APP_VERSION=${APP_VERSION:-dev}
     image: lexwebapp-prod:latest
     container_name: lexwebapp-prod
     ports:

--- a/lexwebapp/Dockerfile
+++ b/lexwebapp/Dockerfile
@@ -21,9 +21,12 @@ ARG VITE_ENABLE_THINKING_STEPS=true
 ARG VITE_AUTO_EXPAND_THINKING=true
 # GIT_SHA busts the cache on every new deploy so stale layers are never reused
 ARG GIT_SHA=unknown
+ARG APP_VERSION=dev
 
 # Copy lexwebapp source code
 COPY lexwebapp/ ./
+# Copy VERSION file if exists (for fallback)
+COPY VERSION* ./
 
 # Set env vars for build
 ENV VITE_API_URL=$VITE_API_URL
@@ -33,6 +36,7 @@ ENV VITE_ENABLE_ALL_MCP_TOOLS=$VITE_ENABLE_ALL_MCP_TOOLS
 ENV VITE_SHOW_TOOL_SELECTOR=$VITE_SHOW_TOOL_SELECTOR
 ENV VITE_ENABLE_THINKING_STEPS=$VITE_ENABLE_THINKING_STEPS
 ENV VITE_AUTO_EXPAND_THINKING=$VITE_AUTO_EXPAND_THINKING
+ENV APP_VERSION=$APP_VERSION
 
 # Build the application using the correct mode and normalize output to /app/lexwebapp/dist
 RUN if [ "$BUILD_ENV" = "production" ]; then \


### PR DESCRIPTION
## Summary
Version showed "dev" because Docker build had no git tags. Fix:
- `Dockerfile`: `ARG APP_VERSION=dev` → `ENV APP_VERSION`
- `docker-compose.prod.yml`: `APP_VERSION=${APP_VERSION:-dev}`
- CI: `export APP_VERSION=$(cat VERSION)` before docker compose build
- `vite.config.ts` reads `process.env.APP_VERSION` first

## Test plan
- [ ] Deploy → sidebar shows `v1.8.x` instead of `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)