### PR TITLE
fix: replace Diia logo with official branding

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -563,9 +563,8 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           >
             {/* Official Diia logo */}
             <svg width="22" height="22" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <rect width="32" height="32" rx="6" fill="white" fillOpacity="0.15"/>
-              <path d="M8 7h7.5C19.09 7 22 9.91 22 13.5S19.09 20 15.5 20H11v5H8V7zm3 3v7h4.5c1.93 0 3.5-1.57 3.5-3.5S17.43 10 15.5 10H11z" fill="white"/>
-              <path d="M23 7h3v18h-3V7z" fill="white"/>
+              <rect width="32" height="32" rx="7" fill="black"/>
+              <text x="16" y="22" textAnchor="middle" fill="white" fontSize="15" fontWeight="700" fontFamily="'e-Ukraine', Arial, Helvetica, sans-serif" letterSpacing="-0.5">Дія</text>
             </svg>
             {isLogin ? 'Увійти через Дію' : 'Зареєструватися через Дію'}
           </motion.button>
@@ -875,10 +874,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               </button>
 
               {/* Diia logo */}
-              <div className="w-16 h-16 bg-[#1A4DC2] rounded-2xl flex items-center justify-center mx-auto mb-4">
-                <svg width="36" height="36" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-                  <path d="M8 7h7.5C19.09 7 22 9.91 22 13.5S19.09 20 15.5 20H11v5H8V7zm3 3v7h4.5c1.93 0 3.5-1.57 3.5-3.5S17.43 10 15.5 10H11z" fill="white"/>
-                  <path d="M23 7h3v18h-3V7z" fill="white"/>
+              <div className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                <svg width="64" height="64" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <rect width="32" height="32" rx="7" fill="black"/>
+                  <text x="16" y="22" textAnchor="middle" fill="white" fontSize="15" fontWeight="700" fontFamily="'e-Ukraine', Arial, Helvetica, sans-serif" letterSpacing="-0.5">Дія</text>
                 </svg>
               </div>
 


### PR DESCRIPTION
## Summary
- Replaced custom Latin "DI" SVG paths with the official Дія logo on the login page
- Updated both the login button and QR modal logos to match the official Diia logobook 2025
- Logo is now a black rounded square with white "Дія" text per official brand guidelines

## Test plan
- [ ] Verify Diia login button shows correct "Дія" logo
- [ ] Verify QR modal shows correct "Дія" logo
- [ ] Check logo renders correctly across browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)