### PR TITLE
fix(billing): collect org EDRPOU in B2B invoice modal

### DIFF
--- a/lexwebapp/src/components/billing/B2BInvoiceRequestModal.tsx
+++ b/lexwebapp/src/components/billing/B2BInvoiceRequestModal.tsx
@@ -1,10 +1,11 @@
 /**
  * B2B Invoice Request Modal
- * Form for requesting a new B2B invoice (bank transfer)
+ * Form for requesting a new B2B invoice (bank transfer).
+ * If org is missing EDRPOU/address, collects them first.
  */
 
 import { useState, useEffect } from 'react';
-import { X, FileText, AlertCircle } from 'lucide-react';
+import { X, FileText, AlertCircle, Building2, Loader2 } from 'lucide-react';
 import { b2bInvoiceApi, billingApi } from '../../utils/api/billing';
 
 interface Props {
@@ -18,17 +19,34 @@ interface TierOption {
   monthly_price_usd: number;
 }
 
+interface OrgInfo {
+  id: string;
+  name: string;
+  edrpou: string | null;
+  legal_address: string | null;
+  billing_email: string | null;
+}
+
 const billingCycles = [
   { value: 'monthly', label: 'Щомісячно', months: 1 },
   { value: 'quarterly', label: 'Щоквартально', months: 3 },
   { value: 'annual', label: 'Щорічно', months: 12 },
 ];
 
-// Approximate USD/UAH rate for display (actual rate applied server-side)
 const DISPLAY_UAH_RATE = 41.5;
 const VAT_RATE = 0.20;
 
 export function B2BInvoiceRequestModal({ onClose, onCreated }: Props) {
+  // Org info state
+  const [orgLoading, setOrgLoading] = useState(true);
+  const [org, setOrg] = useState<OrgInfo | null>(null);
+  const [needsOrgDetails, setNeedsOrgDetails] = useState(false);
+  const [orgName, setOrgName] = useState('');
+  const [orgEdrpou, setOrgEdrpou] = useState('');
+  const [orgAddress, setOrgAddress] = useState('');
+  const [orgSaving, setOrgSaving] = useState(false);
+
+  // Invoice form state
   const [invoiceType, setInvoiceType] = useState<'subscription' | 'topup'>('topup');
   const [tierKey, setTierKey] = useState('');
   const [billingCycle, setBillingCycle] = useState('monthly');
@@ -39,23 +57,62 @@ export function B2BInvoiceRequestModal({ onClose, onCreated }: Props) {
   const [error, setError] = useState('');
 
   useEffect(() => {
-    // Fetch available tiers
-    billingApi.getPricingInfo().then(res => {
-      const data = res.data;
-      if (data.tiers) {
-        setTiers(data.tiers.filter((t: TierOption) => t.tier_key !== 'free' && t.tier_key !== 'internal'));
-        if (data.tiers.length > 0) {
-          const firstPaid = data.tiers.find((t: TierOption) => t.tier_key !== 'free' && t.tier_key !== 'internal');
-          if (firstPaid) setTierKey(firstPaid.tier_key);
+    // Fetch org info and tiers in parallel
+    Promise.all([
+      b2bInvoiceApi.getOrgInfo().catch(() => ({ data: { org: null } })),
+      billingApi.getPricingInfo().catch(() => ({ data: { tiers: [] } })),
+    ]).then(([orgRes, tierRes]) => {
+      const orgData = orgRes.data.org as OrgInfo | null;
+      setOrg(orgData);
+
+      if (!orgData || !orgData.edrpou) {
+        setNeedsOrgDetails(true);
+        if (orgData) {
+          setOrgName(orgData.name || '');
+          setOrgEdrpou(orgData.edrpou || '');
+          setOrgAddress(orgData.legal_address || '');
         }
       }
-    }).catch(() => {});
+
+      const allTiers = tierRes.data.tiers || [];
+      const paidTiers = allTiers.filter((t: TierOption) => t.tier_key !== 'free' && t.tier_key !== 'internal');
+      setTiers(paidTiers);
+      if (paidTiers.length > 0) setTierKey(paidTiers[0].tier_key);
+    }).finally(() => setOrgLoading(false));
   }, []);
+
+  const handleSaveOrg = async () => {
+    if (!orgEdrpou.trim()) {
+      setError('ЄДРПОУ є обов\'язковим полем');
+      return;
+    }
+    if (orgEdrpou.trim().length < 8) {
+      setError('ЄДРПОУ повинен містити 8-10 цифр');
+      return;
+    }
+
+    setOrgSaving(true);
+    setError('');
+    try {
+      await b2bInvoiceApi.updateOrgInfo({
+        name: orgName.trim() || undefined,
+        edrpou: orgEdrpou.trim(),
+        legal_address: orgAddress.trim() || undefined,
+      });
+      setNeedsOrgDetails(false);
+      // Refresh org info
+      const res = await b2bInvoiceApi.getOrgInfo();
+      setOrg(res.data.org);
+    } catch (err: any) {
+      setError(err?.response?.data?.error || 'Помилка збереження реквізитів');
+    } finally {
+      setOrgSaving(false);
+    }
+  };
 
   const selectedTier = tiers.find(t => t.tier_key === tierKey);
   const selectedCycle = billingCycles.find(c => c.value === billingCycle);
 
-  // Calculate estimated amount
   let estimatedUah = 0;
   let estimatedVat = 0;
   let estimatedTotal = 0;
@@ -119,145 +176,234 @@ export function B2BInvoiceRequestModal({ onClose, onCreated }: Props) {
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-6 space-y-5">
-          {/* Invoice type toggle */}
-          <div>
-            <label className="block text-sm font-medium text-claude-text mb-2">Тип рахунку</label>
-            <div className="flex gap-2">
-              <button
-                type="button"
-                onClick={() => setInvoiceType('topup')}
-                className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border transition-colors ${
-                  invoiceType === 'topup'
-                    ? 'bg-claude-accent text-white border-claude-accent'
-                    : 'bg-white text-claude-subtext border-claude-border hover:border-claude-accent'
-                }`}>
-                Поповнення балансу
-              </button>
-              <button
-                type="button"
-                onClick={() => setInvoiceType('subscription')}
-                className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border transition-colors ${
-                  invoiceType === 'subscription'
-                    ? 'bg-claude-accent text-white border-claude-accent'
-                    : 'bg-white text-claude-subtext border-claude-border hover:border-claude-accent'
-                }`}>
-                Підписка
-              </button>
-            </div>
+        {orgLoading ? (
+          <div className="p-8 flex items-center justify-center gap-2 text-claude-subtext">
+            <Loader2 size={18} className="animate-spin" />
+            Завантаження...
           </div>
+        ) : needsOrgDetails ? (
+          /* Step 1: Collect org billing details */
+          <div className="p-6 space-y-5">
+            <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+              <Building2 size={20} className="text-amber-600 flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="text-sm font-medium text-amber-800">
+                  Заповніть реквізити організації
+                </p>
+                <p className="text-xs text-amber-600 mt-0.5">
+                  Для виставлення рахунку потрібні ЄДРПОУ та юридична адреса
+                </p>
+              </div>
+            </div>
 
-          {/* Topup amount */}
-          {invoiceType === 'topup' && (
             <div>
-              <label className="block text-sm font-medium text-claude-text mb-2">
-                Сума поповнення, грн
+              <label className="block text-sm font-medium text-claude-text mb-1.5">
+                Назва організації
               </label>
               <input
-                type="number"
-                min="500"
-                step="100"
-                value={amountUah}
-                onChange={(e) => setAmountUah(e.target.value)}
-                placeholder="Мінімум 500 грн"
+                type="text"
+                value={orgName}
+                onChange={(e) => setOrgName(e.target.value)}
+                placeholder="ТОВ «Назва»"
                 className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-claude-text mb-1.5">
+                ЄДРПОУ <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={orgEdrpou}
+                onChange={(e) => setOrgEdrpou(e.target.value.replace(/\D/g, '').slice(0, 10))}
+                placeholder="12345678"
+                maxLength={10}
+                className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent font-mono"
                 required
               />
-              <p className="text-xs text-claude-subtext mt-1">Мінімальна сума — 500 грн</p>
+              <p className="text-xs text-claude-subtext mt-1">8-10 цифр</p>
             </div>
-          )}
 
-          {/* Subscription: tier + cycle */}
-          {invoiceType === 'subscription' && (
-            <>
-              <div>
-                <label className="block text-sm font-medium text-claude-text mb-2">Тариф</label>
-                <select
-                  value={tierKey}
-                  onChange={(e) => setTierKey(e.target.value)}
-                  className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent"
-                  required>
-                  <option value="">Оберіть тариф</option>
-                  {tiers.map((t) => (
-                    <option key={t.tier_key} value={t.tier_key}>
-                      {t.display_name} — ${t.monthly_price_usd}/міс
-                    </option>
-                  ))}
-                </select>
+            <div>
+              <label className="block text-sm font-medium text-claude-text mb-1.5">
+                Юридична адреса
+              </label>
+              <input
+                type="text"
+                value={orgAddress}
+                onChange={(e) => setOrgAddress(e.target.value)}
+                placeholder="м. Київ, вул. Хрещатик, 1"
+                className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent"
+              />
+            </div>
+
+            {error && (
+              <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
+                <AlertCircle size={16} className="text-red-500 mt-0.5 shrink-0" />
+                <p className="text-sm text-red-700">{error}</p>
               </div>
+            )}
 
-              <div>
-                <label className="block text-sm font-medium text-claude-text mb-2">Період оплати</label>
-                <div className="flex gap-2">
-                  {billingCycles.map((c) => (
-                    <button
-                      key={c.value}
-                      type="button"
-                      onClick={() => setBillingCycle(c.value)}
-                      className={`flex-1 px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
-                        billingCycle === c.value
-                          ? 'bg-claude-accent text-white border-claude-accent'
-                          : 'bg-white text-claude-subtext border-claude-border hover:border-claude-accent'
-                      }`}>
-                      {c.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </>
-          )}
-
-          {/* Notes */}
-          <div>
-            <label className="block text-sm font-medium text-claude-text mb-2">
-              Примітки <span className="text-claude-subtext font-normal">(необов&apos;язково)</span>
-            </label>
-            <textarea
-              value={notes}
-              onChange={(e) => setNotes(e.target.value)}
-              rows={2}
-              className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent resize-none"
-              placeholder="Додаткова інформація..."
-            />
+            <button
+              type="button"
+              onClick={handleSaveOrg}
+              disabled={orgSaving || !orgEdrpou.trim()}
+              className="w-full py-3 bg-claude-accent text-white rounded-lg font-medium text-sm hover:bg-claude-accent/90 transition-colors disabled:opacity-50">
+              {orgSaving ? 'Збереження...' : 'Зберегти та продовжити'}
+            </button>
           </div>
+        ) : (
+          /* Step 2: Invoice form */
+          <form onSubmit={handleSubmit} className="p-6 space-y-5">
+            {/* Org info summary */}
+            {org && (
+              <div className="flex items-center gap-2 p-3 bg-claude-bg/50 border border-claude-border rounded-lg text-xs text-claude-subtext">
+                <Building2 size={14} className="flex-shrink-0" />
+                <span>{org.name}</span>
+                {org.edrpou && <span className="font-mono">· ЄДРПОУ {org.edrpou}</span>}
+              </div>
+            )}
 
-          {/* Calculation preview */}
-          {estimatedTotal > 0 && (
-            <div className="bg-claude-bg/50 border border-claude-border rounded-xl p-4 space-y-2">
-              <div className="flex justify-between text-sm">
-                <span className="text-claude-subtext">Сума</span>
-                <span>{estimatedUah.toLocaleString('uk-UA', { minimumFractionDigits: 2 })} грн</span>
+            {/* Invoice type toggle */}
+            <div>
+              <label className="block text-sm font-medium text-claude-text mb-2">Тип рахунку</label>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => setInvoiceType('topup')}
+                  className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border transition-colors ${
+                    invoiceType === 'topup'
+                      ? 'bg-claude-accent text-white border-claude-accent'
+                      : 'bg-white text-claude-subtext border-claude-border hover:border-claude-accent'
+                  }`}>
+                  Поповнення балансу
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setInvoiceType('subscription')}
+                  className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium border transition-colors ${
+                    invoiceType === 'subscription'
+                      ? 'bg-claude-accent text-white border-claude-accent'
+                      : 'bg-white text-claude-subtext border-claude-border hover:border-claude-accent'
+                  }`}>
+                  Підписка
+                </button>
               </div>
-              <div className="flex justify-between text-sm">
-                <span className="text-claude-subtext">ПДВ 20%</span>
-                <span>{estimatedVat.toLocaleString('uk-UA', { minimumFractionDigits: 2 })} грн</span>
-              </div>
-              <div className="border-t border-claude-border pt-2 flex justify-between text-sm font-semibold">
-                <span>Всього до оплати</span>
-                <span>{estimatedTotal.toLocaleString('uk-UA', { minimumFractionDigits: 2 })} грн</span>
-              </div>
-              <p className="text-xs text-claude-subtext">
-                * Точна сума буде розрахована при формуванні рахунку
-              </p>
             </div>
-          )}
 
-          {/* Error */}
-          {error && (
-            <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
-              <AlertCircle size={16} className="text-red-500 mt-0.5 shrink-0" />
-              <p className="text-sm text-red-700">{error}</p>
+            {/* Topup amount */}
+            {invoiceType === 'topup' && (
+              <div>
+                <label className="block text-sm font-medium text-claude-text mb-2">
+                  Сума поповнення, грн
+                </label>
+                <input
+                  type="number"
+                  min="500"
+                  step="100"
+                  value={amountUah}
+                  onChange={(e) => setAmountUah(e.target.value)}
+                  placeholder="Мінімум 500 грн"
+                  className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent"
+                  required
+                />
+                <p className="text-xs text-claude-subtext mt-1">Мінімальна сума — 500 грн</p>
+              </div>
+            )}
+
+            {/* Subscription: tier + cycle */}
+            {invoiceType === 'subscription' && (
+              <>
+                <div>
+                  <label className="block text-sm font-medium text-claude-text mb-2">Тариф</label>
+                  <select
+                    value={tierKey}
+                    onChange={(e) => setTierKey(e.target.value)}
+                    className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent"
+                    required>
+                    <option value="">Оберіть тариф</option>
+                    {tiers.map((t) => (
+                      <option key={t.tier_key} value={t.tier_key}>
+                        {t.display_name} — ${t.monthly_price_usd}/міс
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-claude-text mb-2">Період оплати</label>
+                  <div className="flex gap-2">
+                    {billingCycles.map((c) => (
+                      <button
+                        key={c.value}
+                        type="button"
+                        onClick={() => setBillingCycle(c.value)}
+                        className={`flex-1 px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
+                          billingCycle === c.value
+                            ? 'bg-claude-accent text-white border-claude-accent'
+                            : 'bg-white text-claude-subtext border-claude-border hover:border-claude-accent'
+                        }`}>
+                        {c.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </>
+            )}
+
+            {/* Notes */}
+            <div>
+              <label className="block text-sm font-medium text-claude-text mb-2">
+                Примітки <span className="text-claude-subtext font-normal">(необов&apos;язково)</span>
+              </label>
+              <textarea
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                rows={2}
+                className="w-full px-4 py-2.5 border border-claude-border rounded-lg text-sm focus:outline-none focus:border-claude-accent resize-none"
+                placeholder="Додаткова інформація..."
+              />
             </div>
-          )}
 
-          {/* Submit */}
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-3 bg-claude-accent text-white rounded-lg font-medium text-sm hover:bg-claude-accent/90 transition-colors disabled:opacity-50">
-            {loading ? 'Створення...' : 'Створити рахунок'}
-          </button>
-        </form>
+            {/* Calculation preview */}
+            {estimatedTotal > 0 && (
+              <div className="bg-claude-bg/50 border border-claude-border rounded-xl p-4 space-y-2">
+                <div className="flex justify-between text-sm">
+                  <span className="text-claude-subtext">Сума</span>
+                  <span>{estimatedUah.toLocaleString('uk-UA', { minimumFractionDigits: 2 })} грн</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-claude-subtext">ПДВ 20%</span>
+                  <span>{estimatedVat.toLocaleString('uk-UA', { minimumFractionDigits: 2 })} грн</span>
+                </div>
+                <div className="border-t border-claude-border pt-2 flex justify-between text-sm font-semibold">
+                  <span>Всього до оплати</span>
+                  <span>{estimatedTotal.toLocaleString('uk-UA', { minimumFractionDigits: 2 })} грн</span>
+                </div>
+                <p className="text-xs text-claude-subtext">
+                  * Точна сума буде розрахована при формуванні рахунку
+                </p>
+              </div>
+            )}
+
+            {/* Error */}
+            {error && (
+              <div className="flex items-start gap-2 p-3 bg-red-50 border border-red-200 rounded-lg">
+                <AlertCircle size={16} className="text-red-500 mt-0.5 shrink-0" />
+                <p className="text-sm text-red-700">{error}</p>
+              </div>
+            )}
+
+            {/* Submit */}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-3 bg-claude-accent text-white rounded-lg font-medium text-sm hover:bg-claude-accent/90 transition-colors disabled:opacity-50">
+              {loading ? 'Створення...' : 'Створити рахунок'}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/lexwebapp/src/utils/api/billing.ts
+++ b/lexwebapp/src/utils/api/billing.ts
@@ -48,6 +48,10 @@ export const b2bInvoiceApi = {
     apiClient.get(`/api/b2b-invoices/${id}/pdf`, { responseType: 'blob' }),
   cancel: (id: string, reason?: string) =>
     apiClient.post(`/api/b2b-invoices/${id}/cancel`, { reason }),
+  getOrgInfo: () =>
+    apiClient.get('/api/b2b-invoices/org-info'),
+  updateOrgInfo: (data: { edrpou?: string; legal_address?: string; name?: string; billing_email?: string }) =>
+    apiClient.patch('/api/b2b-invoices/org-info', data),
 };
 
 export const paymentApi = {

--- a/mcp_backend/src/routes/b2b-invoice-routes.ts
+++ b/mcp_backend/src/routes/b2b-invoice-routes.ts
@@ -62,6 +62,72 @@ export function createB2BInvoiceRoutes(
   // ===== USER ENDPOINTS =====
 
   /**
+   * GET /api/b2b-invoices/org-info — Get org billing details for invoice form
+   */
+  router.get('/org-info', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) return res.status(401).json({ error: 'Потрібна автентифікація' });
+
+      const orgId = await getUserOrgId(userId);
+      if (!orgId) return res.status(200).json({ org: null });
+
+      const result = await db.query(
+        'SELECT id, name, edrpou, legal_address, billing_email FROM organizations WHERE id = $1',
+        [orgId]
+      );
+      res.json({ org: result.rows[0] || null });
+    } catch (error: any) {
+      logger.error('Failed to get org info', { error: error.message });
+      res.status(500).json({ error: 'Помилка отримання даних організації' });
+    }
+  });
+
+  /**
+   * PATCH /api/b2b-invoices/org-info — Update org billing details (edrpou, address)
+   */
+  router.patch('/org-info', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) return res.status(401).json({ error: 'Потрібна автентифікація' });
+
+      const orgId = await getUserOrgId(userId);
+      if (!orgId) return res.status(400).json({ error: 'Ви не належите до жодної організації' });
+
+      // Verify user is org owner
+      const ownerCheck = await db.query('SELECT owner_id FROM organizations WHERE id = $1', [orgId]);
+      if (ownerCheck.rows[0]?.owner_id !== userId) {
+        return res.status(403).json({ error: 'Тільки власник організації може змінювати реквізити' });
+      }
+
+      const { edrpou, legal_address, name, billing_email } = req.body;
+
+      const updates: string[] = [];
+      const values: any[] = [];
+      let idx = 2;
+
+      if (edrpou !== undefined) { updates.push(`edrpou = $${idx++}`); values.push(edrpou); }
+      if (legal_address !== undefined) { updates.push(`legal_address = $${idx++}`); values.push(legal_address); }
+      if (name !== undefined) { updates.push(`name = $${idx++}`); values.push(name); }
+      if (billing_email !== undefined) { updates.push(`billing_email = $${idx++}`); values.push(billing_email); }
+
+      if (updates.length === 0) {
+        return res.status(400).json({ error: 'Немає полів для оновлення' });
+      }
+
+      await db.query(
+        `UPDATE organizations SET ${updates.join(', ')}, updated_at = NOW() WHERE id = $1`,
+        [orgId, ...values]
+      );
+
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('Failed to update org info', { error: error.message });
+      res.status(500).json({ error: 'Помилка оновлення даних організації' });
+    }
+  });
+
+  /**
    * POST /api/b2b-invoices — Request new invoice
    */
   router.post('/', async (req: Request, res: Response) => {


### PR DESCRIPTION
## Summary
- B2B invoice creation failed because org had no EDRPOU filled
- Added first step in invoice modal to collect org details (name, EDRPOU, address) when missing
- Added `GET /api/b2b-invoices/org-info` and `PATCH /api/b2b-invoices/org-info` backend endpoints
- After saving org details, user proceeds to the invoice form as before

## Test plan
- [ ] Open /billing/b2b-invoices, click "Запросити рахунок"
- [ ] If org has no EDRPOU, verify org details form appears first
- [ ] Fill EDRPOU and save, verify invoice form appears
- [ ] Create a topup invoice (500+ грн), verify it succeeds
- [ ] Re-open modal, verify org step is skipped (EDRPOU already saved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)