### PR TITLE
feat: judge analytics system for 5,743 active judges

### DIFF
--- a/lexwebapp/src/hooks/queries/useJudgeAnalytics.ts
+++ b/lexwebapp/src/hooks/queries/useJudgeAnalytics.ts
@@ -1,0 +1,20 @@
+import { judgeAnalyticsService, JudgeAnalyticsFilters } from '../../services/api/JudgeAnalyticsService';
+import { queryKeys } from '../../lib/react-query';
+import { createQueryHook, createDetailQueryHook } from './createQueryHook';
+
+export const useJudgeAnalytics = createQueryHook<
+  Awaited<ReturnType<typeof judgeAnalyticsService.getAnalyticsList>>,
+  JudgeAnalyticsFilters
+>(
+  (params) => queryKeys.judgeAnalytics.list(params),
+  (params) => judgeAnalyticsService.getAnalyticsList(params),
+  { staleTime: 10 * 60 * 1000 }
+);
+
+export const useJudgeAnalyticsDetail = createDetailQueryHook<
+  Awaited<ReturnType<typeof judgeAnalyticsService.getAnalyticsDetail>>
+>(
+  (id) => queryKeys.judgeAnalytics.detail(id),
+  (id) => judgeAnalyticsService.getAnalyticsDetail(id),
+  { staleTime: 10 * 60 * 1000 }
+);

--- a/lexwebapp/src/lib/react-query.ts
+++ b/lexwebapp/src/lib/react-query.ts
@@ -116,4 +116,12 @@ export const queryKeys = {
       ['judges', 'list', params] as const,
     detail: (dossierNumber: string) => ['judges', 'detail', dossierNumber] as const,
   },
+
+  // Judge Analytics
+  judgeAnalytics: {
+    all: ['judgeAnalytics'] as const,
+    list: (params?: object) =>
+      ['judgeAnalytics', 'list', params] as const,
+    detail: (identifier: string) => ['judgeAnalytics', 'detail', identifier] as const,
+  },
 } as const;

--- a/lexwebapp/src/pages/JudgesPage/JudgeAnalyticsTable.tsx
+++ b/lexwebapp/src/pages/JudgesPage/JudgeAnalyticsTable.tsx
@@ -1,0 +1,349 @@
+import { useState, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import {
+  Search,
+  ChevronUp,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  ArrowUpDown,
+  Filter,
+} from 'lucide-react';
+import { useJudgeAnalytics } from '../../hooks/queries/useJudgeAnalytics';
+import { JudgeAnalyticsFilters, JudgeAnalyticsRecord } from '../../services/api/JudgeAnalyticsService';
+import { generateRoute } from '../../router/routes';
+
+const PAGE_SIZE = 25;
+
+const INSTANCE_OPTIONS = [
+  { value: '', label: 'Всі інстанції' },
+  { value: '1', label: 'Перша інстанція' },
+  { value: '2', label: 'Апеляційна' },
+  { value: '3', label: 'Касаційна' },
+];
+
+const SORT_OPTIONS: { value: string; label: string }[] = [
+  { value: 'total_decisions', label: 'Рішень' },
+  { value: 'appeal_rate', label: 'Апеляція %' },
+  { value: 'cases_appealed', label: 'Оскаржено' },
+  { value: 'unique_cases', label: 'Справ' },
+  { value: 'judge_name', label: "Ім'я" },
+];
+
+function getAppealRateColor(rate: number): string {
+  if (rate <= 0) return 'text-claude-subtext';
+  if (rate < 20) return 'text-green-600';
+  if (rate < 40) return 'text-yellow-600';
+  return 'text-red-600';
+}
+
+function getAppealRateBg(rate: number): string {
+  if (rate <= 0) return 'bg-claude-bg';
+  if (rate < 20) return 'bg-green-50';
+  if (rate < 40) return 'bg-yellow-50';
+  return 'bg-red-50';
+}
+
+function getOverturnedCount(outcomes: JudgeAnalyticsRecord['appeal_outcomes']): number {
+  return (outcomes?.overturned || 0) + (outcomes?.modified || 0);
+}
+
+function getDeadlineViolations(vkksu: Record<string, unknown>): number {
+  const violations = vkksu?.deadline_violations as Record<string, number> | undefined;
+  if (!violations) return 0;
+  return Object.values(violations).reduce((sum, v) => sum + (v || 0), 0);
+}
+
+export function JudgeAnalyticsTable() {
+  const navigate = useNavigate();
+
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [debounceTimer, setDebounceTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+  const [page, setPage] = useState(0);
+  const [sortBy, setSortBy] = useState('total_decisions');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [instanceFilter, setInstanceFilter] = useState('');
+  const [courtFilter, setCourtFilter] = useState('');
+  const [showFilters, setShowFilters] = useState(false);
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    if (debounceTimer) clearTimeout(debounceTimer);
+    const timer = setTimeout(() => {
+      setDebouncedSearch(value);
+      setPage(0);
+    }, 300);
+    setDebounceTimer(timer);
+  };
+
+  const filters: JudgeAnalyticsFilters = useMemo(() => ({
+    search: debouncedSearch.trim() || undefined,
+    court_name: courtFilter.trim() || undefined,
+    instance_code: instanceFilter ? parseInt(instanceFilter) : undefined,
+    sort_by: sortBy,
+    sort_order: sortOrder,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  }), [debouncedSearch, courtFilter, instanceFilter, sortBy, sortOrder, page]);
+
+  const { data, isLoading, isError, error } = useJudgeAnalytics(filters);
+  const judges = data?.judges ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+
+  const handleSort = (column: string) => {
+    if (sortBy === column) {
+      setSortOrder(prev => prev === 'desc' ? 'asc' : 'desc');
+    } else {
+      setSortBy(column);
+      setSortOrder('desc');
+    }
+    setPage(0);
+  };
+
+  const handleJudgeClick = (judge: JudgeAnalyticsRecord) => {
+    const id = judge.dossier_number || String(judge.id);
+    navigate(generateRoute.judgeDetail(id));
+  };
+
+  const SortIcon = ({ column }: { column: string }) => {
+    if (sortBy !== column) return <ArrowUpDown size={14} className="text-claude-subtext/50" />;
+    return sortOrder === 'desc'
+      ? <ChevronDown size={14} className="text-claude-accent" />
+      : <ChevronUp size={14} className="text-claude-accent" />;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Search + Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1 group">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            {isLoading ? (
+              <Loader2 className="h-4 w-4 text-claude-subtext animate-spin" />
+            ) : (
+              <Search className="h-4 w-4 text-claude-subtext group-focus-within:text-claude-accent transition-colors" />
+            )}
+          </div>
+          <input
+            type="text"
+            className="block w-full pl-9 pr-4 py-2.5 bg-white border border-claude-border rounded-xl text-sm text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all shadow-sm font-sans"
+            placeholder="Пошук за прізвищем судді..."
+            value={searchQuery}
+            onChange={(e) => handleSearchChange(e.target.value)}
+          />
+        </div>
+        <button
+          onClick={() => setShowFilters(!showFilters)}
+          className={`flex items-center gap-2 px-4 py-2.5 rounded-xl border text-sm font-sans transition-all ${
+            showFilters || instanceFilter || courtFilter
+              ? 'bg-claude-accent text-white border-claude-accent'
+              : 'bg-white text-claude-subtext border-claude-border hover:border-claude-subtext/30'
+          }`}
+        >
+          <Filter size={16} />
+          Фільтри
+        </button>
+      </div>
+
+      {/* Expanded Filters */}
+      {showFilters && (
+        <motion.div
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          className="flex flex-col sm:flex-row gap-3 p-4 bg-white rounded-xl border border-claude-border"
+        >
+          <div className="flex-1">
+            <label className="block text-xs text-claude-subtext mb-1 font-sans">Інстанція</label>
+            <select
+              value={instanceFilter}
+              onChange={(e) => { setInstanceFilter(e.target.value); setPage(0); }}
+              className="w-full px-3 py-2 bg-claude-bg border border-claude-border rounded-lg text-sm font-sans focus:outline-none focus:ring-2 focus:ring-claude-accent/20"
+            >
+              {INSTANCE_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs text-claude-subtext mb-1 font-sans">Суд</label>
+            <input
+              type="text"
+              value={courtFilter}
+              onChange={(e) => { setCourtFilter(e.target.value); setPage(0); }}
+              placeholder="Назва суду..."
+              className="w-full px-3 py-2 bg-claude-bg border border-claude-border rounded-lg text-sm font-sans focus:outline-none focus:ring-2 focus:ring-claude-accent/20"
+            />
+          </div>
+          <div className="flex-1">
+            <label className="block text-xs text-claude-subtext mb-1 font-sans">Сортування</label>
+            <select
+              value={sortBy}
+              onChange={(e) => { setSortBy(e.target.value); setPage(0); }}
+              className="w-full px-3 py-2 bg-claude-bg border border-claude-border rounded-lg text-sm font-sans focus:outline-none focus:ring-2 focus:ring-claude-accent/20"
+            >
+              {SORT_OPTIONS.map(opt => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+        </motion.div>
+      )}
+
+      {/* Error State */}
+      {isError && (
+        <div className="text-center py-6">
+          <p className="text-red-500 text-sm font-sans">
+            Помилка завантаження: {(error as any)?.message || 'Невідома помилка'}
+          </p>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-claude-border bg-claude-bg/50">
+                <th className="px-3 py-3 text-left font-sans font-medium text-claude-subtext w-10">#</th>
+                <th
+                  className="px-3 py-3 text-left font-sans font-medium text-claude-subtext cursor-pointer hover:text-claude-text transition-colors"
+                  onClick={() => handleSort('judge_name')}
+                >
+                  <span className="flex items-center gap-1">Суддя <SortIcon column="judge_name" /></span>
+                </th>
+                <th className="px-3 py-3 text-left font-sans font-medium text-claude-subtext hidden lg:table-cell">Суд</th>
+                <th className="px-3 py-3 text-left font-sans font-medium text-claude-subtext hidden md:table-cell">Інстанція</th>
+                <th
+                  className="px-3 py-3 text-right font-sans font-medium text-claude-subtext cursor-pointer hover:text-claude-text transition-colors"
+                  onClick={() => handleSort('total_decisions')}
+                >
+                  <span className="flex items-center justify-end gap-1">Рішень <SortIcon column="total_decisions" /></span>
+                </th>
+                <th
+                  className="px-3 py-3 text-right font-sans font-medium text-claude-subtext cursor-pointer hover:text-claude-text transition-colors hidden sm:table-cell"
+                  onClick={() => handleSort('unique_cases')}
+                >
+                  <span className="flex items-center justify-end gap-1">Справ <SortIcon column="unique_cases" /></span>
+                </th>
+                <th
+                  className="px-3 py-3 text-right font-sans font-medium text-claude-subtext cursor-pointer hover:text-claude-text transition-colors"
+                  onClick={() => handleSort('appeal_rate')}
+                >
+                  <span className="flex items-center justify-end gap-1">Апеляція % <SortIcon column="appeal_rate" /></span>
+                </th>
+                <th className="px-3 py-3 text-right font-sans font-medium text-claude-subtext hidden md:table-cell">Скасовано</th>
+                <th className="px-3 py-3 text-right font-sans font-medium text-claude-subtext hidden lg:table-cell">Порушення строків</th>
+                <th className="px-3 py-3 text-right font-sans font-medium text-claude-subtext hidden sm:table-cell">Ранг</th>
+              </tr>
+            </thead>
+            <tbody>
+              {judges.map((judge, index) => (
+                <motion.tr
+                  key={judge.id}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  transition={{ duration: 0.2, delay: index * 0.02 }}
+                  onClick={() => handleJudgeClick(judge)}
+                  className="border-b border-claude-border/50 hover:bg-claude-bg/50 cursor-pointer transition-colors"
+                >
+                  <td className="px-3 py-3 text-claude-subtext font-sans">
+                    {page * PAGE_SIZE + index + 1}
+                  </td>
+                  <td className="px-3 py-3">
+                    <div className="font-medium text-claude-text font-serif hover:text-claude-accent transition-colors">
+                      {judge.judge_name}
+                    </div>
+                    <div className="text-xs text-claude-subtext font-sans lg:hidden mt-0.5 line-clamp-1">
+                      {judge.court_name || '—'}
+                    </div>
+                  </td>
+                  <td className="px-3 py-3 text-claude-subtext font-sans text-xs max-w-[200px] truncate hidden lg:table-cell">
+                    {judge.court_name || '—'}
+                  </td>
+                  <td className="px-3 py-3 hidden md:table-cell">
+                    <span className="inline-flex px-2 py-0.5 rounded-full text-xs font-sans bg-claude-bg text-claude-subtext border border-claude-border/50">
+                      {judge.instance_name || '—'}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 text-right font-medium font-serif text-claude-text">
+                    {judge.total_decisions.toLocaleString('uk-UA')}
+                  </td>
+                  <td className="px-3 py-3 text-right font-sans text-claude-subtext hidden sm:table-cell">
+                    {judge.unique_cases.toLocaleString('uk-UA')}
+                  </td>
+                  <td className="px-3 py-3 text-right">
+                    <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium font-sans ${getAppealRateColor(judge.appeal_rate)} ${getAppealRateBg(judge.appeal_rate)}`}>
+                      {judge.appeal_rate > 0 ? `${judge.appeal_rate}%` : '—'}
+                    </span>
+                  </td>
+                  <td className="px-3 py-3 text-right font-sans text-claude-subtext hidden md:table-cell">
+                    {getOverturnedCount(judge.appeal_outcomes) || '—'}
+                  </td>
+                  <td className="px-3 py-3 text-right font-sans hidden lg:table-cell">
+                    {(() => {
+                      const v = getDeadlineViolations(judge.vkksu_data);
+                      return v > 0
+                        ? <span className="text-red-500 font-medium">{v}</span>
+                        : <span className="text-claude-subtext">—</span>;
+                    })()}
+                  </td>
+                  <td className="px-3 py-3 text-right font-sans text-claude-subtext hidden sm:table-cell">
+                    {judge.peer_rank_in_court && judge.peer_total_in_court
+                      ? `${judge.peer_rank_in_court}/${judge.peer_total_in_court}`
+                      : '—'}
+                  </td>
+                </motion.tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Loading overlay */}
+        {isLoading && judges.length === 0 && (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-6 w-6 text-claude-accent animate-spin" />
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && judges.length === 0 && !isError && (
+          <div className="text-center py-12">
+            <p className="text-claude-subtext font-sans">Суддів не знайдено</p>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-3 border-t border-claude-border bg-claude-bg/30">
+            <p className="text-xs text-claude-subtext font-sans">
+              {(page * PAGE_SIZE + 1).toLocaleString('uk-UA')}–{Math.min((page + 1) * PAGE_SIZE, total).toLocaleString('uk-UA')} з {total.toLocaleString('uk-UA')}
+            </p>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setPage(p => Math.max(0, p - 1))}
+                disabled={page === 0}
+                className="p-1.5 rounded-lg hover:bg-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <ChevronLeft size={16} />
+              </button>
+              <span className="text-xs font-sans text-claude-subtext px-2">
+                {page + 1} / {totalPages}
+              </span>
+              <button
+                onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+                disabled={page >= totalPages - 1}
+                className="p-1.5 rounded-lg hover:bg-white transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              >
+                <ChevronRight size={16} />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/JudgesPage/index.tsx
+++ b/lexwebapp/src/pages/JudgesPage/index.tsx
@@ -9,13 +9,19 @@ import {
   LayoutGrid,
   List,
   Loader2,
+  BarChart3,
+  Users,
 } from 'lucide-react';
 import { useJudges } from '../../hooks/queries/useJudges';
 import { Judge } from '../../services/api/JudgesService';
 import { generateRoute } from '../../router/routes';
+import { JudgeAnalyticsTable } from './JudgeAnalyticsTable';
+
+type TabType = 'analytics' | 'search';
 
 export function JudgesPage() {
   const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<TabType>('analytics');
 
   const handleSelectJudge = (judge: Judge) => {
     navigate(generateRoute.judgeDetail(String(judge.dossier_number || judge.id)), {
@@ -84,170 +90,204 @@ export function JudgesPage() {
             </div>
           </div>
 
-          {/* Search Bar */}
-          <div className="flex gap-3">
-            <div className="relative flex-1 group">
-              <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-                {isLoading ? (
-                  <Loader2 className="h-5 w-5 text-claude-subtext animate-spin" />
-                ) : (
-                  <Search className="h-5 w-5 text-claude-subtext group-focus-within:text-claude-accent transition-colors" />
-                )}
-              </div>
-              <input
-                type="text"
-                className="block w-full pl-11 pr-4 py-4 bg-white border border-claude-border rounded-xl text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all shadow-sm font-sans"
-                placeholder="Пошук за прізвищем судді або назвою суду..."
-                value={searchQuery}
-                onChange={(e) => handleSearchChange(e.target.value)}
-              />
-            </div>
-
-            {/* View Mode Toggle */}
-            <div className="flex bg-white border border-claude-border rounded-xl p-1">
-              <button
-                onClick={() => setViewMode('comfortable')}
-                className={`p-2 rounded-lg transition-colors ${viewMode === 'comfortable' ? 'bg-claude-accent text-white' : 'text-claude-subtext hover:text-claude-text'}`}
-                title="Зручний вигляд"
-              >
-                <LayoutGrid size={18} />
-              </button>
-              <button
-                onClick={() => setViewMode('compact')}
-                className={`p-2 rounded-lg transition-colors ${viewMode === 'compact' ? 'bg-claude-accent text-white' : 'text-claude-subtext hover:text-claude-text'}`}
-                title="Компактний вигляд"
-              >
-                <List size={18} />
-              </button>
-            </div>
+          {/* Tab Toggle */}
+          <div className="flex bg-white border border-claude-border rounded-xl p-1 w-fit">
+            <button
+              onClick={() => setActiveTab('analytics')}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-sans transition-all ${
+                activeTab === 'analytics'
+                  ? 'bg-claude-accent text-white shadow-sm'
+                  : 'text-claude-subtext hover:text-claude-text'
+              }`}
+            >
+              <BarChart3 size={16} />
+              Аналітика
+            </button>
+            <button
+              onClick={() => setActiveTab('search')}
+              className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-sans transition-all ${
+                activeTab === 'search'
+                  ? 'bg-claude-accent text-white shadow-sm'
+                  : 'text-claude-subtext hover:text-claude-text'
+              }`}
+            >
+              <Users size={16} />
+              Пошук суддів
+            </button>
           </div>
         </motion.div>
 
-        {/* Error State */}
-        {isError && (
-          <div className="text-center py-8">
-            <p className="text-red-500 font-sans">
-              Помилка завантаження: {(error as any)?.message || 'Невідома помилка'}
-            </p>
-          </div>
-        )}
+        {/* Analytics Tab */}
+        {activeTab === 'analytics' && <JudgeAnalyticsTable />}
 
-        {/* Results Grid */}
-        <div
-          className={`grid ${viewMode === 'compact' ? 'grid-cols-1 gap-2' : 'grid-cols-1 md:grid-cols-2 gap-4'}`}
-        >
-          {judges.map((judge, index) => (
-            <motion.div
-              key={judge.id}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: index * 0.05 + 0.2 }}
-              onClick={() => handleSelectJudge(judge)}
-              className={`group bg-white rounded-2xl border border-claude-border shadow-sm hover:shadow-md hover:border-claude-subtext/30 transition-all cursor-pointer relative overflow-hidden ${viewMode === 'compact' ? 'p-3' : 'p-5'}`}
-            >
-              <div className="absolute top-0 right-0 p-5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 transform translate-x-2 group-hover:translate-x-0">
-                <ChevronRight className="text-claude-subtext" />
-              </div>
-
-              <div className={`flex items-start gap-3 ${viewMode === 'compact' ? 'mb-2' : 'mb-4'}`}>
-                {viewMode === 'comfortable' && (
-                  <div className="w-14 h-14 rounded-full bg-claude-sidebar border-2 border-white shadow-sm flex items-center justify-center text-xl font-serif text-claude-subtext flex-shrink-0">
-                    {judge.full_name
-                      .split(' ')
-                      .map((n) => n[0])
-                      .slice(0, 2)
-                      .join('')}
-                  </div>
-                )}
-                <div className="flex-1">
-                  <h3
-                    className={`font-serif font-medium text-claude-text group-hover:text-claude-accent transition-colors ${viewMode === 'compact' ? 'text-base' : 'text-lg'}`}
-                  >
-                    {judge.full_name}
-                  </h3>
-                  <p
-                    className={`text-claude-subtext font-sans mt-0.5 line-clamp-1 ${viewMode === 'compact' ? 'text-xs' : 'text-sm'}`}
-                  >
-                    {judge.court_name || 'Суд не вказано'}
-                  </p>
-                  {judge.dossier_number && (
-                    <div
-                      className={`mt-2 inline-flex items-center px-2 py-0.5 rounded font-medium font-sans bg-claude-bg text-claude-subtext border border-claude-border/50 ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
-                    >
-                      Досьє: {judge.dossier_number}
-                    </div>
+        {/* Search Tab */}
+        {activeTab === 'search' && (
+          <>
+            {/* Search Bar */}
+            <div className="flex gap-3">
+              <div className="relative flex-1 group">
+                <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
+                  {isLoading ? (
+                    <Loader2 className="h-5 w-5 text-claude-subtext animate-spin" />
+                  ) : (
+                    <Search className="h-5 w-5 text-claude-subtext group-focus-within:text-claude-accent transition-colors" />
                   )}
                 </div>
+                <input
+                  type="text"
+                  className="block w-full pl-11 pr-4 py-4 bg-white border border-claude-border rounded-xl text-claude-text placeholder-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent transition-all shadow-sm font-sans"
+                  placeholder="Пошук за прізвищем судді або назвою суду..."
+                  value={searchQuery}
+                  onChange={(e) => handleSearchChange(e.target.value)}
+                />
               </div>
 
-              <div
-                className={`grid grid-cols-3 gap-2 pt-3 border-t border-claude-border/50 ${viewMode === 'compact' ? 'text-xs' : ''}`}
-              >
-                <div className="text-center">
-                  <div
-                    className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
-                  >
-                    <Calendar size={viewMode === 'compact' ? 10 : 12} />
-                    <span>Перший запис</span>
-                  </div>
-                  <div
-                    className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-sm' : 'text-base'}`}
-                  >
-                    {judge.first_seen
-                      ? new Date(judge.first_seen).toLocaleDateString('uk-UA', { year: 'numeric', month: 'short' })
-                      : '—'}
-                  </div>
-                </div>
-                <div className="text-center border-l border-claude-border/50">
-                  <div
-                    className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
-                  >
-                    <Calendar size={viewMode === 'compact' ? 10 : 12} />
-                    <span>Останній</span>
-                  </div>
-                  <div
-                    className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-sm' : 'text-base'}`}
-                  >
-                    {judge.last_seen
-                      ? new Date(judge.last_seen).toLocaleDateString('uk-UA', { year: 'numeric', month: 'short' })
-                      : '—'}
-                  </div>
-                </div>
-                <div className="text-center border-l border-claude-border/50">
-                  <div
-                    className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
-                  >
-                    <Scale size={viewMode === 'compact' ? 10 : 12} />
-                    <span>Знімків</span>
-                  </div>
-                  <div
-                    className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-sm' : 'text-base'}`}
-                  >
-                    {judge.snapshot_count}
-                  </div>
-                </div>
+              {/* View Mode Toggle */}
+              <div className="flex bg-white border border-claude-border rounded-xl p-1">
+                <button
+                  onClick={() => setViewMode('comfortable')}
+                  className={`p-2 rounded-lg transition-colors ${viewMode === 'comfortable' ? 'bg-claude-accent text-white' : 'text-claude-subtext hover:text-claude-text'}`}
+                  title="Зручний вигляд"
+                >
+                  <LayoutGrid size={18} />
+                </button>
+                <button
+                  onClick={() => setViewMode('compact')}
+                  className={`p-2 rounded-lg transition-colors ${viewMode === 'compact' ? 'bg-claude-accent text-white' : 'text-claude-subtext hover:text-claude-text'}`}
+                  title="Компактний вигляд"
+                >
+                  <List size={18} />
+                </button>
               </div>
-            </motion.div>
-          ))}
-        </div>
-
-        {!isLoading && judges.length === 0 && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            className="text-center py-12"
-          >
-            <div className="w-16 h-16 bg-claude-bg rounded-full flex items-center justify-center mx-auto mb-4 text-claude-subtext">
-              <Search size={24} />
             </div>
-            <h3 className="text-lg font-serif text-claude-text mb-2">
-              Нічого не знайдено
-            </h3>
-            <p className="text-claude-subtext font-sans max-w-md mx-auto">
-              Спробуйте змінити параметри пошуку або перевірити написання
-              прізвища
-            </p>
-          </motion.div>
+
+            {/* Error State */}
+            {isError && (
+              <div className="text-center py-8">
+                <p className="text-red-500 font-sans">
+                  Помилка завантаження: {(error as any)?.message || 'Невідома помилка'}
+                </p>
+              </div>
+            )}
+
+            {/* Results Grid */}
+            <div
+              className={`grid ${viewMode === 'compact' ? 'grid-cols-1 gap-2' : 'grid-cols-1 md:grid-cols-2 gap-4'}`}
+            >
+              {judges.map((judge, index) => (
+                <motion.div
+                  key={judge.id}
+                  initial={{ opacity: 0, y: 20 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 0.4, delay: index * 0.05 + 0.2 }}
+                  onClick={() => handleSelectJudge(judge)}
+                  className={`group bg-white rounded-2xl border border-claude-border shadow-sm hover:shadow-md hover:border-claude-subtext/30 transition-all cursor-pointer relative overflow-hidden ${viewMode === 'compact' ? 'p-3' : 'p-5'}`}
+                >
+                  <div className="absolute top-0 right-0 p-5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 transform translate-x-2 group-hover:translate-x-0">
+                    <ChevronRight className="text-claude-subtext" />
+                  </div>
+
+                  <div className={`flex items-start gap-3 ${viewMode === 'compact' ? 'mb-2' : 'mb-4'}`}>
+                    {viewMode === 'comfortable' && (
+                      <div className="w-14 h-14 rounded-full bg-claude-sidebar border-2 border-white shadow-sm flex items-center justify-center text-xl font-serif text-claude-subtext flex-shrink-0">
+                        {judge.full_name
+                          .split(' ')
+                          .map((n) => n[0])
+                          .slice(0, 2)
+                          .join('')}
+                      </div>
+                    )}
+                    <div className="flex-1">
+                      <h3
+                        className={`font-serif font-medium text-claude-text group-hover:text-claude-accent transition-colors ${viewMode === 'compact' ? 'text-base' : 'text-lg'}`}
+                      >
+                        {judge.full_name}
+                      </h3>
+                      <p
+                        className={`text-claude-subtext font-sans mt-0.5 line-clamp-1 ${viewMode === 'compact' ? 'text-xs' : 'text-sm'}`}
+                      >
+                        {judge.court_name || 'Суд не вказано'}
+                      </p>
+                      {judge.dossier_number && (
+                        <div
+                          className={`mt-2 inline-flex items-center px-2 py-0.5 rounded font-medium font-sans bg-claude-bg text-claude-subtext border border-claude-border/50 ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
+                        >
+                          Досьє: {judge.dossier_number}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div
+                    className={`grid grid-cols-3 gap-2 pt-3 border-t border-claude-border/50 ${viewMode === 'compact' ? 'text-xs' : ''}`}
+                  >
+                    <div className="text-center">
+                      <div
+                        className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
+                      >
+                        <Calendar size={viewMode === 'compact' ? 10 : 12} />
+                        <span>Перший запис</span>
+                      </div>
+                      <div
+                        className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-sm' : 'text-base'}`}
+                      >
+                        {judge.first_seen
+                          ? new Date(judge.first_seen).toLocaleDateString('uk-UA', { year: 'numeric', month: 'short' })
+                          : '—'}
+                      </div>
+                    </div>
+                    <div className="text-center border-l border-claude-border/50">
+                      <div
+                        className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
+                      >
+                        <Calendar size={viewMode === 'compact' ? 10 : 12} />
+                        <span>Останній</span>
+                      </div>
+                      <div
+                        className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-sm' : 'text-base'}`}
+                      >
+                        {judge.last_seen
+                          ? new Date(judge.last_seen).toLocaleDateString('uk-UA', { year: 'numeric', month: 'short' })
+                          : '—'}
+                      </div>
+                    </div>
+                    <div className="text-center border-l border-claude-border/50">
+                      <div
+                        className={`flex items-center justify-center gap-1 text-claude-subtext mb-1 font-sans ${viewMode === 'compact' ? 'text-[10px]' : 'text-xs'}`}
+                      >
+                        <Scale size={viewMode === 'compact' ? 10 : 12} />
+                        <span>Знімків</span>
+                      </div>
+                      <div
+                        className={`font-medium text-claude-text font-serif ${viewMode === 'compact' ? 'text-sm' : 'text-base'}`}
+                      >
+                        {judge.snapshot_count}
+                      </div>
+                    </div>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+
+            {!isLoading && judges.length === 0 && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="text-center py-12"
+              >
+                <div className="w-16 h-16 bg-claude-bg rounded-full flex items-center justify-center mx-auto mb-4 text-claude-subtext">
+                  <Search size={24} />
+                </div>
+                <h3 className="text-lg font-serif text-claude-text mb-2">
+                  Нічого не знайдено
+                </h3>
+                <p className="text-claude-subtext font-sans max-w-md mx-auto">
+                  Спробуйте змінити параметри пошуку або перевірити написання
+                  прізвища
+                </p>
+              </motion.div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/lexwebapp/src/pages/PersonDetailPage/JudgeAnalyticsDetail.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/JudgeAnalyticsDetail.tsx
@@ -1,0 +1,208 @@
+import { motion } from 'framer-motion';
+import {
+  BarChart3,
+  TrendingUp,
+  AlertTriangle,
+  Award,
+  Clock,
+  Scale,
+} from 'lucide-react';
+import { JudgeAnalyticsRecord } from '../../services/api/JudgeAnalyticsService';
+
+interface JudgeAnalyticsDetailProps {
+  analytics: JudgeAnalyticsRecord;
+}
+
+function getAppealRateColor(rate: number): string {
+  if (rate <= 0) return 'text-claude-subtext';
+  if (rate < 20) return 'text-green-600';
+  if (rate < 40) return 'text-yellow-600';
+  return 'text-red-600';
+}
+
+function StatCard({ label, value, icon: Icon, subtext, color }: {
+  label: string;
+  value: string | number;
+  icon: typeof BarChart3;
+  subtext?: string;
+  color?: string;
+}) {
+  return (
+    <div className="bg-white rounded-xl border border-claude-border p-4 shadow-sm">
+      <div className="flex items-center gap-2 mb-2">
+        <Icon size={16} className="text-claude-subtext" />
+        <span className="text-xs text-claude-subtext font-sans">{label}</span>
+      </div>
+      <div className={`text-2xl font-serif font-medium ${color || 'text-claude-text'}`}>
+        {typeof value === 'number' ? value.toLocaleString('uk-UA') : value}
+      </div>
+      {subtext && <p className="text-xs text-claude-subtext font-sans mt-1">{subtext}</p>}
+    </div>
+  );
+}
+
+export function JudgeAnalyticsDetail({ analytics }: JudgeAnalyticsDetailProps) {
+  const outcomes = analytics.appeal_outcomes;
+  const totalOutcomes = (outcomes?.analyzed || 0);
+  const vkksu = analytics.vkksu_data || {};
+  const deadlineViolations = vkksu.deadline_violations as Record<string, number> | undefined;
+  const totalViolations = deadlineViolations
+    ? Object.values(deadlineViolations).reduce((sum, v) => sum + (v || 0), 0)
+    : 0;
+
+  const yearEntries = Object.entries(analytics.decisions_by_year || {})
+    .map(([year, count]) => ({ year: parseInt(year), count: count as number }))
+    .sort((a, b) => a.year - b.year);
+
+  const maxYearCount = Math.max(...yearEntries.map(e => e.count), 1);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="space-y-6 mt-6"
+    >
+      {/* Section Header */}
+      <div className="flex items-center gap-2">
+        <BarChart3 size={20} className="text-claude-accent" />
+        <h2 className="text-xl font-serif font-medium text-claude-text">Аналітика ЄДРСР</h2>
+        <span className="text-xs text-claude-subtext font-sans px-2 py-0.5 bg-claude-bg rounded-full border border-claude-border">
+          {analytics.period_start} — {analytics.period_end}
+        </span>
+      </div>
+
+      {/* Key Metrics */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        <StatCard
+          label="Рішень"
+          value={analytics.total_decisions}
+          icon={Scale}
+        />
+        <StatCard
+          label="Справ"
+          value={analytics.unique_cases}
+          icon={BarChart3}
+        />
+        <StatCard
+          label="Апеляція %"
+          value={analytics.appeal_rate > 0 ? `${analytics.appeal_rate}%` : '—'}
+          icon={TrendingUp}
+          color={getAppealRateColor(analytics.appeal_rate)}
+        />
+        <StatCard
+          label="Ранг у суді"
+          value={analytics.peer_rank_in_court && analytics.peer_total_in_court
+            ? `${analytics.peer_rank_in_court} / ${analytics.peer_total_in_court}`
+            : '—'}
+          icon={Award}
+          subtext={analytics.court_avg_decisions
+            ? `Середня по суду: ${Math.round(analytics.court_avg_decisions)}`
+            : undefined}
+        />
+      </div>
+
+      {/* Appeal Outcomes */}
+      {totalOutcomes > 0 && (
+        <div className="bg-white rounded-xl border border-claude-border p-5 shadow-sm">
+          <h3 className="text-sm font-sans font-medium text-claude-text mb-4">Результати апеляцій</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {[
+              { label: 'Залишено в силі', value: outcomes.upheld, color: 'bg-green-500' },
+              { label: 'Скасовано', value: outcomes.overturned, color: 'bg-red-500' },
+              { label: 'Змінено', value: outcomes.modified, color: 'bg-yellow-500' },
+              { label: 'Не визначено', value: outcomes.unknown, color: 'bg-gray-300' },
+            ].map(item => (
+              <div key={item.label}>
+                <div className="flex items-center gap-2 mb-1">
+                  <div className={`w-2.5 h-2.5 rounded-full ${item.color}`} />
+                  <span className="text-xs text-claude-subtext font-sans">{item.label}</span>
+                </div>
+                <div className="text-lg font-serif font-medium text-claude-text">{item.value}</div>
+                {totalOutcomes > 0 && (
+                  <div className="w-full bg-claude-bg rounded-full h-1.5 mt-1">
+                    <div
+                      className={`h-1.5 rounded-full ${item.color}`}
+                      style={{ width: `${Math.round((item.value / totalOutcomes) * 100)}%` }}
+                    />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Year Trend */}
+      {yearEntries.length > 0 && (
+        <div className="bg-white rounded-xl border border-claude-border p-5 shadow-sm">
+          <h3 className="text-sm font-sans font-medium text-claude-text mb-4">Рішення по роках</h3>
+          <div className="flex items-end gap-2 h-32">
+            {yearEntries.map(entry => (
+              <div key={entry.year} className="flex-1 flex flex-col items-center gap-1">
+                <span className="text-xs font-sans text-claude-text font-medium">
+                  {entry.count.toLocaleString('uk-UA')}
+                </span>
+                <div
+                  className="w-full bg-claude-accent/80 rounded-t-md transition-all"
+                  style={{ height: `${Math.max((entry.count / maxYearCount) * 100, 4)}%` }}
+                />
+                <span className="text-[10px] font-sans text-claude-subtext">{entry.year}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* VKKSU Efficiency */}
+      {totalViolations > 0 && (
+        <div className="bg-white rounded-xl border border-claude-border p-5 shadow-sm">
+          <div className="flex items-center gap-2 mb-4">
+            <Clock size={16} className="text-claude-subtext" />
+            <h3 className="text-sm font-sans font-medium text-claude-text">Ефективність (ВККС)</h3>
+          </div>
+          <div className="flex items-center gap-3 p-3 bg-red-50 rounded-lg border border-red-100">
+            <AlertTriangle size={18} className="text-red-500 flex-shrink-0" />
+            <div>
+              <p className="text-sm font-sans font-medium text-red-700">
+                {totalViolations} порушень строків
+              </p>
+              <p className="text-xs text-red-500 font-sans mt-0.5">
+                {deadlineViolations && Object.entries(deadlineViolations)
+                  .filter(([, v]) => v > 0)
+                  .map(([kind, v]) => `${kind}: ${v}`)
+                  .join(', ')}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Top Categories */}
+      {analytics.top_categories && analytics.top_categories.length > 0 && (
+        <div className="bg-white rounded-xl border border-claude-border p-5 shadow-sm">
+          <h3 className="text-sm font-sans font-medium text-claude-text mb-3">Топ категорій справ</h3>
+          <div className="space-y-2">
+            {analytics.top_categories.slice(0, 7).map((cat, idx) => (
+              <div key={cat.code} className="flex items-center gap-3">
+                <span className="text-xs text-claude-subtext font-sans w-4 text-right">{idx + 1}</span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between gap-2 mb-0.5">
+                    <span className="text-xs font-sans text-claude-text truncate">{cat.name}</span>
+                    <span className="text-xs font-sans text-claude-subtext flex-shrink-0">{cat.count}</span>
+                  </div>
+                  <div className="w-full bg-claude-bg rounded-full h-1">
+                    <div
+                      className="h-1 rounded-full bg-claude-accent/60"
+                      style={{ width: `${Math.round((cat.count / (analytics.top_categories[0]?.count || 1)) * 100)}%` }}
+                    />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </motion.div>
+  );
+}

--- a/lexwebapp/src/pages/PersonDetailPage/JudgeProfile.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/JudgeProfile.tsx
@@ -14,6 +14,7 @@ import type { JudgeProfile } from '../../services/api/JudgesService';
 interface JudgeProfilePageProps {
   profile: JudgeProfile;
   onBack: () => void;
+  children?: React.ReactNode;
 }
 
 function formatDate(dateStr: string | null): string {
@@ -40,7 +41,7 @@ function computeExperience(firstSeen: string | null): string | null {
   return `${y} р. ${m} міс.`;
 }
 
-export function JudgeProfilePage({ profile, onBack }: JudgeProfilePageProps) {
+export function JudgeProfilePage({ profile, onBack, children }: JudgeProfilePageProps) {
   const { basic, court_history, stats } = profile;
 
   const initials = basic.full_name
@@ -359,6 +360,9 @@ export function JudgeProfilePage({ profile, onBack }: JudgeProfilePageProps) {
             </div>
           </motion.div>
         )}
+
+        {/* Additional content (e.g. analytics) */}
+        {children}
       </div>
     </div>
   );

--- a/lexwebapp/src/pages/PersonDetailPage/index.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/index.tsx
@@ -7,8 +7,10 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { LawyerProfilePage } from './LawyerProfile';
 import { JudgeProfilePage } from './JudgeProfile';
+import { JudgeAnalyticsDetail } from './JudgeAnalyticsDetail';
 import { erauService, ERAUProfile } from '../../services/api/ERAUService';
 import { judgesService, JudgeProfile } from '../../services/api/JudgesService';
+import { judgeAnalyticsService, JudgeAnalyticsRecord } from '../../services/api/JudgeAnalyticsService';
 import { ROUTES } from '../../router/routes';
 
 interface PersonDetailPageProps {
@@ -21,6 +23,7 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
 
   const [lawyerProfile, setLawyerProfile] = useState<ERAUProfile | null>(null);
   const [judgeProfile, setJudgeProfile] = useState<JudgeProfile | null>(null);
+  const [judgeAnalytics, setJudgeAnalytics] = useState<JudgeAnalyticsRecord | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -51,16 +54,20 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
       });
   }, [type, id]);
 
-  // Fetch judge profile
+  // Fetch judge profile + analytics
   useEffect(() => {
     if (type !== 'judge' || !id) return;
 
     setLoading(true);
     setError(null);
 
-    judgesService.getJudgeProfile(id)
-      .then((data) => {
-        setJudgeProfile(data);
+    Promise.all([
+      judgesService.getJudgeProfile(id),
+      judgeAnalyticsService.getAnalyticsDetail(id).catch(() => null),
+    ])
+      .then(([profile, analytics]) => {
+        setJudgeProfile(profile);
+        setJudgeAnalytics(analytics);
       })
       .catch((err) => {
         setError(err.message || 'Не вдалося завантажити профіль судді');
@@ -137,5 +144,9 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
     );
   }
 
-  return <JudgeProfilePage profile={judgeProfile} onBack={handleBack} />;
+  return (
+    <JudgeProfilePage profile={judgeProfile} onBack={handleBack}>
+      {judgeAnalytics && <JudgeAnalyticsDetail analytics={judgeAnalytics} />}
+    </JudgeProfilePage>
+  );
 }

--- a/lexwebapp/src/services/api/JudgeAnalyticsService.ts
+++ b/lexwebapp/src/services/api/JudgeAnalyticsService.ts
@@ -1,0 +1,65 @@
+import { BaseService } from '../base/BaseService';
+
+export interface JudgeAnalyticsRecord {
+  id: number;
+  judge_name: string;
+  court_code: number | null;
+  court_name: string | null;
+  instance_code: number | null;
+  instance_name: string | null;
+  dossier_number: string | null;
+  total_decisions: number;
+  unique_cases: number;
+  cases_appealed: number;
+  appeal_rate: number;
+  decisions_by_year: Record<string, number>;
+  decisions_by_form: Record<string, number>;
+  decisions_by_justice_kind: Record<string, number>;
+  top_categories: Array<{ code: number; name: string; count: number }>;
+  appeal_outcomes: {
+    upheld: number;
+    overturned: number;
+    modified: number;
+    unknown: number;
+    analyzed: number;
+  };
+  vkksu_data: Record<string, unknown>;
+  peer_rank_in_court: number | null;
+  peer_total_in_court: number | null;
+  court_avg_decisions: number | null;
+  period_start: string;
+  period_end: string;
+  computed_at: string;
+}
+
+export interface JudgeAnalyticsListResult {
+  judges: JudgeAnalyticsRecord[];
+  total: number;
+}
+
+export interface JudgeAnalyticsFilters {
+  search?: string;
+  court_name?: string;
+  instance_code?: number;
+  justice_kind?: string;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
+  limit?: number;
+  offset?: number;
+}
+
+export class JudgeAnalyticsService extends BaseService {
+  async getAnalyticsList(params?: JudgeAnalyticsFilters): Promise<JudgeAnalyticsListResult> {
+    return this.request(() =>
+      this.client.get<JudgeAnalyticsListResult>('/api/judge-analytics', { params })
+    );
+  }
+
+  async getAnalyticsDetail(identifier: string): Promise<JudgeAnalyticsRecord> {
+    return this.request(() =>
+      this.client.get<JudgeAnalyticsRecord>(`/api/judge-analytics/${encodeURIComponent(identifier)}`)
+    );
+  }
+}
+
+export const judgeAnalyticsService = new JudgeAnalyticsService();

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -44,7 +44,8 @@
     "scrape:court:civil-contracts": "JUSTICE_KIND=Цивільне JUSTICE_KIND_ID=1 DOC_FORM=Рішення SEARCH_TEXT='недійсність договору купівлі-продажу нерухомого майна' MAX_DOCS=500 npm run scrape:court",
     "load:civil-cases": "npm run build && node dist/scripts/load-civil-property-cases.js",
     "backfill:reyestr": "npm run build && node dist/scripts/backfill-fulltext-reyestr.js",
-    "discover:court": "npm run build && node dist/scripts/discover-court-decisions.js"
+    "discover:court": "npm run build && node dist/scripts/discover-court-decisions.js",
+    "compute:judge-analytics": "npx tsx src/scripts/compute-judge-analytics.ts"
   },
   "keywords": [
     "mcp",

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -132,6 +132,8 @@ import { createAttorneyRoutes } from './routes/attorney-routes.js';
 import { createConsultationRoutes } from './routes/consultation-routes.js';
 import { JudgesService } from './services/judges-service.js';
 import { createJudgesRoutes } from './routes/judges-routes.js';
+import { JudgeAnalyticsService } from './services/judge-analytics-service.js';
+import { createJudgeAnalyticsRoutes } from './routes/judge-analytics-routes.js';
 import { ReferralService } from './services/referral-service.js';
 import { createReferralRoutes } from './routes/referral-routes.js';
 import { sanitizeId, maskSensitive } from './utils/sanitize-log.js';
@@ -2053,6 +2055,11 @@ class HTTPMCPServer {
     // Judges routes - search judges from VKKS data
     const judgesService = new JudgesService(this.services.db, this.services.zoAdapter);
     this.app.use('/api/judges', requireJWT as any, createJudgesRoutes(judgesService));
+
+    // Judge analytics routes - pre-computed metrics from EDRSR
+    const judgeAnalyticsService = new JudgeAnalyticsService(this.services.db);
+    this.app.use('/api/judge-analytics', requireJWT as any, createJudgeAnalyticsRoutes(judgeAnalyticsService));
+    logger.info('Judge analytics routes registered at /api/judge-analytics');
 
     // Decisions routes - download court decision full texts from reyestr.court.gov.ua
     this.app.use('/api/decisions', requireJWT as any, createDecisionsRoutes(this.services.reyestrDownloadService));

--- a/mcp_backend/src/migrations/082_judge_analytics.sql
+++ b/mcp_backend/src/migrations/082_judge_analytics.sql
@@ -1,0 +1,61 @@
+-- Judge analytics: pre-computed per-judge metrics from EDRSR (82M+ court decisions)
+-- Stores aggregated statistics for ~5,743 active judges (2022-2026)
+-- Populated by compute-judge-analytics.ts script
+
+CREATE TABLE IF NOT EXISTS judge_analytics (
+  id SERIAL PRIMARY KEY,
+  judge_name TEXT NOT NULL,
+  court_code INTEGER,
+  court_name TEXT,
+  instance_code SMALLINT,
+  instance_name TEXT,
+  dossier_number VARCHAR(50),
+
+  -- Decision counts
+  total_decisions INTEGER NOT NULL DEFAULT 0,
+  unique_cases INTEGER NOT NULL DEFAULT 0,
+  cases_appealed INTEGER NOT NULL DEFAULT 0,
+  appeal_rate NUMERIC(5,2) NOT NULL DEFAULT 0,
+
+  -- Breakdowns (JSONB)
+  decisions_by_year JSONB DEFAULT '{}',
+  decisions_by_form JSONB DEFAULT '{}',
+  decisions_by_justice_kind JSONB DEFAULT '{}',
+  top_categories JSONB DEFAULT '[]',
+
+  -- Appeal outcome analysis (from fulltext)
+  appeal_outcomes JSONB DEFAULT '{"upheld":0,"overturned":0,"modified":0,"unknown":0,"analyzed":0}',
+
+  -- VKKSU efficiency data (from judge_efficiency table)
+  vkksu_data JSONB DEFAULT '{}',
+
+  -- Peer comparison
+  peer_rank_in_court INTEGER,
+  peer_total_in_court INTEGER,
+  court_avg_decisions NUMERIC(10,2),
+
+  -- Metadata
+  period_start DATE DEFAULT '2022-01-01',
+  period_end DATE DEFAULT '2026-12-31',
+  computed_at TIMESTAMPTZ DEFAULT now(),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+
+  UNIQUE(judge_name, court_code)
+);
+
+-- Indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_ja_judge_name ON judge_analytics(judge_name);
+CREATE INDEX IF NOT EXISTS idx_ja_court_code ON judge_analytics(court_code);
+CREATE INDEX IF NOT EXISTS idx_ja_total_decisions_desc ON judge_analytics(total_decisions DESC);
+CREATE INDEX IF NOT EXISTS idx_ja_appeal_rate_desc ON judge_analytics(appeal_rate DESC);
+CREATE INDEX IF NOT EXISTS idx_ja_instance_code ON judge_analytics(instance_code);
+CREATE INDEX IF NOT EXISTS idx_ja_dossier ON judge_analytics(dossier_number);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'update_judge_analytics_updated_at') THEN
+        CREATE TRIGGER update_judge_analytics_updated_at BEFORE UPDATE ON judge_analytics
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;

--- a/mcp_backend/src/routes/judge-analytics-routes.ts
+++ b/mcp_backend/src/routes/judge-analytics-routes.ts
@@ -1,0 +1,48 @@
+import { Router, Response } from 'express';
+import { JudgeAnalyticsService } from '../services/judge-analytics-service.js';
+import { logger } from '../utils/logger.js';
+
+export function createJudgeAnalyticsRoutes(service: JudgeAnalyticsService): Router {
+  const router = Router();
+
+  // GET /api/judge-analytics — paginated list with filters
+  router.get('/', async (req: any, res: Response) => {
+    try {
+      const filters = {
+        search: req.query.search as string | undefined,
+        court_name: req.query.court_name as string | undefined,
+        instance_code: req.query.instance_code ? parseInt(req.query.instance_code as string) : undefined,
+        justice_kind: req.query.justice_kind as string | undefined,
+        sort_by: req.query.sort_by as string | undefined,
+        sort_order: (req.query.sort_order as 'asc' | 'desc') || undefined,
+        limit: Math.min(parseInt(req.query.limit as string) || 25, 200),
+        offset: parseInt(req.query.offset as string) || 0,
+      };
+
+      const result = await service.getAnalyticsList(filters);
+      res.json(result);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[JudgeAnalytics] list error', { error: msg });
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  // GET /api/judge-analytics/:id — detail by dossier_number, id, or judge_name
+  router.get('/:id', async (req: any, res: Response) => {
+    try {
+      const { id } = req.params;
+      const record = await service.getAnalyticsDetail(id);
+      if (!record) {
+        return res.status(404).json({ error: 'Аналітику для цього судді не знайдено' });
+      }
+      res.json(record);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[JudgeAnalytics] detail error', { error: msg, id: req.params.id });
+      res.status(500).json({ error: msg });
+    }
+  });
+
+  return router;
+}

--- a/mcp_backend/src/scripts/compute-judge-analytics.ts
+++ b/mcp_backend/src/scripts/compute-judge-analytics.ts
@@ -1,0 +1,467 @@
+/**
+ * compute-judge-analytics.ts
+ *
+ * Multi-pass bulk SQL computation of per-judge analytics from EDRSR data.
+ * Designed to run as a standalone script: npx tsx src/scripts/compute-judge-analytics.ts
+ *
+ * Pass 1a-1e: Base counts, year/form/justice-kind breakdowns, top categories
+ * Pass 2:    Court info + dossier matching from judges_current
+ * Pass 3:    Appeal rate (first instance → appeal self-join)
+ * Pass 4:    Appeal outcomes from fulltext (20 parallel workers, 4 DB shards)
+ * Pass 5:    VKKSU efficiency join
+ * Pass 6:    Peer ranking via window functions
+ */
+
+import pg from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { Pool } = pg;
+
+const PERIOD_START = '2022-01-01';
+const PERIOD_END = '2026-12-31';
+const WORKER_COUNT = 20;
+
+// Shard DB URLs for fulltext analysis (Pass 4)
+const SHARD_URLS = [
+  process.env.DATABASE_URL || process.env.EDRSR_SHARD_1_URL || '',
+  process.env.EDRSR_SHARD_2_URL || '',
+  process.env.EDRSR_SHARD_3_URL || '',
+  process.env.EDRSR_SHARD_4_URL || '',
+].filter(Boolean);
+
+function createPool(connectionString: string): pg.Pool {
+  return new Pool({
+    connectionString,
+    max: 6,
+    idleTimeoutMillis: 30000,
+    connectionTimeoutMillis: 10000,
+  });
+}
+
+const mainPool = createPool(process.env.DATABASE_URL || '');
+
+function log(msg: string) {
+  console.log(`[${new Date().toISOString()}] ${msg}`);
+}
+
+// ── Pass 1a: Base counts ──────────────────────────────────────────────────
+async function pass1a() {
+  log('Pass 1a: Base counts (total_decisions, unique_cases)');
+  await mainPool.query(`
+    INSERT INTO judge_analytics (judge_name, court_code, total_decisions, unique_cases, period_start, period_end)
+    SELECT
+      d.judge,
+      d.court_code,
+      COUNT(*)::INTEGER AS total_decisions,
+      COUNT(DISTINCT d.cause_num)::INTEGER AS unique_cases,
+      $1::DATE,
+      $2::DATE
+    FROM edrsr_documents d
+    WHERE d.judge IS NOT NULL
+      AND d.adjudication_date >= $1::DATE
+      AND d.adjudication_date <= $2::DATE
+    GROUP BY d.judge, d.court_code
+    ON CONFLICT (judge_name, court_code) DO UPDATE SET
+      total_decisions = EXCLUDED.total_decisions,
+      unique_cases = EXCLUDED.unique_cases,
+      period_start = EXCLUDED.period_start,
+      period_end = EXCLUDED.period_end,
+      computed_at = now()
+  `, [PERIOD_START, PERIOD_END]);
+  const { rows } = await mainPool.query('SELECT COUNT(*) AS cnt FROM judge_analytics');
+  log(`Pass 1a done: ${rows[0].cnt} judges inserted`);
+}
+
+// ── Pass 1b: Year breakdown ────────────────────────────────────────────────
+async function pass1b() {
+  log('Pass 1b: Decisions by year');
+  await mainPool.query(`
+    WITH year_data AS (
+      SELECT judge, court_code,
+        jsonb_object_agg(yr::TEXT, cnt) AS by_year
+      FROM (
+        SELECT judge, court_code,
+          EXTRACT(YEAR FROM adjudication_date)::INTEGER AS yr,
+          COUNT(*) AS cnt
+        FROM edrsr_documents
+        WHERE judge IS NOT NULL
+          AND adjudication_date >= $1::DATE
+          AND adjudication_date <= $2::DATE
+        GROUP BY judge, court_code, EXTRACT(YEAR FROM adjudication_date)
+      ) t
+      GROUP BY judge, court_code
+    )
+    UPDATE judge_analytics ja
+    SET decisions_by_year = yd.by_year
+    FROM year_data yd
+    WHERE ja.judge_name = yd.judge AND ja.court_code = yd.court_code
+  `, [PERIOD_START, PERIOD_END]);
+  log('Pass 1b done');
+}
+
+// ── Pass 1c: Form breakdown ───────────────────────────────────────────────
+async function pass1c() {
+  log('Pass 1c: Decisions by judgment form');
+  await mainPool.query(`
+    WITH form_data AS (
+      SELECT d.judge, d.court_code,
+        jsonb_object_agg(COALESCE(jf.name, d.judgment_code::TEXT), cnt) AS by_form
+      FROM (
+        SELECT judge, court_code, judgment_code, COUNT(*) AS cnt
+        FROM edrsr_documents
+        WHERE judge IS NOT NULL
+          AND adjudication_date >= $1::DATE
+          AND adjudication_date <= $2::DATE
+        GROUP BY judge, court_code, judgment_code
+      ) d
+      LEFT JOIN edrsr_judgment_forms jf ON jf.judgment_code = d.judgment_code
+      GROUP BY d.judge, d.court_code
+    )
+    UPDATE judge_analytics ja
+    SET decisions_by_form = fd.by_form
+    FROM form_data fd
+    WHERE ja.judge_name = fd.judge AND ja.court_code = fd.court_code
+  `, [PERIOD_START, PERIOD_END]);
+  log('Pass 1c done');
+}
+
+// ── Pass 1d: Justice kind breakdown ───────────────────────────────────────
+async function pass1d() {
+  log('Pass 1d: Decisions by justice kind');
+  await mainPool.query(`
+    WITH jk_data AS (
+      SELECT d.judge, d.court_code,
+        jsonb_object_agg(COALESCE(jk.name, d.justice_kind::TEXT), cnt) AS by_jk
+      FROM (
+        SELECT judge, court_code, justice_kind, COUNT(*) AS cnt
+        FROM edrsr_documents
+        WHERE judge IS NOT NULL
+          AND adjudication_date >= $1::DATE
+          AND adjudication_date <= $2::DATE
+        GROUP BY judge, court_code, justice_kind
+      ) d
+      LEFT JOIN edrsr_justice_kinds jk ON jk.justice_kind = d.justice_kind
+      GROUP BY d.judge, d.court_code
+    )
+    UPDATE judge_analytics ja
+    SET decisions_by_justice_kind = jkd.by_jk
+    FROM jk_data jkd
+    WHERE ja.judge_name = jkd.judge AND ja.court_code = jkd.court_code
+  `, [PERIOD_START, PERIOD_END]);
+  log('Pass 1d done');
+}
+
+// ── Pass 1e: Top categories ───────────────────────────────────────────────
+async function pass1e() {
+  log('Pass 1e: Top 10 categories per judge');
+  await mainPool.query(`
+    WITH ranked AS (
+      SELECT d.judge, d.court_code, d.category_code,
+        COALESCE(cc.name, d.category_code::TEXT) AS category_name,
+        COUNT(*) AS cnt,
+        ROW_NUMBER() OVER (PARTITION BY d.judge, d.court_code ORDER BY COUNT(*) DESC) AS rn
+      FROM edrsr_documents d
+      LEFT JOIN edrsr_cause_categories cc ON cc.category_code = d.category_code
+      WHERE d.judge IS NOT NULL
+        AND d.adjudication_date >= $1::DATE
+        AND d.adjudication_date <= $2::DATE
+        AND d.category_code IS NOT NULL
+      GROUP BY d.judge, d.court_code, d.category_code, cc.name
+    ),
+    top10 AS (
+      SELECT judge, court_code,
+        jsonb_agg(
+          jsonb_build_object('code', category_code, 'name', category_name, 'count', cnt)
+          ORDER BY cnt DESC
+        ) AS cats
+      FROM ranked
+      WHERE rn <= 10
+      GROUP BY judge, court_code
+    )
+    UPDATE judge_analytics ja
+    SET top_categories = t.cats
+    FROM top10 t
+    WHERE ja.judge_name = t.judge AND ja.court_code = t.court_code
+  `, [PERIOD_START, PERIOD_END]);
+  log('Pass 1e done');
+}
+
+// ── Pass 2: Court info + dossier ──────────────────────────────────────────
+async function pass2() {
+  log('Pass 2: Court name, instance, dossier number');
+  await mainPool.query(`
+    UPDATE judge_analytics ja
+    SET
+      court_name = c.name,
+      instance_code = c.instance_code,
+      instance_name = i.name
+    FROM edrsr_courts c
+    LEFT JOIN edrsr_instances i ON i.instance_code = c.instance_code
+    WHERE ja.court_code = c.court_code
+  `);
+  // Match dossier numbers from judges_current
+  await mainPool.query(`
+    UPDATE judge_analytics ja
+    SET dossier_number = jc.dossier_number
+    FROM judges_current jc
+    WHERE ja.judge_name = jc.full_name
+      AND ja.dossier_number IS NULL
+  `);
+  log('Pass 2 done');
+}
+
+// ── Pass 3: Appeal rate ───────────────────────────────────────────────────
+async function pass3() {
+  log('Pass 3: Appeal rate (first instance → appeal court join)');
+  // Count cases where the cause_num from a first-instance judge appears in an appeal court
+  await mainPool.query(`
+    WITH first_instance_cases AS (
+      SELECT ja.judge_name, ja.court_code, d.cause_num
+      FROM judge_analytics ja
+      JOIN edrsr_documents d ON d.judge = ja.judge_name AND d.court_code = ja.court_code
+      WHERE ja.instance_code = 1
+        AND d.cause_num IS NOT NULL
+        AND d.adjudication_date >= $1::DATE
+        AND d.adjudication_date <= $2::DATE
+      GROUP BY ja.judge_name, ja.court_code, d.cause_num
+    ),
+    appealed AS (
+      SELECT fic.judge_name, fic.court_code, COUNT(DISTINCT fic.cause_num) AS cnt
+      FROM first_instance_cases fic
+      WHERE EXISTS (
+        SELECT 1 FROM edrsr_documents ap
+        JOIN edrsr_courts ac ON ac.court_code = ap.court_code AND ac.instance_code = 2
+        WHERE ap.cause_num = fic.cause_num
+          AND ap.adjudication_date >= $1::DATE
+      )
+      GROUP BY fic.judge_name, fic.court_code
+    )
+    UPDATE judge_analytics ja
+    SET
+      cases_appealed = COALESCE(a.cnt, 0),
+      appeal_rate = CASE
+        WHEN ja.unique_cases > 0 THEN ROUND(COALESCE(a.cnt, 0)::NUMERIC / ja.unique_cases * 100, 2)
+        ELSE 0
+      END
+    FROM (
+      SELECT ja2.judge_name, ja2.court_code
+      FROM judge_analytics ja2
+      WHERE ja2.instance_code = 1
+    ) j
+    LEFT JOIN appealed a ON a.judge_name = j.judge_name AND a.court_code = j.court_code
+    WHERE ja.judge_name = j.judge_name AND ja.court_code = j.court_code
+  `, [PERIOD_START, PERIOD_END]);
+  log('Pass 3 done');
+}
+
+// ── Pass 4: Appeal outcomes from fulltext (parallel workers) ──────────────
+async function pass4() {
+  if (SHARD_URLS.length === 0) {
+    log('Pass 4: SKIPPED (no shard DB URLs configured)');
+    return;
+  }
+  log(`Pass 4: Appeal outcomes from fulltext (${WORKER_COUNT} workers, ${SHARD_URLS.length} shards)`);
+
+  const shardPools = SHARD_URLS.map(url => createPool(url));
+
+  // Get judges with appealed cases (first instance only)
+  const { rows: judges } = await mainPool.query(`
+    SELECT judge_name, court_code, cases_appealed
+    FROM judge_analytics
+    WHERE instance_code = 1 AND cases_appealed > 0
+    ORDER BY cases_appealed DESC
+  `);
+  log(`Pass 4: ${judges.length} judges with appealed cases`);
+
+  if (judges.length === 0) {
+    for (const p of shardPools) await p.end();
+    return;
+  }
+
+  // Split into batches for workers
+  const batchSize = Math.ceil(judges.length / WORKER_COUNT);
+  const batches: typeof judges[] = [];
+  for (let i = 0; i < judges.length; i += batchSize) {
+    batches.push(judges.slice(i, i + batchSize));
+  }
+
+  const outcomePatterns = {
+    upheld: /залиш(ити|ено)\s+(без\s+змін|в\s+силі)|апеляцій(ну|ну)\s+скаргу\s+без\s+задоволення|скаргу\s+відхил/i,
+    overturned: /скасува(ти|но)\s+(рішення|вирок|ухвалу|постанову)|скасовано\s+повністю|направити\s+на\s+новий\s+розгляд/i,
+    modified: /змін(ити|ено)\s+(рішення|вирок|ухвалу|постанову)|частково\s+задовол/i,
+  };
+
+  async function classifyOutcome(fulltext: string): Promise<'upheld' | 'overturned' | 'modified' | 'unknown'> {
+    if (!fulltext) return 'unknown';
+    // Check last 2000 chars (operative part is usually at the end)
+    const tail = fulltext.slice(-2000);
+    if (outcomePatterns.overturned.test(tail)) return 'overturned';
+    if (outcomePatterns.modified.test(tail)) return 'modified';
+    if (outcomePatterns.upheld.test(tail)) return 'upheld';
+    return 'unknown';
+  }
+
+  async function searchShards(docIds: number[]): Promise<Map<number, string>> {
+    const results = new Map<number, string>();
+    if (docIds.length === 0) return results;
+
+    const promises = shardPools.map(async (pool) => {
+      try {
+        const { rows } = await pool.query(
+          `SELECT doc_id, full_text FROM edrsr_fulltext WHERE doc_id = ANY($1) AND full_text IS NOT NULL`,
+          [docIds]
+        );
+        for (const row of rows) {
+          results.set(row.doc_id, row.full_text);
+        }
+      } catch {
+        // Shard may be unavailable
+      }
+    });
+    await Promise.all(promises);
+    return results;
+  }
+
+  async function processWorkerBatch(batch: typeof judges) {
+    for (const judge of batch) {
+      // Get appeal doc_ids for this judge's cases
+      const { rows: appealDocs } = await mainPool.query(`
+        SELECT DISTINCT ap.doc_id
+        FROM edrsr_documents orig
+        JOIN edrsr_documents ap ON ap.cause_num = orig.cause_num
+        JOIN edrsr_courts ac ON ac.court_code = ap.court_code AND ac.instance_code = 2
+        WHERE orig.judge = $1
+          AND orig.court_code = $2
+          AND orig.cause_num IS NOT NULL
+          AND orig.adjudication_date >= $3::DATE
+          AND ap.adjudication_date >= $3::DATE
+          AND ap.judgment_code IN (3, 4)
+        LIMIT 500
+      `, [judge.judge_name, judge.court_code, PERIOD_START]);
+
+      if (appealDocs.length === 0) continue;
+
+      const docIds = appealDocs.map((r: { doc_id: number }) => r.doc_id);
+      const fulltexts = await searchShards(docIds);
+
+      const outcomes = { upheld: 0, overturned: 0, modified: 0, unknown: 0, analyzed: 0 };
+      for (const [, text] of fulltexts) {
+        const result = await classifyOutcome(text);
+        outcomes[result]++;
+        outcomes.analyzed++;
+      }
+
+      if (outcomes.analyzed > 0) {
+        await mainPool.query(`
+          UPDATE judge_analytics
+          SET appeal_outcomes = $3::JSONB
+          WHERE judge_name = $1 AND court_code = $2
+        `, [judge.judge_name, judge.court_code, JSON.stringify(outcomes)]);
+      }
+    }
+  }
+
+  const workerPromises = batches.map(batch => processWorkerBatch(batch));
+  await Promise.all(workerPromises);
+
+  for (const p of shardPools) await p.end();
+  log('Pass 4 done');
+}
+
+// ── Pass 5: VKKSU efficiency data ─────────────────────────────────────────
+async function pass5() {
+  log('Pass 5: VKKSU efficiency join');
+  // Check if judge_efficiency table exists
+  const { rows: tableCheck } = await mainPool.query(`
+    SELECT 1 FROM information_schema.tables WHERE table_name = 'judge_efficiency' LIMIT 1
+  `);
+  if (tableCheck.length === 0) {
+    log('Pass 5: SKIPPED (judge_efficiency table not found)');
+    return;
+  }
+
+  await mainPool.query(`
+    UPDATE judge_analytics ja
+    SET vkksu_data = jsonb_build_object(
+      'workload', jsonb_build_object(
+        'criminal', jsonb_build_object('judge', je.workload_criminal_judge, 'court', je.workload_criminal_court, 'region', je.workload_criminal_region),
+        'civil', jsonb_build_object('judge', je.workload_civil_judge, 'court', je.workload_civil_court, 'region', je.workload_civil_region),
+        'admin', jsonb_build_object('judge', je.workload_admin_judge, 'court', je.workload_admin_court, 'region', je.workload_admin_region),
+        'commercial', jsonb_build_object('judge', je.workload_commercial_judge, 'court', je.workload_commercial_court, 'region', je.workload_commercial_region),
+        'misdemeanor', jsonb_build_object('judge', je.workload_misdemeanor_judge, 'court', je.workload_misdemeanor_court, 'region', je.workload_misdemeanor_region)
+      ),
+      'overturned', jsonb_build_object(
+        'criminal', je.overturned_criminal_total,
+        'civil', je.overturned_civil_total,
+        'admin', je.overturned_admin_total,
+        'commercial', je.overturned_commercial_total,
+        'misdemeanor', je.overturned_misdemeanor_total
+      ),
+      'deadline_violations', jsonb_build_object(
+        'criminal', je.deadline_violations_criminal,
+        'civil', je.deadline_violations_civil,
+        'admin', je.deadline_violations_admin,
+        'commercial', je.deadline_violations_commercial,
+        'misdemeanor', je.deadline_violations_misdemeanor
+      ),
+      'year', je.year
+    )
+    FROM judge_efficiency je
+    WHERE ja.judge_name = je.judge_name
+  `);
+  log('Pass 5 done');
+}
+
+// ── Pass 6: Peer ranking ──────────────────────────────────────────────────
+async function pass6() {
+  log('Pass 6: Peer ranking within court');
+  await mainPool.query(`
+    WITH ranked AS (
+      SELECT id,
+        RANK() OVER (PARTITION BY court_code ORDER BY total_decisions DESC) AS rnk,
+        COUNT(*) OVER (PARTITION BY court_code) AS total_in_court,
+        AVG(total_decisions) OVER (PARTITION BY court_code) AS avg_decisions
+      FROM judge_analytics
+    )
+    UPDATE judge_analytics ja
+    SET
+      peer_rank_in_court = r.rnk,
+      peer_total_in_court = r.total_in_court,
+      court_avg_decisions = r.avg_decisions
+    FROM ranked r
+    WHERE ja.id = r.id
+  `);
+  log('Pass 6 done');
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+async function main() {
+  log('=== Judge Analytics Computation Started ===');
+  const start = Date.now();
+
+  try {
+    // Pass 1: parallel sub-passes
+    await pass1a();
+    await Promise.all([pass1b(), pass1c(), pass1d(), pass1e()]);
+
+    // Pass 2-6: sequential
+    await pass2();
+    await pass3();
+    await pass4();
+    await pass5();
+    await pass6();
+
+    const { rows } = await mainPool.query('SELECT COUNT(*) AS cnt FROM judge_analytics');
+    const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+    log(`=== Done: ${rows[0].cnt} judges computed in ${elapsed}s ===`);
+  } catch (err) {
+    console.error('FATAL:', err);
+    process.exit(1);
+  } finally {
+    await mainPool.end();
+  }
+}
+
+main();

--- a/mcp_backend/src/services/judge-analytics-service.ts
+++ b/mcp_backend/src/services/judge-analytics-service.ts
@@ -1,0 +1,151 @@
+import { BaseDatabase } from '@secondlayer/shared';
+import { logger } from '../utils/logger.js';
+
+export interface JudgeAnalyticsRecord {
+  id: number;
+  judge_name: string;
+  court_code: number | null;
+  court_name: string | null;
+  instance_code: number | null;
+  instance_name: string | null;
+  dossier_number: string | null;
+  total_decisions: number;
+  unique_cases: number;
+  cases_appealed: number;
+  appeal_rate: number;
+  decisions_by_year: Record<string, number>;
+  decisions_by_form: Record<string, number>;
+  decisions_by_justice_kind: Record<string, number>;
+  top_categories: Array<{ code: number; name: string; count: number }>;
+  appeal_outcomes: {
+    upheld: number;
+    overturned: number;
+    modified: number;
+    unknown: number;
+    analyzed: number;
+  };
+  vkksu_data: Record<string, unknown>;
+  peer_rank_in_court: number | null;
+  peer_total_in_court: number | null;
+  court_avg_decisions: number | null;
+  period_start: string;
+  period_end: string;
+  computed_at: string;
+}
+
+export interface JudgeAnalyticsListResult {
+  judges: JudgeAnalyticsRecord[];
+  total: number;
+}
+
+export interface JudgeAnalyticsFilters {
+  search?: string;
+  court_name?: string;
+  instance_code?: number;
+  justice_kind?: string;
+  sort_by?: string;
+  sort_order?: 'asc' | 'desc';
+  limit?: number;
+  offset?: number;
+}
+
+const ALLOWED_SORT_COLUMNS: Record<string, string> = {
+  total_decisions: 'total_decisions',
+  appeal_rate: 'appeal_rate',
+  cases_appealed: 'cases_appealed',
+  unique_cases: 'unique_cases',
+  judge_name: 'judge_name',
+  court_name: 'court_name',
+  peer_rank_in_court: 'peer_rank_in_court',
+};
+
+export class JudgeAnalyticsService {
+  private db: BaseDatabase;
+
+  constructor(db: BaseDatabase) {
+    this.db = db;
+  }
+
+  async getAnalyticsList(filters: JudgeAnalyticsFilters): Promise<JudgeAnalyticsListResult> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = 1;
+
+    if (filters.search) {
+      conditions.push(`judge_name ILIKE $${paramIdx}`);
+      params.push(`%${filters.search}%`);
+      paramIdx++;
+    }
+
+    if (filters.court_name) {
+      conditions.push(`court_name ILIKE $${paramIdx}`);
+      params.push(`%${filters.court_name}%`);
+      paramIdx++;
+    }
+
+    if (filters.instance_code != null) {
+      conditions.push(`instance_code = $${paramIdx}`);
+      params.push(filters.instance_code);
+      paramIdx++;
+    }
+
+    if (filters.justice_kind) {
+      conditions.push(`decisions_by_justice_kind ? $${paramIdx}`);
+      params.push(filters.justice_kind);
+      paramIdx++;
+    }
+
+    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const sortCol = ALLOWED_SORT_COLUMNS[filters.sort_by || 'total_decisions'] || 'total_decisions';
+    const sortOrder = filters.sort_order === 'asc' ? 'ASC' : 'DESC';
+    const limit = Math.min(filters.limit || 25, 200);
+    const offset = filters.offset || 0;
+
+    const countQuery = `SELECT COUNT(*) AS total FROM judge_analytics ${whereClause}`;
+    const dataQuery = `
+      SELECT * FROM judge_analytics
+      ${whereClause}
+      ORDER BY ${sortCol} ${sortOrder} NULLS LAST
+      LIMIT $${paramIdx} OFFSET $${paramIdx + 1}
+    `;
+
+    const [countResult, dataResult] = await Promise.all([
+      this.db.query<{ total: string }>(countQuery, params),
+      this.db.query<JudgeAnalyticsRecord>(dataQuery, [...params, limit, offset]),
+    ]);
+
+    return {
+      judges: dataResult.rows,
+      total: parseInt(countResult.rows[0]?.total || '0', 10),
+    };
+  }
+
+  async getAnalyticsDetail(identifier: string): Promise<JudgeAnalyticsRecord | null> {
+    // Try dossier number first, then id
+    let result = await this.db.query<JudgeAnalyticsRecord>(
+      `SELECT * FROM judge_analytics WHERE dossier_number = $1 LIMIT 1`,
+      [identifier]
+    );
+
+    if (result.rows.length === 0) {
+      const numId = parseInt(identifier, 10);
+      if (!isNaN(numId)) {
+        result = await this.db.query<JudgeAnalyticsRecord>(
+          `SELECT * FROM judge_analytics WHERE id = $1 LIMIT 1`,
+          [numId]
+        );
+      }
+    }
+
+    if (result.rows.length === 0) {
+      // Try URL-decoded judge name
+      result = await this.db.query<JudgeAnalyticsRecord>(
+        `SELECT * FROM judge_analytics WHERE judge_name = $1 LIMIT 1`,
+        [decodeURIComponent(identifier)]
+      );
+    }
+
+    return result.rows[0] || null;
+  }
+}


### PR DESCRIPTION
## Summary
- Pre-computed per-judge analytics from EDRSR (82M+ court decisions, 2022-2026)
- New `/judges` "Аналітика" tab with sortable table: decisions, appeal rate, overturned, deadline violations, peer rank
- Judge detail page enriched with appeal outcomes, year trends, VKKSU efficiency, top categories
- Computation script with 20 parallel workers for fulltext appeal outcome classification across 4 DB shards

## New files
- `082_judge_analytics.sql` — migration
- `compute-judge-analytics.ts` — 6-pass computation script
- `judge-analytics-service.ts` + `judge-analytics-routes.ts` — backend API
- `JudgeAnalyticsService.ts` + `useJudgeAnalytics.ts` — frontend API layer
- `JudgeAnalyticsTable.tsx` — sortable, paginated, filterable table
- `JudgeAnalyticsDetail.tsx` — detail view with charts

## Test plan
- [ ] CI build passes (backend + frontend)
- [ ] Migration runs: `SELECT COUNT(*) FROM judge_analytics` after compute
- [ ] API works: `curl /api/judge-analytics?limit=5`
- [ ] UI: /judges shows analytics tab with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)