### PR TITLE
fix(monitoring): remove double nodejs_ prefix from metrics

### DIFF
--- a/mcp_backend/src/services/metrics-service.ts
+++ b/mcp_backend/src/services/metrics-service.ts
@@ -38,7 +38,9 @@ export class MetricsService {
     this.registry = new Registry();
 
     // Default Node.js metrics (CPU, memory, GC, event loop lag)
-    collectDefaultMetrics({ register: this.registry, prefix: 'nodejs_' });
+    // Note: prom-client already prefixes these with "nodejs_" (e.g. nodejs_heap_size_used_bytes),
+    // so we must NOT add an extra prefix to avoid double-prefixing (nodejs_nodejs_*).
+    collectDefaultMetrics({ register: this.registry });
 
     // --- HTTP ---
     this.httpRequestDuration = new Histogram({

--- a/mcp_openreyestr/src/services/metrics-service.ts
+++ b/mcp_openreyestr/src/services/metrics-service.ts
@@ -15,7 +15,7 @@ export class MetricsService {
   constructor() {
     this.registry = new Registry();
 
-    collectDefaultMetrics({ register: this.registry, prefix: 'nodejs_' });
+    collectDefaultMetrics({ register: this.registry });
 
     this.httpRequestDuration = new Histogram({
       name: 'http_request_duration_seconds',

--- a/mcp_rada/src/services/metrics-service.ts
+++ b/mcp_rada/src/services/metrics-service.ts
@@ -15,7 +15,7 @@ export class MetricsService {
   constructor() {
     this.registry = new Registry();
 
-    collectDefaultMetrics({ register: this.registry, prefix: 'nodejs_' });
+    collectDefaultMetrics({ register: this.registry });
 
     this.httpRequestDuration = new Histogram({
       name: 'http_request_duration_seconds',


### PR DESCRIPTION
## Summary
- `collectDefaultMetrics({ prefix: 'nodejs_' })` caused double-prefixing: metrics were exported as `nodejs_nodejs_eventloop_lag_p50_seconds` instead of `nodejs_eventloop_lag_p50_seconds`
- All 4 Grafana Node.js Runtime panels (event loop lag, heap memory, GC duration, active handles) showed empty data
- Prometheus recording rules (`nodejs:heap_utilization:ratio`, `nodejs:gc_time:ratio5m`) and alert rules (`HighEventLoopLag`, `HeapMemoryHigh`) were also broken
- Fixed in all 3 services: mcp_backend, mcp_rada, mcp_openreyestr

## Test plan
- [ ] Deploy to stage
- [ ] Verify `curl app-stage:3000/metrics | grep nodejs_eventloop_lag_p50` returns data (not `nodejs_nodejs_*`)
- [ ] Check Grafana Infrastructure dashboard → Node.js Runtime panels show data
- [ ] Verify recording rules produce values: `nodejs:heap_utilization:ratio`

🤖 Generated with [Claude Code](https://claude.com/claude-code)