### PR TITLE
feat(ci): dual versioning — backend v* + frontend fe-v*

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -402,7 +402,8 @@ jobs:
       needs.local-deploy-and-test.result == 'success'
     environment: production
     outputs:
-      version: ${{ steps.version.outputs.next_version }}
+      backend_version: ${{ steps.version.outputs.backend_version }}
+      frontend_version: ${{ steps.version.outputs.frontend_version }}
     env:
       PROD_SERVER: '18.192.189.254'
       PROD_USER: 'ubuntu'
@@ -417,33 +418,66 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Compute next version
+      - name: Compute next versions (backend + frontend)
         id: version
         run: |
-          LAST_TAG=$(git tag -l "v*" --sort=-version:refname | head -1)
-          if [ -z "$LAST_TAG" ]; then
-            echo "next_version=v1.0.0" >> "$GITHUB_OUTPUT"
-          else
-            CURRENT="${LAST_TAG#v}"
-            MAJOR=$(echo "$CURRENT" | cut -d. -f1)
-            MINOR=$(echo "$CURRENT" | cut -d. -f2)
-            PATCH=$(echo "$CURRENT" | cut -d. -f3)
-            COMMITS=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges)
-            if echo "$COMMITS" | grep -qiE "^[a-f0-9]+ (feat|refactor)!:|BREAKING CHANGE"; then
-              MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
-            elif echo "$COMMITS" | grep -qiE "^[a-f0-9]+ feat(\(|:)"; then
-              MINOR=$((MINOR + 1)); PATCH=0
+          # --- Backend version (v*) ---
+          LAST_BE_TAG=$(git tag -l "v*" --sort=-version:refname | head -1)
+          if [ "$BACKEND_CHANGED" = "true" ] || [ "$RADA_CHANGED" = "true" ] || [ "$OPENREYESTR_CHANGED" = "true" ]; then
+            if [ -z "$LAST_BE_TAG" ]; then
+              BE_VERSION="v1.0.0"
             else
-              PATCH=$((PATCH + 1))
+              CURRENT="${LAST_BE_TAG#v}"
+              MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+              MINOR=$(echo "$CURRENT" | cut -d. -f2)
+              PATCH=$(echo "$CURRENT" | cut -d. -f3)
+              COMMITS=$(git log "${LAST_BE_TAG}..HEAD" --oneline --no-merges -- packages/shared/ mcp_backend/ mcp_rada/ mcp_openreyestr/)
+              if echo "$COMMITS" | grep -qiE "^[a-f0-9]+ (feat|refactor)!:|BREAKING CHANGE"; then
+                MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+              elif echo "$COMMITS" | grep -qiE "^[a-f0-9]+ feat(\(|:)"; then
+                MINOR=$((MINOR + 1)); PATCH=0
+              else
+                PATCH=$((PATCH + 1))
+              fi
+              BE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
             fi
-            echo "next_version=v${MAJOR}.${MINOR}.${PATCH}" >> "$GITHUB_OUTPUT"
+          else
+            BE_VERSION="${LAST_BE_TAG:-v1.0.0}"
           fi
-          echo "Next version: $(grep next_version "$GITHUB_OUTPUT" | cut -d= -f2)"
+          echo "backend_version=${BE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Backend version: ${BE_VERSION}"
+
+          # --- Frontend version (fe-v*) ---
+          LAST_FE_TAG=$(git tag -l "fe-v*" --sort=-version:refname | head -1)
+          if [ "$FRONTEND_CHANGED" = "true" ]; then
+            if [ -z "$LAST_FE_TAG" ]; then
+              FE_VERSION="fe-v1.0.0"
+            else
+              CURRENT="${LAST_FE_TAG#fe-v}"
+              MAJOR=$(echo "$CURRENT" | cut -d. -f1)
+              MINOR=$(echo "$CURRENT" | cut -d. -f2)
+              PATCH=$(echo "$CURRENT" | cut -d. -f3)
+              COMMITS=$(git log "${LAST_FE_TAG}..HEAD" --oneline --no-merges -- lexwebapp/)
+              if echo "$COMMITS" | grep -qiE "^[a-f0-9]+ (feat|refactor)!:|BREAKING CHANGE"; then
+                MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+              elif echo "$COMMITS" | grep -qiE "^[a-f0-9]+ feat(\(|:)"; then
+                MINOR=$((MINOR + 1)); PATCH=0
+              else
+                PATCH=$((PATCH + 1))
+              fi
+              FE_VERSION="fe-v${MAJOR}.${MINOR}.${PATCH}"
+            fi
+          else
+            FE_VERSION="${LAST_FE_TAG:-fe-v0.0.0}"
+          fi
+          echo "frontend_version=${FE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Frontend version: ${FE_VERSION}"
 
       - name: Deploy changed services to prod (blue-green)
         env:
           PROD_SSH_KEY_PATH: ${{ secrets.PROD_SSH_KEY_PATH }}
-          NEXT_VERSION: ${{ steps.version.outputs.next_version }}
+          BACKEND_VERSION: ${{ steps.version.outputs.backend_version }}
+          FRONTEND_VERSION: ${{ steps.version.outputs.frontend_version }}
         run: |
           SSH_CMD="ssh -i $PROD_SSH_KEY_PATH -o StrictHostKeyChecking=no ${PROD_USER}@${PROD_SERVER}"
           REMOTE_REPO="/home/${PROD_USER}/SecondLayer"
@@ -453,8 +487,8 @@ jobs:
           # Pull latest code and tags
           $SSH_CMD "git -C ${REMOTE_REPO} fetch origin main --tags && git -C ${REMOTE_REPO} reset --hard origin/main"
 
-          # Write VERSION file for frontend build (uses computed next version)
-          $SSH_CMD "echo '${NEXT_VERSION}' > ${REMOTE_REPO}/VERSION"
+          # Write VERSION file with both versions
+          $SSH_CMD "printf 'BACKEND_VERSION=%s\nFRONTEND_VERSION=%s\n' '${BACKEND_VERSION}' '${FRONTEND_VERSION}' > ${REMOTE_REPO}/VERSION"
 
           # Build dist on prod
           $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix packages/shared install && npm --prefix packages/shared run build"
@@ -473,7 +507,8 @@ jobs:
           $SSH_CMD bash << DEPLOY_SCRIPT
             set -e
             cd ${REMOTE_REPO}/deployment
-            export APP_VERSION=\$(cat ${REMOTE_REPO}/VERSION 2>/dev/null || echo 'dev')
+            export APP_VERSION=\$(grep 'BACKEND_VERSION=' ${REMOTE_REPO}/VERSION 2>/dev/null | cut -d= -f2 || echo 'dev')
+            export APP_FRONTEND_VERSION=\$(grep 'FRONTEND_VERSION=' ${REMOTE_REPO}/VERSION 2>/dev/null | cut -d= -f2 || echo 'dev')
             DC="docker compose -f docker-compose.prod.yml --env-file .env.prod"
 
             # --- Determine active colors (per service group) ---
@@ -850,48 +885,78 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release
+      - name: Create releases
         env:
           GH_TOKEN: ${{ github.token }}
           SERVICES_TO_DEPLOY: ${{ needs.detect-changes.outputs.services_to_deploy }}
-          NEXT_VERSION: ${{ needs.deploy-prod.outputs.version }}
+          BACKEND_VERSION: ${{ needs.deploy-prod.outputs.backend_version }}
+          FRONTEND_VERSION: ${{ needs.deploy-prod.outputs.frontend_version }}
+          BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+          RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+          OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+          FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
         run: |
-          LAST_TAG=$(git tag -l "v*" --sort=-version:refname | head -1)
-
-          if [ -z "$LAST_TAG" ]; then
-            COMMITS=$(git log --oneline --no-merges -50)
-          else
-            COMMITS=$(git log "${LAST_TAG}..HEAD" --oneline --no-merges)
+          ANY_BACKEND=false
+          if [ "$BACKEND_CHANGED" = "true" ] || [ "$RADA_CHANGED" = "true" ] || [ "$OPENREYESTR_CHANGED" = "true" ]; then
+            ANY_BACKEND=true
           fi
 
-          # Build changelog grouped by type
-          FEATURES=$(echo "$COMMITS" | grep -iE "^[a-f0-9]+ feat(\(|:)" | sed 's/^[a-f0-9]* /- /' || true)
-          FIXES=$(echo "$COMMITS" | grep -iE "^[a-f0-9]+ fix(\(|:)" | sed 's/^[a-f0-9]* /- /' || true)
-          OTHER=$(echo "$COMMITS" | grep -viE "^[a-f0-9]+ (feat|fix)(\(|:)" | grep -v "^$" | sed 's/^[a-f0-9]* /- /' || true)
+          # --- Backend release ---
+          if [ "$ANY_BACKEND" = "true" ]; then
+            LAST_BE_TAG=$(git tag -l "v*" --sort=-version:refname | head -1)
+            if [ -z "$LAST_BE_TAG" ]; then
+              BE_COMMITS=$(git log --oneline --no-merges -50 -- packages/shared/ mcp_backend/ mcp_rada/ mcp_openreyestr/)
+            else
+              BE_COMMITS=$(git log "${LAST_BE_TAG}..HEAD" --oneline --no-merges -- packages/shared/ mcp_backend/ mcp_rada/ mcp_openreyestr/)
+            fi
 
-          # Build release body
-          BODY="## Deployed Services\n"
-          BODY="${BODY}\n\`${SERVICES_TO_DEPLOY}\`\n"
+            BE_FEATURES=$(echo "$BE_COMMITS" | grep -iE "^[a-f0-9]+ feat(\(|:)" | sed 's/^[a-f0-9]* /- /' || true)
+            BE_FIXES=$(echo "$BE_COMMITS" | grep -iE "^[a-f0-9]+ fix(\(|:)" | sed 's/^[a-f0-9]* /- /' || true)
+            BE_OTHER=$(echo "$BE_COMMITS" | grep -viE "^[a-f0-9]+ (feat|fix)(\(|:)" | grep -v "^$" | sed 's/^[a-f0-9]* /- /' || true)
 
-          if [ -n "$FEATURES" ]; then
-            BODY="${BODY}\n## Features\n${FEATURES}\n"
+            BODY="## Backend Release\n"
+            [ -n "$BE_FEATURES" ] && BODY="${BODY}\n### Features\n${BE_FEATURES}\n"
+            [ -n "$BE_FIXES" ] && BODY="${BODY}\n### Fixes\n${BE_FIXES}\n"
+            [ -n "$BE_OTHER" ] && BODY="${BODY}\n### Other\n${BE_OTHER}\n"
+            BODY="${BODY}\n---\n**Commit:** ${GITHUB_SHA:0:7} | **Runner:** local"
+
+            echo "Creating backend release ${BACKEND_VERSION}"
+            git tag "${BACKEND_VERSION}"
+            git push origin "${BACKEND_VERSION}"
+            printf "%b" "$BODY" | gh release create "${BACKEND_VERSION}" \
+              --title "${BACKEND_VERSION} (Backend)" \
+              --notes-file - \
+              --latest
           fi
-          if [ -n "$FIXES" ]; then
-            BODY="${BODY}\n## Fixes\n${FIXES}\n"
+
+          # --- Frontend release ---
+          if [ "$FRONTEND_CHANGED" = "true" ]; then
+            LAST_FE_TAG=$(git tag -l "fe-v*" --sort=-version:refname | head -1)
+            if [ -z "$LAST_FE_TAG" ]; then
+              FE_COMMITS=$(git log --oneline --no-merges -50 -- lexwebapp/)
+            else
+              FE_COMMITS=$(git log "${LAST_FE_TAG}..HEAD" --oneline --no-merges -- lexwebapp/)
+            fi
+
+            FE_FEATURES=$(echo "$FE_COMMITS" | grep -iE "^[a-f0-9]+ feat(\(|:)" | sed 's/^[a-f0-9]* /- /' || true)
+            FE_FIXES=$(echo "$FE_COMMITS" | grep -iE "^[a-f0-9]+ fix(\(|:)" | sed 's/^[a-f0-9]* /- /' || true)
+            FE_OTHER=$(echo "$FE_COMMITS" | grep -viE "^[a-f0-9]+ (feat|fix)(\(|:)" | grep -v "^$" | sed 's/^[a-f0-9]* /- /' || true)
+
+            BODY="## Frontend Release\n"
+            [ -n "$FE_FEATURES" ] && BODY="${BODY}\n### Features\n${FE_FEATURES}\n"
+            [ -n "$FE_FIXES" ] && BODY="${BODY}\n### Fixes\n${FE_FIXES}\n"
+            [ -n "$FE_OTHER" ] && BODY="${BODY}\n### Other\n${FE_OTHER}\n"
+            BODY="${BODY}\n---\n**Commit:** ${GITHUB_SHA:0:7} | **Runner:** local"
+
+            echo "Creating frontend release ${FRONTEND_VERSION}"
+            git tag "${FRONTEND_VERSION}"
+            git push origin "${FRONTEND_VERSION}"
+
+            # Frontend release is --latest only if no backend release was created
+            LATEST_FLAG=""
+            [ "$ANY_BACKEND" != "true" ] && LATEST_FLAG="--latest"
+            printf "%b" "$BODY" | gh release create "${FRONTEND_VERSION}" \
+              --title "${FRONTEND_VERSION} (Frontend)" \
+              --notes-file - \
+              $LATEST_FLAG
           fi
-          if [ -n "$OTHER" ]; then
-            BODY="${BODY}\n## Other\n${OTHER}\n"
-          fi
-
-          BODY="${BODY}\n---\n**Commit:** ${GITHUB_SHA:0:7} | **Runner:** local"
-
-          echo "Creating release $NEXT_VERSION"
-
-          # Create tag and release
-          git tag "$NEXT_VERSION"
-          git push origin "$NEXT_VERSION"
-
-          printf "%b" "$BODY" | gh release create "$NEXT_VERSION" \
-            --title "$NEXT_VERSION" \
-            --notes-file - \
-            --latest

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -760,6 +760,7 @@ services:
         - VITE_AUTO_EXPAND_THINKING=true
         - GIT_SHA=${GIT_SHA:-unknown}
         - APP_VERSION=${APP_VERSION:-dev}
+        - APP_FRONTEND_VERSION=${APP_FRONTEND_VERSION:-dev}
     image: lexwebapp-prod:latest
     container_name: lexwebapp-prod
     ports:

--- a/lexwebapp/Dockerfile
+++ b/lexwebapp/Dockerfile
@@ -22,6 +22,7 @@ ARG VITE_AUTO_EXPAND_THINKING=true
 # GIT_SHA busts the cache on every new deploy so stale layers are never reused
 ARG GIT_SHA=unknown
 ARG APP_VERSION=dev
+ARG APP_FRONTEND_VERSION=dev
 
 # Copy lexwebapp source code
 COPY lexwebapp/ ./
@@ -37,6 +38,7 @@ ENV VITE_SHOW_TOOL_SELECTOR=$VITE_SHOW_TOOL_SELECTOR
 ENV VITE_ENABLE_THINKING_STEPS=$VITE_ENABLE_THINKING_STEPS
 ENV VITE_AUTO_EXPAND_THINKING=$VITE_AUTO_EXPAND_THINKING
 ENV APP_VERSION=$APP_VERSION
+ENV APP_FRONTEND_VERSION=$APP_FRONTEND_VERSION
 
 # Build the application using the correct mode and normalize output to /app/lexwebapp/dist
 RUN if [ "$BUILD_ENV" = "production" ]; then \

--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -212,10 +212,19 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
             <div className="h-12 flex items-center">
               <img src="/Image.jpg" alt="Lex" className="h-full w-auto object-contain" />
             </div>
-            {import.meta.env.VITE_APP_VERSION && (
-              <span className="text-[9px] text-claude-subtext/40 font-mono tracking-tight">
-                {import.meta.env.VITE_APP_VERSION}
-              </span>
+            {(import.meta.env.VITE_APP_VERSION || import.meta.env.VITE_APP_FRONTEND_VERSION) && (
+              <div className="flex flex-col">
+                {import.meta.env.VITE_APP_VERSION && (
+                  <span className="text-[9px] text-claude-subtext/40 font-mono tracking-tight">
+                    be {import.meta.env.VITE_APP_VERSION}
+                  </span>
+                )}
+                {import.meta.env.VITE_APP_FRONTEND_VERSION && (
+                  <span className="text-[9px] text-claude-subtext/40 font-mono tracking-tight">
+                    fe {import.meta.env.VITE_APP_FRONTEND_VERSION}
+                  </span>
+                )}
+              </div>
             )}
           </div>
           <button onClick={onClose} className="lg:hidden p-1.5 text-claude-subtext hover:text-claude-text hover:bg-zinc-200/60 rounded-md transition-colors duration-150">

--- a/lexwebapp/src/vite-env.d.ts
+++ b/lexwebapp/src/vite-env.d.ts
@@ -10,6 +10,9 @@ interface ImportMetaEnv {
   readonly VITE_MCP_API_BASE_URL?: string
   readonly VITE_MCP_API_KEY?: string
   readonly VITE_ENABLE_DEVTOOLS?: string
+  readonly VITE_APP_VERSION?: string
+  readonly VITE_APP_FRONTEND_VERSION?: string
+  readonly VITE_BUILD_TIME?: string
   readonly MODE: string
   readonly DEV: boolean
   readonly PROD: boolean

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -24,7 +24,12 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.VITE_APP_VERSION': JSON.stringify(
         process.env.APP_VERSION ||
         (() => { try { return execSync('git tag -l "v*" --sort=-version:refname 2>/dev/null').toString().trim().split('\n')[0]; } catch { return ''; } })() ||
-        (() => { try { return fs.readFileSync(path.resolve(__dirname, '..', 'VERSION'), 'utf8').trim(); } catch { return 'dev'; } })()
+        (() => { try { const v = fs.readFileSync(path.resolve(__dirname, '..', 'VERSION'), 'utf8'); const m = v.match(/BACKEND_VERSION=(.+)/); return m ? m[1] : v.trim(); } catch { return 'dev'; } })()
+      ),
+      'import.meta.env.VITE_APP_FRONTEND_VERSION': JSON.stringify(
+        process.env.APP_FRONTEND_VERSION ||
+        (() => { try { return execSync('git tag -l "fe-v*" --sort=-version:refname 2>/dev/null').toString().trim().split('\n')[0]; } catch { return ''; } })() ||
+        (() => { try { const v = fs.readFileSync(path.resolve(__dirname, '..', 'VERSION'), 'utf8'); const m = v.match(/FRONTEND_VERSION=(.+)/); return m ? m[1] : ''; } catch { return ''; } })()
       ),
     },
     build: {


### PR DESCRIPTION
## Summary
- Backend version continues from `v1.76.0+`, bumped only on `mcp_backend/`, `mcp_rada/`, `mcp_openreyestr/`, `packages/shared/` changes
- Frontend version starts from `fe-v1.0.0`, bumped only on `lexwebapp/` changes
- CI/CD creates separate GitHub releases for each changed component
- Sidebar displays both versions (`be v1.76.0` / `fe v1.0.0`)
- VERSION file uses `BACKEND_VERSION=` / `FRONTEND_VERSION=` key=value format
- Seed tag `fe-v0.0.0` already pushed

## Files changed
- `.github/workflows/ci-local-deploy.yml` — dual version computation + dual release creation
- `deployment/docker-compose.prod.yml` — add `APP_FRONTEND_VERSION` build arg
- `lexwebapp/Dockerfile` — add `APP_FRONTEND_VERSION` ARG/ENV
- `lexwebapp/vite.config.ts` — add `VITE_APP_FRONTEND_VERSION` define
- `lexwebapp/src/vite-env.d.ts` — add type declarations
- `lexwebapp/src/components/sidebar/index.tsx` — display both versions

## Test plan
- [x] Frontend TypeScript build passes
- [x] Seed tag `fe-v0.0.0` pushed to origin
- [ ] Merge and verify CI/CD creates both releases
- [ ] Verify sidebar shows `be v1.76.0 | fe v1.0.0` on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)