### PR TITLE
fix: migration 099 breaks CI/CD — remove null byte literal

### DIFF
--- a/mcp_backend/src/migrations/099_safe_ts_headline_and_utf8_cleanup.sql
+++ b/mcp_backend/src/migrations/099_safe_ts_headline_and_utf8_cleanup.sql
@@ -24,21 +24,6 @@ EXCEPTION WHEN character_not_in_repertoire THEN
 END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
--- 2. Clean invalid UTF-8 bytes from edrsr_fulltext
--- convert_from(convert_to(..., 'UTF8'), 'UTF8') will fail on bad bytes,
--- so we use a regex to strip control characters and then re-encode.
--- This handles the most common case: stray 0x00 bytes and broken multi-byte sequences.
-DO $$
-DECLARE
-  cleaned_count int;
-BEGIN
-  -- Strip null bytes (most common cause of 22021 in imported RTF data)
-  UPDATE edrsr_fulltext
-  SET full_text = regexp_replace(full_text, E'\\x00', '', 'g')
-  WHERE full_text LIKE E'%\x00%';
-
-  GET DIAGNOSTICS cleaned_count = ROW_COUNT;
-  IF cleaned_count > 0 THEN
-    RAISE NOTICE 'Cleaned null bytes from % rows', cleaned_count;
-  END IF;
-END $$;
+-- 2. Note: null byte cleanup removed — PostgreSQL text columns cannot contain
+-- literal 0x00 bytes, so the encoding errors come from other invalid sequences.
+-- safe_ts_headline handles these per-row at query time.


### PR DESCRIPTION
## Summary
- Migration 099 DO block contained `E'\x00'` literal which PostgreSQL rejects as invalid UTF-8
- This blocked `secondlayer-migrate-local` → backend never started → nginx crash loop → CI/CD fails
- Removed the cleanup block — `safe_ts_headline` function handles encoding errors at query time
- **All 5 recent CI/CD runs failed because of this**

## Test plan
- [ ] CI/CD passes after merge
- [ ] Migration 099 applies cleanly (creates safe_ts_headline function)
- [ ] local.legal.org.ua/health returns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)