### PR TITLE
feat: Prozorro + court case status + court schedule MCP tools

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -244,6 +244,7 @@ export class ToolRegistry {
       { clientName: 'openreyestr_search_single_tax_payers', serviceName: 'search_single_tax_payers' },
       { clientName: 'openreyestr_search_tax_debt', serviceName: 'search_tax_debt' },
       { clientName: 'openreyestr_search_esv_debt', serviceName: 'search_esv_debt' },
+      { clientName: 'openreyestr_search_prozorro', serviceName: 'search_prozorro' },
     ];
 
     for (const tool of openreyestrTools) {

--- a/mcp_backend/src/api/tools/court-status-tools.ts
+++ b/mcp_backend/src/api/tools/court-status-tools.ts
@@ -1,0 +1,222 @@
+/**
+ * Court Case Status & Schedule Tools
+ *
+ * 2 tools:
+ * - search_court_case_status — пошук статусів судових справ (1.25M записів)
+ * - search_court_schedule — пошук розкладу засідань (481K записів)
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+export class CourtStatusTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'search_court_case_status',
+        description: `Пошук статусів судових справ (Касаційний суд та інші)
+
+💰 Примерная стоимость: $0.001-$0.005 USD
+Пошук за номером справи, суддею, учасниками або описом. 1.25M записів (2000-2025).`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            case_number: {
+              type: 'string',
+              description: 'Номер справи (наприклад, 352/923/16-ц)',
+            },
+            judge: {
+              type: 'string',
+              description: 'Прізвище судді',
+            },
+            description: {
+              type: 'string',
+              description: 'Ключові слова з опису справи',
+            },
+            court_name: {
+              type: 'string',
+              description: 'Назва суду',
+            },
+            limit: {
+              type: 'number',
+              default: 50,
+              maximum: 100,
+              description: 'Максимальна кількість результатів',
+            },
+          },
+        },
+      },
+      {
+        name: 'search_court_schedule',
+        description: `Пошук розкладу судових засідань
+
+💰 Примерная стоимость: $0.001-$0.005 USD
+Пошук за номером справи, суддею, учасниками або назвою суду. 481K засідань (2026).`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            case_number: {
+              type: 'string',
+              description: 'Номер справи',
+            },
+            judge: {
+              type: 'string',
+              description: 'Прізвище судді',
+            },
+            participant: {
+              type: 'string',
+              description: 'Прізвище або назва учасника справи',
+            },
+            court_name: {
+              type: 'string',
+              description: 'Назва суду',
+            },
+            date_from: {
+              type: 'string',
+              description: 'Дата від (ДД.ММ.РРРР)',
+            },
+            date_to: {
+              type: 'string',
+              description: 'Дата до (ДД.ММ.РРРР)',
+            },
+            limit: {
+              type: 'number',
+              default: 50,
+              maximum: 100,
+              description: 'Максимальна кількість результатів',
+            },
+          },
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
+    switch (name) {
+      case 'search_court_case_status':
+        return this.searchCaseStatus(args);
+      case 'search_court_schedule':
+        return this.searchSchedule(args);
+      default:
+        return null;
+    }
+  }
+
+  private async searchCaseStatus(args: Record<string, unknown>): Promise<ToolResult> {
+    const { case_number, judge, description, court_name, limit = 50 } = args as any;
+
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (case_number) {
+      conditions.push(`case_number = $${pi}`);
+      values.push(case_number);
+      pi++;
+    }
+    if (judge) {
+      conditions.push(`(judge ILIKE $${pi} OR judges ILIKE $${pi})`);
+      values.push(`%${judge}%`);
+      pi++;
+    }
+    if (description) {
+      conditions.push(`description ILIKE $${pi}`);
+      values.push(`%${description}%`);
+      pi++;
+    }
+    if (court_name) {
+      conditions.push(`court_name ILIKE $${pi}`);
+      values.push(`%${court_name}%`);
+      pi++;
+    }
+
+    if (conditions.length === 0) {
+      return this.wrapResponse('Вкажіть номер справи, суддю або опис для пошуку');
+    }
+
+    values.push(Math.min(Number(limit) || 50, 100));
+
+    const sql = `SELECT court_name, case_number, case_type, registration_date, judge, judges, stage_date, stage_name, cause_result, description
+      FROM opendata_court_case_status
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY stage_date DESC NULLS LAST
+      LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('Статусів судових справ не знайдено за вашим запитом');
+      }
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_court_case_status error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async searchSchedule(args: Record<string, unknown>): Promise<ToolResult> {
+    const { case_number, judge, participant, court_name, date_from, date_to, limit = 50 } = args as any;
+
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (case_number) {
+      conditions.push(`case_number = $${pi}`);
+      values.push(case_number);
+      pi++;
+    }
+    if (judge) {
+      conditions.push(`judges ILIKE $${pi}`);
+      values.push(`%${judge}%`);
+      pi++;
+    }
+    if (participant) {
+      conditions.push(`case_involved ILIKE $${pi}`);
+      values.push(`%${participant}%`);
+      pi++;
+    }
+    if (court_name) {
+      conditions.push(`court_name ILIKE $${pi}`);
+      values.push(`%${court_name}%`);
+      pi++;
+    }
+    if (date_from) {
+      conditions.push(`hearing_date >= $${pi}`);
+      values.push(date_from);
+      pi++;
+    }
+    if (date_to) {
+      conditions.push(`hearing_date <= $${pi}`);
+      values.push(date_to);
+      pi++;
+    }
+
+    if (conditions.length === 0) {
+      return this.wrapResponse('Вкажіть номер справи, суддю або учасника для пошуку розкладу');
+    }
+
+    values.push(Math.min(Number(limit) || 50, 100));
+
+    const sql = `SELECT hearing_date, court_name, case_number, judges, court_room, case_involved, case_description
+      FROM opendata_court_schedule
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY hearing_date DESC
+      LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('Засідань не знайдено за вашим запитом');
+      }
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_court_schedule error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -26,6 +26,7 @@ import { EdsrVectorizerService } from '../services/edrsr-vectorizer-service.js';
 import { NextcloudService } from '../services/nextcloud-service.js';
 import { NextcloudTools } from '../api/tools/nextcloud-tools.js';
 import { StateRegistryTools } from '../api/tools/state-registry-tools.js';
+import { CourtStatusTools } from '../api/tools/court-status-tools.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
 import { logger } from '../utils/logger.js';
 import path from 'path';
@@ -125,6 +126,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new LegalActsTools(coreServices.zoLegalActsAdapter));
   toolRegistry.registerHandler(new ECHRPracticeTools(coreServices.zoECHRAdapter));
   toolRegistry.registerHandler(new StateRegistryTools(coreServices.db));
+  toolRegistry.registerHandler(new CourtStatusTools(coreServices.db));
   toolRegistry.registerHandler(new EdsrSearchTools(coreServices.db));
 
   // EDRSR FTS + semantic search + on-demand vectorization

--- a/mcp_openreyestr/src/api/mcp-openreyestr-api.ts
+++ b/mcp_openreyestr/src/api/mcp-openreyestr-api.ts
@@ -398,6 +398,25 @@ export class MCPOpenReyestrAPI {
           },
         },
       },
+      {
+        name: 'search_prozorro',
+        description: `Пошук тендерів у системі ProZorro (публічні закупівлі)
+
+💰 Примерная стоимость: $0.001-$0.005 USD
+Пошук за назвою тендеру, ЄДРПОУ замовника, назвою замовника, статусом або кодом CPV. 662K тендерів з 2015.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Назва або предмет закупівлі' },
+            buyer_edrpou: { type: 'string', description: 'ЄДРПОУ замовника' },
+            buyer_name: { type: 'string', description: 'Назва замовника' },
+            status: { type: 'string', description: 'Статус (complete, active, cancelled, unsuccessful)' },
+            cpv_code: { type: 'string', description: 'Код CPV класифікатора' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1 },
+            offset: { type: 'number', default: 0 },
+          },
+        },
+      },
     ];
   }
 
@@ -467,6 +486,9 @@ export class MCPOpenReyestrAPI {
           break;
         case 'search_esv_debt':
           result = await this.tools.searchEsvDebt(args);
+          break;
+        case 'search_prozorro':
+          result = await this.tools.searchProzorro(args);
           break;
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/mcp_openreyestr/src/api/openreyestr-tools.ts
+++ b/mcp_openreyestr/src/api/openreyestr-tools.ts
@@ -1097,6 +1097,61 @@ export class OpenReyestrTools {
     return result.rows;
   }
 
+  /**
+   * Search Prozorro public procurement tenders
+   */
+  async searchProzorro(params: { query?: string; buyer_edrpou?: string; buyer_name?: string; status?: string; cpv_code?: string; limit?: number; offset?: number }): Promise<any[]> {
+    const { query, buyer_edrpou, buyer_name, status, cpv_code, limit = 50, offset = 0 } = params;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (buyer_edrpou) {
+      conditions.push(`buyer_edrpou = $${paramIndex}`);
+      values.push(buyer_edrpou);
+      paramIndex++;
+    }
+    if (query) {
+      conditions.push(`title ILIKE $${paramIndex}`);
+      values.push(`%${query}%`);
+      paramIndex++;
+    }
+    if (buyer_name) {
+      conditions.push(`buyer_name ILIKE $${paramIndex}`);
+      values.push(`%${buyer_name}%`);
+      paramIndex++;
+    }
+    if (status) {
+      conditions.push(`status = $${paramIndex}`);
+      values.push(status);
+      paramIndex++;
+    }
+    if (cpv_code) {
+      conditions.push(`cpv_code LIKE $${paramIndex}`);
+      values.push(`${cpv_code}%`);
+      paramIndex++;
+    }
+
+    if (conditions.length === 0) {
+      return [{ found: false, message: 'Вкажіть параметри пошуку тендерів' }];
+    }
+
+    values.push(limit, offset);
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    const result = await this.pool.query(
+      `SELECT id, tender_id, tender_number, title, status, procurement_method_type, buyer_name, buyer_edrpou, buyer_region, amount, currency, cpv_code, cpv_description, date_created, tender_start, tender_end
+       FROM prozorro_tenders ${whereClause}
+       ORDER BY date_created DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query: query || buyer_edrpou || buyer_name || '', message: 'Тендерів не знайдено' }];
+    }
+    return result.rows;
+  }
+
   private async findEntityType(record: string): Promise<'UO' | 'FOP' | 'FSU' | null> {
     const uoResult = await this.pool.query(
       'SELECT 1 FROM legal_entities WHERE record = $1',


### PR DESCRIPTION
## Summary
- `search_prozorro`: 662K tenders from prozorro.gov.ua (openreyestr)
- `search_court_case_status`: 1.25M case statuses (backend)
- `search_court_schedule`: 481K hearings schedule (backend)

## Test plan
- [x] TypeScript passes (backend + openreyestr)
- [ ] Verify tools on prod after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)