### PR TITLE
feat(ui): redesign platform UI in Harvey.ai style

### DIFF
--- a/lexwebapp/src/components/ChatInput.tsx
+++ b/lexwebapp/src/components/ChatInput.tsx
@@ -97,7 +97,7 @@ export function ChatInput({
 
   return (
     <>
-    <div className="max-w-3xl mx-auto px-4 md:px-6 pb-2" data-tour="chat-input">
+    <div className="max-w-3xl mx-auto px-4 md:px-8 pb-2" data-tour="chat-input">
       {/* Mode Selection */}
       {onToolChange && selectedTool && (
         <ToolSelector selectedTool={selectedTool} onToolChange={onToolChange} />
@@ -109,16 +109,16 @@ export function ChatInput({
       {/* Load / Save prompt buttons */}
       <PromptManager currentInput={input} onLoadPrompt={handleLoadPrompt} />
 
-      <div className="relative bg-white rounded-xl border border-zinc-200 shadow-elevation-1 focus-within:shadow-input-focus focus-within:border-zinc-400 transition-all duration-200">
-        <div className="flex items-end gap-1.5 p-1.5">
+      <div className="relative bg-white rounded-2xl border border-zinc-200/80 shadow-sm focus-within:shadow-md focus-within:border-zinc-300 transition-all duration-200">
+        <div className="flex items-end gap-1 p-2">
           {/* Plus / Attach button */}
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
-            className="p-2 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-lg transition-colors duration-150 flex-shrink-0"
+            className="p-2 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-50 rounded-xl transition-colors duration-150 flex-shrink-0"
             aria-label="Додати вкладення"
           >
-            <Plus size={16} strokeWidth={2} />
+            <Plus size={16} strokeWidth={1.75} />
           </button>
           <input
             ref={fileInputRef}
@@ -139,38 +139,38 @@ export function ChatInput({
             placeholder="Напишіть повідомлення..."
             disabled={disabled || isStreaming}
             rows={1}
-            className="flex-1 py-2 px-1 bg-transparent border-none resize-none focus:ring-0 focus:outline-none text-zinc-900 placeholder:text-zinc-400 font-sans text-[14px] leading-relaxed max-h-[200px] overflow-hidden"
+            className="flex-1 py-2.5 px-1 bg-transparent border-none resize-none focus:ring-0 focus:outline-none text-zinc-900 placeholder:text-zinc-400 font-sans text-[14px] leading-[1.6] max-h-[200px] overflow-hidden"
             style={{
-              minHeight: '38px'
+              minHeight: '40px'
             }}
           />
 
-          <div className="flex items-center gap-1.5 flex-shrink-0">
+          <div className="flex items-center gap-1.5 flex-shrink-0 pb-0.5">
             {isStreaming ? (
               <button
                 type="button"
                 onClick={onCancel}
-                className="p-2 rounded-lg transition-colors duration-150 bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95"
+                className="p-2 rounded-xl transition-all duration-150 bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95"
                 aria-label="Зупинити генерацію"
                 title="Зупинити"
               >
-                <Square size={15} strokeWidth={2} fill="currentColor" />
+                <Square size={14} strokeWidth={2} fill="currentColor" />
               </button>
             ) : (
               <button
                 onClick={handleSubmit}
                 disabled={(!input.trim() && files.length === 0) || disabled || isUploadingFiles}
-                className={`p-2 rounded-lg transition-colors duration-150 ${
+                className={`p-2 rounded-xl transition-all duration-150 ${
                   (input.trim() || files.length > 0) && !disabled && !isUploadingFiles
-                    ? 'bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95'
+                    ? 'bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95 shadow-sm'
                     : 'bg-zinc-100 text-zinc-300 cursor-not-allowed'
                 }`}
                 aria-label="Надіслати повідомлення"
               >
                 {isUploadingFiles ? (
-                  <Loader2 size={15} strokeWidth={2} className="animate-spin" />
+                  <Loader2 size={14} strokeWidth={2} className="animate-spin" />
                 ) : (
-                  <Send size={15} strokeWidth={2} />
+                  <Send size={14} strokeWidth={2} />
                 )}
               </button>
             )}

--- a/lexwebapp/src/components/DocumentViewerModal/ContentRenderer.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/ContentRenderer.tsx
@@ -17,15 +17,15 @@ export function ContentRenderer({ item, isLoading, errorMessage, onSaveOcrText }
   return (
     <>
       {errorMessage && (
-        <div className="flex items-start gap-3 p-3 mb-4 rounded-lg bg-amber-50 border border-amber-200 text-amber-800 text-[13px]">
-          <AlertTriangle size={16} className="flex-shrink-0 mt-0.5" strokeWidth={2} />
-          <span>{errorMessage}</span>
+        <div className="flex items-start gap-3 px-4 py-3 mb-5 rounded-lg bg-amber-50 border border-amber-200 text-amber-800 text-[12.5px]">
+          <AlertTriangle size={15} className="flex-shrink-0 mt-0.5 text-amber-500" strokeWidth={2} />
+          <span className="leading-relaxed">{errorMessage}</span>
         </div>
       )}
       {isLoading ? (
-        <div className="flex flex-col items-center justify-center py-16 text-claude-subtext">
-          <Loader2 size={28} className="animate-spin mb-3" strokeWidth={2} />
-          <p className="text-[13px]">Завантаження...</p>
+        <div className="flex flex-col items-center justify-center py-20 text-zinc-400">
+          <Loader2 size={24} className="animate-spin mb-4" strokeWidth={1.5} />
+          <p className="text-[12px] font-medium tracking-wide">Завантаження...</p>
         </div>
       ) : isImageWithOcr ? (
         <ImageOcrViewer item={item} onSaveOcrText={onSaveOcrText} />

--- a/lexwebapp/src/components/DocumentViewerModal/ImageOcrViewer.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/ImageOcrViewer.tsx
@@ -44,7 +44,7 @@ export function ImageOcrViewer({ item, onSaveOcrText }: ImageOcrViewerProps) {
   };
 
   return (
-    <div className="flex gap-4 h-full">
+    <div className="flex gap-5 h-full">
       {/* Left: Image preview with zoom/crop/follow */}
       <div className="flex-1 min-w-0">
         <ImageViewer
@@ -55,22 +55,22 @@ export function ImageOcrViewer({ item, onSaveOcrText }: ImageOcrViewerProps) {
       </div>
       {/* Right: Editable OCR text */}
       <div className="flex-1 min-w-0 flex flex-col">
-        <div className="flex items-center justify-between mb-2">
-          <span className="text-xs font-semibold text-claude-subtext uppercase tracking-wide">
+        <div className="flex items-center justify-between mb-2.5">
+          <span className="text-[10px] font-semibold text-zinc-500 uppercase tracking-[0.1em]">
             Розпізнаний текст
           </span>
           {onSaveOcrText && item.documentId && (
             <button
               onClick={handleSaveOcr}
               disabled={ocrSaving || editedOcrText === item.ocrText}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg transition-all disabled:opacity-40 bg-claude-text text-white hover:bg-claude-text/90 disabled:hover:bg-claude-text"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-semibold rounded-md transition-all duration-150 disabled:opacity-40 bg-zinc-900 text-white hover:bg-zinc-800 border border-zinc-900"
             >
               {ocrSaving ? (
-                <Loader2 size={12} className="animate-spin" />
+                <Loader2 size={11} className="animate-spin" />
               ) : ocrSaved ? (
-                <Check size={12} />
+                <Check size={11} />
               ) : (
-                <Save size={12} />
+                <Save size={11} />
               )}
               {ocrSaved ? 'Збережено' : 'Зберегти'}
             </button>
@@ -80,7 +80,7 @@ export function ImageOcrViewer({ item, onSaveOcrText }: ImageOcrViewerProps) {
           ref={ocrTextareaRef}
           value={editedOcrText}
           onChange={(e) => setEditedOcrText(e.target.value)}
-          className="flex-1 w-full p-3 border border-claude-border rounded-lg text-sm text-claude-text font-mono resize-none focus:outline-none focus:border-claude-subtext/40 transition-colors leading-relaxed"
+          className="flex-1 w-full px-3.5 py-3 border border-zinc-200 rounded-lg text-[12.5px] text-zinc-700 font-mono resize-none focus:outline-none focus:ring-1 focus:ring-zinc-900 focus:border-zinc-900 transition-all duration-150 leading-relaxed bg-white"
           placeholder="Текст не розпізнано"
         />
       </div>

--- a/lexwebapp/src/components/DocumentViewerModal/MarkdownViewer.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/MarkdownViewer.tsx
@@ -6,7 +6,27 @@ interface MarkdownViewerProps {
 
 export function MarkdownViewer({ content }: MarkdownViewerProps) {
   return (
-    <div className="prose prose-sm max-w-none prose-headings:text-claude-text prose-p:text-claude-text prose-p:leading-relaxed prose-a:text-blue-600 prose-strong:text-claude-text prose-code:text-[13px] prose-code:bg-claude-bg prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-pre:bg-claude-bg prose-pre:border prose-pre:border-claude-border prose-blockquote:border-claude-border prose-blockquote:text-claude-subtext">
+    <div className="
+      prose prose-zinc max-w-none
+      prose-headings:font-semibold prose-headings:tracking-tight prose-headings:text-zinc-900
+      prose-h1:text-xl prose-h1:mb-4 prose-h1:mt-0 prose-h1:pb-3 prose-h1:border-b prose-h1:border-zinc-200
+      prose-h2:text-base prose-h2:mt-6 prose-h2:mb-3
+      prose-h3:text-[13.5px] prose-h3:mt-5 prose-h3:mb-2 prose-h3:text-zinc-700
+      prose-p:text-[13.5px] prose-p:text-zinc-700 prose-p:leading-[1.8] prose-p:my-3
+      prose-a:text-zinc-900 prose-a:underline prose-a:underline-offset-2 prose-a:decoration-zinc-400 hover:prose-a:decoration-zinc-900 prose-a:transition-all
+      prose-strong:text-zinc-900 prose-strong:font-semibold
+      prose-em:text-zinc-600
+      prose-code:text-[12px] prose-code:bg-zinc-100 prose-code:text-zinc-800 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:font-mono prose-code:before:content-none prose-code:after:content-none
+      prose-pre:bg-zinc-950 prose-pre:text-zinc-200 prose-pre:border prose-pre:border-zinc-800 prose-pre:rounded-lg prose-pre:text-[12px]
+      prose-blockquote:border-l-2 prose-blockquote:border-zinc-300 prose-blockquote:pl-4 prose-blockquote:text-zinc-500 prose-blockquote:italic prose-blockquote:not-italic
+      prose-ul:my-3 prose-li:my-1 prose-li:text-[13.5px] prose-li:text-zinc-700
+      prose-ol:my-3
+      prose-hr:border-zinc-200 prose-hr:my-6
+      prose-table:text-[12.5px]
+      prose-thead:border-b-2 prose-thead:border-zinc-200
+      prose-th:font-semibold prose-th:text-zinc-900 prose-th:py-2 prose-th:px-3
+      prose-td:py-2 prose-td:px-3 prose-td:text-zinc-600 prose-td:border-b prose-td:border-zinc-100
+    ">
       <ReactMarkdown>{content}</ReactMarkdown>
     </div>
   );

--- a/lexwebapp/src/components/DocumentViewerModal/index.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/index.tsx
@@ -90,68 +90,68 @@ export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMes
             {onPrevious && hasPrevious && (
               <button
                 onClick={onPrevious}
-                className="fixed left-3 top-1/2 -translate-y-1/2 z-[1060] p-2 bg-white/90 hover:bg-white rounded-full shadow-lg text-claude-subtext hover:text-claude-text transition-all backdrop-blur-sm"
+                className="fixed left-4 top-1/2 -translate-y-1/2 z-[1060] p-2.5 bg-white hover:bg-zinc-50 rounded-full shadow-lg border border-zinc-200 text-zinc-500 hover:text-zinc-900 transition-all duration-150"
                 title="Попередній (←)"
               >
-                <ChevronLeft size={24} strokeWidth={2} />
+                <ChevronLeft size={20} strokeWidth={2} />
               </button>
             )}
             {/* Right arrow navigation */}
             {onNext && hasNext && (
               <button
                 onClick={onNext}
-                className="fixed right-3 top-1/2 -translate-y-1/2 z-[1060] p-2 bg-white/90 hover:bg-white rounded-full shadow-lg text-claude-subtext hover:text-claude-text transition-all backdrop-blur-sm"
+                className="fixed right-4 top-1/2 -translate-y-1/2 z-[1060] p-2.5 bg-white hover:bg-zinc-50 rounded-full shadow-lg border border-zinc-200 text-zinc-500 hover:text-zinc-900 transition-all duration-150"
                 title="Наступний (→)"
               >
-                <ChevronRight size={24} strokeWidth={2} />
+                <ChevronRight size={20} strokeWidth={2} />
               </button>
             )}
             <div className="flex min-h-full items-center justify-center p-4">
               <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 20 }}
+                initial={{ opacity: 0, scale: 0.97, y: 16 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
-                exit={{ opacity: 0, scale: 0.95, y: 20 }}
-                transition={{ duration: 0.25, ease: [0.22, 1, 0.36, 1] }}
-                className={`bg-white rounded-xl shadow-2xl flex flex-col resize overflow-hidden ${isImageWithOcr ? 'w-[90vw] h-[90vh]' : 'w-[48rem] h-[85vh]'}`}
+                exit={{ opacity: 0, scale: 0.97, y: 16 }}
+                transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+                className={`bg-white rounded-xl shadow-2xl border border-zinc-200/80 flex flex-col resize overflow-hidden ${isImageWithOcr ? 'w-[90vw] h-[90vh]' : 'w-[52rem] h-[85vh]'}`}
                 style={{ minWidth: '24rem', minHeight: '20rem', maxWidth: '98vw', maxHeight: '96vh' }}
                 onClick={(e) => e.stopPropagation()}
               >
-                {/* Header */}
-                <div className="flex items-start justify-between px-6 py-4 border-b border-claude-border/50 flex-shrink-0">
+                {/* Header — dark stripe for premium feel */}
+                <div className="flex items-start justify-between px-5 py-3.5 border-b border-zinc-200/80 flex-shrink-0 bg-zinc-50">
                   <div className="flex items-start gap-3 min-w-0 flex-1">
-                    <div className="p-2 bg-claude-bg rounded-lg flex-shrink-0 mt-0.5">
-                      <Icon size={18} className="text-claude-text" strokeWidth={2} />
+                    <div className="p-1.5 bg-zinc-900 rounded-md flex-shrink-0 mt-0.5">
+                      <Icon size={14} className="text-white" strokeWidth={2} />
                     </div>
                     <div className="min-w-0">
-                      <h2 className="text-base font-semibold text-claude-text leading-tight">
+                      <h2 className="text-[13.5px] font-semibold text-zinc-900 leading-snug tracking-tight">
                         {item.title}
                       </h2>
                       {item.subtitle && (
-                        <p className="text-[12px] text-claude-subtext mt-1">{item.subtitle}</p>
+                        <p className="text-[11px] text-zinc-500 mt-0.5 leading-snug">{item.subtitle}</p>
                       )}
-                      <div className="flex items-center gap-2 mt-2">
+                      <div className="flex items-center gap-2 mt-1.5">
                         {item.badge && (
-                          <span className={`text-[10px] px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide border ${
+                          <span className={`text-[9px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-[0.06em] border ${
                             item.badgeVariant === 'active'
                               ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
                               : item.badgeVariant === 'overturned'
                               ? 'bg-red-50 text-red-600 border-red-200'
                               : item.badgeVariant === 'modified'
-                              ? 'bg-amber-50 text-amber-700 border-amber-200'
-                              : 'bg-claude-bg text-claude-subtext border-claude-border'
+                              ? 'bg-zinc-100 text-zinc-600 border-zinc-200'
+                              : 'bg-zinc-100 text-zinc-500 border-zinc-200'
                           }`}>
                             {item.badge}
                           </span>
                         )}
                         {item.relevance != null && (
                           <div className="flex items-center gap-1.5">
-                            <div className="w-16 h-1.5 bg-claude-bg rounded-full overflow-hidden">
+                            <div className="w-14 h-1 bg-zinc-200 rounded-full overflow-hidden">
                               <div
-                                className="h-full bg-claude-text/50 rounded-full"
+                                className="h-full bg-zinc-700 rounded-full"
                                 style={{ width: `${item.relevance}%` }}
                               />
                             </div>
-                            <span className="text-[10px] text-claude-subtext font-medium">
+                            <span className="text-[10px] text-zinc-400 font-medium tabular-nums">
                               {item.relevance}%
                             </span>
                           </div>
@@ -160,60 +160,61 @@ export function DocumentViewerModal({ isOpen, onClose, item, isLoading, errorMes
                     </div>
                   </div>
 
-                  <div className="flex items-center gap-1 flex-shrink-0 ml-4">
+                  <div className="flex items-center gap-0.5 flex-shrink-0 ml-3">
                     {currentIndex != null && totalCount != null && totalCount > 1 && (
-                      <span className="text-[11px] text-claude-subtext font-medium mr-2 tabular-nums">
+                      <span className="text-[11px] text-zinc-400 font-medium mr-2 tabular-nums">
                         {currentIndex + 1} / {totalCount}
                       </span>
                     )}
                     <button
                       onClick={handleCopy}
                       disabled={isLoading}
-                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all disabled:opacity-40"
+                      className="p-1.5 text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 rounded-md transition-all duration-150 disabled:opacity-40"
                       title="Копіювати"
                     >
-                      {copied ? <Check size={16} strokeWidth={2} /> : <Copy size={16} strokeWidth={2} />}
+                      {copied ? <Check size={15} strokeWidth={2} /> : <Copy size={15} strokeWidth={2} />}
                     </button>
                     <button
                       onClick={handleSave}
                       disabled={isLoading}
-                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all disabled:opacity-40"
+                      className="p-1.5 text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 rounded-md transition-all duration-150 disabled:opacity-40"
                       title="Зберегти як .txt"
                     >
-                      <Download size={16} strokeWidth={2} />
+                      <Download size={15} strokeWidth={2} />
                     </button>
                     {item.externalUrl && (
                       <a
                         href={item.externalUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all"
+                        className="p-1.5 text-zinc-400 hover:text-zinc-700 hover:bg-zinc-100 rounded-md transition-all duration-150"
                         title="Відкрити зовнішнє посилання"
                       >
-                        <ExternalLink size={16} strokeWidth={2} />
+                        <ExternalLink size={15} strokeWidth={2} />
                       </a>
                     )}
                     {onDelete && (
                       <button
                         onClick={onDelete}
                         disabled={isLoading}
-                        className="p-2 text-claude-subtext hover:text-red-500 hover:bg-red-50 rounded-lg transition-all disabled:opacity-40"
+                        className="p-1.5 text-zinc-400 hover:text-red-500 hover:bg-red-50 rounded-md transition-all duration-150 disabled:opacity-40"
                         title="Видалити (Delete)"
                       >
-                        <Trash2 size={16} strokeWidth={2} />
+                        <Trash2 size={15} strokeWidth={2} />
                       </button>
                     )}
+                    <div className="w-px h-4 bg-zinc-200 mx-1" />
                     <button
                       onClick={onClose}
-                      className="p-2 text-claude-subtext hover:text-claude-text hover:bg-claude-bg rounded-lg transition-all"
+                      className="p-1.5 text-zinc-400 hover:text-zinc-800 hover:bg-zinc-100 rounded-md transition-all duration-150"
                     >
-                      <X size={18} strokeWidth={2} />
+                      <X size={16} strokeWidth={2} />
                     </button>
                   </div>
                 </div>
 
                 {/* Content — binary preview or Markdown rendered */}
-                <div className="flex-1 min-h-0 overflow-y-auto px-6 py-5">
+                <div className="flex-1 min-h-0 overflow-y-auto px-7 py-6">
                   <ContentRenderer
                     item={item}
                     isLoading={isLoading}

--- a/lexwebapp/src/components/EmptyState.tsx
+++ b/lexwebapp/src/components/EmptyState.tsx
@@ -5,54 +5,71 @@ interface EmptyStateProps {
   onSelectPrompt: (prompt: string) => void;
 }
 
-export function EmptyState({ onSelectPrompt }: EmptyStateProps) {
-  const prompts = [
-    'Допоможіть скласти позовну заяву про стягнення заборгованості',
-    'Знайдіть практику ВС по договорах поставки',
-    'Проаналізуйте підстави для скасування рішення суду',
-    'Які документи потрібні для банкрутства фізичної особи?',
-  ];
+const PROMPTS = [
+  {
+    label: 'Позовна заява',
+    text: 'Допоможіть скласти позовну заяву про стягнення заборгованості',
+  },
+  {
+    label: 'Судова практика',
+    text: 'Знайдіть практику ВС по договорах поставки',
+  },
+  {
+    label: 'Оскарження',
+    text: 'Проаналізуйте підстави для скасування рішення суду',
+  },
+  {
+    label: 'Банкрутство',
+    text: 'Які документи потрібні для банкрутства фізичної особи?',
+  },
+];
 
+export function EmptyState({ onSelectPrompt }: EmptyStateProps) {
   return (
-    <div className="flex-1 flex items-center justify-center p-6 overflow-y-auto">
-      <div className="max-w-xl w-full">
+    <div className="flex-1 flex flex-col items-center justify-center px-4 md:px-8 pb-6 overflow-y-auto">
+      <div className="max-w-2xl w-full">
         <motion.div
-          initial={{ opacity: 0, y: 12 }}
+          initial={{ opacity: 0, y: 16 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
-          className="mb-10"
+          transition={{ duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
+          className="mb-12 text-center"
         >
-          <h1 className="font-sans text-2xl md:text-3xl font-semibold text-zinc-900 mb-3 tracking-tight">
+          <h1 className="font-sans text-[28px] md:text-[34px] font-semibold text-zinc-900 mb-4 tracking-[-0.02em] leading-tight">
             Чим можу допомогти?
           </h1>
-          <p className="font-sans text-zinc-500 text-sm md:text-base leading-relaxed">
-            AI-асистент для роботи з українським правом. Аналіз практики,
-            підготовка документів, правові консультації.
+          <p className="font-sans text-zinc-500 text-[15px] leading-relaxed max-w-md mx-auto">
+            AI-асистент для роботи з українським правом — аналіз судової практики,
+            підготовка документів та правові консультації.
           </p>
         </motion.div>
 
         <motion.div
-          initial={{ opacity: 0, y: 12 }}
+          initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.5, delay: 0.15, ease: [0.22, 1, 0.36, 1] }}
-          className="space-y-2"
+          transition={{ duration: 0.5, delay: 0.12, ease: [0.22, 1, 0.36, 1] }}
+          className="grid grid-cols-1 md:grid-cols-2 gap-2.5"
         >
-          {prompts.map((prompt, index) => (
+          {PROMPTS.map((prompt, index) => (
             <motion.button
               key={index}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.3, delay: 0.2 + index * 0.07 }}
-              onClick={() => onSelectPrompt(prompt)}
-              className="group w-full text-left px-4 py-3 bg-white border border-zinc-200 hover:border-zinc-300 rounded-xl transition-all duration-150 hover:shadow-elevation-1 flex items-center justify-between gap-3 active:scale-[0.99]"
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.3, delay: 0.18 + index * 0.06, ease: [0.22, 1, 0.36, 1] }}
+              onClick={() => onSelectPrompt(prompt.text)}
+              className="group w-full text-left px-5 py-4 bg-white border border-zinc-200/80 hover:border-zinc-300 rounded-xl transition-all duration-200 hover:shadow-sm flex items-start justify-between gap-3 active:scale-[0.99]"
             >
-              <p className="font-sans text-[13px] md:text-[14px] text-zinc-700 leading-relaxed">
-                {prompt}
-              </p>
+              <div className="flex-1 min-w-0">
+                <p className="font-sans text-[12px] font-semibold text-zinc-400 uppercase tracking-wide mb-1">
+                  {prompt.label}
+                </p>
+                <p className="font-sans text-[13px] text-zinc-700 leading-snug">
+                  {prompt.text}
+                </p>
+              </div>
               <ArrowRight
                 size={14}
-                strokeWidth={2}
-                className="flex-shrink-0 text-zinc-300 group-hover:text-zinc-500 transition-colors duration-150"
+                strokeWidth={1.75}
+                className="flex-shrink-0 text-zinc-300 group-hover:text-zinc-500 transition-colors duration-150 mt-0.5"
               />
             </motion.button>
           ))}

--- a/lexwebapp/src/components/MessageThread.tsx
+++ b/lexwebapp/src/components/MessageThread.tsx
@@ -36,7 +36,7 @@ export function MessageThread({
 
   return <div ref={containerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto scroll-smooth">
       <div className="flex flex-col">
-        <div className="h-4 md:h-6" />
+        <div className="h-6 md:h-10" />
         {messages.map((message, idx) => {
           // For assistant messages, find the preceding user message for regeneration
           let handleRegenerate: (() => void) | undefined;

--- a/lexwebapp/src/components/PlanReviewDisplay.tsx
+++ b/lexwebapp/src/components/PlanReviewDisplay.tsx
@@ -123,23 +123,27 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
       initial={{ opacity: 0, y: 8 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25 }}
-      className="my-3 border border-claude-border rounded-lg overflow-hidden bg-white max-h-[70vh] flex flex-col"
+      className="my-3 border border-zinc-200/80 rounded-lg overflow-hidden bg-white max-h-[70vh] flex flex-col shadow-sm"
     >
       {/* Header */}
-      <div className="p-3 border-b border-claude-border/30 bg-claude-bg/30">
-        <div className="flex items-center gap-2">
-          <Target size={14} className="text-claude-text flex-shrink-0" strokeWidth={2} />
-          <span className="text-[13px] text-claude-text font-medium">
-            {plan.goal}
-          </span>
+      <div className="px-4 py-3 border-b border-zinc-200/60 bg-zinc-50">
+        <div className="flex items-start gap-2.5">
+          <div className="p-1 bg-zinc-900 rounded flex-shrink-0 mt-0.5">
+            <Target size={11} className="text-white" strokeWidth={2} />
+          </div>
+          <div className="min-w-0">
+            <span className="text-[12.5px] text-zinc-900 font-medium leading-snug block">
+              {plan.goal}
+            </span>
+            <p className="text-[10.5px] text-zinc-400 mt-0.5 font-medium">
+              Оберіть глибину аналізу для кожного кроку
+            </p>
+          </div>
         </div>
-        <p className="text-[11px] text-claude-subtext mt-1">
-          Оберіть глибину аналізу для кожного кроку
-        </p>
       </div>
 
       {/* Steps — scrollable on mobile when many steps */}
-      <div className="p-3 space-y-2 overflow-y-auto flex-1 min-h-0">
+      <div className="px-4 py-2 space-y-0.5 overflow-y-auto flex-1 min-h-0 divide-y divide-zinc-100">
         {steps.map((step) => {
           const isDepthCapable = DEPTH_CAPABLE_TOOLS.has(step.tool);
           const isDeep = step.depth === 'deep';
@@ -150,17 +154,17 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
           return (
             <div
               key={step.id}
-              className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1 sm:gap-3 py-1.5"
+              className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-3 py-2.5"
             >
-              <div className="flex items-start gap-2 flex-1 min-w-0">
-                <span className="text-[11px] text-claude-subtext/60 font-mono mt-0.5 w-4 flex-shrink-0 text-right">
+              <div className="flex items-start gap-2.5 flex-1 min-w-0">
+                <span className="text-[10px] text-zinc-300 font-mono mt-0.5 w-4 flex-shrink-0 text-right tabular-nums">
                   {step.id}
                 </span>
                 <div className="min-w-0">
-                  <span className="text-[13px] text-claude-text leading-relaxed">
+                  <span className="text-[12.5px] text-zinc-800 leading-snug">
                     {step.purpose}
                   </span>
-                  <span className="text-[11px] text-claude-subtext/60 ml-1.5">
+                  <span className="text-[10px] text-zinc-400 ml-1.5 font-medium">
                     {getToolLabel(step.tool)}
                   </span>
                 </div>
@@ -168,33 +172,33 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
 
               {/* Cost + Depth toggle */}
               <div className="flex items-center gap-2 flex-shrink-0 pl-6 sm:pl-0">
-                <span className="text-[10px] text-claude-subtext/50 font-mono tabular-nums w-[60px] text-right" title={calls > 1 ? `~${calls} викликів` : undefined}>
-                  {formatUah(cost)}{calls > 1 && <span className="text-claude-subtext/30 ml-0.5">×{calls}</span>}
+                <span className="text-[10px] text-zinc-400 font-mono tabular-nums w-[56px] text-right" title={calls > 1 ? `~${calls} викликів` : undefined}>
+                  {formatUah(cost)}{calls > 1 && <span className="text-zinc-300 ml-0.5">×{calls}</span>}
                 </span>
 
                 {isDepthCapable ? (
                   <button
                     onClick={() => toggleDepth(step.id)}
-                    className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium transition-colors min-w-[105px] justify-center ${
+                    className={`flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-semibold tracking-tight transition-all duration-150 min-w-[100px] justify-center border ${
                       isDeep
-                        ? 'bg-amber-100 text-amber-800 hover:bg-amber-200'
-                        : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                    } ${isRecommended ? 'ring-1 ring-offset-1 ring-blue-300' : ''}`}
+                        ? 'bg-zinc-900 text-white border-zinc-900 hover:bg-zinc-800'
+                        : 'bg-white text-zinc-600 border-zinc-200 hover:border-zinc-300 hover:text-zinc-900'
+                    } ${isRecommended ? 'ring-1 ring-offset-1 ring-zinc-400' : ''}`}
                   >
                     {isDeep ? (
                       <>
-                        <Search size={10} strokeWidth={2.5} />
+                        <Search size={9} strokeWidth={2.5} />
                         Глибокий
                       </>
                     ) : (
                       <>
-                        <Zap size={10} strokeWidth={2.5} />
+                        <Zap size={9} strokeWidth={2.5} />
                         Стандартний
                       </>
                     )}
                   </button>
                 ) : (
-                  <span className="text-[11px] text-claude-subtext/40 min-w-[105px] text-center px-2">
+                  <span className="text-[10px] text-zinc-300 min-w-[100px] text-center px-2 font-medium">
                     фіксований
                   </span>
                 )}
@@ -205,50 +209,49 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
       </div>
 
       {/* Footer: bulk actions + total cost + confirm */}
-      <div className="p-3 border-t border-claude-border/30 bg-claude-bg/20 flex-shrink-0">
-        <div className="flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2">
+      <div className="px-4 py-3 border-t border-zinc-200/60 bg-zinc-50/70 flex-shrink-0">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
             <button
               onClick={setAllDeep}
-              className="text-[11px] text-claude-subtext hover:text-claude-text transition-colors"
+              className="text-[10.5px] text-zinc-500 hover:text-zinc-900 transition-colors font-medium"
             >
               Усі глибокі
             </button>
-            <span className="text-[11px] text-claude-subtext/30">|</span>
+            <span className="text-zinc-300 text-xs">·</span>
             <button
               onClick={setAllStandard}
-              className="text-[11px] text-claude-subtext hover:text-claude-text transition-colors"
+              className="text-[10.5px] text-zinc-500 hover:text-zinc-900 transition-colors font-medium"
             >
-              Усі стандартні
+              Стандартні
             </button>
             {deepCount > 0 && (
-              <span className="text-[11px] text-amber-600 ml-1">
-                ({deepCount} глибоких)
+              <span className="text-[10px] text-zinc-500 bg-zinc-100 border border-zinc-200 px-1.5 py-0.5 rounded font-medium">
+                {deepCount} глибоких
               </span>
             )}
-            <span className="text-[11px] text-claude-subtext/30 ml-1">|</span>
-            <span className="text-[11px] text-claude-subtext font-mono tabular-nums">
+          </div>
+
+          <div className="flex items-center gap-3">
+            <span className="text-[11px] text-zinc-500 font-mono tabular-nums font-medium">
               ~{formatUah(totalCost)}
             </span>
+            <button
+              onClick={onSkip}
+              disabled={isLoading}
+              className="text-[11px] text-zinc-400 hover:text-zinc-700 transition-colors font-medium px-2 py-1"
+            >
+              Пропустити
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={isLoading}
+              className="flex items-center gap-1.5 px-3.5 py-1.5 bg-zinc-900 text-white rounded-md text-[11.5px] font-semibold hover:bg-zinc-800 transition-colors duration-150 disabled:opacity-50"
+            >
+              <Play size={10} strokeWidth={2.5} />
+              {isLoading ? 'Запуск...' : 'Почати аналіз'}
+            </button>
           </div>
-        </div>
-
-        <div className="flex items-center justify-end gap-2 mt-2">
-          <button
-            onClick={onSkip}
-            disabled={isLoading}
-            className="text-[11px] text-claude-subtext hover:text-claude-text transition-colors px-2 py-1"
-          >
-            Пропустити
-          </button>
-          <button
-            onClick={handleConfirm}
-            disabled={isLoading}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-claude-text text-white rounded-md text-[12px] font-medium hover:bg-claude-text/90 transition-colors disabled:opacity-50"
-          >
-            <Play size={11} strokeWidth={2.5} />
-            {isLoading ? 'Запуск...' : 'Почати аналіз'}
-          </button>
         </div>
       </div>
     </motion.div>

--- a/lexwebapp/src/components/chat/DecisionsTab.tsx
+++ b/lexwebapp/src/components/chat/DecisionsTab.tsx
@@ -45,36 +45,33 @@ export function DecisionsTab({ decisions, onOpenModal }: DecisionsTabProps) {
             externalUrl={decision.externalUrl}
             header={
               <>
-                <div className="flex items-start justify-between mb-2">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <div className="p-1 bg-claude-bg rounded-md flex-shrink-0">
-                      <Gavel size={12} className="text-claude-text" strokeWidth={2} />
-                    </div>
-                    <span className="font-mono text-[12px] font-semibold text-claude-text truncate">
+                <div className="flex items-start justify-between mb-1.5">
+                  <div className="flex items-center gap-2 min-w-0 flex-1">
+                    <span className="font-mono text-[11.5px] font-semibold text-zinc-800 truncate leading-tight">
                       {decision.number}
                     </span>
                   </div>
-                  <div className="flex items-center gap-1.5 flex-shrink-0">
-                    <span className={`text-[9px] px-1.5 py-0.5 rounded-full font-semibold uppercase tracking-wide border ${
+                  <div className="flex items-center gap-1.5 flex-shrink-0 ml-2">
+                    <span className={`text-[9px] px-1.5 py-0.5 rounded font-semibold uppercase tracking-[0.04em] border ${
                       decision.status === 'active'
-                        ? 'bg-green-50 text-green-700 border-green-200'
+                        ? 'bg-emerald-50 text-emerald-700 border-emerald-200'
                         : decision.status === 'overturned'
                         ? 'bg-red-50 text-red-600 border-red-200'
-                        : 'bg-amber-50 text-amber-700 border-amber-200'
+                        : 'bg-zinc-100 text-zinc-500 border-zinc-200'
                     }`}>
                       {STATUS_LABELS[decision.status] || decision.status}
                     </span>
-                    {expanded ? <ChevronUp size={14} className="text-claude-subtext" /> : <ChevronDown size={14} className="text-claude-subtext" />}
+                    {expanded ? <ChevronUp size={13} className="text-zinc-400" strokeWidth={2} /> : <ChevronDown size={13} className="text-zinc-400" strokeWidth={2} />}
                   </div>
                 </div>
-                <div className="text-[11px] text-claude-subtext mb-2">
-                  {decision.court} {decision.date && `• ${formatDate(decision.date)}`}
+                <div className="text-[10.5px] text-zinc-400 leading-tight">
+                  {decision.court}{decision.date && <span className="mx-1 text-zinc-300">·</span>}{decision.date && formatDate(decision.date)}
                 </div>
               </>
             }
             preview={
               decision.summary ? (
-                <p className="text-[12px] text-claude-text/80 leading-relaxed line-clamp-2">
+                <p className="text-[11px] text-zinc-500 leading-relaxed line-clamp-2 mt-1.5">
                   {decision.summary}
                 </p>
               ) : null

--- a/lexwebapp/src/components/chat/DocumentsTab.tsx
+++ b/lexwebapp/src/components/chat/DocumentsTab.tsx
@@ -53,32 +53,25 @@ export function DocumentsTab({ otherCourtDocs, vaultDocuments, onOpenDocModal }:
             content={d.summary || 'Немає тексту.'}
             externalUrl={d.externalUrl}
             header={
-              <div className="flex items-start gap-2.5">
-                <div className="p-1 bg-claude-bg rounded-md flex-shrink-0 mt-0.5">
-                  <FileText size={12} className="text-claude-text" strokeWidth={2} />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between">
-                    <div className="font-medium text-[13px] text-claude-text mb-1 truncate leading-tight">
-                      {d.number}
-                    </div>
-                    {expanded ? <ChevronUp size={14} className="text-claude-subtext flex-shrink-0 ml-2" /> : <ChevronDown size={14} className="text-claude-subtext flex-shrink-0 ml-2" />}
+              <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0 pr-2">
+                  <div className="font-medium text-[11.5px] text-zinc-800 truncate leading-tight mb-1">
+                    {d.number}
                   </div>
-                  <div className="flex items-center gap-2 text-[11px] text-claude-subtext">
-                    <span className="px-1.5 py-0.5 rounded text-[10px] font-medium border bg-amber-50 text-amber-700 border-amber-200">
+                  <div className="flex items-center gap-1.5 flex-wrap text-[10px] text-zinc-400">
+                    <span className="px-1.5 py-0.5 rounded bg-zinc-100 text-zinc-500 border border-zinc-200 font-medium text-[9px] uppercase tracking-[0.04em]">
                       {d.documentType}
                     </span>
                     {d.court && <span>{d.court}</span>}
-                    {d.date && <span>{formatDate(d.date)}</span>}
+                    {d.date && <><span className="text-zinc-300">·</span><span>{formatDate(d.date)}</span></>}
                   </div>
                 </div>
+                {expanded ? <ChevronUp size={13} className="text-zinc-400 flex-shrink-0 mt-0.5" strokeWidth={2} /> : <ChevronDown size={13} className="text-zinc-400 flex-shrink-0 mt-0.5" strokeWidth={2} />}
               </div>
             }
             preview={
               d.summary ? (
-                <div className="ml-[30px]">
-                  <p className="text-[11px] text-claude-subtext leading-relaxed mt-1.5 line-clamp-2">{d.summary}</p>
-                </div>
+                <p className="text-[11px] text-zinc-500 leading-relaxed mt-1.5 line-clamp-2">{d.summary}</p>
               ) : null
             }
           />
@@ -101,26 +94,20 @@ export function DocumentsTab({ otherCourtDocs, vaultDocuments, onOpenDocModal }:
             content={doc.metadata?.snippet || doc.metadata?.text || doc.metadata?.content || 'Немає вмісту для перегляду.'}
             onOpenModal={() => onOpenDocModal(doc)}
             header={
-              <div className="flex items-start gap-2.5">
-                <div className="p-1 bg-claude-bg rounded-md flex-shrink-0 mt-0.5">
-                  <FileText size={12} className="text-claude-text" strokeWidth={2} />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between">
-                    <div className="font-medium text-[13px] text-claude-text mb-1 truncate leading-tight">
-                      {doc.title}
-                    </div>
-                    {expanded ? <ChevronUp size={14} className="text-claude-subtext flex-shrink-0 ml-2" /> : <ChevronDown size={14} className="text-claude-subtext flex-shrink-0 ml-2" />}
+              <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0 pr-2">
+                  <div className="font-medium text-[11.5px] text-zinc-800 truncate leading-tight mb-1">
+                    {doc.title}
                   </div>
-                  <div className="flex items-center gap-2 text-[11px] text-claude-subtext">
-                    <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium border ${
+                  <div className="flex items-center gap-1.5 text-[10px] text-zinc-400">
+                    <span className={`px-1.5 py-0.5 rounded font-medium border text-[9px] uppercase tracking-[0.04em] ${
                       doc.type === 'court_decision'
-                        ? 'bg-blue-50 text-blue-700 border-blue-200'
+                        ? 'bg-zinc-900 text-white border-zinc-900'
                         : doc.type === 'legislation'
-                        ? 'bg-purple-50 text-purple-700 border-purple-200'
+                        ? 'bg-zinc-100 text-zinc-600 border-zinc-200'
                         : doc.type === 'contract'
-                        ? 'bg-green-50 text-green-700 border-green-200'
-                        : 'bg-claude-bg text-claude-subtext border-claude-border'
+                        ? 'bg-zinc-100 text-zinc-600 border-zinc-200'
+                        : 'bg-zinc-100 text-zinc-500 border-zinc-200'
                     }`}>
                       {DOC_TYPE_LABELS[doc.type] || doc.type}
                     </span>
@@ -129,15 +116,14 @@ export function DocumentsTab({ otherCourtDocs, vaultDocuments, onOpenDocModal }:
                     )}
                   </div>
                 </div>
+                {expanded ? <ChevronUp size={13} className="text-zinc-400 flex-shrink-0 mt-0.5" strokeWidth={2} /> : <ChevronDown size={13} className="text-zinc-400 flex-shrink-0 mt-0.5" strokeWidth={2} />}
               </div>
             }
             preview={
               doc.metadata?.snippet ? (
-                <div className="ml-[30px]">
-                  <p className="text-[11px] text-claude-subtext leading-relaxed mt-1.5 line-clamp-2">
-                    {doc.metadata.snippet}
-                  </p>
-                </div>
+                <p className="text-[11px] text-zinc-500 leading-relaxed mt-1.5 line-clamp-2">
+                  {doc.metadata.snippet}
+                </p>
               ) : null
             }
           />

--- a/lexwebapp/src/components/chat/ExpandableCard.tsx
+++ b/lexwebapp/src/components/chat/ExpandableCard.tsx
@@ -57,9 +57,9 @@ export function ExpandableCard({
       initial="hidden"
       animate="visible"
       layout
-      className="bg-white border border-zinc-200 rounded-lg overflow-hidden hover:border-zinc-300 hover:shadow-elevation-1 transition-all duration-150"
+      className="bg-white border border-zinc-200/90 rounded-md overflow-hidden hover:border-zinc-300 hover:shadow-sm transition-all duration-150"
     >
-      <div onClick={onToggle} className="p-3 cursor-pointer group">
+      <div onClick={onToggle} className="px-3 py-2.5 cursor-pointer select-none">
         {header}
         {!isExpanded && preview}
       </div>
@@ -74,32 +74,32 @@ export function ExpandableCard({
             className="overflow-hidden"
           >
             <div className="px-3 pb-3 border-t border-zinc-100">
-              <div className="mt-3 max-h-[280px] overflow-y-auto text-[12px] text-zinc-700 leading-relaxed prose prose-sm">
+              <div className="mt-3 max-h-[280px] overflow-y-auto text-[12px] text-zinc-600 leading-[1.7] prose prose-sm prose-p:my-1 prose-p:leading-[1.7]">
                 <ReactMarkdown>{content}</ReactMarkdown>
               </div>
-              <div className="flex items-center gap-1.5 mt-3 pt-2 border-t border-zinc-100">
+              <div className="flex items-center gap-0.5 mt-3 pt-2.5 border-t border-zinc-100">
                 <button
                   onClick={(e) => { e.stopPropagation(); copyContent(content); }}
-                  className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150"
+                  className="flex items-center gap-1.5 text-[10px] text-zinc-400 hover:text-zinc-800 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150 font-medium"
                 >
-                  {copiedId === id ? <Check size={10} /> : <Copy size={10} />}
+                  {copiedId === id ? <Check size={10} strokeWidth={2.5} /> : <Copy size={10} strokeWidth={2} />}
                   {copiedId === id ? 'Скопійовано' : 'Копіювати'}
                 </button>
                 {onOpenModal && (
                   <button
                     onClick={(e) => { e.stopPropagation(); onOpenModal(); }}
-                    className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150"
+                    className="flex items-center gap-1.5 text-[10px] text-zinc-400 hover:text-zinc-800 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150 font-medium"
                   >
-                    <Maximize2 size={10} />
+                    <Maximize2 size={10} strokeWidth={2} />
                     Повний вигляд
                   </button>
                 )}
                 {externalUrl && onOpenModal && (
                   <button
                     onClick={(e) => { e.stopPropagation(); onOpenModal(); }}
-                    className="flex items-center gap-1 text-[10px] text-zinc-400 hover:text-zinc-700 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150"
+                    className="flex items-center gap-1.5 text-[10px] text-zinc-400 hover:text-zinc-800 px-2 py-1 rounded hover:bg-zinc-50 transition-colors duration-150 font-medium"
                   >
-                    <ExternalLink size={10} />
+                    <ExternalLink size={10} strokeWidth={2} />
                     Відкрити
                   </button>
                 )}
@@ -114,9 +114,11 @@ export function ExpandableCard({
 
 export function EmptyTabState({ icon: Icon, text }: { icon: React.ElementType; text: string }) {
   return (
-    <div className="text-center py-10 text-zinc-400">
-      <Icon size={24} className="mx-auto mb-3 opacity-25" strokeWidth={1.5} />
-      <p className="text-[12px]">{text}</p>
+    <div className="text-center py-12 px-4">
+      <div className="w-10 h-10 rounded-full bg-zinc-100 flex items-center justify-center mx-auto mb-3">
+        <Icon size={18} className="text-zinc-400" strokeWidth={1.5} />
+      </div>
+      <p className="text-[11px] text-zinc-400 leading-relaxed font-medium">{text}</p>
     </div>
   );
 }

--- a/lexwebapp/src/components/chat/RegulationsTab.tsx
+++ b/lexwebapp/src/components/chat/RegulationsTab.tsx
@@ -42,26 +42,19 @@ export function RegulationsTab({ citations, onOpenModal }: RegulationsTabProps) 
             content={safeText || 'Немає тексту.'}
             onOpenModal={() => onOpenModal(citation)}
             header={
-              <div className="flex items-start gap-2.5">
-                <div className="p-1 bg-claude-bg rounded-md flex-shrink-0 mt-0.5">
-                  <BookOpen size={12} className="text-claude-text" strokeWidth={2} />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-start justify-between">
-                    <div className="font-medium text-[13px] text-claude-text mb-1 leading-tight">
-                      {citation.source}
-                    </div>
-                    {expanded ? <ChevronUp size={14} className="text-claude-subtext flex-shrink-0 ml-2" /> : <ChevronDown size={14} className="text-claude-subtext flex-shrink-0 ml-2" />}
+              <div className="flex items-start justify-between">
+                <div className="flex-1 min-w-0 pr-2">
+                  <div className="font-medium text-[11.5px] text-zinc-800 leading-snug">
+                    {citation.source}
                   </div>
                 </div>
+                {expanded ? <ChevronUp size={13} className="text-zinc-400 flex-shrink-0 mt-0.5" strokeWidth={2} /> : <ChevronDown size={13} className="text-zinc-400 flex-shrink-0 mt-0.5" strokeWidth={2} />}
               </div>
             }
             preview={
-              <div className="ml-[30px]">
-                <p className="text-[11px] text-claude-subtext leading-relaxed line-clamp-3">
-                  {safeText}
-                </p>
-              </div>
+              <p className="text-[11px] text-zinc-500 leading-relaxed line-clamp-3 mt-1.5">
+                {safeText}
+              </p>
             }
           />
         );

--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -134,11 +134,11 @@ export function AssistantMessage({
 
   return (
     <>
-      <div className="flex gap-3 md:gap-4">
+      <div className="flex gap-4 md:gap-5">
         {/* Avatar */}
-        <div className="flex-shrink-0 mt-1">
-          <div className="w-8 h-8 rounded-lg overflow-hidden flex items-center justify-center">
-            <LexLogo3D spinning={!!isStreaming} size={32} />
+        <div className="flex-shrink-0 mt-0.5">
+          <div className="w-7 h-7 rounded-md overflow-hidden flex items-center justify-center bg-zinc-900 shadow-sm">
+            <LexLogo3D spinning={!!isStreaming} size={28} />
           </div>
         </div>
 
@@ -148,9 +148,9 @@ export function AssistantMessage({
 
           {thinkingSteps && thinkingSteps.length > 0 && (
             <div>
-              <button onClick={() => setShowThinking(!showThinking)} className="flex items-center gap-2 text-[12px] text-zinc-400 hover:text-zinc-700 transition-colors duration-150 mb-2">
-                <ChevronDown size={13} className={`transition-transform duration-200 ${showThinking ? 'rotate-180' : ''}`} strokeWidth={2} />
-                <span className="font-medium tracking-tight">
+              <button onClick={() => setShowThinking(!showThinking)} className="flex items-center gap-1.5 text-[11px] font-medium text-zinc-400 hover:text-zinc-600 transition-colors duration-150 mb-2 tracking-wide uppercase">
+                <ChevronDown size={12} className={`transition-transform duration-200 ${showThinking ? 'rotate-180' : ''}`} strokeWidth={2.5} />
+                <span>
                   {thinkingSteps[0]?.title || 'Обдумую відповідь...'}
                 </span>
               </button>
@@ -163,28 +163,28 @@ export function AssistantMessage({
           <MarkdownContent content={displayContent} isStreaming={isStreaming} openDocByRef={openDocByRef} />
 
           {citationWarnings && citationWarnings.length > 0 && (
-            <div className="space-y-2 mt-4">
+            <div className="space-y-1.5 mt-4">
               {citationWarnings.map((warning, idx) => (
                 <motion.div
                   key={`cw-${idx}`}
                   initial={{ opacity: 0, y: -4 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ duration: 0.25, delay: idx * 0.08 }}
-                  className={`flex items-start gap-3 px-3 py-2.5 rounded-lg border ${
+                  className={`flex items-start gap-3 px-3.5 py-3 rounded-lg border ${
                     warning.status === 'explicitly_overruled'
-                      ? 'bg-orange-50 border-orange-200/70'
-                      : 'bg-amber-50 border-amber-200/70'
+                      ? 'bg-red-50/70 border-red-200/60'
+                      : 'bg-zinc-50 border-zinc-200/60'
                   }`}
                 >
                   <div className="flex-1 min-w-0">
                     <p className={`text-[13px] leading-relaxed ${
                       warning.status === 'explicitly_overruled'
-                        ? 'text-orange-700'
-                        : 'text-amber-700'
+                        ? 'text-red-700'
+                        : 'text-zinc-700'
                     }`}>
                       {warning.message}
                     </p>
-                    <p className="text-[11px] text-zinc-400 mt-1">
+                    <p className="text-[11px] text-zinc-400 mt-1 font-mono">
                       {warning.status === 'explicitly_overruled' ? 'Скасовано вищою інстанцією' : 'Частково змінено'} · впевненість: {Math.round(warning.confidence * 100)}%
                     </p>
                   </div>
@@ -200,7 +200,7 @@ export function AssistantMessage({
           )}
 
           {!isStreaming && content && (
-            <div className="flex items-center gap-0.5 pt-1 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+            <div className="flex items-center gap-0.5 pt-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
               <button
                 onClick={handleCopy}
                 className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
@@ -227,7 +227,7 @@ export function AssistantMessage({
                   <RotateCw size={12} strokeWidth={2} />
                 </button>
               )}
-              <div className="w-px h-3 bg-zinc-200 mx-1" />
+              <div className="w-px h-3 bg-zinc-200 mx-1.5" />
               <button
                 onClick={() => handleFeedback('up')}
                 className={`p-1.5 hover:bg-zinc-100 rounded-md transition-colors duration-150 ${feedback === 'up' ? 'text-zinc-700' : 'text-zinc-400 hover:text-zinc-600'}`}

--- a/lexwebapp/src/components/message/MarkdownContent.tsx
+++ b/lexwebapp/src/components/message/MarkdownContent.tsx
@@ -30,26 +30,26 @@ export const MarkdownContent = React.memo(function MarkdownContent({ content, is
 
   const components = useMemo(() => ({
     p: ({ children }: any) => (
-      <p className="whitespace-pre-wrap m-0 leading-[1.7] my-2 text-claude-text">
+      <p className="whitespace-pre-wrap m-0 leading-[1.72] my-2.5 text-zinc-800">
         {React.Children.map(children, (child: any) =>
           typeof child === 'string' ? highlightLegalCodes(child) : child
         )}
       </p>
     ),
     h1: ({ children }: any) => (
-      <h1 className="text-[20px] font-bold mt-7 mb-3 text-claude-text tracking-tight pb-2 border-b border-claude-border">{children}</h1>
+      <h1 className="text-[19px] font-semibold mt-8 mb-3 text-zinc-900 tracking-[-0.01em] pb-2.5 border-b border-zinc-200">{children}</h1>
     ),
     h2: ({ children }: any) => (
-      <h2 className="text-[17px] font-semibold mt-6 mb-3 text-claude-text tracking-tight pb-2 border-b border-claude-border/70">{children}</h2>
+      <h2 className="text-[16px] font-semibold mt-7 mb-2.5 text-zinc-900 tracking-[-0.01em] pb-2 border-b border-zinc-200/60">{children}</h2>
     ),
     h3: ({ children }: any) => (
-      <h3 className="flex items-baseline gap-2 text-[15px] font-semibold mt-5 mb-2 text-claude-text">
-        <span className="flex-shrink-0 w-[3px] h-[14px] self-center rounded-full bg-claude-accent/70" />
+      <h3 className="flex items-baseline gap-2 text-[14px] font-semibold mt-5 mb-2 text-zinc-900">
+        <span className="flex-shrink-0 w-[2px] h-[13px] self-center rounded-full bg-zinc-400" />
         <span>{children}</span>
       </h3>
     ),
     h4: ({ children }: any) => (
-      <h4 className="text-[14px] font-semibold mt-4 mb-1.5 text-claude-subtext uppercase tracking-wide">{children}</h4>
+      <h4 className="text-[12px] font-semibold mt-4 mb-1.5 text-zinc-500 uppercase tracking-[0.06em]">{children}</h4>
     ),
     ul: ({ children }: any) => (
       <ListTypeContext.Provider value="ul">
@@ -139,15 +139,15 @@ export const MarkdownContent = React.memo(function MarkdownContent({ content, is
   }), [openDocByRef]);
 
   return (
-    <div className="font-sans text-[16px] text-claude-text prose prose-sm max-w-none
+    <div className="font-sans text-[15px] text-claude-text prose prose-sm max-w-none
       prose-headings:font-sans prose-headings:text-claude-text prose-headings:tracking-tight
-      prose-p:leading-[1.7] prose-p:my-2
+      prose-p:leading-[1.72] prose-p:my-2
       prose-code:before:content-none prose-code:after:content-none
       prose-a:text-claude-text prose-a:underline prose-a:decoration-claude-subtext/30 hover:prose-a:decoration-claude-text
       prose-strong:text-claude-text prose-strong:font-semibold
     ">
       {prefix && (
-        <div className="whitespace-pre-wrap leading-[1.7] text-claude-text">{prefix}</div>
+        <div className="whitespace-pre-wrap leading-[1.72] text-claude-text">{prefix}</div>
       )}
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
@@ -155,7 +155,7 @@ export const MarkdownContent = React.memo(function MarkdownContent({ content, is
       >
         {markdownContent}
       </ReactMarkdown>
-      {isStreaming && <span className="inline-block w-[2px] h-[18px] ml-1 bg-claude-text/40 animate-pulse align-middle rounded-[1px]" />}
+      {isStreaming && <span className="inline-block w-[1.5px] h-[17px] ml-0.5 bg-zinc-400 animate-pulse align-middle rounded-sm" />}
     </div>
   );
 });

--- a/lexwebapp/src/components/message/UserMessage.tsx
+++ b/lexwebapp/src/components/message/UserMessage.tsx
@@ -52,27 +52,27 @@ export function UserMessage({ content, onEdit }: UserMessageProps) {
 
   if (isEditing) {
     return (
-      <div className="flex flex-col items-end gap-1.5">
-        <div className="w-full max-w-[80%]">
+      <div className="flex flex-col items-end gap-2">
+        <div className="w-full max-w-[82%]">
           <textarea
             ref={textareaRef}
             value={editDraft}
             onChange={(e) => setEditDraft(e.target.value)}
             onKeyDown={handleEditKeyDown}
             rows={Math.min(10, editDraft.split('\n').length + 1)}
-            className="w-full bg-white border border-zinc-300 rounded-xl px-4 py-3 text-[14px] text-zinc-900 leading-relaxed resize-none focus:outline-none focus:border-zinc-500 shadow-elevation-1"
+            className="w-full bg-white border border-zinc-300 rounded-2xl px-4 py-3 text-[14px] text-zinc-900 leading-[1.65] resize-none focus:outline-none focus:ring-1 focus:ring-zinc-400 focus:border-zinc-400 shadow-sm transition-shadow duration-150"
           />
-          <div className="flex items-center justify-end gap-2 mt-1.5">
-            <span className="text-[11px] text-zinc-400">⌘↵ зберегти · Esc скасувати</span>
+          <div className="flex items-center justify-end gap-2 mt-2">
+            <span className="text-[11px] text-zinc-400 font-mono">⌘↵ зберегти · Esc скасувати</span>
             <button
               onClick={handleEditCancel}
-              className="flex items-center gap-1 px-2.5 py-1 text-[12px] text-zinc-500 hover:text-zinc-700 border border-zinc-200 rounded-md transition-colors duration-150"
+              className="flex items-center gap-1 px-3 py-1.5 text-[12px] font-medium text-zinc-500 hover:text-zinc-700 border border-zinc-200 hover:border-zinc-300 rounded-lg transition-colors duration-150"
             >
               <X size={11} strokeWidth={2} /> Скасувати
             </button>
             <button
               onClick={handleEditSave}
-              className="flex items-center gap-1 px-2.5 py-1 text-[12px] bg-zinc-900 text-white rounded-md hover:bg-zinc-700 transition-colors duration-150"
+              className="flex items-center gap-1 px-3 py-1.5 text-[12px] font-medium bg-zinc-900 text-white rounded-lg hover:bg-zinc-700 transition-colors duration-150"
             >
               <Check size={11} strokeWidth={2.5} /> Надіслати
             </button>
@@ -83,16 +83,16 @@ export function UserMessage({ content, onEdit }: UserMessageProps) {
   }
 
   return (
-    <div className="flex flex-col items-end gap-1">
-      <div className="max-w-[80%] bg-zinc-100 border border-zinc-200/60 rounded-2xl px-4 py-2.5">
-        <p className="font-sans text-[14px] text-zinc-900 leading-relaxed whitespace-pre-wrap">
+    <div className="flex flex-col items-end gap-1.5">
+      <div className="max-w-[82%] bg-zinc-900 text-white rounded-2xl rounded-br-sm px-4 py-3 shadow-sm">
+        <p className="font-sans text-[14px] leading-[1.65] whitespace-pre-wrap">
           {content}
         </p>
       </div>
-      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity duration-200 pr-0.5">
         <button
           onClick={handleCopy}
-          className="p-1 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
+          className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
           title="Копіювати"
         >
           <Copy size={11} strokeWidth={2} />
@@ -100,7 +100,7 @@ export function UserMessage({ content, onEdit }: UserMessageProps) {
         {onEdit && (
           <button
             onClick={() => { setEditDraft(content); setIsEditing(true); }}
-            className="p-1 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
+            className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
             title="Редагувати"
           >
             <Pencil size={11} strokeWidth={2} />

--- a/lexwebapp/src/components/message/index.tsx
+++ b/lexwebapp/src/components/message/index.tsx
@@ -50,12 +50,12 @@ export function Message({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 8 }}
+      initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-      className="group w-full py-5 md:py-6"
+      transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
+      className={`group w-full ${isUser ? 'py-3 md:py-4' : 'py-6 md:py-8'}`}
     >
-      <div className="max-w-3xl mx-auto px-4 md:px-6">
+      <div className="max-w-3xl mx-auto px-4 md:px-8">
         {isUser ? (
           <UserMessage content={content} onEdit={onEdit} />
         ) : (

--- a/lexwebapp/src/components/right-panel/RightPanel.tsx
+++ b/lexwebapp/src/components/right-panel/RightPanel.tsx
@@ -107,17 +107,20 @@ export function RightPanel({ isOpen, onClose }: RightPanelProps) {
       animate={{ x: isOpen ? 0 : rightPanelWidth }}
       transition={{ duration: 0.35, ease: [0.22, 1, 0.36, 1] }}
       style={{ width: rightPanelWidth }}
-      className="fixed lg:static inset-y-0 right-0 z-50 bg-claude-sidebar border-l border-claude-border flex flex-col lg:translate-x-0 lg:h-full"
+      className="fixed lg:static inset-y-0 right-0 z-50 bg-zinc-50 border-l border-zinc-200/80 flex flex-col lg:translate-x-0 lg:h-full"
     >
       <ResizeHandle />
 
       {/* Header */}
-      <div className="px-4 py-3 border-b border-claude-border flex items-center justify-between">
-        <h2 className="font-sans font-medium text-[13px] text-zinc-500 tracking-widest uppercase">
-          Доказова база
-        </h2>
-        <button onClick={onClose} className="lg:hidden p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-200/60 rounded-md transition-colors duration-150">
-          <X size={16} strokeWidth={2} />
+      <div className="px-4 pt-4 pb-3 border-b border-zinc-200/60 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-2.5">
+          <div className="w-1 h-4 bg-zinc-900 rounded-full flex-shrink-0" />
+          <h2 className="font-sans font-semibold text-[11px] text-zinc-900 tracking-[0.12em] uppercase">
+            Доказова база
+          </h2>
+        </div>
+        <button onClick={onClose} className="lg:hidden p-1.5 text-zinc-400 hover:text-zinc-700 hover:bg-zinc-200/70 rounded-md transition-colors duration-150">
+          <X size={15} strokeWidth={2} />
         </button>
       </div>
 

--- a/lexwebapp/src/components/right-panel/TabsHeader.tsx
+++ b/lexwebapp/src/components/right-panel/TabsHeader.tsx
@@ -17,24 +17,26 @@ interface TabsHeaderProps {
 
 export function TabsHeader({ tabs, activeTab, onTabChange }: TabsHeaderProps) {
   return (
-    <div className="border-b border-claude-border">
-      <div className="flex overflow-x-auto scrollbar-hide">
+    <div className="border-b border-zinc-200/60 flex-shrink-0">
+      <div className="flex overflow-x-auto scrollbar-hide px-1">
         {tabs.map((tab) => (
           <button
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
-            className={`flex-1 min-w-0 px-2 py-2.5 text-[10px] font-semibold uppercase tracking-[0.7px] transition-colors duration-150 border-b-2 ${
+            className={`flex-1 min-w-0 px-2 py-3 text-[10px] font-semibold uppercase tracking-[0.08em] transition-all duration-150 border-b-[1.5px] -mb-px ${
               activeTab === tab.id
                 ? 'border-zinc-900 text-zinc-900'
-                : 'border-transparent text-zinc-400 hover:text-zinc-600'
+                : 'border-transparent text-zinc-400 hover:text-zinc-600 hover:border-zinc-300'
             }`}
           >
             <div className="flex items-center justify-center gap-1.5">
-              <tab.icon size={11} strokeWidth={2} />
+              <tab.icon size={10} strokeWidth={2.5} />
               <span className="truncate">{tab.label}</span>
               {tab.count > 0 && (
-                <span className={`text-[9px] min-w-[15px] h-[15px] flex items-center justify-center rounded-full px-1 font-semibold ${
-                  activeTab === tab.id ? 'bg-zinc-900 text-white' : 'bg-zinc-200 text-zinc-500'
+                <span className={`text-[9px] min-w-[16px] h-4 flex items-center justify-center rounded-sm px-1 font-semibold tabular-nums ${
+                  activeTab === tab.id
+                    ? 'bg-zinc-900 text-white'
+                    : 'bg-zinc-200/80 text-zinc-500'
                 }`}>
                   {tab.count}
                 </span>

--- a/lexwebapp/src/components/sidebar/NavItem.tsx
+++ b/lexwebapp/src/components/sidebar/NavItem.tsx
@@ -13,7 +13,7 @@ interface NavItemProps {
 export function NavItem({ icon: Icon, label, route, onClick, badge }: NavItemProps) {
   const location = useLocation();
   const navigate = useNavigate();
-  const isActive = route ? location.pathname === route : false;
+  const isActive = route ? location.pathname === route || location.pathname.startsWith(route + '/') : false;
 
   const handleClick = onClick ?? (() => {
     if (route) {
@@ -29,15 +29,27 @@ export function NavItem({ icon: Icon, label, route, onClick, badge }: NavItemPro
   return (
     <button
       onClick={handleClick}
-      className={`w-full text-left px-2.5 py-1.5 rounded-md text-[13px] transition-colors duration-150 flex items-center gap-2.5 group ${
+      className={`w-full text-left pl-3 pr-2.5 py-[7px] rounded-md text-[12.5px] transition-all duration-150 flex items-center gap-2.5 group relative ${
         isActive
-          ? 'bg-zinc-200/70 text-zinc-900 font-medium'
-          : 'text-zinc-600 hover:bg-zinc-200/40 hover:text-zinc-900'
+          ? 'bg-white/[0.07] text-white'
+          : 'text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200'
       }`}>
-      <Icon size={14} strokeWidth={2} className={`flex-shrink-0 transition-colors duration-150 ${isActive ? 'text-zinc-900' : 'text-zinc-400 group-hover:text-zinc-600'}`} />
-      <span className="truncate font-medium tracking-tight font-sans">{label}</span>
+      {/* Active left accent bar */}
+      {isActive && (
+        <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-4 rounded-full bg-white opacity-70" />
+      )}
+      <Icon
+        size={13}
+        strokeWidth={isActive ? 2 : 1.75}
+        className={`flex-shrink-0 transition-colors duration-150 ${
+          isActive ? 'text-white opacity-90' : 'text-zinc-500 group-hover:text-zinc-300'
+        }`}
+      />
+      <span className={`truncate tracking-[-0.01em] font-sans transition-colors duration-150 ${isActive ? 'font-medium text-zinc-100' : 'font-normal text-zinc-400 group-hover:text-zinc-200'}`}>
+        {label}
+      </span>
       {badge !== undefined && badge > 0 && (
-        <span className="ml-auto flex-shrink-0 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-zinc-900 text-white text-[10px] font-semibold px-1">
+        <span className="ml-auto flex-shrink-0 min-w-[18px] h-[18px] flex items-center justify-center rounded-full bg-white/15 text-white text-[10px] font-semibold px-1 border border-white/10">
           {badge}
         </span>
       )}

--- a/lexwebapp/src/components/sidebar/Section.tsx
+++ b/lexwebapp/src/components/sidebar/Section.tsx
@@ -11,22 +11,22 @@ interface SectionProps {
 
 export function Section({ id, title, collapsed, onToggle, children }: SectionProps) {
   return (
-    <div className="mb-4" data-tour={id}>
+    <div className="mb-5" data-tour={id}>
       <button
         onClick={() => onToggle(id)}
-        className="w-full flex items-center justify-between px-2 py-1.5 group cursor-pointer rounded-md hover:bg-zinc-200/30 transition-colors duration-150"
+        className="w-full flex items-center justify-between px-2 py-1 group cursor-pointer rounded transition-colors duration-150"
       >
-        <h3 className="text-[10px] font-semibold text-zinc-400 uppercase tracking-[0.8px] font-sans">
+        <h3 className="text-[9.5px] font-semibold text-zinc-600 uppercase tracking-[1.1px] font-sans select-none">
           {title}
         </h3>
         <ChevronDown
-          size={11}
+          size={10}
           strokeWidth={2.5}
-          className={`text-zinc-300 group-hover:text-zinc-500 transition-all duration-200 ${collapsed ? '-rotate-90' : ''}`}
+          className={`text-zinc-700 group-hover:text-zinc-500 transition-all duration-200 ${collapsed ? '-rotate-90' : ''}`}
         />
       </button>
       {!collapsed && (
-        <div className="space-y-0.5 mt-0.5">{children}</div>
+        <div className="space-y-0.5 mt-1">{children}</div>
       )}
     </div>
   );

--- a/lexwebapp/src/components/sidebar/SidebarFooter.tsx
+++ b/lexwebapp/src/components/sidebar/SidebarFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { User, LogOut, CreditCard, UsersRound, Plug, FileText, UserPlus } from 'lucide-react';
+import { User, LogOut, CreditCard, UsersRound, Plug, FileText, UserPlus, Code, ChevronUp } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ROUTES } from '../../router/routes';
 import type { UserRole } from '../../types/models/User';
@@ -20,92 +20,139 @@ export function SidebarFooter({
   onProfileMenuClick, onProfileClick, onLogout,
 }: SidebarFooterProps) {
   const navigate = useNavigate();
-  return (
-    <div className="px-3 py-3 border-t border-claude-border relative" ref={profileMenuRef}>
-      <AnimatePresence>
-        {showProfileMenu &&
-        <motion.div
-          initial={{ opacity: 0, y: 8, scale: 0.97 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          exit={{ opacity: 0, y: 8, scale: 0.97 }}
-          transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
-          className="absolute bottom-full left-3 right-3 mb-1.5 bg-white rounded-lg border border-zinc-200 shadow-elevation-3 overflow-hidden z-50">
-            <button
-              onClick={onProfileClick}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
-              <User size={14} className="text-zinc-500 flex-shrink-0" />
-              <span className="text-[13px] font-medium text-zinc-800 font-sans">Профіль</span>
-            </button>
-            {/* "Стати адвокатом" hidden — feature not ready for production */}
-            {role !== 'administrator' && (
-              <button
-                onClick={() => { onProfileMenuClick(); navigate(ROUTES.BILLING); }}
-                className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
-                <CreditCard size={14} className="text-zinc-500 flex-shrink-0" />
-                <span className="text-[13px] font-medium text-zinc-800 font-sans">Біллінг</span>
-              </button>
-            )}
-            <button
-              onClick={() => { onProfileMenuClick(); navigate(ROUTES.MY_CONTRACTS); }}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
-              <FileText size={14} className="text-zinc-500 flex-shrink-0" />
-              <span className="text-[13px] font-medium text-zinc-800 font-sans">Мої договори</span>
-            </button>
-            <button
-              onClick={() => { onProfileMenuClick(); navigate(ROUTES.REFERRAL); }}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
-              <UserPlus size={14} className="text-zinc-500 flex-shrink-0" />
-              <span className="text-[13px] font-medium text-zinc-800 font-sans">Запросити друга</span>
-            </button>
-            <button
-              onClick={() => { onProfileMenuClick(); navigate(ROUTES.MCP_CONNECT); }}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
-              <Plug size={14} className="text-zinc-500 flex-shrink-0" />
-              <span className="text-[13px] font-medium text-zinc-800 font-sans">MCP конект</span>
-            </button>
-            {role === 'company' && (
-              <button
-                onClick={() => { onProfileMenuClick(); navigate(ROUTES.TEAM); }}
-                className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-zinc-50 transition-colors duration-100 border-b border-zinc-100">
-                <UsersRound size={14} className="text-zinc-500 flex-shrink-0" />
-                <span className="text-[13px] font-medium text-zinc-800 font-sans">Команда</span>
-              </button>
-            )}
-            <button
-              onClick={onLogout}
-              className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left hover:bg-red-50 transition-colors duration-100">
-              <LogOut size={14} className="text-red-500 flex-shrink-0" />
-              <span className="text-[13px] font-medium text-red-500 font-sans">Вихід</span>
-            </button>
-          </motion.div>
-        }
-      </AnimatePresence>
 
+  const menuItemClass = "w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors duration-100 hover:bg-white/[0.06]";
+  const menuIconClass = "text-zinc-500 flex-shrink-0";
+  const menuLabelClass = "text-[12.5px] font-normal text-zinc-300 font-sans tracking-[-0.01em]";
+
+  return (
+    <div className="px-2 py-2.5 border-t border-white/[0.06] relative" ref={profileMenuRef}>
+      {/* Legal links */}
       <div className="flex items-center justify-center gap-3 mb-2 px-1">
-        <a href="/ua/offer" target="_blank" rel="noopener noreferrer" className="text-[10px] text-zinc-400 hover:text-zinc-500 transition-colors">
+        <a
+          href="/ua/offer"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[9.5px] text-zinc-700 hover:text-zinc-500 transition-colors tracking-wide"
+        >
           Оферта
         </a>
-        <span className="text-zinc-300 text-[10px]">·</span>
-        <a href="/ua/privacy" target="_blank" rel="noopener noreferrer" className="text-[10px] text-zinc-400 hover:text-zinc-500 transition-colors">
+        <span className="text-zinc-800 text-[9px]">·</span>
+        <a
+          href="/ua/privacy"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[9.5px] text-zinc-700 hover:text-zinc-500 transition-colors tracking-wide"
+        >
           Конфіденційність
         </a>
       </div>
 
+      {/* Profile menu popup */}
+      <AnimatePresence>
+        {showProfileMenu && (
+          <motion.div
+            initial={{ opacity: 0, y: 6, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 6, scale: 0.98 }}
+            transition={{ duration: 0.15, ease: [0.22, 1, 0.36, 1] }}
+            className="absolute bottom-full left-2 right-2 mb-1.5 bg-[#1a1a1a] rounded-lg border border-white/[0.08] shadow-[0_8px_32px_rgba(0,0,0,0.5)] overflow-hidden z-50"
+          >
+            <button onClick={onProfileClick} className={`${menuItemClass} border-b border-white/[0.05]`}>
+              <User size={13} className={menuIconClass} />
+              <span className={menuLabelClass}>Профіль</span>
+            </button>
+
+            {role !== 'administrator' && (
+              <button
+                onClick={() => { onProfileMenuClick(); navigate(ROUTES.BILLING); }}
+                className={`${menuItemClass} border-b border-white/[0.05]`}
+              >
+                <CreditCard size={13} className={menuIconClass} />
+                <span className={menuLabelClass}>Біллінг</span>
+              </button>
+            )}
+
+            <button
+              onClick={() => { onProfileMenuClick(); navigate(ROUTES.MY_CONTRACTS); }}
+              className={`${menuItemClass} border-b border-white/[0.05]`}
+            >
+              <FileText size={13} className={menuIconClass} />
+              <span className={menuLabelClass}>Мої договори</span>
+            </button>
+
+            <button
+              onClick={() => { onProfileMenuClick(); window.open('/ua/developer-offer', '_blank'); }}
+              className={`${menuItemClass} border-b border-white/[0.05]`}
+            >
+              <Code size={13} className={menuIconClass} />
+              <span className={menuLabelClass}>Оферта розробника</span>
+            </button>
+
+            <button
+              onClick={() => { onProfileMenuClick(); navigate(ROUTES.REFERRAL); }}
+              className={`${menuItemClass} border-b border-white/[0.05]`}
+            >
+              <UserPlus size={13} className={menuIconClass} />
+              <span className={menuLabelClass}>Запросити друга</span>
+            </button>
+
+            <button
+              onClick={() => { onProfileMenuClick(); navigate(ROUTES.MCP_CONNECT); }}
+              className={`${menuItemClass} border-b border-white/[0.05]`}
+            >
+              <Plug size={13} className={menuIconClass} />
+              <span className={menuLabelClass}>MCP конект</span>
+            </button>
+
+            {role === 'company' && (
+              <button
+                onClick={() => { onProfileMenuClick(); navigate(ROUTES.TEAM); }}
+                className={`${menuItemClass} border-b border-white/[0.05]`}
+              >
+                <UsersRound size={13} className={menuIconClass} />
+                <span className={menuLabelClass}>Команда</span>
+              </button>
+            )}
+
+            <button
+              onClick={onLogout}
+              className="w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors duration-100 hover:bg-red-500/10"
+            >
+              <LogOut size={13} className="text-red-500/70 flex-shrink-0" />
+              <span className="text-[12.5px] font-normal text-red-400/80 font-sans tracking-[-0.01em]">Вихід</span>
+            </button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Profile trigger button */}
       <button
         onClick={onProfileMenuClick}
-        className="w-full flex items-center gap-2.5 px-2 py-2 hover:bg-zinc-200/40 rounded-lg transition-colors duration-150">
-        {user?.picture ?
-          <img src={user.picture} alt={user.name} className="w-7 h-7 rounded-full object-cover flex-shrink-0" /> :
-          <div className="w-7 h-7 rounded-full bg-zinc-200 flex items-center justify-center text-zinc-600 text-[10px] font-semibold flex-shrink-0">
+        className="w-full flex items-center gap-2.5 px-2 py-1.5 hover:bg-white/[0.05] rounded-md transition-colors duration-150 group"
+      >
+        {user?.picture ? (
+          <img
+            src={user.picture}
+            alt={user.name}
+            className="w-6 h-6 rounded-full object-cover flex-shrink-0 opacity-90"
+          />
+        ) : (
+          <div className="w-6 h-6 rounded-full bg-zinc-700 flex items-center justify-center text-zinc-300 text-[9px] font-semibold flex-shrink-0 border border-white/10">
             {user?.name?.split(' ').map(n => n[0]).join('').toUpperCase() || '?'}
           </div>
-        }
+        )}
         <div className="flex-1 text-left min-w-0">
-          <div className="text-[13px] font-semibold text-zinc-900 tracking-tight font-sans truncate">
+          <div className="text-[12px] font-medium text-zinc-300 tracking-[-0.01em] font-sans truncate leading-tight">
             {user?.name || 'Користувач'}
           </div>
-          <div className="text-[11px] text-zinc-400 font-sans truncate">{user?.email || ''}</div>
+          <div className="text-[10.5px] text-zinc-600 font-sans truncate leading-tight">{user?.email || ''}</div>
         </div>
+        <ChevronUp
+          size={11}
+          strokeWidth={2}
+          className={`flex-shrink-0 text-zinc-700 group-hover:text-zinc-500 transition-all duration-200 ${showProfileMenu ? 'rotate-0' : 'rotate-180'}`}
+        />
       </button>
     </div>
   );

--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -176,17 +176,17 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
             className="fixed inset-0 bg-black/40 z-[60] flex items-center justify-center backdrop-blur-[2px]"
             onClick={() => setDeletingFolder(null)}>
             <motion.div
-              initial={{ opacity: 0, scale: 0.95 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.2 }}
-              className="bg-white rounded-xl border border-claude-border shadow-elevation-3 p-6 max-w-sm mx-4"
+              initial={{ opacity: 0, scale: 0.96 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.96 }}
+              transition={{ duration: 0.18 }}
+              className="bg-[#1a1a1a] rounded-xl border border-white/[0.08] shadow-[0_16px_48px_rgba(0,0,0,0.6)] p-6 max-w-sm mx-4"
               onClick={(e) => e.stopPropagation()}>
-              <h3 className="text-[15px] font-semibold text-claude-text mb-2">Видалити папку?</h3>
-              <p className="text-[13px] text-claude-subtext mb-4">
-                Всі документи в папці <strong>{deletingFolder}</strong> будуть видалені. Цю дію можна скасувати через відновлення документів.
+              <h3 className="text-[14px] font-semibold text-zinc-200 mb-2 tracking-[-0.01em]">Видалити папку?</h3>
+              <p className="text-[12.5px] text-zinc-500 mb-5 leading-relaxed">
+                Всі документи в папці <strong className="text-zinc-300 font-medium">{deletingFolder}</strong> будуть видалені. Цю дію можна скасувати через відновлення документів.
               </p>
               <div className="flex justify-end gap-2">
-                <button onClick={() => setDeletingFolder(null)} className="px-4 py-2 text-[13px] font-medium text-claude-text bg-claude-bg hover:bg-claude-subtext/10 rounded-lg transition-colors">Скасувати</button>
-                <button onClick={() => handleDeleteFolder(deletingFolder)} className="px-4 py-2 text-[13px] font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors">Видалити</button>
+                <button onClick={() => setDeletingFolder(null)} className="px-3.5 py-1.5 text-[12.5px] font-medium text-zinc-400 hover:text-zinc-200 bg-white/[0.05] hover:bg-white/[0.08] border border-white/[0.06] rounded-md transition-colors">Скасувати</button>
+                <button onClick={() => handleDeleteFolder(deletingFolder)} className="px-3.5 py-1.5 text-[12.5px] font-medium text-white bg-red-500/80 hover:bg-red-500 rounded-md transition-colors">Видалити</button>
               </div>
             </motion.div>
           </motion.div>
@@ -199,53 +199,56 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
           transition={{ duration: 0.3, ease: [0.22, 1, 0.36, 1] }}
           onClick={onClose}
-          className="fixed inset-0 bg-black/25 z-40 lg:hidden backdrop-blur-[2px]" />
+          className="fixed inset-0 bg-black/50 z-40 lg:hidden backdrop-blur-[3px]" />
         }
       </AnimatePresence>
 
       {/* Sidebar Container */}
-      <aside className={`fixed lg:static inset-y-0 left-0 lg:inset-auto z-50 w-[260px] h-screen lg:h-full bg-claude-sidebar border-r border-claude-border flex flex-col transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}`}>
+      <aside className={`fixed lg:static inset-y-0 left-0 lg:inset-auto z-50 w-[252px] h-screen lg:h-full bg-[#111111] border-r border-white/[0.06] flex flex-col transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] ${isOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}`}>
 
         {/* Header */}
-        <div className="px-4 py-3 flex items-center justify-between border-b border-claude-border">
+        <div className="px-4 pt-4 pb-3 flex items-center justify-between">
           <div className="flex items-center gap-2.5 px-1">
-            <div className="h-12 flex items-center">
-              <img src="/Image.jpg" alt="Lex" className="h-full w-auto object-contain" />
+            <div className="h-9 flex items-center">
+              <img src="/Image.jpg" alt="Lex" className="h-full w-auto object-contain opacity-90" />
             </div>
             {(import.meta.env.VITE_APP_VERSION || import.meta.env.VITE_APP_FRONTEND_VERSION) && (
               <div className="flex flex-col leading-tight">
                 {import.meta.env.VITE_APP_VERSION && (
-                  <span className="text-[9px] text-claude-subtext/40 font-mono tracking-tight">
+                  <span className="text-[8px] text-zinc-700 font-mono tracking-tight">
                     be {import.meta.env.VITE_APP_VERSION}
                   </span>
                 )}
                 {import.meta.env.VITE_APP_FRONTEND_VERSION && (
-                  <span className="text-[9px] text-claude-subtext/40 font-mono tracking-tight">
+                  <span className="text-[8px] text-zinc-700 font-mono tracking-tight">
                     fe {import.meta.env.VITE_APP_FRONTEND_VERSION}
                   </span>
                 )}
               </div>
             )}
           </div>
-          <button onClick={onClose} className="lg:hidden p-1.5 text-claude-subtext hover:text-claude-text hover:bg-zinc-200/60 rounded-md transition-colors duration-150">
-            <X size={16} strokeWidth={2} />
+          <button onClick={onClose} className="lg:hidden p-1.5 text-zinc-600 hover:text-zinc-400 hover:bg-white/[0.05] rounded-md transition-colors duration-150">
+            <X size={15} strokeWidth={2} />
           </button>
         </div>
 
         {/* New Chat Button */}
-        <div className="px-3 pt-3 pb-2">
-          <button onClick={handleNewChat} className="w-full flex items-center gap-2.5 px-3 py-2 bg-claude-text text-white hover:bg-zinc-700 rounded-lg text-[13px] font-medium transition-colors duration-150 group active:scale-[0.98]">
-            <Plus size={14} strokeWidth={2.5} />
-            <span className="font-sans tracking-tight">Новий запит</span>
+        <div className="px-3 pb-4">
+          <button onClick={handleNewChat} className="w-full flex items-center gap-2 px-3 py-2 bg-white/[0.07] border border-white/[0.08] text-zinc-300 hover:bg-white/[0.10] hover:text-white rounded-md text-[12.5px] font-medium transition-all duration-150 group active:scale-[0.99] tracking-[-0.01em]">
+            <Plus size={13} strokeWidth={2} className="text-zinc-500 group-hover:text-zinc-300 transition-colors duration-150" />
+            <span className="font-sans">Новий запит</span>
           </button>
         </div>
 
+        {/* Divider */}
+        <div className="mx-3 mb-3 border-t border-white/[0.05]" />
+
         {/* Scrollable Content */}
-        <div className="flex-1 overflow-y-auto px-2 py-1">
-          <div className="flex justify-end px-1 py-0.5">
+        <div className="flex-1 overflow-y-auto px-2.5 py-0 scrollbar-hide">
+          <div className="flex justify-end px-1 py-0.5 mb-1">
             <button onClick={toggleAllSections} title={allCollapsed ? 'Розгорнути все' : 'Згорнути все'}
-              className="p-1 text-claude-subtext/40 hover:text-claude-subtext rounded-md transition-colors duration-150">
-              <ChevronsUpDown size={13} strokeWidth={2} />
+              className="p-1 text-zinc-800 hover:text-zinc-600 rounded transition-colors duration-150">
+              <ChevronsUpDown size={12} strokeWidth={2} />
             </button>
           </div>
 
@@ -254,18 +257,23 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
             <>
               {conversations.length > 0 && (
                 <Section id="conversations" title="Розмови" collapsed={collapsedSections.has('conversations')} onToggle={toggleSection}>
-                  <div className="max-h-[280px] overflow-y-auto space-y-0.5">
+                  <div className="max-h-[280px] overflow-y-auto space-y-0.5 scrollbar-hide">
                     {conversations.map((conv) => (
                       <div
                         key={conv.id}
-                        className={`group flex items-center gap-1.5 px-2.5 py-1.5 rounded-md text-[13px] cursor-pointer transition-colors duration-150 ${
-                          activeConversationId === conv.id ? 'bg-zinc-200/70 text-claude-text font-medium' : 'text-claude-text hover:bg-zinc-200/40'
+                        className={`group flex items-center gap-2 pl-3 pr-2 py-[7px] rounded-md text-[12.5px] cursor-pointer transition-all duration-150 relative ${
+                          activeConversationId === conv.id
+                            ? 'bg-white/[0.07] text-white'
+                            : 'text-zinc-500 hover:bg-white/[0.04] hover:text-zinc-300'
                         } ${switchingId === conv.id ? 'opacity-50 pointer-events-none' : ''}`}
                         onClick={() => handleSwitchConversation(conv.id)}>
-                        <MessageSquare size={14} strokeWidth={2} className="flex-shrink-0 opacity-60" />
+                        {activeConversationId === conv.id && (
+                          <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-4 rounded-full bg-white opacity-60" />
+                        )}
+                        <MessageSquare size={12} strokeWidth={1.75} className={`flex-shrink-0 transition-colors duration-150 ${activeConversationId === conv.id ? 'text-zinc-400' : 'text-zinc-700 group-hover:text-zinc-500'}`} />
                         {editingId === conv.id ? (
                           <input
-                            className="flex-1 min-w-0 bg-white border border-claude-border rounded px-1 py-0.5 text-[13px] outline-none"
+                            className="flex-1 min-w-0 bg-white/[0.08] border border-white/[0.12] rounded px-1.5 py-0.5 text-[12px] text-zinc-200 outline-none"
                             value={editTitle}
                             onClick={(e) => e.stopPropagation()}
                             onChange={(e) => setEditTitle(e.target.value)}
@@ -277,14 +285,14 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                             autoFocus
                           />
                         ) : (
-                          <span className="flex-1 truncate font-medium tracking-tight font-sans">{conv.title}</span>
+                          <span className={`flex-1 truncate tracking-[-0.01em] font-sans ${activeConversationId === conv.id ? 'font-medium text-zinc-200' : 'font-normal'}`}>{conv.title}</span>
                         )}
                         {switchingId === conv.id ? (
-                          <div className="w-3 h-3 border-2 border-current border-t-transparent rounded-full animate-spin flex-shrink-0 opacity-50" />
+                          <div className="w-3 h-3 border border-current border-t-transparent rounded-full animate-spin flex-shrink-0 opacity-40" />
                         ) : (
                           <div className="hidden group-hover:flex items-center gap-0.5 flex-shrink-0">
-                            <button onClick={(e) => { e.stopPropagation(); setEditingId(conv.id); setEditTitle(conv.title); }} className="p-1 hover:bg-claude-subtext/15 rounded transition-colors"><Edit3 size={12} /></button>
-                            <button onClick={(e) => { e.stopPropagation(); deleteConversation(conv.id); }} className="p-1 hover:bg-red-100 text-red-500 rounded transition-colors"><Trash2 size={12} /></button>
+                            <button onClick={(e) => { e.stopPropagation(); setEditingId(conv.id); setEditTitle(conv.title); }} className="p-1 hover:bg-white/[0.08] text-zinc-600 hover:text-zinc-400 rounded transition-colors"><Edit3 size={11} /></button>
+                            <button onClick={(e) => { e.stopPropagation(); deleteConversation(conv.id); }} className="p-1 hover:bg-red-500/10 text-zinc-700 hover:text-red-400 rounded transition-colors"><Trash2 size={11} /></button>
                           </div>
                         )}
                       </div>
@@ -311,10 +319,29 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                   const folderRoute = `/documents/folders/${folder}`;
                   const isActive = location.pathname === folderRoute || location.pathname.startsWith(folderRoute + '/');
                   return (
-                    <div key={folder} className={`flex items-center gap-1 px-3 py-2 rounded-lg text-[13px] transition-all duration-200 group cursor-pointer ${isActive ? 'bg-claude-accent/10 text-claude-accent' : 'text-claude-text hover:bg-claude-subtext/8'}`} onClick={() => handleNavigation(folderRoute)}>
-                      {isActive ? <FolderOpen size={15} strokeWidth={2} className="text-claude-accent flex-shrink-0" /> : <Folder size={15} strokeWidth={2} className="text-claude-subtext/60 group-hover:text-claude-text transition-colors duration-200 flex-shrink-0" />}
-                      <span className="flex-1 truncate font-medium tracking-tight font-sans">{folder}</span>
-                      <button onClick={(e) => { e.stopPropagation(); setDeletingFolder(folder); }} className="hidden group-hover:flex p-1 hover:bg-red-100 text-red-500 rounded transition-colors flex-shrink-0"><Trash2 size={12} /></button>
+                    <div
+                      key={folder}
+                      className={`relative flex items-center gap-2.5 pl-3 pr-2 py-[7px] rounded-md text-[12.5px] transition-all duration-150 group cursor-pointer ${
+                        isActive
+                          ? 'bg-white/[0.07] text-white'
+                          : 'text-zinc-500 hover:bg-white/[0.04] hover:text-zinc-300'
+                      }`}
+                      onClick={() => handleNavigation(folderRoute)}
+                    >
+                      {isActive && (
+                        <span className="absolute left-0 top-1/2 -translate-y-1/2 w-[2px] h-4 rounded-full bg-white opacity-60" />
+                      )}
+                      {isActive
+                        ? <FolderOpen size={13} strokeWidth={1.75} className="text-zinc-400 flex-shrink-0" />
+                        : <Folder size={13} strokeWidth={1.75} className="text-zinc-700 group-hover:text-zinc-500 transition-colors duration-150 flex-shrink-0" />
+                      }
+                      <span className={`flex-1 truncate tracking-[-0.01em] font-sans ${isActive ? 'font-medium text-zinc-200' : 'font-normal'}`}>{folder}</span>
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setDeletingFolder(folder); }}
+                        className="hidden group-hover:flex p-1 hover:bg-red-500/10 text-zinc-700 hover:text-red-400 rounded transition-colors flex-shrink-0"
+                      >
+                        <Trash2 size={11} />
+                      </button>
                     </div>
                   );
                 })}
@@ -336,7 +363,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 )}
               </Section>
 
-              <div className="mb-6">
+              <div className="mb-6 mt-1">
                 <NavItem icon={Zap} label="Workflows" route={ROUTES.WORKFLOWS} onClick={() => handleNavigation(ROUTES.WORKFLOWS)} />
               </div>
             </>

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -165,40 +165,40 @@ export function MainLayout() {
 
       <main className="flex-1 flex flex-col min-w-0 relative h-full">
         {/* Desktop Header */}
-        <header className="hidden lg:flex items-center justify-between px-5 py-2.5 border-b border-claude-border bg-claude-bg sticky top-0 z-30">
+        <header className="hidden lg:flex items-center justify-between px-4 py-2 border-b border-claude-border/70 bg-claude-bg/95 backdrop-blur-sm sticky top-0 z-30">
           {/* Left: Toggle button */}
-          <div className="flex items-center gap-2 w-[180px]">
+          <div className="flex items-center gap-2 w-[200px]">
             <button
               onClick={toggleSidebar}
-              className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-zinc-100 rounded-md transition-colors duration-150"
+              className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
               title={isSidebarOpen ? 'Сховати меню' : 'Показати меню'}
             >
               {isSidebarOpen ? (
-                <X size={16} strokeWidth={2} />
+                <X size={15} strokeWidth={1.75} />
               ) : (
-                <Menu size={16} strokeWidth={2} />
+                <Menu size={15} strokeWidth={1.75} />
               )}
             </button>
           </div>
 
           {/* Center: Page title */}
           <div className="flex-1 flex items-center justify-center">
-            <h1 className="font-sans text-sm text-claude-subtext font-medium tracking-wide uppercase">
+            <h1 className="font-sans text-[11px] text-zinc-400 font-medium tracking-[0.12em] uppercase select-none">
               {pageTitle}
             </h1>
           </div>
 
           {/* Right: Toggle right panel button */}
-          <div className="flex items-center justify-end gap-2 w-[180px]">
+          <div className="flex items-center justify-end gap-2 w-[200px]">
             <button
               onClick={toggleRightPanel}
-              className="p-1.5 text-claude-subtext hover:text-claude-text hover:bg-zinc-100 rounded-md transition-colors duration-150"
+              className="p-1.5 text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 rounded-md transition-colors duration-150"
               title={isRightPanelOpen ? 'Сховати панель' : 'Показати панель'}
             >
               {isRightPanelOpen ? (
-                <X size={16} strokeWidth={2} />
+                <X size={15} strokeWidth={1.75} />
               ) : (
-                <PanelRightOpen size={16} strokeWidth={2} />
+                <PanelRightOpen size={15} strokeWidth={1.75} />
               )}
             </button>
           </div>

--- a/lexwebapp/src/pages/ChatPage/index.tsx
+++ b/lexwebapp/src/pages/ChatPage/index.tsx
@@ -149,7 +149,7 @@ export function ChatPage() {
         </div>
       )}
 
-      <div className="w-full bg-claude-bg pt-4 pb-4 z-20 border-t border-claude-border">
+      <div className="w-full bg-claude-bg pt-3 pb-5 z-20 border-t border-claude-border/60">
         <ChatInput
           onSend={handleSend}
           disabled={isStreaming || isPlanLoading || !!pendingPlanReview}
@@ -158,6 +158,9 @@ export function ChatPage() {
           selectedTool={selectedTool}
           onToolChange={setSelectedTool}
         />
+        <p className="text-center text-[11px] text-zinc-400 mt-2.5 font-sans">
+          Lex може допускати помилки. Перевіряйте важливу інформацію.
+        </p>
       </div>
     </>
   );

--- a/lexwebapp/src/pages/LoginPage/ForgotPasswordModal.tsx
+++ b/lexwebapp/src/pages/LoginPage/ForgotPasswordModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { Mail, Loader2, X } from 'lucide-react';
 import showToast from '../../utils/toast';
+import { useForgotPasswordT } from '../../i18n/locales';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 const BASE_URL = API_URL.replace(/\/api$/, '');
@@ -16,11 +17,12 @@ export function ForgotPasswordModal({ initialEmail, onClose, isDark = true }: Fo
   const [email, setEmail] = useState(initialEmail);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const t = isDark;
+  const dk = isDark;
+  const { t } = useForgotPasswordT();
 
   const handleSubmit = async () => {
     if (!email) {
-      setError('Введіть ваш email');
+      setError(t.enterEmail);
       return;
     }
 
@@ -37,15 +39,15 @@ export function ForgotPasswordModal({ initialEmail, onClose, isDark = true }: Fo
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.message || 'Не вдалося відправити лист для скидання паролю');
+        throw new Error(data.message || t.sendError);
       }
 
-      showToast.success('Посилання для скидання паролю відправлено на email');
+      showToast.success(t.sendSuccess);
       onClose();
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Не вдалося відправити лист';
+      const msg = err instanceof Error ? err.message : t.sendFailedGeneric;
       setError(msg);
-      showToast.error('Помилка відправки листа');
+      showToast.error(t.sendErrorToast);
     } finally {
       setIsLoading(false);
     }
@@ -57,7 +59,7 @@ export function ForgotPasswordModal({ initialEmail, onClose, isDark = true }: Fo
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.2 }}
-      className={`fixed inset-0 backdrop-blur-sm flex items-center justify-center z-50 p-4 ${t ? 'bg-black/80' : 'bg-black/40'}`}
+      className={`fixed inset-0 backdrop-blur-sm flex items-center justify-center z-50 p-4 ${dk ? 'bg-black/80' : 'bg-black/40'}`}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -67,32 +69,32 @@ export function ForgotPasswordModal({ initialEmail, onClose, isDark = true }: Fo
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.97, y: 12 }}
         transition={{ duration: 0.2 }}
-        className={`border rounded-2xl p-6 max-w-md w-full shadow-2xl ${t ? 'bg-zinc-950 border-zinc-800' : 'bg-white border-zinc-200'}`}
+        className={`border rounded-2xl p-6 max-w-md w-full shadow-2xl ${dk ? 'bg-zinc-950 border-zinc-800' : 'bg-white border-zinc-200'}`}
       >
         <div className="flex items-center justify-between mb-5">
           <div>
-            <h2 className={`text-base font-semibold ${t ? 'text-zinc-100' : 'text-zinc-900'}`}>Скидання паролю</h2>
-            <p className={`text-xs mt-0.5 leading-relaxed ${t ? 'text-zinc-500' : 'text-zinc-500'}`}>
-              Введіть email — надішлемо посилання для скидання
+            <h2 className={`text-base font-semibold ${dk ? 'text-zinc-100' : 'text-zinc-900'}`}>{t.title}</h2>
+            <p className={`text-xs mt-0.5 leading-relaxed ${dk ? 'text-zinc-500' : 'text-zinc-500'}`}>
+              {t.description}
             </p>
           </div>
           <button
             onClick={onClose}
-            className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors flex-shrink-0 ml-4 ${t ? 'hover:bg-zinc-800 text-zinc-600 hover:text-zinc-300' : 'hover:bg-zinc-100 text-zinc-400 hover:text-zinc-600'}`}
+            className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors flex-shrink-0 ml-4 ${dk ? 'hover:bg-zinc-800 text-zinc-600 hover:text-zinc-300' : 'hover:bg-zinc-100 text-zinc-400 hover:text-zinc-600'}`}
           >
             <X size={16} />
           </button>
         </div>
 
         {error && (
-          <p className={`text-xs mb-4 px-3 py-2 rounded-lg border ${t ? 'text-red-400 bg-red-950/30 border-red-800/30' : 'text-red-600 bg-red-50 border-red-200'}`}>
+          <p className={`text-xs mb-4 px-3 py-2 rounded-lg border ${dk ? 'text-red-400 bg-red-950/30 border-red-800/30' : 'text-red-600 bg-red-50 border-red-200'}`}>
             {error}
           </p>
         )}
 
         <div className="relative mb-4">
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <Mail size={14} className={t ? 'text-zinc-600' : 'text-zinc-400'} />
+            <Mail size={14} className={dk ? 'text-zinc-600' : 'text-zinc-400'} />
           </div>
           <input
             type="email"
@@ -101,23 +103,23 @@ export function ForgotPasswordModal({ initialEmail, onClose, isDark = true }: Fo
             onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
             placeholder="your@email.com"
             autoFocus
-            className={`block w-full pl-9 pr-4 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-1 transition-all ${t ? 'bg-zinc-900 border-zinc-800 text-zinc-100 placeholder-zinc-700 focus:ring-zinc-600 focus:border-zinc-600' : 'bg-zinc-50 border-zinc-200 text-zinc-900 placeholder-zinc-400 focus:ring-zinc-400 focus:border-zinc-400'}`}
+            className={`block w-full pl-9 pr-4 py-2.5 border rounded-lg text-sm focus:outline-none focus:ring-1 transition-all ${dk ? 'bg-zinc-900 border-zinc-800 text-zinc-100 placeholder-zinc-700 focus:ring-zinc-600 focus:border-zinc-600' : 'bg-zinc-50 border-zinc-200 text-zinc-900 placeholder-zinc-400 focus:ring-zinc-400 focus:border-zinc-400'}`}
           />
         </div>
 
         <div className="flex gap-2">
           <button
             onClick={onClose}
-            className={`flex-1 px-4 py-2.5 border rounded-lg text-sm transition-colors duration-150 ${t ? 'border-zinc-800 text-zinc-500 hover:text-zinc-200 hover:border-zinc-700' : 'border-zinc-200 text-zinc-500 hover:text-zinc-700 hover:border-zinc-300'}`}
+            className={`flex-1 px-4 py-2.5 border rounded-lg text-sm transition-colors duration-150 ${dk ? 'border-zinc-800 text-zinc-500 hover:text-zinc-200 hover:border-zinc-700' : 'border-zinc-200 text-zinc-500 hover:text-zinc-700 hover:border-zinc-300'}`}
           >
-            Скасувати
+            {t.cancel}
           </button>
           <button
             onClick={handleSubmit}
             disabled={isLoading}
-            className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150 disabled:opacity-40 flex items-center justify-center ${t ? 'bg-white text-zinc-900 hover:bg-zinc-100' : 'bg-zinc-900 text-white hover:bg-zinc-800'}`}
+            className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors duration-150 disabled:opacity-40 flex items-center justify-center ${dk ? 'bg-white text-zinc-900 hover:bg-zinc-100' : 'bg-zinc-900 text-white hover:bg-zinc-800'}`}
           >
-            {isLoading ? <Loader2 size={15} className="animate-spin" /> : 'Надіслати'}
+            {isLoading ? <Loader2 size={15} className="animate-spin" /> : t.send}
           </button>
         </div>
       </motion.div>

--- a/lexwebapp/src/pages/LoginPage/GDPRModal.tsx
+++ b/lexwebapp/src/pages/LoginPage/GDPRModal.tsx
@@ -1,53 +1,31 @@
 import { motion } from 'framer-motion';
 import { ShieldCheck, ExternalLink, X } from 'lucide-react';
+import { useGdprT } from '../../i18n/locales';
 
 interface GDPRModalProps {
   onClose: () => void;
   isDark?: boolean;
 }
 
-const COMPLIANCE_POINTS = [
-  {
-    title: 'Законність обробки даних',
-    desc: 'Обробка персональних даних здійснюється виключно на підставі вашої згоди або для виконання договору.',
-    article: 'Ст. 6 GDPR',
-  },
-  {
-    title: 'Право на доступ до даних',
-    desc: 'Ви маєте право отримати інформацію про те, які ваші дані ми обробляємо, та отримати їх копію.',
-    article: 'Ст. 15 GDPR',
-  },
-  {
-    title: 'Право на видалення',
-    desc: 'Ви можете вимагати повного видалення ваших персональних даних з наших систем у будь-який час.',
-    article: 'Ст. 17 GDPR',
-  },
-  {
-    title: 'Право на перенесення даних',
-    desc: 'Ви маєте право отримати ваші дані у структурованому форматі для передачі іншому оператору.',
-    article: 'Ст. 20 GDPR',
-  },
-  {
-    title: 'Захист за замовчуванням',
-    desc: 'Ми застосовуємо принципи privacy by design та privacy by default до всіх наших процесів.',
-    article: 'Ст. 25 GDPR',
-  },
-  {
-    title: 'Безпека обробки',
-    desc: 'Дані захищені шифруванням, контролем доступу та регулярним аудитом безпеки.',
-    article: 'Ст. 32 GDPR',
-  },
-];
-
 const OFFICIAL_LINKS = [
-  { href: 'https://eur-lex.europa.eu/legal-content/UK/TXT/?uri=CELEX:32016R0679', label: 'Регламент (ЄС) 2016/679 — повний текст українською' },
+  { href: 'https://eur-lex.europa.eu/legal-content/UK/TXT/?uri=CELEX:32016R0679', labelKey: 'linkUkText' },
   { href: 'https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679', label: 'General Data Protection Regulation (GDPR) — English' },
   { href: 'https://commission.europa.eu/law/law-topic/data-protection_en', label: 'European Commission — Data Protection' },
   { href: 'https://edpb.europa.eu/', label: 'European Data Protection Board (EDPB)' },
 ];
 
 export function GDPRModal({ onClose, isDark = true }: GDPRModalProps) {
-  const t = isDark;
+  const dk = isDark;
+  const { t } = useGdprT();
+
+  const COMPLIANCE_POINTS = [
+    { title: t.cp1Title, desc: t.cp1Desc, article: 'Art. 6 GDPR' },
+    { title: t.cp2Title, desc: t.cp2Desc, article: 'Art. 15 GDPR' },
+    { title: t.cp3Title, desc: t.cp3Desc, article: 'Art. 17 GDPR' },
+    { title: t.cp4Title, desc: t.cp4Desc, article: 'Art. 20 GDPR' },
+    { title: t.cp5Title, desc: t.cp5Desc, article: 'Art. 25 GDPR' },
+    { title: t.cp6Title, desc: t.cp6Desc, article: 'Art. 32 GDPR' },
+  ];
 
   return (
     <motion.div
@@ -55,7 +33,7 @@ export function GDPRModal({ onClose, isDark = true }: GDPRModalProps) {
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.2 }}
-      className={`fixed inset-0 backdrop-blur-sm flex items-center justify-center z-50 p-4 ${t ? 'bg-black/80' : 'bg-black/40'}`}
+      className={`fixed inset-0 backdrop-blur-sm flex items-center justify-center z-50 p-4 ${dk ? 'bg-black/80' : 'bg-black/40'}`}
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
@@ -65,20 +43,20 @@ export function GDPRModal({ onClose, isDark = true }: GDPRModalProps) {
         animate={{ opacity: 1, scale: 1, y: 0 }}
         exit={{ opacity: 0, scale: 0.97, y: 12 }}
         transition={{ duration: 0.2 }}
-        className={`border rounded-2xl max-w-lg w-full shadow-2xl max-h-[90vh] flex flex-col ${t ? 'bg-zinc-950 border-zinc-800' : 'bg-white border-zinc-200'}`}
+        className={`border rounded-2xl max-w-lg w-full shadow-2xl max-h-[90vh] flex flex-col ${dk ? 'bg-zinc-950 border-zinc-800' : 'bg-white border-zinc-200'}`}
       >
         {/* Header */}
-        <div className={`flex items-center gap-3 px-6 py-5 border-b ${t ? 'border-zinc-800' : 'border-zinc-200'}`}>
+        <div className={`flex items-center gap-3 px-6 py-5 border-b ${dk ? 'border-zinc-800' : 'border-zinc-200'}`}>
           <div className="w-9 h-9 bg-[#003399]/10 border border-[#003399]/20 rounded-lg flex items-center justify-center flex-shrink-0">
             <ShieldCheck size={17} className="text-[#4d6ef5]" />
           </div>
           <div className="min-w-0 flex-1">
-            <h2 className={`text-base font-semibold ${t ? 'text-zinc-100' : 'text-zinc-900'}`}>Відповідність GDPR</h2>
-            <p className={`text-xs ${t ? 'text-zinc-600' : 'text-zinc-400'}`}>Регламент ЄС 2016/679</p>
+            <h2 className={`text-base font-semibold ${dk ? 'text-zinc-100' : 'text-zinc-900'}`}>{t.title}</h2>
+            <p className={`text-xs ${dk ? 'text-zinc-600' : 'text-zinc-400'}`}>{t.subtitle}</p>
           </div>
           <button
             onClick={onClose}
-            className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors ${t ? 'hover:bg-zinc-800 text-zinc-600 hover:text-zinc-300' : 'hover:bg-zinc-100 text-zinc-400 hover:text-zinc-600'}`}
+            className={`w-8 h-8 flex items-center justify-center rounded-lg transition-colors ${dk ? 'hover:bg-zinc-800 text-zinc-600 hover:text-zinc-300' : 'hover:bg-zinc-100 text-zinc-400 hover:text-zinc-600'}`}
           >
             <X size={16} />
           </button>
@@ -86,34 +64,34 @@ export function GDPRModal({ onClose, isDark = true }: GDPRModalProps) {
 
         {/* Content */}
         <div className="overflow-y-auto px-6 py-5 space-y-5">
-          <p className={`text-sm leading-relaxed ${t ? 'text-zinc-400' : 'text-zinc-600'}`}>
-            Наш сервіс повністю відповідає вимогам{' '}
-            <strong className={`font-medium ${t ? 'text-zinc-200' : 'text-zinc-800'}`}>Загального регламенту захисту даних (GDPR)</strong>{' '}
-            Європейського Союзу. Ми забезпечуємо найвищий рівень захисту ваших персональних даних.
+          <p className={`text-sm leading-relaxed ${dk ? 'text-zinc-400' : 'text-zinc-600'}`}>
+            {t.intro}{' '}
+            <strong className={`font-medium ${dk ? 'text-zinc-200' : 'text-zinc-800'}`}>{t.gdprName}</strong>{' '}
+            {t.introEnd}
           </p>
 
           <div className="space-y-2">
             {COMPLIANCE_POINTS.map((item) => (
               <div
                 key={item.article}
-                className={`flex gap-3 px-4 py-3 border rounded-lg ${t ? 'bg-zinc-900 border-zinc-800/60' : 'bg-zinc-50 border-zinc-200'}`}
+                className={`flex gap-3 px-4 py-3 border rounded-lg ${dk ? 'bg-zinc-900 border-zinc-800/60' : 'bg-zinc-50 border-zinc-200'}`}
               >
                 <div className="flex-shrink-0 w-5 h-5 bg-[#003399]/10 border border-[#003399]/20 rounded flex items-center justify-center mt-0.5">
                   <ShieldCheck size={12} className="text-[#4d6ef5]" />
                 </div>
                 <div className="min-w-0">
                   <div className="flex items-center gap-2 mb-0.5">
-                    <span className={`text-sm font-medium ${t ? 'text-zinc-200' : 'text-zinc-800'}`}>{item.title}</span>
+                    <span className={`text-sm font-medium ${dk ? 'text-zinc-200' : 'text-zinc-800'}`}>{item.title}</span>
                     <span className="text-[10px] text-[#4d6ef5] bg-[#003399]/10 border border-[#003399]/20 px-1.5 py-0.5 rounded font-semibold tracking-wider uppercase">{item.article}</span>
                   </div>
-                  <p className={`text-xs leading-relaxed ${t ? 'text-zinc-500' : 'text-zinc-500'}`}>{item.desc}</p>
+                  <p className={`text-xs leading-relaxed ${dk ? 'text-zinc-500' : 'text-zinc-500'}`}>{item.desc}</p>
                 </div>
               </div>
             ))}
           </div>
 
-          <div className={`pt-1 border-t ${t ? 'border-zinc-800' : 'border-zinc-200'}`}>
-            <p className={`text-xs font-medium uppercase tracking-wider mb-3 ${t ? 'text-zinc-500' : 'text-zinc-400'}`}>Офіційні документи ЄС</p>
+          <div className={`pt-1 border-t ${dk ? 'border-zinc-800' : 'border-zinc-200'}`}>
+            <p className={`text-xs font-medium uppercase tracking-wider mb-3 ${dk ? 'text-zinc-500' : 'text-zinc-400'}`}>{t.officialDocs}</p>
             <div className="space-y-2">
               {OFFICIAL_LINKS.map((link) => (
                 <a
@@ -121,10 +99,10 @@ export function GDPRModal({ onClose, isDark = true }: GDPRModalProps) {
                   href={link.href}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`flex items-center gap-2 text-xs transition-colors group ${t ? 'text-zinc-500 hover:text-zinc-200' : 'text-zinc-500 hover:text-zinc-800'}`}
+                  className={`flex items-center gap-2 text-xs transition-colors group ${dk ? 'text-zinc-500 hover:text-zinc-200' : 'text-zinc-500 hover:text-zinc-800'}`}
                 >
                   <ExternalLink size={12} className="flex-shrink-0 opacity-50 group-hover:opacity-100" />
-                  <span>{link.label}</span>
+                  <span>{'labelKey' in link && link.labelKey ? (t as Record<string, string>)[link.labelKey] : link.label}</span>
                 </a>
               ))}
             </div>
@@ -132,12 +110,12 @@ export function GDPRModal({ onClose, isDark = true }: GDPRModalProps) {
         </div>
 
         {/* Footer */}
-        <div className={`px-6 py-4 border-t ${t ? 'border-zinc-800' : 'border-zinc-200'}`}>
+        <div className={`px-6 py-4 border-t ${dk ? 'border-zinc-800' : 'border-zinc-200'}`}>
           <button
             onClick={onClose}
-            className={`w-full px-4 py-2.5 border rounded-lg text-sm font-medium transition-colors duration-150 ${t ? 'bg-zinc-800 hover:bg-zinc-700 border-zinc-700 text-zinc-100' : 'bg-zinc-100 hover:bg-zinc-200 border-zinc-200 text-zinc-800'}`}
+            className={`w-full px-4 py-2.5 border rounded-lg text-sm font-medium transition-colors duration-150 ${dk ? 'bg-zinc-800 hover:bg-zinc-700 border-zinc-700 text-zinc-100' : 'bg-zinc-100 hover:bg-zinc-200 border-zinc-200 text-zinc-800'}`}
           >
-            Зрозуміло
+            {t.understood}
           </button>
         </div>
       </motion.div>

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -29,7 +29,7 @@ import { authService } from '../../services';
 import showToast from '../../utils/toast';
 import { ForgotPasswordModal } from './ForgotPasswordModal';
 import { GDPRModal } from './GDPRModal';
-import { useLoginT, setLocale as setI18nLocale, type Locale } from '../../i18n/locales';
+import { useLoginT, useLoginPageT, setLocale as setI18nLocale, type Locale } from '../../i18n/locales';
 
 function LanguageSwitcher() {
   const { locale } = useLoginT();
@@ -40,15 +40,15 @@ function LanguageSwitcher() {
     { code: 'es', label: 'ES' },
   ];
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-0.5">
       {langs.map((l) => (
         <button
           key={l.code}
           onClick={() => { setI18nLocale(l.code); window.location.reload(); }}
-          className={`px-2 py-1 text-[10px] tracking-wider uppercase rounded transition-colors ${
+          className={`px-2 py-1 text-[10px] tracking-wider uppercase rounded transition-colors duration-150 ${
             locale === l.code
-              ? 'text-white bg-zinc-800'
-              : 'text-zinc-600 hover:text-zinc-400'
+              ? 'text-zinc-200 bg-zinc-800/80'
+              : 'text-zinc-700 hover:text-zinc-500'
           }`}
         >
           {l.label}
@@ -86,133 +86,58 @@ const FADE_UP = {
   transition: { duration: 0.5, ease: 'easeOut' as const },
 };
 
-// Animated Julia-set fractal on canvas — dark theme with teal/indigo
-function FractalBackground() {
-  const canvasRef = useRef<HTMLCanvasElement>(null);
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-
-    const ctx = canvas.getContext('2d');
-    if (!ctx) return;
-
-    let animId: number;
-    const startTime = Date.now();
-
-    const MAX_ITER = 35;
-
-    // Full resolution — devicePixelRatio for crisp display
-    const resize = () => {
-      const w = canvas.clientWidth;
-      const h = canvas.clientHeight;
-      if (w > 0 && h > 0) {
-        canvas.width = Math.floor(w * 0.5);
-        canvas.height = Math.floor(h * 0.5);
-      }
-    };
-    // Delay initial resize to ensure layout is complete
-    setTimeout(resize, 100);
-    window.addEventListener('resize', resize);
-
-    function julia(zx: number, zy: number, cx: number, cy: number): number {
-      for (let i = 0; i < MAX_ITER; i++) {
-        if (zx * zx + zy * zy > 4) {
-          return (i + 1 - Math.log(Math.log(Math.sqrt(zx * zx + zy * zy))) / Math.LN2) / MAX_ITER;
-        }
-        const t = zx * zx - zy * zy + cx;
-        zy = 2 * zx * zy + cy;
-        zx = t;
-      }
-      return 0;
-    }
-
-    // Render full-res frame in chunks to avoid blocking UI
-    let currentRow = 0;
-    let imgData: ImageData | null = null;
-    let frameJcx = 0;
-    let frameJcy = 0;
-    const ROWS_PER_TICK = 100; // render N rows per rAF — more rows = faster frames
-
-    function startNewFrame() {
-      const w = canvas!.width;
-      const h = canvas!.height;
-      if (w === 0 || h === 0) return;
-
-      const elapsed = (Date.now() - startTime) / 1000;
-      frameJcx = -0.7 + 0.18 * Math.sin(elapsed * 0.25);
-      frameJcy = 0.27015 + 0.14 * Math.cos(elapsed * 0.19);
-      imgData = ctx!.createImageData(w, h);
-      currentRow = 0;
-    }
-
-    function renderChunk() {
-      animId = requestAnimationFrame(renderChunk);
-
-      const w = canvas!.width;
-      const h = canvas!.height;
-      if (w === 0 || h === 0) return;
-
-      // Start new frame if needed
-      if (!imgData || imgData.width !== w || imgData.height !== h) {
-        startNewFrame();
-      }
-      if (!imgData) return;
-
-      const d = imgData.data;
-      const aspect = w / h;
-      const span = 3.0;
-      const endRow = Math.min(currentRow + ROWS_PER_TICK, h);
-
-      for (let y = currentRow; y < endRow; y++) {
-        for (let x = 0; x < w; x++) {
-          const fx = (x / w - 0.5) * span * aspect;
-          const fy = (y / h - 0.5) * span;
-
-          const v = julia(fx, fy, frameJcx, frameJcy);
-          const idx = (y * w + x) * 4;
-
-          if (v > 0) {
-            const t = v * 3;
-            const r = Math.min(255, Math.floor(t * 25 + v * v * 80));
-            const g = Math.min(255, Math.floor(t * 55 + v * 40));
-            const b = Math.min(255, Math.floor(t * 90 + v * v * 120));
-            d[idx] = r;
-            d[idx + 1] = g;
-            d[idx + 2] = b;
-          } else {
-            d[idx] = 8;
-            d[idx + 1] = 8;
-            d[idx + 2] = 10;
-          }
-          d[idx + 3] = 255;
-        }
-      }
-
-      currentRow = endRow;
-
-      // Frame complete — draw and start next
-      if (currentRow >= h) {
-        ctx!.putImageData(imgData, 0, 0);
-        startNewFrame();
-      }
-    }
-
-    startNewFrame();
-    animId = requestAnimationFrame(renderChunk);
-
-    return () => {
-      cancelAnimationFrame(animId);
-      window.removeEventListener('resize', resize);
-    };
-  }, []);
-
+// Static architectural background — hairline grid with ambient gradients
+// No animation: stillness conveys authority and precision
+function ArchitecturalBackground() {
   return (
-    <canvas
-      ref={canvasRef}
-      style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%', imageRendering: 'auto' }}
-      aria-hidden="true"
-    />
+    <div className="absolute inset-0 overflow-hidden" aria-hidden="true">
+      {/* Base void */}
+      <div className="absolute inset-0 bg-[#080808]" />
+
+      {/* Subtle radial ambient — top-left warmth */}
+      <div
+        className="absolute -top-[30%] -left-[10%] w-[70%] h-[70%] rounded-full"
+        style={{
+          background: 'radial-gradient(ellipse at center, rgba(255,255,255,0.018) 0%, transparent 65%)',
+        }}
+      />
+
+      {/* Subtle radial ambient — bottom-right coolness */}
+      <div
+        className="absolute -bottom-[20%] -right-[5%] w-[55%] h-[55%] rounded-full"
+        style={{
+          background: 'radial-gradient(ellipse at center, rgba(100,120,180,0.022) 0%, transparent 65%)',
+        }}
+      />
+
+      {/* Hairline grid — 40×40px, very subtle */}
+      <svg
+        className="absolute inset-0 w-full h-full"
+        xmlns="http://www.w3.org/2000/svg"
+        style={{ opacity: 0.028 }}
+      >
+        <defs>
+          <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="white" strokeWidth="0.5" />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#grid)" />
+      </svg>
+
+      {/* Vertical gradient fade — top and bottom edges dissolve the grid */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background: 'linear-gradient(to bottom, #080808 0%, transparent 12%, transparent 88%, #080808 100%)',
+        }}
+      />
+      <div
+        className="absolute inset-0"
+        style={{
+          background: 'linear-gradient(to right, #080808 0%, transparent 8%, transparent 92%, #080808 100%)',
+        }}
+      />
+    </div>
   );
 }
 
@@ -220,7 +145,7 @@ function FractalBackground() {
 function PanelDivider() {
   return (
     <div className="hidden lg:block absolute right-0 top-0 bottom-0 w-px">
-      <div className="h-full bg-gradient-to-b from-transparent via-zinc-700/40 to-transparent" />
+      <div className="h-full bg-gradient-to-b from-transparent via-zinc-700/35 to-transparent" />
     </div>
   );
 }
@@ -253,6 +178,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const { login, isAuthenticated } = useAuth();
   const navigate = useNavigate();
   const { t } = useLoginT();
+  const { t: tp } = useLoginPageT();
 
   const getReturnUrl = (): string => {
     const saved = sessionStorage.getItem('login_return_url');
@@ -551,28 +477,39 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
   if (isLoading && !showForgotPassword) {
     return (
       <div className="min-h-screen bg-[#080808] flex items-center justify-center">
-        <div className="flex flex-col items-center gap-5">
+        <ArchitecturalBackground />
+        <div className="relative z-10 flex flex-col items-center gap-6">
           <div className="w-10 h-10 rounded-full border border-zinc-800 flex items-center justify-center">
-            <Loader2 size={18} className="text-zinc-500 animate-spin" />
+            <Loader2 size={16} className="text-zinc-600 animate-spin" />
           </div>
-          <p className="text-[10px] text-zinc-700 tracking-[0.2em] uppercase">{t.authenticating}</p>
+          <p className="text-[10px] text-zinc-700 tracking-[0.22em] uppercase">{t.authenticating}</p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-[#080808] flex relative">
+    <div className="min-h-screen bg-[#080808] flex relative overflow-hidden">
 
-      {/* ── Full-page fractal background ── */}
-      <FractalBackground />
+      {/* ── Architectural background — static, authoritative ── */}
+      <ArchitecturalBackground />
 
       {/* ── Left panel: brand identity ── */}
-      <div
-        className="hidden lg:flex lg:w-[480px] xl:w-[560px] flex-shrink-0 flex-col justify-between relative overflow-hidden"
-      >
-        {/* Semi-transparent backdrop for readability */}
-        <div className="absolute inset-0" style={{ background: 'rgba(8,8,8,0.55)' }} />
+      <div className="hidden lg:flex lg:w-[480px] xl:w-[540px] flex-shrink-0 flex-col justify-between relative overflow-hidden">
+
+        {/* Left panel gets its own deeper overlay for legibility without animation */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: 'linear-gradient(160deg, rgba(10,10,10,0.96) 0%, rgba(8,8,8,0.94) 60%, rgba(9,10,14,0.96) 100%)',
+          }}
+        />
+
+        {/* Subtle inner glow top-left — warmth source */}
+        <div
+          className="absolute -top-16 -left-16 w-80 h-80 rounded-full pointer-events-none"
+          style={{ background: 'radial-gradient(ellipse at center, rgba(255,255,255,0.03) 0%, transparent 70%)' }}
+        />
 
         {/* Divider on the right edge */}
         <PanelDivider />
@@ -586,26 +523,27 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           </div>
 
           {/* Value proposition */}
-          <div className="space-y-12">
+          <div className="space-y-10">
 
-            {/* Headline */}
+            {/* Eyebrow + Headline */}
             <div>
-              <div className="mb-4">
-                <span className="inline-block text-[9px] font-semibold tracking-[0.22em] uppercase text-zinc-600 border border-zinc-800/80 px-2.5 py-1 rounded-sm">
+              <div className="mb-5">
+                <span className="inline-block text-[9px] font-semibold tracking-[0.22em] uppercase text-zinc-600 border border-zinc-800/80 px-2.5 py-[5px] rounded-sm">
                   {t.tagline}
                 </span>
               </div>
-              <h1 className="text-[2.6rem] xl:text-[2.9rem] font-semibold text-white leading-[1.1] tracking-tight">
-                {t.headline1}<br />
+              <h1 className="text-[2.5rem] xl:text-[2.75rem] font-semibold text-white leading-[1.08] tracking-[-0.02em]">
+                {t.headline1}
+                <br />
                 <span className="text-zinc-500">{t.headline2}</span>
               </h1>
-              <p className="mt-5 text-[0.875rem] text-zinc-500 leading-relaxed max-w-[340px]">
+              <p className="mt-5 text-[0.85rem] text-zinc-500 leading-[1.7] max-w-[320px]">
                 {t.description}
               </p>
             </div>
 
             {/* Feature list — architectural numbered style */}
-            <div className="border-l border-zinc-800/80">
+            <div className="border-l border-zinc-800/70">
               {[
                 { label: t.feature01, number: '01' },
                 { label: t.feature02, number: '02' },
@@ -614,10 +552,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               ].map((feature, i) => (
                 <div
                   key={feature.number}
-                  className={`flex items-start gap-4 px-5 py-3.5 ${i < 3 ? 'border-b border-zinc-800/60' : ''}`}
+                  className={`flex items-start gap-4 px-5 py-3.5 ${i < 3 ? 'border-b border-zinc-800/50' : ''}`}
                 >
-                  <span className="text-[10px] font-mono text-zinc-700 mt-0.5 flex-shrink-0 w-5 tabular-nums">{feature.number}</span>
-                  <span className="text-[0.8rem] text-zinc-400 leading-snug">{feature.label}</span>
+                  <span className="text-[10px] font-mono text-zinc-800 mt-0.5 flex-shrink-0 w-5 tabular-nums select-none">{feature.number}</span>
+                  <span className="text-[0.775rem] text-zinc-400 leading-snug">{feature.label}</span>
                 </div>
               ))}
             </div>
@@ -627,45 +565,45 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               onClick={() => setShowWelcome(true)}
               className="group flex items-center gap-3 text-left w-full"
             >
-              <div className="flex-shrink-0 px-2 py-0.5 rounded border border-emerald-800/40 bg-emerald-950/30">
+              <div className="flex-shrink-0 px-2 py-[3px] rounded border border-emerald-800/30 bg-emerald-950/20">
                 <span className="text-[8px] font-bold text-emerald-700 tracking-[0.2em] uppercase">Новим</span>
               </div>
-              <span className="text-[12px] text-zinc-600 group-hover:text-zinc-400 transition-colors duration-200 leading-snug">
+              <span className="text-[11px] text-zinc-600 group-hover:text-zinc-400 transition-colors duration-200 leading-snug">
                 Дізнайтесь про умови та реферальну програму
               </span>
               <ChevronRight
-                size={12}
-                className="text-zinc-700 group-hover:text-zinc-500 flex-shrink-0 transition-all duration-200 group-hover:translate-x-0.5"
+                size={11}
+                className="text-zinc-800 group-hover:text-zinc-600 flex-shrink-0 transition-all duration-200 group-hover:translate-x-0.5"
               />
             </button>
 
           </div>
 
           {/* Bottom navigation */}
-          <div className="flex items-center gap-6 flex-wrap">
+          <div className="flex items-center gap-5 flex-wrap">
             <a
               href="/blog"
               className="inline-flex items-center gap-1.5 text-[10px] text-zinc-700 hover:text-zinc-400 transition-colors duration-200 tracking-wide"
             >
-              <BookOpen size={11} />
+              <BookOpen size={10} />
               <span>Blog</span>
               {hasRecentArticles() && (
-                <span className="w-1 h-1 rounded-full bg-zinc-500 inline-block" />
+                <span className="w-1 h-1 rounded-full bg-zinc-600 inline-block" />
               )}
             </a>
             <a
               href="/lex-news"
               className="inline-flex items-center gap-1.5 text-[10px] text-zinc-700 hover:text-zinc-400 transition-colors duration-200 tracking-wide"
             >
-              <Newspaper size={11} />
+              <Newspaper size={10} />
               <span>Новини</span>
-              <span className="w-1 h-1 rounded-full bg-emerald-700 inline-block" />
+              <span className="w-1 h-1 rounded-full bg-emerald-700/70 inline-block" />
             </a>
             <a
               href="/investor"
               className="inline-flex items-center gap-1.5 text-[10px] text-zinc-700 hover:text-zinc-400 transition-colors duration-200 tracking-wide"
             >
-              <TrendingUp size={11} />
+              <TrendingUp size={10} />
               <span>Для інвесторів</span>
             </a>
           </div>
@@ -676,8 +614,11 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       {/* ── Right panel: auth form ── */}
       <div className="flex-1 flex flex-col items-center justify-center px-6 py-12 lg:px-16 xl:px-24 relative">
 
-        {/* Semi-transparent backdrop for readability */}
-        <div className="absolute inset-0" style={{ background: 'rgba(8,8,8,0.65)' }} />
+        {/* Right panel overlay — slightly transparent to show grid beneath */}
+        <div
+          className="absolute inset-0 pointer-events-none"
+          style={{ background: 'rgba(8,8,8,0.72)' }}
+        />
 
         {/* Language switcher — top right */}
         <div className="absolute top-6 right-6 z-20">
@@ -691,14 +632,14 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
 
         <motion.div
           {...FADE_UP}
-          className="w-full max-w-[400px] relative z-10"
+          className="w-full max-w-[392px] relative z-10"
         >
           {/* Heading */}
           <div className="mb-8">
-            <h2 className="text-[1.5rem] font-semibold text-white tracking-tight leading-tight mb-2">
+            <h2 className="text-[1.45rem] font-semibold text-white tracking-[-0.01em] leading-tight mb-2">
               {isLogin ? t.loginTitle : t.registerTitle}
             </h2>
-            <p className="text-[0.775rem] text-zinc-600 tracking-wide">
+            <p className="text-[0.75rem] text-zinc-600 tracking-wide">
               {isLogin
                 ? 'Оберіть зручний спосіб автентифікації'
                 : 'Зареєструйтесь для початку роботи'}
@@ -714,15 +655,15 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 animate={{ opacity: 1, y: 0 }}
                 exit={{ opacity: 0, y: -8 }}
                 transition={{ duration: 0.2 }}
-                className="mb-6 px-4 py-3 rounded-lg bg-red-950/25 border border-red-900/35 flex items-start gap-3"
+                className="mb-5 px-4 py-3 rounded-lg bg-red-950/20 border border-red-900/30 flex items-start gap-3"
               >
-                <AlertCircle size={13} className="text-red-500 flex-shrink-0 mt-0.5" />
-                <p className="text-[0.775rem] text-red-400 leading-snug flex-1">{error}</p>
+                <AlertCircle size={12} className="text-red-500 flex-shrink-0 mt-px" />
+                <p className="text-[0.75rem] text-red-400 leading-snug flex-1">{error}</p>
                 <button
                   onClick={() => setError(null)}
-                  className="text-red-800 hover:text-red-500 flex-shrink-0 transition-colors ml-1"
+                  className="text-red-900 hover:text-red-600 flex-shrink-0 transition-colors ml-1"
                 >
-                  <X size={13} />
+                  <X size={12} />
                 </button>
               </motion.div>
             )}
@@ -736,10 +677,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 animate={{ opacity: 1, height: 'auto' }}
                 exit={{ opacity: 0, height: 0 }}
                 transition={{ duration: 0.25 }}
-                className="overflow-hidden mb-6"
+                className="overflow-hidden mb-5"
               >
-                <div className="space-y-2.5 px-4 py-4 rounded-lg bg-zinc-900/70 border border-zinc-800/70">
-                  <p className="text-[9px] font-semibold text-zinc-600 uppercase tracking-[0.18em] mb-3">
+                <div className="space-y-2.5 px-4 py-4 rounded-lg bg-zinc-900/50 border border-zinc-800/60">
+                  <p className="text-[9px] font-semibold text-zinc-600 uppercase tracking-[0.2em] mb-3">
                     Для реєстрації необхідно прийняти:
                   </p>
                   {[
@@ -808,7 +749,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           {/* Primary: Google OAuth */}
           <button
             onClick={handleGoogleAuth}
-            className="w-full flex items-center justify-center gap-3 px-4 py-[11px] rounded-lg bg-white text-zinc-900 text-[0.825rem] font-medium hover:bg-zinc-100 active:bg-zinc-200 transition-colors duration-150 mb-2.5 shadow-sm"
+            className="w-full flex items-center justify-center gap-3 px-4 py-[11px] rounded-lg bg-white text-zinc-900 text-[0.825rem] font-medium hover:bg-zinc-100 active:bg-zinc-200 transition-colors duration-150 mb-2 shadow-sm"
           >
             <svg width="15" height="15" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" className="flex-shrink-0">
               <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4" />
@@ -822,18 +763,18 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           {/* Diia Auth */}
           <button
             onClick={handleDiiaAuth}
-            className="w-full flex items-center justify-center gap-3 px-4 py-[11px] rounded-lg bg-[#080808] border border-zinc-800 text-zinc-300 text-[0.825rem] font-medium hover:bg-zinc-900 hover:border-zinc-700 active:bg-zinc-900/60 transition-colors duration-150 mb-2.5"
+            className="w-full flex items-center justify-center gap-3 px-4 py-[11px] rounded-lg bg-[#0a0a0a] border border-zinc-800/80 text-zinc-300 text-[0.825rem] font-medium hover:bg-zinc-900 hover:border-zinc-700 active:opacity-80 transition-colors duration-150 mb-2"
           >
-            <img src="/diia-logo.png" alt="Дія" width="19" height="19" className="flex-shrink-0 rounded-[4px]" />
+            <img src="/diia-logo.png" alt="Дія" width="18" height="18" className="flex-shrink-0 rounded-[3px]" />
             {t.diiaAuth}
           </button>
 
           {/* SSO */}
           <button
             onClick={handleSSOAuth}
-            className={`w-full flex items-center justify-center gap-2.5 px-4 py-[11px] bg-[#080808] border border-zinc-800 text-zinc-600 text-[0.825rem] font-medium hover:bg-zinc-900 hover:border-zinc-700 hover:text-zinc-400 active:bg-zinc-900/60 transition-colors duration-150 ${showSSOForm ? 'rounded-t-lg' : 'rounded-lg mb-5'}`}
+            className={`w-full flex items-center justify-center gap-2.5 px-4 py-[11px] bg-[#0a0a0a] border border-zinc-800/80 text-zinc-600 text-[0.825rem] font-medium hover:bg-zinc-900 hover:border-zinc-700 hover:text-zinc-400 active:opacity-80 transition-colors duration-150 ${showSSOForm ? 'rounded-t-lg' : 'rounded-lg mb-5'}`}
           >
-            <ShieldCheck size={14} className="flex-shrink-0" />
+            <ShieldCheck size={13} className="flex-shrink-0" />
             {t.ssoAuth}
           </button>
 
@@ -846,10 +787,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 transition={{ duration: 0.2 }}
                 className="overflow-hidden mb-5"
               >
-                <div className="bg-zinc-900/70 border border-t-0 border-zinc-800 rounded-b-lg p-4 space-y-3">
+                <div className="bg-zinc-900/60 border border-t-0 border-zinc-800/80 rounded-b-lg p-4 space-y-3">
                   <div className="relative">
                     <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <Mail size={13} className="text-zinc-600" />
+                      <Mail size={12} className="text-zinc-700" />
                     </div>
                     <input
                       type="email"
@@ -857,12 +798,12 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                       onChange={(e) => setSsoEmail(e.target.value)}
                       placeholder="SSO email"
                       autoComplete="username"
-                      className="block w-full pl-9 pr-4 py-2.5 bg-zinc-800/60 border border-zinc-700/60 rounded-md text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 transition-all"
+                      className="block w-full pl-9 pr-4 py-2.5 bg-zinc-800/50 border border-zinc-700/50 rounded-md text-sm text-zinc-200 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                     />
                   </div>
                   <div className="relative">
                     <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <Lock size={13} className="text-zinc-600" />
+                      <Lock size={12} className="text-zinc-700" />
                     </div>
                     <input
                       type={showSSOPassword ? 'text' : 'password'}
@@ -871,22 +812,22 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                       placeholder="SSO пароль"
                       autoComplete="current-password"
                       onKeyDown={(e) => { if (e.key === 'Enter') handleSSOLogin(); }}
-                      className="block w-full pl-9 pr-10 py-2.5 bg-zinc-800/60 border border-zinc-700/60 rounded-md text-sm text-zinc-200 placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-500 focus:border-zinc-500 transition-all"
+                      className="block w-full pl-9 pr-10 py-2.5 bg-zinc-800/50 border border-zinc-700/50 rounded-md text-sm text-zinc-200 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                     />
                     <button
                       type="button"
                       onClick={() => setShowSSOPassword(!showSSOPassword)}
-                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-zinc-600 hover:text-zinc-400 transition-colors"
+                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-zinc-700 hover:text-zinc-500 transition-colors"
                     >
-                      {showSSOPassword ? <EyeOff size={13} /> : <Eye size={13} />}
+                      {showSSOPassword ? <EyeOff size={12} /> : <Eye size={12} />}
                     </button>
                   </div>
                   <button
                     onClick={handleSSOLogin}
                     disabled={ssoLoading}
-                    className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-zinc-700 hover:bg-zinc-600 text-zinc-100 rounded-md text-sm font-medium transition-colors duration-150 disabled:opacity-40"
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-zinc-700/80 hover:bg-zinc-700 text-zinc-100 rounded-md text-sm font-medium transition-colors duration-150 disabled:opacity-40"
                   >
-                    {ssoLoading ? <Loader2 size={14} className="animate-spin" /> : <><ArrowRight size={13} />Увійти</>}
+                    {ssoLoading ? <Loader2 size={13} className="animate-spin" /> : <><ArrowRight size={12} />Увійти</>}
                   </button>
                 </div>
               </motion.div>
@@ -896,7 +837,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           {/* Divider */}
           <div className="relative mb-5">
             <div className="absolute inset-0 flex items-center">
-              <div className="w-full border-t border-zinc-800/60" />
+              <div className="w-full border-t border-zinc-800/50" />
             </div>
             <div className="relative flex justify-center">
               <span className="px-3 bg-[#080808] text-[9px] text-zinc-700 tracking-[0.18em] uppercase">або</span>
@@ -904,7 +845,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           </div>
 
           {/* Auth method tabs */}
-          <div className="flex gap-px mb-5 rounded-lg overflow-hidden border border-zinc-800/60 bg-zinc-900/30">
+          <div className="flex gap-px mb-5 rounded-lg overflow-hidden border border-zinc-800/50 bg-[#0a0a0a]">
             {([
               { key: 'password', icon: Lock, label: 'Пароль' },
               { key: 'hardware-key', icon: Key, label: 'Ключ' },
@@ -915,8 +856,8 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 onClick={() => setAuthMethod(key)}
                 className={`flex-1 flex items-center justify-center gap-1.5 px-3 py-2.5 text-[11px] font-medium transition-all duration-150 ${
                   authMethod === key
-                    ? 'bg-zinc-800/90 text-zinc-200'
-                    : 'text-zinc-600 hover:text-zinc-500 hover:bg-zinc-900/50'
+                    ? 'bg-zinc-800/80 text-zinc-200'
+                    : 'text-zinc-600 hover:text-zinc-500 hover:bg-zinc-900/40'
                 }`}
               >
                 <Icon size={11} />
@@ -946,7 +887,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                     </label>
                     <div className="relative">
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                        <User size={13} className="text-zinc-700" />
+                        <User size={12} className="text-zinc-700" />
                       </div>
                       <input
                         id="name"
@@ -956,7 +897,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         onChange={(e) => setName(e.target.value)}
                         placeholder="Іван Петренко"
                         autoComplete="name"
-                        className="block w-full pl-9 pr-4 py-2.5 bg-zinc-900/50 border border-zinc-800/80 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+                        className="block w-full pl-9 pr-4 py-2.5 bg-zinc-900/50 border border-zinc-800/70 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                       />
                     </div>
                   </div>
@@ -968,7 +909,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                   </label>
                   <div className="relative">
                     <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <Mail size={13} className="text-zinc-700" />
+                      <Mail size={12} className="text-zinc-700" />
                     </div>
                     <input
                       id="email"
@@ -978,7 +919,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                       onChange={(e) => setEmail(e.target.value)}
                       placeholder="your@email.com"
                       autoComplete={isLogin ? 'username' : 'email'}
-                      className="block w-full pl-9 pr-4 py-2.5 bg-zinc-900/50 border border-zinc-800/80 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+                      className="block w-full pl-9 pr-4 py-2.5 bg-zinc-900/50 border border-zinc-800/70 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                     />
                   </div>
                 </div>
@@ -1000,7 +941,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                   </div>
                   <div className="relative">
                     <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <Lock size={13} className="text-zinc-700" />
+                      <Lock size={12} className="text-zinc-700" />
                     </div>
                     <input
                       id="password"
@@ -1010,19 +951,19 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                       onChange={(e) => handlePasswordChange(e.target.value)}
                       placeholder="••••••••"
                       autoComplete={isLogin ? 'current-password' : 'new-password'}
-                      className="block w-full pl-9 pr-10 py-2.5 bg-zinc-900/50 border border-zinc-800/80 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+                      className="block w-full pl-9 pr-10 py-2.5 bg-zinc-900/50 border border-zinc-800/70 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                     />
                     <button
                       type="button"
                       onClick={() => setShowPassword(!showPassword)}
-                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-zinc-700 hover:text-zinc-400 transition-colors"
+                      className="absolute inset-y-0 right-0 pr-3 flex items-center text-zinc-700 hover:text-zinc-500 transition-colors"
                     >
-                      {showPassword ? <EyeOff size={13} /> : <Eye size={13} />}
+                      {showPassword ? <EyeOff size={12} /> : <Eye size={12} />}
                     </button>
                   </div>
 
                   {!isLogin && password && (
-                    <div className="mt-2">
+                    <div className="mt-2.5">
                       <div className="flex gap-0.5">
                         {(['weak', 'medium', 'strong'] as const).map((level, i) => {
                           const filled = (
@@ -1046,14 +987,14 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 <button
                   type="submit"
                   disabled={isLoading || (!isLogin && !allConsentsAccepted)}
-                  className="w-full flex items-center justify-center gap-2 px-4 py-[11px] mt-1 bg-white text-zinc-900 rounded-lg text-[0.825rem] font-medium hover:bg-zinc-100 active:bg-zinc-200 transition-colors duration-150 disabled:opacity-25 disabled:cursor-not-allowed shadow-sm"
+                  className="w-full flex items-center justify-center gap-2 px-4 py-[11px] mt-1 bg-white text-zinc-900 rounded-lg text-[0.825rem] font-medium hover:bg-zinc-100 active:bg-zinc-200 transition-colors duration-150 disabled:opacity-20 disabled:cursor-not-allowed shadow-sm"
                 >
                   {isLoading ? (
                     <Loader2 size={14} className="animate-spin" />
                   ) : (
                     <>
                       {isLogin ? t.loginButton : t.registerButton}
-                      <ArrowRight size={13} />
+                      <ArrowRight size={12} />
                     </>
                   )}
                 </button>
@@ -1069,17 +1010,17 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 transition={{ duration: 0.18 }}
                 className="py-10 text-center"
               >
-                <div className="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-zinc-900/60 border border-zinc-800 mb-5">
-                  <Shield size={22} className="text-zinc-500" />
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-zinc-900/50 border border-zinc-800/70 mb-5">
+                  <Shield size={20} className="text-zinc-600" />
                 </div>
                 <h3 className="text-[0.825rem] font-medium text-zinc-300 mb-1.5">Підключіть ключ безпеки</h3>
-                <p className="text-[0.775rem] text-zinc-600 mb-6 leading-relaxed">Вставте USB-ключ або використайте NFC</p>
+                <p className="text-[0.75rem] text-zinc-600 mb-6 leading-relaxed">Вставте USB-ключ або використайте NFC</p>
                 <button
                   onClick={() => handleWebAuthnLogin('cross-platform')}
                   disabled={isLoading}
-                  className="px-6 py-2.5 bg-zinc-900 border border-zinc-700 text-zinc-400 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-200 transition-colors duration-150 disabled:opacity-40"
+                  className="px-6 py-2.5 bg-zinc-900/80 border border-zinc-700/80 text-zinc-400 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-200 transition-colors duration-150 disabled:opacity-40"
                 >
-                  {isLoading ? <Loader2 size={14} className="animate-spin inline mr-2" /> : null}
+                  {isLoading ? <Loader2 size={13} className="animate-spin inline mr-2" /> : null}
                   Автентифікація
                 </button>
               </motion.div>
@@ -1094,17 +1035,17 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 transition={{ duration: 0.18 }}
                 className="py-10 text-center"
               >
-                <div className="inline-flex items-center justify-center w-14 h-14 rounded-xl bg-zinc-900/60 border border-zinc-800 mb-5">
-                  <Smartphone size={22} className="text-zinc-500" />
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-zinc-900/50 border border-zinc-800/70 mb-5">
+                  <Smartphone size={20} className="text-zinc-600" />
                 </div>
                 <h3 className="text-[0.825rem] font-medium text-zinc-300 mb-1.5">Вхід через телефон</h3>
-                <p className="text-[0.775rem] text-zinc-600 mb-6 leading-relaxed">Браузер покаже QR-код для сканування</p>
+                <p className="text-[0.75rem] text-zinc-600 mb-6 leading-relaxed">Браузер покаже QR-код для сканування</p>
                 <button
                   onClick={() => handleWebAuthnLogin()}
                   disabled={isLoading}
-                  className="px-6 py-2.5 bg-zinc-900 border border-zinc-700 text-zinc-400 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-200 transition-colors duration-150 disabled:opacity-40"
+                  className="px-6 py-2.5 bg-zinc-900/80 border border-zinc-700/80 text-zinc-400 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-200 transition-colors duration-150 disabled:opacity-40"
                 >
-                  {isLoading ? <Loader2 size={14} className="animate-spin inline mr-2" /> : null}
+                  {isLoading ? <Loader2 size={13} className="animate-spin inline mr-2" /> : null}
                   Автентифікація
                 </button>
               </motion.div>
@@ -1125,10 +1066,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           {/* GDPR badge */}
           <button
             onClick={() => setShowGDPR(true)}
-            className="w-full mt-5 px-4 py-3 rounded-lg bg-zinc-900/50 border border-zinc-800/60 hover:border-zinc-700/80 flex items-center gap-3 transition-colors duration-150 text-left group"
+            className="w-full mt-5 px-4 py-3 rounded-lg bg-zinc-900/40 border border-zinc-800/50 hover:border-zinc-700/70 hover:bg-zinc-900/60 flex items-center gap-3 transition-colors duration-150 text-left group"
           >
-            <div className="flex-shrink-0 w-7 h-7 rounded-md bg-[#0d1627] border border-[#1a2d5a]/40 flex items-center justify-center">
-              <ShieldCheck size={12} className="text-[#4d6ef5]" />
+            <div className="flex-shrink-0 w-6 h-6 rounded-md bg-[#0c1524] border border-[#172645]/50 flex items-center justify-center">
+              <ShieldCheck size={11} className="text-[#4d6ef5]" />
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2 mb-0.5">
@@ -1142,7 +1083,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             </div>
             <ChevronRight
               size={11}
-              className="text-zinc-700 group-hover:text-zinc-500 flex-shrink-0 transition-all duration-200 group-hover:translate-x-0.5"
+              className="text-zinc-800 group-hover:text-zinc-600 flex-shrink-0 transition-all duration-200 group-hover:translate-x-0.5"
             />
           </button>
 
@@ -1200,19 +1141,19 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               exit={{ scale: 0.97, opacity: 0, y: 8 }}
               transition={{ duration: 0.2 }}
               onClick={(e) => e.stopPropagation()}
-              className="relative bg-zinc-950 border border-zinc-800/80 rounded-2xl shadow-2xl max-w-lg w-full max-h-[85vh] overflow-y-auto"
+              className="relative bg-zinc-950 border border-zinc-800/70 rounded-2xl shadow-2xl max-w-lg w-full max-h-[85vh] overflow-y-auto"
             >
               <button
                 onClick={() => setShowWelcome(false)}
                 className="absolute top-4 right-4 w-7 h-7 flex items-center justify-center rounded-md text-zinc-700 hover:text-zinc-400 hover:bg-zinc-900 transition-colors z-10"
               >
-                <X size={14} />
+                <X size={13} />
               </button>
 
               <div className="p-8">
                 {/* Header */}
                 <div className="mb-6">
-                  <h3 className="text-xl font-semibold text-white mb-1.5">Ласкаво просимо</h3>
+                  <h3 className="text-xl font-semibold text-white mb-1.5 tracking-tight">Ласкаво просимо</h3>
                   <p className="text-sm text-zinc-500">Ознайомтесь з умовами платформи та реферальною програмою</p>
                 </div>
 
@@ -1221,7 +1162,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                   <p className="text-[10px] font-semibold text-zinc-600 uppercase tracking-[0.18em] mb-3">
                     Правові документи
                   </p>
-                  <div className="space-y-2">
+                  <div className="space-y-1.5">
                     {[
                       { href: '/ua/offer', label: 'Публічна оферта', desc: 'Договір між вами та платформою' },
                       { href: '/ua/terms', label: 'Умови використання', desc: 'Правила користування сервісом' },
@@ -1234,30 +1175,30 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         href={doc.href}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center justify-between px-4 py-3 rounded-lg bg-zinc-900/60 border border-zinc-800/60 hover:border-zinc-700 hover:bg-zinc-900 transition-colors group"
+                        className="flex items-center justify-between px-4 py-3 rounded-lg bg-zinc-900/50 border border-zinc-800/50 hover:border-zinc-700/80 hover:bg-zinc-900/80 transition-colors group"
                       >
                         <div>
                           <p className="text-sm text-zinc-300 group-hover:text-white transition-colors">{doc.label}</p>
                           <p className="text-[11px] text-zinc-600">{doc.desc}</p>
                         </div>
-                        <ChevronRight size={14} className="text-zinc-700 group-hover:text-zinc-400 flex-shrink-0 transition-colors" />
+                        <ChevronRight size={13} className="text-zinc-700 group-hover:text-zinc-500 flex-shrink-0 transition-colors" />
                       </a>
                     ))}
                   </div>
                 </div>
 
                 {/* Divider */}
-                <div className="h-px bg-zinc-800/60 mb-6" />
+                <div className="h-px bg-zinc-800/50 mb-6" />
 
                 {/* Referral program */}
                 <div className="mb-6">
                   <p className="text-[10px] font-semibold text-zinc-600 uppercase tracking-[0.18em] mb-3">
                     Реферальна програма
                   </p>
-                  <div className="px-4 py-4 rounded-lg bg-zinc-900/60 border border-zinc-800/60">
+                  <div className="px-4 py-4 rounded-lg bg-zinc-900/50 border border-zinc-800/50">
                     <div className="flex items-start gap-3 mb-3">
-                      <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-emerald-950/50 border border-emerald-800/30 flex items-center justify-center">
-                        <Gift size={14} className="text-emerald-600" />
+                      <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-emerald-950/40 border border-emerald-800/25 flex items-center justify-center">
+                        <Gift size={13} className="text-emerald-700" />
                       </div>
                       <div>
                         <p className="text-sm text-zinc-300 font-medium mb-0.5">Запрошуйте колег — отримуйте бонуси</p>
@@ -1273,7 +1214,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         'Для участі потрібна верифікація ФОП, ТОВ або адвоката',
                       ].map((item, i) => (
                         <div key={i} className="flex items-center gap-2">
-                          <div className="w-1 h-1 rounded-full bg-emerald-700 flex-shrink-0" />
+                          <div className="w-1 h-1 rounded-full bg-zinc-700 flex-shrink-0" />
                           <span className="text-[11px] text-zinc-500">{item}</span>
                         </div>
                       ))}
@@ -1313,25 +1254,25 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               animate={{ scale: 1, opacity: 1, y: 0 }}
               exit={{ scale: 0.97, opacity: 0, y: 8 }}
               transition={{ duration: 0.2 }}
-              className="relative bg-zinc-950 border border-zinc-800/80 rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center"
+              className="relative bg-zinc-950 border border-zinc-800/70 rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center"
             >
               <button
                 onClick={() => { setDiiaSessionId(null); }}
                 className="absolute top-4 right-4 w-7 h-7 flex items-center justify-center rounded-md text-zinc-700 hover:text-zinc-400 hover:bg-zinc-900 transition-colors"
               >
-                <X size={14} />
+                <X size={13} />
               </button>
 
               <div className="w-11 h-11 rounded-xl flex items-center justify-center mx-auto mb-5">
                 <img src="/diia-logo.png" alt="Дія" width="44" height="44" className="rounded-xl" />
               </div>
 
-              <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5">Завершення входу</h2>
-              <p className="text-[0.775rem] text-zinc-500 mb-6 leading-relaxed">
+              <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5 tracking-tight">Завершення входу</h2>
+              <p className="text-[0.75rem] text-zinc-500 mb-6 leading-relaxed">
                 Обробка авторизації через Дію…
               </p>
 
-              <Loader2 size={24} className="animate-spin text-zinc-500 mx-auto mb-4" />
+              <Loader2 size={22} className="animate-spin text-zinc-600 mx-auto mb-4" />
 
               <p className="text-[10px] text-zinc-700">
                 Очікування підтвердження від Дії
@@ -1358,21 +1299,21 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               exit={{ scale: 0.97, opacity: 0, y: 8 }}
               transition={{ duration: 0.2 }}
               onClick={(e) => e.stopPropagation()}
-              className="relative bg-zinc-950 border border-zinc-800/80 rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center"
+              className="relative bg-zinc-950 border border-zinc-800/70 rounded-2xl shadow-2xl p-8 max-w-sm w-full text-center"
             >
               <button
                 onClick={() => { setDiiaDeeplink(null); setDiiaSessionId(null); }}
                 className="absolute top-4 right-4 w-7 h-7 flex items-center justify-center rounded-md text-zinc-700 hover:text-zinc-400 hover:bg-zinc-900 transition-colors"
               >
-                <X size={14} />
+                <X size={13} />
               </button>
 
               <div className="w-11 h-11 rounded-xl flex items-center justify-center mx-auto mb-5">
                 <img src="/diia-logo.png" alt="Дія" width="44" height="44" className="rounded-xl" />
               </div>
 
-              <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5">Вхід через Дію</h2>
-              <p className="text-[0.775rem] text-zinc-500 mb-6 leading-relaxed">
+              <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5 tracking-tight">Вхід через Дію</h2>
+              <p className="text-[0.75rem] text-zinc-500 mb-6 leading-relaxed">
                 Відкрийте застосунок Дія та відскануйте QR-код або натисніть кнопку нижче
               </p>
 
@@ -1387,7 +1328,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
 
               <a
                 href={diiaDeeplink}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-zinc-900 hover:bg-zinc-800 border border-zinc-800 hover:border-zinc-700 text-zinc-300 rounded-lg font-medium text-sm transition-colors mb-4"
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-zinc-900/80 hover:bg-zinc-800 border border-zinc-800 hover:border-zinc-700 text-zinc-300 rounded-lg font-medium text-sm transition-colors mb-4"
               >
                 Відкрити в застосунку Дія
               </a>


### PR DESCRIPTION
## Summary

Complete visual overhaul of the platform UI inspired by Harvey.ai design philosophy — clean, professional, legal-tech oriented with sophisticated typography and restrained color palette.

### Login page
- Replaced fractal animation with architectural SVG grid + ambient glows
- Tighter headline tracking (-0.02em), refined typography hierarchy
- Receded interactive chrome (smaller icons, softer borders)

### Sidebar
- Dark panel (#111111) with thin 2px accent bars for active state
- Ghost-style buttons (bg-white/7%), near-invisible section headers
- Dark-native popup menu matching sidebar vocabulary

### Chat interface
- Dark user message bubbles with asymmetric corner (rounded-br-sm)
- Improved message spacing rhythm (user tight, assistant generous)
- Frosted-glass header with backdrop-blur
- 2-column EmptyState grid with category labels
- Refined chat input with shadow-sm → shadow-md focus transition

### Right panel & document viewer
- Accent bars on section headers
- Rectangular badges (rounded-sm) for legal precision
- Wider document modal (52rem), inverted type icon treatment
- Refined MarkdownViewer with prose-zinc, generous line-height for legal text
- PlanReviewDisplay with divide-y separators and unified CTA style

## Test plan
- [ ] Login page renders with new architectural background (no animation)
- [ ] Language switcher (UA/EN/DE/ES) works
- [ ] Sidebar dark theme renders correctly, active nav items show accent bar
- [ ] Chat messages display with correct bubble styles
- [ ] EmptyState shows 2-column prompt grid
- [ ] Right panel tabs, cards, and document viewer modal render correctly
- [ ] Mobile responsive — all components adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the platform UI in a Harvey.ai-inspired style with a darker, legal-tech aesthetic, refined typography, and tighter spacing. Improves readability and navigation across login, chat, sidebar, and the right panel.

- New Features
  - Login: architectural SVG grid background, refined type; localized Forgot Password and GDPR modals.
  - Sidebar: dark panel, thin accent bar for active items, ghost buttons, and dark-native menus.
  - Chat: updated user/assistant bubbles, improved spacing rhythm, frosted header, 2‑column EmptyState with labeled prompts, refined ChatInput focus; added safety note under input.
  - Documents & Right panel: wider document modal, polished navigation arrows, `MarkdownViewer` with `prose-zinc` and improved line-height, rectangular badges and divide-y separators; updated tabs/header styling.

- Bug Fixes
  - Sidebar active state now correctly highlights nested routes (prefix match).

<sup>Written for commit 9b0884edf4ceca1eb6d6a3ee756f9ced07691097. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

