### PR TITLE
fix: prod logging - set info level and fix volume mount

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -622,7 +622,7 @@ services:
       NOWPAYMENTS_IPN_SECRET: ${NOWPAYMENTS_IPN_SECRET:-}
       NOWPAYMENTS_PUBLIC_KEY: ${NOWPAYMENTS_PUBLIC_KEY:-}
 
-      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       TZ: Europe/Kiev
     ports:
     - "127.0.0.1:3007:3000"
@@ -637,7 +637,7 @@ services:
         condition: service_completed_successfully
     volumes:
     - app_prod_data:/app/data
-    - app_prod_logs:/app/logs
+    - app_prod_logs:/app/mcp_backend/logs
     - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3000/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
@@ -720,7 +720,7 @@ services:
       SCRAPE_SKIP_EMBEDDINGS: "true"
       SECONDARY_LAYER_KEYS: ${SECONDARY_LAYER_KEYS:-}
       JWT_SECRET: ${JWT_SECRET:-}
-      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://legal.org.ua}
       TZ: Europe/Kiev
     ports:
@@ -934,7 +934,7 @@ services:
       NOWPAYMENTS_API_KEY: ${NOWPAYMENTS_API_KEY:-}
       NOWPAYMENTS_IPN_SECRET: ${NOWPAYMENTS_IPN_SECRET:-}
       NOWPAYMENTS_PUBLIC_KEY: ${NOWPAYMENTS_PUBLIC_KEY:-}
-      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       TZ: Europe/Kiev
     depends_on:
       pgbouncer-prod:
@@ -945,7 +945,7 @@ services:
         condition: service_healthy
     volumes:
     - app_prod_data:/app/data
-    - app_prod_logs:/app/logs
+    - app_prod_logs:/app/mcp_backend/logs
     - ../vision-ocr-credentials.json:/app/credentials/vision-credentials.json:ro
     healthcheck:
       test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3000/health/ready', r => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); });"]
@@ -1129,7 +1129,7 @@ services:
       SCRAPE_SKIP_EMBEDDINGS: "true"
       SECONDARY_LAYER_KEYS: ${SECONDARY_LAYER_KEYS:-}
       JWT_SECRET: ${JWT_SECRET:-}
-      LOG_LEVEL: ${LOG_LEVEL:-warn}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
       ALLOWED_ORIGINS: ${ALLOWED_ORIGINS:-https://legal.org.ua}
       TZ: Europe/Kiev
     volumes:


### PR DESCRIPTION
## Summary
- Changed default `LOG_LEVEL` from `warn` to `info` across all prod services (backend blue/green, document-service, rada, openreyestr)
- Fixed log volume mount path from `/app/logs` to `/app/mcp_backend/logs` (matching actual winston output directory)

**Why:** With `LOG_LEVEL=warn`, request logs (response_id, tool calls, cost tracking) were invisible — making debugging and audit trail impossible for a legaltech platform. Log volume was also mounted at wrong path, so logs were lost on every container restart.

**Already applied on prod** — backend restarted with `info` level and correct mount, verified healthy with 114 lines in `combined.log`.

## Test plan
- [x] Verified backend healthy after restart on prod
- [x] Confirmed `combined.log` is written to volume-mounted path
- [x] Confirmed info-level logs (HTTP requests, tool calls) now visible in `docker logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)