### PR TITLE
fix(ci): add actions:read permission + fix jsdom resolution

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 concurrency:
   group: deploy-stage-to-prod
@@ -99,7 +100,9 @@ jobs:
       - name: Test frontend
         if: needs.detect-changes.outputs.frontend == 'true'
         run: |
-          cd lexwebapp && npm ci
+          cd lexwebapp
+          rm -rf node_modules
+          npm ci
           npm test
           npm run build
         env:


### PR DESCRIPTION
## Summary
- Add `actions: read` permission to CI workflow — self-heal job needs it to fetch failed run logs via `gh run view` (was getting HTTP 403)
- Clean `lexwebapp/node_modules` before `npm ci` to prevent stale hoisted packages after Vite 8 upgrade (`jsdom` ERR_MODULE_NOT_FOUND)

## Test plan
- [ ] CI pipeline passes (frontend test step finds jsdom)
- [ ] Self-heal job can read run logs if build fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)