### PR TITLE
fix(i18n): CF IP priority over browser for ES/LatAm geo

### DIFF
--- a/lexwebapp/src/services/api/GeoService.ts
+++ b/lexwebapp/src/services/api/GeoService.ts
@@ -75,13 +75,21 @@ class GeoServiceClass {
       // CF detection failed, browser-only
     }
 
-    // Merge: browser language/timezone take priority (resistant to VPN)
-    // CF country used only if browser doesn't have a strong signal
+    // Merge: CF takes priority for locale-critical countries (real IP > browser settings),
+    // browser takes priority otherwise (resistant to VPN misdetection)
+    const CF_PRIORITY_COUNTRIES = new Set([
+      'ES', 'MX', 'AR', 'CO', 'CL', 'PE', 'EC', 'VE', 'UY', 'PY',
+      'BO', 'CR', 'PA', 'DO', 'GT', 'HN', 'SV', 'NI', 'CU',
+    ]);
+
     let result: GeoInfo;
 
     if (cfGeo && cfGeo.country === browserGeo.country) {
       // Both agree — high confidence
       result = { ...browserGeo, source: 'merged' };
+    } else if (cfGeo && CF_PRIORITY_COUNTRIES.has(cfGeo.country)) {
+      // CF detected a locale-critical country — trust IP over browser settings
+      result = { ...cfGeo, source: 'cloudflare' };
     } else if (browserGeo.country !== 'OTHER') {
       // Browser has a specific country signal (from timezone/language) — trust it
       result = { ...browserGeo, source: 'browser' };


### PR DESCRIPTION
## Summary
- Fix: Spanish tester (IP 212.30.33.234) sees Ukrainian version because GeoService trusted browser timezone/language over Cloudflare CF-IPCountry
- Now Cloudflare detection takes priority for ES + Latin America countries — real IP location matters more than browser configuration

## Root cause
GeoService merge logic: `if (browserGeo.country !== 'OTHER')` — browser with Ukrainian timezone overrode CF's correct `ES` detection. Added `CF_PRIORITY_COUNTRIES` set so CF wins for locale-critical countries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritize Cloudflare `CF-IPCountry` over browser timezone/language for Spain and Latin America to fix wrong locale selection. Users in these countries now see content based on their real IP.

- **Bug Fixes**
  - Updated GeoService merge logic: CF wins for ES + LatAm; browser remains default elsewhere.
  - Added `CF_PRIORITY_COUNTRIES` set to enforce IP-first behavior for locale-critical countries.
  - Prevents non-local browser settings from overriding correct IP-based detection.

<sup>Written for commit 990a80baf279a68b0b0e743f1ea10f6bf7bfc8af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

