### PR TITLE
feat(news): in-app KMU article viewer with AI analysis

### DIFF
--- a/lexwebapp/src/pages/NewsPage/KmuArticleModal.tsx
+++ b/lexwebapp/src/pages/NewsPage/KmuArticleModal.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { X, Loader2, ExternalLink, Sparkles, AlertCircle } from 'lucide-react';
+
+interface KmuArticleModalProps {
+  url: string;
+  title: string;
+  onClose: () => void;
+}
+
+interface ArticleData {
+  title: string;
+  content: string;
+  analysis: string;
+}
+
+export function KmuArticleModal({ url, title, onClose }: KmuArticleModalProps) {
+  const [data, setData] = useState<ArticleData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchArticle = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const token = localStorage.getItem('auth_token');
+        const params = new URLSearchParams({ url, title });
+        const response = await fetch(`/api/news/article?${params}`, {
+          headers: token ? { Authorization: `Bearer ${token}` } : {},
+        });
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({}));
+          throw new Error(body.error || `HTTP ${response.status}`);
+        }
+        const result = await response.json();
+        setData(result);
+      } catch (err: any) {
+        setError(err.message || 'Не вдалося завантажити статтю');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchArticle();
+  }, [url, title]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm overflow-y-auto"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <motion.div
+        initial={{ opacity: 0, y: 40 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 40 }}
+        transition={{ type: 'spring', damping: 30, stiffness: 300 }}
+        className="max-w-3xl mx-auto my-8 sm:my-12 bg-white rounded-2xl shadow-2xl overflow-hidden"
+      >
+        {/* Header */}
+        <div className="sticky top-0 z-10 bg-white/95 backdrop-blur-sm border-b border-claude-border px-6 sm:px-8 py-4 flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-claude-text truncate pr-4 max-w-[80%]">
+            {title}
+          </h2>
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-claude-bg text-claude-subtext hover:text-claude-text transition-colors"
+              title="Відкрити оригінал"
+            >
+              <ExternalLink size={16} />
+            </a>
+            <button
+              onClick={onClose}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-claude-bg text-claude-subtext hover:text-claude-text transition-colors"
+            >
+              <X size={18} />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 sm:px-8 py-6 sm:py-8">
+          {loading && (
+            <div className="flex flex-col items-center justify-center py-16 gap-3">
+              <Loader2 size={28} className="animate-spin text-claude-accent" />
+              <p className="text-sm text-claude-subtext">Завантаження та аналіз статті...</p>
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-center gap-3 p-4 bg-red-50 border border-red-200 rounded-xl text-red-700 text-sm">
+              <AlertCircle size={18} />
+              {error}
+            </div>
+          )}
+
+          {data && !loading && (
+            <>
+              {/* Article content */}
+              <div className="prose prose-sm sm:prose max-w-none
+                prose-headings:font-serif prose-headings:text-claude-text
+                prose-h2:text-xl prose-h2:mt-6 prose-h2:mb-3
+                prose-h3:text-lg prose-h3:mt-4 prose-h3:mb-2
+                prose-p:text-claude-text prose-p:font-sans prose-p:leading-relaxed
+                prose-li:text-claude-text prose-li:font-sans
+                prose-strong:text-claude-text
+                prose-blockquote:border-claude-accent prose-blockquote:bg-claude-accent/5 prose-blockquote:rounded-r-xl
+              ">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                  {data.content}
+                </ReactMarkdown>
+              </div>
+
+              {/* AI Analysis */}
+              {data.analysis && (
+                <div className="mt-8 p-5 bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 rounded-xl">
+                  <div className="flex items-center gap-2 mb-3">
+                    <Sparkles size={18} className="text-amber-600" />
+                    <h3 className="text-sm font-semibold text-amber-800">
+                      AI-аналіз
+                    </h3>
+                  </div>
+                  <div className="prose prose-sm max-w-none
+                    prose-p:text-amber-900/80 prose-p:font-sans prose-p:leading-relaxed prose-p:my-2
+                    prose-strong:text-amber-900
+                    prose-li:text-amber-900/80
+                  ">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {data.analysis}
+                    </ReactMarkdown>
+                  </div>
+                </div>
+              )}
+
+              {/* Source link */}
+              <div className="mt-6 pt-4 border-t border-claude-border text-center">
+                <a
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-xs text-claude-subtext hover:text-claude-accent transition-colors"
+                >
+                  <ExternalLink size={12} />
+                  Джерело: kmu.gov.ua
+                </a>
+              </div>
+            </>
+          )}
+        </div>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/lexwebapp/src/pages/NewsPage/index.tsx
+++ b/lexwebapp/src/pages/NewsPage/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { motion } from 'framer-motion';
-import { Loader2, ExternalLink, RefreshCw, AlertCircle, Calendar } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Loader2, ExternalLink, RefreshCw, AlertCircle, Calendar, Sparkles } from 'lucide-react';
+import { KmuArticleModal } from './KmuArticleModal';
 
 interface NewsItem {
   title: string;
@@ -51,6 +52,7 @@ export function NewsPage() {
   const [news, setNews] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedItem, setSelectedItem] = useState<NewsItem | null>(null);
 
   const fetchNews = async () => {
     setLoading(true);
@@ -120,15 +122,13 @@ export function NewsPage() {
 
         <div className="space-y-4">
           {news.map((item, index) => (
-            <motion.a
+            <motion.div
               key={item.link || index}
-              href={item.link}
-              target="_blank"
-              rel="noopener noreferrer"
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: index * 0.03, duration: 0.3 }}
-              className="block p-5 bg-white border border-claude-border rounded-xl hover:border-claude-accent/30 hover:shadow-sm transition-all group"
+              onClick={() => setSelectedItem(item)}
+              className="block p-5 bg-white border border-claude-border rounded-xl hover:border-claude-accent/30 hover:shadow-sm transition-all group cursor-pointer"
             >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
@@ -147,9 +147,12 @@ export function NewsPage() {
                     </div>
                   )}
                 </div>
-                <ExternalLink size={16} className="flex-shrink-0 text-claude-subtext/40 group-hover:text-claude-accent transition-colors mt-1" />
+                <div className="flex items-center gap-1.5 flex-shrink-0 mt-1">
+                  <Sparkles size={14} className="text-amber-400 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  <ExternalLink size={16} className="text-claude-subtext/40 group-hover:text-claude-accent transition-colors" />
+                </div>
               </div>
-            </motion.a>
+            </motion.div>
           ))}
         </div>
 
@@ -168,6 +171,17 @@ export function NewsPage() {
           </div>
         )}
       </div>
+
+      {/* Article Modal */}
+      <AnimatePresence>
+        {selectedItem && (
+          <KmuArticleModal
+            url={selectedItem.link}
+            title={selectedItem.title}
+            onClose={() => setSelectedItem(null)}
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -25,6 +25,8 @@ import { createEncryptionRoutes } from './routes/encryption-routes.js';
 import { createWorkerHeartbeatRoute } from './routes/worker-heartbeat-routes.js';
 import { createDecisionsRoutes } from './routes/decisions-routes.js';
 import { createERAUProxyRoutes } from './routes/erau-proxy-routes.js';
+import { createNewsRoutes } from './routes/news-routes.js';
+import { NewsArticleService } from './services/news-article-service.js';
 import { ERAUCacheService } from './services/erau-cache-service.js';
 import { attachTerminalWebSocket } from './routes/terminal-routes.js';
 import { createTeamRoutes } from './routes/team-routes.js';
@@ -474,6 +476,11 @@ class HTTPMCPServer {
     // Decisions routes - download court decision full texts from reyestr.court.gov.ua
     this.app.use('/api/decisions', requireJWT as any, createDecisionsRoutes(this.services.reyestrDownloadService));
     logger.info('Decisions routes registered at /api/decisions');
+
+    // News article routes - fetch KMU articles with AI analysis
+    const newsArticleService = new NewsArticleService(this.services.db);
+    this.app.use('/api/news', requireJWT as any, createNewsRoutes(newsArticleService));
+    logger.info('News article routes registered at /api/news');
 
     // ERAU proxy - Ukrainian Bar Registry (public, no auth required)
     const erauCacheService = new ERAUCacheService(this.services.db);

--- a/mcp_backend/src/migrations/096_news_articles.sql
+++ b/mcp_backend/src/migrations/096_news_articles.sql
@@ -1,0 +1,13 @@
+-- News articles cache with AI analysis
+CREATE TABLE IF NOT EXISTS news_articles (
+  id SERIAL PRIMARY KEY,
+  url TEXT NOT NULL UNIQUE,
+  title TEXT NOT NULL,
+  content TEXT,
+  analysis TEXT,
+  scraped_at TIMESTAMPTZ,
+  analyzed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_news_articles_url ON news_articles(url);

--- a/mcp_backend/src/routes/news-routes.ts
+++ b/mcp_backend/src/routes/news-routes.ts
@@ -1,0 +1,53 @@
+/**
+ * News Routes
+ *
+ * GET /api/news/article?url=...&title=... — Fetch article content + AI analysis
+ */
+
+import { Router, Response } from 'express';
+import { NewsArticleService } from '../services/news-article-service.js';
+import { createRateLimiter } from '../middleware/rate-limit.js';
+import { logger } from '../utils/logger.js';
+
+const newsRateLimit = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 10,
+  keyPrefix: 'news_article',
+});
+
+export function createNewsRoutes(newsArticleService: NewsArticleService): Router {
+  const router = Router();
+
+  router.get('/article', newsRateLimit as any, async (req: any, res: Response) => {
+    try {
+      const url = req.query.url as string;
+      const title = req.query.title as string;
+
+      if (!url) {
+        return res.status(400).json({ error: 'url query parameter required' });
+      }
+      if (!title) {
+        return res.status(400).json({ error: 'title query parameter required' });
+      }
+
+      // Validate URL is from kmu.gov.ua
+      try {
+        const parsed = new URL(url);
+        if (!parsed.hostname.endsWith('kmu.gov.ua')) {
+          return res.status(400).json({ error: 'Only kmu.gov.ua URLs are supported' });
+        }
+      } catch {
+        return res.status(400).json({ error: 'Invalid URL' });
+      }
+
+      const result = await newsArticleService.getArticle(url, title);
+      res.json(result);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      logger.error('[News] article fetch error', { error: msg });
+      res.status(500).json({ error: 'Не вдалося завантажити статтю' });
+    }
+  });
+
+  return router;
+}

--- a/mcp_backend/src/services/news-article-service.ts
+++ b/mcp_backend/src/services/news-article-service.ts
@@ -1,0 +1,210 @@
+/**
+ * News Article Service
+ *
+ * Fetches KMU government news articles via headless browser,
+ * extracts clean text with cheerio, generates AI analysis via Bedrock,
+ * and caches everything in PostgreSQL.
+ */
+
+import * as cheerio from 'cheerio';
+import { Database } from '../database/database.js';
+import { getLLMManager } from '../utils/llm-client-manager.js';
+import { logger } from '../utils/logger.js';
+
+export interface NewsArticleResult {
+  title: string;
+  content: string;
+  analysis: string;
+  scraped_at: string | null;
+  analyzed_at: string | null;
+}
+
+export class NewsArticleService {
+  constructor(private db: Database) {}
+
+  /**
+   * Get article with analysis — from DB cache or scrape + analyze on the fly.
+   */
+  async getArticle(url: string, title: string): Promise<NewsArticleResult> {
+    // 1. Check DB cache
+    const cached = await this.db.query(
+      'SELECT title, content, analysis, scraped_at, analyzed_at FROM news_articles WHERE url = $1',
+      [url]
+    );
+
+    if (cached.rows.length > 0) {
+      const row = cached.rows[0];
+      // If we have content and analysis, return immediately
+      if (row.content && row.analysis) {
+        logger.info('[NewsArticle] Cache hit', { url });
+        return {
+          title: row.title,
+          content: row.content,
+          analysis: row.analysis,
+          scraped_at: row.scraped_at,
+          analyzed_at: row.analyzed_at,
+        };
+      }
+      // If we have content but no analysis, generate analysis
+      if (row.content && !row.analysis) {
+        logger.info('[NewsArticle] Cache hit (content only), generating analysis', { url });
+        const analysis = await this.generateAnalysis(row.title, row.content);
+        await this.db.query(
+          'UPDATE news_articles SET analysis = $1, analyzed_at = NOW() WHERE url = $2',
+          [analysis, url]
+        );
+        return {
+          title: row.title,
+          content: row.content,
+          analysis,
+          scraped_at: row.scraped_at,
+          analyzed_at: new Date().toISOString(),
+        };
+      }
+    }
+
+    // 2. Scrape
+    logger.info('[NewsArticle] Cache miss, scraping', { url });
+    const content = await this.scrapeArticle(url);
+
+    // 3. Analyze
+    const analysis = await this.generateAnalysis(title, content);
+
+    // 4. Upsert into DB
+    await this.db.query(
+      `INSERT INTO news_articles (url, title, content, analysis, scraped_at, analyzed_at)
+       VALUES ($1, $2, $3, $4, NOW(), NOW())
+       ON CONFLICT (url) DO UPDATE SET
+         title = EXCLUDED.title,
+         content = EXCLUDED.content,
+         analysis = EXCLUDED.analysis,
+         scraped_at = NOW(),
+         analyzed_at = NOW()`,
+      [url, title, content, analysis]
+    );
+
+    return {
+      title,
+      content,
+      analysis,
+      scraped_at: new Date().toISOString(),
+      analyzed_at: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Scrape article body from KMU URL via headless browser + cheerio extraction.
+   */
+  private async scrapeArticle(url: string): Promise<string> {
+    const { chromium } = await import('playwright');
+    const browser = await chromium.launch({
+      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+    });
+
+    try {
+      const context = await browser.newContext({
+        userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        ignoreHTTPSErrors: true,
+      });
+      const page = await context.newPage();
+
+      await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+      const html = await page.content();
+      await context.close();
+
+      return this.extractArticleText(html);
+    } finally {
+      await browser.close();
+    }
+  }
+
+  /**
+   * Extract clean article text from KMU page HTML.
+   * Strips navigation, images, ads, scripts, styles.
+   */
+  private extractArticleText(html: string): string {
+    const $ = cheerio.load(html);
+
+    // Remove unwanted elements
+    $('script, style, nav, header, footer, iframe, img, video, audio, svg, figure, .breadcrumb, .social-share, .sidebar, .related-news, .tags, .share-buttons, .advertisement, noscript').remove();
+
+    // KMU articles are typically in .article-content or .content-detail or main article area
+    let articleEl = $('.article-content, .content-detail, .article-body, article .text, .news-detail__text, .statical-page__body').first();
+
+    // Fallback: try article tag or main content area
+    if (!articleEl.length) {
+      articleEl = $('article, main, .main-content, .page-content').first();
+    }
+
+    // Last fallback: body
+    if (!articleEl.length) {
+      articleEl = $('body');
+    }
+
+    // Get text, preserving paragraph structure
+    const blocks: string[] = [];
+    articleEl.find('p, h1, h2, h3, h4, h5, h6, li, blockquote, td').each((_, el) => {
+      const text = $(el).text().trim();
+      if (text.length > 0) {
+        const tag = (el as any).tagName?.toLowerCase() || '';
+        if (tag.startsWith('h')) {
+          blocks.push(`\n## ${text}\n`);
+        } else if (tag === 'li') {
+          blocks.push(`- ${text}`);
+        } else if (tag === 'blockquote') {
+          blocks.push(`> ${text}`);
+        } else {
+          blocks.push(text);
+        }
+      }
+    });
+
+    // If paragraph extraction yielded very little, fall back to full text
+    if (blocks.join('\n').length < 100) {
+      return articleEl.text().replace(/\s+/g, ' ').trim();
+    }
+
+    return blocks.join('\n\n');
+  }
+
+  /**
+   * Generate AI analytical commentary for a news article.
+   */
+  private async generateAnalysis(title: string, content: string): Promise<string> {
+    const llm = getLLMManager();
+
+    // Truncate content to avoid token overflow (keep first ~6000 chars)
+    const truncatedContent = content.length > 6000 ? content.substring(0, 6000) + '\n\n[текст скорочено]' : content;
+
+    const response = await llm.chatCompletion(
+      {
+        messages: [
+          {
+            role: 'system',
+            content: `Ти — досвідчений український аналітик з фокусом на економіку, антикорупційну політику та геополітику. Тобі надано новину з офіційного сайту Кабінету Міністрів України.
+
+Напиши аналітичний коментар українською мовою (3-5 абзаців), який:
+1. Пояснює суть рішення/новини простою мовою
+2. Аналізує реальний вплив на економіку та бізнес-середовище України
+3. Оцінює потенційні корупційні ризики або антикорупційний ефект (якщо релевантно)
+4. Розглядає геополітичний контекст (ЄС-інтеграція, війна, міжнародні відносини)
+5. Дає коротку оцінку: кому це вигідно, а кому може зашкодити
+
+Пиши чітко, фактологічно, без пропаганди. Якщо інформації недостатньо для глибокого аналізу — зазнач це.`,
+          },
+          {
+            role: 'user',
+            content: `Заголовок: ${title}\n\nТекст новини:\n${truncatedContent}`,
+          },
+        ],
+        max_tokens: 2000,
+        temperature: 0.7,
+      },
+      'standard',
+      'bedrock'
+    );
+
+    return response.content;
+  }
+}


### PR DESCRIPTION
## Summary
- Clicking a news item on `/news` now opens an in-app modal instead of navigating to kmu.gov.ua
- Article text is scraped via Playwright + cheerio (images/ads/nav stripped)
- AI analytical commentary generated via Bedrock Sonnet focused on economic/corruption/geopolitical context
- Articles + analysis cached in `news_articles` DB table for instant re-access

## Test plan
- [ ] Open `/news`, click an article — modal opens with content + AI analysis
- [ ] Click same article again — loads instantly from DB cache
- [ ] Verify `SELECT * FROM news_articles` shows cached rows
- [ ] Verify images/ads are stripped from content
- [ ] Verify analysis is in Ukrainian and covers economic/corruption angles
- [ ] TypeScript builds pass: `cd lexwebapp && npx tsc --noEmit` + `cd mcp_backend && npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)