### PR TITLE
fix: PostUploadDestination TS compilation errors

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/PostUploadDestination.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/PostUploadDestination.tsx
@@ -16,8 +16,11 @@ interface Props {
 }
 
 export function PostUploadDestination({ onComplete }: Props) {
-  const pendingDocumentIds = useUploadStore(s => s.pendingDocumentIds);
-  const dismissDestinationPicker = useUploadStore(s => s.dismissDestinationPicker);
+  const items = useUploadStore(s => s.items);
+  const pendingDocumentIds = items
+    .filter(i => i.status === 'completed' && i.documentId)
+    .map(i => i.documentId!);
+  const dismissDestinationPicker = onComplete;
 
   const [destination, setDestination] = useState<Destination>('new-matter');
   const [saving, setSaving] = useState(false);


### PR DESCRIPTION
## Summary

Fix TS errors blocking CI — `PostUploadDestination` referenced non-existent store properties.

- Replace `pendingDocumentIds` with derivation from existing `items` array
- Replace `dismissDestinationPicker` with `onComplete` prop

## Test plan

- [x] TypeScript compiles with 0 errors
- [x] Fixes CI failure from run #23284956310

🤖 Generated with [Claude Code](https://claude.com/claude-code)