### PR TITLE
fix(test): add missing mocks for ConsultationChatTab test

### DIFF
--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -12,6 +12,8 @@ const mockGetMessages = vi.fn();
 const mockSendMessage = vi.fn();
 const mockConnectMessageStream = vi.fn();
 const mockMarkMessagesRead = vi.fn();
+const mockSendTyping = vi.fn();
+const mockGetGlobalUnreadCount = vi.fn();
 
 vi.mock('../../../services', () => ({
   consultationService: {
@@ -19,7 +21,24 @@ vi.mock('../../../services', () => ({
     sendMessage: (...args: any[]) => mockSendMessage(...args),
     connectMessageStream: (...args: any[]) => mockConnectMessageStream(...args),
     markMessagesRead: (...args: any[]) => mockMarkMessagesRead(...args),
+    sendTyping: (...args: any[]) => mockSendTyping(...args),
+    getGlobalUnreadCount: (...args: any[]) => mockGetGlobalUnreadCount(...args),
   },
+}));
+
+// Mock consultation store
+vi.mock('../../../stores/consultationStore', () => ({
+  useConsultationStore: Object.assign(
+    (selector: any) => {
+      const state = {
+        globalUnreadCount: 0,
+        setGlobalUnreadCount: vi.fn(),
+        decrementUnread: vi.fn(),
+      };
+      return selector ? selector(state) : state;
+    },
+    { getState: () => ({ setGlobalUnreadCount: vi.fn() }) }
+  ),
 }));
 
 import { ConsultationChatTab } from '../ConsultationChatTab';
@@ -49,6 +68,7 @@ describe('ConsultationChatTab', () => {
     mockGetMessages.mockResolvedValue({ messages: [], total: 0 });
     mockConnectMessageStream.mockReturnValue(createMockEventSource());
     mockMarkMessagesRead.mockResolvedValue(undefined);
+    mockGetGlobalUnreadCount.mockResolvedValue({ count: 0 });
   });
 
   describe('Empty state', () => {


### PR DESCRIPTION
## Summary

- Add `sendTyping` and `getGlobalUnreadCount` mocks to the consultation service mock in `ConsultationChatTab.test.tsx`
- Add `consultationStore` mock to prevent "sendTyping is not a function" errors

Fixes CI failure from PR #984.

## Test plan

- [x] All 224 frontend tests pass locally
- [x] `ConsultationChatTab.test.tsx` — 10/10 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)