### PR TITLE
feat(platform): refactor PlaygroundPage into 3-panel API testing tool

### DIFF
--- a/platform/src/components/playground/JsonHighlighter.tsx
+++ b/platform/src/components/playground/JsonHighlighter.tsx
@@ -1,0 +1,99 @@
+import { useState, useCallback } from 'react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+
+interface Props {
+  data: unknown;
+  defaultCollapsed?: boolean;
+}
+
+export function JsonHighlighter({ data, defaultCollapsed = false }: Props) {
+  return (
+    <pre className="text-xs font-mono leading-relaxed">
+      <JsonNode value={data} indent={0} defaultCollapsed={defaultCollapsed} />
+    </pre>
+  );
+}
+
+function JsonNode({ value, indent, path = '', defaultCollapsed }: {
+  value: unknown; indent: number; path?: string; defaultCollapsed?: boolean;
+}) {
+  if (value === null) return <span className="text-purple-600">null</span>;
+  if (typeof value === 'boolean') return <span className="text-purple-600">{String(value)}</span>;
+  if (typeof value === 'number') return <span className="text-amber-600">{value}</span>;
+  if (typeof value === 'string') return <span className="text-emerald-600">"{value}"</span>;
+
+  if (Array.isArray(value)) {
+    return <CollapsibleNode items={value} type="array" indent={indent} path={path} defaultCollapsed={defaultCollapsed} />;
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    return <CollapsibleNode items={entries} type="object" indent={indent} path={path} defaultCollapsed={defaultCollapsed} />;
+  }
+
+  return <span className="text-txt-muted">{String(value)}</span>;
+}
+
+function CollapsibleNode({ items, type, indent, path, defaultCollapsed }: {
+  items: unknown[] | [string, unknown][];
+  type: 'array' | 'object';
+  indent: number;
+  path?: string;
+  defaultCollapsed?: boolean;
+}) {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed && items.length > 3);
+  const toggle = useCallback(() => setCollapsed(c => !c), []);
+
+  const open = type === 'array' ? '[' : '{';
+  const close = type === 'array' ? ']' : '}';
+  const pad = '  '.repeat(indent);
+  const innerPad = '  '.repeat(indent + 1);
+
+  if (items.length === 0) {
+    return <span className="text-txt-muted">{open}{close}</span>;
+  }
+
+  if (collapsed) {
+    return (
+      <span>
+        <button onClick={toggle} className="inline-flex items-center text-txt-muted hover:text-txt-primary">
+          <ChevronRight size={10} className="mr-0.5" />
+          <span>{open}</span>
+        </button>
+        <span className="text-txt-muted"> {items.length} items </span>
+        <span className="text-txt-muted">{close}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span>
+      <button onClick={toggle} className="inline-flex items-center text-txt-muted hover:text-txt-primary">
+        <ChevronDown size={10} className="mr-0.5" />
+        <span>{open}</span>
+      </button>
+      {'\n'}
+      {type === 'object'
+        ? (items as [string, unknown][]).map(([key, val], i) => (
+            <span key={key}>
+              {innerPad}
+              <span className="text-brand-700">"{key}"</span>
+              <span className="text-txt-muted">: </span>
+              <JsonNode value={val} indent={indent + 1} path={`${path}.${key}`} defaultCollapsed={defaultCollapsed} />
+              {i < items.length - 1 && <span className="text-txt-muted">,</span>}
+              {'\n'}
+            </span>
+          ))
+        : (items as unknown[]).map((val, i) => (
+            <span key={i}>
+              {innerPad}
+              <JsonNode value={val} indent={indent + 1} path={`${path}[${i}]`} defaultCollapsed={defaultCollapsed} />
+              {i < items.length - 1 && <span className="text-txt-muted">,</span>}
+              {'\n'}
+            </span>
+          ))
+      }
+      {pad}{close}
+    </span>
+  );
+}

--- a/platform/src/components/playground/ParamFormBuilder.tsx
+++ b/platform/src/components/playground/ParamFormBuilder.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState, useCallback } from 'react';
+import type { ToolParam } from '@/utils/tools-data';
+
+interface Props {
+  params: ToolParam[];
+  value: string;
+  onChange: (json: string) => void;
+}
+
+export function ParamFormBuilder({ params, value, onChange }: Props) {
+  const [fields, setFields] = useState<Record<string, string>>(() => {
+    try { return JSON.parse(value); } catch { return {}; }
+  });
+
+  // Sync from external JSON changes (e.g., Fill Example)
+  useEffect(() => {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed === 'object' && parsed !== null) {
+        setFields(Object.fromEntries(
+          Object.entries(parsed).map(([k, v]) => [k, String(v ?? '')])
+        ));
+      }
+    } catch { /* ignore */ }
+  }, [value]);
+
+  const handleChange = useCallback((name: string, rawValue: string, type: string) => {
+    setFields(prev => {
+      const next = { ...prev, [name]: rawValue };
+
+      // Build typed JSON output
+      const output: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(next)) {
+        if (v === '') continue;
+        const paramDef = params.find(p => p.name === k);
+        const t = paramDef?.type || type;
+        if (t === 'number') output[k] = Number(v);
+        else if (t === 'boolean') output[k] = v === 'true';
+        else output[k] = v;
+      }
+      onChange(JSON.stringify(output, null, 2));
+      return next;
+    });
+  }, [params, onChange]);
+
+  return (
+    <div className="space-y-3">
+      {params.map(p => (
+        <div key={p.name}>
+          <label className="flex items-center gap-1.5 text-sm font-medium text-txt-secondary mb-1">
+            <code className="text-brand-700 text-xs">{p.name}</code>
+            <span className="text-[10px] text-txt-muted">({p.type})</span>
+            {p.required && <span className="text-red-500 text-xs">*</span>}
+          </label>
+          {p.type === 'boolean' ? (
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={fields[p.name] === 'true'}
+                onChange={e => handleChange(p.name, String(e.target.checked), p.type)}
+                className="w-4 h-4 rounded border-border text-brand-600 focus:ring-brand-500"
+              />
+              <span className="text-xs text-txt-muted">{p.description}</span>
+            </label>
+          ) : (
+            <>
+              <input
+                type={p.type === 'number' ? 'number' : 'text'}
+                value={fields[p.name] || ''}
+                onChange={e => handleChange(p.name, e.target.value, p.type)}
+                placeholder={p.description}
+                className="w-full px-3 py-1.5 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-white"
+              />
+              <p className="text-[11px] text-txt-muted mt-0.5">{p.description}</p>
+            </>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/platform/src/components/playground/ParamJsonEditor.tsx
+++ b/platform/src/components/playground/ParamJsonEditor.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function ParamJsonEditor({ value, onChange }: Props) {
+  return (
+    <textarea
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      rows={10}
+      className="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-brand-500 resize-y bg-white"
+      placeholder="{}"
+      spellCheck={false}
+    />
+  );
+}

--- a/platform/src/components/playground/RequestHistory.tsx
+++ b/platform/src/components/playground/RequestHistory.tsx
@@ -1,0 +1,67 @@
+import { useState, useCallback } from 'react';
+import { ChevronDown, ChevronUp, Trash2, RotateCcw } from 'lucide-react';
+import type { HistoryEntry } from '@/hooks/useRequestHistory';
+
+interface Props {
+  entries: HistoryEntry[];
+  onReplay: (toolName: string, params: string) => void;
+  onClear: () => void;
+}
+
+function timeAgo(ts: number): string {
+  const diff = Math.floor((Date.now() - ts) / 1000);
+  if (diff < 60) return `${diff}s ago`;
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+export function RequestHistory({ entries, onReplay, onClear }: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const toggle = useCallback(() => setExpanded(e => !e), []);
+
+  if (entries.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl border border-border overflow-hidden">
+      <button
+        onClick={toggle}
+        className="w-full px-4 py-2.5 flex items-center justify-between bg-surface-secondary border-b border-border-light hover:bg-surface-secondary/80 transition-colors"
+      >
+        <span className="text-sm font-semibold text-txt-primary">History ({entries.length})</span>
+        {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+      </button>
+
+      {expanded && (
+        <div className="max-h-60 overflow-y-auto">
+          {entries.map(e => (
+            <button
+              key={e.id}
+              onClick={() => onReplay(e.toolName, e.params)}
+              className="w-full text-left px-4 py-2 border-b border-border-light last:border-0 hover:bg-surface-secondary transition-colors flex items-center gap-3"
+            >
+              <span className={`w-2 h-2 rounded-full shrink-0 ${
+                e.statusCode >= 200 && e.statusCode < 300 ? 'bg-green-500' : 'bg-red-500'
+              }`} />
+              <div className="flex-1 min-w-0">
+                <div className="text-xs font-mono font-medium text-txt-primary truncate">{e.toolName}</div>
+                <div className="text-[10px] text-txt-muted">{e.duration}ms</div>
+              </div>
+              <span className="text-[10px] text-txt-muted shrink-0">{timeAgo(e.timestamp)}</span>
+              <RotateCcw size={11} className="text-txt-muted shrink-0" />
+            </button>
+          ))}
+
+          <div className="px-4 py-2 border-t border-border-light">
+            <button
+              onClick={(e) => { e.stopPropagation(); onClear(); }}
+              className="flex items-center gap-1.5 text-[10px] text-red-500 hover:text-red-700 font-medium"
+            >
+              <Trash2 size={10} /> Clear History
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/platform/src/components/playground/ResponseViewer.tsx
+++ b/platform/src/components/playground/ResponseViewer.tsx
@@ -1,0 +1,92 @@
+import { useState, useCallback, useMemo } from 'react';
+import { Copy, Check, Clock, AlertCircle, Play } from 'lucide-react';
+import { JsonHighlighter } from './JsonHighlighter';
+
+interface Props {
+  response: string | null;
+  error: string | null;
+  statusCode: number | null;
+  duration: number | null;
+}
+
+const SIZE_THRESHOLD = 100_000;
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export function ResponseViewer({ response, error, statusCode, duration }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const copyResponse = useCallback(() => {
+    if (!response) return;
+    navigator.clipboard.writeText(response);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [response]);
+
+  const parsedData = useMemo(() => {
+    if (!response) return null;
+    try { return JSON.parse(response); } catch { return null; }
+  }, [response]);
+
+  const isLarge = response ? response.length > SIZE_THRESHOLD : false;
+
+  return (
+    <div className="bg-white rounded-xl border border-border overflow-hidden flex flex-col">
+      {/* Header */}
+      <div className="px-4 py-2.5 border-b border-border-light bg-surface-secondary flex items-center justify-between">
+        <span className="text-sm font-semibold text-txt-primary">Response</span>
+        <div className="flex items-center gap-3 text-xs text-txt-muted">
+          {statusCode !== null && (
+            <span className={`px-1.5 py-0.5 rounded font-mono font-medium ${
+              statusCode >= 200 && statusCode < 300
+                ? 'bg-green-100 text-green-700'
+                : 'bg-red-100 text-red-700'
+            }`}>
+              {statusCode}
+            </span>
+          )}
+          {duration !== null && (
+            <span className="flex items-center gap-1"><Clock size={11} /> {duration}ms</span>
+          )}
+          {response && (
+            <span>{formatBytes(new Blob([response]).size)}</span>
+          )}
+          {response && (
+            <button
+              onClick={copyResponse}
+              className="flex items-center gap-1 text-txt-muted hover:text-txt-primary transition-colors"
+            >
+              {copied ? <Check size={12} className="text-green-600" /> : <Copy size={12} />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="px-4 py-2 bg-red-50 border-b border-red-200 flex items-center gap-2 text-xs text-red-700">
+          <AlertCircle size={13} /> {error}
+        </div>
+      )}
+
+      {/* Body */}
+      <div className="p-4 flex-1 overflow-auto max-h-[calc(100vh-300px)]">
+        {parsedData !== null ? (
+          <JsonHighlighter data={parsedData} defaultCollapsed={isLarge} />
+        ) : response ? (
+          <pre className="text-xs font-mono text-txt-primary whitespace-pre-wrap break-words">{response}</pre>
+        ) : (
+          <div className="text-center py-12 text-txt-muted">
+            <Play size={24} className="mx-auto mb-2 opacity-30" />
+            <p className="text-sm">Select a tool and click Execute</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/platform/src/components/playground/ToolDetail.tsx
+++ b/platform/src/components/playground/ToolDetail.tsx
@@ -1,0 +1,57 @@
+import { Sparkles } from 'lucide-react';
+import type { Tool } from '@/utils/tools-data';
+import { categoryColors } from '@/utils/tools-data';
+
+interface Props {
+  tool: Tool;
+  onFillExample: () => void;
+}
+
+export function ToolDetail({ tool, onFillExample }: Props) {
+  const color = categoryColors[tool.category] || 'bg-gray-50 text-gray-700';
+
+  return (
+    <div className="bg-white rounded-xl border border-border p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1.5">
+            <h3 className="text-sm font-semibold text-txt-primary font-mono truncate">{tool.name}</h3>
+            <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${color}`}>{tool.category}</span>
+          </div>
+          <p className="text-xs text-txt-muted leading-relaxed">{tool.description}</p>
+        </div>
+        {tool.cost && (
+          <span className="text-[10px] text-txt-muted whitespace-nowrap bg-surface-secondary px-2 py-1 rounded-md">
+            {tool.cost}
+          </span>
+        )}
+      </div>
+
+      {tool.params && tool.params.length > 0 && (
+        <div className="border-t border-border-light pt-3">
+          <div className="text-[10px] font-semibold text-txt-muted uppercase tracking-wide mb-2">Parameters</div>
+          <div className="space-y-1">
+            {tool.params.map(p => (
+              <div key={p.name} className="flex items-baseline gap-2 text-xs">
+                <code className="text-brand-700 font-medium">{p.name}</code>
+                <span className="text-txt-muted">({p.type})</span>
+                {p.required && <span className="text-red-500 text-[10px]">required</span>}
+                <span className="text-txt-muted flex-1 truncate">{p.description}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {tool.example?.request && (
+        <button
+          onClick={onFillExample}
+          className="flex items-center gap-1.5 text-xs text-brand-600 hover:text-brand-700 font-medium"
+        >
+          <Sparkles size={12} />
+          Fill Example
+        </button>
+      )}
+    </div>
+  );
+}

--- a/platform/src/components/playground/ToolSidebar.tsx
+++ b/platform/src/components/playground/ToolSidebar.tsx
@@ -1,0 +1,102 @@
+import { useState, useMemo } from 'react';
+import { Search } from 'lucide-react';
+import { tools, categories, categoryColors } from '@/utils/tools-data';
+
+interface Props {
+  selectedTool: string;
+  onSelectTool: (name: string) => void;
+}
+
+export function ToolSidebar({ selectedTool, onSelectTool }: Props) {
+  const [search, setSearch] = useState('');
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase();
+    return tools.filter(t =>
+      (!q || t.name.toLowerCase().includes(q) || t.description.toLowerCase().includes(q)) &&
+      (!activeCategory || t.category === activeCategory)
+    );
+  }, [search, activeCategory]);
+
+  const grouped = useMemo(() => {
+    const groups: Record<string, typeof tools> = {};
+    for (const t of filtered) {
+      (groups[t.category] ??= []).push(t);
+    }
+    return groups;
+  }, [filtered]);
+
+  return (
+    <div className="w-72 shrink-0 flex flex-col bg-white rounded-xl border border-border overflow-hidden">
+      {/* Search */}
+      <div className="p-3 border-b border-border-light">
+        <div className="relative">
+          <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-txt-muted" />
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search tools..."
+            className="w-full pl-8 pr-3 py-1.5 text-xs border border-border rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500 bg-white"
+          />
+        </div>
+      </div>
+
+      {/* Category Tabs */}
+      <div className="px-3 py-2 border-b border-border-light flex flex-wrap gap-1">
+        <button
+          onClick={() => setActiveCategory(null)}
+          className={`px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors ${
+            !activeCategory ? 'bg-brand-100 text-brand-700' : 'bg-surface-secondary text-txt-muted hover:text-txt-primary'
+          }`}
+        >
+          All ({tools.length})
+        </button>
+        {categories.map(cat => {
+          const count = tools.filter(t => t.category === cat).length;
+          const color = activeCategory === cat
+            ? categoryColors[cat]
+            : 'bg-surface-secondary text-txt-muted hover:text-txt-primary';
+          return (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(activeCategory === cat ? null : cat)}
+              className={`px-2 py-0.5 rounded-full text-[10px] font-medium transition-colors ${color}`}
+            >
+              {cat} ({count})
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Tool List */}
+      <div className="flex-1 overflow-y-auto">
+        {Object.entries(grouped).map(([cat, catTools]) => (
+          <div key={cat}>
+            <div className="px-3 py-1.5 text-[10px] font-semibold text-txt-muted uppercase tracking-wide bg-surface-secondary sticky top-0">
+              {cat}
+            </div>
+            {catTools.map(t => (
+              <button
+                key={t.name}
+                onClick={() => onSelectTool(t.name)}
+                className={`w-full text-left px-3 py-2 border-l-2 transition-colors ${
+                  t.name === selectedTool
+                    ? 'bg-brand-50 border-brand-600 text-txt-primary'
+                    : 'border-transparent hover:bg-surface-secondary text-txt-secondary'
+                }`}
+              >
+                <div className="text-xs font-mono font-medium truncate">{t.name}</div>
+                <div className="text-[10px] text-txt-muted truncate mt-0.5">{t.description}</div>
+              </button>
+            ))}
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="px-3 py-8 text-center text-xs text-txt-muted">No tools found</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/platform/src/hooks/usePlaygroundState.ts
+++ b/platform/src/hooks/usePlaygroundState.ts
@@ -1,0 +1,116 @@
+import { useState, useCallback } from 'react';
+import { api } from '@/utils/api-client';
+import { tools, type Tool } from '@/utils/tools-data';
+import type { useRequestHistory } from './useRequestHistory';
+
+const LAST_KEY = 'playground_last';
+const INPUT_MODE_KEY = 'playground_input_mode';
+
+export type InputMode = 'form' | 'json';
+
+function loadLast(): { tool: string; params: string } {
+  try {
+    const saved = localStorage.getItem(LAST_KEY);
+    if (saved) return JSON.parse(saved);
+  } catch { /* ignore */ }
+  return { tool: tools[0]?.name || '', params: '{}' };
+}
+
+function loadInputMode(): InputMode {
+  return (localStorage.getItem(INPUT_MODE_KEY) as InputMode) || 'form';
+}
+
+export function usePlaygroundState(history: ReturnType<typeof useRequestHistory>) {
+  const last = loadLast();
+  const [selectedTool, setSelectedTool] = useState(last.tool);
+  const [params, setParams] = useState(last.params);
+  const [response, setResponse] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [duration, setDuration] = useState<number | null>(null);
+  const [statusCode, setStatusCode] = useState<number | null>(null);
+  const [inputMode, setInputModeState] = useState<InputMode>(loadInputMode);
+
+  const toolInfo: Tool | undefined = tools.find(t => t.name === selectedTool);
+
+  const setInputMode = useCallback((mode: InputMode) => {
+    setInputModeState(mode);
+    localStorage.setItem(INPUT_MODE_KEY, mode);
+  }, []);
+
+  const handleExecute = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setResponse(null);
+    setDuration(null);
+    setStatusCode(null);
+
+    localStorage.setItem(LAST_KEY, JSON.stringify({ tool: selectedTool, params }));
+
+    let parsedParams: Record<string, unknown>;
+    try {
+      parsedParams = JSON.parse(params);
+    } catch {
+      setError('Invalid JSON');
+      setLoading(false);
+      return;
+    }
+
+    const start = performance.now();
+    let code = 0;
+    let dur = 0;
+    try {
+      const res = await api.post(`/tools/${selectedTool}`, { arguments: parsedParams });
+      dur = Math.round(performance.now() - start);
+      code = res.status;
+      setDuration(dur);
+      setStatusCode(code);
+      setResponse(JSON.stringify(res.data, null, 2));
+    } catch (err: unknown) {
+      dur = Math.round(performance.now() - start);
+      const axiosErr = err as { response?: { status?: number; data?: unknown }; message?: string };
+      code = axiosErr.response?.status || 0;
+      setDuration(dur);
+      setStatusCode(code);
+      if (axiosErr.response?.data) {
+        setResponse(JSON.stringify(axiosErr.response.data, null, 2));
+      }
+      setError(axiosErr.message || 'Request failed');
+    } finally {
+      setLoading(false);
+      history.addEntry({ toolName: selectedTool, params, statusCode: code, duration: dur });
+    }
+  }, [selectedTool, params, history]);
+
+  const handleToolChange = useCallback((name: string) => {
+    setSelectedTool(name);
+    const tool = tools.find(t => t.name === name);
+    if (tool?.example?.request) {
+      setParams(tool.example.request);
+    } else if (tool?.params) {
+      const defaultParams: Record<string, string> = {};
+      tool.params.filter(p => p.required).forEach(p => { defaultParams[p.name] = ''; });
+      setParams(JSON.stringify(defaultParams, null, 2));
+    } else {
+      setParams('{}');
+    }
+    setResponse(null);
+    setError(null);
+  }, []);
+
+  const replayEntry = useCallback((toolName: string, entryParams: string) => {
+    setSelectedTool(toolName);
+    setParams(entryParams);
+    setResponse(null);
+    setError(null);
+  }, []);
+
+  return {
+    selectedTool, params, setParams,
+    response, error, loading,
+    duration, statusCode,
+    toolInfo,
+    inputMode, setInputMode,
+    handleExecute, handleToolChange, replayEntry,
+  };
+}

--- a/platform/src/hooks/useRequestHistory.ts
+++ b/platform/src/hooks/useRequestHistory.ts
@@ -1,0 +1,57 @@
+import { useState, useCallback } from 'react';
+
+const STORAGE_KEY = 'playground_history';
+const MAX_ENTRIES = 20;
+const MAX_PARAMS_LENGTH = 10_000;
+
+export interface HistoryEntry {
+  id: string;
+  toolName: string;
+  params: string;
+  statusCode: number;
+  duration: number;
+  timestamp: number;
+}
+
+function loadHistory(): HistoryEntry[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw);
+  } catch { /* ignore */ }
+  return [];
+}
+
+function persistHistory(entries: HistoryEntry[]) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch { /* quota exceeded — silently drop */ }
+}
+
+export function useRequestHistory() {
+  const [entries, setEntries] = useState<HistoryEntry[]>(loadHistory);
+
+  const addEntry = useCallback((entry: Omit<HistoryEntry, 'id' | 'timestamp'>) => {
+    setEntries(prev => {
+      const next: HistoryEntry[] = [
+        {
+          ...entry,
+          id: crypto.randomUUID(),
+          timestamp: Date.now(),
+          params: entry.params.length > MAX_PARAMS_LENGTH
+            ? entry.params.slice(0, MAX_PARAMS_LENGTH) + '...'
+            : entry.params,
+        },
+        ...prev,
+      ].slice(0, MAX_ENTRIES);
+      persistHistory(next);
+      return next;
+    });
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setEntries([]);
+    localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  return { entries, addEntry, clearHistory };
+}

--- a/platform/src/pages/PlaygroundPage.tsx
+++ b/platform/src/pages/PlaygroundPage.tsx
@@ -1,190 +1,124 @@
-import { useState, useCallback } from 'react';
-import { Play, Loader2, Clock, AlertCircle } from 'lucide-react';
-import { api } from '@/utils/api-client';
-import { tools } from '@/utils/tools-data';
-
-const STORAGE_KEY = 'playground_last';
-
-function loadLast(): { tool: string; params: string } {
-  try {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) return JSON.parse(saved);
-  } catch { /* ignore */ }
-  return { tool: tools[0]?.name || '', params: '{}' };
-}
+import { useEffect, useCallback } from 'react';
+import { Play, Loader2, Code, FormInput } from 'lucide-react';
+import { usePlaygroundState } from '@/hooks/usePlaygroundState';
+import { useRequestHistory } from '@/hooks/useRequestHistory';
+import { ToolSidebar } from '@/components/playground/ToolSidebar';
+import { ToolDetail } from '@/components/playground/ToolDetail';
+import { ParamFormBuilder } from '@/components/playground/ParamFormBuilder';
+import { ParamJsonEditor } from '@/components/playground/ParamJsonEditor';
+import { ResponseViewer } from '@/components/playground/ResponseViewer';
+import { RequestHistory } from '@/components/playground/RequestHistory';
 
 export function PlaygroundPage() {
-  const last = loadLast();
-  const [selectedTool, setSelectedTool] = useState(last.tool);
-  const [params, setParams] = useState(last.params);
-  const [response, setResponse] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [duration, setDuration] = useState<number | null>(null);
-  const [statusCode, setStatusCode] = useState<number | null>(null);
+  const history = useRequestHistory();
+  const state = usePlaygroundState(history);
 
-  const toolInfo = tools.find(t => t.name === selectedTool);
-
-  const handleExecute = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    setResponse(null);
-    setDuration(null);
-    setStatusCode(null);
-
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ tool: selectedTool, params }));
-
-    let parsedParams: Record<string, unknown>;
-    try {
-      parsedParams = JSON.parse(params);
-    } catch {
-      setError('Невалідний JSON');
-      setLoading(false);
-      return;
-    }
-
-    const start = performance.now();
-    try {
-      const res = await api.post(`/tools/${selectedTool}`, { arguments: parsedParams });
-      setDuration(Math.round(performance.now() - start));
-      setStatusCode(res.status);
-      setResponse(JSON.stringify(res.data, null, 2));
-    } catch (err: unknown) {
-      setDuration(Math.round(performance.now() - start));
-      const axiosErr = err as { response?: { status?: number; data?: unknown }; message?: string };
-      setStatusCode(axiosErr.response?.status || 0);
-      if (axiosErr.response?.data) {
-        setResponse(JSON.stringify(axiosErr.response.data, null, 2));
+  // Ctrl+Enter to execute
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter' && !state.loading) {
+        e.preventDefault();
+        state.handleExecute();
       }
-      setError(axiosErr.message || 'Помилка запиту');
-    } finally {
-      setLoading(false);
-    }
-  }, [selectedTool, params]);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [state.handleExecute, state.loading]);
 
-  const handleToolChange = (name: string) => {
-    setSelectedTool(name);
-    const tool = tools.find(t => t.name === name);
-    if (tool?.example?.request) {
-      setParams(tool.example.request);
-    } else if (tool?.params) {
-      const defaultParams: Record<string, string> = {};
-      tool.params.filter(p => p.required).forEach(p => { defaultParams[p.name] = ''; });
-      setParams(JSON.stringify(defaultParams, null, 2));
-    } else {
-      setParams('{}');
+  const handleFillExample = useCallback(() => {
+    if (state.toolInfo?.example?.request) {
+      state.setParams(state.toolInfo.example.request);
     }
-    setResponse(null);
-    setError(null);
-  };
+  }, [state.toolInfo, state.setParams]);
+
+  const hasFormParams = !!(state.toolInfo?.params && state.toolInfo.params.length > 0);
 
   return (
-    <div className="max-w-5xl space-y-6">
+    <div className="space-y-4">
       <div>
         <h1 className="text-2xl font-bold text-txt-primary">API Playground</h1>
-        <p className="text-sm text-txt-muted mt-1">Тестуйте MCP інструменти в реальному часі</p>
+        <p className="text-sm text-txt-muted mt-1">Test MCP tools in real time. <span className="text-txt-muted/60">Ctrl+Enter to execute</span></p>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Request */}
-        <div className="space-y-4">
-          <div className="bg-white rounded-xl border border-border p-5 space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-txt-secondary mb-1">Інструмент</label>
-              <select
-                value={selectedTool}
-                onChange={(e) => handleToolChange(e.target.value)}
-                className="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-brand-500 bg-white"
-              >
-                {tools.map((t) => (
-                  <option key={t.name} value={t.name}>
-                    {t.name} ({t.category})
-                  </option>
-                ))}
-              </select>
-            </div>
+      <div className="flex gap-4" style={{ height: 'calc(100vh - 160px)' }}>
+        {/* Left: Tool Sidebar */}
+        <ToolSidebar
+          selectedTool={state.selectedTool}
+          onSelectTool={state.handleToolChange}
+        />
 
-            {toolInfo && (
-              <div className="text-xs text-txt-muted bg-surface-secondary rounded-lg p-3">
-                <p>{toolInfo.description}</p>
-                {toolInfo.cost && <p className="mt-1">Вартість: {toolInfo.cost}</p>}
+        {/* Center: Request */}
+        <div className="flex-1 flex flex-col gap-4 min-w-0 overflow-y-auto">
+          {state.toolInfo && (
+            <ToolDetail tool={state.toolInfo} onFillExample={handleFillExample} />
+          )}
+
+          {/* Form/JSON Toggle */}
+          <div className="bg-white rounded-xl border border-border p-4 space-y-3">
+            {hasFormParams && (
+              <div className="flex items-center gap-1 bg-surface-secondary rounded-lg p-0.5 w-fit">
+                <button
+                  onClick={() => state.setInputMode('form')}
+                  className={`flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+                    state.inputMode === 'form'
+                      ? 'bg-white text-txt-primary shadow-sm'
+                      : 'text-txt-muted hover:text-txt-primary'
+                  }`}
+                >
+                  <FormInput size={12} /> Form
+                </button>
+                <button
+                  onClick={() => state.setInputMode('json')}
+                  className={`flex items-center gap-1.5 px-3 py-1 rounded-md text-xs font-medium transition-colors ${
+                    state.inputMode === 'json'
+                      ? 'bg-white text-txt-primary shadow-sm'
+                      : 'text-txt-muted hover:text-txt-primary'
+                  }`}
+                >
+                  <Code size={12} /> JSON
+                </button>
               </div>
             )}
 
-            {toolInfo?.params && (
-              <div>
-                <div className="text-xs font-medium text-txt-muted mb-1">Параметри:</div>
-                <div className="text-xs text-txt-muted space-y-0.5">
-                  {toolInfo.params.map(p => (
-                    <div key={p.name}>
-                      <code className="text-brand-700">{p.name}</code>
-                      <span className="text-txt-muted"> ({p.type}){p.required ? ' *' : ''}</span>
-                      <span className="text-txt-muted"> — {p.description}</span>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            <div>
-              <label className="block text-sm font-medium text-txt-secondary mb-1">Параметри (JSON)</label>
-              <textarea
-                value={params}
-                onChange={(e) => setParams(e.target.value)}
-                rows={8}
-                className="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-brand-500 resize-y"
-                placeholder="{}"
+            {state.inputMode === 'form' && hasFormParams ? (
+              <ParamFormBuilder
+                params={state.toolInfo!.params!}
+                value={state.params}
+                onChange={state.setParams}
               />
-            </div>
+            ) : (
+              <ParamJsonEditor value={state.params} onChange={state.setParams} />
+            )}
 
             <button
-              onClick={handleExecute}
-              disabled={loading}
+              onClick={state.handleExecute}
+              disabled={state.loading}
               className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-brand-600 text-white rounded-lg text-sm font-medium hover:bg-brand-700 transition-colors disabled:opacity-50"
             >
-              {loading ? (
-                <><Loader2 size={16} className="animate-spin" /> Виконується...</>
+              {state.loading ? (
+                <><Loader2 size={16} className="animate-spin" /> Executing...</>
               ) : (
-                <><Play size={16} /> Виконати</>
+                <><Play size={16} /> Execute</>
               )}
             </button>
           </div>
         </div>
 
-        {/* Response */}
-        <div className="space-y-4">
-          <div className="bg-white rounded-xl border border-border overflow-hidden">
-            <div className="px-4 py-3 border-b border-border-light bg-surface-secondary flex items-center justify-between">
-              <span className="text-sm font-semibold text-txt-primary">Відповідь</span>
-              <div className="flex items-center gap-3 text-xs text-txt-muted">
-                {statusCode !== null && (
-                  <span className={`font-medium ${statusCode >= 200 && statusCode < 300 ? 'text-green-600' : 'text-red-600'}`}>
-                    {statusCode}
-                  </span>
-                )}
-                {duration !== null && (
-                  <span className="flex items-center gap-1"><Clock size={12} /> {duration}ms</span>
-                )}
-              </div>
-            </div>
-
-            {error && (
-              <div className="px-4 py-2 bg-red-50 border-b border-red-200 flex items-center gap-2 text-sm text-red-700">
-                <AlertCircle size={14} /> {error}
-              </div>
-            )}
-
-            <div className="p-4 max-h-[600px] overflow-auto">
-              {response ? (
-                <pre className="text-xs font-mono text-txt-primary whitespace-pre-wrap break-words">{response}</pre>
-              ) : (
-                <div className="text-center py-12 text-txt-muted">
-                  <Play size={24} className="mx-auto mb-2 opacity-30" />
-                  <p className="text-sm">Виберіть інструмент і натисніть "Виконати"</p>
-                </div>
-              )}
-            </div>
+        {/* Right: Response + History */}
+        <div className="w-[45%] shrink-0 flex flex-col gap-4 min-w-0">
+          <div className="flex-1 min-h-0">
+            <ResponseViewer
+              response={state.response}
+              error={state.error}
+              statusCode={state.statusCode}
+              duration={state.duration}
+            />
           </div>
+          <RequestHistory
+            entries={history.entries}
+            onReplay={state.replayEntry}
+            onClear={history.clearHistory}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Refactored the monolithic PlaygroundPage (192 lines) into a professional 3-panel API testing tool with 9 focused components:

**Left panel:** Tool sidebar with category grouping, search, and color-coded badges
**Center panel:** Tool detail + Form/JSON parameter input toggle + Execute button  
**Right panel:** Syntax-highlighted collapsible JSON response + request history

### New components
- `ToolSidebar` — category tabs, search filter, tool list
- `ToolDetail` — description, cost, params table, Fill Example button
- `ParamFormBuilder` — auto-generated form fields from tool.params
- `ParamJsonEditor` — raw JSON textarea
- `ResponseViewer` — JSON highlighting, status badge, copy, collapse large responses
- `RequestHistory` — last 20 requests with replay
- `JsonHighlighter` — recursive CSS-only JSON renderer (no new deps)
- `usePlaygroundState` / `useRequestHistory` — extracted hooks

### Features
- Ctrl+Enter keyboard shortcut
- Form/JSON toggle persisted in localStorage
- Request history with one-click replay
- Large response auto-collapse (>100KB)
- Zero new dependencies

## Test plan
- [ ] Open /playground — 3-panel layout renders
- [ ] Search tools by name
- [ ] Switch categories
- [ ] Form mode: fields auto-generated from tool params
- [ ] JSON mode: raw textarea works
- [ ] Fill Example pre-fills params
- [ ] Execute tool — response highlighted with syntax colors
- [ ] Ctrl+Enter executes
- [ ] History saves and replays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the monolithic PlaygroundPage into a 3-panel API testing tool to improve usability and maintainability. Adds a searchable tool sidebar, form/JSON input, and a syntax-highlighted response with history, with zero new dependencies.

- **New Features**
  - 3-panel layout: sidebar with search/categories; request with form builder or JSON editor (toggle persists); response with syntax-highlighted JSON.
  - Request history (20 entries) with replay and clear.
  - Ctrl/Cmd+Enter to execute; shows status code, duration, and response size.
  - Large responses auto-collapse (>100KB); copy response.

- **Refactors**
  - Split `PlaygroundPage` into 9 components and 2 hooks (`usePlaygroundState`, `useRequestHistory`) for clearer state and data flow.
  - Persist last used tool and input mode in localStorage.

<sup>Written for commit 016c64a31fda4d625742bf539604bb3961a7c742. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

