### PR TITLE
fix: ensure Winston console logs reach Docker stdout/stderr

### DIFF
--- a/packages/shared/src/utils/logger.ts
+++ b/packages/shared/src/utils/logger.ts
@@ -1,16 +1,17 @@
 import winston from 'winston';
+import { existsSync, mkdirSync } from 'fs';
 
 export type Logger = winston.Logger;
 
 export function createLogger(serviceName: string): Logger {
-  // Build transports array
   const transports: winston.transport[] = [];
 
-  // Only add Console transport if not in MCP STDIO mode
-  // In STDIO mode, stdout is reserved for MCP protocol communication
+  // Console transport: always add unless MCP STDIO mode (stdout reserved for protocol)
   if (process.env.MCP_STDIO_MODE !== 'true') {
     transports.push(
       new winston.transports.Console({
+        // Write warn/error to stderr, info/debug to stdout — Docker captures both
+        stderrLevels: ['error', 'warn'],
         format: winston.format.combine(
           winston.format.colorize(),
           winston.format.simple()
@@ -19,11 +20,19 @@ export function createLogger(serviceName: string): Logger {
     );
   }
 
-  // Always add file transports
-  transports.push(
-    new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
-    new winston.transports.File({ filename: 'logs/combined.log' })
-  );
+  // File transports: only when logs/ directory exists or can be created
+  // Skip in Docker containers where console output goes to docker logs
+  if (process.env.LOG_TO_FILE !== 'false') {
+    try {
+      if (!existsSync('logs')) mkdirSync('logs', { recursive: true });
+      transports.push(
+        new winston.transports.File({ filename: 'logs/error.log', level: 'error' }),
+        new winston.transports.File({ filename: 'logs/combined.log' })
+      );
+    } catch {
+      // File logging unavailable — console-only mode
+    }
+  }
 
   return winston.createLogger({
     level: process.env.LOG_LEVEL || 'info',


### PR DESCRIPTION
## Summary
- Winston file transports silently failed when `logs/` dir missing in container
- Added `stderrLevels` to route error/warn to stderr (Docker captures both streams)
- Create `logs/` directory on demand instead of failing silently
- Added `LOG_TO_FILE=false` env var option to skip file transports entirely

## Test plan
- [x] TypeScript build clean
- [ ] Verify `docker logs` shows application output after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)