### PR TITLE
fix(i18n): respect ?lang= over geo detection

### DIFF
--- a/lexwebapp/src/stores/localeStore.ts
+++ b/lexwebapp/src/stores/localeStore.ts
@@ -105,17 +105,28 @@ export const useLocaleStore = create<LocaleState>()(
             // Skip if already detected and not a force-locale country
             if (state.geoDetected && !forceLocale) return state;
 
-            // Always sync lex_locale for force-locale countries, or on first detection
-            try {
-              if (forceLocale || !localStorage.getItem('lex_locale')) {
-                localStorage.setItem('lex_locale', defaults.language);
-              }
-            } catch { /* ignore */ }
-            return {
-              ...defaults,
-              geoDetected: true,
-              cfCountry,
-            };
+            // Check if user already has an explicit locale (set via ?lang= or language switcher)
+            const existingLocale = localStorage.getItem('lex_locale');
+
+            if (forceLocale) {
+              // Force-locale countries always override
+              try { localStorage.setItem('lex_locale', defaults.language); } catch { /* ignore */ }
+              return { ...defaults, geoDetected: true, cfCountry };
+            }
+
+            if (existingLocale && ['uk', 'en', 'de', 'es'].includes(existingLocale)) {
+              // User has an explicit preference — respect it, only update currency/country
+              return {
+                ...defaults,
+                language: existingLocale as AppLanguage,
+                geoDetected: true,
+                cfCountry,
+              };
+            }
+
+            // First visit, no preference — apply geo defaults
+            try { localStorage.setItem('lex_locale', defaults.language); } catch { /* ignore */ }
+            return { ...defaults, geoDetected: true, cfCountry };
           }),
       }),
       {


### PR DESCRIPTION
## Summary
- Fix: geo detection was overwriting `localeStore.language` with geo defaults even when user explicitly set locale via `?lang=es` or language switcher
- Now `applyGeoDefaults` preserves the user's `lex_locale` choice, only updating currency/country from geo

## Root cause
`applyGeoDefaults` returned `...defaults` which set `language: 'uk'` in zustand store, even though `lex_locale` in localStorage was correctly set to 'es'. Components reading from zustand showed Ukrainian instead of Spanish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes i18n bug where geo detection overwrote a user’s chosen language. We now respect `?lang=` and language switcher by keeping `lex_locale` and only updating currency/country.

- **Bug Fixes**
  - `applyGeoDefaults` keeps `language` from existing `lex_locale` and updates only currency and `cfCountry`.
  - Force-locale countries still override and sync `lex_locale`.
  - First-time visitors without `lex_locale` get geo defaults, which are then saved.

<sup>Written for commit 2a142a2947fc06ba48b6a83e7cf8667a8bd73967. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

