### PR TITLE
fix(ui): Diia modal logos — no wrapping shape per brandbook

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -1318,9 +1318,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 <X size={13} />
               </button>
 
-              <div className="w-11 h-11 rounded-xl flex items-center justify-center mx-auto mb-5">
-                <img src="/diia-logo-stroke.png" alt="Дія" width="44" height="44" />
-              </div>
+              <img src="/diia-logo-stroke.png" alt="Дія" width="44" height="44" className="mx-auto mb-5" />
 
               <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5 tracking-tight">Завершення входу</h2>
               <p className="text-[0.75rem] text-zinc-500 mb-6 leading-relaxed">
@@ -1363,9 +1361,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
                 <X size={13} />
               </button>
 
-              <div className="w-11 h-11 rounded-xl flex items-center justify-center mx-auto mb-5">
-                <img src="/diia-logo-stroke.png" alt="Дія" width="44" height="44" />
-              </div>
+              <img src="/diia-logo-stroke.png" alt="Дія" width="44" height="44" className="mx-auto mb-5" />
 
               <h2 className="text-[0.9rem] font-semibold text-zinc-100 mb-1.5 tracking-tight">Вхід через Дію</h2>
               <p className="text-[0.75rem] text-zinc-500 mb-6 leading-relaxed">


### PR DESCRIPTION
Rule #2: logo must not be inside another form. Removed div wrapper.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the rounded container around the Diia logo in the QR and polling login modals to comply with brandbook rule #2 (logo must not be inside another shape). The logo is now a standalone `img`, centered with `mx-auto mb-5`.

<sup>Written for commit 524079ace79d0800987f234ba904058e04654c82. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

