### PR TITLE
feat: architecture improvements — Redis message bus, EDRSR cache, pre-vectorizer, tool grouping, SSE recovery

### DIFF
--- a/lexwebapp/src/stores/consultationStore.ts
+++ b/lexwebapp/src/stores/consultationStore.ts
@@ -1,6 +1,23 @@
 import { create } from 'zustand';
 import { consultationService, type Consultation } from '../services/api/ConsultationService';
 
+/** Dedup set for recent SSE event IDs (prevents duplicate processing on reconnect) */
+const recentEventIds = new Set<string>();
+const MAX_RECENT_IDS = 500;
+
+function trackEventId(id: string): boolean {
+  if (recentEventIds.has(id)) return false; // Already seen
+  recentEventIds.add(id);
+  if (recentEventIds.size > MAX_RECENT_IDS) {
+    // Evict oldest entries (Set preserves insertion order)
+    const iter = recentEventIds.values();
+    for (let i = 0; i < 100; i++) iter.next();
+    const toDelete = [...recentEventIds].slice(0, 100);
+    toDelete.forEach(id => recentEventIds.delete(id));
+  }
+  return true; // New event
+}
+
 interface ConsultationState {
   globalUnreadCount: number;
   pendingCount: number;
@@ -73,6 +90,10 @@ export const useConsultationStore = create<ConsultationState>((set, get) => ({
     es.addEventListener('new_message', (event) => {
       try {
         const data = JSON.parse(event.data);
+        // Deduplicate: skip if we've already processed this event
+        const eventId = data.messageId || data.consultationId + ':' + data.preview;
+        if (!trackEventId(eventId)) return;
+
         set(s => ({ globalUnreadCount: s.globalUnreadCount + 1 }));
         // Dispatch event for toast notifications
         window.dispatchEvent(new CustomEvent('consultation-new-message', { detail: data }));

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -39,6 +39,8 @@ export interface ToolServices {
   uploadService: UploadService;
   minioService: MinioService;
   vaultTools: VaultTools;
+  edsrFtsService: EdsrFtsService;
+  edsrVectorizer?: EdsrVectorizerService;
 }
 
 export function createToolServices(
@@ -172,5 +174,7 @@ export function createToolServices(
     uploadService,
     minioService,
     vaultTools,
+    edsrFtsService,
+    edsrVectorizer,
   };
 }

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -564,6 +564,28 @@ class HTTPMCPServer {
       }
     }) as any);
 
+    // EDRSR vectorization status endpoint (admin)
+    this.app.get('/api/admin/edrsr-vectorization-status', requireJWT as any, (async (_req: DualAuthRequest, res: express.Response) => {
+      try {
+        const preVectorizer = (this as any)._preVectorizer;
+        if (!preVectorizer) {
+          return res.json({ status: 'not_configured', message: 'Pre-vectorizer not running (VOYAGEAI_API_KEY missing or Redis unavailable)' });
+        }
+        const workerStatus = await preVectorizer.getStatus();
+
+        // Also get Qdrant collection stats
+        let qdrantStats = null;
+        if (this.tools.edsrVectorizer) {
+          qdrantStats = await this.tools.edsrVectorizer.getVectorizationStats();
+        }
+
+        res.json({ worker: workerStatus, qdrant: qdrantStats });
+      } catch (error: any) {
+        logger.error('[Admin] EDRSR vectorization status failed', { error: error.message });
+        res.status(500).json({ error: error.message });
+      }
+    }) as any);
+
     // Template system routes - Dynamic template classification, matching, generation, and analytics
     // POST /api/templates/classify-question - Classify question intent
     // GET /api/templates/classify-question/stats - Classification statistics
@@ -711,6 +733,10 @@ class HTTPMCPServer {
       await this.services.embeddingService.initialize();
       await this.tools.documentParser.initialize();
 
+      // Initialize Redis-backed consultation message bus (falls back to in-memory)
+      const { createConsultationMessageBus } = await import('./services/consultation-message-bus.js');
+      await createConsultationMessageBus();
+
       // Initialize Redis cache for services (optional)
       const redis = await getRedisClient();
       if (redis) {
@@ -727,6 +753,27 @@ class HTTPMCPServer {
         setOidcCache(cache);
         setRateLimitCache(cache);
         setUploadRateLimitCache(cache);
+        // EDRSR cache service (fulltext, metadata, FTS results)
+        const { EdsrCacheService } = await import('./services/edrsr-cache-service.js');
+        const edsrCache = new EdsrCacheService(cache);
+        if (this.tools.edsrFtsService) {
+          this.tools.edsrFtsService.setEdsrCache(edsrCache);
+        }
+
+        // Start EDRSR pre-vectorization background worker (if vectorizer available)
+        if (this.tools.edsrVectorizer) {
+          const { EdsrPreVectorizerWorker } = await import('./workers/edrsr-pre-vectorizer.js');
+          const preVectorizer = new EdsrPreVectorizerWorker(
+            this.tools.edsrVectorizer,
+            this.services.db,
+            cache,
+          );
+          preVectorizer.start();
+          // Expose status endpoint
+          (this as any)._preVectorizer = preVectorizer;
+          logger.info('EDRSR pre-vectorization background worker started');
+        }
+
         logger.info('Redis connected - caching enabled for all services');
       } else {
         logger.info('Redis not available - services will work without caching');

--- a/mcp_backend/src/prompts/tool-registry-catalog.ts
+++ b/mcp_backend/src/prompts/tool-registry-catalog.ts
@@ -1210,6 +1210,165 @@ export function getScenarioPriorityTools(scenarioIds: string[]): string[] {
   return priority;
 }
 
+// ============================
+// Tool Groups — Two-tier selection
+// ============================
+
+/**
+ * Semantic tool groups for two-tier tool selection.
+ * IntentClassifier picks relevant groups based on intent, then expands to tool names.
+ * This reduces the tool count the LLM sees from 45+ down to 8-15.
+ */
+export interface ToolGroup {
+  id: string;
+  label: string;       // Ukrainian label
+  tools: string[];     // Tool names in this group
+  domains: string[];   // Which domains this group covers
+}
+
+export const TOOL_GROUPS: ToolGroup[] = [
+  {
+    id: 'edrsr_search',
+    label: 'Пошук в ЄДРСР',
+    domains: ['court'],
+    tools: [
+      'edrsr_search_decisions',
+      'edrsr_fulltext_search',
+      'edrsr_semantic_search',
+      'edrsr_get_decision',
+      'edrsr_search_by_judge',
+    ],
+  },
+  {
+    id: 'court_practice',
+    label: 'Судова практика',
+    domains: ['court', 'legal_advice'],
+    tools: [
+      'search_legal_precedents',
+      'search_supreme_court_practice',
+      'get_court_decision',
+      'get_case_documents_chain',
+      'count_cases_by_party',
+    ],
+  },
+  {
+    id: 'legislation',
+    label: 'Законодавство',
+    domains: ['legislation', 'legal_advice'],
+    tools: [
+      'get_legislation_article',
+      'search_legislation',
+      'find_relevant_law_articles',
+      'get_legislation_structure',
+    ],
+  },
+  {
+    id: 'registry',
+    label: 'Реєстри',
+    domains: ['registry'],
+    tools: [
+      'openreyestr_get_by_edrpou',
+      'openreyestr_search_entities',
+      'openreyestr_get_entity_details',
+      'openreyestr_search_beneficiaries',
+      'search_erb_debtors',
+      'search_nbu_banks',
+      'openreyestr_search_arbitration_managers',
+      'openreyestr_search_legal_acts',
+      'openreyestr_search_administrative_units',
+      'openreyestr_search_streets',
+      'openreyestr_search_special_forms',
+    ],
+  },
+  {
+    id: 'parliament',
+    label: 'Парламент',
+    domains: ['parliament'],
+    tools: [
+      'rada_search_deputies',
+      'rada_search_bills',
+      'rada_get_legislation_text',
+      'rada_get_voting_record',
+    ],
+  },
+  {
+    id: 'vault',
+    label: 'Документи',
+    domains: ['documents'],
+    tools: [
+      'list_documents',
+      'get_document',
+      'semantic_search',
+      'delete_document',
+      'update_document',
+    ],
+  },
+  {
+    id: 'procedural',
+    label: 'Процесуальне',
+    domains: ['court', 'legal_advice'],
+    tools: [
+      'search_court_sessions',
+      'search_court_registry',
+      'get_court_info',
+      'search_judges',
+      'check_case_status',
+      'calculate_deadlines',
+    ],
+  },
+  {
+    id: 'due_diligence',
+    label: 'Due Diligence',
+    domains: ['registry', 'court'],
+    tools: [
+      'openreyestr_get_by_edrpou',
+      'openreyestr_search_beneficiaries',
+      'search_erb_debtors',
+      'count_cases_by_party',
+    ],
+  },
+  {
+    id: 'echr',
+    label: 'ЄСПЛ',
+    domains: ['echr'],
+    tools: [
+      'search_echr_cases',
+      'get_echr_decision',
+      'search_echr_by_article',
+    ],
+  },
+];
+
+/**
+ * Resolve tool groups by domain list → flat array of unique tool names.
+ */
+export function resolveToolGroupsByDomains(domains: string[]): string[] {
+  const tools = new Set<string>();
+  for (const group of TOOL_GROUPS) {
+    if (group.domains.some(d => domains.includes(d))) {
+      for (const tool of group.tools) {
+        tools.add(tool);
+      }
+    }
+  }
+  return Array.from(tools);
+}
+
+/**
+ * Resolve specific tool group IDs → flat array of unique tool names.
+ */
+export function resolveToolGroupsByIds(groupIds: string[]): string[] {
+  const tools = new Set<string>();
+  for (const group of TOOL_GROUPS) {
+    if (groupIds.includes(group.id)) {
+      for (const tool of group.tools) {
+        tools.add(tool);
+      }
+    }
+  }
+  return Array.from(tools);
+}
+
 // Pre-computed exports
 export const DERIVED_DOMAIN_TOOL_MAP = deriveDomainToolMap(SCENARIO_CATALOG);
 export const DERIVED_DEFAULT_TOOLS = deriveDefaultTools(SCENARIO_CATALOG);

--- a/mcp_backend/src/routes/__tests__/consultation-routes-chat.test.ts
+++ b/mcp_backend/src/routes/__tests__/consultation-routes-chat.test.ts
@@ -11,7 +11,7 @@ import express from 'express';
 import http from 'http';
 import request from 'supertest';
 import { createConsultationRoutes } from '../consultation-routes';
-import { consultationMessageBus } from '../../services/consultation-message-bus';
+import { getConsultationMessageBus } from '../../services/consultation-message-bus';
 
 // ──────────────────────────────────────────────────────────────────────────
 // Mock services
@@ -169,7 +169,7 @@ describe('Consultation Chat Routes', () => {
                 created_at: new Date().toISOString(),
                 sender_name: 'Attorney',
               };
-              consultationMessageBus.publish('cons-1', msg as any);
+              getConsultationMessageBus().publish('cons-1', msg as any);
             }
 
             if (data.includes('event: message')) {

--- a/mcp_backend/src/routes/consultation-routes.ts
+++ b/mcp_backend/src/routes/consultation-routes.ts
@@ -66,8 +66,9 @@ export function createConsultationRoutes(
 
       res.write('event: connected\ndata: {}\n\n');
 
-      const { consultationMessageBus } = await import('../services/consultation-message-bus.js');
-      const unsubscribe = consultationMessageBus.subscribeUser(userId, (event) => {
+      const { getConsultationMessageBus } = await import('../services/consultation-message-bus.js');
+      const bus = getConsultationMessageBus();
+      const unsubscribe = bus.subscribeUser(userId, (event) => {
         res.write(`event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`);
       });
 
@@ -297,18 +298,35 @@ export function createConsultationRoutes(
       // Send initial heartbeat
       res.write('event: connected\ndata: {}\n\n');
 
+      // Replay missed messages if Last-Event-ID is present (SSE reconnection)
+      const lastEventId = req.headers['last-event-id'] as string | undefined;
+      if (lastEventId) {
+        try {
+          const missed = await consultationService.getMessagesSince(consultationId, lastEventId);
+          for (const msg of missed) {
+            res.write(`id: ${msg.id}\nevent: message\ndata: ${JSON.stringify(msg)}\n\n`);
+          }
+          logger.info('SSE replay: sent missed messages', { consultationId, lastEventId, count: missed.length });
+        } catch (err: any) {
+          logger.warn('SSE replay failed (non-critical)', { error: err.message, lastEventId });
+        }
+      }
+
       // Subscribe to message bus
-      const { consultationMessageBus } = await import('../services/consultation-message-bus.js');
-      const unsubscribeMsg = consultationMessageBus.subscribe(consultationId, (message) => {
-        res.write(`event: message\ndata: ${JSON.stringify(message)}\n\n`);
+      const { getConsultationMessageBus } = await import('../services/consultation-message-bus.js');
+      const bus = getConsultationMessageBus();
+      const unsubscribeMsg = bus.subscribe(consultationId, (message) => {
+        // Include id: field for Last-Event-ID support
+        const eventId = (message as any).id || '';
+        res.write(`id: ${eventId}\nevent: message\ndata: ${JSON.stringify(message)}\n\n`);
       });
-      const unsubscribeStatus = consultationMessageBus.subscribeStatus(consultationId, (payload) => {
+      const unsubscribeStatus = bus.subscribeStatus(consultationId, (payload) => {
         res.write(`event: message_status\ndata: ${JSON.stringify(payload)}\n\n`);
       });
-      const unsubscribeConsultationStatus = consultationMessageBus.subscribeConsultationStatus(consultationId, (consultation) => {
-        res.write(`event: consultation_status\ndata: ${JSON.stringify(consultation)}\n\n`);
+      const unsubscribeConsultationStatus = bus.subscribeConsultationStatus(consultationId, (updatedConsultation) => {
+        res.write(`event: consultation_status\ndata: ${JSON.stringify(updatedConsultation)}\n\n`);
       });
-      const unsubscribeTyping = consultationMessageBus.subscribeTyping(consultationId, (data) => {
+      const unsubscribeTyping = bus.subscribeTyping(consultationId, (data) => {
         // Don't echo typing back to the sender
         if (data.userId !== req.user!.id) {
           res.write(`event: typing\ndata: ${JSON.stringify(data)}\n\n`);
@@ -408,8 +426,8 @@ export function createConsultationRoutes(
   router.post('/:id/typing', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
       if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-      const { consultationMessageBus } = await import('../services/consultation-message-bus.js');
-      consultationMessageBus.publishTyping(req.params.id as string, req.user.id, req.user.name);
+      const { getConsultationMessageBus } = await import('../services/consultation-message-bus.js');
+      getConsultationMessageBus().publishTyping(req.params.id as string, req.user.id, req.user.name);
       res.json({ ok: true });
     } catch (error: any) {
       res.status(400).json({ error: error.message });

--- a/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
@@ -589,7 +589,7 @@ describe('IntentClassifier', () => {
       expect(result.unsupportedReason).toBeDefined();
     });
 
-    it('should coerce to unsupported for judge statistics queries', async () => {
+    it('should coerce to institutional_analysis for judge statistics queries', async () => {
       const { classifier } = buildClassifier({
         domains: ['court'],
         keywords: 'test',
@@ -598,11 +598,10 @@ describe('IntentClassifier', () => {
 
       const result = await classifier.classify('Рейтинг суддів за відсотком задоволених позовів');
 
-      expect(result.queryType).toBe('unsupported');
-      expect(result.unsupportedReason).toContain('статистику');
+      expect(result.queryType).toBe('institutional_analysis');
     });
 
-    it('should generate unsupported reason for judge statistics even if LLM did not', async () => {
+    it('should coerce to institutional_analysis for judge statistics even if LLM defaulted to legal_consultation', async () => {
       const { classifier } = buildClassifier({
         domains: ['court'],
         keywords: 'test',
@@ -611,8 +610,7 @@ describe('IntentClassifier', () => {
 
       const result = await classifier.classify('Статистика суддів по задоволеним позовам');
 
-      expect(result.queryType).toBe('unsupported');
-      expect(result.unsupportedReason).toBeTruthy();
+      expect(result.queryType).toBe('institutional_analysis');
     });
 
     it('should preserve LLM queryType when not legal_consultation', async () => {
@@ -827,17 +825,14 @@ describe('IntentClassifier', () => {
 
   describe('filterTools()', () => {
 
-    it('should return default tools when domains is empty', async () => {
+    it('should return default tools + meta-tool when domains is empty', async () => {
       const toolNames = allToolNames();
       const { classifier } = buildClassifier({}, { toolNames });
 
-      // Pass empty domains - should still return at least DEFAULT_TOOLS
+      // Pass empty domains - should still return at least DEFAULT_TOOLS + request_additional_tools
       const filtered = await classifier.filterTools([]);
 
-      // When domains is empty, relevantNames has DEFAULT_TOOLS, then no domain tools are added.
-      // But since domains.length === 0, the fallback condition (relevantNames.size <= DEFAULT_TOOLS.length && domains.length > 0)
-      // is NOT triggered. So we only get default tools.
-      const defaultSet = new Set(DEFAULT_TOOLS);
+      const defaultSet = new Set([...DEFAULT_TOOLS, 'request_additional_tools']);
       for (const tool of filtered) {
         expect(defaultSet.has(tool.name)).toBe(true);
       }
@@ -850,14 +845,11 @@ describe('IntentClassifier', () => {
       const filtered = await classifier.filterTools(['court']);
       const filteredNames = filtered.map((d) => d.name);
 
-      // Court tools from DOMAIN_TOOL_MAP should be included
-      const courtTools = DOMAIN_TOOL_MAP.court || [];
-      for (const tool of courtTools) {
-        if (filteredNames.length < 15) {
-          // tools are capped at 15
-          expect(filteredNames).toContain(tool);
-        }
-      }
+      // Key court tools should be included (from tool groups or DOMAIN_TOOL_MAP)
+      expect(filteredNames).toContain('search_legal_precedents');
+      expect(filteredNames).toContain('get_court_decision');
+      // Meta-tool should always be present
+      expect(filteredNames).toContain('request_additional_tools');
     });
 
     it('should include registry tools for registry domain', async () => {
@@ -897,7 +889,7 @@ describe('IntentClassifier', () => {
       expect(filtered.length).toBeLessThanOrEqual(15);
     });
 
-    it('should only return tools that exist in the registry', async () => {
+    it('should only return tools that exist in the registry plus meta-tool', async () => {
       // Registry with limited tools
       const { classifier } = buildClassifier({}, {
         toolNames: ['search_legal_precedents', 'get_court_decision'],
@@ -906,9 +898,9 @@ describe('IntentClassifier', () => {
       const filtered = await classifier.filterTools(['court']);
       const filteredNames = filtered.map((d) => d.name);
 
-      // Should only contain tools that exist in our limited registry
+      // Should only contain tools from registry + the virtual meta-tool
       for (const name of filteredNames) {
-        expect(['search_legal_precedents', 'get_court_decision']).toContain(name);
+        expect(['search_legal_precedents', 'get_court_decision', 'request_additional_tools']).toContain(name);
       }
     });
 
@@ -1052,15 +1044,16 @@ describe('DOMAIN_TOOL_MAP', () => {
 
 describe('VALID_QUERY_TYPES', () => {
 
-  it('should contain all 12 defined query types', () => {
+  it('should contain all 13 defined query types', () => {
     const expected: QueryType[] = [
       'case_lookup', 'practice_analysis', 'legislation_lookup', 'legal_consultation',
       'registry_lookup', 'parliament_query', 'document_query', 'calculation',
-      'document_drafting', 'comparative_analysis', 'due_diligence', 'unsupported',
+      'document_drafting', 'comparative_analysis', 'due_diligence', 'institutional_analysis',
+      'unsupported',
     ];
     for (const qt of expected) {
       expect(VALID_QUERY_TYPES.has(qt)).toBe(true);
     }
-    expect(VALID_QUERY_TYPES.size).toBe(12);
+    expect(VALID_QUERY_TYPES.size).toBe(13);
   });
 });

--- a/mcp_backend/src/services/__tests__/consultation-message-bus.test.ts
+++ b/mcp_backend/src/services/__tests__/consultation-message-bus.test.ts
@@ -1,4 +1,4 @@
-import { consultationMessageBus } from '../consultation-message-bus';
+import { LocalConsultationMessageBus } from '../consultation-message-bus';
 import type { ConsultationMessage } from '../consultation-service';
 
 function makeMessage(overrides: Partial<ConsultationMessage> = {}): ConsultationMessage {
@@ -8,6 +8,7 @@ function makeMessage(overrides: Partial<ConsultationMessage> = {}): Consultation
     sender_id: 'user-1',
     content: 'Hello',
     message_type: 'text',
+    status: 'sent',
     created_at: new Date(),
     sender_name: 'Test User',
     ...overrides,
@@ -15,12 +16,14 @@ function makeMessage(overrides: Partial<ConsultationMessage> = {}): Consultation
 }
 
 describe('ConsultationMessageBus', () => {
+  const bus = new LocalConsultationMessageBus();
+
   it('delivers messages to subscribers of the correct consultation', () => {
     const callback = jest.fn();
-    const unsubscribe = consultationMessageBus.subscribe('cons-1', callback);
+    const unsubscribe = bus.subscribe('cons-1', callback);
 
     const msg = makeMessage();
-    consultationMessageBus.publish('cons-1', msg);
+    bus.publish('cons-1', msg);
 
     expect(callback).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledWith(msg);
@@ -29,9 +32,9 @@ describe('ConsultationMessageBus', () => {
 
   it('does not deliver messages to subscribers of other consultations', () => {
     const callback = jest.fn();
-    const unsubscribe = consultationMessageBus.subscribe('cons-2', callback);
+    const unsubscribe = bus.subscribe('cons-2', callback);
 
-    consultationMessageBus.publish('cons-1', makeMessage());
+    bus.publish('cons-1', makeMessage());
 
     expect(callback).not.toHaveBeenCalled();
     unsubscribe();
@@ -40,11 +43,11 @@ describe('ConsultationMessageBus', () => {
   it('supports multiple subscribers for the same consultation', () => {
     const cb1 = jest.fn();
     const cb2 = jest.fn();
-    const unsub1 = consultationMessageBus.subscribe('cons-3', cb1);
-    const unsub2 = consultationMessageBus.subscribe('cons-3', cb2);
+    const unsub1 = bus.subscribe('cons-3', cb1);
+    const unsub2 = bus.subscribe('cons-3', cb2);
 
     const msg = makeMessage({ consultation_id: 'cons-3' });
-    consultationMessageBus.publish('cons-3', msg);
+    bus.publish('cons-3', msg);
 
     expect(cb1).toHaveBeenCalledWith(msg);
     expect(cb2).toHaveBeenCalledWith(msg);
@@ -54,10 +57,10 @@ describe('ConsultationMessageBus', () => {
 
   it('unsubscribe stops delivery', () => {
     const callback = jest.fn();
-    const unsubscribe = consultationMessageBus.subscribe('cons-4', callback);
+    const unsubscribe = bus.subscribe('cons-4', callback);
 
     unsubscribe();
-    consultationMessageBus.publish('cons-4', makeMessage({ consultation_id: 'cons-4' }));
+    bus.publish('cons-4', makeMessage({ consultation_id: 'cons-4' }));
 
     expect(callback).not.toHaveBeenCalled();
   });
@@ -65,11 +68,11 @@ describe('ConsultationMessageBus', () => {
   it('unsubscribe only removes the specific callback', () => {
     const cb1 = jest.fn();
     const cb2 = jest.fn();
-    const unsub1 = consultationMessageBus.subscribe('cons-5', cb1);
-    const unsub2 = consultationMessageBus.subscribe('cons-5', cb2);
+    const unsub1 = bus.subscribe('cons-5', cb1);
+    const unsub2 = bus.subscribe('cons-5', cb2);
 
     unsub1();
-    consultationMessageBus.publish('cons-5', makeMessage({ consultation_id: 'cons-5' }));
+    bus.publish('cons-5', makeMessage({ consultation_id: 'cons-5' }));
 
     expect(cb1).not.toHaveBeenCalled();
     expect(cb2).toHaveBeenCalledTimes(1);
@@ -78,7 +81,7 @@ describe('ConsultationMessageBus', () => {
 
   it('handles publish with no subscribers gracefully', () => {
     expect(() => {
-      consultationMessageBus.publish('cons-no-one', makeMessage());
+      bus.publish('cons-no-one', makeMessage());
     }).not.toThrow();
   });
 });

--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -17,8 +17,26 @@ import {
   type QueryType,
   type ChatIntentClassification,
 } from '../prompts/chat-system-prompt.js';
-import { getScenarioPriorityTools } from '../prompts/tool-registry-catalog.js';
+import { getScenarioPriorityTools, resolveToolGroupsByDomains } from '../prompts/tool-registry-catalog.js';
 import { QUERY_TYPE_CONFIG } from '../prompts/query-type-config.js';
+import { TOOL_GROUPS } from '../prompts/tool-registry-catalog.js';
+
+/** Virtual meta-tool definition — safety valve when LLM needs tools not in the filtered set */
+const META_TOOL_DEF: ToolDefinition = {
+  name: 'request_additional_tools',
+  description: `Запитати додаткові інструменти з конкретної групи. Використовуй якщо потрібні інструменти, яких немає у поточному наборі. Доступні групи: ${TOOL_GROUPS.map(g => `${g.id} (${g.label})`).join(', ')}`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      groups: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Масив ідентифікаторів груп інструментів',
+      },
+    },
+    required: ['groups'],
+  },
+};
 
 interface CostRecorder {
   recordStreamingCost(
@@ -245,42 +263,56 @@ export class IntentClassifier {
 
   /**
    * Filter 45+ tools to a relevant subset based on intent domains.
-   * When queryType is provided, tools from matching scenarios are prioritized
-   * so they survive the 15-tool cap.
+   *
+   * Two-tier selection:
+   *   1. Tool Groups (primary) — semantic groups matched by domain
+   *   2. Scenario priority (secondary) — preferred scenarios for the queryType
+   *   3. DOMAIN_TOOL_MAP (fallback) — if groups don't cover enough
+   *
+   * Target: 8-15 tools per request.
    */
   async filterTools(domains: string[], slots?: Record<string, any>, queryType?: QueryType): Promise<ToolDefinition[]> {
     const allDefs = await this.toolRegistry.getAllToolDefinitions();
+    const allDefsByName = new Map(allDefs.map(d => [d.name, d]));
 
-    // Collect tool names from matching domains
-    const relevantNames = new Set<string>(DEFAULT_TOOLS);
-    for (const domain of domains) {
-      const mapped = DOMAIN_TOOL_MAP[domain];
-      if (mapped) {
-        for (const name of mapped) {
-          relevantNames.add(name);
+    // 1. Start with tool groups matched by domains (primary selection)
+    const groupToolNames = new Set<string>(resolveToolGroupsByDomains(domains));
+
+    // 2. Add default tools (appear in 2+ scenarios)
+    for (const name of DEFAULT_TOOLS) {
+      groupToolNames.add(name);
+    }
+
+    // 3. Slot-based additions
+    if (slots?.edrpou) {
+      const registryTools = DOMAIN_TOOL_MAP.registry || [];
+      for (const name of registryTools) {
+        groupToolNames.add(name);
+      }
+    }
+
+    // 4. DOMAIN_TOOL_MAP fallback when groups don't cover enough
+    if (groupToolNames.size < 5 && domains.length > 0) {
+      for (const domain of domains) {
+        const mapped = DOMAIN_TOOL_MAP[domain];
+        if (mapped) {
+          for (const name of mapped) {
+            groupToolNames.add(name);
+          }
         }
       }
     }
 
-    // If EDRPOU is in slots, ensure all registry tools are included
-    if (slots?.edrpou) {
-      const registryTools = DOMAIN_TOOL_MAP.registry || [];
-      for (const name of registryTools) {
-        relevantNames.add(name);
-      }
-    }
-
-    // If no domains matched, use a broader set
-    if (relevantNames.size <= DEFAULT_TOOLS.length && domains.length > 0) {
-      // Add all tools from the 'legal_advice' domain as fallback
+    // 5. Legal advice fallback if still sparse
+    if (groupToolNames.size <= DEFAULT_TOOLS.length && domains.length > 0) {
       const fallback = DOMAIN_TOOL_MAP.legal_advice || [];
       for (const name of fallback) {
-        relevantNames.add(name);
+        groupToolNames.add(name);
       }
     }
 
     // Filter to only tools that actually exist in the registry
-    const filtered = allDefs.filter((d) => relevantNames.has(d.name));
+    const filtered = allDefs.filter((d) => groupToolNames.has(d.name));
 
     // Build priority set from preferred scenarios for this queryType
     const priorityTools = new Set<string>();
@@ -293,14 +325,23 @@ export class IntentClassifier {
       }
     }
 
-    // Sort: scenario-priority tools first, then the rest (preserving original order within each group)
+    // Sort: scenario-priority tools first, then the rest
     if (priorityTools.size > 0) {
       const priority = filtered.filter((d) => priorityTools.has(d.name));
       const rest = filtered.filter((d) => !priorityTools.has(d.name));
-      return [...priority, ...rest].slice(0, 15);
+
+      const combined = [...priority, ...rest].slice(0, 14);
+
+      // Always include request_additional_tools as safety valve
+      combined.push(META_TOOL_DEF);
+
+      return combined;
     }
 
-    // Cap at 15 tools — modern LLMs handle 15-20 tools fine
-    return filtered.slice(0, 15);
+    // Cap at 14 tools + meta-tool = 15
+    const result = filtered.slice(0, 14);
+    result.push(META_TOOL_DEF);
+
+    return result;
   }
 }

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1558,6 +1558,27 @@ export class ChatService {
     let toolResult: any;
     let cached = false;
 
+    // Meta-tool: request_additional_tools — returns available tools by group
+    if (call.name === 'request_additional_tools') {
+      const { resolveToolGroupsByIds } = await import('../prompts/tool-registry-catalog.js');
+      const groupIds = call.arguments?.groups;
+      if (Array.isArray(groupIds)) {
+        const toolNames = resolveToolGroupsByIds(groupIds);
+        const allDefs = await this.toolRegistry.getAllToolDefinitions();
+        const matchedTools = allDefs
+          .filter(d => toolNames.includes(d.name))
+          .map(d => ({ name: d.name, description: d.description }));
+        toolResult = {
+          message: `Додаткові інструменти для груп [${groupIds.join(', ')}]:`,
+          tools: matchedTools,
+          hint: 'Тепер ви можете використовувати ці інструменти у наступних кроках.',
+        };
+      } else {
+        toolResult = { error: 'Параметр groups має бути масивом ідентифікаторів груп (edrsr_search, court_practice, legislation, registry, parliament, vault, procedural, due_diligence, echr)' };
+      }
+      return { call, result: toolResult, cached: false };
+    }
+
     // Check cache for court search tools
     if (this.searchCache && isCourtSearchTool(call.name)) {
       const hit = await this.searchCache.getCachedResult(call.name, call.arguments);

--- a/mcp_backend/src/services/consultation-message-bus.ts
+++ b/mcp_backend/src/services/consultation-message-bus.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type { ConsultationMessage } from './consultation-service.js';
+import { logger } from '../utils/logger.js';
 
 type MessageCallback = (message: ConsultationMessage) => void;
 type StatusCallback = (payload: { messageIds: string[]; status: string }) => void;
@@ -27,7 +28,27 @@ export interface TypingEvent {
 export type UserEvent = ConsultationStatusEvent | NewMessageEvent | TypingEvent;
 type UserEventCallback = (event: UserEvent) => void;
 
-class ConsultationMessageBus {
+// ── Interface ─────────────────────────────────────────────────────────────────
+
+export interface IConsultationMessageBus {
+  subscribe(consultationId: string, callback: MessageCallback): () => void;
+  subscribeStatus(consultationId: string, callback: StatusCallback): () => void;
+  subscribeConsultationStatus(consultationId: string, callback: (consultation: any) => void): () => void;
+  subscribeUser(userId: string, callback: UserEventCallback): () => void;
+  subscribeTyping(consultationId: string, callback: (data: { consultationId: string; userId: string; userName?: string }) => void): () => void;
+
+  publish(consultationId: string, message: ConsultationMessage): void;
+  publishStatus(consultationId: string, messageIds: string[], status: string): void;
+  publishConsultationStatus(consultation: any): void;
+  publishUserEvent(userId: string, event: UserEvent): void;
+  publishTyping(consultationId: string, userId: string, userName?: string): void;
+
+  shutdown?(): Promise<void>;
+}
+
+// ── EventEmitter Implementation (in-memory fallback) ──────────────────────────
+
+export class LocalConsultationMessageBus implements IConsultationMessageBus {
   private emitter = new EventEmitter();
 
   constructor() {
@@ -75,9 +96,7 @@ class ConsultationMessageBus {
   }
 
   publishConsultationStatus(consultation: any): void {
-    // Emit on per-consultation channel (for detail page SSE)
     this.emitter.emit(`consultation_status:${consultation.id}`, consultation);
-    // Emit on user channels (for global user SSE)
     if (consultation.client_user_id) {
       this.publishUserEvent(consultation.client_user_id, {
         type: 'consultation_status',
@@ -109,4 +128,51 @@ class ConsultationMessageBus {
   }
 }
 
-export const consultationMessageBus = new ConsultationMessageBus();
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+let _bus: IConsultationMessageBus | null = null;
+
+/**
+ * Create or return the singleton consultation message bus.
+ * If REDIS_URL is set, attempts to create a Redis-backed bus;
+ * falls back to in-memory EventEmitter on failure or if Redis is unavailable.
+ */
+export async function createConsultationMessageBus(): Promise<IConsultationMessageBus> {
+  if (_bus) return _bus;
+
+  const redisUrl = process.env.REDIS_URL;
+  if (redisUrl) {
+    try {
+      const { RedisConsultationMessageBus } = await import('./redis-consultation-message-bus.js');
+      const redisBus = new RedisConsultationMessageBus(redisUrl);
+      await redisBus.connect();
+      _bus = redisBus;
+      logger.info('[ConsultationMessageBus] Using Redis Pub/Sub implementation');
+      return _bus;
+    } catch (err: any) {
+      logger.warn('[ConsultationMessageBus] Redis Pub/Sub failed, falling back to in-memory EventEmitter', {
+        error: err.message,
+      });
+    }
+  }
+
+  _bus = new LocalConsultationMessageBus();
+  logger.info('[ConsultationMessageBus] Using in-memory EventEmitter implementation');
+  return _bus;
+}
+
+/**
+ * Get the current message bus instance (sync).
+ * Returns a LocalConsultationMessageBus if not yet initialized.
+ */
+export function getConsultationMessageBus(): IConsultationMessageBus {
+  if (!_bus) {
+    _bus = new LocalConsultationMessageBus();
+  }
+  return _bus;
+}
+
+/**
+ * @deprecated Use getConsultationMessageBus() instead. Kept for backward compatibility.
+ */
+export const consultationMessageBus = new LocalConsultationMessageBus();

--- a/mcp_backend/src/services/consultation-service.ts
+++ b/mcp_backend/src/services/consultation-service.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { AuditService } from './audit-service.js';
 import { MatterService } from './matter-service.js';
 import { AttorneyProfileService } from './attorney-profile-service.js';
-import { consultationMessageBus } from './consultation-message-bus.js';
+import { getConsultationMessageBus } from './consultation-message-bus.js';
 import type { EmailService } from './email-service.js';
 
 export interface Consultation {
@@ -149,7 +149,7 @@ export class ConsultationService {
 
     // Emit real-time status event
     const enriched = await this.getConsultation(id, clientUserId) || result.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -273,7 +273,7 @@ export class ConsultationService {
     }
 
     const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -315,7 +315,7 @@ export class ConsultationService {
     }
 
     const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -382,7 +382,7 @@ export class ConsultationService {
 
     // Re-fetch with JOINs for enriched data
     const enriched = await this.getConsultationById(id) || consultation;
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return consultation;
   }
@@ -406,7 +406,7 @@ export class ConsultationService {
     });
 
     const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -481,7 +481,7 @@ export class ConsultationService {
     }
 
     const enriched = await this.getConsultation(id, attorneyUserId) || result.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -553,7 +553,7 @@ export class ConsultationService {
     }
 
     const enriched = await this.getConsultationById(id) || result.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     return result.rows[0];
   }
@@ -635,13 +635,13 @@ export class ConsultationService {
       sender_name: userResult.rows[0]?.name || 'Unknown',
     };
 
-    consultationMessageBus.publish(consultationId, message);
+    getConsultationMessageBus().publish(consultationId, message);
 
     // Emit user-level new_message event for the other party (for global unread badge)
     const recipientId = consultation.client_user_id === senderId
       ? consultation.attorney_user_id
       : consultation.client_user_id;
-    consultationMessageBus.publishUserEvent(recipientId, {
+    getConsultationMessageBus().publishUserEvent(recipientId, {
       type: 'new_message',
       consultationId,
       senderId,
@@ -662,7 +662,7 @@ export class ConsultationService {
     );
     const ids = result.rows.map((r: any) => r.id);
     if (ids.length > 0) {
-      consultationMessageBus.publishStatus(consultationId, ids, 'delivered');
+      getConsultationMessageBus().publishStatus(consultationId, ids, 'delivered');
     }
     return ids;
   }
@@ -679,7 +679,7 @@ export class ConsultationService {
     );
     const ids = result.rows.map((r: any) => r.id);
     if (ids.length > 0) {
-      consultationMessageBus.publishStatus(consultationId, ids, 'read');
+      getConsultationMessageBus().publishStatus(consultationId, ids, 'read');
     }
     return ids;
   }
@@ -719,13 +719,35 @@ export class ConsultationService {
     );
     if (readResult.rows.length > 0) {
       const readIds = readResult.rows.map((r: any) => r.id);
-      consultationMessageBus.publishStatus(consultationId, readIds, 'read');
+      getConsultationMessageBus().publishStatus(consultationId, readIds, 'read');
     }
 
     return {
       messages: result.rows,
       total: parseInt(countResult.rows[0].count, 10),
     };
+  }
+
+  /**
+   * Get messages created after a given message ID (for SSE Last-Event-ID replay).
+   * Returns messages in chronological order.
+   */
+  async getMessagesSince(
+    consultationId: string,
+    lastEventId: string,
+  ): Promise<ConsultationMessage[]> {
+    const result = await this.db.query(
+      `SELECT cm.*, u.name as sender_name
+       FROM consultation_messages cm
+       JOIN users u ON u.id = cm.sender_id
+       WHERE cm.consultation_id = $1 AND cm.created_at > (
+         SELECT created_at FROM consultation_messages WHERE id = $2
+       )
+       ORDER BY cm.created_at ASC
+       LIMIT 100`,
+      [consultationId, lastEventId]
+    );
+    return result.rows;
   }
 
   async getUnreadCount(consultationId: string, userId: string): Promise<number> {
@@ -840,7 +862,7 @@ export class ConsultationService {
     });
 
     const enriched = await this.getConsultationById(consultationId) || consultationResult.rows[0];
-    consultationMessageBus.publishConsultationStatus(enriched);
+    getConsultationMessageBus().publishConsultationStatus(enriched);
 
     // Email notification to the other party
     if (this.emailService) {
@@ -950,7 +972,7 @@ export class ConsultationService {
     });
 
     const enriched = await this.getConsultationById(dispute.consultation_id);
-    if (enriched) consultationMessageBus.publishConsultationStatus(enriched);
+    if (enriched) getConsultationMessageBus().publishConsultationStatus(enriched);
 
     logger.info('Dispute resolved', { disputeId, resolution, consultationId: dispute.consultation_id });
 

--- a/mcp_backend/src/services/edrsr-cache-service.ts
+++ b/mcp_backend/src/services/edrsr-cache-service.ts
@@ -1,0 +1,98 @@
+/**
+ * EdsrCacheService — Read-through Redis cache for EDRSR court decisions.
+ *
+ * Provides caching for:
+ * - Full text of decisions (TTL 24h) — key: edrsr:ft:{docId}
+ * - Document metadata (TTL 24h)     — key: edrsr:meta:{docId}
+ * - FTS search results (TTL 1h)     — key: edrsr:fts:{queryHash}
+ *
+ * Uses existing ICachePort (Redis adapter) — no new infrastructure required.
+ * Graceful degradation: all methods return null on cache miss or error,
+ * allowing callers to fall back to PostgreSQL seamlessly.
+ */
+
+import { createHash } from 'crypto';
+import { logger } from '../utils/logger.js';
+import type { ICachePort } from '../domain/ports/index.js';
+
+// TTL constants (seconds)
+const FULLTEXT_TTL = 86400;  // 24 hours
+const METADATA_TTL = 86400;  // 24 hours
+const FTS_TTL = 3600;        // 1 hour
+
+// Key prefixes
+const KEY_FULLTEXT = 'edrsr:ft:';
+const KEY_METADATA = 'edrsr:meta:';
+const KEY_FTS = 'edrsr:fts:';
+
+export class EdsrCacheService {
+  constructor(private cache: ICachePort) {}
+
+  // ── Fulltext ─────────────────────────────────────────────────────────────
+
+  async getCachedFulltext(docId: number): Promise<string | null> {
+    try {
+      return await this.cache.get(`${KEY_FULLTEXT}${docId}`);
+    } catch (err: any) {
+      logger.debug('[EdsrCache] getCachedFulltext error', { docId, error: err.message });
+      return null;
+    }
+  }
+
+  async setCachedFulltext(docId: number, text: string): Promise<void> {
+    try {
+      await this.cache.set(`${KEY_FULLTEXT}${docId}`, text, FULLTEXT_TTL);
+    } catch (err: any) {
+      logger.debug('[EdsrCache] setCachedFulltext error', { docId, error: err.message });
+    }
+  }
+
+  // ── Metadata ─────────────────────────────────────────────────────────────
+
+  async getCachedMetadata(docId: number): Promise<any | null> {
+    try {
+      const raw = await this.cache.get(`${KEY_METADATA}${docId}`);
+      return raw ? JSON.parse(raw) : null;
+    } catch (err: any) {
+      logger.debug('[EdsrCache] getCachedMetadata error', { docId, error: err.message });
+      return null;
+    }
+  }
+
+  async setCachedMetadata(docId: number, meta: any): Promise<void> {
+    try {
+      await this.cache.set(`${KEY_METADATA}${docId}`, JSON.stringify(meta), METADATA_TTL);
+    } catch (err: any) {
+      logger.debug('[EdsrCache] setCachedMetadata error', { docId, error: err.message });
+    }
+  }
+
+  // ── FTS Results ──────────────────────────────────────────────────────────
+
+  async getCachedFtsResults(query: string, filters: Record<string, any> = {}, limit: number, offset: number): Promise<any | null> {
+    try {
+      const hash = this.hashFtsQuery(query, filters, limit, offset);
+      const raw = await this.cache.get(`${KEY_FTS}${hash}`);
+      return raw ? JSON.parse(raw) : null;
+    } catch (err: any) {
+      logger.debug('[EdsrCache] getCachedFtsResults error', { error: err.message });
+      return null;
+    }
+  }
+
+  async setCachedFtsResults(query: string, filters: Record<string, any> = {}, limit: number, offset: number, results: any): Promise<void> {
+    try {
+      const hash = this.hashFtsQuery(query, filters, limit, offset);
+      await this.cache.set(`${KEY_FTS}${hash}`, JSON.stringify(results), FTS_TTL);
+    } catch (err: any) {
+      logger.debug('[EdsrCache] setCachedFtsResults error', { error: err.message });
+    }
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  private hashFtsQuery(query: string, filters: Record<string, any>, limit: number, offset: number): string {
+    const input = JSON.stringify({ q: query, f: filters, l: limit, o: offset });
+    return createHash('sha256').update(input).digest('hex').slice(0, 16);
+  }
+}

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -14,6 +14,7 @@
  */
 
 import { logger } from '../utils/logger.js';
+import type { EdsrCacheService } from './edrsr-cache-service.js';
 
 export interface EdsrFtsFilters {
   court_code?: number;
@@ -55,6 +56,12 @@ export interface EdsrIndexProgress {
 }
 
 export class EdsrFtsService {
+  private edsrCache: EdsrCacheService | null = null;
+
+  setEdsrCache(cache: EdsrCacheService): void {
+    this.edsrCache = cache;
+  }
+
   /**
    * Full text search over edrsr_fulltext with optional metadata filters from edrsr_documents.
    *
@@ -70,6 +77,15 @@ export class EdsrFtsService {
   ): Promise<EdsrFtsSearchResponse> {
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const safeOffset = Math.max(offset, 0);
+
+    // Check cache first
+    if (this.edsrCache) {
+      const cached = await this.edsrCache.getCachedFtsResults(query, filters, safeLimit, safeOffset);
+      if (cached) {
+        logger.debug('[EdsrFtsService] Cache hit for FTS query', { query });
+        return cached;
+      }
+    }
 
     const conditions: string[] = [];
     const params: any[] = [];
@@ -175,7 +191,7 @@ export class EdsrFtsService {
         returned: dataResult.rows.length,
       });
 
-      return {
+      const response = {
         query,
         total,
         returned: dataResult.rows.length,
@@ -193,6 +209,13 @@ export class EdsrFtsService {
           ...(row.judgment_code !== undefined ? { judgment_code: row.judgment_code } : {}),
         })),
       };
+
+      // Cache the result
+      if (this.edsrCache) {
+        this.edsrCache.setCachedFtsResults(query, filters, safeLimit, safeOffset, response).catch(() => {});
+      }
+
+      return response;
     } catch (err: any) {
       logger.error('[EdsrFtsService] searchFulltext failed', { error: err.message, query });
       throw new Error(`FTS search failed: ${err.message}`);

--- a/mcp_backend/src/services/redis-consultation-message-bus.ts
+++ b/mcp_backend/src/services/redis-consultation-message-bus.ts
@@ -1,0 +1,182 @@
+/**
+ * RedisConsultationMessageBus — Redis Pub/Sub backed message bus for consultations.
+ *
+ * Uses two Redis clients (Redis requires separate connections for pub/sub):
+ *   - subscriber: dedicated to SUBSCRIBE/PSUBSCRIBE
+ *   - publisher: used for PUBLISH
+ *
+ * Channel naming:
+ *   sl:msg:{consultationId}          — individual message delivery
+ *   sl:status:{consultationId}       — message status updates (sent/delivered/read)
+ *   sl:cstatus:{consultationId}      — consultation state changes
+ *   sl:user:{userId}                 — global user-level events
+ *   sl:typing:{consultationId}       — typing indicators
+ *
+ * All payloads are JSON-serialized for cross-process compatibility.
+ */
+
+import { createClient, type RedisClientType } from 'redis';
+import { EventEmitter } from 'events';
+import { logger } from '../utils/logger.js';
+import type { ConsultationMessage } from './consultation-service.js';
+import type {
+  IConsultationMessageBus,
+  UserEvent,
+} from './consultation-message-bus.js';
+
+// Channel prefix
+const P = 'sl:';
+
+type MessageCallback = (message: ConsultationMessage) => void;
+type StatusCallback = (payload: { messageIds: string[]; status: string }) => void;
+type UserEventCallback = (event: UserEvent) => void;
+
+export class RedisConsultationMessageBus implements IConsultationMessageBus {
+  private publisher: RedisClientType;
+  private subscriber: RedisClientType;
+  /** Local emitter bridges Redis messages → per-callback dispatch */
+  private localEmitter = new EventEmitter();
+  /** Track channel → subscription count for subscribe/unsubscribe lifecycle */
+  private channelRefs = new Map<string, number>();
+  private connected = false;
+
+  constructor(private redisUrl: string) {
+    this.publisher = createClient({ url: redisUrl }) as RedisClientType;
+    this.subscriber = createClient({ url: redisUrl }) as RedisClientType;
+    this.localEmitter.setMaxListeners(1000);
+
+    this.publisher.on('error', (err) => logger.error('[RedisMessageBus] Publisher error:', err));
+    this.subscriber.on('error', (err) => logger.error('[RedisMessageBus] Subscriber error:', err));
+  }
+
+  async connect(): Promise<void> {
+    if (this.connected) return;
+    await Promise.all([
+      this.publisher.connect(),
+      this.subscriber.connect(),
+    ]);
+    this.connected = true;
+    logger.info('[RedisMessageBus] Connected (publisher + subscriber)');
+  }
+
+  async shutdown(): Promise<void> {
+    if (!this.connected) return;
+    this.connected = false;
+    try {
+      await this.subscriber.quit();
+      await this.publisher.quit();
+    } catch (err: any) {
+      logger.warn('[RedisMessageBus] Shutdown error:', err.message);
+    }
+    logger.info('[RedisMessageBus] Disconnected');
+  }
+
+  // ── Subscribe helpers ────────────────────────────────────────────────────
+
+  private async addChannelSubscription(channel: string): Promise<void> {
+    const refs = this.channelRefs.get(channel) || 0;
+    this.channelRefs.set(channel, refs + 1);
+
+    if (refs === 0) {
+      // First subscriber for this channel — subscribe in Redis
+      await this.subscriber.subscribe(channel, (message) => {
+        try {
+          const parsed = JSON.parse(message);
+          this.localEmitter.emit(channel, parsed);
+        } catch (err) {
+          logger.warn('[RedisMessageBus] Failed to parse message on channel', { channel, error: (err as Error).message });
+        }
+      });
+    }
+  }
+
+  private async removeChannelSubscription(channel: string): Promise<void> {
+    const refs = (this.channelRefs.get(channel) || 1) - 1;
+    if (refs <= 0) {
+      this.channelRefs.delete(channel);
+      try {
+        await this.subscriber.unsubscribe(channel);
+      } catch {
+        // Non-critical — connection may already be closed
+      }
+    } else {
+      this.channelRefs.set(channel, refs);
+    }
+  }
+
+  private subscribeChannel<T>(channel: string, callback: (data: T) => void): () => void {
+    this.localEmitter.on(channel, callback);
+    this.addChannelSubscription(channel).catch((err) => {
+      logger.warn('[RedisMessageBus] Failed to subscribe to channel', { channel, error: err.message });
+    });
+
+    return () => {
+      this.localEmitter.off(channel, callback);
+      this.removeChannelSubscription(channel).catch(() => {});
+    };
+  }
+
+  private publishChannel(channel: string, data: any): void {
+    if (!this.connected) return;
+    const payload = JSON.stringify(data);
+    this.publisher.publish(channel, payload).catch((err) => {
+      logger.warn('[RedisMessageBus] Publish failed', { channel, error: err.message });
+    });
+  }
+
+  // ── IConsultationMessageBus implementation ───────────────────────────────
+
+  subscribe(consultationId: string, callback: MessageCallback): () => void {
+    return this.subscribeChannel<ConsultationMessage>(`${P}msg:${consultationId}`, callback);
+  }
+
+  subscribeStatus(consultationId: string, callback: StatusCallback): () => void {
+    return this.subscribeChannel<{ messageIds: string[]; status: string }>(`${P}status:${consultationId}`, callback);
+  }
+
+  subscribeConsultationStatus(consultationId: string, callback: (consultation: any) => void): () => void {
+    return this.subscribeChannel<any>(`${P}cstatus:${consultationId}`, callback);
+  }
+
+  subscribeUser(userId: string, callback: UserEventCallback): () => void {
+    return this.subscribeChannel<UserEvent>(`${P}user:${userId}`, callback);
+  }
+
+  subscribeTyping(consultationId: string, callback: (data: { consultationId: string; userId: string; userName?: string }) => void): () => void {
+    return this.subscribeChannel<{ consultationId: string; userId: string; userName?: string }>(`${P}typing:${consultationId}`, callback);
+  }
+
+  publish(consultationId: string, message: ConsultationMessage): void {
+    this.publishChannel(`${P}msg:${consultationId}`, message);
+  }
+
+  publishStatus(consultationId: string, messageIds: string[], status: string): void {
+    this.publishChannel(`${P}status:${consultationId}`, { messageIds, status });
+  }
+
+  publishConsultationStatus(consultation: any): void {
+    // Emit on per-consultation channel
+    this.publishChannel(`${P}cstatus:${consultation.id}`, consultation);
+    // Emit on user channels (for global user SSE)
+    if (consultation.client_user_id) {
+      this.publishUserEvent(consultation.client_user_id, {
+        type: 'consultation_status',
+        consultation,
+      });
+    }
+    if (consultation.attorney_user_id) {
+      this.publishUserEvent(consultation.attorney_user_id, {
+        type: 'consultation_status',
+        consultation,
+      });
+    }
+  }
+
+  publishUserEvent(userId: string, event: UserEvent): void {
+    this.publishChannel(`${P}user:${userId}`, event);
+  }
+
+  publishTyping(consultationId: string, userId: string, userName?: string): void {
+    this.publishChannel(`${P}typing:${consultationId}`, { consultationId, userId, userName });
+  }
+}

--- a/mcp_backend/src/workers/edrsr-pre-vectorizer.ts
+++ b/mcp_backend/src/workers/edrsr-pre-vectorizer.ts
@@ -1,0 +1,249 @@
+/**
+ * EdsrPreVectorizerWorker — Background pre-vectorization of EDRSR court decisions.
+ *
+ * Runs as a setInterval within the existing backend process (no separate worker needed).
+ * Picks up un-vectorized documents in batches, embeds them via VoyageAI, and stores
+ * vectors in Qdrant's `edrsr_decisions` collection.
+ *
+ * On-demand vectorization in EdsrVectorizerService remains as a fallback for
+ * documents not yet processed by the background worker.
+ *
+ * Progress is tracked via Redis keys:
+ *   edrsr:vecprog:last_doc_id   — last processed doc_id (for resumption)
+ *   edrsr:vecprog:total          — total documents vectorized by this worker
+ *   edrsr:vecprog:last_run       — ISO timestamp of last successful batch
+ *
+ * Safety:
+ *   - Uses FOR UPDATE SKIP LOCKED for restart safety
+ *   - Circuit breaker on consecutive API errors (pauses for 30 min)
+ *   - Rate limiting: configurable batch size and interval
+ */
+
+import { logger } from '../utils/logger.js';
+import type { EdsrVectorizerService, EdrsrDocument } from '../services/edrsr-vectorizer-service.js';
+import type { ICachePort } from '../domain/ports/index.js';
+
+// Configuration
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const CIRCUIT_BREAKER_THRESHOLD = 3; // consecutive failures before pause
+const CIRCUIT_BREAKER_PAUSE_MS = 30 * 60 * 1000; // 30 minutes
+const PG_FETCH_BATCH = 500;
+
+// Redis keys for progress tracking
+const KEY_LAST_DOC_ID = 'edrsr:vecprog:last_doc_id';
+const KEY_TOTAL = 'edrsr:vecprog:total';
+const KEY_LAST_RUN = 'edrsr:vecprog:last_run';
+const KEY_STATUS = 'edrsr:vecprog:status';
+
+export interface PreVectorizerStatus {
+  status: 'running' | 'paused' | 'stopped' | 'idle';
+  lastDocId: number;
+  totalVectorized: number;
+  lastRun: string | null;
+  consecutiveErrors: number;
+}
+
+export class EdsrPreVectorizerWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private consecutiveErrors = 0;
+  private circuitBreakerUntil: number = 0;
+  private batchSize: number;
+  private intervalMs: number;
+
+  constructor(
+    private vectorizer: EdsrVectorizerService,
+    private dbPool: any,
+    private cache?: ICachePort | null,
+  ) {
+    this.batchSize = parseInt(process.env.EDRSR_VECTORIZE_BATCH_SIZE || '', 10) || DEFAULT_BATCH_SIZE;
+    this.intervalMs = parseInt(process.env.EDRSR_VECTORIZE_INTERVAL_MS || '', 10) || DEFAULT_INTERVAL_MS;
+  }
+
+  /**
+   * Start the background vectorization worker.
+   */
+  start(): void {
+    if (this.timer) return;
+
+    logger.info('[EdsrPreVectorizer] Starting background worker', {
+      batchSize: this.batchSize,
+      intervalMs: this.intervalMs,
+    });
+
+    // Run first batch after a short delay (let other services initialize)
+    setTimeout(() => this.runBatch(), 10_000);
+
+    this.timer = setInterval(() => this.runBatch(), this.intervalMs);
+    this.updateStatus('running');
+  }
+
+  /**
+   * Stop the background worker.
+   */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    this.updateStatus('stopped');
+    logger.info('[EdsrPreVectorizer] Worker stopped');
+  }
+
+  /**
+   * Get current worker status (for health endpoint).
+   */
+  async getStatus(): Promise<PreVectorizerStatus> {
+    const lastDocId = await this.getRedisInt(KEY_LAST_DOC_ID);
+    const totalVectorized = await this.getRedisInt(KEY_TOTAL);
+    const lastRun = await this.getRedisString(KEY_LAST_RUN);
+
+    let status: PreVectorizerStatus['status'] = 'idle';
+    if (this.running) status = 'running';
+    else if (Date.now() < this.circuitBreakerUntil) status = 'paused';
+    else if (!this.timer) status = 'stopped';
+
+    return {
+      status,
+      lastDocId,
+      totalVectorized,
+      lastRun,
+      consecutiveErrors: this.consecutiveErrors,
+    };
+  }
+
+  // ── Core batch logic ────────────────────────────────────────────────────
+
+  private async runBatch(): Promise<void> {
+    if (this.running) return; // Skip if previous batch is still in progress
+
+    // Circuit breaker check
+    if (Date.now() < this.circuitBreakerUntil) {
+      logger.debug('[EdsrPreVectorizer] Circuit breaker active, skipping batch');
+      return;
+    }
+
+    this.running = true;
+    try {
+      // 1. Find un-vectorized documents using FOR UPDATE SKIP LOCKED
+      const lastDocId = await this.getRedisInt(KEY_LAST_DOC_ID);
+
+      const result = await this.dbPool.query(`
+        SELECT d.doc_id, d.cause_num, d.judge, d.court_code, d.justice_kind,
+               d.judgment_code, d.category_code, d.adjudication_date,
+               f.full_text
+        FROM edrsr_documents d
+        INNER JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+        WHERE d.doc_id > $1
+          AND f.full_text IS NOT NULL
+          AND f.full_text != ''
+        ORDER BY d.doc_id ASC
+        LIMIT $2
+        FOR UPDATE OF d SKIP LOCKED
+      `, [lastDocId, this.batchSize]);
+
+      if (result.rows.length === 0) {
+        logger.debug('[EdsrPreVectorizer] No un-vectorized documents found');
+        this.running = false;
+        return;
+      }
+
+      // 2. Build document objects
+      const docs: EdrsrDocument[] = result.rows.map((row: any) => ({
+        doc_id: row.doc_id,
+        full_text: row.full_text,
+        metadata: {
+          court_code: row.court_code,
+          judge: row.judge,
+          cause_num: row.cause_num,
+          justice_kind: row.justice_kind,
+          adjudication_date: row.adjudication_date
+            ? (typeof row.adjudication_date === 'string'
+              ? row.adjudication_date
+              : row.adjudication_date.toISOString().split('T')[0])
+            : undefined,
+          judgment_code: row.judgment_code,
+          category_code: row.category_code,
+        },
+      }));
+
+      // 3. Check which are already vectorized (Qdrant)
+      const docIds = docs.map(d => d.doc_id);
+      const existingMap = await this.vectorizer.ensureVectorized(docIds, this.dbPool);
+
+      // Count newly vectorized (those not in existingMap before our call)
+      const newlyVectorized = docIds.filter(id => existingMap.has(id)).length;
+
+      // 4. Track progress
+      const maxDocId = Math.max(...docIds);
+      const totalSoFar = await this.getRedisInt(KEY_TOTAL);
+
+      await this.setRedis(KEY_LAST_DOC_ID, String(maxDocId));
+      await this.setRedis(KEY_TOTAL, String(totalSoFar + newlyVectorized));
+      await this.setRedis(KEY_LAST_RUN, new Date().toISOString());
+
+      this.consecutiveErrors = 0;
+
+      logger.info('[EdsrPreVectorizer] Batch complete', {
+        batchSize: docs.length,
+        newlyVectorized,
+        maxDocId,
+        totalVectorized: totalSoFar + newlyVectorized,
+      });
+    } catch (err: any) {
+      this.consecutiveErrors++;
+      logger.error('[EdsrPreVectorizer] Batch failed', {
+        error: err.message,
+        consecutiveErrors: this.consecutiveErrors,
+      });
+
+      // Trip circuit breaker on consecutive failures
+      if (this.consecutiveErrors >= CIRCUIT_BREAKER_THRESHOLD) {
+        this.circuitBreakerUntil = Date.now() + CIRCUIT_BREAKER_PAUSE_MS;
+        this.updateStatus('paused');
+        logger.warn('[EdsrPreVectorizer] Circuit breaker tripped — pausing for 30 minutes', {
+          consecutiveErrors: this.consecutiveErrors,
+        });
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  // ── Redis helpers ────────────────────────────────────────────────────────
+
+  private async getRedisInt(key: string): Promise<number> {
+    if (!this.cache) return 0;
+    try {
+      const val = await this.cache.get(key);
+      return val ? parseInt(val, 10) || 0 : 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  private async getRedisString(key: string): Promise<string | null> {
+    if (!this.cache) return null;
+    try {
+      return await this.cache.get(key);
+    } catch {
+      return null;
+    }
+  }
+
+  private async setRedis(key: string, value: string): Promise<void> {
+    if (!this.cache) return;
+    try {
+      // No TTL — progress keys persist until explicitly reset
+      await this.cache.set(key, value);
+    } catch {
+      // Non-critical
+    }
+  }
+
+  private updateStatus(status: string): void {
+    if (!this.cache) return;
+    this.cache.set(KEY_STATUS, status).catch(() => {});
+  }
+}


### PR DESCRIPTION
## Summary

Five architectural improvements based on full system review:

- **Phase 1: Redis Pub/Sub Message Bus** — Drop-in replacement for EventEmitter-based `ConsultationMessageBus` with Redis Pub/Sub (`sl:msg:`, `sl:status:`, `sl:user:`, `sl:typing:` channels). Factory pattern with automatic fallback to in-memory when Redis unavailable. Enables horizontal scaling.
- **Phase 2: EDRSR Redis Cache** — Read-through cache for fulltext (24h TTL), metadata (24h), and FTS results (1h) via `EdsrCacheService`. Integrated into `EdsrFtsService` with transparent fallback to PostgreSQL on miss.
- **Phase 3: Background Pre-Vectorization** — `EdsrPreVectorizerWorker` runs every 5min, vectorizes documents in batches of 50 with VoyageAI. Circuit breaker (3 failures → 30min pause), Redis progress tracking, `GET /api/admin/edrsr-vectorization-status` health endpoint.
- **Phase 4: Tool Grouping** — 9 semantic tool groups (edrsr_search, court_practice, legislation, registry, parliament, vault, procedural, due_diligence, echr) with two-tier selection. `request_additional_tools` meta-tool as safety valve. Target: 8-15 tools per LLM request instead of 30+.
- **Phase 5: SSE Connection Recovery** — `Last-Event-ID` replay from PostgreSQL on reconnect, `id:` field in SSE events, frontend dedup via Set-based LRU tracker.

## Test plan

- [x] TypeScript compiles cleanly (backend + frontend)
- [x] 131 backend tests pass (message bus, routes, intent classifier, payment, escrow)
- [x] 282 frontend tests pass
- [ ] Deploy locally and verify Redis Pub/Sub message delivery between SSE clients
- [ ] Verify EDRSR cache hit via `redis-cli KEYS edrsr:*` after second query
- [ ] Verify pre-vectorizer status at `GET /api/admin/edrsr-vectorization-status`
- [ ] Verify tool count per chat request is 8-15 (check logs)
- [ ] Verify SSE reconnection replays missed messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)