### PR TITLE
fix: wire cost tracker to LLMManager for vault tools

### DIFF
--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -223,9 +223,10 @@ export function createAppServices(
   billing.billingService.setAuditService(auditService);
   billing.monobankService.setAuditService(auditService);
 
-  // Wire cost tracker to OpenAI manager and ZO adapters
+  // Wire cost tracker to OpenAI manager, LLM manager, and ZO adapters
   const openaiManager = getOpenAIManager();
   openaiManager.setCostTracker(billing.costTracker);
+  getLLMManager().setCostTracker(billing.costTracker);
   coreServices.zoAdapter.setCostTracker(billing.costTracker);
   coreServices.zoPracticeAdapter.setCostTracker(billing.costTracker);
   logger.info('Cost tracking and billing initialized');


### PR DESCRIPTION
## Summary
- `getLLMManager()` was missing `setCostTracker()` call in `app-services.ts`
- All vault tool LLM calls (metadata extraction, classification, encryption-related processing) reported $0 cost
- Added one line to wire the cost tracker to LLMManager alongside the existing OpenAIManager wiring

## Test plan
- [ ] Deploy to prod, run a vault document store operation
- [ ] Verify cost_tracking table shows non-zero `openai_cost_usd` for vault tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)