### PR TITLE
fix(ci): use HTTPS for prod health check

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -617,7 +617,7 @@ jobs:
 
           # Full health check through nginx (works regardless of blue/green)
           for i in 1 2 3 4 5; do
-            HEALTH=$($SSH_CMD "curl -sf --max-time 10 http://localhost/health" 2>/dev/null) && {
+            HEALTH=$($SSH_CMD "curl -sfk --max-time 10 https://localhost/health" 2>/dev/null) && {
               echo "=== Production health (via nginx) ==="
               echo "$HEALTH" | jq . 2>/dev/null || echo "$HEALTH"
               STATUS=$(echo "$HEALTH" | jq -r '.status' 2>/dev/null)


### PR DESCRIPTION
## Summary
- Prod nginx redirects HTTP→HTTPS (301), causing `curl -sf` to fail with exit code 5
- Switch health check URL from `http://localhost/health` to `https://localhost/health` with `-k` flag for self-signed cert

## Context
This was the reason the last ~6 CI runs showed "Deploy to Production" as failed even though the actual deploy succeeded — the health check step was broken.

Also fixed separately (not in this PR):
- **Fail2ban**: unblocked CI runner IP on prod, reloaded fail2ban to respect existing whitelist
- **SSH key**: updated `PROD_SSH_KEY_PATH` GitHub secret to correct path on self-hosted runner

## Test plan
- [ ] Merge and verify next CI run passes the "Prod health check" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)