### PR TITLE
fix(billing): track UAH balance in transaction history

### DIFF
--- a/lexwebapp/src/components/billing/TransactionsTab.tsx
+++ b/lexwebapp/src/components/billing/TransactionsTab.tsx
@@ -35,6 +35,7 @@ interface Transaction {
   amount_usd: number;
   amount_uah: number;
   balance_after_usd: number;
+  balance_after_uah?: number;
   description: string;
   payment_provider?: string;
   payment_id?: string;
@@ -93,7 +94,7 @@ export function TransactionsTab() {
       TYPE_LABELS[t.type] || t.type,
       csvEscape(t.description),
       Number(t.amount_uah || 0).toFixed(2),
-      Number(t.balance_after_usd || 0).toFixed(2),
+      t.balance_after_uah != null ? Number(t.balance_after_uah).toFixed(2) : Number(t.balance_after_usd || 0).toFixed(2),
       t.payment_provider || 'N/A',
     ]);
 
@@ -285,7 +286,9 @@ export function TransactionsTab() {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
                       <div className="text-sm text-claude-text font-medium">
-                        {formatUah(Number(transaction.balance_after_usd) || 0)}
+                        {transaction.balance_after_uah != null
+                          ? `${Number(transaction.balance_after_uah).toFixed(2)} \u20B4`
+                          : formatUah(Number(transaction.balance_after_usd) || 0)}
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">

--- a/mcp_backend/src/migrations/093_add_balance_uah_to_transactions.sql
+++ b/mcp_backend/src/migrations/093_add_balance_uah_to_transactions.sql
@@ -1,0 +1,11 @@
+-- Add UAH balance tracking to billing_transactions
+-- Previously only balance_before_usd / balance_after_usd were stored,
+-- making UAH topups (Monobank) appear to not change the balance.
+
+ALTER TABLE billing_transactions
+  ADD COLUMN IF NOT EXISTS balance_before_uah NUMERIC(10,2),
+  ADD COLUMN IF NOT EXISTS balance_after_uah NUMERIC(10,2);
+
+-- Backfill: set balance_after_uah for existing topup transactions from user_billing
+-- (approximate — uses current balance minus subsequent changes)
+-- We can't perfectly reconstruct historical UAH balances, so leave NULLs for old rows.

--- a/mcp_backend/src/services/billing-service.ts
+++ b/mcp_backend/src/services/billing-service.ts
@@ -305,11 +305,14 @@ export class BillingService {
 
       const balanceBefore = parseFloat(billing.balance_usd);
       const balanceAfter = balanceBefore - chargeAmount;
+      const balanceBeforeUah = parseFloat(billing.balance_uah) || 0;
 
       // Auto-convert USD charge to UAH if not provided
       const chargeAmountUah = params.amountUah != null
         ? params.amountUah
         : await this.convertToUah(chargeAmount);
+
+      const balanceAfterUah = balanceBeforeUah - chargeAmountUah;
 
       // Update balance and statistics
       await client.query(
@@ -339,8 +342,9 @@ export class BillingService {
         `INSERT INTO billing_transactions (
           user_id, type, amount_usd, amount_uah,
           balance_before_usd, balance_after_usd,
+          balance_before_uah, balance_after_uah,
           request_id, description, metadata
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         RETURNING *`,
         [
           params.userId,
@@ -349,6 +353,8 @@ export class BillingService {
           chargeAmountUah,
           balanceBefore,
           balanceAfter,
+          balanceBeforeUah,
+          balanceAfterUah,
           params.requestId,
           params.description || `Request ${params.requestId}`,
           JSON.stringify(transactionMetadata),
@@ -426,11 +432,14 @@ export class BillingService {
       const billing = billingResult.rows[0];
       const balanceBefore = parseFloat(billing.balance_usd);
       const balanceAfter = balanceBefore + params.amountUsd;
+      const balanceBeforeUah = parseFloat(billing.balance_uah) || 0;
 
       // Auto-convert USD to UAH if not provided
       const topUpAmountUah = params.amountUah != null
         ? params.amountUah
         : await this.convertToUah(params.amountUsd);
+
+      const balanceAfterUah = balanceBeforeUah + topUpAmountUah;
 
       // Update balance
       await client.query(
@@ -447,8 +456,9 @@ export class BillingService {
         `INSERT INTO billing_transactions (
           user_id, type, amount_usd, amount_uah,
           balance_before_usd, balance_after_usd,
+          balance_before_uah, balance_after_uah,
           description, payment_provider, payment_id, metadata
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
         RETURNING *`,
         [
           params.userId,
@@ -457,6 +467,8 @@ export class BillingService {
           topUpAmountUah,
           balanceBefore,
           balanceAfter,
+          balanceBeforeUah,
+          balanceAfterUah,
           params.description || `Top up $${params.amountUsd}`,
           params.paymentProvider,
           params.paymentId,


### PR DESCRIPTION
## Summary

- **Added `balance_before_uah` / `balance_after_uah` columns** to `billing_transactions` table (migration 093)
- **`chargeUser` and `topUpBalance` now record UAH balance snapshots** alongside USD
- **Frontend shows UAH balance directly** when available, falls back to USD→UAH conversion for old records

Previously, "Баланс після" showed `formatUah(balance_after_usd)` which was wrong for Monobank topups where `amountUsd=0` — the USD balance didn't change, so it looked like the topup had no effect.

## Test plan

- [ ] Run migration on local/staging
- [ ] Top up via Monobank and verify "Баланс після" shows correct UAH balance
- [ ] Verify charge transactions also show correct UAH balance
- [ ] Old transactions (without UAH columns) fall back to USD→UAH conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)