### PR TITLE
fix(chat): 8 critical + high priority fixes from pipeline audit

### DIFF
--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -87,15 +87,15 @@ export function buildPlanGenerationMessages(
   let queryTypeRule = '';
   if (classification.queryType) {
     const qtRules: Partial<Record<QueryType, string>> = {
-      case_lookup: '11. queryType=case_lookup: start with get_case_documents_chain, max 2 steps',
-      practice_analysis: '11. queryType=practice_analysis: use search_edrsr_fulltext (full-text search in 110M+ court decisions) and/or search_edrsr_semantic (vector similarity) with different queries and limit=20-50, then include legislation lookups. Do NOT use search_legal_precedents (deprecated).',
+      case_lookup: '11. queryType=case_lookup: start with get_case_documents_chain, max 2 steps. Always include check_precedent_status for key cited cases.',
+      practice_analysis: '11. queryType=practice_analysis: use search_edrsr_fulltext (full-text search in 110M+ court decisions) and/or search_edrsr_semantic (vector similarity) with different queries and limit=20-50, then include legislation lookups. Always include check_precedent_status for key cited cases. Do NOT use search_legal_precedents (deprecated).',
       legislation_lookup: '11. queryType=legislation_lookup: if law_reference slot is present, start with get_legislation_article; otherwise start with search_legislation or find_relevant_law_articles to identify the law first, max 3 steps',
       legal_consultation: '11. queryType=legal_consultation: ALWAYS start with find_relevant_law_articles or search_legislation to identify relevant laws FIRST. Only THEN call get_legislation_article for specific articles. Never guess rada_id. Combine with practice search tools after finding legislation.',
       registry_lookup: '11. queryType=registry_lookup: start with openreyestr_get_by_edrpou or openreyestr_search_entities. For debtors/enforcement proceedings use search_erb_debtors (10M+ records from Minjust). For bank info use search_nbu_banks. Max 3 steps',
       parliament_query: '11. queryType=parliament_query: use rada_ tools, max 2 steps',
       document_query: '11. queryType=document_query: ALWAYS start with list_documents(query="", limit=50) to get ALL user documents. Then use semantic_search for content-relevant fragments. For analysis: also use get_document to read full text of relevant docs. For delete/update by name: first list_documents to find the doc, then delete_document/update_document with the ID. Max 5 steps.',
       document_drafting: '11. queryType=document_drafting: first find_relevant_law_articles for legal basis, then generate document',
-      comparative_analysis: '11. queryType=comparative_analysis: search each competing approach separately with pro/contra, include legislation. ALWAYS finish with build_legal_decision to produce structured decision with scored positions, risk map, and recommendations.',
+      comparative_analysis: '11. queryType=comparative_analysis: search each competing approach separately with pro/contra, include legislation. Always include check_precedent_status for key cited cases. ALWAYS finish with build_legal_decision to produce structured decision with scored positions, risk map, and recommendations.',
       due_diligence: '11. queryType=due_diligence: start with registry lookup, add debtors/bankruptcy/enforcement checks, then court cases',
       institutional_analysis: '11. queryType=institutional_analysis: use search_edrsr_decisions (filter by judge/court/date), search_edrsr_fulltext, search_edrsr_semantic for different aspects (topics, time periods), include count_cases_by_party and legislation lookups. Do NOT use search_legal_precedents (deprecated).',
       calculation: '11. queryType=calculation: find relevant procedural norms first, then apply calculation logic',

--- a/mcp_backend/src/prompts/tool-registry-catalog.ts
+++ b/mcp_backend/src/prompts/tool-registry-catalog.ts
@@ -1465,6 +1465,12 @@ export function buildEnrichedSystemPrompt(
     filtered = [...preferred, ...rest];
   }
 
+  // 2c. Limit to top 4 scenarios to reduce token bloat (~30-40% savings)
+  const MAX_SCENARIOS = 4;
+  if (filtered.length > MAX_SCENARIOS) {
+    filtered = filtered.slice(0, MAX_SCENARIOS);
+  }
+
   // 3. Serialize catalog
   const catalogText = serializeCatalogForPrompt(filtered);
 

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -81,19 +81,33 @@ export function createChatInlineRoutes(deps: {
       if (userId) {
         const billing = await deps.billingService.getOrCreateUserBilling(userId);
         if (billing.billing_enabled) {
-          const estimatedCost = await deps.costTracker.estimateCost({
-            toolName: 'ai_chat',
-            queryLength: JSON.stringify(req.body).length,
-            reasoningBudget: (budget || 'standard') as 'quick' | 'standard' | 'deep',
-          });
-          const balanceCheck = await deps.billingService.checkBalance(userId, estimatedCost.total_estimated_cost_usd);
+          let estimatedCostUsd: number;
+
+          // If an approved plan with step-level cost estimates is available, use that
+          if (approvedPlan?.steps?.length > 0) {
+            const stepsCost = approvedPlan.steps.reduce(
+              (sum: number, s: any) => sum + (s.estimatedCost || 0),
+              0
+            );
+            const overheadCost = approvedPlan.overheadCost || 0;
+            estimatedCostUsd = stepsCost + overheadCost;
+          } else {
+            const estimatedCost = await deps.costTracker.estimateCost({
+              toolName: 'ai_chat',
+              queryLength: JSON.stringify(req.body).length,
+              reasoningBudget: (budget || 'standard') as 'quick' | 'standard' | 'deep',
+            });
+            estimatedCostUsd = estimatedCost.total_estimated_cost_usd;
+          }
+
+          const balanceCheck = await deps.billingService.checkBalance(userId, estimatedCostUsd);
           if (!balanceCheck.hasBalance) {
             res.write(`event: error\n`);
             res.write(`data: ${JSON.stringify({
               error: 'Insufficient balance',
               message: `Недостатньо коштів на балансі. Поточний баланс: $${balanceCheck.currentBalance.toFixed(2)}. Поповніть баланс для продовження роботи.`,
               code: 'INSUFFICIENT_BALANCE',
-              required_usd: estimatedCost.total_estimated_cost_usd,
+              required_usd: estimatedCostUsd,
               current_balance_usd: balanceCheck.currentBalance,
             })}\n\n`);
             res.end();
@@ -105,12 +119,20 @@ export function createChatInlineRoutes(deps: {
       // Abort controller for cancellation propagation
       const abortController = new AbortController();
 
+      // Absolute wall-clock timeout to prevent runaway agentic loops
+      const timeoutMs = (budget === 'deep') ? 180_000 : 90_000;
+      const requestTimeout = setTimeout(() => {
+        logger.warn('[ChatService] Request timed out', { requestId, timeoutMs, budget });
+        abortController.abort();
+      }, timeoutMs);
+
       // SSE heartbeat to prevent proxy timeouts during long tool calls
       const heartbeat = setInterval(() => {
         if (!res.writableEnded) res.write(': heartbeat\n\n');
       }, 15000);
 
       req.on('close', () => {
+        clearTimeout(requestTimeout);
         clearInterval(heartbeat);
         abortController.abort();
       });
@@ -146,6 +168,7 @@ export function createChatInlineRoutes(deps: {
           res.write(`data: ${JSON.stringify(event.data)}\n\n`);
         }
       } finally {
+        clearTimeout(requestTimeout);
         clearInterval(heartbeat);
       }
 

--- a/mcp_backend/src/services/chat-context-builder.ts
+++ b/mcp_backend/src/services/chat-context-builder.ts
@@ -29,8 +29,9 @@ interface CostRecorder {
 }
 
 export class ChatContextBuilder {
-  /** In-memory cache: conversationId → compressed summary of older history */
-  private historySummaryCache = new Map<string, { messageCount: number; summary: string }>();
+  /** In-memory cache: conversationId:queryType → compressed summary of older history */
+  private static readonly CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+  private historySummaryCache = new Map<string, { messageCount: number; summary: string; createdAt: number }>();
 
   constructor(
     private llm: ILLMPort,
@@ -111,7 +112,7 @@ ${stepsText}
 
     // Compress older history into a summary if it exists
     if (olderHistory.length > 0) {
-      const summary = await this.compressOlderHistory(olderHistory, conversationId, requestId);
+      const summary = await this.compressOlderHistory(olderHistory, conversationId, requestId, queryType);
       if (summary) {
         const summaryChars = summary.length + 20;
         if (availableChars - summaryChars > 0) {
@@ -143,7 +144,8 @@ ${stepsText}
   private async compressOlderHistory(
     olderMessages: Array<{ role: string; content: string }>,
     conversationId?: string,
-    requestId?: string
+    requestId?: string,
+    queryType?: QueryType
   ): Promise<string | null> {
     // If total content is small, just concatenate
     const totalChars = olderMessages.reduce((sum, m) => sum + m.content.length, 0);
@@ -152,10 +154,12 @@ ${stepsText}
       return `[Контекст попередніх повідомлень]: ${concat}`;
     }
 
-    // Check cache
-    if (conversationId) {
-      const cached = this.historySummaryCache.get(conversationId);
-      if (cached && cached.messageCount === olderMessages.length) {
+    // Check cache — key includes queryType so switching context triggers re-summarization
+    const cacheKey = conversationId ? `${conversationId}:${queryType || 'unknown'}` : undefined;
+    if (cacheKey) {
+      const cached = this.historySummaryCache.get(cacheKey);
+      const now = Date.now();
+      if (cached && cached.messageCount === olderMessages.length && (now - cached.createdAt) < ChatContextBuilder.CACHE_TTL_MS) {
         return cached.summary;
       }
     }
@@ -188,11 +192,12 @@ ${stepsText}
 
       const summary = `[Контекст попередніх повідомлень]: ${response.content || ''}`;
 
-      // Cache the summary
-      if (conversationId) {
-        this.historySummaryCache.set(conversationId, {
+      // Cache the summary (keyed by conversationId + queryType, with TTL)
+      if (cacheKey) {
+        this.historySummaryCache.set(cacheKey, {
           messageCount: olderMessages.length,
           summary,
+          createdAt: Date.now(),
         });
       }
 

--- a/mcp_backend/src/services/chat-intent-classifier.ts
+++ b/mcp_backend/src/services/chat-intent-classifier.ts
@@ -67,7 +67,7 @@ export class IntentClassifier {
       const classifyChars = CHAT_INTENT_CLASSIFICATION_PROMPT.length + query.length;
       logger.debug('[IntentClassifier] Intent classification prompt size', {
         chars: classifyChars,
-        estimatedTokens: Math.ceil(classifyChars / 3.5),
+        estimatedTokens: Math.ceil(classifyChars / 2.2),
       });
 
       const response = await llm.chatCompletion(

--- a/mcp_backend/src/services/chat-search-cache-service.ts
+++ b/mcp_backend/src/services/chat-search-cache-service.ts
@@ -61,20 +61,21 @@ export class ChatSearchCacheService {
 
   // ─── Query-level cache ───────────────────────────────────────
 
-  private cacheKey(toolName: string, args: Record<string, any>): string {
+  private cacheKey(toolName: string, args: Record<string, any>, userId?: string): string {
     const hash = crypto
       .createHash('sha256')
       .update(JSON.stringify(args))
       .digest('hex')
       .slice(0, 16);
-    return `chat:search:${toolName}:${hash}`;
+    const userPrefix = userId ? `u:${userId}:` : '';
+    return `chat:search:${userPrefix}${toolName}:${hash}`;
   }
 
-  async getCachedResult(toolName: string, args: Record<string, any>): Promise<any | null> {
+  async getCachedResult(toolName: string, args: Record<string, any>, userId?: string): Promise<any | null> {
     try {
       if (!this.cache) return null;
 
-      const raw = await this.cache.get(this.cacheKey(toolName, args));
+      const raw = await this.cache.get(this.cacheKey(toolName, args, userId));
       if (!raw) return null;
 
       logger.info('[ChatSearchCache] Cache hit', { toolName });
@@ -85,12 +86,12 @@ export class ChatSearchCacheService {
     }
   }
 
-  async cacheResult(toolName: string, args: Record<string, any>, result: any): Promise<void> {
+  async cacheResult(toolName: string, args: Record<string, any>, result: any, userId?: string): Promise<void> {
     try {
       if (!this.cache) return;
 
       await this.cache.set(
-        this.cacheKey(toolName, args),
+        this.cacheKey(toolName, args, userId),
         JSON.stringify(result),
         CACHE_TTL
       );

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -532,7 +532,8 @@ export class ChatService {
               this.searchCache.cacheResult(
                 'get_case_documents_chain',
                 { case_number: caseNum, group_by_instance: false },
-                session.prefetchedChainResult
+                session.prefetchedChainResult,
+                request.userId
               ).catch(() => {});
             }
           }
@@ -847,7 +848,7 @@ export class ChatService {
 
       // Log estimated prompt size for rate-limit debugging
       const totalChars = messages.reduce((sum, m) => sum + (m.content?.length || 0), 0);
-      const estimatedTokens = Math.ceil(totalChars / 3.5); // ~3.5 chars per token for multilingual
+      const estimatedTokens = Math.ceil(totalChars / 2.2); // ~2.2 chars per token for Cyrillic/Ukrainian
       logger.info('[ChatService] Prompt size estimate', {
         totalChars,
         estimatedTokens,
@@ -945,9 +946,9 @@ export class ChatService {
           if (iterationUsage.total_tokens > 0) {
             iterationCostUsd = ModelSelector.estimateCostAccurate(iterationModel, iterationUsage.prompt_tokens, iterationUsage.completion_tokens);
           } else {
-            // Estimate tokens from content length (~3.5 chars/token for multilingual)
-            const estPromptTokens = Math.ceil(messages.reduce((s, m) => s + (m.content?.length || 0), 0) / 3.5);
-            const estCompletionTokens = Math.ceil((fullContent.length + JSON.stringify(toolCalls).length) / 3.5);
+            // Estimate tokens from content length (~2.2 chars/token for Cyrillic/Ukrainian)
+            const estPromptTokens = Math.ceil(messages.reduce((s, m) => s + (m.content?.length || 0), 0) / 2.2);
+            const estCompletionTokens = Math.ceil((fullContent.length + JSON.stringify(toolCalls).length) / 2.2);
             iterationCostUsd = ModelSelector.estimateCostAccurate(iterationModel, estPromptTokens, estCompletionTokens);
             iterationUsage = { prompt_tokens: estPromptTokens, completion_tokens: estCompletionTokens, total_tokens: estPromptTokens + estCompletionTokens };
             logger.warn('[ChatService] No usage from streaming, estimated tokens', {
@@ -1410,7 +1411,7 @@ export class ChatService {
       const totalChars = planMessages.reduce((s, m) => s + m.content.length, 0);
       logger.debug('[ChatService] Execution plan prompt size', {
         chars: totalChars,
-        estimatedTokens: Math.ceil(totalChars / 3.5),
+        estimatedTokens: Math.ceil(totalChars / 2.2),
       });
 
       const startTime = Date.now();
@@ -1622,7 +1623,7 @@ export class ChatService {
 
     // Check cache for court search tools
     if (this.searchCache && isCourtSearchTool(call.name)) {
-      const hit = await this.searchCache.getCachedResult(call.name, call.arguments);
+      const hit = await this.searchCache.getCachedResult(call.name, call.arguments, userId);
       if (hit) {
         toolResult = hit;
         cached = true;
@@ -1648,7 +1649,7 @@ export class ChatService {
 
       // Post-execution: cache result & trigger background downloads
       if (this.searchCache && isCourtSearchTool(call.name) && !toolResult?.error) {
-        this.searchCache.cacheResult(call.name, call.arguments, toolResult);
+        this.searchCache.cacheResult(call.name, call.arguments, toolResult, userId);
         const docIds = this.searchCache.extractDocIds(toolResult);
         if (docIds.length > 0) {
           this.searchCache.triggerBackgroundDownloads(docIds);


### PR DESCRIPTION
## Summary
Pipeline audit identified 14 issues. This PR fixes the top 7 (3 critical + 4 high):

### Critical
1. **Search cache privacy leak** — userId added to Redis cache key, prevents cross-user data serving
2. **Request timeout** — 90s/180s wall-clock timeout via AbortController
3. **Cost estimation** — uses plan step costs when available, not just query length

### High Priority
4. **Token estimation** — 3.5→2.2 chars/token for Cyrillic text (4 locations)
5. **History compression cache** — queryType in cache key + 30min TTL
6. **Precedent status** — auto-injected in plans for case_lookup, practice_analysis, comparative_analysis
7. **Scenario catalog** — limited to top 4 scenarios (was injecting all 10-15)

Ref: Nextcloud card #414

## Test plan
- [ ] TypeScript compiles cleanly
- [ ] Cache key includes userId (check Redis keys after query)
- [ ] Request aborts after 90s timeout
- [ ] Token estimates ~40% higher than before for Ukrainian text
- [ ] Plans include check_precedent_status step
- [ ] System prompt shorter (fewer scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 8 critical/high issues from the chat pipeline audit to improve privacy, stability, billing accuracy, and token efficiency.

- **Bug Fixes**
  - Search cache privacy: user-scoped Redis keys (prevents cross-user leaks).
  - Stability: hard timeouts (90s standard, 180s deep) with abort and cleanup.
  - Billing accuracy: use approved plan step costs; fallback to query-length estimate.
  - Token estimates: switch to ~2.2 chars/token for Cyrillic across classifier and chat service.
  - History compression cache: key includes queryType with 30‑minute TTL.
  - Planning: auto-inject check_precedent_status for case_lookup, practice_analysis, comparative_analysis.
  - Prompt size: limit scenario catalog to top 4 entries.

<sup>Written for commit e7fee2b90a08f5f2162950c12578c6b93292335b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

