### PR TITLE
fix: add GET /auth/diia/callback — resolve Diia auth 404

### DIFF
--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -159,6 +159,10 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
    * @access  Public
    */
   router.post('/diia/callback', authController.diiaAuthCallback as any);
+  router.get('/diia/callback', (_req, res) => {
+    const frontendUrl = `${_req.headers['x-forwarded-proto'] || _req.protocol}://${_req.headers['x-forwarded-host'] || _req.headers.host}`;
+    res.redirect(`${frontendUrl}/login`);
+  });
 
   /**
    * @route   GET /auth/diia/status/:sessionId
@@ -198,6 +202,10 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
   });
   router.post('/diia/callback', (_req, res) => {
     res.status(501).json({ error: 'Diia auth is not configured' });
+  });
+  router.get('/diia/callback', (_req, res) => {
+    const frontendUrl = `${_req.headers['x-forwarded-proto'] || _req.protocol}://${_req.headers['x-forwarded-host'] || _req.headers.host}`;
+    res.redirect(`${frontendUrl}/login`);
   });
   router.get('/diia/status/:sessionId', (_req, res) => {
     res.status(501).json({ error: 'Diia auth is not configured' });


### PR DESCRIPTION
## Summary
- Diia Sandbox redirects the user's browser to `GET /auth/diia/callback` after authentication
- Only a `POST` handler (webhook) existed, causing `{"error":"Not found","message":"Route GET /auth/diia/callback not found"}`
- Added `GET` handler that redirects to `/login` page (both configured and unconfigured code paths)

## Test plan
- [ ] Initiate Diia auth flow → scan QR in Diia Sandbox → verify no more 404
- [ ] Verify browser redirects to `/login` after Diia callback
- [ ] Verify polling still picks up the completed session and logs user in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `GET /auth/diia/callback` route to handle Diia’s browser redirect after auth and stop 404s. The handler builds the frontend URL from `X-Forwarded-*` headers and redirects the user to `/login` in both configured and unconfigured modes.

<sup>Written for commit 66c03b8064d6c909a073ab69c6e2afc0a78acedb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

