### PR TITLE
fix: workflow routes returning 404 due to doubled path prefixes

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -55,7 +55,7 @@ import { getLLMManager } from './utils/llm-client-manager.js';
 import { setRateLimitCache } from './middleware/rate-limit.js';
 import { setUploadRateLimitCache } from './middleware/upload-rate-limit.js';
 import { createClassificationRoutes } from './routes/classification-routes.js';
-import { createWorkflowRoutes } from './routes/workflow-routes.js';
+import { createWorkflowSetRoutes, createWorkflowRoutes } from './routes/workflow-routes.js';
 import { createAttorneyRoutes } from './routes/attorney-routes.js';
 import { createConsultationRoutes } from './routes/consultation-routes.js';
 import { JudgesService } from './services/judges-service.js';
@@ -483,7 +483,7 @@ class HTTPMCPServer {
     // Workflow routes - workflow sets, workflow execution, cancellation
     // IMPORTANT: Use specific prefixes, NOT '/api' — a catch-all '/api' prefix with requireJWT
     // would block API key auth for all /api/* routes (including /api/tools with dualAuth)
-    this.app.use('/api/workflow-sets', requireJWT as any, createWorkflowRoutes(this.app_.workflowService, this.app_.workflowExecutorService));
+    this.app.use('/api/workflow-sets', requireJWT as any, createWorkflowSetRoutes(this.app_.workflowService));
     this.app.use('/api/workflows', requireJWT as any, createWorkflowRoutes(this.app_.workflowService, this.app_.workflowExecutorService));
     logger.info('Workflow routes registered at /api/workflow-sets, /api/workflows');
 

--- a/mcp_backend/src/routes/workflow-routes.ts
+++ b/mcp_backend/src/routes/workflow-routes.ts
@@ -15,14 +15,16 @@ interface DualAuthRequest {
   query: any;
 }
 
-export function createWorkflowRoutes(
-  workflowService: WorkflowService,
-  workflowExecutor: WorkflowExecutorService
+/**
+ * Workflow-sets routes — mounted at /api/workflow-sets
+ */
+export function createWorkflowSetRoutes(
+  workflowService: WorkflowService
 ): Router {
   const router = Router();
 
   // GET /api/workflow-sets — List user's workflow sets
-  router.get('/workflow-sets', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+  router.get('/', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
@@ -36,7 +38,7 @@ export function createWorkflowRoutes(
   }) as any);
 
   // GET /api/workflow-sets/:id — Get workflow set with all workflows
-  router.get('/workflow-sets/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+  router.get('/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
@@ -50,8 +52,35 @@ export function createWorkflowRoutes(
     }
   }) as any);
 
+  // DELETE /api/workflow-sets/:id — Delete workflow set
+  router.delete('/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    try {
+      const deleted = await workflowService.deleteWorkflowSet(req.params.id, userId);
+      if (!deleted) return res.status(404).json({ error: 'Workflow set not found' });
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('[WorkflowRoutes] Failed to delete workflow set', { error: error.message });
+      res.status(500).json({ error: 'Failed to delete workflow set' });
+    }
+  }) as any);
+
+  return router;
+}
+
+/**
+ * Workflow routes — mounted at /api/workflows
+ */
+export function createWorkflowRoutes(
+  workflowService: WorkflowService,
+  workflowExecutor: WorkflowExecutorService
+): Router {
+  const router = Router();
+
   // GET /api/workflows/:id — Get single workflow detail
-  router.get('/workflows/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+  router.get('/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
@@ -68,7 +97,7 @@ export function createWorkflowRoutes(
   }) as any);
 
   // POST /api/workflows/:id/execute — Execute workflow (SSE stream)
-  router.post('/workflows/:id/execute', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+  router.post('/:id/execute', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
@@ -116,7 +145,7 @@ export function createWorkflowRoutes(
   }) as any);
 
   // POST /api/workflows/:id/cancel — Cancel running workflow
-  router.post('/workflows/:id/cancel', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+  router.post('/:id/cancel', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
@@ -136,21 +165,6 @@ export function createWorkflowRoutes(
     } catch (error: any) {
       logger.error('[WorkflowRoutes] Failed to cancel workflow', { error: error.message });
       res.status(500).json({ error: 'Failed to cancel workflow' });
-    }
-  }) as any);
-
-  // DELETE /api/workflow-sets/:id — Delete workflow set
-  router.delete('/workflow-sets/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
-    const userId = req.user?.id;
-    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
-
-    try {
-      const deleted = await workflowService.deleteWorkflowSet(req.params.id, userId);
-      if (!deleted) return res.status(404).json({ error: 'Workflow set not found' });
-      res.json({ success: true });
-    } catch (error: any) {
-      logger.error('[WorkflowRoutes] Failed to delete workflow set', { error: error.message });
-      res.status(500).json({ error: 'Failed to delete workflow set' });
     }
   }) as any);
 


### PR DESCRIPTION
## Summary
- Workflow routes (`/api/workflow-sets`, `/api/workflows`) were returning 404 because the Express router defined full paths internally (e.g., `/workflow-sets`) while already mounted at `/api/workflow-sets`, causing doubled paths like `/api/workflow-sets/workflow-sets`
- Split single router into `createWorkflowSetRoutes` and `createWorkflowRoutes`, each using root-relative paths (`/`, `/:id`) matching their mount points

## Test plan
- [ ] Verify `GET /api/workflow-sets` returns workflow sets (no longer 404)
- [ ] Verify `GET /api/workflow-sets/:id`, `DELETE /api/workflow-sets/:id` work
- [ ] Verify `GET /api/workflows/:id`, `POST /api/workflows/:id/execute`, `POST /api/workflows/:id/cancel` work
- [ ] Visit https://legal.org.ua/workflows and confirm the page loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)