### PR TITLE
fix(platform): use camelCase field names in ApiKeysPage

### DIFF
--- a/platform/src/pages/ApiKeysPage.tsx
+++ b/platform/src/pages/ApiKeysPage.tsx
@@ -7,10 +7,10 @@ interface ApiKey {
   id: string;
   name: string;
   key: string;
-  created_at: string;
-  last_used_at: string | null;
-  usage_count: number;
-  is_active: boolean;
+  createdAt: string;
+  lastUsedAt: string | null;
+  usageCount: number;
+  isActive: boolean;
 }
 
 export function ApiKeysPage() {
@@ -159,13 +159,13 @@ export function ApiKeysPage() {
                     </div>
                   </td>
                   <td className="px-4 py-3 text-xs text-txt-muted">
-                    {new Date(key.created_at).toLocaleDateString('uk-UA')}
+                    {new Date(key.createdAt).toLocaleDateString('uk-UA')}
                   </td>
                   <td className="px-4 py-3 text-xs text-txt-muted">
-                    {key.last_used_at ? new Date(key.last_used_at).toLocaleDateString('uk-UA') : '—'}
+                    {key.lastUsedAt ? new Date(key.lastUsedAt).toLocaleDateString('uk-UA') : '—'}
                   </td>
                   <td className="px-4 py-3 text-xs text-txt-muted text-right">
-                    {key.usage_count.toLocaleString()}
+                    {(key.usageCount ?? 0).toLocaleString()}
                   </td>
                   <td className="px-4 py-3 text-right">
                     <button


### PR DESCRIPTION
## Summary
- Backend returns camelCase (`usageCount`, `createdAt`, `lastUsedAt`) but frontend used snake_case → white screen crash on /keys page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use camelCase fields from the API in ApiKeysPage to match the backend and prevent the white-screen crash on /keys. Uses createdAt/lastUsedAt/usageCount/isActive and defaults usageCount to 0 when missing.

<sup>Written for commit 30e6d5bad795018944cfa8364f43c502e5115923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

