### PR TITLE
fix(email): add SMTP auth for prod relay

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -605,6 +605,8 @@ services:
       SMTP_HOST: mail.lexapp.co.ua
       SMTP_PORT: "587"
       SMTP_SECURE: "false"
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASS: ${SMTP_PASS}
       EMAIL_FROM: noreply@legal.org.ua
       EMAIL_FROM_NAME: SecondLayer Legal Platform
 
@@ -920,6 +922,8 @@ services:
       SMTP_HOST: mail.lexapp.co.ua
       SMTP_PORT: "587"
       SMTP_SECURE: "false"
+      SMTP_USER: ${SMTP_USER}
+      SMTP_PASS: ${SMTP_PASS}
       EMAIL_FROM: noreply@legal.org.ua
       EMAIL_FROM_NAME: SecondLayer Legal Platform
       PROMETHEUS_URL: http://prometheus-prod:9090


### PR DESCRIPTION
## Summary
- Payment confirmation emails to external addresses (gmail) were failing with `Relay access denied`
- Root cause: `SMTP_USER` and `SMTP_PASS` not passed to backend containers
- Created `noreply@legal.org.ua` mail account on `mail.lexapp.co.ua`
- Added `SMTP_USER`/`SMTP_PASS` env var references to both backend service definitions in prod compose

## Test plan
- [ ] After deploy, trigger a test payment and verify email arrives at teosoph@gmail.com
- [ ] Check backend logs for successful email send

🤖 Generated with [Claude Code](https://claude.com/claude-code)