### PR TITLE
fix: add missing DeveloperOfferPage and content files

### DIFF
--- a/lexwebapp/src/content/legal/developer-offer-en.md
+++ b/lexwebapp/src/content/legal/developer-offer-en.md
@@ -1,0 +1,229 @@
+# PUBLIC OFFER
+
+## on providing access to the platform and software development services
+
+*Last updated: March 23, 2026*
+
+---
+
+Individual Entrepreneur Kyrychenko Ihor Viktorovych
+Tax ID (RNOKPP): 2967214056
+Address: 04132, Ukraine, Kyiv, 47-a Sadova St., 1a
+Email: info@legal.org.ua
+
+## 1. General Provisions
+
+1.1. This document is an official public offer by Individual Entrepreneur Kyrychenko Ihor Viktorovych (hereinafter — the **"Client"**), addressed to an individual entrepreneur (hereinafter — the **"Developer"**), to enter into this Agreement on providing access to the Platform and software development services (hereinafter — the **"Agreement"**) under the terms set forth below.
+
+1.2. This Agreement is a public offer in accordance with Articles 633 and 641 of the Civil Code of Ukraine.
+
+1.3. Acceptance of this offer is:
+- signing of this Agreement by the Developer; or
+- actual commencement of development services,
+
+whichever occurs first (Article 642 of the Civil Code of Ukraine).
+
+1.4. From the moment of acceptance, the Agreement is considered concluded under the terms specified in this document.
+
+1.5. This Agreement has legal force in accordance with Articles 633, 641, and 642 of the Civil Code of Ukraine and is equivalent to a written agreement.
+
+## 2. Definitions
+
+**"Platform"** or **"LEX AI"** — the software product "SecondLayer," available at legal.org.ua, including APIs, MCP servers, and a web application providing AI-powered legal document analysis, semantic search, and related services.
+
+**"Development Services"** — a set of activities including design, programming, testing, deployment, maintenance, and improvement of the Platform, including but not limited to: development of new features, bug fixing, performance optimization, integration of external services, and infrastructure administration.
+
+**"Source Code"** — the totality of program code, scripts, configurations, database migrations, documentation, and other software components of the Platform.
+
+**"Infrastructure"** — servers, databases, storage services, network components, and other technical resources required for the Platform's operation.
+
+**"End Users"** — individuals and legal entities who use the Platform to obtain legal services.
+
+**"Results"** — all results of intellectual activity created by the Developer in the course of performing this Agreement.
+
+**"Confidential Information"** — any information as defined in Section 8 of this Agreement.
+
+**"Reporting Period"** — a calendar month during which development services are provided.
+
+## 3. Subject of the Agreement
+
+3.1. The Client commissions, and the Developer undertakes to provide services for the development, maintenance, and improvement of the Platform in accordance with the terms of this Agreement.
+
+3.2. Development services include:
+- design and development of new Platform features;
+- fixing defects and errors in the Platform;
+- optimization of Platform performance and scalability;
+- integration with external APIs and services;
+- server infrastructure and database administration;
+- technical support and monitoring of Platform operation;
+- preparation of technical documentation.
+
+3.3. The specific scope and volume of work is determined by the Client through the task management system (Linear, GitHub Issues, or other agreed-upon tool).
+
+## 4. Pricing and Payment Terms
+
+4.1. The cost of the Developer's services is determined under the same conditions that apply to End Users of the Platform, namely: in accordance with the pricing plans published on the Platform at legal.org.ua.
+
+4.2. The Developer receives access to all Platform features on terms equivalent to the pricing plans for End Users, at no additional charge, as compensation for providing development services.
+
+4.3. Payment for development services is made in the national currency of Ukraine — hryvnia (UAH) in accordance with Article 524 of the Civil Code of Ukraine.
+
+4.4. Payment method: non-cash transfer to the Developer's bank account based on an invoice or as agreed by the Parties.
+
+4.5. The amount of the Developer's remuneration for development services is established in a separate appendix to this Agreement and may be revised by mutual agreement of the Parties no more than once per quarter.
+
+4.6. The Parties sign a Certificate of Completed Works (services rendered) monthly. The Client sends the Certificate to the Developer by the 5th business day of the month following the reporting month. The Developer signs the Certificate or provides reasoned objections within 5 business days of receipt. If no objections are provided within the specified period, the Certificate is deemed signed.
+
+4.7. Exchange of primary documents may be conducted electronically through electronic document management systems (Vchasno, M.E.Doc, or similar) in accordance with the Law of Ukraine "On Electronic Trust Services."
+
+4.8. The Client is a single tax payer, Group 3. VAT is not charged. The Developer is independently responsible for paying taxes and fees in accordance with their chosen taxation system.
+
+## 5. Intellectual Property
+
+5.1. **Platform Rights.** All intellectual property rights to the Platform, including but not limited to: source code, architecture, algorithms, AI models, databases, interface design, trademarks, documentation, and any other components, belong exclusively to the Client.
+
+5.2. **Developer's Work Results.** All Results of intellectual activity created by the Developer in the course of performing this Agreement, including source code, architectural solutions, databases, algorithms, and technical documentation, become the full and exclusive property of the Client from the moment of their creation in accordance with Article 429 of the Civil Code of Ukraine.
+
+5.3. **Transfer of Rights.** The Developer transfers to the Client exclusive proprietary intellectual property rights to the Results in full, including:
+- the right to use the Results in any manner;
+- the right to modify, adapt, and create derivative works;
+- the right to reproduce, distribute, and make available to the public;
+- the right to transfer (license) to third parties;
+- the right to commercial use without restrictions.
+
+5.4. **License to Developer.** The Client grants the Developer a non-exclusive, revocable license to use the Platform and its components solely for the purpose of providing services under this Agreement. This license automatically terminates upon termination of the Agreement.
+
+5.5. **No Claims.** The Developer guarantees that they have no and will have no claims regarding ownership of the Results created under this Agreement. Compensation for the transfer of rights is included in the cost of services specified in Section 4.
+
+5.6. **Third-Party Components.** When using third-party open-source libraries, frameworks, or components in the development process, the Developer is obligated to inform the Client of their use and ensure the compatibility of their licenses with the commercial use of the Platform.
+
+5.7. **Portfolio.** The Developer has the right to reference participation in the Platform's development in their portfolio without disclosing Confidential Information and with prior written consent of the Client.
+
+## 6. Rights and Obligations of the Parties
+
+**The Client undertakes to:**
+- provide the Developer with access to necessary resources, systems, and information for performing the work;
+- formulate technical tasks and priorities through the task management system;
+- timely review and accept the Results of work;
+- make payments in accordance with Section 4 of this Agreement;
+- notify the Developer of changes in requirements or priorities within a reasonable time.
+
+**The Client has the right to:**
+- monitor the progress and quality of work;
+- make changes to priorities and technical requirements;
+- engage other contractors to work on the Platform;
+- revoke the Developer's access to Platform resources at any time.
+
+**The Developer undertakes to:**
+- perform work with quality, within agreed timelines, and in accordance with technical specifications;
+- comply with code quality standards adopted in the project (code review, testing, documentation);
+- immediately notify the Client of circumstances preventing the performance of work;
+- deliver Results through the version control system (GitHub);
+- ensure the security and confidentiality of data to which access is obtained;
+- not use End User data for any purposes unrelated to providing services under this Agreement;
+- not take actions that may harm the reputation of the Platform or the Client.
+
+**The Developer has the right to:**
+- independently determine methods and tools for performing work;
+- receive from the Client information necessary for performing work;
+- use the Platform on the terms defined in clause 4.2 of this Agreement.
+
+## 7. End User Data and Attorney Privilege
+
+7.1. The Developer acknowledges that in the course of providing services, they may gain access to End User data, including personal data, legal documents, and information constituting attorney-client privilege in accordance with Article 22 of the Law of Ukraine "On the Bar and Practice of Law."
+
+7.2. The Developer undertakes to:
+- process End User data solely for the purpose of providing development and maintenance services for the Platform;
+- not copy, store, or transfer End User data to personal devices or third-party services;
+- not use End User data for training AI models or any other purposes not provided for in this Agreement;
+- immediately notify the Client of any unauthorized access to data;
+- delete all End User data from their devices and systems within 5 business days after termination of the Agreement.
+
+7.3. The Developer acts as a data processor in accordance with the Law of Ukraine "On the Protection of Personal Data" and processes personal data solely on behalf of the Client.
+
+## 8. Confidentiality
+
+8.1. **Confidential Information** — any information transmitted by one Party to the other in connection with the performance of this Agreement, including:
+- source code, architecture, algorithms, and technical solutions of the Platform;
+- business plans, financial information, development strategy;
+- End User data;
+- terms of this Agreement, including financial terms;
+- access keys, passwords, security certificates, API keys;
+- any information marked as "confidential" or that a reasonable person would consider confidential.
+
+8.2. **Exclusions.** The following is not considered Confidential Information:
+- information that is or has become publicly known through no fault of the receiving Party;
+- information known to the Party prior to its receipt from the other Party;
+- information received from a third party without a confidentiality obligation;
+- information independently developed by the Party without using Confidential Information;
+- information subject to disclosure pursuant to legal requirements or court order (subject to prior notification of the other Party).
+
+8.3. The Parties undertake to:
+- not disclose Confidential Information to third parties without prior written consent of the other Party;
+- use Confidential Information solely for the purposes of performing this Agreement;
+- take measures to protect Confidential Information no less than those taken to protect their own confidential information;
+- limit access to Confidential Information to only those persons who need it to perform the Agreement;
+- immediately notify the other Party of any unauthorized disclosure or use of Confidential Information.
+
+8.4. Confidentiality obligations remain in effect for **3 (three) years** after termination of this Agreement.
+
+## 9. Liability of the Parties
+
+9.1. For failure to perform or improper performance of obligations under this Agreement, the Parties bear liability in accordance with this Agreement and the current legislation of Ukraine.
+
+9.2. The aggregate liability of each Party under this Agreement is limited to the amount actually paid by the Client to the Developer for the last 12 (twelve) months preceding the occurrence of the basis for liability.
+
+9.3. Neither Party shall be liable for indirect, incidental, or punitive damages, including lost profits, data loss, or reputational damage.
+
+9.4. The Developer bears full liability for damages caused to the Client as a result of breach of obligations regarding confidentiality (Section 8) and protection of End User data (Section 7), without the limitations established in clause 9.2.
+
+## 10. Force Majeure
+
+10.1. The Parties are released from liability for failure to perform or improper performance of obligations under this Agreement if such failure is a consequence of force majeure circumstances that arose after the conclusion of the Agreement.
+
+10.2. Force majeure circumstances mean extraordinary and unavoidable circumstances that objectively prevent the performance of obligations: natural disasters, military actions, blockades, embargoes, sanctions, decisions of state authorities, large-scale cyberattacks, pandemics.
+
+10.3. A Party invoking force majeure circumstances is obligated to notify the other Party within 5 business days of their occurrence and provide confirmation from the Chamber of Commerce and Industry of Ukraine.
+
+10.4. If force majeure circumstances continue for more than 90 days, each Party has the right to terminate the Agreement by giving 15 days' notice to the other Party.
+
+## 11. Term and Termination
+
+11.1. This Agreement takes effect from the moment of acceptance and is valid for 12 (twelve) months.
+
+11.2. The Agreement is automatically extended for each subsequent 12-month period unless either Party notifies the other of its intention to terminate the Agreement 30 (thirty) days before the end of the current period.
+
+11.3. Each Party has the right to unilaterally terminate the Agreement by giving 30 (thirty) days' written notice to the other Party.
+
+11.4. The Client has the right to terminate the Agreement immediately in the event of:
+- breach by the Developer of confidentiality obligations;
+- breach by the Developer of obligations regarding the protection of End User data;
+- systematic failure or improper performance by the Developer of their obligations (more than 3 breaches during a quarter).
+
+11.5. Upon termination of the Agreement, the Developer is obligated to:
+- transfer to the Client all incomplete Results of work;
+- delete all copies of Confidential Information and End User data from their devices and systems within 5 business days;
+- return or destroy all physical media containing Confidential Information;
+- provide written confirmation of completion of the above requirements.
+
+11.6. Termination of the Agreement does not release the Parties from fulfilling obligations that arose before the moment of termination, including obligations regarding payment, confidentiality, and intellectual property.
+
+## 12. Dispute Resolution
+
+12.1. All disputes arising in connection with this Agreement shall be resolved by the Parties through negotiations.
+
+12.2. If a dispute cannot be resolved through negotiations within 30 days from the receipt of a written claim, the dispute shall be submitted to the commercial court at the location of the Client in accordance with the current legislation of Ukraine.
+
+12.3. This Agreement is governed by and interpreted in accordance with the laws of Ukraine.
+
+## 13. Final Provisions
+
+13.1. This Agreement is drawn up in accordance with Articles 633, 634, 641, 642, 901-907, 1107-1114 of the Civil Code of Ukraine and Articles 179-188 of the Commercial Code of Ukraine.
+
+13.2. Amendments and additions to this Agreement shall be made in writing and signed by both Parties.
+
+13.3. All notices under this Agreement are deemed properly delivered if sent by email to the addresses specified in the Parties' details or through a messenger agreed upon by the Parties.
+
+13.4. If any provision of this Agreement is found invalid or unenforceable, this does not affect the validity of other provisions of the Agreement.
+
+13.5. By entering into this Agreement, the Developer confirms that they have read and agree to the Terms of Use, Privacy Policy, and Data Processing Agreement (DPA), which are integral parts of this Agreement.

--- a/lexwebapp/src/pages/DeveloperOfferPage.tsx
+++ b/lexwebapp/src/pages/DeveloperOfferPage.tsx
@@ -1,0 +1,16 @@
+import { Code } from 'lucide-react';
+import { LegalPageLayout } from '../components/LegalPageLayout';
+import contentUk from '../content/legal/developer-offer-uk.md?raw';
+import contentEn from '../content/legal/developer-offer-en.md?raw';
+
+export function DeveloperOfferPage() {
+  return (
+    <LegalPageLayout
+      icon={<Code size={28} className="text-violet-600" />}
+      iconBgClass="bg-violet-100"
+      routePath="developer-offer"
+      contentUk={contentUk}
+      contentEn={contentEn}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `DeveloperOfferPage.tsx` and `developer-offer-en.md` that were referenced in `router/index.tsx` but not committed
- Fixes TypeScript build failure in CI/CD

## Test plan
- [ ] CI/CD build passes (no more TS2307 error)
- [ ] `/uk_investor` page deploys and renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing `DeveloperOfferPage` and English legal content file referenced by `router/index.tsx` to fix the TS2307 import error and restore CI builds.

- **Bug Fixes**
  - Added `lexwebapp/src/pages/DeveloperOfferPage.tsx` using `LegalPageLayout` with `routePath="developer-offer"`.
  - Added `lexwebapp/src/content/legal/developer-offer-en.md` so `contentEn` import resolves and the page renders.

<sup>Written for commit fec4b8b684c15c1f4bce2af037d07016393a81fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

