### PR TITLE
fix(diia): update branch/offer names and address

### DIFF
--- a/mcp_backend/src/services/diia-service.ts
+++ b/mcp_backend/src/services/diia-service.ts
@@ -120,15 +120,15 @@ export class DiiaService {
     const token = await this.getSessionToken();
 
     const branchBody = {
-      name: 'LexAI Auth',
+      name: 'Авторизація в застосунку Lex / legal.org.ua',
       email: 'admin@legal.org.ua',
       region: 'м. Київ',
-      district: 'Шевченківський р-н',
+      district: 'Деснянський р-н',
       location: 'м. Київ',
-      street: 'вул. Хрещатик',
-      house: '1',
+      street: 'вул. 47-а Садова',
+      house: '1а',
       customFullName: 'ФОП Кириченко І.В. — юридична AI-платформа',
-      customFullAddress: 'м. Київ, вул. Хрещатик, 1',
+      customFullAddress: '04132, Україна, м. Київ, вул. 47-а Садова, 1а',
       deliveryTypes: ['api'],
       offerRequestType: 'dynamic',
       scopes: { diiaId: ['auth'] },
@@ -178,7 +178,7 @@ export class DiiaService {
     const token = await this.getSessionToken();
 
     const offerBody = {
-      name: 'Авторизація LexAI',
+      name: 'Авторизація в застосунку Lex / legal.org.ua',
       returnLink,
       scopes: { diiaId: ['auth'] },
     };
@@ -294,15 +294,15 @@ export class DiiaService {
     const token = await this.getSessionToken();
 
     const branchBody = {
-      name: 'LexAI Підпис',
+      name: 'Підпис документів Lex / legal.org.ua',
       email: 'admin@legal.org.ua',
       region: 'м. Київ',
-      district: 'Шевченківський р-н',
+      district: 'Деснянський р-н',
       location: 'м. Київ',
-      street: 'вул. Хрещатик',
-      house: '1',
+      street: 'вул. 47-а Садова',
+      house: '1а',
       customFullName: 'ФОП Кириченко І.В. — юридична AI-платформа',
-      customFullAddress: 'м. Київ, вул. Хрещатик, 1',
+      customFullAddress: '04132, Україна, м. Київ, вул. 47-а Садова, 1а',
       deliveryTypes: ['api'],
       offerRequestType: 'dynamic',
       scopes: { diiaId: ['hashedFilesSigning'] },
@@ -337,7 +337,7 @@ export class DiiaService {
     const token = await this.getSessionToken();
 
     const offerBody = {
-      name: 'Підписання документів LexAI',
+      name: 'Підпис документів Lex / legal.org.ua',
       returnLink,
       scopes: { diiaId: ['hashedFilesSigning'] },
     };


### PR DESCRIPTION
## Summary
- Update Diia branch/offer display names to "Авторизація в застосунку Lex / legal.org.ua"
- Correct registered address to 04132, Україна, м. Київ, вул. 47-а Садова, 1а
- Applies to both auth and signing branches/offers

## Note
Takes effect only when new branches/offers are created. If `DIIA_BRANCH_ID`/`DIIA_OFFER_ID` are set or branches already exist, old ones need to be removed first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Diia branch/offer display names and registered address to official legal.org.ua details. Auth is now "Авторизація в застосунку Lex / legal.org.ua", signing is "Підпис документів Lex / legal.org.ua", and the address is "04132, Україна, м. Київ, вул. 47-а Садова, 1а".

- **Migration**
  - Takes effect only for newly created branches/offers.
  - If `DIIA_BRANCH_ID` or `DIIA_OFFER_ID` are set or entities already exist, remove them or unset the IDs and recreate.

<sup>Written for commit 61fbaed23e18f04eeb1457c58b86671ad30b4447. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

