### PR TITLE
fix: empty summary and missing court/date in right panel cards

### DIFF
--- a/mcp_backend/src/services/evidence-extractor.ts
+++ b/mcp_backend/src/services/evidence-extractor.ts
@@ -185,15 +185,22 @@ export function extractFromToolResult(
 
     // get_court_decision — single decision with sections
     if (parsed.sections && Array.isArray(parsed.sections) && (parsed.doc_id || parsed.case_number)) {
-      const summarySection = parsed.sections.find((s: any) => s.type === 'DECISION' || s.type === 'COURT_REASONING');
+      // Pick best summary: DECISION > COURT_REASONING > FACTS > HEADER > full_text fallback
+      const summarySection = parsed.sections.find((s: any) => s.type === 'DECISION')
+        || parsed.sections.find((s: any) => s.type === 'COURT_REASONING')
+        || parsed.sections.find((s: any) => s.type === 'FACTS')
+        || parsed.sections.find((s: any) => s.type === 'HEADER');
+      const summaryText = summarySection?.text?.slice(0, 500)
+        || (parsed.full_text ? parsed.full_text.slice(0, 500) : '');
       decisions.push({
         id: `gcd-${parsed.doc_id || Date.now()}`,
         number: parsed.case_number || String(parsed.doc_id) || 'N/A',
-        court: '',
-        date: '',
-        summary: summarySection?.text?.slice(0, 300) || '',
+        court: parsed.court_name || '',
+        date: parsed.adjudication_date || '',
+        summary: summaryText,
         relevance: 100,
         status: 'active',
+        documentType: classifyDocumentType({ judgment_form: parsed.judgment_form }),
         externalUrl: courtDocUrl(parsed.doc_id),
       });
     }


### PR DESCRIPTION
## Summary
- `get_court_decision` evidence extraction only checked for `DECISION` or `COURT_REASONING` sections for the summary text
- Short decisions with only `HEADER`/`FACTS` sections had empty summary → text was cut off / not displayed in the right panel
- `court` and `date` fields were always empty strings — not populated from the API response (`court_name`, `adjudication_date`)
- `documentType` was missing → couldn't classify as Рішення/Постанова/Ухвала

### Changes
- Fallback chain for summary: DECISION → COURT_REASONING → FACTS → HEADER → full_text
- Increased summary slice from 300 to 500 chars
- Populated `court`, `date`, `documentType` from parsed response

## Test plan
- [ ] Open a chat with court decision results in the right panel
- [ ] Verify short decisions show summary text (not blank)
- [ ] Verify court name and date appear on cards
- [ ] TypeScript build passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)