### PR TITLE
fix: call Monobank cancel API on escrow refund

### DIFF
--- a/mcp_backend/src/services/consultation-payment-service.ts
+++ b/mcp_backend/src/services/consultation-payment-service.ts
@@ -317,6 +317,19 @@ export class ConsultationPaymentService {
     });
 
     if (payment) {
+      // Cancel the hold on the client's card via Monobank API
+      if (payment.payment_provider === 'monobank' && payment.payment_provider_id) {
+        try {
+          await this.monobankService.cancelInvoice(payment.payment_provider_id);
+        } catch (err: any) {
+          logger.error('Failed to cancel Monobank invoice during refund', {
+            paymentId: payment.id,
+            invoiceId: payment.payment_provider_id,
+            error: err.message,
+          });
+        }
+      }
+
       logger.info('Consultation payment refunded', {
         paymentId: payment.id,
         consultationId,

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -467,6 +467,34 @@ export class MonobankService {
   }
 
   /**
+   * Cancel (reverse) a held Monobank invoice, releasing the hold on the client's card.
+   */
+  async cancelInvoice(invoiceId: string): Promise<void> {
+    const key = this.apiKey;
+
+    logger.info('[MonobankService] Cancelling invoice (reversing hold)', { invoiceId });
+
+    const response = await fetch(
+      'https://api.monobank.ua/api/merchant/invoice/cancel',
+      {
+        method: 'POST',
+        headers: {
+          'X-Token': key,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ invoiceId }),
+      }
+    );
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Monobank cancel API error: ${response.status} ${body}`);
+    }
+
+    logger.info('[MonobankService] Invoice cancelled successfully', { invoiceId });
+  }
+
+  /**
    * Get the status of a Monobank invoice.
    */
   async getPaymentStatus(invoiceId: string): Promise<MonobankPaymentStatus> {


### PR DESCRIPTION
## Summary
- `refundPayment()` only updated DB status to `refunded` without calling Monobank API, leaving funds frozen on client's card for 3-5 days
- Added `cancelInvoice()` method to `MonobankService` — calls `POST /api/merchant/invoice/cancel`
- `refundPayment()` now calls `cancelInvoice()` to immediately release the hold

## Test plan
- [x] TypeScript builds without errors
- [ ] Create a test consultation, pay via Monobank, then cancel — verify Monobank invoice status changes to `reversed`
- [ ] Verify error handling: if Monobank cancel fails, payment still gets marked as `refunded` in DB (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)