### PR TITLE
feat(ui): add Developer Console button to API docs page

### DIFF
--- a/lexwebapp/src/pages/DeveloperDocsPage/index.tsx
+++ b/lexwebapp/src/pages/DeveloperDocsPage/index.tsx
@@ -44,7 +44,7 @@ export function DeveloperDocsPage() {
           <div className="p-2 bg-claude-accent/10 rounded-xl">
             <BookOpen size={22} className="text-claude-accent" />
           </div>
-          <div>
+          <div className="flex-1">
             <h1 className="text-xl font-semibold text-claude-text font-sans tracking-tight">
               API документація
             </h1>
@@ -52,6 +52,16 @@ export function DeveloperDocsPage() {
               LEX AI Platform &mdash; 56+ MCP інструментів для юридичного аналізу
             </p>
           </div>
+          <a
+            href="https://platform.legal.org.ua"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-4 py-2 bg-claude-accent text-white rounded-lg text-sm font-medium font-sans hover:bg-[#C66345] transition-colors shrink-0"
+          >
+            <Terminal size={16} />
+            Developer Console
+            <ExternalLink size={14} />
+          </a>
         </div>
 
         {/* Tabs */}


### PR DESCRIPTION
## Summary
- Add prominent button linking to platform.legal.org.ua in the /developer/docs header
- Opens in new tab with External Link icon

## Test plan
- [ ] Visit /developer/docs — button visible in header
- [ ] Click opens platform.legal.org.ua in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a prominent “Developer Console” button to the /developer/docs header linking to https://platform.legal.org.ua. Opens in a new tab and shows an external-link icon.

<sup>Written for commit 42537b4a960f856d7e12b24f42df6836ae0867f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

