### PR TITLE
fix: correct sendMessage assertion args in chat test

### DIFF
--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -148,7 +148,7 @@ describe('ConsultationChatTab', () => {
         expect(screen.getByText('Test message')).toBeInTheDocument();
       });
 
-      expect(mockSendMessage).toHaveBeenCalledWith('cons-1', 'Test message');
+      expect(mockSendMessage).toHaveBeenCalledWith('cons-1', 'Test message', undefined, undefined);
     });
 
     it('does not send empty messages', async () => {


### PR DESCRIPTION
## Summary
- Fixed `sendMessage` assertion in `ConsultationChatTab.test.tsx`
- The component calls `sendMessage(id, content, messageType, attachment)` with 4 args, but the test expected only 2
- Updated to match actual call: `('cons-1', 'Test message', undefined, undefined)`

## Test plan
- [ ] CI frontend tests pass — last remaining test failure fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)