### PR TITLE
fix(billing): save card after successful Monobank payment

### DIFF
--- a/mcp_backend/src/migrations/094_payment_methods_unique_constraint.sql
+++ b/mcp_backend/src/migrations/094_payment_methods_unique_constraint.sql
@@ -1,0 +1,12 @@
+-- Migration 094: Add unique constraint for payment method upsert
+-- Prevents duplicate cards (same provider + last4 per user)
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'billing_payment_methods_user_provider_card_unique'
+  ) THEN
+    ALTER TABLE billing_payment_methods
+      ADD CONSTRAINT billing_payment_methods_user_provider_card_unique
+      UNIQUE (user_id, provider, card_last4);
+  END IF;
+END $$;

--- a/mcp_backend/src/routes/billing-inline-routes.ts
+++ b/mcp_backend/src/routes/billing-inline-routes.ts
@@ -277,11 +277,8 @@ export function createBillingInlineRoutes(deps: {
     }
   }) as any);
 
-  // GET /payment-methods - Stub that returns empty array
-  router.get('/payment-methods', (async (_req: DualAuthRequest, res: Response) => {
-    // Payment methods storage not yet implemented — return empty list
-    res.json({ paymentMethods: [] });
-  }) as any);
+  // NOTE: GET /payment-methods is handled by billing-routes.ts (real implementation)
+  // Do NOT add a stub here — it would shadow the real endpoint
 
   // PUT /settings - Update billing settings
   router.put('/settings', (async (req: DualAuthRequest, res: Response) => {

--- a/mcp_backend/src/services/billing-service.ts
+++ b/mcp_backend/src/services/billing-service.ts
@@ -963,6 +963,33 @@ export class BillingService {
   }
 
   /**
+   * Save a payment method (upsert by user + provider + last4 to avoid duplicates)
+   */
+  async savePaymentMethod(userId: string, data: {
+    provider: string;
+    cardLast4?: string;
+    cardBrand?: string;
+    cardBank?: string;
+    label?: string;
+  }): Promise<void> {
+    try {
+      // Upsert: if same card (provider + last4) already exists, update it
+      await this.db.query(
+        `INSERT INTO billing_payment_methods (id, user_id, provider, card_last4, card_brand, card_bank, label, is_primary)
+         VALUES (gen_random_uuid(), $1, $2, $3, $4, $5, $6,
+           NOT EXISTS(SELECT 1 FROM billing_payment_methods WHERE user_id = $1)
+         )
+         ON CONFLICT ON CONSTRAINT billing_payment_methods_user_provider_card_unique
+         DO UPDATE SET card_brand = EXCLUDED.card_brand, card_bank = EXCLUDED.card_bank, updated_at = NOW()`,
+        [userId, data.provider, data.cardLast4 || null, data.cardBrand || null, data.cardBank || null, data.label || null]
+      );
+    } catch (error: any) {
+      // Non-critical — don't fail the payment
+      logger.warn('Failed to save payment method', { userId, error: error.message });
+    }
+  }
+
+  /**
    * Remove a saved payment method
    */
   async removePaymentMethod(userId: string, methodId: string): Promise<void> {

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -294,6 +294,25 @@ export class MonobankService {
       invoiceNumber,
     });
 
+    // Save card details from invoice status (non-blocking)
+    try {
+      const statusData = await this.getInvoiceStatusRaw(body.invoiceId);
+      if (statusData?.paymentInfo?.maskedPan) {
+        const pi2 = statusData.paymentInfo;
+        const last4 = pi2.maskedPan.replace(/[*\s]/g, '').slice(-4);
+        await this.billingService.savePaymentMethod(pi.user_id, {
+          provider: 'monobank',
+          cardLast4: last4,
+          cardBrand: pi2.paymentSystem || null,
+          cardBank: pi2.bank || null,
+          label: `${(pi2.paymentSystem || '').toUpperCase()} •••• ${last4}`,
+        });
+        logger.info('[MonobankService] Card saved from payment', { last4, brand: pi2.paymentSystem });
+      }
+    } catch (cardErr: any) {
+      logger.warn('[MonobankService] Failed to save card (non-critical)', { error: cardErr.message });
+    }
+
     // Send confirmation email
     const metadata = JSON.parse(pi.metadata || '{}');
     if (metadata.email) {
@@ -313,6 +332,19 @@ export class MonobankService {
     }
 
     return { received: true };
+  }
+
+  /**
+   * Get raw invoice status from Monobank (includes paymentInfo with card data).
+   */
+  private async getInvoiceStatusRaw(invoiceId: string): Promise<any> {
+    const key = this.apiKey;
+    const response = await fetch(
+      `https://api.monobank.ua/api/merchant/invoice/status?invoiceId=${encodeURIComponent(invoiceId)}`,
+      { method: 'GET', headers: { 'X-Token': key } }
+    );
+    if (!response.ok) return null;
+    return response.json();
   }
 
   /**


### PR DESCRIPTION
## Summary

- Remove `/payment-methods` stub in `billing-inline-routes.ts` that shadowed the real endpoint (always returned `[]`)
- Add `BillingService.savePaymentMethod()` with upsert by (user_id, provider, card_last4)
- After successful Monobank webhook, fetch invoice status to get `paymentInfo.maskedPan`, `paymentInfo.paymentSystem`, `paymentInfo.bank` and save card
- Add migration 094 for unique constraint

## Root cause

Two issues:
1. `billing-inline-routes.ts` had a hardcoded stub `GET /payment-methods` returning `{ paymentMethods: [] }`, mounted before the real implementation in `billing-routes.ts`
2. Webhook handler credited balance but never extracted/saved card data from Monobank

## Test plan

- [ ] Make a payment via Monobank
- [ ] Check `/api/billing/payment-methods` returns saved card
- [ ] Check Settings page shows the card
- [ ] Second payment with same card — no duplicate
- [ ] Delete card from Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)