### PR TITLE
feat(tools): add build_legal_decision — Decision Layer Protocol

### DIFF
--- a/mcp_backend/src/api/tools/decision-layer-tools.ts
+++ b/mcp_backend/src/api/tools/decision-layer-tools.ts
@@ -1,0 +1,288 @@
+/**
+ * Decision Layer Tools — Legal Decision Protocol (LDP)
+ *
+ * Post-processing tool that takes search/analysis results and produces
+ * a structured legal decision with scored positions, risk map, decision tree,
+ * and actionable recommendations.
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+import type { ILLMPort } from '../../domain/ports/index.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface LegalBasis {
+  norm: string;        // "ст. 344 ЦК України"
+  text?: string;       // brief excerpt
+  rada_id?: string;
+}
+
+interface LegalPosition {
+  id: string;
+  claim: string;
+  legal_basis: LegalBasis[];
+  required_evidence: string[];
+  burden_of_proof: 'plaintiff' | 'defendant';
+}
+
+interface PositionScore {
+  position_id: string;
+  success_rate: number | null;        // % from case data, null if unknown
+  supreme_court_alignment: 'aligned' | 'conflicting' | 'no_data';
+  precedent_count: number;
+  recency_score: number;              // 0-100, higher = more recent practice
+  reversal_risk: number | null;       // % appeals overturned
+  enforceability: 'high' | 'medium' | 'low' | 'unknown';
+  composite_score: number;            // 0-100 weighted
+}
+
+interface RiskItem {
+  category: 'procedural' | 'substantive' | 'evidence' | 'enforcement';
+  description: string;
+  probability: 'high' | 'medium' | 'low';
+  impact: 'critical' | 'significant' | 'minor';
+  mitigation: string;
+  case_examples: string[];
+}
+
+interface DecisionTreeNode {
+  question: string;
+  source?: string;
+  yes_branch: string;   // position_id or next question
+  no_branch: string;
+}
+
+interface ReasoningStep {
+  fact: string;
+  logic: string;
+  conclusion: string;
+}
+
+interface ActionStep {
+  step: number;
+  action: string;
+  deadline?: string;
+  documents_needed?: string[];
+}
+
+export interface LegalDecision {
+  positions: LegalPosition[];
+  scores: PositionScore[];
+  decision_tree: DecisionTreeNode[];
+  risk_map: RiskItem[];
+  reasoning: ReasoningStep[];
+  primary_recommendation: string;     // position_id
+  alternative_recommendation: string; // position_id
+  next_steps: ActionStep[];
+  confidence: number;                 // 0-100
+  limitations: string[];
+}
+
+// ============================================================================
+// System prompt for decision generation
+// ============================================================================
+
+const DECISION_SYSTEM_PROMPT = `You are a Legal Decision Protocol (LDP) engine. You receive search results, case analysis, and legislation data from the LEX platform, and you must produce a STRUCTURED legal decision.
+
+## Output Format
+Return ONLY valid JSON matching the LegalDecision schema. No markdown, no comments.
+
+## Schema
+{
+  "positions": [
+    {
+      "id": "pos_1",
+      "claim": "Конкретне формулювання позовної вимоги",
+      "legal_basis": [{"norm": "ст. 344 ЦК України", "text": "короткий витяг"}],
+      "required_evidence": ["Акт обстеження", "Показання свідків"],
+      "burden_of_proof": "plaintiff"
+    }
+  ],
+  "scores": [
+    {
+      "position_id": "pos_1",
+      "success_rate": 72,
+      "supreme_court_alignment": "aligned",
+      "precedent_count": 15,
+      "recency_score": 85,
+      "reversal_risk": 18,
+      "enforceability": "high",
+      "composite_score": 78
+    }
+  ],
+  "decision_tree": [
+    {
+      "question": "Чи минуло 15 років безперервного володіння?",
+      "source": "ст. 344 ЦК",
+      "yes_branch": "pos_1",
+      "no_branch": "Чи є підстави для скороченого строку?"
+    }
+  ],
+  "risk_map": [
+    {
+      "category": "substantive",
+      "description": "Зміна практики ВП ВС щодо набувальної давності",
+      "probability": "medium",
+      "impact": "critical",
+      "mitigation": "Посилатися на пост. ВП ВС від 2023 року",
+      "case_examples": ["922/989/18"]
+    }
+  ],
+  "reasoning": [
+    {
+      "fact": "ВС у справі 756/1234/23 підтвердив застосування ст. 344 ЦК",
+      "logic": "Наша ситуація підпадає під той самий правовий режим",
+      "conclusion": "Негаторний позов є обґрунтованим"
+    }
+  ],
+  "primary_recommendation": "pos_1",
+  "alternative_recommendation": "pos_2",
+  "next_steps": [
+    {
+      "step": 1,
+      "action": "Подати позов до Господарського суду м. Києва",
+      "deadline": "до 15.04.2026",
+      "documents_needed": ["Позовна заява", "Квитанція про сплату судового збору"]
+    }
+  ],
+  "confidence": 78,
+  "limitations": ["Аналіз базується на 15 справах, вибірка може бути недостатньою"]
+}
+
+## Rules
+1. EVERY score and metric MUST be derived from the provided data. If data is insufficient, set to null and add to limitations.
+2. EVERY reasoning step must cite a specific case number or article from the input.
+3. Generate ALL plausible legal positions, not just the obvious one.
+4. The composite_score formula: 0.25*success_rate + 0.2*SC_alignment(100/50/0) + 0.15*recency + 0.15*(100-reversal_risk) + 0.15*precedent_density + 0.1*enforceability(100/60/30)
+5. Decision tree questions must come from actual branching points found in case law analysis.
+6. Risk map must include at least procedural and substantive risks.
+7. All text in Ukrainian.`;
+
+// ============================================================================
+// Tool Handler
+// ============================================================================
+
+export class DecisionLayerTools extends BaseToolHandler {
+  constructor(private llm: ILLMPort) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'build_legal_decision',
+        description: 'Decision Layer Protocol: приймає результати пошуку/аналізу і генерує структуроване юридичне рішення з scored позиціями, деревом рішень, картою ризиків та рекомендаціями. Використовувати ПІСЛЯ збору даних через інші інструменти.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Юридичне питання користувача',
+            },
+            context: {
+              type: 'string',
+              description: 'Зібраний контекст: результати пошуку справ, законодавство, аналіз практики. Передавати як текст з усіма знайденими даними.',
+            },
+            pro_cases: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Номери справ "за" позицію (з compare_practice_pro_contra)',
+            },
+            contra_cases: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Номери справ "проти" позиції',
+            },
+            legislation: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Релевантні статті законів (текст)',
+            },
+          },
+          required: ['query', 'context'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    if (name !== 'build_legal_decision') return null;
+
+    const { query, context, pro_cases, contra_cases, legislation } = args;
+
+    logger.info('[DecisionLayer] Building legal decision', {
+      queryLength: query?.length,
+      contextLength: context?.length,
+      proCases: pro_cases?.length || 0,
+      contraCases: contra_cases?.length || 0,
+    });
+
+    try {
+      // Build enriched context
+      const parts: string[] = [
+        `## Юридичне питання\n${query}`,
+        `## Зібрані дані\n${context}`,
+      ];
+
+      if (pro_cases?.length) {
+        parts.push(`## Справи "за"\n${pro_cases.join(', ')}`);
+      }
+      if (contra_cases?.length) {
+        parts.push(`## Справи "проти"\n${contra_cases.join(', ')}`);
+      }
+      if (legislation?.length) {
+        parts.push(`## Законодавство\n${legislation.join('\n\n')}`);
+      }
+
+      const userMessage = parts.join('\n\n');
+
+      // Call LLM for structured decision
+      const response = await this.llm.chatCompletion(
+        {
+          messages: [
+            { role: 'system', content: DECISION_SYSTEM_PROMPT },
+            { role: 'user', content: userMessage },
+          ],
+          temperature: 0.3,
+          max_tokens: 4000,
+          response_format: { type: 'json_object' },
+        },
+        'deep',
+      );
+
+      const text = response.content;
+
+      // Try to parse as JSON
+      let decision: LegalDecision;
+      try {
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        decision = JSON.parse(jsonMatch?.[0] || text);
+      } catch {
+        // LLM returned non-JSON — wrap as text response
+        return this.wrapResponse({
+          error: 'Failed to generate structured decision',
+          raw_analysis: text,
+        });
+      }
+
+      // Validate minimum structure
+      if (!decision.positions || !decision.scores || !decision.reasoning) {
+        return this.wrapResponse({
+          error: 'Incomplete decision structure',
+          partial: decision,
+        });
+      }
+
+      return this.wrapResponse(decision);
+    } catch (error: any) {
+      logger.error('[DecisionLayer] Failed to build decision', { error: error.message });
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ error: error.message }) }],
+        isError: true,
+      };
+    }
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -27,6 +27,7 @@ import { NextcloudTools } from '../api/tools/nextcloud-tools.js';
 import { StateRegistryTools } from '../api/tools/state-registry-tools.js';
 import { CourtStatusTools } from '../api/tools/court-status-tools.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
+import { DecisionLayerTools } from '../api/tools/decision-layer-tools.js';
 import { logger } from '../utils/logger.js';
 import path from 'path';
 
@@ -125,6 +126,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new StateRegistryTools(coreServices.db));
   toolRegistry.registerHandler(new CourtStatusTools(coreServices.db));
   toolRegistry.registerHandler(new EdsrSearchTools(coreServices.db));
+  toolRegistry.registerHandler(new DecisionLayerTools(llmAdapter));
 
   // EDRSR FTS + semantic search + on-demand vectorization
   const edsrFtsService = new EdsrFtsService();

--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -95,7 +95,7 @@ export function buildPlanGenerationMessages(
       parliament_query: '11. queryType=parliament_query: use rada_ tools, max 2 steps',
       document_query: '11. queryType=document_query: ALWAYS start with list_documents(query="", limit=50) to get ALL user documents. Then use semantic_search for content-relevant fragments. For analysis: also use get_document to read full text of relevant docs. For delete/update by name: first list_documents to find the doc, then delete_document/update_document with the ID. Max 5 steps.',
       document_drafting: '11. queryType=document_drafting: first find_relevant_law_articles for legal basis, then generate document',
-      comparative_analysis: '11. queryType=comparative_analysis: search each competing approach separately with pro/contra, include legislation',
+      comparative_analysis: '11. queryType=comparative_analysis: search each competing approach separately with pro/contra, include legislation. ALWAYS finish with build_legal_decision to produce structured decision with scored positions, risk map, and recommendations.',
       due_diligence: '11. queryType=due_diligence: start with registry lookup, add debtors/bankruptcy/enforcement checks, then court cases',
       institutional_analysis: '11. queryType=institutional_analysis: use search_edrsr_decisions (filter by judge/court/date), search_edrsr_fulltext, search_edrsr_semantic for different aspects (topics, time periods), include count_cases_by_party and legislation lookups. Do NOT use search_legal_precedents (deprecated).',
       calculation: '11. queryType=calculation: find relevant procedural norms first, then apply calculation logic',

--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -97,7 +97,7 @@ export const QUERY_TYPE_CONFIG: Record<QueryType, QueryTypeConfig> = {
     defaultBudget: 'deep',
     requiresGrounding: true,
     preferredScenarios: ['practice_pro_contra', 'court_practice_search', 'comprehensive_legal_advice'],
-    groundingNote: 'Порівняння МУСИТЬ базуватися на конкретних справах з результатів пошуку. Кожен підхід підкріплюй номерами справ. Обов\'язково побудуй порівняльну таблицю.',
+    groundingNote: 'Порівняння МУСИТЬ базуватися на конкретних справах з результатів пошуку. Кожен підхід підкріплюй номерами справ. Обов\'язково побудуй порівняльну таблицю. Завершуй аналіз викликом build_legal_decision для структурованого рішення з оцінкою позицій та картою ризиків.',
     thinkingPrefix: 'Порівнюю правові підходи',
   },
 


### PR DESCRIPTION
## Summary
New MCP tool `build_legal_decision` implementing Legal Decision Protocol (LDP):
- **Position Candidates** — auto-generates all possible legal positions
- **Decision Matrix** — scores each position (success_rate, reversal_risk, SC alignment, enforceability)
- **Decision Tree** — branching points from case law analysis
- **Risk Map** — categorized risks with mitigation strategies
- **Reasoning Chain** — explicit fact-logic-conclusion
- **Action Plan** — next steps with deadlines

Automatically triggered for `comparative_analysis` queries via plan generation.

Ref: Nextcloud card #413

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Send comparative analysis query ("негаторний чи віндикаційний позов")
- [ ] Verify `build_legal_decision` appears in execution plan
- [ ] Verify structured JSON response with positions, scores, risks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MCP tool `build_legal_decision` to turn search and analysis results into a structured legal decision with scored positions, a decision tree, a risk map, and clear recommendations. It now auto-runs at the end of `comparative_analysis` to output JSON for downstream use.

- **New Features**
  - New tool implementing the Legal Decision Protocol with JSON schema: positions, scores (success_rate, SC alignment, reversal_risk, enforceability, composite_score), decision_tree, risk_map, reasoning, primary/alternative recommendations, next_steps, confidence, limitations.
  - Registered in the tool registry; uses `deep` LLM budget with JSON response formatting and basic validation/error handling.
  - Updated plan generation and query-type config: `comparative_analysis` always finishes with `build_legal_decision`.

<sup>Written for commit 0258de47aeebfd28202be2febc52bfc6ca5be7fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

