### PR TITLE
fix: CI — monitoring-only deploys don't rebuild services

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -32,6 +32,9 @@ outputs:
   services_to_deploy:
     description: 'JSON array of Docker service names to deploy on prod'
     value: ${{ steps.changes.outputs.services_to_deploy }}
+  monitoring:
+    description: 'Whether monitoring configs changed (grafana, prometheus)'
+    value: ${{ steps.changes.outputs.monitoring }}
 
 runs:
   using: 'composite'
@@ -75,6 +78,9 @@ runs:
         DEPLOYMENT=false
         MOBILE=false
 
+        DEPLOY_INFRA=false  # Dockerfiles, compose files, nginx — triggers full rebuild
+        DEPLOY_MONITORING=false  # Grafana, prometheus — deploy-only, no rebuild
+
         while IFS= read -r file; do
           case "$file" in
             packages/shared/*) SHARED=true ;;
@@ -82,7 +88,8 @@ runs:
             mcp_rada/*) RADA=true ;;
             mcp_openreyestr/*) OPENREYESTR=true ;;
             lexwebapp/*) FRONTEND=true ;;
-            deployment/*) DEPLOYMENT=true ;;
+            deployment/grafana/*|deployment/prometheus/*) DEPLOY_MONITORING=true; DEPLOYMENT=true ;;
+            deployment/*) DEPLOY_INFRA=true; DEPLOYMENT=true ;;
             mobile/*) MOBILE=true ;;
           esac
         done <<< "$CHANGED_FILES"
@@ -94,8 +101,9 @@ runs:
           OPENREYESTR=true
         fi
 
-        # If deployment configs changed, rebuild everything
-        if [ "$DEPLOYMENT" = "true" ]; then
+        # If deployment infra changed (Dockerfiles, compose, nginx), rebuild everything
+        # Monitoring-only changes (grafana, prometheus) don't require service rebuilds
+        if [ "$DEPLOY_INFRA" = "true" ]; then
           BACKEND=true
           RADA=true
           OPENREYESTR=true
@@ -142,6 +150,7 @@ runs:
         echo "openreyestr=$OPENREYESTR" >> "$GITHUB_OUTPUT"
         echo "frontend=$FRONTEND" >> "$GITHUB_OUTPUT"
         echo "deployment=$DEPLOYMENT" >> "$GITHUB_OUTPUT"
+        echo "monitoring=$DEPLOY_MONITORING" >> "$GITHUB_OUTPUT"
         echo "mobile=$MOBILE" >> "$GITHUB_OUTPUT"
         echo "any_backend=$ANY_BACKEND" >> "$GITHUB_OUTPUT"
         echo "services_to_build=$SERVICES_TO_BUILD" >> "$GITHUB_OUTPUT"
@@ -155,6 +164,7 @@ runs:
         echo "  openreyestr: $OPENREYESTR"
         echo "  frontend:    $FRONTEND"
         echo "  deployment:  $DEPLOYMENT"
+        echo "  monitoring:  $DEPLOY_MONITORING"
         echo "  mobile:      $MOBILE"
         echo "  services_to_build: $SERVICES_TO_BUILD"
         echo "  services_to_deploy: $SERVICES_TO_DEPLOY"

--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -48,7 +48,8 @@ jobs:
         id: check
         run: |
           SERVICES='${{ steps.changes.outputs.services_to_build }}'
-          if [ "$SERVICES" = '[]' ]; then
+          MONITORING='${{ steps.changes.outputs.monitoring }}'
+          if [ "$SERVICES" = '[]' ] && [ "$MONITORING" != "true" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No services changed — skipping build/test/deploy"
           else
@@ -294,19 +295,20 @@ jobs:
           docker image prune -f
 
       - name: Wait for stage services
-        run: sleep 20
+        run: sleep 30
 
       - name: Stage health checks
         run: |
           FAILED=false
           check_health() {
             local name=$1 url=$2
-            for i in 1 2 3; do
+            for i in 1 2 3 4 5 6; do
               if curl -sf --max-time 10 "$url" > /dev/null; then
                 echo "$name: OK"
                 return 0
               fi
-              sleep 5
+              echo "$name: attempt $i failed, retrying in 10s..."
+              sleep 10
             done
             echo "::error::$name health check failed on stage"
             FAILED=true
@@ -336,6 +338,7 @@ jobs:
       RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
       OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
       FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+      MONITORING_CHANGED: ${{ needs.detect-changes.outputs.monitoring }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -423,6 +426,13 @@ jobs:
             [ -n "\$START" ] && \$DC up -d \$START
 
             \$DC restart nginx-prod
+
+            # Restart monitoring containers if configs changed (grafana dashboards, prometheus rules)
+            if [ "${MONITORING_CHANGED}" = "true" ]; then
+              echo "=== Restarting monitoring services ==="
+              \$DC restart grafana-prod prometheus-prod 2>/dev/null || true
+            fi
+
             docker image prune -f
           DEPLOY_SCRIPT
 


### PR DESCRIPTION
## Summary

- **Root cause**: `detect-changes` treated all `deployment/*` files equally — Grafana dashboard or Prometheus config changes forced full RADA + OpenReyestr rebuild on stage → health checks failed → prod deploy skipped
- Split `deployment/*` detection into `DEPLOY_INFRA` (compose, Dockerfiles, nginx → full rebuild) and `DEPLOY_MONITORING` (grafana, prometheus → restart only)
- Increased stage health check resilience: 6 retries × 10s instead of 3 × 5s
- Prod deploy now restarts `grafana-prod` + `prometheus-prod` containers when monitoring configs change

## Context

PR #816 (Grafana dashboard fixes) merged but never deployed to prod because the pipeline failed on unrelated RADA/OpenReyestr health checks on stage.

## Test plan

- [ ] Verify pipeline passes with these monitoring-only changes
- [ ] Confirm Grafana dashboard `06-external-sources` is updated on prod after merge
- [ ] Verify a future `mcp_rada/*` code change still triggers RADA rebuild + health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)