### PR TITLE
infra: PostgreSQL tuning for r6i.xlarge (32GB RAM)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -5,10 +5,10 @@ services:
     command: >-
       postgres
       -c max_connections=300
-      -c shared_buffers=4GB
-      -c effective_cache_size=8GB
+      -c shared_buffers=8GB
+      -c effective_cache_size=24GB
       -c work_mem=256MB
-      -c maintenance_work_mem=1GB
+      -c maintenance_work_mem=2GB
       -c wal_buffers=64MB
       -c max_wal_size=4GB
       -c min_wal_size=1GB
@@ -46,9 +46,9 @@ services:
       resources:
         limits:
           cpus: "4"
-          memory: 8G
+          memory: 20G
         reservations:
-          memory: 4G
+          memory: 8G
 
   pgbouncer-prod:
     image: edoburu/pgbouncer:latest


### PR DESCRIPTION
## Summary

- PostgreSQL config tuned for upgraded prod instance (t3.xlarge → r6i.xlarge, 16GB → 32GB RAM)
- `shared_buffers`: 4GB → 8GB
- `effective_cache_size`: 8GB → 24GB
- `maintenance_work_mem`: 1GB → 2GB
- Container memory limit: 8GB → 20GB (prevents OOM when shared_buffers=8GB + concurrent workload)
- EBS upgraded to gp3 10K IOPS / 500 MB/s (done via AWS Console)

Part of [LEG-361](https://linear.app/legalorgua/issue/LEG-361) step 3.

## Test plan

- [x] Instance running as r6i.xlarge, 32GB RAM confirmed
- [x] PostgreSQL starts with shared_buffers=8GB, no OOM
- [x] EDRSR fulltext migration running at ~2900 rows/s (vs 640/s before)
- [x] All 28 containers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)