### PR TITLE
feat: add military_preset for EDRSR search (273K+ court decisions)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-search-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-search-tools.ts
@@ -55,7 +55,13 @@ export class EdsrSearchTools extends BaseToolHandler {
             },
             category_code: {
               type: 'number',
-              description: 'Код категорії справи (з таблиці edrsr_cause_categories)',
+              description: `Код категорії справи (з таблиці edrsr_cause_categories).
+Найважливіші категорії для військових справ:
+  40851=Самовільне залишення частини, 40852=Дезертирство, 40846=Непокора,
+  40847=Невиконання наказу, 40752=Ухилення від мобілізації,
+  40853=Ухилення (самокалічення), 40867=Недбале ставлення,
+  40869=Перевищення влади, 40875=Мародерство,
+  40845=Військові кримінальні правопорушення (загальна)`,
             },
             date_from: {
               type: 'string',
@@ -84,6 +90,21 @@ export class EdsrSearchTools extends BaseToolHandler {
               type: 'number',
               default: 0,
               description: 'Зміщення для пагінації',
+            },
+            military_preset: {
+              type: 'string',
+              description: `Пресет для військових справ. Автоматично додає justice_kind=2 (кримінальне) та відповідний category_code.
+Доступні пресети:
+  "awol" — Самовільне залишення частини (ст.407 КК, category_code=40851)
+  "desertion" — Дезертирство (ст.408 КК, category_code=40852)
+  "insubordination" — Непокора (ст.402 КК, category_code=40846)
+  "disobedience" — Невиконання наказу (ст.403 КК, category_code=40847)
+  "draft_evasion" — Ухилення від мобілізації (category_code=40752)
+  "self_harm" — Ухилення через самокалічення (ст.409 КК, category_code=40853)
+  "negligence" — Недбале ставлення (ст.425 КК, category_code=40867)
+  "abuse_of_power" — Перевищення влади (ст.426 КК, category_code=40869)
+  "looting" — Мародерство (ст.432 КК, category_code=40875)
+  "all_military" — Всі військові злочини (category_code IN (40845-40875))`,
             },
           },
           required: [],
@@ -120,9 +141,33 @@ export class EdsrSearchTools extends BaseToolHandler {
     }
   }
 
+  // Military preset category codes mapping
+  private static readonly MILITARY_PRESETS: Record<string, { category_codes: number[]; label: string }> = {
+    'awol':             { category_codes: [40851, 5459, 10660, 12440], label: 'Самовільне залишення частини (ст.407 КК)' },
+    'desertion':        { category_codes: [40852, 2050], label: 'Дезертирство (ст.408 КК)' },
+    'insubordination':  { category_codes: [40846, 5456], label: 'Непокора (ст.402 КК)' },
+    'disobedience':     { category_codes: [40847, 5457], label: 'Невиконання наказу (ст.403 КК)' },
+    'draft_evasion':    { category_codes: [40752, 40751, 5390], label: 'Ухилення від мобілізації' },
+    'self_harm':        { category_codes: [40853, 5460], label: 'Ухилення через самокалічення (ст.409 КК)' },
+    'negligence':       { category_codes: [40867, 2042, 10683], label: 'Недбале ставлення до військової служби (ст.425 КК)' },
+    'abuse_of_power':   { category_codes: [40869, 2043, 10682, 11320], label: 'Перевищення влади (ст.426 КК)' },
+    'looting':          { category_codes: [40875, 5476], label: 'Мародерство (ст.432 КК)' },
+    'all_military':     { category_codes: [40845, 40846, 40847, 40850, 40851, 40852, 40853, 40854, 40855, 40856, 40857, 40862, 40865, 40866, 40867, 40868, 40869, 40871, 40872, 40874, 40875, 40877, 40752, 2039, 2049, 2050, 5459], label: 'Всі військові кримінальні правопорушення' },
+  };
+
   private async searchDecisions(args: any): Promise<ToolResult> {
     const limit = Math.min(Math.max(args.limit || 20, 1), 100);
     const offset = Math.max(args.offset || 0, 0);
+
+    // Apply military preset
+    if (args.military_preset && EdsrSearchTools.MILITARY_PRESETS[args.military_preset]) {
+      const preset = EdsrSearchTools.MILITARY_PRESETS[args.military_preset];
+      args._military_category_codes = preset.category_codes;
+      args._military_label = preset.label;
+      if (!args.justice_kind) {
+        args.justice_kind = 2; // Кримінальне судочинство
+      }
+    }
 
     const conditions: string[] = [];
     const params: any[] = [];
@@ -185,7 +230,11 @@ export class EdsrSearchTools extends BaseToolHandler {
       paramIdx++;
     }
 
-    if (args.category_code) {
+    if (args._military_category_codes && args._military_category_codes.length > 0) {
+      conditions.push(`d.category_code = ANY($${paramIdx})`);
+      params.push(args._military_category_codes);
+      paramIdx++;
+    } else if (args.category_code) {
       conditions.push(`d.category_code = $${paramIdx}`);
       params.push(args.category_code);
       paramIdx++;
@@ -279,7 +328,8 @@ export class EdsrSearchTools extends BaseToolHandler {
       });
 
       return this.wrapResponse({
-        query: args,
+        query: { ...args, _military_category_codes: undefined },
+        ...(args._military_label ? { military_filter: args._military_label } : {}),
         total,
         returned: enriched.length,
         offset,


### PR DESCRIPTION
## Summary

- Add `military_preset` parameter to `search_edrsr_decisions` tool for instant access to 273K+ military court decisions
- 10 presets: awol, desertion, insubordination, disobedience, draft_evasion, self_harm, negligence, abuse_of_power, looting, all_military
- Each preset maps to multiple category_codes (old + new EDRSR systems)
- Auto-sets justice_kind=2 (criminal proceedings)
- Enriched category_code description with top military codes

## Test plan

- [ ] Call `search_edrsr_decisions` with `military_preset: "awol"` — should return AWOL cases
- [ ] Call with `military_preset: "all_military"` — should return all military crimes
- [ ] Verify `military_filter` label appears in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)