### PR TITLE
fix(ci): ensure build-essential for node-gyp on local runner

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -71,6 +71,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure native build tools
+        run: |
+          if ! command -v make &>/dev/null; then
+            sudo apt-get update -qq && sudo apt-get install -y -qq build-essential python3
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary

- Add step to install `build-essential` + `python3` if `make` is missing on local runner
- Fixes `gyp ERR! not found: make` during `npm ci` (node-pty native module)
- Idempotent — skips if already installed

## Test plan

- [ ] CI pipeline passes Build & Test step
- [ ] Deploy to prod succeeds (with nginx retry from #934)

🤖 Generated with [Claude Code](https://claude.com/claude-code)