### PR TITLE
fix: blue-green deploy health check and set -e safety

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -419,7 +419,9 @@ jobs:
             [ "\$FRONTEND_COLOR" = "green" ] && NEW_FRONTEND="blue" || NEW_FRONTEND="green"
 
             ANY_BACKEND=false
-            [ "${BACKEND_CHANGED}" = "true" ] || [ "${RADA_CHANGED}" = "true" ] || [ "${OPENREYESTR_CHANGED}" = "true" ] && ANY_BACKEND=true
+            if [ "${BACKEND_CHANGED}" = "true" ] || [ "${RADA_CHANGED}" = "true" ] || [ "${OPENREYESTR_CHANGED}" = "true" ]; then
+              ANY_BACKEND=true
+            fi
 
             echo "Backend: \$BACKEND_COLOR → \$NEW_BACKEND (changed: \$ANY_BACKEND)"
             echo "Frontend: \$FRONTEND_COLOR → \$NEW_FRONTEND (changed: ${FRONTEND_CHANGED})"

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -16,6 +16,17 @@ error_log /var/log/nginx/legal.org.ua-error.log;
 client_max_body_size 50M;
 
 # ==========================================
+# Health Check (proxied to backend, works with blue-green)
+# ==========================================
+
+location /health {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    access_log off;
+}
+
+# ==========================================
 # Authentication Routes
 # ==========================================
 


### PR DESCRIPTION
## Summary
- Add `/health` location to prod nginx config so health checks route to backend through nginx, regardless of active blue/green color
- Fix `ANY_BACKEND` detection in CI/CD deploy script — the `|| ... && ...` pattern could abort the script under `set -e` when no backend services changed

## Test plan
- [ ] Verify deploy pipeline passes with only frontend changes (triggers the `ANY_BACKEND=false` path)
- [ ] Verify `curl http://localhost/health` returns backend health through nginx after deploy
- [ ] Verify blue-green switch works end-to-end on next prod deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)