### PR TITLE
fix(admin): limits dashboard scroll, visualizations & missing limits

### DIFF
--- a/lexwebapp/src/pages/AdminLimitsPage.tsx
+++ b/lexwebapp/src/pages/AdminLimitsPage.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, AlertTriangle, Shield, Zap, Upload, Archive, CreditCard, Bot, Globe, Info } from 'lucide-react';
+import {
+  RefreshCw, AlertTriangle, Shield, Zap, Upload, Archive, CreditCard,
+  Bot, Globe, Info, Users, Database, Clock, Terminal, FileText, Layers,
+} from 'lucide-react';
 import { adminApi } from '../utils/api/admin';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface RateLimit {
   id: string;
@@ -62,6 +69,10 @@ interface LimitsData {
   archiveLimits: GenericLimit[];
   billingLimits: GenericLimit[];
   scrapingLimits: GenericLimit[];
+  connectionLimits: GenericLimit[];
+  cacheTtls: GenericLimit[];
+  concurrencyLimits: GenericLimit[];
+  processingLimits: GenericLimit[];
   escrow: EscrowInfo;
   currentUsage: {
     activeUploadSessions: number;
@@ -72,8 +83,15 @@ interface LimitsData {
     escrowPayments: number;
     escrowTotalUah: number;
     activeUsers24h: number;
+    concurrentUsersNow: number;
+    pgActiveConnections: number;
+    pgMaxConnections: number;
   };
 }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function formatNumber(n: number): string {
   return n.toLocaleString('uk-UA');
@@ -93,17 +111,61 @@ function SeverityBadge({ severity }: { severity: string }) {
   );
 }
 
-function KpiCard({ icon: Icon, label, value, sub, color = 'text-claude-text' }: {
+// ---------------------------------------------------------------------------
+// Gauge component — circular progress
+// ---------------------------------------------------------------------------
+
+function GaugeCircle({ value, max, label, sub, color = '#3b82f6' }: {
+  value: number;
+  max: number;
+  label: string;
+  sub?: string;
+  color?: string;
+}) {
+  const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
+  const r = 36;
+  const c = 2 * Math.PI * r;
+  const offset = c - (pct / 100) * c;
+  const gaugeColor = pct > 80 ? '#ef4444' : pct > 50 ? '#eab308' : color;
+
+  return (
+    <div className="flex flex-col items-center">
+      <div className="relative w-24 h-24">
+        <svg className="w-24 h-24 -rotate-90" viewBox="0 0 80 80">
+          <circle cx="40" cy="40" r={r} fill="none" stroke="#f3f4f6" strokeWidth="6" />
+          <circle cx="40" cy="40" r={r} fill="none" stroke={gaugeColor} strokeWidth="6"
+            strokeDasharray={c} strokeDashoffset={offset} strokeLinecap="round"
+            className="transition-all duration-700" />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-lg font-bold text-claude-text">{Math.round(pct)}%</span>
+        </div>
+      </div>
+      <div className="mt-2 text-center">
+        <div className="text-sm font-medium text-claude-text">{label}</div>
+        <div className="text-xs text-claude-subtext">{formatNumber(value)} / {formatNumber(max)}</div>
+        {sub && <div className="text-xs text-claude-subtext">{sub}</div>}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// KPI card
+// ---------------------------------------------------------------------------
+
+function KpiCard({ icon: Icon, label, value, sub, color = 'text-claude-text', pulse }: {
   icon: React.ElementType;
   label: string;
   value: string;
   sub?: string;
   color?: string;
+  pulse?: boolean;
 }) {
   return (
     <div className="bg-white rounded-xl border border-claude-border shadow-sm p-5">
       <div className="flex items-center gap-3 mb-2">
-        <Icon className="w-5 h-5 text-claude-subtext" />
+        <Icon className={`w-5 h-5 text-claude-subtext ${pulse ? 'animate-pulse' : ''}`} />
         <span className="text-sm text-claude-subtext">{label}</span>
       </div>
       <div className={`text-2xl font-semibold ${color}`}>{value}</div>
@@ -112,17 +174,31 @@ function KpiCard({ icon: Icon, label, value, sub, color = 'text-claude-text' }: 
   );
 }
 
-function Section({ title, icon: Icon, children }: { title: string; icon: React.ElementType; children: React.ReactNode }) {
+// ---------------------------------------------------------------------------
+// Section wrapper
+// ---------------------------------------------------------------------------
+
+function Section({ title, icon: Icon, badge, children }: {
+  title: string;
+  icon: React.ElementType;
+  badge?: string;
+  children: React.ReactNode;
+}) {
   return (
     <div className="bg-white rounded-xl border border-claude-border shadow-sm overflow-hidden">
       <div className="px-6 py-4 border-b border-claude-border/50 flex items-center gap-2">
         <Icon className="w-5 h-5 text-claude-subtext" />
         <h2 className="text-lg font-semibold text-claude-text font-sans">{title}</h2>
+        {badge && <span className="ml-auto px-2 py-0.5 bg-claude-bg rounded-full text-xs text-claude-subtext">{badge}</span>}
       </div>
       <div className="p-6">{children}</div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Limit row with progress bar
+// ---------------------------------------------------------------------------
 
 function LimitRow({ name, max, current, window, unit, description, severity, maxFormatted }: {
   name: string;
@@ -150,7 +226,7 @@ function LimitRow({ name, max, current, window, unit, description, severity, max
           </div>
           <p className="text-xs text-claude-subtext leading-relaxed">{description}</p>
         </div>
-        <div className="text-right shrink-0 w-36">
+        <div className="text-right shrink-0 w-40">
           {max != null ? (
             <div className="text-sm font-mono text-claude-text">
               {current != null ? formatNumber(current) + ' / ' : ''}{maxFormatted || formatNumber(max)}{unit ? ' ' + unit : ''}
@@ -161,8 +237,8 @@ function LimitRow({ name, max, current, window, unit, description, severity, max
             <div className="text-xs text-claude-subtext italic">зовнішній ліміт</div>
           )}
           {pct != null && (
-            <div className="mt-1 w-full bg-gray-100 rounded-full h-1.5">
-              <div className={`h-1.5 rounded-full ${barColor}`} style={{ width: `${pct}%` }} />
+            <div className="mt-1.5 w-full bg-gray-100 rounded-full h-2">
+              <div className={`h-2 rounded-full transition-all duration-500 ${barColor}`} style={{ width: `${pct}%` }} />
             </div>
           )}
         </div>
@@ -170,6 +246,46 @@ function LimitRow({ name, max, current, window, unit, description, severity, max
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Rate limit bar chart visualization
+// ---------------------------------------------------------------------------
+
+function RateLimitBars({ limits }: { limits: RateLimit[] }) {
+  const maxVal = Math.max(...limits.map(l => l.max));
+  const severityColors: Record<string, string> = {
+    critical: '#ef4444',
+    high: '#f97316',
+    medium: '#eab308',
+    low: '#22c55e',
+  };
+  return (
+    <div className="mb-6 bg-gray-50 rounded-lg p-4">
+      <div className="text-xs text-claude-subtext mb-3 font-medium">Порівняння rate limits (запитів за вікно)</div>
+      <div className="space-y-2">
+        {limits.map(rl => {
+          const pct = (rl.max / maxVal) * 100;
+          return (
+            <div key={rl.id} className="flex items-center gap-3">
+              <div className="w-32 text-xs text-claude-subtext truncate text-right shrink-0">{rl.name}</div>
+              <div className="flex-1 bg-gray-200 rounded-full h-4 relative overflow-hidden">
+                <div
+                  className="h-4 rounded-full transition-all duration-700"
+                  style={{ width: `${pct}%`, backgroundColor: severityColors[rl.severity] || '#6b7280' }}
+                />
+              </div>
+              <div className="w-16 text-xs font-mono text-claude-text text-right">{formatNumber(rl.max)}</div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ===========================================================================
+// Main component
+// ===========================================================================
 
 export function AdminLimitsPage() {
   const [data, setData] = useState<LimitsData | null>(null);
@@ -207,12 +323,14 @@ export function AdminLimitsPage() {
 
   if (error && !data) {
     return (
-      <div className="max-w-3xl mx-auto p-8">
-        <div className="bg-red-50 border border-red-200 rounded-xl p-6 flex items-start gap-3">
-          <AlertTriangle className="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
-          <div>
-            <p className="text-sm font-medium text-red-800">{error}</p>
-            <button onClick={fetch_} className="text-sm text-red-600 underline mt-2">Спробувати знову</button>
+      <div className="flex-1 overflow-y-auto p-6">
+        <div className="max-w-3xl mx-auto">
+          <div className="bg-red-50 border border-red-200 rounded-xl p-6 flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-500 mt-0.5 shrink-0" />
+            <div>
+              <p className="text-sm font-medium text-red-800">{error}</p>
+              <button onClick={fetch_} className="text-sm text-red-600 underline mt-2">Спробувати знову</button>
+            </div>
           </div>
         </div>
       </div>
@@ -224,169 +342,250 @@ export function AdminLimitsPage() {
   const u = data.currentUsage;
 
   return (
-    <div className="max-w-6xl mx-auto p-6 space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold text-claude-text font-sans">Ліміти системи</h1>
-          <p className="text-sm text-claude-subtext mt-1">Реалтайм моніторинг лімітів та поточного використання</p>
+    <div className="flex-1 overflow-y-auto p-6">
+      <div className="max-w-6xl mx-auto space-y-6">
+
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-claude-text font-sans">Ліміти системи</h1>
+            <p className="text-sm text-claude-subtext mt-1">Реалтайм моніторинг лімітів та поточного використання</p>
+          </div>
+          <button
+            onClick={fetch_}
+            disabled={loading}
+            className="flex items-center gap-2 px-4 py-2 bg-claude-bg border border-claude-border rounded-lg text-sm text-claude-text hover:bg-gray-50 transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+            Оновити
+          </button>
         </div>
-        <button
-          onClick={fetch_}
-          disabled={loading}
-          className="flex items-center gap-2 px-4 py-2 bg-claude-bg border border-claude-border rounded-lg text-sm text-claude-text hover:bg-gray-50 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
-          Оновити
-        </button>
-      </div>
 
-      {/* KPI Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        <KpiCard icon={Zap} label="Токени за 24г" value={formatNumber(u.todayTotalTokens)} sub={`Bedrock: ${formatNumber(u.todayBedrockTokens)} | OpenAI: ${formatNumber(u.todayOpenaiTokens)}`} />
-        <KpiCard icon={Globe} label="Запити за 24г" value={formatNumber(u.todayTotalRequests)} sub={`Активних юзерів: ${u.activeUsers24h}`} />
-        <KpiCard icon={CreditCard} label="В escrow" value={`${data.escrow.totalEscrowUah} грн`} sub={`${data.escrow.paymentsInEscrow} платежів`} color={data.escrow.paymentsInEscrow > 0 ? 'text-orange-600' : 'text-claude-text'} />
-        <KpiCard icon={Upload} label="Активні завантаження" value={String(u.activeUploadSessions)} sub="сесій" />
-      </div>
-
-      {/* Rate Limits */}
-      <Section title="Rate Limits (запити)" icon={Shield}>
-        {data.rateLimits.map(rl => (
-          <LimitRow
-            key={rl.id}
-            name={rl.name}
-            max={rl.max}
-            window={rl.window}
-            description={rl.description}
-            severity={rl.severity}
-          />
-        ))}
-      </Section>
-
-      {/* LLM Provider Limits */}
-      <Section title="LLM провайдери" icon={Bot}>
-        <div className="mb-4 flex items-start gap-2 bg-blue-50 rounded-lg p-3">
-          <Info className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
-          <p className="text-xs text-blue-700">Ліміти LLM провайдерів налаштовуються в зовнішніх консолях (AWS Bedrock Service Quotas, OpenAI Dashboard). Тут показано поточне використання за 24 години.</p>
+        {/* KPI Cards — top row */}
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+          <KpiCard icon={Users} label="Онлайн зараз" value={String(u.concurrentUsersNow)} sub="користувачів за 5 хв" pulse={u.concurrentUsersNow > 0} color={u.concurrentUsersNow > 10 ? 'text-orange-600' : 'text-claude-text'} />
+          <KpiCard icon={Users} label="Активні за 24г" value={String(u.activeUsers24h)} sub="унікальних юзерів" />
+          <KpiCard icon={Zap} label="Токени за 24г" value={formatNumber(u.todayTotalTokens)} sub={`Bedrock: ${formatNumber(u.todayBedrockTokens)} | OpenAI: ${formatNumber(u.todayOpenaiTokens)}`} />
+          <KpiCard icon={Globe} label="Запити за 24г" value={formatNumber(u.todayTotalRequests)} />
+          <KpiCard icon={CreditCard} label="В escrow" value={`${data.escrow.totalEscrowUah} грн`} sub={`${data.escrow.paymentsInEscrow} платежів`} color={data.escrow.paymentsInEscrow > 0 ? 'text-orange-600' : 'text-claude-text'} />
         </div>
-        {data.llmLimits.map(ll => (
-          <LimitRow
-            key={ll.id}
-            name={ll.name}
-            max={ll.max}
-            current={ll.current}
-            unit={ll.unit}
-            description={ll.description}
-            severity={ll.severity}
-          />
-        ))}
-      </Section>
 
-      {/* Chat Budget Limits */}
-      <Section title="Бюджети чату" icon={Zap}>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="text-left text-claude-subtext border-b border-claude-border/50">
-                <th className="pb-2 font-medium">Бюджет</th>
-                <th className="pb-2 font-medium text-right">Токени</th>
-                <th className="pb-2 font-medium text-right">Tool Calls</th>
-                <th className="pb-2 font-medium text-right">Контекст</th>
-                <th className="pb-2 font-medium text-right">Результат</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.chatLimits.map(cl => (
-                <tr key={cl.id} className="border-b border-claude-border/20 last:border-0">
-                  <td className="py-3">
-                    <div className="font-medium text-claude-text">{cl.name}</div>
-                    <div className="text-xs text-claude-subtext mt-0.5">{cl.description}</div>
-                  </td>
-                  <td className="py-3 text-right font-mono">{formatNumber(cl.maxTokens)}</td>
-                  <td className="py-3 text-right font-mono">{cl.maxToolCalls}</td>
-                  <td className="py-3 text-right font-mono">{formatNumber(cl.maxContextChars)}</td>
-                  <td className="py-3 text-right font-mono">{formatNumber(cl.maxResultChars)}</td>
+        {/* Gauges row — key resource utilization */}
+        {(u.pgMaxConnections > 0 || u.activeUploadSessions > 0) && (
+          <div className="bg-white rounded-xl border border-claude-border shadow-sm p-6">
+            <h2 className="text-sm font-medium text-claude-subtext mb-4">Використання ресурсів</h2>
+            <div className="flex items-start justify-around flex-wrap gap-6">
+              <GaugeCircle value={u.pgActiveConnections} max={u.pgMaxConnections} label="PostgreSQL" sub="з'єднання" />
+              <GaugeCircle value={u.activeUploadSessions} max={50} label="Upload сесії" sub="на користувача макс 50" color="#8b5cf6" />
+              <GaugeCircle value={u.concurrentUsersNow} max={100} label="Користувачі онлайн" sub="за останні 5 хв" color="#06b6d4" />
+              <GaugeCircle value={u.todayTotalRequests} max={50000} label="Запити / 24г" sub="відносно ~50К норми" color="#f59e0b" />
+            </div>
+          </div>
+        )}
+
+        {/* Rate Limits */}
+        <Section title="Rate Limits (запити)" icon={Shield} badge={`${data.rateLimits.length} лімітів`}>
+          <RateLimitBars limits={data.rateLimits} />
+          {data.rateLimits.map(rl => (
+            <LimitRow
+              key={rl.id}
+              name={rl.name}
+              max={rl.max}
+              window={rl.window}
+              description={rl.description}
+              severity={rl.severity}
+            />
+          ))}
+        </Section>
+
+        {/* LLM Provider Limits */}
+        <Section title="LLM провайдери" icon={Bot}>
+          <div className="mb-4 flex items-start gap-2 bg-blue-50 rounded-lg p-3">
+            <Info className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
+            <p className="text-xs text-blue-700">Ліміти LLM провайдерів налаштовуються в зовнішніх консолях (AWS Bedrock Service Quotas, OpenAI Dashboard). Тут показано поточне використання за 24 години.</p>
+          </div>
+          {data.llmLimits.map(ll => (
+            <LimitRow
+              key={ll.id}
+              name={ll.name}
+              max={ll.max}
+              current={ll.current}
+              unit={ll.unit}
+              description={ll.description}
+              severity={ll.severity}
+            />
+          ))}
+        </Section>
+
+        {/* Chat Budget Limits */}
+        <Section title="Бюджети чату" icon={Zap}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-claude-subtext border-b border-claude-border/50">
+                  <th className="pb-2 font-medium">Бюджет</th>
+                  <th className="pb-2 font-medium text-right">Токени</th>
+                  <th className="pb-2 font-medium text-right">Tool Calls</th>
+                  <th className="pb-2 font-medium text-right">Контекст</th>
+                  <th className="pb-2 font-medium text-right">Результат</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </Section>
-
-      {/* Upload Limits */}
-      <Section title="Завантаження файлів" icon={Upload}>
-        {data.uploadLimits.map(ul => (
-          <LimitRow
-            key={ul.id}
-            name={ul.name}
-            max={ul.max}
-            maxFormatted={ul.maxFormatted}
-            current={ul.current}
-            unit={ul.unit}
-            window={ul.window}
-            description={ul.description}
-          />
-        ))}
-      </Section>
-
-      {/* Archive Limits */}
-      <Section title="Захист від zip-bomb" icon={Archive}>
-        {data.archiveLimits.map(al => (
-          <LimitRow
-            key={al.id}
-            name={al.name}
-            max={al.max}
-            maxFormatted={al.maxFormatted}
-            unit={al.unit}
-            description={al.description}
-          />
-        ))}
-      </Section>
-
-      {/* Billing Limits */}
-      <Section title="Біллінг" icon={CreditCard}>
-        {data.billingLimits.map(bl => (
-          <LimitRow
-            key={bl.id}
-            name={bl.name}
-            description={bl.description}
-            severity={bl.severity}
-          />
-        ))}
-      </Section>
-
-      {/* Scraping Limits */}
-      <Section title="Скрейпінг" icon={Globe}>
-        {data.scrapingLimits.map(sl => (
-          <LimitRow
-            key={sl.id}
-            name={sl.name}
-            max={sl.max}
-            unit={sl.unit}
-            window={sl.window}
-            description={sl.description}
-          />
-        ))}
-      </Section>
-
-      {/* Escrow Info */}
-      <Section title="Escrow (платежі)" icon={CreditCard}>
-        <div className="grid grid-cols-3 gap-4 mb-4">
-          <div className="bg-gray-50 rounded-lg p-4 text-center">
-            <div className="text-2xl font-semibold text-claude-text">{data.escrow.paymentsInEscrow}</div>
-            <div className="text-xs text-claude-subtext mt-1">платежів в escrow</div>
+              </thead>
+              <tbody>
+                {data.chatLimits.map(cl => (
+                  <tr key={cl.id} className="border-b border-claude-border/20 last:border-0">
+                    <td className="py-3">
+                      <div className="font-medium text-claude-text">{cl.name}</div>
+                      <div className="text-xs text-claude-subtext mt-0.5">{cl.description}</div>
+                    </td>
+                    <td className="py-3 text-right font-mono">{formatNumber(cl.maxTokens)}</td>
+                    <td className="py-3 text-right font-mono">{cl.maxToolCalls}</td>
+                    <td className="py-3 text-right font-mono">{formatNumber(cl.maxContextChars)}</td>
+                    <td className="py-3 text-right font-mono">{formatNumber(cl.maxResultChars)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-          <div className="bg-gray-50 rounded-lg p-4 text-center">
-            <div className="text-2xl font-semibold text-claude-text">{data.escrow.totalEscrowUah} грн</div>
-            <div className="text-xs text-claude-subtext mt-1">загальна сума</div>
+        </Section>
+
+        {/* Connection & DB Limits */}
+        <Section title="З'єднання та БД" icon={Database}>
+          {data.connectionLimits.map(cl => (
+            <LimitRow
+              key={cl.id}
+              name={cl.name}
+              max={cl.max}
+              current={cl.current}
+              unit={cl.unit}
+              description={cl.description}
+              severity={cl.severity}
+            />
+          ))}
+        </Section>
+
+        {/* Concurrency Limits */}
+        <Section title="Конкурентність обробки" icon={Layers}>
+          {data.concurrencyLimits.map(cl => (
+            <LimitRow
+              key={cl.id}
+              name={cl.name}
+              max={cl.max}
+              current={cl.current}
+              unit={cl.unit}
+              description={cl.description}
+            />
+          ))}
+        </Section>
+
+        {/* Processing Limits */}
+        <Section title="Обробка документів" icon={FileText}>
+          {data.processingLimits.map(pl => (
+            <LimitRow
+              key={pl.id}
+              name={pl.name}
+              max={pl.max}
+              maxFormatted={pl.maxFormatted}
+              unit={pl.unit}
+              description={pl.description}
+            />
+          ))}
+        </Section>
+
+        {/* Upload Limits */}
+        <Section title="Завантаження файлів" icon={Upload}>
+          {data.uploadLimits.map(ul => (
+            <LimitRow
+              key={ul.id}
+              name={ul.name}
+              max={ul.max}
+              maxFormatted={ul.maxFormatted}
+              current={ul.current}
+              unit={ul.unit}
+              window={ul.window}
+              description={ul.description}
+            />
+          ))}
+        </Section>
+
+        {/* Archive Limits */}
+        <Section title="Захист від zip-bomb" icon={Archive}>
+          {data.archiveLimits.map(al => (
+            <LimitRow
+              key={al.id}
+              name={al.name}
+              max={al.max}
+              maxFormatted={al.maxFormatted}
+              unit={al.unit}
+              description={al.description}
+            />
+          ))}
+        </Section>
+
+        {/* Cache TTLs */}
+        <Section title="Кеш (TTL)" icon={Clock}>
+          {data.cacheTtls.map(ct => (
+            <LimitRow
+              key={ct.id}
+              name={ct.name}
+              max={ct.max}
+              unit={ct.unit}
+              description={ct.description}
+            />
+          ))}
+        </Section>
+
+        {/* Billing Limits */}
+        <Section title="Біллінг" icon={CreditCard}>
+          {data.billingLimits.map(bl => (
+            <LimitRow
+              key={bl.id}
+              name={bl.name}
+              description={bl.description}
+              severity={bl.severity}
+            />
+          ))}
+        </Section>
+
+        {/* Scraping Limits */}
+        <Section title="Скрейпінг" icon={Globe}>
+          {data.scrapingLimits.map(sl => (
+            <LimitRow
+              key={sl.id}
+              name={sl.name}
+              max={sl.max}
+              unit={sl.unit}
+              window={sl.window}
+              description={sl.description}
+            />
+          ))}
+        </Section>
+
+        {/* Escrow Info */}
+        <Section title="Escrow (платежі)" icon={CreditCard}>
+          <div className="grid grid-cols-3 gap-4 mb-4">
+            <div className="bg-gray-50 rounded-lg p-4 text-center">
+              <div className="text-2xl font-semibold text-claude-text">{data.escrow.paymentsInEscrow}</div>
+              <div className="text-xs text-claude-subtext mt-1">платежів в escrow</div>
+            </div>
+            <div className="bg-gray-50 rounded-lg p-4 text-center">
+              <div className="text-2xl font-semibold text-claude-text">{data.escrow.totalEscrowUah} грн</div>
+              <div className="text-xs text-claude-subtext mt-1">загальна сума</div>
+            </div>
+            <div className="bg-gray-50 rounded-lg p-4 text-center">
+              <div className="text-2xl font-semibold text-claude-text">{data.escrow.autoReleaseDays} днів</div>
+              <div className="text-xs text-claude-subtext mt-1">авто-реліз після completed</div>
+            </div>
           </div>
-          <div className="bg-gray-50 rounded-lg p-4 text-center">
-            <div className="text-2xl font-semibold text-claude-text">{data.escrow.autoReleaseDays} днів</div>
-            <div className="text-xs text-claude-subtext mt-1">авто-реліз після completed</div>
-          </div>
-        </div>
-        <p className="text-xs text-claude-subtext">{data.escrow.description}</p>
-      </Section>
+          <p className="text-xs text-claude-subtext">{data.escrow.description}</p>
+        </Section>
+
+        {/* Terminal Limits */}
+        <Section title="Термінал" icon={Terminal}>
+          <LimitRow name="Сесії на адміна" max={2} description="Максимум 2 одночасні термінальні сесії для одного адміністратора." />
+          <LimitRow name="Розмір введення" max={4096} unit="символів" description="Максимальна довжина одного PTY-повідомлення." />
+        </Section>
+
+      </div>
     </div>
   );
 }

--- a/mcp_backend/src/routes/admin/admin-limits.ts
+++ b/mcp_backend/src/routes/admin/admin-limits.ts
@@ -17,6 +17,8 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
         todayTokens,
         pendingPayments,
         activeUsers24h,
+        concurrentUsersNow,
+        pgConnections,
       ] = await Promise.all([
         db.query(`SELECT COUNT(*) as count FROM upload_sessions WHERE status = 'active'`).catch(() => ({ rows: [{ count: 0 }] })),
         db.query(`
@@ -30,6 +32,13 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
         `).catch(() => ({ rows: [{ total_tokens: 0, bedrock_tokens: 0, openai_tokens: 0, total_requests: 0 }] })),
         db.query(`SELECT COUNT(*) as count, COALESCE(SUM(amount_uah), 0) as total_uah FROM consultation_payments WHERE status = 'held'`).catch(() => ({ rows: [{ count: 0, total_uah: 0 }] })),
         db.query(`SELECT COUNT(DISTINCT user_id) as count FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '24 hours'`).catch(() => ({ rows: [{ count: 0 }] })),
+        // Concurrent users — distinct users who made requests in the last 5 minutes
+        db.query(`SELECT COUNT(DISTINCT user_id) as count FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '5 minutes'`).catch(() => ({ rows: [{ count: 0 }] })),
+        // PostgreSQL active connections
+        db.query(`SELECT
+          (SELECT count(*) FROM pg_stat_activity WHERE state = 'active') as active,
+          (SELECT setting::int FROM pg_settings WHERE name = 'max_connections') as max
+        `).catch(() => ({ rows: [{ active: 0, max: 100 }] })),
       ]);
 
       const usage = {
@@ -41,6 +50,9 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
         escrowPayments: parseInt(pendingPayments.rows[0]?.count || '0'),
         escrowTotalUah: parseFloat(pendingPayments.rows[0]?.total_uah || '0'),
         activeUsers24h: parseInt(activeUsers24h.rows[0]?.count || '0'),
+        concurrentUsersNow: parseInt(concurrentUsersNow.rows[0]?.count || '0'),
+        pgActiveConnections: parseInt(pgConnections.rows[0]?.active || '0'),
+        pgMaxConnections: parseInt(pgConnections.rows[0]?.max || '100'),
       };
 
       const limits = {
@@ -165,6 +177,15 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
             description: 'Rate limit Anthropic API. Клієнт автоматично робить 3 retry з backoff. Має ротацію ключів (primary + secondary).',
             severity: 'high',
           },
+          {
+            id: 'voyage-embedding',
+            name: 'VoyageAI Embeddings',
+            max: 50,
+            current: null,
+            unit: 'текстів/batch',
+            description: 'VoyageAI дозволяє до 128 текстів за батч, але ми обмежуємо до 50. 3 retry з backoff при 429. Модель: voyage-3.5, розмірність: 1024.',
+            severity: 'medium',
+          },
         ],
         chatLimits: [
           {
@@ -193,6 +214,104 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
             maxContextChars: 100000,
             maxResultChars: 40000,
             description: 'Глибокий аналіз. Максимальне використання інструментів, великий контекст. Найдорожчий режим.',
+          },
+        ],
+        connectionLimits: [
+          {
+            id: 'pg-connections',
+            name: 'PostgreSQL з\'єднання',
+            max: usage.pgMaxConnections,
+            current: usage.pgActiveConnections,
+            description: 'Активні з\'єднання до PostgreSQL. PgBouncer проксує з\'єднання, тому реальне навантаження може бути вищим.',
+            severity: usage.pgActiveConnections > usage.pgMaxConnections * 0.8 ? 'critical' : 'low',
+          },
+          {
+            id: 'pg-idle-timeout',
+            name: 'PG idle timeout',
+            max: 30,
+            unit: 'секунд',
+            description: 'Час до закриття простоюючого з\'єднання в пулі. Деякі скрипти використовують 60с.',
+          },
+          {
+            id: 'pg-connect-timeout',
+            name: 'PG connect timeout',
+            max: 2,
+            unit: 'секунд',
+            description: 'Максимальний час очікування нового з\'єднання з БД.',
+          },
+          {
+            id: 'jwt-expiry',
+            name: 'JWT термін дії',
+            max: 7,
+            unit: 'днів',
+            description: 'Термін дії JWT токена авторизації. Після закінчення потрібен повторний логін.',
+          },
+        ],
+        concurrencyLimits: [
+          {
+            id: 'upload-processing',
+            name: 'Обробка завантажень',
+            max: 100,
+            unit: 'воркерів',
+            description: 'MAX_CONCURRENT_PROCESSING: максимум одночасних задач обробки файлів. Адаптивна конкурентність автоматично регулює від 5 до 100.',
+          },
+          {
+            id: 'edrsr-vectorizer',
+            name: 'EDRSR векторизація',
+            max: 5,
+            unit: 'воркерів',
+            description: 'Паралельні воркери для векторизації судових рішень ЄДРСР.',
+          },
+          {
+            id: 'search-cache-download',
+            name: 'Кеш пошуку (завантаження)',
+            max: 3,
+            unit: 'паралельних',
+            description: 'Максимум паралельних завантажень повних текстів при кешуванні пошукових результатів.',
+          },
+          {
+            id: 'reyestr-tabs',
+            name: 'Реєстр (browser tabs)',
+            max: 3,
+            unit: 'вкладок',
+            description: 'Максимум паралельних браузерних вкладок для скрейпінгу реєстрів.',
+          },
+        ],
+        processingLimits: [
+          {
+            id: 'embedding-chunk',
+            name: 'Embedding chunk size',
+            max: 512,
+            unit: 'токенів',
+            description: 'Максимальний розмір чанку для embedding (~2048 символів). Перевищення — чанк розбивається.',
+          },
+          {
+            id: 'ocr-pages-full',
+            name: 'OCR повний документ',
+            max: 50,
+            unit: 'сторінок',
+            description: 'Максимум сторінок для OCR-обробки одного документа.',
+          },
+          {
+            id: 'ocr-pages-html',
+            name: 'OCR HTML→screenshot',
+            max: 10,
+            unit: 'сторінок',
+            description: 'Максимум сторінок при конвертації HTML в скріншоти для OCR.',
+          },
+          {
+            id: 'template-batch',
+            name: 'Template matching batch',
+            max: 100,
+            unit: 'питань',
+            description: 'Максимум питань в одному батч-запиті на відповідність шаблонів.',
+          },
+          {
+            id: 'search-results-safety',
+            name: 'Ліміт пошуку (безпека)',
+            max: 100000,
+            unit: 'результатів',
+            description: 'Жорсткий ліміт на кількість результатів пошуку судових рішень. Захист від надмірних запитів.',
           },
         ],
         uploadLimits: [
@@ -254,6 +373,64 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
             unit: ':1',
             description: 'Захист від zip-bomb: якщо ratio > 100:1, архів відхиляється.',
           },
+          {
+            id: 'max-nesting-depth',
+            name: 'Вкладеність архівів',
+            max: 2,
+            unit: 'рівнів',
+            description: 'Максимальна глибина вкладених архівів (архів в архіві).',
+          },
+        ],
+        cacheTtls: [
+          {
+            id: 'cache-deputies',
+            name: 'Депутати (РАДА)',
+            max: 7,
+            unit: 'днів',
+            description: 'Кеш даних народних депутатів від API Верховної Ради.',
+          },
+          {
+            id: 'cache-bills',
+            name: 'Законопроєкти (РАДА)',
+            max: 1,
+            unit: 'день',
+            description: 'Кеш законопроєктів. Оновлюються щодня.',
+          },
+          {
+            id: 'cache-legislation',
+            name: 'Законодавство (РАДА)',
+            max: 30,
+            unit: 'днів',
+            description: 'Кеш текстів законодавства. Рідко змінюється.',
+          },
+          {
+            id: 'cache-edrsr-fulltext',
+            name: 'ЄДРСР повні тексти',
+            max: 24,
+            unit: 'години',
+            description: 'Кеш повних текстів судових рішень ЄДРСР.',
+          },
+          {
+            id: 'cache-edrsr-metadata',
+            name: 'ЄДРСР метадані',
+            max: 7,
+            unit: 'днів',
+            description: 'Кеш метаданих судових рішень ЄДРСР.',
+          },
+          {
+            id: 'cache-currency',
+            name: 'Курс валют',
+            max: 24,
+            unit: 'години',
+            description: 'Кеш курсу UAH/USD для конвертації.',
+          },
+          {
+            id: 'cache-pricing',
+            name: 'Тарифи (Pricing)',
+            max: 5,
+            unit: 'хвилин',
+            description: 'Кеш тарифних планів PricingService.',
+          },
         ],
         billingLimits: [
           {
@@ -267,6 +444,13 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
             name: 'Місячний ліміт витрат (на користувача)',
             description: 'Адміністратор може встановити monthly_limit_usd. Attorney tier: $50/день, $500/місяць. Enterprise: без лімітів.',
             severity: 'high',
+          },
+          {
+            id: 'monobank-min-payment',
+            name: 'Мінімальний платіж Monobank',
+            max: 1,
+            unit: 'грн',
+            description: 'Мінімальна сума оплати через Monobank Acquiring.',
           },
         ],
         scrapingLimits: [
@@ -289,6 +473,20 @@ export function createAdminLimitsRoutes(db: IDatabase): express.Router {
             max: 2000,
             unit: 'мс',
             description: 'Випадкова затримка між запитами скрейпера для уникнення блокувань.',
+          },
+          {
+            id: 'zo-timeout',
+            name: 'ZakonOnline API timeout',
+            max: 120,
+            unit: 'секунд',
+            description: 'Таймаут запитів до ZakonOnline API (30с стандартний, 120с для фільтрів по даті).',
+          },
+          {
+            id: 'court-pages',
+            name: 'Сторінки за запит (discovery)',
+            max: 40,
+            unit: 'сторінок',
+            description: 'Максимум сторінок результатів за один запит при discovery судових рішень.',
           },
         ],
         escrow: {


### PR DESCRIPTION
## Summary
- Fix page scroll (missing `overflow-y-auto` wrapper)
- Add concurrent users online (5min window) as top KPI with pulse animation
- Add circular gauge visualizations for PostgreSQL, uploads, online users, daily requests
- Add horizontal bar chart comparing all rate limits
- New sections: Connections/DB, Concurrency, Document Processing, Cache TTLs
- ~20 new limits: VoyageAI embedding, PG timeouts, JWT, OCR, template batch, Monobank min, archive nesting, ZO timeout, etc.

## Test plan
- [ ] Page scrolls properly on `/admin/limits`
- [ ] Gauges render with correct percentages
- [ ] Concurrent users shows real data (users active in last 5 min)
- [ ] PostgreSQL connections gauge shows active vs max

🤖 Generated with [Claude Code](https://claude.com/claude-code)