### PR TITLE
feat(legislation): legislation monitoring — subscriptions, change detection, diff viewer

### DIFF
--- a/lexwebapp/src/components/legislation/ChangeFeed.tsx
+++ b/lexwebapp/src/components/legislation/ChangeFeed.tsx
@@ -1,0 +1,199 @@
+import { useState, useEffect, useCallback } from 'react';
+import { motion } from 'framer-motion';
+import { Loader2, FileText, AlertCircle, ChevronDown } from 'lucide-react';
+import apiClient from '../../utils/api-client';
+import { DiffViewer } from './DiffViewer';
+
+interface Change {
+  id: number;
+  legislation_id: number;
+  rada_id: string;
+  article_number: string | null;
+  change_type: 'added' | 'modified' | 'removed';
+  old_text: string | null;
+  new_text: string | null;
+  diff_html: string | null;
+  detected_at: string;
+  version_date: string | null;
+  title?: string;
+  short_title?: string;
+}
+
+interface ChangeFeedProps {
+  radaId?: string;
+}
+
+const changeTypeBadge: Record<string, { label: string; color: string }> = {
+  added: { label: 'Додано', color: 'bg-green-50 text-green-700 border-green-200' },
+  modified: { label: 'Змінено', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  removed: { label: 'Видалено', color: 'bg-red-50 text-red-700 border-red-200' },
+};
+
+function formatDateTime(dateStr: string): string {
+  try {
+    const d = new Date(dateStr);
+    if (isNaN(d.getTime())) return dateStr;
+    return d.toLocaleDateString('uk-UA', {
+      day: '2-digit', month: '2-digit', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    });
+  } catch {
+    return dateStr;
+  }
+}
+
+export function ChangeFeed({ radaId }: ChangeFeedProps) {
+  const [changes, setChanges] = useState<Change[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [expandedChange, setExpandedChange] = useState<Change | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+
+  const loadChanges = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params: Record<string, string | number> = { limit: 50, offset: 0 };
+      if (radaId) params.rada_id = radaId;
+
+      const response = await apiClient.get('/api/legislation/monitoring/changes', { params });
+      setChanges(response.data.changes || []);
+      setTotal(response.data.total || 0);
+    } catch (err) {
+      console.error('Failed to load changes:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [radaId]);
+
+  useEffect(() => { loadChanges(); }, [loadChanges]);
+
+  const handleExpand = async (change: Change) => {
+    if (expandedId === change.id) {
+      setExpandedId(null);
+      setExpandedChange(null);
+      return;
+    }
+
+    setExpandedId(change.id);
+
+    if (change.diff_html || change.old_text || change.new_text) {
+      setExpandedChange(change);
+      return;
+    }
+
+    setDetailLoading(true);
+    try {
+      const response = await apiClient.get(`/api/legislation/monitoring/changes/${change.id}`);
+      setExpandedChange(response.data);
+    } catch {
+      setExpandedChange(change);
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 size={24} className="animate-spin text-claude-accent" />
+        <span className="ml-2 text-sm text-claude-subtext font-sans">Завантаження змін...</span>
+      </div>
+    );
+  }
+
+  if (changes.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-12">
+        <FileText size={48} className="text-claude-subtext/30 mb-4" />
+        <p className="text-claude-subtext font-sans text-sm">
+          {radaId
+            ? 'Для цього документа ще не зафіксовано змін'
+            : 'Підпишіться на документи, щоб відстежувати зміни'}
+        </p>
+      </div>
+    );
+  }
+
+  // Group by detected_at date
+  const grouped = changes.reduce<Record<string, Change[]>>((acc, change) => {
+    const dateKey = new Date(change.detected_at).toLocaleDateString('uk-UA');
+    if (!acc[dateKey]) acc[dateKey] = [];
+    acc[dateKey].push(change);
+    return acc;
+  }, {});
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-claude-subtext font-sans">
+        Всього змін: {total}
+      </p>
+
+      {Object.entries(grouped).map(([dateStr, dateChanges]) => (
+        <div key={dateStr}>
+          <h3 className="text-sm font-medium text-claude-subtext font-sans mb-3 flex items-center gap-2">
+            <AlertCircle size={14} />
+            {dateStr}
+          </h3>
+          <div className="space-y-2">
+            {dateChanges.map((change) => {
+              const badge = changeTypeBadge[change.change_type] || changeTypeBadge.modified;
+              return (
+                <motion.div
+                  key={change.id}
+                  initial={{ opacity: 0, y: 5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                >
+                  <button
+                    onClick={() => handleExpand(change)}
+                    className="w-full text-left p-4 bg-white rounded-xl border border-claude-border hover:border-claude-accent/30 transition-all"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-3">
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border ${badge.color}`}>
+                          {badge.label}
+                        </span>
+                        <span className="text-sm font-sans text-claude-text">
+                          {change.short_title || change.title || change.rada_id}
+                          {change.article_number && ` — ст. ${change.article_number}`}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-claude-subtext font-sans">
+                          {formatDateTime(change.detected_at)}
+                        </span>
+                        <ChevronDown
+                          size={16}
+                          className={`text-claude-subtext transition-transform ${expandedId === change.id ? 'rotate-180' : ''}`}
+                        />
+                      </div>
+                    </div>
+                  </button>
+
+                  {expandedId === change.id && (
+                    <div className="mt-2 ml-4">
+                      {detailLoading ? (
+                        <div className="flex items-center py-4">
+                          <Loader2 size={16} className="animate-spin text-claude-accent" />
+                          <span className="ml-2 text-sm text-claude-subtext">Завантаження...</span>
+                        </div>
+                      ) : expandedChange ? (
+                        <DiffViewer
+                          diffHtml={expandedChange.diff_html}
+                          oldText={expandedChange.old_text}
+                          newText={expandedChange.new_text}
+                          articleNumber={expandedChange.article_number}
+                          changeType={expandedChange.change_type}
+                        />
+                      ) : null}
+                    </div>
+                  )}
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/lexwebapp/src/components/legislation/DiffViewer.tsx
+++ b/lexwebapp/src/components/legislation/DiffViewer.tsx
@@ -1,0 +1,76 @@
+import { motion } from 'framer-motion';
+
+interface DiffViewerProps {
+  diffHtml: string | null;
+  oldText?: string | null;
+  newText?: string | null;
+  articleNumber?: string | null;
+  changeType: 'added' | 'modified' | 'removed';
+}
+
+const changeTypeLabels: Record<string, { label: string; color: string }> = {
+  added: { label: 'Додано', color: 'bg-green-50 text-green-700 border-green-200' },
+  modified: { label: 'Змінено', color: 'bg-amber-50 text-amber-700 border-amber-200' },
+  removed: { label: 'Видалено', color: 'bg-red-50 text-red-700 border-red-200' },
+};
+
+export function DiffViewer({ diffHtml, oldText, newText, articleNumber, changeType }: DiffViewerProps) {
+  const typeConfig = changeTypeLabels[changeType] || changeTypeLabels.modified;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="bg-white rounded-xl border border-claude-border overflow-hidden"
+    >
+      <div className="flex items-center gap-3 px-4 py-3 bg-claude-bg border-b border-claude-border">
+        {articleNumber && (
+          <span className="text-sm font-medium text-claude-text font-sans">
+            Стаття {articleNumber}
+          </span>
+        )}
+        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium border ${typeConfig.color}`}>
+          {typeConfig.label}
+        </span>
+      </div>
+
+      <div className="p-4">
+        {changeType === 'modified' && diffHtml ? (
+          <div
+            className="text-sm font-sans text-claude-text leading-relaxed whitespace-pre-wrap diff-content"
+            dangerouslySetInnerHTML={{ __html: diffHtml }}
+          />
+        ) : changeType === 'added' && newText ? (
+          <div className="text-sm font-sans text-claude-text leading-relaxed whitespace-pre-wrap">
+            <ins className="diff-add">{newText}</ins>
+          </div>
+        ) : changeType === 'removed' && oldText ? (
+          <div className="text-sm font-sans text-claude-text leading-relaxed whitespace-pre-wrap">
+            <del className="diff-del">{oldText}</del>
+          </div>
+        ) : (
+          <p className="text-sm text-claude-subtext font-sans">
+            Деталі зміни недоступні
+          </p>
+        )}
+      </div>
+
+      <style>{`
+        .diff-content ins.diff-add,
+        ins.diff-add {
+          background-color: #d4edda;
+          text-decoration: none;
+          padding: 1px 2px;
+          border-radius: 2px;
+        }
+        .diff-content del.diff-del,
+        del.diff-del {
+          background-color: #f8d7da;
+          text-decoration: line-through;
+          padding: 1px 2px;
+          border-radius: 2px;
+        }
+      `}</style>
+    </motion.div>
+  );
+}

--- a/lexwebapp/src/pages/LegislationMonitoringPage.tsx
+++ b/lexwebapp/src/pages/LegislationMonitoringPage.tsx
@@ -4,7 +4,8 @@ import {
   Search,
   Filter,
   Eye,
-  Star,
+  Bell,
+  BellOff,
   FileText,
   Calendar,
   CheckCircle,
@@ -19,10 +20,12 @@ import {
   Loader2,
   ChevronRight,
   ChevronLeft,
-  Clock } from
+  Clock,
+  GitCompareArrows } from
 'lucide-react';
 import apiClient from '../utils/api-client';
 import showToast from '../utils/toast';
+import { ChangeFeed } from '../components/legislation/ChangeFeed';
 
 interface LegislationDocument {
   id: string;
@@ -101,7 +104,6 @@ const typeLabels: Record<string, string> = {
 };
 
 const PAGE_SIZE = 50;
-const FAVORITES_KEY = 'legislation-monitoring-favorites';
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return '\u2014';
@@ -112,19 +114,6 @@ function formatDate(dateStr: string | null): string {
   } catch {
     return dateStr;
   }
-}
-
-function loadFavorites(): Set<string> {
-  try {
-    const stored = localStorage.getItem(FAVORITES_KEY);
-    return stored ? new Set(JSON.parse(stored)) : new Set();
-  } catch {
-    return new Set();
-  }
-}
-
-function saveFavorites(favorites: Set<string>) {
-  localStorage.setItem(FAVORITES_KEY, JSON.stringify([...favorites]));
 }
 
 export function LegislationMonitoringPage({
@@ -144,7 +133,7 @@ export function LegislationMonitoringPage({
   const [selectedArticle, setSelectedArticle] = useState<ArticleContent | null>(null);
   const [articleLoading, setArticleLoading] = useState(false);
 
-  const [activeTab, setActiveTab] = useState<'text' | 'card' | 'history'>('card');
+  const [activeTab, setActiveTab] = useState<'text' | 'card' | 'history' | 'changes'>('card');
   const [filters, setFilters] = useState({
     type: '',
     dateFrom: '',
@@ -157,8 +146,12 @@ export function LegislationMonitoringPage({
   // Available types from server
   const [availableTypes, setAvailableTypes] = useState<string[]>([]);
 
-  // Favorites
-  const [favorites, setFavorites] = useState<Set<string>>(() => loadFavorites());
+  // Subscriptions (server-side)
+  const [subscriptions, setSubscriptions] = useState<Set<string>>(new Set());
+  const [subscriptionLoading, setSubscriptionLoading] = useState<string | null>(null);
+
+  // Top-level view tab
+  const [viewTab, setViewTab] = useState<'list' | 'changes'>('list');
 
   // History tab
   const [amendmentHistory, setAmendmentHistory] = useState<HistoryEntry[]>([]);
@@ -167,10 +160,14 @@ export function LegislationMonitoringPage({
   // Debounce timer for date filters
   const filterDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Load stats and types on mount
+  // Load stats, types, and subscriptions on mount
   useEffect(() => {
     apiClient.get('/api/legislation/stats').then(r => setStats(r.data)).catch(() => {});
     apiClient.get('/api/legislation/types').then(r => setAvailableTypes(r.data.types || [])).catch(() => {});
+    apiClient.get('/api/legislation/monitoring/subscriptions').then(r => {
+      const subs = new Set<string>((r.data.subscriptions || []).map((s: any) => s.rada_id));
+      setSubscriptions(subs);
+    }).catch(() => {});
   }, []);
 
   // Load legislation list
@@ -255,18 +252,24 @@ export function LegislationMonitoringPage({
     if (offset + PAGE_SIZE < totalCount) setOffset(offset + PAGE_SIZE);
   };
 
-  // Favorites
-  const toggleFavorite = (radaId: string) => {
-    setFavorites(prev => {
-      const next = new Set(prev);
-      if (next.has(radaId)) {
-        next.delete(radaId);
+  // Subscriptions
+  const toggleSubscription = async (radaId: string) => {
+    setSubscriptionLoading(radaId);
+    try {
+      if (subscriptions.has(radaId)) {
+        await apiClient.delete(`/api/legislation/monitoring/subscriptions/${encodeURIComponent(radaId)}`);
+        setSubscriptions(prev => { const next = new Set(prev); next.delete(radaId); return next; });
+        showToast.success('Підписку скасовано');
       } else {
-        next.add(radaId);
+        await apiClient.post('/api/legislation/monitoring/subscriptions', { rada_id: radaId });
+        setSubscriptions(prev => { const next = new Set(prev); next.add(radaId); return next; });
+        showToast.success('Підписано на зміни');
       }
-      saveFavorites(next);
-      return next;
-    });
+    } catch (err: any) {
+      showToast.error('Не вдалося змінити підписку');
+    } finally {
+      setSubscriptionLoading(null);
+    }
   };
 
   // Load document structure when selecting a document
@@ -370,10 +373,16 @@ export function LegislationMonitoringPage({
                   </a>
                 )}
                 <button
-                  onClick={() => toggleFavorite(selectedDocument.rada_id)}
-                  className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-colors"
-                  title={favorites.has(selectedDocument.rada_id) ? 'Прибрати з обраного' : 'В обране'}>
-                  <Star size={20} className={favorites.has(selectedDocument.rada_id) ? 'fill-amber-400 text-amber-400' : ''} />
+                  onClick={() => toggleSubscription(selectedDocument.rada_id)}
+                  disabled={subscriptionLoading === selectedDocument.rada_id}
+                  className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-colors disabled:opacity-50"
+                  title={subscriptions.has(selectedDocument.rada_id) ? 'Відписатися від змін' : 'Підписатися на зміни'}>
+                  {subscriptionLoading === selectedDocument.rada_id
+                    ? <Loader2 size={20} className="animate-spin" />
+                    : subscriptions.has(selectedDocument.rada_id)
+                      ? <Bell size={20} className="fill-claude-accent text-claude-accent" />
+                      : <BellOff size={20} />
+                  }
                 </button>
               </div>
             </div>
@@ -387,6 +396,7 @@ export function LegislationMonitoringPage({
               {[
                 { id: 'card', label: 'Картка', icon: BookOpen },
                 { id: 'text', label: 'Текст', icon: FileText },
+                { id: 'changes', label: 'Зміни', icon: GitCompareArrows },
                 { id: 'history', label: 'Історія', icon: History },
               ].map((tab) => {
                 const Icon = tab.icon;
@@ -568,6 +578,16 @@ export function LegislationMonitoringPage({
                       Оберіть статтю у вкладці "Картка" для перегляду тексту
                     </p>
                   )}
+                </motion.div>
+              )}
+
+              {/* Changes tab */}
+              {activeTab === 'changes' && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                >
+                  <ChangeFeed radaId={selectedDocument.rada_id} />
                 </motion.div>
               )}
 
@@ -788,6 +808,31 @@ export function LegislationMonitoringPage({
           </div>
         )}
 
+        {/* View tabs */}
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setViewTab('list')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium font-sans transition-colors ${viewTab === 'list' ? 'bg-claude-accent text-white' : 'bg-white border border-claude-border text-claude-text hover:bg-claude-bg'}`}>
+            <FileText size={16} />
+            Документи
+          </button>
+          <button
+            onClick={() => setViewTab('changes')}
+            className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium font-sans transition-colors ${viewTab === 'changes' ? 'bg-claude-accent text-white' : 'bg-white border border-claude-border text-claude-text hover:bg-claude-bg'}`}>
+            <GitCompareArrows size={16} />
+            Зміни
+            {subscriptions.size > 0 && (
+              <span className="px-1.5 py-0.5 bg-white/20 rounded text-xs">{subscriptions.size}</span>
+            )}
+          </button>
+        </div>
+
+        {viewTab === 'changes' ? (
+          <div className="bg-white rounded-2xl border border-claude-border shadow-sm p-6">
+            <ChangeFeed />
+          </div>
+        ) : (
+        <>
         {/* Results Header */}
         <div className="flex items-center justify-between">
           <p className="text-sm text-claude-subtext font-sans">
@@ -895,10 +940,16 @@ export function LegislationMonitoringPage({
                             </a>
                           )}
                           <button
-                            onClick={(e) => { e.stopPropagation(); toggleFavorite(doc.rada_id); }}
-                            className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded transition-colors"
-                            title={favorites.has(doc.rada_id) ? 'Прибрати з обраного' : 'В обране'}>
-                            <Star size={16} className={favorites.has(doc.rada_id) ? 'fill-amber-400 text-amber-400' : ''} />
+                            onClick={(e) => { e.stopPropagation(); toggleSubscription(doc.rada_id); }}
+                            disabled={subscriptionLoading === doc.rada_id}
+                            className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded transition-colors disabled:opacity-50"
+                            title={subscriptions.has(doc.rada_id) ? 'Відписатися від змін' : 'Підписатися на зміни'}>
+                            {subscriptionLoading === doc.rada_id
+                              ? <Loader2 size={16} className="animate-spin" />
+                              : subscriptions.has(doc.rada_id)
+                                ? <Bell size={16} className="fill-claude-accent text-claude-accent" />
+                                : <BellOff size={16} />
+                            }
                           </button>
                         </div>
                       </td>
@@ -932,6 +983,8 @@ export function LegislationMonitoringPage({
             </div>
           )}
         </div>
+        </>
+        )}
       </div>
     </div>
   );

--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -27,6 +27,7 @@ import { ConsultationService } from '../services/consultation-service.js';
 import { ConsultationPaymentService } from '../services/consultation-payment-service.js';
 import { AttorneyPayoutService } from '../services/attorney-payout-service.js';
 import { OAuthService } from '../services/oauth-service.js';
+import { LegislationMonitoringService } from '../services/legislation-monitoring-service.js';
 import { MCPSSEServer } from '../api/mcp-sse-server.js';
 import { BannerService } from '../services/banner-service.js';
 import { UserService } from '../services/user-service.js';
@@ -67,6 +68,7 @@ export interface AppServices {
   oauthService: OAuthService;
   mcpSSEServer: MCPSSEServer;
   llmAdapter: LLMAdapter;
+  legislationMonitoringService: LegislationMonitoringService;
 }
 
 export function createAppServices(
@@ -219,6 +221,14 @@ export function createAppServices(
   consultationService.setEmailService(billing.emailService);
   logger.info('Attorney consultation services initialized (with payout tracking and email notifications)');
 
+  // Legislation monitoring service
+  const legislationMonitoringService = new LegislationMonitoringService(
+    coreServices.db,
+    coreServices.legislationTools.getLegislationService().getAdapter(),
+    billing.emailService
+  );
+  logger.info('Legislation monitoring service initialized');
+
   // Wire audit service into billing and payment services
   billing.billingService.setAuditService(auditService);
   billing.monobankService.setAuditService(auditService);
@@ -275,5 +285,6 @@ export function createAppServices(
     oauthService,
     mcpSSEServer,
     llmAdapter,
+    legislationMonitoringService,
   };
 }

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -65,6 +65,7 @@ import { createJudgesRoutes } from './routes/judges-routes.js';
 import { JudgeAnalyticsService } from './services/judge-analytics-service.js';
 import { createJudgeAnalyticsRoutes } from './routes/judge-analytics-routes.js';
 import { createReferralRoutes } from './routes/referral-routes.js';
+import { createLegislationMonitoringRoutes } from './routes/legislation-monitoring-routes.js';
 import rateLimit from 'express-rate-limit';
 import cron from 'node-cron';
 
@@ -122,6 +123,14 @@ class HTTPMCPServer {
       logger.info('[Cron] Running stuck escrow and failed payout check');
       this.app_.consultationPaymentService.flagStuckConsultationsAndPayouts().catch(err => {
         logger.error('[Cron] Stuck escrow check failed', { error: (err as Error).message });
+      });
+    }, { timezone: 'Europe/Kyiv' });
+
+    // Cron: check legislation changes daily at 06:00 Kyiv time
+    cron.schedule('0 6 * * *', () => {
+      logger.info('[Cron] Running legislation change detection');
+      this.app_.legislationMonitoringService.checkAllSubscribedLegislation().catch(err => {
+        logger.error('[Cron] Legislation change detection failed', { error: (err as Error).message });
       });
     }, { timezone: 'Europe/Kyiv' });
   }
@@ -485,6 +494,10 @@ class HTTPMCPServer {
     // Referral system routes
     this.app.use('/api/referral', createReferralRoutes(this.billing.referralService));
     logger.info('Referral routes registered at /api/referral');
+
+    // Legislation monitoring routes - subscriptions, changes, notifications
+    this.app.use('/api/legislation/monitoring', requireJWT as any, createLegislationMonitoringRoutes(this.app_.legislationMonitoringService));
+    logger.info('Legislation monitoring routes registered at /api/legislation/monitoring');
 
     // Judges routes - search judges from VKKS data
     const judgesService = new JudgesService(this.services.db, this.services.zoAdapter);

--- a/mcp_backend/src/migrations/100_legislation_monitoring.sql
+++ b/mcp_backend/src/migrations/100_legislation_monitoring.sql
@@ -1,0 +1,45 @@
+-- Migration 100: Legislation monitoring - subscriptions, change tracking, notifications
+
+-- User subscriptions to legislation documents
+CREATE TABLE IF NOT EXISTS legislation_subscriptions (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  legislation_id INTEGER NOT NULL REFERENCES legislation(id) ON DELETE CASCADE,
+  notify_email BOOLEAN DEFAULT true,
+  notify_inapp BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, legislation_id)
+);
+CREATE INDEX IF NOT EXISTS idx_leg_sub_user ON legislation_subscriptions(user_id);
+CREATE INDEX IF NOT EXISTS idx_leg_sub_legislation ON legislation_subscriptions(legislation_id);
+
+-- Change log for detected legislation changes
+CREATE TABLE IF NOT EXISTS legislation_changes (
+  id SERIAL PRIMARY KEY,
+  legislation_id INTEGER NOT NULL REFERENCES legislation(id) ON DELETE CASCADE,
+  rada_id VARCHAR(100) NOT NULL,
+  article_number VARCHAR(50),
+  change_type VARCHAR(20) NOT NULL CHECK (change_type IN ('added', 'modified', 'removed')),
+  old_text TEXT,
+  new_text TEXT,
+  diff_html TEXT,
+  detected_at TIMESTAMPTZ DEFAULT NOW(),
+  version_date TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS idx_leg_changes_legislation ON legislation_changes(legislation_id);
+CREATE INDEX IF NOT EXISTS idx_leg_changes_detected ON legislation_changes(detected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_leg_changes_rada ON legislation_changes(rada_id);
+
+-- Generic in-app notifications
+CREATE TABLE IF NOT EXISTS user_notifications (
+  id SERIAL PRIMARY KEY,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type VARCHAR(50) NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT,
+  link TEXT,
+  metadata JSONB DEFAULT '{}',
+  is_read BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread ON user_notifications(user_id, is_read, created_at DESC);

--- a/mcp_backend/src/routes/legislation-monitoring-routes.ts
+++ b/mcp_backend/src/routes/legislation-monitoring-routes.ts
@@ -1,0 +1,156 @@
+import { Router, Request, Response, RequestHandler } from 'express';
+import { LegislationMonitoringService } from '../services/legislation-monitoring-service.js';
+import { logger } from '../utils/logger.js';
+
+interface AuthRequest extends Request {
+  user?: { id: string };
+}
+
+export function createLegislationMonitoringRoutes(service: LegislationMonitoringService): Router {
+  const router = Router();
+
+  // POST /subscriptions - subscribe to legislation
+  router.post('/subscriptions', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const { rada_id, notify_email, notify_inapp } = req.body;
+      if (!rada_id) { res.status(400).json({ error: 'rada_id обов\'язковий' }); return; }
+
+      const sub = await service.subscribe(userId, rada_id, { notify_email, notify_inapp });
+      res.json(sub);
+    } catch (err: any) {
+      logger.error('[LegMonitoring] Subscribe error', { error: err.message });
+      res.status(400).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // DELETE /subscriptions/:radaId - unsubscribe
+  router.delete('/subscriptions/:radaId', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const deleted = await service.unsubscribe(userId, req.params.radaId as string);
+      res.json({ success: deleted });
+    } catch (err: any) {
+      logger.error('[LegMonitoring] Unsubscribe error', { error: err.message });
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // GET /subscriptions - list user subscriptions
+  router.get('/subscriptions', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const subscriptions = await service.listSubscriptions(userId);
+      res.json({ subscriptions });
+    } catch (err: any) {
+      logger.error('[LegMonitoring] List subscriptions error', { error: err.message });
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // GET /subscriptions/check/:radaId - check if subscribed
+  router.get('/subscriptions/check/:radaId', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const subscribed = await service.isSubscribed(userId, req.params.radaId as string);
+      res.json({ subscribed });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // GET /changes - change feed for subscribed legislation
+  router.get('/changes', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const { rada_id, limit, offset } = req.query;
+      const result = await service.getChangeFeed(userId, {
+        radaId: rada_id as string,
+        limit: limit ? parseInt(limit as string) : undefined,
+        offset: offset ? parseInt(offset as string) : undefined,
+      });
+      res.json(result);
+    } catch (err: any) {
+      logger.error('[LegMonitoring] Change feed error', { error: err.message });
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // GET /changes/legislation/:radaId - changes for specific legislation
+  router.get('/changes/legislation/:radaId', (async (req: AuthRequest, res: Response) => {
+    try {
+      const limit = req.query.limit ? parseInt(String(req.query.limit)) : 50;
+      const changes = await service.getChangesForLegislation(req.params.radaId as string, limit);
+      res.json({ changes });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // GET /changes/:changeId - single change with diff
+  router.get('/changes/:changeId', (async (req: AuthRequest, res: Response) => {
+    try {
+      const change = await service.getChange(parseInt(req.params.changeId as string));
+      if (!change) { res.status(404).json({ error: 'Зміну не знайдено' }); return; }
+      res.json(change);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // GET /notifications - in-app notifications
+  router.get('/notifications', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const { unread_only, limit, offset } = req.query;
+      const result = await service.getNotifications(userId, {
+        unreadOnly: unread_only === 'true',
+        limit: limit ? parseInt(limit as string) : undefined,
+        offset: offset ? parseInt(offset as string) : undefined,
+      });
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // PATCH /notifications/:id/read - mark notification as read
+  router.patch('/notifications/:id/read', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      const success = await service.markNotificationRead(userId, parseInt(req.params.id as string));
+      res.json({ success });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  // POST /notifications/read-all - mark all as read
+  router.post('/notifications/read-all', (async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) { res.status(401).json({ error: 'Не авторизовано' }); return; }
+
+      await service.markAllNotificationsRead(userId);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  }) as RequestHandler);
+
+  return router;
+}

--- a/mcp_backend/src/services/email-service.ts
+++ b/mcp_backend/src/services/email-service.ts
@@ -625,6 +625,39 @@ export class EmailService {
     });
   }
 
+  // ─── Legislation Monitoring Email ───────────────────────
+
+  async sendLegislationChangeNotification(params: {
+    email: string;
+    name: string;
+    lawTitle: string;
+    radaId: string;
+    changeCount: number;
+    changedArticles: string;
+    link: string;
+  }): Promise<void> {
+    try {
+      const articlesText = params.changedArticles
+        ? `<p>Змінені статті: <strong>${params.changedArticles}</strong></p>`
+        : '<p>Виявлено структурні зміни</p>';
+
+      await this.sendConsultationEmail({
+        to: params.email,
+        subject: `LEX — Зміни в ${params.lawTitle}`,
+        heading: 'Зміни в законодавстві',
+        body: `<p>Вітаємо, ${params.name}!</p>
+               <p>У документі <strong>${params.lawTitle}</strong> виявлено <strong>${params.changeCount}</strong> змін.</p>
+               ${articlesText}
+               <p>Перегляньте деталі змін на платформі.</p>`,
+        actionUrl: `${this.frontendUrl}${params.link}`,
+        actionText: 'Переглянути зміни',
+      });
+      logger.info('Legislation change email sent', { email: params.email, radaId: params.radaId });
+    } catch (error: any) {
+      logger.error('Failed to send legislation change email', { error: error.message });
+    }
+  }
+
   /**
    * Generate verification email template
    */

--- a/mcp_backend/src/services/legislation-monitoring-service.ts
+++ b/mcp_backend/src/services/legislation-monitoring-service.ts
@@ -1,0 +1,414 @@
+import { diffWords } from 'diff';
+import { createHash } from 'crypto';
+import type { IDatabase } from '../domain/ports/index.js';
+import type { RadaLegislationAdapter, LegislationArticle } from '../adapters/rada-legislation-adapter.js';
+import type { EmailService } from './email-service.js';
+import { logger } from '../utils/logger.js';
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function generateDiffHtml(oldText: string, newText: string): string {
+  const changes = diffWords(oldText, newText);
+  return changes.map(part => {
+    if (part.added) return `<ins class="diff-add">${escapeHtml(part.value)}</ins>`;
+    if (part.removed) return `<del class="diff-del">${escapeHtml(part.value)}</del>`;
+    return escapeHtml(part.value);
+  }).join('');
+}
+
+function hashText(text: string): string {
+  return createHash('sha256').update(text).digest('hex');
+}
+
+export interface Subscription {
+  id: number;
+  user_id: string;
+  legislation_id: number;
+  rada_id: string;
+  title: string;
+  short_title: string | null;
+  type: string | null;
+  notify_email: boolean;
+  notify_inapp: boolean;
+  created_at: string;
+}
+
+export interface LegislationChange {
+  id: number;
+  legislation_id: number;
+  rada_id: string;
+  article_number: string | null;
+  change_type: 'added' | 'modified' | 'removed';
+  old_text: string | null;
+  new_text: string | null;
+  diff_html: string | null;
+  detected_at: string;
+  version_date: string | null;
+  title?: string;
+}
+
+export class LegislationMonitoringService {
+  constructor(
+    private db: IDatabase,
+    private adapter: RadaLegislationAdapter,
+    private emailService: EmailService
+  ) {}
+
+  async subscribe(userId: string, radaId: string, preferences?: { notify_email?: boolean; notify_inapp?: boolean }): Promise<Subscription> {
+    // Get legislation_id from rada_id
+    const legResult = await this.db.query(
+      'SELECT id FROM legislation WHERE rada_id = $1',
+      [radaId]
+    );
+
+    if (legResult.rows.length === 0) {
+      throw new Error(`Законодавство з rada_id "${radaId}" не знайдено в базі`);
+    }
+
+    const legislationId = legResult.rows[0].id;
+    const notifyEmail = preferences?.notify_email ?? true;
+    const notifyInapp = preferences?.notify_inapp ?? true;
+
+    const result = await this.db.query(
+      `INSERT INTO legislation_subscriptions (user_id, legislation_id, notify_email, notify_inapp)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (user_id, legislation_id) DO UPDATE SET
+         notify_email = EXCLUDED.notify_email,
+         notify_inapp = EXCLUDED.notify_inapp
+       RETURNING *`,
+      [userId, legislationId, notifyEmail, notifyInapp]
+    );
+
+    // Return with legislation info
+    const sub = result.rows[0];
+    const legInfo = await this.db.query(
+      'SELECT rada_id, title, short_title, type FROM legislation WHERE id = $1',
+      [legislationId]
+    );
+    return {
+      ...sub,
+      rada_id: legInfo.rows[0].rada_id,
+      title: legInfo.rows[0].title,
+      short_title: legInfo.rows[0].short_title,
+      type: legInfo.rows[0].type,
+    };
+  }
+
+  async unsubscribe(userId: string, radaId: string): Promise<boolean> {
+    const result = await this.db.query(
+      `DELETE FROM legislation_subscriptions
+       WHERE user_id = $1 AND legislation_id = (SELECT id FROM legislation WHERE rada_id = $2)`,
+      [userId, radaId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async listSubscriptions(userId: string): Promise<Subscription[]> {
+    const result = await this.db.query(
+      `SELECT ls.*, l.rada_id, l.title, l.short_title, l.type
+       FROM legislation_subscriptions ls
+       JOIN legislation l ON l.id = ls.legislation_id
+       WHERE ls.user_id = $1
+       ORDER BY ls.created_at DESC`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  async isSubscribed(userId: string, radaId: string): Promise<boolean> {
+    const result = await this.db.query(
+      `SELECT 1 FROM legislation_subscriptions ls
+       JOIN legislation l ON l.id = ls.legislation_id
+       WHERE ls.user_id = $1 AND l.rada_id = $2`,
+      [userId, radaId]
+    );
+    return result.rows.length > 0;
+  }
+
+  async checkForChanges(radaId: string): Promise<LegislationChange[]> {
+    // Get legislation record
+    const legResult = await this.db.query(
+      'SELECT id FROM legislation WHERE rada_id = $1',
+      [radaId]
+    );
+    if (legResult.rows.length === 0) return [];
+    const legislationId = legResult.rows[0].id;
+
+    // Get current articles from DB
+    const currentResult = await this.db.query(
+      `SELECT article_number, full_text FROM legislation_articles
+       WHERE rada_id = $1 AND is_current = true
+       ORDER BY article_number`,
+      [radaId]
+    );
+    const currentArticles = new Map<string, string>();
+    for (const row of currentResult.rows) {
+      currentArticles.set(row.article_number, row.full_text);
+    }
+
+    // Fetch fresh data from RADA
+    let freshData: Awaited<ReturnType<RadaLegislationAdapter['fetchLegislation']>>;
+    try {
+      freshData = await this.adapter.fetchLegislation(radaId);
+    } catch (err: any) {
+      logger.error(`[LegMonitoring] Failed to fetch ${radaId} from RADA`, { error: err.message });
+      return [];
+    }
+
+    const freshArticles = new Map<string, string>();
+    for (const article of freshData.articles) {
+      freshArticles.set(article.article_number, article.full_text);
+    }
+
+    const changes: LegislationChange[] = [];
+    const now = new Date().toISOString();
+
+    // Detect modified and removed articles
+    for (const [articleNum, oldText] of currentArticles) {
+      const newText = freshArticles.get(articleNum);
+      if (newText === undefined) {
+        // Article removed
+        changes.push({
+          id: 0, legislation_id: legislationId, rada_id: radaId,
+          article_number: articleNum, change_type: 'removed',
+          old_text: oldText, new_text: null, diff_html: null,
+          detected_at: now, version_date: now,
+        });
+      } else if (hashText(oldText) !== hashText(newText)) {
+        // Article modified
+        const diffHtml = generateDiffHtml(oldText, newText);
+        changes.push({
+          id: 0, legislation_id: legislationId, rada_id: radaId,
+          article_number: articleNum, change_type: 'modified',
+          old_text: oldText, new_text: newText, diff_html: diffHtml,
+          detected_at: now, version_date: now,
+        });
+      }
+    }
+
+    // Detect added articles
+    for (const [articleNum, newText] of freshArticles) {
+      if (!currentArticles.has(articleNum)) {
+        changes.push({
+          id: 0, legislation_id: legislationId, rada_id: radaId,
+          article_number: articleNum, change_type: 'added',
+          old_text: null, new_text: newText, diff_html: null,
+          detected_at: now, version_date: now,
+        });
+      }
+    }
+
+    if (changes.length === 0) {
+      logger.info(`[LegMonitoring] No changes detected for ${radaId}`);
+      return [];
+    }
+
+    logger.info(`[LegMonitoring] Detected ${changes.length} changes for ${radaId}`);
+
+    // Store changes in DB
+    for (const change of changes) {
+      const result = await this.db.query(
+        `INSERT INTO legislation_changes (legislation_id, rada_id, article_number, change_type, old_text, new_text, diff_html, detected_at, version_date)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+         RETURNING id`,
+        [change.legislation_id, change.rada_id, change.article_number, change.change_type,
+         change.old_text, change.new_text, change.diff_html, change.detected_at, change.version_date]
+      );
+      change.id = result.rows[0].id;
+    }
+
+    // Update DB articles: mark old as not current, save fresh via adapter
+    await this.db.query(
+      `UPDATE legislation_articles SET is_current = false WHERE rada_id = $1 AND is_current = true`,
+      [radaId]
+    );
+    await this.adapter.saveLegislationToDatabase(freshData.metadata, freshData.articles);
+
+    return changes;
+  }
+
+  async checkAllSubscribedLegislation(): Promise<void> {
+    // Get distinct rada_ids that have at least one subscriber
+    const result = await this.db.query(
+      `SELECT DISTINCT l.rada_id
+       FROM legislation_subscriptions ls
+       JOIN legislation l ON l.id = ls.legislation_id`
+    );
+
+    logger.info(`[LegMonitoring] Checking ${result.rows.length} subscribed legislation documents`);
+
+    for (const row of result.rows) {
+      try {
+        const changes = await this.checkForChanges(row.rada_id);
+        if (changes.length > 0) {
+          await this.notifySubscribers(row.rada_id, changes);
+        }
+        // Small delay to not hammer RADA API
+        await new Promise(r => setTimeout(r, 2000));
+      } catch (err: any) {
+        logger.error(`[LegMonitoring] Error checking ${row.rada_id}`, { error: err.message });
+      }
+    }
+  }
+
+  private async notifySubscribers(radaId: string, changes: LegislationChange[]): Promise<void> {
+    // Get legislation info
+    const legResult = await this.db.query(
+      'SELECT id, title, short_title FROM legislation WHERE rada_id = $1',
+      [radaId]
+    );
+    if (legResult.rows.length === 0) return;
+    const leg = legResult.rows[0];
+
+    // Get subscribers
+    const subResult = await this.db.query(
+      `SELECT ls.user_id, ls.notify_email, ls.notify_inapp, u.email, u.name
+       FROM legislation_subscriptions ls
+       JOIN users u ON u.id = ls.user_id
+       WHERE ls.legislation_id = $1`,
+      [leg.id]
+    );
+
+    const changedArticles = changes.map(c => c.article_number).filter(Boolean).join(', ');
+    const summary = `Виявлено ${changes.length} змін у ${leg.short_title || leg.title}`;
+    const link = `/legislation/monitoring?rada_id=${radaId}`;
+
+    for (const sub of subResult.rows) {
+      // In-app notification
+      if (sub.notify_inapp) {
+        await this.db.query(
+          `INSERT INTO user_notifications (user_id, type, title, body, link, metadata)
+           VALUES ($1, 'legislation_change', $2, $3, $4, $5)`,
+          [
+            sub.user_id,
+            summary,
+            `Змінені статті: ${changedArticles || 'структурні зміни'}`,
+            link,
+            JSON.stringify({ rada_id: radaId, change_count: changes.length }),
+          ]
+        );
+      }
+
+      // Email notification
+      if (sub.notify_email && sub.email) {
+        try {
+          await this.emailService.sendLegislationChangeNotification({
+            email: sub.email,
+            name: sub.name || 'Користувач',
+            lawTitle: leg.short_title || leg.title,
+            radaId,
+            changeCount: changes.length,
+            changedArticles,
+            link,
+          });
+        } catch (err: any) {
+          logger.error(`[LegMonitoring] Failed to send email to ${sub.user_id}`, { error: err.message });
+        }
+      }
+    }
+  }
+
+  async getChangeFeed(userId: string, options?: { radaId?: string; limit?: number; offset?: number }): Promise<{ changes: LegislationChange[]; total: number }> {
+    const limit = Math.min(options?.limit || 50, 100);
+    const offset = options?.offset || 0;
+
+    let whereClause = `WHERE lc.legislation_id IN (SELECT legislation_id FROM legislation_subscriptions WHERE user_id = $1)`;
+    const params: any[] = [userId];
+
+    if (options?.radaId) {
+      params.push(options.radaId);
+      whereClause += ` AND lc.rada_id = $${params.length}`;
+    }
+
+    const countResult = await this.db.query(
+      `SELECT COUNT(*) FROM legislation_changes lc ${whereClause}`,
+      params
+    );
+
+    params.push(limit, offset);
+    const result = await this.db.query(
+      `SELECT lc.*, l.title, l.short_title
+       FROM legislation_changes lc
+       JOIN legislation l ON l.id = lc.legislation_id
+       ${whereClause}
+       ORDER BY lc.detected_at DESC
+       LIMIT $${params.length - 1} OFFSET $${params.length}`,
+      params
+    );
+
+    return {
+      changes: result.rows,
+      total: parseInt(countResult.rows[0].count),
+    };
+  }
+
+  async getChange(changeId: number): Promise<LegislationChange | null> {
+    const result = await this.db.query(
+      `SELECT lc.*, l.title, l.short_title
+       FROM legislation_changes lc
+       JOIN legislation l ON l.id = lc.legislation_id
+       WHERE lc.id = $1`,
+      [changeId]
+    );
+    return result.rows[0] || null;
+  }
+
+  async getChangesForLegislation(radaId: string, limit = 50): Promise<LegislationChange[]> {
+    const result = await this.db.query(
+      `SELECT lc.*, l.title, l.short_title
+       FROM legislation_changes lc
+       JOIN legislation l ON l.id = lc.legislation_id
+       WHERE lc.rada_id = $1
+       ORDER BY lc.detected_at DESC
+       LIMIT $2`,
+      [radaId, limit]
+    );
+    return result.rows;
+  }
+
+  // Notifications
+  async getNotifications(userId: string, options?: { unreadOnly?: boolean; limit?: number; offset?: number }): Promise<{ notifications: any[]; unreadCount: number }> {
+    const limit = Math.min(options?.limit || 50, 100);
+    const offset = options?.offset || 0;
+
+    let whereClause = 'WHERE user_id = $1';
+    if (options?.unreadOnly) {
+      whereClause += ' AND is_read = false';
+    }
+
+    const countResult = await this.db.query(
+      `SELECT COUNT(*) FILTER (WHERE is_read = false) as unread_count FROM user_notifications WHERE user_id = $1`,
+      [userId]
+    );
+
+    const result = await this.db.query(
+      `SELECT * FROM user_notifications ${whereClause} ORDER BY created_at DESC LIMIT $2 OFFSET $3`,
+      [userId, limit, offset]
+    );
+
+    return {
+      notifications: result.rows,
+      unreadCount: parseInt(countResult.rows[0].unread_count),
+    };
+  }
+
+  async markNotificationRead(userId: string, notificationId: number): Promise<boolean> {
+    const result = await this.db.query(
+      `UPDATE user_notifications SET is_read = true WHERE id = $1 AND user_id = $2`,
+      [notificationId, userId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async markAllNotificationsRead(userId: string): Promise<void> {
+    await this.db.query(
+      `UPDATE user_notifications SET is_read = true WHERE user_id = $1 AND is_read = false`,
+      [userId]
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- **Підписки на законодавство**: серверна система (замість localStorage), subscribe/unsubscribe через API з Bell/BellOff UI
- **Автоматичне виявлення змін**: щоденний cron (06:00 Київ) re-fetch з zakon.rada.gov.ua, SHA-256 hash порівняння кожної статті, word-level diff через `diffWords`
- **Нотифікації**: in-app (таблиця `user_notifications`) + email при виявленні змін
- **DiffViewer**: компонент з підсвіткою доданого (зелений) та видаленого (червоний) тексту
- **ChangeFeed**: стрічка змін згрупована за датами, expandable з DiffViewer всередині
- **UI**: нова таба "Зміни" в detail view + перемикач "Документи / Зміни" на головній сторінці моніторингу

### Нові файли
- `mcp_backend/src/migrations/100_legislation_monitoring.sql` — 3 таблиці
- `mcp_backend/src/services/legislation-monitoring-service.ts` — повний сервіс
- `mcp_backend/src/routes/legislation-monitoring-routes.ts` — 10 API endpoints
- `lexwebapp/src/components/legislation/DiffViewer.tsx`
- `lexwebapp/src/components/legislation/ChangeFeed.tsx`

## Test plan

- [ ] Запустити міграцію 100 на dev/prod
- [ ] Підписатися на закон через UI (Bell кнопка) — перевірити що subscription зберігається
- [ ] Відписатися — перевірити що видаляється
- [ ] Перевірити табу "Зміни" в detail view (має показувати "ще не зафіксовано змін" для нових підписок)
- [ ] Перевірити перемикач "Документи / Зміни" на головній сторінці
- [ ] Перевірити що TypeScript компілюється без помилок (backend + frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)