### PR TITLE
feat: stuck escrow alerting + payout reconciliation (LEG-243 P5+P6)

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -116,6 +116,14 @@ class HTTPMCPServer {
         logger.error('[Cron] Monobank reconciliation failed', { error: (err as Error).message });
       });
     }, { timezone: 'Europe/Kyiv' });
+
+    // Cron: flag stuck consultations + alert on failed payouts daily at 08:00 Kyiv time
+    cron.schedule('0 8 * * *', () => {
+      logger.info('[Cron] Running stuck escrow and failed payout check');
+      this.app_.consultationPaymentService.flagStuckConsultationsAndPayouts().catch(err => {
+        logger.error('[Cron] Stuck escrow check failed', { error: (err as Error).message });
+      });
+    }, { timezone: 'Europe/Kyiv' });
   }
 
   private setupMiddleware() {
@@ -262,6 +270,17 @@ class HTTPMCPServer {
         checks.minio = { ...minioResult, latencyMs: Date.now() - start };
       } catch (err: any) {
         checks.minio = { ok: false, error: err.message };
+      }
+
+      // Payout reconciliation (non-blocking)
+      try {
+        const recon = await this.app_.consultationPaymentService.getPayoutReconciliation();
+        checks.payout_reconciliation = {
+          ok: recon.ok,
+          ...(recon.ok ? {} : { error: `Mismatch: ${recon.mismatch.toFixed(2)} UAH (released: ${recon.releasedTotal}, payouts: ${recon.payoutsTotal})` }),
+        };
+      } catch (err: any) {
+        checks.payout_reconciliation = { ok: false, error: err.message };
       }
 
       const allOk = Object.values(checks).every(c => c.ok);

--- a/mcp_backend/src/services/consultation-payment-service.ts
+++ b/mcp_backend/src/services/consultation-payment-service.ts
@@ -342,4 +342,88 @@ export class ConsultationPaymentService {
     );
     return result.rows[0] || null;
   }
+
+  /**
+   * Flag consultations stuck in 'in_progress' for more than 30 days as 'disputed'.
+   * Also logs failed attorney payouts. Intended for daily cron.
+   */
+  async flagStuckConsultationsAndPayouts(): Promise<{ disputed: number; failedPayouts: number }> {
+    // Mark stuck in_progress consultations as disputed
+    const stuckResult = await this.db.query(
+      `UPDATE consultations
+       SET status = 'disputed',
+           dispute_reason = 'Автоматично: консультація в статусі in_progress понад 30 днів',
+           dispute_raised_by = 'system',
+           dispute_raised_at = NOW()
+       WHERE status = 'in_progress'
+         AND started_at < NOW() - INTERVAL '30 days'
+       RETURNING id`
+    );
+
+    for (const row of stuckResult.rows) {
+      logger.warn('[StuckEscrow] Consultation auto-disputed after 30 days', { consultationId: row.id });
+      if (this.auditService) {
+        this.auditService.log({
+          action: 'escrow.auto_disputed',
+          resourceType: 'consultation',
+          resourceId: row.id,
+          details: { reason: 'in_progress > 30 days' },
+        }).catch(() => {});
+      }
+    }
+
+    // Alert on failed payouts
+    const failedPayouts = await this.db.query(
+      `SELECT ap.id, ap.attorney_user_id, ap.amount_uah, ap.consultation_payment_id
+       FROM attorney_payouts ap
+       WHERE ap.status = 'failed'
+         AND ap.updated_at > NOW() - INTERVAL '24 hours'`
+    );
+
+    for (const payout of failedPayouts.rows) {
+      logger.error('[FailedPayout] Attorney payout failed and needs attention', {
+        payoutId: payout.id,
+        attorneyUserId: payout.attorney_user_id,
+        amountUah: payout.amount_uah,
+      });
+    }
+
+    if (stuckResult.rows.length > 0 || failedPayouts.rows.length > 0) {
+      logger.info('[StuckEscrow] Cron completed', {
+        disputed: stuckResult.rows.length,
+        failedPayouts: failedPayouts.rows.length,
+      });
+    }
+
+    return { disputed: stuckResult.rows.length, failedPayouts: failedPayouts.rows.length };
+  }
+
+  /**
+   * Reconciliation assertion: SUM(released payments) should equal SUM(created payouts).
+   * Returns the mismatch amount if any.
+   */
+  async getPayoutReconciliation(): Promise<{
+    ok: boolean;
+    releasedTotal: number;
+    payoutsTotal: number;
+    mismatch: number;
+  }> {
+    const result = await this.db.query(
+      `SELECT
+         COALESCE((SELECT SUM(attorney_payout_uah) FROM consultation_payments WHERE status = 'released'), 0) AS released_total,
+         COALESCE((SELECT SUM(amount_uah) FROM attorney_payouts), 0) AS payouts_total`
+    );
+
+    const row = result.rows[0];
+    const releasedTotal = parseFloat(row.released_total);
+    const payoutsTotal = parseFloat(row.payouts_total);
+    const mismatch = Math.abs(releasedTotal - payoutsTotal);
+
+    return {
+      ok: mismatch < 0.01,
+      releasedTotal,
+      payoutsTotal,
+      mismatch,
+    };
+  }
 }


### PR DESCRIPTION
## Summary
- **P5:** Daily cron (08:00 Kyiv) auto-disputes consultations stuck in `in_progress` for 30+ days. Logs `[FailedPayout]` errors for failed payouts from last 24h
- **P6:** Payout reconciliation SQL assertion added to `/health` endpoint — verifies `SUM(released consultation_payments) = SUM(attorney_payouts)`. Reports mismatch amount if any

## Test plan
- [ ] Verify TypeScript build passes
- [ ] Test stuck consultation detection with a consultation older than 30 days in `in_progress`
- [ ] Verify `/health` endpoint includes `payout_reconciliation` check
- [ ] Confirm health check shows `ok: true` when totals match, `ok: false` with mismatch details otherwise

Closes LEG-243

🤖 Generated with [Claude Code](https://claude.com/claude-code)