### PR TITLE
chore: redeploy Grafana external-sources dashboard

### DIFF
--- a/deployment/grafana/dashboards/06-external-sources.json
+++ b/deployment/grafana/dashboards/06-external-sources.json
@@ -4306,5 +4306,5 @@
   "timezone": "",
   "title": "SecondLayer — External Data Sources",
   "uid": "external-sources",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
## Summary

Triggers monitoring-only deploy for dashboard 06-external-sources that was fixed in PR #816 but never reached prod due to CI failure.

## Test plan

- [ ] Pipeline detects monitoring change, skips service rebuilds
- [ ] Grafana dashboard updated on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)