### PR TITLE
fix(chat): isolate conversation state — prevent cross-chat leakage

### DIFF
--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -199,7 +199,7 @@ export const useChatStore = create<ChatState>()(
         switchConversation: async (conversationId: string) => {
           console.log('[ChatStore] switchConversation called', { conversationId, isAuth: isAuthenticated() });
           if (!isAuthenticated()) { console.warn('[ChatStore] Not authenticated, aborting switch'); return; }
-          const { conversationId: currentId, messages, isStreaming } = get();
+          const { conversationId: currentId, messages, streamController } = get();
 
           // Save current conversation messages to cache before switching
           if (currentId && messages.length > 0) {
@@ -208,16 +208,24 @@ export const useChatStore = create<ChatState>()(
             }));
           }
 
+          // Cancel any active stream from the previous conversation
+          if (streamController) {
+            streamController.abort();
+          }
+
           // Restore cached messages for the target conversation immediately
           const cached = get().conversationCache[conversationId] || [];
-          const targetHasActiveStream = isStreaming && cached.some((m) => m.isStreaming);
 
-          // Set conversationId and show cached messages (or empty while loading)
-          set({ conversationId, messages: cached.length > 0 ? cached : [] });
-
-          // Skip server fetch if the target conversation is currently being streamed
-          // (stream will continue updating the restored cached messages)
-          if (targetHasActiveStream) return;
+          // Reset all per-conversation state to prevent leakage
+          set({
+            conversationId,
+            messages: cached.length > 0 ? cached : [],
+            isStreaming: false,
+            streamController: null,
+            currentTool: null,
+            pendingPlanReview: null,
+            isPlanLoading: false,
+          });
 
           try {
             const response = await api.conversations.get(conversationId);
@@ -293,9 +301,19 @@ export const useChatStore = create<ChatState>()(
 
         // Start a new empty conversation
         newConversation: () => {
+          const { streamController } = get();
+          // Cancel any active stream from the previous conversation
+          if (streamController) {
+            streamController.abort();
+          }
           set({
             messages: [],
             conversationId: null,
+            isStreaming: false,
+            streamController: null,
+            currentTool: null,
+            pendingPlanReview: null,
+            isPlanLoading: false,
           });
         },
 


### PR DESCRIPTION
## Summary
Fix bug where switching between conversations causes state leakage:
- Plan review from Chat A appears in Chat B
- "Running" state persists after switching
- Results/tables from old chat visible in new chat

## Root cause
`switchConversation` and `newConversation` didn't reset per-conversation state:
`isStreaming`, `currentTool`, `pendingPlanReview`, `isPlanLoading`, `streamController`

## Fix
Both functions now:
1. Abort active SSE stream (`streamController.abort()`)
2. Reset all per-conversation state to clean defaults
3. Prevent background streams from updating wrong conversation

## Test plan
- [ ] Start query in Chat A → switch to Chat B → verify no plan/running state leaks
- [ ] Start query → click "New Chat" → verify clean empty state
- [ ] Switch back to Chat A → verify cached messages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross-chat state leakage by isolating per-conversation state in the chat store. Switching chats or starting a new chat now clears running states and stops plan/results from appearing in the wrong conversation.

- **Bug Fixes**
  - Abort active SSE streams on conversation switch or new chat.
  - Reset per-conversation fields to defaults: isStreaming, streamController, currentTool, pendingPlanReview, isPlanLoading.
  - Restore cached messages for the selected chat and ignore late updates from other conversations.

<sup>Written for commit 1e761911992a50564084c7c9f8d4f983bfa7ae1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

