### PR TITLE
fix(mobile): resolve CI build errors from parallel PR merges

### DIFF
--- a/mobile/lib/features/documents/presentation/document_detail_screen.dart
+++ b/mobile/lib/features/documents/presentation/document_detail_screen.dart
@@ -7,7 +7,6 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:dio/dio.dart';
 import 'package:path_provider/path_provider.dart';
 import '../domain/document_notifier.dart';
-import '../data/document_cache_service.dart';
 import '../data/models/document.dart';
 import '../../../shared/theme/app_colors.dart';
 import '../../../shared/l10n/app_localizations.dart';
@@ -115,7 +114,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
         final text = await repo.getDocumentText(docId);
         _textContent = text;
         // Persist to cache
-        if (text != null && text.isNotEmpty) {
+        if (text.isNotEmpty) {
           await cache.cacheText(
             documentId: docId,
             title: widget.document.title,
@@ -130,7 +129,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
         final text = await repo.getDocumentText(docId);
         _textContent = text;
         // Persist to cache
-        if (text != null && text.isNotEmpty) {
+        if (text.isNotEmpty) {
           await cache.cacheText(
             documentId: docId,
             title: widget.document.title,
@@ -269,7 +268,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
             Container(
               padding: const EdgeInsets.symmetric(vertical: 6),
               child: Text(
-                'Сторінка ${_pdfCurrentPage + 1} з $_pdfPages',
+                AppLocalizations.of(context)!.documentPdfPageOf(_pdfCurrentPage + 1, _pdfPages),
                 style: theme.textTheme.bodySmall?.copyWith(
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -293,7 +292,7 @@ class _DocumentDetailPageState extends ConsumerState<DocumentDetailPage>
               onError: (error) {
                 setState(() {
                   _pdfLocalPath = null;
-                  _error = 'Не вдалось відобразити PDF: $error';
+                  _error = AppLocalizations.of(context)!.documentPdfRenderError(error.toString());
                 });
               },
             ),

--- a/mobile/lib/features/documents/presentation/documents_screen.dart
+++ b/mobile/lib/features/documents/presentation/documents_screen.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:intl/intl.dart';
 import '../domain/document_notifier.dart';
-import '../data/document_cache_service.dart';
 import '../../../shared/widgets/loading_indicator.dart';
 import '../../../shared/widgets/error_state.dart';
 import '../../../shared/widgets/empty_state.dart';
@@ -238,7 +237,7 @@ class DocumentsScreen extends ConsumerWidget {
                                                 color: theme
                                                     .colorScheme
                                                     .primary
-                                                    .withOpacity(0.7),
+                                                    .withValues(alpha: 0.7),
                                               ),
                                             )
                                           : null,

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   uuid: ^4.5.1
   file_picker: ^8.1.6
   url_launcher: ^6.3.1
+  path_provider: ^2.1.5
   flutter_dotenv: ^5.2.1
   package_info_plus: ^9.0.0
 


### PR DESCRIPTION
## Summary
- Add `path_provider` to `pubspec.yaml` (was used but not declared as dependency)
- Remove unused `document_cache_service.dart` imports in detail/list screens
- Replace remaining hardcoded Ukrainian strings with `AppLocalizations` calls
- Fix unnecessary null comparisons on non-nullable `String` return type
- Replace deprecated `withOpacity()` with `withValues(alpha:)`

Fixes failed CI run from LEG-382 merge (#873) caused by parallel squash-merges of LEG-380/381/383/384.

## Test plan
- [ ] CI Mobile: Build & Release APK passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)