### PR TITLE
fix(i18n): locale always follows IP country

### DIFF
--- a/lexwebapp/src/stores/localeStore.ts
+++ b/lexwebapp/src/stores/localeStore.ts
@@ -91,40 +91,9 @@ export const useLocaleStore = create<LocaleState>()(
         setCountry: (country) => set({ country }),
 
         applyGeoDefaults: (cfCountry: string) =>
-          set((state) => {
+          set(() => {
             const defaults = getDefaultsForCountry(cfCountry);
-            const code = cfCountry.toUpperCase();
-
-            // Countries that force their locale on every visit (IP-based override)
-            const FORCE_LOCALE_COUNTRIES = new Set([
-              'ES', 'MX', 'AR', 'CO', 'CL', 'PE', 'EC', 'VE', 'UY', 'PY',
-              'BO', 'CR', 'PA', 'DO', 'GT', 'HN', 'SV', 'NI', 'CU',
-            ]);
-            const forceLocale = FORCE_LOCALE_COUNTRIES.has(code);
-
-            // Skip if already detected and not a force-locale country
-            if (state.geoDetected && !forceLocale) return state;
-
-            // Check if user already has an explicit locale (set via ?lang= or language switcher)
-            const existingLocale = localStorage.getItem('lex_locale');
-
-            if (forceLocale) {
-              // Force-locale countries always override
-              try { localStorage.setItem('lex_locale', defaults.language); } catch { /* ignore */ }
-              return { ...defaults, geoDetected: true, cfCountry };
-            }
-
-            if (existingLocale && ['uk', 'en', 'de', 'es'].includes(existingLocale)) {
-              // User has an explicit preference — respect it, only update currency/country
-              return {
-                ...defaults,
-                language: existingLocale as AppLanguage,
-                geoDetected: true,
-                cfCountry,
-              };
-            }
-
-            // First visit, no preference — apply geo defaults
+            // Always set locale based on IP — Spain sees Spanish, Ukraine sees Ukrainian
             try { localStorage.setItem('lex_locale', defaults.language); } catch { /* ignore */ }
             return { ...defaults, geoDetected: true, cfCountry };
           }),


### PR DESCRIPTION
## Summary
Simplified `applyGeoDefaults` — always set locale based on detected IP. No more guards or force-locale lists.

- Spain IP → Spanish
- Ukraine IP → Ukrainian  
- Switch VPN off → locale follows new IP automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always set the app locale from the detected IP country on each visit. Removes guards and force lists so language follows VPN/country changes (e.g., Spain → Spanish, Ukraine → Ukrainian).

- **Bug Fixes**
  - Fixed locale sticking after travel/VPN changes by removing `geoDetected` and force-locale checks.
  - IP-based defaults now always override any existing language and update `lex_locale`.

<sup>Written for commit 73eb54d458a45404b34f188709485a37373bafc8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

