### PR TITLE
feat(mobile): add getDocumentPreview and getDocumentText to DocumentRepository

### DIFF
--- a/mobile/lib/features/documents/data/document_repository.dart
+++ b/mobile/lib/features/documents/data/document_repository.dart
@@ -46,6 +46,27 @@ class DocumentRepository {
         .toList();
   }
 
+  Future<DocumentPreview> getDocumentPreview(String documentId) async {
+    final response = await _api.get('/api/documents/$documentId/preview');
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      return DocumentPreview.fromJson(data);
+    }
+    return const DocumentPreview();
+  }
+
+  Future<String> getDocumentText(String documentId) async {
+    final response = await _api.get('/api/documents/$documentId/text');
+    final data = response.data;
+    if (data is Map<String, dynamic>) {
+      return data['text'] as String? ?? data['content'] as String? ?? '';
+    }
+    if (data is String) {
+      return data;
+    }
+    return '';
+  }
+
   Future<void> deleteDocument(String id) async {
     await _api.delete('/api/documents/$id');
   }

--- a/mobile/lib/features/documents/data/models/document.dart
+++ b/mobile/lib/features/documents/data/models/document.dart
@@ -58,6 +58,34 @@ class DocumentFolder {
       );
 }
 
+class DocumentPreview {
+  final String? previewUrl;
+  final String? mimeType;
+
+  const DocumentPreview({
+    this.previewUrl,
+    this.mimeType,
+  });
+
+  bool get hasPreview => previewUrl != null && previewUrl!.isNotEmpty;
+
+  bool get isPdf =>
+      mimeType?.contains('pdf') == true ||
+      (previewUrl != null && previewUrl!.endsWith('.pdf'));
+
+  bool get isImage =>
+      mimeType?.startsWith('image/') == true ||
+      (previewUrl != null &&
+          RegExp(r'\.(png|jpg|jpeg|gif|webp)$', caseSensitive: false)
+              .hasMatch(previewUrl!));
+
+  factory DocumentPreview.fromJson(Map<String, dynamic> json) =>
+      DocumentPreview(
+        previewUrl: json['preview_url'] as String? ?? json['previewUrl'] as String?,
+        mimeType: json['mime_type'] as String? ?? json['mimeType'] as String?,
+      );
+}
+
 class UploadProgress {
   final String fileName;
   final int totalChunks;


### PR DESCRIPTION
## Summary
- Add `DocumentPreview` model with `hasPreview`, `isPdf`, `isImage` computed properties and `fromJson` factory
- Add `getDocumentPreview(String documentId)` method to `DocumentRepository` — fetches preview metadata (URL, mime type) from `/api/documents/:id/preview`
- Add `getDocumentText(String documentId)` method to `DocumentRepository` — fetches extracted text content from `/api/documents/:id/text`

These methods are required by `DocumentDetailScreen` and `DocumentPagerScreen` (LEG-381).

## Test plan
- [ ] Verify `DocumentPreview.fromJson` handles both snake_case and camelCase keys
- [ ] Verify `getDocumentPreview` returns empty preview when API returns non-map data
- [ ] Verify `getDocumentText` handles string, map with `text`/`content` keys, and fallback
- [ ] Verify `DocumentDetailScreen` renders PDF, image, and text documents correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)