### PR TITLE
fix(ci): use npm --workspace for frontend test

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -100,10 +100,9 @@ jobs:
       - name: Test frontend
         if: needs.detect-changes.outputs.frontend == 'true'
         run: |
-          rm -rf node_modules lexwebapp/node_modules
-          cd lexwebapp && npm ci
-          npm test
-          npm run build
+          npm ci --workspace=lexwebapp
+          npm test --workspace=lexwebapp
+          npm run build --workspace=lexwebapp
         env:
           VITE_API_URL: https://stage.legal.org.ua
 


### PR DESCRIPTION
## Summary
`lexwebapp` is an npm workspace. Running `npm ci` inside the directory causes vitest to hoist to root `node_modules` without jsdom. Use `npm ci --workspace=lexwebapp` from root to properly resolve all dependencies.

## Test plan
- [ ] CI frontend test step passes (jsdom resolved correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)