### PR TITLE
fix: adjust rate limits for 20 concurrent users behind Cloudflare

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -181,7 +181,7 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 2048mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 2048mb --maxmemory-policy volatile-lru
     healthcheck:
       test:
       - CMD

--- a/lexwebapp/src/components/consultation/EscrowStatusBadge.tsx
+++ b/lexwebapp/src/components/consultation/EscrowStatusBadge.tsx
@@ -92,7 +92,7 @@ export function EscrowStatusBadge({ consultationId, consultationStatus, onPaymen
     // Poll for status only while payment exists and is in non-terminal state
     // Don't poll if consultation is only 'accepted' (payment not created yet)
     if (consultationStatus === 'paid' || consultationStatus === 'in_progress') {
-      pollRef.current = setInterval(fetchPayment, 5000);
+      pollRef.current = setInterval(fetchPayment, 15000);
     }
 
     return () => {

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -95,7 +95,7 @@ export function ConsultationDetailPage() {
           return prev;
         });
       }).catch(() => {});
-    }, 5000);
+    }, 15000);
     return () => clearInterval(poll);
   }, [id]);
 

--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -14,6 +14,8 @@ interface RateLimitOptions {
   maxRequests: number;
   keyPrefix?: string;
   skipSuccessfulRequests?: boolean;
+  /** Use authenticated user ID instead of IP for rate limiting (requires JWT auth before this middleware) */
+  keyByUserId?: boolean;
 }
 
 export function createRateLimiter(options: RateLimitOptions) {
@@ -28,7 +30,9 @@ export function createRateLimiter(options: RateLimitOptions) {
       if (!rateCache) {
         return next(); // Cache unavailable, skip rate limiting
       }
-      const identifier = req.ip || req.socket.remoteAddress || 'unknown';
+      const identifier = options.keyByUserId && (req as any).user?.id
+        ? `user:${(req as any).user.id}`
+        : req.ip || req.socket.remoteAddress || 'unknown';
 
       // Skip rate limiting for internal/localhost traffic (Prometheus, health monitors)
       if (identifier === '127.0.0.1' || identifier === '::1' || identifier === '::ffff:127.0.0.1') {
@@ -91,11 +95,13 @@ export const webhookRateLimit = createRateLimiter({
   keyPrefix: 'ratelimit:webhook',
 });
 
-// Chat endpoint rate limiter (max 20 requests per minute)
+// Chat endpoint rate limiter — per authenticated user, not per IP
+// (Cloudflare proxies all traffic through shared IPs)
 export const chatRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 20,
+  maxRequests: 60,
   keyPrefix: 'ratelimit:chat',
+  keyByUserId: true,
 });
 
 // Auth endpoint rate limiter (max 10 requests per 15 minutes)
@@ -113,9 +119,10 @@ export const passwordResetRateLimit = createRateLimiter({
 });
 
 // Global API rate limiter — covers all /api/ routes as a baseline.
-// More specific per-endpoint limiters (auth, chat, etc.) still apply additionally.
+// Raised to 1500/min to handle 20+ concurrent users behind Cloudflare (shared IP).
+// Polling alone generates ~480 req/min for 20 users.
 export const globalApiRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 900,
+  maxRequests: 1500,
   keyPrefix: 'ratelimit:global-api',
 });

--- a/mcp_backend/src/sse-server.ts
+++ b/mcp_backend/src/sse-server.ts
@@ -14,7 +14,7 @@ import rateLimit from 'express-rate-limit';
 
 const sseGlobalRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 60,
+  maxRequests: 120,
   keyPrefix: 'ratelimit:sse-global',
 });
 
@@ -75,7 +75,7 @@ class SSEServer {
     // Global rate limiter (express-rate-limit) — recognised by CodeQL
     this.app.use(rateLimit({
       windowMs: 60 * 1000,
-      max: 60,
+      max: 120,
       standardHeaders: true,
       legacyHeaders: false,
       message: { error: 'Too Many Requests', code: 'RATE_LIMIT_EXCEEDED' },


### PR DESCRIPTION
## Summary

Adjust rate limits so 20 concurrent users don't hit throttling behind Cloudflare (shared IPs).

| Limit | Before | After | Why |
|---|---|---|---|
| Chat | 20/min per IP | **60/min per user (JWT)** | Cloudflare = shared IP, was 1 req/user/min |
| Global API | 900/min per IP | **1500/min per IP** | 20 users polling = 480 req/min baseline |
| SSE | 60/min per IP | **120/min per IP** | Cloudflare reconnects every ~100s |
| Polling | every 5s | **every 15s** | -66% background traffic |
| Redis eviction | noeviction | **volatile-lru** | Prevent OOM under load |

Key change: added `keyByUserId` option to rate limiter — chat now limits per authenticated user instead of per IP address.

## Test plan

- [ ] Deploy, have 2+ users send chat messages simultaneously — no 429 errors
- [ ] Verify consultation polling interval is 15s in Network tab
- [ ] Monitor Redis memory under load
- [ ] Check `X-RateLimit-*` headers in API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)