### PR TITLE
fix(chat): send full conversation history instead of last 6 messages

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -62,14 +62,13 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
       costSummaryRef.current = {};
       responseIdRef.current = null;
 
-      // Build history from prior messages
+      // Build full conversation history — backend handles compression via ChatContextBuilder
       const currentMessages = useChatStore.getState().messages;
       const history = currentMessages
         .filter((m) => m.id !== assistantMessageId && (m.role === 'user' || m.role === 'assistant'))
-        .slice(-6)
         .map((m) => ({
           role: m.role as 'user' | 'assistant',
-          content: m.content.slice(0, 1000),
+          content: m.content,
         }));
 
       const chatConversationId = useChatStore.getState().conversationId || undefined;


### PR DESCRIPTION
## Summary
- Removed `.slice(-6)` limit — frontend now sends the full conversation history to the backend
- Removed client-side `.slice(0, 1000)` truncation — backend's `ChatContextBuilder` already handles truncation (2000 chars) and LLM-based compression of older messages

Previously each new question in a chat lost context from earlier messages because only the last 6 were sent. The backend already has smart history management (last 4 verbatim + older summarized via LLM with caching), so the frontend limit was unnecessary.

## Test plan
- [ ] Open a chat conversation, ask 4+ sequential questions that reference earlier context
- [ ] Verify the assistant correctly references information from all prior messages
- [ ] Check that long conversations don't cause request payload issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The chat client now sends the full conversation history, not just the last 6 messages, so long conversations keep their context. Removed client-side 1k truncation; the backend `ChatContextBuilder` handles compression and size limits.

<sup>Written for commit 429359d94ca4eb00ab16b022dc7262743030b5ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

