### PR TITLE
feat(documents): destination picker + auto-classify after upload

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -7,7 +7,7 @@ import { toastTDynamic } from '../../i18n/toast-i18n';
 import { FolderNavigator } from './FolderNavigator';
 import { UploadQueuePanel } from './UploadQueuePanel';
 import { DocumentViewerModal } from '../../components/DocumentViewerModal';
-import { ClassificationPanel } from './ClassificationPanel';
+import { PostUploadDestination } from './PostUploadDestination';
 import { DeleteConfirmModal } from './DeleteConfirmModal';
 import { EditDocumentModal } from './EditDocumentModal';
 import { MoveDocumentModal } from './MoveDocumentModal';
@@ -24,7 +24,6 @@ import { useDocumentActions } from './useDocumentActions';
 import { useDocumentPreview } from './useDocumentPreview';
 import { useMultiSelect } from './useMultiSelect';
 import { useEditNavigation } from './useEditNavigation';
-import { RetroactiveEncryptionPanel } from '../../components/encryption/RetroactiveEncryptionPanel';
 
 const VIEW_MODE_KEY = 'documents-view-mode';
 
@@ -73,7 +72,6 @@ export function DocumentsPage() {
     loading,
     folders,
     foldersLoading,
-    docStats,
     loadDocuments,
     loadFolders,
     loadStats,
@@ -165,12 +163,13 @@ export function DocumentsPage() {
   });
 
   // Upload state from Zustand store
-  const { items: uploadItems, isUploading, completedFiles, recoveredSessions } = useUploadStore(
+  const { items: uploadItems, isUploading, completedFiles, recoveredSessions, showDestinationPicker } = useUploadStore(
     useShallow(s => ({
       items: s.items,
       isUploading: s.isUploading,
       completedFiles: s.completedFiles,
       recoveredSessions: s.recoveredSessions,
+      showDestinationPicker: s.showDestinationPicker,
     }))
   );
   const addFiles = useUploadStore(s => s.addFiles);
@@ -178,6 +177,7 @@ export function DocumentsPage() {
   const recoverSessions = useUploadStore(s => s.recoverSessions);
   const dismissRecoveredSession = useUploadStore(s => s.dismissRecoveredSession);
   const clearRecoveredSessions = useUploadStore(s => s.clearRecoveredSessions);
+  const dismissDestinationPicker = useUploadStore(s => s.dismissDestinationPicker);
 
   // Undo/redo
   const setOnActionExecuted = useUndoStore((s) => s.setOnActionExecuted);
@@ -293,14 +293,11 @@ export function DocumentsPage() {
             onStartUpload={handleStartUpload}
           />
 
-          <ClassificationPanel
-            stats={docStats}
-            onComplete={() => { loadDocuments(); loadStats(); }}
-          />
-
-          <div className="mb-4">
-            <RetroactiveEncryptionPanel />
-          </div>
+          {showDestinationPicker && (
+            <PostUploadDestination
+              onComplete={() => { dismissDestinationPicker(); loadDocuments(); loadStats(); }}
+            />
+          )}
 
           <DocumentSearchBar
             searchQuery={searchQuery}

--- a/lexwebapp/src/stores/uploadStore.ts
+++ b/lexwebapp/src/stores/uploadStore.ts
@@ -10,7 +10,6 @@ import {
   UploadEvent,
 } from '../services/upload/UploadManager';
 import { uploadService, ActiveSession } from '../services/api/UploadService';
-import { matterService } from '../services/api/MatterService';
 import { showToast } from '../utils/toast';
 import { toastTDynamic } from '../i18n/toast-i18n';
 import { useEncryptionStore } from './encryptionStore';
@@ -43,6 +42,11 @@ interface UploadState {
   // Recovery state
   recoveredSessions: RecoveredSession[];
   isRecovering: boolean;
+
+  // Post-upload destination picker
+  showDestinationPicker: boolean;
+  pendingDocumentIds: string[];
+  dismissDestinationPicker: () => void;
 
   // Actions
   addFiles: (
@@ -93,25 +97,24 @@ export const useUploadStore = create<UploadState>((set) => {
     if (event.type === 'all-completed') {
       set({ ...sync, isUploading: false });
 
-      // Auto-create matter from completed uploads (fire-and-forget)
+      // Show destination picker so user can choose where to put uploaded docs
       const completedItems = sync.items.filter(i => i.status === 'completed');
       if (completedItems.length >= 1) {
-        // Collect documentIds from completed items; some may not have documentId yet
         const knownIds = completedItems.map(i => i.documentId).filter(Boolean) as string[];
 
         if (knownIds.length > 0) {
-          matterService.autoCreateFromUpload(knownIds).then(result => {
-            showToast.success(
-              toastTDynamic('matterCreated', result.matter.matter_name, result.documentsAssigned)
-            );
-          }).catch(err => {
-            console.warn('[UploadStore] Auto-create matter failed (non-critical)', err);
+          set({ showDestinationPicker: true, pendingDocumentIds: knownIds });
+
+          // Auto-classify new uploads (fire-and-forget)
+          import('../utils/api-client').then(({ api }) => {
+            api.documents.startClassification({ documentIds: knownIds }).catch(err => {
+              console.warn('[UploadStore] Auto-classification failed (non-critical)', err);
+            });
           });
         } else {
-          // documentIds not yet available — fetch recent docs from upload sessions
+          // documentIds not yet available — fetch from upload sessions
           const uploadIds = completedItems.map(i => i.uploadId).filter(Boolean) as string[];
           if (uploadIds.length > 0) {
-            // Small delay to let backend finish processing
             setTimeout(() => {
               Promise.all(uploadIds.map(id => uploadService.getStatus(id).catch(() => null)))
                 .then(sessions => {
@@ -119,19 +122,16 @@ export const useUploadStore = create<UploadState>((set) => {
                     .filter(s => s && s.documentId)
                     .map(s => s!.documentId!) as string[];
                   if (docIds.length > 0) {
-                    return matterService.autoCreateFromUpload(docIds);
-                  }
-                  return null;
-                })
-                .then(result => {
-                  if (result) {
-                    showToast.success(
-                      `Створено справу "${result.matter.matter_name}" (${result.documentsAssigned} документів)`
-                    );
+                    set({ showDestinationPicker: true, pendingDocumentIds: docIds });
+
+                    // Auto-classify deferred docs
+                    import('../utils/api-client').then(({ api }) => {
+                      api.documents.startClassification({ documentIds: docIds }).catch(() => {});
+                    });
                   }
                 })
                 .catch(err => {
-                  console.warn('[UploadStore] Auto-create matter (deferred) failed', err);
+                  console.warn('[UploadStore] Deferred doc ID fetch failed', err);
                 });
             }, 5000);
           }
@@ -183,6 +183,9 @@ export const useUploadStore = create<UploadState>((set) => {
     isThrottled: false,
     recoveredSessions: [],
     isRecovering: false,
+    showDestinationPicker: false,
+    pendingDocumentIds: [],
+    dismissDestinationPicker: () => set({ showDestinationPicker: false, pendingDocumentIds: [] }),
 
     addFiles: (files) => {
       // E2EE is mandatory — always encrypt uploads


### PR DESCRIPTION
## Summary
- Removed "Зашифрувати мій сейф" panel — encryption is fully automatic
- Removed manual ClassificationPanel — classification now auto-triggers for newly uploaded files
- Replaced auto-matter creation with PostUploadDestination modal (new/existing matter, new/existing folder, or skip)

## Test plan
- [ ] Upload files → verify PostUploadDestination modal appears after upload completes
- [ ] Choose "Нова справа" → verify matter is created with uploaded docs
- [ ] Choose "Існуюча справа" → verify docs are assigned
- [ ] Choose "Пропустити" → verify modal closes, docs stay unassigned
- [ ] Verify uploaded docs get auto-classified (check type changes after upload)
- [ ] Verify "Зашифрувати мій сейф" panel no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a post‑upload destination picker and auto‑classification for new documents. Simplifies the Documents page by removing manual encryption and classification panels.

- **New Features**
  - Show `PostUploadDestination` after uploads complete, letting users send files to a new/existing matter, a folder, or skip.
  - Auto-start classification for uploaded docs via `api.documents.startClassification({ documentIds })`.
  - Encryption is always on; removed the "Зашифрувати мій сейф" panel and the `ClassificationPanel`.
  - Replaced auto‑matter creation with user choice; added `showDestinationPicker`, `pendingDocumentIds`, and `dismissDestinationPicker` to `uploadStore`.

<sup>Written for commit 1f7dfe5f9008d4055be3077af660260c8a988c32. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

