### PR TITLE
feat(platform): contract page to view signed developer offer

### DIFF
--- a/platform/src/App.tsx
+++ b/platform/src/App.tsx
@@ -15,6 +15,7 @@ import { McpToolsPage } from './pages/docs/McpToolsPage';
 import { ApiReferencePage } from './pages/docs/ApiReferencePage';
 import { RateLimitsPage } from './pages/docs/RateLimitsPage';
 import { IntegrationsPage } from './pages/docs/IntegrationsPage';
+import { ContractPage } from './pages/ContractPage';
 
 export function App() {
   return (
@@ -33,6 +34,7 @@ export function App() {
           <Route path="keys" element={<ApiKeysPage />} />
           <Route path="usage" element={<UsagePage />} />
           <Route path="playground" element={<PlaygroundPage />} />
+          <Route path="contract" element={<ContractPage />} />
 
           <Route path="docs" element={<DocsLayout />}>
             <Route index element={<IntroductionPage />} />

--- a/platform/src/components/Sidebar.tsx
+++ b/platform/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Gauge,
   Cable,
   Play,
+  FileText,
   X,
 } from 'lucide-react';
 
@@ -19,6 +20,7 @@ const navItems = [
   { to: '/keys', icon: Key, label: 'API Keys' },
   { to: '/usage', icon: BarChart3, label: 'Usage' },
   { to: '/playground', icon: Play, label: 'Playground' },
+  { to: '/contract', icon: FileText, label: 'Договір' },
 ];
 
 const docsItems = [

--- a/platform/src/pages/ContractPage.tsx
+++ b/platform/src/pages/ContractPage.tsx
@@ -1,0 +1,68 @@
+import { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { FileText, Loader2 } from 'lucide-react';
+import { api } from '@/utils/api-client';
+import { useAuth } from '@/hooks/useAuth';
+import content from '@/content/developer-offer-uk.md?raw';
+
+interface Contract {
+  version: string;
+  contractNumber: string;
+  contractDate: string;
+  acceptedAt: string;
+  ipAddress: string;
+}
+
+export function ContractPage() {
+  const { user } = useAuth();
+  const [contract, setContract] = useState<Contract | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get('/auth/my-contracts').then(({ data }) => {
+      const dev = data.contracts?.find((c: Contract) => c.version === 'developer-offer-1.0');
+      setContract(dev || null);
+    }).catch(() => {}).finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-brand-600" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-txt-primary">Договір</h1>
+        <p className="text-sm text-txt-muted mt-1">
+          Публічна оферта про надання доступу до платформи
+        </p>
+      </div>
+
+      {contract && (
+        <div className="bg-green-50 border border-green-200 rounded-xl p-4 flex items-start gap-3">
+          <FileText size={20} className="text-green-600 mt-0.5 flex-shrink-0" />
+          <div>
+            <p className="text-sm font-medium text-green-800">
+              Договір №{contract.contractNumber} від {contract.contractDate}
+            </p>
+            <p className="text-xs text-green-700 mt-1">
+              Прийнято {new Date(contract.acceptedAt).toLocaleString('uk-UA')}
+              {user?.email && ` • ${user.email}`}
+            </p>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-white rounded-xl border border-border p-6">
+        <div className="prose prose-sm max-w-none prose-headings:text-txt-primary prose-p:text-txt-secondary prose-li:text-txt-secondary prose-strong:text-txt-primary">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/contract` page showing signed developer offer with contract number and date
- "Договір" link added to sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Contract page to view the signed developer offer, including contract number and date. Linked in the sidebar as “Договір”.

- **New Features**
  - New `/contract` route renders `ContractPage` with offer text from `developer-offer-uk.md`.
  - Fetches via `/auth/my-contracts` and shows contract number, date, acceptance time, and user email (if present) with a loading state.
  - Adds “Договір” sidebar link with `FileText` icon.

<sup>Written for commit a8cfabbd85e7eb1166fc9515d33a3b32412e4a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

