### PR TITLE
fix(legislation): stop infinite re-fetch loop for 1618-15

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -423,7 +423,7 @@ export class RadaLegislationAdapter {
               article.part_number,
               article.paragraph_number,
               article.notes,
-              article.version_date || new Date(),
+              article.version_date || new Date('2000-01-01T00:00:00Z'),
               true,
               article.byte_size,
               article.metadata || {},
@@ -439,7 +439,7 @@ export class RadaLegislationAdapter {
 
       return result;
     } catch (error: any) {
-      logger.error(`Failed to save legislation to database:`, error.message);
+      logger.error(`Failed to save legislation to database: ${error.message}`);
       throw error;
     }
   }

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -247,19 +247,10 @@ export class LegislationService {
     );
 
     if (result.rows.length > 0) {
-      // Check if section data is missing (legacy data before section extraction)
-      const sectionCheck = await this.db.query(
-        `SELECT COUNT(*) as total, COUNT(section_number) as with_sections
-         FROM legislation_articles la
-         JOIN legislation l ON la.legislation_id = l.id
-         WHERE l.rada_id = $1 AND la.is_current = true`,
-        [radaId]
-      );
-      const { total, with_sections } = sectionCheck.rows[0];
-      if (parseInt(total) > 0 && parseInt(with_sections) === 0) {
-        logger.info(`Legislation ${radaId} has no section data, re-fetching...`);
-        return this.refetchLegislation(radaId);
-      }
+      // Legislation exists — no need to re-fetch.
+      // Previously we re-fetched when section_number was missing, but some laws
+      // (e.g. Кримінальний кодекс 1618-15) don't have section structure in RADA API,
+      // causing an infinite re-fetch loop on every request.
       return true;
     }
 
@@ -276,7 +267,7 @@ export class LegislationService {
 
       return true;
     } catch (error: any) {
-      logger.error(`Failed to fetch and save legislation ${radaId}:`, error.message);
+      logger.error(`Failed to fetch and save legislation ${radaId}: ${error.message}`);
       return false;
     }
   }


### PR DESCRIPTION
## Summary

Fixes recurring errors in prod logs:
```
error: Failed to save legislation to database:
error: Failed to fetch and save legislation 1618-15:
```
(10+ errors/min, triggered on every Кримінальний кодекс query)

**Root cause**: `ensureLegislationExists()` checked if articles had `section_number` populated. For 1618-15, 0/506 articles had sections (RADA API doesn't provide them for this law). This triggered a re-fetch on every request, which failed, causing an infinite error loop.

**Fixes**:
1. Remove section-data re-fetch check — if legislation exists, use it as-is
2. Fix `logger.error()` calls to include error message in the string (was silently dropped)
3. Fix `version_date` fallback from `new Date()` to stable `2000-01-01` so ON CONFLICT dedup works

## Test plan
- [x] TypeScript compiles
- [ ] Deploy and verify no more "Failed to save legislation" errors in logs
- [ ] Query Кримінальний кодекс article — should return without triggering re-fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)