### PR TITLE
chore(webapp): upgrade vite 7→8

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -64,7 +64,7 @@
     "postcss": "^8.5.8",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.5.4",
-    "vite": "^7.3.1",
+    "vite": "^8.0.0",
     "vitest": "^4.0.18"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Summary
- Upgrade vite from 7.3.1 to 8.0.0 (replaces Dependabot PR #828 which had lock file conflicts)
- Build verified locally — passes TypeScript check and vite build

## Test plan
- [ ] CI passes
- [ ] Frontend loads on stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)