### PR TITLE
feat(chat): require user confirmation for deep budget escalation

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChatPlan.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatPlan.ts
@@ -15,7 +15,8 @@ export interface UseAIChatPlanOptions {
     query: string,
     assistantMessageId: string,
     approvedPlan?: ExecutionPlan,
-    planSessionId?: string
+    planSessionId?: string,
+    allowDeepEscalation?: boolean
   ) => Promise<void>;
   onError?: (error: Error) => void;
 }
@@ -36,7 +37,7 @@ export function useAIChatPlan(options: UseAIChatPlanOptions) {
    * Phase 1: Request plan for user review, then pause.
    */
   const executeChat = useCallback(
-    async (query: string, _documentIds?: string[]) => {
+    async (query: string, _documentIds?: string[], allowDeepEscalation?: boolean) => {
       const userMessage = {
         id: Date.now().toString(),
         role: 'user' as const,
@@ -86,7 +87,7 @@ export function useAIChatPlan(options: UseAIChatPlanOptions) {
       setCurrentTool('ai_chat');
 
       try {
-        await runChatStream(query, assistantMessageId);
+        await runChatStream(query, assistantMessageId, undefined, undefined, allowDeepEscalation);
       } catch (error: unknown) {
         handleCatchError(assistantMessageId, error, {
           updateMessage, setStreaming, setCurrentTool, onError,

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -51,7 +51,8 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
       query: string,
       assistantMessageId: string,
       approvedPlan?: ExecutionPlan,
-      planSessionId?: string
+      planSessionId?: string,
+      allowDeepEscalation?: boolean
     ) => {
       // Reset accumulators
       accumulatedDecisions.current = [];
@@ -99,10 +100,19 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
         },
 
         onBudgetEscalated: (data) => {
-          showToast.info(
-            toastTDynamic('budgetEscalated', formatUah(data.estimatedCost.minUsd), formatUah(data.estimatedCost.maxUsd)),
-            6000
-          );
+          if (data.requiresConfirmation) {
+            useChatStore.getState().setPendingBudgetEscalation({
+              reason: data.reason,
+              estimatedCostMin: data.estimatedCost.minUsd,
+              estimatedCostMax: data.estimatedCost.maxUsd,
+              query,
+            });
+          } else {
+            showToast.info(
+              toastTDynamic('budgetEscalated', formatUah(data.estimatedCost.minUsd), formatUah(data.estimatedCost.maxUsd)),
+              6000
+            );
+          }
         },
 
         onThinking: (data) => {
@@ -311,7 +321,7 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             costSummary: costSummaryRef.current as CostSummary,
           });
         },
-      }, 'standard', chatConversationId, approvedPlan, planSessionId);
+      }, 'standard', chatConversationId, approvedPlan, planSessionId, allowDeepEscalation);
 
       setStreamController(controller);
     },

--- a/lexwebapp/src/pages/ChatPage/index.tsx
+++ b/lexwebapp/src/pages/ChatPage/index.tsx
@@ -5,10 +5,12 @@
  */
 
 import { useState, useCallback } from 'react';
+import { TrendingUp } from 'lucide-react';
 import { ChatInput } from '../../components/ChatInput';
 import { MessageThread } from '../../components/MessageThread';
 import { EmptyState } from '../../components/EmptyState';
 import { PlanReviewDisplay } from '../../components/PlanReviewDisplay';
+import { useCurrencyRate } from '../../hooks/useCurrencyRate';
 import { useChatStore } from '../../stores';
 import { useMCPTool, useAIChat } from '../../hooks/useMCPTool';
 import { AI_CHAT_MODE } from '../../hooks/chat/tool-categories';
@@ -25,6 +27,8 @@ export function ChatPage() {
   const isPlanLoading = useChatStore(s => s.isPlanLoading);
   const cancelStream = useChatStore(s => s.cancelStream);
   const removeMessage = useChatStore(s => s.removeMessage);
+  const pendingBudgetEscalation = useChatStore(s => s.pendingBudgetEscalation);
+  const setPendingBudgetEscalation = useChatStore(s => s.setPendingBudgetEscalation);
 
   // MCP Tool hook (for manual tool mode)
   const { executeTool } = useMCPTool(selectedTool === AI_CHAT_MODE ? 'search_legal_precedents' : selectedTool, {
@@ -33,6 +37,19 @@ export function ChatPage() {
 
   // AI Chat hook (agentic mode)
   const { executeChat, confirmPlanAndExecute, skipPlanReview } = useAIChat();
+  const { formatUah } = useCurrencyRate();
+
+  const handleConfirmDeepBudget = useCallback(() => {
+    const esc = useChatStore.getState().pendingBudgetEscalation;
+    if (!esc) return;
+    setPendingBudgetEscalation(null);
+    // Re-send the same query with allowDeepEscalation
+    executeChat(esc.query, undefined, true);
+  }, [executeChat, setPendingBudgetEscalation]);
+
+  const handleSkipDeepBudget = useCallback(() => {
+    setPendingBudgetEscalation(null);
+  }, [setPendingBudgetEscalation]);
 
   /**
    * Parse content to tool-specific parameters
@@ -146,6 +163,35 @@ export function ChatPage() {
             onSkip={skipPlanReview}
             isLoading={isStreaming}
           />
+        </div>
+      )}
+
+      {/* Budget escalation confirmation */}
+      {pendingBudgetEscalation && (
+        <div className="w-full max-w-3xl mx-auto px-4 mb-3">
+          <div className="flex items-center gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+            <TrendingUp size={20} className="text-amber-600 shrink-0" />
+            <div className="flex-1">
+              <p className="text-sm font-medium text-amber-900">
+                Рекомендовано глибокий аналіз
+              </p>
+              <p className="text-xs text-amber-700 mt-0.5">
+                Орієнтовна вартість: {formatUah(pendingBudgetEscalation.estimatedCostMin)}–{formatUah(pendingBudgetEscalation.estimatedCostMax)}
+              </p>
+            </div>
+            <button
+              onClick={handleSkipDeepBudget}
+              className="px-3 py-1.5 text-xs font-medium text-amber-700 hover:text-amber-900 transition-colors"
+            >
+              Залишити стандартний
+            </button>
+            <button
+              onClick={handleConfirmDeepBudget}
+              className="px-4 py-1.5 text-xs font-medium bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
+            >
+              Глибокий аналіз
+            </button>
+          </div>
         </div>
       )}
 

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -38,7 +38,7 @@ export interface ChatStreamCallbacks {
   onCitationWarning?: (data: CitationWarning) => void;
   onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string; conversationId?: string }) => void;
   onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
-  onBudgetEscalated?: (data: { reason: string; estimatedCost: { minUsd: number; maxUsd: number } }) => void;
+  onBudgetEscalated?: (data: { reason: string; estimatedCost: { minUsd: number; maxUsd: number }; requiresConfirmation?: boolean }) => void;
   onError?: (data: { message?: string; code?: string; current_balance_usd?: number }) => void;
 }
 
@@ -145,7 +145,8 @@ export class MCPService extends BaseService {
     budget: string = 'standard',
     conversationId?: string,
     approvedPlan?: import('../../types/models/Message').ExecutionPlan,
-    planSessionId?: string
+    planSessionId?: string,
+    allowDeepEscalation?: boolean
   ): Promise<AbortController> {
     const controller = new AbortController();
 
@@ -156,7 +157,7 @@ export class MCPService extends BaseService {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${this.getAuthToken()}`,
         },
-        body: JSON.stringify({ query, history, budget, conversationId, approvedPlan, planSessionId }),
+        body: JSON.stringify({ query, history, budget, conversationId, approvedPlan, planSessionId, allowDeepEscalation }),
         signal: controller.signal,
       });
 

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -23,6 +23,14 @@ export interface PendingPlanReview {
   assistantMessageId: string;
 }
 
+/** Pending budget escalation awaiting user confirmation */
+export interface PendingBudgetEscalation {
+  reason: string;
+  estimatedCostMin: number;
+  estimatedCostMax: number;
+  query: string;
+}
+
 interface ChatState {
   // State
   messages: Message[];
@@ -33,6 +41,9 @@ interface ChatState {
   // Plan review state
   pendingPlanReview: PendingPlanReview | null;
   isPlanLoading: boolean;
+
+  // Budget escalation state
+  pendingBudgetEscalation: PendingBudgetEscalation | null;
 
   // Conversation state
   conversationId: string | null;
@@ -60,6 +71,9 @@ interface ChatState {
   setPendingPlanReview: (review: PendingPlanReview | null) => void;
   setIsPlanLoading: (loading: boolean) => void;
 
+  // Budget escalation actions
+  setPendingBudgetEscalation: (escalation: PendingBudgetEscalation | null) => void;
+
   // Conversation actions
   loadConversations: () => Promise<void>;
   createConversation: (title?: string) => Promise<string>;
@@ -86,6 +100,7 @@ export const useChatStore = create<ChatState>()(
         currentTool: null,
         pendingPlanReview: null,
         isPlanLoading: false,
+        pendingBudgetEscalation: null,
         conversationId: null,
         conversations: [],
         conversationsLoading: false,
@@ -147,6 +162,7 @@ export const useChatStore = create<ChatState>()(
         // Plan review actions
         setPendingPlanReview: (review) => set({ pendingPlanReview: review }),
         setIsPlanLoading: (loading) => set({ isPlanLoading: loading }),
+        setPendingBudgetEscalation: (escalation) => set({ pendingBudgetEscalation: escalation }),
 
         // Cancel active stream
         cancelStream: () => {

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -60,7 +60,7 @@ export function createChatInlineRoutes(deps: {
     const requestId = `chat-${uuidv4()}`;
 
     try {
-      const { query, history, budget, conversationId, approvedPlan, planSessionId } = req.body;
+      const { query, history, budget, conversationId, approvedPlan, planSessionId, allowDeepEscalation } = req.body;
 
       if (!query || typeof query !== 'string') {
         return res.status(400).json({ error: 'query is required' });
@@ -149,6 +149,7 @@ export function createChatInlineRoutes(deps: {
         signal: abortController.signal,
         approvedPlan,
         planSessionId,
+        allowDeepEscalation: !!allowDeepEscalation,
       };
       try {
         for await (const event of deps.chatService.chat(chatRequest)) {

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -66,6 +66,8 @@ export interface ChatRequest {
   approvedPlan?: ExecutionPlan;
   /** Session ID from a prior /api/chat/plan call — reuses cached classification */
   planSessionId?: string;
+  /** If true, allow auto-escalation to deep budget without user confirmation */
+  allowDeepEscalation?: boolean;
 }
 
 /** Cached result from /api/chat/plan for reuse during execution */
@@ -798,18 +800,27 @@ export class ChatService {
         classification.domains.includes('court') &&
         PRACTICE_ANALYSIS_KEYWORDS.test(query)
       ) {
-        effectiveBudget = 'deep';
-        logger.info('[ChatService] Auto-escalated to deep budget (court practice analysis query)', {
-          queryLength: query.length,
-          domains: classification.domains,
-        });
-        yield {
-          type: 'budget_escalated',
-          data: {
-            reason: 'court_practice_analysis',
-            estimatedCost: { minUsd: 0.30, maxUsd: 0.90 },
-          },
-        };
+        if (request.allowDeepEscalation) {
+          effectiveBudget = 'deep';
+          logger.info('[ChatService] Escalated to deep budget (user confirmed court practice analysis)', {
+            queryLength: query.length,
+            domains: classification.domains,
+          });
+        } else {
+          // Stay on standard, notify user they can re-run with deep
+          logger.info('[ChatService] Deep budget recommended but not confirmed, staying on standard', {
+            queryLength: query.length,
+            domains: classification.domains,
+          });
+          yield {
+            type: 'budget_escalated',
+            data: {
+              reason: 'court_practice_analysis',
+              estimatedCost: { minUsd: 0.30, maxUsd: 0.90 },
+              requiresConfirmation: true,
+            },
+          };
+        }
       }
 
       // Apply budget floor from queryType config (never downgrade below config minimum)


### PR DESCRIPTION
## Summary
Deep budget escalation (court practice analysis) now requires user confirmation instead of silently upgrading.

**Backend:**
- `allowDeepEscalation` field added to ChatRequest
- `budget_escalated` SSE event includes `requiresConfirmation: true`
- Without confirmation, stays on standard budget

**Frontend:**
- `PendingBudgetEscalation` state in chatStore
- Amber confirmation banner with cost estimate
- "Deep analysis" button re-sends query with `allowDeepEscalation=true`
- "Keep standard" dismisses the banner

## Test plan
- [ ] Send court practice query ("аналіз практики щодо оренди")
- [ ] Amber banner appears with cost estimate
- [ ] "Keep standard" dismisses banner, response continues on standard
- [ ] "Deep analysis" re-sends with deep budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require explicit user confirmation before switching to deep budget for court practice analysis. Prevents silent upgrades and shows a confirmation banner with cost estimates.

- **New Features**
  - Backend: Added `allowDeepEscalation` to ChatRequest; `budget_escalated` SSE includes `requiresConfirmation`; stays on standard unless confirmed.
  - Frontend: Added `pendingBudgetEscalation` in chat store; amber banner shows reason and cost range; “Deep analysis” resends with `allowDeepEscalation=true`; “Keep standard” dismisses and continues on standard.

<sup>Written for commit 61e83957f57305ffa0598b2e7d59b6ee778d7df0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

