### PR TITLE
chore: deploy diia callback fix to prod

### DIFF
--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -159,6 +159,8 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
    * @access  Public
    */
   router.post('/diia/callback', authController.diiaAuthCallback as any);
+
+  // Diia redirects the user's browser here via GET after auth — redirect to login page
   router.get('/diia/callback', (_req, res) => {
     const frontendUrl = `${_req.headers['x-forwarded-proto'] || _req.protocol}://${_req.headers['x-forwarded-host'] || _req.headers.host}`;
     res.redirect(`${frontendUrl}/login`);


### PR DESCRIPTION
Triggers backend deploy with the symlink fix from #1111.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploy the Diia auth callback fix to production. Adds a comment clarifying that GET `/diia/callback` redirects the browser to the frontend `/login` after auth.

<sup>Written for commit 4de4bba0c910969ffe2fbeb27ec09a75cc5452af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

