### PR TITLE
fix(billing): fix payment success email — newBalance.toFixed crash

### DIFF
--- a/mcp_backend/src/services/email-service.ts
+++ b/mcp_backend/src/services/email-service.ts
@@ -476,7 +476,7 @@ export class EmailService {
           </tr>
           <tr>
             <td>Поточний баланс</td>
-            <td>$${params.newBalance.toFixed(2)} USD</td>
+            <td>$${Number(params.newBalance).toFixed(2)} USD</td>
           </tr>
           <tr>
             <td>Дата</td>


### PR DESCRIPTION
## Summary
- `transaction.balance_after_usd` from PG numeric column is a string, not a number
- `params.newBalance.toFixed(2)` threw `"is not a function"`, preventing emails from sending
- Fix: wrap with `Number()` before calling `.toFixed()`

## Test plan
- [x] TypeScript builds clean
- [ ] Make a test payment → email should arrive this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)