### PR TITLE
fix: retry nginx config test for Docker DNS resolution during deploy

### DIFF
--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -971,8 +971,17 @@ UPSTREAM_EOF
             # Ensure nginx is running
             $DC up -d nginx-prod
 
-            # Validate and reload nginx config
-            if ! docker exec nginx-prod nginx -t 2>&1; then
+            # Validate and reload nginx config (retry up to 5 times — Docker DNS may need a moment)
+            NGINX_OK=false
+            for NGINX_TRY in 1 2 3 4 5; do
+                if docker exec nginx-prod nginx -t 2>&1; then
+                    NGINX_OK=true
+                    break
+                fi
+                echo "nginx -t attempt $NGINX_TRY/5 failed — waiting 3s for Docker DNS..."
+                sleep 3
+            done
+            if [ "$NGINX_OK" != "true" ]; then
                 echo "ERROR: nginx config validation failed! Reverting upstream..."
                 # Revert to old color upstream
                 if [ "$ACTIVE_COLOR" = "blue" ]; then


### PR DESCRIPTION
## Summary

- Add retry loop (5 attempts, 3s delay) before `nginx -t` during blue-green deploy
- Fixes `host not found in upstream "lexwebapp-prod-green:80"` errors caused by Docker DNS not immediately resolving green container hostnames after startup

## Root cause

The deploy script starts green containers, waits for health checks, writes new upstream config, then immediately runs `nginx -t`. Docker's embedded DNS resolver (`127.0.0.11`) may not have registered the new container hostname yet, causing nginx config validation to fail and aborting the deploy.

## Test plan

- [ ] Deploy to prod — nginx config test should pass (with retries if needed)
- [ ] No change to rollback behavior — if all 5 retries fail, upstream is still reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)