### PR TITLE
fix: use EU inference profile for Bedrock model in CI

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -114,7 +114,7 @@ jobs:
       needs.build-and-test.result == 'failure'
     env:
       CLAUDE_CODE_USE_BEDROCK: '1'
-      CLAUDE_CODE_BEDROCK_MODEL: anthropic.claude-sonnet-4-6
+      CLAUDE_CODE_BEDROCK_MODEL: eu.anthropic.claude-sonnet-4-6
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: eu-central-1
@@ -476,7 +476,7 @@ jobs:
       needs.deploy-prod.result == 'failure'
     env:
       CLAUDE_CODE_USE_BEDROCK: '1'
-      CLAUDE_CODE_BEDROCK_MODEL: anthropic.claude-sonnet-4-6
+      CLAUDE_CODE_BEDROCK_MODEL: eu.anthropic.claude-sonnet-4-6
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: eu-central-1


### PR DESCRIPTION
## Summary
- Changed `CLAUDE_CODE_BEDROCK_MODEL` from `anthropic.claude-sonnet-4-6` to `eu.anthropic.claude-sonnet-4-6` in CI workflow
- The model `anthropic.claude-sonnet-4-6` only supports `INFERENCE_PROFILE` invocation type — direct model ID doesn't work
- This fixes the CI self-heal step that was failing with `400 The provided model identifier is invalid`

## Test plan
- [ ] CI self-heal step should work on next build failure (no more `400` model error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)