### PR TITLE
fix(cors): add platform.legal.org.ua to ALLOWED_ORIGINS

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -578,7 +578,7 @@ services:
       DIIA_ACQUIRER_TOKEN: ${DIIA_ACQUIRER_TOKEN:-}
       DIIA_AUTH_ACQUIRER_TOKEN: ${DIIA_AUTH_ACQUIRER_TOKEN:-}
       FRONTEND_URL: https://legal.org.ua
-      ALLOWED_ORIGINS: https://legal.org.ua,https://mcp.legal.org.ua
+      ALLOWED_ORIGINS: https://legal.org.ua,https://mcp.legal.org.ua,https://platform.legal.org.ua
 
       # Bulk scrape pipeline (AWS SQS + S3)
       BULK_SCRAPE_SQS_QUEUE_URL: ${BULK_SCRAPE_SQS_QUEUE_URL:-}
@@ -945,7 +945,7 @@ services:
       DIIA_ACQUIRER_TOKEN: ${DIIA_ACQUIRER_TOKEN:-}
       DIIA_AUTH_ACQUIRER_TOKEN: ${DIIA_AUTH_ACQUIRER_TOKEN:-}
       FRONTEND_URL: https://legal.org.ua
-      ALLOWED_ORIGINS: https://legal.org.ua,https://mcp.legal.org.ua
+      ALLOWED_ORIGINS: https://legal.org.ua,https://mcp.legal.org.ua,https://platform.legal.org.ua
       BULK_SCRAPE_SQS_QUEUE_URL: ${BULK_SCRAPE_SQS_QUEUE_URL:-}
       BULK_SCRAPE_SQS_DLQ_URL: ${BULK_SCRAPE_SQS_DLQ_URL:-}
       BULK_SCRAPE_S3_BUCKET: ${BULK_SCRAPE_S3_BUCKET:-}


### PR DESCRIPTION
## Summary
- Google auth on platform.legal.org.ua was blocked by CORS
- Added `https://platform.legal.org.ua` to ALLOWED_ORIGINS in docker-compose.prod.yml
- Already applied on prod (backend restarted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CORS blocking Google auth on platform.legal.org.ua. Added https://platform.legal.org.ua to ALLOWED_ORIGINS in docker-compose.prod.yml to allow requests from the platform domain.

<sup>Written for commit b33838381979a37ea10a6e7212f188f20ae1c859. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

