### PR TITLE
feat: referral lifetime rewards + FOP/TOV/attorney verification

### DIFF
--- a/lexwebapp/src/pages/ReferralPage/index.tsx
+++ b/lexwebapp/src/pages/ReferralPage/index.tsx
@@ -1,39 +1,200 @@
 /**
  * ReferralPage
- * Dashboard showing referral link, stats, and list of referred users
+ * Dashboard showing referral link, stats, and list of referred users.
+ * Requires FOP/TOV/Attorney verification to participate.
  */
 
 import { useState, useEffect } from 'react';
-import { Copy, Check, UserPlus, Gift, Users, TrendingUp, Award, DollarSign, Link2 } from 'lucide-react';
-import { ReferralService, ReferralStats, ReferralEntry } from '../../services/api/ReferralService';
+import { Copy, Check, UserPlus, Gift, Users, TrendingUp, Award, DollarSign, Link2, ShieldCheck, Building2, Briefcase, Scale } from 'lucide-react';
+import { ReferralService, ReferralStats, ReferralEntry, ReferrerStatus, ReferrerType } from '../../services/api/ReferralService';
 import { showToast } from '../../utils/toast';
 
 const referralService = new ReferralService();
 
+const REFERRER_TYPE_LABELS: Record<ReferrerType, string> = {
+  fop: 'ФОП (фізична особа-підприємець)',
+  tov: 'ТОВ (товариство з обмеженою відповідальністю)',
+  attorney: 'Адвокат (свідоцтво ЄРАУ)',
+};
+
+const REFERRER_TYPE_ICONS: Record<ReferrerType, typeof Building2> = {
+  fop: Briefcase,
+  tov: Building2,
+  attorney: Scale,
+};
+
+function VerificationForm({ onVerified }: { onVerified: () => void }) {
+  const [referrerType, setReferrerType] = useState<ReferrerType | null>(null);
+  const [businessCode, setBusinessCode] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!referrerType || !businessCode.trim()) {
+      showToast.error('Заповніть всі поля');
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await referralService.submitVerification(referrerType, businessCode.trim());
+      showToast.success('Верифікацію пройдено');
+      onVerified();
+    } catch {
+      showToast.error('Не вдалося пройти верифікацію');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const codeLabel = referrerType === 'attorney' ? 'Номер свідоцтва ЄРАУ' : 'Код ЄДРПОУ';
+  const codePlaceholder = referrerType === 'attorney' ? 'Наприклад: 12345' : 'Наприклад: 12345678';
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8 md:px-8 lg:px-12">
+      <div className="mb-8">
+        <h1 className="text-3xl md:text-4xl font-serif text-claude-text font-medium tracking-tight mb-2">
+          Реферальна програма
+        </h1>
+        <p className="text-sm text-claude-subtext">
+          Для участі необхідна верифікація як ФОП, ТОВ або Адвокат
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-claude-border p-6 mb-6">
+        <div className="flex items-center gap-2 mb-5">
+          <div className="p-2 bg-claude-accent/10 rounded-lg">
+            <ShieldCheck size={16} className="text-claude-accent" />
+          </div>
+          <h2 className="text-sm font-semibold text-claude-text uppercase tracking-wide">
+            Верифікація учасника
+          </h2>
+        </div>
+
+        <p className="text-sm text-claude-subtext mb-6 leading-relaxed">
+          Реферальна програма доступна для верифікованих ФОП, ТОВ та адвокатів.
+          Це необхідно для коректного оформлення виплат відповідно до податкового законодавства.
+        </p>
+
+        <div className="space-y-3 mb-6">
+          {(['fop', 'tov', 'attorney'] as ReferrerType[]).map((type) => {
+            const Icon = REFERRER_TYPE_ICONS[type];
+            const isSelected = referrerType === type;
+            return (
+              <button
+                key={type}
+                onClick={() => setReferrerType(type)}
+                className={`w-full flex items-center gap-3 p-4 rounded-lg border transition-all text-left ${
+                  isSelected
+                    ? 'border-claude-accent bg-claude-accent/5'
+                    : 'border-claude-border hover:border-claude-subtext/30 hover:bg-claude-bg/50'
+                }`}
+              >
+                <div className={`p-2 rounded-lg ${isSelected ? 'bg-claude-accent/10' : 'bg-claude-bg'}`}>
+                  <Icon size={16} className={isSelected ? 'text-claude-accent' : 'text-claude-subtext'} />
+                </div>
+                <span className={`text-sm font-medium ${isSelected ? 'text-claude-text' : 'text-claude-subtext'}`}>
+                  {REFERRER_TYPE_LABELS[type]}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+
+        {referrerType && (
+          <div className="space-y-4">
+            <div>
+              <label className="block text-xs font-semibold text-claude-subtext uppercase tracking-wide mb-1.5">
+                {codeLabel}
+              </label>
+              <input
+                type="text"
+                value={businessCode}
+                onChange={(e) => setBusinessCode(e.target.value)}
+                placeholder={codePlaceholder}
+                className="w-full px-4 py-2.5 rounded-lg border border-claude-border bg-white text-sm text-claude-text placeholder:text-claude-subtext/50 focus:outline-none focus:ring-2 focus:ring-claude-accent/20 focus:border-claude-accent"
+              />
+            </div>
+
+            <button
+              onClick={handleSubmit}
+              disabled={submitting || !businessCode.trim()}
+              className="w-full px-4 py-2.5 bg-claude-accent text-white rounded-lg hover:bg-claude-accent/90 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {submitting ? 'Верифікація...' : 'Підтвердити та отримати реферальний код'}
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Program Terms preview */}
+      <div className="bg-white rounded-xl border border-claude-border p-6">
+        <div className="flex items-center gap-2 mb-5">
+          <div className="p-2 bg-claude-accent/10 rounded-lg">
+            <Award size={16} className="text-claude-accent" />
+          </div>
+          <h2 className="text-sm font-semibold text-claude-text uppercase tracking-wide">
+            Умови програми
+          </h2>
+        </div>
+        <div className="space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-claude-accent/10 flex items-center justify-center">
+              <TrendingUp size={16} className="text-claude-accent" />
+            </div>
+            <div>
+              <h3 className="text-sm font-serif font-medium text-claude-text">До 20% від кожного платежу</h3>
+              <p className="text-xs text-claude-subtext mt-1 leading-relaxed">
+                Ви отримуєте до 20% реферальної винагороди з кожного платежу клієнта, якого ви привели на платформу. Винагорода нараховується постійно, поки клієнт залишається активним.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0 w-8 h-8 rounded-full bg-claude-accent/10 flex items-center justify-center">
+              <Award size={16} className="text-claude-accent" />
+            </div>
+            <div>
+              <h3 className="text-sm font-serif font-medium text-claude-text">Equity Share для топ-рефералів</h3>
+              <p className="text-xs text-claude-subtext mt-1 leading-relaxed">
+                Якщо за 3 місяці ви запросите 10+ клієнтів, кожен з яких платить від $500/міс — вся сума виплачених вам реферальних відсотків додатково конвертується в equity share компанії.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function ReferralPage() {
   const [stats, setStats] = useState<ReferralStats | null>(null);
   const [referrals, setReferrals] = useState<ReferralEntry[]>([]);
+  const [verification, setVerification] = useState<ReferrerStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [copiedCode, setCopiedCode] = useState(false);
   const [copiedLink, setCopiedLink] = useState(false);
 
-  useEffect(() => {
-    async function load() {
-      try {
+  const loadData = async () => {
+    try {
+      const verStatus = await referralService.getVerificationStatus();
+      setVerification(verStatus);
+
+      if (verStatus.isVerified) {
         const [s, r] = await Promise.all([
           referralService.getStats(),
           referralService.getReferrals(),
         ]);
         setStats(s);
         setReferrals(r);
-      } catch (err) {
-        console.error('Failed to load referral data', err);
-        showToast.error('Не вдалося завантажити дані');
-      } finally {
-        setLoading(false);
       }
+    } catch (err) {
+      console.error('Failed to load referral data', err);
+      showToast.error('Не вдалося завантажити дані');
+    } finally {
+      setLoading(false);
     }
-    load();
+  };
+
+  useEffect(() => {
+    loadData();
   }, []);
 
   const referralLink = stats ? `${window.location.origin}/r/${stats.referralCode}` : '';
@@ -70,6 +231,11 @@ export function ReferralPage() {
     );
   }
 
+  // Show verification form if not verified
+  if (!verification?.isVerified) {
+    return <VerificationForm onVerified={() => { setLoading(true); loadData(); }} />;
+  }
+
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 md:px-8 lg:px-12">
       {/* Header */}
@@ -91,6 +257,10 @@ export function ReferralPage() {
           <h2 className="text-sm font-semibold text-claude-text uppercase tracking-wide">
             Ваше реферальне посилання
           </h2>
+          <span className="ml-auto inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-emerald-50 text-emerald-700 border border-emerald-200">
+            <ShieldCheck size={10} />
+            {verification.referrerType === 'attorney' ? 'Адвокат' : verification.referrerType?.toUpperCase()}
+          </span>
         </div>
 
         <div className="space-y-3">
@@ -238,7 +408,7 @@ export function ReferralPage() {
                       )}
                     </td>
                     <td className="px-6 py-3 text-right text-claude-subtext font-mono text-xs">
-                      {(r.totalPaidUsd ?? 0) > 0
+                      {r.totalPaidUsd > 0
                         ? `$${r.totalPaidUsd.toFixed(2)}`
                         : '—'}
                     </td>

--- a/lexwebapp/src/services/api/ReferralService.ts
+++ b/lexwebapp/src/services/api/ReferralService.ts
@@ -23,6 +23,15 @@ export interface ReferralEntry {
   totalPaidUsd: number;
 }
 
+export type ReferrerType = 'fop' | 'tov' | 'attorney';
+
+export interface ReferrerStatus {
+  isVerified: boolean;
+  referrerType: ReferrerType | null;
+  businessCode: string | null;
+  verifiedAt: string | null;
+}
+
 export class ReferralService extends BaseService {
   async getCode(): Promise<string> {
     return this.request(
@@ -46,6 +55,18 @@ export class ReferralService extends BaseService {
     return this.request(
       () => this.client.get<{ valid: boolean }>(`/api/referral/resolve/${code}`),
       (data) => data.valid
+    );
+  }
+
+  async getVerificationStatus(): Promise<ReferrerStatus> {
+    return this.request(
+      () => this.client.get<ReferrerStatus>('/api/referral/verification')
+    );
+  }
+
+  async submitVerification(referrerType: ReferrerType, businessCode: string): Promise<void> {
+    return this.request(
+      () => this.client.post('/api/referral/verification', { referrerType, businessCode })
     );
   }
 }

--- a/mcp_backend/src/migrations/084_referral_verification_lifetime.sql
+++ b/mcp_backend/src/migrations/084_referral_verification_lifetime.sql
@@ -1,0 +1,24 @@
+-- Migration 084: Referral system — verification + lifetime rewards
+-- 1. Add verification fields to referral_codes (FOP/TOV/Attorney only)
+-- 2. Allow multiple rewards per referred user (lifetime, not just first top-up)
+
+-- Add verification fields
+ALTER TABLE referral_codes ADD COLUMN IF NOT EXISTS referrer_type TEXT;
+ALTER TABLE referral_codes ADD COLUMN IF NOT EXISTS business_code TEXT;
+ALTER TABLE referral_codes ADD COLUMN IF NOT EXISTS verified_at TIMESTAMPTZ;
+
+-- Add constraint for referrer_type values
+DO $$ BEGIN
+  ALTER TABLE referral_codes ADD CONSTRAINT chk_referrer_type
+    CHECK (referrer_type IS NULL OR referrer_type IN ('fop', 'tov', 'attorney'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Add unique constraint on source_transaction_id to prevent double-processing same transaction
+-- but allow multiple rewards from same referred user (lifetime model)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_referral_rewards_transaction
+  ON referral_rewards(source_transaction_id) WHERE source_transaction_id IS NOT NULL;
+
+-- Index for efficient lookup of total paid by referred users
+CREATE INDEX IF NOT EXISTS idx_referral_rewards_source_user
+  ON referral_rewards(source_user_id);

--- a/mcp_backend/src/routes/referral-routes.ts
+++ b/mcp_backend/src/routes/referral-routes.ts
@@ -13,7 +13,7 @@ export function createReferralRoutes(referralService: ReferralService): Router {
 
   /**
    * GET /api/referral/code
-   * Get current user's referral code (creates one if needed)
+   * Get current user's referral code (creates one if needed, requires verification)
    */
   router.get('/code', requireJWT as any, async (req: Request, res: Response) => {
     try {
@@ -23,7 +23,52 @@ export function createReferralRoutes(referralService: ReferralService): Router {
       const code = await referralService.getOrCreateCode(userId);
       return res.json({ code });
     } catch (err: any) {
+      if (err.message === 'REFERRAL_NOT_VERIFIED') {
+        return res.status(403).json({ error: 'REFERRAL_NOT_VERIFIED', message: 'Для участі в реферальній програмі потрібна верифікація ФОП/ТОВ/Адвокат' });
+      }
       logger.error('Failed to get referral code', { error: err.message });
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * GET /api/referral/verification
+   * Get verification status
+   */
+  router.get('/verification', requireJWT as any, async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const status = await referralService.getVerificationStatus(userId);
+      return res.json(status);
+    } catch (err: any) {
+      logger.error('Failed to get verification status', { error: err.message });
+      return res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  /**
+   * POST /api/referral/verification
+   * Submit verification for referral program
+   */
+  router.post('/verification', requireJWT as any, async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const { referrerType, businessCode } = req.body;
+      if (!referrerType || !businessCode) {
+        return res.status(400).json({ error: 'referrerType та businessCode обов\'язкові' });
+      }
+      if (!['fop', 'tov', 'attorney'].includes(referrerType)) {
+        return res.status(400).json({ error: 'referrerType повинен бути fop, tov або attorney' });
+      }
+
+      await referralService.submitVerification(userId, { referrerType, businessCode });
+      return res.json({ success: true });
+    } catch (err: any) {
+      logger.error('Failed to submit verification', { error: err.message });
       return res.status(500).json({ error: 'Internal server error' });
     }
   });

--- a/mcp_backend/src/services/referral-service.ts
+++ b/mcp_backend/src/services/referral-service.ts
@@ -1,6 +1,7 @@
 /**
  * Referral Service
- * Manages referral codes, links, and rewards (MVP: 1 level, 20% of first top-up)
+ * Manages referral codes, links, and rewards (lifetime 20% of every top-up)
+ * Participation restricted to verified FOP/TOV/Attorneys
  */
 
 import type { IDatabase } from '../domain/ports/index.js';
@@ -36,6 +37,21 @@ export interface ReferralEntry {
   hasToppedUp: boolean;
   rewardAmountUsd: number;
   rewardAmountUah: number;
+  totalPaidUsd: number;
+}
+
+export type ReferrerType = 'fop' | 'tov' | 'attorney';
+
+export interface ReferrerVerification {
+  referrerType: ReferrerType;
+  businessCode: string;
+}
+
+export interface ReferrerStatus {
+  isVerified: boolean;
+  referrerType: ReferrerType | null;
+  businessCode: string | null;
+  verifiedAt: string | null;
 }
 
 export class ReferralService {
@@ -45,14 +61,18 @@ export class ReferralService {
   ) {}
 
   /**
-   * Get existing referral code or create a new one
+   * Get existing referral code or create a new one.
+   * Requires verified FOP/TOV/Attorney status.
    */
   async getOrCreateCode(userId: string): Promise<string> {
     const existing = await this.db.query(
-      'SELECT code FROM referral_codes WHERE user_id = $1 AND is_active = true',
+      'SELECT code, verified_at FROM referral_codes WHERE user_id = $1 AND is_active = true',
       [userId]
     );
     if (existing.rows.length > 0) {
+      if (!existing.rows[0].verified_at) {
+        throw new Error('REFERRAL_NOT_VERIFIED');
+      }
       return existing.rows[0].code;
     }
 
@@ -72,6 +92,59 @@ export class ReferralService {
       }
     }
     throw new Error('Failed to generate unique referral code');
+  }
+
+  /**
+   * Submit verification request for referral program participation
+   */
+  async submitVerification(userId: string, verification: ReferrerVerification): Promise<void> {
+    const { referrerType, businessCode } = verification;
+
+    // Upsert referral code with verification data
+    const existing = await this.db.query(
+      'SELECT id FROM referral_codes WHERE user_id = $1',
+      [userId]
+    );
+
+    if (existing.rows.length > 0) {
+      await this.db.query(
+        `UPDATE referral_codes
+         SET referrer_type = $1, business_code = $2, verified_at = NOW()
+         WHERE user_id = $3`,
+        [referrerType, businessCode, userId]
+      );
+    } else {
+      const code = generateReferralCode();
+      await this.db.query(
+        `INSERT INTO referral_codes (user_id, code, referrer_type, business_code, verified_at)
+         VALUES ($1, $2, $3, $4, NOW())`,
+        [userId, code, referrerType, businessCode]
+      );
+    }
+
+    logger.info('Referral verification submitted', { userId, referrerType, businessCode });
+  }
+
+  /**
+   * Get verification status for a user
+   */
+  async getVerificationStatus(userId: string): Promise<ReferrerStatus> {
+    const result = await this.db.query(
+      'SELECT referrer_type, business_code, verified_at FROM referral_codes WHERE user_id = $1',
+      [userId]
+    );
+
+    if (result.rows.length === 0 || !result.rows[0].verified_at) {
+      return { isVerified: false, referrerType: null, businessCode: null, verifiedAt: null };
+    }
+
+    const row = result.rows[0];
+    return {
+      isVerified: true,
+      referrerType: row.referrer_type,
+      businessCode: row.business_code,
+      verifiedAt: row.verified_at,
+    };
   }
 
   /**
@@ -105,8 +178,8 @@ export class ReferralService {
   }
 
   /**
-   * Process referral reward on first top-up by referred user.
-   * Checks if reward was already given for this source user.
+   * Process referral reward on every top-up by referred user (lifetime model).
+   * Deduplicates by transaction ID to prevent double-processing.
    */
   async processReward(
     referredUserId: string,
@@ -123,12 +196,12 @@ export class ReferralService {
 
     const referrerId = linkResult.rows[0].referrer_id;
 
-    // Check if reward already given for this referred user
+    // Check if reward already given for this specific transaction
     const existingReward = await this.db.query(
-      'SELECT id FROM referral_rewards WHERE beneficiary_id = $1 AND source_user_id = $2',
-      [referrerId, referredUserId]
+      'SELECT id FROM referral_rewards WHERE source_transaction_id = $1',
+      [transactionId]
     );
-    if (existingReward.rows.length > 0) return; // already rewarded
+    if (existingReward.rows.length > 0) return; // already processed this transaction
 
     const rewardUsd = Number((transactionAmountUsd * REFERRAL_REWARD_PERCENT / 100).toFixed(2));
     const rewardUah = Number((transactionAmountUah * REFERRAL_REWARD_PERCENT / 100).toFixed(2));
@@ -194,7 +267,7 @@ export class ReferralService {
   }
 
   /**
-   * Get list of referrals for a user
+   * Get list of referrals for a user (with aggregated lifetime rewards)
    */
   async getReferrals(userId: string): Promise<ReferralEntry[]> {
     const result = await this.db.query(
@@ -203,12 +276,23 @@ export class ReferralService {
         u.name AS referred_name,
         u.email AS referred_email,
         rl.registered_at,
-        COALESCE(rr.amount_usd, 0) AS reward_amount_usd,
-        COALESCE(rr.amount_uah, 0) AS reward_amount_uah,
-        CASE WHEN rr.id IS NOT NULL THEN true ELSE false END AS has_topped_up
+        COALESCE(rr_agg.total_reward_usd, 0) AS reward_amount_usd,
+        COALESCE(rr_agg.total_reward_uah, 0) AS reward_amount_uah,
+        COALESCE(rr_agg.total_paid_usd, 0) AS total_paid_usd,
+        COALESCE(rr_agg.reward_count, 0) > 0 AS has_topped_up
       FROM referral_links rl
       JOIN users u ON u.id = rl.referred_id
-      LEFT JOIN referral_rewards rr ON rr.beneficiary_id = $1 AND rr.source_user_id = rl.referred_id
+      LEFT JOIN (
+        SELECT
+          source_user_id,
+          SUM(amount_usd) AS total_reward_usd,
+          SUM(amount_uah) AS total_reward_uah,
+          SUM(amount_usd / (percentage / 100)) AS total_paid_usd,
+          COUNT(*) AS reward_count
+        FROM referral_rewards
+        WHERE beneficiary_id = $1
+        GROUP BY source_user_id
+      ) rr_agg ON rr_agg.source_user_id = rl.referred_id
       WHERE rl.referrer_id = $1
       ORDER BY rl.registered_at DESC`,
       [userId]
@@ -222,6 +306,7 @@ export class ReferralService {
       hasToppedUp: row.has_topped_up,
       rewardAmountUsd: parseFloat(row.reward_amount_usd),
       rewardAmountUah: parseFloat(row.reward_amount_uah),
+      totalPaidUsd: parseFloat(row.total_paid_usd),
     }));
   }
 }


### PR DESCRIPTION
## Summary

- **Lifetime rewards**: referral reward now triggers on every top-up (not just the first), 20% of each payment credited to referrer
- **Verification gate**: referral program restricted to verified FOP/TOV/Attorneys — verification form with ЄДРПОУ/ЄРАУ code required before accessing the program
- **Bug fix**: `totalPaidUsd` now correctly returned from backend API (was missing, frontend always showed $0.00)
- **Migration 084**: adds `referrer_type`, `business_code`, `verified_at` columns + per-transaction dedup index

Closes LEG-370

## Test plan

- [ ] Verify new migration applies cleanly on staging DB
- [ ] Unverified user sees verification form, not the referral dashboard
- [ ] After submitting FOP/TOV/Attorney verification, user sees referral code
- [ ] Referred user top-up triggers 20% reward to referrer
- [ ] Second top-up by same referred user also triggers 20% reward (lifetime model)
- [ ] Same transaction is not double-processed (dedup by transaction ID)
- [ ] `totalPaidUsd` column shows correct aggregated amounts in referral table
- [ ] Verification badge shows correct type (ФОП/ТОВ/Адвокат) next to referral link

🤖 Generated with [Claude Code](https://claude.com/claude-code)