### PR TITLE
fix: ConsultationsPage test mock missing ROUTES export

### DIFF
--- a/lexwebapp/src/pages/__tests__/ConsultationsPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/ConsultationsPage.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../services/api/ConsultationService', () => ({
 
 // Mock routes
 vi.mock('../../router/routes', () => ({
+  ROUTES: { CONSULTATIONS: '/consultations' },
   generateRoute: {
     consultationDetail: (id: string) => `/consultations/${id}`,
   },


### PR DESCRIPTION
## Summary
- `vi.mock('../../router/routes')` was missing `ROUTES` export
- Frontend tests failed → CI/CD blocked

## Test plan
- [x] `npx vitest run ConsultationsPage.test.tsx` — 10/10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)