### PR TITLE
feat(billing): 5 free requests per day for zero-balance users

### DIFF
--- a/lexwebapp/src/hooks/chat/chat-error-utils.ts
+++ b/lexwebapp/src/hooks/chat/chat-error-utils.ts
@@ -13,7 +13,7 @@ import { getErrorMessage } from '../../utils/errors';
  */
 export function handleStreamError(
   assistantMessageId: string,
-  error: { message?: string; code?: string; current_balance_usd?: number },
+  error: { message?: string; code?: string; current_balance_usd?: number; free_tier?: { daily_limit: number; used_today: number; remaining: number } },
   deps: {
     updateMessage: ReturnType<typeof useChatStore.getState>['updateMessage'];
     setStreaming: ReturnType<typeof useChatStore.getState>['setStreaming'];
@@ -31,8 +31,14 @@ export function handleStreamError(
     const balance = error.current_balance_usd != null
       ? `$${error.current_balance_usd.toFixed(2)}`
       : '';
-    content = `⚠️ **Недостатньо коштів на балансі**${balance ? ` (поточний баланс: ${balance})` : ''}.\n\nДля продовження роботи, будь ласка, [поповніть баланс](/billing).`;
-    toastMessage = 'Недостатньо коштів на балансі';
+    const freeTier = error.free_tier;
+    if (freeTier && freeTier.daily_limit > 0) {
+      content = `⚠️ **Вичерпано безкоштовні запити** (${freeTier.used_today}/${freeTier.daily_limit} за сьогодні).\n\nДля необмеженого доступу, будь ласка, [поповніть баланс](/billing).`;
+      toastMessage = `Безкоштовні запити вичерпано (${freeTier.used_today}/${freeTier.daily_limit})`;
+    } else {
+      content = `⚠️ **Недостатньо коштів на балансі**${balance ? ` (поточний баланс: ${balance})` : ''}.\n\nДля продовження роботи, будь ласка, [поповніть баланс](/billing).`;
+      toastMessage = 'Недостатньо коштів на балансі';
+    }
   } else {
     const msg = error.message || 'Невідома помилка';
     content = `Помилка: ${msg}`;

--- a/lexwebapp/src/services/api/SSEClient.ts
+++ b/lexwebapp/src/services/api/SSEClient.ts
@@ -51,6 +51,14 @@ export class SSEClient {
 
       if (!response.ok) {
         const errorText = await response.text();
+        // Parse structured error (402 balance, 429 rate limit)
+        try {
+          const errorJson = JSON.parse(errorText);
+          if (errorJson.code) {
+            handlers.onError?.(errorJson);
+            return controller;
+          }
+        } catch { /* not JSON, fall through */ }
         throw new Error(
           `SSE stream failed: ${response.status} ${response.statusText} - ${errorText}`
         );

--- a/mcp_backend/src/middleware/balance-check.ts
+++ b/mcp_backend/src/middleware/balance-check.ts
@@ -25,6 +25,9 @@ const FREE_TOOLS = new Set([
   'get_legislation_section',
 ]);
 
+/** Free tier: max requests per day with zero balance */
+const FREE_TIER_DAILY_LIMIT = 5;
+
 export function createBalanceCheckMiddleware(
   billingService: BillingService,
   costTracker: CostTracker
@@ -89,10 +92,23 @@ export function createBalanceCheckMiddleware(
       );
 
       if (!balanceCheck.hasBalance) {
+        // Free tier: allow up to FREE_TIER_DAILY_LIMIT requests per day with zero balance
+        const dailyCount = await billingService.getDailyRequestCount(userId);
+        if (dailyCount < FREE_TIER_DAILY_LIMIT) {
+          logger.info('Free tier request allowed', {
+            userId,
+            toolName,
+            dailyCount,
+            remaining: FREE_TIER_DAILY_LIMIT - dailyCount - 1,
+          });
+          return next();
+        }
+
         logger.warn('Insufficient balance', {
           userId,
           required: estimatedCost.total_estimated_cost_usd,
           available: balanceCheck.currentBalance,
+          dailyCount,
         });
 
         return res.status(402).json({
@@ -103,6 +119,11 @@ export function createBalanceCheckMiddleware(
             current_usd: balanceCheck.currentBalance,
             required_usd: estimatedCost.total_estimated_cost_usd,
             shortfall_usd: estimatedCost.total_estimated_cost_usd - balanceCheck.currentBalance,
+          },
+          free_tier: {
+            daily_limit: FREE_TIER_DAILY_LIMIT,
+            used_today: dailyCount,
+            remaining: 0,
           },
           topup_url: `${process.env.FRONTEND_URL || 'https://billing.legal.org.ua'}/topup`,
         });

--- a/mcp_backend/src/services/billing-service.ts
+++ b/mcp_backend/src/services/billing-service.ts
@@ -219,6 +219,21 @@ export class BillingService {
   }
 
   /**
+   * Get the number of completed requests for a user today
+   */
+  async getDailyRequestCount(userId: string): Promise<number> {
+    const result = await this.db.query(
+      `SELECT COUNT(*) as cnt
+       FROM cost_tracking
+       WHERE user_id = $1
+         AND created_at >= CURRENT_DATE
+         AND status = 'completed'`,
+      [userId]
+    );
+    return parseInt(result.rows[0]?.cnt || '0', 10);
+  }
+
+  /**
    * Check if user is within daily and monthly limits
    */
   async checkLimits(userId: string, additionalCostUsd: number): Promise<{


### PR DESCRIPTION
## Summary
- Users with $0 balance can make **5 requests per day** for free
- After 5 requests, shows "Вичерпано безкоштовні запити (5/5)" with topup link
- Backend: `balance-check.ts` middleware checks `getDailyRequestCount()` before rejecting 402
- Frontend: SSE client parses structured 402 JSON errors, chat UI shows free tier info

## Changes
- `mcp_backend/src/middleware/balance-check.ts` — free tier bypass logic
- `mcp_backend/src/services/billing-service.ts` — `getDailyRequestCount()` method
- `lexwebapp/src/services/api/SSEClient.ts` — parse structured error responses
- `lexwebapp/src/hooks/chat/chat-error-utils.ts` — free tier exhausted message

## Test plan
- [ ] New user with $0 balance can send 5 chat messages
- [ ] 6th message shows "Вичерпано безкоштовні запити (5/5)"
- [ ] Free read-only tools (list_documents, etc.) don't count
- [ ] Users with positive balance are unaffected
- [ ] API key auth users are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow zero-balance users to make 5 free requests per day. After the limit, we return a structured 402 and show a clear “free requests exhausted” message with a billing link.

- **New Features**
  - Backend: Allow up to 5 requests/day for users with $0 balance; when exceeded, return 402 JSON with `code`, `free_tier` { `daily_limit`, `used_today`, `remaining` }, and `topup_url` (counts via `getDailyRequestCount()`).
  - Frontend: `SSEClient` parses structured JSON errors (402/429) and forwards them; chat UI shows a localized “free requests exhausted” message with today’s usage and a top-up link.
  - Scope: Users with positive balance and API key auth are unchanged.

<sup>Written for commit 777962e07413231460faee6f167b4961f41d36e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

