### PR TITLE
fix(billing): handle jsonb metadata — fix missing payment emails

### DIFF
--- a/mcp_backend/src/services/binance-pay-service.ts
+++ b/mcp_backend/src/services/binance-pay-service.ts
@@ -208,7 +208,7 @@ export class BinancePayService {
       });
 
       // Send email
-      const metadata = JSON.parse(pi.metadata || '{}');
+      const metadata = typeof pi.metadata === 'string' ? JSON.parse(pi.metadata) : (pi.metadata || {});
       if (metadata.email) {
         await this.emailService.sendPaymentSuccess({
           email: metadata.email,

--- a/mcp_backend/src/services/metamask-service.ts
+++ b/mcp_backend/src/services/metamask-service.ts
@@ -261,7 +261,7 @@ export class MetaMaskService {
       });
 
       // Send confirmation email
-      const metadata = JSON.parse(pi.metadata || '{}');
+      const metadata = typeof pi.metadata === 'string' ? JSON.parse(pi.metadata) : (pi.metadata || {});
       if (metadata.email) {
         await this.emailService.sendPaymentSuccess({
           email: metadata.email,

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -314,7 +314,7 @@ export class MonobankService {
     }
 
     // Send confirmation email
-    const metadata = JSON.parse(pi.metadata || '{}');
+    const metadata = typeof pi.metadata === 'string' ? JSON.parse(pi.metadata) : (pi.metadata || {});
     if (metadata.email) {
       try {
         await this.emailService.sendPaymentSuccess({

--- a/mcp_backend/src/services/nowpayments-service.ts
+++ b/mcp_backend/src/services/nowpayments-service.ts
@@ -193,7 +193,7 @@ export class NOWPaymentsService {
     });
 
     // Send confirmation email
-    const metadata = JSON.parse(pi.metadata || '{}');
+    const metadata = typeof pi.metadata === 'string' ? JSON.parse(pi.metadata) : (pi.metadata || {});
     if (metadata.email) {
       await this.emailService.sendPaymentSuccess({
         email: metadata.email,


### PR DESCRIPTION
## Summary
- `payment_intents.metadata` is a `jsonb` column — PostgreSQL returns it as a parsed JS object
- `JSON.parse(pi.metadata)` was calling `.toString()` on the object → `"[object Object]"` → SyntaxError
- This error prevented confirmation emails from being sent after successful Monobank payments
- Fixed in all 4 payment services: monobank, metamask, binance-pay, nowpayments

## Root cause
```js
// Before (broken): jsonb column is already an object, JSON.parse fails
const metadata = JSON.parse(pi.metadata || '{}');

// After (fixed): handle both string and object
const metadata = typeof pi.metadata === 'string' ? JSON.parse(pi.metadata) : (pi.metadata || {});
```

## Test plan
- [x] TypeScript builds clean
- [ ] Make a test payment → email should arrive
- [ ] Verify balance is credited correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)