### PR TITLE
fix(mobile): add localization keys to ARB source file

### DIFF
--- a/mobile/lib/shared/l10n/app_uk.arb
+++ b/mobile/lib/shared/l10n/app_uk.arb
@@ -57,5 +57,32 @@
   "cancel": "Скасувати",
   "delete": "Видалити",
   "save": "Зберегти",
-  "close": "Закрити"
+  "close": "Закрити",
+  "documentPdfPageOf": "Сторінка {current} з {total}",
+  "@documentPdfPageOf": {
+    "placeholders": {
+      "current": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "documentPdfRenderError": "Не вдалось відобразити PDF: {error}",
+  "@documentPdfRenderError": {
+    "placeholders": {
+      "error": { "type": "String" }
+    }
+  },
+  "documentOpenInBrowser": "Відкрити у браузері",
+  "documentOpenPdf": "Відкрити PDF",
+  "documentImageLoadError": "Не вдалось завантажити зображення",
+  "documentEmpty": "Документ порожній",
+  "documentItemOf": "{current} з {total}",
+  "@documentItemOf": {
+    "placeholders": {
+      "current": { "type": "int" },
+      "total": { "type": "int" }
+    }
+  },
+  "documentsEmpty": "Немає документів",
+  "documentsEmptySubtitle": "Натисніть + щоб завантажити файл",
+  "documentDeleteConfirm": "Видалити документ?"
 }


### PR DESCRIPTION
## Summary
- Added 11 missing localization keys to `app_uk.arb` (the source of truth for Flutter l10n)
- PR #871 added keys to generated `.dart` files but missed the `.arb` source
- Flutter's `generate: true` regenerates `.dart` from `.arb` on build, so CI was losing the keys

## Test plan
- [ ] CI Mobile: Build & Release APK passes (flutter analyze + flutter test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)