### PR TITLE
feat: payouts tab on consultations page

### DIFF
--- a/lexwebapp/src/pages/ConsultationsPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationsPage/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Loader2, CreditCard } from 'lucide-react';
+import { MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Loader2, CreditCard, Wallet } from 'lucide-react';
 import { consultationService } from '../../services/api/ConsultationService';
 import { generateRoute } from '../../router/routes';
 
@@ -19,6 +19,7 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
 export function ConsultationsPage() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState<'list' | 'payouts'>('list');
 
   // Clear stale redirect so attorney always sees full list first
   useEffect(() => {
@@ -40,10 +41,24 @@ export function ConsultationsPage() {
   const consultations = data?.consultations ?? [];
   const total = data?.total ?? 0;
 
+  const { data: payouts, isLoading: payoutsLoading } = useQuery({
+    queryKey: ['my-payouts'],
+    queryFn: () => consultationService.getMyPayouts(),
+    enabled: activeTab === 'payouts',
+  });
+
+  const totalEarned = (payouts ?? [])
+    .filter(p => p.status === 'completed')
+    .reduce((sum, p) => sum + Number(p.amount_uah), 0);
+  const totalPending = (payouts ?? [])
+    .filter(p => p.status === 'pending')
+    .reduce((sum, p) => sum + Number(p.amount_uah), 0);
+
   // Invalidate query on SSE consultation status events
   useEffect(() => {
     const handler = () => {
       queryClient.invalidateQueries({ queryKey: ['consultations'] });
+      queryClient.invalidateQueries({ queryKey: ['my-payouts'] });
     };
     window.addEventListener('consultation-updated', handler);
     return () => window.removeEventListener('consultation-updated', handler);
@@ -52,11 +67,95 @@ export function ConsultationsPage() {
   return (
     <div className="h-full overflow-y-auto">
     <div className="max-w-5xl mx-auto p-6">
-      <div className="flex items-center gap-3 mb-8">
-        <MessageSquare className="w-7 h-7 text-indigo-600" />
-        <h1 className="text-2xl font-bold text-gray-900">Консультації</h1>
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center gap-3">
+          <MessageSquare className="w-7 h-7 text-indigo-600" />
+          <h1 className="text-2xl font-bold text-gray-900">Консультації</h1>
+        </div>
+        <div className="flex bg-gray-100 rounded-lg p-1">
+          <button
+            onClick={() => setActiveTab('list')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              activeTab === 'list' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            <MessageSquare className="w-4 h-4 inline mr-1.5" />
+            Список
+          </button>
+          <button
+            onClick={() => setActiveTab('payouts')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              activeTab === 'payouts' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            <Wallet className="w-4 h-4 inline mr-1.5" />
+            Виплати
+          </button>
+        </div>
       </div>
 
+      {activeTab === 'payouts' ? (
+        <div>
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 gap-4 mb-6">
+            <div className="bg-emerald-50 border border-emerald-200 rounded-xl p-4">
+              <p className="text-sm text-emerald-600 mb-1">Зараховано</p>
+              <p className="text-2xl font-bold text-emerald-800">{totalEarned.toFixed(2)} грн</p>
+            </div>
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-4">
+              <p className="text-sm text-amber-600 mb-1">Очікує</p>
+              <p className="text-2xl font-bold text-amber-800">{totalPending.toFixed(2)} грн</p>
+            </div>
+          </div>
+
+          {payoutsLoading ? (
+            <div className="flex items-center justify-center py-20">
+              <Loader2 className="w-8 h-8 animate-spin text-indigo-500" />
+            </div>
+          ) : !payouts || payouts.length === 0 ? (
+            <div className="text-center py-20">
+              <Wallet className="w-12 h-12 text-gray-300 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-600 mb-2">Виплат поки немає</h3>
+              <p className="text-gray-400">Виплати з'являться після завершення консультацій</p>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {payouts.map(p => {
+                const statusLabels: Record<string, { label: string; color: string }> = {
+                  pending: { label: 'Очікує', color: 'bg-yellow-100 text-yellow-700' },
+                  processing: { label: 'Обробка', color: 'bg-blue-100 text-blue-700' },
+                  completed: { label: 'Зараховано', color: 'bg-green-100 text-green-700' },
+                  failed: { label: 'Помилка', color: 'bg-red-100 text-red-700' },
+                };
+                const cfg = statusLabels[p.status] || statusLabels.pending;
+                return (
+                  <div
+                    key={p.id}
+                    onClick={() => p.consultation_id && navigate(generateRoute.consultationDetail(p.consultation_id))}
+                    className="border rounded-lg p-4 bg-white hover:border-indigo-300 hover:shadow-sm transition-all cursor-pointer"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="font-medium text-gray-900">{p.request_title || 'Консультація'}</p>
+                        <p className="text-xs text-gray-400 mt-1">
+                          {new Date(p.created_at).toLocaleDateString('uk-UA', { day: 'numeric', month: 'long', year: 'numeric' })}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-3">
+                        <span className="text-lg font-bold text-gray-900">{Number(p.amount_uah).toFixed(2)} грн</span>
+                        <span className={`px-2.5 py-1 rounded-full text-xs font-medium ${cfg.color}`}>
+                          {cfg.label}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ) : (
+      <>
       <div className="flex gap-3 mb-6">
         <select
           className="px-3 py-2 border rounded-md text-sm bg-white"
@@ -131,6 +230,8 @@ export function ConsultationsPage() {
             );
           })}
         </div>
+      )}
+      </>
       )}
     </div>
     </div>

--- a/lexwebapp/src/services/api/ConsultationService.ts
+++ b/lexwebapp/src/services/api/ConsultationService.ts
@@ -197,6 +197,21 @@ export class ConsultationService extends BaseService {
   async getMyClients(): Promise<{ clients: AttorneyClient[] }> {
     return this.request(() => this.client.get('/api/consultations/my-clients'));
   }
+
+  async getMyPayouts(): Promise<AttorneyPayout[]> {
+    return this.request(() => this.client.get('/api/consultations/my-payouts'));
+  }
+}
+
+export interface AttorneyPayout {
+  id: string;
+  attorney_user_id: string;
+  consultation_payment_id: string;
+  amount_uah: number;
+  status: 'pending' | 'processing' | 'completed' | 'failed';
+  created_at: string;
+  consultation_id?: string;
+  request_title?: string;
 }
 
 export interface AttorneyClient {


### PR DESCRIPTION
## Summary
Added "Виплати" tab to consultations page for attorneys to see earnings.

- Tab switcher: Список | Виплати
- Summary cards: earned + pending in UAH
- Payout list with status badges
- Uses existing GET /api/consultations/my-payouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)