### PR TITLE
fix(billing): exempt read-only legislation tools from balance check

### DIFF
--- a/mcp_backend/src/middleware/balance-check.ts
+++ b/mcp_backend/src/middleware/balance-check.ts
@@ -19,6 +19,10 @@ const FREE_TOOLS = new Set([
   'get_document_sections',
   'list_conversations',
   'get_conversation',
+  'get_legislation_structure',
+  'get_legislation_article',
+  'get_legislation_articles',
+  'get_legislation_section',
 ]);
 
 export function createBalanceCheckMiddleware(


### PR DESCRIPTION
## Summary
- Added `get_legislation_structure`, `get_legislation_article`, `get_legislation_articles`, and `get_legislation_section` to `FREE_TOOLS` in balance-check middleware
- These tools are pure PostgreSQL reads with zero LLM/API costs — they should not be blocked by monthly spending limits
- `search_legislation` remains billable (uses AI for reference parsing + vector search)

## Test plan
- [ ] Open /legislation/library, click "Цивільний кодекс" — should load structure without 429 error
- [ ] Navigate between articles — should work without billing blocks
- [ ] Verify `search_legislation` still goes through balance check

🤖 Generated with [Claude Code](https://claude.com/claude-code)