### PR TITLE
feat: add military workflow presets for /workflows page

### DIFF
--- a/lexwebapp/src/pages/WorkflowsPage/index.tsx
+++ b/lexwebapp/src/pages/WorkflowsPage/index.tsx
@@ -2,11 +2,12 @@
  * WorkflowsPage — Lists all workflow sets for the current user.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Zap, Clock, CheckCircle, AlertCircle, Trash2, Loader2 } from 'lucide-react';
+import { Zap, Clock, CheckCircle, AlertCircle, Trash2, Loader2, Shield, UserX, ShieldAlert, Plus } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { useWorkflowStore } from '../../stores/workflowStore';
+import { workflowService } from '../../services/api/WorkflowService';
 
 const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof CheckCircle }> = {
   pending: { label: 'Очікує', color: 'bg-gray-100 text-gray-700', icon: Clock },
@@ -14,6 +15,12 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
   completed: { label: 'Завершено', color: 'bg-green-100 text-green-700', icon: CheckCircle },
   partial: { label: 'Частково', color: 'bg-yellow-100 text-yellow-700', icon: AlertCircle },
   failed: { label: 'Помилка', color: 'bg-red-100 text-red-700', icon: AlertCircle },
+};
+
+const PRESET_ICONS: Record<string, typeof Shield> = {
+  shield: Shield,
+  'user-x': UserX,
+  'shield-alert': ShieldAlert,
 };
 
 export function WorkflowsPage() {
@@ -24,9 +31,26 @@ export function WorkflowsPage() {
   const fetchWorkflowSets = useWorkflowStore(s => s.fetchWorkflowSets);
   const deleteWorkflowSet = useWorkflowStore(s => s.deleteWorkflowSet);
 
+  const [presets, setPresets] = useState<Array<{ id: string; title: string; description: string; icon: string; category: string }>>([]);
+  const [creatingPreset, setCreatingPreset] = useState<string | null>(null);
+
   useEffect(() => {
     fetchWorkflowSets();
+    workflowService.listPresets().then(setPresets).catch(() => {});
   }, [fetchWorkflowSets]);
+
+  const handleCreateFromPreset = async (presetId: string) => {
+    setCreatingPreset(presetId);
+    try {
+      const result = await workflowService.createFromPreset(presetId);
+      await fetchWorkflowSets();
+      navigate(`/workflows/${result.id}`);
+    } catch (err) {
+      console.error('Failed to create from preset:', err);
+    } finally {
+      setCreatingPreset(null);
+    }
+  };
 
   const handleDelete = async (e: React.MouseEvent, id: string) => {
     e.stopPropagation();
@@ -46,6 +70,39 @@ export function WorkflowsPage() {
       {error && (
         <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
           {error}
+        </div>
+      )}
+
+      {presets.length > 0 && (
+        <div className="mb-8">
+          <div className="flex items-center gap-2 mb-4">
+            <Plus className="w-5 h-5 text-indigo-500" />
+            <h2 className="text-lg font-semibold text-gray-800">Готові шаблони аналізу</h2>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            {presets.map((preset) => {
+              const IconComponent = PRESET_ICONS[preset.icon] || Shield;
+              const isCreating = creatingPreset === preset.id;
+              return (
+                <button
+                  key={preset.id}
+                  onClick={() => handleCreateFromPreset(preset.id)}
+                  disabled={isCreating}
+                  className="text-left bg-gradient-to-br from-indigo-50 to-white border border-indigo-200 rounded-xl p-4 hover:border-indigo-400 hover:shadow-md transition-all disabled:opacity-50"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    {isCreating ? (
+                      <Loader2 className="w-5 h-5 animate-spin text-indigo-500" />
+                    ) : (
+                      <IconComponent className="w-5 h-5 text-indigo-600" />
+                    )}
+                    <span className="font-medium text-gray-900 text-sm">{preset.title}</span>
+                  </div>
+                  <p className="text-xs text-gray-500 line-clamp-2">{preset.description}</p>
+                </button>
+              );
+            })}
+          </div>
         </div>
       )}
 

--- a/lexwebapp/src/services/api/WorkflowService.ts
+++ b/lexwebapp/src/services/api/WorkflowService.ts
@@ -33,6 +33,17 @@ export class WorkflowService extends BaseService {
     return this.requestVoid(() => this.client.delete(`/api/workflow-sets/${id}`));
   }
 
+  async listPresets(): Promise<Array<{ id: string; title: string; description: string; icon: string; category: string }>> {
+    return this.request(
+      () => this.client.get('/api/workflow-sets/presets'),
+      (data: { presets?: Array<{ id: string; title: string; description: string; icon: string; category: string }> }) => data.presets || []
+    );
+  }
+
+  async createFromPreset(presetId: string): Promise<WorkflowSet> {
+    return this.request(() => this.client.post(`/api/workflow-sets/presets/${presetId}`));
+  }
+
   async cancelWorkflow(id: string): Promise<void> {
     return this.requestVoid(() => this.client.post(`/api/workflows/${id}/cancel`));
   }

--- a/mcp_backend/src/routes/workflow-routes.ts
+++ b/mcp_backend/src/routes/workflow-routes.ts
@@ -7,6 +7,7 @@ import { Router, Response } from 'express';
 import { logger } from '../utils/logger.js';
 import { WorkflowService } from '../services/workflow-service.js';
 import { WorkflowExecutorService } from '../services/workflow-executor-service.js';
+import { getWorkflowPreset, WORKFLOW_PRESET_LIST } from '../services/workflow-presets.js';
 
 interface DualAuthRequest {
   user?: { id: string; email?: string };
@@ -49,6 +50,52 @@ export function createWorkflowSetRoutes(
     } catch (error: any) {
       logger.error('[WorkflowRoutes] Failed to get workflow set', { error: error.message });
       res.status(500).json({ error: 'Failed to get workflow set' });
+    }
+  }) as any);
+
+  // GET /api/workflow-sets/presets — List available presets
+  router.get('/presets', (async (_req: DualAuthRequest, res: Response): Promise<any> => {
+    res.json({ presets: WORKFLOW_PRESET_LIST });
+  }) as any);
+
+  // POST /api/workflow-sets/presets/:presetId — Create workflow set from preset
+  router.post('/presets/:presetId', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const preset = getWorkflowPreset(req.params.presetId);
+    if (!preset) {
+      return res.status(404).json({
+        error: `Preset "${req.params.presetId}" not found`,
+        available: WORKFLOW_PRESET_LIST.map(p => p.id),
+      });
+    }
+
+    try {
+      const workflowSet = await workflowService.createWorkflowSet({
+        userId,
+        title: preset.title,
+        description: preset.description,
+        sourceQuery: `[preset:${req.params.presetId}] ${preset.title}`,
+        metadata: { preset: req.params.presetId },
+        workflows: preset.workflows.map(wf => ({
+          sequenceNumber: wf.sequenceNumber,
+          title: wf.title,
+          description: wf.description,
+          plan: wf.plan,
+        })),
+      });
+
+      logger.info('[WorkflowRoutes] Created workflow set from preset', {
+        presetId: req.params.presetId,
+        workflowSetId: workflowSet.id,
+        workflowCount: preset.workflows.length,
+      });
+
+      res.json(workflowSet);
+    } catch (error: any) {
+      logger.error('[WorkflowRoutes] Failed to create from preset', { error: error.message });
+      res.status(500).json({ error: 'Failed to create workflow set from preset' });
     }
   }) as any);
 

--- a/mcp_backend/src/services/workflow-presets.ts
+++ b/mcp_backend/src/services/workflow-presets.ts
@@ -1,0 +1,370 @@
+/**
+ * Workflow Presets — Pre-defined workflow templates for common legal scenarios.
+ *
+ * Military lawyer preset provides 5 ready-to-run workflows covering
+ * the most common military criminal defense scenarios in Ukraine (2022-2026).
+ */
+
+import type { GeneratedWorkflowSet } from './workflow-generator-service.js';
+
+export interface WorkflowPresetMeta {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  category: string;
+}
+
+export const WORKFLOW_PRESET_LIST: WorkflowPresetMeta[] = [
+  {
+    id: 'military_defense',
+    title: 'Військовий адвокат: повний аналіз',
+    description: 'Комплексний аналіз судової практики по військових злочинах: самовільне залишення частини, дезертирство, ухилення від мобілізації, непокора. 273K+ рішень.',
+    icon: 'shield',
+    category: 'military',
+  },
+  {
+    id: 'military_awol',
+    title: 'Ст. 407 КК — Самовільне залишення частини',
+    description: 'Аналіз 191K+ рішень по ст. 407 КК: статистика вироків, позиції ВС, пом\'якшуючі обставини, типові покарання.',
+    icon: 'user-x',
+    category: 'military',
+  },
+  {
+    id: 'military_draft_evasion',
+    title: 'Ухилення від мобілізації',
+    description: 'Аналіз 26K+ рішень щодо ухилення від призову: адмінвідповідальність, кримінальна відповідальність, практика ТЦК.',
+    icon: 'shield-alert',
+    category: 'military',
+  },
+];
+
+export function getWorkflowPreset(presetId: string): GeneratedWorkflowSet | null {
+  switch (presetId) {
+    case 'military_defense':
+      return MILITARY_DEFENSE_FULL;
+    case 'military_awol':
+      return MILITARY_AWOL;
+    case 'military_draft_evasion':
+      return MILITARY_DRAFT_EVASION;
+    default:
+      return null;
+  }
+}
+
+const MILITARY_DEFENSE_FULL: GeneratedWorkflowSet = {
+  title: 'Військовий адвокат: комплексний аналіз практики',
+  description: 'Аналіз судової практики по основних категоріях військових злочинів з 24.02.2022: статистика, позиції ВС, законодавча база, пом\'якшуючі обставини.',
+  workflows: [
+    {
+      sequenceNumber: 1,
+      title: 'Статистика військових справ з початку повномасштабного вторгнення',
+      description: 'Загальний обсяг та розподіл військових кримінальних справ за категоріями',
+      plan: {
+        goal: 'Визначити обсяг та розподіл військових справ з 24.02.2022',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'awol', date_from: '2022-02-24', limit: 5 },
+            purpose: 'Кількість справ по ст. 407 КК (самовільне залишення)',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'desertion', date_from: '2022-02-24', limit: 5 },
+            purpose: 'Кількість справ по ст. 408 КК (дезертирство)',
+          },
+          {
+            id: 3,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'insubordination', date_from: '2022-02-24', limit: 5 },
+            purpose: 'Кількість справ по ст. 402 КК (непокора)',
+          },
+          {
+            id: 4,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'draft_evasion', date_from: '2022-02-24', limit: 5 },
+            purpose: 'Кількість справ щодо ухилення від мобілізації',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 2,
+      title: 'Правові позиції Верховного Суду по військових злочинах',
+      description: 'Пошук прецедентних рішень ВС по ст. 407, 408, 402 КК',
+      plan: {
+        goal: 'Знайти ключові правові позиції ВС щодо військових злочинів',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'awol', instance_code: 1, date_from: '2022-02-24', judgment_code: 1, limit: 10 },
+            purpose: 'Вироки касаційної інстанції по самовільному залишенню частини',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'desertion', instance_code: 1, date_from: '2022-02-24', judgment_code: 1, limit: 10 },
+            purpose: 'Вироки касаційної інстанції по дезертирству',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 3,
+      title: 'Законодавча база для військового захисту',
+      description: 'Ключові статті КК, статутів ЗСУ, ЗУ про воєнний стан',
+      plan: {
+        goal: 'Зібрати нормативну базу для захисту у військових справах',
+        steps: [
+          {
+            id: 1,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КК ст. 407' },
+            purpose: 'Ст. 407 КК — Самовільне залишення частини',
+          },
+          {
+            id: 2,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КК ст. 408' },
+            purpose: 'Ст. 408 КК — Дезертирство',
+          },
+          {
+            id: 3,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'ст. 1 Закону про воєнний стан' },
+            purpose: 'ЗУ Про воєнний стан — визначення',
+          },
+          {
+            id: 4,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'ст. 12 Закону про мобілізацію' },
+            purpose: 'ЗУ Про мобілізацію — обов\'язки громадян',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 4,
+      title: 'Аналіз пом\'якшуючих обставин у військових справах',
+      description: 'Повнотекстовий пошук рішень з пом\'якшуючими обставинами',
+      plan: {
+        goal: 'Знайти рішення з пом\'якшуючими обставинами для побудови стратегії захисту',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'пом\'якшуючі обставини самовільне залишення частини звільнений від покарання', justice_kind: 2, limit: 10 },
+            purpose: 'Рішення зі звільненням від покарання по ст. 407 КК',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'угода про визнання винуватості самовільне залишення військової частини', justice_kind: 2, limit: 10 },
+            purpose: 'Рішення з угодами про визнання винуватості',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 5,
+      title: 'Ухилення від мобілізації: адмін vs кримінальна відповідальність',
+      description: 'Порівняння адміністративної та кримінальної практики по ухиленню',
+      plan: {
+        goal: 'Розмежувати адмін та кримінальну відповідальність за ухилення від мобілізації',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'draft_evasion', justice_kind: 5, date_from: '2024-01-01', limit: 10 },
+            purpose: 'Адміністративні справи по ухиленню (КУпАП ст. 210-1)',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'draft_evasion', justice_kind: 2, date_from: '2024-01-01', limit: 10 },
+            purpose: 'Кримінальні справи по ухиленню від мобілізації',
+          },
+          {
+            id: 3,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КУпАП ст. 210' },
+            purpose: 'Ст. 210 КУпАП — адмінвідповідальність за порушення військового обліку',
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const MILITARY_AWOL: GeneratedWorkflowSet = {
+  title: 'Ст. 407 КК — Самовільне залишення частини: повний аналіз',
+  description: 'Детальний аналіз 191K+ рішень по ст. 407 КК: типові покарання, позиції ВС, пом\'якшуючі та обтяжуючі обставини, статистика по інстанціях.',
+  workflows: [
+    {
+      sequenceNumber: 1,
+      title: 'Статистика та розподіл по інстанціях',
+      description: 'Кількість справ по ст. 407 КК в розрізі інстанцій та років',
+      plan: {
+        goal: 'Визначити обсяг та динаміку справ по ст. 407 КК',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'awol', instance_code: 3, date_from: '2022-02-24', limit: 5 },
+            purpose: 'Справи першої інстанції',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'awol', instance_code: 2, date_from: '2022-02-24', limit: 5 },
+            purpose: 'Апеляційні рішення',
+          },
+          {
+            id: 3,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'awol', instance_code: 1, date_from: '2022-02-24', limit: 5 },
+            purpose: 'Касаційні рішення ВС',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 2,
+      title: 'Типові покарання та звільнення від покарання',
+      description: 'Пошук вироків з різними видами покарань',
+      plan: {
+        goal: 'Визначити спектр покарань по ст. 407 КК',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'стаття 407 позбавлення волі вирок засуджено', justice_kind: 2, limit: 10 },
+            purpose: 'Вироки з реальним позбавленням волі',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'стаття 407 звільнити від покарання випробувальний строк', justice_kind: 2, limit: 10 },
+            purpose: 'Вироки зі звільненням від покарання',
+          },
+          {
+            id: 3,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'стаття 407 закрити кримінальне провадження звільнити', justice_kind: 2, limit: 10 },
+            purpose: 'Закриття провадження',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 3,
+      title: 'Нормативна база: ст. 407 КК + Статут внутрішньої служби',
+      description: 'Тексти ключових норм для захисту',
+      plan: {
+        goal: 'Зібрати нормативну базу для ст. 407 КК',
+        steps: [
+          {
+            id: 1,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КК ст. 407' },
+            purpose: 'Текст ст. 407 КК — Самовільне залишення частини',
+          },
+          {
+            id: 2,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КК ст. 66' },
+            purpose: 'Ст. 66 КК — Обставини, які пом\'якшують покарання',
+          },
+          {
+            id: 3,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КК ст. 75' },
+            purpose: 'Ст. 75 КК — Звільнення від відбування покарання з випробуванням',
+          },
+        ],
+      },
+    },
+  ],
+};
+
+const MILITARY_DRAFT_EVASION: GeneratedWorkflowSet = {
+  title: 'Ухилення від мобілізації: аналіз практики',
+  description: 'Аналіз 26K+ рішень: адмін vs кримінальна відповідальність, роль ТЦК, бронювання, відстрочки.',
+  workflows: [
+    {
+      sequenceNumber: 1,
+      title: 'Обсяг справ та розподіл за видами відповідальності',
+      description: 'Порівняння адмін та кримінальних справ по ухиленню',
+      plan: {
+        goal: 'Визначити співвідношення адмін/кримінальної відповідальності',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'draft_evasion', justice_kind: 5, date_from: '2024-01-01', limit: 10 },
+            purpose: 'Адміністративні справи (КУпАП ст. 210, 210-1)',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_decisions',
+            params: { military_preset: 'draft_evasion', justice_kind: 2, date_from: '2024-01-01', limit: 10 },
+            purpose: 'Кримінальні справи по ухиленню від мобілізації',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 2,
+      title: 'Нормативна база: мобілізація, бронювання, відстрочки',
+      description: 'Ключові норми для захисту від обвинувачень в ухиленні',
+      plan: {
+        goal: 'Зібрати нормативну базу щодо мобілізації та відстрочок',
+        steps: [
+          {
+            id: 1,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'ст. 1 Закону про мобілізацію' },
+            purpose: 'ЗУ Про мобілізацію — визначення термінів',
+          },
+          {
+            id: 2,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'КУпАП ст. 210' },
+            purpose: 'КУпАП ст. 210 — адмінвідповідальність',
+          },
+          {
+            id: 3,
+            tool: 'get_legislation_section',
+            params: { legislation_reference: 'ст. 23 Закону про мобілізацію' },
+            purpose: 'Підстави для відстрочки від мобілізації',
+          },
+        ],
+      },
+    },
+    {
+      sequenceNumber: 3,
+      title: 'Судова практика: підстави для закриття справ',
+      description: 'Пошук рішень де справи закривались або обвинувачення було змінено',
+      plan: {
+        goal: 'Знайти успішні кейси захисту від обвинувачень в ухиленні',
+        steps: [
+          {
+            id: 1,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'ухилення мобілізація закрити провадження виправдати', justice_kind: 2, limit: 10 },
+            purpose: 'Справи з закриттям провадження',
+          },
+          {
+            id: 2,
+            tool: 'search_edrsr_fulltext',
+            params: { query: 'неналежне повідомлення ТЦК вручення повістки ухилення', justice_kind: 2, limit: 10 },
+            purpose: 'Справи з неналежним повідомленням ТЦК',
+          },
+        ],
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- Add 3 pre-built military workflow templates accessible from `/workflows` page:
  - **military_defense** — full 5-workflow analysis covering AWOL, desertion, insubordination, draft evasion, legislation base, mitigating circumstances
  - **military_awol** — deep dive into 191K+ AWOL cases (art. 407 CC): statistics by instance, sentencing patterns, normative base
  - **military_draft_evasion** — 26K+ draft evasion cases: admin vs criminal liability, TCC practices, successful defenses
- Backend: `workflow-presets.ts` + routes `GET /presets`, `POST /presets/:id`
- Frontend: preset cards section with one-click workflow set creation

Each preset uses the new `military_preset` parameter from PR #1023 and `get_legislation_section` with newly loaded military legislation from PR #1021/#1022.

## Test plan

- [ ] Visit `/workflows` — see 3 preset cards
- [ ] Click "Військовий адвокат: повний аналіз" — creates workflow set, redirects to detail page
- [ ] Execute first workflow — should return EDRSR results with military cases
- [ ] Verify legislation steps return articles from newly loaded military laws

🤖 Generated with [Claude Code](https://claude.com/claude-code)