### PR TITLE
feat(consultation): real-time SSE flow, modals, typing indicators

### DIFF
--- a/lexwebapp/src/components/attorney/PendingInvitationsModal.tsx
+++ b/lexwebapp/src/components/attorney/PendingInvitationsModal.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { X, Clock, FileText, MessageSquare } from 'lucide-react';
+import { X, Clock, FileText, MessageSquare, CheckCircle, Loader2 } from 'lucide-react';
 import { consultationService, type Consultation } from '../../services/api/ConsultationService';
+import { useConsultationStore } from '../../stores/consultationStore';
 import showToast from '../../utils/toast';
 
 interface PendingInvitationsModalProps {
@@ -24,21 +25,45 @@ const TYPE_LABELS: Record<string, string> = {
 };
 
 export function PendingInvitationsModal({ open, consultations, onClose }: PendingInvitationsModalProps) {
+  const storePending = useConsultationStore(s => s.pendingConsultations);
   const [items, setItems] = useState<Consultation[]>(consultations);
 
-  // Sync internal items state when consultations prop changes
+  // Sync from props and store
   useEffect(() => {
     if (consultations.length > 0) {
       setItems(consultations);
     }
   }, [consultations]);
+
+  // Also merge in new requests from store (real-time)
+  useEffect(() => {
+    if (storePending.length > 0) {
+      setItems(prev => {
+        const existingIds = new Set(prev.map(c => c.id));
+        const newOnes = storePending.filter(c => !existingIds.has(c.id));
+        return newOnes.length > 0 ? [...newOnes, ...prev] : prev;
+      });
+    }
+  }, [storePending]);
+
   const [processing, setProcessing] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [feeValue, setFeeValue] = useState('');
+  const [declineId, setDeclineId] = useState<string | null>(null);
+  const [declineReason, setDeclineReason] = useState('');
 
   const handleAccept = async (id: string) => {
+    const fee = parseFloat(feeValue);
+    if (!fee || fee <= 0) {
+      showToast.error('Вкажіть коректну суму гонорару');
+      return;
+    }
     setProcessing(id);
     try {
-      await consultationService.acceptConsultation(id);
+      await consultationService.acceptConsultation(id, fee);
       setItems(prev => prev.filter(c => c.id !== id));
+      setExpandedId(null);
+      setFeeValue('');
       showToast.success('Запит прийнято');
     } catch {
       showToast.error('Не вдалося прийняти запит');
@@ -50,8 +75,10 @@ export function PendingInvitationsModal({ open, consultations, onClose }: Pendin
   const handleDecline = async (id: string) => {
     setProcessing(id);
     try {
-      await consultationService.declineConsultation(id);
+      await consultationService.declineConsultation(id, declineReason || undefined);
       setItems(prev => prev.filter(c => c.id !== id));
+      setDeclineId(null);
+      setDeclineReason('');
       showToast.success('Запит відхилено');
     } catch {
       showToast.error('Не вдалося відхилити запит');
@@ -109,6 +136,8 @@ export function PendingInvitationsModal({ open, consultations, onClose }: Pendin
               {items.map(consultation => {
                 const urgency = URGENCY_LABELS[consultation.urgency] || URGENCY_LABELS.normal;
                 const isProcessing = processing === consultation.id;
+                const isExpanded = expandedId === consultation.id;
+                const isDeclining = declineId === consultation.id;
 
                 return (
                   <motion.div
@@ -148,22 +177,89 @@ export function PendingInvitationsModal({ open, consultations, onClose }: Pendin
                       </p>
                     )}
 
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() => handleAccept(consultation.id)}
-                        disabled={isProcessing}
-                        className="flex-1 px-3 py-2 text-[13px] font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 rounded-lg transition-colors"
-                      >
-                        {isProcessing ? '...' : 'Прийняти'}
-                      </button>
-                      <button
-                        onClick={() => handleDecline(consultation.id)}
-                        disabled={isProcessing}
-                        className="flex-1 px-3 py-2 text-[13px] font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 rounded-lg transition-colors"
-                      >
-                        Відхилити
-                      </button>
-                    </div>
+                    {/* Accept expanded: fee input */}
+                    {isExpanded && (
+                      <div className="mb-3 p-3 bg-green-50 border border-green-100 rounded-lg">
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Сума гонорару (грн)</label>
+                        <input
+                          type="number"
+                          min="1"
+                          step="1"
+                          value={feeValue}
+                          onChange={e => setFeeValue(e.target.value)}
+                          placeholder="Наприклад: 2000"
+                          className="w-full px-3 py-1.5 border rounded-lg text-sm focus:ring-2 focus:ring-green-500 focus:border-green-500 mb-2"
+                          autoFocus
+                          onKeyDown={e => { if (e.key === 'Enter') handleAccept(consultation.id); }}
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => handleAccept(consultation.id)}
+                            disabled={isProcessing || !feeValue || parseFloat(feeValue) <= 0}
+                            className="flex-1 px-3 py-1.5 text-[13px] font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 rounded-lg transition-colors flex items-center justify-center gap-1"
+                          >
+                            {isProcessing ? <Loader2 size={14} className="animate-spin" /> : <CheckCircle size={14} />}
+                            Прийняти за {feeValue ? `${feeValue} грн` : '...'}
+                          </button>
+                          <button
+                            onClick={() => { setExpandedId(null); setFeeValue(''); }}
+                            className="px-3 py-1.5 text-[13px] font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                          >
+                            Назад
+                          </button>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Decline expanded: reason input */}
+                    {isDeclining && (
+                      <div className="mb-3 p-3 bg-red-50 border border-red-100 rounded-lg">
+                        <label className="block text-xs font-medium text-gray-700 mb-1">Причина відмови (необов'язково)</label>
+                        <textarea
+                          value={declineReason}
+                          onChange={e => setDeclineReason(e.target.value)}
+                          placeholder="Вкажіть причину..."
+                          rows={2}
+                          className="w-full px-3 py-1.5 border rounded-lg text-sm focus:ring-2 focus:ring-red-400 focus:border-red-400 mb-2 resize-none"
+                          autoFocus
+                        />
+                        <div className="flex gap-2">
+                          <button
+                            onClick={() => handleDecline(consultation.id)}
+                            disabled={isProcessing}
+                            className="flex-1 px-3 py-1.5 text-[13px] font-medium text-white bg-red-600 hover:bg-red-700 disabled:opacity-50 rounded-lg transition-colors"
+                          >
+                            {isProcessing ? '...' : 'Підтвердити відхилення'}
+                          </button>
+                          <button
+                            onClick={() => { setDeclineId(null); setDeclineReason(''); }}
+                            className="px-3 py-1.5 text-[13px] font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-lg transition-colors"
+                          >
+                            Назад
+                          </button>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Default buttons */}
+                    {!isExpanded && !isDeclining && (
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => { setExpandedId(consultation.id); setFeeValue(''); setDeclineId(null); }}
+                          disabled={isProcessing}
+                          className="flex-1 px-3 py-2 text-[13px] font-medium text-white bg-green-600 hover:bg-green-700 disabled:opacity-50 rounded-lg transition-colors"
+                        >
+                          Прийняти
+                        </button>
+                        <button
+                          onClick={() => { setDeclineId(consultation.id); setExpandedId(null); }}
+                          disabled={isProcessing}
+                          className="flex-1 px-3 py-2 text-[13px] font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 disabled:opacity-50 rounded-lg transition-colors"
+                        >
+                          Відхилити
+                        </button>
+                      </div>
+                    )}
                   </motion.div>
                 );
               })}

--- a/lexwebapp/src/components/chat/ConsultationChatTab.tsx
+++ b/lexwebapp/src/components/chat/ConsultationChatTab.tsx
@@ -3,6 +3,7 @@ import { Send, MessageSquare, Loader2, Paperclip, FileText, Download, X, Check, 
 import { useAuth } from '../../contexts/AuthContext';
 import { consultationService } from '../../services';
 import { uploadService } from '../../services/api/UploadService';
+import { useConsultationStore } from '../../stores/consultationStore';
 import type { ConsultationMessage } from '../../services/api/ConsultationService';
 
 interface ConsultationChatTabProps {
@@ -89,9 +90,12 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
   const [isUploading, setIsUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [typingUser, setTypingUser] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const eventSourceRef = useRef<EventSource | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const typingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastTypingSentRef = useRef<number>(0);
 
   const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -162,6 +166,25 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
       }
     });
 
+    // Handle typing indicators
+    es.addEventListener('typing', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.userId !== user?.id) {
+          setTypingUser(data.userName || 'Співрозмовник');
+          // Clear after 4s (sender sends every 3s while typing)
+          if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
+          typingTimeoutRef.current = setTimeout(() => setTypingUser(null), 4000);
+        }
+      } catch {}
+    });
+
+    // Handle consultation status changes
+    es.addEventListener('consultation_status', () => {
+      // Dispatch global event for other components
+      window.dispatchEvent(new CustomEvent('consultation-updated'));
+    });
+
     es.onerror = () => {
       // EventSource will auto-reconnect
     };
@@ -169,13 +192,21 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
     return () => {
       es.close();
       eventSourceRef.current = null;
+      if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
     };
   }, [consultationId, onUnreadCountChange, scrollToBottom, user?.id]);
 
   // Mark messages as read when chat becomes visible
   useEffect(() => {
     if (consultationId && messages.length > 0) {
-      consultationService.markMessagesRead(consultationId).catch(() => {});
+      consultationService.markMessagesRead(consultationId)
+        .then(() => {
+          // Re-fetch global unread to get accurate count
+          consultationService.getGlobalUnreadCount()
+            .then(r => useConsultationStore.getState().setGlobalUnreadCount(r.count))
+            .catch(() => {});
+        })
+        .catch(() => {});
     }
   }, [consultationId, messages.length]);
 
@@ -286,6 +317,15 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
     }
   };
 
+  const sendTypingIndicator = useCallback(() => {
+    if (!consultationId) return;
+    const now = Date.now();
+    if (now - lastTypingSentRef.current > 3000) {
+      lastTypingSentRef.current = now;
+      consultationService.sendTyping(consultationId);
+    }
+  }, [consultationId]);
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -359,6 +399,13 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
             </div>
           );
         })}
+        {typingUser && (
+          <div className="flex justify-start">
+            <div className="bg-claude-user text-claude-subtext rounded-xl rounded-bl-sm px-3 py-2">
+              <p className="text-[11px] italic">{typingUser} пише...</p>
+            </div>
+          </div>
+        )}
         <div ref={messagesEndRef} />
       </div>
 
@@ -414,7 +461,7 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
             </button>
             <textarea
               value={input}
-              onChange={(e) => setInput(e.target.value)}
+              onChange={(e) => { setInput(e.target.value); sendTypingIndicator(); }}
               onKeyDown={handleKeyDown}
               placeholder="Написати повідомлення..."
               rows={1}

--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -10,8 +10,8 @@ import {
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../contexts/AuthContext';
 import { useChatStore } from '../../stores/chatStore';
+import { useConsultationStore } from '../../stores/consultationStore';
 import { api } from '../../utils/api-client';
-import { consultationService } from '../../services/api/ConsultationService';
 import type { UserRole } from '../../types/models/User';
 
 import { NavItem } from './NavItem';
@@ -46,7 +46,8 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   const [vaultFolders, setVaultFolders] = useState<string[]>([]);
   const [vaultFoldersLoaded, setVaultFoldersLoaded] = useState(false);
   const [deletingFolder, setDeletingFolder] = useState<string | null>(null);
-  const [pendingCount, setPendingCount] = useState(0);
+  const pendingCount = useConsultationStore(s => s.pendingCount);
+  const globalUnreadCount = useConsultationStore(s => s.globalUnreadCount);
   const profileMenuRef = useRef<HTMLDivElement>(null);
 
   const conversations = useChatStore(s => s.conversations);
@@ -111,19 +112,6 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
     window.addEventListener('vault-folders-changed', handler);
     return () => window.removeEventListener('vault-folders-changed', handler);
   }, []);
-
-  // Poll pending consultations for attorneys (every 60s)
-  useEffect(() => {
-    if (!user?.id || !isAttorney) return;
-    const fetchPending = () => {
-      consultationService.getUnseenPending()
-        .then(data => setPendingCount(data.count))
-        .catch(() => {});
-    };
-    fetchPending();
-    const interval = setInterval(fetchPending, 60_000);
-    return () => clearInterval(interval);
-  }, [user?.id, isAttorney]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -324,7 +312,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 {!isAttorney && (
                   <NavItem icon={Search} label="Знайти адвоката" route={ROUTES.ATTORNEYS} onClick={() => handleNavigation(ROUTES.ATTORNEYS)} />
                 )}
-                <NavItem icon={Briefcase} label="Мої консультації" route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} badge={pendingCount > 0 ? pendingCount : undefined} />
+                <NavItem icon={Briefcase} label="Мої консультації" route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} badge={(pendingCount + globalUnreadCount) > 0 ? pendingCount + globalUnreadCount : undefined} />
                 {isAttorney && (
                   <NavItem icon={Users} label="Мої клієнти" route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
                 )}

--- a/lexwebapp/src/components/ui/ConfirmModal.tsx
+++ b/lexwebapp/src/components/ui/ConfirmModal.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { X, Loader2 } from 'lucide-react';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  inputLabel?: string;
+  inputPlaceholder?: string;
+  variant?: 'default' | 'danger';
+  loading?: boolean;
+  onConfirm: (inputValue?: string) => void;
+  onCancel: () => void;
+}
+
+export function ConfirmModal({
+  isOpen,
+  title,
+  description,
+  confirmLabel = 'Підтвердити',
+  cancelLabel = 'Скасувати',
+  inputLabel,
+  inputPlaceholder,
+  variant = 'default',
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const handleConfirm = () => {
+    onConfirm(inputLabel ? inputValue : undefined);
+    setInputValue('');
+  };
+
+  const handleCancel = () => {
+    setInputValue('');
+    onCancel();
+  };
+
+  const confirmBg = variant === 'danger'
+    ? 'bg-red-600 hover:bg-red-700'
+    : 'bg-indigo-600 hover:bg-indigo-700';
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/50 z-[60]"
+            onClick={handleCancel}
+          />
+          <div className="fixed inset-0 z-[61] flex items-center justify-center p-4">
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 20 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 20 }}
+              transition={{ duration: 0.2 }}
+              className="bg-white rounded-xl shadow-2xl w-full max-w-md"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+                <h3 className="text-lg font-semibold text-gray-900">{title}</h3>
+                <button
+                  onClick={handleCancel}
+                  className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-lg transition-colors"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+
+              <div className="px-5 py-4">
+                {description && (
+                  <p className="text-sm text-gray-600 mb-4">{description}</p>
+                )}
+
+                {inputLabel && (
+                  <div className="mb-4">
+                    <label className="block text-sm font-medium text-gray-700 mb-1">
+                      {inputLabel}
+                    </label>
+                    <textarea
+                      value={inputValue}
+                      onChange={e => setInputValue(e.target.value)}
+                      placeholder={inputPlaceholder}
+                      rows={3}
+                      className="w-full px-3 py-2 border rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 resize-none"
+                      autoFocus
+                    />
+                  </div>
+                )}
+              </div>
+
+              <div className="flex gap-3 px-5 py-4 border-t border-gray-100">
+                <button
+                  onClick={handleCancel}
+                  disabled={loading}
+                  className="flex-1 py-2.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  {cancelLabel}
+                </button>
+                <button
+                  onClick={handleConfirm}
+                  disabled={loading}
+                  className={`flex-1 py-2.5 text-white rounded-lg text-sm font-medium disabled:opacity-50 flex items-center justify-center gap-2 ${confirmBg}`}
+                >
+                  {loading && <Loader2 className="w-4 h-4 animate-spin" />}
+                  {confirmLabel}
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -11,9 +11,9 @@ import { RightPanel } from '../components/RightPanel';
 import { TimeTrackerWidget } from '../components/time/TimeTrackerWidget';
 import { PendingInvitationsModal } from '../components/attorney/PendingInvitationsModal';
 import { useAuth } from '../contexts/AuthContext';
-import { useUIStore } from '../stores';
+import { useUIStore, useConsultationStore } from '../stores';
 import { ROUTES } from '../router/routes';
-import { consultationService, type Consultation } from '../services/api/ConsultationService';
+import { consultationService } from '../services/api/ConsultationService';
 import showToast from '../utils/toast';
 
 // Map routes to page titles
@@ -59,27 +59,40 @@ const SESSION_KEY = 'pending_invitations_dismissed';
 export function MainLayout() {
   const location = useLocation();
   const { logout, user } = useAuth();
-  const [pendingConsultations, setPendingConsultations] = useState<Consultation[]>([]);
   const [showInvitationsModal, setShowInvitationsModal] = useState(false);
+  const pendingConsultations = useConsultationStore(s => s.pendingConsultations);
+  const connect = useConsultationStore(s => s.connect);
+  const disconnect = useConsultationStore(s => s.disconnect);
+  const fetchInitialCounts = useConsultationStore(s => s.fetchInitialCounts);
 
-  // Fetch unseen pending consultations for attorneys
+  // Connect SSE + fetch initial counts on auth
   useEffect(() => {
     if (!user?.id) return;
 
-    consultationService.getUnseenPending()
-      .then(data => {
-        if (data.count > 0) {
-          setPendingConsultations(data.consultations);
-          // Show modal only once per session
-          if (!sessionStorage.getItem(SESSION_KEY)) {
-            setShowInvitationsModal(true);
-          }
-          // Always show toast notification
-          const word = data.count === 1 ? 'новий запит' : data.count < 5 ? 'нових запити' : 'нових запитів';
-          showToast.info(`У вас ${data.count} ${word} на консультацію`);
-        }
-      })
-      .catch(() => {});
+    connect();
+    fetchInitialCounts().then(() => {
+      const pending = useConsultationStore.getState().pendingConsultations;
+      if (pending.length > 0 && !sessionStorage.getItem(SESSION_KEY)) {
+        setShowInvitationsModal(true);
+        const count = pending.length;
+        const word = count === 1 ? 'новий запит' : count < 5 ? 'нових запити' : 'нових запитів';
+        showToast.info(`У вас ${count} ${word} на консультацію`);
+      }
+    });
+
+    // Listen for new pending requests arriving via SSE
+    const handleNewPending = (e: Event) => {
+      const consultation = (e as CustomEvent).detail;
+      if (consultation?.status === 'pending') {
+        showToast.info(`Новий запит на консультацію: ${consultation.request_title || 'без назви'}`);
+      }
+    };
+    window.addEventListener('consultation-updated', handleNewPending);
+
+    return () => {
+      disconnect();
+      window.removeEventListener('consultation-updated', handleNewPending);
+    };
   }, [user?.id]);
 
   const handleInvitationsClose = useCallback((remainingIds: string[]) => {

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -4,9 +4,12 @@ import { ArrowLeft, Loader2, Star, CreditCard, CheckCircle, XCircle, Play, Messa
 import { consultationService, type Consultation } from '../../services/api/ConsultationService';
 import { useAuth } from '../../contexts/AuthContext';
 import { getErrorMessage } from '../../utils/errors';
+import showToast from '../../utils/toast';
 import { ConsultationChatTab } from '../../components/chat/ConsultationChatTab';
 import { EscrowStatusBadge } from '../../components/consultation/EscrowStatusBadge';
 import { SharedDocumentsSection } from '../../components/consultation/SharedDocumentsSection';
+import { ConfirmModal } from '../../components/ui/ConfirmModal';
+import { useConsultationStore } from '../../stores/consultationStore';
 
 const STATUS_STEPS = ['pending', 'accepted', 'paid', 'in_progress', 'completed'];
 const STATUS_LABELS: Record<string, string> = {
@@ -27,6 +30,9 @@ export function ConsultationDetailPage() {
   const [reviewText, setReviewText] = useState('');
   const [showAcceptModal, setShowAcceptModal] = useState(false);
   const [acceptFee, setAcceptFee] = useState('');
+  const [activeModal, setActiveModal] = useState<'decline' | 'complete' | 'cancel' | null>(null);
+
+  const addStatusListener = useConsultationStore(s => s.addStatusListener);
 
   const isClient = consultation?.client_user_id === user?.id;
   const isAttorney = consultation?.attorney_user_id === user?.id;
@@ -49,7 +55,16 @@ export function ConsultationDetailPage() {
     if (id) sessionStorage.setItem('lastConsultationId', id);
   }, [id]);
 
-  const handleAction = async (action: string) => {
+  // Subscribe to real-time consultation status changes
+  useEffect(() => {
+    if (!id) return;
+    const unsub = addStatusListener(id, (updated) => {
+      setConsultation(updated);
+    });
+    return unsub;
+  }, [id, addStatusListener]);
+
+  const handleAction = async (action: string, inputValue?: string) => {
     if (!id) return;
     setActionLoading(action);
     try {
@@ -57,25 +72,33 @@ export function ConsultationDetailPage() {
       switch (action) {
         case 'accept': {
           const fee = parseFloat(acceptFee);
-          if (!fee || fee <= 0) { alert('Вкажіть коректну суму гонорару'); return; }
+          if (!fee || fee <= 0) { showToast.error('Вкажіть коректну суму гонорару'); return; }
           result = await consultationService.acceptConsultation(id, fee);
           setShowAcceptModal(false);
+          showToast.success('Консультацію прийнято');
           break;
         }
         case 'decline': {
-          const reason = prompt('Причина відмови:');
-          result = await consultationService.declineConsultation(id, reason || undefined);
+          result = await consultationService.declineConsultation(id, inputValue || undefined);
+          setActiveModal(null);
+          showToast.success('Консультацію відхилено');
           break;
         }
-        case 'start': result = await consultationService.startConsultation(id); break;
+        case 'start': {
+          result = await consultationService.startConsultation(id);
+          showToast.success('Консультацію розпочато');
+          break;
+        }
         case 'complete': {
-          const summary = prompt('Підсумок консультації:');
-          result = await consultationService.completeConsultation(id, summary || undefined);
+          result = await consultationService.completeConsultation(id, inputValue || undefined);
+          setActiveModal(null);
+          showToast.success('Консультацію завершено');
           break;
         }
         case 'cancel': {
-          const reason = prompt('Причина скасування:');
-          result = await consultationService.cancelConsultation(id, reason || undefined);
+          result = await consultationService.cancelConsultation(id, inputValue || undefined);
+          setActiveModal(null);
+          showToast.success('Консультацію скасовано');
           break;
         }
         case 'pay': {
@@ -87,7 +110,7 @@ export function ConsultationDetailPage() {
       }
       setConsultation(result);
     } catch (err: unknown) {
-      alert(getErrorMessage(err));
+      showToast.error(getErrorMessage(err));
     } finally {
       setActionLoading('');
     }
@@ -98,9 +121,9 @@ export function ConsultationDetailPage() {
     try {
       await consultationService.submitReview(id, { rating, reviewText: reviewText || undefined });
       setShowReview(false);
-      alert('Дякуємо за відгук!');
+      showToast.success('Дякуємо за відгук!');
     } catch (err: unknown) {
-      alert(getErrorMessage(err));
+      showToast.error(getErrorMessage(err));
     }
   };
 
@@ -205,7 +228,7 @@ export function ConsultationDetailPage() {
                   {actionLoading === 'accept' ? <Loader2 className="w-4 h-4 animate-spin inline" /> : <CheckCircle className="w-4 h-4 inline mr-1" />}
                   Прийняти
                 </button>
-                <button onClick={() => handleAction('decline')} disabled={!!actionLoading}
+                <button onClick={() => setActiveModal('decline')} disabled={!!actionLoading}
                   className="px-3 py-1.5 bg-red-600 text-white rounded-lg text-sm hover:bg-red-700 disabled:opacity-50">
                   Відхилити
                 </button>
@@ -226,13 +249,13 @@ export function ConsultationDetailPage() {
               </button>
             )}
             {isAttorney && consultation.status === 'in_progress' && (
-              <button onClick={() => handleAction('complete')} disabled={!!actionLoading}
+              <button onClick={() => setActiveModal('complete')} disabled={!!actionLoading}
                 className="px-3 py-1.5 bg-green-600 text-white rounded-lg text-sm hover:bg-green-700 disabled:opacity-50">
                 Завершити
               </button>
             )}
             {!isTerminal && consultation.status !== 'completed' && (
-              <button onClick={() => handleAction('cancel')} disabled={!!actionLoading}
+              <button onClick={() => setActiveModal('cancel')} disabled={!!actionLoading}
                 className="px-3 py-1.5 border border-red-300 text-red-600 rounded-lg text-sm hover:bg-red-50 disabled:opacity-50">
                 <XCircle className="w-4 h-4 inline mr-1" />
                 Скасувати
@@ -265,6 +288,47 @@ export function ConsultationDetailPage() {
           />
         </div>
       </div>
+
+      {/* Decline modal */}
+      <ConfirmModal
+        isOpen={activeModal === 'decline'}
+        title="Відхилити консультацію"
+        description="Ви впевнені, що хочете відхилити цей запит?"
+        confirmLabel="Відхилити"
+        variant="danger"
+        inputLabel="Причина відмови"
+        inputPlaceholder="Вкажіть причину відмови (необов'язково)..."
+        loading={actionLoading === 'decline'}
+        onConfirm={(reason) => handleAction('decline', reason)}
+        onCancel={() => setActiveModal(null)}
+      />
+
+      {/* Complete modal */}
+      <ConfirmModal
+        isOpen={activeModal === 'complete'}
+        title="Завершити консультацію"
+        description="Після завершення клієнт зможе залишити відгук, а кошти будуть звільнені."
+        confirmLabel="Завершити"
+        inputLabel="Підсумок консультації"
+        inputPlaceholder="Опишіть результати консультації..."
+        loading={actionLoading === 'complete'}
+        onConfirm={(summary) => handleAction('complete', summary)}
+        onCancel={() => setActiveModal(null)}
+      />
+
+      {/* Cancel modal */}
+      <ConfirmModal
+        isOpen={activeModal === 'cancel'}
+        title="Скасувати консультацію"
+        description="Ви впевнені? Якщо оплата вже здійснена, кошти будуть повернені."
+        confirmLabel="Скасувати консультацію"
+        variant="danger"
+        inputLabel="Причина скасування"
+        inputPlaceholder="Вкажіть причину скасування..."
+        loading={actionLoading === 'cancel'}
+        onConfirm={(reason) => handleAction('cancel', reason)}
+        onCancel={() => setActiveModal(null)}
+      />
 
       {/* Escrow confirmation modal */}
       {showEscrow && consultation && (

--- a/lexwebapp/src/pages/ConsultationsPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationsPage/index.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Loader2, CreditCard } from 'lucide-react';
-import { consultationService, type Consultation } from '../../services/api/ConsultationService';
+import { consultationService } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
 
 const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof Clock }> = {
@@ -17,30 +18,36 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
 
 export function ConsultationsPage() {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
   // Clear stale redirect so attorney always sees full list first
   useEffect(() => {
     sessionStorage.removeItem('lastConsultationId');
   }, []);
-  const [consultations, setConsultations] = useState<Consultation[]>([]);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
+
   const [role, setRole] = useState<string>('');
   const [statusFilter, setStatusFilter] = useState<string>('');
 
-  useEffect(() => {
-    setLoading(true);
-    consultationService.listConsultations({
+  const { data, isLoading } = useQuery({
+    queryKey: ['consultations', role, statusFilter],
+    queryFn: () => consultationService.listConsultations({
       role: role || undefined,
       status: statusFilter || undefined,
       limit: 50,
-    })
-      .then(result => {
-        setConsultations(result.consultations);
-        setTotal(result.total);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, [role, statusFilter]);
+    }),
+  });
+
+  const consultations = data?.consultations ?? [];
+  const total = data?.total ?? 0;
+
+  // Invalidate query on SSE consultation status events
+  useEffect(() => {
+    const handler = () => {
+      queryClient.invalidateQueries({ queryKey: ['consultations'] });
+    };
+    window.addEventListener('consultation-updated', handler);
+    return () => window.removeEventListener('consultation-updated', handler);
+  }, [queryClient]);
 
   return (
     <div className="h-full overflow-y-auto">
@@ -72,7 +79,7 @@ export function ConsultationsPage() {
         </select>
       </div>
 
-      {loading ? (
+      {isLoading ? (
         <div className="flex items-center justify-center py-20">
           <Loader2 className="w-8 h-8 animate-spin text-indigo-500" />
         </div>

--- a/lexwebapp/src/services/api/ConsultationService.ts
+++ b/lexwebapp/src/services/api/ConsultationService.ts
@@ -174,6 +174,14 @@ export class ConsultationService extends BaseService {
     return this.request(() => this.client.post(`/api/consultations/${id}/review`, data));
   }
 
+  async getGlobalUnreadCount(): Promise<{ count: number }> {
+    return this.request(() => this.client.get<{ count: number }>('/api/consultations/unread-total'));
+  }
+
+  sendTyping(id: string): void {
+    this.client.post(`/api/consultations/${id}/typing`).catch(() => {});
+  }
+
   async getUnseenPending(): Promise<{ consultations: Consultation[]; count: number }> {
     return this.request(() => this.client.get('/api/consultations/pending-unseen'));
   }

--- a/lexwebapp/src/stores/consultationStore.ts
+++ b/lexwebapp/src/stores/consultationStore.ts
@@ -1,0 +1,139 @@
+import { create } from 'zustand';
+import { consultationService, type Consultation } from '../services/api/ConsultationService';
+
+interface ConsultationState {
+  globalUnreadCount: number;
+  pendingCount: number;
+  pendingConsultations: Consultation[];
+  eventSource: EventSource | null;
+  listeners: Map<string, Set<(consultation: Consultation) => void>>;
+
+  connect: () => void;
+  disconnect: () => void;
+  fetchInitialCounts: () => Promise<void>;
+  setGlobalUnreadCount: (count: number) => void;
+  decrementUnread: (by?: number) => void;
+  setPendingConsultations: (consultations: Consultation[]) => void;
+
+  // Per-consultation status listeners
+  addStatusListener: (consultationId: string, cb: (consultation: Consultation) => void) => () => void;
+}
+
+export const useConsultationStore = create<ConsultationState>((set, get) => ({
+  globalUnreadCount: 0,
+  pendingCount: 0,
+  pendingConsultations: [],
+  eventSource: null,
+  listeners: new Map(),
+
+  connect: () => {
+    const existing = get().eventSource;
+    if (existing) return;
+
+    const token = localStorage.getItem('auth_token');
+    if (!token) return;
+
+    const baseURL = import.meta.env.VITE_API_URL || '';
+    const url = `${baseURL}/api/consultations/user-stream?token=${encodeURIComponent(token)}`;
+    const es = new EventSource(url);
+
+    es.addEventListener('consultation_status', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        const consultation = data.consultation;
+        if (!consultation) return;
+
+        // Notify per-consultation listeners
+        const listeners = get().listeners.get(consultation.id);
+        if (listeners) {
+          listeners.forEach(cb => cb(consultation));
+        }
+
+        // Update pending counts
+        if (consultation.status === 'pending') {
+          set(s => ({
+            pendingCount: s.pendingCount + 1,
+            pendingConsultations: [consultation, ...s.pendingConsultations.filter(c => c.id !== consultation.id)],
+          }));
+        } else {
+          set(s => ({
+            pendingConsultations: s.pendingConsultations.filter(c => c.id !== consultation.id),
+            pendingCount: Math.max(0, s.pendingConsultations.filter(c => c.id !== consultation.id).length),
+          }));
+        }
+
+        // Invalidate TanStack Query caches
+        try {
+          // Use window event to signal query invalidation (avoids direct queryClient dependency)
+          window.dispatchEvent(new CustomEvent('consultation-updated', { detail: consultation }));
+        } catch {}
+      } catch {}
+    });
+
+    es.addEventListener('new_message', (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        set(s => ({ globalUnreadCount: s.globalUnreadCount + 1 }));
+        // Dispatch event for toast notifications
+        window.dispatchEvent(new CustomEvent('consultation-new-message', { detail: data }));
+      } catch {}
+    });
+
+    es.onerror = () => {
+      // EventSource auto-reconnects
+    };
+
+    set({ eventSource: es });
+  },
+
+  disconnect: () => {
+    const es = get().eventSource;
+    if (es) {
+      es.close();
+      set({ eventSource: null });
+    }
+  },
+
+  fetchInitialCounts: async () => {
+    try {
+      const [unreadResult, pendingResult] = await Promise.all([
+        consultationService.getGlobalUnreadCount(),
+        consultationService.getUnseenPending(),
+      ]);
+      set({
+        globalUnreadCount: unreadResult.count,
+        pendingCount: pendingResult.count,
+        pendingConsultations: pendingResult.consultations,
+      });
+    } catch {}
+  },
+
+  setGlobalUnreadCount: (count) => set({ globalUnreadCount: count }),
+
+  decrementUnread: (by = 1) => set(s => ({
+    globalUnreadCount: Math.max(0, s.globalUnreadCount - by),
+  })),
+
+  setPendingConsultations: (consultations) => set({
+    pendingConsultations: consultations,
+    pendingCount: consultations.length,
+  }),
+
+  addStatusListener: (consultationId, cb) => {
+    const { listeners } = get();
+    if (!listeners.has(consultationId)) {
+      listeners.set(consultationId, new Set());
+    }
+    listeners.get(consultationId)!.add(cb);
+    set({ listeners: new Map(listeners) });
+
+    return () => {
+      const current = get().listeners;
+      const set_ = current.get(consultationId);
+      if (set_) {
+        set_.delete(cb);
+        if (set_.size === 0) current.delete(consultationId);
+      }
+    };
+  },
+}));

--- a/lexwebapp/src/stores/index.ts
+++ b/lexwebapp/src/stores/index.ts
@@ -10,3 +10,4 @@ export { useUploadStore } from './uploadStore';
 export { useClientMatterStore } from './clientMatterStore';
 export { useTimerStore, getTimerForMatter, hasMatterTimer } from './timerStore';
 export { useDecisionsSearchStore } from './decisionsSearchStore';
+export { useConsultationStore } from './consultationStore';

--- a/mcp_backend/src/routes/consultation-routes.ts
+++ b/mcp_backend/src/routes/consultation-routes.ts
@@ -48,6 +48,53 @@ export function createConsultationRoutes(
     }
   }) as any);
 
+  // GET /api/consultations/user-stream — SSE stream for user-level events
+  router.get('/user-stream', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      const userId = req.user.id;
+
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+      res.flushHeaders();
+
+      res.write('event: connected\ndata: {}\n\n');
+
+      const { consultationMessageBus } = await import('../services/consultation-message-bus.js');
+      const unsubscribe = consultationMessageBus.subscribeUser(userId, (event) => {
+        res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
+      });
+
+      const heartbeat = setInterval(() => {
+        res.write('event: heartbeat\ndata: {}\n\n');
+      }, 30000);
+
+      req.on('close', () => {
+        unsubscribe();
+        clearInterval(heartbeat);
+      });
+    } catch (error: any) {
+      logger.error('Failed to setup user stream', { error: error.message });
+      if (!res.headersSent) {
+        res.status(500).json({ error: 'Failed to setup user stream' });
+      }
+    }
+  }) as any);
+
+  // GET /api/consultations/unread-total — global unread message count
+  router.get('/unread-total', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      const count = await consultationService.getGlobalUnreadCount(req.user.id);
+      res.json({ count });
+    } catch (error: any) {
+      logger.error('Failed to get global unread count', { error: error.message });
+      res.status(500).json({ error: 'Failed to get unread count' });
+    }
+  }) as any);
+
   // GET /api/consultations/pending-unseen — unseen pending requests for attorney
   router.get('/pending-unseen', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
@@ -237,6 +284,15 @@ export function createConsultationRoutes(
       const unsubscribeStatus = consultationMessageBus.subscribeStatus(consultationId, (payload) => {
         res.write(`event: message_status\ndata: ${JSON.stringify(payload)}\n\n`);
       });
+      const unsubscribeConsultationStatus = consultationMessageBus.subscribeConsultationStatus(consultationId, (consultation) => {
+        res.write(`event: consultation_status\ndata: ${JSON.stringify(consultation)}\n\n`);
+      });
+      const unsubscribeTyping = consultationMessageBus.subscribeTyping(consultationId, (data) => {
+        // Don't echo typing back to the sender
+        if (data.userId !== req.user!.id) {
+          res.write(`event: typing\ndata: ${JSON.stringify(data)}\n\n`);
+        }
+      });
 
       // Mark existing messages as delivered when client connects
       try {
@@ -254,6 +310,8 @@ export function createConsultationRoutes(
       req.on('close', () => {
         unsubscribeMsg();
         unsubscribeStatus();
+        unsubscribeConsultationStatus();
+        unsubscribeTyping();
         clearInterval(heartbeat);
       });
     } catch (error: any) {
@@ -321,6 +379,18 @@ export function createConsultationRoutes(
       res.status(201).json(message);
     } catch (error: any) {
       logger.error('Failed to send message', { error: error.message });
+      res.status(400).json({ error: error.message });
+    }
+  }) as any);
+
+  // POST /api/consultations/:id/typing — fire-and-forget typing indicator
+  router.post('/:id/typing', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      const { consultationMessageBus } = await import('../services/consultation-message-bus.js');
+      consultationMessageBus.publishTyping(req.params.id as string, req.user.id, req.user.name);
+      res.json({ ok: true });
+    } catch (error: any) {
       res.status(400).json({ error: error.message });
     }
   }) as any);

--- a/mcp_backend/src/services/consultation-message-bus.ts
+++ b/mcp_backend/src/services/consultation-message-bus.ts
@@ -4,6 +4,29 @@ import type { ConsultationMessage } from './consultation-service.js';
 type MessageCallback = (message: ConsultationMessage) => void;
 type StatusCallback = (payload: { messageIds: string[]; status: string }) => void;
 
+export interface ConsultationStatusEvent {
+  type: 'consultation_status';
+  consultation: any;
+}
+
+export interface NewMessageEvent {
+  type: 'new_message';
+  consultationId: string;
+  senderId: string;
+  senderName?: string;
+  preview: string;
+}
+
+export interface TypingEvent {
+  type: 'typing';
+  consultationId: string;
+  userId: string;
+  userName?: string;
+}
+
+export type UserEvent = ConsultationStatusEvent | NewMessageEvent | TypingEvent;
+type UserEventCallback = (event: UserEvent) => void;
+
 class ConsultationMessageBus {
   private emitter = new EventEmitter();
 
@@ -27,12 +50,62 @@ class ConsultationMessageBus {
     };
   }
 
+  subscribeConsultationStatus(consultationId: string, callback: (consultation: any) => void): () => void {
+    const event = `consultation_status:${consultationId}`;
+    this.emitter.on(event, callback);
+    return () => {
+      this.emitter.off(event, callback);
+    };
+  }
+
+  subscribeUser(userId: string, callback: UserEventCallback): () => void {
+    const event = `user_event:${userId}`;
+    this.emitter.on(event, callback);
+    return () => {
+      this.emitter.off(event, callback);
+    };
+  }
+
   publish(consultationId: string, message: ConsultationMessage): void {
     this.emitter.emit(`msg:${consultationId}`, message);
   }
 
   publishStatus(consultationId: string, messageIds: string[], status: string): void {
     this.emitter.emit(`status:${consultationId}`, { messageIds, status });
+  }
+
+  publishConsultationStatus(consultation: any): void {
+    // Emit on per-consultation channel (for detail page SSE)
+    this.emitter.emit(`consultation_status:${consultation.id}`, consultation);
+    // Emit on user channels (for global user SSE)
+    if (consultation.client_user_id) {
+      this.publishUserEvent(consultation.client_user_id, {
+        type: 'consultation_status',
+        consultation,
+      });
+    }
+    if (consultation.attorney_user_id) {
+      this.publishUserEvent(consultation.attorney_user_id, {
+        type: 'consultation_status',
+        consultation,
+      });
+    }
+  }
+
+  publishUserEvent(userId: string, event: UserEvent): void {
+    this.emitter.emit(`user_event:${userId}`, event);
+  }
+
+  publishTyping(consultationId: string, userId: string, userName?: string): void {
+    this.emitter.emit(`typing:${consultationId}`, { consultationId, userId, userName });
+  }
+
+  subscribeTyping(consultationId: string, callback: (data: { consultationId: string; userId: string; userName?: string }) => void): () => void {
+    const event = `typing:${consultationId}`;
+    this.emitter.on(event, callback);
+    return () => {
+      this.emitter.off(event, callback);
+    };
   }
 }
 

--- a/mcp_backend/src/services/consultation-service.ts
+++ b/mcp_backend/src/services/consultation-service.ts
@@ -116,6 +116,11 @@ export class ConsultationService {
     });
 
     logger.info('Consultation created', { id, clientUserId, attorneyUserId: data.attorneyUserId });
+
+    // Emit real-time status event
+    const enriched = await this.getConsultation(id, clientUserId) || result.rows[0];
+    consultationMessageBus.publishConsultationStatus(enriched);
+
     return result.rows[0];
   }
 
@@ -219,6 +224,9 @@ export class ConsultationService {
       details: { agreedFee },
     });
 
+    const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
+    consultationMessageBus.publishConsultationStatus(enriched);
+
     return result.rows[0];
   }
 
@@ -240,6 +248,9 @@ export class ConsultationService {
       resourceId: id,
       details: { reason },
     });
+
+    const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
+    consultationMessageBus.publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -284,6 +295,10 @@ export class ConsultationService {
       details: { paymentId, matterId: consultation.matter_id },
     });
 
+    // Re-fetch with JOINs for enriched data
+    const enriched = await this.getConsultationById(id) || consultation;
+    consultationMessageBus.publishConsultationStatus(enriched);
+
     return consultation;
   }
 
@@ -304,6 +319,9 @@ export class ConsultationService {
       resourceType: 'consultation',
       resourceId: id,
     });
+
+    const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
+    consultationMessageBus.publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -361,6 +379,9 @@ export class ConsultationService {
       resourceId: id,
     });
 
+    const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
+    consultationMessageBus.publishConsultationStatus(enriched);
+
     return result.rows[0];
   }
 
@@ -409,6 +430,9 @@ export class ConsultationService {
       resourceId: id,
       details: { reason, previousStatus: consultation.status },
     });
+
+    const enriched = await this.getConsultationById(id) || result.rows[0];
+    consultationMessageBus.publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -470,7 +494,7 @@ export class ConsultationService {
     attachment?: { url: string; name: string; type: string; size: number }
   ): Promise<ConsultationMessage> {
     // Verify sender is a party to this consultation
-    await this.requireConsultation(consultationId, senderId);
+    const consultation = await this.requireConsultation(consultationId, senderId);
 
     const id = uuidv4();
     const result = await this.db.query(
@@ -491,6 +515,18 @@ export class ConsultationService {
     };
 
     consultationMessageBus.publish(consultationId, message);
+
+    // Emit user-level new_message event for the other party (for global unread badge)
+    const recipientId = consultation.client_user_id === senderId
+      ? consultation.attorney_user_id
+      : consultation.client_user_id;
+    consultationMessageBus.publishUserEvent(recipientId, {
+      type: 'new_message',
+      consultationId,
+      senderId,
+      senderName: message.sender_name,
+      preview: content.substring(0, 100),
+    });
 
     return message;
   }
@@ -553,12 +589,17 @@ export class ConsultationService {
       ),
     ]);
 
-    // Mark messages as read
-    await this.db.query(
-      `UPDATE consultation_messages SET read_at = NOW()
-       WHERE consultation_id = $1 AND sender_id != $2 AND read_at IS NULL`,
+    // Mark messages as read (fix: also set status to 'read')
+    const readResult = await this.db.query(
+      `UPDATE consultation_messages SET status = 'read', read_at = NOW()
+       WHERE consultation_id = $1 AND sender_id != $2 AND status != 'read'
+       RETURNING id`,
       [consultationId, userId]
     );
+    if (readResult.rows.length > 0) {
+      const readIds = readResult.rows.map((r: any) => r.id);
+      consultationMessageBus.publishStatus(consultationId, readIds, 'read');
+    }
 
     return {
       messages: result.rows,
@@ -570,7 +611,7 @@ export class ConsultationService {
     await this.requireConsultation(consultationId, userId);
     const result = await this.db.query(
       `SELECT COUNT(*) FROM consultation_messages
-       WHERE consultation_id = $1 AND sender_id != $2 AND read_at IS NULL`,
+       WHERE consultation_id = $1 AND sender_id != $2 AND status != 'read'`,
       [consultationId, userId]
     );
     return parseInt(result.rows[0].count, 10);
@@ -623,6 +664,38 @@ export class ConsultationService {
     });
 
     return result.rows[0];
+  }
+
+  // ─── Internal helpers ──────────────────────────────────
+
+  /** Fetch consultation with JOINs (no auth check — internal use only for events) */
+  private async getConsultationById(id: string): Promise<Consultation | null> {
+    const result = await this.db.query(
+      `SELECT c.*,
+              cu.name as client_name,
+              au.name as attorney_name,
+              m.matter_name
+       FROM consultations c
+       JOIN users cu ON cu.id = c.client_user_id
+       JOIN users au ON au.id = c.attorney_user_id
+       LEFT JOIN matters m ON m.id = c.matter_id
+       WHERE c.id = $1`,
+      [id]
+    );
+    return result.rows[0] || null;
+  }
+
+  // ─── Global unread count ──────────────────────────────
+
+  async getGlobalUnreadCount(userId: string): Promise<number> {
+    const result = await this.db.query(
+      `SELECT COUNT(*) FROM consultation_messages cm
+       JOIN consultations c ON c.id = cm.consultation_id
+       WHERE cm.sender_id != $1 AND cm.status != 'read'
+         AND (c.client_user_id = $1 OR c.attorney_user_id = $1)`,
+      [userId]
+    );
+    return parseInt(result.rows[0].count, 10);
   }
 
   // ─── Helpers ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Real-time SSE**: User-level SSE stream (`/api/consultations/user-stream`) pushes consultation status changes and new message notifications to all connected clients — no polling needed
- **Typing indicators**: Debounced typing events sent via `POST /:id/typing`, displayed as "пише..." bubble in chat
- **Native dialogs replaced**: `ConfirmModal` component replaces all `prompt()`/`alert()` calls in ConsultationDetailPage (decline, complete, cancel actions)
- **PendingInvitationsModal fixed**: Accept now requires fee input (inline expandable form); decline shows optional reason textarea
- **Global unread badge**: Sidebar shows combined pending + unread count from Zustand store, updated reactively via SSE
- **ConsultationsPage live updates**: Converted to TanStack `useQuery`, auto-invalidates on SSE events
- **Bug fix**: `getMessages()` now sets `status='read'` alongside `read_at` (was only setting `read_at`, causing inconsistent message status tracking)

### Backend changes
| File | Change |
|------|--------|
| `consultation-message-bus.ts` | User-level events, typing, consultation status subscriptions |
| `consultation-service.ts` | Emit status events on all transitions, global unread count, read_at fix |
| `consultation-routes.ts` | 3 new endpoints: user-stream SSE, unread-total, typing |

### Frontend changes
| File | Change |
|------|--------|
| `consultationStore.ts` (new) | Zustand store: SSE connection, counts, status listeners |
| `ConfirmModal.tsx` (new) | Generic confirm modal with textarea, danger variant |
| `ConsultationDetailPage` | ConfirmModal + toast, real-time status via store listener |
| `ConsultationsPage` | TanStack useQuery + SSE invalidation |
| `PendingInvitationsModal` | Fee input on accept, decline reason, real-time merge |
| `MainLayout` | SSE connect on auth, toast for new pending |
| `Sidebar` | Reactive badges from store (replaces 60s polling) |
| `ConsultationChatTab` | Typing indicator send/display, accurate unread decrement |

## Test plan

- [ ] Open two browsers (client + attorney). Send message → appears instantly with correct status (sent → delivered → read)
- [ ] Attorney accepts consultation → client's detail page auto-updates timeline without refresh
- [ ] Client pays → attorney's page auto-updates to "paid" status
- [ ] Create new consultation → attorney sees toast + PendingInvitationsModal updates without refresh
- [ ] PendingInvitationsModal: click "Прийняти" → fee input appears, must enter valid amount
- [ ] PendingInvitationsModal: click "Відхилити" → reason textarea appears
- [ ] ConsultationDetailPage: decline/complete/cancel show proper modals instead of browser prompts
- [ ] Error messages appear as toast notifications, not `alert()`
- [ ] ConsultationsPage updates automatically when any consultation status changes
- [ ] Sidebar badge shows combined pending + unread count, updates reactively
- [ ] Typing in chat → other party sees "пише..." bubble that disappears after 4s
- [ ] After Monobank payment webhook → ConsultationDetailPage transitions to "paid" automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)