### PR TITLE
fix(i18n): language switcher respects user's manual choice

### DIFF
--- a/lexwebapp/src/i18n/locales.ts
+++ b/lexwebapp/src/i18n/locales.ts
@@ -575,6 +575,7 @@ export function getLocale(): Locale {
 
 export function setLocale(locale: Locale) {
   localStorage.setItem('lex_locale', locale);
+  localStorage.setItem('lex_locale_user_chosen', 'true');
   const url = new URL(window.location.href);
   url.searchParams.set('lang', locale);
   window.history.replaceState({}, '', url.toString());

--- a/lexwebapp/src/stores/localeStore.ts
+++ b/lexwebapp/src/stores/localeStore.ts
@@ -93,7 +93,15 @@ export const useLocaleStore = create<LocaleState>()(
         applyGeoDefaults: (cfCountry: string) =>
           set(() => {
             const defaults = getDefaultsForCountry(cfCountry);
-            // Always set locale based on IP — Spain sees Spanish, Ukraine sees Ukrainian
+            // If user manually chose a locale via language switcher, respect it
+            const userChosen = localStorage.getItem('lex_locale_user_chosen') === 'true';
+            if (userChosen) {
+              const chosen = localStorage.getItem('lex_locale') as AppLanguage | null;
+              if (chosen && ['uk', 'en', 'de', 'es'].includes(chosen)) {
+                return { ...defaults, language: chosen, geoDetected: true, cfCountry };
+              }
+            }
+            // Auto-set locale based on IP
             try { localStorage.setItem('lex_locale', defaults.language); } catch { /* ignore */ }
             return { ...defaults, geoDetected: true, cfCountry };
           }),


### PR DESCRIPTION
## Summary
- Language switcher now sets `lex_locale_user_chosen` flag in localStorage
- `applyGeoDefaults` respects this flag — won't override manual choice with IP detection
- New visitors: auto-detect by IP (Spain→Spanish, Ukraine→Ukrainian)
- Manual switchers: keep their choice across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Language switcher now persists a `lex_locale_user_chosen` flag so a user’s manual locale won’t be overridden by IP-based detection; new visitors still auto-detect by country. Manual switches keep their language across reloads.

<sup>Written for commit fdcde48f875a369de91355cc77ecdf9a012b6435. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

