### PR TITLE
fix(billing): update label on card upsert and reassign primary on delete

### DIFF
--- a/mcp_backend/src/services/billing-service.ts
+++ b/mcp_backend/src/services/billing-service.ts
@@ -980,7 +980,7 @@ export class BillingService {
            NOT EXISTS(SELECT 1 FROM billing_payment_methods WHERE user_id = $1)
          )
          ON CONFLICT ON CONSTRAINT billing_payment_methods_user_provider_card_unique
-         DO UPDATE SET card_brand = EXCLUDED.card_brand, card_bank = EXCLUDED.card_bank, updated_at = NOW()`,
+         DO UPDATE SET card_brand = EXCLUDED.card_brand, card_bank = EXCLUDED.card_bank, label = EXCLUDED.label, updated_at = NOW()`,
         [userId, data.provider, data.cardLast4 || null, data.cardBrand || null, data.cardBank || null, data.label || null]
       );
     } catch (error: any) {
@@ -993,13 +993,27 @@ export class BillingService {
    * Remove a saved payment method
    */
   async removePaymentMethod(userId: string, methodId: string): Promise<void> {
-    const result = await this.db.query(
-      'DELETE FROM billing_payment_methods WHERE id = $1 AND user_id = $2',
-      [methodId, userId]
-    );
-    if (result.rowCount === 0) {
-      throw new Error('Payment method not found');
-    }
+    await this.db.transaction(async (client) => {
+      const result = await client.query(
+        'DELETE FROM billing_payment_methods WHERE id = $1 AND user_id = $2 RETURNING is_primary',
+        [methodId, userId]
+      );
+      if (result.rowCount === 0) {
+        throw new Error('Payment method not found');
+      }
+      // If deleted card was primary, promote the most recent remaining card
+      if (result.rows[0].is_primary) {
+        await client.query(
+          `UPDATE billing_payment_methods SET is_primary = true
+           WHERE id = (
+             SELECT id FROM billing_payment_methods
+             WHERE user_id = $1
+             ORDER BY created_at DESC LIMIT 1
+           )`,
+          [userId]
+        );
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Upsert in `savePaymentMethod` now updates `label` (was only updating `card_brand` and `card_bank`)
- `removePaymentMethod` now promotes the most recent remaining card to primary when deleting a primary card (wrapped in transaction)

## Test plan
- [ ] Pay via Monobank twice with same card — verify label updates
- [ ] Add two cards, delete the primary — verify second becomes primary
- [ ] Delete the only card — verify no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)