### PR TITLE
fix(legislation): sort КМУ DB results oldest-first

### DIFF
--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -314,7 +314,7 @@ export class LegislationService {
     // First check if we already have it in DB with any year suffix
     // Only trust DB entries that have title (non-empty = successfully fetched)
     const dbResult = await this.db.query(
-      `SELECT rada_id FROM legislation WHERE rada_id LIKE $1 AND title IS NOT NULL AND title != '' AND total_articles > 0 LIMIT 1`,
+      `SELECT rada_id FROM legislation WHERE rada_id LIKE $1 AND title IS NOT NULL AND title != '' AND total_articles > 0 ORDER BY LENGTH(rada_id) ASC, rada_id ASC LIMIT 1`,
       [`${kmuNumber}-%`]
     );
     if (dbResult.rows.length > 0) {


### PR DESCRIPTION
## Summary
- Fix DB query to return oldest КМУ resolution when multiple share same number
- `1388-98-п` (1998, len=9) now returned before `1388-2024-п` (2024, len=11)

## Test plan
- [ ] `search_legislation("постанова КМУ 1388 пункт 6")` returns 1388-98-п

🤖 Generated with [Claude Code](https://claude.com/claude-code)