### PR TITLE
feat(admin): system limits dashboard

### DIFF
--- a/lexwebapp/src/components/sidebar/nav-config.ts
+++ b/lexwebapp/src/components/sidebar/nav-config.ts
@@ -3,7 +3,7 @@ import {
   BarChart3, Newspaper,
   Clock, FileText, Search, Activity, Database, Users, DollarSign,
   Server, Boxes, Globe, CreditCard, Settings, Terminal, Tag, Zap,
-  Layers, HardDrive,
+  Layers, HardDrive, Gauge,
 } from 'lucide-react';
 import { ROUTES } from '../../router/routes';
 
@@ -60,4 +60,5 @@ export const monitoringSections = [
   { id: 'user-activity', label: 'Активність юзерів', icon: Zap, route: ROUTES.ADMIN_USER_ACTIVITY },
   { id: 'bulk-scrape', label: 'Пайплайн збору', icon: Database, route: ROUTES.ADMIN_BULK_SCRAPE },
   { id: 'pg-monitoring', label: 'PG Моніторинг', icon: HardDrive, route: ROUTES.ADMIN_PG_MONITORING },
+  { id: 'limits', label: 'Ліміти системи', icon: Gauge, route: ROUTES.ADMIN_LIMITS },
 ];

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -52,6 +52,7 @@ const PAGE_TITLES: Record<string, string> = {
   [ROUTES.ADMIN_BULK_SCRAPE]: 'Пайплайн збору даних',
   [ROUTES.ADMIN_OPEN_DATA_CATALOG]: 'Каталог OpenData',
   [ROUTES.ADMIN_PG_MONITORING]: 'PG Моніторинг',
+  [ROUTES.ADMIN_LIMITS]: 'Ліміти системи',
   [ROUTES.ATTORNEY_CLIENTS]: 'Мої клієнти',
 };
 

--- a/lexwebapp/src/pages/AdminLimitsPage.tsx
+++ b/lexwebapp/src/pages/AdminLimitsPage.tsx
@@ -1,0 +1,392 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, AlertTriangle, Shield, Zap, Upload, Archive, CreditCard, Bot, Globe, Info } from 'lucide-react';
+import { adminApi } from '../utils/api/admin';
+
+interface RateLimit {
+  id: string;
+  name: string;
+  max: number;
+  window: string;
+  windowMs: number;
+  keyBy: string;
+  description: string;
+  severity: string;
+}
+
+interface LLMLimit {
+  id: string;
+  name: string;
+  max: number | null;
+  current: number | null;
+  unit: string;
+  description: string;
+  severity: string;
+  status?: string;
+}
+
+interface ChatLimit {
+  id: string;
+  name: string;
+  maxTokens: number;
+  maxToolCalls: number;
+  maxContextChars: number;
+  maxResultChars: number;
+  description: string;
+}
+
+interface GenericLimit {
+  id: string;
+  name: string;
+  max?: number;
+  min?: number;
+  maxFormatted?: string;
+  current?: number | null;
+  unit?: string;
+  window?: string;
+  description: string;
+  severity?: string;
+}
+
+interface EscrowInfo {
+  paymentsInEscrow: number;
+  totalEscrowUah: number;
+  autoReleaseDays: number;
+  description: string;
+}
+
+interface LimitsData {
+  rateLimits: RateLimit[];
+  llmLimits: LLMLimit[];
+  chatLimits: ChatLimit[];
+  uploadLimits: GenericLimit[];
+  archiveLimits: GenericLimit[];
+  billingLimits: GenericLimit[];
+  scrapingLimits: GenericLimit[];
+  escrow: EscrowInfo;
+  currentUsage: {
+    activeUploadSessions: number;
+    todayTotalTokens: number;
+    todayBedrockTokens: number;
+    todayOpenaiTokens: number;
+    todayTotalRequests: number;
+    escrowPayments: number;
+    escrowTotalUah: number;
+    activeUsers24h: number;
+  };
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('uk-UA');
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const colors: Record<string, string> = {
+    critical: 'bg-red-100 text-red-700',
+    high: 'bg-orange-100 text-orange-700',
+    medium: 'bg-yellow-100 text-yellow-700',
+    low: 'bg-green-100 text-green-700',
+  };
+  return (
+    <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${colors[severity] || 'bg-gray-100 text-gray-600'}`}>
+      {severity}
+    </span>
+  );
+}
+
+function KpiCard({ icon: Icon, label, value, sub, color = 'text-claude-text' }: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  sub?: string;
+  color?: string;
+}) {
+  return (
+    <div className="bg-white rounded-xl border border-claude-border shadow-sm p-5">
+      <div className="flex items-center gap-3 mb-2">
+        <Icon className="w-5 h-5 text-claude-subtext" />
+        <span className="text-sm text-claude-subtext">{label}</span>
+      </div>
+      <div className={`text-2xl font-semibold ${color}`}>{value}</div>
+      {sub && <div className="text-xs text-claude-subtext mt-1">{sub}</div>}
+    </div>
+  );
+}
+
+function Section({ title, icon: Icon, children }: { title: string; icon: React.ElementType; children: React.ReactNode }) {
+  return (
+    <div className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
+      <div className="px-6 py-4 border-b border-claude-border/50 flex items-center gap-2">
+        <Icon className="w-5 h-5 text-claude-subtext" />
+        <h2 className="text-lg font-semibold text-claude-text font-sans">{title}</h2>
+      </div>
+      <div className="p-6">{children}</div>
+    </div>
+  );
+}
+
+function LimitRow({ name, max, current, window, unit, description, severity, maxFormatted }: {
+  name: string;
+  max?: number | null;
+  current?: number | null;
+  window?: string;
+  unit?: string;
+  description: string;
+  severity?: string;
+  maxFormatted?: string;
+}) {
+  const pct = max && current != null ? Math.min((current / max) * 100, 100) : null;
+  const barColor = pct != null
+    ? pct > 80 ? 'bg-red-500' : pct > 50 ? 'bg-yellow-500' : 'bg-green-500'
+    : 'bg-gray-300';
+
+  return (
+    <div className="py-3 border-b border-claude-border/20 last:border-0">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="font-medium text-sm text-claude-text">{name}</span>
+            {severity && <SeverityBadge severity={severity} />}
+            {window && <span className="text-xs text-claude-subtext bg-gray-50 px-2 py-0.5 rounded">{window}</span>}
+          </div>
+          <p className="text-xs text-claude-subtext leading-relaxed">{description}</p>
+        </div>
+        <div className="text-right shrink-0 w-36">
+          {max != null ? (
+            <div className="text-sm font-mono text-claude-text">
+              {current != null ? formatNumber(current) + ' / ' : ''}{maxFormatted || formatNumber(max)}{unit ? ' ' + unit : ''}
+            </div>
+          ) : current != null ? (
+            <div className="text-sm font-mono text-claude-text">{formatNumber(current)}{unit ? ' ' + unit : ''}</div>
+          ) : (
+            <div className="text-xs text-claude-subtext italic">зовнішній ліміт</div>
+          )}
+          {pct != null && (
+            <div className="mt-1 w-full bg-gray-100 rounded-full h-1.5">
+              <div className={`h-1.5 rounded-full ${barColor}`} style={{ width: `${pct}%` }} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AdminLimitsPage() {
+  const [data, setData] = useState<LimitsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch_ = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await adminApi.getLimits();
+      setData(res.data);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Помилка завантаження');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { fetch_(); }, [fetch_]);
+
+  // Auto-refresh every 30 seconds
+  useEffect(() => {
+    const interval = setInterval(fetch_, 30000);
+    return () => clearInterval(interval);
+  }, [fetch_]);
+
+  if (loading && !data) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="w-8 h-8 border-4 border-claude-accent border-t-transparent rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <div className="max-w-3xl mx-auto p-8">
+        <div className="bg-red-50 border border-red-200 rounded-xl p-6 flex items-start gap-3">
+          <AlertTriangle className="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-red-800">{error}</p>
+            <button onClick={fetch_} className="text-sm text-red-600 underline mt-2">Спробувати знову</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const u = data.currentUsage;
+
+  return (
+    <div className="max-w-6xl mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-claude-text font-sans">Ліміти системи</h1>
+          <p className="text-sm text-claude-subtext mt-1">Реалтайм моніторинг лімітів та поточного використання</p>
+        </div>
+        <button
+          onClick={fetch_}
+          disabled={loading}
+          className="flex items-center gap-2 px-4 py-2 bg-claude-bg border border-claude-border rounded-lg text-sm text-claude-text hover:bg-gray-50 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Оновити
+        </button>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <KpiCard icon={Zap} label="Токени за 24г" value={formatNumber(u.todayTotalTokens)} sub={`Bedrock: ${formatNumber(u.todayBedrockTokens)} | OpenAI: ${formatNumber(u.todayOpenaiTokens)}`} />
+        <KpiCard icon={Globe} label="Запити за 24г" value={formatNumber(u.todayTotalRequests)} sub={`Активних юзерів: ${u.activeUsers24h}`} />
+        <KpiCard icon={CreditCard} label="В escrow" value={`${data.escrow.totalEscrowUah} грн`} sub={`${data.escrow.paymentsInEscrow} платежів`} color={data.escrow.paymentsInEscrow > 0 ? 'text-orange-600' : 'text-claude-text'} />
+        <KpiCard icon={Upload} label="Активні завантаження" value={String(u.activeUploadSessions)} sub="сесій" />
+      </div>
+
+      {/* Rate Limits */}
+      <Section title="Rate Limits (запити)" icon={Shield}>
+        {data.rateLimits.map(rl => (
+          <LimitRow
+            key={rl.id}
+            name={rl.name}
+            max={rl.max}
+            window={rl.window}
+            description={rl.description}
+            severity={rl.severity}
+          />
+        ))}
+      </Section>
+
+      {/* LLM Provider Limits */}
+      <Section title="LLM провайдери" icon={Bot}>
+        <div className="mb-4 flex items-start gap-2 bg-blue-50 rounded-lg p-3">
+          <Info className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
+          <p className="text-xs text-blue-700">Ліміти LLM провайдерів налаштовуються в зовнішніх консолях (AWS Bedrock Service Quotas, OpenAI Dashboard). Тут показано поточне використання за 24 години.</p>
+        </div>
+        {data.llmLimits.map(ll => (
+          <LimitRow
+            key={ll.id}
+            name={ll.name}
+            max={ll.max}
+            current={ll.current}
+            unit={ll.unit}
+            description={ll.description}
+            severity={ll.severity}
+          />
+        ))}
+      </Section>
+
+      {/* Chat Budget Limits */}
+      <Section title="Бюджети чату" icon={Zap}>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-claude-subtext border-b border-claude-border/50">
+                <th className="pb-2 font-medium">Бюджет</th>
+                <th className="pb-2 font-medium text-right">Токени</th>
+                <th className="pb-2 font-medium text-right">Tool Calls</th>
+                <th className="pb-2 font-medium text-right">Контекст</th>
+                <th className="pb-2 font-medium text-right">Результат</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.chatLimits.map(cl => (
+                <tr key={cl.id} className="border-b border-claude-border/20 last:border-0">
+                  <td className="py-3">
+                    <div className="font-medium text-claude-text">{cl.name}</div>
+                    <div className="text-xs text-claude-subtext mt-0.5">{cl.description}</div>
+                  </td>
+                  <td className="py-3 text-right font-mono">{formatNumber(cl.maxTokens)}</td>
+                  <td className="py-3 text-right font-mono">{cl.maxToolCalls}</td>
+                  <td className="py-3 text-right font-mono">{formatNumber(cl.maxContextChars)}</td>
+                  <td className="py-3 text-right font-mono">{formatNumber(cl.maxResultChars)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Section>
+
+      {/* Upload Limits */}
+      <Section title="Завантаження файлів" icon={Upload}>
+        {data.uploadLimits.map(ul => (
+          <LimitRow
+            key={ul.id}
+            name={ul.name}
+            max={ul.max}
+            maxFormatted={ul.maxFormatted}
+            current={ul.current}
+            unit={ul.unit}
+            window={ul.window}
+            description={ul.description}
+          />
+        ))}
+      </Section>
+
+      {/* Archive Limits */}
+      <Section title="Захист від zip-bomb" icon={Archive}>
+        {data.archiveLimits.map(al => (
+          <LimitRow
+            key={al.id}
+            name={al.name}
+            max={al.max}
+            maxFormatted={al.maxFormatted}
+            unit={al.unit}
+            description={al.description}
+          />
+        ))}
+      </Section>
+
+      {/* Billing Limits */}
+      <Section title="Біллінг" icon={CreditCard}>
+        {data.billingLimits.map(bl => (
+          <LimitRow
+            key={bl.id}
+            name={bl.name}
+            description={bl.description}
+            severity={bl.severity}
+          />
+        ))}
+      </Section>
+
+      {/* Scraping Limits */}
+      <Section title="Скрейпінг" icon={Globe}>
+        {data.scrapingLimits.map(sl => (
+          <LimitRow
+            key={sl.id}
+            name={sl.name}
+            max={sl.max}
+            unit={sl.unit}
+            window={sl.window}
+            description={sl.description}
+          />
+        ))}
+      </Section>
+
+      {/* Escrow Info */}
+      <Section title="Escrow (платежі)" icon={CreditCard}>
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          <div className="bg-gray-50 rounded-lg p-4 text-center">
+            <div className="text-2xl font-semibold text-claude-text">{data.escrow.paymentsInEscrow}</div>
+            <div className="text-xs text-claude-subtext mt-1">платежів в escrow</div>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-4 text-center">
+            <div className="text-2xl font-semibold text-claude-text">{data.escrow.totalEscrowUah} грн</div>
+            <div className="text-xs text-claude-subtext mt-1">загальна сума</div>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-4 text-center">
+            <div className="text-2xl font-semibold text-claude-text">{data.escrow.autoReleaseDays} днів</div>
+            <div className="text-xs text-claude-subtext mt-1">авто-реліз після completed</div>
+          </div>
+        </div>
+        <p className="text-xs text-claude-subtext">{data.escrow.description}</p>
+      </Section>
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -150,6 +150,7 @@ const AdminUserActivityPage = lazyWithRetry(() => import('../pages/AdminUserActi
 const AdminBulkScrapePage = lazyWithRetry(() => import('../pages/AdminBulkScrapePage').then(m => ({ default: m.AdminBulkScrapePage })));
 const AdminOpenDataCatalogPage = lazyWithRetry(() => import('../pages/AdminOpenDataCatalogPage').then(m => ({ default: m.AdminOpenDataCatalogPage })));
 const AdminPGMonitoringPage = lazyWithRetry(() => import('../pages/AdminPGMonitoringPage').then(m => ({ default: m.AdminPGMonitoringPage })));
+const AdminLimitsPage = lazyWithRetry(() => import('../pages/AdminLimitsPage').then(m => ({ default: m.AdminLimitsPage })));
 
 export const router = createBrowserRouter([
   {
@@ -511,6 +512,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ADMIN_PG_MONITORING,
             element: S(AdminPGMonitoringPage),
+          },
+          {
+            path: ROUTES.ADMIN_LIMITS,
+            element: S(AdminLimitsPage),
           },
         ],
       },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -128,6 +128,7 @@ export const ROUTES = {
   ADMIN_BULK_SCRAPE: '/admin/bulk-scrape',
   ADMIN_OPEN_DATA_CATALOG: '/admin/open-data-catalog',
   ADMIN_PG_MONITORING: '/admin/pg-monitoring',
+  ADMIN_LIMITS: '/admin/limits',
 } as const;
 
 // Helper function to generate dynamic routes

--- a/lexwebapp/src/utils/api/admin.ts
+++ b/lexwebapp/src/utils/api/admin.ts
@@ -185,4 +185,8 @@ export const adminApi = {
   // PG Monitoring — EDRSR stats
   getPGMonitoring: () =>
     apiClient.get('/api/admin/pg-monitoring'),
+
+  // System limits
+  getLimits: () =>
+    apiClient.get('/api/admin/limits'),
 };

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -26,6 +26,7 @@ import {
   createAdminDataSourcesRoutes,
   createAdminScrapingRoutes,
   createAdminImportRoutes,
+  createAdminLimitsRoutes,
 } from './admin/index.js';
 
 export function createAdminRoutes(
@@ -55,6 +56,7 @@ export function createAdminRoutes(
   router.use(createAdminDataSourcesRoutes(db));
   router.use(createAdminScrapingRoutes(db));
   router.use(createAdminImportRoutes(db));
+  router.use(createAdminLimitsRoutes(db));
 
   return router;
 }

--- a/mcp_backend/src/routes/admin/admin-limits.ts
+++ b/mcp_backend/src/routes/admin/admin-limits.ts
@@ -1,0 +1,311 @@
+/**
+ * Admin Limits Routes — real-time view of all system limits and current usage.
+ */
+
+import express from 'express';
+import type { IDatabase } from '../../domain/ports/index.js';
+import { logger } from '../../utils/logger.js';
+
+export function createAdminLimitsRoutes(db: IDatabase): express.Router {
+  const router = express.Router();
+
+  router.get('/limits', async (_req, res) => {
+    try {
+      // Fetch current usage data in parallel
+      const [
+        activeUploads,
+        todayTokens,
+        pendingPayments,
+        activeUsers24h,
+      ] = await Promise.all([
+        db.query(`SELECT COUNT(*) as count FROM upload_sessions WHERE status = 'active'`).catch(() => ({ rows: [{ count: 0 }] })),
+        db.query(`
+          SELECT
+            COALESCE(SUM(prompt_tokens + completion_tokens), 0) as total_tokens,
+            COALESCE(SUM(CASE WHEN provider = 'bedrock' THEN prompt_tokens + completion_tokens ELSE 0 END), 0) as bedrock_tokens,
+            COALESCE(SUM(CASE WHEN provider = 'openai' THEN prompt_tokens + completion_tokens ELSE 0 END), 0) as openai_tokens,
+            COUNT(*) as total_requests
+          FROM cost_tracking
+          WHERE created_at >= NOW() - INTERVAL '24 hours'
+        `).catch(() => ({ rows: [{ total_tokens: 0, bedrock_tokens: 0, openai_tokens: 0, total_requests: 0 }] })),
+        db.query(`SELECT COUNT(*) as count, COALESCE(SUM(amount_uah), 0) as total_uah FROM consultation_payments WHERE status = 'held'`).catch(() => ({ rows: [{ count: 0, total_uah: 0 }] })),
+        db.query(`SELECT COUNT(DISTINCT user_id) as count FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '24 hours'`).catch(() => ({ rows: [{ count: 0 }] })),
+      ]);
+
+      const usage = {
+        activeUploadSessions: parseInt(activeUploads.rows[0]?.count || '0'),
+        todayTotalTokens: parseInt(todayTokens.rows[0]?.total_tokens || '0'),
+        todayBedrockTokens: parseInt(todayTokens.rows[0]?.bedrock_tokens || '0'),
+        todayOpenaiTokens: parseInt(todayTokens.rows[0]?.openai_tokens || '0'),
+        todayTotalRequests: parseInt(todayTokens.rows[0]?.total_requests || '0'),
+        escrowPayments: parseInt(pendingPayments.rows[0]?.count || '0'),
+        escrowTotalUah: parseFloat(pendingPayments.rows[0]?.total_uah || '0'),
+        activeUsers24h: parseInt(activeUsers24h.rows[0]?.count || '0'),
+      };
+
+      const limits = {
+        rateLimits: [
+          {
+            id: 'chat',
+            name: 'Чат (на користувача)',
+            max: 60,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'userId',
+            description: 'Максимум запитів до чату на одного авторизованого користувача. Прив\'язано до userId (не IP) через Cloudflare.',
+            severity: 'high',
+          },
+          {
+            id: 'global-api',
+            name: 'Глобальний API',
+            max: 1500,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'IP',
+            description: 'Загальний ліміт на всі /api/ маршрути з одного IP. Підвищено до 1500 для 20+ користувачів за Cloudflare (спільний IP).',
+            severity: 'medium',
+          },
+          {
+            id: 'consultation',
+            name: 'Консультації (на користувача)',
+            max: 300,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'userId',
+            description: 'Ліміт запитів до API консультацій. Високий через polling + SSE reconnects у кількох вкладках.',
+            severity: 'low',
+          },
+          {
+            id: 'auth',
+            name: 'Автентифікація',
+            max: 10,
+            window: '15 хвилин',
+            windowMs: 900000,
+            keyBy: 'IP',
+            description: 'Захист від brute-force атак на логін. 10 спроб на 15 хвилин з одного IP.',
+            severity: 'high',
+          },
+          {
+            id: 'password-reset',
+            name: 'Скидання паролю',
+            max: 3,
+            window: '1 година',
+            windowMs: 3600000,
+            keyBy: 'IP',
+            description: 'Суворий ліміт для захисту від зловживань скиданням паролю.',
+            severity: 'high',
+          },
+          {
+            id: 'webhook',
+            name: 'Вебхуки (Monobank)',
+            max: 10,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'IP',
+            description: 'Ліміт вхідних вебхуків від платіжних систем.',
+            severity: 'medium',
+          },
+          {
+            id: 'upload-init',
+            name: 'Ініціалізація завантаження',
+            max: 500,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'userId',
+            description: 'Максимум створень нових сесій завантаження на користувача.',
+            severity: 'low',
+          },
+          {
+            id: 'upload-chunk',
+            name: 'Завантаження чанків',
+            max: 1500,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'userId',
+            description: 'Максимум завантажень чанків файлів на користувача.',
+            severity: 'low',
+          },
+          {
+            id: 'express-global',
+            name: 'Express глобальний',
+            max: 900,
+            window: '1 хвилина',
+            windowMs: 60000,
+            keyBy: 'IP',
+            description: 'Базовий express-rate-limit для всіх маршрутів (крім /upload).',
+            severity: 'medium',
+          },
+        ],
+        llmLimits: [
+          {
+            id: 'bedrock-daily-tokens',
+            name: 'AWS Bedrock (денний ліміт токенів)',
+            max: null,
+            current: usage.todayBedrockTokens,
+            unit: 'токени',
+            description: 'Денний ліміт токенів встановлюється AWS для кожної моделі/регіону. Помилка "Too many tokens per day" означає вичерпання квоти. Ліміт налаштовується в AWS Console → Bedrock → Service Quotas.',
+            severity: 'critical',
+            status: usage.todayBedrockTokens > 500000 ? 'warning' : 'ok',
+          },
+          {
+            id: 'openai-rpm',
+            name: 'OpenAI (RPM)',
+            max: null,
+            current: null,
+            unit: 'запити/хв',
+            description: 'Rate limit OpenAI API. Залежить від тарифного плану акаунту. Клієнт автоматично робить 3 retry з exponential backoff при 429.',
+            severity: 'high',
+          },
+          {
+            id: 'anthropic-rpm',
+            name: 'Anthropic API (RPM)',
+            max: null,
+            current: null,
+            unit: 'запити/хв',
+            description: 'Rate limit Anthropic API. Клієнт автоматично робить 3 retry з backoff. Має ротацію ключів (primary + secondary).',
+            severity: 'high',
+          },
+        ],
+        chatLimits: [
+          {
+            id: 'chat-quick',
+            name: 'Чат: Quick бюджет',
+            maxTokens: 4096,
+            maxToolCalls: 5,
+            maxContextChars: 48000,
+            maxResultChars: 6000,
+            description: 'Швидкі відповіді. Мінімальне використання інструментів, короткий контекст.',
+          },
+          {
+            id: 'chat-standard',
+            name: 'Чат: Standard бюджет',
+            maxTokens: 8192,
+            maxToolCalls: 7,
+            maxContextChars: 64000,
+            maxResultChars: 8000,
+            description: 'Стандартний режим. Збалансоване використання інструментів та контексту.',
+          },
+          {
+            id: 'chat-deep',
+            name: 'Чат: Deep бюджет',
+            maxTokens: 16384,
+            maxToolCalls: 20,
+            maxContextChars: 100000,
+            maxResultChars: 40000,
+            description: 'Глибокий аналіз. Максимальне використання інструментів, великий контекст. Найдорожчий режим.',
+          },
+        ],
+        uploadLimits: [
+          {
+            id: 'max-file-size',
+            name: 'Максимальний розмір файлу',
+            max: 2147483648,
+            maxFormatted: '2 GB',
+            current: null,
+            description: 'Максимальний розмір одного файлу для завантаження.',
+          },
+          {
+            id: 'chunk-size',
+            name: 'Розмір чанку',
+            max: 5242880,
+            maxFormatted: '5 MB',
+            description: 'Файли розбиваються на чанки по 5 MB для надійного завантаження.',
+          },
+          {
+            id: 'max-user-sessions',
+            name: 'Сесії завантаження (на користувача)',
+            max: 50,
+            current: usage.activeUploadSessions,
+            description: 'Максимум одночасних сесій завантаження для одного користувача. Конфігурується через MAX_USER_SESSIONS.',
+          },
+          {
+            id: 'upload-queue',
+            name: 'Черга обробки (BullMQ)',
+            max: 40,
+            window: '5 секунд',
+            description: 'Ліміт BullMQ: 40 jobs на 5 секунд. Адаптивна конкурентність від 5 до 100 воркерів.',
+          },
+          {
+            id: 'session-ttl',
+            name: 'TTL сесії завантаження',
+            max: 24,
+            unit: 'годин',
+            description: 'Сесія завантаження автоматично закривається через 24 години.',
+          },
+        ],
+        archiveLimits: [
+          {
+            id: 'max-archive-files',
+            name: 'Файлів в архіві',
+            max: 200,
+            description: 'Максимум файлів в одному ZIP/архіві. Захист від zip-bomb.',
+          },
+          {
+            id: 'max-decompressed-size',
+            name: 'Розмір розпакованого архіву',
+            max: 524288000,
+            maxFormatted: '500 MB',
+            description: 'Загальний максимальний розмір всіх файлів після розпаковки.',
+          },
+          {
+            id: 'max-compression-ratio',
+            name: 'Максимальне стиснення',
+            max: 100,
+            unit: ':1',
+            description: 'Захист від zip-bomb: якщо ratio > 100:1, архів відхиляється.',
+          },
+        ],
+        billingLimits: [
+          {
+            id: 'billing-daily',
+            name: 'Денний ліміт витрат (на користувача)',
+            description: 'Адміністратор може встановити daily_limit_usd для кожного користувача. За замовчуванням залежить від тарифного плану.',
+            severity: 'high',
+          },
+          {
+            id: 'billing-monthly',
+            name: 'Місячний ліміт витрат (на користувача)',
+            description: 'Адміністратор може встановити monthly_limit_usd. Attorney tier: $50/день, $500/місяць. Enterprise: без лімітів.',
+            severity: 'high',
+          },
+        ],
+        scrapingLimits: [
+          {
+            id: 'scrape-concurrent',
+            name: 'Одночасні скрейпінги',
+            max: 10,
+            description: 'Максимум паралельних задач скрейпінгу. Конфігурується через SCRAPE_MAX_CONCURRENT.',
+          },
+          {
+            id: 'scrape-queue',
+            name: 'Черга скрейпінгу',
+            max: 200,
+            description: 'Максимальна глибина черги задач скрейпінгу.',
+          },
+          {
+            id: 'scrape-interval',
+            name: 'Інтервал між запитами',
+            min: 500,
+            max: 2000,
+            unit: 'мс',
+            description: 'Випадкова затримка між запитами скрейпера для уникнення блокувань.',
+          },
+        ],
+        escrow: {
+          paymentsInEscrow: usage.escrowPayments,
+          totalEscrowUah: usage.escrowTotalUah,
+          autoReleaseDays: 7,
+          description: 'Платежі утримуються в escrow до завершення консультації. Автоматичний реліз через 7 днів після completed.',
+        },
+        currentUsage: usage,
+      };
+
+      res.json(limits);
+    } catch (err) {
+      logger.error('[AdminLimits] Error fetching limits', { error: (err as Error).message });
+      res.status(500).json({ error: 'Failed to fetch limits data' });
+    }
+  });
+
+  return router;
+}

--- a/mcp_backend/src/routes/admin/index.ts
+++ b/mcp_backend/src/routes/admin/index.ts
@@ -7,4 +7,5 @@ export { createAdminMetricsRoutes } from './admin-metrics.js';
 export { createAdminDataSourcesRoutes } from './admin-data-sources.js';
 export { createAdminScrapingRoutes } from './admin-scraping.js';
 export { createAdminImportRoutes } from './admin-import.js';
+export { createAdminLimitsRoutes } from './admin-limits.js';
 export { createRequireAdmin, createLogAdminAction } from './admin-middleware.js';


### PR DESCRIPTION
## Summary
- New admin page **Ліміти системи** (`/admin/limits`) with real-time monitoring of all system limits
- Backend endpoint `GET /api/admin/limits` returns all limits config + current usage from DB
- KPI cards: tokens/24h, requests/24h, escrow balance, active uploads
- Sections: Rate limits, LLM providers, Chat budgets, Upload/Archive limits, Billing, Scraping, Escrow
- Each limit has severity badge, description in Ukrainian, and usage bar where applicable
- Auto-refreshes every 30 seconds

## Test plan
- [ ] Open `/admin/limits` — verify page loads with all sections
- [ ] Check KPI cards show real data from DB
- [ ] Verify auto-refresh updates values
- [ ] Confirm sidebar shows "Ліміти системи" under monitoring section

🤖 Generated with [Claude Code](https://claude.com/claude-code)