### PR TITLE
fix(backend): prevent UTF-8 crash on encrypted document queries

### DIFF
--- a/mcp_backend/src/api/vault-tools.ts
+++ b/mcp_backend/src/api/vault-tools.ts
@@ -998,7 +998,9 @@ Pipeline:
       const query = `
         SELECT id, type, title, metadata, storage_type, mime_type, created_at, updated_at,
                COALESCE(is_encrypted, false) AS is_encrypted,
-               LEFT(regexp_replace(full_text, '[^\\x20-\\x7E\\u0400-\\u04FF\\u0500-\\u052F\\s]', '', 'g'), 300) AS text_preview
+               CASE WHEN COALESCE(is_encrypted, false) THEN NULL
+                    ELSE LEFT(regexp_replace(full_text, '[^\\x20-\\x7E\\u0400-\\u04FF\\u0500-\\u052F\\s]', '', 'g'), 300)
+               END AS text_preview
         FROM documents
         WHERE ${whereClause}
         ORDER BY ${orderClause}

--- a/mcp_backend/src/routes/matter-routes.ts
+++ b/mcp_backend/src/routes/matter-routes.ts
@@ -466,7 +466,9 @@ export function createMatterRoutes(
       //    Skip LEFT() on encrypted docs — their full_text contains binary data that breaks UTF-8 functions
       const docResult = await db.query(
         `SELECT id, title,
-                CASE WHEN COALESCE(is_encrypted, false) THEN NULL ELSE LEFT(full_text, 2000) END as snippet,
+                CASE WHEN COALESCE(is_encrypted, false) OR full_text IS NULL THEN NULL
+                     ELSE LEFT(regexp_replace(full_text, '[^\\x20-\\x7E\\u0400-\\u04FF\\u0500-\\u052F\\s]', '', 'g'), 2000)
+                END as snippet,
                 mime_type,
                 metadata->>'folderPath' as folder_path,
                 metadata->>'originalFilename' as original_filename


### PR DESCRIPTION
## Summary
- **vault-tools** (`list_documents`): wrapped `text_preview` extraction in `CASE WHEN is_encrypted` to skip ciphertext stored in `full_text`
- **matter-routes** (auto-create matter): added `regexp_replace` sanitization for `full_text` to handle both encrypted docs and docs with invalid UTF-8 from DOCX extraction

## Problem
Encrypted documents store base64-encoded ciphertext in the `full_text` column. SQL `LEFT(full_text, N)` crashes with `invalid byte sequence for encoding "UTF8": 0xd0`. This broke the auto-create matter flow and could break document listing.

Reproduced on prod with user teosoph's DOCX uploads.

## Test plan
- [ ] Upload an encrypted DOCX document, verify list_documents returns it with `is_encrypted: true` and E2EE badge displays
- [ ] Verify auto-create matter works with encrypted documents in the selection
- [ ] Verify unencrypted documents still show text previews correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents UTF-8 crashes when querying documents by skipping preview/snippet extraction for encrypted docs and sanitizing invalid bytes for others. Restores the auto-create matter flow and stabilizes document listing.

- **Bug Fixes**
  - `vault-tools` (`list_documents`): Set `text_preview` to NULL for encrypted docs; otherwise use a sanitized `LEFT(..., 300)`.
  - `matter-routes` (auto-create): Set `snippet` to NULL when encrypted or `full_text` is NULL; otherwise use a sanitized `LEFT(..., 2000)`.

<sup>Written for commit 0a3898927f4b7deedb84cf67385c643098a4545f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

