### PR TITLE
feat(encryption): mandatory E2EE for all document uploads

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/UploadQueuePanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/UploadQueuePanel.tsx
@@ -9,11 +9,9 @@ import {
   Play,
   RotateCcw,
   XCircle,
-  Lock,
 } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { useUploadStore } from '../../stores/uploadStore';
-import { useEncryptionStore } from '../../stores/encryptionStore';
 import { UploadItemRow } from './UploadItemRow';
 import { DOC_TYPE_LABELS } from './constants';
 import { formatFileSize } from './constants';
@@ -126,9 +124,6 @@ export function UploadQueuePanel({
                   ))}
                 </select>
               </div>
-
-              {/* Encryption toggle */}
-              <EncryptionToggle />
 
               {/* Default doc type selector */}
               <div className="relative">
@@ -283,29 +278,3 @@ export function UploadQueuePanel({
   );
 }
 
-function EncryptionToggle() {
-  const { hasEncryption, encryptNewUploads, setEncryptNewUploads } = useEncryptionStore(
-    useShallow(s => ({
-      hasEncryption: s.hasEncryption,
-      encryptNewUploads: s.encryptNewUploads,
-      setEncryptNewUploads: s.setEncryptNewUploads,
-    }))
-  );
-
-  if (!hasEncryption) return null;
-
-  return (
-    <button
-      onClick={() => setEncryptNewUploads(!encryptNewUploads)}
-      className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border rounded-lg transition-colors font-sans ${
-        encryptNewUploads
-          ? 'text-emerald-700 border-emerald-300 bg-emerald-50'
-          : 'text-claude-subtext border-claude-border hover:bg-claude-bg'
-      }`}
-      title={encryptNewUploads ? 'Шифрування увімкнено' : 'Увімкнути шифрування'}
-    >
-      <Lock size={12} />
-      {encryptNewUploads ? 'E2EE' : 'E2EE'}
-    </button>
-  );
-}

--- a/lexwebapp/src/pages/DocumentsPage/UploadZone.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/UploadZone.tsx
@@ -1,9 +1,10 @@
 import React, { useCallback, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Upload, FolderUp, Shield } from 'lucide-react';
+import { Upload, FolderUp, Lock } from 'lucide-react';
 import type { DocType } from './types';
 import { useEncryptionStore } from '../../stores/encryptionStore';
 import { EncryptionSetupDialog } from '../../components/encryption/EncryptionSetupDialog';
+import { showToast } from '../../utils/toast';
 
 const ACCEPTED_TYPES =
   '.pdf,.docx,.doc,.html,.htm,.txt,.rtf,.jpg,.jpeg,.png,.bmp,.gif,.xlsx,.xls,.csv,.mp4,.mov,.avi,.mkv,.webm,.eml,.zip,.gz,.tgz,.tar';
@@ -104,8 +105,32 @@ export function UploadZone({
   fileInputRef,
   folderInputRef,
 }: UploadZoneProps) {
+  const { hasEncryption, isUnlocked } = useEncryptionStore();
+  const [showEncryptionDialog, setShowEncryptionDialog] = useState(false);
+
+  /**
+   * E2EE is mandatory. If user has no keys or keys are locked,
+   * show setup/unlock dialog instead of starting upload.
+   */
+  const ensureEncryptionReady = useCallback((): boolean => {
+    if (!hasEncryption) {
+      setShowEncryptionDialog(true);
+      showToast.info('Для завантаження документів потрібно створити ключ шифрування');
+      return false;
+    }
+    if (!isUnlocked) {
+      setShowEncryptionDialog(true);
+      showToast.info('Розблокуйте шифрування для завантаження документів');
+      return false;
+    }
+    return true;
+  }, [hasEncryption, isUnlocked]);
+
   const handleFilesSelected = useCallback(
     (files: FileList | File[]) => {
+      // E2EE mandatory: block upload if encryption not ready
+      if (!ensureEncryptionReady()) return;
+
       const newItems = Array.from(files)
         .filter((f) => f.size > 0)
         .map((file) => ({
@@ -119,7 +144,7 @@ export function UploadZone({
       addFiles(newItems);
       setShowUploadPanel(true);
     },
-    [defaultDocType, addFiles, currentFolderPath, setShowUploadPanel]
+    [defaultDocType, addFiles, currentFolderPath, setShowUploadPanel, ensureEncryptionReady]
   );
 
   const handleFileSelect = () => fileInputRef.current?.click();
@@ -178,36 +203,11 @@ export function UploadZone({
     }
   };
 
-  const { hasEncryption, isUnlocked, encryptNewUploads, setEncryptNewUploads } = useEncryptionStore();
-  const [showEncryptionDialog, setShowEncryptionDialog] = useState(false);
-
-  const handleEncryptionToggle = () => {
-    if (!hasEncryption) {
-      // First time: show setup dialog
-      setShowEncryptionDialog(true);
-      return;
-    }
-    if (!isUnlocked) {
-      // Keys exist but locked: show unlock dialog
-      setShowEncryptionDialog(true);
-      return;
-    }
-    // Toggle encryption for new uploads
-    setEncryptNewUploads(!encryptNewUploads);
-  };
-
   return (
     <>
       <EncryptionSetupDialog
         isOpen={showEncryptionDialog}
-        onClose={() => {
-          setShowEncryptionDialog(false);
-          // If unlock/setup succeeded, enable encryption
-          const state = useEncryptionStore.getState();
-          if (state.isUnlocked) {
-            setEncryptNewUploads(true);
-          }
-        }}
+        onClose={() => setShowEncryptionDialog(false)}
         mode={hasEncryption ? 'unlock' : 'setup'}
       />
 
@@ -254,22 +254,19 @@ export function UploadZone({
                 <FolderUp size={14} strokeWidth={2} />
                 Папку
               </button>
-              <button
-                onClick={handleEncryptionToggle}
-                className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium transition-all active:scale-[0.98] font-sans ${
-                  encryptNewUploads && isUnlocked
-                    ? 'bg-green-50 border border-green-300 text-green-700 hover:bg-green-100'
-                    : 'bg-white border border-claude-border text-claude-subtext hover:bg-claude-bg'
+              <span
+                className={`inline-flex items-center gap-1.5 px-3 py-2 rounded-xl text-sm font-medium font-sans ${
+                  isUnlocked
+                    ? 'bg-green-50 border border-green-300 text-green-700'
+                    : 'bg-amber-50 border border-amber-300 text-amber-700 cursor-pointer'
                 }`}
-                title={
-                  encryptNewUploads && isUnlocked
-                    ? 'Шифрування увімкнено'
-                    : 'Увімкнути шифрування'
-                }
+                title={isUnlocked ? 'Шифрування активне' : 'Потрібно розблокувати шифрування'}
+                onClick={!isUnlocked ? () => setShowEncryptionDialog(true) : undefined}
+                role={!isUnlocked ? 'button' : undefined}
               >
-                <Shield size={14} strokeWidth={2} />
-                {encryptNewUploads && isUnlocked ? 'E2EE' : 'E2EE'}
-              </button>
+                <Lock size={14} strokeWidth={2} />
+                E2EE
+              </span>
               <span className="text-xs text-claude-subtext/40 font-sans ml-1 hidden sm:inline">
                 або перетягніть файли · Ctrl+U
               </span>

--- a/lexwebapp/src/stores/encryptionStore.ts
+++ b/lexwebapp/src/stores/encryptionStore.ts
@@ -28,15 +28,11 @@ interface EncryptionState {
   isLoading: boolean;
   /** Error message from last operation */
   error: string | null;
-  /** Whether to encrypt new uploads by default */
-  encryptNewUploads: boolean;
-
   // Actions
   checkStatus: () => Promise<void>;
   setup: (password: string) => Promise<EncryptedKeyBundle>;
   unlock: (password: string) => Promise<void>;
   lock: () => void;
-  setEncryptNewUploads: (value: boolean) => void;
   reset: () => void;
 }
 
@@ -49,7 +45,6 @@ export const useEncryptionStore = create<EncryptionState>()(
       publicKey: null,
       isLoading: false,
       error: null,
-      encryptNewUploads: false,
 
       /**
        * Check if the current user has encryption set up.
@@ -154,10 +149,6 @@ export const useEncryptionStore = create<EncryptionState>()(
         });
       },
 
-      setEncryptNewUploads: (value: boolean) => {
-        set({ encryptNewUploads: value });
-      },
-
       /**
        * Full reset (on logout).
        */
@@ -171,7 +162,6 @@ export const useEncryptionStore = create<EncryptionState>()(
           publicKey: null,
           isLoading: false,
           error: null,
-          encryptNewUploads: false,
         });
       },
     }),

--- a/lexwebapp/src/stores/uploadStore.ts
+++ b/lexwebapp/src/stores/uploadStore.ts
@@ -137,9 +137,9 @@ export const useUploadStore = create<UploadState>((set) => {
         }
       }
 
-      // Post-upload encryption: if encryption is enabled, encrypt completed documents
+      // Post-upload encryption: always encrypt completed documents (E2EE mandatory)
       const encState = useEncryptionStore.getState();
-      if (encState.encryptNewUploads && encState.isUnlocked && encState.publicKey) {
+      if (encState.isUnlocked && encState.publicKey) {
         const docIds = completedItems.map(i => i.documentId).filter(Boolean) as string[];
         if (docIds.length > 0) {
           encryptUploadedDocuments(docIds, encState.publicKey).then(results => {
@@ -184,11 +184,10 @@ export const useUploadStore = create<UploadState>((set) => {
     isRecovering: false,
 
     addFiles: (files) => {
-      // Inject encrypt flag from encryption store
-      const encryptNewUploads = useEncryptionStore.getState().encryptNewUploads;
+      // E2EE is mandatory — always encrypt uploads
       const filesWithEncrypt = files.map(f => ({
         ...f,
-        encrypt: encryptNewUploads,
+        encrypt: true,
       }));
       uploadManager.addFiles(filesWithEncrypt);
       set(syncFromManager(uploadManager));

--- a/mcp_backend/src/routes/upload-routes.ts
+++ b/mcp_backend/src/routes/upload-routes.ts
@@ -645,10 +645,10 @@ async function processUpload(
 
     const documentId = await processUploadFile(session, assembledPath, deps, extraMetadata);
 
-    // Encrypt content after parse/embed if requested (hybrid E2EE)
+    // Encrypt content after parse/embed (E2EE mandatory — encrypt both text and source)
     if (session.encrypt) {
       try {
-        const encrypted = await encryptDocumentContent(db, documentId, session.userId);
+        const encrypted = await encryptDocumentContent(db, documentId, session.userId, minioService);
         if (encrypted) {
           logger.info('[Upload] Document encrypted after processing', {
             sessionId: session.id,

--- a/mcp_backend/src/services/document-encryption.ts
+++ b/mcp_backend/src/services/document-encryption.ts
@@ -11,6 +11,7 @@ import crypto from 'crypto';
 import nacl from 'tweetnacl';
 import { logger } from '../utils/logger.js';
 import type { IDatabase } from '../domain/ports/index.js';
+import type { MinioService } from './minio-service.js';
 
 const HKDF_INFO = Buffer.from('SecondLayer-E2EE-DEK-v1', 'utf-8');
 
@@ -108,12 +109,15 @@ export async function wrapDEK(
  * Encrypt a document's content and wrap the DEK for the owner.
  * Called after parsing/embedding in the upload pipeline.
  *
- * Returns documentId for convenience.
+ * Encrypts:
+ * - full_text and full_text_html (PostgreSQL)
+ * - Original file in MinIO (if storage_type='minio' and minioService provided)
  */
 export async function encryptDocumentContent(
   db: IDatabase,
   documentId: string,
-  userId: string
+  userId: string,
+  minioService?: MinioService
 ): Promise<boolean> {
   // Get user's public key
   const keyResult = await db.query<{ public_key: string }>(
@@ -132,12 +136,17 @@ export async function encryptDocumentContent(
   const publicKeyBase64 = keyResult.rows[0].public_key;
   const publicKey = new Uint8Array(Buffer.from(publicKeyBase64, 'base64'));
 
-  // Get document content
+  // Get document content + storage info
   const docResult = await db.query<{
     full_text: string | null;
     full_text_html: string | null;
+    storage_type: string | null;
+    storage_path: string | null;
+    mime_type: string | null;
+    user_id: string;
+    metadata: any;
   }>(
-    'SELECT full_text, full_text_html FROM documents WHERE id = $1',
+    'SELECT full_text, full_text_html, storage_type, storage_path, mime_type, user_id, metadata FROM documents WHERE id = $1',
     [documentId]
   );
 
@@ -146,7 +155,7 @@ export async function encryptDocumentContent(
     return false;
   }
 
-  const { full_text, full_text_html } = docResult.rows[0];
+  const { full_text, full_text_html, storage_type, metadata } = docResult.rows[0];
 
   // Generate DEK for this document
   const dek = generateDEK();
@@ -156,6 +165,38 @@ export async function encryptDocumentContent(
   const encryptedFullTextHtml = full_text_html
     ? encryptContent(full_text_html, dek)
     : null;
+
+  // Encrypt original file in MinIO (source encryption)
+  let sourceEncrypted = false;
+  if (storage_type === 'minio' && minioService && metadata) {
+    const meta = typeof metadata === 'string' ? JSON.parse(metadata) : metadata;
+    const objectKey = meta.minioKey;
+    if (objectKey) {
+      try {
+        const fileBuffer = await minioService.getFileBuffer(userId, objectKey);
+        const encryptedBuffer = encryptBinary(fileBuffer, dek);
+        await minioService.uploadBuffer(
+          userId,
+          objectKey,
+          encryptedBuffer,
+          'application/octet-stream' // encrypted binary, original mime lost intentionally
+        );
+        sourceEncrypted = true;
+        logger.info('[Encryption] Original file encrypted in MinIO', {
+          documentId,
+          objectKey,
+          originalSize: fileBuffer.length,
+          encryptedSize: encryptedBuffer.length,
+        });
+      } catch (err: any) {
+        logger.error('[Encryption] Failed to encrypt MinIO file (text still encrypted)', {
+          documentId,
+          objectKey,
+          error: err.message,
+        });
+      }
+    }
+  }
 
   // Wrap DEK with user's public key
   const wrappedDEK = await wrapDEK(dek, publicKey);
@@ -190,6 +231,7 @@ export async function encryptDocumentContent(
     userId,
     hasFullText: !!full_text,
     hasFullTextHtml: !!full_text_html,
+    sourceEncrypted,
   });
 
   return true;

--- a/mcp_backend/src/services/minio-service.ts
+++ b/mcp_backend/src/services/minio-service.ts
@@ -153,6 +153,46 @@ export class MinioService {
     }
   }
 
+  /**
+   * Download a file from MinIO as a Buffer.
+   */
+  async getFileBuffer(userId: string, objectKey: string): Promise<Buffer> {
+    const bucket = this.getBucketName(userId);
+    try {
+      const stream = await this.client.getObject(bucket, objectKey);
+      const chunks: Buffer[] = [];
+      for await (const chunk of stream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      return Buffer.concat(chunks);
+    } catch (error: any) {
+      logger.error('[MinIO] getFileBuffer failed', { bucket, key: objectKey, error: error.message });
+      throw error;
+    }
+  }
+
+  /**
+   * Upload a Buffer to MinIO (overwrite existing object).
+   */
+  async uploadBuffer(
+    userId: string,
+    objectKey: string,
+    data: Buffer,
+    mimeType: string
+  ): Promise<MinioUploadResult> {
+    const bucket = await this.ensureBucket(userId);
+    try {
+      const result = await this.client.putObject(bucket, objectKey, data, data.length, {
+        'Content-Type': mimeType,
+      });
+      logger.info('[MinIO] Buffer uploaded', { bucket, key: objectKey, size: data.length });
+      return { bucket, key: objectKey, etag: result.etag, size: data.length };
+    } catch (error: any) {
+      logger.error('[MinIO] Buffer upload failed', { bucket, key: objectKey, error: error.message });
+      throw error;
+    }
+  }
+
   async deleteFile(userId: string, objectKey: string): Promise<void> {
     const bucket = this.getBucketName(userId);
     try {


### PR DESCRIPTION
## Summary
- Remove optional encryption toggle — all uploads now require E2EE
- Users must create encryption keys before uploading (setup/unlock dialog shown automatically)
- Both extracted text (PostgreSQL) and original source files (MinIO) are encrypted with per-document DEK
- E2EE badge already shown on encrypted documents in table/grid views

## Changes
- **encryptionStore**: removed `encryptNewUploads` toggle (encryption always on)
- **UploadZone**: replaced E2EE toggle with mandatory gate — blocks uploads without encryption keys
- **UploadQueuePanel**: removed `EncryptionToggle` component
- **uploadStore**: always sets `encrypt: true`, always encrypts after completion
- **document-encryption.ts**: enhanced to also encrypt original files in MinIO (source + text)
- **minio-service.ts**: added `getFileBuffer()` and `uploadBuffer()` methods

## Test plan
- [ ] Verify new user cannot upload without creating encryption key first
- [ ] Verify existing user with locked keys is prompted to unlock before upload
- [ ] Verify uploaded documents get `is_encrypted=true` flag
- [ ] Verify E2EE badge shows on documents in table and grid views
- [ ] Verify document preview decrypts correctly
- [ ] Verify MinIO-stored source files are encrypted

🤖 Generated with [Claude Code](https://claude.com/claude-code)