### PR TITLE
fix: add explicit type annotation to redis error handler in mcp_rada

### DIFF
--- a/mcp_rada/src/utils/redis-client.ts
+++ b/mcp_rada/src/utils/redis-client.ts
@@ -17,7 +17,7 @@ export async function initRedisClient(): Promise<void> {
     const redisUrl = process.env.REDIS_URL || `redis://${redisHost}:${redisPort}`;
     redisClient = createClient({ url: redisUrl });
 
-    redisClient.on('error', (err) => {
+    redisClient.on('error', (err: Error) => {
       logger.error('[Redis] Client error:', err);
     });
 


### PR DESCRIPTION
## Summary
- Fixes CI build failure in `mcp_rada` caused by implicit `any` type on `err` parameter in `redis-client.ts` line 20
- This was the only remaining CI failure on `main` (run #805)

## Test plan
- [ ] CI build passes for mcp_rada (`tsc` compiles without errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)