### PR TITLE
feat(payments): add Monobank env vars to local Docker Compose (LEG-126)

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -131,3 +131,13 @@ ENABLE_UNIFIED_GATEWAY=true
 NOWPAYMENTS_API_KEY=your_nowpayments_api_key
 NOWPAYMENTS_IPN_SECRET=your_nowpayments_ipn_secret
 NOWPAYMENTS_PUBLIC_KEY=your_nowpayments_public_key
+
+# =============================================================================
+# Monobank Acquiring (Internet Payments)
+# =============================================================================
+# Get your token from https://web.monobank.ua/
+# API docs: https://api.monobank.ua/docs/acquiring.html
+# Test environment: https://api.monobank.ua/ (no real charges, any Luhn-valid card)
+MONOBANK_API_KEY=your_monobank_api_token
+# Base URL for webhook callbacks (must be publicly accessible)
+PUBLIC_URL=https://local.legal.org.ua

--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -321,6 +321,11 @@ services:
       # Terminal service (dedicated Debian container for admin shell)
       TERMINAL_SERVICE_URL: ws://terminal-service-local:3010
 
+      # Payment gateways
+      MONOBANK_API_KEY: ${MONOBANK_API_KEY:-}
+      MONOBANK_REDIRECT_URL: ${MONOBANK_REDIRECT_URL:-}
+      PUBLIC_URL: ${PUBLIC_URL:-https://local.legal.org.ua}
+
     ports:
       - "3000:3000"  # Standard backend port
 


### PR DESCRIPTION
## Summary
- Wire `MONOBANK_API_KEY`, `MONOBANK_REDIRECT_URL` and `PUBLIC_URL` into `docker-compose.local.yml` so the real MonobankService activates when the key is present
- Document Monobank vars in `.env.example`

## Test plan
- [x] Set `MONOBANK_API_KEY` in `.env.local` with test token from Monobank
- [x] Verified container starts with `💳 Using REAL Monobank service`
- [x] Created test invoice (10 UAH) — got `invoiceId` and `pageUrl` from Monobank API
- [x] Checked invoice status — returns `created` with correct amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)