### PR TITLE
fix: use npm install for platform in CI (no lock file)

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Build platform
         if: needs.detect-changes.outputs.platform == 'true'
-        run: cd platform && npm ci && npm run build
+        run: cd platform && npm install --legacy-peer-deps && npm run build
 
   # ─── Step 2b: Self-heal build failures with Claude Code ─────────────
   self-heal-build:


### PR DESCRIPTION
## Summary
- `npm ci` requires package-lock.json which is gitignored in this repo
- Switch to `npm install --legacy-peer-deps` for platform build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)