### PR TITLE
feat(infra): improve Docker healthchecks across all services

### DIFF
--- a/deployment/Dockerfile.mono-backend
+++ b/deployment/Dockerfile.mono-backend
@@ -94,4 +94,7 @@ COPY --from=builder /app/mcp_backend/src/migrations ./src/migrations
 
 EXPOSE 3000
 
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3000/health/ready', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); })"
+
 CMD ["node", "--max-old-space-size=2048", "dist/http-server.js"]

--- a/deployment/Dockerfile.mono-openreyestr
+++ b/deployment/Dockerfile.mono-openreyestr
@@ -71,8 +71,8 @@ USER nodejs
 
 EXPOSE 3004
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3004/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+# Health check — uses /health/ready to verify DB connectivity, outputs error details to stderr
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3004/health/ready', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); })"
 
 CMD ["node", "dist/http-server.js"]

--- a/deployment/Dockerfile.mono-rada
+++ b/deployment/Dockerfile.mono-rada
@@ -64,4 +64,7 @@ COPY --from=builder /app/mcp_rada/src/migrations ./src/migrations
 
 EXPOSE 3001
 
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3001/health/ready', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); })"
+
 CMD ["node", "dist/http-server.js"]

--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -351,10 +351,10 @@ services:
           "CMD",
           "node",
           "-e",
-          "require('http').get('http://127.0.0.1:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1));",
+          "require('http').get('http://127.0.0.1:3000/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });",
         ]
-      interval: 30s
-      timeout: 10s
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 40s
 
@@ -435,6 +435,18 @@ services:
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-http://localhost:5173,http://localhost:3000}
     ports:
       - "3001:3001"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://127.0.0.1:3001/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });",
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - secondlayer-local
@@ -636,10 +648,10 @@ services:
           "CMD",
           "node",
           "-e",
-          "require('http').get('http://127.0.0.1:3004/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1));",
+          "require('http').get('http://127.0.0.1:3004/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });",
         ]
-      interval: 30s
-      timeout: 10s
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
 

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -325,9 +325,9 @@ services:
       TZ: Europe/Kiev
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3001/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3001/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
     networks:
@@ -398,9 +398,9 @@ services:
       migrate-openreyestr-prod:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3005/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3005/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
     restart: unless-stopped
@@ -637,14 +637,9 @@ services:
     - app_prod_logs:/app/logs
     - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
     healthcheck:
-      test:
-      - CMD
-      - wget
-      - --spider
-      - -q
-      - http://127.0.0.1:3000/health
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3000/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 60s
     restart: unless-stopped
@@ -730,9 +725,9 @@ services:
     volumes:
       - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3002/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3002/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
     restart: unless-stopped

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -320,9 +320,9 @@ services:
     # Ports removed - service accessed via unified gateway only
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3001/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3001/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
     networks:
@@ -396,9 +396,9 @@ services:
       migrate-openreyestr-stage:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3005/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3005/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
     restart: unless-stopped
@@ -605,14 +605,9 @@ services:
     # Vision API credentials for document analysis (OCR)
     - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
     healthcheck:
-      test:
-      - CMD
-      - wget
-      - --spider
-      - -q
-      - http://127.0.0.1:3000/health
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3000/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 60s
     restart: unless-stopped
@@ -719,9 +714,9 @@ services:
       - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
 
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3002/health"]
-      interval: 30s
-      timeout: 10s
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3002/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
+      interval: 15s
+      timeout: 5s
       retries: 3
       start_period: 30s
 

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -694,22 +694,26 @@ class HTTPMCPServer {
     // Readiness probe — DB is accessible (200/503)
     this.app.get('/health/ready', healthCheckRateLimit as any, async (_req, res) => {
       try {
+        const start = Date.now();
         await this.services.db.query('SELECT 1');
-        res.json({ status: 'ok' });
+        const latencyMs = Date.now() - start;
+        res.json({ status: 'ok', latencyMs });
       } catch (err: any) {
+        logger.warn('Healthcheck /ready failed', { error: err.message });
         res.status(503).json({ status: 'unavailable', error: err.message });
       }
     });
 
     // Full health check with dependency status (public - no auth, rate limited)
     this.app.get('/health', healthCheckRateLimit as any, async (_req, res) => {
-      const checks: Record<string, { ok: boolean; error?: string }> = {};
+      const checks: Record<string, { ok: boolean; latencyMs?: number; error?: string }> = {};
       let degraded = false;
 
       // PostgreSQL
       try {
+        const start = Date.now();
         await this.services.db.query('SELECT 1');
-        checks.postgres = { ok: true };
+        checks.postgres = { ok: true, latencyMs: Date.now() - start };
       } catch (err: any) {
         checks.postgres = { ok: false, error: err.message };
         degraded = true;
@@ -717,10 +721,11 @@ class HTTPMCPServer {
 
       // Redis
       try {
+        const start = Date.now();
         const redis = await getRedisClient();
         if (redis) {
           await redis.ping();
-          checks.redis = { ok: true };
+          checks.redis = { ok: true, latencyMs: Date.now() - start };
         } else {
           checks.redis = { ok: false, error: 'not connected' };
           degraded = true;
@@ -731,20 +736,41 @@ class HTTPMCPServer {
       }
 
       // Qdrant
-      const qdrantResult = await this.services.embeddingService.healthCheck();
-      checks.qdrant = qdrantResult;
-      if (!qdrantResult.ok) degraded = true;
+      try {
+        const start = Date.now();
+        const qdrantResult = await this.services.embeddingService.healthCheck();
+        checks.qdrant = { ...qdrantResult, latencyMs: Date.now() - start };
+        if (!qdrantResult.ok) degraded = true;
+      } catch (err: any) {
+        checks.qdrant = { ok: false, error: err.message };
+        degraded = true;
+      }
 
       // MinIO
-      const minioResult = await this.minioService.healthCheck();
-      checks.minio = minioResult;
-      if (!minioResult.ok) degraded = true;
+      try {
+        const start = Date.now();
+        const minioResult = await this.minioService.healthCheck();
+        checks.minio = { ...minioResult, latencyMs: Date.now() - start };
+        if (!minioResult.ok) degraded = true;
+      } catch (err: any) {
+        checks.minio = { ok: false, error: err.message };
+        degraded = true;
+      }
 
       const status = degraded ? 'degraded' : 'ok';
+
+      if (degraded) {
+        const failedChecks = Object.entries(checks)
+          .filter(([, v]) => !v.ok)
+          .map(([k, v]) => `${k}: ${v.error}`);
+        logger.warn('Healthcheck degraded', { failedChecks });
+      }
+
       res.status(degraded ? 503 : 200).json({
         status,
         service: 'secondlayer-mcp-http',
-        version: '1.0.0',
+        uptime: Math.round(process.uptime()),
+        memoryMB: Math.round(process.memoryUsage().rss / 1024 / 1024),
         checks,
       });
     });

--- a/mcp_openreyestr/src/http-server.ts
+++ b/mcp_openreyestr/src/http-server.ts
@@ -124,31 +124,45 @@ class HTTPOpenReyestrServer {
     // Readiness probe
     this.app.get('/health/ready', healthCheckRateLimit as any, async (_req, res) => {
       try {
+        const start = Date.now();
         await this.db.query('SELECT 1');
-        res.json({ status: 'ok' });
+        const latencyMs = Date.now() - start;
+        res.json({ status: 'ok', latencyMs });
       } catch (err: any) {
+        logger.warn('Healthcheck /ready failed', { error: err.message });
         res.status(503).json({ status: 'unavailable', error: err.message });
       }
     });
 
     // Full health check with dependency status
     this.app.get('/health', healthCheckRateLimit as any, async (_req, res) => {
-      const checks: Record<string, { ok: boolean; error?: string }> = {};
+      const checks: Record<string, { ok: boolean; latencyMs?: number; error?: string }> = {};
       let degraded = false;
 
+      // PostgreSQL
       try {
+        const start = Date.now();
         await this.db.query('SELECT 1');
-        checks.postgres = { ok: true };
+        checks.postgres = { ok: true, latencyMs: Date.now() - start };
       } catch (err: any) {
         checks.postgres = { ok: false, error: err.message };
         degraded = true;
       }
 
       const status = degraded ? 'degraded' : 'ok';
+
+      if (degraded) {
+        const failedChecks = Object.entries(checks)
+          .filter(([, v]) => !v.ok)
+          .map(([k, v]) => `${k}: ${v.error}`);
+        logger.warn('Healthcheck degraded', { failedChecks });
+      }
+
       res.status(degraded ? 503 : 200).json({
         status,
         service: 'openreyestr-mcp-http',
-        version: '1.0.0',
+        uptime: Math.round(process.uptime()),
+        memoryMB: Math.round(process.memoryUsage().rss / 1024 / 1024),
         checks,
       });
     });

--- a/mcp_rada/src/http-server.ts
+++ b/mcp_rada/src/http-server.ts
@@ -13,7 +13,7 @@ import { healthCheckRateLimit, globalApiRateLimit } from './middleware/rate-limi
 import rateLimit from 'express-rate-limit';
 import { createRadaCoreServices, RadaCoreServices } from './factories/rada-services';
 import { requestContext } from './utils/openai-client';
-import { initRedisClient } from './utils/redis-client';
+import { initRedisClient, getRedisClient } from './utils/redis-client';
 import { MetricsService } from './services/metrics-service';
 
 dotenv.config();
@@ -114,31 +114,56 @@ class HTTPRadaServer {
     // Readiness probe
     this.app.get('/health/ready', healthCheckRateLimit as any, async (_req, res) => {
       try {
+        const start = Date.now();
         await this.services.db.query('SELECT 1');
-        res.json({ status: 'ok' });
+        const latencyMs = Date.now() - start;
+        res.json({ status: 'ok', latencyMs });
       } catch (err: any) {
+        logger.warn('Healthcheck /ready failed', { error: err.message });
         res.status(503).json({ status: 'unavailable', error: err.message });
       }
     });
 
     // Full health check with dependency status
     this.app.get('/health', healthCheckRateLimit as any, async (_req, res) => {
-      const checks: Record<string, { ok: boolean; error?: string }> = {};
+      const checks: Record<string, { ok: boolean; latencyMs?: number; error?: string }> = {};
       let degraded = false;
 
+      // PostgreSQL
       try {
+        const start = Date.now();
         await this.services.db.query('SELECT 1');
-        checks.postgres = { ok: true };
+        checks.postgres = { ok: true, latencyMs: Date.now() - start };
       } catch (err: any) {
         checks.postgres = { ok: false, error: err.message };
         degraded = true;
       }
 
+      // Redis
+      try {
+        const start = Date.now();
+        const redis = getRedisClient();
+        await redis.ping();
+        checks.redis = { ok: true, latencyMs: Date.now() - start };
+      } catch (err: any) {
+        checks.redis = { ok: false, error: err.message };
+        degraded = true;
+      }
+
       const status = degraded ? 'degraded' : 'ok';
+
+      if (degraded) {
+        const failedChecks = Object.entries(checks)
+          .filter(([, v]) => !v.ok)
+          .map(([k, v]) => `${k}: ${v.error}`);
+        logger.warn('Healthcheck degraded', { failedChecks });
+      }
+
       res.status(degraded ? 503 : 200).json({
         status,
         service: 'rada-mcp-http',
-        version: '1.0.0',
+        uptime: Math.round(process.uptime()),
+        memoryMB: Math.round(process.memoryUsage().rss / 1024 / 1024),
         checks,
       });
     });


### PR DESCRIPTION
## Summary

- **Health endpoints** (`/health`, `/health/ready`): добавлено latency tracking для кожної залежності, uptime, memory usage, і logging degraded стану з деталями помилок
- **Dockerfiles**: додано `HEALTHCHECK` директиву для backend і rada (раніше були відсутні), оновлено openreyestr
- **Docker Compose** (local/stage/prod): уніфіковано healthcheck-и — замість `wget --spider` (який мовчки ігнорує помилки) використовується `node` скрипт, який виводить response body в stderr при failure
- **Rada**: додано Redis check у `/health` endpoint, додано відсутній healthcheck для `rada-mcp-app-local`
- Інтервал зменшено з 30s до 15s для швидшого виявлення проблем

### Що змінюється

| До | Після |
|---|---|
| `wget --spider -q /health` — тихо fail/pass | `node` скрипт на `/health/ready` — stderr показує error body |
| `/health` повертає тільки `{ok: true}` | Повертає `latencyMs`, `uptime`, `memoryMB` |
| Degraded стан не логується | `logger.warn()` з переліком failed checks |
| Backend/Rada Dockerfiles без HEALTHCHECK | HEALTHCHECK директива є у всіх трьох |
| Rada local без healthcheck | Healthcheck додано |
| Rada не перевіряє Redis | Redis check у `/health` |

### Приклад відповіді /health

```json
{
  "status": "degraded",
  "service": "secondlayer-mcp-http",
  "uptime": 3600,
  "memoryMB": 512,
  "checks": {
    "postgres": { "ok": true, "latencyMs": 2 },
    "redis": { "ok": false, "error": "ECONNREFUSED" },
    "qdrant": { "ok": true, "latencyMs": 5 },
    "minio": { "ok": true, "latencyMs": 3 }
  }
}
```

## Test plan

- [ ] Перевірити `docker inspect --format='{{json .State.Health}}' <container>` — має показувати error details при failure
- [ ] Перевірити `GET /health` — повертає latencyMs, uptime, memoryMB
- [ ] Перевірити що при зупиненому Redis/Postgres контейнер переходить в unhealthy з деталями
- [ ] Перевірити що rada `/health` показує стан Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)