### PR TITLE
feat(mobile): sync consultation features — payouts, typing, vault, polling

### DIFF
--- a/mobile/lib/core/network/sse_client.dart
+++ b/mobile/lib/core/network/sse_client.dart
@@ -27,18 +27,57 @@ class SSEClient {
     required void Function() onDone,
     required void Function(dynamic error) onError,
   }) async {
-    final token = await storage.getToken();
-    final uri = Uri.parse('${config.apiUrl}$path');
-
-    final request = http.Request('POST', uri)
-      ..headers.addAll({
-        'Content-Type': 'application/json',
-        'Accept': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        if (token != null) 'Authorization': 'Bearer $token',
-      })
+    final request = http.Request(
+      'POST',
+      Uri.parse('${config.apiUrl}$path'),
+    )
+      ..headers.addAll(await _headers())
       ..body = jsonEncode(body);
 
+    return _sendRequest(
+      request: request,
+      onEvent: onEvent,
+      onDone: onDone,
+      onError: onError,
+    );
+  }
+
+  /// Opens a GET SSE stream (used for consultation messages).
+  Future<StreamSubscription?> streamGet({
+    required String path,
+    required void Function(SSEEvent event) onEvent,
+    required void Function() onDone,
+    required void Function(dynamic error) onError,
+  }) async {
+    final request = http.Request(
+      'GET',
+      Uri.parse('${config.apiUrl}$path'),
+    )..headers.addAll(await _headers());
+
+    return _sendRequest(
+      request: request,
+      onEvent: onEvent,
+      onDone: onDone,
+      onError: onError,
+    );
+  }
+
+  Future<Map<String, String>> _headers() async {
+    final token = await storage.getToken();
+    return {
+      'Content-Type': 'application/json',
+      'Accept': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      if (token != null) 'Authorization': 'Bearer $token',
+    };
+  }
+
+  Future<StreamSubscription?> _sendRequest({
+    required http.Request request,
+    required void Function(SSEEvent event) onEvent,
+    required void Function() onDone,
+    required void Function(dynamic error) onError,
+  }) async {
     try {
       final client = http.Client();
       final response = await client.send(request);

--- a/mobile/lib/features/consultation/data/consultation_repository.dart
+++ b/mobile/lib/features/consultation/data/consultation_repository.dart
@@ -22,6 +22,11 @@ class ConsultationRepository {
         .toList();
   }
 
+  Future<Consultation> getConsultation(String consultationId) async {
+    final response = await _api.get('/api/consultations/$consultationId');
+    return Consultation.fromJson(response.data as Map<String, dynamic>);
+  }
+
   Future<List<ConsultationMessage>> getMessages(String consultationId) async {
     final response =
         await _api.get('/api/consultations/$consultationId/messages');
@@ -61,24 +66,53 @@ class ConsultationRepository {
   }
 
   Future<void> markAsRead(String consultationId) async {
-    await _api.post('/api/consultations/$consultationId/read');
+    await _api.put('/api/consultations/$consultationId/read');
+  }
+
+  Future<void> sendTyping(String consultationId) async {
+    await _api.post('/api/consultations/$consultationId/typing');
+  }
+
+  Future<Map<String, dynamic>> saveAttachmentToVault({
+    required String consultationId,
+    required String messageId,
+    required String attachmentId,
+  }) async {
+    final response = await _api.post(
+      '/api/consultations/$consultationId/messages/$messageId/attachments/$attachmentId/vault',
+    );
+    return response.data as Map<String, dynamic>;
+  }
+
+  Future<ConsultationPayment?> getPaymentStatus(
+      String consultationId) async {
+    try {
+      final response =
+          await _api.get('/api/consultations/$consultationId/payment');
+      return ConsultationPayment.fromJson(
+          response.data as Map<String, dynamic>);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<List<AttorneyPayout>> getMyPayouts() async {
+    final response = await _api.get('/api/consultations/payouts/me');
+    final list = response.data as List? ?? [];
+    return list
+        .map((e) => AttorneyPayout.fromJson(e as Map<String, dynamic>))
+        .toList();
   }
 
   Future<StreamSubscription?> streamMessages({
     required String consultationId,
-    required void Function(ConsultationMessage message) onMessage,
+    required void Function(SSEEvent event) onEvent,
     required void Function() onDone,
     required void Function(dynamic error) onError,
   }) {
-    return _sse.stream(
+    return _sse.streamGet(
       path: '/api/consultations/$consultationId/messages/stream',
-      body: {},
-      onEvent: (event) {
-        if (event.event == 'message' && event.data is Map<String, dynamic>) {
-          onMessage(ConsultationMessage.fromJson(
-              event.data as Map<String, dynamic>));
-        }
-      },
+      onEvent: onEvent,
       onDone: onDone,
       onError: onError,
     );

--- a/mobile/lib/features/consultation/data/models/consultation.dart
+++ b/mobile/lib/features/consultation/data/models/consultation.dart
@@ -2,7 +2,15 @@ class Consultation {
   final String id;
   final String title;
   final String? clientName;
-  final String status; // 'active' | 'closed' | 'pending'
+  final String? attorneyName;
+  final String? clientUserId;
+  final String? attorneyUserId;
+  final String status;
+  final String? requestDescription;
+  final double? agreedFeeUah;
+  final List<String> documentIds;
+  final String? declineReason;
+  final String? cancelReason;
   final DateTime createdAt;
   final DateTime updatedAt;
   final int unreadCount;
@@ -11,7 +19,15 @@ class Consultation {
     required this.id,
     required this.title,
     this.clientName,
-    this.status = 'active',
+    this.attorneyName,
+    this.clientUserId,
+    this.attorneyUserId,
+    this.status = 'pending',
+    this.requestDescription,
+    this.agreedFeeUah,
+    this.documentIds = const [],
+    this.declineReason,
+    this.cancelReason,
     required this.createdAt,
     required this.updatedAt,
     this.unreadCount = 0,
@@ -19,13 +35,85 @@ class Consultation {
 
   factory Consultation.fromJson(Map<String, dynamic> json) => Consultation(
         id: json['id'] as String? ?? '',
-        title: json['title'] as String? ?? '',
+        title: json['request_title'] as String? ?? json['title'] as String? ?? '',
         clientName: json['client_name'] as String?,
-        status: json['status'] as String? ?? 'active',
-        createdAt: DateTime.parse(
-            json['created_at'] as String? ?? DateTime.now().toIso8601String()),
-        updatedAt: DateTime.parse(
-            json['updated_at'] as String? ?? DateTime.now().toIso8601String()),
+        attorneyName: json['attorney_name'] as String?,
+        clientUserId: json['client_user_id'] as String?,
+        attorneyUserId: json['attorney_user_id'] as String?,
+        status: json['status'] as String? ?? 'pending',
+        requestDescription: json['request_description'] as String?,
+        agreedFeeUah: (json['agreed_fee_uah'] as num?)?.toDouble(),
+        documentIds: (json['document_ids'] as List?)?.map((e) => e.toString()).toList() ?? [],
+        declineReason: json['decline_reason'] as String?,
+        cancelReason: json['cancel_reason'] as String?,
+        createdAt: DateTime.parse(json['created_at'] as String? ?? DateTime.now().toIso8601String()),
+        updatedAt: DateTime.parse(json['updated_at'] as String? ?? DateTime.now().toIso8601String()),
         unreadCount: json['unread_count'] as int? ?? 0,
+      );
+}
+
+class ConsultationPayment {
+  final String id;
+  final String consultationId;
+  final double amountUah;
+  final double platformFeeUah;
+  final double attorneyPayoutUah;
+  final String status;
+  final String? paymentProvider;
+  final DateTime createdAt;
+
+  const ConsultationPayment({
+    required this.id,
+    required this.consultationId,
+    required this.amountUah,
+    required this.platformFeeUah,
+    required this.attorneyPayoutUah,
+    required this.status,
+    this.paymentProvider,
+    required this.createdAt,
+  });
+
+  factory ConsultationPayment.fromJson(Map<String, dynamic> json) => ConsultationPayment(
+        id: json['id'] as String? ?? '',
+        consultationId: json['consultation_id'] as String? ?? '',
+        amountUah: (json['amount_uah'] as num?)?.toDouble() ?? 0,
+        platformFeeUah: (json['platform_fee_uah'] as num?)?.toDouble() ?? 0,
+        attorneyPayoutUah: (json['attorney_payout_uah'] as num?)?.toDouble() ?? 0,
+        status: json['status'] as String? ?? 'pending',
+        paymentProvider: json['payment_provider'] as String?,
+        createdAt: DateTime.parse(json['created_at'] as String? ?? DateTime.now().toIso8601String()),
+      );
+}
+
+class AttorneyPayout {
+  final String id;
+  final String attorneyUserId;
+  final String? consultationPaymentId;
+  final double amountUah;
+  final String status;
+  final DateTime createdAt;
+  final String? consultationId;
+  final String? requestTitle;
+
+  const AttorneyPayout({
+    required this.id,
+    required this.attorneyUserId,
+    this.consultationPaymentId,
+    required this.amountUah,
+    required this.status,
+    required this.createdAt,
+    this.consultationId,
+    this.requestTitle,
+  });
+
+  factory AttorneyPayout.fromJson(Map<String, dynamic> json) => AttorneyPayout(
+        id: json['id'] as String? ?? '',
+        attorneyUserId: json['attorney_user_id'] as String? ?? '',
+        consultationPaymentId: json['consultation_payment_id'] as String?,
+        amountUah: (json['amount_uah'] as num?)?.toDouble() ?? 0,
+        status: json['status'] as String? ?? 'pending',
+        createdAt: DateTime.parse(json['created_at'] as String? ?? DateTime.now().toIso8601String()),
+        consultationId: json['consultation_id'] as String?,
+        requestTitle: json['request_title'] as String?,
       );
 }

--- a/mobile/lib/features/consultation/domain/consultation_notifier.dart
+++ b/mobile/lib/features/consultation/domain/consultation_notifier.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/di/service_locator.dart';
+import '../../../core/network/sse_client.dart';
 import '../data/consultation_repository.dart';
 import '../data/models/consultation_message.dart';
 import 'consultation_state.dart';
@@ -39,6 +40,22 @@ class ConsultationListNotifier extends Notifier<ConsultationState> {
       );
     }
   }
+
+  Future<void> loadPayouts() async {
+    state = state.copyWith(isLoadingPayouts: true);
+    try {
+      final payouts = await _repo.getMyPayouts();
+      state = state.copyWith(
+        payouts: payouts,
+        isLoadingPayouts: false,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoadingPayouts: false,
+        error: e.toString(),
+      );
+    }
+  }
 }
 
 // Individual consultation chat
@@ -51,11 +68,19 @@ class ConsultationChatNotifier
     extends FamilyNotifier<ConsultationChatState, String> {
   late final ConsultationRepository _repo;
   StreamSubscription? _subscription;
+  Timer? _pollingTimer;
+  Timer? _typingDebounce;
+  Timer? _typingClearTimer;
 
   @override
   ConsultationChatState build(String consultationId) {
     _repo = ref.read(consultationRepositoryProvider);
-    ref.onDispose(() => _subscription?.cancel());
+    ref.onDispose(() {
+      _subscription?.cancel();
+      _pollingTimer?.cancel();
+      _typingDebounce?.cancel();
+      _typingClearTimer?.cancel();
+    });
     return ConsultationChatState(consultationId: consultationId);
   }
 
@@ -65,32 +90,131 @@ class ConsultationChatNotifier
       final messages = await _repo.getMessages(arg);
       state = state.copyWith(messages: messages, isLoading: false);
       _startStream();
+      _startPolling();
       _repo.markAsRead(arg);
     } catch (e) {
       state = state.copyWith(isLoading: false, error: e.toString());
     }
   }
 
+  void _startPolling() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(const Duration(seconds: 5), (_) async {
+      try {
+        final messages = await _repo.getMessages(arg);
+        // Merge: keep optimistic messages, update existing, add new
+        final merged = <ConsultationMessage>[];
+        final existingIds = <String>{};
+        for (final m in messages) {
+          merged.add(m);
+          existingIds.add(m.id);
+        }
+        // Keep optimistic (temp_*) messages that haven't been replaced
+        for (final m in state.messages) {
+          if (m.id.startsWith('temp_') && !existingIds.contains(m.id)) {
+            merged.add(m);
+          }
+        }
+        state = state.copyWith(messages: merged);
+      } catch (_) {
+        // Silently ignore polling errors
+      }
+    });
+  }
+
   Future<void> _startStream() async {
     _subscription = await _repo.streamMessages(
       consultationId: arg,
-      onMessage: (message) {
-        // Dedupe: replace optimistic message or add new
-        final existing = state.messages.indexWhere((m) => m.id == message.id);
-        if (existing >= 0) {
-          final updated = List<ConsultationMessage>.from(state.messages);
-          updated[existing] = message;
-          state = state.copyWith(messages: updated);
-        } else {
-          state = state.copyWith(
-              messages: [...state.messages, message]);
-        }
+      onEvent: (SSEEvent event) {
+        _handleSSEEvent(event);
       },
       onDone: () {},
       onError: (error) {
         state = state.copyWith(error: error.toString());
       },
     );
+  }
+
+  void _handleSSEEvent(SSEEvent event) {
+    switch (event.event) {
+      case 'message':
+        if (event.data is Map<String, dynamic>) {
+          final message = ConsultationMessage.fromJson(
+              event.data as Map<String, dynamic>);
+          _upsertMessage(message);
+        }
+        break;
+      case 'message_status':
+        if (event.data is Map<String, dynamic>) {
+          final data = event.data as Map<String, dynamic>;
+          final messageId = data['message_id'] as String?;
+          final newStatus = data['status'] as String?;
+          if (messageId != null && newStatus != null) {
+            final updated = state.messages.map((m) {
+              if (m.id == messageId) return m.copyWith(status: newStatus);
+              return m;
+            }).toList();
+            state = state.copyWith(messages: updated);
+          }
+        }
+        break;
+      case 'typing':
+        if (event.data is Map<String, dynamic>) {
+          final data = event.data as Map<String, dynamic>;
+          final userName = data['user_name'] as String?;
+          state = state.copyWith(typingUserName: userName);
+          _typingClearTimer?.cancel();
+          _typingClearTimer = Timer(const Duration(seconds: 4), () {
+            state = state.copyWith(clearTyping: true);
+          });
+        }
+        break;
+      case 'consultation_status':
+        // Refresh consultation data
+        _repo.getConsultation(arg).then((_) {
+          // Status changes handled by list screen refresh
+        }).catchError((_) {});
+        break;
+    }
+  }
+
+  void _upsertMessage(ConsultationMessage message) {
+    final existing = state.messages.indexWhere((m) => m.id == message.id);
+    if (existing >= 0) {
+      final updated = List<ConsultationMessage>.from(state.messages);
+      updated[existing] = message;
+      state = state.copyWith(messages: updated);
+    } else {
+      state = state.copyWith(messages: [...state.messages, message]);
+    }
+  }
+
+  void onTyping() {
+    _typingDebounce?.cancel();
+    _typingDebounce = Timer(const Duration(seconds: 3), () {
+      _repo.sendTyping(arg).catchError((_) {});
+    });
+  }
+
+  Future<void> saveAttachmentToVault({
+    required String messageId,
+    required String attachmentId,
+  }) async {
+    try {
+      await _repo.saveAttachmentToVault(
+        consultationId: arg,
+        messageId: messageId,
+        attachmentId: attachmentId,
+      );
+      state = state.copyWith(
+        savedAttachmentMessageIds: {
+          ...state.savedAttachmentMessageIds,
+          messageId,
+        },
+      );
+    } catch (e) {
+      state = state.copyWith(error: e.toString());
+    }
   }
 
   Future<void> sendMessage(String content) async {

--- a/mobile/lib/features/consultation/domain/consultation_state.dart
+++ b/mobile/lib/features/consultation/domain/consultation_state.dart
@@ -4,17 +4,23 @@ import '../data/models/consultation_message.dart';
 class ConsultationState {
   final List<Consultation> consultations;
   final bool isLoadingConsultations;
+  final List<AttorneyPayout> payouts;
+  final bool isLoadingPayouts;
   final String? error;
 
   const ConsultationState({
     this.consultations = const [],
     this.isLoadingConsultations = false,
+    this.payouts = const [],
+    this.isLoadingPayouts = false,
     this.error,
   });
 
   ConsultationState copyWith({
     List<Consultation>? consultations,
     bool? isLoadingConsultations,
+    List<AttorneyPayout>? payouts,
+    bool? isLoadingPayouts,
     String? error,
     bool clearError = false,
   }) =>
@@ -22,6 +28,8 @@ class ConsultationState {
         consultations: consultations ?? this.consultations,
         isLoadingConsultations:
             isLoadingConsultations ?? this.isLoadingConsultations,
+        payouts: payouts ?? this.payouts,
+        isLoadingPayouts: isLoadingPayouts ?? this.isLoadingPayouts,
         error: clearError ? null : (error ?? this.error),
       );
 }
@@ -30,21 +38,25 @@ class ConsultationChatState {
   final String consultationId;
   final List<ConsultationMessage> messages;
   final bool isLoading;
-  final bool isTyping;
+  final String? typingUserName;
+  final Set<String> savedAttachmentMessageIds;
   final String? error;
 
   const ConsultationChatState({
     required this.consultationId,
     this.messages = const [],
     this.isLoading = false,
-    this.isTyping = false,
+    this.typingUserName,
+    this.savedAttachmentMessageIds = const {},
     this.error,
   });
 
   ConsultationChatState copyWith({
     List<ConsultationMessage>? messages,
     bool? isLoading,
-    bool? isTyping,
+    String? typingUserName,
+    bool clearTyping = false,
+    Set<String>? savedAttachmentMessageIds,
     String? error,
     bool clearError = false,
   }) =>
@@ -52,7 +64,10 @@ class ConsultationChatState {
         consultationId: consultationId,
         messages: messages ?? this.messages,
         isLoading: isLoading ?? this.isLoading,
-        isTyping: isTyping ?? this.isTyping,
+        typingUserName:
+            clearTyping ? null : (typingUserName ?? this.typingUserName),
+        savedAttachmentMessageIds:
+            savedAttachmentMessageIds ?? this.savedAttachmentMessageIds,
         error: clearError ? null : (error ?? this.error),
       );
 }

--- a/mobile/lib/features/consultation/presentation/consultation_chat_screen.dart
+++ b/mobile/lib/features/consultation/presentation/consultation_chat_screen.dart
@@ -79,10 +79,49 @@ class _ConsultationChatScreenState
                           return ConsultationMessageBubble(
                             message: chatState.messages[index],
                             isMe: chatState.messages[index].senderId == 'me',
+                            onSaveToVault: chatState.messages[index].attachments.isNotEmpty
+                                ? (attachmentId) => ref
+                                    .read(consultationChatProvider(
+                                            widget.consultationId)
+                                        .notifier)
+                                    .saveAttachmentToVault(
+                                      messageId:
+                                          chatState.messages[index].id,
+                                      attachmentId: attachmentId,
+                                    )
+                                : null,
+                            isSavedToVault:
+                                chatState.savedAttachmentMessageIds
+                                    .contains(chatState.messages[index].id),
                           );
                         },
                       ),
           ),
+
+          // Typing indicator
+          if (chatState.typingUserName != null)
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                children: [
+                  const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${chatState.typingUserName} друкує...',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSurfaceVariant,
+                        ),
+                  ),
+                ],
+              ),
+            ),
 
           // Input
           ConsultationInput(
@@ -90,6 +129,10 @@ class _ConsultationChatScreenState
                 .read(
                     consultationChatProvider(widget.consultationId).notifier)
                 .sendMessage(text),
+            onTyping: () => ref
+                .read(
+                    consultationChatProvider(widget.consultationId).notifier)
+                .onTyping(),
           ),
         ],
       ),

--- a/mobile/lib/features/consultation/presentation/consultation_list_screen.dart
+++ b/mobile/lib/features/consultation/presentation/consultation_list_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import '../data/models/consultation.dart';
 import '../domain/consultation_notifier.dart';
+import '../domain/consultation_state.dart';
 import '../../../shared/theme/app_colors.dart';
 
 class ConsultationListScreen extends ConsumerStatefulWidget {
@@ -14,98 +16,397 @@ class ConsultationListScreen extends ConsumerStatefulWidget {
 }
 
 class _ConsultationListScreenState
-    extends ConsumerState<ConsultationListScreen> {
+    extends ConsumerState<ConsultationListScreen>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  bool _isAttorney = false;
+
   @override
   void initState() {
     super.initState();
-    Future.microtask(
-        () => ref.read(consultationListProvider.notifier).loadConsultations());
+    _tabController = TabController(length: 2, vsync: this);
+    Future.microtask(() {
+      ref.read(consultationListProvider.notifier).loadConsultations();
+      _checkAttorneyAndLoadPayouts();
+    });
+  }
+
+  void _checkAttorneyAndLoadPayouts() {
+    // Always show tabs — backend will return empty payouts for non-attorneys
+    setState(() => _isAttorney = true);
+    ref.read(consultationListProvider.notifier).loadPayouts();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(consultationListProvider);
-    final theme = Theme.of(context);
-    final dateFormat = DateFormat('dd.MM.yyyy HH:mm', 'uk');
 
     return Scaffold(
       appBar: AppBar(
         title: const Text('Консультації'),
+        bottom: _isAttorney
+            ? TabBar(
+                controller: _tabController,
+                tabs: const [
+                  Tab(text: 'Список'),
+                  Tab(text: 'Виплати'),
+                ],
+              )
+            : null,
       ),
-      body: state.isLoadingConsultations
-          ? const Center(child: CircularProgressIndicator())
-          : state.consultations.isEmpty
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.forum_outlined,
-                          size: 48,
-                          color: theme.colorScheme.onSurfaceVariant),
-                      const SizedBox(height: 12),
-                      Text(
-                        'Немає консультацій',
-                        style: theme.textTheme.bodyLarge?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ],
+      body: _isAttorney
+          ? TabBarView(
+              controller: _tabController,
+              children: [
+                _ConsultationsTab(state: state),
+                _PayoutsTab(state: state),
+              ],
+            )
+          : _ConsultationsTab(state: state),
+    );
+  }
+}
+
+class _ConsultationsTab extends StatelessWidget {
+  final ConsultationState state;
+  const _ConsultationsTab({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat('dd.MM.yyyy HH:mm', 'uk');
+
+    if (state.isLoadingConsultations) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.consultations.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.forum_outlined,
+                size: 48, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text(
+              'Немає консультацій',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.separated(
+      itemCount: state.consultations.length,
+      separatorBuilder: (_, __) => const Divider(height: 1),
+      itemBuilder: (_, index) {
+        final c = state.consultations[index];
+        return ListTile(
+          leading: CircleAvatar(
+            backgroundColor: AppColors.primary.withValues(alpha: 0.12),
+            child: Text(
+              (c.clientName ?? c.title).substring(0, 1).toUpperCase(),
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          title: Text(
+            c.title,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              fontWeight:
+                  c.unreadCount > 0 ? FontWeight.w600 : FontWeight.w400,
+            ),
+          ),
+          subtitle: Row(
+            children: [
+              Text(
+                dateFormat.format(c.updatedAt),
+                style: theme.textTheme.bodySmall,
+              ),
+              if (c.agreedFeeUah != null) ...[
+                const SizedBox(width: 8),
+                Text(
+                  '${c.agreedFeeUah!.toStringAsFixed(0)} грн',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+              const SizedBox(width: 8),
+              _StatusChip(status: c.status),
+            ],
+          ),
+          trailing: c.unreadCount > 0
+              ? Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 8, vertical: 2),
+                  decoration: BoxDecoration(
+                    color: AppColors.primary,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  child: Text(
+                    '${c.unreadCount}',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 )
-              : ListView.separated(
-                  itemCount: state.consultations.length,
-                  separatorBuilder: (_, __) => const Divider(height: 1),
-                  itemBuilder: (_, index) {
-                    final c = state.consultations[index];
-                    return ListTile(
-                      leading: CircleAvatar(
-                        backgroundColor: AppColors.primary.withValues(alpha: 0.12),
-                        child: Text(
-                          (c.clientName ?? c.title)
-                              .substring(0, 1)
-                              .toUpperCase(),
-                          style: const TextStyle(
-                            color: AppColors.primary,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ),
-                      title: Text(
-                        c.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          fontWeight: c.unreadCount > 0
-                              ? FontWeight.w600
-                              : FontWeight.w400,
-                        ),
-                      ),
-                      subtitle: Text(
-                        dateFormat.format(c.updatedAt),
-                        style: theme.textTheme.bodySmall,
-                      ),
-                      trailing: c.unreadCount > 0
-                          ? Container(
-                              padding: const EdgeInsets.symmetric(
-                                  horizontal: 8, vertical: 2),
-                              decoration: BoxDecoration(
-                                color: AppColors.primary,
-                                borderRadius: BorderRadius.circular(10),
-                              ),
-                              child: Text(
-                                '${c.unreadCount}',
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 11,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                            )
-                          : null,
-                      onTap: () => context.go('/consultations/${c.id}'),
-                    );
-                  },
-                ),
+              : null,
+          onTap: () => context.go('/consultations/${c.id}'),
+        );
+      },
     );
+  }
+}
+
+class _PayoutsTab extends StatelessWidget {
+  final ConsultationState state;
+  const _PayoutsTab({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat('dd.MM.yyyy', 'uk');
+
+    if (state.isLoadingPayouts) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (state.payouts.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.payments_outlined,
+                size: 48, color: theme.colorScheme.onSurfaceVariant),
+            const SizedBox(height: 12),
+            Text(
+              'Виплат поки немає',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    // Summary cards
+    final totalAmount =
+        state.payouts.fold<double>(0, (sum, p) => sum + p.amountUah);
+    final pendingAmount = state.payouts
+        .where((p) => p.status == 'pending')
+        .fold<double>(0, (sum, p) => sum + p.amountUah);
+    final paidAmount = state.payouts
+        .where((p) => p.status == 'paid')
+        .fold<double>(0, (sum, p) => sum + p.amountUah);
+
+    return Column(
+      children: [
+        // Summary cards
+        Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              _SummaryCard(
+                label: 'Всього',
+                amount: totalAmount,
+                color: AppColors.primary,
+              ),
+              const SizedBox(width: 8),
+              _SummaryCard(
+                label: 'Очікує',
+                amount: pendingAmount,
+                color: Colors.orange,
+              ),
+              const SizedBox(width: 8),
+              _SummaryCard(
+                label: 'Виплачено',
+                amount: paidAmount,
+                color: Colors.green,
+              ),
+            ],
+          ),
+        ),
+
+        // Payout list
+        Expanded(
+          child: ListView.separated(
+            itemCount: state.payouts.length,
+            separatorBuilder: (_, __) => const Divider(height: 1),
+            itemBuilder: (_, index) {
+              final p = state.payouts[index];
+              return ListTile(
+                leading: CircleAvatar(
+                  backgroundColor: _statusColor(p.status).withValues(alpha: 0.12),
+                  child: Icon(
+                    _statusIcon(p.status),
+                    color: _statusColor(p.status),
+                    size: 20,
+                  ),
+                ),
+                title: Text(
+                  p.requestTitle ?? 'Консультація',
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                subtitle: Text(dateFormat.format(p.createdAt)),
+                trailing: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      '${p.amountUah.toStringAsFixed(0)} грн',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    _StatusChip(status: p.status),
+                  ],
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  Color _statusColor(String status) {
+    switch (status) {
+      case 'paid':
+        return Colors.green;
+      case 'pending':
+        return Colors.orange;
+      case 'failed':
+        return AppColors.error;
+      default:
+        return AppColors.textSecondary;
+    }
+  }
+
+  IconData _statusIcon(String status) {
+    switch (status) {
+      case 'paid':
+        return Icons.check_circle_outline;
+      case 'pending':
+        return Icons.schedule;
+      case 'failed':
+        return Icons.error_outline;
+      default:
+        return Icons.payments_outlined;
+    }
+  }
+}
+
+class _SummaryCard extends StatelessWidget {
+  final String label;
+  final double amount;
+  final Color color;
+
+  const _SummaryCard({
+    required this.label,
+    required this.amount,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Expanded(
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.08),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: color.withValues(alpha: 0.2)),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              label,
+              style: theme.textTheme.labelSmall?.copyWith(
+                color: color,
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              '${amount.toStringAsFixed(0)} грн',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: color,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusChip extends StatelessWidget {
+  final String status;
+  const _StatusChip({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final (label, color) = _statusInfo(status);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: 10,
+          fontWeight: FontWeight.w600,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  (String, Color) _statusInfo(String status) {
+    switch (status) {
+      case 'pending':
+        return ('Очікує', Colors.orange);
+      case 'accepted':
+        return ('Прийнято', Colors.blue);
+      case 'active':
+        return ('Активна', Colors.green);
+      case 'completed':
+        return ('Завершено', AppColors.primary);
+      case 'declined':
+        return ('Відхилено', AppColors.error);
+      case 'cancelled':
+        return ('Скасовано', AppColors.textSecondary);
+      case 'paid':
+        return ('Виплачено', Colors.green);
+      case 'failed':
+        return ('Помилка', AppColors.error);
+      default:
+        return (status, AppColors.textSecondary);
+    }
   }
 }

--- a/mobile/lib/features/consultation/presentation/widgets/consultation_input.dart
+++ b/mobile/lib/features/consultation/presentation/widgets/consultation_input.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 
 class ConsultationInput extends StatefulWidget {
   final ValueChanged<String> onSend;
+  final VoidCallback? onTyping;
 
-  const ConsultationInput({super.key, required this.onSend});
+  const ConsultationInput({super.key, required this.onSend, this.onTyping});
 
   @override
   State<ConsultationInput> createState() => _ConsultationInputState();
@@ -60,6 +61,7 @@ class _ConsultationInputState extends State<ConsultationInput> {
               maxLines: 4,
               minLines: 1,
               textInputAction: TextInputAction.newline,
+              onChanged: (_) => widget.onTyping?.call(),
               decoration: InputDecoration(
                 hintText: 'Написати повідомлення...',
                 border: OutlineInputBorder(

--- a/mobile/lib/features/consultation/presentation/widgets/consultation_message_bubble.dart
+++ b/mobile/lib/features/consultation/presentation/widgets/consultation_message_bubble.dart
@@ -5,11 +5,15 @@ import '../../../../shared/theme/app_colors.dart';
 class ConsultationMessageBubble extends StatelessWidget {
   final ConsultationMessage message;
   final bool isMe;
+  final void Function(String attachmentId)? onSaveToVault;
+  final bool isSavedToVault;
 
   const ConsultationMessageBubble({
     super.key,
     required this.message,
     required this.isMe,
+    this.onSaveToVault,
+    this.isSavedToVault = false,
   });
 
   @override
@@ -65,7 +69,12 @@ class ConsultationMessageBubble extends StatelessWidget {
               children: [
                 // Attachments
                 if (message.attachments.isNotEmpty)
-                  _AttachmentsDisplay(attachments: message.attachments),
+                  _AttachmentsDisplay(
+                    attachments: message.attachments,
+                    showVaultButton: !isMe && onSaveToVault != null,
+                    isSavedToVault: isSavedToVault,
+                    onSaveToVault: onSaveToVault,
+                  ),
 
                 // Text content
                 if (message.content.isNotEmpty)
@@ -138,7 +147,16 @@ class _StatusIcon extends StatelessWidget {
 
 class _AttachmentsDisplay extends StatelessWidget {
   final List<ConsultationAttachment> attachments;
-  const _AttachmentsDisplay({required this.attachments});
+  final bool showVaultButton;
+  final bool isSavedToVault;
+  final void Function(String attachmentId)? onSaveToVault;
+
+  const _AttachmentsDisplay({
+    required this.attachments,
+    this.showVaultButton = false,
+    this.isSavedToVault = false,
+    this.onSaveToVault,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -151,19 +169,32 @@ class _AttachmentsDisplay extends StatelessWidget {
           if (att.type == 'image') {
             return Padding(
               padding: const EdgeInsets.only(bottom: 6),
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: Image.network(
-                  att.url,
-                  width: 200,
-                  fit: BoxFit.cover,
-                  errorBuilder: (_, __, ___) => Container(
-                    width: 200,
-                    height: 100,
-                    color: AppColors.surfaceVariant,
-                    child: const Icon(Icons.broken_image),
+              child: Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: Image.network(
+                      att.url,
+                      width: 200,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => Container(
+                        width: 200,
+                        height: 100,
+                        color: AppColors.surfaceVariant,
+                        child: const Icon(Icons.broken_image),
+                      ),
+                    ),
                   ),
-                ),
+                  if (showVaultButton)
+                    Positioned(
+                      top: 4,
+                      right: 4,
+                      child: _VaultButton(
+                        isSaved: isSavedToVault,
+                        onTap: () => onSaveToVault?.call(att.id),
+                      ),
+                    ),
+                ],
               ),
             );
           }
@@ -187,11 +218,69 @@ class _AttachmentsDisplay extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                 ),
+                if (showVaultButton) ...[
+                  const SizedBox(width: 6),
+                  _VaultButton(
+                    isSaved: isSavedToVault,
+                    onTap: () => onSaveToVault?.call(att.id),
+                  ),
+                ],
               ],
             ),
           );
         }),
       ],
+    );
+  }
+}
+
+class _VaultButton extends StatefulWidget {
+  final bool isSaved;
+  final VoidCallback? onTap;
+
+  const _VaultButton({required this.isSaved, this.onTap});
+
+  @override
+  State<_VaultButton> createState() => _VaultButtonState();
+}
+
+class _VaultButtonState extends State<_VaultButton> {
+  bool _isSaving = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.isSaved) {
+      return const Icon(
+        Icons.check_circle,
+        size: 20,
+        color: Colors.green,
+      );
+    }
+
+    if (_isSaving) {
+      return const SizedBox(
+        width: 20,
+        height: 20,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    }
+
+    return GestureDetector(
+      onTap: () async {
+        setState(() => _isSaving = true);
+        widget.onTap?.call();
+        // The parent will update isSaved via state
+        // but keep spinner for a moment in case of delay
+        await Future.delayed(const Duration(milliseconds: 500));
+        if (mounted && !widget.isSaved) {
+          setState(() => _isSaving = false);
+        }
+      },
+      child: const Icon(
+        Icons.folder_outlined,
+        size: 20,
+        color: AppColors.textSecondary,
+      ),
     );
   }
 }

--- a/mobile/test/unit/consultation_message_model_test.dart
+++ b/mobile/test/unit/consultation_message_model_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:secondlayer_mobile/features/consultation/data/models/consultation_message.dart';
+
+void main() {
+  group('ConsultationMessage', () {
+    test('fromJson parses all fields', () {
+      final json = {
+        'id': 'm1',
+        'consultation_id': 'c1',
+        'sender_id': 's1',
+        'sender_name': 'Іван',
+        'content': 'Привіт',
+        'status': 'delivered',
+        'created_at': '2025-01-01T10:00:00Z',
+        'attachments': [],
+      };
+
+      final m = ConsultationMessage.fromJson(json);
+
+      expect(m.id, 'm1');
+      expect(m.consultationId, 'c1');
+      expect(m.senderId, 's1');
+      expect(m.senderName, 'Іван');
+      expect(m.content, 'Привіт');
+      expect(m.status, 'delivered');
+      expect(m.attachments, isEmpty);
+    });
+
+    test('fromJson handles missing fields', () {
+      final json = <String, dynamic>{};
+
+      final m = ConsultationMessage.fromJson(json);
+
+      expect(m.id, '');
+      expect(m.consultationId, '');
+      expect(m.senderId, '');
+      expect(m.senderName, '');
+      expect(m.content, '');
+      expect(m.status, 'sent');
+      expect(m.attachments, isEmpty);
+    });
+
+    test('fromJson parses attachments', () {
+      final json = {
+        'id': 'm2',
+        'consultation_id': 'c1',
+        'sender_id': 's1',
+        'sender_name': 'Олена',
+        'content': '',
+        'created_at': '2025-01-01T10:00:00Z',
+        'attachments': [
+          {
+            'id': 'a1',
+            'name': 'document.pdf',
+            'type': 'file',
+            'url': 'https://example.com/doc.pdf',
+            'size': 1024,
+          },
+        ],
+      };
+
+      final m = ConsultationMessage.fromJson(json);
+
+      expect(m.attachments.length, 1);
+      expect(m.attachments[0].id, 'a1');
+      expect(m.attachments[0].name, 'document.pdf');
+      expect(m.attachments[0].type, 'file');
+      expect(m.attachments[0].url, 'https://example.com/doc.pdf');
+      expect(m.attachments[0].size, 1024);
+    });
+
+    test('copyWith changes status only', () {
+      final original = ConsultationMessage(
+        id: 'm1',
+        consultationId: 'c1',
+        senderId: 's1',
+        senderName: 'Test',
+        content: 'Hello',
+        status: 'sending',
+        createdAt: DateTime(2025, 1, 1),
+      );
+
+      final updated = original.copyWith(status: 'sent');
+
+      expect(updated.id, 'm1');
+      expect(updated.content, 'Hello');
+      expect(updated.status, 'sent');
+      expect(updated.senderName, 'Test');
+    });
+
+    test('copyWith preserves status when not provided', () {
+      final original = ConsultationMessage(
+        id: 'm1',
+        consultationId: 'c1',
+        senderId: 's1',
+        senderName: 'Test',
+        content: 'Hello',
+        status: 'delivered',
+        createdAt: DateTime(2025, 1, 1),
+      );
+
+      final updated = original.copyWith();
+
+      expect(updated.status, 'delivered');
+    });
+
+    test('default status is sent', () {
+      final m = ConsultationMessage(
+        id: 'm1',
+        consultationId: 'c1',
+        senderId: 's1',
+        senderName: 'Test',
+        content: 'Hello',
+        createdAt: DateTime(2025, 1, 1),
+      );
+
+      expect(m.status, 'sent');
+    });
+
+    test('fromJson handles null attachments', () {
+      final json = {
+        'id': 'm3',
+        'consultation_id': 'c1',
+        'sender_id': 's1',
+        'sender_name': 'Test',
+        'content': 'Hi',
+        'created_at': '2025-01-01T10:00:00Z',
+        'attachments': null,
+      };
+
+      final m = ConsultationMessage.fromJson(json);
+      expect(m.attachments, isEmpty);
+    });
+
+    test('fromJson handles multiple attachments', () {
+      final json = {
+        'id': 'm4',
+        'consultation_id': 'c1',
+        'sender_id': 's1',
+        'sender_name': 'Test',
+        'content': '',
+        'created_at': '2025-01-01T10:00:00Z',
+        'attachments': [
+          {'id': 'a1', 'name': 'file1.pdf', 'type': 'file', 'url': 'http://a'},
+          {'id': 'a2', 'name': 'image.jpg', 'type': 'image', 'url': 'http://b'},
+        ],
+      };
+
+      final m = ConsultationMessage.fromJson(json);
+      expect(m.attachments.length, 2);
+      expect(m.attachments[0].type, 'file');
+      expect(m.attachments[1].type, 'image');
+    });
+  });
+
+  group('ConsultationAttachment', () {
+    test('fromJson parses all fields', () {
+      final json = {
+        'id': 'a1',
+        'name': 'test.pdf',
+        'type': 'file',
+        'url': 'https://example.com/test.pdf',
+        'size': 2048,
+      };
+
+      final a = ConsultationAttachment.fromJson(json);
+
+      expect(a.id, 'a1');
+      expect(a.name, 'test.pdf');
+      expect(a.type, 'file');
+      expect(a.url, 'https://example.com/test.pdf');
+      expect(a.size, 2048);
+    });
+
+    test('fromJson handles missing fields', () {
+      final json = <String, dynamic>{};
+
+      final a = ConsultationAttachment.fromJson(json);
+
+      expect(a.id, '');
+      expect(a.name, '');
+      expect(a.type, 'file');
+      expect(a.url, '');
+      expect(a.size, isNull);
+    });
+
+    test('fromJson handles null size', () {
+      final json = {
+        'id': 'a2',
+        'name': 'photo.jpg',
+        'type': 'image',
+        'url': 'https://example.com/photo.jpg',
+        'size': null,
+      };
+
+      final a = ConsultationAttachment.fromJson(json);
+      expect(a.size, isNull);
+    });
+
+    test('default type is file', () {
+      final json = {
+        'id': 'a3',
+        'name': 'unknown',
+        'url': 'https://example.com/file',
+      };
+
+      final a = ConsultationAttachment.fromJson(json);
+      expect(a.type, 'file');
+    });
+  });
+}

--- a/mobile/test/unit/consultation_model_test.dart
+++ b/mobile/test/unit/consultation_model_test.dart
@@ -1,0 +1,274 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:secondlayer_mobile/features/consultation/data/models/consultation.dart';
+
+void main() {
+  group('Consultation', () {
+    test('fromJson parses all fields correctly', () {
+      final json = {
+        'id': 'c1',
+        'request_title': 'Земельна справа',
+        'client_name': 'Іван',
+        'attorney_name': 'Олена',
+        'client_user_id': 'u1',
+        'attorney_user_id': 'u2',
+        'status': 'active',
+        'request_description': 'Потрібна консультація',
+        'agreed_fee_uah': 500.0,
+        'document_ids': ['d1', 'd2'],
+        'decline_reason': null,
+        'cancel_reason': null,
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-02T12:00:00Z',
+        'unread_count': 3,
+      };
+
+      final c = Consultation.fromJson(json);
+
+      expect(c.id, 'c1');
+      expect(c.title, 'Земельна справа');
+      expect(c.clientName, 'Іван');
+      expect(c.attorneyName, 'Олена');
+      expect(c.clientUserId, 'u1');
+      expect(c.attorneyUserId, 'u2');
+      expect(c.status, 'active');
+      expect(c.requestDescription, 'Потрібна консультація');
+      expect(c.agreedFeeUah, 500.0);
+      expect(c.documentIds, ['d1', 'd2']);
+      expect(c.declineReason, isNull);
+      expect(c.cancelReason, isNull);
+      expect(c.unreadCount, 3);
+    });
+
+    test('fromJson uses request_title fallback to title', () {
+      final json = {
+        'id': 'c2',
+        'title': 'Fallback Title',
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-01T10:00:00Z',
+      };
+
+      final c = Consultation.fromJson(json);
+      expect(c.title, 'Fallback Title');
+    });
+
+    test('fromJson request_title takes priority over title', () {
+      final json = {
+        'id': 'c3',
+        'request_title': 'Primary',
+        'title': 'Secondary',
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-01T10:00:00Z',
+      };
+
+      final c = Consultation.fromJson(json);
+      expect(c.title, 'Primary');
+    });
+
+    test('fromJson handles missing fields with defaults', () {
+      final json = <String, dynamic>{};
+
+      final c = Consultation.fromJson(json);
+
+      expect(c.id, '');
+      expect(c.title, '');
+      expect(c.clientName, isNull);
+      expect(c.attorneyName, isNull);
+      expect(c.status, 'pending');
+      expect(c.agreedFeeUah, isNull);
+      expect(c.documentIds, isEmpty);
+      expect(c.unreadCount, 0);
+    });
+
+    test('fromJson parses numeric fee from int', () {
+      final json = {
+        'id': 'c4',
+        'agreed_fee_uah': 1000,
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-01T10:00:00Z',
+      };
+
+      final c = Consultation.fromJson(json);
+      expect(c.agreedFeeUah, 1000.0);
+    });
+
+    test('default status is pending', () {
+      final c = Consultation.fromJson({'id': 'c5'});
+      expect(c.status, 'pending');
+    });
+
+    test('fromJson handles empty document_ids list', () {
+      final json = {
+        'id': 'c6',
+        'document_ids': [],
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-01T10:00:00Z',
+      };
+
+      final c = Consultation.fromJson(json);
+      expect(c.documentIds, isEmpty);
+    });
+
+    test('fromJson handles null document_ids', () {
+      final json = {
+        'id': 'c7',
+        'document_ids': null,
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-01T10:00:00Z',
+      };
+
+      final c = Consultation.fromJson(json);
+      expect(c.documentIds, isEmpty);
+    });
+  });
+
+  group('ConsultationPayment', () {
+    test('fromJson parses all fields', () {
+      final json = {
+        'id': 'p1',
+        'consultation_id': 'c1',
+        'amount_uah': 500.0,
+        'platform_fee_uah': 50.0,
+        'attorney_payout_uah': 450.0,
+        'status': 'completed',
+        'payment_provider': 'monobank',
+        'created_at': '2025-01-01T10:00:00Z',
+      };
+
+      final p = ConsultationPayment.fromJson(json);
+
+      expect(p.id, 'p1');
+      expect(p.consultationId, 'c1');
+      expect(p.amountUah, 500.0);
+      expect(p.platformFeeUah, 50.0);
+      expect(p.attorneyPayoutUah, 450.0);
+      expect(p.status, 'completed');
+      expect(p.paymentProvider, 'monobank');
+    });
+
+    test('fromJson handles missing fields with defaults', () {
+      final json = <String, dynamic>{};
+
+      final p = ConsultationPayment.fromJson(json);
+
+      expect(p.id, '');
+      expect(p.consultationId, '');
+      expect(p.amountUah, 0);
+      expect(p.platformFeeUah, 0);
+      expect(p.attorneyPayoutUah, 0);
+      expect(p.status, 'pending');
+      expect(p.paymentProvider, isNull);
+    });
+
+    test('fromJson parses numeric amounts from int', () {
+      final json = {
+        'id': 'p2',
+        'consultation_id': 'c2',
+        'amount_uah': 1000,
+        'platform_fee_uah': 100,
+        'attorney_payout_uah': 900,
+        'status': 'pending',
+        'created_at': '2025-01-01T10:00:00Z',
+      };
+
+      final p = ConsultationPayment.fromJson(json);
+      expect(p.amountUah, 1000.0);
+      expect(p.platformFeeUah, 100.0);
+      expect(p.attorneyPayoutUah, 900.0);
+    });
+
+    test('fromJson handles null payment_provider', () {
+      final json = {
+        'id': 'p3',
+        'consultation_id': 'c3',
+        'created_at': '2025-01-01T10:00:00Z',
+      };
+
+      final p = ConsultationPayment.fromJson(json);
+      expect(p.paymentProvider, isNull);
+    });
+  });
+
+  group('AttorneyPayout', () {
+    test('fromJson parses all fields', () {
+      final json = {
+        'id': 'ap1',
+        'attorney_user_id': 'u1',
+        'consultation_payment_id': 'p1',
+        'amount_uah': 450.0,
+        'status': 'paid',
+        'created_at': '2025-01-01T10:00:00Z',
+        'consultation_id': 'c1',
+        'request_title': 'Земельна справа',
+      };
+
+      final a = AttorneyPayout.fromJson(json);
+
+      expect(a.id, 'ap1');
+      expect(a.attorneyUserId, 'u1');
+      expect(a.consultationPaymentId, 'p1');
+      expect(a.amountUah, 450.0);
+      expect(a.status, 'paid');
+      expect(a.consultationId, 'c1');
+      expect(a.requestTitle, 'Земельна справа');
+    });
+
+    test('fromJson handles missing fields with defaults', () {
+      final json = <String, dynamic>{};
+
+      final a = AttorneyPayout.fromJson(json);
+
+      expect(a.id, '');
+      expect(a.attorneyUserId, '');
+      expect(a.consultationPaymentId, isNull);
+      expect(a.amountUah, 0);
+      expect(a.status, 'pending');
+      expect(a.consultationId, isNull);
+      expect(a.requestTitle, isNull);
+    });
+
+    test('fromJson parses amount from int', () {
+      final json = {
+        'id': 'ap2',
+        'attorney_user_id': 'u2',
+        'amount_uah': 300,
+        'status': 'pending',
+        'created_at': '2025-01-01T10:00:00Z',
+      };
+
+      final a = AttorneyPayout.fromJson(json);
+      expect(a.amountUah, 300.0);
+    });
+
+    test('fromJson handles null optional fields', () {
+      final json = {
+        'id': 'ap3',
+        'attorney_user_id': 'u3',
+        'consultation_payment_id': null,
+        'amount_uah': 200.0,
+        'status': 'pending',
+        'created_at': '2025-01-01T10:00:00Z',
+        'consultation_id': null,
+        'request_title': null,
+      };
+
+      final a = AttorneyPayout.fromJson(json);
+      expect(a.consultationPaymentId, isNull);
+      expect(a.consultationId, isNull);
+      expect(a.requestTitle, isNull);
+    });
+
+    test('various statuses are preserved', () {
+      for (final status in ['pending', 'paid', 'failed', 'processing']) {
+        final json = {
+          'id': 'ap',
+          'attorney_user_id': 'u',
+          'amount_uah': 100,
+          'status': status,
+          'created_at': '2025-01-01T10:00:00Z',
+        };
+        final a = AttorneyPayout.fromJson(json);
+        expect(a.status, status);
+      }
+    });
+  });
+}

--- a/mobile/test/unit/consultation_repository_test.dart
+++ b/mobile/test/unit/consultation_repository_test.dart
@@ -1,0 +1,244 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:secondlayer_mobile/features/consultation/data/models/consultation.dart';
+import 'package:secondlayer_mobile/features/consultation/data/models/consultation_message.dart';
+
+// Repository tests that verify model parsing from API-like responses
+// These are integration-level model tests using realistic API response shapes
+
+void main() {
+  group('ConsultationRepository model parsing', () {
+    test('parses consultation list response', () {
+      final responseData = [
+        {
+          'id': 'c1',
+          'request_title': 'Земельна справа',
+          'client_name': 'Іван Петренко',
+          'attorney_name': 'Олена Коваль',
+          'client_user_id': 'u1',
+          'attorney_user_id': 'u2',
+          'status': 'active',
+          'agreed_fee_uah': 500,
+          'created_at': '2025-01-01T10:00:00Z',
+          'updated_at': '2025-01-02T12:00:00Z',
+          'unread_count': 2,
+        },
+        {
+          'id': 'c2',
+          'request_title': 'Трудовий спір',
+          'client_name': 'Марія Іваненко',
+          'status': 'pending',
+          'created_at': '2025-01-03T10:00:00Z',
+          'updated_at': '2025-01-03T10:00:00Z',
+          'unread_count': 0,
+        },
+      ];
+
+      final consultations = responseData
+          .map((e) => Consultation.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(consultations.length, 2);
+      expect(consultations[0].title, 'Земельна справа');
+      expect(consultations[0].agreedFeeUah, 500.0);
+      expect(consultations[0].unreadCount, 2);
+      expect(consultations[1].title, 'Трудовий спір');
+      expect(consultations[1].attorneyName, isNull);
+    });
+
+    test('parses messages list response', () {
+      final responseData = [
+        {
+          'id': 'm1',
+          'consultation_id': 'c1',
+          'sender_id': 'u1',
+          'sender_name': 'Іван',
+          'content': 'Доброго дня',
+          'status': 'read',
+          'created_at': '2025-01-01T10:00:00Z',
+          'attachments': [],
+        },
+        {
+          'id': 'm2',
+          'consultation_id': 'c1',
+          'sender_id': 'u2',
+          'sender_name': 'Олена',
+          'content': 'Вітаю! Чим можу допомогти?',
+          'status': 'delivered',
+          'created_at': '2025-01-01T10:05:00Z',
+          'attachments': [
+            {
+              'id': 'a1',
+              'name': 'contract.pdf',
+              'type': 'file',
+              'url': 'https://example.com/contract.pdf',
+              'size': 4096,
+            },
+          ],
+        },
+      ];
+
+      final messages = responseData
+          .map((e) => ConsultationMessage.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(messages.length, 2);
+      expect(messages[0].content, 'Доброго дня');
+      expect(messages[0].status, 'read');
+      expect(messages[1].attachments.length, 1);
+      expect(messages[1].attachments[0].name, 'contract.pdf');
+    });
+
+    test('parses payouts list response', () {
+      final responseData = [
+        {
+          'id': 'ap1',
+          'attorney_user_id': 'u2',
+          'consultation_payment_id': 'p1',
+          'amount_uah': 450.0,
+          'status': 'paid',
+          'created_at': '2025-01-05T10:00:00Z',
+          'consultation_id': 'c1',
+          'request_title': 'Земельна справа',
+        },
+        {
+          'id': 'ap2',
+          'attorney_user_id': 'u2',
+          'amount_uah': 800.0,
+          'status': 'pending',
+          'created_at': '2025-01-06T10:00:00Z',
+          'consultation_id': 'c3',
+          'request_title': 'Сімейна справа',
+        },
+      ];
+
+      final payouts = responseData
+          .map((e) => AttorneyPayout.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(payouts.length, 2);
+      expect(payouts[0].amountUah, 450.0);
+      expect(payouts[0].status, 'paid');
+      expect(payouts[0].requestTitle, 'Земельна справа');
+      expect(payouts[1].amountUah, 800.0);
+      expect(payouts[1].status, 'pending');
+    });
+
+    test('parses payment status response', () {
+      final responseData = {
+        'id': 'p1',
+        'consultation_id': 'c1',
+        'amount_uah': 500.0,
+        'platform_fee_uah': 50.0,
+        'attorney_payout_uah': 450.0,
+        'status': 'completed',
+        'payment_provider': 'monobank',
+        'created_at': '2025-01-04T10:00:00Z',
+      };
+
+      final payment = ConsultationPayment.fromJson(responseData);
+
+      expect(payment.id, 'p1');
+      expect(payment.amountUah, 500.0);
+      expect(payment.platformFeeUah, 50.0);
+      expect(payment.attorneyPayoutUah, 450.0);
+      expect(payment.status, 'completed');
+    });
+
+    test('handles empty consultation list', () {
+      final responseData = <dynamic>[];
+
+      final consultations = responseData
+          .map((e) => Consultation.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(consultations, isEmpty);
+    });
+
+    test('handles empty messages list', () {
+      final responseData = <dynamic>[];
+
+      final messages = responseData
+          .map((e) => ConsultationMessage.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(messages, isEmpty);
+    });
+
+    test('handles empty payouts list', () {
+      final responseData = <dynamic>[];
+
+      final payouts = responseData
+          .map((e) => AttorneyPayout.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      expect(payouts, isEmpty);
+    });
+
+    test('consultation with all statuses', () {
+      final statuses = [
+        'pending',
+        'accepted',
+        'active',
+        'completed',
+        'declined',
+        'cancelled',
+      ];
+
+      for (final status in statuses) {
+        final json = {
+          'id': 'c_$status',
+          'title': 'Test $status',
+          'status': status,
+          'created_at': '2025-01-01T10:00:00Z',
+          'updated_at': '2025-01-01T10:00:00Z',
+        };
+
+        final c = Consultation.fromJson(json);
+        expect(c.status, status);
+      }
+    });
+
+    test('message with all statuses', () {
+      final statuses = ['sending', 'sent', 'delivered', 'read', 'failed'];
+
+      for (final status in statuses) {
+        final json = {
+          'id': 'm_$status',
+          'consultation_id': 'c1',
+          'sender_id': 's1',
+          'sender_name': 'Test',
+          'content': 'Hello',
+          'status': status,
+          'created_at': '2025-01-01T10:00:00Z',
+        };
+
+        final m = ConsultationMessage.fromJson(json);
+        expect(m.status, status);
+      }
+    });
+
+    test('payout totals calculation', () {
+      final payoutsData = [
+        {'id': 'p1', 'attorney_user_id': 'u1', 'amount_uah': 100, 'status': 'paid', 'created_at': '2025-01-01T10:00:00Z'},
+        {'id': 'p2', 'attorney_user_id': 'u1', 'amount_uah': 200, 'status': 'paid', 'created_at': '2025-01-01T10:00:00Z'},
+        {'id': 'p3', 'attorney_user_id': 'u1', 'amount_uah': 300, 'status': 'pending', 'created_at': '2025-01-01T10:00:00Z'},
+      ];
+
+      final payouts = payoutsData
+          .map((e) => AttorneyPayout.fromJson(e))
+          .toList();
+
+      final totalAmount = payouts.fold<double>(0, (sum, p) => sum + p.amountUah);
+      final paidAmount = payouts
+          .where((p) => p.status == 'paid')
+          .fold<double>(0, (sum, p) => sum + p.amountUah);
+      final pendingAmount = payouts
+          .where((p) => p.status == 'pending')
+          .fold<double>(0, (sum, p) => sum + p.amountUah);
+
+      expect(totalAmount, 600.0);
+      expect(paidAmount, 300.0);
+      expect(pendingAmount, 300.0);
+    });
+  });
+}

--- a/mobile/test/unit/consultation_state_test.dart
+++ b/mobile/test/unit/consultation_state_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:secondlayer_mobile/features/consultation/data/models/consultation.dart';
+import 'package:secondlayer_mobile/features/consultation/data/models/consultation_message.dart';
+import 'package:secondlayer_mobile/features/consultation/domain/consultation_state.dart';
+
+void main() {
+  group('ConsultationState', () {
+    test('default values', () {
+      const state = ConsultationState();
+
+      expect(state.consultations, isEmpty);
+      expect(state.isLoadingConsultations, false);
+      expect(state.payouts, isEmpty);
+      expect(state.isLoadingPayouts, false);
+      expect(state.error, isNull);
+    });
+
+    test('copyWith updates consultations', () {
+      const state = ConsultationState();
+      final consultation = Consultation.fromJson({
+        'id': 'c1',
+        'title': 'Test',
+        'created_at': '2025-01-01T10:00:00Z',
+        'updated_at': '2025-01-01T10:00:00Z',
+      });
+
+      final updated = state.copyWith(consultations: [consultation]);
+
+      expect(updated.consultations.length, 1);
+      expect(updated.consultations[0].id, 'c1');
+    });
+
+    test('copyWith updates isLoadingConsultations', () {
+      const state = ConsultationState();
+
+      final updated = state.copyWith(isLoadingConsultations: true);
+
+      expect(updated.isLoadingConsultations, true);
+    });
+
+    test('copyWith updates payouts', () {
+      const state = ConsultationState();
+      final payout = AttorneyPayout.fromJson({
+        'id': 'p1',
+        'attorney_user_id': 'u1',
+        'amount_uah': 500,
+        'status': 'paid',
+        'created_at': '2025-01-01T10:00:00Z',
+      });
+
+      final updated = state.copyWith(payouts: [payout]);
+
+      expect(updated.payouts.length, 1);
+      expect(updated.payouts[0].id, 'p1');
+    });
+
+    test('copyWith updates isLoadingPayouts', () {
+      const state = ConsultationState();
+
+      final updated = state.copyWith(isLoadingPayouts: true);
+
+      expect(updated.isLoadingPayouts, true);
+    });
+
+    test('copyWith updates error', () {
+      const state = ConsultationState();
+
+      final updated = state.copyWith(error: 'Something went wrong');
+
+      expect(updated.error, 'Something went wrong');
+    });
+
+    test('copyWith clearError removes error', () {
+      final state = const ConsultationState().copyWith(error: 'Error');
+
+      final updated = state.copyWith(clearError: true);
+
+      expect(updated.error, isNull);
+    });
+
+    test('copyWith preserves fields not specified', () {
+      final state = const ConsultationState().copyWith(
+        isLoadingConsultations: true,
+        isLoadingPayouts: true,
+        error: 'Error',
+      );
+
+      final updated = state.copyWith(isLoadingConsultations: false);
+
+      expect(updated.isLoadingConsultations, false);
+      expect(updated.isLoadingPayouts, true);
+      expect(updated.error, 'Error');
+    });
+  });
+
+  group('ConsultationChatState', () {
+    test('default values', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      expect(state.consultationId, 'c1');
+      expect(state.messages, isEmpty);
+      expect(state.isLoading, false);
+      expect(state.typingUserName, isNull);
+      expect(state.savedAttachmentMessageIds, isEmpty);
+      expect(state.error, isNull);
+    });
+
+    test('copyWith updates messages', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+      final message = ConsultationMessage(
+        id: 'm1',
+        consultationId: 'c1',
+        senderId: 's1',
+        senderName: 'Test',
+        content: 'Hello',
+        createdAt: DateTime(2025, 1, 1),
+      );
+
+      final updated = state.copyWith(messages: [message]);
+
+      expect(updated.messages.length, 1);
+      expect(updated.messages[0].id, 'm1');
+    });
+
+    test('copyWith updates isLoading', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      final updated = state.copyWith(isLoading: true);
+
+      expect(updated.isLoading, true);
+    });
+
+    test('copyWith updates typingUserName', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      final updated = state.copyWith(typingUserName: 'Олена');
+
+      expect(updated.typingUserName, 'Олена');
+    });
+
+    test('copyWith clearTyping removes typingUserName', () {
+      final state = const ConsultationChatState(consultationId: 'c1')
+          .copyWith(typingUserName: 'Олена');
+
+      final updated = state.copyWith(clearTyping: true);
+
+      expect(updated.typingUserName, isNull);
+    });
+
+    test('copyWith updates savedAttachmentMessageIds', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      final updated =
+          state.copyWith(savedAttachmentMessageIds: {'m1', 'm2'});
+
+      expect(updated.savedAttachmentMessageIds, {'m1', 'm2'});
+    });
+
+    test('copyWith updates error', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      final updated = state.copyWith(error: 'Network error');
+
+      expect(updated.error, 'Network error');
+    });
+
+    test('copyWith clearError removes error', () {
+      final state = const ConsultationChatState(consultationId: 'c1')
+          .copyWith(error: 'Error');
+
+      final updated = state.copyWith(clearError: true);
+
+      expect(updated.error, isNull);
+    });
+
+    test('copyWith preserves consultationId', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      final updated = state.copyWith(isLoading: true);
+
+      expect(updated.consultationId, 'c1');
+    });
+
+    test('copyWith preserves fields not specified', () {
+      final state = const ConsultationChatState(consultationId: 'c1')
+          .copyWith(
+        isLoading: true,
+        typingUserName: 'User',
+        savedAttachmentMessageIds: {'m1'},
+        error: 'Error',
+      );
+
+      final updated = state.copyWith(isLoading: false);
+
+      expect(updated.isLoading, false);
+      expect(updated.typingUserName, 'User');
+      expect(updated.savedAttachmentMessageIds, {'m1'});
+      expect(updated.error, 'Error');
+    });
+
+    test('clearTyping takes priority over typingUserName', () {
+      const state = ConsultationChatState(consultationId: 'c1');
+
+      // When both clearTyping and typingUserName are set, clearTyping wins
+      final updated =
+          state.copyWith(typingUserName: 'Test', clearTyping: true);
+
+      expect(updated.typingUserName, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Payouts tab for attorneys with summary cards (total/pending/paid) and status badges
- Typing indicators: debounced 3s send, SSE receive, auto-clear after 4s
- Save attachment to vault button on received messages (folder icon → spinner → checkmark)
- Polling fallback (5s) alongside SSE for reliable real-time message updates
- GET SSE support in SSEClient via new `streamGet()` method
- Expanded Consultation model with all backend fields (attorney, fees, document IDs, reasons)
- ConsultationPayment and AttorneyPayout model classes
- Status chips for all consultation and payout states
- 58 new unit tests covering models, repository parsing, and state management

## Test plan
- [x] `flutter analyze` passes with 0 errors
- [x] All 58 new unit tests pass
- [ ] Manual: verify payouts tab loads for attorney users
- [ ] Manual: verify typing indicator appears when other party types
- [ ] Manual: verify save-to-vault button on received attachments
- [ ] Manual: verify polling keeps messages in sync when SSE drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)