### PR TITLE
fix(ci): clean stale root node_modules on self-hosted runner

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Test frontend
         if: needs.detect-changes.outputs.frontend == 'true'
         run: |
+          rm -rf node_modules
           npm ci --workspace=lexwebapp
           npm test --workspace=lexwebapp
           npm run build --workspace=lexwebapp


### PR DESCRIPTION
Fix persistent jsdom ERR_MODULE_NOT_FOUND after Vite 8 upgrade. Also manually cleaned runner.