### PR TITLE
fix: proper Ukrainian message on judge 404

### DIFF
--- a/lexwebapp/src/pages/PersonDetailPage/index.tsx
+++ b/lexwebapp/src/pages/PersonDetailPage/index.tsx
@@ -62,10 +62,17 @@ export function PersonDetailPage({ type }: PersonDetailPageProps) {
     setError(null);
 
     Promise.all([
-      judgesService.getJudgeProfile(id),
+      judgesService.getJudgeProfile(id).catch((err) => {
+        if (err.status === 404) return null;
+        throw err;
+      }),
       judgeAnalyticsService.getAnalyticsDetail(id).catch(() => null),
     ])
       .then(([profile, analytics]) => {
+        if (!profile) {
+          setError('Суддю з таким номером досьє не знайдено');
+          return;
+        }
         setJudgeProfile(profile);
         setJudgeAnalytics(analytics);
       })

--- a/mcp_backend/src/routes/judge-analytics-routes.ts
+++ b/mcp_backend/src/routes/judge-analytics-routes.ts
@@ -34,7 +34,7 @@ export function createJudgeAnalyticsRoutes(service: JudgeAnalyticsService): Rout
       const { id } = req.params;
       const record = await service.getAnalyticsDetail(id);
       if (!record) {
-        return res.status(404).json({ error: 'Аналітику для цього судді не знайдено' });
+        return res.status(404).json({ error: 'Not found', message: 'Аналітику для цього судді не знайдено' });
       }
       res.json(record);
     } catch (err: unknown) {

--- a/mcp_backend/src/routes/judges-routes.ts
+++ b/mcp_backend/src/routes/judges-routes.ts
@@ -25,7 +25,7 @@ export function createJudgesRoutes(judgesService: JudgesService): Router {
       const { dossierNumber } = req.params;
       const profile = await judgesService.getJudgeProfile(dossierNumber);
       if (!profile) {
-        return res.status(404).json({ error: 'Judge not found' });
+        return res.status(404).json({ error: 'Judge not found', message: 'Суддю з таким номером досьє не знайдено' });
       }
       res.json(profile);
     } catch (err: unknown) {
@@ -40,7 +40,7 @@ export function createJudgesRoutes(judgesService: JudgesService): Router {
       const { dossierNumber } = req.params;
       const judge = await judgesService.getJudgeByDossier(dossierNumber);
       if (!judge) {
-        return res.status(404).json({ error: 'Judge not found' });
+        return res.status(404).json({ error: 'Judge not found', message: 'Суддю з таким номером досьє не знайдено' });
       }
       res.json(judge);
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

- Backend judge routes now return `message` field in 404 responses (Ukrainian text)
- Frontend `PersonDetailPage` catches 404 gracefully — shows "Суддю не знайдено" instead of triggering generic error toast
- Fixes "An error occurred. Please try again." toast on `/judges/13583`

## Test plan

- [ ] Navigate to `/judges/99999` (non-existent) — should show "Суддю з таким номером досьє не знайдено" without error toast
- [ ] Navigate to valid judge — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)