### PR TITLE
fix(ci): nested install for frontend to avoid jsdom hoisting

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -97,13 +97,13 @@ jobs:
         if: needs.detect-changes.outputs.openreyestr == 'true'
         run: cd mcp_openreyestr && npm ci && npm run build
 
-      - name: Install frontend deps
-        if: needs.detect-changes.outputs.frontend == 'true'
-        run: npm ci
-
       - name: Test frontend
         if: needs.detect-changes.outputs.frontend == 'true'
-        run: cd lexwebapp && npm test && npm run build
+        run: |
+          cd lexwebapp
+          npm ci --install-strategy=nested
+          npm test
+          npm run build
         env:
           VITE_API_URL: https://stage.legal.org.ua
 


### PR DESCRIPTION
Root npm ci times out (all workspaces). Use nested strategy in lexwebapp only.