### PR TITLE
fix(auth): restore Diia auth session on mobile same-device flow

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -250,8 +250,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       const diiaDeeplinkParam = urlParams.get('diia_deeplink');
       const diiaSessionParam = urlParams.get('diia_session');
 
-      if (diiaDeeplinkParam && diiaSessionParam) {
-        setDiiaDeeplink(diiaDeeplinkParam);
+      if (diiaSessionParam) {
+        if (diiaDeeplinkParam) {
+          setDiiaDeeplink(diiaDeeplinkParam);
+        }
         setDiiaSessionId(diiaSessionParam);
         window.history.replaceState({}, '', window.location.pathname);
         return;
@@ -1257,6 +1259,49 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                   Зареєструватися
                 </button>
               </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Diia completing — returned from Diia app, polling in progress */}
+      <AnimatePresence>
+        {diiaSessionId && !diiaDeeplink && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 bg-black/85 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+          >
+            <motion.div
+              initial={{ scale: 0.97, opacity: 0, y: 8 }}
+              animate={{ scale: 1, opacity: 1, y: 0 }}
+              exit={{ scale: 0.97, opacity: 0, y: 8 }}
+              transition={{ duration: 0.2 }}
+              className="relative bg-zinc-950 border border-zinc-800/80 rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center"
+            >
+              <button
+                onClick={() => { setDiiaSessionId(null); }}
+                className="absolute top-4 right-4 w-7 h-7 flex items-center justify-center rounded-md text-zinc-700 hover:text-zinc-400 hover:bg-zinc-900 transition-colors"
+              >
+                <X size={14} />
+              </button>
+
+              <div className="w-11 h-11 rounded-xl flex items-center justify-center mx-auto mb-5">
+                <img src="/diia-logo.png" alt="Дія" width="44" height="44" className="rounded-xl" />
+              </div>
+
+              <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5">Завершення входу</h2>
+              <p className="text-[0.775rem] text-zinc-500 mb-6 leading-relaxed">
+                Обробка авторизації через Дію…
+              </p>
+
+              <Loader2 size={24} className="animate-spin text-zinc-500 mx-auto mb-4" />
+
+              <p className="text-[10px] text-zinc-700">
+                Очікування підтвердження від Дії
+              </p>
             </motion.div>
           </motion.div>
         )}

--- a/mcp_backend/src/controllers/auth-diia.ts
+++ b/mcp_backend/src/controllers/auth-diia.ts
@@ -59,6 +59,17 @@ export async function diiaAuthInit(req: Request, res: Response): Promise<void> {
       diia_session: requestId,
       diia_deeplink: deeplink,
     });
+
+    // Persist session ID in cookie so GET /auth/diia/callback can resume polling
+    // after Diia app redirects back (mobile same-device flow loses the original tab)
+    res.cookie('diia_session', requestId, {
+      httpOnly: false,
+      secure: true,
+      sameSite: 'lax',
+      maxAge: DIIA_SESSION_TTL * 1000,
+      path: '/',
+    });
+
     res.redirect(`${baseUrl}/login?${params.toString()}`);
   } catch (error: any) {
     logger.error('[Diia] Auth init failed:', error);

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -160,10 +160,20 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
    */
   router.post('/diia/callback', authController.diiaAuthCallback as any);
 
-  // Diia redirects the user's browser here via GET after auth — redirect to login page
+  // Diia redirects the user's browser here via GET after auth.
+  // On mobile same-device flow the original polling tab is lost,
+  // so pass the session ID from cookie so the login page can resume polling.
   router.get('/diia/callback', (_req, res) => {
     const frontendUrl = `${_req.headers['x-forwarded-proto'] || _req.protocol}://${_req.headers['x-forwarded-host'] || _req.headers.host}`;
-    res.redirect(`${frontendUrl}/login`);
+    const cookieHeader = _req.headers.cookie || '';
+    const match = cookieHeader.match(/(?:^|;\s*)diia_session=([^;]+)/);
+    const diiaSession = match ? decodeURIComponent(match[1]) : null;
+    if (diiaSession) {
+      res.clearCookie('diia_session', { path: '/' });
+      res.redirect(`${frontendUrl}/login?diia_session=${encodeURIComponent(diiaSession)}`);
+    } else {
+      res.redirect(`${frontendUrl}/login?diia_callback=success`);
+    }
   });
 
   /**


### PR DESCRIPTION
## Summary
- When logging in via Diia on a mobile phone (same device), the Diia app opens a new browser tab after auth — the original tab with polling is lost, so nothing happens
- Now sets a `diia_session` cookie during init, reads it in GET `/auth/diia/callback` to redirect with `?diia_session=XXX`
- Login page resumes polling from the session param and shows a "completing" modal while waiting

## Changed files
- `mcp_backend/src/controllers/auth-diia.ts` — set `diia_session` cookie on auth init
- `mcp_backend/src/routes/auth.ts` — GET callback reads cookie and redirects with session param
- `lexwebapp/src/pages/LoginPage/index.tsx` — handle `diia_session` without `diia_deeplink`, show completing modal

## Test plan
- [ ] Desktop: Diia QR flow still works (scan from phone, desktop gets token)
- [ ] Mobile: tap "Увійти через Дію" → Diia app → return to browser → login completes
- [ ] Edge case: cookie missing → falls back to `/login?diia_callback=success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Diia mobile same‑device login by restoring the auth session after returning from the Diia app. The login page now resumes polling and completes instead of landing on a blank screen.

- **Bug Fixes**
  - Backend `diiaAuthInit`: set `diia_session` cookie with the request ID.
  - GET `/auth/diia/callback`: read and clear `diia_session` cookie; redirect to `/login?diia_session=...` (fallback to `/login?diia_callback=success`).
  - Login page: parse `diia_session`, resume polling without a `diia_deeplink`, and show a short “completing” modal while waiting.

<sup>Written for commit bc31b8a6cf6a1f7fd57cf6f734da49604aa4459f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

