### PR TITLE
feat(billing): sync billing info with database

### DIFF
--- a/lexwebapp/src/components/billing/SettingsTab.tsx
+++ b/lexwebapp/src/components/billing/SettingsTab.tsx
@@ -131,14 +131,30 @@ export function SettingsTab() {
   const fetchAllData = async () => {
     setIsLoading(true);
     try {
-      const [methodsRes, settingsRes, balanceRes] = await Promise.all([
+      const [methodsRes, settingsRes, balanceRes, billingInfoRes] = await Promise.all([
         api.billing.getPaymentMethods(),
         api.billing.getSettings(),
         api.billing.getBalance(),
+        api.billing.getBillingInfo(),
       ]);
 
       // Payment methods
       setPaymentMethods(methodsRes.data?.paymentMethods || []);
+
+      // Billing info
+      const bi = billingInfoRes.data;
+      if (bi) {
+        setBillingInfo({
+          companyName: bi.companyName || '',
+          edrpou: bi.edrpou || '',
+          address: bi.address || '',
+          city: bi.city || '',
+          postalCode: bi.postalCode || '',
+          country: bi.country || 'Ukraine',
+          email: bi.email || '',
+          phone: bi.phone || '',
+        });
+      }
 
       // Limits from settings
       const s = settingsRes.data;
@@ -216,9 +232,8 @@ export function SettingsTab() {
   const handleSaveBillingInfo = async () => {
     setIsSavingBilling(true);
     try {
-      // TODO: Backend endpoint for billing info (company, EDRPOU, address) not yet implemented
-      // For now, store locally and show a notice
-      showToast.info('Збереження платіжних даних буде доступне найближчим часом');
+      await api.billing.updateBillingInfo(billingInfo);
+      showToast.success('Платіжну інформацію збережено');
     } catch (error) {
       console.error('Failed to save billing info:', error);
       showToast.error('Не вдалося зберегти платіжну інформацію');

--- a/lexwebapp/src/utils/api/billing.ts
+++ b/lexwebapp/src/utils/api/billing.ts
@@ -25,6 +25,17 @@ export const billingApi = {
     apiClient.get(`/api/billing/statistics?period=${period}`),
   getUsageChart: (days: number = 30) =>
     apiClient.get(`/api/billing/usage-chart?days=${days}`),
+  getBillingInfo: () => apiClient.get('/api/billing/billing-info'),
+  updateBillingInfo: (data: {
+    companyName?: string;
+    edrpou?: string;
+    address?: string;
+    city?: string;
+    postalCode?: string;
+    country?: string;
+    email?: string;
+    phone?: string;
+  }) => apiClient.put('/api/billing/billing-info', data),
   getPaymentMethods: () => apiClient.get('/api/billing/payment-methods'),
   addPaymentMethod: (data: Record<string, unknown>) =>
     apiClient.post('/api/billing/payment-methods', data),

--- a/mcp_backend/src/migrations/095_billing_info_fields.sql
+++ b/mcp_backend/src/migrations/095_billing_info_fields.sql
@@ -1,0 +1,16 @@
+-- Migration 095: Add billing info fields to user_billing
+-- Company details for invoicing (companyName, EDRPOU, address, etc.)
+
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'user_billing' AND column_name = 'company_name') THEN
+    ALTER TABLE user_billing
+      ADD COLUMN company_name VARCHAR(255),
+      ADD COLUMN edrpou VARCHAR(20),
+      ADD COLUMN billing_address TEXT,
+      ADD COLUMN billing_city VARCHAR(100),
+      ADD COLUMN billing_postal_code VARCHAR(20),
+      ADD COLUMN billing_country VARCHAR(100) DEFAULT 'Ukraine',
+      ADD COLUMN billing_email VARCHAR(255),
+      ADD COLUMN billing_phone VARCHAR(50);
+  END IF;
+END $$;

--- a/mcp_backend/src/routes/billing-routes.ts
+++ b/mcp_backend/src/routes/billing-routes.ts
@@ -291,6 +291,42 @@ export function createBillingRoutes(
   });
 
   /**
+   * GET /api/billing/billing-info
+   * Get user's billing info (company details for invoicing)
+   */
+  router.get('/billing-info', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+      const info = await billingService.getBillingInfo(userId);
+      res.json(info);
+    } catch (error: any) {
+      logger.error('Failed to get billing info', { error: error.message });
+      res.status(500).json({ error: 'Не вдалося отримати платіжну інформацію' });
+    }
+  });
+
+  /**
+   * PUT /api/billing/billing-info
+   * Update user's billing info (company details for invoicing)
+   */
+  router.put('/billing-info', async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) {
+        return res.status(401).json({ error: 'Authentication required' });
+      }
+      await billingService.updateBillingInfo(userId, req.body);
+      res.json({ success: true, message: 'Платіжну інформацію збережено' });
+    } catch (error: any) {
+      logger.error('Failed to update billing info', { error: error.message });
+      res.status(500).json({ error: 'Не вдалося зберегти платіжну інформацію' });
+    }
+  });
+
+  /**
    * GET /api/billing/payment-methods
    * Get user's saved payment methods
    */

--- a/mcp_backend/src/services/billing-service.ts
+++ b/mcp_backend/src/services/billing-service.ts
@@ -1038,6 +1038,68 @@ export class BillingService {
   }
 
   /**
+   * Get billing info (company details for invoicing)
+   */
+  async getBillingInfo(userId: string): Promise<{
+    companyName: string;
+    edrpou: string;
+    address: string;
+    city: string;
+    postalCode: string;
+    country: string;
+    email: string;
+    phone: string;
+  }> {
+    const result = await this.db.query(
+      `SELECT company_name, edrpou, billing_address, billing_city,
+              billing_postal_code, billing_country, billing_email, billing_phone
+       FROM user_billing WHERE user_id = $1`,
+      [userId]
+    );
+    const row = result.rows[0];
+    return {
+      companyName: row?.company_name || '',
+      edrpou: row?.edrpou || '',
+      address: row?.billing_address || '',
+      city: row?.billing_city || '',
+      postalCode: row?.billing_postal_code || '',
+      country: row?.billing_country || 'Ukraine',
+      email: row?.billing_email || '',
+      phone: row?.billing_phone || '',
+    };
+  }
+
+  /**
+   * Update billing info (company details for invoicing)
+   */
+  async updateBillingInfo(userId: string, data: {
+    companyName?: string;
+    edrpou?: string;
+    address?: string;
+    city?: string;
+    postalCode?: string;
+    country?: string;
+    email?: string;
+    phone?: string;
+  }): Promise<void> {
+    await this.db.query(
+      `UPDATE user_billing SET
+        company_name = COALESCE($2, company_name),
+        edrpou = COALESCE($3, edrpou),
+        billing_address = COALESCE($4, billing_address),
+        billing_city = COALESCE($5, billing_city),
+        billing_postal_code = COALESCE($6, billing_postal_code),
+        billing_country = COALESCE($7, billing_country),
+        billing_email = COALESCE($8, billing_email),
+        billing_phone = COALESCE($9, billing_phone),
+        updated_at = NOW()
+       WHERE user_id = $1`,
+      [userId, data.companyName, data.edrpou, data.address, data.city,
+       data.postalCode, data.country, data.email, data.phone]
+    );
+  }
+
+  /**
    * Get email notification preferences for a user
    */
   async getEmailPreferences(userId: string): Promise<EmailPreferences> {


### PR DESCRIPTION
## Summary
- Add migration 095: `company_name`, `edrpou`, `billing_address`, `billing_city`, `billing_postal_code`, `billing_country`, `billing_email`, `billing_phone` columns on `user_billing`
- Add `getBillingInfo()` / `updateBillingInfo()` to billing service
- Add `GET/PUT /api/billing/billing-info` endpoints
- Frontend SettingsTab now fetches billing info on load and saves to DB (was a TODO stub showing "буде доступне найближчим часом")

## Test plan
- [ ] Open /billing/settings — verify billing info fields load from DB
- [ ] Fill in company name, EDRPOU, address — save and reload — verify data persists
- [ ] Verify migration runs without errors on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)