### PR TITLE
fix: SSE auth — extract query token before requireJWT

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -537,7 +537,13 @@ class HTTPMCPServer {
     logger.info('Encryption routes registered at /api/encryption');
 
     // Consultation routes - all require JWT
-    this.app.use('/api/consultations', requireJWT as any, createConsultationRoutes(
+    // SSE endpoints use query param token (EventSource API doesn't support custom headers)
+    this.app.use('/api/consultations', ((req: any, _res: any, next: any) => {
+      if (!req.headers.authorization && req.query.token) {
+        req.headers.authorization = `Bearer ${req.query.token}`;
+      }
+      next();
+    }) as any, requireJWT as any, createConsultationRoutes(
       this.app_.consultationService,
       this.app_.consultationPaymentService,
       this.app_.attorneyPayoutService,


### PR DESCRIPTION
## Summary
- `EventSource` API doesn't support custom headers, so SSE endpoints pass JWT via `?token=` query param
- Query-to-header middleware was inside the consultation router, but `requireJWT` ran **before** it
- SSE connections were always rejected with 401 "User authentication required"
- Moved query token extraction before `requireJWT` in the middleware chain

## Test plan
- [ ] Open consultations page as attorney — no Firefox SSE connection error
- [ ] Real-time consultation status updates work without page refresh
- [ ] Regular API calls with Authorization header still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)