### PR TITLE
fix: disable pdfjs worker to fix PDF upload parsing timeout

### DIFF
--- a/mcp_backend/src/services/document-parser.ts
+++ b/mcp_backend/src/services/document-parser.ts
@@ -172,7 +172,7 @@ if (!Map.prototype.getOrInsertComputed) {
 </script>
 <script type="module">
 import { getDocument, GlobalWorkerOptions } from './pdf.min.mjs';
-GlobalWorkerOptions.workerSrc = './pdf.worker.min.mjs';
+GlobalWorkerOptions.workerSrc = '';
 
 window.extractText = async function(base64Data, maxPages) {
   const binary = atob(base64Data);
@@ -281,7 +281,7 @@ if (!Map.prototype.getOrInsertComputed) {
 </script>
 <script type="module">
 import { getDocument, GlobalWorkerOptions } from './pdf.min.mjs';
-GlobalWorkerOptions.workerSrc = './pdf.worker.min.mjs';
+GlobalWorkerOptions.workerSrc = '';
 
 window.renderPDF = async function(base64Data, maxPages, scale) {
   const binary = atob(base64Data);


### PR DESCRIPTION
## Summary
- pdfjs-dist v5.5 uses `Map.prototype.getOrInsertComputed` (TC39 Stage 3) which is unavailable in Chromium Web Worker context
- The polyfill only applies to main thread — worker hangs and times out after 15s, breaking all PDF uploads
- Fix: set `GlobalWorkerOptions.workerSrc = ''` so pdfjs runs entirely in main thread where the polyfill works

## Test plan
- [ ] Upload a PDF via https://legal.org.ua/documents and verify it processes successfully
- [ ] Verify both text-based and scanned (OCR) PDFs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)