### PR TITLE
fix(ci): clean root node_modules for jsdom hoisting

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -100,9 +100,8 @@ jobs:
       - name: Test frontend
         if: needs.detect-changes.outputs.frontend == 'true'
         run: |
-          cd lexwebapp
-          rm -rf node_modules
-          npm ci
+          rm -rf node_modules lexwebapp/node_modules
+          cd lexwebapp && npm ci
           npm test
           npm run build
         env:

--- a/lexwebapp/src/pages/JudgesPage/JudgeAnalyticsTable.tsx
+++ b/lexwebapp/src/pages/JudgesPage/JudgeAnalyticsTable.tsx
@@ -17,7 +17,7 @@ import { generateRoute } from '../../router/routes';
 
 const PAGE_SIZE = 25;
 
-// EDRSR instance codes: 1=Касаційна, 2=Апеляційна, 3=Перша
+// EDRSR instance codes: 1=Касаційна, 2=Апеляційна, 3=Перша інстанція
 const INSTANCE_TABS = [
   { value: '', label: 'Всі', count: null },
   { value: '3', label: 'Перша інстанція', count: null },


### PR DESCRIPTION
## Summary
- Clean **root** `node_modules` in addition to `lexwebapp/node_modules` before frontend test
- Vitest is hoisted to root by npm workspaces but jsdom isn't → ERR_MODULE_NOT_FOUND
- Includes trivial frontend change to trigger detect-changes and deploy instance tabs from PR #847

## Test plan
- [ ] CI passes frontend test step (jsdom found)
- [ ] Frontend deploys with instance tabs on judges page

🤖 Generated with [Claude Code](https://claude.com/claude-code)