### PR TITLE
refactor: consolidate ServiceProxy and ToolRegistry HTTP clients

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -10,8 +10,8 @@
 
 import { ToolRoute, ServiceType } from '../types/gateway.js';
 import { logger } from '../utils/logger.js';
-import axios, { AxiosInstance } from 'axios';
 import { BaseToolHandler, ToolResult, ToolDefinition as BaseToolDefinition, StreamEventCallback } from './base-tool-handler.js';
+import { RemoteServiceClient } from '../services/remote-service-client.js';
 
 export interface ToolDefinition {
   name: string;
@@ -26,17 +26,15 @@ export interface RemoteServiceConfig {
 
 export class ToolRegistry {
   private routes: Map<string, ToolRoute>;
-  private axiosClient: AxiosInstance;
   private handlers: BaseToolHandler[] = [];
   private handlerMap: Map<string, BaseToolHandler> = new Map();
   private remoteToolDefs: ToolDefinition[] = [];
   private remoteToolDefsLoaded = false;
+  private remoteClient: RemoteServiceClient;
 
-  constructor() {
+  constructor(remoteClient?: RemoteServiceClient) {
     this.routes = new Map();
-    this.axiosClient = axios.create({
-      timeout: 60000,
-    });
+    this.remoteClient = remoteClient || new RemoteServiceClient();
     this.initializeRoutes();
   }
 
@@ -88,63 +86,24 @@ export class ToolRegistry {
    * Execute a tool on a remote service via HTTP proxy.
    */
   private async executeRemoteTool(route: ToolRoute, args: any): Promise<any> {
-    const config = this.getRemoteServiceConfig(route.service);
-    if (!config.baseUrl || !config.apiKey) {
-      throw new Error(`Remote service ${route.service} is not configured (missing URL or API key)`);
-    }
-
-    const url = `${config.baseUrl}/api/tools/${route.serviceName}`;
     logger.info('[ToolRegistry] Proxying to remote service', {
       tool: route.toolName,
       service: route.service,
       serviceName: route.serviceName,
     });
 
-    try {
-      const response = await this.axiosClient.post(
-        url,
-        { arguments: args },
-        {
-          headers: {
-            Authorization: `Bearer ${config.apiKey}`,
-            Accept: 'application/json',
-          },
-          timeout: 60000,
-        }
-      );
+    const responseData = await this.remoteClient.callRemoteTool({
+      service: route.service,
+      toolName: route.serviceName,
+      args,
+    });
 
-      logger.info('[ToolRegistry] Remote call successful', {
-        tool: route.toolName,
-        service: route.service,
-      });
+    logger.info('[ToolRegistry] Remote call successful', {
+      tool: route.toolName,
+      service: route.service,
+    });
 
-      return response.data?.result || response.data;
-    } catch (error: any) {
-      logger.error('[ToolRegistry] Remote call failed', {
-        tool: route.toolName,
-        service: route.service,
-        error: error.message,
-        status: error.response?.status,
-      });
-      throw new Error(`Remote service call failed (${route.service}/${route.serviceName}): ${error.message}`);
-    }
-  }
-
-  /**
-   * Get remote service connection config from env vars.
-   */
-  private getRemoteServiceConfig(service: ServiceType): RemoteServiceConfig {
-    const configs: Record<string, RemoteServiceConfig> = {
-      rada: {
-        baseUrl: process.env.RADA_MCP_URL || '',
-        apiKey: process.env.RADA_API_KEY || '',
-      },
-      openreyestr: {
-        baseUrl: process.env.OPENREYESTR_MCP_URL || '',
-        apiKey: process.env.OPENREYESTR_API_KEY || '',
-      },
-    };
-    return configs[service] || { baseUrl: '', apiKey: '' };
+    return responseData?.result || responseData;
   }
 
   /**
@@ -210,47 +169,31 @@ export class ToolRegistry {
     const defs: ToolDefinition[] = [];
 
     // Fetch RADA tools
-    const radaConfig = this.getRemoteServiceConfig('rada');
+    const radaConfig = this.remoteClient.getServiceConfig('rada');
     if (radaConfig.baseUrl && radaConfig.apiKey) {
-      try {
-        const response = await this.axiosClient.get(`${radaConfig.baseUrl}/api/tools`, {
-          headers: { Authorization: `Bearer ${radaConfig.apiKey}` },
-          timeout: 5000,
+      const tools = await this.remoteClient.fetchRemoteToolDefinitions(radaConfig.baseUrl, radaConfig.apiKey);
+      for (const tool of tools) {
+        defs.push({
+          name: `rada_${tool.name}`,
+          description: `[RADA] ${tool.description}`,
+          inputSchema: tool.inputSchema,
         });
-        const tools = response.data.tools || [];
-        for (const tool of tools) {
-          defs.push({
-            name: `rada_${tool.name}`,
-            description: `[RADA] ${tool.description}`,
-            inputSchema: tool.inputSchema,
-          });
-        }
-        logger.info('[ToolRegistry] Fetched RADA tool definitions', { count: tools.length });
-      } catch (err: any) {
-        logger.warn('[ToolRegistry] Failed to fetch RADA tools', { error: err.message });
       }
+      logger.info('[ToolRegistry] Fetched RADA tool definitions', { count: tools.length });
     }
 
     // Fetch OpenReyestr tools
-    const orConfig = this.getRemoteServiceConfig('openreyestr');
+    const orConfig = this.remoteClient.getServiceConfig('openreyestr');
     if (orConfig.baseUrl && orConfig.apiKey) {
-      try {
-        const response = await this.axiosClient.get(`${orConfig.baseUrl}/api/tools`, {
-          headers: { Authorization: `Bearer ${orConfig.apiKey}` },
-          timeout: 5000,
+      const tools = await this.remoteClient.fetchRemoteToolDefinitions(orConfig.baseUrl, orConfig.apiKey);
+      for (const tool of tools) {
+        defs.push({
+          name: `openreyestr_${tool.name}`,
+          description: `[OpenReyestr] ${tool.description}`,
+          inputSchema: tool.inputSchema,
         });
-        const tools = response.data.tools || [];
-        for (const tool of tools) {
-          defs.push({
-            name: `openreyestr_${tool.name}`,
-            description: `[OpenReyestr] ${tool.description}`,
-            inputSchema: tool.inputSchema,
-          });
-        }
-        logger.info('[ToolRegistry] Fetched OpenReyestr tool definitions', { count: tools.length });
-      } catch (err: any) {
-        logger.warn('[ToolRegistry] Failed to fetch OpenReyestr tools', { error: err.message });
       }
+      logger.info('[ToolRegistry] Fetched OpenReyestr tool definitions', { count: tools.length });
     }
 
     this.remoteToolDefs = defs;
@@ -335,58 +278,28 @@ export class ToolRegistry {
 
     // Fetch RADA tools if configured
     if (radaBaseUrl && radaApiKey) {
-      try {
-        const response = await this.axiosClient.get(`${radaBaseUrl}/api/tools`, {
-          headers: {
-            Authorization: `Bearer ${radaApiKey}`,
-          },
-          timeout: 5000,
-        });
+      const radaTools = await this.remoteClient.fetchRemoteToolDefinitions(radaBaseUrl, radaApiKey);
+      logger.debug('Fetched RADA tools', { count: radaTools.length });
 
-        const radaTools = response.data.tools || [];
-        logger.debug('Fetched RADA tools', { count: radaTools.length });
-
-        // Prefix RADA tools with 'rada_'
-        for (const tool of radaTools) {
-          allTools.push({
-            name: `rada_${tool.name}`,
-            description: `[RADA] ${tool.description}`,
-            inputSchema: tool.inputSchema,
-          });
-        }
-      } catch (error: any) {
-        logger.warn('Failed to fetch RADA tools', {
-          error: error.message,
-          baseUrl: radaBaseUrl,
+      for (const tool of radaTools) {
+        allTools.push({
+          name: `rada_${tool.name}`,
+          description: `[RADA] ${tool.description}`,
+          inputSchema: tool.inputSchema,
         });
       }
     }
 
     // Fetch OpenReyestr tools if configured
     if (openreyestrBaseUrl && openreyestrApiKey) {
-      try {
-        const response = await this.axiosClient.get(`${openreyestrBaseUrl}/api/tools`, {
-          headers: {
-            Authorization: `Bearer ${openreyestrApiKey}`,
-          },
-          timeout: 5000,
-        });
+      const openreyestrTools = await this.remoteClient.fetchRemoteToolDefinitions(openreyestrBaseUrl, openreyestrApiKey);
+      logger.debug('Fetched OpenReyestr tools', { count: openreyestrTools.length });
 
-        const openreyestrTools = response.data.tools || [];
-        logger.debug('Fetched OpenReyestr tools', { count: openreyestrTools.length });
-
-        // Prefix OpenReyestr tools with 'openreyestr_'
-        for (const tool of openreyestrTools) {
-          allTools.push({
-            name: `openreyestr_${tool.name}`,
-            description: `[OpenReyestr] ${tool.description}`,
-            inputSchema: tool.inputSchema,
-          });
-        }
-      } catch (error: any) {
-        logger.warn('Failed to fetch OpenReyestr tools', {
-          error: error.message,
-          baseUrl: openreyestrBaseUrl,
+      for (const tool of openreyestrTools) {
+        allTools.push({
+          name: `openreyestr_${tool.name}`,
+          description: `[OpenReyestr] ${tool.description}`,
+          inputSchema: tool.inputSchema,
         });
       }
     }

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -6,6 +6,7 @@ import { BatchDocumentTools } from '../api/batch-document-tools.js';
 import { MetadataExtractor } from '../services/metadata-extractor.js';
 import { ToolRegistry } from '../api/tool-registry.js';
 import { ServiceProxy } from '../services/service-proxy.js';
+import { RemoteServiceClient } from '../services/remote-service-client.js';
 import { UploadService } from '../services/upload-service.js';
 import { MinioService } from '../services/minio-service.js';
 import { VaultTools } from '../api/vault-tools.js';
@@ -67,9 +68,10 @@ export function createToolServices(
   );
   logger.info('Batch document processing tools initialized');
 
-  // Unified Gateway components
-  const toolRegistry = new ToolRegistry();
-  const serviceProxy = new ServiceProxy(costTracker);
+  // Unified Gateway components — single shared HTTP client for remote services
+  const remoteClient = new RemoteServiceClient();
+  const toolRegistry = new ToolRegistry(remoteClient);
+  const serviceProxy = new ServiceProxy(costTracker, remoteClient);
   logger.info('Unified Gateway initialized (Tool Registry + Service Proxy)');
 
   // Register all tool handlers with the central registry

--- a/mcp_backend/src/services/remote-service-client.ts
+++ b/mcp_backend/src/services/remote-service-client.ts
@@ -1,0 +1,178 @@
+/**
+ * RemoteServiceClient - Shared HTTP client for communicating with remote MCP services (RADA, OpenReyestr).
+ *
+ * Consolidates the duplicate axios instances and env-var reading that previously
+ * lived in both ServiceProxy and ToolRegistry.
+ */
+
+import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import { logger } from '../utils/logger.js';
+import { ServiceType } from '../types/gateway.js';
+
+export interface RemoteServiceConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+export interface CallRemoteToolParams {
+  service: ServiceType;
+  toolName: string;
+  args: any;
+  requestId?: string;
+  acceptHeader?: string;
+}
+
+export interface FetchedToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: any;
+}
+
+export class RemoteServiceClient {
+  private axiosClient: AxiosInstance;
+  private metricsCallback: ((service: string, status: string, durationSec: number) => void) | null = null;
+
+  constructor() {
+    this.axiosClient = axios.create({
+      timeout: 60000,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  /**
+   * Get service configuration from environment variables.
+   */
+  getServiceConfig(service: ServiceType): RemoteServiceConfig {
+    const configs: Record<ServiceType, RemoteServiceConfig> = {
+      backend: {
+        baseUrl: '',
+        apiKey: '',
+      },
+      rada: {
+        baseUrl: process.env.RADA_MCP_URL || 'http://rada-mcp-app-stage:3001',
+        apiKey: process.env.RADA_API_KEY || '',
+      },
+      openreyestr: {
+        baseUrl: process.env.OPENREYESTR_MCP_URL || 'http://app-openreyestr-stage:3005',
+        apiKey: process.env.OPENREYESTR_API_KEY || '',
+      },
+    };
+
+    return configs[service] || { baseUrl: '', apiKey: '' };
+  }
+
+  /**
+   * Call a tool on a remote MCP service via HTTP POST.
+   *
+   * Supports both JSON responses and SSE streaming (when acceptHeader
+   * includes 'text/event-stream', the raw stream is returned).
+   */
+  async callRemoteTool(params: CallRemoteToolParams): Promise<AxiosResponse['data']> {
+    const { service, toolName, args, requestId, acceptHeader } = params;
+
+    const config = this.getServiceConfig(service);
+
+    if (!config.baseUrl || !config.apiKey) {
+      throw new Error(`Service ${service} is not configured (missing URL or API key)`);
+    }
+
+    const url = `${config.baseUrl}/api/tools/${toolName}`;
+    const isStreaming = !!acceptHeader?.includes('event-stream');
+
+    logger.info('[RemoteServiceClient] Calling remote service', {
+      service,
+      tool: toolName,
+      url,
+      requestId,
+      streaming: isStreaming,
+    });
+
+    const callStart = Date.now();
+    try {
+      const headers: Record<string, string> = {
+        Authorization: `Bearer ${config.apiKey}`,
+        Accept: acceptHeader || 'application/json',
+      };
+      if (requestId) {
+        headers['X-Parent-Request-ID'] = requestId;
+      }
+
+      const response: AxiosResponse = await this.axiosClient.post(
+        url,
+        { arguments: args },
+        {
+          headers,
+          responseType: isStreaming ? 'stream' : 'json',
+        }
+      );
+
+      const callDuration = (Date.now() - callStart) / 1000;
+      this.metricsCallback?.(service, 'success', callDuration);
+
+      logger.info('[RemoteServiceClient] Remote call successful', {
+        service,
+        tool: toolName,
+        requestId,
+        statusCode: response.status,
+      });
+
+      return response.data;
+    } catch (error: any) {
+      const callDuration = (Date.now() - callStart) / 1000;
+      this.metricsCallback?.(service, 'error', callDuration);
+
+      logger.error('[RemoteServiceClient] Remote call failed', {
+        service,
+        tool: toolName,
+        requestId,
+        error: error.message,
+        status: error.response?.status,
+        data: error.response?.data,
+      });
+
+      throw new Error(
+        `Remote service call failed (${service}/${toolName}): ${error.message}`
+      );
+    }
+  }
+
+  /**
+   * Fetch tool definitions from a remote service via GET /api/tools.
+   */
+  async fetchRemoteToolDefinitions(
+    serviceUrl: string,
+    apiKey: string
+  ): Promise<FetchedToolDefinition[]> {
+    try {
+      const response = await this.axiosClient.get(`${serviceUrl}/api/tools`, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+        timeout: 5000,
+      });
+      return response.data.tools || [];
+    } catch (err: any) {
+      logger.warn('[RemoteServiceClient] Failed to fetch remote tool definitions', {
+        serviceUrl,
+        error: err.message,
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Set optional metrics callback for external API call tracking.
+   */
+  setMetricsCallback(callback: (service: string, status: string, durationSec: number) => void): void {
+    this.metricsCallback = callback;
+  }
+
+  /**
+   * Check if a remote service is configured and available.
+   */
+  isServiceAvailable(service: ServiceType): boolean {
+    if (service === 'backend') return true;
+    const config = this.getServiceConfig(service);
+    return !!(config.baseUrl && config.apiKey);
+  }
+}

--- a/mcp_backend/src/services/service-proxy.ts
+++ b/mcp_backend/src/services/service-proxy.ts
@@ -1,11 +1,15 @@
 /**
  * Service Proxy - HTTP client for proxying requests to remote MCP services (RADA, OpenReyestr)
+ *
+ * Delegates HTTP transport to RemoteServiceClient; retains cost-tracking integration.
  */
 
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
 import { logger } from '../utils/logger.js';
 import { CostTracker } from './cost-tracker.js';
 import { ServiceType } from '../types/gateway.js';
+import { RemoteServiceClient } from './remote-service-client.js';
+
+export { RemoteServiceConfig } from './remote-service-client.js';
 
 export interface ServiceProxyConfig {
   baseUrl: string;
@@ -13,17 +17,10 @@ export interface ServiceProxyConfig {
 }
 
 export class ServiceProxy {
-  private axiosClient: AxiosInstance;
-  private externalApiMetrics: ((service: string, status: string, durationSec: number) => void) | null = null;
-
-  constructor(private costTracker: CostTracker) {
-    this.axiosClient = axios.create({
-      timeout: 60000,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-  }
+  constructor(
+    private costTracker: CostTracker,
+    private remoteClient: RemoteServiceClient
+  ) {}
 
   /**
    * Call a remote MCP service (RADA or OpenReyestr)
@@ -37,81 +34,30 @@ export class ServiceProxy {
   }): Promise<any> {
     const { service, serviceName, args, requestId, acceptHeader } = params;
 
-    const config = this.getServiceConfig(service);
-
-    if (!config.baseUrl || !config.apiKey) {
-      throw new Error(`Service ${service} is not configured (missing URL or API key)`);
-    }
-
-    const url = `${config.baseUrl}/api/tools/${serviceName}`;
-
-    logger.info('[ServiceProxy] Calling remote service', {
+    const responseData = await this.remoteClient.callRemoteTool({
       service,
-      tool: serviceName,
-      url,
+      toolName: serviceName,
+      args,
       requestId,
-      streaming: acceptHeader?.includes('event-stream'),
+      acceptHeader,
     });
 
-    const callStart = Date.now();
-    try {
-      // Make HTTP request to remote service
-      const response: AxiosResponse = await this.axiosClient.post(
-        url,
-        { arguments: args },
-        {
-          headers: {
-            Authorization: `Bearer ${config.apiKey}`,
-            Accept: acceptHeader || 'application/json',
-            'X-Parent-Request-ID': requestId,
-          },
-          responseType: acceptHeader?.includes('event-stream') ? 'stream' : 'json',
-        }
-      );
-      const callDuration = (Date.now() - callStart) / 1000;
-      this.externalApiMetrics?.(service, 'success', callDuration);
-
-      // For streaming responses, return the raw stream
-      if (acceptHeader?.includes('event-stream')) {
-        return response.data;
-      }
-
-      // Extract cost tracking from response
-      if (response.data?.cost_tracking?.actual_cost) {
-        await this.recordRemoteServiceCost({
-          requestId,
-          service,
-          toolName: serviceName,
-          costData: response.data.cost_tracking.actual_cost,
-        });
-      }
-
-      logger.info('[ServiceProxy] Remote call successful', {
-        service,
-        tool: serviceName,
-        requestId,
-        statusCode: response.status,
-      });
-
-      return response.data;
-    } catch (error: any) {
-      const callDuration = (Date.now() - callStart) / 1000;
-      this.externalApiMetrics?.(service, 'error', callDuration);
-
-      logger.error('[ServiceProxy] Remote call failed', {
-        service,
-        tool: serviceName,
-        requestId,
-        error: error.message,
-        status: error.response?.status,
-        data: error.response?.data,
-      });
-
-      // Re-throw with more context
-      throw new Error(
-        `Remote service call failed (${service}/${serviceName}): ${error.message}`
-      );
+    // For streaming responses, return the raw stream (no cost extraction)
+    if (acceptHeader?.includes('event-stream')) {
+      return responseData;
     }
+
+    // Extract cost tracking from response
+    if (responseData?.cost_tracking?.actual_cost) {
+      await this.recordRemoteServiceCost({
+        requestId,
+        service,
+        toolName: serviceName,
+        costData: responseData.cost_tracking.actual_cost,
+      });
+    }
+
+    return responseData;
   }
 
   /**
@@ -164,42 +110,15 @@ export class ServiceProxy {
     }
   }
 
-  /**
-   * Get service configuration from environment variables
-   */
-  private getServiceConfig(service: ServiceType): ServiceProxyConfig {
-    const configs: Record<ServiceType, ServiceProxyConfig> = {
-      backend: {
-        baseUrl: '',
-        apiKey: '',
-      },
-      rada: {
-        baseUrl: process.env.RADA_MCP_URL || 'http://rada-mcp-app-stage:3001',
-        apiKey: process.env.RADA_API_KEY || '',
-      },
-      openreyestr: {
-        baseUrl: process.env.OPENREYESTR_MCP_URL || 'http://app-openreyestr-stage:3005',
-        apiKey: process.env.OPENREYESTR_API_KEY || '',
-      },
-    };
-
-    return configs[service];
-  }
-
   setExternalApiMetrics(callback: (service: string, status: string, durationSec: number) => void) {
-    this.externalApiMetrics = callback;
+    this.remoteClient.setMetricsCallback(callback);
   }
 
   /**
    * Check if a service is configured and available
    */
   isServiceAvailable(service: ServiceType): boolean {
-    if (service === 'backend') {
-      return true; // Backend is always available
-    }
-
-    const config = this.getServiceConfig(service);
-    return !!(config.baseUrl && config.apiKey);
+    return this.remoteClient.isServiceAvailable(service);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Extract shared HTTP transport from `ServiceProxy` and `ToolRegistry` into a new `RemoteServiceClient` class (`mcp_backend/src/services/remote-service-client.ts`)
- Both classes previously created independent axios instances with identical config (60s timeout), read the same env vars (`RADA_MCP_URL`, `RADA_API_KEY`, `OPENREYESTR_MCP_URL`, `OPENREYESTR_API_KEY`), and duplicated `POST /api/tools/:toolName` and `GET /api/tools` logic
- `RemoteServiceClient` provides: single `AxiosInstance`, `callRemoteTool()` (supports JSON + SSE streaming via `responseType: 'stream'`), `fetchRemoteToolDefinitions()`, `getServiceConfig()`, optional metrics callback
- `ServiceProxy` and `ToolRegistry` accept `RemoteServiceClient` as a constructor dependency; public interfaces are preserved so downstream consumers (`tool-execution-routes.ts`, etc.) need no changes

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Verify remote tool execution (RADA/OpenReyestr) works on stage after deploy
- [ ] Verify SSE streaming proxy still works for remote tools
- [ ] Verify `GET /api/tools` returns both local and remote tool definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)