### PR TITLE
fix: CI health checks — docker exec for unexposed RADA/OpenReyestr ports

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -299,7 +299,9 @@ jobs:
 
       - name: Stage health checks
         run: |
+          DC="docker compose -f docker-compose.stage.yml --env-file .env.stage"
           FAILED=false
+
           check_health() {
             local name=$1 url=$2
             for i in 1 2 3 4 5 6; do
@@ -314,9 +316,23 @@ jobs:
             FAILED=true
           }
 
+          check_health_docker() {
+            local name=$1 container=$2 url=$3
+            for i in 1 2 3 4 5 6; do
+              if $DC exec -T "$container" wget --spider -q "$url" 2>/dev/null; then
+                echo "$name: OK"
+                return 0
+              fi
+              echo "$name: attempt $i failed, retrying in 10s..."
+              sleep 10
+            done
+            echo "::error::$name health check failed on stage"
+            FAILED=true
+          }
+
           [ "$BACKEND_CHANGED" = "true" ] && check_health "Backend" "http://localhost:3004/health"
-          [ "$RADA_CHANGED" = "true" ] && check_health "RADA" "http://localhost:3001/health"
-          [ "$OPENREYESTR_CHANGED" = "true" ] && check_health "OpenReyestr" "http://localhost:3005/health"
+          [ "$RADA_CHANGED" = "true" ] && check_health_docker "RADA" "rada-mcp-app-stage" "http://127.0.0.1:3001/health"
+          [ "$OPENREYESTR_CHANGED" = "true" ] && check_health_docker "OpenReyestr" "app-openreyestr-stage" "http://127.0.0.1:3005/health"
 
           check_health "Stage (public)" "https://stage.legal.org.ua/health"
 


### PR DESCRIPTION
## Summary

- **Root cause**: RADA and OpenReyestr stage ports are not exposed to host (`# Ports removed - service accessed via unified gateway only`), so `curl localhost:3001/3005` always fails
- Health checks now use `docker compose exec` to check from inside the container
- Also includes monitoring-only deploy fix from PR #817

## Context

This is the actual root cause of PR #816's failed deployment. The previous fix (#817) addressed detect-changes granularity, but the health checks would still fail for any PR that changes RADA/OpenReyestr code.

## Test plan

- [ ] Pipeline passes with this fix
- [ ] RADA and OpenReyestr health checks work via docker exec
- [ ] Grafana dashboard 06-external-sources deployed to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)