### PR TITLE
fix(infra): reduce prod CPU limits to fit 8 vCPUs

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -45,7 +45,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "4"
+          cpus: "2"
           memory: 20G
         reservations:
           memory: 8G
@@ -651,7 +651,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '3'
+          cpus: '2'
           memory: 8G
         reservations:
           cpus: '1'
@@ -739,7 +739,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
+          cpus: '0.5'
           memory: 3G
         reservations:
           cpus: '0.25'
@@ -999,7 +999,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '3'
+          cpus: '2'
           memory: 8G
         reservations:
           cpus: '1'
@@ -1186,7 +1186,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
+          cpus: '0.5'
           memory: 3G
         reservations:
           cpus: '0.25'


### PR DESCRIPTION
## Summary
- postgres: 4 → 2 CPUs
- backend (blue/green): 3 → 2 CPUs
- document-service (blue/green): 1 → 0.5 CPUs
- Total active limits: ~10.1 → ~6.6 (fits 8 vCPU instance)

## Test plan
- [ ] Deploy to prod and verify container health
- [ ] Monitor CPU usage under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce production CPU limits to fit the 8 vCPU instance. Postgres 4->2, backend (blue/green) 3->2, and document-service (blue/green) 1->0.5, lowering total active limits from ~10.1 to ~6.6 vCPUs.

<sup>Written for commit 63081c2022377f9f42ebe3da3406e8bd900d7966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

