### PR TITLE
fix: payouts tab crash — extract array from API response

### DIFF
--- a/lexwebapp/src/services/api/ConsultationService.ts
+++ b/lexwebapp/src/services/api/ConsultationService.ts
@@ -199,7 +199,10 @@ export class ConsultationService extends BaseService {
   }
 
   async getMyPayouts(): Promise<AttorneyPayout[]> {
-    return this.request(() => this.client.get('/api/consultations/my-payouts'));
+    return this.request(
+      () => this.client.get<{ payouts: AttorneyPayout[] }>('/api/consultations/my-payouts'),
+      (data) => data.payouts,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- `getMyPayouts()` returned raw `{ payouts: [...] }` object instead of the array
- `ConsultationsPage` called `.filter()` on the object → crash: `filter is not a function`
- Added transform to extract `data.payouts` from response

## Test plan
- [ ] Attorney opens Консультації → Виплати tab loads without crash
- [ ] Payout data displays correctly (amounts, statuses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)