### PR TITLE
fix: polling fallback for consultation real-time updates

### DIFF
--- a/lexwebapp/src/components/chat/ConsultationChatTab.tsx
+++ b/lexwebapp/src/components/chat/ConsultationChatTab.tsx
@@ -201,6 +201,26 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
     };
   }, [consultationId, onUnreadCountChange, scrollToBottom, user?.id]);
 
+  // Polling fallback: SSE through Cloudflare is unreliable, poll every 5s
+  useEffect(() => {
+    if (!consultationId) return;
+    const poll = setInterval(() => {
+      consultationService.getMessages(consultationId, { limit: 100 }).then((result) => {
+        setMessages(prev => {
+          if (result.messages.length === prev.length) return prev;
+          // Merge: keep all messages, deduplicate by id
+          const ids = new Set(prev.map(m => m.id));
+          const newMsgs = result.messages.filter(m => !ids.has(m.id));
+          if (newMsgs.length === 0) return prev;
+          const merged = [...prev, ...newMsgs];
+          setTimeout(scrollToBottom, 100);
+          return merged;
+        });
+      }).catch(() => {});
+    }, 5000);
+    return () => clearInterval(poll);
+  }, [consultationId, scrollToBottom]);
+
   // Mark messages as read when chat becomes visible
   useEffect(() => {
     if (consultationId && messages.length > 0) {

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -70,15 +70,33 @@ export function ConsultationDetailPage() {
     const handler = (event: Event) => {
       const detail = (event as CustomEvent).detail;
       if (detail && detail.id === id) {
-        // Per-conversation SSE sends consultation object directly
         setConsultation(detail);
       } else {
-        // No detail or different consultation — refetch
         load();
       }
     };
     window.addEventListener('consultation-updated', handler);
     return () => window.removeEventListener('consultation-updated', handler);
+  }, [id]);
+
+  // Polling fallback: refetch consultation every 5s to catch status/fee changes
+  // SSE through Cloudflare is unreliable
+  useEffect(() => {
+    if (!id) return;
+    const poll = setInterval(() => {
+      consultationService.getConsultation(id).then((c) => {
+        if (!c) return;
+        setConsultation(prev => {
+          if (!prev) return c;
+          // Only update if something changed
+          if (prev.status !== c.status || prev.agreed_fee_uah !== c.agreed_fee_uah || prev.updated_at !== c.updated_at) {
+            return c;
+          }
+          return prev;
+        });
+      }).catch(() => {});
+    }, 5000);
+    return () => clearInterval(poll);
   }, [id]);
 
   const handleAction = async (action: string, inputValue?: string) => {


### PR DESCRIPTION
## Summary
SSE through Cloudflare drops every 2-5 seconds — events are missed. Added 5s polling as reliable fallback.

## Changes
- **ConsultationChatTab**: polls messages every 5s, merges with dedup
- **ConsultationDetailPage**: polls consultation every 5s, updates on status/fee/timestamp change

SSE remains primary for instant delivery, polling ensures reliability.

## Test plan
- [ ] Send message as attorney → client sees it within 5s without refresh
- [ ] Accept consultation with fee → client sees payment button within 5s
- [ ] No duplicate messages in chat
- [ ] No unnecessary re-renders (only updates when data changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)