### PR TITLE
fix(diia): use sandbox API endpoint while on test token

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -574,7 +574,7 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
       # Diia (Дія) Auth
-      DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2t.diia.gov.ua}
+      DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2s.diia.gov.ua}
       DIIA_ACQUIRER_TOKEN: ${DIIA_ACQUIRER_TOKEN:-}
       DIIA_AUTH_ACQUIRER_TOKEN: ${DIIA_AUTH_ACQUIRER_TOKEN:-}
       FRONTEND_URL: https://legal.org.ua
@@ -899,7 +899,7 @@ services:
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
-      DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2t.diia.gov.ua}
+      DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2s.diia.gov.ua}
       DIIA_ACQUIRER_TOKEN: ${DIIA_ACQUIRER_TOKEN:-}
       DIIA_AUTH_ACQUIRER_TOKEN: ${DIIA_AUTH_ACQUIRER_TOKEN:-}
       FRONTEND_URL: https://legal.org.ua

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -555,7 +555,7 @@ services:
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
       GOOGLE_CALLBACK_URL: ${GOOGLE_CALLBACK_URL:-https://stage.legal.org.ua/auth/google/callback}
       # Diia (Дія) Auth
-      DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2t.diia.gov.ua}
+      DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2s.diia.gov.ua}
       DIIA_ACQUIRER_TOKEN: ${DIIA_ACQUIRER_TOKEN:-}
       DIIA_AUTH_ACQUIRER_TOKEN: ${DIIA_AUTH_ACQUIRER_TOKEN:-}
       FRONTEND_URL: ${FRONTEND_URL:-https://stage.legal.org.ua}


### PR DESCRIPTION
## Summary
- Switch default `DIIA_BASE_URL` from `api2t.diia.gov.ua` (production) to `api2s.diia.gov.ua` (sandbox) in docker-compose files
- Test token (`lexai_test_token_opa105`) only works with sandbox endpoint — production endpoint returns 403
- Prod `.env.prod` already fixed on server via SSH

## Context
Diia auth was returning `error=diia_failed` on login page because the test token was being sent to the production Diia API. Once we receive a production token from Diia (step 6 of their onboarding), we'll switch back to `api2t`.

## Test plan
- [ ] Verify `https://legal.org.ua/auth/diia` returns 302 with `diia_deeplink` params (after next deploy)
- [ ] Verify QR modal appears on login page
- [ ] Verify scanning QR in Diia app triggers callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)