### PR TITLE
chore: rebuild frontend — dual versioning + diia logo

### DIFF
--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -213,7 +213,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
               <img src="/Image.jpg" alt="Lex" className="h-full w-auto object-contain" />
             </div>
             {(import.meta.env.VITE_APP_VERSION || import.meta.env.VITE_APP_FRONTEND_VERSION) && (
-              <div className="flex flex-col">
+              <div className="flex flex-col leading-tight">
                 {import.meta.env.VITE_APP_VERSION && (
                   <span className="text-[9px] text-claude-subtext/40 font-mono tracking-tight">
                     be {import.meta.env.VITE_APP_VERSION}


### PR DESCRIPTION
Frontend on prod was built before dual versioning PR #1095 merged. Triggers rebuild to show both be/fe versions and include official Diia logo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the frontend so production shows both backend and frontend versions and includes the official Diia logo. Also tightens the sidebar version text line-height so both versions fit cleanly.

<sup>Written for commit 75c6bc10cba81e872adb81209dddd82bfe698087. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

