### PR TITLE
fix: escrow payment — 30% fee, cost breakdown, polling fix

### DIFF
--- a/lexwebapp/src/components/consultation/EscrowStatusBadge.tsx
+++ b/lexwebapp/src/components/consultation/EscrowStatusBadge.tsx
@@ -89,8 +89,9 @@ export function EscrowStatusBadge({ consultationId, consultationStatus, onPaymen
   useEffect(() => {
     fetchPayment();
 
-    // Poll for status while payment is in-progress
-    if (['accepted', 'paid'].includes(consultationStatus)) {
+    // Poll for status only while payment exists and is in non-terminal state
+    // Don't poll if consultation is only 'accepted' (payment not created yet)
+    if (consultationStatus === 'paid' || consultationStatus === 'in_progress') {
       pollRef.current = setInterval(fetchPayment, 5000);
     }
 

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -138,7 +138,11 @@ export function ConsultationDetailPage() {
         }
         case 'pay': {
           const payResult = await consultationService.initiatePayment(id);
-          if (payResult.paymentUrl) window.location.href = payResult.paymentUrl;
+          if (payResult.paymentUrl) {
+            window.location.href = payResult.paymentUrl;
+          } else {
+            showToast.error('Не вдалося отримати посилання на оплату від Monobank');
+          }
           return;
         }
         default: return;
@@ -388,9 +392,23 @@ export function ConsultationDetailPage() {
                 <span className="text-gray-500">Послуга</span>
                 <span className="font-medium text-gray-800">{consultation.request_title}</span>
               </div>
-              <div className="border-t pt-2 mt-2 flex justify-between items-center">
-                <span className="text-sm font-medium text-gray-700">Сума резервування</span>
-                <span className="text-xl font-bold text-gray-900">{consultation.agreed_fee_uah} грн</span>
+              <div className="border-t pt-2 mt-2 space-y-1.5">
+                <div className="flex justify-between items-center">
+                  <span className="text-sm font-medium text-gray-700">Сума резервування</span>
+                  <span className="text-xl font-bold text-gray-900">{consultation.agreed_fee_uah} грн</span>
+                </div>
+                <div className="flex justify-between text-xs text-gray-500">
+                  <span>Виплата адвокату (70%)</span>
+                  <span>{(consultation.agreed_fee_uah! * 0.7).toFixed(2)} грн</span>
+                </div>
+                <div className="flex justify-between text-xs text-gray-500">
+                  <span>Комісія платформи (30%)</span>
+                  <span>{(consultation.agreed_fee_uah! * 0.3).toFixed(2)} грн</span>
+                </div>
+                <div className="flex justify-between text-xs text-gray-400">
+                  <span>Еквайрінг Monobank</span>
+                  <span>включено</span>
+                </div>
               </div>
             </div>
 

--- a/mcp_backend/src/routes/consultation-routes.ts
+++ b/mcp_backend/src/routes/consultation-routes.ts
@@ -265,11 +265,19 @@ export function createConsultationRoutes(
   router.post('/:id/pay', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
       if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
+      logger.info('Initiating consultation payment', { consultationId: req.params.id, userId: req.user.id });
       const payment = await consultationPaymentService.createPayment(req.params.id as string, req.user.id);
+      logger.info('Payment record created', { paymentId: payment.id, amount: payment.amount_uah });
       const result = await consultationPaymentService.initiatePayment(payment.id);
+      logger.info('Monobank invoice created', { paymentId: payment.id, hasUrl: !!result.paymentUrl });
       res.json(result);
     } catch (error: any) {
-      logger.error('Failed to initiate consultation payment', { error: error.message });
+      logger.error('Failed to initiate consultation payment', {
+        error: error.message,
+        consultationId: req.params.id,
+        userId: req.user?.id,
+        stack: error.stack?.substring(0, 500),
+      });
       res.status(400).json({ error: error.message });
     }
   }) as any);

--- a/mcp_backend/src/services/consultation-payment-service.ts
+++ b/mcp_backend/src/services/consultation-payment-service.ts
@@ -4,7 +4,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { ConsultationService } from './consultation-service.js';
 import { AttorneyPayoutService } from './attorney-payout-service.js';
 
-const PLATFORM_FEE_PERCENT = 10; // 10% platform fee
+const PLATFORM_FEE_PERCENT = 30; // 30% platform fee
 const AUTO_RELEASE_DAYS = 7; // Days after completion to auto-release escrow
 
 export interface ConsultationPayment {


### PR DESCRIPTION
## Summary

- Platform fee changed from 10% to **30%** in consultation-payment-service.ts
- Added **cost breakdown** in escrow payment modal:
  - Виплата адвокату (70%)
  - Комісія платформи (30%)
  - Еквайрінг Monobank — включено
- Fixed **infinite payment status polling** — EscrowStatusBadge was polling GET `/payment` every 5s even when no payment existed (status `accepted`). Now only polls for `paid`/`in_progress` states
- Added **detailed logging** for payment initiation (createPayment → initiatePayment → Monobank)
- Better error message when Monobank payment URL is not returned

## Test plan

- [ ] Create consultation, attorney accepts with fee 100 UAH
- [ ] Client sees "Оплатити 100 грн" button
- [ ] Click → escrow modal shows breakdown: 70 грн адвокату, 30 грн платформа
- [ ] Click "Підтвердити та оплатити" → redirect to Monobank
- [ ] Verify no infinite polling in Network tab when status is `accepted`
- [ ] Check prod logs for detailed payment flow logging

🤖 Generated with [Claude Code](https://claude.com/claude-code)