### PR TITLE
fix(billing): fix +-sign bug in tariffs + 13 Playwright tests

### DIFF
--- a/lexwebapp/src/components/billing/TariffsTab.tsx
+++ b/lexwebapp/src/components/billing/TariffsTab.tsx
@@ -219,13 +219,8 @@ export function TariffsTab({ onUpgradeTopUp: onUpgradeTopUpProp }: TariffsTabPro
       return;
     }
 
-    const tierOrder = ['free', 'startup', 'business', 'enterprise'];
-    const currentIdx = tierOrder.indexOf(currentTier);
-    const targetIdx = tierOrder.indexOf(tierId);
-    const isUpgrade = targetIdx > currentIdx;
-
-    if (isUpgrade) {
-      // Calculate cost difference
+    if (isUpgradeTo(tierId)) {
+      // Upgrade — calculate cost difference and redirect to top-up
       const currentTierData = tiers.find((t) => t.tier === currentTier);
       const targetTierData = tiers.find((t) => t.tier === tierId);
 
@@ -238,12 +233,10 @@ export function TariffsTab({ onUpgradeTopUp: onUpgradeTopUpProp }: TariffsTabPro
 
       const priceDifference = targetPrice - currentPrice;
 
-      if (priceDifference > 0) {
-        if (onUpgradeTopUp) {
-          onUpgradeTopUp(priceDifference, tierId);
-        }
-        return;
+      if (priceDifference > 0 && onUpgradeTopUp) {
+        onUpgradeTopUp(priceDifference, tierId);
       }
+      return;
     }
 
     // Downgrade — confirm with refund info before applying
@@ -274,37 +267,27 @@ export function TariffsTab({ onUpgradeTopUp: onUpgradeTopUpProp }: TariffsTabPro
     }
   };
 
-  const getUpgradeCost = (tierId: string): number => {
+
+  /** Determine if switching to tierId is an upgrade (costs more) based on price, not tier order */
+  const isUpgradeTo = (tierId: string): boolean => {
     const currentTierData = tiers.find((t) => t.tier === currentTier);
     const targetTierData = tiers.find((t) => t.tier === tierId);
-    const currentPrice = billingCycle === 'monthly'
-      ? (currentTierData?.monthly_price_usd || 0)
-      : (currentTierData?.annual_price_usd || 0);
-    const targetPrice = billingCycle === 'monthly'
-      ? (targetTierData?.monthly_price_usd || 0)
-      : (targetTierData?.annual_price_usd || 0);
-    return targetPrice - currentPrice;
+    const currentPrice = currentTierData?.monthly_price_usd || 0;
+    const targetPrice = targetTierData?.monthly_price_usd || 0;
+    return targetPrice > currentPrice;
   };
 
   const getCtaText = (tierId: string): string => {
     if (tierId === currentTier) return 'Поточний план';
     if (tierId === 'enterprise') return "Зв'язатися з нами";
-    const tierOrder = ['free', 'startup', 'business', 'enterprise'];
-    const currentIdx = tierOrder.indexOf(currentTier);
-    const targetIdx = tierOrder.indexOf(tierId);
-    if (targetIdx > currentIdx) {
-      return `Перейти на ${TIER_LABELS[tierId] || tierId}`;
-    }
-    return `Знизити до ${TIER_LABELS[tierId] || tierId}`;
+    return isUpgradeTo(tierId)
+      ? `Перейти на ${TIER_LABELS[tierId] || tierId}`
+      : `Знизити до ${TIER_LABELS[tierId] || tierId}`;
   };
 
   /** Returns a description of what happens financially when switching plans */
   const getPlanSwitchInfo = (tierId: string): string | null => {
     if (tierId === currentTier || tierId === 'enterprise') return null;
-    const tierOrder = ['free', 'startup', 'business', 'enterprise'];
-    const currentIdx = tierOrder.indexOf(currentTier);
-    const targetIdx = tierOrder.indexOf(tierId);
-    const isUpgrade = targetIdx > currentIdx;
 
     const currentTierData = tiers.find((t) => t.tier === currentTier);
     const targetTierData = tiers.find((t) => t.tier === tierId);
@@ -314,19 +297,22 @@ export function TariffsTab({ onUpgradeTopUp: onUpgradeTopUpProp }: TariffsTabPro
     const targetPrice = billingCycle === 'monthly'
       ? (targetTierData?.monthly_price_usd || 0)
       : (targetTierData?.annual_price_usd || 0);
-    const diff = targetPrice - currentPrice;
     const period = billingCycle === 'monthly' ? 'міс' : 'рік';
 
-    if (isUpgrade) {
+    if (targetPrice > currentPrice) {
+      // Upgrade — user pays more
+      const surcharge = targetPrice - currentPrice;
       if (currentPrice === 0) {
         return `Оплата: ${toUah(targetPrice).toFixed(0)} \u20B4/${period}`;
       }
-      return `Доплата: +${toUah(diff).toFixed(0)} \u20B4/${period} (різниця тарифів)`;
+      return `Доплата: ${toUah(surcharge).toFixed(0)} \u20B4/${period} (різниця тарифів)`;
     } else {
+      // Downgrade — user gets refund
+      const refund = currentPrice - targetPrice;
       if (targetPrice === 0) {
-        return `Повернення: ${toUah(Math.abs(diff)).toFixed(0)} \u20B4 на баланс`;
+        return `Повернення: ${toUah(refund).toFixed(0)} \u20B4 на баланс`;
       }
-      return `Повернення різниці: ${toUah(Math.abs(diff)).toFixed(0)} \u20B4/${period} на баланс`;
+      return `Повернення різниці: ${toUah(refund).toFixed(0)} \u20B4/${period} на баланс`;
     }
   };
 
@@ -492,7 +478,7 @@ export function TariffsTab({ onUpgradeTopUp: onUpgradeTopUpProp }: TariffsTabPro
                 <div className="h-10 flex items-center justify-center">
                   {switchInfo && (
                     <p className={`text-xs text-center ${
-                      getUpgradeCost(tier.tier) > 0 ? 'text-claude-subtext' : 'text-green-600'
+                      isUpgradeTo(tier.tier) ? 'text-claude-subtext' : 'text-green-600'
                     }`}>
                       {switchInfo}
                     </p>

--- a/tests/e2e/test-billing-tariffs.spec.ts
+++ b/tests/e2e/test-billing-tariffs.spec.ts
@@ -1,0 +1,346 @@
+/**
+ * E2E Tests: Billing Tariffs Page
+ *
+ * API-level tests:
+ *  1. GET /api/billing/pricing-info — returns tiers with valid prices
+ *  2. PUT /api/billing/settings — downgrade issues refund
+ *  3. PUT /api/billing/settings — upgrade does not issue refund
+ *  4. PUT /api/billing/settings — same tier no refund
+ *
+ * UI-level tests:
+ *  5. Tariffs page renders all plan cards
+ *  6. Monthly/yearly toggle does not cause layout shift
+ *  7. Plan switch info never shows "+-" (sign formatting bug)
+ *  8. Plan switch info shows correct surcharge/refund text
+ *  9. Current plan button is disabled
+ * 10. Enterprise card shows contact CTA
+ *
+ * Usage:
+ *   cd tests && npx playwright test e2e/test-billing-tariffs.spec.ts
+ *   TEST_API_URL=https://legal.org.ua npx playwright test e2e/test-billing-tariffs.spec.ts
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE_URL = process.env.TEST_BASE_URL || 'http://localhost:5173';
+const API_BASE = process.env.TEST_API_URL || 'http://localhost:3000';
+
+const TEST_EMAIL = process.env.TEST_EMAIL || 'testuser@secondlayer.com';
+const TEST_PASSWORD = process.env.TEST_PASSWORD || 'testuser123';
+
+// ============================================================================
+// Auth
+// ============================================================================
+
+let authToken: string;
+
+test.beforeAll(async ({ request }) => {
+  const envToken = process.env.TEST_JWT_TOKEN;
+  if (envToken) {
+    authToken = envToken;
+    console.log('  Auth: using TEST_JWT_TOKEN from env');
+    return;
+  }
+
+  const loginResponse = await request.post(`${API_BASE}/auth/login`, {
+    data: { email: TEST_EMAIL, password: TEST_PASSWORD },
+    headers: { 'Content-Type': 'application/json' },
+    timeout: 10000,
+  });
+
+  if (loginResponse.status() === 429) {
+    throw new Error(
+      'Rate limited (429). Set TEST_JWT_TOKEN env var.\n' +
+      `  Generate: curl -s -X POST ${API_BASE}/auth/login -H 'Content-Type: application/json' ` +
+      `-d '{"email":"${TEST_EMAIL}","password":"${TEST_PASSWORD}"}' | jq -r .token`
+    );
+  }
+
+  expect(loginResponse.status(), `Login failed (${loginResponse.status()})`).toBe(200);
+  const loginData = await loginResponse.json();
+  authToken = loginData.token;
+  expect(authToken).toBeTruthy();
+  console.log(`  Auth OK: ${loginData.user?.email}`);
+});
+
+function authHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${authToken}`,
+  };
+}
+
+// ============================================================================
+// API Tests
+// ============================================================================
+
+test.describe('API: Pricing Info', () => {
+  test('GET /api/billing/pricing-info returns valid tiers', async ({ request }) => {
+    const res = await request.get(`${API_BASE}/api/billing/pricing-info`, {
+      headers: authHeaders(),
+    });
+    expect(res.status()).toBe(200);
+
+    const data = await res.json();
+    expect(data.current_tier).toBeTruthy();
+    expect(Array.isArray(data.available_tiers)).toBe(true);
+    expect(data.available_tiers.length).toBeGreaterThanOrEqual(3);
+
+    // Every tier must have non-negative prices
+    for (const tier of data.available_tiers) {
+      expect(tier.tier).toBeTruthy();
+      expect(tier.monthly_price_usd).toBeGreaterThanOrEqual(0);
+      if (tier.annual_price_usd !== undefined) {
+        expect(tier.annual_price_usd).toBeGreaterThanOrEqual(0);
+      }
+      // Annual should be cheaper per-month than monthly (if both > 0)
+      if (tier.monthly_price_usd > 0 && tier.annual_price_usd > 0) {
+        const annualPerMonth = tier.annual_price_usd / 12;
+        expect(annualPerMonth).toBeLessThan(tier.monthly_price_usd);
+      }
+    }
+  });
+
+  test('pricing tiers have required fields', async ({ request }) => {
+    const res = await request.get(`${API_BASE}/api/billing/pricing-info`, {
+      headers: authHeaders(),
+    });
+    const data = await res.json();
+
+    for (const tier of data.available_tiers) {
+      expect(tier).toHaveProperty('tier');
+      expect(tier).toHaveProperty('markup_percentage');
+      expect(tier).toHaveProperty('features');
+      expect(Array.isArray(tier.features)).toBe(true);
+      expect(tier.markup_percentage).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+test.describe('API: Plan Switch Refund', () => {
+  let originalTier: string;
+
+  test.beforeAll(async ({ request }) => {
+    // Save current tier to restore later
+    const res = await request.get(`${API_BASE}/api/billing/pricing-info`, {
+      headers: authHeaders(),
+    });
+    const data = await res.json();
+    originalTier = data.current_tier;
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Restore original tier
+    if (originalTier) {
+      await request.put(`${API_BASE}/api/billing/settings`, {
+        headers: authHeaders(),
+        data: { pricingTier: originalTier },
+      });
+    }
+  });
+
+  test('downgrade from paid tier to free returns refund', async ({ request }) => {
+    // First ensure we're on a paid tier
+    const setupRes = await request.put(`${API_BASE}/api/billing/settings`, {
+      headers: authHeaders(),
+      data: { pricingTier: 'startup' },
+    });
+    expect(setupRes.status()).toBe(200);
+
+    // Now downgrade to free
+    const res = await request.put(`${API_BASE}/api/billing/settings`, {
+      headers: authHeaders(),
+      data: { pricingTier: 'free' },
+    });
+    expect(res.status()).toBe(200);
+
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.refund_usd).toBeGreaterThan(0);
+    expect(data.refund_uah).toBeGreaterThan(0);
+  });
+
+  test('upgrade from free to startup does NOT return refund', async ({ request }) => {
+    // Ensure we're on free
+    await request.put(`${API_BASE}/api/billing/settings`, {
+      headers: authHeaders(),
+      data: { pricingTier: 'free' },
+    });
+
+    // Upgrade to startup
+    const res = await request.put(`${API_BASE}/api/billing/settings`, {
+      headers: authHeaders(),
+      data: { pricingTier: 'startup' },
+    });
+    expect(res.status()).toBe(200);
+
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.refund_usd).toBeUndefined();
+  });
+
+  test('switching to same tier does NOT return refund', async ({ request }) => {
+    const infoRes = await request.get(`${API_BASE}/api/billing/pricing-info`, {
+      headers: authHeaders(),
+    });
+    const currentTier = (await infoRes.json()).current_tier;
+
+    const res = await request.put(`${API_BASE}/api/billing/settings`, {
+      headers: authHeaders(),
+      data: { pricingTier: currentTier },
+    });
+    expect(res.status()).toBe(200);
+
+    const data = await res.json();
+    expect(data.refund_usd).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// UI Tests
+// ============================================================================
+
+test.describe('UI: Tariffs Page', () => {
+  let page: Page;
+
+  /** Navigate to tariffs page with auth token injected */
+  async function goToTariffs(p: Page) {
+    // Set auth token in localStorage before navigating
+    await p.goto(BASE_URL, { waitUntil: 'domcontentloaded' });
+    await p.evaluate((token) => {
+      localStorage.setItem('auth_token', token);
+      localStorage.setItem('token', token);
+    }, authToken);
+    await p.goto(`${BASE_URL}/billing/tariffs`, { waitUntil: 'networkidle' });
+    // Wait for plan cards to render (at least 3 visible)
+    await p.waitForSelector('[data-testid="plan-card"], .rounded-xl', { timeout: 10000 });
+  }
+
+  test('renders plan cards with prices', async ({ page }) => {
+    await goToTariffs(page);
+
+    // Should have at least 3 plan cards (Free, Startup, Business)
+    const cards = page.locator('text=/\\d+ ₴/');
+    await expect(cards.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('monthly/yearly toggle does not cause layout jump', async ({ page }) => {
+    await goToTariffs(page);
+
+    // Find the toggle button
+    const toggle = page.locator('button:has(div.rounded-full)').first();
+    if (!(await toggle.isVisible())) {
+      test.skip();
+      return;
+    }
+
+    // Measure grid height in monthly mode
+    const grid = page.locator('.grid').first();
+    const heightBefore = await grid.boundingBox();
+
+    // Click toggle to yearly
+    await toggle.click();
+    await page.waitForTimeout(500); // wait for animation
+
+    // Measure grid height in yearly mode
+    const heightAfter = await grid.boundingBox();
+
+    if (heightBefore && heightAfter) {
+      // Height should not jump by more than 30px (minor text changes OK)
+      const heightDiff = Math.abs(heightAfter.height - heightBefore.height);
+      expect(heightDiff).toBeLessThan(30);
+    }
+  });
+
+  test('plan switch info never shows "+−" or "+-" sign formatting', async ({ page }) => {
+    await goToTariffs(page);
+
+    // Get all text content from the page
+    const content = await page.textContent('body');
+
+    // Should never have "+-" or "+−" (plus followed by minus) in prices
+    expect(content).not.toMatch(/\+\s*[-−]\s*\d/);
+    // Should never have "−+" either
+    expect(content).not.toMatch(/[-−]\s*\+\s*\d/);
+  });
+
+  test('plan switch info shows valid amounts (no negative in surcharge)', async ({ page }) => {
+    await goToTariffs(page);
+
+    // All "Доплата" lines should have positive amounts
+    const surchargeTexts = page.locator('text=/Доплата/');
+    const surchargeCount = await surchargeTexts.count();
+    for (let i = 0; i < surchargeCount; i++) {
+      const text = await surchargeTexts.nth(i).textContent();
+      if (text) {
+        // Extract number after "Доплата:"
+        const match = text.match(/Доплата:\s*([-\d\s]+)\s*₴/);
+        if (match) {
+          const amount = parseInt(match[1].replace(/\s/g, ''), 10);
+          expect(amount, `Surcharge should be positive: "${text}"`).toBeGreaterThan(0);
+        }
+      }
+    }
+
+    // All "Повернення" lines should have positive amounts
+    const refundTexts = page.locator('text=/Повернення/');
+    const refundCount = await refundTexts.count();
+    for (let i = 0; i < refundCount; i++) {
+      const text = await refundTexts.nth(i).textContent();
+      if (text) {
+        const match = text.match(/Повернення[^:]*:\s*([-\d\s]+)\s*₴/);
+        if (match) {
+          const amount = parseInt(match[1].replace(/\s/g, ''), 10);
+          expect(amount, `Refund should be positive: "${text}"`).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  test('current plan button shows "Поточний план" and is disabled', async ({ page }) => {
+    await goToTariffs(page);
+
+    const currentPlanBtn = page.locator('button:has-text("Поточний план")');
+    await expect(currentPlanBtn.first()).toBeVisible({ timeout: 10000 });
+    await expect(currentPlanBtn.first()).toBeDisabled();
+  });
+
+  test('enterprise card shows contact CTA', async ({ page }) => {
+    await goToTariffs(page);
+
+    const enterpriseBtn = page.locator('button:has-text("Зв\'язатися з нами")');
+    // Enterprise might not always be visible, only check if present
+    if (await enterpriseBtn.count() > 0) {
+      await expect(enterpriseBtn.first()).toBeVisible();
+      await expect(enterpriseBtn.first()).toBeEnabled();
+    }
+  });
+
+  test('FAQ section is present and expandable', async ({ page }) => {
+    await goToTariffs(page);
+
+    // FAQ header
+    const faqHeader = page.locator('text=Часті запитання');
+    await expect(faqHeader).toBeVisible();
+
+    // Click first FAQ item
+    const firstQuestion = page.locator('text=Чи можу я змінити тариф у будь-який час?');
+    if (await firstQuestion.isVisible()) {
+      await firstQuestion.click();
+      // Answer should become visible
+      const answer = page.locator('text=Підвищення набирає чинності одразу');
+      await expect(answer).toBeVisible({ timeout: 3000 });
+    }
+  });
+
+  test('feature comparison table is visible', async ({ page }) => {
+    await goToTariffs(page);
+
+    const comparisonHeader = page.locator('text=Порівняння тарифів');
+    await expect(comparisonHeader).toBeVisible();
+
+    // Table should have feature rows
+    const table = page.locator('table');
+    await expect(table.first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `tierOrder` array in TariffsTab was hardcoded as `['free', 'startup', 'business', 'enterprise']` — missing the `attorney` tier ($49/mo). Users on `attorney` tier got `indexOf()` = -1, causing ALL other tiers to be classified as "upgrade", even cheaper ones. This produced `+-876 ₴/міс` (negative diff with `+` prefix).
- **Fix**: replaced `tierOrder`-based upgrade detection with **price-based comparison** (`isUpgradeTo()`): if target `monthly_price_usd` > current, it's an upgrade. Works for any tier including future ones.
- **Cleanup**: removed dead `getUpgradeCost()`, unused `Crown`/`Sparkles` imports

### Playwright tests (13 total)

| # | Test | Type |
|---|------|------|
| 1 | pricing-info returns valid tiers with non-negative prices | API |
| 2 | pricing tiers have required fields | API |
| 3 | downgrade from paid tier returns refund | API |
| 4 | upgrade does NOT return refund | API |
| 5 | same tier switch no refund | API |
| 6 | plan cards render with prices | UI |
| 7 | monthly/yearly toggle no layout jump (height diff < 30px) | UI |
| 8 | no "+−" or "+-" sign formatting anywhere on page | UI |
| 9 | surcharge/refund amounts always positive | UI |
| 10 | current plan button disabled | UI |
| 11 | enterprise contact CTA | UI |
| 12 | FAQ expandable | UI |
| 13 | feature comparison table visible | UI |

## Test plan
- [x] Frontend TypeScript compiles
- [x] Playwright lists 13 tests without errors
- [ ] Run: `cd tests && npx playwright test e2e/test-billing-tariffs.spec.ts`
- [ ] Verify attorney user no longer sees "+-" amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)