### PR TITLE
fix: load EDRSR full text on case number click in chat

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { Copy, RotateCw, Star, ThumbsUp, ThumbsDown, ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { Decision } from '../DecisionCard';
@@ -14,6 +14,7 @@ import { isRawJsonContent } from './utils';
 import showToast from '../../utils/toast';
 import type { ExecutionPlan, CitationWarning, CostSummary as CostSummaryType } from '../../types/models/Message';
 import { useChatStore } from '../../stores';
+import { EvidenceService } from '../../services/api/EvidenceService';
 
 interface AssistantMessageProps {
   content: string;
@@ -48,24 +49,54 @@ export function AssistantMessage({
 
   const allMessages = useChatStore(state => state.messages);
 
+  const [isDocLoading, setIsDocLoading] = useState(false);
+  const loadingDocRef = useRef<string | null>(null);
+
   const openDocByRef = useCallback((docId: string) => {
     const allDecisions = allMessages.flatMap(m => (m as any).decisions ?? []) as Decision[];
     const decision = allDecisions.find(d =>
       d.id.includes(docId) || (d as any).externalUrl?.includes(`/Review/${docId}`)
     );
-    if (decision) {
-      const STATUS_LABELS: Record<string, string> = { active: 'Чинне', overturned: 'Скасовано', modified: 'Змінено' };
-      setDocViewerItem({
-        type: 'decision',
-        title: decision.number,
-        subtitle: [decision.court, decision.date].filter(Boolean).join(' • '),
-        badge: STATUS_LABELS[decision.status] || decision.status,
-        badgeVariant: decision.status as 'active' | 'overturned' | 'modified',
-        content: decision.summary || 'Текст рішення не завантажено.',
-        relevance: decision.relevance,
-        externalUrl: (decision as any).externalUrl,
+    if (!decision) return;
+
+    const STATUS_LABELS: Record<string, string> = { active: 'Чинне', overturned: 'Скасовано', modified: 'Змінено' };
+
+    // Show modal immediately with summary
+    setDocViewerItem({
+      type: 'decision',
+      title: decision.number,
+      subtitle: [decision.court, decision.date].filter(Boolean).join(' • '),
+      badge: STATUS_LABELS[decision.status] || decision.status,
+      badgeVariant: decision.status as 'active' | 'overturned' | 'modified',
+      content: decision.summary || 'Завантаження повного тексту...',
+      relevance: decision.relevance,
+      externalUrl: (decision as any).externalUrl,
+    });
+    setIsDocViewerOpen(true);
+
+    // Extract numeric EDRSR doc_id from decision id (format: "d-{doc_id}" or from externalUrl)
+    const edsrDocId = (decision as any).docId
+      || decision.id.replace(/^d-/, '')
+      || (decision as any).externalUrl?.match(/\/Review\/(\d+)/)?.[1];
+
+    if (edsrDocId && /^\d+$/.test(String(edsrDocId))) {
+      // Prevent duplicate fetches
+      if (loadingDocRef.current === String(edsrDocId)) return;
+      loadingDocRef.current = String(edsrDocId);
+      setIsDocLoading(true);
+
+      EvidenceService.getEdsrFulltext(edsrDocId).then(result => {
+        if (result?.full_text) {
+          setDocViewerItem(prev => prev ? {
+            ...prev,
+            content: result.full_text!,
+            subtitle: [result.court_name || decision.court, result.judgment_form, decision.date].filter(Boolean).join(' • '),
+          } : prev);
+        }
+      }).finally(() => {
+        setIsDocLoading(false);
+        loadingDocRef.current = null;
       });
-      setIsDocViewerOpen(true);
     }
   }, [allMessages]);
 
@@ -218,6 +249,7 @@ export function AssistantMessage({
         isOpen={isDocViewerOpen}
         onClose={() => setIsDocViewerOpen(false)}
         item={docViewerItem}
+        isLoading={isDocLoading}
       />
     </>
   );


### PR DESCRIPTION
## Summary
When clicking a case number link in chat response, only the summary was shown in the modal. Now fetches full text from `/api/edrsr/:docId/fulltext`.

## Changes
- `AssistantMessage.tsx` — `openDocByRef` now:
  1. Shows modal immediately with summary (no delay)
  2. Extracts numeric EDRSR doc_id from decision id
  3. Fetches full text via `EvidenceService.getEdsrFulltext()`
  4. Updates modal content with full text when loaded
  5. Enriches subtitle with court name + judgment form

## Test plan
- [ ] Click case number in chat response table
- [ ] Modal opens immediately with summary
- [ ] Full text loads and replaces summary
- [ ] External URL link works
- [ ] No duplicate fetch on rapid clicks

🤖 Generated with [Claude Code](https://claude.com/claude-code)