### PR TITLE
fix: listen before initialize to prevent health check timeout

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -825,9 +825,9 @@ class HTTPMCPServer {
     await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));
     logger.info(`HTTP server listening on http://${host}:${port} (initializing services...)`);
 
-    await this.initialize();
-
-    logger.info(`HTTP MCP Server fully initialized on http://${host}:${port}`);
+    this.initialize()
+      .then(() => logger.info(`HTTP MCP Server fully initialized on http://${host}:${port}`))
+      .catch((error) => logger.error('Failed to initialize services:', error));
   }
 }
 


### PR DESCRIPTION
## Summary
- `initialize()` blocks event loop during heavy DB I/O (EDRSR indexing), preventing health checks
- Server now listens immediately, initializes services in background
- Health endpoint responds during startup

## Test plan
- [ ] App starts and /health responds within seconds
- [ ] Services initialize in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)