### PR TITLE
fix(legislation): fix KMU resolution + add punkt parsing

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -345,21 +345,22 @@ export class RadaLegislationAdapter {
   private extractArticlesFallback($: cheerio.CheerioAPI, radaId: string): LegislationArticle[] {
     const articles: LegislationArticle[] = [];
     const bodyText = $('body').text();
-    
+
+    // Try Стаття pattern first (laws, codes)
     const articlePattern = /Стаття\s+(\d+(?:-\d+)?)\.\s*([^\n]+)/gi;
     let match;
-    
+
     while ((match = articlePattern.exec(bodyText)) !== null) {
       const articleNumber = match[1];
       const title = match[2].trim();
-      
+
       const startIndex = match.index;
       const nextMatch = articlePattern.exec(bodyText);
       const endIndex = nextMatch ? nextMatch.index : bodyText.length;
       articlePattern.lastIndex = nextMatch ? nextMatch.index : bodyText.length;
-      
+
       const fullText = bodyText.substring(startIndex, endIndex).trim();
-      
+
       if (fullText.length > 20) {
         articles.push({
           article_number: articleNumber,
@@ -373,7 +374,50 @@ export class RadaLegislationAdapter {
         });
       }
     }
-    
+
+    // If no articles found, try пункт pattern (КМУ постанови, порядки, правила)
+    // Format: "1. Text..." at line start, numbered sequentially
+    if (articles.length === 0) {
+      const punktPattern = /(?:^|\n)\s*(\d+)\.\s+([А-ЯІЇЄҐ][^\n]{10,})/g;
+      const punktMatches: Array<{ number: string; title: string; index: number }> = [];
+
+      while ((match = punktPattern.exec(bodyText)) !== null) {
+        const num = parseInt(match[1], 10);
+        // Only consider reasonable punkt numbers (1-999) and skip footnotes/references
+        if (num > 0 && num < 1000) {
+          punktMatches.push({
+            number: match[1],
+            title: match[2].trim().substring(0, 200),
+            index: match.index,
+          });
+        }
+      }
+
+      // Extract text between consecutive punkts
+      for (let i = 0; i < punktMatches.length; i++) {
+        const startIdx = punktMatches[i].index;
+        const endIdx = i + 1 < punktMatches.length ? punktMatches[i + 1].index : bodyText.length;
+        const fullText = bodyText.substring(startIdx, endIdx).trim();
+
+        if (fullText.length > 20) {
+          articles.push({
+            article_number: punktMatches[i].number,
+            title: punktMatches[i].title.split(/[.;]/)[0].trim(),
+            full_text: fullText,
+            byte_size: Buffer.byteLength(fullText, 'utf8'),
+            metadata: {
+              rada_id: radaId,
+              extraction_method: 'fallback_punkt',
+            },
+          });
+        }
+      }
+
+      if (articles.length > 0) {
+        logger.info(`Extracted ${articles.length} punkts (not articles) from ${radaId} via fallback`);
+      }
+    }
+
     return articles;
   }
 

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -312,13 +312,25 @@ export class LegislationService {
    */
   async resolveKmuRadaId(kmuNumber: string): Promise<string | null> {
     // First check if we already have it in DB with any year suffix
+    // Only trust DB entries that have title (non-empty = successfully fetched)
     const dbResult = await this.db.query(
-      `SELECT rada_id FROM legislation WHERE rada_id LIKE $1 LIMIT 1`,
+      `SELECT rada_id FROM legislation WHERE rada_id LIKE $1 AND title IS NOT NULL AND title != '' AND total_articles > 0 LIMIT 1`,
       [`${kmuNumber}-%`]
     );
     if (dbResult.rows.length > 0) {
       logger.info(`[resolveKmuRadaId] Found KMU:${kmuNumber} in DB: ${dbResult.rows[0].rada_id}`);
       return dbResult.rows[0].rada_id;
+    }
+
+    // Clean up stale/empty DB entries for this KMU number
+    const staleResult = await this.db.query(
+      `DELETE FROM legislation WHERE rada_id LIKE $1 AND (title IS NULL OR title = '' OR total_articles = 0) RETURNING rada_id`,
+      [`${kmuNumber}-%`]
+    );
+    if (staleResult.rows.length > 0) {
+      logger.info(`[resolveKmuRadaId] Cleaned up ${staleResult.rows.length} stale entries for KMU:${kmuNumber}`, {
+        cleaned: staleResult.rows.map((r: any) => r.rada_id),
+      });
     }
 
     // Generate candidate rada_ids with year suffixes in batches (parallel within batch)


### PR DESCRIPTION
## Summary
- **Fix `resolveKmuRadaId`**: was returning stale/empty DB entries (e.g. `1388-2000-п` with no title, 0 articles) instead of fetching correct rada_id from RADA API. Now validates entries have title + articles, and auto-cleans stale records.
- **Add punkt parsing for КМУ постанови**: `extractArticlesFallback` only matched `Стаття N` pattern. КМУ resolutions use numbered paragraphs (`1.`, `2.`, `6.`). Added fallback punkt parser so content like Постанова КМУ №1388 gets properly extracted and indexed.

## Context
An attorney asked "есть норма которая требует заявление одного из собственников" — the agentic loop exhausted `maxToolCalls` (7 iterations, 16 tool calls) because:
1. `resolveKmuRadaId` found stale `1388-2000-п` in DB → returned it → 0 articles
2. Even when fetching `1388-98-п` from RADA API, the parser couldn't extract punkts → 0 articles stored
3. Vector search returned 0 results → text search returned 0 → loop repeated until exhaustion

## Test plan
- [ ] Deploy and verify `1388-98-п` resolves correctly and punkt 6 (про співвласників) is extracted
- [ ] Verify vector search finds this resolution for queries about "заява співвласника"
- [ ] Test with other КМУ постанови to confirm punkt parser works generically

🤖 Generated with [Claude Code](https://claude.com/claude-code)