### PR TITLE
fix: add @aws-sdk/client-bedrock + fix duplicate key — unblock prod deploy

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -62,6 +62,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@aws-sdk/client-bedrock": "^3.1014.0",
     "@aws-sdk/client-s3": "^3.1005.0",
     "@aws-sdk/client-sqs": "^3.1005.0",
     "@google-cloud/vision": "^5.3.4",


### PR DESCRIPTION
Fixes two TypeScript build errors blocking prod deploy: missing bedrock dep and duplicate object key.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing `@aws-sdk/client-bedrock` dependency and remove a duplicate `legislation_lookup` key to fix TypeScript build errors and unblock prod deploy.

- **Bug Fixes**
  - Added `@aws-sdk/client-bedrock` to `mcp_backend/package.json` to satisfy imports in `batch-embed-court-sessions.ts`.
  - Removed older duplicate `legislation_lookup` entry in `prompt-sections.ts` (TS1117).

<sup>Written for commit 638ff0a28662ab95216e758252fb7217ba5f6d6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

