### PR TITLE
feat(legislation): fix find_relevant_law_articles + add get_legislation_history

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -511,7 +511,66 @@ export class LegislationTools extends BaseToolHandler {
           required: ['rada_id'],
         },
       },
+      {
+        name: 'get_legislation_history',
+        description: `Отримати історію змін (редакцій) законодавчого акту. Показує які статті змінювались, коли і в якій редакції.
+
+Використовуй коли потрібно:
+- Простежити як змінювалась конкретна норма з часом
+- Знайти які постанови/закони вносили зміни до акту
+- Проаналізувати еволюцію правового регулювання
+
+💰 Вартість: $0.00 (тільки PostgreSQL запит)`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            rada_id: {
+              type: 'string',
+              description: 'ID законодавчого акту на zakon.rada.gov.ua (наприклад, "1388-98-п" для Постанови КМУ №1388, "435-15" для ЦК)',
+            },
+          },
+          required: ['rada_id'],
+        },
+      },
     ];
+  }
+
+  async getLegislationHistory(args: { rada_id: string }): Promise<any> {
+    if (!args.rada_id) {
+      throw new Error('rada_id is required');
+    }
+
+    const radaId = normalizeRadaId(args.rada_id);
+    logger.info('[MCP Tool] get_legislation_history started', { rada_id: radaId });
+
+    // Get amendment history (non-current article versions)
+    const history = await this.service.getAmendmentHistory(radaId);
+
+    // Also get current legislation metadata
+    const structure = await this.service.getLegislationStructure(radaId);
+
+    if (!structure && history.length === 0) {
+      return {
+        rada_id: radaId,
+        error: `Законодавчий акт ${radaId} не знайдено в базі даних`,
+        suggestion: 'Перевірте правильність rada_id. Для постанов КМУ формат: "1388-98-п", для законів: "435-15"',
+        url: `https://zakon.rada.gov.ua/laws/show/${radaId}`,
+      };
+    }
+
+    return {
+      rada_id: radaId,
+      title: structure?.title || null,
+      type: structure?.type || null,
+      total_current_articles: structure?.total_articles || null,
+      url: `https://zakon.rada.gov.ua/laws/show/${radaId}`,
+      amendment_history: history,
+      total_amendments: history.length,
+      amended_articles: [...new Set(history.map(h => h.article_number))],
+      note: history.length === 0
+        ? 'Історія змін порожня — можливо акт ще не був змінений або попередні редакції не збережено в базі. Перевірте актуальний текст на zakon.rada.gov.ua'
+        : undefined,
+    };
   }
 
   async executeTool(name: string, args: any): Promise<ToolResult | null> {
@@ -526,6 +585,8 @@ export class LegislationTools extends BaseToolHandler {
         return this.wrapResponse(await this.searchLegislation(args));
       case 'get_legislation_structure':
         return this.wrapResponse(await this.getLegislationStructure(args));
+      case 'get_legislation_history':
+        return this.wrapResponse(await this.getLegislationHistory(args));
       default:
         return null;
     }

--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -263,11 +263,41 @@ export class MCPQueryAPI extends BaseToolHandler {
   }
 
   private async findRelevantLawArticles(args: any) {
-    const patterns = await this.patternStore.findPatterns(args.intent);
-    const articles = new Set<string>();
+    const query = String(args?.query || args?.intent || '').trim();
+    if (!query) {
+      throw new Error('query parameter is required');
+    }
+    const limit = args.limit || 10;
 
-    for (const pattern of patterns) {
-      pattern.law_articles.forEach((a) => articles.add(a));
+    logger.info('[MCP Tool] find_relevant_law_articles started', {
+      query: query.substring(0, 100),
+      limit,
+    });
+
+    // Primary: semantic search in legislation via LegislationTools
+    const searchResult = await this.legislationTools.searchLegislation({
+      query,
+      limit,
+    } as any);
+
+    const articles = searchResult?.articles || [];
+
+    // Secondary: supplement with legal patterns from court practice
+    let patternsInfo: any = null;
+    try {
+      const patterns = await this.patternStore.findPatterns(query);
+      if (patterns.length > 0) {
+        const patternArticles = new Set<string>();
+        for (const pattern of patterns) {
+          pattern.law_articles.forEach((a: string) => patternArticles.add(a));
+        }
+        patternsInfo = {
+          from_court_practice: Array.from(patternArticles).slice(0, 5),
+          patterns_count: patterns.length,
+        };
+      }
+    } catch {
+      // Pattern store is optional — don't fail if unavailable
     }
 
     return {
@@ -276,8 +306,19 @@ export class MCPQueryAPI extends BaseToolHandler {
           type: 'text',
           text: JSON.stringify(
             {
-              articles: Array.from(articles).slice(0, args.limit || 10),
-              patterns_count: patterns.length,
+              query,
+              total_found: articles.length,
+              articles: articles.map((a: any) => ({
+                rada_id: a.rada_id,
+                article_number: a.article_number,
+                title: a.title,
+                full_text: a.full_text,
+                url: a.url,
+              })),
+              ...(patternsInfo ? { court_practice_references: patternsInfo } : {}),
+              suggestion: articles.length === 0
+                ? 'Спробуйте уточнити запит або вказати конкретний закон. Наприклад: "постанова КМУ про реєстрацію транспортних засобів"'
+                : undefined,
             },
             null,
             2
@@ -363,17 +404,22 @@ export class MCPQueryAPI extends BaseToolHandler {
       },
       {
         name: 'find_relevant_law_articles',
-        description: `Находит статьи законов, которые часто применяются в делах по теме
+        description: `Знаходить статті законів та підзаконних актів за ОПИСОМ СИТУАЦІЇ. Використовуй коли користувач описує ситуацію без назви конкретного закону.
 
-💰 Примерная стоимость: $0.01-$0.02 USD
-Запрос к базе данных legal patterns. Минимальная стоимость (только PostgreSQL запросы).`,
+Приклади: "реєстрація авто з кількома власниками", "звільнення без попередження", "затоплення квартири сусідом".
+Повертає: релевантні статті з повним текстом і посиланням на джерело.
+
+💰 Вартість: $0.01-$0.05 USD (семантичний пошук + OpenAI embedding)`,
         inputSchema: {
           type: 'object',
           properties: {
-            intent: { type: 'string' },
-            limit: { type: 'number', default: 10 },
+            query: {
+              type: 'string',
+              description: 'Опис юридичної ситуації українською мовою (наприклад: "реєстрація транспортного засобу що належить кільком власникам нотаріальне засвідчення")',
+            },
+            limit: { type: 'number', default: 10, description: 'Максимальна кількість результатів' },
           },
-          required: ['intent'],
+          required: ['query'],
         },
       },
       {

--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -117,7 +117,8 @@ CRITICAL: You MUST ALWAYS return a plan with at least 1 step. NEVER return an em
 7. depends_on = list of step ids that must complete first
 8. purpose in Ukrainian, max 10 words
 9. For court practice analysis: use search_edrsr_fulltext and/or search_edrsr_semantic steps with different queries. Do NOT use search_legal_precedents (deprecated, returns 0 results)
-10. ALWAYS include a get_legislation_article or search_legislation step when the query involves legal norms, articles of law, or legal analysis. The UI has a "Норми" panel that is populated ONLY from legislation tool results — without calling these tools, the panel stays empty${queryTypeRule ? '\n' + queryTypeRule : ''}
+10. ALWAYS include a get_legislation_article or search_legislation step when the query involves legal norms, articles of law, or legal analysis. The UI has a "Норми" panel that is populated ONLY from legislation tool results — without calling these tools, the panel stays empty
+10a. When the query asks about amendment history or changes to a law over time, include a get_legislation_history step${queryTypeRule ? '\n' + queryTypeRule : ''}
 
 ## JSON schema
 {
@@ -289,7 +290,8 @@ export const CHAT_INTENT_CLASSIFICATION_PROMPT = `Ти — класифікат�
 - search_legislation — пошук законів за темою
 - get_legislation_article — конкретна стаття закону (наприклад "ст. 16 ЦК")
 - get_legislation_section — розділ/глава закону
-- find_relevant_law_articles — знайти статті за описом ситуації
+- find_relevant_law_articles — знайти статті за ОПИСОМ СИТУАЦІЇ (коли конкретний закон невідомий, семантичний пошук по всьому законодавству)
+- get_legislation_history — історія змін (редакцій) законодавчого акту за rada_id
 - search_procedural_norms — пошук процесуальних норм
 
 ### registry — Державні реєстри (OpenReyestr / data.gov.ua / НАІС / НБУ / Мін'юст)
@@ -426,7 +428,7 @@ export const DOMAIN_TOOL_MAP: Record<string, string[]> = {
     'vectorize_edrsr_results', 'get_edrsr_decision_fulltext',
     'search_legal_precedents', 'count_cases_by_party', 'search_supreme_court_practice',
     'get_case_documents_chain', 'analyze_case_pattern', 'find_similar_fact_pattern_cases',
-    'search_legislation', 'find_relevant_law_articles',
+    'search_legislation', 'find_relevant_law_articles', 'get_legislation_history',
   ],
   // Ensure registry tools that don't appear in catalog scenarios are still mapped
   registry: [

--- a/mcp_backend/src/prompts/tool-registry-catalog.ts
+++ b/mcp_backend/src/prompts/tool-registry-catalog.ts
@@ -454,16 +454,20 @@ export const SCENARIO_CATALOG: ScenarioCatalogEntry[] = [
     exampleQueries: [
       'Мене звільнили без попередження, які мої права?',
       'Сусід заливає квартиру, що робити за законом?',
+      'Є норма яка вимагає нотаріальне засвідчення при реєстрації авто з кількома власниками',
     ],
     dataSources: [
       { name: 'Rada API', provides: 'норми що регулюють ситуацію' },
     ],
     toolChain: [
-      { tool: 'find_relevant_law_articles', purpose: 'знайти застосовні норми за описом ситуації' },
+      { tool: 'find_relevant_law_articles', purpose: 'знайти застосовні норми за описом ситуації (семантичний пошук по законодавству)' },
+      { tool: 'get_legislation_article', purpose: 'отримати повний текст знайденої статті', optional: true },
+      { tool: 'get_legislation_history', purpose: 'переглянути історію змін до знайденого акту', optional: true },
     ],
     responseTemplate: [
       { heading: 'Ситуація', instruction: 'переформулювання запиту юридичною мовою' },
       { heading: 'Застосовні норми', instruction: 'конкретні статті з цитатами' },
+      { heading: 'Історія змін', instruction: 'як змінювалась норма з часом (якщо запитували)', optional: true },
       { heading: 'Порядок дій', instruction: 'покрокові рекомендації' },
       { heading: 'Джерела', instruction: 'посилання на закони' },
     ],


### PR DESCRIPTION
## Summary
- **find_relevant_law_articles was broken** — it searched LegalPatternStore (court case patterns from DB) instead of actual legislation. Renamed input from `intent` to `query`, now uses `LegislationTools.searchLegislation()` for real semantic search across all legislation. Pattern store kept as secondary supplement (shows which articles courts frequently cite on the topic)
- **New MCP tool `get_legislation_history`** — exposes existing `getAmendmentHistory()` service method as a chat-accessible tool. Shows which articles were amended, when, and in which version. Critical for queries like teosoph's "trace amendment history of a regulation"
- **Updated prompts and catalog** — scenario `relevant_articles_by_situation` now includes `get_legislation_history` in its tool chain, system prompt lists the new tool, plan generation includes rule 10a for amendment history queries

## Context
User asked about a regulation requiring notarized co-owner statement for vehicle registration (КМУ Постанова №1388). ChatGPT found the right law and traced 8 amendments. Our system looped because `find_relevant_law_articles` searched patterns instead of legislation, and we had no tool for amendment history.

## Test plan
- [ ] Query "є норма яка вимагає нотаріальне засвідчення заяви при реєстрації авто з кількома власниками" — should use find_relevant_law_articles and find relevant legislation
- [ ] Query "історія змін до Цивільного кодексу" — should trigger get_legislation_history
- [ ] Verify find_relevant_law_articles still works for simple queries like "захист прав споживачів"
- [ ] Verify get_legislation_history returns data for known rada_ids (e.g. "435-15")

🤖 Generated with [Claude Code](https://claude.com/claude-code)