### PR TITLE
feat(payments): complete Monobank payment flow (LEG-126)

### DIFF
--- a/lexwebapp/src/pages/PaymentErrorPage.tsx
+++ b/lexwebapp/src/pages/PaymentErrorPage.tsx
@@ -44,11 +44,11 @@ export function PaymentErrorPage() {
         </div>
 
         <h1 className="text-2xl font-bold text-gray-900 mb-2">
-          Payment Failed
+          Оплата не вдалася
         </h1>
 
         <p className="text-gray-600 mb-6">
-          Unfortunately, your payment could not be processed. No charges were made to your account.
+          На жаль, платіж не було оброблено. Кошти з вашого рахунку не списано.
         </p>
 
         {(orderInfo.orderId || orderInfo.reason) && (
@@ -56,25 +56,25 @@ export function PaymentErrorPage() {
             <div className="space-y-2 text-sm">
               {orderInfo.orderId && (
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Order ID:</span>
+                  <span className="text-gray-500">Номер замовлення:</span>
                   <span className="font-medium text-gray-800">{orderInfo.orderId}</span>
                 </div>
               )}
               {orderInfo.amount && (
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Amount:</span>
+                  <span className="text-gray-500">Сума:</span>
                   <span className="font-medium text-gray-800">
                     {orderInfo.currency === 'UAH' ? '₴' : '$'}{orderInfo.amount}
                   </span>
                 </div>
               )}
               <div className="flex justify-between">
-                <span className="text-gray-500">Status:</span>
-                <span className="font-medium text-red-700">Declined</span>
+                <span className="text-gray-500">Статус:</span>
+                <span className="font-medium text-red-700">Відхилено</span>
               </div>
               {orderInfo.reason && (
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Reason:</span>
+                  <span className="text-gray-500">Причина:</span>
                   <span className="font-medium text-red-700">{orderInfo.reason}</span>
                 </div>
               )}
@@ -88,20 +88,20 @@ export function PaymentErrorPage() {
             className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors font-medium"
           >
             <RefreshCw size={18} />
-            Try Again
+            Спробувати ще раз
           </button>
 
           <button
             onClick={() => navigate(ROUTES.CHAT)}
             className="w-full flex items-center justify-center gap-2 px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors font-medium"
           >
-            Go to Dashboard
+            На головну
             <ArrowRight size={18} />
           </button>
         </div>
 
         <p className="text-xs text-gray-400 mt-4">
-          If this problem persists, please contact our support team.
+          Якщо проблема повторюється, зверніться до служби підтримки.
         </p>
       </div>
     </div>

--- a/lexwebapp/src/pages/PaymentSuccessPage.tsx
+++ b/lexwebapp/src/pages/PaymentSuccessPage.tsx
@@ -42,31 +42,31 @@ export function PaymentSuccessPage() {
         </div>
 
         <h1 className="text-2xl font-bold text-gray-900 mb-2">
-          Payment Successful
+          Оплата успішна
         </h1>
 
         <p className="text-gray-600 mb-6">
-          Your payment has been processed successfully. Your account balance will be updated shortly.
+          Ваш платіж успішно оброблено. Баланс буде оновлено найближчим часом.
         </p>
 
         {orderInfo.orderId && (
           <div className="bg-green-50 border border-green-200 rounded-lg p-4 mb-6 text-left">
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
-                <span className="text-gray-500">Order ID:</span>
+                <span className="text-gray-500">Номер замовлення:</span>
                 <span className="font-medium text-gray-800">{orderInfo.orderId}</span>
               </div>
               {orderInfo.amount && (
                 <div className="flex justify-between">
-                  <span className="text-gray-500">Amount:</span>
+                  <span className="text-gray-500">Сума:</span>
                   <span className="font-medium text-gray-800">
                     {orderInfo.currency === 'UAH' ? '₴' : '$'}{orderInfo.amount}
                   </span>
                 </div>
               )}
               <div className="flex justify-between">
-                <span className="text-gray-500">Status:</span>
-                <span className="font-medium text-green-700">Approved</span>
+                <span className="text-gray-500">Статус:</span>
+                <span className="font-medium text-green-700">Підтверджено</span>
               </div>
             </div>
           </div>
@@ -76,12 +76,12 @@ export function PaymentSuccessPage() {
           onClick={() => navigate(ROUTES.BILLING)}
           className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium"
         >
-          Go to Billing
+          Перейти до білінгу
           <ArrowRight size={18} />
         </button>
 
         <p className="text-xs text-gray-400 mt-4">
-          You will receive an email confirmation shortly.
+          Підтвердження буде надіслано на вашу електронну пошту.
         </p>
       </div>
     </div>

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -504,10 +504,10 @@ class HTTPMCPServer {
                             process.env.MONOBANK_API_KEY.includes('mock') ||
                             process.env.MONOBANK_API_KEY.includes('test');
     if (useMockMonobank) {
-      this.monobankService = new MockMonobankService(this.billingService, this.emailService);
+      this.monobankService = new MockMonobankService(this.billingService, this.emailService, this.services.db);
       logger.warn('🧪 Using MOCK Monobank service (no real payments will be processed)');
     } else {
-      this.monobankService = new MonobankService(this.billingService, this.emailService);
+      this.monobankService = new MonobankService(this.billingService, this.emailService, this.services.db);
       logger.info('💳 Using REAL Monobank service');
     }
 
@@ -2401,8 +2401,9 @@ class HTTPMCPServer {
     }) as any);
 
     // Payment routes - require JWT (user login)
-    // POST /api/billing/payment/stripe/create - Create Stripe PaymentIntent
-    // POST /api/billing/payment/fondy/create - Create Fondy payment
+    // POST /api/billing/payment/monobank/create - Create Monobank invoice
+    // POST /api/billing/payment/nowpayments/create - Create NOWPayments invoice
+    // GET /api/billing/payment/monobank/:invoiceId/status - Check Monobank status
     // GET /api/billing/payment/:provider/:paymentId/status - Check payment status
     this.app.use('/api/billing/payment', requireJWT as any, createPaymentRouter(this.monobankService, this.metamaskService, this.binancePayService, this.nowpaymentsService, this.services.db));
 

--- a/mcp_backend/src/routes/payment-routes.ts
+++ b/mcp_backend/src/routes/payment-routes.ts
@@ -65,8 +65,9 @@ export function createPaymentRouter(
         });
       }
 
-      const description = `SecondLayer balance top-up: ${amount_uah} UAH`;
-      const result = await monobankService.createInvoice(userId, amount_uah, description, redirect_url);
+      const email = req.user?.email;
+      const description = `Поповнення балансу SecondLayer: ${amount_uah} ₴`;
+      const result = await monobankService.createInvoice(userId, amount_uah, description, redirect_url, email);
 
       return res.json(result);
     } catch (error: any) {

--- a/mcp_backend/src/scripts/seed-test-account.ts
+++ b/mcp_backend/src/scripts/seed-test-account.ts
@@ -166,11 +166,11 @@ async function seedTestAccount() {
 
     // 3. Create mock transactions
     const transactions = [
-      { type: 'topup', amount_usd: 20.00, provider: 'stripe', desc: 'Initial top-up via Stripe' },
-      { type: 'topup', amount_usd: 25.00, provider: 'stripe', desc: 'Balance top-up via Stripe' },
-      { type: 'topup', amount_usd: 15.00, provider: 'fondy', desc: 'Balance top-up via Fondy', amount_uah: 555.56 },
+      { type: 'topup', amount_usd: 20.00, provider: 'monobank', desc: 'Поповнення через Monobank' },
+      { type: 'topup', amount_usd: 25.00, provider: 'monobank', desc: 'Поповнення через Monobank', amount_uah: 1037.50 },
+      { type: 'topup', amount_usd: 15.00, provider: 'monobank', desc: 'Поповнення через Monobank', amount_uah: 622.50 },
       { type: 'topup', amount_usd: 30.00, provider: 'manual', desc: 'Manual credit adjustment' },
-      { type: 'topup', amount_usd: 10.00, provider: 'stripe', desc: 'Balance top-up via Stripe' },
+      { type: 'topup', amount_usd: 10.00, provider: 'nowpayments', desc: 'Crypto top-up via NOWPayments' },
       { type: 'charge', amount_usd: -2.50, provider: null, desc: 'Tool execution: search_court_cases' },
       { type: 'charge', amount_usd: -5.00, provider: null, desc: 'Tool execution: semantic_search' },
       { type: 'charge', amount_usd: -1.25, provider: null, desc: 'Tool execution: get_document_text' },
@@ -209,21 +209,23 @@ async function seedTestAccount() {
     // 4. Create mock payment intents
     const paymentIntents = [
       {
-        provider: 'stripe',
-        external_id: 'pi_test_succeeded_' + Date.now(),
-        amount_usd: 25.00,
+        provider: 'monobank',
+        external_id: 'SL-' + userId.substring(0, 8) + '-' + (Date.now() - 86400000),
+        amount_usd: 0,
+        amount_uah: 1037.50,
         status: 'succeeded',
       },
       {
-        provider: 'stripe',
-        external_id: 'pi_test_pending_' + Date.now(),
-        amount_usd: 50.00,
+        provider: 'monobank',
+        external_id: 'SL-' + userId.substring(0, 8) + '-' + Date.now(),
+        amount_usd: 0,
+        amount_uah: 2075.00,
         status: 'pending',
       },
       {
-        provider: 'fondy',
-        external_id: 'SL-' + userId.substring(0, 8) + '-' + Date.now(),
-        amount_uah: 555.56,
+        provider: 'nowpayments',
+        external_id: 'np_' + Date.now(),
+        amount_usd: 10.00,
         status: 'succeeded',
       },
     ];

--- a/mcp_backend/src/services/__mocks__/monobank-service-mock.ts
+++ b/mcp_backend/src/services/__mocks__/monobank-service-mock.ts
@@ -1,32 +1,91 @@
 /**
  * MockMonobankService
  * Dev/test stub that simulates Monobank without real API calls.
+ * Stores invoices in-memory for idempotent webhook simulation.
  */
 
 import { logger } from '../../utils/logger.js';
 import { MonobankService, MonobankInvoiceResult, MonobankPaymentStatus, MonobankWebhookBody } from '../monobank-service.js';
+import { BillingService } from '../billing-service.js';
+import { EmailService } from '../email-service.js';
+import type { IDatabase } from '../../domain/ports/index.js';
 
 export class MockMonobankService extends MonobankService {
+  private mockInvoices: Map<string, any> = new Map();
+
+  constructor(
+    billingService: BillingService,
+    emailService: EmailService,
+    db?: IDatabase
+  ) {
+    // Pass a no-op db if not provided (for backward compatibility in tests)
+    super(billingService, emailService, db || { query: async () => ({ rows: [] }) } as any);
+    logger.info('MockMonobankService initialized (TEST MODE)');
+  }
+
   async createInvoice(
     userId: string,
     amountUah: number,
     description: string,
-    redirectUrl?: string
+    redirectUrl?: string,
+    email?: string
   ): Promise<MonobankInvoiceResult> {
+    if (amountUah < 1) {
+      throw new Error('Мінімальна сума поповнення — 1 ₴');
+    }
+
     const invoiceId = `mock-mono-${Date.now()}-${userId.substring(0, 8)}`;
     const pageUrl = `${process.env.FRONTEND_URL || 'http://localhost:5173'}/payment/success?mock=true&invoiceId=${invoiceId}`;
 
+    this.mockInvoices.set(invoiceId, {
+      userId,
+      amountUah,
+      email,
+      status: 'pending',
+    });
+
     logger.info('[MockMonobankService] Created mock invoice', { userId, amountUah, invoiceId });
 
-    return { invoiceId, pageUrl };
+    return { invoiceId, pageUrl, paymentIntentId: invoiceId };
   }
 
   async handleWebhook(_rawBody: Buffer | string, body: MonobankWebhookBody, _signature: string): Promise<{ received: boolean }> {
     logger.info('[MockMonobankService] Mock webhook received', { invoiceId: body.invoiceId, status: body.status });
+
+    if (body.status === 'success' && this.mockInvoices.has(body.invoiceId)) {
+      const invoice = this.mockInvoices.get(body.invoiceId);
+      if (invoice.status !== 'succeeded') {
+        invoice.status = 'succeeded';
+        this.mockInvoices.set(body.invoiceId, invoice);
+
+        await this.billingService.topUpBalance({
+          userId: invoice.userId,
+          amountUsd: 0,
+          amountUah: invoice.amountUah,
+          description: `[MOCK] Поповнення через Monobank: ${invoice.amountUah} ₴`,
+          paymentProvider: 'monobank_mock',
+          paymentId: body.invoiceId,
+          metadata: { invoiceId: body.invoiceId },
+        });
+
+        logger.info('[MockMonobankService] Payment succeeded', { invoiceId: body.invoiceId, amountUah: invoice.amountUah });
+      }
+    }
+
     return { received: true };
   }
 
   async getPaymentStatus(invoiceId: string): Promise<MonobankPaymentStatus> {
+    const invoice = this.mockInvoices.get(invoiceId);
+    if (invoice) {
+      return {
+        status: invoice.status === 'succeeded' ? 'success' : 'created',
+        amount: invoice.amountUah,
+        currency: 'UAH',
+        invoiceId,
+      };
+    }
+
     logger.info('[MockMonobankService] Mock status check', { invoiceId });
     return {
       status: 'success',
@@ -34,5 +93,21 @@ export class MockMonobankService extends MonobankService {
       currency: 'UAH',
       invoiceId,
     };
+  }
+
+  /**
+   * Mock-only: simulate a successful payment (for testing)
+   */
+  async simulatePaymentSuccess(invoiceId: string): Promise<void> {
+    const invoice = this.mockInvoices.get(invoiceId);
+    if (!invoice) {
+      throw new Error('Invoice not found');
+    }
+
+    await this.handleWebhook(
+      Buffer.from(JSON.stringify({ invoiceId, status: 'success', amount: Math.round(invoice.amountUah * 100), ccy: 980 })),
+      { invoiceId, status: 'success', amount: Math.round(invoice.amountUah * 100), ccy: 980 },
+      'mock_signature'
+    );
   }
 }

--- a/mcp_backend/src/services/__tests__/monobank-service.test.ts
+++ b/mcp_backend/src/services/__tests__/monobank-service.test.ts
@@ -2,11 +2,11 @@
  * Monobank Service Tests
  *
  * Tests cover:
- * - createInvoice: invoice creation via Monobank API, kopeck conversion
+ * - createInvoice: invoice creation via Monobank API, kopeck conversion, payment_intent storage
  * - validateSignature: HMAC-SHA256 signature verification
- * - handleWebhook: webhook processing, signature check, success handling
+ * - handleWebhook: webhook processing, signature check, balance credit, idempotency, email
  * - getPaymentStatus: status polling with kopeck→UAH conversion
- * - MockMonobankService: mock mode behaviour
+ * - MockMonobankService: mock mode behaviour with balance crediting
  */
 
 import crypto from 'crypto';
@@ -32,6 +32,7 @@ function makeBillingService(overrides: any = {}) {
       id: 'txn-001',
       balance_after_usd: 25.0,
     }),
+    setTransactionInvoiceNumber: jest.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -42,6 +43,21 @@ function makeEmailService(overrides: any = {}) {
     ...overrides,
   };
 }
+
+function makeDb(overrides: any = {}) {
+  return {
+    query: jest.fn().mockResolvedValue({ rows: [] }),
+    ...overrides,
+  };
+}
+
+const PI_ROW = {
+  id: 'pi-uuid-001',
+  user_id: 'user-abc12345',
+  amount_uah: '150.00',
+  status: 'pending',
+  metadata: JSON.stringify({ email: 'user@example.com', orderRef: 'SL-user-abc-1710000000' }),
+};
 
 // ──────────────────────────────────────────────────────────────────────────
 // MonobankService — configuration
@@ -58,7 +74,8 @@ describe('MonobankService — configuration', () => {
     delete process.env.MONOBANK_API_KEY;
     const service = new MonobankService(
       makeBillingService() as any,
-      makeEmailService() as any
+      makeEmailService() as any,
+      makeDb() as any
     );
     await expect(
       service.createInvoice('user-1', 100, 'Test payment')
@@ -69,11 +86,24 @@ describe('MonobankService — configuration', () => {
     delete process.env.MONOBANK_API_KEY;
     const service = new MonobankService(
       makeBillingService() as any,
-      makeEmailService() as any
+      makeEmailService() as any,
+      makeDb() as any
     );
     await expect(
       service.getPaymentStatus('inv-123')
     ).rejects.toThrow('MONOBANK_API_KEY is missing');
+  });
+
+  it('rejects amounts below 1 UAH', async () => {
+    process.env.MONOBANK_API_KEY = TEST_API_KEY;
+    const service = new MonobankService(
+      makeBillingService() as any,
+      makeEmailService() as any,
+      makeDb() as any
+    );
+    await expect(
+      service.createInvoice('user-1', 0.5, 'Test')
+    ).rejects.toThrow('Мінімальна сума поповнення');
   });
 });
 
@@ -83,15 +113,19 @@ describe('MonobankService — configuration', () => {
 
 describe('MonobankService — createInvoice', () => {
   let service: MonobankService;
+  let db: ReturnType<typeof makeDb>;
   const origEnv = { ...process.env };
 
   beforeEach(() => {
     process.env.MONOBANK_API_KEY = TEST_API_KEY;
     process.env.FRONTEND_URL = 'https://app.legal.org.ua';
     process.env.PUBLIC_URL = 'https://api.legal.org.ua';
+    db = makeDb();
+    db.query.mockResolvedValue({ rows: [{ id: 'pi-uuid-new' }] });
     service = new MonobankService(
       makeBillingService() as any,
-      makeEmailService() as any
+      makeEmailService() as any,
+      db as any
     );
   });
 
@@ -144,56 +178,32 @@ describe('MonobankService — createInvoice', () => {
     expect(callBody.merchantPaymInfo.reference).toMatch(/^SL-user-abc-\d+$/);
   });
 
-  it('sets webhookUrl from PUBLIC_URL', async () => {
-    const mockFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ invoiceId: 'inv-004', pageUrl: 'https://pay.mbnk.biz/inv-004' }),
-    });
-    global.fetch = mockFetch as any;
-
-    await service.createInvoice('user-abc12345', 100, 'Top-up');
-
-    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(callBody.webHookUrl).toBe('https://api.legal.org.ua/webhooks/monobank');
-  });
-
-  it('uses custom redirect_url when provided', async () => {
-    const mockFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ invoiceId: 'inv-005', pageUrl: 'https://pay.mbnk.biz/inv-005' }),
-    });
-    global.fetch = mockFetch as any;
-
-    await service.createInvoice('user-abc12345', 100, 'Top-up', 'https://custom.redirect/done');
-
-    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(callBody.redirectUrl).toBe('https://custom.redirect/done');
-  });
-
-  it('uses default redirect_url from FRONTEND_URL', async () => {
-    const mockFetch = jest.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ invoiceId: 'inv-006', pageUrl: 'https://pay.mbnk.biz/inv-006' }),
-    });
-    global.fetch = mockFetch as any;
-
-    await service.createInvoice('user-abc12345', 100, 'Top-up');
-
-    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(callBody.redirectUrl).toBe('https://app.legal.org.ua/payment/success');
-  });
-
-  it('returns invoiceId and pageUrl from API response', async () => {
+  it('stores payment_intent in database', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ invoiceId: 'inv-007', pageUrl: 'https://pay.mbnk.biz/inv-007' }),
+      json: async () => ({ invoiceId: 'inv-004', pageUrl: 'https://pay.mbnk.biz/inv-004' }),
+    }) as any;
+
+    await service.createInvoice('user-abc12345', 100, 'Top-up', undefined, 'test@example.com');
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT INTO payment_intents'),
+      expect.arrayContaining(['user-abc12345', 'inv-004', 0, 100])
+    );
+  });
+
+  it('returns invoiceId, pageUrl, and paymentIntentId', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ invoiceId: 'inv-005', pageUrl: 'https://pay.mbnk.biz/inv-005' }),
     }) as any;
 
     const result = await service.createInvoice('user-abc12345', 200, 'Top-up');
 
     expect(result).toEqual({
-      invoiceId: 'inv-007',
-      pageUrl: 'https://pay.mbnk.biz/inv-007',
+      invoiceId: 'inv-005',
+      pageUrl: 'https://pay.mbnk.biz/inv-005',
+      paymentIntentId: 'pi-uuid-new',
     });
   });
 
@@ -212,7 +222,7 @@ describe('MonobankService — createInvoice', () => {
   it('sets validity to 3600 seconds (1 hour)', async () => {
     const mockFetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ invoiceId: 'inv-008', pageUrl: 'https://pay.mbnk.biz/inv-008' }),
+      json: async () => ({ invoiceId: 'inv-006', pageUrl: 'https://pay.mbnk.biz/inv-006' }),
     });
     global.fetch = mockFetch as any;
 
@@ -221,21 +231,37 @@ describe('MonobankService — createInvoice', () => {
     const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(callBody.validity).toBe(3600);
   });
+
+  it('sets webhookUrl from PUBLIC_URL', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ invoiceId: 'inv-007', pageUrl: 'https://pay.mbnk.biz/inv-007' }),
+    });
+    global.fetch = mockFetch as any;
+
+    await service.createInvoice('user-abc12345', 100, 'Top-up');
+
+    const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(callBody.webHookUrl).toBe('https://api.legal.org.ua/webhooks/monobank');
+  });
 });
 
 // ──────────────────────────────────────────────────────────────────────────
-// MonobankService — validateSignature (via handleWebhook)
+// MonobankService — webhook signature validation
 // ──────────────────────────────────────────────────────────────────────────
 
 describe('MonobankService — webhook signature validation', () => {
   let service: MonobankService;
+  let db: ReturnType<typeof makeDb>;
   const origEnv = { ...process.env };
 
   beforeEach(() => {
     process.env.MONOBANK_API_KEY = TEST_API_KEY;
+    db = makeDb();
     service = new MonobankService(
       makeBillingService() as any,
-      makeEmailService() as any
+      makeEmailService() as any,
+      db as any
     );
   });
 
@@ -243,45 +269,30 @@ describe('MonobankService — webhook signature validation', () => {
     process.env = { ...origEnv };
   });
 
-  it('accepts a valid HMAC-SHA256 signature', async () => {
-    const bodyStr = JSON.stringify({ invoiceId: 'inv-100', status: 'success', amount: 10000, ccy: 980 });
+  it('accepts a valid HMAC-SHA256 signature', () => {
+    const bodyStr = JSON.stringify({ invoiceId: 'inv-100', status: 'created', amount: 10000, ccy: 980 });
     const rawBody = Buffer.from(bodyStr);
     const signature = makeSignature(rawBody);
-    const parsed: MonobankWebhookBody = JSON.parse(bodyStr);
-
-    const result = await service.handleWebhook(rawBody, parsed, signature);
-    expect(result).toEqual({ received: true });
+    expect(service.validateSignature(rawBody, signature)).toBe(true);
   });
 
-  it('rejects an invalid signature', async () => {
+  it('rejects an invalid signature', () => {
     const bodyStr = JSON.stringify({ invoiceId: 'inv-101', status: 'success', amount: 10000, ccy: 980 });
     const rawBody = Buffer.from(bodyStr);
-    const parsed: MonobankWebhookBody = JSON.parse(bodyStr);
-
-    await expect(
-      service.handleWebhook(rawBody, parsed, 'invalid_signature_base64')
-    ).rejects.toThrow('Invalid webhook signature');
+    expect(service.validateSignature(rawBody, 'invalid_signature_base64')).toBe(false);
   });
 
-  it('rejects a tampered body with valid-looking signature', async () => {
+  it('rejects a tampered body with valid-looking signature', () => {
     const originalBody = JSON.stringify({ invoiceId: 'inv-102', status: 'success', amount: 10000, ccy: 980 });
     const signature = makeSignature(originalBody);
-
     const tamperedBody = JSON.stringify({ invoiceId: 'inv-102', status: 'success', amount: 99999, ccy: 980 });
-    const parsed: MonobankWebhookBody = JSON.parse(tamperedBody);
-
-    await expect(
-      service.handleWebhook(Buffer.from(tamperedBody), parsed, signature)
-    ).rejects.toThrow('Invalid webhook signature');
+    expect(service.validateSignature(Buffer.from(tamperedBody), signature)).toBe(false);
   });
 
-  it('handles string rawBody in signature validation', async () => {
+  it('handles string rawBody in signature validation', () => {
     const bodyStr = JSON.stringify({ invoiceId: 'inv-103', status: 'created', amount: 5000, ccy: 980 });
     const signature = makeSignature(bodyStr);
-    const parsed: MonobankWebhookBody = JSON.parse(bodyStr);
-
-    const result = await service.handleWebhook(bodyStr, parsed, signature);
-    expect(result).toEqual({ received: true });
+    expect(service.validateSignature(bodyStr, signature)).toBe(true);
   });
 });
 
@@ -291,49 +302,156 @@ describe('MonobankService — webhook signature validation', () => {
 
 describe('MonobankService — handleWebhook processing', () => {
   let service: MonobankService;
+  let billing: ReturnType<typeof makeBillingService>;
+  let email: ReturnType<typeof makeEmailService>;
+  let db: ReturnType<typeof makeDb>;
   const origEnv = { ...process.env };
 
   beforeEach(() => {
     process.env.MONOBANK_API_KEY = TEST_API_KEY;
-    service = new MonobankService(
-      makeBillingService() as any,
-      makeEmailService() as any
-    );
+    billing = makeBillingService();
+    email = makeEmailService();
+    db = makeDb();
+    service = new MonobankService(billing as any, email as any, db as any);
   });
 
   afterEach(() => {
     process.env = { ...origEnv };
   });
 
-  it('returns received:true for successful payment with reference', async () => {
-    const body = { invoiceId: 'inv-200', status: 'success', amount: 15000, ccy: 980, reference: 'SL-user1234-1710000000' };
-    const bodyStr = JSON.stringify(body);
-    const rawBody = Buffer.from(bodyStr);
-    const signature = makeSignature(rawBody);
+  it('rejects invalid signature', async () => {
+    const bodyStr = JSON.stringify({ invoiceId: 'inv-200', status: 'success', amount: 10000, ccy: 980 });
+    const parsed: MonobankWebhookBody = JSON.parse(bodyStr);
 
-    const result = await service.handleWebhook(rawBody, body as MonobankWebhookBody, signature);
-    expect(result).toEqual({ received: true });
+    await expect(
+      service.handleWebhook(Buffer.from(bodyStr), parsed, 'bad_sig')
+    ).rejects.toThrow('Invalid webhook signature');
   });
 
-  it('returns received:true for non-success statuses', async () => {
+  it('returns received:true for non-success statuses without crediting', async () => {
     const body = { invoiceId: 'inv-201', status: 'processing', amount: 5000, ccy: 980 };
     const bodyStr = JSON.stringify(body);
-    const rawBody = Buffer.from(bodyStr);
-    const signature = makeSignature(rawBody);
+    const signature = makeSignature(bodyStr);
 
-    const result = await service.handleWebhook(rawBody, body as MonobankWebhookBody, signature);
+    const result = await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
     expect(result).toEqual({ received: true });
+    expect(billing.topUpBalance).not.toHaveBeenCalled();
   });
 
-  it('extracts user prefix from reference on success', async () => {
-    const body = { invoiceId: 'inv-202', status: 'success', amount: 20000, ccy: 980, reference: 'SL-abcdef12-1710000000' };
+  it('updates status for terminal failure statuses', async () => {
+    const body = { invoiceId: 'inv-fail', status: 'failure', amount: 5000, ccy: 980 };
     const bodyStr = JSON.stringify(body);
-    const rawBody = Buffer.from(bodyStr);
-    const signature = makeSignature(rawBody);
+    const signature = makeSignature(bodyStr);
 
-    // Should not throw — logs the user prefix
-    const result = await service.handleWebhook(rawBody, body as MonobankWebhookBody, signature);
+    await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE payment_intents SET status'),
+      expect.arrayContaining(['failed', 'inv-fail', 'monobank'])
+    );
+  });
+
+  it('credits balance on successful payment', async () => {
+    const body = { invoiceId: 'inv-202', status: 'success', amount: 15000, ccy: 980, reference: 'SL-user-abc-1710000000' };
+    const bodyStr = JSON.stringify(body);
+    const signature = makeSignature(bodyStr);
+
+    // First query: find payment_intent
+    db.query
+      .mockResolvedValueOnce({ rows: [PI_ROW] })  // SELECT
+      .mockResolvedValueOnce({ rows: [] });         // UPDATE
+
+    const result = await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
     expect(result).toEqual({ received: true });
+
+    // Should credit balance
+    expect(billing.topUpBalance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: PI_ROW.user_id,
+        amountUah: 150.0,
+        paymentProvider: 'monobank',
+      })
+    );
+
+    // Should generate invoice number
+    expect(billing.setTransactionInvoiceNumber).toHaveBeenCalled();
+  });
+
+  it('sends confirmation email on success', async () => {
+    const body = { invoiceId: 'inv-203', status: 'success', amount: 15000, ccy: 980 };
+    const bodyStr = JSON.stringify(body);
+    const signature = makeSignature(bodyStr);
+
+    db.query
+      .mockResolvedValueOnce({ rows: [PI_ROW] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
+
+    expect(email.sendPaymentSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'user@example.com',
+        amount: 150.0,
+        currency: 'UAH',
+      })
+    );
+  });
+
+  it('is idempotent — skips already-succeeded payments', async () => {
+    const body = { invoiceId: 'inv-204', status: 'success', amount: 15000, ccy: 980 };
+    const bodyStr = JSON.stringify(body);
+    const signature = makeSignature(bodyStr);
+
+    db.query.mockResolvedValueOnce({ rows: [{ ...PI_ROW, status: 'succeeded' }] });
+
+    const result = await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
+    expect(result).toEqual({ received: true });
+    expect(billing.topUpBalance).not.toHaveBeenCalled();
+  });
+
+  it('handles unknown invoiceId gracefully', async () => {
+    const body = { invoiceId: 'unknown', status: 'success', amount: 10000, ccy: 980 };
+    const bodyStr = JSON.stringify(body);
+    const signature = makeSignature(bodyStr);
+
+    db.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
+    expect(result).toEqual({ received: true });
+    expect(billing.topUpBalance).not.toHaveBeenCalled();
+  });
+
+  it('skips email when no email in metadata', async () => {
+    const piWithoutEmail = { ...PI_ROW, metadata: JSON.stringify({}) };
+    const body = { invoiceId: 'inv-205', status: 'success', amount: 15000, ccy: 980 };
+    const bodyStr = JSON.stringify(body);
+    const signature = makeSignature(bodyStr);
+
+    db.query
+      .mockResolvedValueOnce({ rows: [piWithoutEmail] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
+
+    expect(email.sendPaymentSuccess).not.toHaveBeenCalled();
+    expect(billing.topUpBalance).toHaveBeenCalled();
+  });
+
+  it('marks payment_intent as succeeded in DB', async () => {
+    const body = { invoiceId: 'inv-206', status: 'success', amount: 15000, ccy: 980 };
+    const bodyStr = JSON.stringify(body);
+    const signature = makeSignature(bodyStr);
+
+    db.query
+      .mockResolvedValueOnce({ rows: [PI_ROW] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await service.handleWebhook(Buffer.from(bodyStr), body as MonobankWebhookBody, signature);
+
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE payment_intents SET status'),
+      expect.arrayContaining(['succeeded', PI_ROW.id])
+    );
   });
 });
 
@@ -349,7 +467,8 @@ describe('MonobankService — getPaymentStatus', () => {
     process.env.MONOBANK_API_KEY = TEST_API_KEY;
     service = new MonobankService(
       makeBillingService() as any,
-      makeEmailService() as any
+      makeEmailService() as any,
+      makeDb() as any
     );
   });
 
@@ -425,20 +544,28 @@ describe('MonobankService — getPaymentStatus', () => {
 
 describe('MockMonobankService', () => {
   let mock: MockMonobankService;
+  let billing: ReturnType<typeof makeBillingService>;
 
   beforeEach(() => {
+    billing = makeBillingService();
     mock = new MockMonobankService(
-      makeBillingService() as any,
+      billing as any,
       makeEmailService() as any
     );
   });
 
-  it('createInvoice returns mock invoice with unique ID', async () => {
+  it('createInvoice returns mock invoice with unique ID and paymentIntentId', async () => {
     const result = await mock.createInvoice('user-1', 100, 'Test payment');
 
     expect(result.invoiceId).toMatch(/^mock-mono-\d+-user-1$/);
     expect(result.pageUrl).toContain('mock=true');
-    expect(result.pageUrl).toContain(result.invoiceId);
+    expect(result.paymentIntentId).toBe(result.invoiceId);
+  });
+
+  it('rejects amounts below 1 UAH', async () => {
+    await expect(
+      mock.createInvoice('user-1', 0.5, 'Test')
+    ).rejects.toThrow('Мінімальна сума поповнення');
   });
 
   it('createInvoice generates different IDs for different users', async () => {
@@ -448,21 +575,52 @@ describe('MockMonobankService', () => {
     expect(r1.invoiceId).not.toBe(r2.invoiceId);
   });
 
-  it('handleWebhook always returns received:true (skips signature)', async () => {
-    const body: MonobankWebhookBody = { invoiceId: 'mock-inv', status: 'success', amount: 10000, ccy: 980 };
-    const result = await mock.handleWebhook(Buffer.from('{}'), body, 'any-signature');
+  it('handleWebhook credits balance on success', async () => {
+    const { invoiceId } = await mock.createInvoice('user-1', 250, 'Test');
+    const body: MonobankWebhookBody = { invoiceId, status: 'success', amount: 25000, ccy: 980 };
+    await mock.handleWebhook(Buffer.from('{}'), body, 'any-signature');
 
-    expect(result).toEqual({ received: true });
+    expect(billing.topUpBalance).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-1', amountUah: 250 })
+    );
   });
 
-  it('getPaymentStatus returns success with zero amount', async () => {
-    const result = await mock.getPaymentStatus('mock-inv-123');
+  it('handleWebhook is idempotent — no double credit', async () => {
+    const { invoiceId } = await mock.createInvoice('user-1', 100, 'Test');
+    const body: MonobankWebhookBody = { invoiceId, status: 'success', amount: 10000, ccy: 980 };
 
-    expect(result).toEqual({
-      status: 'success',
-      amount: 0,
-      currency: 'UAH',
-      invoiceId: 'mock-inv-123',
-    });
+    await mock.handleWebhook(Buffer.from('{}'), body, 'sig');
+    await mock.handleWebhook(Buffer.from('{}'), body, 'sig');
+
+    expect(billing.topUpBalance).toHaveBeenCalledTimes(1);
+  });
+
+  it('getPaymentStatus returns pending after create, success after webhook', async () => {
+    const { invoiceId } = await mock.createInvoice('user-1', 100, 'Test');
+
+    const before = await mock.getPaymentStatus(invoiceId);
+    expect(before.status).toBe('created');
+
+    const body: MonobankWebhookBody = { invoiceId, status: 'success', amount: 10000, ccy: 980 };
+    await mock.handleWebhook(Buffer.from('{}'), body, 'sig');
+
+    const after = await mock.getPaymentStatus(invoiceId);
+    expect(after.status).toBe('success');
+    expect(after.amount).toBe(100);
+  });
+
+  it('simulatePaymentSuccess triggers balance top-up', async () => {
+    const { invoiceId } = await mock.createInvoice('user-2', 500, 'Test');
+    await mock.simulatePaymentSuccess(invoiceId);
+
+    expect(billing.topUpBalance).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-2', amountUah: 500 })
+    );
+  });
+
+  it('simulatePaymentSuccess throws for unknown invoice', async () => {
+    await expect(
+      mock.simulatePaymentSuccess('fake-id')
+    ).rejects.toThrow('Invoice not found');
   });
 });

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -1,6 +1,6 @@
 /**
  * MonobankService
- * Stub implementation for Monobank Acquiring payment integration.
+ * Full Monobank Acquiring payment integration.
  * Configure MONOBANK_API_KEY to enable real payments.
  */
 
@@ -8,10 +8,13 @@ import { createHmac } from 'crypto';
 import { logger } from '../utils/logger.js';
 import { BillingService } from './billing-service.js';
 import { EmailService } from './email-service.js';
+import { invoiceService } from './invoice-service.js';
+import type { IDatabase } from '../domain/ports/index.js';
 
 export interface MonobankInvoiceResult {
   invoiceId: string;
   pageUrl: string;
+  paymentIntentId: string;
 }
 
 export interface MonobankPaymentStatus {
@@ -33,7 +36,8 @@ export interface MonobankWebhookBody {
 export class MonobankService {
   constructor(
     protected billingService: BillingService,
-    protected emailService: EmailService
+    protected emailService: EmailService,
+    protected db: IDatabase
   ) {}
 
   private get apiKey(): string {
@@ -48,18 +52,25 @@ export class MonobankService {
 
   /**
    * Create a Monobank invoice (hosted payment page).
+   * Stores payment_intent in DB for idempotent webhook processing.
    */
   async createInvoice(
     userId: string,
     amountUah: number,
     description: string,
-    redirectUrl?: string
+    redirectUrl?: string,
+    email?: string
   ): Promise<MonobankInvoiceResult> {
     const key = this.apiKey; // throws if not configured
+
+    if (amountUah < 1) {
+      throw new Error('Мінімальна сума поповнення — 1 ₴');
+    }
 
     // Amount in kopecks (1 UAH = 100 kopecks)
     const amountKopecks = Math.round(amountUah * 100);
     const finalRedirectUrl = redirectUrl || `${this.redirectUrl}/payment/success`;
+    const orderRef = `SL-${userId.substring(0, 8)}-${Date.now()}`;
 
     logger.info('[MonobankService] Creating invoice', { userId, amountUah, amountKopecks });
 
@@ -73,7 +84,7 @@ export class MonobankService {
         amount: amountKopecks,
         ccy: 980, // UAH
         merchantPaymInfo: {
-          reference: `SL-${userId.substring(0, 8)}-${Date.now()}`,
+          reference: orderRef,
           destination: description,
           comment: description,
         },
@@ -89,11 +100,35 @@ export class MonobankService {
     }
 
     const data = (await response.json()) as { invoiceId: string; pageUrl: string };
-    logger.info('[MonobankService] Invoice created', { userId, invoiceId: data.invoiceId });
+
+    // Store payment_intent for idempotent webhook processing
+    const insertResult = await this.db.query(
+      `INSERT INTO payment_intents
+        (user_id, provider, external_id, amount_usd, amount_uah, status, metadata)
+       VALUES ($1, 'monobank', $2, $3, $4, 'pending', $5)
+       RETURNING id`,
+      [
+        userId,
+        data.invoiceId,
+        0, // amount_usd not applicable for UAH payments
+        amountUah,
+        JSON.stringify({ email, orderRef, pageUrl: data.pageUrl }),
+      ]
+    );
+
+    const paymentIntentId = insertResult.rows[0].id;
+
+    logger.info('[MonobankService] Invoice created', {
+      userId,
+      invoiceId: data.invoiceId,
+      paymentIntentId,
+      amountUah,
+    });
 
     return {
       invoiceId: data.invoiceId,
       pageUrl: data.pageUrl,
+      paymentIntentId,
     };
   }
 
@@ -101,7 +136,7 @@ export class MonobankService {
    * Validate Monobank webhook HMAC-SHA256 signature.
    * Monobank signs the raw request body with the merchant token as the key.
    */
-  private validateSignature(rawBody: Buffer | string, signature: string): boolean {
+  validateSignature(rawBody: Buffer | string, signature: string): boolean {
     const key = this.apiKey;
     const expected = createHmac('sha256', key)
       .update(typeof rawBody === 'string' ? rawBody : rawBody)
@@ -111,6 +146,7 @@ export class MonobankService {
 
   /**
    * Handle Monobank webhook callback.
+   * Validates signature, looks up payment_intent, credits balance, sends email.
    */
   async handleWebhook(rawBody: Buffer | string, body: MonobankWebhookBody, signature: string): Promise<{ received: boolean }> {
     if (!this.validateSignature(rawBody, signature)) {
@@ -123,14 +159,81 @@ export class MonobankService {
       status: body.status,
     });
 
-    if (body.status === 'success' && body.invoiceId) {
-      // reference contains our "SL-{userId}-{timestamp}" string
-      const reference = (body as any).reference || '';
-      const parts = reference.split('-');
-      if (parts.length >= 2) {
-        const userPrefix = parts[1];
-        logger.info('[MonobankService] Payment success for user prefix', { userPrefix, reference });
-        // Full implementation: look up user by reference in DB and credit their account
+    // Only process successful payments
+    if (body.status !== 'success') {
+      // Update status for non-success terminal statuses
+      if (['failure', 'reversed', 'expired'].includes(body.status)) {
+        await this.db.query(
+          'UPDATE payment_intents SET status = $1, updated_at = NOW() WHERE external_id = $2 AND provider = $3',
+          [body.status === 'failure' ? 'failed' : body.status, body.invoiceId, 'monobank']
+        );
+      }
+      return { received: true };
+    }
+
+    // Look up payment_intent by invoiceId (external_id)
+    const piResult = await this.db.query(
+      'SELECT * FROM payment_intents WHERE external_id = $1 AND provider = $2',
+      [body.invoiceId, 'monobank']
+    );
+
+    if (piResult.rows.length === 0) {
+      logger.warn('[MonobankService] Webhook: payment intent not found', { invoiceId: body.invoiceId });
+      return { received: true };
+    }
+
+    const pi = piResult.rows[0];
+
+    // Idempotency: skip if already processed
+    if (pi.status === 'succeeded') {
+      logger.warn('[MonobankService] Webhook: already processed', { invoiceId: body.invoiceId });
+      return { received: true };
+    }
+
+    // Mark as succeeded
+    await this.db.query(
+      'UPDATE payment_intents SET status = $1, updated_at = NOW() WHERE id = $2',
+      ['succeeded', pi.id]
+    );
+
+    // Credit user balance
+    const amountUah = parseFloat(pi.amount_uah) || (body.amount / 100);
+    const transaction = await this.billingService.topUpBalance({
+      userId: pi.user_id,
+      amountUsd: 0,
+      amountUah,
+      description: `Поповнення через Monobank: ${amountUah} ₴`,
+      paymentProvider: 'monobank',
+      paymentId: pi.id,
+      metadata: { invoiceId: body.invoiceId, reference: body.reference },
+    });
+
+    // Generate invoice number
+    const invoiceNumber = invoiceService.generateInvoiceNumber(transaction.id);
+    await this.billingService.setTransactionInvoiceNumber(transaction.id, invoiceNumber);
+
+    logger.info('[MonobankService] Payment succeeded', {
+      paymentIntentId: pi.id,
+      amountUah,
+      transactionId: transaction.id,
+      invoiceNumber,
+    });
+
+    // Send confirmation email
+    const metadata = JSON.parse(pi.metadata || '{}');
+    if (metadata.email) {
+      try {
+        await this.emailService.sendPaymentSuccess({
+          email: metadata.email,
+          name: 'User',
+          amount: amountUah,
+          currency: 'UAH',
+          newBalance: transaction.balance_after_usd,
+          paymentId: pi.id,
+          userId: pi.user_id,
+        });
+      } catch (emailErr: any) {
+        logger.error('[MonobankService] Failed to send confirmation email', { error: emailErr.message });
       }
     }
 


### PR DESCRIPTION
## Summary
- **Complete Monobank payment lifecycle** — was previously a stub that only logged webhook data
- `handleWebhook` now: validates HMAC-SHA256 → looks up `payment_intent` → credits balance → generates invoice → sends email
- `createInvoice` now stores `payment_intent` record in DB for idempotent processing
- Idempotency protection: skips already-succeeded payments, prevents double-crediting
- `MonobankService` and `MockMonobankService` now accept `IDatabase`
- Frontend: `PaymentSuccessPage` and `PaymentErrorPage` localized to Ukrainian
- `seed-test-account.ts`: replaced deprecated `stripe`/`fondy` with `monobank`/`nowpayments`
- **36 unit tests** all passing

Closes LEG-126

## Test plan
- [x] 36 unit tests pass (`npx jest monobank-service.test.ts`)
- [x] Backend TypeScript build passes
- [x] Frontend TypeScript build passes (no regressions)
- [ ] Verify payment flow on staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)