### PR TITLE
fix(i18n): always run geo detection for force-locale countries

### DIFF
--- a/lexwebapp/src/hooks/useGeoDetection.ts
+++ b/lexwebapp/src/hooks/useGeoDetection.ts
@@ -11,16 +11,11 @@ import { geoService } from '../services/api/GeoService';
 export function useGeoDetection() {
   const isAllowed = useConsentStore((s) => s.isAllowed);
   const hasConsented = useConsentStore((s) => s.hasConsented);
-  const geoDetected = useLocaleStore((s) => s.geoDetected);
   const applyGeoDefaults = useLocaleStore((s) => s.applyGeoDefaults);
 
   useEffect(() => {
-    // Only detect if:
-    // 1. User hasn't been geo-detected yet
-    // 2. User has consented AND functional cookies are allowed
-    //    OR user hasn't consented yet (we detect to show proper defaults, but don't persist until consent)
-    if (geoDetected) return;
-
+    // Always run geo detection (applyGeoDefaults handles force-locale countries like ES/LatAm).
+    // For non-force countries, applyGeoDefaults skips if already detected.
     const shouldDetect = !hasConsented || isAllowed('functional');
     if (!shouldDetect) return;
 
@@ -29,5 +24,5 @@ export function useGeoDetection() {
     }).catch(() => {
       // Silently fail - defaults are UA/uk/UAH
     });
-  }, [hasConsented, geoDetected, isAllowed, applyGeoDefaults]);
+  }, [hasConsented, isAllowed, applyGeoDefaults]);
 }


### PR DESCRIPTION
## Summary
- Root cause: `useGeoDetection` had `if (geoDetected) return` guard — Spanish tester who visited before had `geoDetected: true` with `language: 'uk'` stuck in localStorage
- Fix: always run geo detection; `applyGeoDefaults` handles the skip logic internally (skips for non-force countries if already detected, always applies for ES/LatAm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always run geo detection so force-locale countries (ES/LatAm) are applied on every visit and stale locales get corrected.
Removed the early return in useGeoDetection and rely on applyGeoDefaults to skip re-applying for non-force countries when already detected.

<sup>Written for commit 5480ba2378f5c3787adc5fdfaeece9e74bf66b2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

