### PR TITLE
fix: document-service healthcheck port 3001→3002

### DIFF
--- a/deployment/Dockerfile.document-service
+++ b/deployment/Dockerfile.document-service
@@ -71,10 +71,10 @@ RUN mkdir -p /tmp/document-parser && chmod 777 /tmp/document-parser
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3001/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
+    CMD node -e "require('http').get('http://localhost:3002/health', (r) => {process.exit(r.statusCode === 200 ? 0 : 1)})"
 
 # Expose port
-EXPOSE 3001
+EXPOSE 3002
 
 # Run document service
 CMD ["node", "dist/document-service.js"]


### PR DESCRIPTION
## Summary
- HEALTHCHECK and EXPOSE in `Dockerfile.document-service` were hardcoded to port 3001, but the service listens on port 3002 (`DOCUMENT_SERVICE_PORT`)
- This caused every prod blue-green deploy to fail health check and rollback, blocking all releases since v1.25.3
- Fixes port to 3002

## Test plan
- [ ] CI/CD pipeline passes — document-service-prod-green reports healthy
- [ ] Prod deploy completes successfully and version updates past v1.25.3

Closes #911, #912, #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)