### PR TITLE
fix: show consultations for attorneys + notifications

### DIFF
--- a/lexwebapp/src/components/sidebar/NavItem.tsx
+++ b/lexwebapp/src/components/sidebar/NavItem.tsx
@@ -7,9 +7,10 @@ interface NavItemProps {
   label: string;
   route?: string | null;
   onClick?: () => void;
+  badge?: number;
 }
 
-export function NavItem({ icon: Icon, label, route, onClick }: NavItemProps) {
+export function NavItem({ icon: Icon, label, route, onClick, badge }: NavItemProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const isActive = route ? location.pathname === route : false;
@@ -31,6 +32,11 @@ export function NavItem({ icon: Icon, label, route, onClick }: NavItemProps) {
       className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${isActive ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
       <Icon size={15} strokeWidth={2} className="text-claude-subtext/60 group-hover:text-claude-text transition-colors duration-200 flex-shrink-0" />
       <span className="truncate font-medium tracking-tight font-sans">{label}</span>
+      {badge !== undefined && badge > 0 && (
+        <span className="ml-auto flex-shrink-0 min-w-[20px] h-5 flex items-center justify-center rounded-full bg-red-500 text-white text-[11px] font-semibold px-1.5">
+          {badge}
+        </span>
+      )}
     </button>
   );
 }

--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -5,12 +5,13 @@ import showToast from '../../utils/toast';
 import {
   Plus, MessageSquare, X, Edit3, Trash2,
   ChevronsUpDown, Archive, Folder, FolderOpen,
-  Zap,
+  Zap, Briefcase, Users, Search,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../contexts/AuthContext';
 import { useChatStore } from '../../stores/chatStore';
 import { api } from '../../utils/api-client';
+import { consultationService } from '../../services/api/ConsultationService';
 import type { UserRole } from '../../types/models/User';
 
 import { NavItem } from './NavItem';
@@ -45,6 +46,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   const [vaultFolders, setVaultFolders] = useState<string[]>([]);
   const [vaultFoldersLoaded, setVaultFoldersLoaded] = useState(false);
   const [deletingFolder, setDeletingFolder] = useState<string | null>(null);
+  const [pendingCount, setPendingCount] = useState(0);
   const profileMenuRef = useRef<HTMLDivElement>(null);
 
   const conversations = useChatStore(s => s.conversations);
@@ -100,6 +102,19 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
     window.addEventListener('vault-folders-changed', handler);
     return () => window.removeEventListener('vault-folders-changed', handler);
   }, []);
+
+  // Poll pending consultations for attorneys (every 60s)
+  useEffect(() => {
+    if (!user?.id || !isAttorney) return;
+    const fetchPending = () => {
+      consultationService.getUnseenPending()
+        .then(data => setPendingCount(data.count))
+        .catch(() => {});
+    };
+    fetchPending();
+    const interval = setInterval(fetchPending, 60_000);
+    return () => clearInterval(interval);
+  }, [user?.id, isAttorney]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -296,13 +311,15 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 ))}
               </Section>
 
-              {!isAttorney && (
-                <Section id="attorneys" title="Адвокати" collapsed={collapsedSections.has('attorneys')} onToggle={toggleSection}>
-                  {attorneyClientSections.map((s) => (
-                    <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
-                  ))}
-                </Section>
-              )}
+              <Section id="attorneys" title={isAttorney ? 'Консультації' : 'Адвокати'} collapsed={collapsedSections.has('attorneys')} onToggle={toggleSection}>
+                {!isAttorney && (
+                  <NavItem icon={Search} label="Знайти адвоката" route={ROUTES.ATTORNEYS} onClick={() => handleNavigation(ROUTES.ATTORNEYS)} />
+                )}
+                <NavItem icon={Briefcase} label="Мої консультації" route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} badge={pendingCount > 0 ? pendingCount : undefined} />
+                {isAttorney && (
+                  <NavItem icon={Users} label="Мої клієнти" route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
+                )}
+              </Section>
 
               <div className="mb-6">
                 <NavItem icon={Zap} label="Workflows" route={ROUTES.WORKFLOWS} onClick={() => handleNavigation(ROUTES.WORKFLOWS)} />

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useUIStore } from '../stores';
 import { ROUTES } from '../router/routes';
 import { consultationService, type Consultation } from '../services/api/ConsultationService';
+import showToast from '../utils/toast';
 
 // Map routes to page titles
 const PAGE_TITLES: Record<string, string> = {
@@ -68,13 +69,18 @@ export function MainLayout() {
   // Fetch unseen pending consultations for attorneys
   useEffect(() => {
     if (!user?.id) return;
-    if (sessionStorage.getItem(SESSION_KEY)) return;
 
     consultationService.getUnseenPending()
       .then(data => {
         if (data.count > 0) {
           setPendingConsultations(data.consultations);
-          setShowInvitationsModal(true);
+          // Show modal only once per session
+          if (!sessionStorage.getItem(SESSION_KEY)) {
+            setShowInvitationsModal(true);
+          }
+          // Always show toast notification
+          const word = data.count === 1 ? 'новий запит' : data.count < 5 ? 'нових запити' : 'нових запитів';
+          showToast.info(`У вас ${data.count} ${word} на консультацію`);
         }
       })
       .catch(() => {});


### PR DESCRIPTION
## Summary
- Attorneys couldn't see consultation requests — sidebar section was hidden by `!isAttorney` check
- Now both clients and attorneys see "Мої консультації" with red badge (pending count)
- Attorneys also see "Мої клієнти" link; clients see "Знайти адвоката"
- Toast notification fires on every page load, not blocked by sessionStorage
- Sidebar polls pending count every 60s for live badge updates

## Test plan
- [ ] Login as attorney (Рябчук) — verify "Консультації" section visible in sidebar
- [ ] Verify red badge shows count of pending requests
- [ ] Verify toast notification appears on page load
- [ ] Login as client — verify "Адвокати" section shows "Знайти адвоката" + "Мої консультації"

🤖 Generated with [Claude Code](https://claude.com/claude-code)