### PR TITLE
feat: save consultation attachment to vault

### DIFF
--- a/lexwebapp/src/components/chat/ConsultationChatTab.tsx
+++ b/lexwebapp/src/components/chat/ConsultationChatTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Send, MessageSquare, Loader2, Paperclip, FileText, Download, X, Check, CheckCheck, Image as ImageIcon } from 'lucide-react';
+import { Send, MessageSquare, Loader2, Paperclip, FileText, Download, FolderDown, X, Check, CheckCheck, Image as ImageIcon } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { consultationService } from '../../services';
 import { uploadService } from '../../services/api/UploadService';
@@ -37,11 +37,42 @@ function MessageStatus({ message, isMine }: { message: ConsultationMessage; isMi
   return <Check size={12} className="text-white/50 inline-block ml-1" />;
 }
 
-function AttachmentDisplay({ message }: { message: ConsultationMessage }) {
+function AttachmentDisplay({ message, consultationId, isMine }: { message: ConsultationMessage; consultationId?: string; isMine?: boolean }) {
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
   if (!message.attachment_url) return null;
 
   const isImage = isImageType(message.attachment_type);
   const attachmentUrl = message.attachment_url;
+
+  const handleSaveToVault = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!consultationId || saving || saved) return;
+    setSaving(true);
+    try {
+      const res = await consultationService.saveAttachmentToVault(consultationId, message.id);
+      if (res.documentId) {
+        setSaved(true);
+      }
+    } catch {
+      // silently fail
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveButton = !isMine && consultationId && (
+    <button
+      onClick={handleSaveToVault}
+      disabled={saving || saved}
+      className="flex-shrink-0 opacity-50 hover:opacity-100 transition-opacity disabled:opacity-30"
+      title={saved ? 'Збережено' : 'Зберегти до моїх документів'}
+    >
+      {saving ? <Loader2 size={14} className="animate-spin" /> : saved ? <Check size={14} className="text-green-500" /> : <FolderDown size={14} />}
+    </button>
+  );
 
   if (isImage) {
     return (
@@ -54,30 +85,36 @@ function AttachmentDisplay({ message }: { message: ConsultationMessage }) {
             loading="lazy"
           />
         </a>
-        {message.attachment_name && (
-          <p className="text-[10px] opacity-60 mt-0.5 truncate">{message.attachment_name}</p>
-        )}
+        <div className="flex items-center justify-between mt-0.5">
+          {message.attachment_name && (
+            <p className="text-[10px] opacity-60 truncate">{message.attachment_name}</p>
+          )}
+          {saveButton}
+        </div>
       </div>
     );
   }
 
   // Non-image file
   return (
-    <a
-      href={attachmentUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="mt-1.5 flex items-center gap-2 p-2 rounded-lg bg-black/10 hover:bg-black/15 transition-colors max-w-[240px]"
-    >
-      <FileText size={16} className="flex-shrink-0 opacity-70" />
-      <div className="min-w-0 flex-1">
-        <p className="text-xs font-medium truncate">{message.attachment_name || 'Файл'}</p>
-        {message.attachment_size && (
-          <p className="text-[10px] opacity-60">{formatFileSize(message.attachment_size)}</p>
-        )}
-      </div>
-      <Download size={14} className="flex-shrink-0 opacity-50" />
-    </a>
+    <div className="mt-1.5 flex items-center gap-2 p-2 rounded-lg bg-black/10 max-w-[240px]">
+      <a
+        href={attachmentUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-2 min-w-0 flex-1 hover:opacity-80 transition-opacity"
+      >
+        <FileText size={16} className="flex-shrink-0 opacity-70" />
+        <div className="min-w-0 flex-1">
+          <p className="text-xs font-medium truncate">{message.attachment_name || 'Файл'}</p>
+          {message.attachment_size && (
+            <p className="text-[10px] opacity-60">{formatFileSize(message.attachment_size)}</p>
+          )}
+        </div>
+        <Download size={14} className="flex-shrink-0 opacity-50" />
+      </a>
+      {saveButton}
+    </div>
   );
 }
 
@@ -413,7 +450,7 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
                 {msg.content && (
                   <p className="text-[13px] leading-relaxed whitespace-pre-wrap break-words">{msg.content}</p>
                 )}
-                <AttachmentDisplay message={msg} />
+                <AttachmentDisplay message={msg} consultationId={consultationId ?? undefined} isMine={isMine} />
                 <div className={`flex items-center justify-end gap-0.5 mt-1 ${isMine ? 'text-white/60' : 'text-claude-subtext'}`}>
                   <span className="text-[9px]">
                     {new Date(msg.created_at).toLocaleTimeString('uk-UA', { hour: '2-digit', minute: '2-digit' })}

--- a/lexwebapp/src/services/api/ConsultationService.ts
+++ b/lexwebapp/src/services/api/ConsultationService.ts
@@ -170,6 +170,10 @@ export class ConsultationService extends BaseService {
     return eventSource;
   }
 
+  async saveAttachmentToVault(consultationId: string, messageId: string): Promise<{ documentId: string; alreadyExists?: boolean }> {
+    return this.request(() => this.client.post(`/api/consultations/${consultationId}/messages/${messageId}/save-to-vault`));
+  }
+
   async submitReview(id: string, data: SubmitReviewRequest): Promise<{ success: boolean }> {
     return this.request(() => this.client.post(`/api/consultations/${id}/review`, data));
   }

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -517,7 +517,8 @@ class HTTPMCPServer {
       this.services.db,
       (type, delta) => {
         this.app_.metricsService.sseActiveConnections.inc({ type }, delta);
-      }
+      },
+      this.tools.minioService
     ));
     logger.info('Consultation routes registered at /api/consultations');
 

--- a/mcp_backend/src/routes/consultation-routes.ts
+++ b/mcp_backend/src/routes/consultation-routes.ts
@@ -5,6 +5,8 @@ import { ConsultationPaymentService } from '../services/consultation-payment-ser
 import { AttorneyPayoutService } from '../services/attorney-payout-service.js';
 import type { IDatabase } from '../domain/ports/index.js';
 import { logger } from '../utils/logger.js';
+import { MinioService } from '../services/minio-service.js';
+import { v4 as uuidv4 } from 'uuid';
 
 /** Optional callback for SSE connection metrics */
 export type SseMetricsCallback = (type: 'user_stream' | 'message_stream', delta: 1 | -1) => void;
@@ -14,7 +16,8 @@ export function createConsultationRoutes(
   consultationPaymentService: ConsultationPaymentService,
   payoutService?: AttorneyPayoutService,
   db?: IDatabase,
-  sseMetrics?: SseMetricsCallback
+  sseMetrics?: SseMetricsCallback,
+  minioService?: MinioService
 ): Router {
   const router = Router();
 
@@ -573,6 +576,112 @@ export function createConsultationRoutes(
     } catch (error: any) {
       logger.error('Failed to process payout', { error: error.message });
       res.status(400).json({ error: error.message });
+    }
+  }) as any);
+
+  // POST /:id/messages/:messageId/save-to-vault — save chat attachment to attorney's vault
+  router.post('/:id/messages/:messageId/save-to-vault', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'Не авторизовано' });
+      if (!db || !minioService) return res.status(500).json({ error: 'Сервіс недоступний' });
+
+      const { id: consultationId, messageId } = req.params;
+
+      // Verify user is a party to the consultation
+      const consultation = await db.query(
+        'SELECT * FROM consultations WHERE id = $1 AND (client_user_id = $2 OR attorney_user_id = $2)',
+        [consultationId, userId]
+      );
+      if (consultation.rows.length === 0) return res.status(403).json({ error: 'Немає доступу' });
+
+      // Get the message with attachment
+      const msgResult = await db.query(
+        'SELECT * FROM consultation_messages WHERE id = $1 AND consultation_id = $2',
+        [messageId, consultationId]
+      );
+      if (msgResult.rows.length === 0) return res.status(404).json({ error: 'Повідомлення не знайдено' });
+
+      const msg = msgResult.rows[0];
+      if (!msg.attachment_url) return res.status(400).json({ error: 'Повідомлення не містить вкладення' });
+
+      // Extract uploadId from attachment_url: /api/documents/{uploadId}/download
+      const uploadIdMatch = msg.attachment_url.match(/\/api\/documents\/([^/]+)\/download/);
+      if (!uploadIdMatch) return res.status(400).json({ error: 'Невідомий формат вкладення' });
+      const uploadId = uploadIdMatch[1];
+
+      // Find the source document record (uploaded by sender)
+      const sourceDoc = await db.query(
+        `SELECT id, user_id, title, storage_type, storage_path, mime_type, file_size, full_text, metadata
+         FROM documents WHERE zakononline_id = $1 OR id::text = $1 LIMIT 1`,
+        [uploadId]
+      );
+
+      if (sourceDoc.rows.length === 0) return res.status(404).json({ error: 'Документ не знайдено' });
+      const src = sourceDoc.rows[0];
+
+      // Check if already saved by this user
+      const existing = await db.query(
+        `SELECT id FROM documents WHERE user_id = $1 AND metadata->>'sourceConsultationMessageId' = $2 AND deleted_at IS NULL LIMIT 1`,
+        [userId, messageId]
+      );
+      if (existing.rows.length > 0) {
+        return res.json({ documentId: existing.rows[0].id, alreadyExists: true });
+      }
+
+      // Copy file in MinIO: source bucket → target bucket
+      const srcStoragePath = src.storage_path || '';
+      const srcParts = srcStoragePath.split('/');
+      const srcBucket = srcParts[0];
+      const srcKey = srcParts.slice(1).join('/');
+
+      let newStoragePath = '';
+      let fileSize = src.file_size || msg.attachment_size || 0;
+
+      if (srcBucket && srcKey) {
+        const buffer = await minioService.getFileBuffer(src.user_id, srcKey);
+        const newKey = MinioService.generateObjectKey(msg.attachment_name || src.title || 'document');
+        const result = await minioService.uploadBuffer(userId, newKey, buffer, msg.attachment_type || src.mime_type || 'application/octet-stream');
+        newStoragePath = `${result.bucket}/${result.key}`;
+        fileSize = result.size;
+      }
+
+      // Create new document record for the user
+      const newId = uuidv4();
+      const metadata = {
+        ...(src.metadata || {}),
+        sourceConsultationId: consultationId,
+        sourceConsultationMessageId: messageId,
+        sourceDocumentId: src.id,
+        savedAt: new Date().toISOString(),
+        originalFilename: msg.attachment_name || src.title,
+        minioKey: newStoragePath.split('/').slice(1).join('/'),
+        minioBucket: newStoragePath.split('/')[0],
+        fileSize,
+        mimeType: msg.attachment_type || src.mime_type,
+      };
+
+      await db.query(
+        `INSERT INTO documents (id, zakononline_id, type, title, full_text, metadata, storage_type, storage_path, file_size, mime_type, user_id)
+         VALUES ($1, $1, $2, $3, $4, $5, 'minio', $6, $7, $8, $9)`,
+        [
+          newId,
+          src.type || 'other',
+          msg.attachment_name || src.title || 'Документ з консультації',
+          src.full_text || null,
+          JSON.stringify(metadata),
+          newStoragePath,
+          fileSize,
+          msg.attachment_type || src.mime_type || 'application/octet-stream',
+          userId,
+        ]
+      );
+
+      logger.info('[Consultation] Attachment saved to vault', { userId, documentId: newId, messageId, consultationId });
+      res.json({ documentId: newId, title: msg.attachment_name || src.title });
+    } catch (error: any) {
+      logger.error('[Consultation] save-to-vault failed', { error: error.message });
+      res.status(500).json({ error: 'Не вдалося зберегти документ' });
     }
   }) as any);
 


### PR DESCRIPTION
## Summary
Attorney/client can save the other party's chat attachments to their own document vault.

## Backend
- `POST /api/consultations/:id/messages/:messageId/save-to-vault`
- Copies file from sender's MinIO bucket to receiver's bucket
- Creates document record with consultation metadata
- Dedup check prevents double-save

## Frontend
- Save button (FolderDown icon) on attachments from other party
- Loading spinner → green checkmark on success
- Hidden on own messages

## Test plan
- [ ] Client sends PDF in chat → attorney sees save button
- [ ] Attorney clicks save → document appears in their vault
- [ ] Second click shows "already saved"
- [ ] Client doesn't see save button on own attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)