### PR TITLE
fix(test): remove unused vars in consultation tests

### DIFF
--- a/lexwebapp/src/components/attorney/__tests__/PendingInvitationsModal.test.tsx
+++ b/lexwebapp/src/components/attorney/__tests__/PendingInvitationsModal.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 vi.mock('framer-motion', () => ({
   AnimatePresence: ({ children }: any) => children,
   motion: {
-    div: ({ children, className, onClick, ...rest }: any) => (
+    div: ({ children, className, onClick }: any) => (
       <div className={className} onClick={onClick}>{children}</div>
     ),
   },
@@ -289,7 +289,6 @@ describe('PendingInvitationsModal', () => {
 
       // Fee confirm and back buttons should be in flex container
       const confirmBtn = screen.getByText(/Прийняти за/).closest('button');
-      const backBtn = screen.getByText('Назад').closest('button');
 
       expect(confirmBtn?.className).toContain('flex-1');
       const btnContainer = confirmBtn?.parentElement;

--- a/lexwebapp/src/components/ui/__tests__/ConfirmModal.test.tsx
+++ b/lexwebapp/src/components/ui/__tests__/ConfirmModal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfirmModal } from '../ConfirmModal';
 
@@ -138,12 +138,8 @@ describe('ConfirmModal', () => {
   describe('loading state', () => {
     it('disables buttons when loading', () => {
       render(<ConfirmModal {...defaultProps} loading={true} />);
-      const buttons = screen.getAllByRole('button');
-      // Cancel and confirm buttons (skip X)
-      const cancelBtn = screen.getByText('Скасувати').closest('button');
-      const confirmBtn = screen.getByText('Підтвердити').closest('button');
-      expect(cancelBtn).toBeDisabled();
-      expect(confirmBtn).toBeDisabled();
+      expect(screen.getByText('Скасувати').closest('button')).toBeDisabled();
+      expect(screen.getByText('Підтвердити').closest('button')).toBeDisabled();
     });
   });
 });

--- a/lexwebapp/src/pages/__tests__/ConsultationDetailPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/ConsultationDetailPage.test.tsx
@@ -7,7 +7,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 vi.mock('framer-motion', () => ({
   AnimatePresence: ({ children }: any) => children,
   motion: {
-    div: ({ children, className, onClick, ...rest }: any) => (
+    div: ({ children, className, onClick }: any) => (
       <div className={className} onClick={onClick}>{children}</div>
     ),
   },

--- a/lexwebapp/src/pages/__tests__/ConsultationsPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/ConsultationsPage.test.tsx
@@ -195,7 +195,6 @@ describe('ConsultationsPage', () => {
 
       // Cards should be in a space-y-3 container
       const card1 = screen.getByText('Перша').closest('.border');
-      const card2 = screen.getByText('Друга').closest('.border');
       const container = card1?.parentElement;
       expect(container?.className).toContain('space-y-3');
     });


### PR DESCRIPTION
## Summary

Remove unused variables (`rest`, `backBtn`, `buttons`, `card2`, `waitFor`) causing TS6133 errors in CI build.

Fixes CI failure from PR #986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)