### PR TITLE
fix: prevent infinite loop in chunkText that blocks event loop

### DIFF
--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -87,10 +87,16 @@ function chunkText(text: string, maxChars = MAX_CHUNK_CHARS, overlapWords = CHUN
 
     chunks.push(text.slice(start, end));
 
+    if (end >= text.length) break;
+
     // Overlap: go back by overlapWords words
     const words = text.slice(start, end).split(/\s+/);
     const overlapText = words.slice(-overlapWords).join(' ');
-    start = end - overlapText.length;
+    const newStart = end - overlapText.length;
+
+    // Safety: always advance by at least half the chunk size to prevent infinite loops
+    // (can happen when text has ≤50 very long words, making overlap ≥ chunk size)
+    start = Math.max(newStart, start + Math.floor(maxChars / 2));
 
     if (start >= text.length - 100) break; // Don't create tiny last chunk
   }


### PR DESCRIPTION
## Summary
- `chunkText()` in the EDRSR vectorizer could enter an infinite loop when processing documents with very long words (≤50 words per 2048-char chunk)
- The overlap calculation (`start = end - overlapText.length`) would not advance `start` when the overlap covered the entire chunk
- This caused `_vectorizeBatch` to consume 100% CPU indefinitely, blocking the Node.js event loop
- **Impact**: server unresponsive to ALL HTTP requests — health checks, login, API calls

## Root cause
When a document chunk has ≤50 words, `words.slice(-50)` returns all words, so `overlapText` equals the full chunk. Then `start = end - chunk.length = start` — no progress.

## Fix
Ensure `start` always advances by at least `maxChars / 2` (1024 chars), preventing the loop from stalling. Also added early `break` when `end >= text.length`.

## Test plan
- [x] Hotfixed on prod — CPU dropped from 101% to 0.12%, container now healthy
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)