### PR TITLE
fix: workflow presets — wrong filters returned 0 results

### DIFF
--- a/mcp_backend/src/services/workflow-presets.ts
+++ b/mcp_backend/src/services/workflow-presets.ts
@@ -108,14 +108,14 @@ const MILITARY_DEFENSE_FULL: GeneratedWorkflowSet = {
           {
             id: 1,
             tool: 'search_edrsr_decisions',
-            params: { military_preset: 'awol', instance_code: 1, date_from: '2022-02-24', judgment_code: 1, limit: 10 },
-            purpose: 'Вироки касаційної інстанції по самовільному залишенню частини',
+            params: { military_preset: 'awol', instance_code: 1, date_from: '2022-02-24', limit: 10 },
+            purpose: 'Рішення касаційної інстанції по самовільному залишенню частини',
           },
           {
             id: 2,
             tool: 'search_edrsr_decisions',
-            params: { military_preset: 'desertion', instance_code: 1, date_from: '2022-02-24', judgment_code: 1, limit: 10 },
-            purpose: 'Вироки касаційної інстанції по дезертирству',
+            params: { military_preset: 'desertion', instance_code: 1, date_from: '2022-02-24', limit: 10 },
+            purpose: 'Рішення касаційної інстанції по дезертирству',
           },
         ],
       },
@@ -186,13 +186,13 @@ const MILITARY_DEFENSE_FULL: GeneratedWorkflowSet = {
           {
             id: 1,
             tool: 'search_edrsr_decisions',
-            params: { military_preset: 'draft_evasion', justice_kind: 5, date_from: '2024-01-01', limit: 10 },
-            purpose: 'Адміністративні справи по ухиленню (КУпАП ст. 210-1)',
+            params: { category_code: 41260, justice_kind: 5, date_from: '2024-01-01', limit: 10 },
+            purpose: 'Адміністративні справи — непокора розпорядженню військовослужбовця',
           },
           {
             id: 2,
             tool: 'search_edrsr_decisions',
-            params: { military_preset: 'draft_evasion', justice_kind: 2, date_from: '2024-01-01', limit: 10 },
+            params: { military_preset: 'draft_evasion', date_from: '2024-01-01', limit: 10 },
             purpose: 'Кримінальні справи по ухиленню від мобілізації',
           },
           {
@@ -312,13 +312,13 @@ const MILITARY_DRAFT_EVASION: GeneratedWorkflowSet = {
           {
             id: 1,
             tool: 'search_edrsr_decisions',
-            params: { military_preset: 'draft_evasion', justice_kind: 5, date_from: '2024-01-01', limit: 10 },
-            purpose: 'Адміністративні справи (КУпАП ст. 210, 210-1)',
+            params: { category_code: 41260, justice_kind: 5, date_from: '2024-01-01', limit: 10 },
+            purpose: 'Адміністративні справи — непокора розпорядженню військовослужбовця',
           },
           {
             id: 2,
             tool: 'search_edrsr_decisions',
-            params: { military_preset: 'draft_evasion', justice_kind: 2, date_from: '2024-01-01', limit: 10 },
+            params: { military_preset: 'draft_evasion', date_from: '2024-01-01', limit: 10 },
             purpose: 'Кримінальні справи по ухиленню від мобілізації',
           },
         ],


### PR DESCRIPTION
## Summary
- Cassation queries had `judgment_code: 1` (вирок) but cassation courts issue ухвали (5) and постанови (2) → 0 results for 505 actual decisions
- Admin draft evasion used `military_preset: 'draft_evasion'` with `justice_kind: 5` but all 19620 draft evasion cases are criminal (justice_kind: 2). Admin cases use `category_code: 41260`
- Verified with prod DB queries

## Test plan
- [ ] AWOL cassation preset returns ~505 results (was 0)
- [ ] Draft evasion admin preset returns ~22573 results (was 0)
- [ ] Draft evasion criminal preset returns ~19620 results

🤖 Generated with [Claude Code](https://claude.com/claude-code)