### PR TITLE
fix(ci): replace npm ci with npm install

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -86,13 +86,13 @@ jobs:
           node-version: 20
 
       - name: Build shared package
-        run: cd packages/shared && npm ci && npm run build
+        run: cd packages/shared && npm install && npm run build
 
       # Backend/RADA/OpenReyestr integration tests require running infrastructure (DB, Redis, MinIO).
       # CI runs TypeScript compilation + unit tests (mocked, no infra needed).
       - name: Build backend
         if: needs.detect-changes.outputs.backend == 'true'
-        run: cd mcp_backend && npm ci && npm run build
+        run: cd mcp_backend && npm install && npm run build
 
       - name: Unit test backend (controllers)
         if: needs.detect-changes.outputs.backend == 'true'
@@ -100,17 +100,17 @@ jobs:
 
       - name: Build RADA
         if: needs.detect-changes.outputs.rada == 'true'
-        run: cd mcp_rada && npm ci && npm run build
+        run: cd mcp_rada && npm install && npm run build
 
       - name: Build OpenReyestr
         if: needs.detect-changes.outputs.openreyestr == 'true'
-        run: cd mcp_openreyestr && npm ci && npm run build
+        run: cd mcp_openreyestr && npm install && npm run build
 
       - name: Test frontend
         if: needs.detect-changes.outputs.frontend == 'true'
         run: |
           cd lexwebapp
-          npm ci --install-strategy=nested
+          npm install
           npm test
           npm run build
         env:


### PR DESCRIPTION
## Summary
- `npm ci` requires `package-lock.json` which doesn't exist in this monorepo
- Replaced all `npm ci` calls with `npm install` in the CI/CD workflow
- Fixes build failures on main after recent merges

## Test plan
- [ ] CI pipeline passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace all `npm ci` calls with `npm install` in `.github/workflows/ci-local-deploy.yml` because the monorepo has no `package-lock.json`. This unblocks CI builds for `packages/shared`, `mcp_backend`, `mcp_rada`, `mcp_openreyestr`, and `lexwebapp`.

<sup>Written for commit c95b686681a1bee86158d3600964b1a10b5deed3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

