### PR TITLE
fix(platform): cast balance to Number before toFixed

### DIFF
--- a/platform/src/pages/DashboardPage.tsx
+++ b/platform/src/pages/DashboardPage.tsx
@@ -27,7 +27,7 @@ export function DashboardPage() {
         const keys = keysRes.data.keys || [];
         setData({
           keysCount: keys.length,
-          balance: balanceRes.data.balance || 0,
+          balance: Number(balanceRes.data.balance) || 0,
           firstKey: keys.length > 0 ? keys[0].key : null,
           totalCalls: usageRes.data.total_calls || 0,
         });

--- a/platform/src/pages/UsagePage.tsx
+++ b/platform/src/pages/UsagePage.tsx
@@ -32,9 +32,9 @@ export function UsagePage() {
         setByTool(toolRes.data.data || []);
         setTransactions(txRes.data.transactions || []);
         setBalance({
-          balance: balRes.data.balance || 0,
-          lifetimePurchased: balRes.data.lifetimePurchased || 0,
-          lifetimeUsed: balRes.data.lifetimeUsed || 0,
+          balance: Number(balRes.data.balance) || 0,
+          lifetimePurchased: Number(balRes.data.lifetimePurchased) || 0,
+          lifetimeUsed: Number(balRes.data.lifetimeUsed) || 0,
         });
       } catch { /* ignore */ } finally { setLoading(false); }
     }


### PR DESCRIPTION
## Summary
- `balance.toFixed(2)` crashed because API returns balance as string
- Cast to `Number()` in DashboardPage and UsagePage
- `/api/usage/summary` 404 is expected — endpoint doesn't exist yet, `.catch()` already handles it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash when rendering balances by casting API string values to numbers before formatting with toFixed. Applied to DashboardPage (balance) and UsagePage (balance, lifetimePurchased, lifetimeUsed).

<sup>Written for commit 752acb51956d4853c37bf518286482e1c8d927b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

