### PR TITLE
feat: Google Ads gtag.js tracking

### DIFF
--- a/lexwebapp/index.html
+++ b/lexwebapp/index.html
@@ -8,6 +8,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#1a1b2e" />
     <title>LEX — AI-юрист</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-18033840618"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'AW-18033840618');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -470,6 +470,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
         if (!response.ok) throw new Error(data.message || 'Registration failed');
 
         localStorage.removeItem('referral_code');
+        // Track registration as Google Ads conversion
+        if (typeof window.gtag === 'function') {
+          window.gtag('event', 'conversion', { send_to: 'AW-18033840618/registration' });
+        }
         showToast.success('Реєстрацію завершено! Перевірте email для підтвердження акаунту.');
         setIsLogin(true);
         setEmail('');

--- a/lexwebapp/src/vite-env.d.ts
+++ b/lexwebapp/src/vite-env.d.ts
@@ -1,5 +1,10 @@
 /// <reference types="vite/client" />
 
+interface Window {
+  gtag?: (...args: unknown[]) => void;
+  dataLayer?: unknown[];
+}
+
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string
   readonly VITE_MCP_API_BASE_URL?: string


### PR DESCRIPTION
## Summary
- Add Google Ads gtag.js (`AW-18033840618`) to index.html
- Track user registration as conversion event
- TypeScript declaration for `window.gtag`

## Test plan
- [x] TypeScript passes
- [ ] Verify gtag loads in browser network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)