### PR TITLE
fix: point grafana.legal.org.ua to prod Grafana

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -863,7 +863,7 @@ services:
     image: grafana/grafana:10.2.3
     container_name: grafana-prod
     environment:
-      - GF_SERVER_ROOT_URL=https://grafana-prod.legal.org.ua
+      - GF_SERVER_ROOT_URL=https://grafana.legal.org.ua
       - GF_SERVER_SERVE_FROM_SUB_PATH=false
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false

--- a/deployment/nginx/stage.legal.org.ua.conf
+++ b/deployment/nginx/stage.legal.org.ua.conf
@@ -92,7 +92,7 @@ server {
     error_log /var/log/nginx/grafana.legal.org.ua-error.log;
 
     location / {
-        proxy_pass http://grafana-stage:3000;
+        proxy_pass http://grafana-prod:3000;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Nginx proxied `grafana.legal.org.ua` to `grafana-stage` instead of `grafana-prod`
- Updated prod compose `GF_SERVER_ROOT_URL` to `https://grafana.legal.org.ua`

## Test plan
- [ ] Open https://grafana.legal.org.ua/login — should show prod Grafana
- [ ] Login with prod admin credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)