### PR TITLE
test(diia): add Diia login regression tests + CI guard

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -98,6 +98,15 @@ jobs:
         if: needs.detect-changes.outputs.backend == 'true'
         run: cd mcp_backend && npx jest --no-cache src/controllers/__tests__/ --forceExit
 
+      - name: Unit test Diia auth & signing (regression guard)
+        if: needs.detect-changes.outputs.backend == 'true'
+        run: |
+          cd mcp_backend && npx jest --no-cache \
+            src/controllers/__tests__/diia-auth.test.ts \
+            src/controllers/__tests__/diia-sign.test.ts \
+            src/services/__tests__/diia-service.test.ts \
+            --forceExit
+
       - name: Build RADA
         if: needs.detect-changes.outputs.rada == 'true'
         run: cd mcp_rada && npm install && npm run build

--- a/mcp_backend/src/controllers/__tests__/diia-auth.test.ts
+++ b/mcp_backend/src/controllers/__tests__/diia-auth.test.ts
@@ -1,0 +1,516 @@
+/**
+ * Unit tests for Diia auth flow.
+ * Validates the Redis key mapping between init → callback → status polling.
+ */
+
+import { Request, Response } from 'express';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockCache: Record<string, string> = {};
+
+const fakeCachePort = {
+  get: jest.fn(async (key: string) => mockCache[key] ?? null),
+  set: jest.fn(async (key: string, value: string, _ttl?: number) => {
+    mockCache[key] = value;
+  }),
+  del: jest.fn(async (...keys: string[]) => {
+    let count = 0;
+    for (const k of keys) {
+      if (k in mockCache) { delete mockCache[k]; count++; }
+    }
+    return count;
+  }),
+  increment: jest.fn(async () => 1),
+  ping: jest.fn(async () => true),
+  isConnected: jest.fn(() => true),
+  connect: jest.fn(async () => {}),
+  disconnect: jest.fn(async () => {}),
+};
+
+const fakeUser = {
+  id: 'user-uuid-123',
+  google_id: '',
+  email: 'diia_abc123@diia.legal.org.ua',
+  name: 'Дія Користувач',
+  email_verified: true,
+  created_at: new Date(),
+  updated_at: new Date(),
+  role: 'user' as const,
+};
+
+const fakeUserService = {
+  findByEmail: jest.fn(async () => null as any),
+  createUser: jest.fn(async () => fakeUser),
+  findById: jest.fn(async () => fakeUser),
+  updateLastLogin: jest.fn(async () => {}),
+};
+
+const fakeDiiaService = {
+  isConfigured: jest.fn(() => true),
+  initAuthSession: jest.fn(async () => ({
+    deeplink: 'https://diia.app/auth/deeplink-test',
+    requestId: 'plain-uuid-abc',
+    hashedRequestId: 'hashed-base64-xyz==',
+  })),
+};
+
+// Mock dependencies
+jest.mock('../../services/diia-service.js', () => ({
+  getDiiaService: () => fakeDiiaService,
+  DiiaPermissionError: class DiiaPermissionError extends Error {
+    constructor(msg: string) { super(msg); this.name = 'DiiaPermissionError'; }
+  },
+}));
+
+const mockGetUserService = jest.fn(() => fakeUserService);
+jest.mock('../../middleware/dual-auth.js', () => ({
+  getUserService: () => mockGetUserService(),
+  getWebAuthnService: () => null,
+}));
+
+jest.mock('../../services/authentik-service.js', () => ({
+  provisionAuthentikUser: jest.fn(async () => {}),
+}));
+
+jest.mock('../../services/nextcloud-provisioning.js', () => ({
+  provisionNextcloudUser: jest.fn(async () => {}),
+}));
+
+jest.mock('../../services/oidc-service.js', () => ({}));
+
+jest.mock('../../services/email-service.js', () => ({
+  EmailService: jest.fn(),
+}));
+
+jest.mock('../../services/minio-service.js', () => ({
+  MinioService: jest.fn(),
+}));
+
+jest.mock('../../services/banner-service.js', () => ({
+  BannerService: jest.fn(),
+}));
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+// Import module under test AFTER mocks
+import {
+  setAuthCache,
+  diiaAuthInit,
+  diiaAuthCallback,
+  diiaAuthStatus,
+} from '../auth.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(overrides: Partial<Request> = {}): Request {
+  return {
+    headers: {
+      'x-forwarded-proto': 'https',
+      'x-forwarded-host': 'legal.org.ua',
+      host: 'legal.org.ua',
+      ...((overrides.headers as Record<string, string>) ?? {}),
+    },
+    params: {},
+    protocol: 'http',
+    ...overrides,
+  } as unknown as Request;
+}
+
+function makeRes(): Response & { _redirectUrl?: string; _json?: any; _status?: number } {
+  const res: any = {
+    _redirectUrl: undefined,
+    _json: undefined,
+    _status: 200,
+    redirect: jest.fn(function (this: any, url: string) { this._redirectUrl = url; }),
+    json: jest.fn(function (this: any, body: any) { this._json = body; return this; }),
+    status: jest.fn(function (this: any, code: number) { this._status = code; return this; }),
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  };
+  return res;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('Diia Auth Flow', () => {
+  beforeEach(() => {
+    // Clear the in-memory cache
+    for (const key of Object.keys(mockCache)) delete mockCache[key];
+    jest.clearAllMocks();
+    setAuthCache(fakeCachePort);
+  });
+
+  describe('diiaAuthInit', () => {
+    it('stores pending session under both plain and hashed keys', async () => {
+      const req = makeReq();
+      const res = makeRes();
+
+      await diiaAuthInit(req, res);
+
+      // Should have stored two keys
+      expect(fakeCachePort.set).toHaveBeenCalledTimes(2);
+
+      // Plain key: { status: 'pending' }
+      const plainVal = mockCache['diia:session:plain-uuid-abc'];
+      expect(plainVal).toBeDefined();
+      expect(JSON.parse(plainVal)).toEqual({ status: 'pending' });
+
+      // Hashed key: { status: 'pending', plainRequestId: 'plain-uuid-abc' }
+      const hashedVal = mockCache['diia:session:hashed-base64-xyz=='];
+      expect(hashedVal).toBeDefined();
+      const hashedData = JSON.parse(hashedVal);
+      expect(hashedData.status).toBe('pending');
+      expect(hashedData.plainRequestId).toBe('plain-uuid-abc');
+    });
+
+    it('redirects to /login with diia_session and diia_deeplink params', async () => {
+      const req = makeReq();
+      const res = makeRes();
+
+      await diiaAuthInit(req, res);
+
+      expect(res.redirect).toHaveBeenCalledTimes(1);
+      const url = res._redirectUrl!;
+      expect(url).toContain('https://legal.org.ua/login');
+      expect(url).toContain('diia_session=plain-uuid-abc');
+      expect(url).toContain('diia_deeplink=');
+    });
+
+    it('redirects with error when Diia is not configured', async () => {
+      fakeDiiaService.isConfigured.mockReturnValueOnce(false);
+      const req = makeReq();
+      const res = makeRes();
+
+      await diiaAuthInit(req, res);
+
+      expect(res._redirectUrl).toContain('error=diia_not_configured');
+    });
+  });
+
+  describe('diiaAuthCallback', () => {
+    beforeEach(async () => {
+      // Simulate a prior init that created both keys
+      mockCache['diia:session:plain-uuid-abc'] = JSON.stringify({ status: 'pending' });
+      mockCache['diia:session:hashed-base64-xyz=='] = JSON.stringify({
+        status: 'pending',
+        plainRequestId: 'plain-uuid-abc',
+      });
+    });
+
+    it('updates BOTH plain and hashed keys to complete', async () => {
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      // Both keys should be 'complete'
+      const plainData = JSON.parse(mockCache['diia:session:plain-uuid-abc']);
+      expect(plainData.status).toBe('complete');
+      expect(plainData.userId).toBe('user-uuid-123');
+
+      const hashedData = JSON.parse(mockCache['diia:session:hashed-base64-xyz==']);
+      expect(hashedData.status).toBe('complete');
+      expect(hashedData.userId).toBe('user-uuid-123');
+    });
+
+    it('responds with { success: true } for Diia webhook', async () => {
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      expect(res._json).toEqual({ success: true });
+    });
+
+    it('returns 400 when X-Document-Request-Trace-Id is missing', async () => {
+      const req = makeReq({ headers: {} });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      expect(res._status).toBe(400);
+      expect(res._json.success).toBe(false);
+    });
+
+    it('creates a new user when none exists', async () => {
+      fakeUserService.findByEmail.mockResolvedValueOnce(null);
+
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      expect(fakeUserService.createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          email: expect.stringContaining('diia_'),
+          name: 'Дія Користувач',
+          emailVerified: true,
+        }),
+      );
+    });
+
+    it('updates last login for existing user', async () => {
+      fakeUserService.findByEmail.mockResolvedValueOnce(fakeUser);
+
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      expect(fakeUserService.updateLastLogin).toHaveBeenCalledWith('user-uuid-123');
+      expect(fakeUserService.createUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('diiaAuthStatus', () => {
+    it('returns { status: "pending" } before callback fires', async () => {
+      mockCache['diia:session:plain-uuid-abc'] = JSON.stringify({ status: 'pending' });
+
+      const req = makeReq({ params: { sessionId: 'plain-uuid-abc' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      expect(res._json).toEqual({ status: 'pending' });
+    });
+
+    it('returns token after callback marks session complete', async () => {
+      // Simulate completed session
+      mockCache['diia:session:plain-uuid-abc'] = JSON.stringify({
+        status: 'complete',
+        userId: 'user-uuid-123',
+      });
+
+      const req = makeReq({ params: { sessionId: 'plain-uuid-abc' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      expect(res._json.status).toBe('complete');
+      expect(res._json.token).toBeDefined();
+      expect(typeof res._json.token).toBe('string');
+    });
+
+    it('returns { status: "expired" } when session key is gone', async () => {
+      // No key in cache
+      const req = makeReq({ params: { sessionId: 'nonexistent-id' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      expect(res._status).toBe(404);
+      expect(res._json).toEqual({ status: 'expired' });
+    });
+
+    it('consumes the session key after returning token', async () => {
+      mockCache['diia:session:my-session'] = JSON.stringify({
+        status: 'complete',
+        userId: 'user-uuid-123',
+      });
+
+      const req = makeReq({ params: { sessionId: 'my-session' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      // Key should be deleted
+      expect(fakeCachePort.del).toHaveBeenCalledWith('diia:session:my-session');
+    });
+  });
+
+  describe('diiaAuthInit — edge cases', () => {
+    it('sets diia_session cookie with correct TTL and flags', async () => {
+      const req = makeReq();
+      const res = makeRes();
+
+      await diiaAuthInit(req, res);
+
+      expect(res.cookie).toHaveBeenCalledWith(
+        'diia_session',
+        'plain-uuid-abc',
+        expect.objectContaining({
+          httpOnly: false,
+          secure: true,
+          sameSite: 'lax',
+          maxAge: 600000, // 10 min
+          path: '/',
+        }),
+      );
+    });
+
+    it('redirects with diia_scope_forbidden on DiiaPermissionError', async () => {
+      // Import the mocked class to throw it
+      const { DiiaPermissionError } = jest.requireMock('../../services/diia-service.js') as any;
+      fakeDiiaService.initAuthSession.mockRejectedValueOnce(
+        new DiiaPermissionError('scope not active'),
+      );
+
+      const req = makeReq();
+      const res = makeRes();
+
+      await diiaAuthInit(req, res);
+
+      expect(res._redirectUrl).toContain('error=diia_scope_forbidden');
+    });
+
+    it('redirects with diia_failed on generic error', async () => {
+      fakeDiiaService.initAuthSession.mockRejectedValueOnce(new Error('network timeout'));
+
+      const req = makeReq();
+      const res = makeRes();
+
+      await diiaAuthInit(req, res);
+
+      expect(res._redirectUrl).toContain('error=diia_failed');
+    });
+  });
+
+  describe('diiaAuthCallback — edge cases', () => {
+    beforeEach(() => {
+      mockCache['diia:session:plain-uuid-abc'] = JSON.stringify({ status: 'pending' });
+      mockCache['diia:session:hashed-base64-xyz=='] = JSON.stringify({
+        status: 'pending',
+        plainRequestId: 'plain-uuid-abc',
+      });
+    });
+
+    it('returns 503 when userService is unavailable', async () => {
+      mockGetUserService.mockReturnValueOnce(null as any);
+
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      expect(res._status).toBe(503);
+    });
+
+    it('generates diia-specific email from traceId', async () => {
+      fakeUserService.findByEmail.mockResolvedValueOnce(null);
+
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      expect(fakeUserService.findByEmail).toHaveBeenCalledWith(
+        expect.stringMatching(/^diia_.*@diia\.legal\.org\.ua$/),
+      );
+    });
+
+    it('still returns success even if session lookup fails (idempotent webhook)', async () => {
+      // Unknown trace ID — no session in Redis
+      const req = makeReq({
+        headers: { 'x-document-request-trace-id': 'unknown-trace-id-abc' },
+      });
+      const res = makeRes();
+
+      await diiaAuthCallback(req, res);
+
+      // Should not crash — webhook must be idempotent
+      expect(res._json.success).toBe(true);
+    });
+  });
+
+  describe('diiaAuthStatus — edge cases', () => {
+    it('returns 503 when cache is unavailable', async () => {
+      setAuthCache(null as any);
+
+      const req = makeReq({ params: { sessionId: 'any' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      expect(res._status).toBe(503);
+    });
+
+    it('returns 503 when userService unavailable on complete session', async () => {
+      mockCache['diia:session:test-sess'] = JSON.stringify({
+        status: 'complete',
+        userId: 'user-uuid-123',
+      });
+
+      mockGetUserService.mockReturnValueOnce(null as any);
+
+      const req = makeReq({ params: { sessionId: 'test-sess' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      expect(res._status).toBe(503);
+    });
+
+    it('returns expired when user not found by ID', async () => {
+      mockCache['diia:session:test-sess'] = JSON.stringify({
+        status: 'complete',
+        userId: 'deleted-user',
+      });
+
+      fakeUserService.findById.mockResolvedValueOnce(null as any);
+
+      const req = makeReq({ params: { sessionId: 'test-sess' } } as any);
+      const res = makeRes();
+
+      await diiaAuthStatus(req, res);
+
+      expect(res._status).toBe(404);
+      expect(res._json).toEqual({ status: 'expired' });
+    });
+  });
+
+  describe('Full flow: init → callback → status', () => {
+    it('frontend polling gets token after Diia webhook fires', async () => {
+      // Step 1: Init
+      const initReq = makeReq();
+      const initRes = makeRes();
+      await diiaAuthInit(initReq, initRes);
+
+      // Verify pending state
+      const plainPending = JSON.parse(mockCache['diia:session:plain-uuid-abc']);
+      expect(plainPending.status).toBe('pending');
+
+      // Step 2: Frontend polls — should see pending
+      const pollReq1 = makeReq({ params: { sessionId: 'plain-uuid-abc' } } as any);
+      const pollRes1 = makeRes();
+      await diiaAuthStatus(pollReq1, pollRes1);
+      expect(pollRes1._json).toEqual({ status: 'pending' });
+
+      // Step 3: Diia webhook fires
+      fakeUserService.findByEmail.mockResolvedValueOnce(null);
+      const callbackReq = makeReq({
+        headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
+      });
+      const callbackRes = makeRes();
+      await diiaAuthCallback(callbackReq, callbackRes);
+      expect(callbackRes._json).toEqual({ success: true });
+
+      // Step 4: Frontend polls again — should get token
+      const pollReq2 = makeReq({ params: { sessionId: 'plain-uuid-abc' } } as any);
+      const pollRes2 = makeRes();
+      await diiaAuthStatus(pollReq2, pollRes2);
+      expect(pollRes2._json.status).toBe('complete');
+      expect(pollRes2._json.token).toBeDefined();
+    });
+  });
+});

--- a/mcp_backend/src/services/__tests__/diia-service.test.ts
+++ b/mcp_backend/src/services/__tests__/diia-service.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Unit tests for DiiaService.
+ * Mocks fetch to test API integration without external calls.
+ */
+
+import crypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+// Set env vars before importing
+const ORIGINAL_ENV = process.env;
+beforeAll(() => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    DIIA_ACQUIRER_TOKEN: 'test-acquirer-token',
+    DIIA_AUTH_ACQUIRER_TOKEN: 'test-basic-auth',
+    DIIA_BASE_URL: 'https://api2s.diia.gov.ua',
+    DIIA_BRANCH_ID: '',
+    DIIA_OFFER_ID: '',
+    DIIA_SIGN_BRANCH_ID: '',
+    DIIA_SIGN_OFFER_ID: '',
+  };
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+// Import after env setup (uses top-level constants from env)
+// We need to re-import fresh each time due to singleton + cached env vars
+let DiiaService: any;
+let DiiaPermissionError: any;
+
+beforeEach(async () => {
+  jest.resetModules();
+  mockFetch.mockReset();
+
+  // Re-mock after resetModules
+  jest.mock('../../utils/logger.js', () => ({
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+  }));
+
+  const mod = await import('../diia-service.js');
+  DiiaService = mod.DiiaService;
+  DiiaPermissionError = mod.DiiaPermissionError;
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockOkJson(data: any) {
+  return { ok: true, status: 200, json: async () => data, text: async () => JSON.stringify(data) };
+}
+
+function mockError(status: number, body: string) {
+  return { ok: false, status, json: async () => ({}), text: async () => body };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DiiaService', () => {
+  describe('getSessionToken', () => {
+    it('fetches session token from Diia API', async () => {
+      mockFetch.mockResolvedValueOnce(mockOkJson({ token: 'bearer-abc-123' }));
+
+      const service = new DiiaService();
+      const token = await service.getSessionToken();
+
+      expect(token).toBe('bearer-abc-123');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api2s.diia.gov.ua/api/v1/auth/acquirer/test-acquirer-token',
+        expect.objectContaining({
+          method: 'GET',
+          headers: expect.objectContaining({
+            Authorization: 'Basic test-basic-auth',
+          }),
+        }),
+      );
+    });
+
+    it('caches token on second call', async () => {
+      mockFetch.mockResolvedValueOnce(mockOkJson({ token: 'bearer-cached' }));
+
+      const service = new DiiaService();
+      await service.getSessionToken();
+      const token2 = await service.getSessionToken();
+
+      expect(token2).toBe('bearer-cached');
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws on API error', async () => {
+      mockFetch.mockResolvedValueOnce(mockError(401, 'Unauthorized'));
+
+      const service = new DiiaService();
+      await expect(service.getSessionToken()).rejects.toThrow('Diia session token failed: 401');
+    });
+  });
+
+  describe('getBranches', () => {
+    it('returns branch list from Diia API', async () => {
+      const branches = [{ id: 'br-1', name: 'Test Branch' }];
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' })) // session token
+        .mockResolvedValueOnce(mockOkJson({ branches }));
+
+      const service = new DiiaService();
+      const result = await service.getBranches();
+
+      expect(result).toEqual(branches);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns empty array when no branches field', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        .mockResolvedValueOnce(mockOkJson({}));
+
+      const service = new DiiaService();
+      const result = await service.getBranches();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('createBranch', () => {
+    it('creates a branch and returns its ID', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        .mockResolvedValueOnce(mockOkJson({ _id: 'new-branch-id' }));
+
+      const service = new DiiaService();
+      const branchId = await service.createBranch();
+
+      expect(branchId).toBe('new-branch-id');
+    });
+
+    it('throws DiiaPermissionError on 403 forbidden', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        .mockResolvedValueOnce(mockError(403, 'forbidden: scope not active'));
+
+      const service = new DiiaService();
+      await expect(service.createBranch()).rejects.toThrow(DiiaPermissionError);
+    });
+  });
+
+  describe('getAuthDeeplink', () => {
+    it('returns deeplink, requestId, and hashedRequestId', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        .mockResolvedValueOnce(mockOkJson({ deeplink: 'https://diia.app/dl/123' }));
+
+      const service = new DiiaService();
+      const result = await service.getAuthDeeplink('br-1', 'of-1');
+
+      expect(result.deeplink).toBe('https://diia.app/dl/123');
+      expect(result.requestId).toBeDefined();
+      expect(result.hashedRequestId).toBeDefined();
+
+      // Verify hash is SHA256(requestId) in base64
+      const expectedHash = crypto.createHash('sha256').update(result.requestId).digest('base64');
+      expect(result.hashedRequestId).toBe(expectedHash);
+    });
+
+    it('sends ECDSA signAlgo and hashed requestId', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        .mockResolvedValueOnce(mockOkJson({ deeplink: 'https://diia.app/dl/456' }));
+
+      const service = new DiiaService();
+      await service.getAuthDeeplink('br-1', 'of-1');
+
+      const [url, opts] = mockFetch.mock.calls[1];
+      expect(url).toContain('/api/v2/acquirers/branch/br-1/offer-request/dynamic');
+      const body = JSON.parse(opts.body);
+      expect(body.signAlgo).toBe('ECDSA');
+      expect(body.offerId).toBe('of-1');
+    });
+  });
+
+  describe('initAuthSession', () => {
+    it('auto-discovers branch and offer, returns deeplink', async () => {
+      mockFetch
+        // getSessionToken
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        // getBranches
+        .mockResolvedValueOnce(mockOkJson({
+          branches: [{ id: 'br-found', name: 'Auth', scopes: { diiaId: ['auth'] } }],
+        }))
+        // updateBranch (fire-and-forget)
+        .mockResolvedValueOnce(mockOkJson({}))
+        // getOffers
+        .mockResolvedValueOnce(mockOkJson({
+          offers: [{ id: 'of-found', name: 'Авторизація в застосунку Lex' }],
+        }))
+        // getAuthDeeplink
+        .mockResolvedValueOnce(mockOkJson({ deeplink: 'https://diia.app/dl/auto' }));
+
+      const service = new DiiaService();
+      const result = await service.initAuthSession('https://legal.org.ua/auth/callback');
+
+      expect(result.deeplink).toBe('https://diia.app/dl/auto');
+      expect(result.requestId).toBeDefined();
+    });
+
+    it('creates branch when none exist', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        // getBranches: empty
+        .mockResolvedValueOnce(mockOkJson({ branches: [] }))
+        // createBranch
+        .mockResolvedValueOnce(mockOkJson({ _id: 'new-br' }))
+        // getOffers: empty
+        .mockResolvedValueOnce(mockOkJson({ offers: [] }))
+        // createOffer
+        .mockResolvedValueOnce(mockOkJson({ _id: 'new-of' }))
+        // getAuthDeeplink
+        .mockResolvedValueOnce(mockOkJson({ deeplink: 'https://diia.app/dl/new' }));
+
+      const service = new DiiaService();
+      const result = await service.initAuthSession('https://legal.org.ua/callback');
+
+      expect(result.deeplink).toBe('https://diia.app/dl/new');
+    });
+  });
+
+  describe('initSigningSession', () => {
+    const testFiles = [
+      { fileName: 'contract.pdf', fileHash: 'abc123==' },
+    ];
+
+    it('auto-discovers signing branch and returns deeplink', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        // getBranches
+        .mockResolvedValueOnce(mockOkJson({
+          branches: [{
+            id: 'sign-br',
+            name: 'Signing',
+            scopes: { diiaId: ['hashedFilesSigning'] },
+          }],
+        }))
+        // updateBranch
+        .mockResolvedValueOnce(mockOkJson({}))
+        // getOffers
+        .mockResolvedValueOnce(mockOkJson({
+          offers: [{ id: 'sign-of', name: 'Підпис документів' }],
+        }))
+        // updateOffer
+        .mockResolvedValueOnce(mockOkJson({}))
+        // getSigningDeeplink
+        .mockResolvedValueOnce(mockOkJson({ deeplink: 'https://diia.app/sign/auto' }));
+
+      const service = new DiiaService();
+      const result = await service.initSigningSession('https://legal.org.ua/docs', testFiles);
+
+      expect(result.deeplink).toBe('https://diia.app/sign/auto');
+    });
+
+    it('sends file hashes in deeplink request body', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockOkJson({ token: 'tk' }))
+        .mockResolvedValueOnce(mockOkJson({ deeplink: 'https://diia.app/sign/test' }));
+
+      const service = new DiiaService();
+      await service.getSigningDeeplink('br-1', 'of-1', testFiles);
+
+      const [, opts] = mockFetch.mock.calls[1];
+      const body = JSON.parse(opts.body);
+      expect(body.data.hashedFilesSigning.hashedFiles).toEqual(testFiles);
+      expect(body.signAlgo).toBe('ECDSA');
+    });
+  });
+
+  describe('isConfigured', () => {
+    it('returns true when DIIA_ACQUIRER_TOKEN is set', () => {
+      const service = new DiiaService();
+      expect(service.isConfigured()).toBe(true);
+    });
+  });
+
+  describe('DiiaPermissionError', () => {
+    it('is an instance of Error with correct name', () => {
+      const err = new DiiaPermissionError('scope not active');
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('DiiaPermissionError');
+      expect(err.message).toBe('scope not active');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix and expand `diia-auth.test.ts` — add missing mocks (`DiiaPermissionError`, `res.cookie`) + 10 new edge case tests
- Add `diia-service.test.ts` — 15 unit tests for DiiaService (token caching, branch CRUD, deeplink SHA256+ECDSA, auto-discovery)
- Add dedicated CI step in `ci-local-deploy.yml` to run all 56 Diia tests on every backend change

## Test plan
- [x] All 56 Diia tests pass locally (3 suites: auth 21, sign 20, service 15)
- [x] Full backend test suite passes (74 tests, 4 suites)
- [x] TypeScript build passes clean
- [ ] CI runs tests on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 56 regression tests for Diia auth and signing plus a CI guard to run them on every backend change. Tests cover the auth flow (init → callback → status), edge cases (cookies, permission errors, idempotent webhook, service outages), and `DiiaService` behaviors (session token caching, branch/offer CRUD, ECDSA + SHA256 deeplinks, auto-discovery).

<sup>Written for commit daa1f061172ba1d6cee9a695353ab2df561bb235. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

