### PR TITLE
fix(deploy): add missing payment env vars to green profile

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -923,8 +923,10 @@ services:
       EMAIL_FROM: noreply@legal.org.ua
       EMAIL_FROM_NAME: SecondLayer Legal Platform
       PROMETHEUS_URL: http://prometheus-prod:9090
+      MOCK_PAYMENTS: "false"
+      PUBLIC_URL: https://legal.org.ua
       MONOBANK_API_KEY: ${MONOBANK_API_KEY:-}
-      MONOBANK_REDIRECT_URL: ${MONOBANK_REDIRECT_URL:-}
+      MONOBANK_REDIRECT_URL: ${MONOBANK_REDIRECT_URL:-https://legal.org.ua}
       NOWPAYMENTS_API_KEY: ${NOWPAYMENTS_API_KEY:-}
       NOWPAYMENTS_IPN_SECRET: ${NOWPAYMENTS_IPN_SECRET:-}
       NOWPAYMENTS_PUBLIC_KEY: ${NOWPAYMENTS_PUBLIC_KEY:-}


### PR DESCRIPTION
## Summary
- Green profile in `docker-compose.prod.yml` was missing `PUBLIC_URL` and `MOCK_PAYMENTS` env vars
- This caused Monobank payments to fail: `PUBLIC_URL environment variable is required for payment webhooks`
- Added `PUBLIC_URL: https://legal.org.ua`, `MOCK_PAYMENTS: "false"`, and `MONOBANK_REDIRECT_URL` default

## Test plan
- [ ] Verify Monobank payment flow works after deploy
- [ ] Verify `PUBLIC_URL` is set inside green container

🤖 Generated with [Claude Code](https://claude.com/claude-code)