### PR TITLE
fix(billing): handle both Buffer and parsed object in Monobank webhook

### DIFF
--- a/mcp_backend/src/routes/payment-routes.ts
+++ b/mcp_backend/src/routes/payment-routes.ts
@@ -218,9 +218,9 @@ export function createWebhookRouter(
       if (!signature) {
         return res.status(400).json({ error: 'Missing X-Sign header' });
       }
-      // req.body is a Buffer here (raw body parser is used for /webhooks)
-      const rawBody: Buffer = req.body;
-      const parsed = JSON.parse(rawBody.toString('utf8'));
+      // req.body is a Buffer when raw body parser works, or already parsed object
+      const rawBody: Buffer = Buffer.isBuffer(req.body) ? req.body : Buffer.from(JSON.stringify(req.body));
+      const parsed = Buffer.isBuffer(req.body) ? JSON.parse(req.body.toString('utf8')) : req.body;
       const result = await monobankService.handleWebhook(rawBody, parsed, signature);
 
       // Check if this is a consultation payment and handle accordingly


### PR DESCRIPTION
## Summary

- Monobank webhook handler assumed `req.body` is always a `Buffer` from `express.raw()`
- In practice, body sometimes arrives as already-parsed object, causing `JSON.parse("[object Object]")` to fail
- Now handles both cases gracefully: Buffer → parse, object → use directly

## Test plan

- [ ] Trigger Monobank test payment and verify webhook processes without error
- [ ] Check logs for absence of `"is not valid JSON"` errors


🤖 Generated with [Claude Code](https://claude.com/claude-code)