### PR TITLE
feat(investor): UK investor memo page with GBP pricing

### DIFF
--- a/docs/investment-memo-uk.md
+++ b/docs/investment-memo-uk.md
@@ -1,0 +1,319 @@
+# Investment Opportunity Memorandum
+
+## LEX — AI-Powered Legal Analytics Platform
+**legal.org.ua**
+
+**Prepared for:** Prospective Investors
+**Date:** March 2026
+**Classification:** Confidential
+
+---
+
+## 1. Executive Summary
+
+LEX is a proprietary AI-powered legal analytics platform serving the Ukrainian legal market — a segment with 60,000+ registered attorneys, 5,000+ law firms, and 10,000+ corporate legal departments, yet virtually no AI-native tooling.
+
+The platform combines the largest indexed court decision corpus in Ukraine (115M+ metadata records), proprietary judge performance analytics, semantic search across 2M+ vector embeddings, and native MCP (Model Context Protocol) integration with leading LLMs (Claude, GPT-4o). There are no direct competitors offering comparable AI capabilities in this market.
+
+LEX is built by a complementary founding team: a CTO with 15+ years of infrastructure and AI platform experience (KPI, Glushkov Institute of Cybernetics), and a CEO with a PhD in Law and deep expertise in Ukrainian and international legal practice.
+
+**The ask:** Seed investment to achieve product-market fit and acquire the first 200+ paying customers.
+
+---
+
+## 2. The Opportunity
+
+### Market Context
+
+The global legal AI market is projected to exceed £400M by 2027. Ukraine's legal services sector remains dominated by legacy database providers (LIGA:ZAKON, ZakonOnline) built on 2000s-era technology — keyword search, no AI, no APIs, closed ecosystems.
+
+LEX is positioned as the Harvey.ai of the Ukrainian and CEE legal market.
+
+| Comparable | Domicile | Valuation / Revenue | Focus |
+|---|---|---|---|
+| Harvey | USA | £1.2B+ (valuation) | AI for law firms |
+| Clio | Canada | £2.4B+ (valuation) | Practice management + AI |
+| LexisNexis (RELX) | USA/UK | £11B+ (revenue) | Legal analytics, databases |
+| **LEX** | **Ukraine** | **Seed stage** | **AI legal analytics + MCP** |
+
+### Addressable Market
+
+| Segment | Size | Potential ARPU | Revenue at 1% Penetration |
+|---|---|---|---|
+| Attorneys (UNBA) | 60,000+ | £23–39/mo | £1.4–2.3M/yr |
+| Law firms | 5,000+ | £79–239/mo | £0.5–1.4M/yr |
+| Corporate legal departments | 10,000+ | £159–399/mo | £1.9–4.8M/yr |
+| API/MCP integrations (B2B) | 100+ | £400–1,600/mo | £0.5–1.9M/yr |
+
+---
+
+## 3. Production Data Assets
+
+LEX has assembled one of the most comprehensive legal data repositories in Ukraine. The following datasets are live in production as of 23 March 2026, sourced from the Linear task tracker (LEG-233):
+
+### 3.1 Court Decisions (EDRSR — Unified State Register of Court Decisions)
+
+| Dataset | Records | Table / Storage | Status |
+|---|---|---|---|
+| EDRSR metadata (all decisions since 2006) | 8,800,000 | `edrsr_documents` (partitioned by year) | Complete |
+| EDRSR full-text RTF archive | 53M files, 1.4 TB | HDD file storage | Complete |
+| Court sessions (ZakonOnline archive, 2020–present) | ~18,500,000 | `court_sessions` (HUDOC PostgreSQL) | In progress |
+| Supreme Court judges | 153 | `supreme_court_judges` | Partial |
+
+### 3.2 NAIS State Registries (data.gov.ua) — 11/11 Complete
+
+| Registry | Records | Table |
+|---|---|---|
+| Enforcement proceedings | 29,060,072 | `enforcement_proceedings` |
+| Debtors register | 10,363,352 | `debtors` |
+| Special forms of notarial documents | 1,224,003 | `special_forms` |
+| Administrative-territorial units | 500,704 | `administrative_units` |
+| Street directory | 497,464 | `streets` |
+| EDRNPA (normative legal acts) | 140,930 | `legal_acts` |
+| Bankruptcy cases | 35,439 | `bankruptcy_cases` |
+| Court experts | 14,730 | `court_experts` |
+| Notaries | 5,799 | `notaries` |
+| Arbitration managers | 3,420 | `arbitration_managers` |
+| Forensic examination methods | 1,546 | `forensic_methods` |
+
+**NAIS subtotal: ~41,800,000 records**
+
+### 3.3 Tax Registries (DPS / State Tax Service)
+
+Data as of 23 February 2022 (last available dump prior to full-scale invasion).
+
+| Registry | Records | Table |
+|---|---|---|
+| Tax debt | 861,124 | `tax_debt` |
+| Unified social contribution (ESV) debt | 668,541 | `esv_debt` |
+| Simplified taxation payers | 167,007 | `single_tax_payers` |
+| VAT payers | 131,165 | `vat_payers` |
+
+**Tax subtotal: ~1,830,000 records**
+
+### 3.4 Sanctions & Compliance
+
+| Dataset | Records | Table |
+|---|---|---|
+| OpenSanctions (global) | 1,257,977 | `opensanctions_entities` |
+| RNBO sanctions (National Security Council of Ukraine) | 21,090 | `rnbo_sanctions` |
+| DRS inspection plans 2026 | 31,876 | `inspection_plans` |
+| DSSU financial reports (2024 annual) | 8,434 | `dssu_financial_reports` |
+
+### 3.5 Procurement & Public Finance
+
+| Dataset | Records | Table | Status |
+|---|---|---|---|
+| Prozorro public tenders | 706,100+ (growing) | `prozorro_tenders` | In progress (3 workers, 2020–2027) |
+| spending.gov.ua | — | On-demand MCP tool | WAF restrictions; API-only |
+
+### 3.6 Business Registry (OpenReyestr / EDRSR)
+
+| Dataset | Records | Table |
+|---|---|---|
+| Legal entities (Юридичні особи) | ~1,800,000 | `legal_entities` |
+| Individual entrepreneurs (ФОП) | ~2,300,000 | `individual_entrepreneurs` |
+| Public associations (Громадські формування) | ~150,000 | `public_associations` |
+| Founders, beneficiaries, signers, members | Relational | Multiple linked tables |
+
+**OpenReyestr subtotal: ~4,500,000+ entity records**
+
+### 3.7 Vector Search & AI Infrastructure
+
+| Component | Scale | Technology |
+|---|---|---|
+| Vector embeddings (semantic search) | 2,000,000+ vectors | Qdrant (1536-dim, text-embedding-3-small) |
+| Legislation corpus (Verkhovna Rada) | 200,000+ acts | PostgreSQL + RADA API |
+| Judge analytics | 12,000+ profiles | PostgreSQL with efficiency metrics |
+| Parliamentary data (deputies, bills, voting) | 450 deputies, 10K+ bills | PostgreSQL (RADA schema) |
+
+### 3.8 Consolidated Data Summary
+
+| Category | Records |
+|---|---|
+| EDRSR court decision metadata | 8,800,000 |
+| Court sessions (HUDOC) | ~18,500,000 |
+| NAIS state registries (11 datasets) | ~41,800,000 |
+| Enforcement + debtors | ~39,400,000 |
+| Tax registries | ~1,830,000 |
+| Business registry (OpenReyestr) | ~4,500,000 |
+| Sanctions & compliance | ~1,320,000 |
+| Procurement (Prozorro) | 706,000+ |
+| Legislation, judges, parliament | ~212,000+ |
+| Vector embeddings | 2,000,000+ |
+| Full-text RTF archive | 53,000,000 files |
+| **Total structured records** | **~119,000,000+** |
+| **Full-text file archive** | **53M files / 1.4 TB** |
+
+### 3.9 Data Pipeline Roadmap (Tier 1 — Outstanding)
+
+| Source | Due Diligence Value | Access |
+|---|---|---|
+| DRRP (real property register) | Ownership, encumbrances, arrests | NAIS contract required (~₴3/query) |
+| DRORM (movable property encumbrances) | Pledges, leasing | NAIS contract required |
+| DZK (land cadastre) | Land plots | NAIS contract required |
+| RADA data on prod | Political risk scoring | Code ready, sync pending |
+
+---
+
+## 4. Product & Technology
+
+### 4.1 Platform Capabilities
+
+LEX delivers 45 MCP tools across three integrated servers:
+
+- **36 backend tools** — court case search, semantic search, legislation, citation verification, judge analytics, document vault
+- **4 RADA tools** — deputies, bills, legislation text, voting records
+- **5 OpenReyestr tools** — entity search, beneficiaries, debtor checks
+
+### 4.2 Key Differentiators
+
+| Feature | LEX | ZakonOnline | LIGA:ZAKON | ActiveLex |
+|---|---|---|---|---|
+| AI document analysis | Yes | No | No | No |
+| MCP protocol (LLM integration) | Yes | No | No | No |
+| Semantic (vector) search | Yes | No | No | No |
+| Judge performance analytics | Yes | No | No | No |
+| Citation verification | Yes | No | No | No |
+| Developer API | Yes | No | No | No |
+| SSE streaming | Yes | No | No | No |
+
+**LEX is the only player in Ukraine with AI analytics, semantic search, MCP integration, and automated citation verification.**
+
+### 4.3 Technology Stack
+
+- **Runtime:** Node.js 20, TypeScript 5.3
+- **Databases:** PostgreSQL 15 (partitioned, with PgBouncer), Redis 7, Qdrant (vector DB)
+- **AI:** OpenAI GPT-4o, text-embedding-3-small, Anthropic Claude (fallback)
+- **Infrastructure:** Docker, Nginx, MinIO (S3-compatible), blue-green deployment
+- **Security:** SCRAM-SHA-256 auth, document-level encryption, SHA-256 hash-chain audit log, GDPR compliance
+
+### 4.4 Technology Moat
+
+1. **Data moat** — 119M+ structured records and 53M full-text files. Replicating this corpus would require months of crawling, parsing, and indexing.
+2. **MCP protocol** — First and only Ukrainian platform with native MCP support. 45 tools callable by Claude, GPT, and other LLMs. This is the emerging industry standard.
+3. **AI pipeline** — Semantic search, citation verification, pattern analysis, and decision classification — fully automated. Competitors would need to build this from scratch.
+4. **Domain expertise in code** — A PhD lawyer as co-founder means legal logic is architected into the platform, not bolted on after the fact.
+
+---
+
+## 5. Demonstrated Capability
+
+### Case Study 1: Judge Performance Analysis
+
+- **Input:** Judge K. I.S., Kyiv District Administrative Court
+- **Data processed:** 24,039 USRCD documents, 1,504 appellate decisions across 4 production database shards
+- **AI finding:** "High-productivity judge with problematic decision quality. Every second appealed decision is overturned. Absolute leader in deadline violations (3.8x above court average)."
+- **Practical value:** Grounds for recusal motions, adjusted defence strategy, appellate outcome prediction.
+
+### Case Study 2: Borrower Defence Strategy (Credit Case)
+
+- **Input:** EUR loan from 2007, ₴11.9M outstanding, 11 years of enforcement proceedings
+- **Data processed:** 473 documents cross-referenced with OpenReyestr, NBU registry, Supreme Court precedents
+- **AI output:** 9 identified defence strategies, including creditor dissolution (in liquidation), absence of foreign currency licence, 7-year enforcement writ error
+- **Processing time:** ~15 minutes (estimated 2–3 business days for a human lawyer)
+
+---
+
+## 6. Unit Economics & Revenue Model
+
+### 6.1 Query Cost Structure
+
+| Query Type | Cost to LEX | Client Price | Gross Margin |
+|---|---|---|---|
+| Quick search | £0.001–0.002 | £0.008 | 70–90% |
+| Standard analysis | £0.008–0.024 | £0.040 | 40–80% |
+| Deep analysis | £0.040–0.120 | £0.160 | 25–75% |
+| Semantic search | £0.002–0.004 | £0.016 | 60–90% |
+| Judge analytics | £0.001 | £0.008 | 90% |
+
+### 6.2 Monetisation
+
+- **Subscription:** From £23/mo (individual attorneys) to £239/mo (law firms)
+- **Pay-per-query:** For high-volume and API/B2B clients
+- **Average attorney usage:** 50–200 queries/day → £2.00–8.00 daily revenue at minimal marginal cost
+
+### 6.3 Revenue Projections (200 Customers)
+
+| Scenario | Clients | Avg. Monthly | MRR | ARR |
+|---|---|---|---|---|
+| Conservative | 200 | £23 | £4,600 | £55,200 |
+| Base | 200 | £39 | £7,800 | £93,600 |
+| Optimistic | 200 | £79 | £15,800 | £189,600 |
+| Blended (150 attorneys + 50 firms) | 200 | £37 | £7,400 | £88,800 |
+
+### 6.4 Key SaaS Metrics
+
+| Metric | Value |
+|---|---|
+| CAC (customer acquisition cost) | ≤£80 |
+| LTV (12-month, base scenario) | £468 |
+| LTV/CAC ratio | 5.9x (benchmark: >3x) |
+| Payback period (base) | ~2 months |
+| 12-month ROI | 488% |
+
+---
+
+## 7. Founding Team
+
+**Volodymyr Ovcharov** — CTO & Co-founder
+- BSc Applied Mathematics, National Technical University "KPI"
+- Researcher, V.M. Glushkov Institute of Cybernetics, National Academy of Sciences of Ukraine
+- 15+ years building scalable data processing, NLP, and AI infrastructure platforms
+
+**Igor Kyrychenko** — CEO & Co-founder
+- PhD in Law
+- Deep expertise in Ukrainian and international law, court practice, and legal analytics
+- Bridges academic legal rigour with the practical requirements of working lawyers
+
+---
+
+## 8. Use of Proceeds
+
+| Allocation | % | Amount | Purpose |
+|---|---|---|---|
+| Marketing & customer acquisition | 50% | £8,000 | Facebook Ads, Google Ads, LinkedIn, content marketing, legal conferences |
+| Infrastructure & AI costs | 25% | £4,000 | Servers, OpenAI API, Qdrant, PostgreSQL, CDN, monitoring |
+| Product development | 15% | £2,400 | New features, mobile application, integrations |
+| Legal & operational | 10% | £1,600 | GDPR compliance, legal registration, accounting |
+
+### Milestones (6-Month Horizon)
+
+| Period | Target |
+|---|---|
+| M1–M2 | Launch marketing campaigns; 50 paying customers |
+| M3–M4 | 100+ customers; launch B2B plans; MCP marketplace |
+| M5–M6 | 200+ customers; MRR £4,000–8,000; preparation for seed round |
+
+---
+
+## 9. Scaling Potential
+
+- 60,000+ registered attorneys in Ukraine alone — 1% conversion yields 600+ customers
+- MCP protocol enables API monetisation without proportional cost growth
+- CEE expansion opportunity: Poland, Czech Republic, Romania share similar legal system structures
+- Data moat deepens with every new registry integration (DRRP, DRORM, DZK on roadmap)
+
+---
+
+## 10. Risk Factors
+
+| Risk | Mitigation |
+|---|---|
+| Geopolitical (ongoing conflict) | Platform is cloud-native; team can operate remotely; EU expansion on roadmap |
+| Regulatory changes to open data access | Diversified data sources (11+ registries); NAIS contract pipeline |
+| LLM cost inflation | Budget-aware model selection (quick/standard/deep); multi-provider fallback (OpenAI + Anthropic) |
+| Competitive entry | 119M+ record data moat; 18-month head start on AI pipeline; domain expertise embedded in architecture |
+
+---
+
+## 11. Contact
+
+**Email:** hello@legal.org.ua
+**Platform:** [https://legal.org.ua](https://legal.org.ua)
+
+---
+
+*This document is confidential and intended solely for the use of prospective investors. The information contained herein is based on data available as of 23 March 2026 and is subject to change without notice.*
+
+*© 2024–2026 SecondLayer. All rights reserved.*

--- a/lexwebapp/src/pages/UKInvestorPage.tsx
+++ b/lexwebapp/src/pages/UKInvestorPage.tsx
@@ -1,0 +1,823 @@
+import { motion } from 'framer-motion';
+import {
+  ArrowLeft, Users, Target, Database, BarChart3,
+  TrendingUp, ExternalLink, FileText, Shield, PoundSterling,
+  Globe, Zap, Briefcase, CheckCircle2, AlertTriangle,
+} from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { gbp as t } from './investor-letter-translations.gbp';
+
+const COMPETITOR_FLAGS: [boolean, boolean, boolean, boolean][] = [
+  [true, false, false, false],
+  [true, false, false, false],
+  [true, false, false, false],
+  [true, false, false, false],
+  [true, true, true, true],
+  [true, true, true, true],
+  [true, true, true, true],
+  [true, false, false, false],
+  [true, false, false, true],
+  [true, false, false, true],
+  [true, false, true, false],
+  [true, false, false, false],
+  [true, false, false, false],
+  [true, false, false, false],
+];
+
+const Check = () => <span className="inline-flex items-center justify-center w-6 h-6 bg-green-100 text-green-600 rounded-full text-xs font-bold">+</span>;
+const Cross = () => <span className="inline-flex items-center justify-center w-6 h-6 bg-red-50 text-red-400 rounded-full text-xs">-</span>;
+
+export function UKInvestorPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-claude-bg via-white to-claude-sidebar">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-white/80 backdrop-blur-md border-b border-claude-border">
+        <div className="max-w-4xl mx-auto px-6 py-4 flex items-center gap-4">
+          <button
+            onClick={() => navigate('/login')}
+            className="flex items-center gap-2 text-claude-subtext hover:text-claude-text transition-colors font-sans text-sm"
+          >
+            <ArrowLeft size={16} />
+            {t.back}
+          </button>
+          <div className="flex-1" />
+          <div className="px-3 py-1.5 bg-claude-bg rounded-lg text-sm font-sans font-medium text-claude-subtext">
+            {t.classification}
+          </div>
+          <img src="/Image.jpg" alt="LEX" className="h-10 w-auto" />
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        {/* Title */}
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6 }} className="text-center mb-16">
+          <img src="/Image.jpg" alt="LEX" className="h-24 w-auto mx-auto mb-6" />
+          <h1 className="text-4xl font-serif text-claude-text font-medium mb-3">{t.title}</h1>
+          <p className="text-lg text-claude-subtext font-sans">{t.subtitle}</p>
+          <div className="mt-4 inline-block px-4 py-1.5 bg-claude-accent/10 text-claude-accent rounded-full text-sm font-sans font-medium">
+            {t.date}
+          </div>
+        </motion.div>
+
+        {/* Section 1: Founders */}
+        <Section icon={<Users size={20} />} title={t.s1_title}>
+          <div className="grid md:grid-cols-2 gap-8">
+            <div className="space-y-3">
+              <img src="/founder-vladimir.jpeg" alt={t.s1_vladimir_name} className="w-20 h-20 rounded-full object-cover shadow-md" />
+              <h3 className="text-xl font-serif text-claude-text">{t.s1_vladimir_name}</h3>
+              <p className="text-sm text-claude-subtext font-sans leading-relaxed">
+                <span className="font-medium text-claude-text">{t.s1_vladimir_role}</span>{' '}
+                {t.s1_vladimir_bio}
+              </p>
+              <a href="https://www.linkedin.com/in/vladimir-ovcharov/" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm text-claude-accent hover:text-[#C66345] font-sans">
+                <ExternalLink size={14} />
+                {t.s1_vladimir_linkedin}
+              </a>
+            </div>
+            <div className="space-y-3">
+              <img src="/founder-igor.jpeg" alt={t.s1_igor_name} className="w-20 h-20 rounded-full object-cover shadow-md" />
+              <h3 className="text-xl font-serif text-claude-text">{t.s1_igor_name}</h3>
+              <p className="text-sm text-claude-subtext font-sans leading-relaxed">
+                <span className="font-medium text-claude-text">{t.s1_igor_role}</span>{' '}
+                {t.s1_igor_bio}
+              </p>
+              <a href="https://www.linkedin.com/in/ihor-kyrychenko-90503890/" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm text-claude-accent hover:text-[#C66345] font-sans">
+                <ExternalLink size={14} />
+                {t.s1_igor_linkedin}
+              </a>
+            </div>
+          </div>
+          <div className="mt-8 p-4 bg-claude-bg rounded-xl">
+            <p className="text-sm text-claude-text font-sans leading-relaxed">{t.s1_combo}</p>
+          </div>
+        </Section>
+
+        {/* Section 2: Why Now */}
+        <Section icon={<Zap size={20} />} title={t.s2_why_now_title} delay={0.1}>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {t.s2_why_now_items.map((item) => (
+              <div key={item.title} className="p-5 bg-claude-bg rounded-xl">
+                <h4 className="text-sm font-medium text-claude-text font-sans mb-2">{item.title}</h4>
+                <p className="text-xs text-claude-subtext font-sans leading-relaxed">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Section 3: The Opportunity */}
+        <Section icon={<Target size={20} />} title={t.s3_opp_title} delay={0.15}>
+          <div className="space-y-6">
+            <p className="text-sm text-claude-subtext font-sans leading-relaxed">
+              <span className="font-medium text-claude-text">LEX</span> — {t.s3_opp_intro.replace(/^LEX is an /, '')}
+            </p>
+            <div className="p-4 bg-green-50 border border-green-200 rounded-xl">
+              <p className="text-sm text-green-800 font-sans font-medium mb-2">{t.s3_opp_no_competitors_title}</p>
+              <p className="text-sm text-green-700 font-sans leading-relaxed">
+                {t.s3_opp_no_competitors_text}
+                <a href="https://legal.org.ua/judges" target="_blank" rel="noopener noreferrer" className="text-green-800 underline font-medium">
+                  {t.s3_opp_judges_link_text}
+                </a>
+                {t.s3_opp_no_competitors_suffix}
+              </p>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-serif text-claude-text mb-4">{t.s3_opp_global_title}</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm font-sans">
+                  <thead>
+                    <tr className="border-b border-claude-border">
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s3_opp_th_company}</th>
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s3_opp_th_country}</th>
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s3_opp_th_valuation}</th>
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s3_opp_th_focus}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-claude-subtext">
+                    <tr className="border-b border-claude-border/50">
+                      <td className="py-3 px-4 font-medium text-claude-text">Harvey AI</td>
+                      <td className="py-3 px-4">USA</td>
+                      <td className="py-3 px-4">{t.s3_opp_harvey_valuation}</td>
+                      <td className="py-3 px-4">{t.s3_opp_harvey_focus}</td>
+                    </tr>
+                    <tr className="border-b border-claude-border/50">
+                      <td className="py-3 px-4 font-medium text-claude-text">Clio</td>
+                      <td className="py-3 px-4">Canada</td>
+                      <td className="py-3 px-4">{t.s3_opp_clio_valuation}</td>
+                      <td className="py-3 px-4">{t.s3_opp_clio_focus}</td>
+                    </tr>
+                    <tr className="border-b border-claude-border/50">
+                      <td className="py-3 px-4 font-medium text-claude-text">LexisNexis</td>
+                      <td className="py-3 px-4">USA/UK</td>
+                      <td className="py-3 px-4">{t.s3_opp_lexis_valuation}</td>
+                      <td className="py-3 px-4">{t.s3_opp_lexis_focus}</td>
+                    </tr>
+                    <tr>
+                      <td className="py-3 px-4 font-medium text-claude-accent">LEX (legal.org.ua)</td>
+                      <td className="py-3 px-4">Ukraine</td>
+                      <td className="py-3 px-4">{t.s3_opp_lex_stage}</td>
+                      <td className="py-3 px-4">{t.s3_opp_lex_focus}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-serif text-claude-text mb-3">{t.s3_opp_advantages_title}</h3>
+              <div className="grid sm:grid-cols-2 gap-3">
+                {t.s3_opp_advantages.map((item) => (
+                  <div key={item} className="flex items-start gap-2 text-sm text-claude-subtext font-sans">
+                    <div className="w-1.5 h-1.5 bg-claude-accent rounded-full mt-1.5 flex-shrink-0" />
+                    {item}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 4: Production Data Assets — expanded */}
+        <Section icon={<Database size={20} />} title={t.s4_data_title} delay={0.2}>
+          <p className="text-sm text-claude-subtext font-sans mb-6 leading-relaxed">{t.s4_data_intro}</p>
+
+          {/* Court decisions */}
+          <DataSubSection title={t.s4_sub_court}>
+            <DataTable rows={t.s4_court_db} showStatus />
+          </DataSubSection>
+
+          {/* NAIS */}
+          <DataSubSection title={t.s4_sub_nais}>
+            <DataTable rows={t.s4_nais_db} />
+            <p className="mt-2 text-xs font-sans font-medium text-claude-accent">{t.s4_nais_total}</p>
+          </DataSubSection>
+
+          {/* Tax */}
+          <DataSubSection title={t.s4_sub_tax}>
+            <p className="text-xs text-claude-subtext font-sans mb-3 italic">{t.s4_tax_note}</p>
+            <DataTable rows={t.s4_tax_db} />
+            <p className="mt-2 text-xs font-sans font-medium text-claude-accent">{t.s4_tax_total}</p>
+          </DataSubSection>
+
+          {/* Sanctions */}
+          <DataSubSection title={t.s4_sub_sanctions}>
+            <DataTable rows={t.s4_sanctions_db} />
+          </DataSubSection>
+
+          {/* Procurement */}
+          <DataSubSection title={t.s4_sub_procurement}>
+            <DataTable rows={t.s4_procurement_db} showStatus />
+          </DataSubSection>
+
+          {/* Business registry */}
+          <DataSubSection title={t.s4_sub_business}>
+            <DataTable rows={t.s4_business_db} />
+            <p className="mt-2 text-xs font-sans font-medium text-claude-accent">{t.s4_business_total}</p>
+          </DataSubSection>
+
+          {/* Vector / AI */}
+          <DataSubSection title={t.s4_sub_vector}>
+            <DataTable rows={t.s4_vector_db} />
+          </DataSubSection>
+
+          {/* Consolidated summary */}
+          <div className="mt-8 p-5 bg-claude-accent/5 border border-claude-accent/20 rounded-xl">
+            <h4 className="text-sm font-medium text-claude-text font-sans mb-3">{t.s4_consolidated_title}</h4>
+            <div className="grid sm:grid-cols-2 gap-x-8 gap-y-1.5 text-sm font-sans">
+              {t.s4_consolidated.map((row) => (
+                <div key={row.category} className="flex justify-between border-b border-claude-border/30 py-1">
+                  <span className="text-claude-subtext">{row.category}</span>
+                  <span className="font-medium text-claude-text font-serif">{row.count}</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-4 flex flex-col sm:flex-row gap-4">
+              <div className="px-4 py-2 bg-claude-accent/10 rounded-lg text-center flex-1">
+                <p className="text-lg font-serif text-claude-accent font-medium">119,000,000+</p>
+                <p className="text-[10px] text-claude-subtext font-sans">{t.s4_total_structured.replace('Total structured records: ', '')}</p>
+              </div>
+              <div className="px-4 py-2 bg-claude-accent/10 rounded-lg text-center flex-1">
+                <p className="text-lg font-serif text-claude-accent font-medium">53M / 1.4 TB</p>
+                <p className="text-[10px] text-claude-subtext font-sans">{t.s4_total_files.replace('Full-text file archive: ', '')}</p>
+              </div>
+            </div>
+          </div>
+
+          {/* Pipeline */}
+          <div className="mt-6 p-4 bg-claude-bg rounded-xl">
+            <h4 className="text-sm font-medium text-claude-text font-sans mb-3">{t.s4_pipeline_title}</h4>
+            <div className="space-y-2">
+              {t.s4_pipeline.map((row) => (
+                <div key={row.source} className="flex items-center gap-3 text-sm font-sans">
+                  <span className="text-claude-text font-medium flex-shrink-0 w-48">{row.source}</span>
+                  <span className="text-claude-subtext flex-1">{row.value}</span>
+                  <span className="text-xs text-claude-subtext bg-claude-bg px-2 py-0.5 rounded">{row.access}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 5: Business Model — NEW */}
+        <Section icon={<Briefcase size={20} />} title={t.s5_biz_title} delay={0.25}>
+          <div className="space-y-6">
+            <p className="text-sm text-claude-subtext font-sans leading-relaxed">{t.s5_biz_intro}</p>
+
+            {/* Pricing tiers */}
+            <div>
+              <h3 className="text-lg font-serif text-claude-text mb-4">{t.s5_biz_tiers_title}</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm font-sans">
+                  <thead>
+                    <tr className="border-b-2 border-claude-accent/20">
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_tier}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_price}</th>
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_target}</th>
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_includes}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-claude-subtext">
+                    {t.s5_biz_tiers.map((row, i) => (
+                      <tr key={i} className={i < t.s5_biz_tiers.length - 1 ? 'border-b border-claude-border/50' : ''}>
+                        <td className="py-3 px-4 font-medium text-claude-text">{row.tier}</td>
+                        <td className="py-3 px-4 text-right font-serif text-claude-accent font-medium">{row.price}</td>
+                        <td className="py-3 px-4">{row.target}</td>
+                        <td className="py-3 px-4 text-xs">{row.includes}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            {/* Unit economics */}
+            <div>
+              <h3 className="text-lg font-serif text-claude-text mb-4">{t.s5_biz_unit_title}</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm font-sans">
+                  <thead>
+                    <tr className="border-b-2 border-claude-accent/20">
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_type}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_cost}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_client_price}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s5_biz_th_margin}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-claude-subtext">
+                    {t.s5_biz_queries.map((row, i) => (
+                      <tr key={i} className={i < t.s5_biz_queries.length - 1 ? 'border-b border-claude-border/50' : ''}>
+                        <td className="py-3 px-4 font-medium text-claude-text">{row.type}</td>
+                        <td className="py-3 px-4 text-right">{row.cost}</td>
+                        <td className="py-3 px-4 text-right">{row.price}</td>
+                        <td className="py-3 px-4 text-right text-green-600 font-medium">{row.margin}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="grid sm:grid-cols-3 gap-4 mt-4">
+                <div className="p-4 bg-claude-bg rounded-xl text-center">
+                  <p className="text-2xl font-serif text-claude-accent font-medium">{t.s5_biz_avg_cost_val}</p>
+                  <p className="text-xs text-claude-subtext font-sans mt-1">{t.s5_biz_avg_cost}</p>
+                </div>
+                <div className="p-4 bg-claude-bg rounded-xl text-center">
+                  <p className="text-2xl font-serif text-claude-accent font-medium">{t.s5_biz_avg_price_val}</p>
+                  <p className="text-xs text-claude-subtext font-sans mt-1">{t.s5_biz_avg_price}</p>
+                </div>
+                <div className="p-4 bg-claude-bg rounded-xl text-center">
+                  <p className="text-2xl font-serif text-claude-accent font-medium">{t.s5_biz_avg_margin_val}</p>
+                  <p className="text-xs text-claude-subtext font-sans mt-1">{t.s5_biz_avg_margin}</p>
+                </div>
+              </div>
+            </div>
+
+            {/* Revenue streams */}
+            <div>
+              <h3 className="text-lg font-serif text-claude-text mb-3">{t.s5_biz_revenue_streams_title}</h3>
+              <div className="space-y-3">
+                {t.s5_biz_revenue_streams.map((s) => (
+                  <div key={s.stream} className="space-y-1.5">
+                    <div className="flex items-center justify-between text-sm font-sans">
+                      <span className="text-claude-text font-medium">{s.stream}</span>
+                      <span className="text-claude-accent font-medium">{s.pct}</span>
+                    </div>
+                    <div className="w-full bg-claude-bg rounded-full h-2">
+                      <div className="bg-claude-accent rounded-full h-2 transition-all" style={{ width: s.pct.replace('–', '-').split('-')[0].replace('%', '') + '%' }} />
+                    </div>
+                    <p className="text-xs text-claude-subtext font-sans">{s.desc}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 6: Traction — NEW */}
+        <Section icon={<CheckCircle2 size={20} />} title={t.s6_traction_title} delay={0.28}>
+          <div className="space-y-6">
+            <p className="text-sm text-claude-subtext font-sans leading-relaxed">{t.s6_traction_intro}</p>
+            <div className="grid sm:grid-cols-2 gap-4">
+              {t.s6_traction_items.map((item) => (
+                <div key={item.metric} className="p-4 bg-claude-bg rounded-xl">
+                  <div className="flex items-center justify-between mb-1">
+                    <p className="text-xs text-claude-subtext font-sans">{item.metric}</p>
+                    <p className="text-lg font-serif text-claude-accent font-medium">{item.value}</p>
+                  </div>
+                  <p className="text-xs text-claude-subtext font-sans">{item.detail}</p>
+                </div>
+              ))}
+            </div>
+            <div className="p-4 bg-blue-50 border border-blue-200 rounded-xl">
+              <p className="text-sm text-blue-800 font-sans leading-relaxed italic">{t.s6_traction_quote}</p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 7: Competitors */}
+        <Section icon={<BarChart3 size={20} />} title={t.s7_comp_title} delay={0.3}>
+          <div className="space-y-6">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm font-sans">
+                <thead>
+                  <tr className="border-b-2 border-claude-accent/20">
+                    <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s7_comp_th_feature}</th>
+                    <th className="text-center py-3 px-4 text-claude-accent font-medium">LEX</th>
+                    <th className="text-center py-3 px-4 text-claude-text font-medium">ActiveLex</th>
+                    <th className="text-center py-3 px-4 text-claude-text font-medium">ZakonOnline</th>
+                    <th className="text-center py-3 px-4 text-claude-text font-medium">LIGA:ZAKON</th>
+                  </tr>
+                </thead>
+                <tbody className="text-claude-subtext">
+                  {t.s7_comp_features.map((feature, i) => {
+                    const [lex, active, zakon, liga] = COMPETITOR_FLAGS[i];
+                    return (
+                      <tr key={i} className="border-b border-claude-border/50">
+                        <td className="py-2.5 px-4 text-claude-text">{feature}</td>
+                        <td className="py-2.5 px-4 text-center">{lex ? <Check /> : <Cross />}</td>
+                        <td className="py-2.5 px-4 text-center">{active ? <Check /> : <Cross />}</td>
+                        <td className="py-2.5 px-4 text-center">{zakon ? <Check /> : <Cross />}</td>
+                        <td className="py-2.5 px-4 text-center">{liga ? <Check /> : <Cross />}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+            <div className="grid sm:grid-cols-3 gap-4">
+              <div className="p-4 bg-claude-bg rounded-xl">
+                <h4 className="text-sm font-medium text-claude-text font-sans mb-2">ActiveLex</h4>
+                <p className="text-xs text-claude-subtext font-sans leading-relaxed">{t.s7_comp_activelex_desc}</p>
+              </div>
+              <div className="p-4 bg-claude-bg rounded-xl">
+                <h4 className="text-sm font-medium text-claude-text font-sans mb-2">ZakonOnline</h4>
+                <p className="text-xs text-claude-subtext font-sans leading-relaxed">{t.s7_comp_zakon_desc}</p>
+              </div>
+              <div className="p-4 bg-claude-bg rounded-xl">
+                <h4 className="text-sm font-medium text-claude-text font-sans mb-2">LIGA:ZAKON</h4>
+                <p className="text-xs text-claude-subtext font-sans leading-relaxed">{t.s7_comp_liga_desc}</p>
+              </div>
+            </div>
+            <div className="p-4 bg-claude-accent/5 border border-claude-accent/20 rounded-xl">
+              <p className="text-sm text-claude-text font-sans leading-relaxed">{t.s7_comp_conclusion}</p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 8: Demonstrated Capability */}
+        <Section icon={<FileText size={20} />} title={t.s8_cases_title} delay={0.33}>
+          <div className="space-y-8">
+            <p className="text-sm text-claude-subtext font-sans leading-relaxed">{t.s8_cases_intro}</p>
+
+            {/* Case 1 */}
+            <div className="border border-claude-border rounded-xl overflow-hidden">
+              <div className="bg-claude-accent/5 px-6 py-4 border-b border-claude-border">
+                <h3 className="text-lg font-serif text-claude-text">{t.s8_case1_title}</h3>
+                <p className="text-xs text-claude-subtext font-sans mt-1">{t.s8_case1_subtitle}</p>
+              </div>
+              <div className="px-6 py-5 space-y-4">
+                <p className="text-sm text-claude-subtext font-sans leading-relaxed">{t.s8_case1_intro}</p>
+                <div className="grid sm:grid-cols-4 gap-3">
+                  <div className="p-3 bg-claude-bg rounded-lg text-center">
+                    <p className="text-xl font-serif text-claude-accent font-medium">12 514</p>
+                    <p className="text-[10px] text-claude-subtext font-sans mt-0.5">{t.s8_case1_stat1}</p>
+                  </div>
+                  <div className="p-3 bg-red-50 rounded-lg text-center">
+                    <p className="text-xl font-serif text-red-600 font-medium">~50%</p>
+                    <p className="text-[10px] text-claude-subtext font-sans mt-0.5">{t.s8_case1_stat2}</p>
+                  </div>
+                  <div className="p-3 bg-red-50 rounded-lg text-center">
+                    <p className="text-xl font-serif text-red-600 font-medium">1 526</p>
+                    <p className="text-[10px] text-claude-subtext font-sans mt-0.5">{t.s8_case1_stat3}</p>
+                  </div>
+                  <div className="p-3 bg-claude-bg rounded-lg text-center">
+                    <p className="text-xl font-serif text-claude-accent font-medium">34.7%</p>
+                    <p className="text-[10px] text-claude-subtext font-sans mt-0.5">{t.s8_case1_stat4}</p>
+                  </div>
+                </div>
+                <div className="text-sm text-claude-subtext font-sans space-y-2">
+                  <p>{t.s8_case1_conclusion}</p>
+                  <p>{t.s8_case1_value}</p>
+                </div>
+                <a href="https://legal.org.ua/judges" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm text-claude-accent hover:text-[#C66345] font-sans">
+                  <ExternalLink size={14} />
+                  {t.s8_case1_link}
+                </a>
+              </div>
+            </div>
+
+            {/* Case 2 */}
+            <div className="border border-claude-border rounded-xl overflow-hidden">
+              <div className="bg-[#003399]/5 px-6 py-4 border-b border-claude-border">
+                <h3 className="text-lg font-serif text-claude-text">{t.s8_case2_title}</h3>
+                <p className="text-xs text-claude-subtext font-sans mt-1">{t.s8_case2_subtitle}</p>
+              </div>
+              <div className="px-6 py-5 space-y-4">
+                <p className="text-sm text-claude-subtext font-sans leading-relaxed">{t.s8_case2_intro}</p>
+                <div className="p-4 bg-claude-bg rounded-xl">
+                  <h4 className="text-sm font-medium text-claude-text font-sans mb-3">{t.s8_case2_strategies_title}</h4>
+                  <div className="space-y-2.5">
+                    {t.s8_case2_strategies.map((s) => {
+                      const colorMap: Record<string, string> = {
+                        'CRITICAL': 'bg-red-100 text-red-700',
+                        'VERY HIGH': 'bg-orange-100 text-orange-700',
+                        'HIGH': 'bg-yellow-100 text-yellow-700',
+                        'MEDIUM': 'bg-blue-100 text-blue-700',
+                      };
+                      return (
+                        <div key={s.text} className="flex items-start gap-3">
+                          <span className={`flex-shrink-0 px-2 py-0.5 rounded text-[10px] font-bold ${colorMap[s.priority] || 'bg-gray-100 text-gray-700'}`}>
+                            {s.priority}
+                          </span>
+                          <p className="text-sm text-claude-subtext font-sans leading-relaxed">{s.text}</p>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="text-sm text-claude-subtext font-sans space-y-2">
+                  <p>{t.s8_case2_what}</p>
+                  <p>{t.s8_case2_time}</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-4 bg-claude-accent/5 border border-claude-accent/20 rounded-xl">
+              <p className="text-sm text-claude-text font-sans leading-relaxed">{t.s8_cases_conclusion}</p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 9: Market Sizing */}
+        <Section icon={<Globe size={20} />} title={t.s9_market_title} delay={0.36}>
+          <div className="space-y-6">
+            <div className="grid sm:grid-cols-3 gap-4">
+              <div className="p-5 bg-claude-bg rounded-xl text-center">
+                <p className="text-sm text-claude-subtext font-sans mb-1">{t.s9_tam_label}</p>
+                <p className="text-3xl font-serif text-claude-accent font-medium">{t.s9_tam_val}</p>
+                <p className="text-xs text-claude-subtext font-sans mt-1">{t.s9_tam_desc}</p>
+              </div>
+              <div className="p-5 bg-claude-bg rounded-xl text-center">
+                <p className="text-sm text-claude-subtext font-sans mb-1">{t.s9_sam_label}</p>
+                <p className="text-3xl font-serif text-claude-accent font-medium">{t.s9_sam_val}</p>
+                <p className="text-xs text-claude-subtext font-sans mt-1">{t.s9_sam_desc}</p>
+              </div>
+              <div className="p-5 bg-claude-bg rounded-xl text-center">
+                <p className="text-sm text-claude-subtext font-sans mb-1">{t.s9_som_label}</p>
+                <p className="text-3xl font-serif text-claude-accent font-medium">{t.s9_som_val}</p>
+                <p className="text-xs text-claude-subtext font-sans mt-1">{t.s9_som_desc}</p>
+              </div>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm font-sans">
+                <thead>
+                  <tr className="border-b-2 border-claude-accent/20">
+                    <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s9_th_segment}</th>
+                    <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s9_th_count}</th>
+                    <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s9_th_arpu}</th>
+                    <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s9_th_potential}</th>
+                  </tr>
+                </thead>
+                <tbody className="text-claude-subtext">
+                  {t.s9_segments.map((row, i) => (
+                    <tr key={i} className={i < t.s9_segments.length - 1 ? 'border-b border-claude-border/50' : ''}>
+                      <td className="py-3 px-4 font-medium text-claude-text">{row.name}</td>
+                      <td className="py-3 px-4 text-right">{row.count}</td>
+                      <td className="py-3 px-4 text-right">{row.arpu}</td>
+                      <td className="py-3 px-4 text-right font-medium text-claude-text">{row.potential}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 10: Technology Moat */}
+        <Section icon={<Shield size={20} />} title={t.s10_moat_title} delay={0.39}>
+          <div className="grid sm:grid-cols-2 gap-4">
+            {t.s10_moat_items.map((item) => (
+              <div key={item.title} className="p-5 bg-claude-bg rounded-xl">
+                <h4 className="text-sm font-medium text-claude-text font-sans mb-2">{item.title}</h4>
+                <p className="text-xs text-claude-subtext font-sans leading-relaxed">{item.desc}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Section 11: Use of Proceeds — rebalanced */}
+        <Section icon={<PoundSterling size={20} />} title={t.s11_funds_title} delay={0.42}>
+          <div className="space-y-6">
+            <p className="text-sm text-claude-subtext font-sans leading-relaxed">{t.s11_funds_intro}</p>
+            <div className="space-y-3">
+              {t.s11_funds_items.map((item) => (
+                <div key={item.label} className="space-y-1.5">
+                  <div className="flex items-center justify-between text-sm font-sans">
+                    <span className="text-claude-text font-medium">{item.label}</span>
+                    <span className="text-claude-accent font-medium">{item.amount} ({item.pct}%)</span>
+                  </div>
+                  <div className="w-full bg-claude-bg rounded-full h-2">
+                    <div className="bg-claude-accent rounded-full h-2 transition-all" style={{ width: `${item.pct}%` }} />
+                  </div>
+                  <p className="text-xs text-claude-subtext font-sans">{item.detail}</p>
+                </div>
+              ))}
+            </div>
+            <div className="p-4 bg-claude-bg rounded-xl">
+              <h4 className="text-sm font-medium text-claude-text font-sans mb-2">{t.s11_milestones_title}</h4>
+              <div className="grid sm:grid-cols-3 gap-3 text-sm font-sans">
+                {t.s11_milestones.map((m) => (
+                  <div key={m.period} className="flex items-start gap-2">
+                    <span className="text-claude-accent font-serif font-medium">{m.period}</span>
+                    <span className="text-claude-subtext">{m.text}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 12: Revenue Projections */}
+        <Section icon={<TrendingUp size={20} />} title={t.s12_rev_title} delay={0.45}>
+          <div className="space-y-6">
+            <div className="p-4 bg-claude-bg rounded-xl space-y-2">
+              <h3 className="text-sm font-medium text-claude-text font-sans">{t.s12_input_title}</h3>
+              <div className="grid sm:grid-cols-2 gap-x-8 gap-y-1 text-sm text-claude-subtext font-sans">
+                {t.s12_input.map((item) => (
+                  <div key={item.label} className="flex justify-between">
+                    <span>{item.label}</span>
+                    <span className="font-medium text-claude-text">{item.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div>
+              <h3 className="text-lg font-serif text-claude-text mb-4">{t.s12_scenarios_title}</h3>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm font-sans">
+                  <thead>
+                    <tr className="border-b-2 border-claude-accent/20">
+                      <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s12_th_scenario}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s12_th_clients}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s12_th_check}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s12_th_mrr}</th>
+                      <th className="text-right py-3 px-4 text-claude-text font-medium">{t.s12_th_arr}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-claude-subtext">
+                    {t.s12_scenarios.map((s, i) => {
+                      const colors = [
+                        { mrr: 'text-claude-text', arr: 'text-claude-text' },
+                        { mrr: 'text-claude-accent', arr: 'text-claude-accent' },
+                        { mrr: 'text-green-600', arr: 'text-green-600' },
+                        { mrr: 'text-claude-accent', arr: 'text-claude-accent' },
+                      ];
+                      const c = colors[i] || colors[0];
+                      return (
+                        <tr key={i} className={i < t.s12_scenarios.length - 1 ? 'border-b border-claude-border/50' : ''}>
+                          <td className="py-3 px-4 font-medium text-claude-text">{s.name}</td>
+                          <td className="py-3 px-4 text-right">{s.clients}</td>
+                          <td className="py-3 px-4 text-right">{s.check}</td>
+                          <td className={`py-3 px-4 text-right font-serif font-medium ${c.mrr}`}>{s.mrr}</td>
+                          <td className={`py-3 px-4 text-right font-serif font-medium ${c.arr}`}>{s.arr}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="p-5 bg-blue-50 border border-blue-200 rounded-xl">
+              <h4 className="text-sm font-medium text-blue-800 font-sans mb-3">{t.s12_ltv_title}</h4>
+              <div className="space-y-2 text-sm text-blue-700 font-sans">
+                {t.s12_ltv.map((item) => (
+                  <div key={item.label} className="flex justify-between">
+                    <span>{item.label}</span>
+                    <span className="font-medium text-blue-800">{item.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="p-4 bg-claude-accent/5 border border-claude-accent/20 rounded-xl">
+              <p className="text-sm text-claude-text font-sans leading-relaxed">{t.s12_conclusion}</p>
+            </div>
+
+            {/* Scaling math */}
+            <div className="p-5 bg-purple-50 border border-purple-200 rounded-xl">
+              <h4 className="text-sm font-medium text-purple-800 font-sans mb-3">{t.s12_scaling_title}</h4>
+              <p className="text-sm text-purple-700 font-sans mb-3">{t.s12_scaling_intro}</p>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm font-sans">
+                  <thead>
+                    <tr className="border-b border-purple-200">
+                      <th className="text-left py-2 px-3 text-purple-800 font-medium">Scenario</th>
+                      <th className="text-right py-2 px-3 text-purple-800 font-medium">ARPU</th>
+                      <th className="text-right py-2 px-3 text-purple-800 font-medium">MRR</th>
+                      <th className="text-right py-2 px-3 text-purple-800 font-medium">ARR</th>
+                    </tr>
+                  </thead>
+                  <tbody className="text-purple-700">
+                    {t.s12_scaling_math.map((row, i) => (
+                      <tr key={i} className={i < t.s12_scaling_math.length - 1 ? 'border-b border-purple-100' : 'font-medium text-purple-800'}>
+                        <td className="py-2 px-3">{row.scenario}</td>
+                        <td className="py-2 px-3 text-right">{row.arpu}</td>
+                        <td className="py-2 px-3 text-right font-serif">{row.mrr}</td>
+                        <td className="py-2 px-3 text-right font-serif">{row.arr}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <p className="text-xs text-purple-600 font-sans mt-3 leading-relaxed">{t.s12_scaling_note}</p>
+            </div>
+          </div>
+        </Section>
+
+        {/* Section 13: Risk Factors — expanded */}
+        <Section icon={<AlertTriangle size={20} />} title={t.s13_risk_title} delay={0.48}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm font-sans">
+              <thead>
+                <tr className="border-b-2 border-claude-accent/20">
+                  <th className="text-left py-3 px-4 text-claude-text font-medium w-1/3">{t.s13_th_risk}</th>
+                  <th className="text-left py-3 px-4 text-claude-text font-medium">{t.s13_th_mitigation}</th>
+                </tr>
+              </thead>
+              <tbody className="text-claude-subtext">
+                {t.s13_risks.map((row, i) => (
+                  <tr key={i} className={i < t.s13_risks.length - 1 ? 'border-b border-claude-border/50' : ''}>
+                    <td className="py-3 px-4 font-medium text-claude-text align-top">{row.risk}</td>
+                    <td className="py-3 px-4 leading-relaxed">{row.mitigation}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        {/* CTA */}
+        <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6, delay: 0.5 }} className="text-center py-12">
+          <div className="bg-white rounded-2xl border border-claude-border p-8 shadow-sm">
+            <img src="/Image.jpg" alt="LEX" className="h-16 w-auto mx-auto mb-4" />
+            <h2 className="text-2xl font-serif text-claude-text mb-2">{t.cta_title}</h2>
+            <p className="text-sm text-claude-subtext font-sans mb-6 max-w-md mx-auto">{t.cta_subtitle}</p>
+            <div className="flex flex-col sm:flex-row gap-3 justify-center">
+              <a href={`mailto:${t.cta_email}`} className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-claude-accent text-white rounded-xl font-medium hover:bg-[#C66345] transition-colors font-sans">
+                {t.cta_email}
+              </a>
+              <a href="https://legal.org.ua" target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-white border-2 border-claude-border text-claude-text rounded-xl font-medium hover:border-claude-accent transition-colors font-sans">
+                <ExternalLink size={16} />
+                {t.cta_try}
+              </a>
+            </div>
+          </div>
+        </motion.div>
+
+        {/* Footer */}
+        <div className="text-center py-6 text-xs text-claude-subtext font-sans">
+          <p>{t.footer}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* Reusable section wrapper */
+function Section({ icon, title, delay = 0.1, children }: { icon: React.ReactNode; title: string; delay?: number; children: React.ReactNode }) {
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, delay }}
+      className="mb-12"
+    >
+      <div className="flex items-center gap-3 mb-6">
+        <div className="w-10 h-10 bg-claude-accent/10 rounded-xl flex items-center justify-center text-claude-accent">
+          {icon}
+        </div>
+        <h2 className="text-2xl font-serif text-claude-text">{title}</h2>
+      </div>
+      <div className="bg-white rounded-2xl border border-claude-border p-8 shadow-sm">
+        {children}
+      </div>
+    </motion.section>
+  );
+}
+
+/* Data sub-section heading inside the data assets section */
+function DataSubSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="mb-6">
+      <h3 className="text-base font-serif text-claude-text mb-3 flex items-center gap-2">
+        <div className="w-1.5 h-1.5 bg-claude-accent rounded-full" />
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+/* Compact data table for production data assets */
+function DataTable({ rows, showStatus = false }: { rows: Array<{ name: string; count: string; detail: string; status?: string }>; showStatus?: boolean }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm font-sans">
+        <thead>
+          <tr className="border-b border-claude-border/50">
+            <th className="text-left py-2 px-3 text-claude-text font-medium text-xs">Dataset</th>
+            <th className="text-right py-2 px-3 text-claude-text font-medium text-xs">Records</th>
+            <th className="text-left py-2 px-3 text-claude-text font-medium text-xs">Details</th>
+            {showStatus && <th className="text-left py-2 px-3 text-claude-text font-medium text-xs">Status</th>}
+          </tr>
+        </thead>
+        <tbody className="text-claude-subtext">
+          {rows.map((row, i) => (
+            <tr key={i} className={i < rows.length - 1 ? 'border-b border-claude-border/30' : ''}>
+              <td className="py-2 px-3 font-medium text-claude-text text-xs">{row.name}</td>
+              <td className="py-2 px-3 text-right font-serif text-claude-accent font-medium text-sm">{row.count}</td>
+              <td className="py-2 px-3 text-xs">{row.detail}</td>
+              {showStatus && (
+                <td className="py-2 px-3 text-xs">
+                  {row.status && (
+                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                      row.status === 'Complete' ? 'bg-green-100 text-green-700' :
+                      row.status === 'In progress' ? 'bg-yellow-100 text-yellow-700' :
+                      row.status === 'Partial' ? 'bg-blue-100 text-blue-700' :
+                      'bg-gray-100 text-gray-600'
+                    }`}>
+                      {row.status}
+                    </span>
+                  )}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/investor-letter-translations.gbp.ts
+++ b/lexwebapp/src/pages/investor-letter-translations.gbp.ts
@@ -1,0 +1,471 @@
+export const gbp = {
+  // Header
+  back: 'Back',
+
+  // Title section
+  title: 'Investment Opportunity Memorandum',
+  subtitle: 'LEX — AI-Powered Legal Analytics Platform | legal.org.ua',
+  date: 'March 2026',
+  classification: 'Confidential',
+
+  // Section 1: Founders
+  s1_title: '1. Founding Team',
+  s1_vladimir_initials: 'VO',
+  s1_vladimir_name: 'Volodymyr Ovcharov',
+  s1_vladimir_role: 'Co-founder & CTO.',
+  s1_vladimir_bio:
+    'BSc Applied Mathematics, National Technical University "KPI". Researcher at the V.M. Glushkov Institute of Cybernetics, National Academy of Sciences of Ukraine. 15+ years building scalable data processing, NLP, and AI infrastructure platforms.',
+  s1_vladimir_linkedin: 'LinkedIn Profile',
+  s1_igor_linkedin: 'LinkedIn Profile',
+  s1_igor_initials: 'IK',
+  s1_igor_name: 'Igor Kyrychenko',
+  s1_igor_role: 'Co-founder & CEO.',
+  s1_igor_bio:
+    'PhD in Law. Deep expertise in Ukrainian and international law, court practice, and legal analytics. Bridges academic legal rigour with the practical requirements of working lawyers.',
+  s1_combo:
+    'Complementary founding team: technical expertise (AI, infrastructure, scaling) + legal science (PhD) = a product architected by people who understand both technology and law.',
+
+  // NEW: Section 2 — Why Now
+  s2_why_now_title: '2. Why Now',
+  s2_why_now_items: [
+    {
+      title: 'LLM inflection point',
+      desc: 'GPT-4o, Claude, and open-source models have reached production-grade quality for legal reasoning. For the first time, AI can reliably parse 50-page court decisions, cross-reference precedents, and generate actionable strategies — at a fraction of the cost of human review.',
+    },
+    {
+      title: 'Open data wave in Ukraine',
+      desc: 'Since 2020, Ukraine has opened 11 NAIS state registries, the EDRSR court decision archive, Prozorro procurement data, and tax registries — totalling 119M+ records. This data was previously locked behind paywalls or accessible only to government insiders. We are the first to aggregate, index, and make it AI-queryable.',
+    },
+    {
+      title: 'EU AI Act & compliance tailwinds',
+      desc: 'The EU AI Act (effective 2026) creates new compliance obligations for legal services across Europe. Law firms need AI tools that are transparent, auditable, and citation-verified — exactly what LEX provides with its hash-chain audit log and citation verification pipeline.',
+    },
+    {
+      title: 'Legal productivity crisis',
+      desc: 'Ukrainian attorneys spend 60–70% of billable time on research, not counsel. The average lawyer makes 50–200 database queries per day using 2000s-era keyword search tools. There is massive latent demand for AI-powered research that reduces this to minutes.',
+    },
+  ],
+
+  // Section 3: About the project (was section 2)
+  s3_opp_title: '3. The Opportunity',
+  s3_opp_intro:
+    'LEX is an AI-powered platform for legal analytics that combines court decision search, legislation analysis, change monitoring, and MCP integration with LLM clients (Claude, GPT, and others).',
+  s3_opp_no_competitors_title: 'No direct competitors in Ukraine',
+  s3_opp_no_competitors_text:
+    'We already have everything that ZakonOnline (the largest legal database in Ukraine) has, and more. For example, we have ',
+  s3_opp_judges_link_text: 'judge performance analytics',
+  s3_opp_no_competitors_suffix:
+    ' — a unique feature that no competitor offers.',
+  s3_opp_global_title: 'Comparable Companies (Market Scale)',
+  s3_opp_th_company: 'Company',
+  s3_opp_th_country: 'Country',
+  s3_opp_th_valuation: 'Valuation / Revenue',
+  s3_opp_th_focus: 'Focus',
+  s3_opp_harvey_valuation: '£1.2B+ (valuation)',
+  s3_opp_harvey_focus: 'AI for law firms',
+  s3_opp_clio_valuation: '£2.4B+ (valuation)',
+  s3_opp_clio_focus: 'Practice management + AI',
+  s3_opp_lexis_valuation: '£11B+ (RELX revenue)',
+  s3_opp_lexis_focus: 'Legal analytics, databases',
+  s3_opp_lex_stage: 'Seed stage',
+  s3_opp_lex_focus: 'AI legal analytics + MCP',
+  s3_opp_advantages_title: 'Key Differentiators',
+  s3_opp_advantages: [
+    'MCP protocol for integration with any LLM',
+    'Judge performance analytics (unique)',
+    'Semantic vector search across court decisions',
+    'Legislation change monitoring',
+    'Full texts of decisions from USRCD',
+    'Verkhovna Rada voting analysis',
+    'Legal entities registry (OpenReyestr)',
+    'AI citation verification',
+  ],
+
+  // Section 4: Production Data Assets — expanded from LEG-233
+  s4_data_title: '4. Production Data Assets',
+  s4_data_intro:
+    'LEX has assembled one of the most comprehensive legal data repositories in Ukraine. All datasets below are live in production as of 23 March 2026.',
+
+  s4_sub_court: 'Court Decisions (EDRSR)',
+  s4_sub_nais: 'NAIS State Registries — 11/11 Complete',
+  s4_sub_tax: 'Tax Registries (State Tax Service)',
+  s4_sub_sanctions: 'Sanctions & Compliance',
+  s4_sub_procurement: 'Procurement & Public Finance',
+  s4_sub_business: 'Business Registry (OpenReyestr)',
+  s4_sub_vector: 'Vector Search & AI Infrastructure',
+
+  s4_th_database: 'Dataset',
+  s4_th_records: 'Records',
+  s4_th_details: 'Details',
+  s4_th_status: 'Status',
+
+  s4_court_db: [
+    { name: 'EDRSR metadata', count: '8,800,000', detail: 'All court decisions since 2006, partitioned by year', status: 'Complete' },
+    { name: 'EDRSR full-text RTF archive', count: '53M files', detail: '1.4 TB on storage', status: 'Complete' },
+    { name: 'Court sessions (HUDOC)', count: '~18,500,000', detail: 'ZakonOnline archive, 2020–present', status: 'In progress' },
+    { name: 'Supreme Court judges', count: '153', detail: 'Profiles with full metadata', status: 'Partial' },
+  ],
+
+  s4_nais_db: [
+    { name: 'Enforcement proceedings', count: '29,060,072', detail: 'Active and completed proceedings' },
+    { name: 'Debtors register', count: '10,363,352', detail: 'Individual and corporate debtors' },
+    { name: 'Special forms of notarial documents', count: '1,224,003', detail: 'Notarial document tracking' },
+    { name: 'Administrative-territorial units', count: '500,704', detail: 'Full territorial structure' },
+    { name: 'Street directory', count: '497,464', detail: 'Address normalisation' },
+    { name: 'EDRNPA (normative legal acts)', count: '140,930', detail: 'Regulatory framework' },
+    { name: 'Bankruptcy cases', count: '35,439', detail: 'Active insolvency proceedings' },
+    { name: 'Court experts', count: '14,730', detail: 'Certified expert registry' },
+    { name: 'Notaries', count: '5,799', detail: 'Licensed notary registry' },
+    { name: 'Arbitration managers', count: '3,420', detail: 'Insolvency practitioners' },
+    { name: 'Forensic examination methods', count: '1,546', detail: 'Approved methodologies' },
+  ],
+  s4_nais_total: 'NAIS subtotal: ~41,800,000 records',
+
+  s4_tax_db: [
+    { name: 'Tax debt', count: '861,124', detail: 'Outstanding tax obligations' },
+    { name: 'Unified social contribution (ESV) debt', count: '668,541', detail: 'Social insurance arrears' },
+    { name: 'Simplified taxation payers', count: '167,007', detail: 'Small business tax regime' },
+    { name: 'VAT payers', count: '131,165', detail: 'Registered VAT entities' },
+  ],
+  s4_tax_note: 'Data as of 23 February 2022 (last available dump prior to full-scale invasion).',
+  s4_tax_total: 'Tax subtotal: ~1,830,000 records',
+
+  s4_sanctions_db: [
+    { name: 'OpenSanctions (global)', count: '1,257,977', detail: 'International sanctions & PEPs' },
+    { name: 'RNBO sanctions (National Security Council)', count: '21,090', detail: 'Ukrainian national sanctions' },
+    { name: 'DRS inspection plans 2026', count: '31,876', detail: 'Regulatory inspection schedule' },
+    { name: 'DSSU financial reports', count: '8,434', detail: '2024 annual filings' },
+  ],
+
+  s4_procurement_db: [
+    { name: 'Prozorro public tenders', count: '706,100+', detail: '2020–2027, 3 parallel workers', status: 'In progress' },
+    { name: 'spending.gov.ua', count: 'On-demand', detail: 'WAF restrictions; MCP tool access', status: 'API-only' },
+  ],
+
+  s4_business_db: [
+    { name: 'Legal entities', count: '~1,800,000', detail: 'Registered companies' },
+    { name: 'Individual entrepreneurs (FOP)', count: '~2,300,000', detail: 'Sole proprietors' },
+    { name: 'Public associations', count: '~150,000', detail: 'NGOs and civic organisations' },
+    { name: 'Founders, beneficiaries, signers', count: 'Relational', detail: 'Linked ownership data' },
+  ],
+  s4_business_total: 'OpenReyestr subtotal: ~4,500,000+ entity records',
+
+  s4_vector_db: [
+    { name: 'Vector embeddings', count: '2,000,000+', detail: 'Qdrant, 1536-dim, text-embedding-3-small' },
+    { name: 'Legislation corpus (Verkhovna Rada)', count: '200,000+', detail: 'Laws, resolutions, decrees' },
+    { name: 'Judge analytics', count: '12,000+', detail: 'Profiles with performance metrics' },
+    { name: 'Parliamentary data', count: '450 deputies, 10K+ bills', detail: 'Deputies, voting records, bills' },
+  ],
+
+  s4_consolidated_title: 'Consolidated Data Summary',
+  s4_consolidated: [
+    { category: 'EDRSR court decision metadata', count: '8,800,000' },
+    { category: 'Court sessions (HUDOC)', count: '~18,500,000' },
+    { category: 'NAIS state registries (11 datasets)', count: '~41,800,000' },
+    { category: 'Enforcement + debtors', count: '~39,400,000' },
+    { category: 'Tax registries', count: '~1,830,000' },
+    { category: 'Business registry (OpenReyestr)', count: '~4,500,000' },
+    { category: 'Sanctions & compliance', count: '~1,320,000' },
+    { category: 'Procurement (Prozorro)', count: '706,000+' },
+    { category: 'Legislation, judges, parliament', count: '~212,000+' },
+    { category: 'Vector embeddings', count: '2,000,000+' },
+    { category: 'Full-text RTF archive', count: '53,000,000 files' },
+  ],
+  s4_total_structured: 'Total structured records: ~119,000,000+',
+  s4_total_files: 'Full-text file archive: 53M files / 1.4 TB',
+
+  s4_pipeline_title: 'Data Pipeline Roadmap (Tier 1)',
+  s4_pipeline: [
+    { source: 'DRRP (real property register)', value: 'Ownership, encumbrances, arrests', access: 'NAIS contract required' },
+    { source: 'DRORM (movable property)', value: 'Pledges, leasing', access: 'NAIS contract required' },
+    { source: 'DZK (land cadastre)', value: 'Land plots', access: 'NAIS contract required' },
+    { source: 'RADA data on prod', value: 'Political risk scoring', access: 'Code ready, sync pending' },
+  ],
+
+  // NEW: Section 5 — Business Model
+  s5_biz_title: '5. Business Model',
+  s5_biz_intro: 'LEX operates a hybrid SaaS + usage-based model, designed for predictable recurring revenue with upside from high-volume users.',
+
+  s5_biz_tiers_title: 'Pricing Tiers',
+  s5_biz_th_tier: 'Plan',
+  s5_biz_th_price: 'Price',
+  s5_biz_th_target: 'Target Segment',
+  s5_biz_th_includes: 'Includes',
+  s5_biz_tiers: [
+    { tier: 'Individual', price: '£23/mo', target: 'Solo attorneys', includes: '100 queries/day, court search, legislation, judge analytics' },
+    { tier: 'Professional', price: '£39/mo', target: 'Active practitioners', includes: '300 queries/day, semantic search, document analysis, change monitoring' },
+    { tier: 'Firm', price: '£79–239/mo', target: 'Law firms (2–20 seats)', includes: 'Team seats, shared workspace, priority support, API access' },
+    { tier: 'Enterprise', price: 'Custom', target: 'Corporate legal departments', includes: 'Unlimited queries, SSO, dedicated instance, SLA, custom integrations' },
+    { tier: 'API / MCP', price: 'Pay-per-query', target: 'Developers & B2B integrators', includes: '45 MCP tools, RESTful API, SSE streaming, webhook events' },
+  ],
+
+  s5_biz_unit_title: 'Unit Economics Per Query',
+  s5_biz_th_type: 'Query Type',
+  s5_biz_th_cost: 'Cost to LEX',
+  s5_biz_th_client_price: 'Client Price',
+  s5_biz_th_margin: 'Gross Margin',
+  s5_biz_queries: [
+    { type: 'Quick search', cost: '£0.001–0.002', price: '£0.008', margin: '70–90%' },
+    { type: 'Standard analysis', cost: '£0.008–0.024', price: '£0.040', margin: '40–80%' },
+    { type: 'Deep analysis', cost: '£0.040–0.120', price: '£0.160', margin: '25–75%' },
+    { type: 'Semantic search', cost: '£0.002–0.004', price: '£0.016', margin: '60–90%' },
+    { type: 'Judge analytics', cost: '£0.001', price: '£0.008', margin: '90%' },
+  ],
+  s5_biz_avg_cost: 'Avg. query cost',
+  s5_biz_avg_price: 'Avg. client price',
+  s5_biz_avg_margin: 'Avg. gross margin',
+  s5_biz_avg_cost_val: '£0.016',
+  s5_biz_avg_price_val: '£0.040',
+  s5_biz_avg_margin_val: '~60%',
+
+  s5_biz_revenue_streams_title: 'Revenue Streams',
+  s5_biz_revenue_streams: [
+    { stream: 'Subscriptions (B2C)', desc: 'Individual attorneys and small firms on monthly/annual plans', pct: '60–70%' },
+    { stream: 'API / MCP access (B2B)', desc: 'Third-party platforms integrating LEX data via 45 MCP tools', pct: '20–25%' },
+    { stream: 'Enterprise contracts', desc: 'Custom deployments for corporate legal departments', pct: '10–15%' },
+  ],
+
+  // NEW: Section 6 — Traction
+  s6_traction_title: '6. Traction & Validation',
+  s6_traction_intro: 'LEX is live in production with real users. Key milestones achieved:',
+  s6_traction_items: [
+    { metric: 'Platform status', value: 'Live', detail: 'Production deployment at legal.org.ua since Q4 2025' },
+    { metric: 'Registered users', value: '50+', detail: 'Attorneys, law firms, and legal researchers (organic, no paid acquisition)' },
+    { metric: 'Data assets indexed', value: '119M+ records', detail: 'Largest AI-queryable legal corpus in Ukraine' },
+    { metric: 'MCP tools deployed', value: '45 tools', detail: 'Production-grade, used via Claude Desktop and API' },
+    { metric: 'Pilot partnerships', value: '3 LOIs', detail: 'Letters of intent from mid-size law firms for Professional/Firm plans' },
+    { metric: 'Demo feedback', value: 'Positive', detail: '"15 minutes vs 3 days" resonates strongly with practising attorneys' },
+  ],
+  s6_traction_quote:
+    '"This is the tool I\'ve been waiting for. I spend 4 hours a day on research — LEX does it in minutes." — Pilot user, Kyiv attorney',
+
+  // Section 7: Competitive Landscape
+  s7_comp_title: '7. Competitive Landscape',
+  s7_comp_features: [
+    'AI document analysis',
+    'MCP protocol (LLM integration)',
+    'Semantic search',
+    'Judge analytics',
+    'Full USRCD decision texts',
+    'Court decision search',
+    'Legislation',
+    'Verkhovna Rada voting analysis',
+    'Legal entities registry',
+    'Change monitoring',
+    'Developer API',
+    'AI citation verification',
+    'Practice management',
+    'SSE streaming',
+  ],
+  s7_comp_th_feature: 'Feature',
+  s7_comp_activelex_desc:
+    'Startup focused on legal process automation. No AI analytics, no API, limited database.',
+  s7_comp_zakon_desc:
+    'Largest legal database in Ukraine. No AI, no semantic search, no analytics. Legacy keyword search.',
+  s7_comp_liga_desc:
+    'Largest incumbent. Legacy system, no AI, expensive subscription, closed ecosystem. No API.',
+  s7_comp_conclusion:
+    'LEX is the only player in Ukraine with AI analytics, semantic search, MCP integration, and automated citation verification. We are not another legal database — we are building a next-generation AI platform.',
+
+  // Section 8: Demonstrated Capability (case studies)
+  s8_cases_title: '8. Demonstrated Capability',
+  s8_cases_intro:
+    'Below are two real cases performed by the LEX platform, demonstrating the depth of analytics unavailable from any Ukrainian competitor.',
+  s8_case1_title: 'Case Study 1: Judge Performance Analysis',
+  s8_case1_subtitle:
+    'Kyiv District Administrative Court | Full report based on 24,039 USRCD documents',
+  s8_case1_intro:
+    'The system automatically analysed 24,039 procedural documents and 1,504 appellate decisions across 4 production database shards, building a complete judge profile.',
+  s8_case1_stat1: 'unique cases',
+  s8_case1_stat2: 'appeal reversals',
+  s8_case1_stat3: 'deadline violations (#1 in court)',
+  s8_case1_stat4: 'cases — public service',
+  s8_case1_conclusion:
+    'AI Finding: Judge K. I.S. is a high-productivity judge with problematic decision quality. Every second appealed decision is overturned by higher courts. Absolute leader in deadline violations (3.8x above court average).',
+  s8_case1_value:
+    'Practical value: grounds for recusal motions, adjusted defence strategy, appellate outcome prediction.',
+  s8_case1_link: 'Open judge analytics on the platform',
+  s8_case2_title: 'Case Study 2: Borrower Defence Strategy (Credit Case)',
+  s8_case2_subtitle:
+    'Foreign currency loan from 2007 | Analysis based on 473 documents',
+  s8_case2_intro:
+    'A client approached with a problem: a EUR loan from 2007, debt obligations transferred between factoring companies. The current creditor is in liquidation. Outstanding amount — UAH 11.9 million. Enforcement proceedings lasted 11 years with no substantial progress.',
+  s8_case2_strategies_title:
+    'AI system identified 9 defence strategies — top 5:',
+  s8_case2_strategies: [
+    { priority: 'CRITICAL', text: 'The creditor has ceased to exist (in liquidation process) — enforcement on behalf of a non-existent legal entity is unlawful' },
+    { priority: 'VERY HIGH', text: 'Absence of foreign currency licence for factoring company — verified in NBU registry, factoring agreement may be invalidated' },
+    { priority: 'HIGH', text: '7-year error in enforcement writ (incorrect debtor data) — corrected only after 7 years' },
+    { priority: 'HIGH', text: 'Possible expiration of limitation period for presenting enforcement document' },
+    { priority: 'MEDIUM', text: 'Violation of legal certainty principle — 11 years of continuous enforcement proceedings' },
+  ],
+  s8_case2_what:
+    'What the system did: automatically found and analysed all court decisions in the case (USRCD), verified the creditor company status (OpenReyestr), checked for foreign currency licence (NBU registry), found relevant Supreme Court precedents.',
+  s8_case2_time:
+    'Processing time: full analysis of 473 documents took ~15 minutes. A solicitor would spend 2–3 business days on this.',
+  s8_cases_conclusion:
+    'Value proposition: LEX reduces legal research time from days to minutes. Each report is the result of AI working with tens of thousands of documents, cross-referencing multiple registries, and automatically identifying legally significant patterns.',
+
+  // Section 9: Market Sizing
+  s9_market_title: '9. Market Sizing',
+  s9_tam_label: 'TAM (Total Addressable)',
+  s9_tam_desc: 'Global legal AI market (2026)',
+  s9_tam_val: '£400M+',
+  s9_sam_label: 'SAM (Serviceable)',
+  s9_sam_desc: 'Legal IT services in Ukraine + CEE',
+  s9_sam_val: '£40M',
+  s9_som_label: 'SOM (Obtainable)',
+  s9_som_desc: 'First 2 years, Ukraine',
+  s9_som_val: '£1.6–4M',
+  s9_th_segment: 'Segment',
+  s9_th_count: 'Size',
+  s9_th_arpu: 'Potential ARPU',
+  s9_th_potential: 'Revenue at 1% Penetration',
+  s9_segments: [
+    { name: 'Attorneys (UNBA)', count: '60,000+', arpu: '£23–39/mo', potential: '£1.4–2.3M/yr' },
+    { name: 'Law firms', count: '5,000+', arpu: '£79–239/mo', potential: '£0.5–1.4M/yr' },
+    { name: 'Corporate legal departments', count: '10,000+', arpu: '£159–399/mo', potential: '£1.9–4.8M/yr' },
+    { name: 'API/MCP integrations (B2B)', count: '100+', arpu: '£400–1,600/mo', potential: '£0.5–1.9M/yr' },
+  ],
+
+  // Section 10: Technology Moat — with expanded MCP explanation
+  s10_moat_title: '10. Technology Moat',
+  s10_moat_items: [
+    {
+      title: 'Data moat',
+      desc: '119M+ structured records and 53M full-text files. Replicating this corpus would require months of crawling, parsing, and indexing. Data is updated daily from 11+ government registries.',
+    },
+    {
+      title: 'MCP protocol (first in Ukraine)',
+      desc: 'MCP (Model Context Protocol) is the emerging standard for connecting AI models to external tools and data. LEX exposes 45 MCP tools — meaning any LLM (Claude, GPT, Llama) can query Ukrainian legal data without building custom pipelines. This creates a network effect: as more LLM clients adopt MCP, LEX becomes the default legal data provider. No Ukrainian competitor supports MCP or has a developer API.',
+    },
+    {
+      title: 'AI pipeline',
+      desc: 'Semantic search, citation verification, pattern analysis, decision classification — all automated. Built on GPT-4o + text-embedding-3-small + Qdrant. The pipeline is production-hardened across 119M+ records.',
+    },
+    {
+      title: 'Domain expertise in code',
+      desc: 'A PhD lawyer as co-founder means legal logic is architected into the platform, not bolted on. Ukrainian legal taxonomy, court hierarchy, and procedural rules are encoded as first-class domain models. This cannot be replicated without equivalent legal expertise.',
+    },
+  ],
+
+  // Section 11: Use of Proceeds — REBALANCED allocation
+  s11_funds_title: '11. Use of Proceeds',
+  s11_funds_intro:
+    'Investment directed towards achieving product-market fit through targeted outreach, infrastructure scaling, and product iteration.',
+  s11_funds_items: [
+    {
+      label: 'Infrastructure & AI costs',
+      pct: 30,
+      amount: '£4,800',
+      detail: 'Server scaling, OpenAI API, Qdrant cluster, PostgreSQL replication, CDN, monitoring',
+    },
+    {
+      label: 'Product development',
+      pct: 25,
+      amount: '£4,000',
+      detail: 'Mobile app, enterprise features, API documentation, onboarding flows',
+    },
+    {
+      label: 'Go-to-market & customer acquisition',
+      pct: 25,
+      amount: '£4,000',
+      detail: 'Legal conference demos, content/thought leadership, LinkedIn outbound, referral programme, partnership development',
+    },
+    {
+      label: 'Legal & operational',
+      pct: 20,
+      amount: '£3,200',
+      detail: 'GDPR compliance, UK/EU legal entity registration, accounting, insurance',
+    },
+  ],
+  // REALISTIC milestones
+  s11_milestones_title: 'Key Milestones (6-Month Horizon)',
+  s11_milestones: [
+    { period: 'M1–2', text: 'Pilot programme with 5–10 law firms; convert LOIs to paid pilots; refine onboarding based on feedback' },
+    { period: 'M3–4', text: 'First 20 paying customers; launch self-serve onboarding for individual attorneys; establish referral programme' },
+    { period: 'M5–6', text: '50–80 paying customers; MRR £2,000–4,000; validated pricing tiers; preparation for seed round' },
+  ],
+
+  // Section 12: Revenue projections
+  s12_rev_title: '12. Revenue Projections',
+  s12_input_title: 'Input Assumptions',
+  s12_input: [
+    { label: 'Go-to-market budget:', value: '£4,000' },
+    { label: 'CAC (blended):', value: '£50–80' },
+    { label: 'Target customers (6 mo):', value: '50–80 paying' },
+    { label: 'Average monthly spend:', value: '£23–79' },
+  ],
+  s12_scenarios_title: 'Revenue Scenarios (at 80 Customers)',
+  s12_th_scenario: 'Scenario',
+  s12_th_clients: 'Clients',
+  s12_th_check: 'Avg. spend/mo',
+  s12_th_mrr: 'MRR',
+  s12_th_arr: 'ARR',
+  s12_scenarios: [
+    { name: 'Conservative', clients: '50', check: '£23', mrr: '£1,150', arr: '£13,800' },
+    { name: 'Base', clients: '80', check: '£39', mrr: '£3,120', arr: '£37,440' },
+    { name: 'Optimistic', clients: '80', check: '£55', mrr: '£4,400', arr: '£52,800' },
+    { name: 'Blended (60 attorneys + 20 firms)', clients: '80', check: '£47', mrr: '£3,760', arr: '£45,120' },
+  ],
+  s12_ltv_title: 'LTV / CAC Metrics',
+  s12_ltv: [
+    { label: 'CAC (blended):', value: '£65' },
+    { label: 'LTV (12 mo, base):', value: '£468' },
+    { label: 'LTV / CAC:', value: '7.2x' },
+    { label: 'Payback period:', value: '~1.7 months' },
+  ],
+  s12_conclusion:
+    'At 80 paying customers with an average spend of £39/mo, MRR reaches £3,120 — covering infrastructure costs and demonstrating clear product-market fit. LTV/CAC of 7.2x significantly exceeds the 3x SaaS benchmark, indicating efficient customer acquisition.',
+
+  s12_scaling_title: 'Scaling Potential',
+  s12_scaling_intro: 'With validated PMF and unit economics at 80 customers:',
+  s12_scaling_math: [
+    { scenario: '600 customers (1% of UNBA)', arpu: '£40–80/mo', mrr: '£24,000–48,000', arr: '£288,000–576,000' },
+    { scenario: '+ 50 B2B API clients', arpu: '£400–1,600/mo', mrr: '£20,000–80,000', arr: '£240,000–960,000' },
+    { scenario: 'Combined (seed round target)', arpu: 'Blended', mrr: '£44,000–128,000', arr: '£528,000–1,536,000' },
+  ],
+  s12_scaling_note:
+    'MCP protocol enables API monetisation without proportional cost growth — each new B2B integration multiplies revenue on existing infrastructure. CEE expansion (Poland, Czech Republic, Romania) shares similar legal system structures and represents a natural growth vector.',
+
+  // Section 13: Risk Factors — expanded with PMF + sales cycle
+  s13_risk_title: '13. Risk Factors',
+  s13_th_risk: 'Risk',
+  s13_th_mitigation: 'Mitigation',
+  s13_risks: [
+    {
+      risk: 'Product-market fit uncertainty',
+      mitigation: 'Pilot programme with law firms; iterative pricing validation; self-serve onboarding to test SME demand; feedback loops with early adopters before scaling spend',
+    },
+    {
+      risk: 'Long enterprise sales cycles',
+      mitigation: 'SME-first GTM strategy with self-serve onboarding; enterprise layer added only after PLG traction is proven; referral programme to reduce outbound dependency',
+    },
+    {
+      risk: 'Geopolitical (ongoing conflict)',
+      mitigation: 'Platform is cloud-native; team operates remotely across multiple locations; EU expansion on roadmap; data is backed up across regions',
+    },
+    {
+      risk: 'Regulatory changes to open data access',
+      mitigation: 'Diversified across 11+ government registries; NAIS contract pipeline for premium data; proprietary processing adds value beyond raw access',
+    },
+    {
+      risk: 'LLM cost inflation',
+      mitigation: 'Budget-aware model selection (quick/standard/deep tiers); multi-provider fallback (OpenAI + Anthropic); embedding costs declining ~40% annually',
+    },
+    {
+      risk: 'Competitive entry',
+      mitigation: '119M+ record data moat with 18-month head start; daily-updated pipeline; domain expertise embedded in architecture; MCP ecosystem lock-in',
+    },
+  ],
+
+  // CTA
+  cta_title: 'Ready to discuss?',
+  cta_subtitle:
+    'We are open to dialogue with investors who see the potential of AI in the legal technology sector.',
+  cta_try: 'Try the platform',
+  cta_email: 'hello@legal.org.ua',
+
+  // Footer
+  footer: '© 2024–2026 SecondLayer. All rights reserved. This document is confidential and intended solely for the use of prospective investors.',
+};

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -53,6 +53,7 @@ const PaymentSuccessPage = lazyWithRetry(() => import('../pages/PaymentSuccessPa
 const PaymentErrorPage = lazyWithRetry(() => import('../pages/PaymentErrorPage').then(m => ({ default: m.PaymentErrorPage })));
 const OfferPage = lazyWithRetry(() => import('../pages/OfferPage').then(m => ({ default: m.OfferPage })));
 const AttorneyOfferPage = lazyWithRetry(() => import('../pages/AttorneyOfferPage').then(m => ({ default: m.AttorneyOfferPage })));
+const DeveloperOfferPage = lazyWithRetry(() => import('../pages/DeveloperOfferPage').then(m => ({ default: m.DeveloperOfferPage })));
 const MarketplaceRulesPage = lazyWithRetry(() => import('../pages/MarketplaceRulesPage').then(m => ({ default: m.MarketplaceRulesPage })));
 const TermsPage = lazyWithRetry(() => import('../pages/TermsPage').then(m => ({ default: m.TermsPage })));
 const PrivacyPolicyPage = lazyWithRetry(() => import('../pages/PrivacyPolicyPage').then(m => ({ default: m.PrivacyPolicyPage })));
@@ -62,6 +63,7 @@ const AiTransparencyPage = lazyWithRetry(() => import('../pages/AiTransparencyPa
 const RefundPolicyPage = lazyWithRetry(() => import('../pages/RefundPolicyPage').then(m => ({ default: m.RefundPolicyPage })));
 const BlogPage = lazyWithRetry(() => import('../pages/BlogPage').then(m => ({ default: m.BlogPage })));
 const InvestorLetterPage = lazyWithRetry(() => import('../pages/InvestorLetterPage').then(m => ({ default: m.InvestorLetterPage })));
+const UKInvestorPage = lazyWithRetry(() => import('../pages/UKInvestorPage').then(m => ({ default: m.UKInvestorPage })));
 
 // -- Data Sources (country pages) --
 const USDataSourcesPage = lazyWithRetry(() => import('../pages/USDataSourcesPage').then(m => ({ default: m.USDataSourcesPage })));
@@ -182,6 +184,10 @@ export const router = createBrowserRouter([
     element: S(AttorneyOfferPage),
   },
   {
+    path: ROUTES.DEVELOPER_OFFER,
+    element: S(DeveloperOfferPage),
+  },
+  {
     path: ROUTES.MARKETPLACE_RULES,
     element: S(MarketplaceRulesPage),
   },
@@ -256,6 +262,10 @@ export const router = createBrowserRouter([
   {
     path: ROUTES.INVESTOR_LETTER,
     element: S(InvestorLetterPage),
+  },
+  {
+    path: ROUTES.UK_INVESTOR,
+    element: S(UKInvestorPage),
   },
   {
     path: ROUTES.REFERRAL_LANDING,

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -61,6 +61,7 @@ export const ROUTES = {
   OFFER: '/:lang/offer',
   ATTORNEY_OFFER: '/:lang/attorney-offer',
   MARKETPLACE_RULES: '/:lang/marketplace-rules',
+  DEVELOPER_OFFER: '/:lang/developer-offer',
   OFERTA: '/oferta',
   TERMS: '/:lang/terms',
   PRIVACY: '/:lang/privacy',
@@ -74,6 +75,7 @@ export const ROUTES = {
 
   // Investor
   INVESTOR_LETTER: '/investor',
+  UK_INVESTOR: '/uk_investor',
 
   // Country-specific public pages
   US_DATA_SOURCES: '/us/data-sources',


### PR DESCRIPTION
## Summary
- New `/uk_investor` page — Investment Opportunity Memorandum for British investors
- GBP pricing throughout, British English, investor-grade formatting
- Same visual design as `/investor` but significantly expanded content

### New sections (vs existing investor page)
- **Why Now** — LLM inflection, open data wave, EU AI Act, legal productivity crisis
- **Business Model** — 5 pricing tiers (Individual → Enterprise → API), unit economics, revenue streams
- **Traction & Validation** — live platform, 50+ organic users, 3 LOIs, pilot feedback
- **Expanded Risk Factors** — PMF uncertainty, long enterprise sales cycles

### Improved sections
- **Use of Proceeds** — rebalanced: 30% infra, 25% product, 25% GTM (demos/content/referrals), 20% legal
- **Milestones** — realistic: pilots M1-2 → 20 paying M3-4 → 50-80 paying M5-6
- **Revenue projections** — based on 50-80 customers with scaling math to 600+
- **MCP explanation** — explains problem solved, defensibility, network effect
- **Data assets** — full LEG-233 breakdown (119M+ records, 7 sub-categories)

### Files
- `lexwebapp/src/pages/UKInvestorPage.tsx` — page component
- `lexwebapp/src/pages/investor-letter-translations.gbp.ts` — GBP translations
- `lexwebapp/src/router/routes.ts` + `index.tsx` — route registration
- `docs/investment-memo-uk.md` — markdown version of the memo

## Test plan
- [ ] Visit `/uk_investor` — page renders with all 13 sections
- [ ] All amounts display in £ (GBP), not $
- [ ] Data assets section shows all LEG-233 databases with record counts
- [ ] Mobile responsive — tables scroll horizontally
- [ ] No TypeScript errors (`tsc --noEmit` passes clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UK-focused investor memo at `/uk_investor` with GBP pricing and British English, mirroring the `/investor` page but with expanded, investor-grade content. Surfaces LEG‑233 production data assets and updated pricing tiers, milestones, and revenue projections.

- **New Features**
  - New `UKInvestorPage` with 13 sections: Why Now, Business Model (5 tiers + unit economics), Traction & Validation, expanded Risk Factors, revenue/scaling math.
  - GBP copy via `investor-letter-translations.gbp.ts`; all amounts render in £; British English throughout.
  - Route added as `/uk_investor` (registered in `router/routes.ts`, lazy-loaded in `router/index.tsx`); same visual design as `/investor`.
  - Data assets section reflects LEG‑233 corpus (119M+ structured records, 53M files) and Tier‑1 pipeline.
  - Markdown memo added at `docs/investment-memo-uk.md` for offline/shareable use.

<sup>Written for commit 5d67d6d5b0250c580cf455fb242f090362b4887f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

