### PR TITLE
feat(mobile): persistent document caching for offline access

### DIFF
--- a/mobile/lib/core/di/service_locator.dart
+++ b/mobile/lib/core/di/service_locator.dart
@@ -1,4 +1,5 @@
 import '../../config/app_config.dart';
+import '../../features/documents/data/document_cache_service.dart';
 import '../network/api_client.dart';
 import '../network/sse_client.dart';
 import '../storage/secure_storage.dart';
@@ -14,12 +15,16 @@ class ServiceLocator {
   late final LocalCache localCache;
   late final ApiClient apiClient;
   late final SSEClient sseClient;
+  late final DocumentCacheService documentCache;
 
   Future<void> init(AppConfig appConfig) async {
     config = appConfig;
     secureStorage = SecureStorage();
     localCache = LocalCache();
     await localCache.init();
+
+    documentCache = DocumentCacheService();
+    await documentCache.init();
 
     apiClient = ApiClient(config: config, storage: secureStorage);
     sseClient = SSEClient(config: config, storage: secureStorage);

--- a/mobile/lib/features/documents/data/document_cache_service.dart
+++ b/mobile/lib/features/documents/data/document_cache_service.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+
+/// Metadata for a cached document stored in Hive.
+class CachedDocumentMeta {
+  final String id;
+  final String title;
+  final String localPath;
+  final DateTime cachedAt;
+  final int sizeBytes;
+  final String type; // 'pdf' | 'text'
+
+  const CachedDocumentMeta({
+    required this.id,
+    required this.title,
+    required this.localPath,
+    required this.cachedAt,
+    required this.sizeBytes,
+    required this.type,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'localPath': localPath,
+        'cachedAt': cachedAt.toIso8601String(),
+        'sizeBytes': sizeBytes,
+        'type': type,
+      };
+
+  factory CachedDocumentMeta.fromJson(Map<dynamic, dynamic> json) =>
+      CachedDocumentMeta(
+        id: json['id'] as String,
+        title: json['title'] as String,
+        localPath: json['localPath'] as String,
+        cachedAt: DateTime.parse(json['cachedAt'] as String),
+        sizeBytes: json['sizeBytes'] as int,
+        type: json['type'] as String,
+      );
+}
+
+/// Persistent document cache using Hive for metadata and
+/// the app documents directory for file storage.
+class DocumentCacheService {
+  static const _boxName = 'document_cache';
+  late final Box _box;
+  late final String _cacheDir;
+
+  Future<void> init() async {
+    _box = await Hive.openBox(_boxName);
+    final appDir = await getApplicationDocumentsDirectory();
+    _cacheDir = '${appDir.path}/cached_documents';
+    await Directory(_cacheDir).create(recursive: true);
+  }
+
+  /// Returns the persistent file path for a given document.
+  String _filePath(String documentId, String extension) =>
+      '$_cacheDir/$documentId.$extension';
+
+  /// Check whether a document is cached.
+  bool isCached(String documentId) => _box.containsKey(documentId);
+
+  /// Get cached metadata for a document.
+  CachedDocumentMeta? getMeta(String documentId) {
+    final raw = _box.get(documentId);
+    if (raw == null) return null;
+    return CachedDocumentMeta.fromJson(Map<dynamic, dynamic>.from(raw as Map));
+  }
+
+  /// Get all cached document IDs (for quick lookup in list views).
+  Set<String> get cachedIds =>
+      _box.keys.cast<String>().toSet();
+
+  /// Cache a PDF file: copies from [sourcePath] to persistent storage.
+  Future<CachedDocumentMeta> cachePdf({
+    required String documentId,
+    required String title,
+    required String sourcePath,
+  }) async {
+    final destPath = _filePath(documentId, 'pdf');
+    final sourceFile = File(sourcePath);
+    await sourceFile.copy(destPath);
+    final stat = await File(destPath).stat();
+
+    final meta = CachedDocumentMeta(
+      id: documentId,
+      title: title,
+      localPath: destPath,
+      cachedAt: DateTime.now(),
+      sizeBytes: stat.size,
+      type: 'pdf',
+    );
+    await _box.put(documentId, meta.toJson());
+    return meta;
+  }
+
+  /// Cache text content for a document.
+  Future<CachedDocumentMeta> cacheText({
+    required String documentId,
+    required String title,
+    required String content,
+  }) async {
+    final destPath = _filePath(documentId, 'txt');
+    final file = File(destPath);
+    await file.writeAsString(content);
+    final stat = await file.stat();
+
+    final meta = CachedDocumentMeta(
+      id: documentId,
+      title: title,
+      localPath: destPath,
+      cachedAt: DateTime.now(),
+      sizeBytes: stat.size,
+      type: 'text',
+    );
+    await _box.put(documentId, meta.toJson());
+    return meta;
+  }
+
+  /// Read cached text content.
+  Future<String?> readCachedText(String documentId) async {
+    final meta = getMeta(documentId);
+    if (meta == null || meta.type != 'text') return null;
+    final file = File(meta.localPath);
+    if (!file.existsSync()) {
+      await _removeMeta(documentId);
+      return null;
+    }
+    return file.readAsString();
+  }
+
+  /// Get the local path for a cached PDF.
+  String? getCachedPdfPath(String documentId) {
+    final meta = getMeta(documentId);
+    if (meta == null || meta.type != 'pdf') return null;
+    final file = File(meta.localPath);
+    if (!file.existsSync()) {
+      _removeMeta(documentId);
+      return null;
+    }
+    return meta.localPath;
+  }
+
+  /// Remove a single cached document.
+  Future<void> removeCached(String documentId) async {
+    final meta = getMeta(documentId);
+    if (meta != null) {
+      final file = File(meta.localPath);
+      if (file.existsSync()) await file.delete();
+    }
+    await _removeMeta(documentId);
+  }
+
+  /// Clear entire document cache — files and metadata.
+  Future<void> clearAll() async {
+    // Delete all cached files
+    final dir = Directory(_cacheDir);
+    if (dir.existsSync()) {
+      await for (final entity in dir.list()) {
+        if (entity is File) await entity.delete();
+      }
+    }
+    await _box.clear();
+  }
+
+  /// Total size of cached documents in bytes.
+  int get totalCacheSize {
+    int total = 0;
+    for (final key in _box.keys) {
+      final meta = getMeta(key as String);
+      if (meta != null) total += meta.sizeBytes;
+    }
+    return total;
+  }
+
+  /// Human-readable cache size.
+  String get totalCacheSizeFormatted {
+    final bytes = totalCacheSize;
+    if (bytes < 1024) return '$bytes B';
+    if (bytes < 1024 * 1024) {
+      return '${(bytes / 1024).toStringAsFixed(1)} KB';
+    }
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+
+  Future<void> _removeMeta(String documentId) async {
+    await _box.delete(documentId);
+  }
+}

--- a/mobile/lib/features/documents/domain/document_notifier.dart
+++ b/mobile/lib/features/documents/domain/document_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/di/service_locator.dart';
+import '../data/document_cache_service.dart';
 import '../data/document_repository.dart';
 import '../data/upload_service.dart';
 import '../data/models/document.dart';
@@ -11,6 +12,10 @@ final documentRepositoryProvider = Provider<DocumentRepository>((ref) {
 
 final uploadServiceProvider = Provider<UploadService>((ref) {
   return UploadService(api: sl.apiClient);
+});
+
+final documentCacheServiceProvider = Provider<DocumentCacheService>((ref) {
+  return sl.documentCache;
 });
 
 final documentNotifierProvider =

--- a/mobile/lib/features/documents/presentation/document_detail_screen.dart
+++ b/mobile/lib/features/documents/presentation/document_detail_screen.dart
@@ -7,6 +7,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:dio/dio.dart';
 import 'package:path_provider/path_provider.dart';
 import '../domain/document_notifier.dart';
+import '../data/document_cache_service.dart';
 import '../data/models/document.dart';
 import '../../../shared/theme/app_colors.dart';
 
@@ -69,24 +70,72 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
     });
 
     final repo = ref.read(documentRepositoryProvider);
+    final cache = ref.read(documentCacheServiceProvider);
+    final docId = widget.document.id;
 
+    // Try loading from persistent cache first
+    if (cache.isCached(docId)) {
+      final meta = cache.getMeta(docId);
+      if (meta != null) {
+        if (meta.type == 'pdf') {
+          final path = cache.getCachedPdfPath(docId);
+          if (path != null) {
+            _pdfLocalPath = path;
+            setState(() => _isLoading = false);
+            return;
+          }
+        } else if (meta.type == 'text') {
+          final text = await cache.readCachedText(docId);
+          if (text != null) {
+            _textContent = text;
+            setState(() => _isLoading = false);
+            return;
+          }
+        }
+      }
+    }
+
+    // Fetch from network
     try {
-      final preview = await repo.getDocumentPreview(widget.document.id);
+      final preview = await repo.getDocumentPreview(docId);
       _preview = preview;
 
       if (preview.hasPreview && preview.isPdf) {
-        // Download PDF to local temp file for rendering
         await _downloadPdf(preview.previewUrl!);
+        // Persist to cache
+        if (_pdfLocalPath != null) {
+          await cache.cachePdf(
+            documentId: docId,
+            title: widget.document.title,
+            sourcePath: _pdfLocalPath!,
+          );
+        }
       } else if (!preview.hasPreview) {
-        final text = await repo.getDocumentText(widget.document.id);
+        final text = await repo.getDocumentText(docId);
         _textContent = text;
+        // Persist to cache
+        if (text != null && text.isNotEmpty) {
+          await cache.cacheText(
+            documentId: docId,
+            title: widget.document.title,
+            content: text,
+          );
+        }
       }
 
       setState(() => _isLoading = false);
     } catch (e) {
       try {
-        final text = await repo.getDocumentText(widget.document.id);
+        final text = await repo.getDocumentText(docId);
         _textContent = text;
+        // Persist to cache
+        if (text != null && text.isNotEmpty) {
+          await cache.cacheText(
+            documentId: docId,
+            title: widget.document.title,
+            content: text,
+          );
+        }
         setState(() => _isLoading = false);
       } catch (e2) {
         setState(() {
@@ -103,7 +152,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
       final filePath =
           '${dir.path}/doc_${widget.document.id.hashCode}.pdf';
 
-      // Skip download if already cached
+      // Skip download if already in temp
       if (File(filePath).existsSync()) {
         _pdfLocalPath = filePath;
         return;
@@ -205,6 +254,47 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
               onPressed: () => _openInBrowser(_preview!.previewUrl!),
               icon: const Icon(Icons.open_in_browser, size: 16),
               label: const Text('Відкрити у браузері'),
+            ),
+          ),
+        ],
+      );
+    }
+
+    // PDF loaded from cache (no _preview available)
+    if (_pdfLocalPath != null) {
+      return Column(
+        children: [
+          if (_pdfPages > 0)
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 6),
+              child: Text(
+                'Сторінка ${_pdfCurrentPage + 1} з $_pdfPages',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          Expanded(
+            child: PDFView(
+              filePath: _pdfLocalPath!,
+              enableSwipe: true,
+              swipeHorizontal: false,
+              autoSpacing: true,
+              pageFling: true,
+              pageSnap: true,
+              fitPolicy: FitPolicy.WIDTH,
+              onRender: (pages) {
+                setState(() => _pdfPages = pages ?? 0);
+              },
+              onPageChanged: (page, total) {
+                setState(() => _pdfCurrentPage = page ?? 0);
+              },
+              onError: (error) {
+                setState(() {
+                  _pdfLocalPath = null;
+                  _error = 'Не вдалось відобразити PDF: $error';
+                });
+              },
             ),
           ),
         ],

--- a/mobile/lib/features/documents/presentation/documents_screen.dart
+++ b/mobile/lib/features/documents/presentation/documents_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:intl/intl.dart';
 import '../domain/document_notifier.dart';
+import '../data/document_cache_service.dart';
 import '../../../shared/widgets/loading_indicator.dart';
 import '../../../shared/widgets/error_state.dart';
 import '../../../shared/widgets/empty_state.dart';
@@ -16,6 +17,8 @@ class DocumentsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(documentNotifierProvider);
+    final cache = ref.read(documentCacheServiceProvider);
+    final cachedIds = cache.cachedIds;
     final theme = Theme.of(context);
     final dateFormat = DateFormat('dd.MM.yyyy', 'uk');
 
@@ -29,6 +32,64 @@ class DocumentsScreen extends ConsumerWidget {
                     ref.read(documentNotifierProvider.notifier).navigateUp(),
               )
             : null,
+        actions: [
+          if (cachedIds.isNotEmpty)
+            PopupMenuButton<String>(
+              icon: const Icon(Icons.more_vert),
+              onSelected: (value) async {
+                if (value == 'clear_cache') {
+                  final confirmed = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: const Text('Очистити кеш документів?'),
+                      content: Text(
+                        'Кешовано документів: ${cachedIds.length} '
+                        '(${cache.totalCacheSizeFormatted})',
+                      ),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, false),
+                          child: const Text('Скасувати'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(ctx, true),
+                          child: const Text('Очистити'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirmed == true) {
+                    await cache.clearAll();
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Кеш документів очищено'),
+                        ),
+                      );
+                      // Force rebuild to update cached indicators
+                      ref
+                          .read(documentNotifierProvider.notifier)
+                          .loadDocuments();
+                    }
+                  }
+                }
+              },
+              itemBuilder: (ctx) => [
+                PopupMenuItem<String>(
+                  value: 'clear_cache',
+                  child: Row(
+                    children: [
+                      const Icon(Icons.delete_sweep, size: 20),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Очистити кеш (${cache.totalCacheSizeFormatted})',
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+        ],
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _pickAndUpload(ref),
@@ -167,6 +228,19 @@ class DocumentsScreen extends ConsumerWidget {
                                         ].where((s) => s.isNotEmpty).join(' · '),
                                         style: theme.textTheme.bodySmall,
                                       ),
+                                      trailing: cachedIds.contains(doc.id)
+                                          ? Tooltip(
+                                              message: 'Збережено офлайн',
+                                              child: Icon(
+                                                Icons.download_done,
+                                                size: 18,
+                                                color: theme
+                                                    .colorScheme
+                                                    .primary
+                                                    .withOpacity(0.7),
+                                              ),
+                                            )
+                                          : null,
                                       onTap: () => context.pushNamed(
                                         RouteNames.documentDetail,
                                         pathParameters: {'id': doc.id},


### PR DESCRIPTION
## Summary
- Add `DocumentCacheService` using Hive to store cached document metadata (id, title, path, cachedAt, sizeBytes) and persist PDF/text files to the app documents directory
- Update `DocumentDetailScreen` to check persistent cache first before network fetch, and save documents after download
- Show a download-done indicator icon on cached documents in `DocumentsScreen` list
- Add "clear cache" option in the AppBar overflow menu with size info and confirmation dialog
- Register `DocumentCacheService` in `ServiceLocator` and expose via Riverpod provider

Closes LEG-383

## Test plan
- [ ] Open a document (PDF or text) and verify it loads normally
- [ ] Close and reopen the same document — should load instantly from cache
- [ ] Toggle airplane mode and reopen a cached document — should still render
- [ ] Verify the download-done icon appears next to cached documents in the list
- [ ] Use the overflow menu "clear cache" option and confirm the indicator icons disappear
- [ ] Verify cache size is displayed correctly in the menu and confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)