### PR TITLE
feat(security): End-to-End Document Encryption (E2EE) — Phases 1-4 (LEG-392)

### DIFF
--- a/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
+++ b/lexwebapp/src/components/consultation/ConsultationRequestModal.tsx
@@ -11,6 +11,9 @@ import { PaymentStep } from './PaymentStep';
 import type { VaultDocument } from '../../pages/DocumentsPage/types';
 import type { Conversation } from '../../services/api/ConversationService';
 import { getErrorMessage } from '../../utils/errors';
+import { useEncryptionStore } from '../../stores/encryptionStore';
+import { encryptionService } from '../../services/api/EncryptionService';
+import { rewrapDEK } from '../../services/crypto';
 
 interface Props {
   attorneyId: string;
@@ -78,6 +81,40 @@ export function ConsultationRequestModal({ attorneyId, attorneyName, consultatio
         conversationIds: selectedConversationIds.length > 0 ? selectedConversationIds : undefined,
       };
       const consultation = await consultationService.createConsultation(payload);
+
+      // E2EE: Auto-wrap DEKs for encrypted documents being shared
+      if (selectedDocIds.length > 0) {
+        const encState = useEncryptionStore.getState();
+        if (encState.isUnlocked && encState.privateKey) {
+          // Find encrypted docs among selected
+          const encryptedDocs = allDocs.filter(
+            d => d.is_encrypted && selectedDocIds.includes(d.id)
+          );
+
+          if (encryptedDocs.length > 0) {
+            try {
+              // Get attorney's public key
+              const { public_key: attorneyPubKey } = await encryptionService.getPublicKey(attorneyId);
+              const attorneyPubKeyBytes = (await import('../../services/crypto')).decodeBase64(attorneyPubKey);
+
+              // Rewrap each encrypted doc's DEK for the attorney
+              for (const doc of encryptedDocs) {
+                try {
+                  const { encrypted_dek: myWrappedDEK } = await encryptionService.getDocumentKey(doc.id);
+                  const rewrappedDEK = await rewrapDEK(myWrappedDEK, encState.privateKey, attorneyPubKeyBytes);
+                  await encryptionService.shareDocument(doc.id, attorneyId, rewrappedDEK);
+                } catch (e) {
+                  console.warn(`[Consultation] Failed to share DEK for doc ${doc.id}:`, e);
+                }
+              }
+            } catch (e) {
+              // Attorney may not have encryption set up — not a blocker
+              console.warn('[Consultation] Failed to share encrypted docs with attorney:', e);
+            }
+          }
+        }
+      }
+
       onClose();
       navigate(generateRoute.consultationDetail(consultation.id));
     } catch (err: unknown) {

--- a/lexwebapp/src/components/consultation/SharedDocumentsSection.tsx
+++ b/lexwebapp/src/components/consultation/SharedDocumentsSection.tsx
@@ -1,0 +1,114 @@
+/**
+ * SharedDocumentsSection
+ * Shows shared documents in a consultation with E2EE status and access management.
+ * Only visible when the consultation has document_ids.
+ */
+
+import { useState, useEffect } from 'react';
+import { FileText, Lock, UserX, Loader2 } from 'lucide-react';
+import { mcpService } from '../../services';
+import { encryptionService } from '../../services/api/EncryptionService';
+import { showToast } from '../../utils/toast';
+import type { VaultDocument } from '../../pages/DocumentsPage/types';
+
+interface Props {
+  documentIds: string[];
+  attorneyUserId: string;
+  isClient: boolean;
+  consultationStatus: string;
+}
+
+export function SharedDocumentsSection({ documentIds, attorneyUserId, isClient, consultationStatus }: Props) {
+  const [docs, setDocs] = useState<VaultDocument[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (documentIds.length === 0) {
+      setLoading(false);
+      return;
+    }
+
+    // Load document metadata
+    mcpService.callTool('list_documents', { limit: 200 }).then(result => {
+      const parsed = result?.result?.content?.[0]?.text
+        ? JSON.parse(result.result.content[0].text)
+        : result?.result || result;
+      const allDocs: VaultDocument[] = parsed.documents || [];
+      const shared = allDocs.filter(d => documentIds.includes(d.id));
+      setDocs(shared);
+    }).catch(() => {
+      // Fail silently
+    }).finally(() => setLoading(false));
+  }, [documentIds]);
+
+  const handleRevokeAccess = async (docId: string) => {
+    setRevoking(docId);
+    try {
+      await encryptionService.revokeAccess(docId, attorneyUserId);
+      showToast.success('Доступ до документа відкликано');
+    } catch (err: any) {
+      showToast.error('Не вдалося відкликати доступ');
+    } finally {
+      setRevoking(null);
+    }
+  };
+
+  if (documentIds.length === 0) return null;
+
+  const isActive = ['paid', 'in_progress'].includes(consultationStatus);
+
+  return (
+    <div className="bg-white border rounded-lg p-4 mb-4">
+      <h3 className="text-sm font-semibold text-gray-700 mb-3 flex items-center gap-2">
+        <FileText size={16} className="text-gray-400" />
+        Спільні документи ({documentIds.length})
+      </h3>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-sm text-gray-400">
+          <Loader2 size={14} className="animate-spin" />
+          Завантаження...
+        </div>
+      ) : docs.length === 0 ? (
+        <p className="text-sm text-gray-400">Документи не знайдено</p>
+      ) : (
+        <div className="space-y-2">
+          {docs.map(doc => (
+            <div
+              key={doc.id}
+              className="flex items-center justify-between gap-2 px-3 py-2 bg-gray-50 rounded-lg"
+            >
+              <div className="flex items-center gap-2 min-w-0">
+                <FileText size={14} className="text-gray-400 flex-shrink-0" />
+                <span className="text-sm text-gray-700 truncate">{doc.title}</span>
+                {doc.is_encrypted && (
+                  <span className="inline-flex items-center px-1.5 py-0.5 text-[9px] font-semibold rounded border border-green-300 bg-green-50 text-green-700 flex-shrink-0">
+                    <Lock size={8} className="mr-0.5" />
+                    E2EE
+                  </span>
+                )}
+              </div>
+
+              {isClient && isActive && doc.is_encrypted && (
+                <button
+                  onClick={() => handleRevokeAccess(doc.id)}
+                  disabled={revoking === doc.id}
+                  className="flex items-center gap-1 px-2 py-1 text-xs text-red-600 hover:bg-red-50 rounded transition-colors disabled:opacity-50"
+                  title="Відкликати доступ до зашифрованого документа"
+                >
+                  {revoking === doc.id ? (
+                    <Loader2 size={12} className="animate-spin" />
+                  ) : (
+                    <UserX size={12} />
+                  )}
+                  Відкликати
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lexwebapp/src/components/encryption/EncryptionSetupDialog.tsx
+++ b/lexwebapp/src/components/encryption/EncryptionSetupDialog.tsx
@@ -1,0 +1,223 @@
+/**
+ * EncryptionSetupDialog
+ * Modal for first-time E2EE setup: password entry, key generation, key file download.
+ * Also handles unlock flow for returning users.
+ */
+
+import React, { useState } from 'react';
+import { Modal } from '../ui/Modal/Modal';
+import { Shield, Download, Eye, EyeOff, Loader2, KeyRound, Lock } from 'lucide-react';
+import { useEncryptionStore, downloadKeyFile } from '../../stores/encryptionStore';
+import type { EncryptedKeyBundle } from '../../services/crypto';
+
+interface EncryptionSetupDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** 'setup' for first time, 'unlock' for returning users */
+  mode: 'setup' | 'unlock';
+}
+
+export function EncryptionSetupDialog({ isOpen, onClose, mode }: EncryptionSetupDialogProps) {
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [keyBundle, setKeyBundle] = useState<EncryptedKeyBundle | null>(null);
+  const [keyDownloaded, setKeyDownloaded] = useState(false);
+
+  const { setup, unlock, isLoading, error } = useEncryptionStore();
+
+  const handleSetup = async () => {
+    if (password.length < 8) return;
+    if (password !== confirmPassword) return;
+
+    try {
+      const bundle = await setup(password);
+      setKeyBundle(bundle);
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  const handleUnlock = async () => {
+    if (!password) return;
+    try {
+      await unlock(password);
+      handleClose();
+    } catch {
+      // Error is handled in store
+    }
+  };
+
+  const handleDownloadKey = () => {
+    if (keyBundle) {
+      downloadKeyFile(keyBundle);
+      setKeyDownloaded(true);
+    }
+  };
+
+  const handleClose = () => {
+    setPassword('');
+    setConfirmPassword('');
+    setShowPassword(false);
+    setKeyBundle(null);
+    setKeyDownloaded(false);
+    onClose();
+  };
+
+  const handleFinish = () => {
+    handleClose();
+  };
+
+  const isSetupMode = mode === 'setup';
+  const showKeyDownload = isSetupMode && keyBundle;
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={isSetupMode ? 'Налаштування шифрування' : 'Розблокувати сейф'}
+      size="md"
+    >
+      {showKeyDownload ? (
+        /* Key download step */
+        <div className="space-y-4">
+          <div className="flex items-center gap-3 p-4 bg-green-50 border border-green-200 rounded-xl">
+            <Shield size={20} className="text-green-600 flex-shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-green-800">
+                Ключі шифрування створено
+              </p>
+              <p className="text-xs text-green-600 mt-0.5">
+                Завантажте резервний файл ключа. Без нього та пароля ви не зможете відновити доступ до зашифрованих документів.
+              </p>
+            </div>
+          </div>
+
+          <button
+            onClick={handleDownloadKey}
+            className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all"
+          >
+            <Download size={16} />
+            Завантажити файл ключа
+          </button>
+
+          {keyDownloaded && (
+            <button
+              onClick={handleFinish}
+              className="w-full px-4 py-2.5 bg-green-600 text-white rounded-xl text-sm font-medium hover:bg-green-700 transition-all"
+            >
+              Готово
+            </button>
+          )}
+
+          <p className="text-xs text-claude-subtext/60 text-center">
+            Збережіть файл у надійному місці. Він потрібен для відновлення доступу.
+          </p>
+        </div>
+      ) : (
+        /* Password entry step */
+        <div className="space-y-4">
+          <div className="flex items-center gap-3 p-4 bg-blue-50 border border-blue-200 rounded-xl">
+            {isSetupMode ? (
+              <KeyRound size={20} className="text-blue-600 flex-shrink-0" />
+            ) : (
+              <Lock size={20} className="text-blue-600 flex-shrink-0" />
+            )}
+            <p className="text-sm text-blue-800">
+              {isSetupMode
+                ? 'Створіть пароль для захисту ваших документів. Цей пароль використовується для шифрування ключів локально у вашому браузері.'
+                : 'Введіть пароль шифрування для доступу до зашифрованих документів.'
+              }
+            </p>
+          </div>
+
+          {error && (
+            <div className="p-3 bg-red-50 border border-red-200 rounded-lg text-sm text-red-700">
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-claude-text mb-1.5">
+              {isSetupMode ? 'Пароль шифрування' : 'Пароль'}
+            </label>
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !isSetupMode) handleUnlock();
+                }}
+                placeholder={isSetupMode ? 'Мінімум 8 символів' : 'Введіть пароль'}
+                className="w-full px-3 py-2.5 pr-10 border border-claude-border rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-claude-accent/30 focus:border-claude-accent"
+                autoFocus
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-claude-subtext/50 hover:text-claude-subtext"
+              >
+                {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+              </button>
+            </div>
+          </div>
+
+          {isSetupMode && (
+            <div>
+              <label className="block text-sm font-medium text-claude-text mb-1.5">
+                Підтвердження пароля
+              </label>
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleSetup();
+                }}
+                placeholder="Повторіть пароль"
+                className="w-full px-3 py-2.5 border border-claude-border rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-claude-accent/30 focus:border-claude-accent"
+              />
+              {confirmPassword && password !== confirmPassword && (
+                <p className="text-xs text-red-500 mt-1">Паролі не збігаються</p>
+              )}
+            </div>
+          )}
+
+          <button
+            onClick={isSetupMode ? handleSetup : handleUnlock}
+            disabled={
+              isLoading ||
+              !password ||
+              (isSetupMode && (password.length < 8 || password !== confirmPassword))
+            }
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 size={16} className="animate-spin" />
+                {isSetupMode ? 'Генерація ключів...' : 'Розблокування...'}
+              </>
+            ) : isSetupMode ? (
+              <>
+                <Shield size={16} />
+                Створити ключі шифрування
+              </>
+            ) : (
+              <>
+                <Lock size={16} />
+                Розблокувати
+              </>
+            )}
+          </button>
+
+          {isSetupMode && (
+            <p className="text-xs text-claude-subtext/60 text-center">
+              Сервер ніколи не бачить ваш пароль або приватний ключ. Шифрування відбувається у вашому браузері.
+            </p>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/lexwebapp/src/components/encryption/RetroactiveEncryptionPanel.tsx
+++ b/lexwebapp/src/components/encryption/RetroactiveEncryptionPanel.tsx
@@ -1,0 +1,203 @@
+/**
+ * RetroactiveEncryptionPanel
+ * Panel for batch-encrypting existing unencrypted documents in the user's vault.
+ * Shows stats, progress, and allows the user to start batch encryption.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Shield, Lock, Loader2, CheckCircle, AlertTriangle } from 'lucide-react';
+import { encryptionService } from '../../services/api/EncryptionService';
+import { useEncryptionStore } from '../../stores/encryptionStore';
+import { encryptUploadedDocument } from '../../services/crypto/PostUploadEncryptor';
+import { EncryptionSetupDialog } from './EncryptionSetupDialog';
+
+interface VaultStats {
+  total: number;
+  encrypted: number;
+  unencrypted: number;
+}
+
+export function RetroactiveEncryptionPanel() {
+  const [stats, setStats] = useState<VaultStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [encrypting, setEncrypting] = useState(false);
+  const [progress, setProgress] = useState({ done: 0, total: 0, failed: 0 });
+  const [showSetup, setShowSetup] = useState(false);
+  const cancelRef = useRef(false);
+
+  const { hasEncryption, isUnlocked, publicKey } = useEncryptionStore();
+
+  const loadStats = useCallback(async () => {
+    try {
+      const s = await encryptionService.getVaultStats();
+      setStats(s);
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
+  const handleEncryptAll = async () => {
+    if (!isUnlocked || !publicKey) {
+      setShowSetup(true);
+      return;
+    }
+
+    setEncrypting(true);
+    cancelRef.current = false;
+
+    let done = 0;
+    let failed = 0;
+    let offset = 0;
+    const batchSize = 20;
+
+    // First, get total count
+    const totalUnencrypted = stats?.unencrypted || 0;
+    setProgress({ done: 0, total: totalUnencrypted, failed: 0 });
+
+    while (!cancelRef.current) {
+      try {
+        const { documents } = await encryptionService.getUnencryptedDocuments(batchSize, offset);
+        if (documents.length === 0) break;
+
+        for (const doc of documents) {
+          if (cancelRef.current) break;
+
+          const result = await encryptUploadedDocument(doc.id, publicKey);
+          if (result.success) {
+            done++;
+          } else {
+            failed++;
+          }
+          setProgress({ done, total: totalUnencrypted, failed });
+        }
+
+        // Don't increment offset — we're consuming from the front since encrypted docs drop off
+      } catch {
+        failed++;
+        setProgress(p => ({ ...p, failed }));
+        break;
+      }
+    }
+
+    setEncrypting(false);
+    loadStats(); // Refresh stats
+  };
+
+  const handleCancel = () => {
+    cancelRef.current = true;
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white border rounded-xl p-5">
+        <div className="flex items-center gap-2 text-sm text-claude-subtext">
+          <Loader2 size={14} className="animate-spin" />
+          Завантаження статистики...
+        </div>
+      </div>
+    );
+  }
+
+  if (!stats || stats.total === 0) return null;
+
+  const encryptionPercent = stats.total > 0 ? Math.round((stats.encrypted / stats.total) * 100) : 0;
+  const allEncrypted = stats.unencrypted === 0;
+
+  return (
+    <>
+      <EncryptionSetupDialog
+        isOpen={showSetup}
+        onClose={() => {
+          setShowSetup(false);
+          const state = useEncryptionStore.getState();
+          if (state.isUnlocked && state.publicKey) {
+            handleEncryptAll();
+          }
+        }}
+        mode={hasEncryption ? 'unlock' : 'setup'}
+      />
+
+      <div className="bg-white border rounded-xl p-5 space-y-4">
+        <div className="flex items-center gap-2">
+          <Shield size={18} className="text-claude-text" />
+          <h3 className="text-sm font-semibold text-claude-text">Шифрування сейфу</h3>
+        </div>
+
+        {/* Stats bar */}
+        <div>
+          <div className="flex justify-between text-xs text-claude-subtext mb-1.5">
+            <span>{stats.encrypted} з {stats.total} зашифровано</span>
+            <span>{encryptionPercent}%</span>
+          </div>
+          <div className="w-full h-2 bg-gray-100 rounded-full overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-500 ${
+                allEncrypted ? 'bg-green-500' : 'bg-claude-accent'
+              }`}
+              style={{ width: `${encryptionPercent}%` }}
+            />
+          </div>
+        </div>
+
+        {allEncrypted ? (
+          <div className="flex items-center gap-2 text-sm text-green-700">
+            <CheckCircle size={16} />
+            Всі документи зашифровані
+          </div>
+        ) : encrypting ? (
+          /* Encryption in progress */
+          <div className="space-y-3">
+            <div className="flex items-center gap-2 text-sm text-claude-text">
+              <Loader2 size={14} className="animate-spin" />
+              Шифрування: {progress.done} / {progress.total}
+              {progress.failed > 0 && (
+                <span className="text-red-500 text-xs">({progress.failed} помилок)</span>
+              )}
+            </div>
+            <div className="w-full h-1.5 bg-gray-100 rounded-full overflow-hidden">
+              <div
+                className="h-full bg-claude-accent rounded-full transition-all"
+                style={{ width: `${progress.total > 0 ? (progress.done / progress.total) * 100 : 0}%` }}
+              />
+            </div>
+            <button
+              onClick={handleCancel}
+              className="text-xs text-red-500 hover:text-red-700"
+            >
+              Зупинити
+            </button>
+          </div>
+        ) : (
+          /* Start encryption */
+          <div className="space-y-3">
+            <p className="text-xs text-claude-subtext">
+              {stats.unencrypted} документів без шифрування. Зашифруйте їх для максимального захисту.
+              Embeddings та метадані залишаться для пошуку.
+            </p>
+
+            {!hasEncryption && (
+              <div className="flex items-start gap-2 p-3 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-700">
+                <AlertTriangle size={14} className="flex-shrink-0 mt-0.5" />
+                Спочатку потрібно налаштувати шифрування (створити пароль та ключі).
+              </div>
+            )}
+
+            <button
+              onClick={handleEncryptAll}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all"
+            >
+              <Lock size={14} />
+              Зашифрувати мій сейф
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -5,6 +5,8 @@ import { consultationService, type Consultation } from '../../services/api/Consu
 import { useAuth } from '../../contexts/AuthContext';
 import { getErrorMessage } from '../../utils/errors';
 import { ConsultationChatTab } from '../../components/chat/ConsultationChatTab';
+import { EscrowStatusBadge } from '../../components/consultation/EscrowStatusBadge';
+import { SharedDocumentsSection } from '../../components/consultation/SharedDocumentsSection';
 
 const STATUS_STEPS = ['pending', 'accepted', 'paid', 'in_progress', 'completed'];
 const STATUS_LABELS: Record<string, string> = {
@@ -167,6 +169,25 @@ export function ConsultationDetailPage() {
             </div>
           )}
 
+          {/* Escrow payment status */}
+          {consultation.agreed_fee_uah && consultation.agreed_fee_uah > 0 && !['pending', 'declined'].includes(consultation.status) && (
+            <EscrowStatusBadge
+              consultationId={consultation.id}
+              consultationStatus={consultation.status}
+              onPaymentConfirmed={load}
+            />
+          )}
+
+          {/* Shared documents */}
+          {consultation.document_ids?.length > 0 && (
+            <SharedDocumentsSection
+              documentIds={consultation.document_ids}
+              attorneyUserId={consultation.attorney_user_id}
+              isClient={isClient}
+              consultationStatus={consultation.status}
+            />
+          )}
+
           {/* Action buttons */}
           <div className="flex flex-wrap gap-2">
             {isAttorney && consultation.status === 'pending' && (
@@ -280,10 +301,6 @@ export function ConsultationDetailPage() {
                 </p>
               </div>
             </div>
-
-            <p className="text-xs text-gray-400 text-center mb-4">
-              Тестовий режим — реальне списання не відбувається
-            </p>
 
             <div className="flex gap-3">
               <button

--- a/lexwebapp/src/pages/DocumentsPage/DocumentGrid.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentGrid.tsx
@@ -7,6 +7,7 @@ import {
   Trash2,
   FolderInput,
   AlertTriangle,
+  Lock,
 } from 'lucide-react';
 import type { VaultDocument, SortField, SortOrder } from './types';
 import { isEditable, getFileExtension } from './types';
@@ -213,6 +214,12 @@ export function DocumentGrid({
                   >
                     {DOC_TYPE_LABELS[doc.type] || doc.type}
                   </span>
+                  {doc.is_encrypted && (
+                    <span className="inline-flex items-center px-1.5 py-0.5 text-[9px] font-semibold rounded-md border border-green-300 bg-green-50 text-green-700 font-sans backdrop-blur-sm" title="Зашифровано (E2EE)">
+                      <Lock size={9} className="mr-0.5" />
+                      E2EE
+                    </span>
+                  )}
                 </div>
                 {/* Context menu overlay */}
                 <div className="absolute top-1.5 left-1.5">

--- a/lexwebapp/src/pages/DocumentsPage/DocumentTable.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/DocumentTable.tsx
@@ -8,6 +8,7 @@ import {
   Pencil,
   Trash2,
   FolderInput,
+  Lock,
   AlertTriangle,
 } from 'lucide-react';
 import type { VaultDocument, SortField, SortOrder } from './types';
@@ -276,6 +277,12 @@ export function DocumentTable({
                     >
                       {DOC_TYPE_LABELS[doc.type] || doc.type}
                     </span>
+                    {doc.is_encrypted && (
+                      <span className="inline-flex items-center ml-1 px-1.5 py-0.5 text-[9px] font-semibold rounded-md border border-green-300 bg-green-50 text-green-700 font-sans" title="Зашифровано (E2EE)">
+                        <Lock size={9} className="mr-0.5" />
+                        E2EE
+                      </span>
+                    )}
                   </td>
                   <td className="px-5 py-3 text-xs text-claude-subtext/60 font-sans whitespace-nowrap">
                     {doc.metadata?.documentDate

--- a/lexwebapp/src/pages/DocumentsPage/UploadZone.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/UploadZone.tsx
@@ -1,7 +1,9 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Upload, FolderUp } from 'lucide-react';
+import { Upload, FolderUp, Shield } from 'lucide-react';
 import type { DocType } from './types';
+import { useEncryptionStore } from '../../stores/encryptionStore';
+import { EncryptionSetupDialog } from '../../components/encryption/EncryptionSetupDialog';
 
 const ACCEPTED_TYPES =
   '.pdf,.docx,.doc,.html,.htm,.txt,.rtf,.jpg,.jpeg,.png,.bmp,.gif,.xlsx,.xls,.csv,.mp4,.mov,.avi,.mkv,.webm,.eml,.zip,.gz,.tgz,.tar';
@@ -176,8 +178,39 @@ export function UploadZone({
     }
   };
 
+  const { hasEncryption, isUnlocked, encryptNewUploads, setEncryptNewUploads } = useEncryptionStore();
+  const [showEncryptionDialog, setShowEncryptionDialog] = useState(false);
+
+  const handleEncryptionToggle = () => {
+    if (!hasEncryption) {
+      // First time: show setup dialog
+      setShowEncryptionDialog(true);
+      return;
+    }
+    if (!isUnlocked) {
+      // Keys exist but locked: show unlock dialog
+      setShowEncryptionDialog(true);
+      return;
+    }
+    // Toggle encryption for new uploads
+    setEncryptNewUploads(!encryptNewUploads);
+  };
+
   return (
     <>
+      <EncryptionSetupDialog
+        isOpen={showEncryptionDialog}
+        onClose={() => {
+          setShowEncryptionDialog(false);
+          // If unlock/setup succeeded, enable encryption
+          const state = useEncryptionStore.getState();
+          if (state.isUnlocked) {
+            setEncryptNewUploads(true);
+          }
+        }}
+        mode={hasEncryption ? 'unlock' : 'setup'}
+      />
+
       {/* Hidden file inputs */}
       <input
         ref={fileInputRef}
@@ -220,6 +253,22 @@ export function UploadZone({
               >
                 <FolderUp size={14} strokeWidth={2} />
                 Папку
+              </button>
+              <button
+                onClick={handleEncryptionToggle}
+                className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium transition-all active:scale-[0.98] font-sans ${
+                  encryptNewUploads && isUnlocked
+                    ? 'bg-green-50 border border-green-300 text-green-700 hover:bg-green-100'
+                    : 'bg-white border border-claude-border text-claude-subtext hover:bg-claude-bg'
+                }`}
+                title={
+                  encryptNewUploads && isUnlocked
+                    ? 'Шифрування увімкнено'
+                    : 'Увімкнути шифрування'
+                }
+              >
+                <Shield size={14} strokeWidth={2} />
+                {encryptNewUploads && isUnlocked ? 'E2EE' : 'E2EE'}
               </button>
               <span className="text-xs text-claude-subtext/40 font-sans ml-1 hidden sm:inline">
                 або перетягніть файли · Ctrl+U

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -23,6 +23,7 @@ import { useDocumentActions } from './useDocumentActions';
 import { useDocumentPreview } from './useDocumentPreview';
 import { useMultiSelect } from './useMultiSelect';
 import { useEditNavigation } from './useEditNavigation';
+import { RetroactiveEncryptionPanel } from '../../components/encryption/RetroactiveEncryptionPanel';
 
 const VIEW_MODE_KEY = 'documents-view-mode';
 
@@ -295,6 +296,10 @@ export function DocumentsPage() {
             stats={docStats}
             onComplete={() => { loadDocuments(); loadStats(); }}
           />
+
+          <div className="mb-4">
+            <RetroactiveEncryptionPanel />
+          </div>
 
           <DocumentSearchBar
             searchQuery={searchQuery}

--- a/lexwebapp/src/pages/DocumentsPage/types.ts
+++ b/lexwebapp/src/pages/DocumentsPage/types.ts
@@ -4,6 +4,7 @@ export interface VaultDocument {
   type: 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';
   storage_type?: 'vault' | 'minio';
   mime_type?: string;
+  is_encrypted?: boolean;
   text_preview?: string;
   metadata: {
     uploadedAt: string;

--- a/lexwebapp/src/pages/DocumentsPage/useDocumentPreview.ts
+++ b/lexwebapp/src/pages/DocumentsPage/useDocumentPreview.ts
@@ -11,6 +11,9 @@ import { processEmlContent } from '../../utils/eml-parser';
 import type { VaultDocument, DocType, SortField, SortOrder } from './types';
 import { isPreviewableBinary } from './types';
 import { DOC_TYPE_LABELS } from './constants';
+import { useEncryptionStore } from '../../stores/encryptionStore';
+import { encryptionService } from '../../services/api/EncryptionService';
+import { decryptContent, unwrapDEK } from '../../services/crypto';
 
 export interface PreviewDocData {
   type: 'document';
@@ -57,6 +60,25 @@ export function useDocumentPreview(options: UseDocumentPreviewOptions) {
   const [previewIndex, setPreviewIndex] = useState<number>(-1);
   const [previewDeletePending, setPreviewDeletePending] = useState(false);
 
+  /**
+   * Decrypt document content if it's encrypted.
+   * Fetches wrapped DEK from server, unwraps with private key, decrypts content.
+   */
+  const decryptDocumentContent = useCallback(async (
+    documentId: string,
+    encryptedContent: string
+  ): Promise<string> => {
+    const { privateKey, isUnlocked } = useEncryptionStore.getState();
+    if (!isUnlocked || !privateKey) {
+      throw new Error('Сейф заблоковано. Розблокуйте шифрування для перегляду.');
+    }
+
+    // Fetch wrapped DEK for this document
+    const keyData = await encryptionService.getDocumentKey(documentId);
+    const dek = await unwrapDEK(keyData.encrypted_dek, privateKey);
+    return decryptContent(encryptedContent, dek);
+  }, []);
+
   const handleDocumentClick = useCallback(async (doc: VaultDocument, index?: number) => {
     if (index != null) setPreviewIndex(index);
     else setPreviewIndex(documents.findIndex((d) => d.id === doc.id));
@@ -74,9 +96,18 @@ export function useDocumentPreview(options: UseDocumentPreviewOptions) {
 
         const { previewUrl, mimeType: serverMime } = previewResp.data;
         const badge = DOC_TYPE_LABELS[doc.type] || doc.type;
-        const ocrText = docResp?.data?.full_text ?? undefined;
+        let ocrText = docResp?.data?.full_text ?? undefined;
         const effectiveMime = serverMime || mimeType;
         const isImagePreview = effectiveMime?.startsWith('image/');
+
+        // Decrypt OCR text if the document is encrypted
+        if (doc.is_encrypted && ocrText) {
+          try {
+            ocrText = await decryptDocumentContent(doc.id, ocrText);
+          } catch {
+            ocrText = undefined; // Can't decrypt — show binary preview only
+          }
+        }
 
         if (previewUrl) {
           setPreviewDoc({
@@ -133,7 +164,18 @@ export function useDocumentPreview(options: UseDocumentPreviewOptions) {
         ? JSON.parse(result.result.content[0].text)
         : result?.result || result;
 
-      const rawContent = parsed.content || parsed.text || parsed.sections?.map((s: any) => s.content).join('\n\n') || 'Вміст недоступний';
+      let rawContent = parsed.content || parsed.text || parsed.sections?.map((s: any) => s.content).join('\n\n') || 'Вміст недоступний';
+
+      // Decrypt if document is encrypted
+      const isEncrypted = doc.is_encrypted || parsed.is_encrypted;
+      if (isEncrypted && rawContent && rawContent !== 'Вміст недоступний') {
+        try {
+          rawContent = await decryptDocumentContent(doc.id, rawContent);
+        } catch (decryptErr: any) {
+          rawContent = `🔒 ${decryptErr.message || 'Не вдалося розшифрувати документ. Розблокуйте сейф.'}`;
+        }
+      }
+
       const content = processEmlContent(rawContent);
       const badge = DOC_TYPE_LABELS[doc.type] || doc.type;
 

--- a/lexwebapp/src/services/api/EncryptionService.ts
+++ b/lexwebapp/src/services/api/EncryptionService.ts
@@ -1,0 +1,220 @@
+/**
+ * Encryption Service
+ * API client for E2EE key management endpoints.
+ */
+
+import { BaseService } from '../base/BaseService';
+
+export interface EncryptionKeySetupResponse {
+  id: string;
+  public_key: string;
+  kdf_algorithm: string;
+  kdf_params: Record<string, unknown>;
+  key_version: number;
+}
+
+export interface EncryptionStatusResponse {
+  has_encryption: boolean;
+}
+
+export interface PublicKeyResponse {
+  public_key: string;
+}
+
+export interface MyKeyResponse {
+  encrypted_private_key: string;
+  kdf_algorithm: string;
+  kdf_params: Record<string, unknown>;
+  key_version: number;
+}
+
+export interface DocumentKeyResponse {
+  id: string;
+  document_id: string;
+  user_id: string;
+  encrypted_dek: string;
+  granted_by: string | null;
+  granted_at: string;
+  revoked_at: string | null;
+}
+
+export interface DocumentSharesResponse {
+  shares: DocumentKeyResponse[];
+}
+
+export interface DiiaRecoveryResponse {
+  diia_encrypted_master_secret: string;
+  diia_recovery_challenge: string;
+  diia_recovery_salt: string;
+}
+
+export class EncryptionService extends BaseService {
+  /**
+   * Initialize encryption keys for the current user
+   */
+  async setupKeys(data: {
+    public_key: string;
+    encrypted_private_key: string;
+    kdf_algorithm: string;
+    kdf_params: Record<string, unknown>;
+  }): Promise<EncryptionKeySetupResponse> {
+    return this.request(
+      () => this.client.post<EncryptionKeySetupResponse>('/encryption/setup', data)
+    );
+  }
+
+  /**
+   * Check if the current user has encryption set up
+   */
+  async getStatus(): Promise<EncryptionStatusResponse> {
+    return this.request(
+      () => this.client.get<EncryptionStatusResponse>('/encryption/status')
+    );
+  }
+
+  /**
+   * Get any user's public key (for sharing)
+   */
+  async getPublicKey(userId: string): Promise<PublicKeyResponse> {
+    return this.request(
+      () => this.client.get<PublicKeyResponse>(`/encryption/public-key/${userId}`)
+    );
+  }
+
+  /**
+   * Get the current user's encrypted private key + KDF params
+   */
+  async getMyKey(): Promise<MyKeyResponse> {
+    return this.request(
+      () => this.client.get<MyKeyResponse>('/encryption/my-key')
+    );
+  }
+
+  /**
+   * Store a wrapped DEK for a document
+   */
+  async saveDocumentKey(documentId: string, encryptedDek: string): Promise<DocumentKeyResponse> {
+    return this.request(
+      () => this.client.post<DocumentKeyResponse>('/encryption/document-keys', {
+        document_id: documentId,
+        encrypted_dek: encryptedDek,
+      })
+    );
+  }
+
+  /**
+   * Get the wrapped DEK for a document
+   */
+  async getDocumentKey(documentId: string): Promise<DocumentKeyResponse> {
+    return this.request(
+      () => this.client.get<DocumentKeyResponse>(`/encryption/document-keys/${documentId}`)
+    );
+  }
+
+  /**
+   * Share a document with another user
+   */
+  async shareDocument(
+    documentId: string,
+    targetUserId: string,
+    encryptedDek: string
+  ): Promise<DocumentKeyResponse> {
+    return this.request(
+      () => this.client.post<DocumentKeyResponse>('/encryption/share', {
+        document_id: documentId,
+        target_user_id: targetUserId,
+        encrypted_dek: encryptedDek,
+      })
+    );
+  }
+
+  /**
+   * Revoke a user's access to a document
+   */
+  async revokeAccess(documentId: string, userId: string): Promise<void> {
+    return this.requestVoid(
+      () => this.client.delete(`/encryption/share/${documentId}/${userId}`)
+    );
+  }
+
+  /**
+   * List all users who have access to a document
+   */
+  async getDocumentShares(documentId: string): Promise<DocumentSharesResponse> {
+    return this.request(
+      () => this.client.get<DocumentSharesResponse>(
+        `/encryption/document-keys/${documentId}/shares`
+      )
+    );
+  }
+
+  /**
+   * Store Diia recovery data
+   */
+  async initDiiaRecovery(data: {
+    encrypted_master_secret: string;
+    recovery_challenge: string;
+    recovery_salt: string;
+  }): Promise<void> {
+    return this.requestVoid(
+      () => this.client.post('/encryption/diia/init-recovery', data)
+    );
+  }
+
+  /**
+   * Get Diia recovery data
+   */
+  async getDiiaRecoveryData(): Promise<DiiaRecoveryResponse> {
+    return this.request(
+      () => this.client.get<DiiaRecoveryResponse>('/encryption/diia/recovery-data')
+    );
+  }
+
+  /**
+   * Encrypt a document's content after server-side processing (hybrid flow).
+   * Replaces plaintext in DB with ciphertext and stores wrapped DEK.
+   */
+  async encryptDocument(
+    documentId: string,
+    encryptedContent: string,
+    encryptedDek: string
+  ): Promise<{ success: boolean; document_id: string }> {
+    return this.request(
+      () => this.client.post<{ success: boolean; document_id: string }>(
+        '/encryption/encrypt-document',
+        {
+          document_id: documentId,
+          encrypted_content: encryptedContent,
+          encrypted_dek: encryptedDek,
+        }
+      )
+    );
+  }
+
+  /**
+   * Get vault encryption stats (total, encrypted, unencrypted count)
+   */
+  async getVaultStats(): Promise<{ total: number; encrypted: number; unencrypted: number }> {
+    return this.request(
+      () => this.client.get<{ total: number; encrypted: number; unencrypted: number }>(
+        '/encryption/vault-stats'
+      )
+    );
+  }
+
+  /**
+   * List unencrypted document IDs for batch encryption
+   */
+  async getUnencryptedDocuments(
+    limit = 50,
+    offset = 0
+  ): Promise<{ documents: Array<{ id: string; title: string }> }> {
+    return this.request(
+      () => this.client.get<{ documents: Array<{ id: string; title: string }> }>(
+        `/encryption/unencrypted-documents?limit=${limit}&offset=${offset}`
+      )
+    );
+  }
+}
+
+export const encryptionService = new EncryptionService();

--- a/lexwebapp/src/services/crypto/CryptoKeyManager.ts
+++ b/lexwebapp/src/services/crypto/CryptoKeyManager.ts
@@ -1,0 +1,246 @@
+/**
+ * CryptoKeyManager
+ * Manages user key pair generation, master secret derivation (Argon2id/PBKDF2),
+ * and private key encryption/decryption. All operations use Web Crypto API.
+ *
+ * Key hierarchy:
+ *   Master Secret (from password via Argon2id) → encrypts X25519 private key
+ *   X25519 key pair → used for ECDH key wrapping of per-document DEKs
+ */
+
+// We use tweetnacl for X25519 since Web Crypto doesn't support it natively
+import nacl from 'tweetnacl';
+import { encodeBase64, decodeBase64 } from './utils';
+
+export interface KeyPair {
+  publicKey: Uint8Array;
+  privateKey: Uint8Array;
+}
+
+export interface EncryptedKeyBundle {
+  publicKey: string;           // base64
+  encryptedPrivateKey: string; // base64 (IV + ciphertext + tag)
+  kdfAlgorithm: string;
+  kdfParams: KdfParams;
+}
+
+export interface KdfParams {
+  salt: string;     // base64
+  memory?: number;  // Argon2id memory in KiB
+  iterations?: number;
+  parallelism?: number;
+}
+
+/**
+ * Generate a new X25519 key pair.
+ */
+export function generateKeyPair(): KeyPair {
+  const keyPair = nacl.box.keyPair();
+  return {
+    publicKey: keyPair.publicKey,
+    privateKey: keyPair.secretKey,
+  };
+}
+
+/**
+ * Derive a 256-bit key from a password using PBKDF2 (Web Crypto native).
+ * Used as fallback when Argon2id WASM is unavailable.
+ */
+export async function deriveKeyPBKDF2(
+  password: string,
+  salt: Uint8Array,
+  iterations: number = 600_000
+): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(password),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations,
+      hash: 'SHA-256',
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * Derive a 256-bit key from a password using Argon2id (via WASM).
+ * Falls back to PBKDF2 if argon2-browser is not available.
+ */
+export async function deriveKeyFromPassword(
+  password: string,
+  salt?: Uint8Array
+): Promise<{ key: CryptoKey; salt: Uint8Array; algorithm: string; params: KdfParams }> {
+  const actualSalt = salt || crypto.getRandomValues(new Uint8Array(16));
+
+  try {
+    // Try Argon2id via WASM (use variable to prevent Vite static analysis)
+    const argon2Module = 'argon2-browser';
+    const argon2 = await import(/* @vite-ignore */ argon2Module);
+    const result = await argon2.hash({
+      pass: password,
+      salt: actualSalt,
+      type: argon2.ArgonType.Argon2id,
+      mem: 65536,   // 64 MB
+      time: 3,
+      parallelism: 4,
+      hashLen: 32,
+    });
+
+    const key = await crypto.subtle.importKey(
+      'raw',
+      result.hash,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+
+    return {
+      key,
+      salt: actualSalt,
+      algorithm: 'argon2id',
+      params: {
+        salt: encodeBase64(actualSalt),
+        memory: 65536,
+        iterations: 3,
+        parallelism: 4,
+      },
+    };
+  } catch {
+    // Fallback to PBKDF2
+    const key = await deriveKeyPBKDF2(password, actualSalt);
+    return {
+      key,
+      salt: actualSalt,
+      algorithm: 'pbkdf2',
+      params: {
+        salt: encodeBase64(actualSalt),
+        iterations: 600_000,
+      },
+    };
+  }
+}
+
+/**
+ * Encrypt a private key with the derived master key (AES-256-GCM).
+ * Returns base64-encoded IV (12 bytes) + ciphertext + auth tag.
+ */
+export async function encryptPrivateKey(
+  privateKey: Uint8Array,
+  masterKey: CryptoKey
+): Promise<string> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    masterKey,
+    privateKey
+  );
+
+  // Concatenate IV + ciphertext (includes auth tag)
+  const result = new Uint8Array(iv.length + ciphertext.byteLength);
+  result.set(iv);
+  result.set(new Uint8Array(ciphertext), iv.length);
+
+  return encodeBase64(result);
+}
+
+/**
+ * Decrypt a private key with the derived master key.
+ */
+export async function decryptPrivateKey(
+  encryptedPrivateKey: string,
+  masterKey: CryptoKey
+): Promise<Uint8Array> {
+  const data = decodeBase64(encryptedPrivateKey);
+  const iv = data.slice(0, 12);
+  const ciphertext = data.slice(12);
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    masterKey,
+    ciphertext
+  );
+
+  return new Uint8Array(plaintext);
+}
+
+/**
+ * Full setup flow: generate keys, derive master from password, encrypt private key.
+ */
+export async function setupEncryption(password: string): Promise<EncryptedKeyBundle> {
+  const keyPair = generateKeyPair();
+  const { key: masterKey, algorithm, params } = await deriveKeyFromPassword(password);
+  const encryptedPrivateKey = await encryptPrivateKey(keyPair.privateKey, masterKey);
+
+  return {
+    publicKey: encodeBase64(keyPair.publicKey),
+    encryptedPrivateKey,
+    kdfAlgorithm: algorithm,
+    kdfParams: params,
+  };
+}
+
+/**
+ * Unlock the private key by deriving master from password.
+ */
+export async function unlockPrivateKey(
+  password: string,
+  encryptedPrivateKey: string,
+  kdfParams: KdfParams,
+  kdfAlgorithm: string
+): Promise<Uint8Array> {
+  const salt = decodeBase64(kdfParams.salt);
+
+  let masterKey: CryptoKey;
+  if (kdfAlgorithm === 'argon2id') {
+    const result = await deriveKeyFromPassword(password, salt);
+    masterKey = result.key;
+  } else {
+    masterKey = await deriveKeyPBKDF2(password, salt, kdfParams.iterations);
+  }
+
+  return decryptPrivateKey(encryptedPrivateKey, masterKey);
+}
+
+/**
+ * Export the master secret as a downloadable key file (for backup).
+ * The file contains the raw key pair encrypted with the password.
+ */
+export function exportKeyFile(bundle: EncryptedKeyBundle): Blob {
+  const json = JSON.stringify({
+    version: 1,
+    publicKey: bundle.publicKey,
+    encryptedPrivateKey: bundle.encryptedPrivateKey,
+    kdfAlgorithm: bundle.kdfAlgorithm,
+    kdfParams: bundle.kdfParams,
+  }, null, 2);
+
+  return new Blob([json], { type: 'application/json' });
+}
+
+/**
+ * Import a key file (for recovery).
+ */
+export function importKeyFile(content: string): EncryptedKeyBundle {
+  const parsed = JSON.parse(content);
+  if (parsed.version !== 1) {
+    throw new Error('Непідтримувана версія ключового файлу');
+  }
+  return {
+    publicKey: parsed.publicKey,
+    encryptedPrivateKey: parsed.encryptedPrivateKey,
+    kdfAlgorithm: parsed.kdfAlgorithm,
+    kdfParams: parsed.kdfParams,
+  };
+}

--- a/lexwebapp/src/services/crypto/DocumentEncryptor.ts
+++ b/lexwebapp/src/services/crypto/DocumentEncryptor.ts
@@ -1,0 +1,119 @@
+/**
+ * DocumentEncryptor
+ * Handles AES-256-GCM encryption/decryption of document content.
+ * Each document gets a unique DEK (Data Encryption Key).
+ */
+
+import { encodeBase64, decodeBase64, randomBytes } from './utils';
+
+/**
+ * Generate a random 256-bit DEK for a document.
+ */
+export function generateDEK(): Uint8Array {
+  return randomBytes(32);
+}
+
+/**
+ * Import a raw DEK into a Web Crypto CryptoKey.
+ */
+async function importDEK(dek: Uint8Array): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    dek,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * Encrypt document content with AES-256-GCM.
+ * Returns base64-encoded: IV (12 bytes) + ciphertext + auth tag (16 bytes).
+ */
+export async function encryptContent(
+  content: string,
+  dek: Uint8Array
+): Promise<string> {
+  const key = await importDEK(dek);
+  const iv = randomBytes(12);
+  const encoder = new TextEncoder();
+  const plaintext = encoder.encode(content);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    plaintext
+  );
+
+  const result = new Uint8Array(iv.length + ciphertext.byteLength);
+  result.set(iv);
+  result.set(new Uint8Array(ciphertext), iv.length);
+
+  return encodeBase64(result);
+}
+
+/**
+ * Decrypt document content with AES-256-GCM.
+ */
+export async function decryptContent(
+  encryptedContent: string,
+  dek: Uint8Array
+): Promise<string> {
+  const key = await importDEK(dek);
+  const data = decodeBase64(encryptedContent);
+  const iv = data.slice(0, 12);
+  const ciphertext = data.slice(12);
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    ciphertext
+  );
+
+  const decoder = new TextDecoder();
+  return decoder.decode(plaintext);
+}
+
+/**
+ * Encrypt a binary file (Uint8Array) with AES-256-GCM.
+ * Returns IV + ciphertext as Uint8Array.
+ */
+export async function encryptBinary(
+  data: Uint8Array,
+  dek: Uint8Array
+): Promise<Uint8Array> {
+  const key = await importDEK(dek);
+  const iv = randomBytes(12);
+
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    data
+  );
+
+  const result = new Uint8Array(iv.length + ciphertext.byteLength);
+  result.set(iv);
+  result.set(new Uint8Array(ciphertext), iv.length);
+
+  return result;
+}
+
+/**
+ * Decrypt a binary file (Uint8Array) with AES-256-GCM.
+ */
+export async function decryptBinary(
+  encryptedData: Uint8Array,
+  dek: Uint8Array
+): Promise<Uint8Array> {
+  const key = await importDEK(dek);
+  const iv = encryptedData.slice(0, 12);
+  const ciphertext = encryptedData.slice(12);
+
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    key,
+    ciphertext
+  );
+
+  return new Uint8Array(plaintext);
+}

--- a/lexwebapp/src/services/crypto/KeyExchange.ts
+++ b/lexwebapp/src/services/crypto/KeyExchange.ts
@@ -1,0 +1,127 @@
+/**
+ * KeyExchange
+ * ECDH-based DEK wrapping/unwrapping using X25519.
+ *
+ * Wrap flow (encrypt DEK for a recipient):
+ *   1. Generate ephemeral X25519 key pair
+ *   2. ECDH(ephemeral_private, recipient_public) → shared_secret
+ *   3. HKDF(shared_secret) → wrapping_key
+ *   4. AES-256-GCM(wrapping_key, DEK) → wrapped_dek
+ *   5. Output: ephemeral_public + IV + wrapped_dek
+ *
+ * Unwrap flow (decrypt DEK):
+ *   1. ECDH(recipient_private, ephemeral_public) → shared_secret
+ *   2. HKDF(shared_secret) → wrapping_key
+ *   3. AES-256-GCM-decrypt(wrapping_key, wrapped_dek) → DEK
+ */
+
+import nacl from 'tweetnacl';
+import { encodeBase64, decodeBase64, randomBytes } from './utils';
+
+const HKDF_INFO = new TextEncoder().encode('SecondLayer-E2EE-DEK-v1');
+
+/**
+ * Derive a wrapping key from shared secret via HKDF-SHA256.
+ */
+async function deriveWrappingKey(sharedSecret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw',
+    sharedSecret,
+    'HKDF',
+    false,
+    ['deriveKey']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'HKDF',
+      hash: 'SHA-256',
+      salt,
+      info: HKDF_INFO,
+    },
+    keyMaterial,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+/**
+ * Wrap a DEK for a recipient using their public key.
+ * Returns base64-encoded: ephemeral_public (32) + salt (16) + IV (12) + ciphertext.
+ */
+export async function wrapDEK(
+  dek: Uint8Array,
+  recipientPublicKey: Uint8Array
+): Promise<string> {
+  // Generate ephemeral key pair for this wrap operation
+  const ephemeral = nacl.box.keyPair();
+
+  // X25519 ECDH: ephemeral_private × recipient_public → shared_secret
+  const sharedSecret = nacl.scalarMult(ephemeral.secretKey, recipientPublicKey);
+
+  // Derive wrapping key via HKDF
+  const salt = randomBytes(16);
+  const wrappingKey = await deriveWrappingKey(sharedSecret, salt);
+
+  // Encrypt the DEK with AES-256-GCM
+  const iv = randomBytes(12);
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    wrappingKey,
+    dek
+  );
+
+  // Pack: ephemeral_public (32) + salt (16) + IV (12) + ciphertext
+  const result = new Uint8Array(32 + 16 + 12 + ciphertext.byteLength);
+  result.set(ephemeral.publicKey, 0);
+  result.set(salt, 32);
+  result.set(iv, 48);
+  result.set(new Uint8Array(ciphertext), 60);
+
+  return encodeBase64(result);
+}
+
+/**
+ * Unwrap a DEK using the recipient's private key.
+ */
+export async function unwrapDEK(
+  wrappedDEK: string,
+  recipientPrivateKey: Uint8Array
+): Promise<Uint8Array> {
+  const data = decodeBase64(wrappedDEK);
+
+  // Unpack
+  const ephemeralPublic = data.slice(0, 32);
+  const salt = data.slice(32, 48);
+  const iv = data.slice(48, 60);
+  const ciphertext = data.slice(60);
+
+  // X25519 ECDH: recipient_private × ephemeral_public → shared_secret
+  const sharedSecret = nacl.scalarMult(recipientPrivateKey, ephemeralPublic);
+
+  // Derive wrapping key via HKDF
+  const wrappingKey = await deriveWrappingKey(sharedSecret, salt);
+
+  // Decrypt the DEK
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv },
+    wrappingKey,
+    ciphertext
+  );
+
+  return new Uint8Array(plaintext);
+}
+
+/**
+ * Re-wrap a DEK for a new recipient.
+ * Unwraps with the current user's private key, then wraps with the new recipient's public key.
+ */
+export async function rewrapDEK(
+  wrappedDEK: string,
+  currentPrivateKey: Uint8Array,
+  newRecipientPublicKey: Uint8Array
+): Promise<string> {
+  const dek = await unwrapDEK(wrappedDEK, currentPrivateKey);
+  return wrapDEK(dek, newRecipientPublicKey);
+}

--- a/lexwebapp/src/services/crypto/PostUploadEncryptor.ts
+++ b/lexwebapp/src/services/crypto/PostUploadEncryptor.ts
@@ -1,0 +1,87 @@
+/**
+ * PostUploadEncryptor
+ * After a document is uploaded and server-side processed (parsed, embedded),
+ * this service encrypts the document content client-side and replaces the
+ * plaintext on the server with ciphertext (hybrid E2EE flow).
+ *
+ * Flow:
+ * 1. Fetch document content from server (get_document)
+ * 2. Generate a random DEK
+ * 3. Encrypt content with DEK (AES-256-GCM)
+ * 4. Wrap DEK with user's public key (ECDH-ES)
+ * 5. Send encrypted content + wrapped DEK to server
+ */
+
+import { mcpService } from '../api/MCPService';
+import { encryptionService } from '../api/EncryptionService';
+import { generateDEK, encryptContent } from './DocumentEncryptor';
+import { wrapDEK } from './KeyExchange';
+import { decodeBase64 } from './utils';
+
+export interface EncryptDocumentResult {
+  documentId: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Encrypt a single document after upload processing.
+ * @param documentId - The document ID returned after upload completion
+ * @param userPublicKey - User's X25519 public key (base64)
+ */
+export async function encryptUploadedDocument(
+  documentId: string,
+  userPublicKey: string,
+): Promise<EncryptDocumentResult> {
+  try {
+    // Step 1: Fetch the parsed content from server
+    const result = await mcpService.callTool('get_document', {
+      documentId,
+      includeSections: false,
+      includePatterns: false,
+    });
+
+    const parsed = result?.result?.content?.[0]?.text
+      ? JSON.parse(result.result.content[0].text)
+      : result?.result || result;
+
+    const content = parsed.content || parsed.text || '';
+    if (!content) {
+      return { documentId, success: false, error: 'No content to encrypt' };
+    }
+
+    // Step 2: Generate DEK and encrypt content
+    const dek = generateDEK();
+    const encryptedContent = await encryptContent(content, dek);
+
+    // Step 3: Wrap DEK with user's public key
+    const publicKeyBytes = decodeBase64(userPublicKey);
+    const wrappedDEK = await wrapDEK(dek, publicKeyBytes);
+
+    // Step 4: Send encrypted content + wrapped DEK to server
+    await encryptionService.encryptDocument(documentId, encryptedContent, wrappedDEK);
+
+    return { documentId, success: true };
+  } catch (error: any) {
+    console.error(`[PostUploadEncryptor] Failed to encrypt document ${documentId}:`, error);
+    return { documentId, success: false, error: error.message };
+  }
+}
+
+/**
+ * Encrypt multiple documents after batch upload.
+ */
+export async function encryptUploadedDocuments(
+  documentIds: string[],
+  userPublicKey: string,
+): Promise<EncryptDocumentResult[]> {
+  const results: EncryptDocumentResult[] = [];
+
+  // Process sequentially to avoid overwhelming the server
+  for (const documentId of documentIds) {
+    const result = await encryptUploadedDocument(documentId, userPublicKey);
+    results.push(result);
+  }
+
+  return results;
+}

--- a/lexwebapp/src/services/crypto/__tests__/crypto.test.ts
+++ b/lexwebapp/src/services/crypto/__tests__/crypto.test.ts
@@ -1,0 +1,241 @@
+/**
+ * E2EE Crypto Module Tests
+ *
+ * Tests cover:
+ * - encodeBase64 / decodeBase64 roundtrip
+ * - AES-256-GCM encrypt/decrypt content roundtrip
+ * - AES-256-GCM encrypt/decrypt binary roundtrip
+ * - DEK generation
+ * - ECDH key exchange: wrap/unwrap DEK roundtrip
+ * - rewrapDEK for sharing
+ * - Key derivation + private key encrypt/decrypt roundtrip
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  encodeBase64,
+  decodeBase64,
+  randomBytes,
+  timingSafeEqual,
+} from '../utils';
+import {
+  generateDEK,
+  encryptContent,
+  decryptContent,
+  encryptBinary,
+  decryptBinary,
+} from '../DocumentEncryptor';
+import {
+  wrapDEK,
+  unwrapDEK,
+  rewrapDEK,
+} from '../KeyExchange';
+import {
+  generateKeyPair,
+  encryptPrivateKey,
+  decryptPrivateKey,
+  exportKeyFile,
+  importKeyFile,
+} from '../CryptoKeyManager';
+
+describe('utils', () => {
+  it('encodeBase64/decodeBase64 roundtrip', () => {
+    const data = randomBytes(32);
+    const encoded = encodeBase64(data);
+    const decoded = decodeBase64(encoded);
+    expect(timingSafeEqual(data, decoded)).toBe(true);
+  });
+
+  it('randomBytes returns correct length', () => {
+    expect(randomBytes(16).length).toBe(16);
+    expect(randomBytes(32).length).toBe(32);
+  });
+
+  it('timingSafeEqual returns false for different arrays', () => {
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([1, 2, 4]);
+    expect(timingSafeEqual(a, b)).toBe(false);
+  });
+
+  it('timingSafeEqual returns false for different lengths', () => {
+    const a = new Uint8Array([1, 2, 3]);
+    const b = new Uint8Array([1, 2]);
+    expect(timingSafeEqual(a, b)).toBe(false);
+  });
+});
+
+describe('DocumentEncryptor', () => {
+  it('encrypt/decrypt content roundtrip', async () => {
+    const dek = generateDEK();
+    const plaintext = 'Конституція України. Стаття 1. Україна є суверенна і незалежна держава.';
+
+    const encrypted = await encryptContent(plaintext, dek);
+    expect(encrypted).not.toBe(plaintext);
+
+    const decrypted = await decryptContent(encrypted, dek);
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it('different DEKs produce different ciphertext', async () => {
+    const dek1 = generateDEK();
+    const dek2 = generateDEK();
+    const plaintext = 'Test content';
+
+    const enc1 = await encryptContent(plaintext, dek1);
+    const enc2 = await encryptContent(plaintext, dek2);
+    expect(enc1).not.toBe(enc2);
+  });
+
+  it('decrypt with wrong DEK fails', async () => {
+    const dek1 = generateDEK();
+    const dek2 = generateDEK();
+    const encrypted = await encryptContent('secret', dek1);
+
+    await expect(decryptContent(encrypted, dek2)).rejects.toThrow();
+  });
+
+  it('encrypt/decrypt binary roundtrip', async () => {
+    const dek = generateDEK();
+    const data = randomBytes(1024);
+
+    const encrypted = await encryptBinary(data, dek);
+    expect(encrypted.length).toBeGreaterThan(data.length);
+
+    const decrypted = await decryptBinary(encrypted, dek);
+    expect(timingSafeEqual(data, decrypted)).toBe(true);
+  });
+
+  it('generateDEK returns 32 bytes', () => {
+    const dek = generateDEK();
+    expect(dek.length).toBe(32);
+  });
+});
+
+describe('KeyExchange', () => {
+  it('wrap/unwrap DEK roundtrip', async () => {
+    const keyPair = generateKeyPair();
+    const dek = generateDEK();
+
+    const wrapped = await wrapDEK(dek, keyPair.publicKey);
+    expect(wrapped).toBeTruthy();
+    expect(typeof wrapped).toBe('string');
+
+    const unwrapped = await unwrapDEK(wrapped, keyPair.privateKey);
+    expect(timingSafeEqual(dek, unwrapped)).toBe(true);
+  });
+
+  it('unwrap with wrong private key fails', async () => {
+    const keyPair1 = generateKeyPair();
+    const keyPair2 = generateKeyPair();
+    const dek = generateDEK();
+
+    const wrapped = await wrapDEK(dek, keyPair1.publicKey);
+    await expect(unwrapDEK(wrapped, keyPair2.privateKey)).rejects.toThrow();
+  });
+
+  it('rewrapDEK: share document between users', async () => {
+    const owner = generateKeyPair();
+    const lawyer = generateKeyPair();
+    const dek = generateDEK();
+
+    // Owner wraps DEK
+    const ownerWrapped = await wrapDEK(dek, owner.publicKey);
+
+    // Owner rewraps for lawyer
+    const lawyerWrapped = await rewrapDEK(ownerWrapped, owner.privateKey, lawyer.publicKey);
+
+    // Lawyer unwraps
+    const unwrapped = await unwrapDEK(lawyerWrapped, lawyer.privateKey);
+    expect(timingSafeEqual(dek, unwrapped)).toBe(true);
+  });
+});
+
+describe('CryptoKeyManager', () => {
+  it('generateKeyPair returns valid key pair', () => {
+    const kp = generateKeyPair();
+    expect(kp.publicKey.length).toBe(32);
+    expect(kp.privateKey.length).toBe(32);
+  });
+
+  it('encrypt/decrypt private key roundtrip', async () => {
+    const kp = generateKeyPair();
+
+    // Derive a master key (use PBKDF2 directly for test speed)
+    const salt = randomBytes(16);
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode('test-password'),
+      'PBKDF2',
+      false,
+      ['deriveKey']
+    );
+    const masterKey = await crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: 1000, hash: 'SHA-256' },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt']
+    );
+
+    const encrypted = await encryptPrivateKey(kp.privateKey, masterKey);
+    expect(typeof encrypted).toBe('string');
+
+    const decrypted = await decryptPrivateKey(encrypted, masterKey);
+    expect(timingSafeEqual(kp.privateKey, decrypted)).toBe(true);
+  });
+
+  it('exportKeyFile / importKeyFile roundtrip', () => {
+    const bundle = {
+      publicKey: 'test-pk',
+      encryptedPrivateKey: 'test-epk',
+      kdfAlgorithm: 'pbkdf2',
+      kdfParams: { salt: 'test-salt', iterations: 1000 },
+    };
+
+    const blob = exportKeyFile(bundle);
+    expect(blob.type).toBe('application/json');
+
+    // Simulate reading the blob content
+    const content = JSON.stringify({
+      version: 1,
+      publicKey: bundle.publicKey,
+      encryptedPrivateKey: bundle.encryptedPrivateKey,
+      kdfAlgorithm: bundle.kdfAlgorithm,
+      kdfParams: bundle.kdfParams,
+    });
+
+    const imported = importKeyFile(content);
+    expect(imported.publicKey).toBe(bundle.publicKey);
+    expect(imported.encryptedPrivateKey).toBe(bundle.encryptedPrivateKey);
+    expect(imported.kdfAlgorithm).toBe(bundle.kdfAlgorithm);
+  });
+});
+
+describe('Full E2EE flow', () => {
+  it('encrypt document → share → recipient decrypts', async () => {
+    // Setup: owner and lawyer generate key pairs
+    const owner = generateKeyPair();
+    const lawyer = generateKeyPair();
+
+    // Step 1: Owner encrypts document
+    const dek = generateDEK();
+    const plaintext = 'Договір про надання правової допомоги №123';
+    const encrypted = await encryptContent(plaintext, dek);
+
+    // Step 2: Owner wraps DEK with own public key (stored on server)
+    const ownerWrappedDEK = await wrapDEK(dek, owner.publicKey);
+
+    // Step 3: Owner shares with lawyer (rewrap)
+    const lawyerWrappedDEK = await rewrapDEK(
+      ownerWrappedDEK,
+      owner.privateKey,
+      lawyer.publicKey
+    );
+
+    // Step 4: Lawyer unwraps DEK and decrypts document
+    const lawyerDEK = await unwrapDEK(lawyerWrappedDEK, lawyer.privateKey);
+    const decrypted = await decryptContent(encrypted, lawyerDEK);
+
+    expect(decrypted).toBe(plaintext);
+  });
+});

--- a/lexwebapp/src/services/crypto/__tests__/e2ee-integration.test.ts
+++ b/lexwebapp/src/services/crypto/__tests__/e2ee-integration.test.ts
@@ -1,0 +1,279 @@
+/**
+ * E2EE Integration Tests
+ *
+ * Tests the complete end-to-end encryption lifecycle:
+ * 1. Setup encryption keys for client and lawyer
+ * 2. Encrypt a document
+ * 3. Share encrypted document with lawyer
+ * 4. Lawyer decrypts the document
+ * 5. Revoke access
+ * 6. Verify revoked lawyer cannot decrypt
+ * 7. Verify plaintext is not visible in "stored" data
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateKeyPair,
+  generateDEK,
+  encryptContent,
+  decryptContent,
+  wrapDEK,
+  unwrapDEK,
+  rewrapDEK,
+  encryptPrivateKey,
+  decryptPrivateKey,
+  encodeBase64,
+  decodeBase64,
+  timingSafeEqual,
+} from '../index';
+
+describe('E2EE Integration: Full Lifecycle', () => {
+  // Simulated server storage
+  let serverDB: {
+    userKeys: Map<string, { publicKey: string; encryptedPrivateKey: string }>;
+    documentKeys: Map<string, Map<string, { encryptedDek: string; revoked: boolean }>>;
+    documents: Map<string, { content: string; isEncrypted: boolean }>;
+  };
+
+  beforeEach(() => {
+    serverDB = {
+      userKeys: new Map(),
+      documentKeys: new Map(),
+      documents: new Map(),
+    };
+  });
+
+  /**
+   * Simulate server: store user keys
+   */
+  function serverSetupKeys(userId: string, publicKey: string, encryptedPrivateKey: string) {
+    serverDB.userKeys.set(userId, { publicKey, encryptedPrivateKey });
+  }
+
+  /**
+   * Simulate server: store document
+   */
+  function serverStoreDocument(docId: string, content: string, isEncrypted: boolean) {
+    serverDB.documents.set(docId, { content, isEncrypted });
+  }
+
+  /**
+   * Simulate server: save wrapped DEK
+   */
+  function serverSaveDocumentKey(docId: string, userId: string, encryptedDek: string) {
+    if (!serverDB.documentKeys.has(docId)) {
+      serverDB.documentKeys.set(docId, new Map());
+    }
+    serverDB.documentKeys.get(docId)!.set(userId, { encryptedDek, revoked: false });
+  }
+
+  /**
+   * Simulate server: revoke DEK access
+   */
+  function serverRevokeAccess(docId: string, userId: string) {
+    const docKeys = serverDB.documentKeys.get(docId);
+    if (docKeys?.has(userId)) {
+      docKeys.get(userId)!.revoked = true;
+    }
+  }
+
+  /**
+   * Simulate server: get wrapped DEK (respects revocation)
+   */
+  function serverGetDocumentKey(docId: string, userId: string): string | null {
+    const docKeys = serverDB.documentKeys.get(docId);
+    const entry = docKeys?.get(userId);
+    if (!entry || entry.revoked) return null;
+    return entry.encryptedDek;
+  }
+
+  it('complete lifecycle: setup → encrypt → share → decrypt → revoke', async () => {
+    // ========== PHASE 1: Setup keys for both users ==========
+    const clientKP = generateKeyPair();
+    const lawyerKP = generateKeyPair();
+
+    // Simulate password-based encryption of private keys
+    const password = 'test-password-123';
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const keyMaterial = await crypto.subtle.importKey(
+      'raw', new TextEncoder().encode(password), 'PBKDF2', false, ['deriveKey']
+    );
+    const masterKey = await crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: 1000, hash: 'SHA-256' },
+      keyMaterial,
+      { name: 'AES-GCM', length: 256 },
+      false, ['encrypt', 'decrypt']
+    );
+
+    const clientEncPK = await encryptPrivateKey(clientKP.privateKey, masterKey);
+    const lawyerEncPK = await encryptPrivateKey(lawyerKP.privateKey, masterKey);
+
+    // Store on "server"
+    serverSetupKeys('client-1', encodeBase64(clientKP.publicKey), clientEncPK);
+    serverSetupKeys('lawyer-1', encodeBase64(lawyerKP.publicKey), lawyerEncPK);
+
+    // Verify keys are stored
+    expect(serverDB.userKeys.has('client-1')).toBe(true);
+    expect(serverDB.userKeys.has('lawyer-1')).toBe(true);
+
+    // ========== PHASE 2: Client encrypts a document ==========
+    const originalContent = 'ДОГОВІР №123\n\nМіж ТОВ "Тест" та фізичною особою Іванов І.І.\nПредмет: надання юридичних послуг.\n\nКонфіденційна інформація.';
+    const docId = 'doc-uuid-1';
+
+    // Generate DEK and encrypt content
+    const dek = generateDEK();
+    const encryptedContent = await encryptContent(originalContent, dek);
+
+    // Verify encrypted content is NOT the plaintext
+    expect(encryptedContent).not.toBe(originalContent);
+    expect(encryptedContent).not.toContain('ДОГОВІР');
+    expect(encryptedContent).not.toContain('Конфіденційна');
+
+    // Wrap DEK with client's public key
+    const clientWrappedDEK = await wrapDEK(dek, clientKP.publicKey);
+
+    // Store encrypted document and key on "server"
+    serverStoreDocument(docId, encryptedContent, true);
+    serverSaveDocumentKey(docId, 'client-1', clientWrappedDEK);
+
+    // ========== PHASE 3: Verify server doesn't have plaintext ==========
+    const storedDoc = serverDB.documents.get(docId)!;
+    expect(storedDoc.isEncrypted).toBe(true);
+    expect(storedDoc.content).not.toContain('ДОГОВІР');
+    expect(storedDoc.content).not.toContain('Іванов');
+    expect(storedDoc.content).not.toContain('Конфіденційна');
+
+    // ========== PHASE 4: Client retrieves and decrypts ==========
+    const clientWrapped = serverGetDocumentKey(docId, 'client-1')!;
+    expect(clientWrapped).toBeTruthy();
+
+    const clientDEK = await unwrapDEK(clientWrapped, clientKP.privateKey);
+    const clientDecrypted = await decryptContent(storedDoc.content, clientDEK);
+    expect(clientDecrypted).toBe(originalContent);
+
+    // ========== PHASE 5: Client shares with lawyer ==========
+    const lawyerPubKey = serverDB.userKeys.get('lawyer-1')!.publicKey;
+    const lawyerPubKeyBytes = decodeBase64(lawyerPubKey);
+
+    // Client rewraps DEK for lawyer
+    const lawyerWrappedDEK = await rewrapDEK(
+      clientWrapped,
+      clientKP.privateKey,
+      lawyerPubKeyBytes
+    );
+
+    // Store lawyer's wrapped DEK on "server"
+    serverSaveDocumentKey(docId, 'lawyer-1', lawyerWrappedDEK);
+
+    // ========== PHASE 6: Lawyer decrypts ==========
+    const lawyerWrapped = serverGetDocumentKey(docId, 'lawyer-1')!;
+    expect(lawyerWrapped).toBeTruthy();
+
+    const lawyerDEK = await unwrapDEK(lawyerWrapped, lawyerKP.privateKey);
+    const lawyerDecrypted = await decryptContent(storedDoc.content, lawyerDEK);
+    expect(lawyerDecrypted).toBe(originalContent);
+
+    // ========== PHASE 7: Revoke lawyer's access ==========
+    serverRevokeAccess(docId, 'lawyer-1');
+
+    // Lawyer can no longer get the key
+    const revokedKey = serverGetDocumentKey(docId, 'lawyer-1');
+    expect(revokedKey).toBeNull();
+
+    // Client still has access
+    const clientKeyAfterRevoke = serverGetDocumentKey(docId, 'client-1');
+    expect(clientKeyAfterRevoke).toBeTruthy();
+    const clientDEK2 = await unwrapDEK(clientKeyAfterRevoke!, clientKP.privateKey);
+    const clientDecrypted2 = await decryptContent(storedDoc.content, clientDEK2);
+    expect(clientDecrypted2).toBe(originalContent);
+  });
+
+  it('different documents use different DEKs', async () => {
+    const kp = generateKeyPair();
+
+    const dek1 = generateDEK();
+    const dek2 = generateDEK();
+    expect(timingSafeEqual(dek1, dek2)).toBe(false);
+
+    const content = 'Same content';
+    const enc1 = await encryptContent(content, dek1);
+    const enc2 = await encryptContent(content, dek2);
+
+    // Different DEKs produce different ciphertext
+    expect(enc1).not.toBe(enc2);
+
+    // Both decrypt correctly with their own DEKs
+    expect(await decryptContent(enc1, dek1)).toBe(content);
+    expect(await decryptContent(enc2, dek2)).toBe(content);
+
+    // Cross-decryption fails
+    await expect(decryptContent(enc1, dek2)).rejects.toThrow();
+  });
+
+  it('compromised DEK only exposes one document', async () => {
+    const kp = generateKeyPair();
+    const doc1Content = 'Secret document 1';
+    const doc2Content = 'Secret document 2';
+
+    const dek1 = generateDEK();
+    const dek2 = generateDEK();
+
+    const enc1 = await encryptContent(doc1Content, dek1);
+    const enc2 = await encryptContent(doc2Content, dek2);
+
+    // If attacker gets dek1, they can only decrypt doc1
+    expect(await decryptContent(enc1, dek1)).toBe(doc1Content);
+    await expect(decryptContent(enc2, dek1)).rejects.toThrow();
+  });
+
+  it('password unlock: wrong password fails to decrypt private key', async () => {
+    const kp = generateKeyPair();
+
+    // Encrypt private key with correct password
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const mkCorrect = await crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: 1000, hash: 'SHA-256' },
+      await crypto.subtle.importKey('raw', new TextEncoder().encode('correct'), 'PBKDF2', false, ['deriveKey']),
+      { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
+    );
+    const mkWrong = await crypto.subtle.deriveKey(
+      { name: 'PBKDF2', salt, iterations: 1000, hash: 'SHA-256' },
+      await crypto.subtle.importKey('raw', new TextEncoder().encode('wrong'), 'PBKDF2', false, ['deriveKey']),
+      { name: 'AES-GCM', length: 256 }, false, ['encrypt', 'decrypt']
+    );
+
+    const encrypted = await encryptPrivateKey(kp.privateKey, mkCorrect);
+
+    // Correct password works
+    const decrypted = await decryptPrivateKey(encrypted, mkCorrect);
+    expect(timingSafeEqual(decrypted, kp.privateKey)).toBe(true);
+
+    // Wrong password fails
+    await expect(decryptPrivateKey(encrypted, mkWrong)).rejects.toThrow();
+  });
+
+  it('multi-user sharing: 3 users share same document', async () => {
+    const owner = generateKeyPair();
+    const lawyer1 = generateKeyPair();
+    const lawyer2 = generateKeyPair();
+
+    const dek = generateDEK();
+    const content = 'Multi-party document';
+    const encrypted = await encryptContent(content, dek);
+
+    // Owner wraps DEK for themselves
+    const ownerWrapped = await wrapDEK(dek, owner.publicKey);
+
+    // Owner shares with lawyer1 and lawyer2
+    const lawyer1Wrapped = await rewrapDEK(ownerWrapped, owner.privateKey, lawyer1.publicKey);
+    const lawyer2Wrapped = await rewrapDEK(ownerWrapped, owner.privateKey, lawyer2.publicKey);
+
+    // All three can decrypt
+    expect(await decryptContent(encrypted, await unwrapDEK(ownerWrapped, owner.privateKey))).toBe(content);
+    expect(await decryptContent(encrypted, await unwrapDEK(lawyer1Wrapped, lawyer1.privateKey))).toBe(content);
+    expect(await decryptContent(encrypted, await unwrapDEK(lawyer2Wrapped, lawyer2.privateKey))).toBe(content);
+
+    // lawyer1 can't use lawyer2's wrapped DEK
+    await expect(unwrapDEK(lawyer2Wrapped, lawyer1.privateKey)).rejects.toThrow();
+  });
+});

--- a/lexwebapp/src/services/crypto/index.ts
+++ b/lexwebapp/src/services/crypto/index.ts
@@ -1,0 +1,47 @@
+/**
+ * Crypto Module — E2EE for SecondLayer documents
+ *
+ * All cryptographic operations happen exclusively in the browser.
+ * The server never sees plaintext private keys or DEKs.
+ */
+
+export {
+  generateKeyPair,
+  deriveKeyFromPassword,
+  deriveKeyPBKDF2,
+  encryptPrivateKey,
+  decryptPrivateKey,
+  setupEncryption,
+  unlockPrivateKey,
+  exportKeyFile,
+  importKeyFile,
+  type KeyPair,
+  type EncryptedKeyBundle,
+  type KdfParams,
+} from './CryptoKeyManager';
+
+export {
+  generateDEK,
+  encryptContent,
+  decryptContent,
+  encryptBinary,
+  decryptBinary,
+} from './DocumentEncryptor';
+
+export {
+  wrapDEK,
+  unwrapDEK,
+  rewrapDEK,
+} from './KeyExchange';
+
+export {
+  encodeBase64,
+  decodeBase64,
+  randomBytes,
+  timingSafeEqual,
+} from './utils';
+
+export {
+  encryptUploadedDocument,
+  encryptUploadedDocuments,
+} from './PostUploadEncryptor';

--- a/lexwebapp/src/services/crypto/utils.ts
+++ b/lexwebapp/src/services/crypto/utils.ts
@@ -1,0 +1,42 @@
+/**
+ * Crypto utility functions — base64 encoding/decoding for Uint8Array.
+ */
+
+/**
+ * Encode Uint8Array to URL-safe base64 string.
+ */
+export function encodeBase64(data: Uint8Array): string {
+  const binary = String.fromCharCode(...data);
+  return btoa(binary);
+}
+
+/**
+ * Decode base64 string to Uint8Array.
+ */
+export function decodeBase64(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Generate cryptographically random bytes.
+ */
+export function randomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length));
+}
+
+/**
+ * Constant-time comparison of two Uint8Arrays.
+ */
+export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a[i] ^ b[i];
+  }
+  return result === 0;
+}

--- a/lexwebapp/src/services/index.ts
+++ b/lexwebapp/src/services/index.ts
@@ -32,3 +32,6 @@ export { geoService } from './api/GeoService';
 // Attorney & Consultation services
 export { AttorneyService, attorneyService } from './api/AttorneyService';
 export { ConsultationService, consultationService } from './api/ConsultationService';
+
+// Encryption service (E2EE)
+export { EncryptionService, encryptionService } from './api/EncryptionService';

--- a/lexwebapp/src/stores/encryptionStore.ts
+++ b/lexwebapp/src/stores/encryptionStore.ts
@@ -1,0 +1,196 @@
+/**
+ * Encryption Store
+ * Zustand store managing E2EE state: setup status, unlocked private key, encryption preferences.
+ * The private key is held in memory only (never persisted) and cleared on logout/tab close.
+ */
+
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { encryptionService } from '../services/api/EncryptionService';
+import {
+  setupEncryption,
+  unlockPrivateKey,
+  exportKeyFile,
+  decodeBase64,
+  type EncryptedKeyBundle,
+  type KdfParams,
+} from '../services/crypto';
+
+interface EncryptionState {
+  /** Whether the user has encryption keys set up on the server */
+  hasEncryption: boolean;
+  /** Whether the private key is currently unlocked in memory */
+  isUnlocked: boolean;
+  /** The decrypted private key (X25519, 32 bytes) — in-memory only */
+  privateKey: Uint8Array | null;
+  /** The user's public key (base64) */
+  publicKey: string | null;
+  /** Whether encryption is being set up or unlocked */
+  isLoading: boolean;
+  /** Error message from last operation */
+  error: string | null;
+  /** Whether to encrypt new uploads by default */
+  encryptNewUploads: boolean;
+
+  // Actions
+  checkStatus: () => Promise<void>;
+  setup: (password: string) => Promise<EncryptedKeyBundle>;
+  unlock: (password: string) => Promise<void>;
+  lock: () => void;
+  setEncryptNewUploads: (value: boolean) => void;
+  reset: () => void;
+}
+
+export const useEncryptionStore = create<EncryptionState>()(
+  devtools(
+    (set, get) => ({
+      hasEncryption: false,
+      isUnlocked: false,
+      privateKey: null,
+      publicKey: null,
+      isLoading: false,
+      error: null,
+      encryptNewUploads: false,
+
+      /**
+       * Check if the current user has encryption set up.
+       */
+      checkStatus: async () => {
+        try {
+          const { has_encryption } = await encryptionService.getStatus();
+          set({ hasEncryption: has_encryption });
+        } catch {
+          // Silently fail — user may not be authenticated yet
+        }
+      },
+
+      /**
+       * First-time encryption setup: generate keys, encrypt with password, send to server.
+       * Returns the bundle so caller can offer key file download.
+       */
+      setup: async (password: string) => {
+        set({ isLoading: true, error: null });
+        try {
+          // Generate key pair + encrypt private key with password
+          const bundle = await setupEncryption(password);
+
+          // Send public key + encrypted private key to server
+          await encryptionService.setupKeys({
+            public_key: bundle.publicKey,
+            encrypted_private_key: bundle.encryptedPrivateKey,
+            kdf_algorithm: bundle.kdfAlgorithm,
+            kdf_params: bundle.kdfParams as unknown as Record<string, unknown>,
+          });
+
+          // Unlock immediately after setup
+          const privateKey = decodeBase64(bundle.publicKey); // We still have the raw key
+          // Actually, we need to re-derive the private key from the bundle
+          const pk = await unlockPrivateKey(
+            password,
+            bundle.encryptedPrivateKey,
+            bundle.kdfParams,
+            bundle.kdfAlgorithm,
+          );
+
+          set({
+            hasEncryption: true,
+            isUnlocked: true,
+            privateKey: pk,
+            publicKey: bundle.publicKey,
+            isLoading: false,
+          });
+
+          return bundle;
+        } catch (error: any) {
+          set({
+            isLoading: false,
+            error: error.message || 'Помилка налаштування шифрування',
+          });
+          throw error;
+        }
+      },
+
+      /**
+       * Unlock the private key by deriving master from password.
+       */
+      unlock: async (password: string) => {
+        set({ isLoading: true, error: null });
+        try {
+          const myKey = await encryptionService.getMyKey();
+          const privateKey = await unlockPrivateKey(
+            password,
+            myKey.encrypted_private_key,
+            myKey.kdf_params as unknown as KdfParams,
+            myKey.kdf_algorithm,
+          );
+
+          // Also fetch public key
+          const status = await encryptionService.getStatus();
+
+          set({
+            isUnlocked: true,
+            privateKey,
+            hasEncryption: status.has_encryption,
+            isLoading: false,
+          });
+        } catch (error: any) {
+          set({
+            isLoading: false,
+            error: 'Невірний пароль шифрування',
+          });
+          throw error;
+        }
+      },
+
+      /**
+       * Lock the private key (clear from memory).
+       */
+      lock: () => {
+        const { privateKey } = get();
+        // Zero out the key before discarding
+        if (privateKey) {
+          privateKey.fill(0);
+        }
+        set({
+          isUnlocked: false,
+          privateKey: null,
+        });
+      },
+
+      setEncryptNewUploads: (value: boolean) => {
+        set({ encryptNewUploads: value });
+      },
+
+      /**
+       * Full reset (on logout).
+       */
+      reset: () => {
+        const { privateKey } = get();
+        if (privateKey) privateKey.fill(0);
+        set({
+          hasEncryption: false,
+          isUnlocked: false,
+          privateKey: null,
+          publicKey: null,
+          isLoading: false,
+          error: null,
+          encryptNewUploads: false,
+        });
+      },
+    }),
+    { name: 'EncryptionStore' }
+  )
+);
+
+/**
+ * Helper: download the key file to the user's device.
+ */
+export function downloadKeyFile(bundle: EncryptedKeyBundle, fileName = 'secondlayer-key.json') {
+  const blob = exportKeyFile(bundle);
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/lexwebapp/src/stores/uploadStore.ts
+++ b/lexwebapp/src/stores/uploadStore.ts
@@ -12,6 +12,8 @@ import {
 import { uploadService, ActiveSession } from '../services/api/UploadService';
 import { matterService } from '../services/api/MatterService';
 import { showToast } from '../utils/toast';
+import { useEncryptionStore } from './encryptionStore';
+import { encryptUploadedDocuments } from '../services/crypto/PostUploadEncryptor';
 
 export interface RecoveredSession {
   uploadId: string;
@@ -134,6 +136,26 @@ export const useUploadStore = create<UploadState>((set) => {
           }
         }
       }
+
+      // Post-upload encryption: if encryption is enabled, encrypt completed documents
+      const encState = useEncryptionStore.getState();
+      if (encState.encryptNewUploads && encState.isUnlocked && encState.publicKey) {
+        const docIds = completedItems.map(i => i.documentId).filter(Boolean) as string[];
+        if (docIds.length > 0) {
+          encryptUploadedDocuments(docIds, encState.publicKey).then(results => {
+            const succeeded = results.filter(r => r.success).length;
+            const failed = results.filter(r => !r.success).length;
+            if (succeeded > 0) {
+              showToast.success(`Зашифровано ${succeeded} документів`);
+            }
+            if (failed > 0) {
+              showToast.error(`Не вдалося зашифрувати ${failed} документів`);
+            }
+          }).catch(err => {
+            console.warn('[UploadStore] Post-upload encryption failed', err);
+          });
+        }
+      }
     } else if (event.type === 'throttle-changed') {
       set({
         ...sync,
@@ -162,7 +184,13 @@ export const useUploadStore = create<UploadState>((set) => {
     isRecovering: false,
 
     addFiles: (files) => {
-      uploadManager.addFiles(files);
+      // Inject encrypt flag from encryption store
+      const encryptNewUploads = useEncryptionStore.getState().encryptNewUploads;
+      const filesWithEncrypt = files.map(f => ({
+        ...f,
+        encrypt: encryptNewUploads,
+      }));
+      uploadManager.addFiles(filesWithEncrypt);
       set(syncFromManager(uploadManager));
     },
 

--- a/lexwebapp/src/types/argon2-browser.d.ts
+++ b/lexwebapp/src/types/argon2-browser.d.ts
@@ -1,0 +1,26 @@
+declare module 'argon2-browser' {
+  export enum ArgonType {
+    Argon2d = 0,
+    Argon2i = 1,
+    Argon2id = 2,
+  }
+
+  export interface HashOptions {
+    pass: string | Uint8Array;
+    salt: string | Uint8Array;
+    time?: number;
+    mem?: number;
+    hashLen?: number;
+    parallelism?: number;
+    type?: ArgonType;
+  }
+
+  export interface HashResult {
+    hash: Uint8Array;
+    hashHex: string;
+    encoded: string;
+  }
+
+  export function hash(options: HashOptions): Promise<HashResult>;
+  export function verify(options: { pass: string; encoded: string }): Promise<boolean>;
+}

--- a/lexwebapp/src/types/tweetnacl.d.ts
+++ b/lexwebapp/src/types/tweetnacl.d.ts
@@ -1,0 +1,33 @@
+declare module 'tweetnacl' {
+  export interface BoxKeyPair {
+    publicKey: Uint8Array;
+    secretKey: Uint8Array;
+  }
+
+  export const box: {
+    keyPair(): BoxKeyPair;
+    (msg: Uint8Array, nonce: Uint8Array, theirPublicKey: Uint8Array, mySecretKey: Uint8Array): Uint8Array;
+    open(box: Uint8Array, nonce: Uint8Array, theirPublicKey: Uint8Array, mySecretKey: Uint8Array): Uint8Array | null;
+    before(theirPublicKey: Uint8Array, mySecretKey: Uint8Array): Uint8Array;
+    after(msg: Uint8Array, nonce: Uint8Array, sharedKey: Uint8Array): Uint8Array;
+    open_after(box: Uint8Array, nonce: Uint8Array, sharedKey: Uint8Array): Uint8Array | null;
+    keyPair: {
+      (): BoxKeyPair;
+      fromSecretKey(secretKey: Uint8Array): BoxKeyPair;
+    };
+    nonceLength: number;
+    publicKeyLength: number;
+    secretKeyLength: number;
+    sharedKeyLength: number;
+    overheadLength: number;
+  };
+
+  export function scalarMult(n: Uint8Array, p: Uint8Array): Uint8Array;
+
+  export const scalarMult: {
+    (n: Uint8Array, p: Uint8Array): Uint8Array;
+    base(n: Uint8Array): Uint8Array;
+    scalarLength: number;
+    groupElementLength: number;
+  };
+}

--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -30,6 +30,7 @@ export interface VaultDocument {
   title: string;
   type: 'contract' | 'legislation' | 'court_decision' | 'internal' | 'other';
   content: string;
+  is_encrypted?: boolean;
   metadata: {
     uploadedAt: string;
     uploadedBy?: string;
@@ -847,6 +848,7 @@ Pipeline:
         title: doc.title || 'Untitled',
         type: doc.type as any,
         content,
+        is_encrypted: (doc as any).is_encrypted || false,
         metadata: docMeta,
       };
 
@@ -995,6 +997,7 @@ Pipeline:
 
       const query = `
         SELECT id, type, title, metadata, storage_type, mime_type, created_at, updated_at,
+               COALESCE(is_encrypted, false) AS is_encrypted,
                LEFT(regexp_replace(full_text, '[^\\x20-\\x7E\\u0400-\\u04FF\\u0500-\\u052F\\s]', '', 'g'), 300) AS text_preview
         FROM documents
         WHERE ${whereClause}
@@ -1017,6 +1020,7 @@ Pipeline:
         type: row.type,
         storage_type: row.storage_type || 'vault',
         mime_type: row.mime_type || null,
+        is_encrypted: row.is_encrypted || false,
         content: '', // Don't include full content in list
         text_preview: row.text_preview || '',
         metadata: typeof row.metadata === 'string' ? JSON.parse(row.metadata) : row.metadata || {},

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -37,6 +37,8 @@ import { InvoiceService } from './services/invoice-service.js';
 import { createPaymentRouter, createWebhookRouter } from './routes/payment-routes.js';
 import { createBillingRoutes } from './routes/billing-routes.js';
 import { createAdminRoutes } from './routes/admin-routes.js';
+import { EncryptionKeyService } from './services/encryption-key-service.js';
+import { createEncryptionRoutes } from './routes/encryption-routes.js';
 import { createWorkerHeartbeatRoute } from './routes/worker-heartbeat-routes.js';
 import { createDecisionsRoutes } from './routes/decisions-routes.js';
 import { createERAUProxyRoutes } from './routes/erau-proxy-routes.js';
@@ -150,6 +152,7 @@ class HTTPMCPServer {
   private batchDocumentTools: BatchDocumentTools;
   private costTracker: CostTracker;
   private billingService: BillingService;
+  private encryptionKeyService: EncryptionKeyService;
   private pricingService: PricingService;
   private subscriptionService: SubscriptionService;
   private userPreferencesService: UserPreferencesService;
@@ -233,6 +236,7 @@ class HTTPMCPServer {
     // Initialize cost tracker, billing service, and currency service
     this.costTracker = new CostTracker(this.services.db);
     this.billingService = new BillingService(this.services.db);
+    this.encryptionKeyService = new EncryptionKeyService(this.services.db);
     this.currencyService = new CurrencyService();
 
     // Fetch NBU exchange rate on startup
@@ -2520,6 +2524,10 @@ class HTTPMCPServer {
     // Attorney routes - search is public (optionalJWT), profile management requires JWT
     this.app.use('/api/attorneys', optionalJWT as any, createAttorneyRoutes(this.attorneyProfileService));
     logger.info('Attorney routes registered at /api/attorneys');
+
+    // E2EE encryption key management routes - all require JWT
+    this.app.use('/api/encryption', requireJWT as any, createEncryptionRoutes(this.encryptionKeyService, this.services.db));
+    logger.info('Encryption routes registered at /api/encryption');
 
     // Consultation routes - all require JWT
     this.app.use('/api/consultations', requireJWT as any, createConsultationRoutes(

--- a/mcp_backend/src/migrations/087_document_encryption.sql
+++ b/mcp_backend/src/migrations/087_document_encryption.sql
@@ -1,0 +1,46 @@
+-- Migration 087: End-to-end document encryption infrastructure
+-- Adds user encryption keys, document keys, and encryption flags
+
+-- User encryption key pairs (X25519)
+CREATE TABLE IF NOT EXISTS user_encryption_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+  public_key TEXT NOT NULL,                    -- X25519 public key, base64
+  encrypted_private_key TEXT NOT NULL,         -- AES-256-GCM(master_secret, private_key), base64
+  kdf_algorithm VARCHAR(20) DEFAULT 'argon2id',
+  kdf_params JSONB DEFAULT '{}',              -- {salt, iterations, memory, parallelism}
+  diia_encrypted_master_secret TEXT,           -- Master secret wrapped via Diia signature
+  diia_recovery_challenge TEXT,
+  diia_recovery_salt TEXT,
+  key_version INTEGER DEFAULT 1,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_encryption_keys_user_id
+  ON user_encryption_keys(user_id);
+
+-- Document encryption keys (wrapped DEKs per user)
+CREATE TABLE IF NOT EXISTS document_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id UUID NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  encrypted_dek TEXT NOT NULL,                -- ECDH-ES wrapped DEK, base64
+  granted_by UUID REFERENCES users(id),
+  granted_at TIMESTAMPTZ DEFAULT NOW(),
+  revoked_at TIMESTAMPTZ,
+  UNIQUE(document_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_document_keys_document_id
+  ON document_keys(document_id);
+
+CREATE INDEX IF NOT EXISTS idx_document_keys_user_id
+  ON document_keys(user_id);
+
+-- Add encryption flag to documents
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS is_encrypted BOOLEAN DEFAULT FALSE;
+ALTER TABLE documents ADD COLUMN IF NOT EXISTS encryption_version INTEGER;
+
+COMMENT ON TABLE user_encryption_keys IS 'User X25519 key pairs for document E2EE — private key encrypted client-side';
+COMMENT ON TABLE document_keys IS 'Per-document DEKs wrapped with user public keys (envelope encryption)';

--- a/mcp_backend/src/routes/encryption-routes.ts
+++ b/mcp_backend/src/routes/encryption-routes.ts
@@ -1,0 +1,393 @@
+/**
+ * Encryption Routes
+ * API endpoints for E2EE key management and document key sharing.
+ * All crypto operations happen client-side — server only stores ciphertext.
+ */
+
+import express, { Response } from 'express';
+import { EncryptionKeyService } from '../services/encryption-key-service.js';
+import type { IDatabase } from '../domain/ports/index.js';
+import { logger } from '../utils/logger.js';
+import { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+
+export function createEncryptionRoutes(
+  encryptionKeyService: EncryptionKeyService,
+  db?: IDatabase
+): express.Router {
+  const router = express.Router();
+
+  /**
+   * POST /api/encryption/setup
+   * Initialize user encryption keys (called once during E2EE setup)
+   */
+  router.post('/setup', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const { public_key, encrypted_private_key, kdf_algorithm, kdf_params } = req.body;
+      if (!public_key || !encrypted_private_key) {
+        return res.status(400).json({ error: 'public_key and encrypted_private_key are required' });
+      }
+
+      const key = await encryptionKeyService.setupKeys(userId, {
+        public_key,
+        encrypted_private_key,
+        kdf_algorithm,
+        kdf_params,
+      });
+
+      res.status(201).json({
+        id: key.id,
+        public_key: key.public_key,
+        kdf_algorithm: key.kdf_algorithm,
+        kdf_params: key.kdf_params,
+        key_version: key.key_version,
+      });
+    } catch (error: any) {
+      logger.error('Failed to setup encryption keys', { error: error.message });
+      res.status(500).json({ error: 'Не вдалося налаштувати шифрування' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/status
+   * Check if the current user has encryption set up
+   */
+  router.get('/status', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const hasSetup = await encryptionKeyService.hasEncryptionSetup(userId);
+      res.json({ has_encryption: hasSetup });
+    } catch (error: any) {
+      logger.error('Failed to check encryption status', { error: error.message });
+      res.status(500).json({ error: 'Помилка перевірки статусу шифрування' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/public-key/:userId
+   * Get any user's public key (for sharing)
+   */
+  router.get('/public-key/:userId', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+
+      const publicKey = await encryptionKeyService.getPublicKey(req.params.userId as string);
+      if (!publicKey) {
+        return res.status(404).json({ error: 'Ключ шифрування не знайдено' });
+      }
+
+      res.json({ public_key: publicKey });
+    } catch (error: any) {
+      logger.error('Failed to get public key', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання ключа' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/my-key
+   * Get the current user's encrypted private key + KDF params
+   */
+  router.get('/my-key', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const key = await encryptionKeyService.getMyKey(userId);
+      if (!key) {
+        return res.status(404).json({ error: 'Ключі шифрування не налаштовано' });
+      }
+
+      res.json({
+        encrypted_private_key: key.encrypted_private_key,
+        kdf_algorithm: key.kdf_algorithm,
+        kdf_params: key.kdf_params,
+        key_version: key.key_version,
+      });
+    } catch (error: any) {
+      logger.error('Failed to get encryption key', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання ключа' });
+    }
+  }) as any);
+
+  /**
+   * POST /api/encryption/document-keys
+   * Store a wrapped DEK for a document
+   */
+  router.post('/document-keys', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const { document_id, encrypted_dek } = req.body;
+      if (!document_id || !encrypted_dek) {
+        return res.status(400).json({ error: 'document_id and encrypted_dek are required' });
+      }
+
+      const key = await encryptionKeyService.saveDocumentKey(userId, {
+        document_id,
+        encrypted_dek,
+      });
+
+      res.status(201).json(key);
+    } catch (error: any) {
+      logger.error('Failed to save document key', { error: error.message });
+      res.status(500).json({ error: 'Помилка збереження ключа документа' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/document-keys/:documentId
+   * Get the wrapped DEK for a document
+   */
+  router.get('/document-keys/:documentId', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const key = await encryptionKeyService.getDocumentKey(userId, req.params.documentId as string);
+      if (!key) {
+        return res.status(404).json({ error: 'Ключ документа не знайдено' });
+      }
+
+      res.json(key);
+    } catch (error: any) {
+      logger.error('Failed to get document key', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання ключа документа' });
+    }
+  }) as any);
+
+  /**
+   * POST /api/encryption/share
+   * Share a document by storing a re-wrapped DEK for another user
+   */
+  router.post('/share', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const { document_id, target_user_id, encrypted_dek } = req.body;
+      if (!document_id || !target_user_id || !encrypted_dek) {
+        return res.status(400).json({ error: 'document_id, target_user_id, and encrypted_dek are required' });
+      }
+
+      const key = await encryptionKeyService.shareDocument(userId, {
+        document_id,
+        target_user_id,
+        encrypted_dek,
+      });
+
+      res.status(201).json(key);
+    } catch (error: any) {
+      logger.error('Failed to share document', { error: error.message });
+      res.status(400).json({ error: error.message || 'Помилка надання доступу' });
+    }
+  }) as any);
+
+  /**
+   * DELETE /api/encryption/share/:documentId/:userId
+   * Revoke a user's access to a document
+   */
+  router.delete('/share/:documentId/:userId', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const revokerId = req.user?.id;
+      if (!revokerId) return res.status(401).json({ error: 'Unauthorized' });
+
+      await encryptionKeyService.revokeAccess(
+        revokerId,
+        req.params.documentId as string,
+        req.params.userId as string
+      );
+
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('Failed to revoke access', { error: error.message });
+      res.status(400).json({ error: error.message || 'Помилка відкликання доступу' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/document-keys/:documentId/shares
+   * List all users who have access to a document
+   */
+  router.get('/document-keys/:documentId/shares', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const shares = await encryptionKeyService.getDocumentShares(userId, req.params.documentId as string);
+      res.json({ shares });
+    } catch (error: any) {
+      logger.error('Failed to get document shares', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання списку доступу' });
+    }
+  }) as any);
+
+  /**
+   * POST /api/encryption/diia/init-recovery
+   * Store Diia recovery data
+   */
+  router.post('/diia/init-recovery', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const { encrypted_master_secret, recovery_challenge, recovery_salt } = req.body;
+      if (!encrypted_master_secret || !recovery_challenge || !recovery_salt) {
+        return res.status(400).json({ error: 'All recovery fields are required' });
+      }
+
+      await encryptionKeyService.saveDiiaRecovery(
+        userId,
+        encrypted_master_secret,
+        recovery_challenge,
+        recovery_salt
+      );
+
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('Failed to init Diia recovery', { error: error.message });
+      res.status(500).json({ error: 'Помилка налаштування відновлення через Дію' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/diia/recovery-data
+   * Get Diia recovery challenge + encrypted master secret
+   */
+  router.get('/diia/recovery-data', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const recovery = await encryptionKeyService.getDiiaRecovery(userId);
+      if (!recovery) {
+        return res.status(404).json({ error: 'Відновлення через Дію не налаштовано' });
+      }
+
+      res.json(recovery);
+    } catch (error: any) {
+      logger.error('Failed to get Diia recovery data', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання даних відновлення' });
+    }
+  }) as any);
+
+  /**
+   * POST /api/encryption/encrypt-document
+   * Replace document content with encrypted version after server-side processing.
+   * Hybrid flow: server parsed/embedded the plaintext, now client sends ciphertext.
+   */
+  router.post('/encrypt-document', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+      if (!db) return res.status(500).json({ error: 'Database not available' });
+
+      const { document_id, encrypted_content, encrypted_dek } = req.body;
+      if (!document_id || !encrypted_content || !encrypted_dek) {
+        return res.status(400).json({
+          error: 'document_id, encrypted_content, and encrypted_dek are required',
+        });
+      }
+
+      // Verify the document belongs to this user
+      const docResult = await db.query(
+        `SELECT id FROM documents WHERE id = $1 AND user_id = $2 AND deleted_at IS NULL`,
+        [document_id, userId]
+      );
+      if (docResult.rows.length === 0) {
+        return res.status(404).json({ error: 'Документ не знайдено' });
+      }
+
+      // Replace plaintext content with encrypted content
+      await db.query(
+        `UPDATE documents SET
+           full_text = $2,
+           full_text_html = NULL,
+           is_encrypted = true,
+           encryption_version = 1,
+           updated_at = NOW()
+         WHERE id = $1`,
+        [document_id, encrypted_content]
+      );
+
+      // Save the wrapped DEK for this user
+      await encryptionKeyService.saveDocumentKey(userId, {
+        document_id,
+        encrypted_dek,
+      });
+
+      logger.info('Document encrypted', { documentId: document_id, userId });
+      res.json({ success: true, document_id });
+    } catch (error: any) {
+      logger.error('Failed to encrypt document', { error: error.message });
+      res.status(500).json({ error: 'Помилка шифрування документа' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/vault-stats
+   * Get encryption stats for the current user's vault.
+   */
+  router.get('/vault-stats', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+      if (!db) return res.status(500).json({ error: 'Database not available' });
+
+      const result = await db.query<{ total: string; encrypted: string }>(
+        `SELECT
+           COUNT(*) AS total,
+           COUNT(*) FILTER (WHERE is_encrypted = true) AS encrypted
+         FROM documents
+         WHERE user_id = $1 AND deleted_at IS NULL`,
+        [userId]
+      );
+
+      const { total, encrypted } = result.rows[0];
+      res.json({
+        total: parseInt(total),
+        encrypted: parseInt(encrypted),
+        unencrypted: parseInt(total) - parseInt(encrypted),
+      });
+    } catch (error: any) {
+      logger.error('Failed to get vault stats', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання статистики' });
+    }
+  }) as any);
+
+  /**
+   * GET /api/encryption/unencrypted-documents
+   * List IDs of unencrypted documents for batch encryption.
+   */
+  router.get('/unencrypted-documents', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+      if (!db) return res.status(500).json({ error: 'Database not available' });
+
+      const limit = Math.min(100, Math.max(1, Number(req.query.limit || 50)));
+      const offset = Math.max(0, Number(req.query.offset || 0));
+
+      const result = await db.query<{ id: string; title: string }>(
+        `SELECT id, title FROM documents
+         WHERE user_id = $1 AND deleted_at IS NULL
+           AND (is_encrypted IS NULL OR is_encrypted = false)
+           AND full_text IS NOT NULL AND full_text != ''
+         ORDER BY created_at DESC
+         LIMIT $2 OFFSET $3`,
+        [userId, limit, offset]
+      );
+
+      res.json({ documents: result.rows });
+    } catch (error: any) {
+      logger.error('Failed to list unencrypted documents', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання списку документів' });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/__tests__/encryption-key-service.test.ts
+++ b/mcp_backend/src/services/__tests__/encryption-key-service.test.ts
@@ -1,0 +1,228 @@
+/**
+ * EncryptionKeyService Tests
+ *
+ * Tests cover:
+ * - setupKeys: create and upsert user encryption keys
+ * - getPublicKey / getMyKey: retrieval
+ * - saveDocumentKey / getDocumentKey: DEK storage and retrieval
+ * - shareDocument: granting access with re-wrapped DEK
+ * - revokeAccess: removing shared access
+ * - getDocumentShares: listing all shares
+ * - hasEncryptionSetup: status check
+ */
+
+import { EncryptionKeyService } from '../encryption-key-service';
+
+const USER_ID = 'user-001';
+const USER_ID_2 = 'user-002';
+const DOC_ID = 'doc-001';
+
+function makeKeyRow(overrides: any = {}) {
+  return {
+    id: 'key-001',
+    user_id: USER_ID,
+    public_key: 'base64-public-key',
+    encrypted_private_key: 'base64-encrypted-private-key',
+    kdf_algorithm: 'argon2id',
+    kdf_params: { salt: 'abc', memory: 65536, iterations: 3, parallelism: 4 },
+    key_version: 1,
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeDocKeyRow(overrides: any = {}) {
+  return {
+    id: 'dk-001',
+    document_id: DOC_ID,
+    user_id: USER_ID,
+    encrypted_dek: 'base64-wrapped-dek',
+    granted_by: USER_ID,
+    granted_at: new Date(),
+    revoked_at: null,
+    ...overrides,
+  };
+}
+
+function makeDb(overrides: any = {}) {
+  return {
+    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    ...overrides,
+  };
+}
+
+describe('EncryptionKeyService', () => {
+  describe('setupKeys', () => {
+    it('should insert new encryption keys', async () => {
+      const row = makeKeyRow();
+      const db = makeDb({ query: jest.fn().mockResolvedValue({ rows: [row] }) });
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.setupKeys(USER_ID, {
+        public_key: 'base64-public-key',
+        encrypted_private_key: 'base64-encrypted-private-key',
+        kdf_algorithm: 'argon2id',
+        kdf_params: { salt: 'abc', memory: 65536 },
+      });
+
+      expect(result).toEqual(row);
+      expect(db.query).toHaveBeenCalledTimes(1);
+      expect(db.query.mock.calls[0][0]).toContain('INSERT INTO user_encryption_keys');
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('should return public key for existing user', async () => {
+      const db = makeDb({
+        query: jest.fn().mockResolvedValue({ rows: [{ public_key: 'pk-123' }] }),
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.getPublicKey(USER_ID);
+      expect(result).toBe('pk-123');
+    });
+
+    it('should return null for user without keys', async () => {
+      const db = makeDb();
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.getPublicKey(USER_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getMyKey', () => {
+    it('should return full key data', async () => {
+      const row = makeKeyRow();
+      const db = makeDb({ query: jest.fn().mockResolvedValue({ rows: [row] }) });
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.getMyKey(USER_ID);
+      expect(result).toEqual(row);
+    });
+
+    it('should return null if no keys', async () => {
+      const db = makeDb();
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.getMyKey(USER_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('saveDocumentKey', () => {
+    it('should store wrapped DEK', async () => {
+      const row = makeDocKeyRow();
+      const db = makeDb({ query: jest.fn().mockResolvedValue({ rows: [row] }) });
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.saveDocumentKey(USER_ID, {
+        document_id: DOC_ID,
+        encrypted_dek: 'base64-wrapped-dek',
+      });
+
+      expect(result).toEqual(row);
+      expect(db.query.mock.calls[0][0]).toContain('INSERT INTO document_keys');
+    });
+  });
+
+  describe('getDocumentKey', () => {
+    it('should return wrapped DEK for authorized user', async () => {
+      const row = makeDocKeyRow();
+      const db = makeDb({ query: jest.fn().mockResolvedValue({ rows: [row] }) });
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.getDocumentKey(USER_ID, DOC_ID);
+      expect(result).toEqual(row);
+    });
+
+    it('should return null for unauthorized user', async () => {
+      const db = makeDb();
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.getDocumentKey('unknown-user', DOC_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('shareDocument', () => {
+    it('should create new wrapped DEK for target user', async () => {
+      const grantorDocKey = makeDocKeyRow();
+      const sharedDocKey = makeDocKeyRow({ user_id: USER_ID_2, granted_by: USER_ID });
+
+      const db = makeDb({
+        query: jest.fn()
+          .mockResolvedValueOnce({ rows: [grantorDocKey] }) // getDocumentKey check
+          .mockResolvedValueOnce({ rows: [sharedDocKey] }),  // insert
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      const result = await svc.shareDocument(USER_ID, {
+        document_id: DOC_ID,
+        target_user_id: USER_ID_2,
+        encrypted_dek: 'rewrapped-dek',
+      });
+
+      expect(result.user_id).toBe(USER_ID_2);
+      expect(result.granted_by).toBe(USER_ID);
+    });
+
+    it('should throw if grantor has no access', async () => {
+      const db = makeDb({
+        query: jest.fn().mockResolvedValueOnce({ rows: [] }), // no grantor key
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      await expect(
+        svc.shareDocument(USER_ID, {
+          document_id: DOC_ID,
+          target_user_id: USER_ID_2,
+          encrypted_dek: 'rewrapped-dek',
+        })
+      ).rejects.toThrow('У вас немає доступу до цього документа');
+    });
+  });
+
+  describe('revokeAccess', () => {
+    it('should revoke access when owner calls', async () => {
+      const db = makeDb({
+        query: jest.fn().mockResolvedValue({ rowCount: 1 }),
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      await expect(svc.revokeAccess(USER_ID, DOC_ID, USER_ID_2)).resolves.toBeUndefined();
+    });
+
+    it('should throw if revocation fails', async () => {
+      const db = makeDb({
+        query: jest.fn().mockResolvedValue({ rowCount: 0 }),
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      await expect(svc.revokeAccess(USER_ID, DOC_ID, USER_ID_2)).rejects.toThrow(
+        'Не вдалося відкликати доступ'
+      );
+    });
+  });
+
+  describe('hasEncryptionSetup', () => {
+    it('should return true when keys exist', async () => {
+      const db = makeDb({
+        query: jest.fn().mockResolvedValue({ rows: [{ count: '1' }] }),
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      expect(await svc.hasEncryptionSetup(USER_ID)).toBe(true);
+    });
+
+    it('should return false when no keys', async () => {
+      const db = makeDb({
+        query: jest.fn().mockResolvedValue({ rows: [{ count: '0' }] }),
+      });
+      const svc = new EncryptionKeyService(db as any);
+
+      expect(await svc.hasEncryptionSetup(USER_ID)).toBe(false);
+    });
+  });
+});

--- a/mcp_backend/src/services/consultation-service.ts
+++ b/mcp_backend/src/services/consultation-service.ts
@@ -336,6 +336,24 @@ export class ConsultationService {
       }
     }
 
+    // Revoke E2EE document key access for shared encrypted documents
+    if (consultation.document_ids?.length > 0) {
+      try {
+        await this.db.query(
+          `UPDATE document_keys SET revoked_at = NOW()
+           WHERE user_id = $1 AND document_id = ANY($2) AND revoked_at IS NULL`,
+          [consultation.attorney_user_id, consultation.document_ids]
+        );
+        logger.info('Attorney E2EE document key access revoked', {
+          consultationId: id,
+          attorneyUserId: consultation.attorney_user_id,
+          documentCount: consultation.document_ids.length,
+        });
+      } catch (err: any) {
+        logger.warn('Failed to revoke E2EE document keys', { error: err.message });
+      }
+    }
+
     await this.auditService.log({
       userId: attorneyUserId,
       action: 'consultation.completed',
@@ -368,6 +386,19 @@ export class ConsultationService {
         );
       } catch (_err) {
         // Ignore — may not exist
+      }
+    }
+
+    // Revoke E2EE document key access for shared encrypted documents
+    if (consultation.document_ids?.length > 0) {
+      try {
+        await this.db.query(
+          `UPDATE document_keys SET revoked_at = NOW()
+           WHERE user_id = $1 AND document_id = ANY($2) AND revoked_at IS NULL`,
+          [consultation.attorney_user_id, consultation.document_ids]
+        );
+      } catch (_err) {
+        // Non-critical — keys may not exist
       }
     }
 

--- a/mcp_backend/src/services/document-service.ts
+++ b/mcp_backend/src/services/document-service.ts
@@ -23,6 +23,8 @@ export interface Document {
   client_id?: string;
   document_class?: string;
   privilege_status?: string;
+  is_encrypted?: boolean;
+  encryption_version?: number;
   created_at?: Date;
   updated_at?: Date;
 }

--- a/mcp_backend/src/services/encryption-key-service.ts
+++ b/mcp_backend/src/services/encryption-key-service.ts
@@ -1,0 +1,255 @@
+/**
+ * Encryption Key Service
+ * Manages user encryption keys and document key wrapping for E2EE.
+ * Server never sees plaintext private keys or DEKs — only ciphertext.
+ */
+
+import type { IDatabase } from '../domain/ports/index.js';
+import { logger } from '../utils/logger.js';
+
+export interface UserEncryptionKey {
+  id: string;
+  user_id: string;
+  public_key: string;
+  encrypted_private_key: string;
+  kdf_algorithm: string;
+  kdf_params: Record<string, unknown>;
+  key_version: number;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface DocumentKey {
+  id: string;
+  document_id: string;
+  user_id: string;
+  encrypted_dek: string;
+  granted_by: string | null;
+  granted_at: Date;
+  revoked_at: Date | null;
+}
+
+export interface SetupKeysRequest {
+  public_key: string;
+  encrypted_private_key: string;
+  kdf_algorithm?: string;
+  kdf_params?: Record<string, unknown>;
+}
+
+export interface SaveDocumentKeyRequest {
+  document_id: string;
+  encrypted_dek: string;
+}
+
+export interface ShareDocumentRequest {
+  document_id: string;
+  target_user_id: string;
+  encrypted_dek: string;
+}
+
+export class EncryptionKeyService {
+  constructor(private db: IDatabase) {}
+
+  /**
+   * Initialize or update user encryption keys.
+   * Called once during E2EE setup in the browser.
+   */
+  async setupKeys(userId: string, req: SetupKeysRequest): Promise<UserEncryptionKey> {
+    const result = await this.db.query<UserEncryptionKey>(
+      `INSERT INTO user_encryption_keys (user_id, public_key, encrypted_private_key, kdf_algorithm, kdf_params)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (user_id) DO UPDATE SET
+         public_key = EXCLUDED.public_key,
+         encrypted_private_key = EXCLUDED.encrypted_private_key,
+         kdf_algorithm = EXCLUDED.kdf_algorithm,
+         kdf_params = EXCLUDED.kdf_params,
+         key_version = user_encryption_keys.key_version + 1,
+         updated_at = NOW()
+       RETURNING *`,
+      [
+        userId,
+        req.public_key,
+        req.encrypted_private_key,
+        req.kdf_algorithm || 'argon2id',
+        JSON.stringify(req.kdf_params || {}),
+      ]
+    );
+    logger.info('Encryption keys set up', { userId, keyVersion: result.rows[0].key_version });
+    return result.rows[0];
+  }
+
+  /**
+   * Get the public key for any user (needed for sharing).
+   */
+  async getPublicKey(userId: string): Promise<string | null> {
+    const result = await this.db.query<{ public_key: string }>(
+      `SELECT public_key FROM user_encryption_keys WHERE user_id = $1`,
+      [userId]
+    );
+    return result.rows[0]?.public_key || null;
+  }
+
+  /**
+   * Get the current user's encrypted private key + KDF params (for client-side decryption).
+   */
+  async getMyKey(userId: string): Promise<UserEncryptionKey | null> {
+    const result = await this.db.query<UserEncryptionKey>(
+      `SELECT * FROM user_encryption_keys WHERE user_id = $1`,
+      [userId]
+    );
+    return result.rows[0] || null;
+  }
+
+  /**
+   * Store a wrapped DEK for a document (owner saving their own key).
+   */
+  async saveDocumentKey(userId: string, req: SaveDocumentKeyRequest): Promise<DocumentKey> {
+    const result = await this.db.query<DocumentKey>(
+      `INSERT INTO document_keys (document_id, user_id, encrypted_dek, granted_by)
+       VALUES ($1, $2, $3, $2)
+       ON CONFLICT (document_id, user_id) DO UPDATE SET
+         encrypted_dek = EXCLUDED.encrypted_dek,
+         granted_at = NOW(),
+         revoked_at = NULL
+       RETURNING *`,
+      [req.document_id, userId, req.encrypted_dek]
+    );
+    logger.info('Document key saved', { documentId: req.document_id, userId });
+    return result.rows[0];
+  }
+
+  /**
+   * Get the wrapped DEK for a document for the requesting user.
+   */
+  async getDocumentKey(userId: string, documentId: string): Promise<DocumentKey | null> {
+    const result = await this.db.query<DocumentKey>(
+      `SELECT * FROM document_keys
+       WHERE document_id = $1 AND user_id = $2 AND revoked_at IS NULL`,
+      [documentId, userId]
+    );
+    return result.rows[0] || null;
+  }
+
+  /**
+   * Share a document by storing a wrapped DEK for another user.
+   * The caller must have already unwrapped the DEK and re-wrapped it
+   * with the target user's public key — all done client-side.
+   */
+  async shareDocument(grantorId: string, req: ShareDocumentRequest): Promise<DocumentKey> {
+    // Verify grantor has access
+    const grantorKey = await this.getDocumentKey(grantorId, req.document_id);
+    if (!grantorKey) {
+      throw new Error('У вас немає доступу до цього документа');
+    }
+
+    const result = await this.db.query<DocumentKey>(
+      `INSERT INTO document_keys (document_id, user_id, encrypted_dek, granted_by)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (document_id, user_id) DO UPDATE SET
+         encrypted_dek = EXCLUDED.encrypted_dek,
+         granted_by = EXCLUDED.granted_by,
+         granted_at = NOW(),
+         revoked_at = NULL
+       RETURNING *`,
+      [req.document_id, req.target_user_id, req.encrypted_dek, grantorId]
+    );
+    logger.info('Document shared', {
+      documentId: req.document_id,
+      grantorId,
+      targetUserId: req.target_user_id,
+    });
+    return result.rows[0];
+  }
+
+  /**
+   * Revoke a user's access to a document.
+   */
+  async revokeAccess(revokerId: string, documentId: string, targetUserId: string): Promise<void> {
+    // Only the document owner (granted_by = self) or the grantor can revoke
+    const result = await this.db.query(
+      `UPDATE document_keys SET revoked_at = NOW()
+       WHERE document_id = $1 AND user_id = $2 AND revoked_at IS NULL
+       AND EXISTS (
+         SELECT 1 FROM document_keys dk
+         WHERE dk.document_id = $1 AND dk.user_id = $3
+         AND dk.granted_by = dk.user_id AND dk.revoked_at IS NULL
+       )`,
+      [documentId, targetUserId, revokerId]
+    );
+    if (result.rowCount === 0) {
+      throw new Error('Не вдалося відкликати доступ');
+    }
+    logger.info('Document access revoked', { documentId, targetUserId, revokerId });
+  }
+
+  /**
+   * List all users who have access to a document.
+   */
+  async getDocumentShares(userId: string, documentId: string): Promise<DocumentKey[]> {
+    // Only the owner can list shares
+    const result = await this.db.query<DocumentKey>(
+      `SELECT dk.* FROM document_keys dk
+       WHERE dk.document_id = $1 AND dk.revoked_at IS NULL
+       AND EXISTS (
+         SELECT 1 FROM document_keys owner_dk
+         WHERE owner_dk.document_id = $1 AND owner_dk.user_id = $2
+         AND owner_dk.granted_by = owner_dk.user_id AND owner_dk.revoked_at IS NULL
+       )`,
+      [documentId, userId]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Check if a user has encryption set up.
+   */
+  async hasEncryptionSetup(userId: string): Promise<boolean> {
+    const result = await this.db.query<{ count: string }>(
+      `SELECT COUNT(*) as count FROM user_encryption_keys WHERE user_id = $1`,
+      [userId]
+    );
+    return parseInt(result.rows[0].count) > 0;
+  }
+
+  /**
+   * Store Diia recovery data for master secret recovery.
+   */
+  async saveDiiaRecovery(
+    userId: string,
+    encryptedMasterSecret: string,
+    recoveryChallenge: string,
+    recoverySalt: string
+  ): Promise<void> {
+    await this.db.query(
+      `UPDATE user_encryption_keys SET
+         diia_encrypted_master_secret = $2,
+         diia_recovery_challenge = $3,
+         diia_recovery_salt = $4,
+         updated_at = NOW()
+       WHERE user_id = $1`,
+      [userId, encryptedMasterSecret, recoveryChallenge, recoverySalt]
+    );
+    logger.info('Diia recovery data saved', { userId });
+  }
+
+  /**
+   * Get Diia recovery data for master secret recovery.
+   */
+  async getDiiaRecovery(userId: string): Promise<{
+    diia_encrypted_master_secret: string;
+    diia_recovery_challenge: string;
+    diia_recovery_salt: string;
+  } | null> {
+    const result = await this.db.query<{
+      diia_encrypted_master_secret: string;
+      diia_recovery_challenge: string;
+      diia_recovery_salt: string;
+    }>(
+      `SELECT diia_encrypted_master_secret, diia_recovery_challenge, diia_recovery_salt
+       FROM user_encryption_keys
+       WHERE user_id = $1 AND diia_encrypted_master_secret IS NOT NULL`,
+      [userId]
+    );
+    return result.rows[0] || null;
+  }
+}


### PR DESCRIPTION
## Summary

- **Three-level envelope encryption** (DEK → KEK → Master Secret) for user documents
- All cryptography runs in browser (Web Crypto API + tweetnacl for X25519)
- Server never sees private keys or DEKs — only stores ciphertext

### What's included

- **Phase 1**: DB migration, `EncryptionKeyService`, 15 API endpoints, frontend crypto module (AES-256-GCM, X25519 ECDH, Argon2id KDF)
- **Phase 2**: E2EE toggle in upload zone, encryption setup dialog, hybrid pipeline (server parses → client encrypts), decryption in viewer, E2EE badges
- **Phase 3**: Auto-rewrap DEKs on consultation sharing, `SharedDocumentsSection` with revocation, auto-revoke on complete/cancel
- **Phase 4**: "Encrypt my vault" batch encryption panel with progress bar

### Key files

| Area | Files |
|------|-------|
| Migration | `087_document_encryption.sql` |
| Backend | `encryption-key-service.ts`, `encryption-routes.ts` (15 endpoints) |
| Frontend crypto | `CryptoKeyManager.ts`, `DocumentEncryptor.ts`, `KeyExchange.ts`, `PostUploadEncryptor.ts` |
| UI | `EncryptionSetupDialog.tsx`, `RetroactiveEncryptionPanel.tsx`, `SharedDocumentsSection.tsx` |
| State | `encryptionStore.ts` |

## Test plan

- [x] Backend: 14 unit tests pass (encryption-key-service)
- [x] Frontend: 16 unit tests pass (crypto roundtrip, key exchange)
- [x] Frontend: 5 integration tests pass (full lifecycle: setup → encrypt → share → decrypt → revoke)
- [x] TypeScript: 0 errors on both backend and frontend
- [ ] Manual: upload doc with E2EE toggle → verify ciphertext in DB → decrypt in viewer
- [ ] Manual: share encrypted doc in consultation → attorney decrypts
- [ ] Manual: revoke access → verify attorney can't decrypt

Closes LEG-392

🤖 Generated with [Claude Code](https://claude.com/claude-code)