### PR TITLE
fix(chat): improve queryType detection in intent classifier fallback

### DIFF
--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -161,8 +161,12 @@ export class IntentClassifier {
 
       // Regex-based queryType coercions when LLM defaults to legal_consultation
       if (queryType === 'legal_consultation') {
+        // Legislation amendment history: "зміни до закону", "редакції", "історія змін", "еволюція норми"
+        if (/зміни?.{0,30}(?:закон|норм|стат|редакц|пункт|постанов)|редакці[яї]|історі[яї].{0,20}(?:змін|закон|норм)|еволюці[яї].{0,20}норм/i.test(query)) {
+          queryType = 'legislation_lookup';
+        }
         // Legislation: "ст. 16 ЦК", "стаття 382 КК", "ч. 3 ст. 16"
-        if (/ст(?:атт[яію])?\.?\s?\d+/i.test(query) || /(?:^|\s)(?:ЦК|КК|ГПК|ЦПК|КАС|ГК|ЗК|СК|КЗпП)(?:\s|$|[,.])/i.test(query)) {
+        else if (/ст(?:атт[яію])?\.?\s?\d+/i.test(query) || /(?:^|\s)(?:ЦК|КК|ГПК|ЦПК|КАС|ГК|ЗК|СК|КЗпП)(?:\s|$|[,.])/i.test(query)) {
           queryType = 'legislation_lookup';
         }
         // Registry: ЄДРПОУ, 8-digit code, ТОВ/ПАТ/ФОП lookup
@@ -252,11 +256,27 @@ export class IntentClassifier {
         }
       }
 
+      // Determine queryType from keywords instead of always defaulting to legal_consultation
+      let fallbackQueryType: QueryType = 'legal_consultation';
+      if (/зміни?.{0,30}(?:закон|норм|стат|редакц|пункт|постанов)|редакці[яї]|історі[яї].{0,20}(?:змін|закон|норм)|еволюці[яї].{0,20}норм/i.test(query)) {
+        fallbackQueryType = 'legislation_lookup';
+      } else if (/стат(?:т[яі]|ей).{0,20}(?:кодекс|закон|ЦК|ГК|КК|КПК|ЦПК|ГПК|КАС)/i.test(query) || /(?:кодекс|закон).{0,30}стат/i.test(query)) {
+        fallbackQueryType = 'legislation_lookup';
+      } else if (/практик[аи]|судов[аіі].{0,20}практик|як суди/i.test(query)) {
+        fallbackQueryType = 'practice_analysis';
+      } else if (/порівня|негаторн|віндикаційн|який спосіб захисту/i.test(query)) {
+        fallbackQueryType = 'comparative_analysis';
+      } else if (/ЄДРПОУ|edrpou|ТОВ |ПАТ |юридичн.{0,10}особ|компані|підприємств/i.test(query)) {
+        fallbackQueryType = 'registry_lookup';
+      } else if (fallbackSlots.case_number) {
+        fallbackQueryType = 'case_lookup';
+      }
+
       return {
         domains: intent.domains,
         keywords: query,
         slots: Object.keys(fallbackSlots).length > 0 ? fallbackSlots : undefined,
-        queryType: 'legal_consultation' as QueryType,
+        queryType: fallbackQueryType,
       };
     }
   }


### PR DESCRIPTION
## Summary
- When LLM intent classification fails (invalid JSON — happened 4/4 times for the 1388 query), fallback now determines `queryType` from keywords instead of always defaulting to `legal_consultation`
- Added amendment history regex pattern (`зміни/редакції/історія`) to both LLM-path coercions and keyword fallback to correctly detect `legislation_lookup`
- This ensures `get_legislation_history` gets included in execution plans for amendment analysis queries

## Root cause
Response `chat-1174c417-568c-4301-8f86-199dc4c88705` — intent classifier failed with `Expected ',' or '}' after property value in JSON`, fell back to `legal_consultation`, plan never included `get_legislation_history`, assistant couldn't get historical edition texts.

## Test plan
- [ ] Send query about legislative amendment history — verify `queryType=legislation_lookup` in logs
- [ ] Verify `get_legislation_history` appears in execution plan
- [ ] Verify assistant receives and uses full_text from different editions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves fallback `queryType` detection when LLM intent parsing fails, correctly routing amendment history queries to `legislation_lookup` so plans include `get_legislation_history`. Fallback now derives `queryType` from keywords instead of always using `legal_consultation`.

- **Bug Fixes**
  - Added amendment history patterns (`зміни/редакції/історія/еволюція`) to both LLM-path coercions and the fallback to set `queryType=legislation_lookup`.
  - Fallback now infers `queryType` from keywords (legislation, practice, comparative, registry, case lookup), ensuring tools like `get_legislation_history` are included when needed.

<sup>Written for commit a4cdb85053a8ba93c2c46e5a4791447046117d78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

