### PR TITLE
feat(i18n): full Spanish localization + geo-forced locale

### DIFF
--- a/lexwebapp/src/components/sidebar/SidebarFooter.tsx
+++ b/lexwebapp/src/components/sidebar/SidebarFooter.tsx
@@ -4,6 +4,7 @@ import { User, LogOut, CreditCard, UsersRound, Plug, FileText, UserPlus, Code, C
 import { motion, AnimatePresence } from 'framer-motion';
 import { ROUTES } from '../../router/routes';
 import type { UserRole } from '../../types/models/User';
+import { appT } from '../../i18n/app-i18n';
 
 interface SidebarFooterProps {
   user: { name?: string; email?: string; picture?: string; role?: UserRole; userType?: string } | null;
@@ -35,7 +36,7 @@ export function SidebarFooter({
           rel="noopener noreferrer"
           className="text-[9.5px] text-zinc-700 hover:text-zinc-500 transition-colors tracking-wide"
         >
-          Оферта
+          {appT('nav.offer')}
         </a>
         <span className="text-zinc-800 text-[9px]">·</span>
         <a
@@ -44,7 +45,7 @@ export function SidebarFooter({
           rel="noopener noreferrer"
           className="text-[9.5px] text-zinc-700 hover:text-zinc-500 transition-colors tracking-wide"
         >
-          Конфіденційність
+          {appT('nav.privacy')}
         </a>
       </div>
 
@@ -60,7 +61,7 @@ export function SidebarFooter({
           >
             <button onClick={onProfileClick} className={`${menuItemClass} border-b border-white/[0.05]`}>
               <User size={13} className={menuIconClass} />
-              <span className={menuLabelClass}>Профіль</span>
+              <span className={menuLabelClass}>{appT('nav.profile')}</span>
             </button>
 
             {role !== 'administrator' && (
@@ -69,7 +70,7 @@ export function SidebarFooter({
                 className={`${menuItemClass} border-b border-white/[0.05]`}
               >
                 <CreditCard size={13} className={menuIconClass} />
-                <span className={menuLabelClass}>Біллінг</span>
+                <span className={menuLabelClass}>{appT('nav.profileBilling')}</span>
               </button>
             )}
 
@@ -78,7 +79,7 @@ export function SidebarFooter({
               className={`${menuItemClass} border-b border-white/[0.05]`}
             >
               <FileText size={13} className={menuIconClass} />
-              <span className={menuLabelClass}>Мої договори</span>
+              <span className={menuLabelClass}>{appT('nav.myContracts')}</span>
             </button>
 
             <button
@@ -86,7 +87,7 @@ export function SidebarFooter({
               className={`${menuItemClass} border-b border-white/[0.05]`}
             >
               <Code size={13} className={menuIconClass} />
-              <span className={menuLabelClass}>Оферта розробника</span>
+              <span className={menuLabelClass}>{appT('nav.devOffer')}</span>
             </button>
 
             <button
@@ -94,7 +95,7 @@ export function SidebarFooter({
               className={`${menuItemClass} border-b border-white/[0.05]`}
             >
               <UserPlus size={13} className={menuIconClass} />
-              <span className={menuLabelClass}>Запросити друга</span>
+              <span className={menuLabelClass}>{appT('nav.inviteFriend')}</span>
             </button>
 
             <button
@@ -102,7 +103,7 @@ export function SidebarFooter({
               className={`${menuItemClass} border-b border-white/[0.05]`}
             >
               <Plug size={13} className={menuIconClass} />
-              <span className={menuLabelClass}>MCP конект</span>
+              <span className={menuLabelClass}>{appT('nav.mcpConnect')}</span>
             </button>
 
             <button
@@ -110,7 +111,7 @@ export function SidebarFooter({
               className={`${menuItemClass} border-b border-white/[0.05]`}
             >
               <BookOpen size={13} className={menuIconClass} />
-              <span className={menuLabelClass}>API документація</span>
+              <span className={menuLabelClass}>{appT('nav.apiDocs')}</span>
             </button>
 
             {role === 'company' && (
@@ -119,7 +120,7 @@ export function SidebarFooter({
                 className={`${menuItemClass} border-b border-white/[0.05]`}
               >
                 <UsersRound size={13} className={menuIconClass} />
-                <span className={menuLabelClass}>Команда</span>
+                <span className={menuLabelClass}>{appT('nav.team')}</span>
               </button>
             )}
 
@@ -128,7 +129,7 @@ export function SidebarFooter({
               className="w-full flex items-center gap-2.5 px-3 py-2 text-left transition-colors duration-100 hover:bg-red-500/10"
             >
               <LogOut size={13} className="text-red-500/70 flex-shrink-0" />
-              <span className="text-[12.5px] font-normal text-red-400/80 font-sans tracking-[-0.01em]">Вихід</span>
+              <span className="text-[12.5px] font-normal text-red-400/80 font-sans tracking-[-0.01em]">{appT('nav.logout')}</span>
             </button>
           </motion.div>
         )}
@@ -152,7 +153,7 @@ export function SidebarFooter({
         )}
         <div className="flex-1 text-left min-w-0">
           <div className="text-[12px] font-medium text-zinc-300 tracking-[-0.01em] font-sans truncate leading-tight">
-            {user?.name || 'Користувач'}
+            {user?.name || appT('nav.defaultUser')}
           </div>
           <div className="text-[10.5px] text-zinc-600 font-sans truncate leading-tight">{user?.email || ''}</div>
         </div>

--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -14,13 +14,14 @@ import { useChatStore } from '../../stores/chatStore';
 import { useConsultationStore } from '../../stores/consultationStore';
 import { api } from '../../utils/api-client';
 import type { UserRole } from '../../types/models/User';
+import { appT } from '../../i18n/app-i18n';
 
 import { NavItem } from './NavItem';
 import { Section } from './Section';
 import { SidebarFooter } from './SidebarFooter';
 import {
-  researchSections, legislationSections, getMattersSections,
-  developerSections, externalSourcesSections, monitoringSections,
+  getResearchSections, getLegislationSections, getMattersSections,
+  getDeveloperSections, getExternalSourcesSections, getMonitoringSections,
 } from './nav-config';
 
 interface SidebarProps {
@@ -35,7 +36,12 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
   const { user } = useAuth();
   const role: UserRole = user?.role || 'user';
   const isAttorney = user?.userType === 'attorney';
+  const researchSections = getResearchSections();
+  const legislationSections = getLegislationSections();
   const mattersSections = getMattersSections(isAttorney);
+  const developerSections = getDeveloperSections();
+  const externalSourcesSections = getExternalSourcesSections();
+  const monitoringSections = getMonitoringSections();
 
   const [showProfileMenu, setShowProfileMenu] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -181,13 +187,13 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
               transition={{ duration: 0.18 }}
               className="bg-[#1a1a1a] rounded-xl border border-white/[0.08] shadow-[0_16px_48px_rgba(0,0,0,0.6)] p-6 max-w-sm mx-4"
               onClick={(e) => e.stopPropagation()}>
-              <h3 className="text-[14px] font-semibold text-zinc-200 mb-2 tracking-[-0.01em]">Видалити папку?</h3>
+              <h3 className="text-[14px] font-semibold text-zinc-200 mb-2 tracking-[-0.01em]">{appT('nav.deleteFolder')}</h3>
               <p className="text-[12.5px] text-zinc-500 mb-5 leading-relaxed">
-                Всі документи в папці <strong className="text-zinc-300 font-medium">{deletingFolder}</strong> будуть видалені. Цю дію можна скасувати через відновлення документів.
+                {appT('nav.deleteFolderPrefix')} <strong className="text-zinc-300 font-medium">{deletingFolder}</strong> {appT('nav.deleteFolderDesc')}
               </p>
               <div className="flex justify-end gap-2">
-                <button onClick={() => setDeletingFolder(null)} className="px-3.5 py-1.5 text-[12.5px] font-medium text-zinc-400 hover:text-zinc-200 bg-white/[0.05] hover:bg-white/[0.08] border border-white/[0.06] rounded-md transition-colors">Скасувати</button>
-                <button onClick={() => handleDeleteFolder(deletingFolder)} className="px-3.5 py-1.5 text-[12.5px] font-medium text-white bg-red-500/80 hover:bg-red-500 rounded-md transition-colors">Видалити</button>
+                <button onClick={() => setDeletingFolder(null)} className="px-3.5 py-1.5 text-[12.5px] font-medium text-zinc-400 hover:text-zinc-200 bg-white/[0.05] hover:bg-white/[0.08] border border-white/[0.06] rounded-md transition-colors">{appT('nav.cancel')}</button>
+                <button onClick={() => handleDeleteFolder(deletingFolder)} className="px-3.5 py-1.5 text-[12.5px] font-medium text-white bg-red-500/80 hover:bg-red-500 rounded-md transition-colors">{appT('nav.delete')}</button>
               </div>
             </motion.div>
           </motion.div>
@@ -237,7 +243,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
         <div className="px-3 pb-4">
           <button onClick={handleNewChat} className="w-full flex items-center gap-2 px-3 py-2 bg-white/[0.07] border border-white/[0.08] text-zinc-300 hover:bg-white/[0.10] hover:text-white rounded-md text-[12.5px] font-medium transition-all duration-150 group active:scale-[0.99] tracking-[-0.01em]">
             <Plus size={13} strokeWidth={2} className="text-zinc-500 group-hover:text-zinc-300 transition-colors duration-150" />
-            <span className="font-sans">Новий запит</span>
+            <span className="font-sans">{appT('nav.newQuery')}</span>
           </button>
         </div>
 
@@ -247,7 +253,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
         {/* Scrollable Content */}
         <div className="flex-1 overflow-y-auto px-2.5 py-0 scrollbar-hide">
           <div className="flex justify-end px-1 py-0.5 mb-1">
-            <button onClick={toggleAllSections} title={allCollapsed ? 'Розгорнути все' : 'Згорнути все'}
+            <button onClick={toggleAllSections} title={allCollapsed ? appT('nav.expandAll') : appT('nav.collapseAll')}
               className="p-1 text-zinc-800 hover:text-zinc-600 rounded transition-colors duration-150">
               <ChevronsUpDown size={12} strokeWidth={2} />
             </button>
@@ -257,7 +263,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
           {role !== 'administrator' && (
             <>
               {conversations.length > 0 && (
-                <Section id="conversations" title="Розмови" collapsed={collapsedSections.has('conversations')} onToggle={toggleSection}>
+                <Section id="conversations" title={appT('nav.section.conversations')} collapsed={collapsedSections.has('conversations')} onToggle={toggleSection}>
                   <div className="max-h-[280px] overflow-y-auto space-y-0.5 scrollbar-hide">
                     {conversations.map((conv) => (
                       <div
@@ -302,20 +308,20 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 </Section>
               )}
 
-              <Section id="research" title="Дослідження" collapsed={collapsedSections.has('research')} onToggle={toggleSection}>
+              <Section id="research" title={appT('nav.section.research')} collapsed={collapsedSections.has('research')} onToggle={toggleSection}>
                 {researchSections.map((s) => (
                   <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
                 ))}
               </Section>
 
-              <Section id="legislation" title="Законодавство" collapsed={collapsedSections.has('legislation')} onToggle={toggleSection}>
+              <Section id="legislation" title={appT('nav.section.legislation')} collapsed={collapsedSections.has('legislation')} onToggle={toggleSection}>
                 {legislationSections.map((s) => (
                   <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
                 ))}
               </Section>
 
-              <Section id="vault" title="Vault" collapsed={collapsedSections.has('vault')} onToggle={toggleSection}>
-                <NavItem icon={Archive} label="Всі документи" route={ROUTES.DOCUMENTS} onClick={() => handleNavigation(ROUTES.DOCUMENTS)} />
+              <Section id="vault" title={appT('nav.section.vault')} collapsed={collapsedSections.has('vault')} onToggle={toggleSection}>
+                <NavItem icon={Archive} label={appT('nav.allDocuments')} route={ROUTES.DOCUMENTS} onClick={() => handleNavigation(ROUTES.DOCUMENTS)} />
                 {vaultFolders.map((folder) => {
                   const folderRoute = `/documents/folders/${folder}`;
                   const isActive = location.pathname === folderRoute || location.pathname.startsWith(folderRoute + '/');
@@ -348,19 +354,19 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 })}
               </Section>
 
-              <Section id="matters" title="Справи" collapsed={collapsedSections.has('matters')} onToggle={toggleSection}>
+              <Section id="matters" title={appT('nav.section.matters')} collapsed={collapsedSections.has('matters')} onToggle={toggleSection}>
                 {mattersSections.map((s) => (
                   <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
                 ))}
               </Section>
 
-              <Section id="attorneys" title={isAttorney ? 'Консультації' : 'Адвокати'} collapsed={collapsedSections.has('attorneys')} onToggle={toggleSection}>
+              <Section id="attorneys" title={isAttorney ? appT('nav.section.consultations') : appT('nav.section.attorneys')} collapsed={collapsedSections.has('attorneys')} onToggle={toggleSection}>
                 {!isAttorney && (
-                  <NavItem icon={Search} label="Знайти адвоката" route={ROUTES.ATTORNEYS} onClick={() => handleNavigation(ROUTES.ATTORNEYS)} />
+                  <NavItem icon={Search} label={appT('nav.findAttorney')} route={ROUTES.ATTORNEYS} onClick={() => handleNavigation(ROUTES.ATTORNEYS)} />
                 )}
-                <NavItem icon={Briefcase} label="Мої консультації" route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} badge={(pendingCount + globalUnreadCount) > 0 ? pendingCount + globalUnreadCount : undefined} />
+                <NavItem icon={Briefcase} label={appT('nav.myConsultations')} route={ROUTES.CONSULTATIONS} onClick={() => handleNavigation(ROUTES.CONSULTATIONS)} badge={(pendingCount + globalUnreadCount) > 0 ? pendingCount + globalUnreadCount : undefined} />
                 {isAttorney && (
-                  <NavItem icon={Users} label="Мої клієнти" route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
+                  <NavItem icon={Users} label={appT('nav.myClients')} route={ROUTES.ATTORNEY_CLIENTS} onClick={() => handleNavigation(ROUTES.ATTORNEY_CLIENTS)} />
                 )}
               </Section>
 
@@ -368,7 +374,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 <NavItem icon={Zap} label="Workflows" route={ROUTES.WORKFLOWS} onClick={() => handleNavigation(ROUTES.WORKFLOWS)} />
               </div>
 
-              <Section id="developer" title="Розробникам" collapsed={collapsedSections.has('developer')} onToggle={toggleSection}>
+              <Section id="developer" title={appT('nav.section.developer')} collapsed={collapsedSections.has('developer')} onToggle={toggleSection}>
                 {developerSections.map((s) => (
                   <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
                 ))}
@@ -379,13 +385,13 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
           {/* ADMIN MENU */}
           {role === 'administrator' && (
             <>
-              <Section id="external-sources" title="Зовнішні джерела" collapsed={collapsedSections.has('external-sources')} onToggle={toggleSection}>
+              <Section id="external-sources" title={appT('nav.section.externalSources')} collapsed={collapsedSections.has('external-sources')} onToggle={toggleSection}>
                 {externalSourcesSections.map((s) => (
                   <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
                 ))}
               </Section>
 
-              <Section id="monitoring" title="Моніторинг" collapsed={collapsedSections.has('monitoring')} onToggle={toggleSection}>
+              <Section id="monitoring" title={appT('nav.section.monitoring')} collapsed={collapsedSections.has('monitoring')} onToggle={toggleSection}>
                 {monitoringSections.map((s) => (
                   <NavItem key={s.id} icon={s.icon} label={s.label} route={s.route} onClick={() => handleNavigation(s.route)} />
                 ))}

--- a/lexwebapp/src/components/sidebar/nav-config.ts
+++ b/lexwebapp/src/components/sidebar/nav-config.ts
@@ -6,63 +6,72 @@ import {
   Layers, HardDrive, Gauge, Code,
 } from 'lucide-react';
 import { ROUTES } from '../../router/routes';
+import { appT } from '../../i18n/app-i18n';
 
-export const researchSections = [
-  { id: 'decisions', label: 'Судові рішення', icon: Gavel, route: ROUTES.DECISIONS_SEARCH },
-  { id: 'regulations', label: 'Нормативні акти', icon: BookOpen, route: ROUTES.LEGAL_CODES_LIBRARY },
-  { id: 'commentary', label: 'Коментарі та практика', icon: TrendingUp, route: ROUTES.COURT_PRACTICE_ANALYSIS },
-  { id: 'verification', label: 'Перевірка актуальності', icon: CheckCircle, route: ROUTES.LEGISLATION_MONITORING },
-  { id: 'judges', label: 'Судді', icon: Scale, route: ROUTES.JUDGES },
-  { id: 'lawyers', label: 'Адвокати', icon: Briefcase, route: ROUTES.LAWYERS },
+export const getResearchSections = () => [
+  { id: 'decisions', label: appT('nav.decisions'), icon: Gavel, route: ROUTES.DECISIONS_SEARCH },
+  { id: 'regulations', label: appT('nav.regulations'), icon: BookOpen, route: ROUTES.LEGAL_CODES_LIBRARY },
+  { id: 'commentary', label: appT('nav.commentary'), icon: TrendingUp, route: ROUTES.COURT_PRACTICE_ANALYSIS },
+  { id: 'verification', label: appT('nav.verification'), icon: CheckCircle, route: ROUTES.LEGISLATION_MONITORING },
+  { id: 'judges', label: appT('nav.judges'), icon: Scale, route: ROUTES.JUDGES },
+  { id: 'lawyers', label: appT('nav.lawyers'), icon: Briefcase, route: ROUTES.LAWYERS },
 ];
 
-export const legislationSections = [
-  { id: 'legislation-db', label: 'База законодавства', icon: BookOpen, route: ROUTES.LEGISLATION_MONITORING },
-  { id: 'codes', label: 'Кодекси та закони', icon: Scale, route: ROUTES.LEGAL_CODES_LIBRARY },
-  { id: 'news', label: 'Новини КМУ', icon: Newspaper, route: ROUTES.NEWS },
-  { id: 'lex-news', label: 'Новини LEX', icon: Globe, route: ROUTES.LEX_NEWS },
+export const getLegislationSections = () => [
+  { id: 'legislation-db', label: appT('nav.legislationDb'), icon: BookOpen, route: ROUTES.LEGISLATION_MONITORING },
+  { id: 'codes', label: appT('nav.codes'), icon: Scale, route: ROUTES.LEGAL_CODES_LIBRARY },
+  { id: 'news', label: appT('nav.newsKmu'), icon: Newspaper, route: ROUTES.NEWS },
+  { id: 'lex-news', label: appT('nav.newsLex'), icon: Globe, route: ROUTES.LEX_NEWS },
 ];
 
 export function getMattersSections(isAttorney: boolean) {
   return [
-    { id: 'matters', label: 'Справи', icon: Briefcase, route: ROUTES.MATTERS },
+    { id: 'matters', label: appT('nav.matters'), icon: Briefcase, route: ROUTES.MATTERS },
     ...(isAttorney ? [
-      { id: 'time-entries', label: 'Time Entries', icon: Clock, route: ROUTES.TIME_ENTRIES },
-      { id: 'invoices', label: 'Invoices', icon: FileText, route: ROUTES.INVOICES },
+      { id: 'time-entries', label: appT('nav.timeEntries'), icon: Clock, route: ROUTES.TIME_ENTRIES },
+      { id: 'invoices', label: appT('nav.invoices'), icon: FileText, route: ROUTES.INVOICES },
     ] : []),
-    { id: 'case-analysis', label: 'Аналіз справ', icon: Search, route: ROUTES.CASE_ANALYSIS },
+    { id: 'case-analysis', label: appT('nav.caseAnalysis'), icon: Search, route: ROUTES.CASE_ANALYSIS },
   ];
 }
 
-export const attorneyClientSections = [
-  { id: 'attorney-search', label: 'Знайти адвоката', icon: Search, route: ROUTES.ATTORNEYS },
-  { id: 'my-consultations', label: 'Мої консультації', icon: Briefcase, route: ROUTES.CONSULTATIONS },
+export const getAttorneyClientSections = () => [
+  { id: 'attorney-search', label: appT('nav.findAttorney'), icon: Search, route: ROUTES.ATTORNEYS },
+  { id: 'my-consultations', label: appT('nav.myConsultations'), icon: Briefcase, route: ROUTES.CONSULTATIONS },
 ];
 
-export const developerSections = [
-  { id: 'dev-docs', label: 'API документація', icon: Code, route: ROUTES.DEVELOPER_DOCS },
+export const getDeveloperSections = () => [
+  { id: 'dev-docs', label: appT('nav.apiDocs'), icon: Code, route: ROUTES.DEVELOPER_DOCS },
 ];
 
-export const externalSourcesSections = [
-  { id: 'ext-monitoring', label: 'Моніторинг', icon: Database, route: ROUTES.ADMIN_MONITORING },
-  { id: 'ext-data-sources', label: 'Джерела даних', icon: Globe, route: ROUTES.ADMIN_DATA_SOURCES },
-  { id: 'ext-open-data-catalog', label: 'Каталог OpenData', icon: Layers, route: ROUTES.ADMIN_OPEN_DATA_CATALOG },
+export const getExternalSourcesSections = () => [
+  { id: 'ext-monitoring', label: appT('nav.extMonitoring'), icon: Database, route: ROUTES.ADMIN_MONITORING },
+  { id: 'ext-data-sources', label: appT('nav.extDataSources'), icon: Globe, route: ROUTES.ADMIN_DATA_SOURCES },
+  { id: 'ext-open-data-catalog', label: appT('nav.extOpenData'), icon: Layers, route: ROUTES.ADMIN_OPEN_DATA_CATALOG },
 ];
 
-export const monitoringSections = [
-  { id: 'system-overview', label: 'Огляд системи', icon: Activity, route: ROUTES.ADMIN_OVERVIEW },
-  { id: 'admin-users', label: 'Користувачі', icon: Users, route: ROUTES.ADMIN_USERS },
-  { id: 'api-costs', label: 'Витрати API', icon: DollarSign, route: ROUTES.ADMIN_COSTS },
-  { id: 'infrastructure', label: 'Інфраструктура', icon: Server, route: ROUTES.ADMIN_INFRASTRUCTURE },
-  { id: 'containers', label: 'Контейнери', icon: Boxes, route: ROUTES.ADMIN_CONTAINERS },
-  { id: 'admin-billing', label: 'Біллінг', icon: CreditCard, route: ROUTES.ADMIN_BILLING },
-  { id: 'system-config', label: 'Конфігурація', icon: Settings, route: ROUTES.ADMIN_CONFIG },
-  { id: 'db-compare', label: 'Порівняння БД', icon: Database, route: ROUTES.ADMIN_DB_COMPARE },
-  { id: 'service-pricing', label: 'Собівартість сервісів', icon: Tag, route: ROUTES.ADMIN_SERVICE_PRICING },
-  { id: 'terminal', label: 'Термінал', icon: Terminal, route: ROUTES.ADMIN_TERMINAL },
-  { id: 'zo-stats', label: 'Статистика рішень', icon: BarChart3, route: ROUTES.ADMIN_ZO_STATS },
-  { id: 'user-activity', label: 'Активність юзерів', icon: Zap, route: ROUTES.ADMIN_USER_ACTIVITY },
-  { id: 'bulk-scrape', label: 'Пайплайн збору', icon: Database, route: ROUTES.ADMIN_BULK_SCRAPE },
-  { id: 'pg-monitoring', label: 'PG Моніторинг', icon: HardDrive, route: ROUTES.ADMIN_PG_MONITORING },
-  { id: 'limits', label: 'Ліміти системи', icon: Gauge, route: ROUTES.ADMIN_LIMITS },
+export const getMonitoringSections = () => [
+  { id: 'system-overview', label: appT('nav.systemOverview'), icon: Activity, route: ROUTES.ADMIN_OVERVIEW },
+  { id: 'admin-users', label: appT('nav.users'), icon: Users, route: ROUTES.ADMIN_USERS },
+  { id: 'api-costs', label: appT('nav.apiCosts'), icon: DollarSign, route: ROUTES.ADMIN_COSTS },
+  { id: 'infrastructure', label: appT('nav.infrastructure'), icon: Server, route: ROUTES.ADMIN_INFRASTRUCTURE },
+  { id: 'containers', label: appT('nav.containers'), icon: Boxes, route: ROUTES.ADMIN_CONTAINERS },
+  { id: 'admin-billing', label: appT('nav.billing'), icon: CreditCard, route: ROUTES.ADMIN_BILLING },
+  { id: 'system-config', label: appT('nav.config'), icon: Settings, route: ROUTES.ADMIN_CONFIG },
+  { id: 'db-compare', label: appT('nav.dbCompare'), icon: Database, route: ROUTES.ADMIN_DB_COMPARE },
+  { id: 'service-pricing', label: appT('nav.servicePricing'), icon: Tag, route: ROUTES.ADMIN_SERVICE_PRICING },
+  { id: 'terminal', label: appT('nav.terminal'), icon: Terminal, route: ROUTES.ADMIN_TERMINAL },
+  { id: 'zo-stats', label: appT('nav.zoStats'), icon: BarChart3, route: ROUTES.ADMIN_ZO_STATS },
+  { id: 'user-activity', label: appT('nav.userActivity'), icon: Zap, route: ROUTES.ADMIN_USER_ACTIVITY },
+  { id: 'bulk-scrape', label: appT('nav.bulkScrape'), icon: Database, route: ROUTES.ADMIN_BULK_SCRAPE },
+  { id: 'pg-monitoring', label: appT('nav.pgMonitoring'), icon: HardDrive, route: ROUTES.ADMIN_PG_MONITORING },
+  { id: 'limits', label: appT('nav.limits'), icon: Gauge, route: ROUTES.ADMIN_LIMITS },
 ];
+
+// Legacy static exports for backward compatibility
+export const researchSections = getResearchSections();
+export const legislationSections = getLegislationSections();
+export const attorneyClientSections = getAttorneyClientSections();
+export const developerSections = getDeveloperSections();
+export const externalSourcesSections = getExternalSourcesSections();
+export const monitoringSections = getMonitoringSections();

--- a/lexwebapp/src/i18n/app-i18n.ts
+++ b/lexwebapp/src/i18n/app-i18n.ts
@@ -845,6 +845,98 @@ const translations: TranslationMap = {
   'layout.showMenu': { uk: 'Показати меню', en: 'Show menu', de: 'Menü anzeigen', es: 'Mostrar menú' },
   'layout.hidePanel': { uk: 'Сховати панель', en: 'Hide panel', de: 'Panel ausblenden', es: 'Ocultar panel' },
   'layout.showPanel': { uk: 'Показати панель', en: 'Show panel', de: 'Panel anzeigen', es: 'Mostrar panel' },
+
+  // ═══════════════════════════════════════════════════════════
+  // Sidebar Navigation
+  // ═══════════════════════════════════════════════════════════
+  'nav.newQuery': { uk: 'Новий запит', en: 'New query', de: 'Neue Anfrage', es: 'Nueva consulta' },
+  'nav.expandAll': { uk: 'Розгорнути все', en: 'Expand all', de: 'Alle aufklappen', es: 'Expandir todo' },
+  'nav.collapseAll': { uk: 'Згорнути все', en: 'Collapse all', de: 'Alle zuklappen', es: 'Contraer todo' },
+
+  // Section titles
+  'nav.section.conversations': { uk: 'Розмови', en: 'Conversations', de: 'Gespräche', es: 'Conversaciones' },
+  'nav.section.research': { uk: 'Дослідження', en: 'Research', de: 'Forschung', es: 'Investigación' },
+  'nav.section.legislation': { uk: 'Законодавство', en: 'Legislation', de: 'Gesetzgebung', es: 'Legislación' },
+  'nav.section.vault': { uk: 'Vault', en: 'Vault', de: 'Tresor', es: 'Bóveda' },
+  'nav.section.matters': { uk: 'Справи', en: 'Matters', de: 'Fälle', es: 'Asuntos' },
+  'nav.section.consultations': { uk: 'Консультації', en: 'Consultations', de: 'Beratungen', es: 'Consultas' },
+  'nav.section.attorneys': { uk: 'Адвокати', en: 'Attorneys', de: 'Anwälte', es: 'Abogados' },
+  'nav.section.developer': { uk: 'Розробникам', en: 'Developers', de: 'Entwickler', es: 'Desarrolladores' },
+  'nav.section.externalSources': { uk: 'Зовнішні джерела', en: 'External Sources', de: 'Externe Quellen', es: 'Fuentes externas' },
+  'nav.section.monitoring': { uk: 'Моніторинг', en: 'Monitoring', de: 'Überwachung', es: 'Monitoreo' },
+
+  // Research items
+  'nav.decisions': { uk: 'Судові рішення', en: 'Court Decisions', de: 'Gerichtsentscheidungen', es: 'Resoluciones judiciales' },
+  'nav.regulations': { uk: 'Нормативні акти', en: 'Regulatory Acts', de: 'Rechtsvorschriften', es: 'Actos normativos' },
+  'nav.commentary': { uk: 'Коментарі та практика', en: 'Commentary & Practice', de: 'Kommentare & Praxis', es: 'Comentarios y práctica' },
+  'nav.verification': { uk: 'Перевірка актуальності', en: 'Relevance Check', de: 'Aktualitätsprüfung', es: 'Verificación de vigencia' },
+  'nav.judges': { uk: 'Судді', en: 'Judges', de: 'Richter', es: 'Jueces' },
+  'nav.lawyers': { uk: 'Адвокати', en: 'Lawyers', de: 'Anwälte', es: 'Abogados' },
+
+  // Legislation items
+  'nav.legislationDb': { uk: 'База законодавства', en: 'Legislation Database', de: 'Gesetzesdatenbank', es: 'Base de legislación' },
+  'nav.codes': { uk: 'Кодекси та закони', en: 'Codes & Laws', de: 'Gesetzbücher & Gesetze', es: 'Códigos y leyes' },
+  'nav.newsKmu': { uk: 'Новини КМУ', en: 'CMU News', de: 'KMU-Nachrichten', es: 'Noticias del Gobierno' },
+  'nav.newsLex': { uk: 'Новини LEX', en: 'LEX News', de: 'LEX-Nachrichten', es: 'Noticias LEX' },
+
+  // Vault
+  'nav.allDocuments': { uk: 'Всі документи', en: 'All Documents', de: 'Alle Dokumente', es: 'Todos los documentos' },
+
+  // Matters
+  'nav.matters': { uk: 'Справи', en: 'Matters', de: 'Fälle', es: 'Asuntos' },
+  'nav.timeEntries': { uk: 'Time Entries', en: 'Time Entries', de: 'Zeiteinträge', es: 'Registros de tiempo' },
+  'nav.invoices': { uk: 'Invoices', en: 'Invoices', de: 'Rechnungen', es: 'Facturas' },
+  'nav.caseAnalysis': { uk: 'Аналіз справ', en: 'Case Analysis', de: 'Fallanalyse', es: 'Análisis de casos' },
+
+  // Attorneys
+  'nav.findAttorney': { uk: 'Знайти адвоката', en: 'Find a Lawyer', de: 'Anwalt finden', es: 'Buscar abogado' },
+  'nav.myConsultations': { uk: 'Мої консультації', en: 'My Consultations', de: 'Meine Beratungen', es: 'Mis consultas' },
+  'nav.myClients': { uk: 'Мої клієнти', en: 'My Clients', de: 'Meine Mandanten', es: 'Mis clientes' },
+
+  // Developer
+  'nav.apiDocs': { uk: 'API документація', en: 'API Documentation', de: 'API-Dokumentation', es: 'Documentación API' },
+
+  // External sources (admin)
+  'nav.extMonitoring': { uk: 'Моніторинг', en: 'Monitoring', de: 'Überwachung', es: 'Monitoreo' },
+  'nav.extDataSources': { uk: 'Джерела даних', en: 'Data Sources', de: 'Datenquellen', es: 'Fuentes de datos' },
+  'nav.extOpenData': { uk: 'Каталог OpenData', en: 'OpenData Catalog', de: 'OpenData-Katalog', es: 'Catálogo OpenData' },
+
+  // Monitoring (admin)
+  'nav.systemOverview': { uk: 'Огляд системи', en: 'System Overview', de: 'Systemübersicht', es: 'Resumen del sistema' },
+  'nav.users': { uk: 'Користувачі', en: 'Users', de: 'Benutzer', es: 'Usuarios' },
+  'nav.apiCosts': { uk: 'Витрати API', en: 'API Costs', de: 'API-Kosten', es: 'Costos API' },
+  'nav.infrastructure': { uk: 'Інфраструктура', en: 'Infrastructure', de: 'Infrastruktur', es: 'Infraestructura' },
+  'nav.containers': { uk: 'Контейнери', en: 'Containers', de: 'Container', es: 'Contenedores' },
+  'nav.billing': { uk: 'Біллінг', en: 'Billing', de: 'Abrechnung', es: 'Facturación' },
+  'nav.config': { uk: 'Конфігурація', en: 'Configuration', de: 'Konfiguration', es: 'Configuración' },
+  'nav.dbCompare': { uk: 'Порівняння БД', en: 'DB Comparison', de: 'DB-Vergleich', es: 'Comparación de BD' },
+  'nav.servicePricing': { uk: 'Собівартість сервісів', en: 'Service Pricing', de: 'Servicepreise', es: 'Precios de servicios' },
+  'nav.terminal': { uk: 'Термінал', en: 'Terminal', de: 'Terminal', es: 'Terminal' },
+  'nav.zoStats': { uk: 'Статистика рішень', en: 'Decision Statistics', de: 'Entscheidungsstatistik', es: 'Estadísticas de resoluciones' },
+  'nav.userActivity': { uk: 'Активність юзерів', en: 'User Activity', de: 'Benutzeraktivität', es: 'Actividad de usuarios' },
+  'nav.bulkScrape': { uk: 'Пайплайн збору', en: 'Collection Pipeline', de: 'Sammlungspipeline', es: 'Pipeline de recopilación' },
+  'nav.pgMonitoring': { uk: 'PG Моніторинг', en: 'PG Monitoring', de: 'PG-Überwachung', es: 'Monitoreo PG' },
+  'nav.limits': { uk: 'Ліміти системи', en: 'System Limits', de: 'Systemlimits', es: 'Límites del sistema' },
+
+  // Sidebar footer / profile menu
+  'nav.offer': { uk: 'Оферта', en: 'Terms of Service', de: 'Nutzungsbedingungen', es: 'Términos de servicio' },
+  'nav.privacy': { uk: 'Конфіденційність', en: 'Privacy', de: 'Datenschutz', es: 'Privacidad' },
+  'nav.profile': { uk: 'Профіль', en: 'Profile', de: 'Profil', es: 'Perfil' },
+  'nav.profileBilling': { uk: 'Біллінг', en: 'Billing', de: 'Abrechnung', es: 'Facturación' },
+  'nav.myContracts': { uk: 'Мої договори', en: 'My Contracts', de: 'Meine Verträge', es: 'Mis contratos' },
+  'nav.devOffer': { uk: 'Оферта розробника', en: 'Developer Terms', de: 'Entwicklerbedingungen', es: 'Términos para desarrolladores' },
+  'nav.inviteFriend': { uk: 'Запросити друга', en: 'Invite a Friend', de: 'Freund einladen', es: 'Invitar a un amigo' },
+  'nav.mcpConnect': { uk: 'MCP конект', en: 'MCP Connect', de: 'MCP Connect', es: 'MCP Connect' },
+  'nav.team': { uk: 'Команда', en: 'Team', de: 'Team', es: 'Equipo' },
+  'nav.logout': { uk: 'Вихід', en: 'Log out', de: 'Abmelden', es: 'Cerrar sesión' },
+  'nav.defaultUser': { uk: 'Користувач', en: 'User', de: 'Benutzer', es: 'Usuario' },
+
+  // Folder delete modal
+  'nav.deleteFolder': { uk: 'Видалити папку?', en: 'Delete folder?', de: 'Ordner löschen?', es: '¿Eliminar carpeta?' },
+  'nav.deleteFolderDesc': { uk: 'будуть видалені. Цю дію можна скасувати через відновлення документів.', en: 'will be deleted. This can be undone via document recovery.', de: 'werden gelöscht. Dies kann über die Dokumentwiederherstellung rückgängig gemacht werden.', es: 'serán eliminados. Esto se puede deshacer a través de la recuperación de documentos.' },
+  'nav.deleteFolderPrefix': { uk: 'Всі документи в папці', en: 'All documents in folder', de: 'Alle Dokumente im Ordner', es: 'Todos los documentos en la carpeta' },
+  'nav.cancel': { uk: 'Скасувати', en: 'Cancel', de: 'Abbrechen', es: 'Cancelar' },
+  'nav.delete': { uk: 'Видалити', en: 'Delete', de: 'Löschen', es: 'Eliminar' },
 };
 
 /**

--- a/lexwebapp/src/i18n/locales.ts
+++ b/lexwebapp/src/i18n/locales.ts
@@ -77,6 +77,76 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     strengthWeak: 'Слабкий',
     strengthMedium: 'Середній',
     strengthStrong: 'Надійний',
+    // Promo banner
+    promoNew: 'НОВИМ',
+    promoDesc: 'Дізнайтесь про умови та реферальну програму',
+    // Bottom nav
+    newsLink: 'Новини',
+    investorsLink: 'Для інвесторів',
+    // Auth subtitle
+    authSubtitleLogin: 'Оберіть зручний спосіб автентифікації',
+    authSubtitleRegister: 'Зареєструйтесь для початку роботи',
+    // Divider
+    orDivider: 'або',
+    // Auth method tabs
+    tabPassword: 'Пароль',
+    tabKey: 'Ключ',
+    tabPhone: 'Телефон',
+    // Form labels
+    nameLabel: "Ім'я",
+    namePlaceholderExample: 'Іван Петренко',
+    passwordLabel: 'Пароль',
+    // Password strength messages
+    strengthWeakDesc: 'Слабкий — додайте великі літери, цифри або спецсимволи',
+    strengthMediumDesc: 'Середній пароль',
+    strengthStrongDesc: 'Надійний пароль',
+    // Hardware key
+    hardwareKeyTitle: 'Підключіть ключ безпеки',
+    hardwareKeyDesc: 'Вставте USB-ключ або використайте NFC',
+    // Phone key
+    phoneKeyTitle: 'Вхід через телефон',
+    phoneKeyDesc: 'Браузер покаже QR-код для сканування',
+    // GDPR badge
+    gdprDesc: 'Захист персональних даних',
+    gdprCompliance: 'Відповідає Регламенту ЄС 2016/679',
+    // Footer legal links
+    footerTerms: 'Умови',
+    footerOffer: 'Оферта',
+    footerPrivacy: 'Конфіденційність',
+    footerDpa: 'DPA',
+    footerAiPolicy: 'Політика AI',
+    footerAiTransparency: 'Прозорість AI',
+    // Registration consent
+    consentRequired: 'Для реєстрації необхідно прийняти:',
+    consentTerms: 'Умови використання',
+    consentOffer: 'Публічну оферту',
+    consentAnd: ' та ',
+    consentPrivacy: 'Політику конфіденційності',
+    consentDpa: 'Угоду про обробку даних (DPA)',
+    // SSO form
+    ssoLoginButtonText: 'Увійти',
+    // Welcome modal
+    welcomeModalTitle: 'Ласкаво просимо',
+    welcomeModalDesc: 'Ознайомтесь з умовами платформи та реферальною програмою',
+    legalDocsTitle: 'Правові документи',
+    docOffer: 'Публічна оферта',
+    docOfferDesc: 'Договір між вами та платформою',
+    docTerms: 'Умови використання',
+    docTermsDesc: 'Правила користування сервісом',
+    docPrivacy: 'Політика конфіденційності',
+    docPrivacyDesc: 'Як ми захищаємо ваші дані',
+    docDpa: 'Угода про обробку даних (DPA)',
+    docDpaDesc: 'Відповідність GDPR',
+    docRefund: 'Політика повернення коштів',
+    docRefundDesc: 'Умови повернення оплати',
+    // Referral program
+    referralTitle: 'Реферальна програма',
+    referralHeadline: 'Запрошуйте колег — отримуйте бонуси',
+    referralDesc: 'Поділіться реферальним посиланням з колегами-юристами. За кожного нового користувача, який зареєструється та поповнить рахунок, ви отримаєте бонус на баланс платформи.',
+    referralItem1: 'Реферальне посилання доступне після реєстрації',
+    referralItem2: 'Бонус нараховується автоматично',
+    referralItem3: 'Для участі потрібна верифікація ФОП, ТОВ або адвоката',
+    referralCta: 'Зареєструватися',
   },
   en: {
     tagline: 'For Law Firms',
@@ -139,6 +209,75 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     strengthWeak: 'Weak',
     strengthMedium: 'Medium',
     strengthStrong: 'Strong',
+    // Promo banner
+    promoNew: 'NEW',
+    promoDesc: 'Learn about terms and referral program',
+    // Bottom nav
+    newsLink: 'News',
+    investorsLink: 'For Investors',
+    // Auth subtitle
+    authSubtitleLogin: 'Choose your authentication method',
+    authSubtitleRegister: 'Register to get started',
+    // Divider
+    orDivider: 'or',
+    // Auth method tabs
+    tabPassword: 'Password',
+    tabKey: 'Key',
+    tabPhone: 'Phone',
+    // Form labels
+    nameLabel: 'Name',
+    namePlaceholderExample: 'John Doe',
+    passwordLabel: 'Password',
+    // Password strength messages
+    strengthWeakDesc: 'Weak — add uppercase letters, numbers or special characters',
+    strengthMediumDesc: 'Medium password',
+    strengthStrongDesc: 'Strong password',
+    // Hardware key
+    hardwareKeyTitle: 'Connect your security key',
+    hardwareKeyDesc: 'Insert USB key or use NFC',
+    // Phone key
+    phoneKeyTitle: 'Phone login',
+    phoneKeyDesc: 'Browser will show QR code to scan',
+    // GDPR badge
+    gdprDesc: 'Personal data protection',
+    gdprCompliance: 'Compliant with EU Regulation 2016/679',
+    // Footer legal links
+    footerTerms: 'Terms',
+    footerOffer: 'Offer',
+    footerPrivacy: 'Privacy',
+    footerDpa: 'DPA',
+    footerAiPolicy: 'AI Policy',
+    footerAiTransparency: 'AI Transparency',
+    // Registration consent
+    consentRequired: 'To register, you must accept:',
+    consentTerms: 'Terms of Use',
+    consentOffer: 'Public Offer',
+    consentAnd: ' and ',
+    consentPrivacy: 'Privacy Policy',
+    consentDpa: 'Data Processing Agreement (DPA)',
+    // SSO form
+    ssoLoginButtonText: 'Sign In',
+    // Welcome modal
+    welcomeModalTitle: 'Welcome',
+    welcomeModalDesc: 'Review platform terms and referral program',
+    legalDocsTitle: 'Legal Documents',
+    docOffer: 'Public Offer',
+    docOfferDesc: 'Agreement between you and the platform',
+    docTerms: 'Terms of Use',
+    docTermsDesc: 'Service usage rules',
+    docPrivacy: 'Privacy Policy',
+    docPrivacyDesc: 'How we protect your data',
+    docDpa: 'Data Processing Agreement (DPA)',
+    docDpaDesc: 'GDPR compliance',
+    docRefund: 'Refund Policy',
+    docRefundDesc: 'Payment refund conditions',
+    referralTitle: 'Referral Program',
+    referralHeadline: 'Invite colleagues — earn bonuses',
+    referralDesc: 'Share your referral link with fellow lawyers. For every new user who registers and tops up their account, you will receive a bonus to your platform balance.',
+    referralItem1: 'Referral link available after registration',
+    referralItem2: 'Bonus is credited automatically',
+    referralItem3: 'Verification as a sole proprietor, LLC or attorney required',
+    referralCta: 'Register',
   },
   de: {
     tagline: 'Fur Anwaltskanzleien',
@@ -201,6 +340,75 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     strengthWeak: 'Schwach',
     strengthMedium: 'Mittel',
     strengthStrong: 'Stark',
+    // Promo banner
+    promoNew: 'NEU',
+    promoDesc: 'Erfahren Sie mehr über Bedingungen und Empfehlungsprogramm',
+    // Bottom nav
+    newsLink: 'Nachrichten',
+    investorsLink: 'Für Investoren',
+    // Auth subtitle
+    authSubtitleLogin: 'Wählen Sie Ihre Authentifizierungsmethode',
+    authSubtitleRegister: 'Registrieren Sie sich, um loszulegen',
+    // Divider
+    orDivider: 'oder',
+    // Auth method tabs
+    tabPassword: 'Passwort',
+    tabKey: 'Schlüssel',
+    tabPhone: 'Telefon',
+    // Form labels
+    nameLabel: 'Name',
+    namePlaceholderExample: 'Max Mustermann',
+    passwordLabel: 'Passwort',
+    // Password strength messages
+    strengthWeakDesc: 'Schwach — Großbuchstaben, Zahlen oder Sonderzeichen hinzufügen',
+    strengthMediumDesc: 'Mittleres Passwort',
+    strengthStrongDesc: 'Starkes Passwort',
+    // Hardware key
+    hardwareKeyTitle: 'Schließen Sie Ihren Sicherheitsschlüssel an',
+    hardwareKeyDesc: 'USB-Schlüssel einstecken oder NFC verwenden',
+    // Phone key
+    phoneKeyTitle: 'Anmeldung per Telefon',
+    phoneKeyDesc: 'Der Browser zeigt einen QR-Code zum Scannen an',
+    // GDPR badge
+    gdprDesc: 'Schutz personenbezogener Daten',
+    gdprCompliance: 'Konform mit EU-Verordnung 2016/679',
+    // Footer legal links
+    footerTerms: 'Bedingungen',
+    footerOffer: 'Angebot',
+    footerPrivacy: 'Datenschutz',
+    footerDpa: 'DPA',
+    footerAiPolicy: 'KI-Richtlinie',
+    footerAiTransparency: 'KI-Transparenz',
+    // Registration consent
+    consentRequired: 'Für die Registrierung müssen Sie akzeptieren:',
+    consentTerms: 'Nutzungsbedingungen',
+    consentOffer: 'Öffentliches Angebot',
+    consentAnd: ' und ',
+    consentPrivacy: 'Datenschutzerklärung',
+    consentDpa: 'Datenverarbeitungsvereinbarung (DPA)',
+    // SSO form
+    ssoLoginButtonText: 'Anmelden',
+    // Welcome modal
+    welcomeModalTitle: 'Willkommen',
+    welcomeModalDesc: 'Überprüfen Sie die Plattformbedingungen und das Empfehlungsprogramm',
+    legalDocsTitle: 'Rechtsdokumente',
+    docOffer: 'Öffentliches Angebot',
+    docOfferDesc: 'Vereinbarung zwischen Ihnen und der Plattform',
+    docTerms: 'Nutzungsbedingungen',
+    docTermsDesc: 'Regeln für die Nutzung des Dienstes',
+    docPrivacy: 'Datenschutzerklärung',
+    docPrivacyDesc: 'Wie wir Ihre Daten schützen',
+    docDpa: 'Datenverarbeitungsvereinbarung (DPA)',
+    docDpaDesc: 'GDPR-Konformität',
+    docRefund: 'Rückerstattungsrichtlinie',
+    docRefundDesc: 'Bedingungen für Rückerstattungen',
+    referralTitle: 'Empfehlungsprogramm',
+    referralHeadline: 'Laden Sie Kollegen ein — verdienen Sie Boni',
+    referralDesc: 'Teilen Sie Ihren Empfehlungslink mit Anwaltskollegen. Für jeden neuen Benutzer, der sich registriert und sein Konto auflädt, erhalten Sie einen Bonus auf Ihr Plattformguthaben.',
+    referralItem1: 'Empfehlungslink nach der Registrierung verfügbar',
+    referralItem2: 'Bonus wird automatisch gutgeschrieben',
+    referralItem3: 'Verifizierung als Einzelunternehmer, GmbH oder Anwalt erforderlich',
+    referralCta: 'Registrieren',
   },
   es: {
     tagline: 'Para Despachos de Abogados',
@@ -263,6 +471,75 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     strengthWeak: 'Débil',
     strengthMedium: 'Medio',
     strengthStrong: 'Fuerte',
+    // Promo banner
+    promoNew: 'NUEVO',
+    promoDesc: 'Conozca los términos y el programa de referidos',
+    // Bottom nav
+    newsLink: 'Noticias',
+    investorsLink: 'Para inversores',
+    // Auth subtitle
+    authSubtitleLogin: 'Elija su método de autenticación',
+    authSubtitleRegister: 'Regístrese para comenzar',
+    // Divider
+    orDivider: 'o',
+    // Auth method tabs
+    tabPassword: 'Contraseña',
+    tabKey: 'Llave',
+    tabPhone: 'Teléfono',
+    // Form labels
+    nameLabel: 'Nombre',
+    namePlaceholderExample: 'Juan García',
+    passwordLabel: 'Contraseña',
+    // Password strength messages
+    strengthWeakDesc: 'Débil — agregue mayúsculas, números o caracteres especiales',
+    strengthMediumDesc: 'Contraseña media',
+    strengthStrongDesc: 'Contraseña fuerte',
+    // Hardware key
+    hardwareKeyTitle: 'Conecte su llave de seguridad',
+    hardwareKeyDesc: 'Inserte la llave USB o use NFC',
+    // Phone key
+    phoneKeyTitle: 'Inicio de sesión por teléfono',
+    phoneKeyDesc: 'El navegador mostrará un código QR para escanear',
+    // GDPR badge
+    gdprDesc: 'Protección de datos personales',
+    gdprCompliance: 'Cumple con el Reglamento UE 2016/679',
+    // Footer legal links
+    footerTerms: 'Términos',
+    footerOffer: 'Oferta',
+    footerPrivacy: 'Privacidad',
+    footerDpa: 'DPA',
+    footerAiPolicy: 'Política de IA',
+    footerAiTransparency: 'Transparencia IA',
+    // Registration consent
+    consentRequired: 'Para registrarse, debe aceptar:',
+    consentTerms: 'Términos de uso',
+    consentOffer: 'Oferta pública',
+    consentAnd: ' y ',
+    consentPrivacy: 'Política de privacidad',
+    consentDpa: 'Acuerdo de procesamiento de datos (DPA)',
+    // SSO form
+    ssoLoginButtonText: 'Iniciar sesión',
+    // Welcome modal
+    welcomeModalTitle: 'Bienvenido',
+    welcomeModalDesc: 'Revise los términos de la plataforma y el programa de referidos',
+    legalDocsTitle: 'Documentos legales',
+    docOffer: 'Oferta pública',
+    docOfferDesc: 'Acuerdo entre usted y la plataforma',
+    docTerms: 'Términos de uso',
+    docTermsDesc: 'Reglas de uso del servicio',
+    docPrivacy: 'Política de privacidad',
+    docPrivacyDesc: 'Cómo protegemos sus datos',
+    docDpa: 'Acuerdo de procesamiento de datos (DPA)',
+    docDpaDesc: 'Cumplimiento del RGPD',
+    docRefund: 'Política de reembolso',
+    docRefundDesc: 'Condiciones de reembolso',
+    referralTitle: 'Programa de referidos',
+    referralHeadline: 'Invite colegas — obtenga bonos',
+    referralDesc: 'Comparta su enlace de referido con colegas abogados. Por cada nuevo usuario que se registre y recargue su cuenta, recibirá un bono en su saldo de la plataforma.',
+    referralItem1: 'Enlace de referido disponible después del registro',
+    referralItem2: 'El bono se acredita automáticamente',
+    referralItem3: 'Se requiere verificación como autónomo, empresa o abogado',
+    referralCta: 'Registrarse',
   },
 };
 

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -566,10 +566,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               className="group flex items-center gap-3 text-left w-full"
             >
               <div className="flex-shrink-0 px-2 py-[3px] rounded border border-emerald-800/30 bg-emerald-950/20">
-                <span className="text-[8px] font-bold text-emerald-700 tracking-[0.2em] uppercase">Новим</span>
+                <span className="text-[8px] font-bold text-emerald-700 tracking-[0.2em] uppercase">{t.promoNew}</span>
               </div>
               <span className="text-[11px] text-zinc-600 group-hover:text-zinc-400 transition-colors duration-200 leading-snug">
-                Дізнайтесь про умови та реферальну програму
+                {t.promoDesc}
               </span>
               <ChevronRight
                 size={11}
@@ -586,7 +586,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               className="inline-flex items-center gap-1.5 text-[10px] text-zinc-700 hover:text-zinc-400 transition-colors duration-200 tracking-wide"
             >
               <BookOpen size={10} />
-              <span>Blog</span>
+              <span>{t.readBlog}</span>
               {hasRecentArticles() && (
                 <span className="w-1 h-1 rounded-full bg-zinc-600 inline-block" />
               )}
@@ -596,7 +596,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               className="inline-flex items-center gap-1.5 text-[10px] text-zinc-700 hover:text-zinc-400 transition-colors duration-200 tracking-wide"
             >
               <Newspaper size={10} />
-              <span>Новини</span>
+              <span>{t.newsLink}</span>
               <span className="w-1 h-1 rounded-full bg-emerald-700/70 inline-block" />
             </a>
             <a
@@ -604,7 +604,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               className="inline-flex items-center gap-1.5 text-[10px] text-zinc-700 hover:text-zinc-400 transition-colors duration-200 tracking-wide"
             >
               <TrendingUp size={10} />
-              <span>Для інвесторів</span>
+              <span>{t.investorsLink}</span>
             </a>
           </div>
 
@@ -641,8 +641,8 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             </h2>
             <p className="text-[0.75rem] text-zinc-600 tracking-wide">
               {isLogin
-                ? 'Оберіть зручний спосіб автентифікації'
-                : 'Зареєструйтесь для початку роботи'}
+                ? t.authSubtitleLogin
+                : t.authSubtitleRegister}
             </p>
           </div>
 
@@ -681,28 +681,28 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               >
                 <div className="space-y-2.5 px-4 py-4 rounded-lg bg-zinc-900/50 border border-zinc-800/60">
                   <p className="text-[9px] font-semibold text-zinc-600 uppercase tracking-[0.2em] mb-3">
-                    Для реєстрації необхідно прийняти:
+                    {t.consentRequired}
                   </p>
                   {[
                     {
                       checked: acceptedTerms,
                       onChange: setAcceptedTerms,
                       links: [
-                        { href: '/ua/terms', label: 'Умови використання' },
-                        { href: '/ua/offer', label: 'Публічну оферту' },
+                        { href: '/ua/terms', label: t.consentTerms },
+                        { href: '/ua/offer', label: t.consentOffer },
                       ],
-                      separator: ' та ',
+                      separator: t.consentAnd,
                     },
                     {
                       checked: acceptedPrivacy,
                       onChange: setAcceptedPrivacy,
-                      links: [{ href: '/ua/privacy', label: 'Політику конфіденційності' }],
+                      links: [{ href: '/ua/privacy', label: t.consentPrivacy }],
                       separator: '',
                     },
                     {
                       checked: acceptedDpa,
                       onChange: setAcceptedDpa,
-                      links: [{ href: '/ua/dpa', label: 'Угоду про обробку даних (DPA)' }],
+                      links: [{ href: '/ua/dpa', label: t.consentDpa }],
                       separator: '',
                     },
                   ].map((item, i) => (
@@ -827,7 +827,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                     disabled={ssoLoading}
                     className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-zinc-700/80 hover:bg-zinc-700 text-zinc-100 rounded-md text-sm font-medium transition-colors duration-150 disabled:opacity-40"
                   >
-                    {ssoLoading ? <Loader2 size={13} className="animate-spin" /> : <><ArrowRight size={12} />Увійти</>}
+                    {ssoLoading ? <Loader2 size={13} className="animate-spin" /> : <><ArrowRight size={12} />{t.ssoLoginButtonText}</>}
                   </button>
                 </div>
               </motion.div>
@@ -840,16 +840,16 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               <div className="w-full border-t border-zinc-800/50" />
             </div>
             <div className="relative flex justify-center">
-              <span className="px-3 bg-[#080808] text-[9px] text-zinc-700 tracking-[0.18em] uppercase">або</span>
+              <span className="px-3 bg-[#080808] text-[9px] text-zinc-700 tracking-[0.18em] uppercase">{t.orDivider}</span>
             </div>
           </div>
 
           {/* Auth method tabs */}
           <div className="flex gap-px mb-5 rounded-lg overflow-hidden border border-zinc-800/50 bg-[#0a0a0a]">
             {([
-              { key: 'password', icon: Lock, label: 'Пароль' },
-              { key: 'hardware-key', icon: Key, label: 'Ключ' },
-              { key: 'phone-key', icon: Smartphone, label: 'Телефон' },
+              { key: 'password', icon: Lock, label: t.tabPassword },
+              { key: 'hardware-key', icon: Key, label: t.tabKey },
+              { key: 'phone-key', icon: Smartphone, label: t.tabPhone },
             ] as const).map(({ key, icon: Icon, label }) => (
               <button
                 key={key}
@@ -883,7 +883,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 {!isLogin && (
                   <div>
                     <label htmlFor="name" className="block text-[10px] font-medium text-zinc-600 mb-1.5 tracking-[0.08em] uppercase">
-                      Ім'я
+                      {t.nameLabel}
                     </label>
                     <div className="relative">
                       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
@@ -895,7 +895,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         type="text"
                         value={name}
                         onChange={(e) => setName(e.target.value)}
-                        placeholder="Іван Петренко"
+                        placeholder={t.namePlaceholderExample}
                         autoComplete="name"
                         className="block w-full pl-9 pr-4 py-2.5 bg-zinc-900/50 border border-zinc-800/70 rounded-lg text-sm text-zinc-100 placeholder-zinc-700 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
                       />
@@ -927,7 +927,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 <div>
                   <div className="flex items-center justify-between mb-1.5">
                     <label htmlFor="password" className="block text-[10px] font-medium text-zinc-600 tracking-[0.08em] uppercase">
-                      Пароль
+                      {t.passwordLabel}
                     </label>
                     {isLogin && (
                       <button
@@ -935,7 +935,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         onClick={() => { setShowForgotPassword(true); setError(null); }}
                         className="text-[11px] text-zinc-700 hover:text-zinc-400 transition-colors duration-150"
                       >
-                        Забули пароль?
+                        {t.forgotPassword}
                       </button>
                     )}
                   </div>
@@ -976,9 +976,9 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         })}
                       </div>
                       <p className="text-[10px] text-zinc-700 mt-1.5">
-                        {passwordStrength === 'weak' && 'Слабкий — додайте великі літери, цифри або спецсимволи'}
-                        {passwordStrength === 'medium' && 'Середній пароль'}
-                        {passwordStrength === 'strong' && 'Надійний пароль'}
+                        {passwordStrength === 'weak' && t.strengthWeakDesc}
+                        {passwordStrength === 'medium' && t.strengthMediumDesc}
+                        {passwordStrength === 'strong' && t.strengthStrongDesc}
                       </p>
                     </div>
                   )}
@@ -1013,15 +1013,15 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-zinc-900/50 border border-zinc-800/70 mb-5">
                   <Shield size={20} className="text-zinc-600" />
                 </div>
-                <h3 className="text-[0.825rem] font-medium text-zinc-300 mb-1.5">Підключіть ключ безпеки</h3>
-                <p className="text-[0.75rem] text-zinc-600 mb-6 leading-relaxed">Вставте USB-ключ або використайте NFC</p>
+                <h3 className="text-[0.825rem] font-medium text-zinc-300 mb-1.5">{t.hardwareKeyTitle}</h3>
+                <p className="text-[0.75rem] text-zinc-600 mb-6 leading-relaxed">{t.hardwareKeyDesc}</p>
                 <button
                   onClick={() => handleWebAuthnLogin('cross-platform')}
                   disabled={isLoading}
                   className="px-6 py-2.5 bg-zinc-900/80 border border-zinc-700/80 text-zinc-400 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-200 transition-colors duration-150 disabled:opacity-40"
                 >
                   {isLoading ? <Loader2 size={13} className="animate-spin inline mr-2" /> : null}
-                  Автентифікація
+                  {t.authenticating}
                 </button>
               </motion.div>
             )}
@@ -1038,15 +1038,15 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 <div className="inline-flex items-center justify-center w-12 h-12 rounded-xl bg-zinc-900/50 border border-zinc-800/70 mb-5">
                   <Smartphone size={20} className="text-zinc-600" />
                 </div>
-                <h3 className="text-[0.825rem] font-medium text-zinc-300 mb-1.5">Вхід через телефон</h3>
-                <p className="text-[0.75rem] text-zinc-600 mb-6 leading-relaxed">Браузер покаже QR-код для сканування</p>
+                <h3 className="text-[0.825rem] font-medium text-zinc-300 mb-1.5">{t.phoneKeyTitle}</h3>
+                <p className="text-[0.75rem] text-zinc-600 mb-6 leading-relaxed">{t.phoneKeyDesc}</p>
                 <button
                   onClick={() => handleWebAuthnLogin()}
                   disabled={isLoading}
                   className="px-6 py-2.5 bg-zinc-900/80 border border-zinc-700/80 text-zinc-400 rounded-lg text-sm font-medium hover:bg-zinc-800 hover:text-zinc-200 transition-colors duration-150 disabled:opacity-40"
                 >
                   {isLoading ? <Loader2 size={13} className="animate-spin inline mr-2" /> : null}
-                  Автентифікація
+                  {t.authenticating}
                 </button>
               </motion.div>
             )}
@@ -1075,10 +1075,10 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               <div className="flex items-center gap-2 mb-0.5">
                 <span className="text-[8px] font-bold text-[#4d6ef5] tracking-[0.2em] uppercase">GDPR</span>
                 <span className="w-px h-2 bg-zinc-800 inline-block" />
-                <span className="text-[10px] text-zinc-500">Захист персональних даних</span>
+                <span className="text-[10px] text-zinc-500">{t.gdprDesc}</span>
               </div>
               <p className="text-[9px] text-zinc-700 tracking-wide">
-                Відповідає Регламенту ЄС 2016/679
+                {t.gdprCompliance}
               </p>
             </div>
             <ChevronRight
@@ -1090,12 +1090,12 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           {/* Footer legal links */}
           <div className="mt-5 flex flex-wrap justify-center gap-x-3 gap-y-1">
             {[
-              { href: '/ua/terms', label: 'Умови' },
-              { href: '/ua/offer', label: 'Оферта' },
-              { href: '/ua/privacy', label: 'Конфіденційність' },
-              { href: '/ua/dpa', label: 'DPA' },
-              { href: '/ua/ai-usage', label: 'Політика AI' },
-              { href: '/ua/ai-transparency', label: 'Прозорість AI' },
+              { href: '/ua/terms', label: t.footerTerms },
+              { href: '/ua/offer', label: t.footerOffer },
+              { href: '/ua/privacy', label: t.footerPrivacy },
+              { href: '/ua/dpa', label: t.footerDpa },
+              { href: '/ua/ai-usage', label: t.footerAiPolicy },
+              { href: '/ua/ai-transparency', label: t.footerAiTransparency },
             ].map(({ href, label }) => (
               <a
                 key={href}
@@ -1153,22 +1153,22 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               <div className="p-8">
                 {/* Header */}
                 <div className="mb-6">
-                  <h3 className="text-xl font-semibold text-white mb-1.5 tracking-tight">Ласкаво просимо</h3>
-                  <p className="text-sm text-zinc-500">Ознайомтесь з умовами платформи та реферальною програмою</p>
+                  <h3 className="text-xl font-semibold text-white mb-1.5 tracking-tight">{t.welcomeModalTitle}</h3>
+                  <p className="text-sm text-zinc-500">{t.welcomeModalDesc}</p>
                 </div>
 
                 {/* Documents section */}
                 <div className="mb-6">
                   <p className="text-[10px] font-semibold text-zinc-600 uppercase tracking-[0.18em] mb-3">
-                    Правові документи
+                    {t.legalDocsTitle}
                   </p>
                   <div className="space-y-1.5">
                     {[
-                      { href: '/ua/offer', label: 'Публічна оферта', desc: 'Договір між вами та платформою' },
-                      { href: '/ua/terms', label: 'Умови використання', desc: 'Правила користування сервісом' },
-                      { href: '/ua/privacy', label: 'Політика конфіденційності', desc: 'Як ми захищаємо ваші дані' },
-                      { href: '/ua/dpa', label: 'Угода про обробку даних (DPA)', desc: 'Відповідність GDPR' },
-                      { href: '/ua/refund', label: 'Політика повернення коштів', desc: 'Умови повернення оплати' },
+                      { href: '/ua/offer', label: t.docOffer, desc: t.docOfferDesc },
+                      { href: '/ua/terms', label: t.docTerms, desc: t.docTermsDesc },
+                      { href: '/ua/privacy', label: t.docPrivacy, desc: t.docPrivacyDesc },
+                      { href: '/ua/dpa', label: t.docDpa, desc: t.docDpaDesc },
+                      { href: '/ua/refund', label: t.docRefund, desc: t.docRefundDesc },
                     ].map((doc) => (
                       <a
                         key={doc.href}
@@ -1193,7 +1193,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 {/* Referral program */}
                 <div className="mb-6">
                   <p className="text-[10px] font-semibold text-zinc-600 uppercase tracking-[0.18em] mb-3">
-                    Реферальна програма
+                    {t.referralTitle}
                   </p>
                   <div className="px-4 py-4 rounded-lg bg-zinc-900/50 border border-zinc-800/50">
                     <div className="flex items-start gap-3 mb-3">
@@ -1201,17 +1201,17 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                         <Gift size={13} className="text-emerald-700" />
                       </div>
                       <div>
-                        <p className="text-sm text-zinc-300 font-medium mb-0.5">Запрошуйте колег — отримуйте бонуси</p>
+                        <p className="text-sm text-zinc-300 font-medium mb-0.5">{t.referralHeadline}</p>
                         <p className="text-[11px] text-zinc-600 leading-relaxed">
-                          Поділіться реферальним посиланням з колегами-юристами. За кожного нового користувача, який зареєструється та поповнить рахунок, ви отримаєте бонус на баланс платформи.
+                          {t.referralDesc}
                         </p>
                       </div>
                     </div>
                     <div className="space-y-1.5 ml-11">
                       {[
-                        'Реферальне посилання доступне після реєстрації',
-                        'Бонус нараховується автоматично',
-                        'Для участі потрібна верифікація ФОП, ТОВ або адвоката',
+                        t.referralItem1,
+                        t.referralItem2,
+                        t.referralItem3,
                       ].map((item, i) => (
                         <div key={i} className="flex items-center gap-2">
                           <div className="w-1 h-1 rounded-full bg-zinc-700 flex-shrink-0" />
@@ -1231,7 +1231,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                   className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white text-zinc-900 rounded-lg text-sm font-medium hover:bg-zinc-100 transition-colors"
                 >
                   <UserPlus size={14} />
-                  Зареєструватися
+                  {t.referralCta}
                 </button>
               </div>
             </motion.div>

--- a/lexwebapp/src/stores/localeStore.ts
+++ b/lexwebapp/src/stores/localeStore.ts
@@ -92,12 +92,22 @@ export const useLocaleStore = create<LocaleState>()(
 
         applyGeoDefaults: (cfCountry: string) =>
           set((state) => {
-            // Only apply defaults on first detection
-            if (state.geoDetected) return state;
             const defaults = getDefaultsForCountry(cfCountry);
-            // Sync with login page locale (lex_locale) if not already set
+            const code = cfCountry.toUpperCase();
+
+            // Countries that force their locale on every visit (IP-based override)
+            const FORCE_LOCALE_COUNTRIES = new Set([
+              'ES', 'MX', 'AR', 'CO', 'CL', 'PE', 'EC', 'VE', 'UY', 'PY',
+              'BO', 'CR', 'PA', 'DO', 'GT', 'HN', 'SV', 'NI', 'CU',
+            ]);
+            const forceLocale = FORCE_LOCALE_COUNTRIES.has(code);
+
+            // Skip if already detected and not a force-locale country
+            if (state.geoDetected && !forceLocale) return state;
+
+            // Always sync lex_locale for force-locale countries, or on first detection
             try {
-              if (!localStorage.getItem('lex_locale')) {
+              if (forceLocale || !localStorage.getItem('lex_locale')) {
                 localStorage.setItem('lex_locale', defaults.language);
               }
             } catch { /* ignore */ }


### PR DESCRIPTION
## Summary
- Full i18n for sidebar navigation, profile menu, folder delete modal (80+ keys, uk/en/de/es)
- Full i18n for login page — promo banner, auth tabs, GDPR badge, footer links, consent, welcome modal, referral program (50+ keys)
- Force Spanish locale for ES/LatAm IPs via `FORCE_LOCALE_COUNTRIES` in localeStore — overrides saved preferences when IP is from Spain or Latin America

## Test plan
- [ ] Open `legal.org.ua?lang=es` — verify all login page text is in Spanish
- [ ] Login and verify sidebar menu, profile menu, folder delete modal are in Spanish
- [ ] Test geo-detection: access via Spanish IP → locale auto-set to `es`
- [ ] Verify Ukrainian (default) and English locales still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add full Spanish localization for the sidebar and login experience. Also auto-sets Spanish for users from Spain and Latin America by IP to improve onboarding.

- **New Features**
  - Sidebar fully localized: sections, items, footer, profile menu, and delete-folder modal (80+ keys in `app-i18n.ts`) across uk/en/de/es.
  - Login page fully localized: promo banner, auth tabs, GDPR badge, footer links, consent, welcome modal, and referral program (50+ keys in `locales.ts`).
  - Geo-forced locale in `localeStore`: Spanish is enforced for ES/LatAm IPs (`FORCE_LOCALE_COUNTRIES`), overriding saved preferences; other locales unaffected.

- **Refactors**
  - Replaced hardcoded strings with `appT`/`t.*` across sidebar and Login.
  - Converted sidebar `nav-config` to i18n-aware getters (`getResearchSections`, `getLegislationSections`, etc.) with legacy static exports kept for compatibility.

<sup>Written for commit fa8173c730149681b9ed7b0699be5edcf2ff8c66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

