### PR TITLE
feat(LEG-395): evidence panel API + Redis cache for EDRSR

### DIFF
--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -3,6 +3,7 @@ import { BillingServices } from './billing-services.js';
 import { ToolServices } from './tool-services.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
 import { ConversationService } from '../services/conversation-service.js';
+import { ConversationEvidenceService } from '../services/conversation-evidence-service.js';
 import { GdprService } from '../services/gdpr-service.js';
 import { AuditService } from '../services/audit-service.js';
 import { MatterService } from '../services/matter-service.js';
@@ -40,6 +41,7 @@ import { logger } from '../utils/logger.js';
 
 export interface AppServices {
   conversationService: ConversationService;
+  evidenceService: ConversationEvidenceService;
   gdprService: GdprService;
   auditService: AuditService;
   matterService: MatterService;
@@ -79,6 +81,7 @@ export function createAppServices(
 
   // Conversation & GDPR
   const conversationService = new ConversationService(coreServices.db);
+  const evidenceService = new ConversationEvidenceService(coreServices.db);
   const gdprService = new GdprService(coreServices.db, tools.minioService, coreServices.embeddingService);
 
   // Wire MinIO and Banner to auth controllers
@@ -238,6 +241,7 @@ export function createAppServices(
 
   return {
     conversationService,
+    evidenceService,
     gdprService,
     auditService,
     matterService,

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -44,6 +44,8 @@ import { createOAuthRouter } from './routes/oauth-routes.js';
 import { healthCheckRateLimit, webhookRateLimit, globalApiRateLimit } from './middleware/rate-limit.js';
 import { createUploadRouter } from './routes/upload-routes.js';
 import { createConversationRouter } from './routes/conversation-routes.js';
+import { createEvidenceRoutes } from './routes/evidence-routes.js';
+import { createEdsrRoutes } from './routes/edrsr-routes.js';
 import { createGdprRouter } from './routes/gdpr-routes.js';
 import { createBlogCommentsRouter } from './routes/blog-comments.js';
 import { createMatterRoutes } from './routes/matter-routes.js';
@@ -410,7 +412,12 @@ class HTTPMCPServer {
 
     // Conversation routes - server-side chat persistence
     this.app.use('/api/conversations', requireJWT as any, createConversationRouter(this.app_.conversationService));
-    logger.info('Conversation routes registered at /api/conversations');
+    this.app.use('/api/conversations', requireJWT as any, createEvidenceRoutes(this.app_.evidenceService));
+    logger.info('Conversation and evidence routes registered at /api/conversations');
+
+    // EDRSR direct access routes
+    this.app.use('/api/edrsr', requireJWT as any, createEdsrRoutes(this.services.db));
+    logger.info('EDRSR routes registered at /api/edrsr');
 
     // Blog comments - GET is public, POST/DELETE require JWT (checked inside handler)
     this.app.use('/api/blog', optionalJWT as any, createBlogCommentsRouter(this.services.db.getPool()));
@@ -739,6 +746,7 @@ class HTTPMCPServer {
         this.services.zoECHRAdapter.setCachePort(cache);
         this.services.shepardizationService.setCachePort(cache);
         this.app_.chatSearchCache.setCachePort(cache);
+        this.app_.evidenceService.setCachePort(cache);
         setAuthCache(cache);
         setOidcCache(cache);
         setRateLimitCache(cache);

--- a/mcp_backend/src/routes/edrsr-routes.ts
+++ b/mcp_backend/src/routes/edrsr-routes.ts
@@ -1,0 +1,198 @@
+/**
+ * EDRSR routes — direct access to court decisions registry.
+ *
+ * GET  /api/edrsr/:docId/fulltext  — Full text of a specific decision
+ * POST /api/edrsr/search           — Search EDRSR without chat
+ */
+
+import { Router, type Response } from 'express';
+import type { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+import type { IDatabase } from '../domain/ports/index.js';
+import { logger } from '../utils/logger.js';
+
+export function createEdsrRoutes(db: IDatabase): Router {
+  const router = Router();
+
+  // GET /api/edrsr/:docId/fulltext
+  router.get('/:docId/fulltext', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const docId = req.params.docId;
+      if (!docId || isNaN(Number(docId))) {
+        return res.status(400).json({ error: 'Невірний doc_id' });
+      }
+
+      // Fetch metadata
+      const metaResult = await db.query(
+        `SELECT doc_id, cause_num, judge, court_code, justice_kind,
+                judgment_code, adjudication_date, receipt_date, status
+         FROM edrsr_documents
+         WHERE doc_id = $1
+         LIMIT 1`,
+        [Number(docId)]
+      );
+
+      if (metaResult.rows.length === 0) {
+        return res.status(404).json({ error: 'Документ не знайдено' });
+      }
+
+      // Fetch fulltext
+      const textResult = await db.query(
+        `SELECT full_text FROM edrsr_fulltext WHERE doc_id = $1 LIMIT 1`,
+        [Number(docId)]
+      );
+
+      const meta = metaResult.rows[0];
+
+      // Enrich with court name and judgment form
+      const [courtResult, formResult] = await Promise.all([
+        db.query('SELECT name FROM edrsr_courts WHERE court_code = $1 LIMIT 1', [meta.court_code]),
+        db.query('SELECT name FROM edrsr_judgment_forms WHERE code = $1 LIMIT 1', [meta.judgment_code]),
+      ]);
+
+      res.json({
+        doc_id: meta.doc_id,
+        cause_num: meta.cause_num,
+        judge: meta.judge,
+        court_code: meta.court_code,
+        court_name: courtResult.rows[0]?.name || null,
+        justice_kind: meta.justice_kind,
+        judgment_code: meta.judgment_code,
+        judgment_form: formResult.rows[0]?.name || null,
+        adjudication_date: meta.adjudication_date,
+        receipt_date: meta.receipt_date,
+        full_text: textResult.rows[0]?.full_text || null,
+        external_url: `https://reyestr.court.gov.ua/Review/${docId}`,
+      });
+    } catch (err: any) {
+      logger.error('[EdsrRoutes] getFulltext error', { error: err.message, docId: req.params.docId });
+      res.status(500).json({ error: 'Помилка отримання тексту рішення' });
+    }
+  }) as any);
+
+  // POST /api/edrsr/search
+  router.post('/search', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const {
+        cause_num, judge, court_code, court_name, justice_kind,
+        judgment_code, date_from, date_to, instance_code,
+        limit: rawLimit, offset: rawOffset,
+      } = req.body;
+
+      const limit = Math.min(Math.max(Number(rawLimit) || 20, 1), 100);
+      const offset = Math.max(Number(rawOffset) || 0, 0);
+
+      const conditions: string[] = [];
+      const params: any[] = [];
+      let paramIdx = 1;
+
+      if (cause_num) {
+        conditions.push(`d.cause_num = $${paramIdx++}`);
+        params.push(cause_num);
+      }
+      if (judge) {
+        conditions.push(`LOWER(d.judge) LIKE LOWER($${paramIdx++})`);
+        params.push(`%${judge}%`);
+      }
+      if (court_code) {
+        conditions.push(`d.court_code = $${paramIdx++}`);
+        params.push(Number(court_code));
+      }
+      if (court_name) {
+        const courtLookup = await db.query(
+          'SELECT court_code FROM edrsr_courts WHERE LOWER(name) LIKE LOWER($1) LIMIT 20',
+          [`%${court_name}%`]
+        );
+        if (courtLookup.rows.length > 0) {
+          const codes = courtLookup.rows.map((r: any) => r.court_code);
+          conditions.push(`d.court_code = ANY($${paramIdx++})`);
+          params.push(codes);
+        } else {
+          return res.json({ results: [], total: 0, note: `Суд "${court_name}" не знайдено` });
+        }
+      }
+      if (justice_kind) {
+        conditions.push(`d.justice_kind = $${paramIdx++}`);
+        params.push(Number(justice_kind));
+      }
+      if (judgment_code) {
+        conditions.push(`d.judgment_code = $${paramIdx++}`);
+        params.push(Number(judgment_code));
+      }
+      if (instance_code) {
+        conditions.push(`d.instance_code = $${paramIdx++}`);
+        params.push(Number(instance_code));
+      }
+      if (date_from) {
+        conditions.push(`d.adjudication_date >= $${paramIdx++}`);
+        params.push(date_from);
+      }
+      if (date_to) {
+        conditions.push(`d.adjudication_date <= $${paramIdx++}`);
+        params.push(date_to);
+      }
+
+      if (conditions.length === 0) {
+        return res.status(400).json({ error: 'Потрібен хоча б один параметр пошуку' });
+      }
+
+      const whereClause = conditions.join(' AND ');
+
+      const [dataResult, countResult] = await Promise.all([
+        db.query(
+          `SELECT d.doc_id, d.cause_num, d.judge, d.court_code, d.justice_kind,
+                  d.judgment_code, d.adjudication_date, d.receipt_date, d.status
+           FROM edrsr_documents d
+           WHERE ${whereClause}
+           ORDER BY d.adjudication_date DESC
+           LIMIT $${paramIdx++} OFFSET $${paramIdx++}`,
+          [...params, limit, offset]
+        ),
+        db.query(
+          `SELECT COUNT(*)::int as total FROM edrsr_documents d WHERE ${whereClause}`,
+          params
+        ),
+      ]);
+
+      // Enrich with court names and judgment forms
+      const courtCodes = [...new Set(dataResult.rows.map((r: any) => r.court_code))];
+      const judgmentCodes = [...new Set(dataResult.rows.map((r: any) => r.judgment_code))];
+
+      const [courts, forms] = await Promise.all([
+        courtCodes.length > 0
+          ? db.query('SELECT court_code, name FROM edrsr_courts WHERE court_code = ANY($1)', [courtCodes])
+          : { rows: [] },
+        judgmentCodes.length > 0
+          ? db.query('SELECT code, name FROM edrsr_judgment_forms WHERE code = ANY($1)', [judgmentCodes])
+          : { rows: [] },
+      ]);
+
+      const courtMap = new Map((courts as any).rows.map((r: any) => [r.court_code, r.name]));
+      const formMap = new Map((forms as any).rows.map((r: any) => [r.code, r.name]));
+
+      const results = dataResult.rows.map((r: any) => ({
+        ...r,
+        court_name: courtMap.get(r.court_code) || null,
+        judgment_form: formMap.get(r.judgment_code) || null,
+        external_url: `https://reyestr.court.gov.ua/Review/${r.doc_id}`,
+      }));
+
+      res.json({
+        results,
+        total: countResult.rows[0]?.total || 0,
+        limit,
+        offset,
+      });
+    } catch (err: any) {
+      logger.error('[EdsrRoutes] search error', { error: err.message });
+      res.status(500).json({ error: 'Помилка пошуку' });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/routes/evidence-routes.ts
+++ b/mcp_backend/src/routes/evidence-routes.ts
@@ -1,0 +1,60 @@
+/**
+ * Evidence routes — API endpoints for the right panel tabs.
+ *
+ * GET /api/conversations/:id/decisions      — Рішення, Вирок, Постанова
+ * GET /api/conversations/:id/court-documents — Ухвала, Окрема думка, Окрема ухвала
+ * GET /api/conversations/:id/regulations    — Legislation citations
+ */
+
+import { Router, type Response } from 'express';
+import type { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+import { ConversationEvidenceService } from '../services/conversation-evidence-service.js';
+import { logger } from '../utils/logger.js';
+
+export function createEvidenceRoutes(evidenceService: ConversationEvidenceService): Router {
+  const router = Router({ mergeParams: true });
+
+  // GET /api/conversations/:id/decisions
+  router.get('/:id/decisions', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const decisions = await evidenceService.getDecisions(String(req.params.id), userId);
+      res.json({ decisions, total: decisions.length });
+    } catch (err: any) {
+      logger.error('[EvidenceRoutes] getDecisions error', { error: err.message });
+      res.status(500).json({ error: 'Помилка отримання рішень' });
+    }
+  }) as any);
+
+  // GET /api/conversations/:id/court-documents
+  router.get('/:id/court-documents', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const documents = await evidenceService.getCourtDocuments(String(req.params.id), userId);
+      res.json({ documents, total: documents.length });
+    } catch (err: any) {
+      logger.error('[EvidenceRoutes] getCourtDocuments error', { error: err.message });
+      res.status(500).json({ error: 'Помилка отримання документів' });
+    }
+  }) as any);
+
+  // GET /api/conversations/:id/regulations
+  router.get('/:id/regulations', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+
+      const regulations = await evidenceService.getRegulations(String(req.params.id), userId);
+      res.json({ regulations, total: regulations.length });
+    } catch (err: any) {
+      logger.error('[EvidenceRoutes] getRegulations error', { error: err.message });
+      res.status(500).json({ error: 'Помилка отримання норм' });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/chat-search-cache-service.ts
+++ b/mcp_backend/src/services/chat-search-cache-service.ts
@@ -26,6 +26,18 @@ const COURT_SEARCH_TOOLS = new Set([
   'compare_practice_pro_contra',
   'get_case_documents_chain',
   'count_cases_by_party',
+  'search_edrsr_decisions',
+  'search_edrsr_fulltext',
+  'search_edrsr_semantic',
+  'get_edrsr_decision_fulltext',
+]);
+
+/** EDRSR tools have fulltext locally — no need for background ZO downloads */
+const EDRSR_TOOLS = new Set([
+  'search_edrsr_decisions',
+  'search_edrsr_fulltext',
+  'search_edrsr_semantic',
+  'get_edrsr_decision_fulltext',
 ]);
 
 export function isCourtSearchTool(toolName: string): boolean {
@@ -160,8 +172,10 @@ export class ChatSearchCacheService {
   /**
    * Fire-and-forget: download full text for documents that don't have it yet.
    */
-  triggerBackgroundDownloads(docIds: string[]): void {
+  triggerBackgroundDownloads(docIds: string[], toolName?: string): void {
     if (docIds.length === 0) return;
+    // EDRSR tools have fulltext in local PostgreSQL — no need for ZO downloads
+    if (toolName && EDRSR_TOOLS.has(toolName)) return;
 
     setImmediate(async () => {
       try {

--- a/mcp_backend/src/services/conversation-evidence-service.ts
+++ b/mcp_backend/src/services/conversation-evidence-service.ts
@@ -1,0 +1,209 @@
+/**
+ * ConversationEvidenceService — aggregates and caches evidence
+ * (decisions, court documents, regulations) per conversation.
+ *
+ * Source of truth: conversation_messages JSONB columns (decisions, citations, documents).
+ * Redis provides fast read-through cache with 2h TTL.
+ */
+
+import { logger } from '../utils/logger.js';
+import type { IDatabase } from '../domain/ports/index.js';
+import type { ICachePort } from '../domain/ports/index.js';
+import type { Decision, Citation, VaultDocument } from '@secondlayer/shared';
+
+const EVIDENCE_CACHE_TTL = 7200; // 2 hours
+
+/** Document types that go to the "Рішення" tab */
+const DECISION_TYPES = new Set(['Рішення', 'Вирок', 'Постанова']);
+
+/** Document types that go to the "Документи" tab */
+const PROCEDURAL_TYPES = new Set(['Ухвала', 'Окрема думка', 'Окрема ухвала']);
+
+export interface AggregatedEvidence {
+  decisions: Decision[];
+  courtDocuments: Decision[];
+  regulations: Citation[];
+  vaultDocuments: VaultDocument[];
+}
+
+export class ConversationEvidenceService {
+  constructor(
+    private db: IDatabase,
+    private cache: ICachePort | null = null
+  ) {}
+
+  setCachePort(cache: ICachePort): void {
+    this.cache = cache;
+  }
+
+  // ─── Public API ────────────────────────────────────────────
+
+  async getDecisions(conversationId: string, userId: string): Promise<Decision[]> {
+    const evidence = await this.getAggregatedEvidence(conversationId, userId);
+    return evidence.decisions;
+  }
+
+  async getCourtDocuments(conversationId: string, userId: string): Promise<Decision[]> {
+    const evidence = await this.getAggregatedEvidence(conversationId, userId);
+    return evidence.courtDocuments;
+  }
+
+  async getRegulations(conversationId: string, userId: string): Promise<Citation[]> {
+    const evidence = await this.getAggregatedEvidence(conversationId, userId);
+    return evidence.regulations;
+  }
+
+  // ─── Cache management ──────────────────────────────────────
+
+  async updateEvidenceCache(conversationId: string, userId: string): Promise<void> {
+    try {
+      const evidence = await this.aggregateFromDb(conversationId, userId);
+      if (this.cache) {
+        await this.cache.set(
+          this.cacheKey(conversationId),
+          JSON.stringify(evidence),
+          EVIDENCE_CACHE_TTL
+        );
+        logger.debug('[ConversationEvidence] Cache updated', { conversationId });
+      }
+    } catch (err: any) {
+      logger.warn('[ConversationEvidence] updateEvidenceCache error', { error: err.message });
+    }
+  }
+
+  async invalidateCache(conversationId: string): Promise<void> {
+    try {
+      if (this.cache) {
+        await this.cache.del(this.cacheKey(conversationId));
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // ─── Internal ──────────────────────────────────────────────
+
+  private cacheKey(conversationId: string): string {
+    return `conv:evidence:${conversationId}:all`;
+  }
+
+  private async getAggregatedEvidence(conversationId: string, userId: string): Promise<AggregatedEvidence> {
+    // Try Redis first
+    if (this.cache) {
+      try {
+        const cached = await this.cache.get(this.cacheKey(conversationId));
+        if (cached) {
+          logger.debug('[ConversationEvidence] Cache hit', { conversationId });
+          return JSON.parse(cached);
+        }
+      } catch {
+        // fall through to DB
+      }
+    }
+
+    // Cache miss — aggregate from DB
+    const evidence = await this.aggregateFromDb(conversationId, userId);
+
+    // Write through to cache
+    if (this.cache) {
+      try {
+        await this.cache.set(
+          this.cacheKey(conversationId),
+          JSON.stringify(evidence),
+          EVIDENCE_CACHE_TTL
+        );
+      } catch {
+        // ignore cache write errors
+      }
+    }
+
+    return evidence;
+  }
+
+  private async aggregateFromDb(conversationId: string, userId: string): Promise<AggregatedEvidence> {
+    // Verify ownership
+    const ownership = await this.db.query(
+      `SELECT id FROM conversations
+       WHERE id = $1 AND (
+         user_id = $2
+         OR (matter_id IS NOT NULL AND EXISTS (
+           SELECT 1 FROM matter_team
+           WHERE matter_id = conversations.matter_id AND user_id = $2 AND removed_at IS NULL
+         ))
+       )`,
+      [conversationId, userId]
+    );
+
+    if (ownership.rows.length === 0) {
+      return { decisions: [], courtDocuments: [], regulations: [], vaultDocuments: [] };
+    }
+
+    // Fetch all evidence from conversation messages
+    const result = await this.db.query(
+      `SELECT decisions, citations, documents
+       FROM conversation_messages
+       WHERE conversation_id = $1 AND role = 'assistant'
+       ORDER BY created_at`,
+      [conversationId]
+    );
+
+    const allDecisions: Decision[] = [];
+    const allCitations: Citation[] = [];
+    const allDocuments: VaultDocument[] = [];
+    const seenDecisionIds = new Set<string>();
+    const seenCitationKeys = new Set<string>();
+    const seenDocIds = new Set<string>();
+
+    for (const row of result.rows) {
+      // Decisions
+      if (Array.isArray(row.decisions)) {
+        for (const d of row.decisions) {
+          const key = d.id || `${d.number}-${d.date}`;
+          if (!seenDecisionIds.has(key)) {
+            seenDecisionIds.add(key);
+            allDecisions.push(d);
+          }
+        }
+      }
+
+      // Citations (regulations)
+      if (Array.isArray(row.citations)) {
+        for (const c of row.citations) {
+          const key = `${c.source}:${(c.text || '').substring(0, 50)}`;
+          if (!seenCitationKeys.has(key)) {
+            seenCitationKeys.add(key);
+            allCitations.push(c);
+          }
+        }
+      }
+
+      // Vault documents
+      if (Array.isArray(row.documents)) {
+        for (const doc of row.documents) {
+          if (!seenDocIds.has(doc.id)) {
+            seenDocIds.add(doc.id);
+            allDocuments.push(doc);
+          }
+        }
+      }
+    }
+
+    // Split decisions into proper decisions vs procedural documents
+    const decisions: Decision[] = [];
+    const courtDocuments: Decision[] = [];
+
+    for (const d of allDecisions) {
+      const docType = d.documentType || '';
+      if (PROCEDURAL_TYPES.has(docType)) {
+        courtDocuments.push(d);
+      } else if (DECISION_TYPES.has(docType) || !docType) {
+        // Default to decisions tab if no type
+        decisions.push(d);
+      } else {
+        courtDocuments.push(d);
+      }
+    }
+
+    return { decisions, courtDocuments, regulations: allCitations, vaultDocuments: allDocuments };
+  }
+}


### PR DESCRIPTION
## Summary
Backend implementation for the right panel evidence system (LEG-395).

- **Redis cache** for EDRSR search tools (`search_edrsr_fulltext`, `search_edrsr_semantic`, `search_edrsr_decisions`) — 30min TTL
- **ConversationEvidenceService** — aggregates decisions/documents/regulations from `conversation_messages` JSONB with Redis cache (2h TTL)
- **Evidence API routes** for right panel tabs:
  - `GET /api/conversations/:id/decisions` — Рішення, Вирок, Постанова
  - `GET /api/conversations/:id/court-documents` — Ухвала, Окрема думка
  - `GET /api/conversations/:id/regulations` — legislation citations
- **EDRSR direct access routes**:
  - `GET /api/edrsr/:docId/fulltext` — full text from local PostgreSQL (no external API)
  - `POST /api/edrsr/search` — direct EDRSR metadata search without chat

## Test plan
- [ ] Build passes (`tsc --noEmit`)
- [ ] Deploy to prod, verify routes respond with JWT auth
- [ ] Test `/api/edrsr/:docId/fulltext` with a known doc_id
- [ ] Test `/api/conversations/:id/decisions` for a conversation with court results
- [ ] Verify Redis caching works (second call faster)
- [ ] Frontend integration (separate PR)

Closes LEG-395 (partially — frontend in next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)