### PR TITLE
fix(ci): docker cp nginx upstreams to fix 502 after blue-green deploy

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -567,6 +567,9 @@ jobs:
 
             printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-upstreams.conf
 
+            # Copy upstreams into nginx container (bind mount inode may be stale after git reset --hard)
+            docker cp nginx/includes/prod-upstreams.conf nginx-prod:/etc/nginx/includes/prod-upstreams.conf
+
             # Validate and reload nginx (graceful, zero-downtime)
             docker exec nginx-prod nginx -t
             docker exec nginx-prod nginx -s reload


### PR DESCRIPTION
## Summary

- **Root cause**: `git reset --hard origin/main` creates `prod-upstreams.conf` with a new inode. Docker bind mount references the old inode. `nginx -s reload` reads stale config pointing to non-existent containers → 502.
- **Fix**: `docker cp` the upstreams file directly into the nginx container before reload, bypassing the bind mount inode issue.

## Test plan

- [ ] Deploy via CI/CD and verify nginx serves correct upstreams after blue-green switch
- [ ] No more 502 errors after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)