### PR TITLE
fix: use correct container names in nginx upstream config

### DIFF
--- a/.github/workflows/ci-stage-deploy.yml
+++ b/.github/workflows/ci-stage-deploy.yml
@@ -526,9 +526,9 @@ jobs:
 
             # --- 5. Switch nginx upstreams to new color ---
             if [ "\$ANY_BACKEND" = "true" ]; then
-              [ "\$NEW_BACKEND" = "green" ] && BE_HOST="app-prod-green" || BE_HOST="app-prod"
+              [ "\$NEW_BACKEND" = "green" ] && BE_HOST="secondlayer-app-prod-green" || BE_HOST="secondlayer-app-prod"
             else
-              [ "\$BACKEND_COLOR" = "green" ] && BE_HOST="app-prod-green" || BE_HOST="app-prod"
+              [ "\$BACKEND_COLOR" = "green" ] && BE_HOST="secondlayer-app-prod-green" || BE_HOST="secondlayer-app-prod"
             fi
             if [ "${FRONTEND_CHANGED}" = "true" ]; then
               [ "\$NEW_FRONTEND" = "green" ] && FE_HOST="lexwebapp-prod-green" || FE_HOST="lexwebapp-prod"


### PR DESCRIPTION
## Summary
- Blue-green deploy script wrote `app-prod` / `app-prod-green` to nginx upstreams, but actual container names are `secondlayer-app-prod` / `secondlayer-app-prod-green`
- This caused **502 Bad Gateway** on prod after every deploy — nginx couldn't resolve the upstream host
- Root cause of prod being stuck on v1.25.3 (along with the document-service healthcheck port fix in #918)

## Test plan
- [ ] Next prod deploy writes correct container names to `prod-upstreams.conf`
- [ ] No 502 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)