### PR TITLE
fix(legislation): extract title from og:title for КМУ resolutions

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -97,9 +97,22 @@ export class RadaLegislationAdapter {
   }
 
   private extractMetadata($: cheerio.CheerioAPI, radaId: string, url: string): LegislationMetadata {
-    const titleElement = $('.title, .doc-title, h1').first();
-    const title = titleElement.text().trim();
-    
+    let title = $('.title, .doc-title, h1').first().text().trim();
+
+    // Fallback: RADA /print pages use og:title or span.rvts23 for КМУ resolutions
+    if (!title) {
+      title = $('meta[property="og:title"]').attr('content')?.trim() || '';
+    }
+    if (!title) {
+      // Find the longest rvts23 span that looks like a title (skip "КАБІНЕТ МІНІСТРІВ УКРАЇНИ" etc.)
+      $('span.rvts23, .rvts23').each((_i, el) => {
+        const text = $(el).text().trim();
+        if (text.length > 20 && text.length > title.length && /^(Про |ПОРЯДОК |ПРАВИЛА |ПОЛОЖЕННЯ )/i.test(text)) {
+          title = text;
+        }
+      });
+    }
+
     const shortTitle = this.extractShortTitle(title);
     const type = this.determineDocumentType(title, radaId);
     


### PR DESCRIPTION
## Summary
- RADA `/print` pages for КМУ постанови don't use `.title`/`.doc-title`/`h1` — title is in `og:title` meta tag or `span.rvts23`
- Without title, `resolveKmuRadaId` skips the document (line 344: `if (result.metadata.title)` is falsy)
- Fix: fallback chain `og:title` → `span.rvts23` matching КМУ title prefixes

## Context
Follow-up to #1093. Even with stale DB cleanup and punkt parser, `fetchLegislation('1388-98-п')` returned empty title → `resolveKmuRadaId` treated it as "not found" → all 33 year suffix attempts failed → "Постанову КМУ №1388 не знайдено".

## Verified locally
```
Title: Про затвердження Порядку державної реєстрації...
Fallback punkts: 49
Пункт 6 contains "співвласник": true
Пункт 6 contains "нотаріально": true
Would resolveKmuRadaId succeed? YES
```

## Test plan
- [ ] Deploy and test `search_legislation("постанова КМУ 1388")`
- [ ] Verify punkt 6 about co-owner statements is returned
- [ ] Test chat with "есть норма которая требует заявление одного из собственников"

🤖 Generated with [Claude Code](https://claude.com/claude-code)