### PR TITLE
feat: Harvey-style redesign for login and chat

### DIFF
--- a/lexwebapp/src/components/ChatInput.tsx
+++ b/lexwebapp/src/components/ChatInput.tsx
@@ -109,16 +109,16 @@ export function ChatInput({
       {/* Load / Save prompt buttons */}
       <PromptManager currentInput={input} onLoadPrompt={handleLoadPrompt} />
 
-      <div className="relative bg-white rounded-2xl border border-claude-border shadow-sm focus-within:shadow-md focus-within:border-claude-subtext/40 transition-all duration-300">
-        <div className="flex items-end gap-2 p-2">
+      <div className="relative bg-white rounded-xl border border-zinc-200 shadow-elevation-1 focus-within:shadow-input-focus focus-within:border-zinc-400 transition-all duration-200">
+        <div className="flex items-end gap-1.5 p-1.5">
           {/* Plus / Attach button */}
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-lg transition-all duration-200 flex-shrink-0"
+            className="p-2 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-lg transition-colors duration-150 flex-shrink-0"
             aria-label="Додати вкладення"
           >
-            <Plus size={18} strokeWidth={2} />
+            <Plus size={16} strokeWidth={2} />
           </button>
           <input
             ref={fileInputRef}
@@ -136,41 +136,41 @@ export function ChatInput({
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Відповісти..."
+            placeholder="Напишіть повідомлення..."
             disabled={disabled || isStreaming}
             rows={1}
-            className="flex-1 py-2 px-2 bg-transparent border-none resize-none focus:ring-0 focus:outline-none text-claude-text placeholder:text-claude-subtext/40 font-sans text-[15px] leading-relaxed max-h-[200px] overflow-hidden"
+            className="flex-1 py-2 px-1 bg-transparent border-none resize-none focus:ring-0 focus:outline-none text-zinc-900 placeholder:text-zinc-400 font-sans text-[14px] leading-relaxed max-h-[200px] overflow-hidden"
             style={{
-              minHeight: '40px'
+              minHeight: '38px'
             }}
           />
 
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-1.5 flex-shrink-0">
             {isStreaming ? (
               <button
                 type="button"
                 onClick={onCancel}
-                className="p-2 rounded-lg transition-all duration-200 bg-claude-text text-white hover:bg-claude-text/90 shadow-sm active:scale-95"
+                className="p-2 rounded-lg transition-colors duration-150 bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95"
                 aria-label="Зупинити генерацію"
                 title="Зупинити"
               >
-                <Square size={18} strokeWidth={2} fill="currentColor" />
+                <Square size={15} strokeWidth={2} fill="currentColor" />
               </button>
             ) : (
               <button
                 onClick={handleSubmit}
                 disabled={(!input.trim() && files.length === 0) || disabled || isUploadingFiles}
-                className={`p-2 rounded-lg transition-all duration-200 ${
+                className={`p-2 rounded-lg transition-colors duration-150 ${
                   (input.trim() || files.length > 0) && !disabled && !isUploadingFiles
-                    ? 'bg-claude-text text-white hover:bg-claude-text/90 shadow-sm active:scale-95'
-                    : 'bg-claude-subtext/10 text-claude-subtext/30 cursor-not-allowed'
+                    ? 'bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95'
+                    : 'bg-zinc-100 text-zinc-300 cursor-not-allowed'
                 }`}
                 aria-label="Надіслати повідомлення"
               >
                 {isUploadingFiles ? (
-                  <Loader2 size={18} strokeWidth={2} className="animate-spin" />
+                  <Loader2 size={15} strokeWidth={2} className="animate-spin" />
                 ) : (
-                  <Send size={18} strokeWidth={2} />
+                  <Send size={15} strokeWidth={2} />
                 )}
               </button>
             )}

--- a/lexwebapp/src/components/EmptyState.tsx
+++ b/lexwebapp/src/components/EmptyState.tsx
@@ -1,92 +1,63 @@
-import { Sparkles } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import { motion } from 'framer-motion';
+
 interface EmptyStateProps {
   onSelectPrompt: (prompt: string) => void;
 }
+
 export function EmptyState({ onSelectPrompt }: EmptyStateProps) {
   const prompts = [
-  'Допоможіть скласти позовну заяву про стягнення заборгованості',
-  'Знайдіть практику ВС по договорах поставки',
-  'Проаналізуйте підстави для скасування рішення суду',
-  'Які документи потрібні для банкрутства фізичної особи?'];
+    'Допоможіть скласти позовну заяву про стягнення заборгованості',
+    'Знайдіть практику ВС по договорах поставки',
+    'Проаналізуйте підстави для скасування рішення суду',
+    'Які документи потрібні для банкрутства фізичної особи?',
+  ];
 
   return (
-    <div className="flex-1 flex items-center justify-center p-4 overflow-y-auto">
-      <div className="max-w-2xl w-full">
+    <div className="flex-1 flex items-center justify-center p-6 overflow-y-auto">
+      <div className="max-w-xl w-full">
         <motion.div
-          initial={{
-            opacity: 0,
-            y: 20
-          }}
-          animate={{
-            opacity: 1,
-            y: 0
-          }}
-          transition={{
-            duration: 0.6,
-            ease: [0.22, 1, 0.36, 1]
-          }}
-          className="text-center mb-12">
-
-          <h1 className="font-sans text-3xl md:text-4xl font-bold text-claude-text mb-4 tracking-tight">
-            Ласкаво просимо до Lex
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+          className="mb-10"
+        >
+          <h1 className="font-sans text-2xl md:text-3xl font-semibold text-zinc-900 mb-3 tracking-tight">
+            Чим можу допомогти?
           </h1>
-          <p className="font-sans text-claude-subtext text-base md:text-lg leading-relaxed max-w-xl mx-auto">
-            Ваш AI-асистент для роботи з українським правом. Аналіз практики,
+          <p className="font-sans text-zinc-500 text-sm md:text-base leading-relaxed">
+            AI-асистент для роботи з українським правом. Аналіз практики,
             підготовка документів, правові консультації.
           </p>
         </motion.div>
 
         <motion.div
-          initial={{
-            opacity: 0,
-            y: 20
-          }}
-          animate={{
-            opacity: 1,
-            y: 0
-          }}
-          transition={{
-            duration: 0.6,
-            delay: 0.2,
-            ease: [0.22, 1, 0.36, 1]
-          }}
-          className="grid gap-3 md:gap-4">
-
-          {prompts.map((prompt, index) =>
-          <motion.button
-            key={index}
-            initial={{
-              opacity: 0,
-              x: -20
-            }}
-            animate={{
-              opacity: 1,
-              x: 0
-            }}
-            transition={{
-              duration: 0.4,
-              delay: 0.3 + index * 0.1
-            }}
-            onClick={() => onSelectPrompt(prompt)}
-            className="group text-left p-4 md:p-5 bg-white border border-claude-border hover:border-claude-subtext/40 rounded-xl transition-all duration-300 hover:shadow-elevation-1 active:scale-[0.98]">
-
-              <div className="flex items-start gap-3 md:gap-4">
-                <div className="p-2 bg-claude-subtext/8 rounded-lg group-hover:bg-claude-subtext/12 transition-colors duration-200 flex-shrink-0">
-                  <Sparkles
-                  size={18}
-                  className="text-claude-text"
-                  strokeWidth={2} />
-
-                </div>
-                <p className="font-sans text-[14px] md:text-[15px] text-claude-text leading-relaxed flex-1">
-                  {prompt}
-                </p>
-              </div>
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.15, ease: [0.22, 1, 0.36, 1] }}
+          className="space-y-2"
+        >
+          {prompts.map((prompt, index) => (
+            <motion.button
+              key={index}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.3, delay: 0.2 + index * 0.07 }}
+              onClick={() => onSelectPrompt(prompt)}
+              className="group w-full text-left px-4 py-3 bg-white border border-zinc-200 hover:border-zinc-300 rounded-xl transition-all duration-150 hover:shadow-elevation-1 flex items-center justify-between gap-3 active:scale-[0.99]"
+            >
+              <p className="font-sans text-[13px] md:text-[14px] text-zinc-700 leading-relaxed">
+                {prompt}
+              </p>
+              <ArrowRight
+                size={14}
+                strokeWidth={2}
+                className="flex-shrink-0 text-zinc-300 group-hover:text-zinc-500 transition-colors duration-150"
+              />
             </motion.button>
-          )}
+          ))}
         </motion.div>
       </div>
-    </div>);
-
+    </div>
+  );
 }

--- a/lexwebapp/src/components/chat/ExpandableCard.tsx
+++ b/lexwebapp/src/components/chat/ExpandableCard.tsx
@@ -4,16 +4,16 @@
  */
 
 import { useState } from 'react';
-import { Copy, Check, Maximize2, ExternalLink, Eye } from 'lucide-react';
+import { Copy, Check, Maximize2, ExternalLink } from 'lucide-react';
 import { motion, AnimatePresence, type Variants } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 
 const cardVariants: Variants = {
-  hidden: { opacity: 0, y: 8 },
+  hidden: { opacity: 0, y: 6 },
   visible: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { duration: 0.3, ease: [0.22, 1, 0.36, 1], delay: i * 0.04 },
+    transition: { duration: 0.25, ease: [0.22, 1, 0.36, 1], delay: i * 0.03 },
   }),
 };
 
@@ -57,19 +57,11 @@ export function ExpandableCard({
       initial="hidden"
       animate="visible"
       layout
-      className="bg-white border border-claude-border rounded-xl overflow-hidden hover:border-claude-subtext/30 hover:shadow-md transition-all duration-200"
+      className="bg-white border border-zinc-200 rounded-lg overflow-hidden hover:border-zinc-300 hover:shadow-elevation-1 transition-all duration-150"
     >
       <div onClick={onToggle} className="p-3 cursor-pointer group">
         {header}
         {!isExpanded && preview}
-        {!isExpanded && (
-          <div className="flex items-center justify-end pt-2 border-t border-claude-border/30 mt-2">
-            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-              <Eye size={12} className="text-claude-subtext" strokeWidth={2} />
-              <span className="text-[10px] text-claude-subtext">Розгорнути</span>
-            </div>
-          </div>
-        )}
       </div>
 
       <AnimatePresence>
@@ -78,36 +70,36 @@ export function ExpandableCard({
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
+            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
             className="overflow-hidden"
           >
-            <div className="px-3 pb-3 border-t border-claude-border/30">
-              <div className="mt-3 max-h-[300px] overflow-y-auto text-[12px] text-claude-text/90 leading-relaxed prose prose-sm prose-slate">
+            <div className="px-3 pb-3 border-t border-zinc-100">
+              <div className="mt-3 max-h-[280px] overflow-y-auto text-[12px] text-zinc-700 leading-relaxed prose prose-sm">
                 <ReactMarkdown>{content}</ReactMarkdown>
               </div>
-              <div className="flex items-center gap-2 mt-3 pt-2 border-t border-claude-border/30">
+              <div className="flex items-center gap-1.5 mt-3 pt-2 border-t border-zinc-100">
                 <button
                   onClick={(e) => { e.stopPropagation(); copyContent(content); }}
-                  className="flex items-center gap-1 text-[10px] text-claude-subtext hover:text-claude-text px-2 py-1 rounded-md hover:bg-claude-bg transition-colors"
+                  className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150"
                 >
-                  {copiedId === id ? <Check size={11} /> : <Copy size={11} />}
+                  {copiedId === id ? <Check size={10} /> : <Copy size={10} />}
                   {copiedId === id ? 'Скопійовано' : 'Копіювати'}
                 </button>
                 {onOpenModal && (
                   <button
                     onClick={(e) => { e.stopPropagation(); onOpenModal(); }}
-                    className="flex items-center gap-1 text-[10px] text-claude-subtext hover:text-claude-text px-2 py-1 rounded-md hover:bg-claude-bg transition-colors"
+                    className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150"
                   >
-                    <Maximize2 size={11} />
+                    <Maximize2 size={10} />
                     Повний вигляд
                   </button>
                 )}
                 {externalUrl && onOpenModal && (
                   <button
                     onClick={(e) => { e.stopPropagation(); onOpenModal(); }}
-                    className="flex items-center gap-1 text-[10px] text-claude-subtext hover:text-claude-text px-2 py-1 rounded-md hover:bg-claude-bg transition-colors"
+                    className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150"
                   >
-                    <ExternalLink size={11} />
+                    <ExternalLink size={10} />
                     Відкрити
                   </button>
                 )}
@@ -122,8 +114,8 @@ export function ExpandableCard({
 
 export function EmptyTabState({ icon: Icon, text }: { icon: React.ElementType; text: string }) {
   return (
-    <div className="text-center py-12 text-claude-subtext/50">
-      <Icon size={28} className="mx-auto mb-3 opacity-30" strokeWidth={1.5} />
+    <div className="text-center py-10 text-zinc-400">
+      <Icon size={24} className="mx-auto mb-3 opacity-25" strokeWidth={1.5} />
       <p className="text-[12px]">{text}</p>
     </div>
   );

--- a/lexwebapp/src/components/chat/ToolSelector.tsx
+++ b/lexwebapp/src/components/chat/ToolSelector.tsx
@@ -22,8 +22,8 @@ export function ToolSelector({ selectedTool, onToolChange }: ToolSelectorProps) 
   );
 
   return (
-    <div className="mb-3 pb-1">
-      <div className="flex flex-wrap gap-2">
+    <div className="mb-2.5 pb-0.5">
+      <div className="flex flex-wrap gap-1.5">
         {/* AI Chat pill (default) */}
         <button
           onClick={() => {
@@ -31,13 +31,13 @@ export function ToolSelector({ selectedTool, onToolChange }: ToolSelectorProps) 
             setShowManualTools(false);
             setExpandedCategory(null);
           }}
-          className={`flex-shrink-0 px-3 py-1.5 rounded-full text-[12px] font-medium transition-all duration-200 border flex items-center gap-1.5 ${
+          className={`flex-shrink-0 px-3 py-1 rounded-full text-[12px] font-medium transition-colors duration-150 border flex items-center gap-1.5 ${
             isAIChat
-              ? 'bg-claude-text text-white border-claude-text shadow-sm'
-              : 'bg-white text-claude-subtext border-claude-border hover:border-claude-subtext/40 hover:text-claude-text'
+              ? 'bg-zinc-900 text-white border-zinc-900'
+              : 'bg-white text-zinc-500 border-zinc-200 hover:border-zinc-300 hover:text-zinc-700'
           }`}
         >
-          <Sparkles size={12} />
+          <Sparkles size={11} />
           AI Чат
         </button>
 
@@ -47,19 +47,19 @@ export function ToolSelector({ selectedTool, onToolChange }: ToolSelectorProps) 
             setShowManualTools(!showManualTools);
             if (showManualTools) setExpandedCategory(null);
           }}
-          className={`flex-shrink-0 px-3 py-1.5 rounded-full text-[12px] font-medium transition-all duration-200 border flex items-center gap-1 ${
+          className={`flex-shrink-0 px-3 py-1 rounded-full text-[12px] font-medium transition-colors duration-150 border flex items-center gap-1 ${
             !isAIChat
-              ? 'bg-claude-text/10 text-claude-text border-claude-text/30'
-              : 'bg-white text-claude-subtext border-claude-border hover:border-claude-subtext/40 hover:text-claude-text'
+              ? 'bg-zinc-100 text-zinc-700 border-zinc-200'
+              : 'bg-white text-zinc-500 border-zinc-200 hover:border-zinc-300 hover:text-zinc-700'
           }`}
         >
           Інструменти
-          <ChevronDown size={12} className={`transition-transform ${showManualTools ? 'rotate-180' : ''}`} />
+          <ChevronDown size={11} className={`transition-transform duration-150 ${showManualTools ? 'rotate-180' : ''}`} />
         </button>
 
         {/* Active tool indicator (when tools panel is collapsed) */}
         {!isAIChat && !showManualTools && activeCategory && (
-          <span className="flex-shrink-0 px-3 py-1.5 rounded-full text-[12px] font-medium bg-claude-text text-white border border-claude-text shadow-sm">
+          <span className="flex-shrink-0 px-3 py-1 rounded-full text-[12px] font-medium bg-zinc-900 text-white border border-zinc-900">
             {activeCategory.tools.find(t => t.name === selectedTool)?.label}
           </span>
         )}
@@ -67,35 +67,35 @@ export function ToolSelector({ selectedTool, onToolChange }: ToolSelectorProps) 
 
       {/* Category pills */}
       {showManualTools && (
-        <div className="mt-2 space-y-2">
-          <div className="flex flex-wrap gap-1.5">
+        <div className="mt-2 space-y-1.5">
+          <div className="flex flex-wrap gap-1">
             {TOOL_CATEGORIES.map((cat) => (
               <button
                 key={cat.id}
                 onClick={() => setExpandedCategory(expandedCategory === cat.id ? null : cat.id)}
-                className={`flex-shrink-0 px-2.5 py-1 rounded-lg text-[11px] font-medium transition-all duration-200 border flex items-center gap-1 ${
+                className={`flex-shrink-0 px-2.5 py-1 rounded-md text-[11px] font-medium transition-colors duration-150 border flex items-center gap-1 ${
                   expandedCategory === cat.id || activeCategory?.id === cat.id
-                    ? 'bg-claude-text/10 text-claude-text border-claude-text/30'
-                    : 'bg-white text-claude-subtext border-claude-border hover:border-claude-subtext/40 hover:text-claude-text'
+                    ? 'bg-zinc-100 text-zinc-800 border-zinc-300'
+                    : 'bg-white text-zinc-500 border-zinc-200 hover:border-zinc-300 hover:text-zinc-700'
                 }`}
               >
                 {cat.label}
-                <ChevronDown size={10} className={`transition-transform ${expandedCategory === cat.id ? 'rotate-180' : ''}`} />
+                <ChevronDown size={10} className={`transition-transform duration-150 ${expandedCategory === cat.id ? 'rotate-180' : ''}`} />
               </button>
             ))}
           </div>
 
           {/* Tools in selected category */}
           {expandedCategory && (
-            <div className="flex flex-wrap gap-1.5 pl-1">
+            <div className="flex flex-wrap gap-1 pl-0.5">
               {TOOL_CATEGORIES.find(c => c.id === expandedCategory)?.tools.map((tool) => (
                 <button
                   key={tool.name}
                   onClick={() => onToolChange(tool.name)}
-                  className={`flex-shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium transition-all duration-200 border ${
+                  className={`flex-shrink-0 px-2.5 py-1 rounded-full text-[11px] font-medium transition-colors duration-150 border ${
                     selectedTool === tool.name
-                      ? 'bg-claude-text text-white border-claude-text shadow-sm'
-                      : 'bg-white text-claude-subtext border-claude-border hover:border-claude-subtext/40 hover:text-claude-text'
+                      ? 'bg-zinc-900 text-white border-zinc-900'
+                      : 'bg-white text-zinc-500 border-zinc-200 hover:border-zinc-300 hover:text-zinc-700'
                   }`}
                 >
                   {tool.label}

--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -148,9 +148,9 @@ export function AssistantMessage({
 
           {thinkingSteps && thinkingSteps.length > 0 && (
             <div>
-              <button onClick={() => setShowThinking(!showThinking)} className="flex items-center gap-2 text-[13px] text-claude-subtext hover:text-claude-text transition-colors mb-2">
-                <ChevronDown size={14} className={`transition-transform ${showThinking ? 'rotate-180' : ''}`} strokeWidth={2} />
-                <span className="font-medium">
+              <button onClick={() => setShowThinking(!showThinking)} className="flex items-center gap-2 text-[12px] text-zinc-400 hover:text-zinc-700 transition-colors duration-150 mb-2">
+                <ChevronDown size={13} className={`transition-transform duration-200 ${showThinking ? 'rotate-180' : ''}`} strokeWidth={2} />
+                <span className="font-medium tracking-tight">
                   {thinkingSteps[0]?.title || 'Обдумую відповідь...'}
                 </span>
               </button>
@@ -167,28 +167,25 @@ export function AssistantMessage({
               {citationWarnings.map((warning, idx) => (
                 <motion.div
                   key={`cw-${idx}`}
-                  initial={{ opacity: 0, y: -5 }}
+                  initial={{ opacity: 0, y: -4 }}
                   animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3, delay: idx * 0.1 }}
-                  className={`flex items-start gap-3 px-4 py-3 rounded-lg border ${
+                  transition={{ duration: 0.25, delay: idx * 0.08 }}
+                  className={`flex items-start gap-3 px-3 py-2.5 rounded-lg border ${
                     warning.status === 'explicitly_overruled'
-                      ? 'bg-orange-50/70 border-orange-200 dark:bg-orange-950/20 dark:border-orange-800/50'
-                      : 'bg-amber-50/70 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800/50'
+                      ? 'bg-orange-50 border-orange-200/70'
+                      : 'bg-amber-50 border-amber-200/70'
                   }`}
                 >
-                  <span className="text-base mt-0.5 opacity-70">
-                    {warning.status === 'explicitly_overruled' ? '\u{1F4CB}' : '\u{1F4CC}'}
-                  </span>
                   <div className="flex-1 min-w-0">
-                    <p className={`text-sm ${
+                    <p className={`text-[13px] leading-relaxed ${
                       warning.status === 'explicitly_overruled'
-                        ? 'text-orange-700 dark:text-orange-300'
-                        : 'text-amber-700 dark:text-amber-300'
+                        ? 'text-orange-700'
+                        : 'text-amber-700'
                     }`}>
                       {warning.message}
                     </p>
-                    <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
-                      {warning.status === 'explicitly_overruled' ? 'Скасовано вищою інстанцією' : 'Частково змінено'} &middot; впевненість: {Math.round(warning.confidence * 100)}%
+                    <p className="text-[11px] text-zinc-400 mt-1">
+                      {warning.status === 'explicitly_overruled' ? 'Скасовано вищою інстанцією' : 'Частково змінено'} · впевненість: {Math.round(warning.confidence * 100)}%
                     </p>
                   </div>
                 </motion.div>
@@ -203,49 +200,49 @@ export function AssistantMessage({
           )}
 
           {!isStreaming && content && (
-            <div className="flex items-center gap-1 pt-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <div className="flex items-center gap-0.5 pt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
               <button
                 onClick={handleCopy}
-                className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-md transition-all duration-200"
+                className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
                 aria-label="Copy message"
                 title="Копіювати"
               >
-                <Copy size={13} strokeWidth={2} />
+                <Copy size={12} strokeWidth={2} />
               </button>
               <button
                 onClick={handleStar}
-                className={`p-1.5 hover:bg-claude-subtext/8 rounded-md transition-all duration-200 ${starred ? 'text-claude-text' : 'text-claude-subtext hover:text-claude-text'}`}
+                className={`p-1.5 hover:bg-zinc-100 rounded-md transition-colors duration-150 ${starred ? 'text-zinc-700' : 'text-zinc-400 hover:text-zinc-600'}`}
                 aria-label="Save to favorites"
                 title="Зберегти в обране"
               >
-                <Star size={13} strokeWidth={2} fill={starred ? 'currentColor' : 'none'} />
+                <Star size={12} strokeWidth={2} fill={starred ? 'currentColor' : 'none'} />
               </button>
               {onRegenerate && (
                 <button
                   onClick={onRegenerate}
-                  className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-md transition-all duration-200"
+                  className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
                   aria-label="Regenerate response"
                   title="Повторити"
                 >
-                  <RotateCw size={13} strokeWidth={2} />
+                  <RotateCw size={12} strokeWidth={2} />
                 </button>
               )}
-              <div className="w-px h-3 bg-claude-border mx-1" />
+              <div className="w-px h-3 bg-zinc-200 mx-1" />
               <button
                 onClick={() => handleFeedback('up')}
-                className={`p-1.5 hover:bg-claude-subtext/10 rounded-md transition-all duration-200 ${feedback === 'up' ? 'text-claude-text' : 'text-claude-subtext hover:text-claude-text'}`}
+                className={`p-1.5 hover:bg-zinc-100 rounded-md transition-colors duration-150 ${feedback === 'up' ? 'text-zinc-700' : 'text-zinc-400 hover:text-zinc-600'}`}
                 aria-label="Good response"
                 title="Гарна відповідь"
               >
-                <ThumbsUp size={13} strokeWidth={2} fill={feedback === 'up' ? 'currentColor' : 'none'} />
+                <ThumbsUp size={12} strokeWidth={2} fill={feedback === 'up' ? 'currentColor' : 'none'} />
               </button>
               <button
                 onClick={() => handleFeedback('down')}
-                className={`p-1.5 hover:bg-claude-subtext/10 rounded-md transition-all duration-200 ${feedback === 'down' ? 'text-claude-text' : 'text-claude-subtext hover:text-claude-text'}`}
+                className={`p-1.5 hover:bg-zinc-100 rounded-md transition-colors duration-150 ${feedback === 'down' ? 'text-zinc-700' : 'text-zinc-400 hover:text-zinc-600'}`}
                 aria-label="Bad response"
                 title="Погана відповідь"
               >
-                <ThumbsDown size={13} strokeWidth={2} fill={feedback === 'down' ? 'currentColor' : 'none'} />
+                <ThumbsDown size={12} strokeWidth={2} fill={feedback === 'down' ? 'currentColor' : 'none'} />
               </button>
             </div>
           )}

--- a/lexwebapp/src/components/message/UserMessage.tsx
+++ b/lexwebapp/src/components/message/UserMessage.tsx
@@ -53,26 +53,26 @@ export function UserMessage({ content, onEdit }: UserMessageProps) {
   if (isEditing) {
     return (
       <div className="flex flex-col items-end gap-1.5">
-        <div className="w-full max-w-[85%]">
+        <div className="w-full max-w-[80%]">
           <textarea
             ref={textareaRef}
             value={editDraft}
             onChange={(e) => setEditDraft(e.target.value)}
             onKeyDown={handleEditKeyDown}
             rows={Math.min(10, editDraft.split('\n').length + 1)}
-            className="w-full bg-claude-bg/80 border border-claude-text/30 rounded-2xl px-4 py-3 text-[15px] text-claude-text leading-relaxed resize-none focus:outline-none focus:border-claude-text/60 shadow-sm"
+            className="w-full bg-white border border-zinc-300 rounded-xl px-4 py-3 text-[14px] text-zinc-900 leading-relaxed resize-none focus:outline-none focus:border-zinc-500 shadow-elevation-1"
           />
           <div className="flex items-center justify-end gap-2 mt-1.5">
-            <span className="text-[11px] text-claude-subtext">⌘↵ зберегти · Esc скасувати</span>
+            <span className="text-[11px] text-zinc-400">⌘↵ зберегти · Esc скасувати</span>
             <button
               onClick={handleEditCancel}
-              className="flex items-center gap-1 px-2.5 py-1 text-[12px] text-claude-subtext hover:text-claude-text border border-claude-border rounded-lg transition-colors"
+              className="flex items-center gap-1 px-2.5 py-1 text-[12px] text-zinc-500 hover:text-zinc-700 border border-zinc-200 rounded-md transition-colors duration-150"
             >
               <X size={11} strokeWidth={2} /> Скасувати
             </button>
             <button
               onClick={handleEditSave}
-              className="flex items-center gap-1 px-2.5 py-1 text-[12px] text-claude-text border border-claude-border bg-claude-bg rounded-lg hover:bg-claude-subtext/10 transition-colors"
+              className="flex items-center gap-1 px-2.5 py-1 text-[12px] bg-zinc-900 text-white rounded-md hover:bg-zinc-700 transition-colors duration-150"
             >
               <Check size={11} strokeWidth={2.5} /> Надіслати
             </button>
@@ -83,27 +83,27 @@ export function UserMessage({ content, onEdit }: UserMessageProps) {
   }
 
   return (
-    <div className="flex flex-col items-end gap-1.5">
-      <div className="max-w-[85%] bg-claude-bg/60 backdrop-blur-sm border border-claude-border/50 rounded-2xl px-4 py-3 shadow-sm">
-        <p className="font-sans text-[15px] text-claude-text leading-relaxed whitespace-pre-wrap">
+    <div className="flex flex-col items-end gap-1">
+      <div className="max-w-[80%] bg-zinc-100 border border-zinc-200/60 rounded-2xl px-4 py-2.5">
+        <p className="font-sans text-[14px] text-zinc-900 leading-relaxed whitespace-pre-wrap">
           {content}
         </p>
       </div>
       <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
         <button
           onClick={handleCopy}
-          className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-md transition-all duration-200"
+          className="p-1 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
           title="Копіювати"
         >
-          <Copy size={12} strokeWidth={2} />
+          <Copy size={11} strokeWidth={2} />
         </button>
         {onEdit && (
           <button
             onClick={() => { setEditDraft(content); setIsEditing(true); }}
-            className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-md transition-all duration-200"
+            className="p-1 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
             title="Редагувати"
           >
-            <Pencil size={12} strokeWidth={2} />
+            <Pencil size={11} strokeWidth={2} />
           </button>
         )}
       </div>

--- a/lexwebapp/src/components/right-panel/RightPanel.tsx
+++ b/lexwebapp/src/components/right-panel/RightPanel.tsx
@@ -105,19 +105,19 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
     <motion.aside
       initial={false}
       animate={{ x: isOpen ? 0 : rightPanelWidth }}
-      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
       style={{ width: rightPanelWidth }}
-      className="fixed lg:static inset-y-0 right-0 z-50 bg-white border-l border-claude-border flex flex-col lg:translate-x-0 lg:h-full"
+      className="fixed lg:static inset-y-0 right-0 z-50 bg-claude-sidebar border-l border-claude-border flex flex-col lg:translate-x-0 lg:h-full"
     >
       <ResizeHandle />
 
       {/* Header */}
-      <div className="px-4 py-3 border-b border-claude-border/50 flex items-center justify-between">
-        <h2 className="font-sans font-semibold text-[15px] text-claude-text tracking-tight">
+      <div className="px-4 py-3 border-b border-claude-border flex items-center justify-between">
+        <h2 className="font-sans font-medium text-[13px] text-zinc-500 tracking-widest uppercase">
           Доказова база
         </h2>
-        <button onClick={onClose} className="lg:hidden p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-subtext/8 rounded-lg transition-all duration-200">
-          <X size={18} strokeWidth={2} />
+        <button onClick={onClose} className="lg:hidden p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-200/60 rounded-md transition-colors duration-150">
+          <X size={16} strokeWidth={2} />
         </button>
       </div>
 

--- a/lexwebapp/src/components/right-panel/TabsHeader.tsx
+++ b/lexwebapp/src/components/right-panel/TabsHeader.tsx
@@ -17,24 +17,24 @@ interface TabsHeaderProps {
 
 export function TabsHeader({ tabs, activeTab, onTabChange }: TabsHeaderProps) {
   return (
-    <div className="border-b border-claude-border/50 bg-claude-bg/30">
-      <div className="flex overflow-x-auto no-scrollbar">
+    <div className="border-b border-claude-border">
+      <div className="flex overflow-x-auto scrollbar-hide">
         {tabs.map((tab) => (
           <button
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
-            className={`flex-1 min-w-0 px-2 py-2.5 text-[10px] font-medium uppercase tracking-wider transition-all duration-200 border-b-2 ${
+            className={`flex-1 min-w-0 px-2 py-2.5 text-[10px] font-semibold uppercase tracking-[0.7px] transition-colors duration-150 border-b-2 ${
               activeTab === tab.id
-                ? 'border-claude-text text-claude-text'
-                : 'border-transparent text-claude-subtext hover:text-claude-text'
+                ? 'border-zinc-900 text-zinc-900'
+                : 'border-transparent text-zinc-400 hover:text-zinc-600'
             }`}
           >
-            <div className="flex items-center justify-center gap-1">
-              <tab.icon size={12} strokeWidth={2} />
+            <div className="flex items-center justify-center gap-1.5">
+              <tab.icon size={11} strokeWidth={2} />
               <span className="truncate">{tab.label}</span>
               {tab.count > 0 && (
-                <span className={`text-[9px] min-w-[16px] h-4 flex items-center justify-center rounded-full px-1 font-semibold ${
-                  activeTab === tab.id ? 'bg-claude-text text-white' : 'bg-claude-subtext/15 text-claude-subtext'
+                <span className={`text-[9px] min-w-[15px] h-[15px] flex items-center justify-center rounded-full px-1 font-semibold ${
+                  activeTab === tab.id ? 'bg-zinc-900 text-white' : 'bg-zinc-200 text-zinc-500'
                 }`}>
                   {tab.count}
                 </span>

--- a/lexwebapp/src/components/sidebar/NavItem.tsx
+++ b/lexwebapp/src/components/sidebar/NavItem.tsx
@@ -29,11 +29,15 @@ export function NavItem({ icon: Icon, label, route, onClick, badge }: NavItemPro
   return (
     <button
       onClick={handleClick}
-      className={`w-full text-left px-3 py-2 rounded-lg text-[13px] transition-all duration-200 flex items-center gap-3 group ${isActive ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`}>
-      <Icon size={15} strokeWidth={2} className="text-claude-subtext/60 group-hover:text-claude-text transition-colors duration-200 flex-shrink-0" />
+      className={`w-full text-left px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-150 flex items-center gap-2.5 group ${
+        isActive
+          ? 'bg-zinc-200/70 text-zinc-900 font-medium'
+          : 'text-zinc-600 hover:bg-zinc-200/40 hover:text-zinc-900'
+      }`}>
+      <Icon size={14} strokeWidth={2} className={`flex-shrink-0 transition-colors duration-150 ${isActive ? 'text-zinc-900' : 'text-zinc-400 group-hover:text-zinc-600'}`} />
       <span className="truncate font-medium tracking-tight font-sans">{label}</span>
       {badge !== undefined && badge > 0 && (
-        <span className="ml-auto flex-shrink-0 min-w-[20px] h-5 flex items-center justify-center rounded-full bg-red-500 text-white text-[11px] font-semibold px-1.5">
+        <span className="ml-auto flex-shrink-0 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-zinc-900 text-white text-[10px] font-semibold px-1">
           {badge}
         </span>
       )}

--- a/lexwebapp/src/components/sidebar/Section.tsx
+++ b/lexwebapp/src/components/sidebar/Section.tsx
@@ -11,22 +11,22 @@ interface SectionProps {
 
 export function Section({ id, title, collapsed, onToggle, children }: SectionProps) {
   return (
-    <div className="mb-6" data-tour={id}>
+    <div className="mb-4" data-tour={id}>
       <button
         onClick={() => onToggle(id)}
-        className="w-full flex items-center justify-between px-3 py-2 group cursor-pointer"
+        className="w-full flex items-center justify-between px-2 py-1.5 group cursor-pointer rounded-md hover:bg-zinc-200/30 transition-colors duration-150"
       >
-        <h3 className="text-[11px] font-semibold text-claude-subtext/70 uppercase tracking-[0.5px] font-sans">
+        <h3 className="text-[10px] font-semibold text-zinc-400 uppercase tracking-[0.8px] font-sans">
           {title}
         </h3>
         <ChevronDown
-          size={12}
+          size={11}
           strokeWidth={2.5}
-          className={`text-claude-subtext/40 group-hover:text-claude-subtext/70 transition-transform duration-200 ${collapsed ? '-rotate-90' : ''}`}
+          className={`text-zinc-300 group-hover:text-zinc-500 transition-all duration-200 ${collapsed ? '-rotate-90' : ''}`}
         />
       </button>
       {!collapsed && (
-        <div className="space-y-0.5">{children}</div>
+        <div className="space-y-0.5 mt-0.5">{children}</div>
       )}
     </div>
   );

--- a/lexwebapp/src/components/sidebar/SidebarFooter.tsx
+++ b/lexwebapp/src/components/sidebar/SidebarFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { User, LogOut, CreditCard, UsersRound, Plug, FileText, Shield, ScrollText, UserPlus } from 'lucide-react';
+import { User, LogOut, CreditCard, UsersRound, Plug, FileText, UserPlus } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ROUTES } from '../../router/routes';
 import type { UserRole } from '../../types/models/User';
@@ -21,105 +21,90 @@ export function SidebarFooter({
 }: SidebarFooterProps) {
   const navigate = useNavigate();
   return (
-    <div className="p-4 border-t border-claude-border relative" ref={profileMenuRef}>
+    <div className="px-3 py-3 border-t border-claude-border relative" ref={profileMenuRef}>
       <AnimatePresence>
         {showProfileMenu &&
         <motion.div
-          initial={{ opacity: 0, y: 10, scale: 0.95 }}
+          initial={{ opacity: 0, y: 8, scale: 0.97 }}
           animate={{ opacity: 1, y: 0, scale: 1 }}
-          exit={{ opacity: 0, y: 10, scale: 0.95 }}
-          transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
-          className="absolute bottom-full left-4 right-4 mb-2 bg-white rounded-xl border border-claude-border shadow-xl overflow-hidden z-50">
+          exit={{ opacity: 0, y: 8, scale: 0.97 }}
+          transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
+          className="absolute bottom-full left-3 right-3 mb-1.5 bg-white rounded-lg border border-zinc-200 shadow-elevation-3 overflow-hidden z-50">
             <button
               onClick={onProfileClick}
-              className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
-              <div className="p-1.5 bg-claude-accent/10 rounded-lg">
-                <User size={16} className="text-claude-accent" />
-              </div>
-              <span className="text-[13px] font-medium text-claude-text font-sans">Профіль</span>
+              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
+              <User size={14} className="text-zinc-500 flex-shrink-0" />
+              <span className="text-[13px] font-medium text-zinc-800 font-sans">Профіль</span>
             </button>
             {/* "Стати адвокатом" hidden — feature not ready for production */}
             {role !== 'administrator' && (
               <button
                 onClick={() => { onProfileMenuClick(); navigate(ROUTES.BILLING); }}
-                className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
-                <div className="p-1.5 bg-claude-subtext/8 rounded-lg">
-                  <CreditCard size={16} className="text-claude-subtext" />
-                </div>
-                <span className="text-[13px] font-medium text-claude-text font-sans">Біллінг</span>
+                className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
+                <CreditCard size={14} className="text-zinc-500 flex-shrink-0" />
+                <span className="text-[13px] font-medium text-zinc-800 font-sans">Біллінг</span>
               </button>
             )}
             <button
               onClick={() => { onProfileMenuClick(); navigate(ROUTES.MY_CONTRACTS); }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
-              <div className="p-1.5 bg-claude-subtext/8 rounded-lg">
-                <FileText size={16} className="text-claude-subtext" />
-              </div>
-              <span className="text-[13px] font-medium text-claude-text font-sans">Мої договори</span>
+              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
+              <FileText size={14} className="text-zinc-500 flex-shrink-0" />
+              <span className="text-[13px] font-medium text-zinc-800 font-sans">Мої договори</span>
             </button>
             <button
               onClick={() => { onProfileMenuClick(); navigate(ROUTES.REFERRAL); }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
-              <div className="p-1.5 bg-claude-subtext/8 rounded-lg">
-                <UserPlus size={16} className="text-claude-subtext" />
-              </div>
-              <span className="text-[13px] font-medium text-claude-text font-sans">Запросити друга</span>
+              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
+              <UserPlus size={14} className="text-zinc-500 flex-shrink-0" />
+              <span className="text-[13px] font-medium text-zinc-800 font-sans">Запросити друга</span>
             </button>
             <button
               onClick={() => { onProfileMenuClick(); navigate(ROUTES.MCP_CONNECT); }}
-              className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
-              <div className="p-1.5 bg-claude-subtext/8 rounded-lg">
-                <Plug size={16} className="text-claude-subtext" />
-              </div>
-              <span className="text-[13px] font-medium text-claude-text font-sans">MCP конект</span>
+              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
+              <Plug size={14} className="text-zinc-500 flex-shrink-0" />
+              <span className="text-[13px] font-medium text-zinc-800 font-sans">MCP конект</span>
             </button>
             {role === 'company' && (
               <button
                 onClick={() => { onProfileMenuClick(); navigate(ROUTES.TEAM); }}
-                className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-claude-bg transition-colors border-b border-claude-border/50">
-                <div className="p-1.5 bg-claude-subtext/8 rounded-lg">
-                  <UsersRound size={16} className="text-claude-subtext" />
-                </div>
-                <span className="text-[13px] font-medium text-claude-text font-sans">Команда</span>
+                className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
+                <UsersRound size={14} className="text-zinc-500 flex-shrink-0" />
+                <span className="text-[13px] font-medium text-zinc-800 font-sans">Команда</span>
               </button>
             )}
             <button
               onClick={onLogout}
-              className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-red-50 transition-colors">
-              <div className="p-1.5 bg-red-50 rounded-lg">
-                <LogOut size={16} className="text-red-600" />
-              </div>
-              <span className="text-[13px] font-medium text-red-600 font-sans">Вихід</span>
+              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-red-50 transition-colors duration-100">
+              <LogOut size={14} className="text-red-500 flex-shrink-0" />
+              <span className="text-[13px] font-medium text-red-500 font-sans">Вихід</span>
             </button>
           </motion.div>
         }
       </AnimatePresence>
 
-      <div className="flex items-center justify-center gap-3 mb-2 px-2">
-        <a href="/ua/offer" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-[10px] text-claude-subtext/60 hover:text-claude-subtext transition-colors">
-          <ScrollText size={10} />
-          <span>Оферта</span>
+      <div className="flex items-center justify-center gap-3 mb-2 px-1">
+        <a href="/ua/offer" target="_blank" rel="noopener noreferrer" className="text-[10px] text-zinc-400 hover:text-zinc-500 transition-colors">
+          Оферта
         </a>
-        <a href="/ua/privacy" target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 text-[10px] text-claude-subtext/60 hover:text-claude-subtext transition-colors">
-          <Shield size={10} />
-          <span>Конфіденційність</span>
+        <span className="text-zinc-300 text-[10px]">·</span>
+        <a href="/ua/privacy" target="_blank" rel="noopener noreferrer" className="text-[10px] text-zinc-400 hover:text-zinc-500 transition-colors">
+          Конфіденційність
         </a>
       </div>
 
       <button
         onClick={onProfileMenuClick}
-        className="w-full flex items-center gap-3 px-2 py-2 hover:bg-claude-subtext/8 rounded-lg transition-all duration-200">
+        className="w-full flex items-center gap-2.5 px-2 py-2 hover:bg-zinc-200/40 rounded-lg transition-colors duration-150">
         {user?.picture ?
-          <img src={user.picture} alt={user.name} className="w-8 h-8 rounded-full object-cover" /> :
-          <div className="w-8 h-8 rounded-full bg-claude-subtext/15 flex items-center justify-center text-claude-subtext text-[11px] font-semibold">
+          <img src={user.picture} alt={user.name} className="w-7 h-7 rounded-full object-cover flex-shrink-0" /> :
+          <div className="w-7 h-7 rounded-full bg-zinc-200 flex items-center justify-center text-zinc-600 text-[10px] font-semibold flex-shrink-0">
             {user?.name?.split(' ').map(n => n[0]).join('').toUpperCase() || '?'}
           </div>
         }
-        <div className="flex-1 text-left">
-          <div className="text-[13px] font-semibold text-claude-text tracking-tight font-sans">
+        <div className="flex-1 text-left min-w-0">
+          <div className="text-[13px] font-semibold text-zinc-900 tracking-tight font-sans truncate">
             {user?.name || 'Користувач'}
           </div>
-          <div className="text-[11px] text-claude-subtext/70 font-sans">{user?.email || ''}</div>
+          <div className="text-[11px] text-zinc-400 font-sans truncate">{user?.email || ''}</div>
         </div>
       </button>
     </div>

--- a/lexwebapp/src/index.css
+++ b/lexwebapp/src/index.css
@@ -10,10 +10,10 @@
   }
 }
 
-/* Custom scrollbar for a cleaner look */
+/* Custom scrollbar — thin, minimal */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 5px;
+  height: 5px;
 }
 
 ::-webkit-scrollbar-track {
@@ -21,12 +21,12 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #D1D1CD;
-  border-radius: 4px;
+  background: #D4D4D8;
+  border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #B0B0AC;
+  background: #A1A1AA;
 }
 
 /* 3D spinning LX logo */
@@ -66,7 +66,7 @@
     -ms-overflow-style: none;  /* IE and Edge */
     scrollbar-width: none;  /* Firefox */
   }
-  
+
   .scrollbar-hide::-webkit-scrollbar {
     display: none;  /* Chrome, Safari and Opera */
   }

--- a/lexwebapp/src/pages/ChatPage/index.tsx
+++ b/lexwebapp/src/pages/ChatPage/index.tsx
@@ -149,7 +149,7 @@ export function ChatPage() {
         </div>
       )}
 
-      <div className="w-full bg-gradient-to-t from-claude-bg via-claude-bg to-transparent pt-6 pb-4 z-20 border-t border-claude-border/30">
+      <div className="w-full bg-claude-bg pt-4 pb-4 z-20 border-t border-claude-border">
         <ChatInput
           onSend={handleSend}
           disabled={isStreaming || isPlanLoading || !!pendingPlanReview}

--- a/lexwebapp/tailwind.config.js
+++ b/lexwebapp/tailwind.config.js
@@ -9,13 +9,13 @@ export default {
     extend: {
       colors: {
         claude: {
-          bg: '#F5F5F0',
-          sidebar: '#F0F0EB', // Slightly darker than bg
-          accent: '#D97757', // Warm orange
-          text: '#2D2D2D',
-          subtext: '#6B6B6B',
-          border: '#E5E5E0',
-          user: '#EAEAE5', // Subtle background for user messages
+          bg: '#FAFAFA',       // Near-white, clean
+          sidebar: '#F4F4F5',  // Zinc-100 — cooler, more professional
+          accent: '#18181B',   // Zinc-900 — near-black primary CTA
+          text: '#18181B',     // Zinc-900 — strong, confident
+          subtext: '#71717A',  // Zinc-500 — cool gray
+          border: '#E4E4E7',   // Zinc-200 — subtle, clean
+          user: '#F1F1F4',     // Slightly off-white for user messages
         }
       },
       fontFamily: {
@@ -25,27 +25,31 @@ export default {
       typography: {
         DEFAULT: {
           css: {
-            // Override default prose colors to match claude theme
-            // Default prose assumes dark code bg (#1f2937) with light code text (#e5e7eb)
-            // We use light backgrounds, so all text must be dark
-            '--tw-prose-body': '#2D2D2D',
-            '--tw-prose-headings': '#2D2D2D',
-            '--tw-prose-lead': '#6B6B6B',
-            '--tw-prose-links': '#2D2D2D',
-            '--tw-prose-bold': '#2D2D2D',
-            '--tw-prose-counters': '#6B6B6B',
-            '--tw-prose-bullets': '#6B6B6B',
-            '--tw-prose-hr': '#E5E5E0',
-            '--tw-prose-quotes': '#2D2D2D',
-            '--tw-prose-quote-borders': '#E5E5E0',
-            '--tw-prose-captions': '#6B6B6B',
-            '--tw-prose-code': '#2D2D2D',
-            '--tw-prose-pre-code': '#2D2D2D',
-            '--tw-prose-pre-bg': '#F5F5F0',
-            '--tw-prose-th-borders': '#E5E5E0',
-            '--tw-prose-td-borders': '#E5E5E0',
+            '--tw-prose-body': '#18181B',
+            '--tw-prose-headings': '#18181B',
+            '--tw-prose-lead': '#71717A',
+            '--tw-prose-links': '#18181B',
+            '--tw-prose-bold': '#18181B',
+            '--tw-prose-counters': '#71717A',
+            '--tw-prose-bullets': '#71717A',
+            '--tw-prose-hr': '#E4E4E7',
+            '--tw-prose-quotes': '#18181B',
+            '--tw-prose-quote-borders': '#E4E4E7',
+            '--tw-prose-captions': '#71717A',
+            '--tw-prose-code': '#18181B',
+            '--tw-prose-pre-code': '#18181B',
+            '--tw-prose-pre-bg': '#F4F4F5',
+            '--tw-prose-th-borders': '#E4E4E7',
+            '--tw-prose-td-borders': '#E4E4E7',
           },
         },
+      },
+      boxShadow: {
+        'elevation-0': 'none',
+        'elevation-1': '0 1px 3px 0 rgba(0,0,0,0.06), 0 1px 2px -1px rgba(0,0,0,0.04)',
+        'elevation-2': '0 4px 6px -1px rgba(0,0,0,0.07), 0 2px 4px -2px rgba(0,0,0,0.04)',
+        'elevation-3': '0 10px 15px -3px rgba(0,0,0,0.08), 0 4px 6px -4px rgba(0,0,0,0.04)',
+        'input-focus': '0 0 0 3px rgba(24,24,27,0.08)',
       },
       animation: {
         'fade-in': 'fadeIn 0.3s ease-out',


### PR DESCRIPTION
## Summary
- Redesigned login page with split-panel layout, light/dark theme toggle, zinc color palette
- Redesigned chat interface: sidebar, messages, input, right panel, empty state, tool selector
- Repalette from warm cream/orange to cool zinc system (Harvey.ai-inspired legal-tech aesthetic)

## Test plan
- [ ] Verify login page renders correctly in light (default) and dark theme
- [ ] Verify theme toggle persists across page reloads
- [ ] Verify all auth methods work (Google, Diia, SSO, password, WebAuthn)
- [ ] Verify chat interface layout (sidebar, messages, right panel)
- [ ] Verify message bubbles render correctly for user and assistant
- [ ] Verify empty state and tool selector styling
- [ ] Verify modals (GDPR, Forgot Password) match selected theme
- [ ] Verify mobile responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)