### PR TITLE
fix(nginx): add server blocks for nextcloud.legal.org.ua

### DIFF
--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -204,6 +204,59 @@ server {
     include /etc/nginx/includes/prod-server-common.conf;
 }
 
+# HTTP - nextcloud.legal.org.ua (Nextcloud file storage)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name nextcloud.legal.org.ua;
+
+    set_real_ip_from 172.31.0.0/16;
+    real_ip_header X-Forwarded-For;
+
+    # Direct access without ALB → redirect to HTTPS
+    if ($http_x_forwarded_proto = "") {
+        return 301 https://$host$request_uri;
+    }
+
+    # Behind ALB → proxy to Nextcloud
+    location / {
+        proxy_pass http://nextcloud-prod:80/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        client_max_body_size 512M;
+    }
+}
+
+# HTTPS - nextcloud.legal.org.ua (Nextcloud — direct access)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name nextcloud.legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+
+    location / {
+        proxy_pass http://nextcloud-prod:80/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        client_max_body_size 512M;
+    }
+}
+
 # WebSocket upgrade map
 map $http_upgrade $connection_upgrade {
     default upgrade;


### PR DESCRIPTION
## Summary
- Adds HTTP server block for `nextcloud.legal.org.ua` (Cloudflare → port 80)
- Adds HTTPS server block for direct access (port 443)
- Fixes 405 Not Allowed errors for PUT/DELETE in Nextcloud Deck UI

## Context
After CI/CD deploy, the Nextcloud subdomain had no dedicated server block in nginx. Requests hit the default server which didn't proxy properly, causing 405 errors when editing cards in Deck.

## Test plan
- [x] `nginx -t` passes without errors
- [x] Nextcloud UI loads at `nextcloud.legal.org.ua`
- [ ] Verify Deck card editing works (PUT requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dedicated HTTP and HTTPS NGINX server blocks for nextcloud.legal.org.ua that proxy to `nextcloud-prod`. Fixes 405 errors for PUT/DELETE in Nextcloud Deck and enables direct HTTPS access.

- **Bug Fixes**
  - Route traffic via new server blocks (80/443) instead of the default server.
  - Set required proxy headers (including X-Forwarded-Proto), disable proxy buffering, and raise `client_max_body_size` to 512M.
  - Redirect direct HTTP requests to HTTPS when not behind the ALB.

<sup>Written for commit 135be69c76c1f2cf22dfcb03e2530e6dd02289df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

