### PR TITLE
fix(security): upgrade flatted to 3.4.2 — Prototype Pollution (Dependabot #155)

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -63,6 +63,7 @@
     "eslint": "^10.0.3",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "flatted": "^3.4.2",
     "globals": "^17.4.0",
     "jsdom": "^29.0.0",
     "postcss": "^8.5.8",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "hono": ">=4.12.7",
     "@hono/node-server": ">=1.19.10",
     "underscore": ">=1.13.8",
-    "flatted": ">=3.4.0",
+    "flatted": ">=3.4.2",
     "undici": ">=6.24.0",
     "@tootallnate/once": ">=3.0.1",
     "dompurify": ">=3.3.3"


### PR DESCRIPTION
## Summary
- Fixes **high severity** Prototype Pollution via `parse()` in `flatted <= 3.4.1`
- Updated override in root `package.json` from `>=3.4.0` to `>=3.4.2`
- Transitive dep via `@vitest/ui` → `flatted`

## Test plan
- [x] 282/282 vitest tests pass
- [x] `npm ls flatted` shows 3.4.2 everywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `flatted` to 3.4.2 and enforce it repo-wide to fix a high-severity Prototype Pollution issue in <=3.4.1 pulled via `@vitest/ui`.

- **Dependencies**
  - Set root override for `flatted` to >=3.4.2 (was >=3.4.0).
  - Added `flatted` ^3.4.2 to `lexwebapp/package.json` to lock the patched version.

<sup>Written for commit bc86782d28d6172bcb977c74dd8df2914dc5c100. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

