### PR TITLE
fix: add missing markMessagesRead mock in chat tests

### DIFF
--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -11,12 +11,14 @@ vi.mock('../../../contexts/AuthContext', () => ({
 const mockGetMessages = vi.fn();
 const mockSendMessage = vi.fn();
 const mockConnectMessageStream = vi.fn();
+const mockMarkMessagesRead = vi.fn();
 
 vi.mock('../../../services', () => ({
   consultationService: {
     getMessages: (...args: any[]) => mockGetMessages(...args),
     sendMessage: (...args: any[]) => mockSendMessage(...args),
     connectMessageStream: (...args: any[]) => mockConnectMessageStream(...args),
+    markMessagesRead: (...args: any[]) => mockMarkMessagesRead(...args),
   },
 }));
 
@@ -46,6 +48,7 @@ describe('ConsultationChatTab', () => {
     vi.clearAllMocks();
     mockGetMessages.mockResolvedValue({ messages: [], total: 0 });
     mockConnectMessageStream.mockReturnValue(createMockEventSource());
+    mockMarkMessagesRead.mockResolvedValue(undefined);
   });
 
   describe('Empty state', () => {


### PR DESCRIPTION
## Summary
- Added missing `markMessagesRead` mock to `ConsultationChatTab.test.tsx`
- Fixes 3 failing frontend tests in CI (`fetches and displays messages`, `sends message on Enter key`, `restores input on send failure`)
- Root cause: `markMessagesRead` was added to `ConsultationChatTab` component but not mocked in tests

## Test plan
- [ ] CI passes — all 3 previously failing tests should pass now

🤖 Generated with [Claude Code](https://claude.com/claude-code)