### PR TITLE
fix(ui): Diia button spacing per brandbook

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -818,7 +818,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
           {/* Diia Auth */}
           <button
             onClick={handleDiiaAuth}
-            className="w-full flex items-center justify-center gap-3 px-4 py-[11px] rounded-lg bg-[#0a0a0a] border border-zinc-800/80 text-zinc-300 text-[0.825rem] font-medium hover:bg-zinc-900 hover:border-zinc-700 active:opacity-80 transition-colors duration-150 mb-2"
+            className="w-full flex items-center justify-center gap-1.5 px-4 py-[11px] rounded-lg bg-[#0a0a0a] border border-zinc-800/80 text-zinc-300 text-[0.825rem] font-medium hover:bg-zinc-900 hover:border-zinc-700 active:opacity-80 transition-colors duration-150 mb-2"
           >
             <img src="/diia-logo-stroke.png" alt="Дія" width="24" height="24" className="flex-shrink-0" />
             {t.diiaAuth}


### PR DESCRIPTION
Gap logo↔text: 6px (1/4 of 24px logo). Per Мінцифри 2025 guidelines p.7.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adjusted the Diia auth button spacing on the Login page to match Мінцифри 2025 guidelines: reduced logo-text gap from 12px to 6px (1/4 of the 24px logo).

<sup>Written for commit 7f09697e73bea2b3d004b2151a3a6c13a31f4427. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

