### PR TITLE
feat(LEG-395): frontend evidence hydration + EDRSR service

### DIFF
--- a/lexwebapp/src/components/RightPanel.tsx
+++ b/lexwebapp/src/components/RightPanel.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useLocation } from 'react-router-dom';
 import { Decision } from './DecisionCard';
 import { DocumentViewerModal } from './DocumentViewerModal';
-import { useUIStore, useDecisionsSearchStore } from '../stores';
+import { useUIStore, useDecisionsSearchStore, useChatStore } from '../stores';
 import { useEvidenceAggregator } from '../hooks/chat/useEvidenceAggregator';
 import { DecisionsTab } from './chat/DecisionsTab';
 import { RegulationsTab } from './chat/RegulationsTab';
@@ -77,7 +77,8 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
 
   // Chat tab removed from right panel — consultation pages have their own embedded chat
 
-  const { decisions: chatDecisions, otherCourtDocs, citations, vaultDocuments, messagesCount } = useEvidenceAggregator();
+  const conversationId = useChatStore(s => s.conversationId);
+  const { decisions: chatDecisions, otherCourtDocs, citations, vaultDocuments, messagesCount } = useEvidenceAggregator(conversationId ?? undefined);
   const downloadedDecisions = useDecisionsSearchStore(s => s.downloadedDecisions);
 
   // On /decisions page, merge downloaded decisions into the decisions list

--- a/lexwebapp/src/hooks/chat/useEvidenceAggregator.ts
+++ b/lexwebapp/src/hooks/chat/useEvidenceAggregator.ts
@@ -1,10 +1,16 @@
 /**
  * useEvidenceAggregator — aggregates and deduplicates evidence from all chat messages.
  * Returns decisions (split into proper decisions vs other court docs), citations, and vault documents.
+ *
+ * Supports two data sources:
+ * 1. SSE-streamed evidence during active chat (real-time, from messages in store)
+ * 2. API-fetched evidence for persisted conversations (hydration on conversation load)
  */
 
-import { useMemo } from 'react';
+import { useMemo, useEffect, useState, useRef } from 'react';
 import { useChatStore } from '../../stores';
+import { EvidenceService } from '../../services/api/EvidenceService';
+import type { Decision, Citation } from '../../types/models/Message';
 
 /** Proper court decisions — shown in the "Рішення" tab */
 const DECISION_TYPES = new Set(['Рішення', 'Вирок', 'Постанова']);
@@ -12,9 +18,42 @@ const DECISION_TYPES = new Set(['Рішення', 'Вирок', 'Постано�
 /** Procedural court docs (ухвали, окремі думки) — shown in "Документи" tab */
 const PROCEDURAL_TYPES = new Set(['Ухвала', 'Окрема думка', 'Окрема ухвала']);
 
-export function useEvidenceAggregator() {
+export function useEvidenceAggregator(conversationId?: string) {
   const messages = useChatStore(state => state.messages);
 
+  // API-fetched evidence for persisted conversations
+  const [apiDecisions, setApiDecisions] = useState<Decision[]>([]);
+  const [apiCourtDocs, setApiCourtDocs] = useState<Decision[]>([]);
+  const [apiCitations, setApiCitations] = useState<Citation[]>([]);
+  const fetchedConvRef = useRef<string | null>(null);
+
+  // Hydrate from API when conversationId changes and we have no SSE data
+  useEffect(() => {
+    if (!conversationId || fetchedConvRef.current === conversationId) return;
+
+    // Only hydrate if we have few messages (loading persisted conversation)
+    const hasAssistantMessages = messages.some(m => m.role === 'assistant' && (m.decisions?.length || m.citations?.length));
+    if (hasAssistantMessages) {
+      fetchedConvRef.current = conversationId;
+      return;
+    }
+
+    fetchedConvRef.current = conversationId;
+
+    Promise.all([
+      EvidenceService.getDecisions(conversationId),
+      EvidenceService.getCourtDocuments(conversationId),
+      EvidenceService.getRegulations(conversationId),
+    ]).then(([decisions, courtDocs, regulations]) => {
+      setApiDecisions(decisions);
+      setApiCourtDocs(courtDocs);
+      setApiCitations(regulations);
+    }).catch(() => {
+      // Silently fail — SSE data will be primary source
+    });
+  }, [conversationId, messages]);
+
+  // SSE-streamed evidence from current messages
   const allDecisions = useMemo(() => {
     const seen = new Set<string>();
     return messages.flatMap(m => m.decisions ?? []).filter(d => {
@@ -24,25 +63,58 @@ export function useEvidenceAggregator() {
     });
   }, [messages]);
 
-  const decisions = useMemo(() =>
-    allDecisions.filter(d => !d.documentType || DECISION_TYPES.has(d.documentType)),
-    [allDecisions]
-  );
+  // Merge SSE + API decisions with dedup
+  const decisions = useMemo(() => {
+    const sseDecisions = allDecisions.filter(d => !d.documentType || DECISION_TYPES.has(d.documentType));
+    if (apiDecisions.length === 0) return sseDecisions;
 
-  const otherCourtDocs = useMemo(() =>
-    allDecisions.filter(d => d.documentType && PROCEDURAL_TYPES.has(d.documentType)),
-    [allDecisions]
-  );
+    const seen = new Set(sseDecisions.map(d => d.id));
+    const merged = [...sseDecisions];
+    for (const d of apiDecisions) {
+      if (!seen.has(d.id)) {
+        seen.add(d.id);
+        merged.push(d);
+      }
+    }
+    return merged;
+  }, [allDecisions, apiDecisions]);
+
+  const otherCourtDocs = useMemo(() => {
+    const sseDocs = allDecisions.filter(d => d.documentType && PROCEDURAL_TYPES.has(d.documentType));
+    if (apiCourtDocs.length === 0) return sseDocs;
+
+    const seen = new Set(sseDocs.map(d => d.id));
+    const merged = [...sseDocs];
+    for (const d of apiCourtDocs) {
+      if (!seen.has(d.id)) {
+        seen.add(d.id);
+        merged.push(d);
+      }
+    }
+    return merged;
+  }, [allDecisions, apiCourtDocs]);
 
   const citations = useMemo(() => {
     const seen = new Set<string>();
-    return messages.flatMap(m => m.citations ?? []).filter(c => {
+    const sseCitations = messages.flatMap(m => m.citations ?? []).filter(c => {
       const key = c.source.toLowerCase().replace(/\s+/g, ' ').trim();
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
     });
-  }, [messages]);
+
+    if (apiCitations.length === 0) return sseCitations;
+
+    const merged = [...sseCitations];
+    for (const c of apiCitations) {
+      const key = c.source.toLowerCase().replace(/\s+/g, ' ').trim();
+      if (!seen.has(key)) {
+        seen.add(key);
+        merged.push(c);
+      }
+    }
+    return merged;
+  }, [messages, apiCitations]);
 
   const vaultDocuments = useMemo(() => {
     const seen = new Set<string>();

--- a/lexwebapp/src/services/api/EvidenceService.ts
+++ b/lexwebapp/src/services/api/EvidenceService.ts
@@ -1,0 +1,100 @@
+/**
+ * Evidence Service — API client for right panel evidence tabs + EDRSR direct access
+ */
+
+import { BaseService } from '../base/BaseService';
+import type { Decision, Citation } from '../../types/models/Message';
+
+export interface EdsrFulltextResponse {
+  doc_id: number;
+  cause_num: string;
+  judge: string;
+  court_code: number;
+  court_name: string | null;
+  justice_kind: number;
+  judgment_code: number;
+  judgment_form: string | null;
+  adjudication_date: string;
+  receipt_date: string;
+  full_text: string | null;
+  external_url: string;
+}
+
+export interface EdsrSearchParams {
+  cause_num?: string;
+  judge?: string;
+  court_code?: number;
+  court_name?: string;
+  justice_kind?: number;
+  judgment_code?: number;
+  date_from?: string;
+  date_to?: string;
+  instance_code?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface EdsrSearchResponse {
+  results: EdsrFulltextResponse[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+class EvidenceServiceClass extends BaseService {
+  // ── Evidence tabs (per conversation) ──────────────────────
+
+  async getDecisions(conversationId: string): Promise<Decision[]> {
+    try {
+      const { data } = await this.client.get(`/api/conversations/${conversationId}/decisions`);
+      return data.decisions || [];
+    } catch (error) {
+      console.warn('[EvidenceService] getDecisions failed:', error);
+      return [];
+    }
+  }
+
+  async getCourtDocuments(conversationId: string): Promise<Decision[]> {
+    try {
+      const { data } = await this.client.get(`/api/conversations/${conversationId}/court-documents`);
+      return data.documents || [];
+    } catch (error) {
+      console.warn('[EvidenceService] getCourtDocuments failed:', error);
+      return [];
+    }
+  }
+
+  async getRegulations(conversationId: string): Promise<Citation[]> {
+    try {
+      const { data } = await this.client.get(`/api/conversations/${conversationId}/regulations`);
+      return data.regulations || [];
+    } catch (error) {
+      console.warn('[EvidenceService] getRegulations failed:', error);
+      return [];
+    }
+  }
+
+  // ── EDRSR direct access ───────────────────────────────────
+
+  async getEdsrFulltext(docId: string | number): Promise<EdsrFulltextResponse | null> {
+    try {
+      const { data } = await this.client.get(`/api/edrsr/${docId}/fulltext`);
+      return data;
+    } catch (error) {
+      console.warn('[EvidenceService] getEdsrFulltext failed:', error);
+      return null;
+    }
+  }
+
+  async searchEdrsr(params: EdsrSearchParams): Promise<EdsrSearchResponse> {
+    try {
+      const { data } = await this.client.post('/api/edrsr/search', params);
+      return data;
+    } catch (error) {
+      console.warn('[EvidenceService] searchEdrsr failed:', error);
+      return { results: [], total: 0, limit: params.limit || 20, offset: params.offset || 0 };
+    }
+  }
+}
+
+export const EvidenceService = new EvidenceServiceClass();


### PR DESCRIPTION
## Summary
Frontend integration for evidence panel API routes (LEG-395).

- **EvidenceService** — API client for evidence tabs + EDRSR direct access
- **useEvidenceAggregator** — now supports dual data source:
  - SSE real-time during active chat
  - API hydration when opening persisted conversations
  - Merge + dedup by id
- **RightPanel** — passes `conversationId` to aggregator for hydration

## Files
- `lexwebapp/src/services/api/EvidenceService.ts` — new API client
- `lexwebapp/src/hooks/chat/useEvidenceAggregator.ts` — dual source aggregation
- `lexwebapp/src/components/RightPanel.tsx` — wire conversationId

## Test plan
- [ ] Open active chat → evidence appears via SSE (existing behavior)
- [ ] Open persisted conversation → evidence loads from API
- [ ] Verify dedup works (no duplicates between SSE and API)
- [ ] TypeScript builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)