### PR TITLE
fix: add /health/ready endpoint to document-service

### DIFF
--- a/mcp_backend/src/document-service.ts
+++ b/mcp_backend/src/document-service.ts
@@ -85,7 +85,7 @@ class DocumentAnalysisServer {
     });
 
     // Ready check (includes dependencies)
-    this.app.get('/ready', async (_req, res) => {
+    this.app.get(['/ready', '/health/ready'], async (_req, res) => {
       try {
         res.json({
           status: 'ready',


### PR DESCRIPTION
## Summary

- Docker healthcheck in compose checks `/health/ready` but document-service only had `/ready`
- This caused `document-service-prod-green` to always fail health checks, blocking all blue-green deployments since #909
- Added `/health/ready` as alias for the existing `/ready` endpoint

**This was the root cause of CI/CD deploy failures in #909 and #910.**

## Test plan

- [ ] Verify CI/CD pipeline deploys successfully (document-service passes health check)
- [ ] Verify `curl http://localhost:3008/health/ready` returns 200 on prod after deploy


🤖 Generated with [Claude Code](https://claude.com/claude-code)