### PR TITLE
fix(ci): force-recreate nginx on blue-green switch

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -567,13 +567,9 @@ jobs:
 
             printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-upstreams.conf
 
-            # Write directly inside nginx container (bind mount inode stale after git reset --hard, docker cp fails: device busy)
-            docker exec nginx-prod sh -c "cat /dev/stdin > /etc/nginx/includes/prod-upstreams.conf" < nginx/includes/prod-upstreams.conf
-
-            # Validate and reload nginx (graceful, zero-downtime)
-            docker exec nginx-prod nginx -t
-            docker exec nginx-prod nginx -s reload
-            echo "Nginx reloaded — traffic switched to new containers"
+            # Recreate nginx to pick up new upstreams (bind mount inode goes stale after git reset --hard)
+            \$DC up -d nginx-prod --force-recreate
+            echo "Nginx recreated — traffic switched to new containers"
 
             # Allow in-flight requests to complete
             sleep 5


### PR DESCRIPTION
## Summary

Replace docker exec/reload with `docker compose up -d nginx-prod --force-recreate` after blue-green upstreams switch. This guarantees nginx picks up the correct upstreams file regardless of bind mount inode staleness.

Previous approaches failed:
- `nginx -s reload` → stale bind mount inode after `git reset --hard`
- `docker cp` → "device or resource busy" on bind mounts
- `docker exec cat < file` → unreliable inside SSH heredoc

## Test plan

- [ ] Deploy via CI/CD, verify no 502 after blue-green switch
- [ ] Verify nginx container restarts in ~1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)