### PR TITLE
fix: correct Google Ads registration conversion label

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -472,7 +472,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
         localStorage.removeItem('referral_code');
         // Track registration as Google Ads conversion
         if (typeof window.gtag === 'function') {
-          window.gtag('event', 'conversion', { send_to: 'AW-18033840618/registration' });
+          window.gtag('event', 'conversion', { send_to: 'AW-18033840618/60XJCI7zyo0cEOqjmpdD', value: 1.0, currency: 'UAH' });
         }
         showToast.success('Реєстрацію завершено! Перевірте email для підтвердження акаунту.');
         setIsLogin(true);


### PR DESCRIPTION
Replaces placeholder label with actual conversion label `60XJCI7zyo0cEOqjmpdD`