### PR TITLE
fix(judges): add TRIM to court_name comparisons

### DIFF
--- a/mcp_backend/src/scripts/compute-judge-analytics.ts
+++ b/mcp_backend/src/scripts/compute-judge-analytics.ts
@@ -243,7 +243,7 @@ async function pass2() {
       FROM judge_analytics ja
       JOIN judges_current jc
         ON LOWER(SPLIT_PART(ja.judge_name, ' ', 1)) = LOWER(SPLIT_PART(jc.full_name, ' ', 1))
-        AND LOWER(ja.court_name) = LOWER(jc.court_name)
+        AND LOWER(TRIM(ja.court_name)) = LOWER(TRIM(jc.court_name))
       WHERE ja.dossier_number IS NULL
         AND jc.dossier_number IS NOT NULL
     )
@@ -267,7 +267,7 @@ async function pass2() {
         ON LOWER(TRIM(SPLIT_PART(ja.judge_name, ' ',
              array_length(string_to_array(ja.judge_name, ' '), 1)))) =
            LOWER(SPLIT_PART(jc.full_name, ' ', 1))
-        AND LOWER(ja.court_name) = LOWER(jc.court_name)
+        AND LOWER(TRIM(ja.court_name)) = LOWER(TRIM(jc.court_name))
       WHERE ja.dossier_number IS NULL
         AND jc.dossier_number IS NOT NULL
         AND ja.judge_name ~ '^[А-ЯІЇЄҐA-Z]\\.[А-ЯІЇЄҐA-Z]?\\.' -- matches "І.П." or "І." prefix pattern
@@ -289,7 +289,7 @@ async function pass2() {
       FROM judge_analytics ja
       JOIN judges_current jc
         ON LOWER(SPLIT_PART(ja.judge_name, ' ', 1)) = LOWER(SPLIT_PART(jc.full_name, ' ', 1))
-        AND LOWER(ja.court_name) = LOWER(jc.court_name)
+        AND LOWER(TRIM(ja.court_name)) = LOWER(TRIM(jc.court_name))
       WHERE ja.dossier_number IS NULL
         AND jc.dossier_number IS NOT NULL
         AND ja.judge_name ~ '[А-ЯІЇЄҐA-Z]\\.' -- has initials somewhere


### PR DESCRIPTION
## Problem
EDRSR court names have trailing spaces, VKKSU don't.
`LOWER(ja.court_name) = LOWER(jc.court_name)` fails even for identical courts.

Example:
- EDRSR: "Рівненський окружний адміністративний суд " (trailing space)
- VKKSU: "Рівненський окружний адміністративний суд" (no space)

## Solution
Add `TRIM()` to all court_name comparisons in Pass 2c/2d/2e.

## Expected Impact
Should match ~2000+ additional judges (the ones blocked by trailing spaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)