### PR TITLE
fix(billing): handle Monobank PEM-encoded public key for webhook signature

### DIFF
--- a/mcp_backend/src/services/__tests__/monobank-service.test.ts
+++ b/mcp_backend/src/services/__tests__/monobank-service.test.ts
@@ -21,8 +21,8 @@ const TEST_API_KEY = 'test_monobank_api_key_12345';
 
 // Generate a test ECDSA P-256 key pair for signature tests
 const testKeyPair = crypto.generateKeyPairSync('ec', { namedCurve: 'prime256v1' });
-const testPubKeyDer = testKeyPair.publicKey.export({ format: 'der', type: 'spki' });
-const testPubKeyBase64 = testPubKeyDer.toString('base64');
+const testPubKeyPem = testKeyPair.publicKey.export({ format: 'pem', type: 'spki' }) as string;
+const testPubKeyBase64 = Buffer.from(testPubKeyPem).toString('base64');
 
 function makeEcdsaSignature(body: string | Buffer): string {
   const sign = crypto.createSign('SHA256');

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -169,12 +169,8 @@ export class MonobankService {
   async validateSignature(rawBody: Buffer | string, signature: string): Promise<boolean> {
     try {
       const pubKeyBase64 = await this.getMonobankPublicKey();
-      const pubKeyDer = Buffer.from(pubKeyBase64, 'base64');
-      const pubKey = createPublicKey({
-        key: pubKeyDer,
-        format: 'der',
-        type: 'spki',
-      });
+      const pubKeyPem = Buffer.from(pubKeyBase64, 'base64').toString('utf8');
+      const pubKey = createPublicKey(pubKeyPem);
 
       const verify = createVerify('SHA256');
       verify.update(typeof rawBody === 'string' ? rawBody : rawBody);


### PR DESCRIPTION
## Summary
- Monobank API changed `/api/merchant/pubkey` response format — now returns PEM key (base64-encoded) instead of raw DER
- Our code parsed it as DER, causing `asn1 encoding routines::wrong tag` errors on every webhook callback
- All payment top-ups were succeeding but balance wasn't being credited because webhook signature validation failed

## Fix
- Decode base64 → UTF-8 PEM string → pass to `createPublicKey()` which auto-detects PEM format
- Updated tests to match new format

## Test plan
- [x] All 48 monobank-service tests pass
- [x] TypeScript build clean
- [ ] Deploy to prod and verify webhook signature validation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)