### PR TITLE
fix: real-time consultation updates without page refresh

### DIFF
--- a/lexwebapp/src/components/chat/ConsultationChatTab.tsx
+++ b/lexwebapp/src/components/chat/ConsultationChatTab.tsx
@@ -180,9 +180,14 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
     });
 
     // Handle consultation status changes
-    es.addEventListener('consultation_status', () => {
-      // Dispatch global event for other components
-      window.dispatchEvent(new CustomEvent('consultation-updated'));
+    es.addEventListener('consultation_status', (event) => {
+      try {
+        const updated = JSON.parse(event.data);
+        // Dispatch with full consultation data for other components
+        window.dispatchEvent(new CustomEvent('consultation-updated', { detail: updated }));
+      } catch {
+        window.dispatchEvent(new CustomEvent('consultation-updated'));
+      }
     });
 
     es.onerror = () => {

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -55,7 +55,7 @@ export function ConsultationDetailPage() {
     if (id) sessionStorage.setItem('lastConsultationId', id);
   }, [id]);
 
-  // Subscribe to real-time consultation status changes
+  // Subscribe to real-time consultation status changes (user-level SSE)
   useEffect(() => {
     if (!id) return;
     const unsub = addStatusListener(id, (updated) => {
@@ -63,6 +63,23 @@ export function ConsultationDetailPage() {
     });
     return unsub;
   }, [id, addStatusListener]);
+
+  // Fallback: listen to per-conversation SSE via window event
+  useEffect(() => {
+    if (!id) return;
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent).detail;
+      if (detail && detail.id === id) {
+        // Per-conversation SSE sends consultation object directly
+        setConsultation(detail);
+      } else {
+        // No detail or different consultation — refetch
+        load();
+      }
+    };
+    window.addEventListener('consultation-updated', handler);
+    return () => window.removeEventListener('consultation-updated', handler);
+  }, [id]);
 
   const handleAction = async (action: string, inputValue?: string) => {
     if (!id) return;


### PR DESCRIPTION
## Summary
Users and attorneys had to refresh the page to see new status changes (payment button, fee amount, status transitions).

## Root cause
1. `ConsultationChatTab` received `consultation_status` SSE event but **ignored the data** — dispatched empty window event
2. `ConsultationDetailPage` only listened to user-level SSE via `addStatusListener`, but didn't handle the per-conversation SSE window event

## Fix
- `ConsultationChatTab` now parses SSE data and dispatches `consultation-updated` with full consultation object
- `ConsultationDetailPage` listens to `consultation-updated` window event as fallback — updates state immediately or refetches if needed

## Test plan
- [ ] Attorney accepts consultation with fee → client sees payment button without refresh
- [ ] Client pays → attorney sees status change without refresh
- [ ] Messages still arrive in real-time (existing SSE)
- [ ] Status badge updates immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)