### PR TITLE
feat: workflow template picker with search & filters

### DIFF
--- a/lexwebapp/src/pages/WorkflowsPage/index.tsx
+++ b/lexwebapp/src/pages/WorkflowsPage/index.tsx
@@ -1,10 +1,11 @@
 /**
  * WorkflowsPage — Lists all workflow sets for the current user.
+ * Includes a preset template picker with search and category filters.
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Zap, Clock, CheckCircle, AlertCircle, Trash2, Loader2, Shield, UserX, ShieldAlert, Plus } from 'lucide-react';
+import { Zap, Clock, CheckCircle, AlertCircle, Trash2, Loader2, Shield, UserX, ShieldAlert, Plus, Search, X, ListChecks } from 'lucide-react';
 import { useShallow } from 'zustand/react/shallow';
 import { useWorkflowStore } from '../../stores/workflowStore';
 import { workflowService } from '../../services/api/WorkflowService';
@@ -23,6 +24,20 @@ const PRESET_ICONS: Record<string, typeof Shield> = {
   'shield-alert': ShieldAlert,
 };
 
+const CATEGORY_LABELS: Record<string, string> = {
+  military: 'Військове право',
+};
+
+type PresetItem = {
+  id: string;
+  title: string;
+  description: string;
+  icon: string;
+  category: string;
+  tags: string[];
+  stepsCount: number;
+};
+
 export function WorkflowsPage() {
   const navigate = useNavigate();
   const { workflowSets, isLoading, error } = useWorkflowStore(
@@ -31,13 +46,38 @@ export function WorkflowsPage() {
   const fetchWorkflowSets = useWorkflowStore(s => s.fetchWorkflowSets);
   const deleteWorkflowSet = useWorkflowStore(s => s.deleteWorkflowSet);
 
-  const [presets, setPresets] = useState<Array<{ id: string; title: string; description: string; icon: string; category: string }>>([]);
+  const [presets, setPresets] = useState<PresetItem[]>([]);
   const [creatingPreset, setCreatingPreset] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
 
   useEffect(() => {
     fetchWorkflowSets();
     workflowService.listPresets().then(setPresets).catch(() => {});
   }, [fetchWorkflowSets]);
+
+  // Derive unique categories from presets
+  const categories = useMemo(() => {
+    const cats = [...new Set(presets.map(p => p.category))];
+    return cats.map(c => ({ id: c, label: CATEGORY_LABELS[c] || c }));
+  }, [presets]);
+
+  // Filter presets by search + category
+  const filteredPresets = useMemo(() => {
+    let result = presets;
+    if (activeCategory) {
+      result = result.filter(p => p.category === activeCategory);
+    }
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(p =>
+        p.title.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q) ||
+        p.tags.some(t => t.toLowerCase().includes(q))
+      );
+    }
+    return result;
+  }, [presets, searchQuery, activeCategory]);
 
   const handleCreateFromPreset = async (presetId: string) => {
     setCreatingPreset(presetId);
@@ -73,39 +113,112 @@ export function WorkflowsPage() {
         </div>
       )}
 
+      {/* ── Preset Templates Section ── */}
       {presets.length > 0 && (
-        <div className="mb-8">
+        <div className="mb-10">
           <div className="flex items-center gap-2 mb-4">
             <Plus className="w-5 h-5 text-indigo-500" />
             <h2 className="text-lg font-semibold text-gray-800">Готові шаблони аналізу</h2>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-            {presets.map((preset) => {
-              const IconComponent = PRESET_ICONS[preset.icon] || Shield;
-              const isCreating = creatingPreset === preset.id;
-              return (
+
+          {/* Search + Filters */}
+          <div className="flex flex-col sm:flex-row gap-3 mb-4">
+            {/* Search input */}
+            <div className="relative flex-1">
+              <Search size={16} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Пошук шаблонів..."
+                className="w-full pl-10 pr-9 py-2.5 bg-white border border-gray-200 rounded-xl text-sm focus:outline-none focus:border-indigo-400 transition-colors"
+              />
+              {searchQuery && (
                 <button
-                  key={preset.id}
-                  onClick={() => handleCreateFromPreset(preset.id)}
-                  disabled={isCreating}
-                  className="text-left bg-gradient-to-br from-indigo-50 to-white border border-indigo-200 rounded-xl p-4 hover:border-indigo-400 hover:shadow-md transition-all disabled:opacity-50"
+                  onClick={() => setSearchQuery('')}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
                 >
-                  <div className="flex items-center gap-2 mb-2">
-                    {isCreating ? (
-                      <Loader2 className="w-5 h-5 animate-spin text-indigo-500" />
-                    ) : (
-                      <IconComponent className="w-5 h-5 text-indigo-600" />
-                    )}
-                    <span className="font-medium text-gray-900 text-sm">{preset.title}</span>
-                  </div>
-                  <p className="text-xs text-gray-500 line-clamp-2">{preset.description}</p>
+                  <X size={14} />
                 </button>
-              );
-            })}
+              )}
+            </div>
+
+            {/* Category filters */}
+            <div className="flex items-center gap-2 flex-wrap">
+              <button
+                onClick={() => setActiveCategory(null)}
+                className={`px-3 py-2 rounded-xl text-xs font-medium border transition-all ${
+                  !activeCategory
+                    ? 'bg-indigo-600 text-white border-indigo-600'
+                    : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+                }`}
+              >
+                Всі
+              </button>
+              {categories.map((cat) => (
+                <button
+                  key={cat.id}
+                  onClick={() => setActiveCategory(activeCategory === cat.id ? null : cat.id)}
+                  className={`px-3 py-2 rounded-xl text-xs font-medium border transition-all ${
+                    activeCategory === cat.id
+                      ? 'bg-indigo-600 text-white border-indigo-600'
+                      : 'bg-white text-gray-600 border-gray-200 hover:border-indigo-300'
+                  }`}
+                >
+                  {cat.label}
+                </button>
+              ))}
+            </div>
           </div>
+
+          {/* Preset cards */}
+          {filteredPresets.length === 0 ? (
+            <div className="text-center py-8 text-gray-400 text-sm">
+              Шаблонів за запитом не знайдено
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {filteredPresets.map((preset) => {
+                const IconComponent = PRESET_ICONS[preset.icon] || Shield;
+                const isCreating = creatingPreset === preset.id;
+                return (
+                  <button
+                    key={preset.id}
+                    onClick={() => handleCreateFromPreset(preset.id)}
+                    disabled={isCreating}
+                    className="text-left bg-gradient-to-br from-indigo-50 to-white border border-indigo-200 rounded-xl p-4 hover:border-indigo-400 hover:shadow-md transition-all disabled:opacity-50 group"
+                  >
+                    <div className="flex items-center gap-2 mb-2">
+                      {isCreating ? (
+                        <Loader2 className="w-5 h-5 animate-spin text-indigo-500" />
+                      ) : (
+                        <IconComponent className="w-5 h-5 text-indigo-600" />
+                      )}
+                      <span className="font-medium text-gray-900 text-sm flex-1">{preset.title}</span>
+                    </div>
+                    <p className="text-xs text-gray-500 line-clamp-2 mb-3">{preset.description}</p>
+                    <div className="flex items-center justify-between">
+                      <div className="flex flex-wrap gap-1">
+                        {preset.tags.slice(0, 3).map((tag) => (
+                          <span key={tag} className="inline-flex px-1.5 py-0.5 rounded-md bg-indigo-100/60 text-indigo-600 text-[10px] font-medium">
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <span className="inline-flex items-center gap-1 text-[10px] text-gray-400">
+                        <ListChecks size={10} />
+                        {preset.stepsCount}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
 
+      {/* ── Existing Workflow Sets ── */}
       {isLoading ? (
         <div className="flex items-center justify-center py-20">
           <Loader2 className="w-8 h-8 animate-spin text-indigo-500" />
@@ -115,7 +228,7 @@ export function WorkflowsPage() {
           <Zap className="w-12 h-12 text-gray-300 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-600 mb-2">Робочих процесів поки немає</h3>
           <p className="text-gray-400 max-w-md mx-auto">
-            Задайте в чаті запит на глибокий інституційний аналіз (наприклад, "проаналізуй всі рішення суддів Оболонського суду за 15 років") — система автоматично створить набір робочих процесів.
+            Задайте в чаті запит на глибокий інституційний аналіз (наприклад, &quot;проаналізуй всі рішення суддів Оболонського суду за 15 років&quot;) — система автоматично створить набір робочих процесів.
           </p>
         </div>
       ) : (

--- a/lexwebapp/src/services/api/WorkflowService.ts
+++ b/lexwebapp/src/services/api/WorkflowService.ts
@@ -33,10 +33,10 @@ export class WorkflowService extends BaseService {
     return this.requestVoid(() => this.client.delete(`/api/workflow-sets/${id}`));
   }
 
-  async listPresets(): Promise<Array<{ id: string; title: string; description: string; icon: string; category: string }>> {
+  async listPresets(): Promise<Array<{ id: string; title: string; description: string; icon: string; category: string; tags: string[]; stepsCount: number }>> {
     return this.request(
       () => this.client.get('/api/workflow-sets/presets'),
-      (data: { presets?: Array<{ id: string; title: string; description: string; icon: string; category: string }> }) => data.presets || []
+      (data: { presets?: Array<{ id: string; title: string; description: string; icon: string; category: string; tags: string[]; stepsCount: number }> }) => data.presets || []
     );
   }
 

--- a/mcp_backend/src/services/workflow-presets.ts
+++ b/mcp_backend/src/services/workflow-presets.ts
@@ -13,6 +13,8 @@ export interface WorkflowPresetMeta {
   description: string;
   icon: string;
   category: string;
+  tags: string[];
+  stepsCount: number;
 }
 
 export const WORKFLOW_PRESET_LIST: WorkflowPresetMeta[] = [
@@ -22,6 +24,8 @@ export const WORKFLOW_PRESET_LIST: WorkflowPresetMeta[] = [
     description: 'Комплексний аналіз судової практики по військових злочинах: самовільне залишення частини, дезертирство, ухилення від мобілізації, непокора. 273K+ рішень.',
     icon: 'shield',
     category: 'military',
+    tags: ['кримінальне право', 'судова практика', 'законодавство'],
+    stepsCount: 5,
   },
   {
     id: 'military_awol',
@@ -29,6 +33,8 @@ export const WORKFLOW_PRESET_LIST: WorkflowPresetMeta[] = [
     description: 'Аналіз 191K+ рішень по ст. 407 КК: статистика вироків, позиції ВС, пом\'якшуючі обставини, типові покарання.',
     icon: 'user-x',
     category: 'military',
+    tags: ['кримінальне право', 'судова практика'],
+    stepsCount: 3,
   },
   {
     id: 'military_draft_evasion',
@@ -36,6 +42,8 @@ export const WORKFLOW_PRESET_LIST: WorkflowPresetMeta[] = [
     description: 'Аналіз 26K+ рішень щодо ухилення від призову: адмінвідповідальність, кримінальна відповідальність, практика ТЦК.',
     icon: 'shield-alert',
     category: 'military',
+    tags: ['адмінправо', 'кримінальне право', 'судова практика'],
+    stepsCount: 3,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Added search input to filter templates by name, description, or tags
- Added category filter pills (Всі / Військове право) — auto-derived from presets
- Template cards now show tags (pill badges) and step count
- Backend `WorkflowPresetMeta` extended with `tags[]` and `stepsCount`
- Empty state when no templates match search/filter criteria

## Test plan
- [ ] Visit `/workflows` — see search bar + category pills above template cards
- [ ] Type "407" in search — only AWOL template remains visible
- [ ] Type "адмін" — only draft evasion template (has адмінправо tag)
- [ ] Click "Військове право" filter — all 3 show (toggle off → shows all)
- [ ] Clear search with X button — all templates restore
- [ ] Click a template card — creates workflow set, navigates to detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)