### PR TITLE
fix: update Diia auth offer name to "Авторизація в застосунку Lex"

### DIFF
--- a/mcp_backend/src/services/diia-service.ts
+++ b/mcp_backend/src/services/diia-service.ts
@@ -118,7 +118,7 @@ export class DiiaService {
   /** Common branch details shared between create and update */
   private getAuthBranchBody() {
     return {
-      name: 'Авторизація в застосунку Lex / legal.org.ua',
+      name: 'Авторизація в застосунку Lex',
       email: 'hello@legal.org.ua',
       region: 'м. Київ',
       district: 'Деснянський р-н',
@@ -223,7 +223,7 @@ export class DiiaService {
     const token = await this.getSessionToken();
 
     const offerBody = {
-      name: 'Авторизація в застосунку Lex / legal.org.ua',
+      name: 'Авторизація в застосунку Lex',
       returnLink,
       scopes: { diiaId: ['auth'] },
     };
@@ -324,7 +324,7 @@ export class DiiaService {
         offerId = offers[0].id || offers[0]._id || '';
         // Update offer name in background
         this.updateOffer(branchId, offerId, {
-          name: 'Авторизація в застосунку Lex / legal.org.ua',
+          name: 'Авторизація в застосунку Lex',
           scopes: { diiaId: ['auth'] },
         }).catch(() => {});
       } else {


### PR DESCRIPTION
## Summary
- Updated Diia auth branch and offer name from `Авторизація в застосунку Lex / legal.org.ua` to `Авторизація в застосунку Lex`
- Affects 3 places: branch creation, offer creation, and offer update

## Test plan
- [ ] Login via Diia — verify the auth screen shows "Авторизація в застосунку Lex"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Diia auth branch and offer name to "Авторизація в застосунку Lex" to fix the stale label in the Diia app and keep the login flow consistent. Previously it showed as "Авторизація LexAI".

- **Bug Fixes**
  - Apply the new name in branch creation, offer creation, and offer update.
  - Diia login now shows "Авторизація в застосунку Lex" (not "Авторизація LexAI").

<sup>Written for commit 46957a3ccbdec7c5c30be1d7f370b4f7b7fd7527. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

