### PR TITLE
fix: add react-is dependency for platform build

### DIFF
--- a/platform/package.json
+++ b/platform/package.json
@@ -18,6 +18,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-hot-toast": "^2.6.0",
+    "react-is": "^19.2.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0",


### PR DESCRIPTION
## Summary
- Add `react-is` to platform dependencies — required by recharts, missing caused Docker build failure on prod

## Test plan
- [ ] `docker compose build platform-prod` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)