### PR TITLE
fix(chat): force legislation search before article lookup

### DIFF
--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -89,8 +89,8 @@ export function buildPlanGenerationMessages(
     const qtRules: Partial<Record<QueryType, string>> = {
       case_lookup: '11. queryType=case_lookup: start with get_case_documents_chain, max 2 steps',
       practice_analysis: '11. queryType=practice_analysis: use search_edrsr_fulltext (full-text search in 110M+ court decisions) and/or search_edrsr_semantic (vector similarity) with different queries and limit=20-50, then include legislation lookups. Do NOT use search_legal_precedents (deprecated).',
-      legislation_lookup: '11. queryType=legislation_lookup: start with get_legislation_article or search_legislation, max 2 steps',
-      legal_consultation: '11. queryType=legal_consultation: combine legislation + practice search tools',
+      legislation_lookup: '11. queryType=legislation_lookup: if law_reference slot is present, start with get_legislation_article; otherwise start with search_legislation or find_relevant_law_articles to identify the law first, max 3 steps',
+      legal_consultation: '11. queryType=legal_consultation: ALWAYS start with find_relevant_law_articles or search_legislation to identify relevant laws FIRST. Only THEN call get_legislation_article for specific articles. Never guess rada_id. Combine with practice search tools after finding legislation.',
       registry_lookup: '11. queryType=registry_lookup: start with openreyestr_get_by_edrpou or openreyestr_search_entities. For debtors/enforcement proceedings use search_erb_debtors (10M+ records from Minjust). For bank info use search_nbu_banks. Max 3 steps',
       parliament_query: '11. queryType=parliament_query: use rada_ tools, max 2 steps',
       document_query: '11. queryType=document_query: ALWAYS start with list_documents(query="", limit=50) to get ALL user documents. Then use semantic_search for content-relevant fragments. For analysis: also use get_document to read full text of relevant docs. For delete/update by name: first list_documents to find the doc, then delete_document/update_document with the ID. Max 5 steps.',
@@ -244,6 +244,12 @@ export const CHAT_SYSTEM_PROMPT = `Ти — юридичний асистент 
 - Пропозиції повторити запит для отримання тих самих даних
 - Рекомендації викликати той самий інструмент з "більш детальними параметрами"
 - Розлогий опис чого немає і чому — тільки одне речення про відсутні поля
+
+## Стратегія пошуку законодавства
+- Коли користувач описує ситуацію БЕЗ назви конкретного закону чи статті — ЗАВЖДИ починай з find_relevant_law_articles або search_legislation щоб СПОЧАТКУ визначити який саме закон регулює це питання
+- НІКОЛИ не викликай get_legislation_article без відомого rada_id або назви закону. Цей інструмент потребує конкретне посилання (наприклад "ст. 16 ЦК" або rada_id). Якщо закон невідомий — спочатку знайди його через search_legislation або find_relevant_law_articles
+- Після того як знайшов закон через search_legislation / find_relevant_law_articles — виклич get_legislation_article для отримання тексту конкретних статей
+- Якщо запит стосується змін до закону в різні роки — використай search_legislation для пошуку редакцій та пов'язаних законів-змін
 
 ## Правила
 - НЕ використовуй емодзі у відповідях. Відповідь повинна бути суворо текстовою — без 📋, 🔍, ✓, ⚠️ та будь-яких інших символів-емодзі.

--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -48,8 +48,8 @@ export const QUERY_TYPE_CONFIG: Record<QueryType, QueryTypeConfig> = {
   legal_consultation: {
     defaultBudget: 'standard',
     requiresGrounding: true,
-    preferredScenarios: ['comprehensive_legal_advice', 'relevant_articles_by_situation', 'legislation_search'],
-    groundingNote: 'Відповідь має посилатися на конкретні статті законів та/або судову практику. Загальні поради без правового обґрунтування неприпустимі.',
+    preferredScenarios: ['relevant_articles_by_situation', 'legislation_search', 'comprehensive_legal_advice'],
+    groundingNote: 'СПОЧАТКУ знайди відповідний закон через find_relevant_law_articles або search_legislation. НІКОЛИ не викликай get_legislation_article без відомого rada_id — спочатку визнач закон. Відповідь має посилатися на конкретні статті законів та/або судову практику. Загальні поради без правового обґрунтування неприпустимі.',
     thinkingPrefix: 'Готую юридичну консультацію',
   },
 

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -1035,16 +1035,32 @@ export class ChatService {
             content: fullContent || '',
             tool_calls: toolCalls,
           });
+          // Build per-tool nudge with alternative suggestions
           for (const call of toolCalls) {
+            let note = 'Цей інструмент вже було викликано з такими параметрами. Використай наявні результати.';
+            if (call.name === 'get_legislation_article') {
+              note += ' Якщо потрібний закон не знайдено — спробуй search_legislation або find_relevant_law_articles для пошуку за описом ситуації.';
+            } else if (call.name === 'get_court_decision' || call.name === 'get_case_documents_chain') {
+              note += ' Якщо потрібна справа не знайдена — спробуй search_edrsr_fulltext з іншими ключовими словами.';
+            }
             messages.push({
               role: 'tool',
-              content: JSON.stringify({ note: 'Цей інструмент вже було викликано з такими параметрами. Використай наявні результати.' }),
+              content: JSON.stringify({ note }),
               tool_call_id: call.id,
             });
           }
+          // Detect if duplicate calls include legislation lookups without prior search
+          const hasLegislationDupes = duplicateToolCalls.some(c => c.name === 'get_legislation_article');
+          const hasUsedSearch = collectedToolCalls.some(c =>
+            c.name === 'search_legislation' || c.name === 'find_relevant_law_articles'
+          );
+          let nudge = 'Дані вже отримано. Перейди до аналізу на основі зібраних результатів. Не повторюй виклики інструментів.';
+          if (hasLegislationDupes && !hasUsedSearch) {
+            nudge = 'get_legislation_article не дав результату. Спочатку визнач потрібний закон через find_relevant_law_articles або search_legislation, а потім виклич get_legislation_article з отриманим rada_id. Не повторюй попередні виклики.';
+          }
           messages.push({
             role: 'user',
-            content: 'Дані вже отримано. Перейди до аналізу на основі зібраних результатів. Не повторюй виклики інструментів.',
+            content: nudge,
           });
           // Continue to next iteration — the model should now produce a text answer
           iteration++;


### PR DESCRIPTION
## Summary
- When users describe a legal situation without naming a specific law (e.g. teosoph's query about vehicle co-ownership notarization), the LLM was calling `get_legislation_article` with guessed params, getting empty results, and looping on duplicate tool calls (iterations 4,5,6,9) instead of finding the law first
- Adds explicit system prompt instruction: always use `find_relevant_law_articles` or `search_legislation` FIRST when no specific law is referenced
- Updates plan generation rules for `legal_consultation` and `legislation_lookup` query types
- Enhances duplicate tool call nudge: when `get_legislation_article` repeats without prior search, the system now suggests alternative search tools instead of just saying "use existing results"
- Reorders `legal_consultation` preferred scenarios to prioritize `relevant_articles_by_situation`

## Test plan
- [ ] Send teosoph's exact query and verify LLM starts with `find_relevant_law_articles` or `search_legislation`
- [ ] Verify `get_legislation_article` is NOT called without prior law identification
- [ ] Verify duplicate tool call nudge suggests search alternatives
- [ ] Test normal legislation_lookup with specific article (e.g. "ст. 16 ЦК") still works directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)