### PR TITLE
fix: tool call dedup hash used wrong param names

### DIFF
--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -88,8 +88,8 @@ const CITATION_CHECK_TIMEOUT_MS = 5_000;
 // Tools where deduplication hashes only on the primary key (e.g. caseNumber),
 // ignoring secondary params like groupByInstance, includeFullText, maxDocs.
 const COARSE_HASH_TOOLS: Record<string, string[]> = {
-  get_case_documents_chain: ['caseNumber'],
-  get_court_decision: ['caseNumber'],
+  get_case_documents_chain: ['case_number'],
+  get_court_decision: ['doc_id', 'case_number'],
   load_full_texts: ['doc_ids'],
 };
 


### PR DESCRIPTION
## Summary
- `COARSE_HASH_TOOLS` for `get_court_decision` used `caseNumber` (camelCase), but LLM passes `case_number` (snake_case from tool schema) — the key never matched, so subset was always `{}`
- All `get_court_decision` calls hashed to `99914b932bd3` (MD5 of `{}`), making every call after the first look like a duplicate — even with completely different `doc_id` values
- Added `doc_id` as a primary hash key alongside `case_number`, since LLM commonly calls with `doc_id` only
- Fixed `get_case_documents_chain` key from `caseNumber` to `case_number` (same issue)

## Impact
Observed in `chat-7fe7cac3`: 10 skipped tool calls across iterations 2-3, forcing premature answer generation. Users got incomplete analysis because the model couldn't fetch individual court decisions.

## Test plan
- [ ] Send a chat query that triggers multiple `get_court_decision` calls with different `doc_id` values
- [ ] Verify each unique `doc_id` call executes (not skipped as duplicate)
- [ ] Verify identical repeated calls are still correctly deduplicated
- [ ] TypeScript build passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)