### PR TITLE
fix: add GET /api/encryption/setup to prevent 405

### DIFF
--- a/mcp_backend/src/routes/encryption-routes.ts
+++ b/mcp_backend/src/routes/encryption-routes.ts
@@ -17,6 +17,20 @@ export function createEncryptionRoutes(
   const router = express.Router();
 
   /**
+   * GET /api/encryption/setup — returns setup status (alias for /status)
+   */
+  router.get('/setup', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+      const hasSetup = await encryptionKeyService.hasEncryptionSetup(userId);
+      res.json({ has_encryption: hasSetup });
+    } catch (error: any) {
+      res.status(500).json({ error: 'Помилка перевірки статусу шифрування' });
+    }
+  }) as any);
+
+  /**
    * POST /api/encryption/setup
    * Initialize user encryption keys (called once during E2EE setup)
    */


### PR DESCRIPTION
## Summary

- Browser sends GET to `/api/encryption/setup` when loading encryption settings page
- Without GET handler, Express returns 405 Method Not Allowed
- Added GET handler returning encryption setup status (alias for `/status`)

## Test plan

- [ ] Load encryption settings page — no 405 errors in console


🤖 Generated with [Claude Code](https://claude.com/claude-code)