### PR TITLE
fix: full content display in thinking steps

### DIFF
--- a/lexwebapp/src/components/ThinkingSteps.tsx
+++ b/lexwebapp/src/components/ThinkingSteps.tsx
@@ -76,9 +76,9 @@ export function ThinkingSteps({
           }} transition={{
             duration: 0.2
           }} className="border-t border-claude-border/30">
-                  <div className="p-3 text-[13px] text-claude-text leading-relaxed bg-claude-bg/30">
+                  <pre className="p-3 text-[12px] text-claude-text leading-relaxed bg-claude-bg/30 whitespace-pre-wrap break-words max-h-[400px] overflow-y-auto font-mono">
                     {step.content}
-                  </div>
+                  </pre>
                 </motion.div>}
             </AnimatePresence>
           </motion.div>)}

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -138,8 +138,8 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
 
         onToolResult: (data) => {
           const toolPreview = typeof data.result === 'string'
-            ? data.result.slice(0, 500)
-            : JSON.stringify(data.result, null, 2).slice(0, 500);
+            ? data.result
+            : JSON.stringify(data.result, null, 2);
 
           const costSuffix = data.cost_usd ? ` · ${formatUah(data.cost_usd)}` : '';
           addThinkingStep(assistantMessageId, {

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -232,8 +232,8 @@ export const useChatStore = create<ChatState>()(
                     id: `step-${i}`,
                     title: `✓ ${s.tool || 'tool'}`,
                     content: typeof s.result === 'string'
-                      ? s.result.slice(0, 500)
-                      : (JSON.stringify(s.result ?? '', null, 2) || '').slice(0, 500),
+                      ? s.result
+                      : (JSON.stringify(s.result ?? '', null, 2) || ''),
                     isComplete: true,
                   }))
                 : undefined,


### PR DESCRIPTION
## Summary
- Remove 500-character truncation of tool result content in thinking steps (streaming + saved conversations)
- Render thinking step content in scrollable monospace `<pre>` block instead of plain `<div>`

## Test plan
- [ ] Open a conversation with tool calls, expand thinking steps — full JSON should be visible
- [ ] Load a saved conversation — thinking steps should show full content
- [ ] Long content should scroll within 400px max-height container

🤖 Generated with [Claude Code](https://claude.com/claude-code)