### PR TITLE
fix(build): exclude vectorize-opendata-titan.ts from build

### DIFF
--- a/mcp_backend/tsconfig.json
+++ b/mcp_backend/tsconfig.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/__tests__", "src/__tests__"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__", "src/__tests__", "src/scripts/vectorize-opendata-titan.ts"]
 }


### PR DESCRIPTION
Fixes Docker build failure due to missing @aws-sdk/client-bedrock-runtime dep.