### PR TITLE
fix: raise consultation rate limit 120→300 req/min

### DIFF
--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -119,10 +119,10 @@ export const passwordResetRateLimit = createRateLimiter({
 });
 
 // Consultation rate limiter — keyed by userId to avoid Cloudflare shared IP issues.
-// Generous limit: polling fallback at 30s = ~2 req/min per user, plus SSE + detail page.
+// 300/min: handles multiple open tabs with polling + SSE reconnects.
 export const consultationRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 120,
+  maxRequests: 300,
   keyPrefix: 'ratelimit:consultation',
   keyByUserId: true,
 });


### PR DESCRIPTION
## Summary

- Raise per-user consultation rate limit from 120 to 300 req/min
- 120/min was too low — advocat user with multiple tabs + old 5s polling frontend hit the limit, blocking chat requests too

## Root cause

The 120/min consultation rate limit deployed in #1066 was too aggressive. Users on the old frontend (5s polling) with consultation tab open exhaust 120 req/min quickly, which then blocks ALL their requests including AI chat.

## Test plan

- [ ] advocat user no longer gets 429 on consultation pages
- [ ] AI chat works normally while consultation tab is open

🤖 Generated with [Claude Code](https://claude.com/claude-code)