### PR TITLE
fix(test): LegalCodesLibraryPage test case mismatch

### DIFF
--- a/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
@@ -147,7 +147,7 @@ describe('LegalCodesLibraryPage', () => {
 
       await waitFor(() => {
         expect(screen.getByText(/Результати пошуку/)).toBeInTheDocument();
-        expect(screen.getByText('Ст. 12. Тестова стаття')).toBeInTheDocument();
+        expect(screen.getByText('ст. 12. Тестова стаття')).toBeInTheDocument();
       });
     });
 
@@ -533,7 +533,7 @@ describe('LegalCodesLibraryPage', () => {
       await openArticle();
 
       expect(screen.getByText('1 / 2')).toBeInTheDocument();
-      expect(screen.getByText('Ст. 2')).toBeInTheDocument();
+      expect(screen.getByText('ст. 2')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- Tests expected uppercase `Ст.` but i18n `articlesAbbr` uses lowercase `ст.` after Spanish localization PR
- 2 assertions updated: search results display + prev/next navigation

## Test plan
- [x] `npx vitest run src/pages/__tests__/LegalCodesLibraryPage.test.tsx` — 29/29 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update LegalCodesLibraryPage tests to match i18n: expect lowercase "ст." instead of "Ст." for article labels. Fixes assertions in search results and prev/next navigation.

<sup>Written for commit 7591ce30df3e7a867153cb2d224f0b7dda5b54a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

