### PR TITLE
feat(judges): add Pass 2d/2e for abbreviated name formats

### DIFF
--- a/mcp_backend/src/scripts/compute-judge-analytics.ts
+++ b/mcp_backend/src/scripts/compute-judge-analytics.ts
@@ -256,6 +256,53 @@ async function pass2() {
   `);
   log(`Pass 2c: Surname+court match — ${surnameMatch.rowCount} additional judges matched`);
 
+  // Pass 2d: Abbreviated names with surname LAST (e.g. "В.В. Щербаков" → "Щербаков Володимир Валерійович")
+  // Extract last word from EDRSR name, match to first word (surname) in VKKSU
+  const abbrevMatch = await mainPool.query(`
+    WITH abbrev_matches AS (
+      SELECT ja.id as analytics_id, jc.dossier_number,
+             COUNT(*) OVER (PARTITION BY ja.id) as match_count
+      FROM judge_analytics ja
+      JOIN judges_current jc
+        ON LOWER(TRIM(SPLIT_PART(ja.judge_name, ' ',
+             array_length(string_to_array(ja.judge_name, ' '), 1)))) =
+           LOWER(SPLIT_PART(jc.full_name, ' ', 1))
+        AND LOWER(ja.court_name) = LOWER(jc.court_name)
+      WHERE ja.dossier_number IS NULL
+        AND jc.dossier_number IS NOT NULL
+        AND ja.judge_name ~ '^[А-ЯІЇЄҐA-Z]\\.[А-ЯІЇЄҐA-Z]?\\.' -- matches "І.П." or "І." prefix pattern
+    )
+    UPDATE judge_analytics ja
+    SET dossier_number = am.dossier_number
+    FROM abbrev_matches am
+    WHERE ja.id = am.analytics_id
+      AND am.match_count = 1
+    RETURNING ja.id
+  `);
+  log(`Pass 2d: Abbreviated (И.О. Фамилия) match — ${abbrevMatch.rowCount} additional judges matched`);
+
+  // Pass 2e: Format "Фамилія І.О." or "Фамилія І. О." — surname first, initials after
+  const surnameInitialsMatch = await mainPool.query(`
+    WITH si_matches AS (
+      SELECT ja.id as analytics_id, jc.dossier_number,
+             COUNT(*) OVER (PARTITION BY ja.id) as match_count
+      FROM judge_analytics ja
+      JOIN judges_current jc
+        ON LOWER(SPLIT_PART(ja.judge_name, ' ', 1)) = LOWER(SPLIT_PART(jc.full_name, ' ', 1))
+        AND LOWER(ja.court_name) = LOWER(jc.court_name)
+      WHERE ja.dossier_number IS NULL
+        AND jc.dossier_number IS NOT NULL
+        AND ja.judge_name ~ '[А-ЯІЇЄҐA-Z]\\.' -- has initials somewhere
+    )
+    UPDATE judge_analytics ja
+    SET dossier_number = sim.dossier_number
+    FROM si_matches sim
+    WHERE ja.id = sim.analytics_id
+      AND sim.match_count = 1
+    RETURNING ja.id
+  `);
+  log(`Pass 2e: Surname+initials match — ${surnameInitialsMatch.rowCount} additional judges matched`);
+
   // Log unmatched for debugging
   const unmatched = await mainPool.query(`
     SELECT COUNT(*) as cnt FROM judge_analytics WHERE dossier_number IS NULL


### PR DESCRIPTION
## Problem
2,509 judges remain without dossier_number because EDRSR uses abbreviated names like:
- "В.В. Щербаков" (initials + surname)
- "Колеснікова І.С." (surname + initials)

While VKKSU has full names: "Щербаков Володимир Валерійович"

## Solution
- **Pass 2d**: Handles "І.П. Прізвище" format — extracts last word as surname
- **Pass 2e**: Handles "Прізвище І.О." format — extracts first word as surname

Both match by surname + court when exactly one candidate.

## Expected Impact
Current: 3,881 (60.7%) judges with dossier
Expected: ~5,500+ (85%+) after this fix

## Test plan
- [ ] Merge and deploy
- [ ] Run `node /app/mcp_backend/dist/scripts/compute-judge-analytics.js` on prod
- [ ] Check logs for Pass 2d/2e match counts
- [ ] Verify final dossier_number coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)