### PR TITLE
fix: merge consecutive same-role messages for Bedrock

### DIFF
--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -860,7 +860,19 @@ export class LLMClientManager {
       });
     }
 
-    return { system, messages: bedrockMessages };
+    // Bedrock requires strict user/assistant alternation.
+    // Merge consecutive same-role messages to avoid "Error in input stream".
+    const merged: BedrockMessage[] = [];
+    for (const msg of bedrockMessages) {
+      const prev = merged[merged.length - 1];
+      if (prev && prev.role === msg.role && Array.isArray(prev.content) && Array.isArray(msg.content)) {
+        prev.content.push(...msg.content);
+      } else {
+        merged.push(msg);
+      }
+    }
+
+    return { system, messages: merged };
   }
 
   private buildBedrockToolConfig(request: UnifiedChatRequest): ToolConfiguration | undefined {


### PR DESCRIPTION
## Summary

- When chat history exceeds 4 messages, `ChatContextBuilder` compresses older messages into a user-role summary, which creates consecutive `user` messages (summary + first recent message)
- Bedrock ConverseStream rejects consecutive same-role messages with "Error in input stream"
- Fix: merge consecutive same-role messages in `convertToBedrockMessages()` before sending to Bedrock

## Test plan
- [ ] Send a chat query in a conversation with 3+ prior exchanges (6+ history messages)
- [ ] Verify no "Error in input stream" error
- [ ] Verify chat responses still work correctly for new conversations (no history)

🤖 Generated with [Claude Code](https://claude.com/claude-code)