### PR TITLE
fix: handle invalid UTF-8 in EDRSR fulltext queries

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-search-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-search-tools.ts
@@ -227,24 +227,50 @@ export class EdsrSearchTools extends BaseToolHandler {
       d.doc_url, d.status, d.date_publ
       ${includeFulltext ? ', LEFT(f.full_text, 10000) as full_text' : ''}`;
 
-    try {
-      // Count query (with timeout for safety on large result sets)
-      const countSql = `SELECT COUNT(*)::int as total FROM ${fromClause} WHERE ${whereClause}`;
+    const executeSearch = async (withFulltext: boolean) => {
+      const actualFromClause = `edrsr_documents d
+      ${needsCourtJoin ? 'LEFT JOIN edrsr_courts c ON c.court_code = d.court_code' : ''}
+      ${withFulltext ? 'LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id' : ''}`;
+
+      const actualSelectFields = `
+      d.doc_id, d.cause_num, d.judge, d.court_code, d.justice_kind,
+      d.judgment_code, d.category_code, d.adjudication_date, d.receipt_date,
+      d.doc_url, d.status, d.date_publ
+      ${withFulltext ? ', LEFT(f.full_text, 10000) as full_text' : ''}`;
+
+      const countSql = `SELECT COUNT(*)::int as total FROM ${actualFromClause} WHERE ${whereClause}`;
       const countResult = await this.db.query(countSql, params);
       const total = countResult.rows[0]?.total || 0;
 
-      // Data query
       const dataSql = `
-        SELECT ${selectFields}
-        FROM ${fromClause}
+        SELECT ${actualSelectFields}
+        FROM ${actualFromClause}
         WHERE ${whereClause}
         ORDER BY d.adjudication_date DESC NULLS LAST
         LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`;
 
       const dataResult = await this.db.query(dataSql, [...params, limit, offset]);
+      return { total, rows: dataResult.rows };
+    };
+
+    try {
+      let total: number;
+      let rows: any[];
+
+      try {
+        ({ total, rows } = await executeSearch(includeFulltext));
+      } catch (err: any) {
+        // Retry without fulltext JOIN if encoding error (some records have invalid UTF-8 bytes)
+        if (includeFulltext && err.code === '22021') {
+          logger.warn('[EdsrSearchTools] Retrying without fulltext due to encoding error', { cause_num: args.cause_num });
+          ({ total, rows } = await executeSearch(false));
+        } else {
+          throw err;
+        }
+      }
 
       // Enrich with reference data
-      const enriched = await this.enrichResults(dataResult.rows);
+      const enriched = await this.enrichResults(rows);
 
       logger.info('[EdsrSearchTools] search_edrsr_decisions', {
         filters: Object.keys(args).filter(k => args[k] !== undefined && k !== 'limit' && k !== 'offset'),

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -156,19 +156,26 @@ export class EdsrFtsService {
       }
     }
 
-    const selectFields = hasMetadataFilter
-      ? `f.doc_id,
-         ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
-         ts_headline('simple', LEFT(f.full_text, 2000), plainto_tsquery('simple', $1),
-           'MaxWords=60, MinWords=20, StartSel=**, StopSel=**') AS headline,
-         d.adjudication_date, d.cause_num, d.judge, d.court_code,
-         d.justice_kind, d.judgment_code`
-      : `f.doc_id,
-         ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
-         ts_headline('simple', LEFT(f.full_text, 2000), plainto_tsquery('simple', $1),
-           'MaxWords=60, MinWords=20, StartSel=**, StopSel=**') AS headline`;
+    const buildSelectFields = (withHeadline: boolean) => {
+      const headlineExpr = withHeadline
+        ? `ts_headline('simple', LEFT(f.full_text, 2000), plainto_tsquery('simple', $1),
+           'MaxWords=60, MinWords=20, StartSel=**, StopSel=**') AS headline`
+        : `NULL AS headline`;
 
-    try {
+      return hasMetadataFilter
+        ? `f.doc_id,
+           ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
+           ${headlineExpr},
+           d.adjudication_date, d.cause_num, d.judge, d.court_code,
+           d.justice_kind, d.judgment_code`
+        : `f.doc_id,
+           ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
+           ${headlineExpr}`;
+    };
+
+    const executeQuery = async (withHeadline: boolean) => {
+      const selectFields = buildSelectFields(withHeadline);
+
       // Count query
       const countSql = `SELECT COUNT(*)::int AS total FROM ${fromClause}${extraJoin} WHERE ${whereClause}`;
       const countResult = await dbPool.query(countSql, params);
@@ -183,6 +190,24 @@ export class EdsrFtsService {
         LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`;
 
       const dataResult = await dbPool.query(dataSql, [...params, safeLimit, safeOffset]);
+      return { total, dataResult };
+    };
+
+    try {
+      let total: number;
+      let dataResult: any;
+
+      try {
+        ({ total, dataResult } = await executeQuery(true));
+      } catch (headlineErr: any) {
+        // Retry without ts_headline if encoding error (some records have invalid UTF-8 bytes)
+        if (headlineErr.code === '22021') {
+          logger.warn('[EdsrFtsService] Retrying without ts_headline due to encoding error', { query });
+          ({ total, dataResult } = await executeQuery(false));
+        } else {
+          throw headlineErr;
+        }
+      }
 
       logger.info('[EdsrFtsService] searchFulltext', {
         query,


### PR DESCRIPTION
## Summary
- ~17.6% of `edrsr_fulltext` records contain invalid UTF-8 byte sequences from early RTF imports
- `ts_headline()` and `LEFT(full_text, N)` fail with `invalid byte sequence for encoding "UTF8": 0xd0/0xd1` (PostgreSQL error 22021)
- Both `EdsrFtsService.searchFulltext()` and `EdsrSearchTools.searchDecisions()` now retry without `ts_headline`/fulltext JOIN on encoding errors
- Returns results without snippets/fulltext rather than failing entirely
- Background data cleanup running on prod via `clean_edrsr_fulltext_batch()` function

## Test plan
- [ ] Search EDRSR by cause_num with `include_fulltext: true` — should return results even if some have bad encoding
- [ ] FTS search (`search_edrsr_fulltext`) — should return doc_ids with `headline: null` instead of failing
- [ ] Verify no regressions on clean records

🤖 Generated with [Claude Code](https://claude.com/claude-code)