### PR TITLE
feat: observability and telemetry for architectural components

### DIFF
--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -178,6 +178,11 @@ export function createAppServices(
   tools.serviceProxy.setExternalApiMetrics(externalApiMetricsCallback);
   getLLMManager().setExternalApiMetrics(externalApiMetricsCallback);
   coreServices.legislationTools.getLegislationService().getAdapter().setExternalApiMetrics(externalApiMetricsCallback);
+  // Wire ChatService tool group metrics
+  chatService.setToolGroupMetricsCallback((groups) => {
+    metricsService.chatToolGroupRequests.inc({ groups });
+  });
+
   logger.info('Prometheus metrics service initialized');
 
   // Upload recovery service (uses BullMQ for re-enqueuing)

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -528,7 +528,10 @@ class HTTPMCPServer {
       this.app_.consultationService,
       this.app_.consultationPaymentService,
       this.app_.attorneyPayoutService,
-      this.services.db
+      this.services.db,
+      (type, delta) => {
+        this.app_.metricsService.sseActiveConnections.inc({ type }, delta);
+      }
     ));
     logger.info('Consultation routes registered at /api/consultations');
 
@@ -734,8 +737,16 @@ class HTTPMCPServer {
       await this.tools.documentParser.initialize();
 
       // Initialize Redis-backed consultation message bus (falls back to in-memory)
-      const { createConsultationMessageBus } = await import('./services/consultation-message-bus.js');
+      const { createConsultationMessageBus, getConsultationMessageBus } = await import('./services/consultation-message-bus.js');
       await createConsultationMessageBus();
+
+      // Wire message bus metrics
+      const bus = getConsultationMessageBus();
+      if (bus.setMetricsCallback) {
+        bus.setMetricsCallback((channel) => {
+          this.app_.metricsService.consultationBusMessages.inc({ channel });
+        });
+      }
 
       // Initialize Redis cache for services (optional)
       const redis = await getRedisClient();
@@ -756,6 +767,9 @@ class HTTPMCPServer {
         // EDRSR cache service (fulltext, metadata, FTS results)
         const { EdsrCacheService } = await import('./services/edrsr-cache-service.js');
         const edsrCache = new EdsrCacheService(cache);
+        edsrCache.setMetricsCallback((operation, result) => {
+          this.app_.metricsService.edsrCacheOps.inc({ operation, result });
+        });
         if (this.tools.edsrFtsService) {
           this.tools.edsrFtsService.setEdsrCache(edsrCache);
         }
@@ -768,7 +782,17 @@ class HTTPMCPServer {
             this.services.db,
             cache,
           );
+          preVectorizer.setMetricsCallback((event, value) => {
+            if (event === 'docs_processed') {
+              this.app_.metricsService.edsrVectorizerDocsProcessed.inc(value);
+            } else if (event === 'batch_error') {
+              this.app_.metricsService.edsrVectorizerErrors.inc(value);
+            } else if (event === 'status_change') {
+              this.app_.metricsService.edsrVectorizerStatus.set(value);
+            }
+          });
           preVectorizer.start();
+          this.app_.metricsService.edsrVectorizerStatus.set(1); // running
           // Expose status endpoint
           (this as any)._preVectorizer = preVectorizer;
           logger.info('EDRSR pre-vectorization background worker started');

--- a/mcp_backend/src/routes/consultation-routes.ts
+++ b/mcp_backend/src/routes/consultation-routes.ts
@@ -6,11 +6,15 @@ import { AttorneyPayoutService } from '../services/attorney-payout-service.js';
 import type { IDatabase } from '../domain/ports/index.js';
 import { logger } from '../utils/logger.js';
 
+/** Optional callback for SSE connection metrics */
+export type SseMetricsCallback = (type: 'user_stream' | 'message_stream', delta: 1 | -1) => void;
+
 export function createConsultationRoutes(
   consultationService: ConsultationService,
   consultationPaymentService: ConsultationPaymentService,
   payoutService?: AttorneyPayoutService,
-  db?: IDatabase
+  db?: IDatabase,
+  sseMetrics?: SseMetricsCallback
 ): Router {
   const router = Router();
 
@@ -65,6 +69,7 @@ export function createConsultationRoutes(
       res.flushHeaders();
 
       res.write('event: connected\ndata: {}\n\n');
+      sseMetrics?.('user_stream', 1);
 
       const { getConsultationMessageBus } = await import('../services/consultation-message-bus.js');
       const bus = getConsultationMessageBus();
@@ -79,6 +84,7 @@ export function createConsultationRoutes(
       req.on('close', () => {
         unsubscribe();
         clearInterval(heartbeat);
+        sseMetrics?.('user_stream', -1);
       });
     } catch (error: any) {
       logger.error('Failed to setup user stream', { error: error.message });
@@ -297,6 +303,7 @@ export function createConsultationRoutes(
 
       // Send initial heartbeat
       res.write('event: connected\ndata: {}\n\n');
+      sseMetrics?.('message_stream', 1);
 
       // Replay missed messages if Last-Event-ID is present (SSE reconnection)
       const lastEventId = req.headers['last-event-id'] as string | undefined;
@@ -352,6 +359,7 @@ export function createConsultationRoutes(
         unsubscribeConsultationStatus();
         unsubscribeTyping();
         clearInterval(heartbeat);
+        sseMetrics?.('message_stream', -1);
       });
     } catch (error: any) {
       logger.error('Failed to setup message stream', { error: error.message });

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -208,6 +208,7 @@ export class ChatService {
   private resultCompactor: ResultCompactor;
   private contextBuilder: ChatContextBuilder;
   private nameVariationService: NameVariationService;
+  private toolGroupMetricsCallback?: (groups: string) => void;
 
   constructor(
     private toolRegistry: ToolRegistry,
@@ -242,6 +243,10 @@ export class ChatService {
         }
       }
     }, 2 * 60 * 1000);
+  }
+
+  setToolGroupMetricsCallback(cb: (groups: string) => void): void {
+    this.toolGroupMetricsCallback = cb;
   }
 
   /**
@@ -1573,8 +1578,16 @@ export class ChatService {
           tools: matchedTools,
           hint: 'Тепер ви можете використовувати ці інструменти у наступних кроках.',
         };
+        logger.info('[ChatService] Meta-tool request_additional_tools invoked', {
+          groups: groupIds,
+          toolsReturned: matchedTools.length,
+        });
+        this.toolGroupMetricsCallback?.(groupIds.join(','));
       } else {
         toolResult = { error: 'Параметр groups має бути масивом ідентифікаторів груп (edrsr_search, court_practice, legislation, registry, parliament, vault, procedural, due_diligence, echr)' };
+        logger.warn('[ChatService] Meta-tool request_additional_tools called with invalid args', {
+          args: call.arguments,
+        });
       }
       return { call, result: toolResult, cached: false };
     }

--- a/mcp_backend/src/services/consultation-message-bus.ts
+++ b/mcp_backend/src/services/consultation-message-bus.ts
@@ -44,15 +44,23 @@ export interface IConsultationMessageBus {
   publishTyping(consultationId: string, userId: string, userName?: string): void;
 
   shutdown?(): Promise<void>;
+  setMetricsCallback?(cb: BusMetricsCallback): void;
 }
+
+export type BusMetricsCallback = (channel: string) => void;
 
 // ── EventEmitter Implementation (in-memory fallback) ──────────────────────────
 
 export class LocalConsultationMessageBus implements IConsultationMessageBus {
   private emitter = new EventEmitter();
+  private metricsCallback?: BusMetricsCallback;
 
   constructor() {
     this.emitter.setMaxListeners(1000);
+  }
+
+  setMetricsCallback(cb: BusMetricsCallback): void {
+    this.metricsCallback = cb;
   }
 
   subscribe(consultationId: string, callback: MessageCallback): () => void {
@@ -89,14 +97,17 @@ export class LocalConsultationMessageBus implements IConsultationMessageBus {
 
   publish(consultationId: string, message: ConsultationMessage): void {
     this.emitter.emit(`msg:${consultationId}`, message);
+    this.metricsCallback?.('msg');
   }
 
   publishStatus(consultationId: string, messageIds: string[], status: string): void {
     this.emitter.emit(`status:${consultationId}`, { messageIds, status });
+    this.metricsCallback?.('status');
   }
 
   publishConsultationStatus(consultation: any): void {
     this.emitter.emit(`consultation_status:${consultation.id}`, consultation);
+    this.metricsCallback?.('consultation_status');
     if (consultation.client_user_id) {
       this.publishUserEvent(consultation.client_user_id, {
         type: 'consultation_status',
@@ -113,10 +124,12 @@ export class LocalConsultationMessageBus implements IConsultationMessageBus {
 
   publishUserEvent(userId: string, event: UserEvent): void {
     this.emitter.emit(`user_event:${userId}`, event);
+    this.metricsCallback?.('user_event');
   }
 
   publishTyping(consultationId: string, userId: string, userName?: string): void {
     this.emitter.emit(`typing:${consultationId}`, { consultationId, userId, userName });
+    this.metricsCallback?.('typing');
   }
 
   subscribeTyping(consultationId: string, callback: (data: { consultationId: string; userId: string; userName?: string }) => void): () => void {

--- a/mcp_backend/src/services/edrsr-cache-service.ts
+++ b/mcp_backend/src/services/edrsr-cache-service.ts
@@ -25,16 +25,27 @@ const KEY_FULLTEXT = 'edrsr:ft:';
 const KEY_METADATA = 'edrsr:meta:';
 const KEY_FTS = 'edrsr:fts:';
 
+export type CacheMetricsCallback = (operation: string, result: 'hit' | 'miss') => void;
+
 export class EdsrCacheService {
+  private metricsCallback?: CacheMetricsCallback;
+
   constructor(private cache: ICachePort) {}
+
+  setMetricsCallback(cb: CacheMetricsCallback): void {
+    this.metricsCallback = cb;
+  }
 
   // ── Fulltext ─────────────────────────────────────────────────────────────
 
   async getCachedFulltext(docId: number): Promise<string | null> {
     try {
-      return await this.cache.get(`${KEY_FULLTEXT}${docId}`);
+      const result = await this.cache.get(`${KEY_FULLTEXT}${docId}`);
+      this.metricsCallback?.('fulltext', result ? 'hit' : 'miss');
+      return result;
     } catch (err: any) {
       logger.debug('[EdsrCache] getCachedFulltext error', { docId, error: err.message });
+      this.metricsCallback?.('fulltext', 'miss');
       return null;
     }
   }
@@ -52,9 +63,11 @@ export class EdsrCacheService {
   async getCachedMetadata(docId: number): Promise<any | null> {
     try {
       const raw = await this.cache.get(`${KEY_METADATA}${docId}`);
+      this.metricsCallback?.('metadata', raw ? 'hit' : 'miss');
       return raw ? JSON.parse(raw) : null;
     } catch (err: any) {
       logger.debug('[EdsrCache] getCachedMetadata error', { docId, error: err.message });
+      this.metricsCallback?.('metadata', 'miss');
       return null;
     }
   }
@@ -73,9 +86,11 @@ export class EdsrCacheService {
     try {
       const hash = this.hashFtsQuery(query, filters, limit, offset);
       const raw = await this.cache.get(`${KEY_FTS}${hash}`);
+      this.metricsCallback?.('fts', raw ? 'hit' : 'miss');
       return raw ? JSON.parse(raw) : null;
     } catch (err: any) {
       logger.debug('[EdsrCache] getCachedFtsResults error', { error: err.message });
+      this.metricsCallback?.('fts', 'miss');
       return null;
     }
   }

--- a/mcp_backend/src/services/metrics-service.ts
+++ b/mcp_backend/src/services/metrics-service.ts
@@ -34,6 +34,23 @@ export class MetricsService {
   // Cost metrics
   readonly costTrackingTotalUsd: Counter;
 
+  // SSE connection metrics
+  readonly sseActiveConnections: Gauge;
+
+  // EDRSR cache metrics
+  readonly edsrCacheOps: Counter;
+
+  // Vectorizer worker metrics
+  readonly edsrVectorizerDocsProcessed: Counter;
+  readonly edsrVectorizerErrors: Counter;
+  readonly edsrVectorizerStatus: Gauge;
+
+  // Consultation message bus metrics
+  readonly consultationBusMessages: Counter;
+
+  // Chat tool grouping metrics
+  readonly chatToolGroupRequests: Counter;
+
   constructor() {
     this.registry = new Registry();
 
@@ -134,6 +151,57 @@ export class MetricsService {
       name: 'cost_tracking_total_usd',
       help: 'Total cost tracked in USD',
       labelNames: ['tool_name'] as const,
+      registers: [this.registry],
+    });
+
+    // --- SSE Connections ---
+    this.sseActiveConnections = new Gauge({
+      name: 'sse_active_connections',
+      help: 'Active SSE connections by type',
+      labelNames: ['type'] as const, // 'user_stream' | 'message_stream'
+      registers: [this.registry],
+    });
+
+    // --- EDRSR Cache ---
+    this.edsrCacheOps = new Counter({
+      name: 'edrsr_cache_operations_total',
+      help: 'EDRSR cache operations',
+      labelNames: ['operation', 'result'] as const, // operation: fulltext|metadata|fts, result: hit|miss
+      registers: [this.registry],
+    });
+
+    // --- Vectorizer Worker ---
+    this.edsrVectorizerDocsProcessed = new Counter({
+      name: 'edrsr_vectorizer_docs_processed_total',
+      help: 'Documents processed by EDRSR pre-vectorizer',
+      registers: [this.registry],
+    });
+
+    this.edsrVectorizerErrors = new Counter({
+      name: 'edrsr_vectorizer_errors_total',
+      help: 'EDRSR pre-vectorizer batch errors',
+      registers: [this.registry],
+    });
+
+    this.edsrVectorizerStatus = new Gauge({
+      name: 'edrsr_vectorizer_status',
+      help: 'EDRSR pre-vectorizer status (1=running, 0=stopped, -1=paused)',
+      registers: [this.registry],
+    });
+
+    // --- Consultation Message Bus ---
+    this.consultationBusMessages = new Counter({
+      name: 'consultation_bus_messages_total',
+      help: 'Messages published via consultation message bus',
+      labelNames: ['channel'] as const, // msg|status|consultation_status|typing|user_event
+      registers: [this.registry],
+    });
+
+    // --- Chat Tool Grouping ---
+    this.chatToolGroupRequests = new Counter({
+      name: 'chat_tool_group_requests_total',
+      help: 'LLM requests for additional tool groups via meta-tool',
+      labelNames: ['groups'] as const,
       registers: [this.registry],
     });
 

--- a/mcp_backend/src/workers/edrsr-pre-vectorizer.ts
+++ b/mcp_backend/src/workers/edrsr-pre-vectorizer.ts
@@ -44,6 +44,8 @@ export interface PreVectorizerStatus {
   consecutiveErrors: number;
 }
 
+export type VectorizerMetricsCallback = (event: 'docs_processed' | 'batch_error' | 'status_change', value: number) => void;
+
 export class EdsrPreVectorizerWorker {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
@@ -51,6 +53,7 @@ export class EdsrPreVectorizerWorker {
   private circuitBreakerUntil: number = 0;
   private batchSize: number;
   private intervalMs: number;
+  private metricsCallback?: VectorizerMetricsCallback;
 
   constructor(
     private vectorizer: EdsrVectorizerService,
@@ -59,6 +62,10 @@ export class EdsrPreVectorizerWorker {
   ) {
     this.batchSize = parseInt(process.env.EDRSR_VECTORIZE_BATCH_SIZE || '', 10) || DEFAULT_BATCH_SIZE;
     this.intervalMs = parseInt(process.env.EDRSR_VECTORIZE_INTERVAL_MS || '', 10) || DEFAULT_INTERVAL_MS;
+  }
+
+  setMetricsCallback(cb: VectorizerMetricsCallback): void {
+    this.metricsCallback = cb;
   }
 
   /**
@@ -184,6 +191,8 @@ export class EdsrPreVectorizerWorker {
       await this.setRedis(KEY_LAST_RUN, new Date().toISOString());
 
       this.consecutiveErrors = 0;
+      this.metricsCallback?.('docs_processed', newlyVectorized);
+      this.metricsCallback?.('status_change', 1); // running
 
       logger.info('[EdsrPreVectorizer] Batch complete', {
         batchSize: docs.length,
@@ -193,6 +202,7 @@ export class EdsrPreVectorizerWorker {
       });
     } catch (err: any) {
       this.consecutiveErrors++;
+      this.metricsCallback?.('batch_error', 1);
       logger.error('[EdsrPreVectorizer] Batch failed', {
         error: err.message,
         consecutiveErrors: this.consecutiveErrors,
@@ -202,6 +212,7 @@ export class EdsrPreVectorizerWorker {
       if (this.consecutiveErrors >= CIRCUIT_BREAKER_THRESHOLD) {
         this.circuitBreakerUntil = Date.now() + CIRCUIT_BREAKER_PAUSE_MS;
         this.updateStatus('paused');
+        this.metricsCallback?.('status_change', -1); // paused
         logger.warn('[EdsrPreVectorizer] Circuit breaker tripped — pausing for 30 minutes', {
           consecutiveErrors: this.consecutiveErrors,
         });


### PR DESCRIPTION
## Summary

Adds Prometheus metrics and logging for all new components from #992:

- **SSE connections** — `sse_active_connections` gauge by type (user_stream / message_stream), tracks open/close
- **EDRSR cache** — `edrsr_cache_operations_total` counter by operation (fulltext/metadata/fts) and result (hit/miss)
- **Vectorizer worker** — `edrsr_vectorizer_docs_processed_total`, `edrsr_vectorizer_errors_total` counters + `edrsr_vectorizer_status` gauge (1=running, 0=stopped, -1=paused)
- **Message bus** — `consultation_bus_messages_total` counter by channel (msg/status/consultation_status/typing/user_event)
- **Tool grouping** — `chat_tool_group_requests_total` counter by requested groups + structured logging for meta-tool invocations

All metrics follow existing callback pattern (setMetricsCallback) — zero coupling to prom-client in service layer.

## Test plan

- [x] TypeScript compiles (backend + frontend)
- [x] 131 backend tests pass
- [ ] Verify metrics at `GET /metrics` endpoint after deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)