### PR TITLE
fix(ci): add --legacy-peer-deps for eslint peer dep conflict

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -86,7 +86,7 @@ jobs:
           node-version: 20
 
       - name: Build shared package
-        run: cd packages/shared && npm install && npm run build
+        run: cd packages/shared && npm install --legacy-peer-deps && npm run build
 
       # Backend/RADA/OpenReyestr integration tests require running infrastructure (DB, Redis, MinIO).
       # CI runs TypeScript compilation + unit tests (mocked, no infra needed).
@@ -110,7 +110,7 @@ jobs:
         if: needs.detect-changes.outputs.frontend == 'true'
         run: |
           cd lexwebapp
-          npm install
+          npm install --legacy-peer-deps
           npm test
           npm run build
         env:


### PR DESCRIPTION
## Summary
- CI failing on `npm install` due to eslint@10 vs eslint-plugin-react-hooks@7 peer dep conflict
- Added `--legacy-peer-deps` to shared package and lexwebapp install steps (platform already had it)

## Test plan
- [ ] CI pipeline passes on this PR
- [ ] Subsequent merges to main trigger successful deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI install failures by adding --legacy-peer-deps to the shared and `lexwebapp` install steps, resolving the `eslint`@10 vs `eslint-plugin-react-hooks`@7 peer dependency conflict.

- **Bug Fixes**
  - Add `--legacy-peer-deps` to `packages/shared` and `lexwebapp` install commands in `.github/workflows/ci-local-deploy.yml` to bypass the workspace peer dep clash until `eslint-plugin-react-hooks` supports `eslint` 10.

<sup>Written for commit 52ab89457cd9ed2f590a6611f065bc1a6934492f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

