### PR TITLE
fix(crypto): TS 5.9 strict BufferSource compatibility for Web Crypto API

### DIFF
--- a/lexwebapp/src/components/encryption/EncryptionSetupDialog.tsx
+++ b/lexwebapp/src/components/encryption/EncryptionSetupDialog.tsx
@@ -4,7 +4,7 @@
  * Also handles unlock flow for returning users.
  */
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Modal } from '../ui/Modal/Modal';
 import { Shield, Download, Eye, EyeOff, Loader2, KeyRound, Lock } from 'lucide-react';
 import { useEncryptionStore, downloadKeyFile } from '../../stores/encryptionStore';

--- a/lexwebapp/src/services/crypto/CryptoKeyManager.ts
+++ b/lexwebapp/src/services/crypto/CryptoKeyManager.ts
@@ -10,7 +10,7 @@
 
 // We use tweetnacl for X25519 since Web Crypto doesn't support it natively
 import nacl from 'tweetnacl';
-import { encodeBase64, decodeBase64 } from './utils';
+import { encodeBase64, decodeBase64, toBuffer } from './utils';
 
 export interface KeyPair {
   publicKey: Uint8Array;
@@ -63,7 +63,7 @@ export async function deriveKeyPBKDF2(
   return crypto.subtle.deriveKey(
     {
       name: 'PBKDF2',
-      salt,
+      salt: toBuffer(salt),
       iterations,
       hash: 'SHA-256',
     },
@@ -100,7 +100,7 @@ export async function deriveKeyFromPassword(
 
     const key = await crypto.subtle.importKey(
       'raw',
-      result.hash,
+      toBuffer(result.hash),
       { name: 'AES-GCM', length: 256 },
       false,
       ['encrypt', 'decrypt']
@@ -142,9 +142,9 @@ export async function encryptPrivateKey(
 ): Promise<string> {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     masterKey,
-    privateKey
+    toBuffer(privateKey)
   );
 
   // Concatenate IV + ciphertext (includes auth tag)
@@ -167,9 +167,9 @@ export async function decryptPrivateKey(
   const ciphertext = data.slice(12);
 
   const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     masterKey,
-    ciphertext
+    toBuffer(ciphertext)
   );
 
   return new Uint8Array(plaintext);

--- a/lexwebapp/src/services/crypto/DocumentEncryptor.ts
+++ b/lexwebapp/src/services/crypto/DocumentEncryptor.ts
@@ -4,7 +4,7 @@
  * Each document gets a unique DEK (Data Encryption Key).
  */
 
-import { encodeBase64, decodeBase64, randomBytes } from './utils';
+import { encodeBase64, decodeBase64, randomBytes, toBuffer } from './utils';
 
 /**
  * Generate a random 256-bit DEK for a document.
@@ -19,7 +19,7 @@ export function generateDEK(): Uint8Array {
 async function importDEK(dek: Uint8Array): Promise<CryptoKey> {
   return crypto.subtle.importKey(
     'raw',
-    dek,
+    toBuffer(dek),
     { name: 'AES-GCM', length: 256 },
     false,
     ['encrypt', 'decrypt']
@@ -40,9 +40,9 @@ export async function encryptContent(
   const plaintext = encoder.encode(content);
 
   const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     key,
-    plaintext
+    toBuffer(plaintext)
   );
 
   const result = new Uint8Array(iv.length + ciphertext.byteLength);
@@ -65,9 +65,9 @@ export async function decryptContent(
   const ciphertext = data.slice(12);
 
   const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     key,
-    ciphertext
+    toBuffer(ciphertext)
   );
 
   const decoder = new TextDecoder();
@@ -86,9 +86,9 @@ export async function encryptBinary(
   const iv = randomBytes(12);
 
   const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     key,
-    data
+    toBuffer(data)
   );
 
   const result = new Uint8Array(iv.length + ciphertext.byteLength);
@@ -110,9 +110,9 @@ export async function decryptBinary(
   const ciphertext = encryptedData.slice(12);
 
   const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     key,
-    ciphertext
+    toBuffer(ciphertext)
   );
 
   return new Uint8Array(plaintext);

--- a/lexwebapp/src/services/crypto/KeyExchange.ts
+++ b/lexwebapp/src/services/crypto/KeyExchange.ts
@@ -16,7 +16,7 @@
  */
 
 import nacl from 'tweetnacl';
-import { encodeBase64, decodeBase64, randomBytes } from './utils';
+import { encodeBase64, decodeBase64, randomBytes, toBuffer } from './utils';
 
 const HKDF_INFO = new TextEncoder().encode('SecondLayer-E2EE-DEK-v1');
 
@@ -26,7 +26,7 @@ const HKDF_INFO = new TextEncoder().encode('SecondLayer-E2EE-DEK-v1');
 async function deriveWrappingKey(sharedSecret: Uint8Array, salt: Uint8Array): Promise<CryptoKey> {
   const keyMaterial = await crypto.subtle.importKey(
     'raw',
-    sharedSecret,
+    toBuffer(sharedSecret),
     'HKDF',
     false,
     ['deriveKey']
@@ -36,8 +36,8 @@ async function deriveWrappingKey(sharedSecret: Uint8Array, salt: Uint8Array): Pr
     {
       name: 'HKDF',
       hash: 'SHA-256',
-      salt,
-      info: HKDF_INFO,
+      salt: toBuffer(salt),
+      info: toBuffer(HKDF_INFO),
     },
     keyMaterial,
     { name: 'AES-GCM', length: 256 },
@@ -67,9 +67,9 @@ export async function wrapDEK(
   // Encrypt the DEK with AES-256-GCM
   const iv = randomBytes(12);
   const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     wrappingKey,
-    dek
+    toBuffer(dek)
   );
 
   // Pack: ephemeral_public (32) + salt (16) + IV (12) + ciphertext
@@ -105,9 +105,9 @@ export async function unwrapDEK(
 
   // Decrypt the DEK
   const plaintext = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv },
+    { name: 'AES-GCM', iv: toBuffer(iv) },
     wrappingKey,
-    ciphertext
+    toBuffer(ciphertext)
   );
 
   return new Uint8Array(plaintext);

--- a/lexwebapp/src/services/crypto/__tests__/crypto.test.ts
+++ b/lexwebapp/src/services/crypto/__tests__/crypto.test.ts
@@ -170,7 +170,7 @@ describe('CryptoKeyManager', () => {
       ['deriveKey']
     );
     const masterKey = await crypto.subtle.deriveKey(
-      { name: 'PBKDF2', salt, iterations: 1000, hash: 'SHA-256' },
+      { name: 'PBKDF2', salt: salt as unknown as BufferSource, iterations: 1000, hash: 'SHA-256' },
       keyMaterial,
       { name: 'AES-GCM', length: 256 },
       false,

--- a/lexwebapp/src/services/crypto/__tests__/e2ee-integration.test.ts
+++ b/lexwebapp/src/services/crypto/__tests__/e2ee-integration.test.ts
@@ -11,7 +11,7 @@
  * 7. Verify plaintext is not visible in "stored" data
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   generateKeyPair,
   generateDEK,
@@ -189,8 +189,6 @@ describe('E2EE Integration: Full Lifecycle', () => {
   });
 
   it('different documents use different DEKs', async () => {
-    const kp = generateKeyPair();
-
     const dek1 = generateDEK();
     const dek2 = generateDEK();
     expect(timingSafeEqual(dek1, dek2)).toBe(false);
@@ -211,7 +209,6 @@ describe('E2EE Integration: Full Lifecycle', () => {
   });
 
   it('compromised DEK only exposes one document', async () => {
-    const kp = generateKeyPair();
     const doc1Content = 'Secret document 1';
     const doc2Content = 'Secret document 2';
 

--- a/lexwebapp/src/services/crypto/index.ts
+++ b/lexwebapp/src/services/crypto/index.ts
@@ -39,6 +39,7 @@ export {
   decodeBase64,
   randomBytes,
   timingSafeEqual,
+  toBuffer,
 } from './utils';
 
 export {

--- a/lexwebapp/src/services/crypto/utils.ts
+++ b/lexwebapp/src/services/crypto/utils.ts
@@ -30,6 +30,16 @@ export function randomBytes(length: number): Uint8Array {
 }
 
 /**
+ * Cast Uint8Array to BufferSource for Web Crypto API compatibility.
+ * TS 5.9+ treats Uint8Array.buffer as ArrayBufferLike (includes SharedArrayBuffer),
+ * but Web Crypto typings require ArrayBuffer. This is a type-level cast only —
+ * at runtime Uint8Array is already accepted by all Web Crypto implementations.
+ */
+export function toBuffer(data: Uint8Array): BufferSource {
+  return data as unknown as BufferSource;
+}
+
+/**
  * Constant-time comparison of two Uint8Arrays.
  */
 export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {

--- a/lexwebapp/src/stores/encryptionStore.ts
+++ b/lexwebapp/src/stores/encryptionStore.ts
@@ -11,7 +11,6 @@ import {
   setupEncryption,
   unlockPrivateKey,
   exportKeyFile,
-  decodeBase64,
   type EncryptedKeyBundle,
   type KdfParams,
 } from '../services/crypto';
@@ -82,9 +81,7 @@ export const useEncryptionStore = create<EncryptionState>()(
             kdf_params: bundle.kdfParams as unknown as Record<string, unknown>,
           });
 
-          // Unlock immediately after setup
-          const privateKey = decodeBase64(bundle.publicKey); // We still have the raw key
-          // Actually, we need to re-derive the private key from the bundle
+          // Unlock immediately after setup — re-derive private key from the bundle
           const pk = await unlockPrivateKey(
             password,
             bundle.encryptedPrivateKey,


### PR DESCRIPTION
## Summary

Fix CI build failure caused by TypeScript 5.9 strict typing for Web Crypto API.

- `Uint8Array.buffer` is typed as `ArrayBufferLike` (includes `SharedArrayBuffer`) but Web Crypto expects `ArrayBuffer`
- Added `toBuffer()` type-level cast helper — no runtime change, just satisfies the type checker
- Fixed unused imports/variables caught by strict mode

## Test plan

- [x] All 21 crypto tests pass locally
- [x] TypeScript compiles with 0 errors
- [x] Fixes CI failure from run #23284589473

🤖 Generated with [Claude Code](https://claude.com/claude-code)