### PR TITLE
fix(openreyestr): increase XML entity expansion limit

### DIFF
--- a/mcp_openreyestr/src/services/generic-xml-importer.ts
+++ b/mcp_openreyestr/src/services/generic-xml-importer.ts
@@ -115,6 +115,10 @@ async function importXmlInMemory(
     ignoreAttributes: false,
     parseTagValue: false,
     trimValues: true,
+    processEntities: {
+      enabled: true,
+      maxTotalExpansions: 100000,
+    },
   });
   const result = parser.parse(xmlContent);
 


### PR DESCRIPTION
## Summary
- Increases `maxTotalExpansions` from default 1000 to 100000 in fast-xml-parser config
- Fixes `court_experts` and `bankruptcy_cases` NAIS imports failing with "Entity expansion limit exceeded: 1003 > 1000"

## Test plan
- [x] TypeScript type-check passes
- [ ] Deploy and re-run `court_experts` and `bankruptcy_cases` sync on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)