### PR TITLE
fix(billing): fix analytics page not scrolling to bottom

### DIFF
--- a/lexwebapp/src/pages/BillingDashboard.tsx
+++ b/lexwebapp/src/pages/BillingDashboard.tsx
@@ -66,7 +66,7 @@ export function BillingDashboard() {
   };
 
   return (
-    <div className="flex flex-col h-screen bg-claude-bg">
+    <div className="flex flex-col h-full bg-claude-bg">
       {/* Header */}
       <div className="bg-white border-b border-claude-border px-6 py-4">
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Summary
- BillingDashboard used `h-screen` but MainLayout already sets `h-screen`
- Double `h-screen` caused content to overflow without scroll
- Changed to `h-full` so BillingDashboard fills available space within MainLayout

## Test plan
- [ ] Open /billing/analytics, verify page scrolls to bottom (daily cost chart visible)
- [ ] Verify other billing tabs still scroll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)