### PR TITLE
feat(mobile): localize hardcoded strings in Document screens

### DIFF
--- a/mobile/lib/features/documents/presentation/document_detail_screen.dart
+++ b/mobile/lib/features/documents/presentation/document_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:path_provider/path_provider.dart';
 import '../domain/document_notifier.dart';
 import '../data/models/document.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/l10n/app_localizations.dart';
 
 /// Standalone screen with AppBar — used when opening a single document.
 class DocumentDetailScreen extends ConsumerWidget {
@@ -151,7 +152,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
             ElevatedButton.icon(
               onPressed: _loadContent,
               icon: const Icon(Icons.refresh),
-              label: const Text('Спробувати знову'),
+              label: Text(AppLocalizations.of(context)!.retry),
             ),
           ],
         ),
@@ -169,7 +170,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
             Container(
               padding: const EdgeInsets.symmetric(vertical: 6),
               child: Text(
-                'Сторінка ${_pdfCurrentPage + 1} з $_pdfPages',
+                AppLocalizations.of(context)!.documentPdfPageOf(_pdfCurrentPage + 1, _pdfPages),
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -193,7 +194,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
               onError: (error) {
                 setState(() {
                   _pdfLocalPath = null;
-                  _error = 'Не вдалось відобразити PDF: $error';
+                  _error = AppLocalizations.of(context)!.documentPdfRenderError(error.toString());
                 });
               },
             ),
@@ -204,7 +205,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
             child: TextButton.icon(
               onPressed: () => _openInBrowser(_preview!.previewUrl!),
               icon: const Icon(Icons.open_in_browser, size: 16),
-              label: const Text('Відкрити у браузері'),
+              label: Text(AppLocalizations.of(context)!.documentOpenInBrowser),
             ),
           ),
         ],
@@ -231,7 +232,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
               ElevatedButton.icon(
                 onPressed: () => _openInBrowser(_preview!.previewUrl!),
                 icon: const Icon(Icons.open_in_browser),
-                label: const Text('Відкрити PDF'),
+                label: Text(AppLocalizations.of(context)!.documentOpenPdf),
               ),
             ],
           ),
@@ -262,10 +263,10 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
               children: [
                 const Icon(Icons.broken_image, size: 48),
                 const SizedBox(height: 8),
-                const Text('Не вдалось завантажити зображення'),
+                Text(AppLocalizations.of(context)!.documentImageLoadError),
                 TextButton(
                   onPressed: () => _openInBrowser(_preview!.previewUrl!),
-                  child: const Text('Відкрити у браузері'),
+                  child: Text(AppLocalizations.of(context)!.documentOpenInBrowser),
                 ),
               ],
             ),
@@ -318,7 +319,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
       );
     }
 
-    return const Center(child: Text('Документ порожній'));
+    return Center(child: Text(AppLocalizations.of(context)!.documentEmpty));
   }
 
   Future<void> _openInBrowser(String url) async {

--- a/mobile/lib/features/documents/presentation/document_pager_screen.dart
+++ b/mobile/lib/features/documents/presentation/document_pager_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../data/models/document.dart';
 import 'document_detail_screen.dart';
 import '../../../shared/theme/app_colors.dart';
+import '../../../shared/l10n/app_localizations.dart';
 
 /// Full-screen pager that lets you swipe between documents.
 class DocumentPagerScreen extends StatefulWidget {
@@ -51,7 +52,7 @@ class _DocumentPagerScreenState extends State<DocumentPagerScreen> {
               overflow: TextOverflow.ellipsis,
             ),
             Text(
-              '${_currentIndex + 1} з ${widget.documents.length}',
+              AppLocalizations.of(context)!.documentItemOf(_currentIndex + 1, widget.documents.length),
               style: theme.textTheme.bodySmall?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),

--- a/mobile/lib/features/documents/presentation/documents_screen.dart
+++ b/mobile/lib/features/documents/presentation/documents_screen.dart
@@ -9,6 +9,7 @@ import '../../../shared/widgets/loading_indicator.dart';
 import '../../../shared/widgets/error_state.dart';
 import '../../../shared/widgets/empty_state.dart';
 import '../../../navigation/route_names.dart';
+import '../../../shared/l10n/app_localizations.dart';
 
 class DocumentsScreen extends ConsumerWidget {
   const DocumentsScreen({super.key});
@@ -21,7 +22,7 @@ class DocumentsScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Документи'),
+        title: Text(AppLocalizations.of(context)!.documents),
         leading: state.breadcrumb.isNotEmpty
             ? IconButton(
                 icon: const Icon(Icons.arrow_back),
@@ -87,10 +88,10 @@ class DocumentsScreen extends ConsumerWidget {
                             .loadDocuments(),
                       )
                     : state.folders.isEmpty && state.documents.isEmpty
-                        ? const EmptyState(
+                        ? EmptyState(
                             icon: Icons.folder_open,
-                            title: 'Немає документів',
-                            subtitle: 'Натисніть + щоб завантажити файл',
+                            title: AppLocalizations.of(context)!.documentsEmpty,
+                            subtitle: AppLocalizations.of(context)!.documentsEmptySubtitle,
                           )
                         : ListView(
                             children: [
@@ -126,20 +127,20 @@ class DocumentsScreen extends ConsumerWidget {
                                         context: context,
                                         builder: (ctx) => AlertDialog(
                                           title:
-                                              const Text('Видалити документ?'),
+                                              Text(AppLocalizations.of(context)!.documentDeleteConfirm),
                                           content: Text(doc.title),
                                           actions: [
                                             TextButton(
                                               onPressed: () =>
                                                   Navigator.pop(ctx, false),
                                               child:
-                                                  const Text('Скасувати'),
+                                                  Text(AppLocalizations.of(context)!.cancel),
                                             ),
                                             TextButton(
                                               onPressed: () =>
                                                   Navigator.pop(ctx, true),
                                               child:
-                                                  const Text('Видалити'),
+                                                  Text(AppLocalizations.of(context)!.delete),
                                             ),
                                           ],
                                         ),

--- a/mobile/lib/shared/l10n/app_localizations.dart
+++ b/mobile/lib/shared/l10n/app_localizations.dart
@@ -441,6 +441,66 @@ abstract class AppLocalizations {
   /// In uk, this message translates to:
   /// **'Закрити'**
   String get close;
+
+  /// No description provided for @documentPdfPageOf.
+  ///
+  /// In uk, this message translates to:
+  /// **'Сторінка {current} з {total}'**
+  String documentPdfPageOf(int current, int total);
+
+  /// No description provided for @documentPdfRenderError.
+  ///
+  /// In uk, this message translates to:
+  /// **'Не вдалось відобразити PDF: {error}'**
+  String documentPdfRenderError(String error);
+
+  /// No description provided for @documentOpenInBrowser.
+  ///
+  /// In uk, this message translates to:
+  /// **'Відкрити у браузері'**
+  String get documentOpenInBrowser;
+
+  /// No description provided for @documentOpenPdf.
+  ///
+  /// In uk, this message translates to:
+  /// **'Відкрити PDF'**
+  String get documentOpenPdf;
+
+  /// No description provided for @documentImageLoadError.
+  ///
+  /// In uk, this message translates to:
+  /// **'Не вдалось завантажити зображення'**
+  String get documentImageLoadError;
+
+  /// No description provided for @documentEmpty.
+  ///
+  /// In uk, this message translates to:
+  /// **'Документ порожній'**
+  String get documentEmpty;
+
+  /// No description provided for @documentItemOf.
+  ///
+  /// In uk, this message translates to:
+  /// **'{current} з {total}'**
+  String documentItemOf(int current, int total);
+
+  /// No description provided for @documentsEmpty.
+  ///
+  /// In uk, this message translates to:
+  /// **'Немає документів'**
+  String get documentsEmpty;
+
+  /// No description provided for @documentsEmptySubtitle.
+  ///
+  /// In uk, this message translates to:
+  /// **'Натисніть + щоб завантажити файл'**
+  String get documentsEmptySubtitle;
+
+  /// No description provided for @documentDeleteConfirm.
+  ///
+  /// In uk, this message translates to:
+  /// **'Видалити документ?'**
+  String get documentDeleteConfirm;
 }
 
 class _AppLocalizationsDelegate

--- a/mobile/lib/shared/l10n/app_localizations_uk.dart
+++ b/mobile/lib/shared/l10n/app_localizations_uk.dart
@@ -181,4 +181,36 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get close => 'Закрити';
+
+  @override
+  String documentPdfPageOf(int current, int total) =>
+      'Сторінка $current з $total';
+
+  @override
+  String documentPdfRenderError(String error) =>
+      'Не вдалось відобразити PDF: $error';
+
+  @override
+  String get documentOpenInBrowser => 'Відкрити у браузері';
+
+  @override
+  String get documentOpenPdf => 'Відкрити PDF';
+
+  @override
+  String get documentImageLoadError => 'Не вдалось завантажити зображення';
+
+  @override
+  String get documentEmpty => 'Документ порожній';
+
+  @override
+  String documentItemOf(int current, int total) => '$current з $total';
+
+  @override
+  String get documentsEmpty => 'Немає документів';
+
+  @override
+  String get documentsEmptySubtitle => 'Натисніть + щоб завантажити файл';
+
+  @override
+  String get documentDeleteConfirm => 'Видалити документ?';
 }


### PR DESCRIPTION
## Summary
- Replaces all hardcoded Ukrainian strings in `DocumentDetailScreen`, `DocumentPagerScreen`, and `DocumentsScreen` with `AppLocalizations` keys
- Adds 11 new localization keys to `app_localizations.dart` (base) and `app_localizations_uk.dart` (Ukrainian translations)
- Parameterized keys for PDF page counter (`documentPdfPageOf`), document item counter (`documentItemOf`), and PDF render error (`documentPdfRenderError`)

## New localization keys
| Key | Ukrainian value |
|-----|----------------|
| `documentPdfPageOf(current, total)` | Сторінка {current} з {total} |
| `documentPdfRenderError(error)` | Не вдалось відобразити PDF: {error} |
| `documentOpenInBrowser` | Відкрити у браузері |
| `documentOpenPdf` | Відкрити PDF |
| `documentImageLoadError` | Не вдалось завантажити зображення |
| `documentEmpty` | Документ порожній |
| `documentItemOf(current, total)` | {current} з {total} |
| `documentsEmpty` | Немає документів |
| `documentsEmptySubtitle` | Натисніть + щоб завантажити файл |
| `documentDeleteConfirm` | Видалити документ? |

Existing keys reused: `retry`, `documents`, `cancel`, `delete`

## Test plan
- [ ] Verify DocumentDetailScreen renders localized error/retry/PDF page labels
- [ ] Verify DocumentPagerScreen shows localized document counter in AppBar
- [ ] Verify DocumentsScreen shows localized title, empty state, and delete dialog
- [ ] Confirm no regression in non-document screens

Closes LEG-384

🤖 Generated with [Claude Code](https://claude.com/claude-code)