### PR TITLE
fix(ci): prevent shell injection in self-healing prompts

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -163,25 +163,21 @@ jobs:
       - name: Claude Code — diagnose and fix
         if: steps.guard.outputs.skip == 'false'
         id: claude-fix
+        continue-on-error: true
         run: |
-          ERROR_LOG=$(cat /tmp/ci-errors.log)
           BRANCH_NAME="ci-autofix/$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA:0:7}"
-
           git checkout -b "$BRANCH_NAME"
 
-          npx -y @anthropic-ai/claude-code@latest -p "$(cat <<PROMPT
-          The CI/CD build-and-test job failed. Here are the error logs:
-
-          \`\`\`
-          ${ERROR_LOG}
-          \`\`\`
+          cat > /tmp/ci-prompt.txt <<'PROMPT_END'
+          The CI/CD build-and-test job failed. The error logs are in /tmp/ci-errors.log — read that file first.
 
           Your task:
-          1. Analyze the errors and identify the root cause
-          2. Fix the code — edit the minimal set of files needed
-          3. Run the TypeScript build (npm run build in the affected service) to verify your fix compiles
-          4. Stage ONLY the files you changed and commit with message: "fix: [ci-autofix] <description>"
-          5. Do NOT push — the pipeline will handle pushing and PR creation
+          1. Read /tmp/ci-errors.log to understand the failure
+          2. Analyze the errors and identify the root cause
+          3. Fix the code — edit the minimal set of files needed
+          4. Run the TypeScript build (npm run build in the affected service) to verify your fix compiles
+          5. Stage ONLY the files you changed and commit with message: "fix: [ci-autofix] <description>"
+          6. Do NOT push — the pipeline will handle pushing and PR creation
 
           Rules:
           - Do NOT change test expectations to make tests pass — fix the actual code
@@ -190,10 +186,12 @@ jobs:
           - Do NOT run git push
           - If the error is in environment config (missing env vars, wrong URLs), fix it in the workflow env or skip
           - If you cannot fix the issue, create a GitHub issue describing the problem instead of committing broken code
+          PROMPT_END
 
-          Working directory: $(pwd)
-          PROMPT
-          )" --allowedTools "Bash,Read,Edit,Write,Glob,Grep" --max-turns 25 --model eu.anthropic.claude-sonnet-4-6
+          npx -y @anthropic-ai/claude-code@latest \
+            -p "$(cat /tmp/ci-prompt.txt)" \
+            --allowedTools "Bash,Read,Edit,Write,Glob,Grep" \
+            --max-turns 25
         timeout-minutes: 10
 
       - name: Check if fix was produced
@@ -719,29 +717,27 @@ jobs:
       - name: Claude Code — diagnose and create fix PR
         if: steps.guard.outputs.skip == 'false'
         id: claude-fix
+        continue-on-error: true
         run: |
-          DIAG_LOG=$(cat /tmp/deploy-diag.log)
-          FAILED_RUN_LOG=$(gh run view "${{ github.run_id }}" --log-failed 2>&1 | tail -80)
+          gh run view "${{ github.run_id }}" --log-failed 2>&1 | tail -80 > /tmp/ci-run-errors.log
           BRANCH_NAME="ci-autofix/deploy-$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA:0:7}"
 
           git checkout -b "$BRANCH_NAME"
 
-          npx -y @anthropic-ai/claude-code@latest -p "$(cat <<PROMPT
-          Production deployment failed. Here are the diagnostics:
+          cat > /tmp/ci-prompt.txt <<'PROMPT_END'
+          Production deployment failed. Diagnostics are saved in files — read them first:
 
-          === CI Run Error Log ===
-          ${FAILED_RUN_LOG}
-
-          === Production Server Diagnostics ===
-          ${DIAG_LOG}
+          1. /tmp/ci-run-errors.log — CI run error output
+          2. /tmp/deploy-diag.log — production server diagnostics (container status, logs, health checks)
 
           Your task:
-          1. Analyze the failure — is it a code bug, config issue, Docker build error, or infrastructure problem?
-          2. If it's a code fix (typo, missing import, wrong env var, Docker config):
+          1. Read both diagnostic files to understand the failure
+          2. Analyze the failure — is it a code bug, config issue, Docker build error, or infrastructure problem?
+          3. If it's a code fix (typo, missing import, wrong env var, Docker config):
              - Fix the code locally
              - Stage ONLY the files you changed and commit with message: "fix: [ci-autofix] <description>"
              - Do NOT push — the pipeline will handle pushing and PR creation
-          3. If you cannot fix it with code changes, create a GitHub issue describing the problem
+          4. If you cannot fix it with code changes, create a GitHub issue describing the problem
 
           Rules:
           - Do NOT SSH to production servers — no direct prod access
@@ -749,10 +745,12 @@ jobs:
           - Do NOT modify CI workflow files
           - Do NOT run git reset, git revert, or any destructive git commands
           - Focus on identifying and fixing the root cause in code
+          PROMPT_END
 
-          Working directory: $(pwd)
-          PROMPT
-          )" --allowedTools "Bash,Read,Edit,Write,Glob,Grep" --max-turns 25 --model eu.anthropic.claude-sonnet-4-6
+          npx -y @anthropic-ai/claude-code@latest \
+            -p "$(cat /tmp/ci-prompt.txt)" \
+            --allowedTools "Bash,Read,Edit,Write,Glob,Grep" \
+            --max-turns 25
         timeout-minutes: 10
 
       - name: Check if fix was produced


### PR DESCRIPTION
## Summary
- Pass error logs via tmpfiles instead of unquoted heredoc shell expansion (prevents `$()` and backtick injection from CI logs)
- Use quoted heredoc (`<<'PROMPT_END'`) for prompt text — no delimiter collision risk
- Add `continue-on-error: true` to Claude Code steps so `check-fix` and `push` run even on timeout
- Remove redundant `--model` CLI flag (already set via `CLAUDE_CODE_BEDROCK_MODEL` env var)

## Test plan
- [ ] Trigger self-heal-build by merging a commit with a deliberate type error
- [ ] Verify Claude Code reads `/tmp/ci-errors.log` and produces a fix PR
- [ ] Verify timeout doesn't block subsequent steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)