### PR TITLE
fix: consultation 429 — polling 5s→30s, per-user rate limit

### DIFF
--- a/lexwebapp/src/components/chat/ConsultationChatTab.tsx
+++ b/lexwebapp/src/components/chat/ConsultationChatTab.tsx
@@ -238,7 +238,7 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
     };
   }, [consultationId, onUnreadCountChange, scrollToBottom, user?.id]);
 
-  // Polling fallback: SSE through Cloudflare is unreliable, poll every 5s
+  // Polling fallback: SSE through Cloudflare is unreliable, poll every 30s
   useEffect(() => {
     if (!consultationId) return;
     const poll = setInterval(() => {
@@ -254,7 +254,7 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
           return merged;
         });
       }).catch(() => {});
-    }, 5000);
+    }, 30000);
     return () => clearInterval(poll);
   }, [consultationId, scrollToBottom]);
 

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -41,7 +41,7 @@ import { createTemplateRoutes } from './routes/template-routes.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { createOAuthRouter } from './routes/oauth-routes.js';
 // createHybridAuthMiddleware available from './middleware/oauth-auth.js' if needed
-import { healthCheckRateLimit, webhookRateLimit, globalApiRateLimit } from './middleware/rate-limit.js';
+import { healthCheckRateLimit, webhookRateLimit, globalApiRateLimit, consultationRateLimit } from './middleware/rate-limit.js';
 import { createUploadRouter } from './routes/upload-routes.js';
 import { createConversationRouter } from './routes/conversation-routes.js';
 import { createEvidenceRoutes } from './routes/evidence-routes.js';
@@ -556,7 +556,7 @@ class HTTPMCPServer {
         req.headers.authorization = `Bearer ${req.query.token}`;
       }
       next();
-    }) as any, requireJWT as any, createConsultationRoutes(
+    }) as any, requireJWT as any, consultationRateLimit as any, createConsultationRoutes(
       this.app_.consultationService,
       this.app_.consultationPaymentService,
       this.app_.attorneyPayoutService,

--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -118,9 +118,17 @@ export const passwordResetRateLimit = createRateLimiter({
   keyPrefix: 'ratelimit:password-reset',
 });
 
+// Consultation rate limiter — keyed by userId to avoid Cloudflare shared IP issues.
+// Generous limit: polling fallback at 30s = ~2 req/min per user, plus SSE + detail page.
+export const consultationRateLimit = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 120,
+  keyPrefix: 'ratelimit:consultation',
+  keyByUserId: true,
+});
+
 // Global API rate limiter — covers all /api/ routes as a baseline.
 // Raised to 1500/min to handle 20+ concurrent users behind Cloudflare (shared IP).
-// Polling alone generates ~480 req/min for 20 users.
 export const globalApiRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
   maxRequests: 1500,


### PR DESCRIPTION
## Summary

- **Polling interval 5s → 30s**: SSE is the primary message channel, polling is only a fallback — 30s is sufficient
- **Per-user consultation rate limit**: 120 req/min keyed by `userId` (not IP), prevents Cloudflare shared-IP exhaustion

## Root cause

All users behind Cloudflare share IP `172.64.200.71`. Consultation page polls `/messages` every 5s + fetches detail every ~5s = ~24 req/min per user. With 20+ users, global 1500/min limit is exhausted → 429 for everyone.

## Test plan

- [ ] Open consultation chat — messages still arrive via SSE in real-time
- [ ] Polling fallback fires every 30s (check Network tab)
- [ ] Multiple users on consultations simultaneously — no 429 errors
- [ ] Single user spamming refresh — gets per-user 429 (not global)

🤖 Generated with [Claude Code](https://claude.com/claude-code)