### PR TITLE
fix: avoid lock contention in migration 080 GIN index creation

### DIFF
--- a/mcp_backend/src/migrations/080_edrsr_fulltext_search.sql
+++ b/mcp_backend/src/migrations/080_edrsr_fulltext_search.sql
@@ -13,7 +13,13 @@ DO $$ BEGIN
 END $$;
 
 -- GIN index on tsvector column for fast full text search
--- Note: not using CONCURRENTLY because migration runner wraps in transaction block.
--- On 125M rows with mostly NULL tsv values this will be fast (NULLs are not indexed by GIN).
--- The index will grow incrementally as the background service populates tsv values.
-CREATE INDEX IF NOT EXISTS idx_edrsr_fulltext_tsv ON edrsr_fulltext USING gin(tsv);
+-- Wrapped in existence check to avoid lock contention on 125M-row table
+-- when background FTS workers are running concurrent UPDATEs.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE indexname = 'idx_edrsr_fulltext_tsv'
+  ) THEN
+    CREATE INDEX idx_edrsr_fulltext_tsv ON edrsr_fulltext USING gin(tsv);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- `CREATE INDEX IF NOT EXISTS` still acquires a table lock even when index exists
- Background FTS workers running concurrent UPDATEs on 125M+ rows cause lock_timeout
- Wrap in `pg_indexes` existence check to skip entirely when already created

## Test plan
- [x] Index already exists on prod — migration will now skip cleanly
- [ ] CI/CD pipeline passes and deploys to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)