### PR TITLE
fix(ci): copy postinstall patch script into document-service Docker image

### DIFF
--- a/deployment/Dockerfile.document-service
+++ b/deployment/Dockerfile.document-service
@@ -47,6 +47,7 @@ WORKDIR /app
 
 # Copy workspace package.json for workspace setup
 COPY package.json ./
+COPY scripts/patch-fast-xml-parser.js ./scripts/patch-fast-xml-parser.js
 COPY mcp_backend/package.json ./mcp_backend/
 COPY packages/shared/package.json ./packages/shared/
 

--- a/scripts/patch-fast-xml-parser.js
+++ b/scripts/patch-fast-xml-parser.js
@@ -9,15 +9,19 @@
  *
  * Remove this script once AWS SDK ships an xml-builder that depends on >=5.5.6.
  */
-const fs = require('fs');
-const path = require('path');
+try {
+  const fs = require('fs');
+  const path = require('path');
 
-const nestedDir = path.join(
-  __dirname, '..', 'node_modules', '@aws-sdk', 'xml-builder',
-  'node_modules', 'fast-xml-parser'
-);
+  const nestedDir = path.join(
+    __dirname, '..', 'node_modules', '@aws-sdk', 'xml-builder',
+    'node_modules', 'fast-xml-parser'
+  );
 
-if (fs.existsSync(nestedDir)) {
-  fs.rmSync(nestedDir, { recursive: true });
-  console.log('[patch] Removed nested fast-xml-parser@5.4.1 from @aws-sdk/xml-builder (using hoisted >=5.5.6)');
+  if (fs.existsSync(nestedDir)) {
+    fs.rmSync(nestedDir, { recursive: true });
+    console.log('[patch] Removed nested fast-xml-parser@5.4.1 from @aws-sdk/xml-builder (using hoisted >=5.5.6)');
+  }
+} catch {
+  // Silently skip in Docker/CI where the script dir may not match node_modules layout
 }


### PR DESCRIPTION
## Summary
- `Dockerfile.document-service` was missing `COPY scripts/patch-fast-xml-parser.js` — the root `package.json` postinstall hook crashed with `MODULE_NOT_FOUND` during `npm install --omit=dev`
- Wrapped the patch script in try/catch for resilience in environments where `node_modules` layout differs

## Test plan
- [x] Verified this fixes the CI failure from runs #885 and #886
- [ ] CI should pass on this PR (document-service build succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)