### PR TITLE
feat: URL routes for consultations list & payouts

### DIFF
--- a/lexwebapp/src/pages/ConsultationsPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationsPage/index.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { MessageSquare, Clock, CheckCircle, XCircle, AlertCircle, Loader2, CreditCard, Wallet } from 'lucide-react';
 import { consultationService } from '../../services/api/ConsultationService';
-import { generateRoute } from '../../router/routes';
+import { generateRoute, ROUTES } from '../../router/routes';
 
 const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof Clock }> = {
   pending: { label: 'Очікує', color: 'bg-yellow-100 text-yellow-700', icon: Clock },
@@ -18,8 +18,13 @@ const STATUS_CONFIG: Record<string, { label: string; color: string; icon: typeof
 
 export function ConsultationsPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState<'list' | 'payouts'>('list');
+  const activeTab = location.pathname === ROUTES.CONSULTATIONS_PAYOUTS ? 'payouts' : 'list';
+
+  const setActiveTab = (tab: 'list' | 'payouts') => {
+    navigate(tab === 'payouts' ? ROUTES.CONSULTATIONS_PAYOUTS : ROUTES.CONSULTATIONS, { replace: true });
+  };
 
   // Clear stale redirect so attorney always sees full list first
   useEffect(() => {

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -429,6 +429,10 @@ export const router = createBrowserRouter([
             element: S(ConsultationsPage),
           },
           {
+            path: ROUTES.CONSULTATIONS_PAYOUTS,
+            element: S(ConsultationsPage),
+          },
+          {
             path: ROUTES.CONSULTATION_DETAIL,
             element: S(ConsultationDetailPage),
           },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -103,6 +103,7 @@ export const ROUTES = {
   ATTORNEY_PROFILE_EDIT: '/attorney/profile',
   ATTORNEY_CLIENTS: '/attorney/clients',
   CONSULTATIONS: '/consultations',
+  CONSULTATIONS_PAYOUTS: '/consultations/payouts',
   CONSULTATION_DETAIL: '/consultations/:id',
 
   // Workflows


### PR DESCRIPTION
## Summary
- Added `/consultations/payouts` route so the payouts tab is bookmarkable
- `/consultations` shows the list tab, `/consultations/payouts` shows payouts
- Tabs now navigate via URL (`replace: true`) instead of local `useState`

## Test plan
- [ ] Open `/consultations` — list tab is active
- [ ] Click "Виплати" tab — URL changes to `/consultations/payouts`
- [ ] Refresh on `/consultations/payouts` — payouts tab stays active
- [ ] Click consultation card — navigates to `/consultations/:id` detail page
- [ ] Browser back/forward works between tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)