### PR TITLE
feat(mobile): integrate document detail & pager into app router

### DIFF
--- a/mobile/lib/features/documents/presentation/document_detail_screen.dart
+++ b/mobile/lib/features/documents/presentation/document_detail_screen.dart
@@ -1,0 +1,340 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_pdfview/flutter_pdfview.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:dio/dio.dart';
+import 'package:path_provider/path_provider.dart';
+import '../domain/document_notifier.dart';
+import '../data/models/document.dart';
+import '../../../shared/theme/app_colors.dart';
+
+/// Standalone screen with AppBar — used when opening a single document.
+class DocumentDetailScreen extends ConsumerWidget {
+  final VaultDocument document;
+
+  const DocumentDetailScreen({super.key, required this.document});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          document.title,
+          style: Theme.of(context).textTheme.titleSmall,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+        ),
+      ),
+      body: DocumentDetailPage(document: document),
+    );
+  }
+}
+
+/// Content-only widget — works inside PageView or standalone Scaffold.
+class DocumentDetailPage extends ConsumerStatefulWidget {
+  final VaultDocument document;
+
+  const DocumentDetailPage({super.key, required this.document});
+
+  @override
+  ConsumerState<DocumentDetailPage> createState() =>
+      _DocumentDetailPageState();
+}
+
+class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
+    with AutomaticKeepAliveClientMixin {
+  bool _isLoading = true;
+  String? _textContent;
+  DocumentPreview? _preview;
+  String? _pdfLocalPath;
+  int _pdfPages = 0;
+  int _pdfCurrentPage = 0;
+  String? _error;
+
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadContent();
+  }
+
+  Future<void> _loadContent() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    final repo = ref.read(documentRepositoryProvider);
+
+    try {
+      final preview = await repo.getDocumentPreview(widget.document.id);
+      _preview = preview;
+
+      if (preview.hasPreview && preview.isPdf) {
+        // Download PDF to local temp file for rendering
+        await _downloadPdf(preview.previewUrl!);
+      } else if (!preview.hasPreview) {
+        final text = await repo.getDocumentText(widget.document.id);
+        _textContent = text;
+      }
+
+      setState(() => _isLoading = false);
+    } catch (e) {
+      try {
+        final text = await repo.getDocumentText(widget.document.id);
+        _textContent = text;
+        setState(() => _isLoading = false);
+      } catch (e2) {
+        setState(() {
+          _isLoading = false;
+          _error = e2.toString().replaceFirst('Exception: ', '');
+        });
+      }
+    }
+  }
+
+  Future<void> _downloadPdf(String url) async {
+    try {
+      final dir = await getTemporaryDirectory();
+      final filePath =
+          '${dir.path}/doc_${widget.document.id.hashCode}.pdf';
+
+      // Skip download if already cached
+      if (File(filePath).existsSync()) {
+        _pdfLocalPath = filePath;
+        return;
+      }
+
+      await Dio().download(url, filePath);
+      _pdfLocalPath = filePath;
+    } catch (e) {
+      // PDF download failed — fallback to open in browser
+      _pdfLocalPath = null;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    final theme = Theme.of(context);
+
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return _buildError(theme);
+    }
+
+    return _buildContent(theme);
+  }
+
+  Widget _buildError(ThemeData theme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.error_outline, size: 48, color: AppColors.error),
+            const SizedBox(height: 12),
+            Text(
+              _error!,
+              style: theme.textTheme.bodyMedium,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: _loadContent,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Спробувати знову'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(ThemeData theme) {
+    // PDF — inline viewer
+    if (_preview?.isPdf == true && _pdfLocalPath != null) {
+      return Column(
+        children: [
+          // Page counter
+          if (_pdfPages > 0)
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Text(
+                'Сторінка ${_pdfCurrentPage + 1} з $_pdfPages',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          Expanded(
+            child: PDFView(
+              filePath: _pdfLocalPath!,
+              enableSwipe: true,
+              swipeHorizontal: false,
+              autoSpacing: true,
+              pageFling: true,
+              pageSnap: true,
+              fitPolicy: FitPolicy.WIDTH,
+              onRender: (pages) {
+                setState(() => _pdfPages = pages ?? 0);
+              },
+              onPageChanged: (page, total) {
+                setState(() => _pdfCurrentPage = page ?? 0);
+              },
+              onError: (error) {
+                setState(() {
+                  _pdfLocalPath = null;
+                  _error = 'Не вдалось відобразити PDF: $error';
+                });
+              },
+            ),
+          ),
+          // Open in browser fallback button
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextButton.icon(
+              onPressed: () => _openInBrowser(_preview!.previewUrl!),
+              icon: const Icon(Icons.open_in_browser, size: 16),
+              label: const Text('Відкрити у браузері'),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // PDF without local file — fallback to browser
+    if (_preview?.isPdf == true && _preview?.hasPreview == true) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.picture_as_pdf,
+                  size: 64, color: theme.colorScheme.primary),
+              const SizedBox(height: 16),
+              Text(
+                widget.document.title,
+                style: theme.textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: () => _openInBrowser(_preview!.previewUrl!),
+                icon: const Icon(Icons.open_in_browser),
+                label: const Text('Відкрити PDF'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    // Image preview
+    if (_preview?.hasPreview == true && _preview!.isImage) {
+      return InteractiveViewer(
+        child: Center(
+          child: Image.network(
+            _preview!.previewUrl!,
+            fit: BoxFit.contain,
+            loadingBuilder: (_, child, progress) {
+              if (progress == null) return child;
+              return Center(
+                child: CircularProgressIndicator(
+                  value: progress.expectedTotalBytes != null
+                      ? progress.cumulativeBytesLoaded /
+                          progress.expectedTotalBytes!
+                      : null,
+                ),
+              );
+            },
+            errorBuilder: (_, __, ___) => Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Icon(Icons.broken_image, size: 48),
+                const SizedBox(height: 8),
+                const Text('Не вдалось завантажити зображення'),
+                TextButton(
+                  onPressed: () => _openInBrowser(_preview!.previewUrl!),
+                  child: const Text('Відкрити у браузері'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // Text content
+    if (_textContent != null && _textContent!.isNotEmpty) {
+      return SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Icon(_iconForType(widget.document.type),
+                      size: 20, color: theme.colorScheme.primary),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      widget.document.title,
+                      style: theme.textTheme.labelLarge,
+                    ),
+                  ),
+                  if (widget.document.sizeFormatted.isNotEmpty)
+                    Text(
+                      widget.document.sizeFormatted,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            MarkdownBody(
+              data: _textContent!,
+              selectable: true,
+            ),
+          ],
+        ),
+      );
+    }
+
+    return const Center(child: Text('Документ порожній'));
+  }
+
+  Future<void> _openInBrowser(String url) async {
+    final uri = Uri.parse(url);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  IconData _iconForType(String type) {
+    if (type.contains('pdf')) return Icons.picture_as_pdf;
+    if (type.contains('word') || type.contains('docx') || type.contains('doc')) {
+      return Icons.description;
+    }
+    if (type.contains('text') || type.contains('txt')) return Icons.text_snippet;
+    if (type.contains('html')) return Icons.code;
+    return Icons.insert_drive_file;
+  }
+}

--- a/mobile/lib/features/documents/presentation/document_pager_screen.dart
+++ b/mobile/lib/features/documents/presentation/document_pager_screen.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import '../data/models/document.dart';
+import 'document_detail_screen.dart';
+import '../../../shared/theme/app_colors.dart';
+
+/// Full-screen pager that lets you swipe between documents.
+class DocumentPagerScreen extends StatefulWidget {
+  final List<VaultDocument> documents;
+  final int initialIndex;
+
+  const DocumentPagerScreen({
+    super.key,
+    required this.documents,
+    required this.initialIndex,
+  });
+
+  @override
+  State<DocumentPagerScreen> createState() => _DocumentPagerScreenState();
+}
+
+class _DocumentPagerScreenState extends State<DocumentPagerScreen> {
+  late final PageController _pageController;
+  late int _currentIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialIndex;
+    _pageController = PageController(initialPage: widget.initialIndex);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.documents[_currentIndex].title,
+              style: theme.textTheme.titleSmall,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+            Text(
+              '${_currentIndex + 1} з ${widget.documents.length}',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          // Page indicator
+          _PageIndicator(
+            total: widget.documents.length,
+            current: _currentIndex,
+          ),
+
+          // Swipeable pages
+          Expanded(
+            child: PageView.builder(
+              controller: _pageController,
+              itemCount: widget.documents.length,
+              onPageChanged: (index) {
+                setState(() => _currentIndex = index);
+              },
+              itemBuilder: (context, index) {
+                return DocumentDetailPage(
+                  key: ValueKey(widget.documents[index].id),
+                  document: widget.documents[index],
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PageIndicator extends StatelessWidget {
+  final int total;
+  final int current;
+
+  const _PageIndicator({required this.total, required this.current});
+
+  @override
+  Widget build(BuildContext context) {
+    if (total <= 1) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.chevron_left,
+            size: 16,
+            color: current > 0
+                ? AppColors.primary
+                : AppColors.textSecondary.withValues(alpha: 0.3),
+          ),
+          const SizedBox(width: 8),
+          // Show dots for small lists, text for large
+          if (total <= 10)
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(total, (i) {
+                return Container(
+                  width: i == current ? 16 : 6,
+                  height: 6,
+                  margin: const EdgeInsets.symmetric(horizontal: 2),
+                  decoration: BoxDecoration(
+                    color: i == current
+                        ? AppColors.primary
+                        : AppColors.border,
+                    borderRadius: BorderRadius.circular(3),
+                  ),
+                );
+              }),
+            )
+          else
+            Text(
+              '${current + 1} / $total',
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                color: AppColors.textSecondary,
+              ),
+            ),
+          const SizedBox(width: 8),
+          Icon(
+            Icons.chevron_right,
+            size: 16,
+            color: current < total - 1
+                ? AppColors.primary
+                : AppColors.textSecondary.withValues(alpha: 0.3),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/documents/presentation/documents_screen.dart
+++ b/mobile/lib/features/documents/presentation/documents_screen.dart
@@ -1,12 +1,14 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:intl/intl.dart';
 import '../domain/document_notifier.dart';
 import '../../../shared/widgets/loading_indicator.dart';
 import '../../../shared/widgets/error_state.dart';
 import '../../../shared/widgets/empty_state.dart';
+import '../../../navigation/route_names.dart';
 
 class DocumentsScreen extends ConsumerWidget {
   const DocumentsScreen({super.key});
@@ -164,6 +166,11 @@ class DocumentsScreen extends ConsumerWidget {
                                             dateFormat.format(doc.uploadedAt!),
                                         ].where((s) => s.isNotEmpty).join(' · '),
                                         style: theme.textTheme.bodySmall,
+                                      ),
+                                      onTap: () => context.pushNamed(
+                                        RouteNames.documentDetail,
+                                        pathParameters: {'id': doc.id},
+                                        extra: doc,
                                       ),
                                     ),
                                   )),

--- a/mobile/lib/navigation/app_router.dart
+++ b/mobile/lib/navigation/app_router.dart
@@ -11,6 +11,9 @@ import '../features/legislation/presentation/library_screen.dart';
 import '../features/legislation/presentation/toc_screen.dart';
 import '../features/legislation/presentation/article_screen.dart';
 import '../features/documents/presentation/documents_screen.dart';
+import '../features/documents/presentation/document_detail_screen.dart';
+import '../features/documents/presentation/document_pager_screen.dart';
+import '../features/documents/data/models/document.dart';
 import '../features/more/more_screen.dart';
 import '../features/profile/presentation/profile_screen.dart';
 import '../features/matters/presentation/clients_screen.dart';
@@ -105,6 +108,29 @@ final routerProvider = Provider<GoRouter>((ref) {
             path: '/documents',
             name: RouteNames.documents,
             builder: (_, __) => const DocumentsScreen(),
+            routes: [
+              GoRoute(
+                path: 'pager',
+                name: RouteNames.documentPager,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (_, state) {
+                  final extra = state.extra as Map<String, dynamic>;
+                  return DocumentPagerScreen(
+                    documents: extra['documents'] as List<VaultDocument>,
+                    initialIndex: extra['initialIndex'] as int,
+                  );
+                },
+              ),
+              GoRoute(
+                path: ':id',
+                name: RouteNames.documentDetail,
+                parentNavigatorKey: _rootNavigatorKey,
+                builder: (_, state) {
+                  final doc = state.extra as VaultDocument;
+                  return DocumentDetailScreen(document: doc);
+                },
+              ),
+            ],
           ),
           GoRoute(
             path: '/more',

--- a/mobile/lib/navigation/route_names.dart
+++ b/mobile/lib/navigation/route_names.dart
@@ -8,6 +8,8 @@ class RouteNames {
   static const legislationToc = 'legislation-toc';
   static const legislationArticle = 'legislation-article';
   static const documents = 'documents';
+  static const documentDetail = 'document-detail';
+  static const documentPager = 'document-pager';
   static const more = 'more';
   static const profile = 'profile';
   static const clients = 'clients';


### PR DESCRIPTION
## Summary
- Add routes for `DocumentDetailScreen` (`/documents/:id`) and `DocumentPagerScreen` (`/documents/pager`) in `app_router.dart`
- Both routes use `parentNavigatorKey: _rootNavigatorKey` for full-screen navigation outside the bottom nav shell
- Add tap handler on document list items in `DocumentsScreen` to navigate to the detail view
- Add `documentDetail` and `documentPager` to `RouteNames`

## Test plan
- [ ] Tap a document in the documents list and verify it opens the detail screen full-screen (no bottom nav)
- [ ] Verify the back button on detail screen returns to the documents list
- [ ] Navigate to pager screen programmatically with a list of documents and verify swipe between documents works
- [ ] Verify bottom nav still highlights "Документи" tab correctly when returning from detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)