### PR TITLE
fix: fulltext modal stuck on loading for court decisions

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -70,14 +70,14 @@ export function AssistantMessage({
       badgeVariant: decision.status as 'active' | 'overturned' | 'modified',
       content: decision.summary || 'Завантаження повного тексту...',
       relevance: decision.relevance,
-      externalUrl: (decision as any).externalUrl,
+      externalUrl: decision.externalUrl,
     });
     setIsDocViewerOpen(true);
 
-    // Extract numeric EDRSR doc_id from decision id (format: "d-{doc_id}" or from externalUrl)
-    const edsrDocId = (decision as any).docId
-      || decision.id.replace(/^d-/, '')
-      || (decision as any).externalUrl?.match(/\/Review\/(\d+)/)?.[1];
+    // Extract numeric EDRSR doc_id from decision id (prefixes: d-, sc-, chain-, pc-, gcd-) or from externalUrl
+    const edsrDocId = decision.docId
+      || decision.id.replace(/^(?:d|sc|chain|pc|gcd)-/, '')
+      || decision.externalUrl?.match(/\/Review\/(\d+)/)?.[1];
 
     if (edsrDocId && /^\d+$/.test(String(edsrDocId))) {
       // Prevent duplicate fetches
@@ -91,6 +91,13 @@ export function AssistantMessage({
             ...prev,
             content: result.full_text!,
             subtitle: [result.court_name || decision.court, result.judgment_form, decision.date].filter(Boolean).join(' • '),
+          } : prev);
+        } else {
+          setDocViewerItem(prev => prev ? {
+            ...prev,
+            content: prev.content === 'Завантаження повного тексту...'
+              ? (decision.summary || 'Повний текст рішення недоступний.')
+              : prev.content,
           } : prev);
         }
       }).finally(() => {


### PR DESCRIPTION
## Summary
- Fixed regex that only stripped `d-` prefix from decision IDs — now handles all prefixes (`sc-`, `chain-`, `pc-`, `gcd-`) generated by `evidence-extractor.ts`
- Added fallback when `full_text` is null/empty — shows decision summary instead of infinite "Завантаження повного тексту..." spinner
- Removed unnecessary `as any` casts for `docId` and `externalUrl` (already in `Decision` type)

## Test plan
- [ ] Open chat with court decision results (e.g. case 922/989/18)
- [ ] Click on a decision card to open the fulltext modal
- [ ] Verify fulltext loads instead of showing infinite spinner
- [ ] Test with decisions that have different ID prefixes (sc-, chain-, pc-, gcd-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)