### PR TITLE
fix: handle NULL keys in jsonb_object_agg for judge analytics

### DIFF
--- a/mcp_backend/src/scripts/compute-judge-analytics.ts
+++ b/mcp_backend/src/scripts/compute-judge-analytics.ts
@@ -107,7 +107,7 @@ async function pass1c() {
   await mainPool.query(`
     WITH form_data AS (
       SELECT d.judge, d.court_code,
-        jsonb_object_agg(COALESCE(jf.name, d.judgment_code::TEXT), cnt) AS by_form
+        jsonb_object_agg(COALESCE(jf.name, d.judgment_code::TEXT, 'Невідомо'), cnt) AS by_form
       FROM (
         SELECT judge, court_code, judgment_code, COUNT(*) AS cnt
         FROM edrsr_documents
@@ -133,7 +133,7 @@ async function pass1d() {
   await mainPool.query(`
     WITH jk_data AS (
       SELECT d.judge, d.court_code,
-        jsonb_object_agg(COALESCE(jk.name, d.justice_kind::TEXT), cnt) AS by_jk
+        jsonb_object_agg(COALESCE(jk.name, d.justice_kind::TEXT, 'Невідомо'), cnt) AS by_jk
       FROM (
         SELECT judge, court_code, justice_kind, COUNT(*) AS cnt
         FROM edrsr_documents


### PR DESCRIPTION
## Summary
- Computation script crashed at pass 1d with `field name must not be null`
- `justice_kind` and `judgment_code` can be NULL in edrsr_documents
- Added `'Невідомо'` fallback to COALESCE chain in passes 1c and 1d

## Test plan
- [ ] Re-run `compute-judge-analytics.ts` completes all 6 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)