### PR TITLE
fix(test): increase test timeout for CI search results

### DIFF
--- a/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
@@ -129,7 +129,7 @@ describe('LegalCodesLibraryPage', () => {
       });
     });
 
-    it('displays search results', async () => {
+    it('displays search results', { timeout: 15000 }, async () => {
       const user = userEvent.setup();
       mockCallTool.mockResolvedValue(
         makeToolResult({


### PR DESCRIPTION
## Summary
- Vitest default 5s test timeout is shorter than our 10s findByText timeout
- Add `{ timeout: 15000 }` to the individual test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend the "displays search results" test to be CI-stable by increasing the `vitest` timeout and using resilient queries. The test now waits up to 15s and relies on `findByText` with 10s retries.

- **Bug Fixes**
  - Set per-test timeout to 15s to avoid the 5s default being shorter than query timeouts.
  - Replace `waitFor` assertions with `@testing-library/react` `findByText` (10s) to retry until results render.
  - Keep a function matcher on the `<p>` element to match full text when split across DOM nodes.

<sup>Written for commit 504429f8b69c3351a8643c8ea8adf63d5c1ca8e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

