### PR TITLE
chore(scripts): add EDRSR court decision import scripts

### DIFF
--- a/scripts/edrsr/download-and-import-2010-2013.py
+++ b/scripts/edrsr/download-and-import-2010-2013.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""
+Download RTF full texts for 2010-2013 from reyestr.court.gov.ua and import into edrsr_fulltext.
+Uses asyncio for downloads, multiprocessing for RTF→text, COPY for DB import.
+
+Run all 4 years in parallel:
+  python3 download-and-import-2010-2013.py --year 2010 --workers 200 &
+  python3 download-and-import-2010-2013.py --year 2011 --workers 200 &
+  python3 download-and-import-2010-2013.py --year 2012 --workers 200 &
+  python3 download-and-import-2010-2013.py --year 2013 --workers 200 &
+  wait
+
+Single year:
+  python3 download-and-import-2010-2013.py --year 2010 --workers 200
+
+All years sequentially:
+  python3 download-and-import-2010-2013.py --workers 200
+
+Skip download (import only from existing RTFs):
+  python3 download-and-import-2010-2013.py --year 2010 --skip-download --import-workers 12
+"""
+import asyncio
+import aiohttp
+import csv
+import gc
+import io
+import os
+import re
+import subprocess
+import sys
+import time
+import argparse
+from pathlib import Path
+from multiprocessing import Pool
+
+csv.field_size_limit(sys.maxsize)
+
+# ── Config ──
+BASE_RTF_DIR = Path("/data/edrsr")
+CONTAINER = "secondlayer-postgres-local"
+PGUSER = "secondlayer"
+PGDB = "secondlayer_local"
+MAX_RTF_SIZE = 50 * 1024 * 1024  # 50MB
+
+
+# ── RTF → plaintext ──
+def decode_win1251_byte(match):
+    byte_val = int(match.group(1), 16)
+    if byte_val > 127:
+        try:
+            return bytes([byte_val]).decode('windows-1251')
+        except Exception:
+            return chr(byte_val)
+    return chr(byte_val)
+
+
+def decode_unicode(match):
+    code = int(match.group(1))
+    return chr(code) if 0 <= code <= 0x10FFFF else ''
+
+
+def remove_nested_group(text, keyword):
+    idx = text.find('{\\' + keyword)
+    while idx != -1:
+        depth = 0
+        end = idx
+        for i in range(idx, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        text = text[:idx] + text[end:]
+        idx = text.find('{\\' + keyword)
+    return text
+
+
+def convert_one_file(filepath_str: str) -> tuple[int, str] | None:
+    """Convert single RTF file to (doc_id, text)."""
+    filepath = Path(filepath_str)
+    try:
+        size = filepath.stat().st_size
+        if size > MAX_RTF_SIZE or size == 0:
+            return None
+        raw = filepath.read_bytes()
+    except (IOError, OSError):
+        return None
+
+    doc_id = int(filepath.stem)
+
+    # Skip non-RTF files (HTML responses from server errors etc)
+    if not raw[:20].startswith(b'{\\rtf'):
+        return None
+
+    text = raw.decode('latin1')
+    for kw in ['fonttbl', 'colortbl', 'stylesheet', 'info', '*\\']:
+        text = remove_nested_group(text, kw)
+    text = re.sub(r'\\rtf1[^\\{]*', '', text)
+    text = re.sub(r'\\par\b', '\n', text)
+    text = re.sub(r'\\line\b', '\n', text)
+    text = re.sub(r'\\tab\b', '\t', text)
+    text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
+    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
+    text = text.replace('{', '').replace('}', '')
+    text = text.replace('\x00', '')
+    text = text.replace('\r\n', '\n')
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = text.strip()
+    text = text.encode('utf-8', errors='surrogatepass').decode('utf-8', errors='replace')
+    return (doc_id, text) if text else None
+
+
+def psql_copy_upsert(csv_data: str) -> int:
+    """COPY CSV into edrsr_fulltext via stdin with temp table + ON CONFLICT."""
+    lines = []
+    reader = csv.reader(io.StringIO(csv_data))
+    for row in reader:
+        if len(row) == 2:
+            doc_id, text = row
+            text = text.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n').replace('\r', '')
+            lines.append(f"{doc_id}\t{text}")
+
+    if not lines:
+        return 0
+
+    copy_block = '\n'.join(lines)
+    sql_script = f"""CREATE TEMP TABLE _ft_tmp (doc_id bigint, full_text text);
+COPY _ft_tmp FROM stdin;
+{copy_block}
+\\.
+INSERT INTO edrsr_fulltext(doc_id, full_text)
+SELECT doc_id, full_text FROM _ft_tmp
+ON CONFLICT (doc_id) DO NOTHING;
+DROP TABLE _ft_tmp;
+"""
+    cmd = ["docker", "exec", "-i", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB]
+    r = subprocess.run(cmd, input=sql_script, capture_output=True, text=True)
+
+    if r.returncode != 0 and 'ERROR' in r.stderr:
+        print(f"  psql error: {r.stderr[:300]}", file=sys.stderr)
+        return 0
+
+    for line in r.stdout.strip().split('\n'):
+        if line.startswith('INSERT '):
+            try:
+                return int(line.split()[2])
+            except (IndexError, ValueError):
+                pass
+    return len(lines)
+
+
+# ── Download ──
+class Stats:
+    def __init__(self, total: int):
+        self.total = total
+        self.downloaded = 0
+        self.failed = 0
+        self.skipped = 0
+        self.start = time.time()
+        self.lock = asyncio.Lock()
+
+    async def inc(self, field: str, n: int = 1):
+        async with self.lock:
+            setattr(self, field, getattr(self, field) + n)
+
+    def report(self) -> str:
+        elapsed = time.time() - self.start
+        done = self.downloaded + self.failed + self.skipped
+        rate = self.downloaded / elapsed if elapsed > 0 else 0
+        remaining = self.total - done
+        eta = remaining / rate if rate > 0 else 0
+        pct = 100.0 * done / self.total if self.total else 0
+        return (
+            f"[{done:,}/{self.total:,}] ({pct:.1f}%) "
+            f"ok={self.downloaded:,} fail={self.failed:,} skip={self.skipped:,} | "
+            f"{rate:.0f}/s | ETA {eta/60:.0f}m"
+        )
+
+
+async def download_one(
+    session: aiohttp.ClientSession,
+    doc_id: int,
+    url: str,
+    rtf_dir: Path,
+    stats: Stats,
+    semaphore: asyncio.Semaphore,
+):
+    outpath = rtf_dir / f"{doc_id}.rtf"
+    if outpath.exists() and outpath.stat().st_size > 0:
+        await stats.inc('skipped')
+        return
+
+    async with semaphore:
+        for attempt in range(3):
+            try:
+                async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                    if resp.status == 200:
+                        data = await resp.read()
+                        if data:
+                            outpath.write_bytes(data)
+                            await stats.inc('downloaded')
+                            return
+                    elif resp.status == 429:
+                        await asyncio.sleep(5 * (attempt + 1))
+                        continue
+                    elif resp.status in (404, 403):
+                        await stats.inc('failed')
+                        return
+            except Exception:
+                pass
+            await asyncio.sleep(1 * (attempt + 1))
+
+        await stats.inc('failed')
+
+
+async def download_all(items: list[tuple[int, str]], rtf_dir: Path, workers: int):
+    """Download all RTFs with asyncio."""
+    stats = Stats(len(items))
+    semaphore = asyncio.Semaphore(workers)
+
+    connector = aiohttp.TCPConnector(limit=workers, limit_per_host=workers)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [download_one(session, doc_id, url, rtf_dir, stats, semaphore) for doc_id, url in items]
+
+        async def progress():
+            while True:
+                await asyncio.sleep(30)
+                print(f"    {stats.report()}", flush=True)
+
+        prog_task = asyncio.create_task(progress())
+        # Process in batches of 500K to avoid memory issues
+        batch_size = 500_000
+        for i in range(0, len(tasks), batch_size):
+            batch = tasks[i:i + batch_size]
+            await asyncio.gather(*batch)
+            done = min(i + batch_size, len(tasks))
+            print(f"    Batch {done:,}/{len(tasks):,} done: {stats.report()}", flush=True)
+        prog_task.cancel()
+
+    return stats
+
+
+def process_year(year: int, args):
+    """Download + import for a single year."""
+    rtf_dir = BASE_RTF_DIR / f"rtf{year}"
+    year_filter = f"adjudication_date >= '{year}-01-01' AND adjudication_date < '{year + 1}-01-01'"
+
+    print(f"\n{'='*60}")
+    print(f"  YEAR {year}")
+    print(f"{'='*60}")
+    print(f"  RTF dir: {rtf_dir}")
+    print(f"  Download workers: {args.workers}, Import workers: {args.import_workers}")
+    print(flush=True)
+
+    rtf_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.skip_download:
+        # Step 1: Get missing doc_ids with URLs
+        print(f"  [{year}] [1/4] Querying missing doc_id + doc_url from PG...", flush=True)
+        cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-Atc",
+               f"""SELECT d.doc_id || '|' || d.doc_url
+                   FROM edrsr_documents d
+                   LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+                   WHERE {year_filter}
+                     AND d.doc_url IS NOT NULL AND d.doc_url != ''
+                     AND ft.doc_id IS NULL
+                   ORDER BY d.doc_id;"""]
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+        items = []
+        for line in r.stdout.strip().split('\n'):
+            if '|' in line:
+                parts = line.split('|', 1)
+                if len(parts) == 2:
+                    try:
+                        items.append((int(parts[0]), parts[1]))
+                    except ValueError:
+                        pass
+
+        print(f"  [{year}] Missing docs with URLs: {len(items):,}", flush=True)
+
+        if items:
+            # Step 2: Filter already on disk
+            print(f"  [{year}] [2/4] Filtering already downloaded...", flush=True)
+            to_download = []
+            for doc_id, url in items:
+                p = rtf_dir / f"{doc_id}.rtf"
+                if not p.exists() or p.stat().st_size == 0:
+                    to_download.append((doc_id, url))
+            on_disk = len(items) - len(to_download)
+            print(f"  [{year}] Already on disk: {on_disk:,}", flush=True)
+            print(f"  [{year}] To download: {len(to_download):,}", flush=True)
+
+            # Step 3: Download
+            if to_download:
+                print(f"  [{year}] [3/4] Downloading {len(to_download):,} RTFs ({args.workers} concurrent)...", flush=True)
+                dl_start = time.time()
+                stats = asyncio.run(download_all(to_download, rtf_dir, args.workers))
+                elapsed = time.time() - dl_start
+                rate = stats.downloaded / elapsed if elapsed > 0 else 0
+                print(f"  [{year}] Download done: {stats.downloaded:,} ok, {stats.failed:,} failed "
+                      f"in {elapsed/60:.1f}m ({rate:.0f}/s)", flush=True)
+            else:
+                print(f"  [{year}] [3/4] All files already downloaded", flush=True)
+        else:
+            print(f"  [{year}] Nothing to download!", flush=True)
+
+    if args.skip_import:
+        print(f"  [{year}] Skipping import (--skip-import)")
+        return
+
+    # Step 4: Import to local PG
+    print(f"  [{year}] [4/4] Importing RTFs to PG ({args.import_workers} workers, batch {args.batch})...", flush=True)
+
+    # Scan RTF dir
+    print(f"  [{year}] Scanning RTF dir...", flush=True)
+    all_doc_ids = []
+    for entry in os.scandir(rtf_dir):
+        if entry.name.endswith('.rtf'):
+            try:
+                all_doc_ids.append(int(entry.name[:-4]))
+            except ValueError:
+                pass
+    print(f"  [{year}] RTF files on disk: {len(all_doc_ids):,}", flush=True)
+
+    if not all_doc_ids:
+        print(f"  [{year}] No RTF files to import!")
+        return
+
+    # Get already imported
+    print(f"  [{year}] Checking already imported...", flush=True)
+    min_id, max_id = min(all_doc_ids), max(all_doc_ids)
+    cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-Atc",
+           f"SELECT doc_id FROM edrsr_fulltext WHERE doc_id BETWEEN {min_id} AND {max_id};"]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    existing = set()
+    for line in r.stdout.split('\n'):
+        line = line.strip()
+        if line:
+            try:
+                existing.add(int(line))
+            except ValueError:
+                pass
+    print(f"  [{year}] Already in DB: {len(existing):,}", flush=True)
+
+    to_import_ids = sorted(set(all_doc_ids) - existing)
+    del all_doc_ids, existing
+    gc.collect()
+
+    print(f"  [{year}] To convert+import: {len(to_import_ids):,}", flush=True)
+
+    if not to_import_ids:
+        print(f"  [{year}] Nothing to import!")
+        return
+
+    to_import_files = [f"{rtf_dir}/{doc_id}.rtf" for doc_id in to_import_ids]
+    total_files = len(to_import_files)
+    del to_import_ids
+    gc.collect()
+
+    total_imported = 0
+    total_batches = (total_files + args.batch - 1) // args.batch
+    start = time.time()
+
+    with Pool(processes=args.import_workers) as pool:
+        for batch_idx in range(total_batches):
+            batch_start = batch_idx * args.batch
+            batch_files = to_import_files[batch_start:batch_start + args.batch]
+
+            results = pool.map(convert_one_file, batch_files, chunksize=50)
+
+            buf = io.StringIO()
+            writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL)
+            converted = 0
+            for res in results:
+                if res is not None:
+                    writer.writerow(res)
+                    converted += 1
+
+            if converted > 0:
+                copied = psql_copy_upsert(buf.getvalue())
+                total_imported += copied
+
+            if (batch_idx + 1) % 20 == 0 or batch_idx == total_batches - 1:
+                elapsed = time.time() - start
+                rate = total_imported / elapsed if elapsed > 0 else 0
+                done_files = min(batch_start + len(batch_files), total_files)
+                pct = 100.0 * done_files / total_files
+                remaining = total_files - done_files
+                eta = remaining / rate if rate > 0 else 0
+                print(f"  [{year}] {batch_idx+1}/{total_batches} ({pct:.1f}%) | "
+                      f"{total_imported:,} imported | {rate:.0f}/s | ETA {eta/60:.0f}m",
+                      flush=True)
+
+    elapsed = time.time() - start
+    rate = total_imported / elapsed if elapsed > 0 else 0
+    print(f"\n  [{year}] === Done! {total_imported:,} records in {elapsed/60:.1f}m ({rate:.0f}/s) ===", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Download & import EDRSR fulltexts for 2010-2013')
+    parser.add_argument('--year', type=int, default=None, help='Single year (2010-2013). If omitted, processes all.')
+    parser.add_argument('--workers', type=int, default=200, help='Parallel downloads (default: 200)')
+    parser.add_argument('--import-workers', type=int, default=12, help='CPU workers for RTF conversion (default: 12)')
+    parser.add_argument('--batch', type=int, default=5000, help='DB import batch size (default: 5000)')
+    parser.add_argument('--skip-download', action='store_true', help='Skip download, only import')
+    parser.add_argument('--skip-import', action='store_true', help='Skip import, only download')
+    args = parser.parse_args()
+
+    print("=== ЄДРСР Fulltext Download & Import (2010-2013) ===")
+    print(f"Download workers: {args.workers}, Import workers: {args.import_workers}")
+    print(flush=True)
+
+    years = [args.year] if args.year else [2010, 2011, 2012, 2013]
+    global_start = time.time()
+
+    for year in years:
+        process_year(year, args)
+
+    elapsed = time.time() - global_start
+    print(f"\n{'='*60}")
+    print(f"  ALL YEARS DONE in {elapsed/60:.1f}m")
+    print(f"{'='*60}")
+
+    # Final verification
+    print("\nVerification:", flush=True)
+    cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-c",
+           f"""SELECT extract(year from d.adjudication_date)::int AS year,
+                      count(d.doc_id) AS total_docs,
+                      count(ft.doc_id) AS with_fulltext,
+                      round(100.0 * count(ft.doc_id) / NULLIF(count(d.doc_id),0), 1) AS pct
+               FROM edrsr_documents d
+               LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+               WHERE d.adjudication_date >= '2010-01-01' AND d.adjudication_date < '2014-01-01'
+               GROUP BY 1 ORDER BY 1;"""]
+    subprocess.run(cmd)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/download-and-import-2018-2019.py
+++ b/scripts/edrsr/download-and-import-2018-2019.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""
+Download RTF full texts for 2018-2019 from reyestr.court.gov.ua and import into edrsr_fulltext.
+Uses asyncio for downloads, multiprocessing for RTF→text, COPY for DB import.
+
+Usage:
+  python3 download-and-import-2018-2019.py --workers 200 --batch 5000
+  python3 download-and-import-2018-2019.py --skip-download --import-workers 12
+"""
+import asyncio
+import aiohttp
+import csv
+import io
+import os
+import re
+import subprocess
+import sys
+import time
+import argparse
+from pathlib import Path
+from multiprocessing import Pool, cpu_count
+
+csv.field_size_limit(sys.maxsize)
+
+# ── Config ──
+RTF_DIR = Path("/tmp/edrsr-rtf-2018-2019")
+CONTAINER = "secondlayer-postgres-local"
+PGUSER = "secondlayer"
+PGDB = "secondlayer_local"
+YEAR_FILTER = "adjudication_date >= '2018-01-01' AND adjudication_date < '2020-01-01'"
+
+
+# ── RTF → plaintext ──
+def decode_win1251_byte(match):
+    byte_val = int(match.group(1), 16)
+    if byte_val > 127:
+        try:
+            return bytes([byte_val]).decode('windows-1251')
+        except Exception:
+            return chr(byte_val)
+    return chr(byte_val)
+
+
+def decode_unicode(match):
+    code = int(match.group(1))
+    return chr(code) if 0 <= code <= 0x10FFFF else ''
+
+
+def remove_nested_group(text, keyword):
+    idx = text.find('{\\' + keyword)
+    while idx != -1:
+        depth = 0
+        end = idx
+        for i in range(idx, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        text = text[:idx] + text[end:]
+        idx = text.find('{\\' + keyword)
+    return text
+
+
+def convert_one_file(filepath_str: str) -> tuple[int, str] | None:
+    """Convert single RTF file to (doc_id, text)."""
+    filepath = Path(filepath_str)
+    try:
+        raw = filepath.read_bytes()
+    except (IOError, OSError):
+        return None
+
+    doc_id = int(filepath.stem)
+    text = raw.decode('latin1')
+    for kw in ['fonttbl', 'colortbl', 'stylesheet', 'info', '*\\']:
+        text = remove_nested_group(text, kw)
+    text = re.sub(r'\\rtf1[^\\{]*', '', text)
+    text = re.sub(r'\\par\b', '\n', text)
+    text = re.sub(r'\\line\b', '\n', text)
+    text = re.sub(r'\\tab\b', '\t', text)
+    text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
+    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
+    text = text.replace('{', '').replace('}', '')
+    text = text.replace('\x00', '')
+    text = text.replace('\r\n', '\n')
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = text.strip()
+    text = text.encode('utf-8', errors='surrogatepass').decode('utf-8', errors='replace')
+    return (doc_id, text) if text else None
+
+
+def psql_copy_upsert(csv_data: str) -> int:
+    """COPY CSV into edrsr_fulltext via stdin with temp table + ON CONFLICT."""
+    lines = []
+    reader = csv.reader(io.StringIO(csv_data))
+    for row in reader:
+        if len(row) == 2:
+            doc_id, text = row
+            text = text.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n').replace('\r', '')
+            lines.append(f"{doc_id}\t{text}")
+
+    if not lines:
+        return 0
+
+    copy_block = '\n'.join(lines)
+    sql_script = f"""CREATE TEMP TABLE _ft_tmp (doc_id bigint, full_text text);
+COPY _ft_tmp FROM stdin;
+{copy_block}
+\\.
+INSERT INTO edrsr_fulltext(doc_id, full_text)
+SELECT doc_id, full_text FROM _ft_tmp
+ON CONFLICT (doc_id) DO NOTHING;
+DROP TABLE _ft_tmp;
+"""
+    cmd = ["docker", "exec", "-i", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB]
+    r = subprocess.run(cmd, input=sql_script, capture_output=True, text=True)
+
+    if r.returncode != 0 and 'ERROR' in r.stderr:
+        print(f"  psql error: {r.stderr[:300]}", file=sys.stderr)
+        return 0
+
+    for line in r.stdout.strip().split('\n'):
+        if line.startswith('INSERT '):
+            try:
+                return int(line.split()[2])
+            except (IndexError, ValueError):
+                pass
+    return len(lines)
+
+
+# ── Download ──
+class Stats:
+    def __init__(self, total: int):
+        self.total = total
+        self.downloaded = 0
+        self.failed = 0
+        self.skipped = 0
+        self.start = time.time()
+        self.lock = asyncio.Lock()
+
+    async def inc(self, field: str, n: int = 1):
+        async with self.lock:
+            setattr(self, field, getattr(self, field) + n)
+
+    def report(self) -> str:
+        elapsed = time.time() - self.start
+        done = self.downloaded + self.failed + self.skipped
+        rate = self.downloaded / elapsed if elapsed > 0 else 0
+        remaining = self.total - done
+        eta = remaining / rate if rate > 0 else 0
+        pct = 100.0 * done / self.total if self.total else 0
+        return (
+            f"  [{done:,}/{self.total:,}] ({pct:.1f}%) "
+            f"ok={self.downloaded:,} fail={self.failed:,} skip={self.skipped:,} | "
+            f"{rate:.0f}/s | ETA {eta/60:.0f}m"
+        )
+
+
+async def download_one(
+    session: aiohttp.ClientSession,
+    doc_id: int,
+    url: str,
+    stats: Stats,
+    semaphore: asyncio.Semaphore,
+):
+    outpath = RTF_DIR / f"{doc_id}.rtf"
+    if outpath.exists() and outpath.stat().st_size > 0:
+        await stats.inc('skipped')
+        return
+
+    async with semaphore:
+        for attempt in range(3):
+            try:
+                async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                    if resp.status == 200:
+                        data = await resp.read()
+                        if data:
+                            outpath.write_bytes(data)
+                            await stats.inc('downloaded')
+                            return
+                    elif resp.status == 429:
+                        await asyncio.sleep(5 * (attempt + 1))
+                        continue
+                    elif resp.status in (404, 403):
+                        await stats.inc('failed')
+                        return
+            except Exception:
+                pass
+            await asyncio.sleep(1 * (attempt + 1))
+
+        await stats.inc('failed')
+
+
+async def download_batch(items: list[tuple[int, str]], workers: int, batch_num: int, total_batches: int):
+    """Download a batch of RTFs."""
+    stats = Stats(len(items))
+    semaphore = asyncio.Semaphore(workers)
+
+    connector = aiohttp.TCPConnector(limit=workers, limit_per_host=workers)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [download_one(session, doc_id, url, stats, semaphore) for doc_id, url in items]
+
+        async def progress():
+            while True:
+                await asyncio.sleep(30)
+                print(f"  Batch {batch_num}/{total_batches}: {stats.report()}", flush=True)
+
+        prog_task = asyncio.create_task(progress())
+        await asyncio.gather(*tasks)
+        prog_task.cancel()
+
+    return stats
+
+
+# ── Main ──
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workers', type=int, default=200, help='Parallel downloads')
+    parser.add_argument('--import-workers', type=int, default=12, help='CPU workers for RTF conversion')
+    parser.add_argument('--batch', type=int, default=5000, help='DB import batch size')
+    parser.add_argument('--download-batch', type=int, default=500000, help='Download batch size')
+    parser.add_argument('--skip-download', action='store_true', help='Skip download, only import')
+    parser.add_argument('--skip-import', action='store_true', help='Skip import, only download')
+    parser.add_argument('--year', type=int, default=None, help='Single year (2018 or 2019)')
+    args = parser.parse_args()
+
+    RTF_DIR.mkdir(parents=True, exist_ok=True)
+
+    year_filter = YEAR_FILTER
+    if args.year:
+        year_filter = f"adjudication_date >= '{args.year}-01-01' AND adjudication_date < '{args.year + 1}-01-01'"
+
+    print("=== ЄДРСР Fulltext Download & Import (2018-2019) ===")
+    print(f"Download workers: {args.workers}, Import workers: {args.import_workers}")
+    print(f"RTF dir: {RTF_DIR}")
+    print(flush=True)
+
+    if not args.skip_download:
+        # Step 1: Get missing doc_ids with URLs
+        print("[1/4] Querying missing doc_id + doc_url from PG...", flush=True)
+        cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-Atc",
+               f"""SELECT d.doc_id || '|' || d.doc_url
+                   FROM edrsr_documents d
+                   LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+                   WHERE {year_filter}
+                     AND d.doc_url IS NOT NULL AND d.doc_url != ''
+                     AND ft.doc_id IS NULL
+                   ORDER BY d.doc_id;"""]
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+        items = []
+        for line in r.stdout.strip().split('\n'):
+            if '|' in line:
+                parts = line.split('|', 1)
+                if len(parts) == 2:
+                    try:
+                        items.append((int(parts[0]), parts[1]))
+                    except ValueError:
+                        pass
+
+        print(f"  Missing docs with URLs: {len(items):,}", flush=True)
+
+        if not items:
+            print("Nothing to download!")
+            if not args.skip_import:
+                pass  # still try import from existing files
+            else:
+                return
+
+        # Step 2: Filter already on disk
+        print("[2/4] Filtering already downloaded...", flush=True)
+        before = len(items)
+        to_download = []
+        for doc_id, url in items:
+            p = RTF_DIR / f"{doc_id}.rtf"
+            if not p.exists() or p.stat().st_size == 0:
+                to_download.append((doc_id, url))
+        skipped = before - len(to_download)
+        print(f"  Already on disk: {skipped:,}", flush=True)
+        print(f"  To download: {len(to_download):,}", flush=True)
+
+        # Step 3: Download in batches
+        if to_download:
+            total_batches = (len(to_download) + args.download_batch - 1) // args.download_batch
+            print(f"[3/4] Downloading {len(to_download):,} RTFs ({args.workers} concurrent, {total_batches} batches)...", flush=True)
+            total_ok = 0
+            total_fail = 0
+            dl_start = time.time()
+
+            for batch_idx in range(total_batches):
+                batch_start = batch_idx * args.download_batch
+                batch_items = to_download[batch_start:batch_start + args.download_batch]
+                stats = asyncio.run(download_batch(batch_items, args.workers, batch_idx + 1, total_batches))
+                total_ok += stats.downloaded
+                total_fail += stats.failed
+                elapsed = time.time() - dl_start
+                rate = total_ok / elapsed if elapsed > 0 else 0
+                print(f"  Batch {batch_idx+1}/{total_batches} done: +{stats.downloaded:,} ok, +{stats.failed:,} fail | "
+                      f"Total: {total_ok:,} ok ({rate:.0f}/s)", flush=True)
+
+            elapsed = time.time() - dl_start
+            print(f"\n  Download complete: {total_ok:,} ok, {total_fail:,} failed in {elapsed/60:.1f}m", flush=True)
+        else:
+            print("[3/4] All files already downloaded", flush=True)
+
+    if args.skip_import:
+        print("Skipping import (--skip-import)")
+        return
+
+    # Step 4: Import to local PG
+    print(f"\n[4/4] Importing RTFs to local PG ({args.import_workers} workers, batch {args.batch})...", flush=True)
+
+    # Get all downloaded files — just collect (doc_id, filepath) as lightweight list
+    print("  Scanning RTF dir...", flush=True)
+    all_doc_ids = []
+    rtf_dir_str = str(RTF_DIR)
+    for entry in os.scandir(RTF_DIR):
+        if entry.name.endswith('.rtf'):
+            try:
+                doc_id = int(entry.name[:-4])
+                all_doc_ids.append(doc_id)
+            except ValueError:
+                pass
+    print(f"  RTF files on disk: {len(all_doc_ids):,}", flush=True)
+
+    # Get already imported
+    print("  Checking already imported...", flush=True)
+    if all_doc_ids:
+        min_id = min(all_doc_ids)
+        max_id = max(all_doc_ids)
+        cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-Atc",
+               f"SELECT doc_id FROM edrsr_fulltext WHERE doc_id BETWEEN {min_id} AND {max_id};"]
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        existing = {int(x) for x in r.stdout.strip().split('\n') if x}
+    else:
+        existing = set()
+    print(f"  Already in DB: {len(existing):,}", flush=True)
+
+    to_import_ids = sorted(set(all_doc_ids) - existing)
+    # Free memory before fork
+    del all_doc_ids, existing
+    import gc; gc.collect()
+
+    print(f"  To convert+import: {len(to_import_ids):,}", flush=True)
+
+    if not to_import_ids:
+        print("Nothing to import!")
+        return
+
+    # Build file paths as simple strings (minimal memory)
+    to_import_files = [f"{rtf_dir_str}/{doc_id}.rtf" for doc_id in to_import_ids]
+    del to_import_ids
+    gc.collect()
+
+    # Process in batches with multiprocessing
+    total_imported = 0
+    total_batches = (len(to_import_files) + args.batch - 1) // args.batch
+    start = time.time()
+
+    with Pool(processes=args.import_workers) as pool:
+        for batch_idx in range(total_batches):
+            batch_start = batch_idx * args.batch
+            batch_files = to_import_files[batch_start:batch_start + args.batch]
+
+            # Parallel RTF→text
+            results = pool.map(convert_one_file, batch_files, chunksize=50)
+
+            # Build CSV
+            buf = io.StringIO()
+            writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL)
+            converted = 0
+            for res in results:
+                if res is not None:
+                    writer.writerow(res)
+                    converted += 1
+
+            # COPY to PG
+            if converted > 0:
+                copied = psql_copy_upsert(buf.getvalue())
+                total_imported += copied
+
+            if (batch_idx + 1) % 20 == 0 or batch_idx == total_batches - 1:
+                elapsed = time.time() - start
+                rate = total_imported / elapsed if elapsed > 0 else 0
+                done_ids = batch_start + len(batch_files)
+                pct = 100.0 * done_ids / len(to_import_ids)
+                remaining = len(to_import_ids) - done_ids
+                eta = remaining / rate if rate > 0 else 0
+                print(f"  Batch {batch_idx+1}/{total_batches} ({pct:.1f}%) | "
+                      f"{total_imported:,} imported | {rate:.0f}/s | ETA {eta/60:.0f}m",
+                      flush=True)
+
+    elapsed = time.time() - start
+    rate = total_imported / elapsed if elapsed > 0 else 0
+    print(f"\n=== Import done! {total_imported:,} records in {elapsed/60:.1f}m ({rate:.0f}/s) ===", flush=True)
+
+    # Verify
+    cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-c",
+           f"""SELECT extract(year from d.adjudication_date)::int AS year,
+                      count(d.doc_id) AS total_docs,
+                      count(ft.doc_id) AS with_fulltext,
+                      round(100.0 * count(ft.doc_id) / NULLIF(count(d.doc_id),0), 1) AS pct
+               FROM edrsr_documents d
+               LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+               WHERE {year_filter}
+               GROUP BY 1 ORDER BY 1;"""]
+    subprocess.run(cmd)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/download-and-import-fulltext.sh
+++ b/scripts/edrsr/download-and-import-fulltext.sh
@@ -1,0 +1,302 @@
+#!/bin/bash
+# Download RTF full texts from reyestr.court.gov.ua and import into edrsr_fulltext
+#
+# Usage: ./download-and-import-fulltext.sh [PARALLEL] [BATCH_SIZE]
+#   PARALLEL  - number of concurrent downloads (default: 50)
+#   BATCH_SIZE - DB import batch size (default: 1000)
+
+set -euo pipefail
+
+PARALLEL="${1:-50}"
+BATCH_SIZE="${2:-1000}"
+CONTAINER="${CONTAINER:-secondlayer-postgres-local}"
+PGUSER="${PGUSER:-secondlayer}"
+PGDATABASE="${PGDATABASE:-secondlayer_local}"
+
+# NVMe fast storage
+RTF_DIR="/tmp/edrsr-rtf-2025-2026"
+WORK_DIR="/tmp/edrsr-download-work-$$"
+mkdir -p "$RTF_DIR" "$WORK_DIR"
+
+echo "=== ЄДРСР Fulltext Download & Import ==="
+echo "Parallel downloads: $PARALLEL"
+echo "RTF dir: $RTF_DIR"
+echo "DB import batch: $BATCH_SIZE"
+echo ""
+
+# 1. Export doc_id + doc_url for 2025-2026 docs that have URLs and no fulltext yet
+echo "[1/5] Exporting doc_id + doc_url list..."
+docker exec "$CONTAINER" psql -U "$PGUSER" -d "$PGDATABASE" -Atc "
+SELECT d.doc_id || '|' || d.doc_url
+FROM edrsr_documents d
+LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+WHERE d.adjudication_date >= '2025-01-01'
+  AND d.doc_url IS NOT NULL AND d.doc_url != ''
+  AND ft.doc_id IS NULL
+ORDER BY d.doc_id;
+" > "$WORK_DIR/urls.txt"
+
+TOTAL=$(wc -l < "$WORK_DIR/urls.txt")
+echo "  Documents to download: $TOTAL"
+
+if [ "$TOTAL" -eq 0 ]; then
+  echo "Nothing to download!"
+  rm -rf "$WORK_DIR"
+  exit 0
+fi
+
+# 2. Filter out already-downloaded RTFs
+echo "[2/5] Filtering already downloaded..."
+> "$WORK_DIR/todo.txt"
+while IFS='|' read -r doc_id url; do
+  if [ ! -f "$RTF_DIR/${doc_id}.rtf" ]; then
+    echo "${doc_id}|${url}" >> "$WORK_DIR/todo.txt"
+  fi
+done < "$WORK_DIR/urls.txt"
+
+TODO=$(wc -l < "$WORK_DIR/todo.txt")
+ALREADY=$((TOTAL - TODO))
+echo "  Already on disk: $ALREADY"
+echo "  To download: $TODO"
+
+# 3. Download with xargs + curl
+echo "[3/5] Downloading RTFs ($PARALLEL parallel)..."
+
+# Create download script
+cat > "$WORK_DIR/download-one.sh" << 'DLEOF'
+#!/bin/bash
+IFS='|' read -r doc_id url <<< "$1"
+rtf_dir="$2"
+outfile="${rtf_dir}/${doc_id}.rtf"
+
+# Skip if exists
+[ -f "$outfile" ] && exit 0
+
+# Download with retry
+for attempt in 1 2 3; do
+  http_code=$(curl -sS -o "$outfile" -w "%{http_code}" \
+    --connect-timeout 10 --max-time 30 \
+    "$url" 2>/dev/null)
+
+  if [ "$http_code" = "200" ] && [ -s "$outfile" ]; then
+    exit 0
+  fi
+
+  rm -f "$outfile"
+  sleep $((attempt * 2))
+done
+
+# Failed after 3 attempts
+echo "FAIL:${doc_id}:${http_code}" >&2
+exit 0
+DLEOF
+chmod +x "$WORK_DIR/download-one.sh"
+
+START_TIME=$(date +%s)
+
+# Use xargs for parallel downloads with progress
+cat "$WORK_DIR/todo.txt" | \
+  xargs -P "$PARALLEL" -I {} bash "$WORK_DIR/download-one.sh" {} "$RTF_DIR" 2>"$WORK_DIR/failures.log" &
+
+DL_PID=$!
+
+# Progress monitor
+while kill -0 $DL_PID 2>/dev/null; do
+  DOWNLOADED=$(find "$RTF_DIR" -name '*.rtf' -newer "$WORK_DIR/todo.txt" 2>/dev/null | wc -l)
+  EXISTING_RTF=$(ls "$RTF_DIR"/*.rtf 2>/dev/null | wc -l)
+  ELAPSED=$(($(date +%s) - START_TIME))
+  if [ "$ELAPSED" -gt 0 ]; then
+    RATE=$((DOWNLOADED / ELAPSED))
+    if [ "$RATE" -gt 0 ]; then
+      ETA=$(( (TODO - DOWNLOADED) / RATE ))
+      echo -ne "\r  Downloaded: $EXISTING_RTF / $TOTAL | ${RATE}/s | ETA: ${ETA}s    "
+    else
+      echo -ne "\r  Downloaded: $EXISTING_RTF / $TOTAL | starting...    "
+    fi
+  fi
+  sleep 5
+done
+wait $DL_PID || true
+
+echo ""
+EXISTING_RTF=$(ls "$RTF_DIR"/*.rtf 2>/dev/null | wc -l)
+FAIL_COUNT=$(wc -l < "$WORK_DIR/failures.log" 2>/dev/null || echo 0)
+DL_TIME=$(($(date +%s) - START_TIME))
+echo "  Download complete: $EXISTING_RTF files on disk, ${FAIL_COUNT} failures, ${DL_TIME}s"
+
+if [ -s "$WORK_DIR/failures.log" ]; then
+  echo "  First 10 failures:"
+  head -10 "$WORK_DIR/failures.log" | sed 's/^/    /'
+fi
+
+# 4. Convert RTF → text and batch import
+echo "[4/5] Converting RTF → text and importing..."
+
+# RTF to text converter
+cat > "$WORK_DIR/rtf2csv.py" << 'PYEOF'
+#!/usr/bin/env python3
+"""Convert RTF files to CSV for PG COPY. Reads doc_ids from stdin."""
+import sys, re, os, csv
+
+def decode_win1251_byte(match):
+    byte_val = int(match.group(1), 16)
+    if byte_val > 127:
+        try:
+            return bytes([byte_val]).decode('windows-1251')
+        except:
+            return chr(byte_val)
+    return chr(byte_val)
+
+def decode_unicode(match):
+    code = int(match.group(1))
+    if 0 <= code <= 0x10FFFF:
+        return chr(code)
+    return ''
+
+def remove_nested_group(text, keyword):
+    idx = text.find('{\\' + keyword)
+    while idx != -1:
+        depth = 0
+        end = idx
+        for i in range(idx, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        text = text[:idx] + text[end:]
+        idx = text.find('{\\' + keyword)
+    return text
+
+def rtf_to_text(filepath):
+    try:
+        with open(filepath, 'rb') as f:
+            raw = f.read()
+    except (IOError, OSError):
+        return None
+    text = raw.decode('latin1')
+    for kw in ['fonttbl', 'colortbl', 'stylesheet', 'info', '*\\']:
+        text = remove_nested_group(text, kw)
+    text = re.sub(r'\\rtf1[^\\{]*', '', text)
+    text = re.sub(r'\\par\b', '\n', text)
+    text = re.sub(r'\\line\b', '\n', text)
+    text = re.sub(r'\\tab\b', '\t', text)
+    text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
+    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
+    text = text.replace('{', '').replace('}', '')
+    text = text.replace('\x00', '')
+    text = text.replace('\r\n', '\n')
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = text.strip()
+    return text if text else None
+
+def main():
+    rtf_dir = sys.argv[1]
+    writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
+    count = 0
+    for line in sys.stdin:
+        doc_id = line.strip()
+        if not doc_id:
+            continue
+        filepath = os.path.join(rtf_dir, f"{doc_id}.rtf")
+        if not os.path.exists(filepath):
+            continue
+        text = rtf_to_text(filepath)
+        if text:
+            writer.writerow([doc_id, text])
+            count += 1
+    print(f"Converted: {count}", file=sys.stderr)
+
+if __name__ == '__main__':
+    main()
+PYEOF
+
+# Get list of downloaded RTFs that aren't imported yet
+echo "  Building import list..."
+ls "$RTF_DIR"/*.rtf 2>/dev/null | sed 's|.*/||; s|\.rtf$||' | sort -n > "$WORK_DIR/downloaded_ids.txt"
+
+# Check which are already imported
+docker exec "$CONTAINER" psql -U "$PGUSER" -d "$PGDATABASE" -Atc \
+  "SELECT doc_id FROM edrsr_fulltext WHERE doc_id >= 133000000 ORDER BY doc_id;" > "$WORK_DIR/imported_ids.txt" 2>/dev/null || true
+
+if [ -s "$WORK_DIR/imported_ids.txt" ]; then
+  comm -23 "$WORK_DIR/downloaded_ids.txt" "$WORK_DIR/imported_ids.txt" > "$WORK_DIR/to_import.txt"
+else
+  cp "$WORK_DIR/downloaded_ids.txt" "$WORK_DIR/to_import.txt"
+fi
+
+IMPORT_TODO=$(wc -l < "$WORK_DIR/to_import.txt")
+echo "  RTFs to convert+import: $IMPORT_TODO"
+
+if [ "$IMPORT_TODO" -eq 0 ]; then
+  echo "  Nothing to import!"
+else
+  # Split into batches
+  split -l "$BATCH_SIZE" -d -a 5 "$WORK_DIR/to_import.txt" "$WORK_DIR/ibatch_"
+  IBATCH_COUNT=$(ls "$WORK_DIR"/ibatch_* | wc -l)
+  echo "  Import batches: $IBATCH_COUNT (${BATCH_SIZE} each)"
+
+  IMPORT_START=$(date +%s)
+  IDONE=0
+  ITOTAL=0
+
+  for batch in "$WORK_DIR"/ibatch_*; do
+    batch_name=$(basename "$batch")
+
+    # Convert RTF → CSV
+    csv_file="${batch}.csv"
+    python3 "$WORK_DIR/rtf2csv.py" "$RTF_DIR" < "$batch" > "$csv_file" 2>/dev/null
+
+    if [ -s "$csv_file" ]; then
+      converted=$(wc -l < "$csv_file")
+
+      # Import via COPY
+      docker exec -i "$CONTAINER" psql -U "$PGUSER" -d "$PGDATABASE" -c \
+        "COPY edrsr_fulltext(doc_id, full_text) FROM STDIN WITH (FORMAT csv);" < "$csv_file" 2>/dev/null
+
+      ITOTAL=$((ITOTAL + converted))
+    fi
+
+    rm -f "$csv_file"
+    IDONE=$((IDONE + 1))
+
+    if [ $((IDONE % 10)) -eq 0 ] || [ "$IDONE" -eq "$IBATCH_COUNT" ]; then
+      IELAPSED=$(($(date +%s) - IMPORT_START))
+      echo "  Import progress: batch $IDONE/$IBATCH_COUNT, $ITOTAL records, ${IELAPSED}s"
+    fi
+  done
+fi
+
+# 5. Verification
+echo ""
+echo "[5/5] Verification..."
+docker exec "$CONTAINER" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+SELECT
+  count(*) AS total_fulltext,
+  count(CASE WHEN doc_id >= 133000000 THEN 1 END) AS new_2025_2026,
+  pg_size_pretty(pg_total_relation_size('edrsr_fulltext')) AS table_size
+FROM edrsr_fulltext;
+"
+
+docker exec "$CONTAINER" psql -U "$PGUSER" -d "$PGDATABASE" -c "
+SELECT
+  extract(year from d.adjudication_date) AS year,
+  count(d.doc_id) AS total_docs,
+  count(ft.doc_id) AS with_fulltext,
+  round(100.0 * count(ft.doc_id) / count(d.doc_id), 1) AS pct
+FROM edrsr_documents d
+LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+WHERE d.adjudication_date >= '2025-01-01'
+GROUP BY 1 ORDER BY 1;
+"
+
+TOTAL_TIME=$(($(date +%s) - START_TIME))
+echo ""
+echo "=== Done! Total time: ${TOTAL_TIME}s ==="
+echo "RTF files stored at: $RTF_DIR"
+
+# Cleanup work dir (keep RTFs)
+rm -rf "$WORK_DIR"

--- a/scripts/edrsr/download-and-import-missing.py
+++ b/scripts/edrsr/download-and-import-missing.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+"""
+Download missing RTF full texts for any year and import into edrsr_fulltext.
+Uses asyncio for downloads, multiprocessing for RTF→text, COPY for DB import.
+
+Usage (parallel by year):
+  for y in 2014 2015 2016 2017 2018 2019 2020 2021 2022 2023 2024; do
+    python3 download-and-import-missing.py --year $y --workers 100 &
+  done
+  wait
+
+Single year:
+  python3 download-and-import-missing.py --year 2019 --workers 200
+"""
+import asyncio
+import aiohttp
+import csv
+import gc
+import io
+import os
+import re
+import subprocess
+import sys
+import time
+import argparse
+from pathlib import Path
+from multiprocessing import Pool
+
+csv.field_size_limit(sys.maxsize)
+
+CONTAINER = "secondlayer-postgres-local"
+PGUSER = "secondlayer"
+PGDB = "secondlayer_local"
+MAX_RTF_SIZE = 50 * 1024 * 1024
+
+
+def decode_win1251_byte(match):
+    byte_val = int(match.group(1), 16)
+    if byte_val > 127:
+        try:
+            return bytes([byte_val]).decode('windows-1251')
+        except Exception:
+            return chr(byte_val)
+    return chr(byte_val)
+
+
+def decode_unicode(match):
+    code = int(match.group(1))
+    return chr(code) if 0 <= code <= 0x10FFFF else ''
+
+
+def remove_nested_group(text, keyword):
+    idx = text.find('{\\' + keyword)
+    while idx != -1:
+        depth = 0
+        end = idx
+        for i in range(idx, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        text = text[:idx] + text[end:]
+        idx = text.find('{\\' + keyword)
+    return text
+
+
+def convert_one_file(filepath_str: str) -> tuple[int, str] | None:
+    filepath = Path(filepath_str)
+    try:
+        size = filepath.stat().st_size
+        if size > MAX_RTF_SIZE or size == 0:
+            return None
+        raw = filepath.read_bytes()
+    except (IOError, OSError):
+        return None
+
+    doc_id = int(filepath.stem)
+    if not raw[:20].startswith(b'{\\rtf'):
+        return None
+
+    text = raw.decode('latin1')
+    for kw in ['fonttbl', 'colortbl', 'stylesheet', 'info', '*\\']:
+        text = remove_nested_group(text, kw)
+    text = re.sub(r'\\rtf1[^\\{]*', '', text)
+    text = re.sub(r'\\par\b', '\n', text)
+    text = re.sub(r'\\line\b', '\n', text)
+    text = re.sub(r'\\tab\b', '\t', text)
+    text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
+    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
+    text = text.replace('{', '').replace('}', '')
+    text = text.replace('\x00', '')
+    text = text.replace('\r\n', '\n')
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = text.strip()
+    text = text.encode('utf-8', errors='surrogatepass').decode('utf-8', errors='replace')
+    return (doc_id, text) if text else None
+
+
+def psql_copy_upsert(csv_data: str) -> int:
+    lines = []
+    reader = csv.reader(io.StringIO(csv_data))
+    for row in reader:
+        if len(row) == 2:
+            doc_id, text = row
+            text = text.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n').replace('\r', '')
+            lines.append(f"{doc_id}\t{text}")
+    if not lines:
+        return 0
+
+    copy_block = '\n'.join(lines)
+    sql_script = f"""CREATE TEMP TABLE _ft_tmp (doc_id bigint, full_text text);
+COPY _ft_tmp FROM stdin;
+{copy_block}
+\\.
+INSERT INTO edrsr_fulltext(doc_id, full_text)
+SELECT doc_id, full_text FROM _ft_tmp
+ON CONFLICT (doc_id) DO NOTHING;
+DROP TABLE _ft_tmp;
+"""
+    cmd = ["docker", "exec", "-i", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB]
+    r = subprocess.run(cmd, input=sql_script, capture_output=True, text=True)
+    if r.returncode != 0 and 'ERROR' in r.stderr:
+        print(f"  psql error: {r.stderr[:300]}", file=sys.stderr)
+        return 0
+    for line in r.stdout.strip().split('\n'):
+        if line.startswith('INSERT '):
+            try:
+                return int(line.split()[2])
+            except (IndexError, ValueError):
+                pass
+    return len(lines)
+
+
+class Stats:
+    def __init__(self, total: int):
+        self.total = total
+        self.downloaded = 0
+        self.failed = 0
+        self.skipped = 0
+        self.start = time.time()
+        self.lock = asyncio.Lock()
+
+    async def inc(self, field: str, n: int = 1):
+        async with self.lock:
+            setattr(self, field, getattr(self, field) + n)
+
+    def report(self) -> str:
+        elapsed = time.time() - self.start
+        done = self.downloaded + self.failed + self.skipped
+        rate = self.downloaded / elapsed if elapsed > 0 else 0
+        remaining = self.total - done
+        eta = remaining / rate if rate > 0 else 0
+        pct = 100.0 * done / self.total if self.total else 0
+        return (
+            f"[{done:,}/{self.total:,}] ({pct:.1f}%) "
+            f"ok={self.downloaded:,} fail={self.failed:,} skip={self.skipped:,} | "
+            f"{rate:.0f}/s | ETA {eta/60:.0f}m"
+        )
+
+
+async def download_one(session, doc_id, url, rtf_dir, stats, semaphore):
+    outpath = rtf_dir / f"{doc_id}.rtf"
+    if outpath.exists() and outpath.stat().st_size > 0:
+        await stats.inc('skipped')
+        return
+
+    async with semaphore:
+        for attempt in range(3):
+            try:
+                async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                    if resp.status == 200:
+                        data = await resp.read()
+                        if data:
+                            outpath.write_bytes(data)
+                            await stats.inc('downloaded')
+                            return
+                    elif resp.status == 429:
+                        await asyncio.sleep(5 * (attempt + 1))
+                        continue
+                    elif resp.status in (404, 403):
+                        await stats.inc('failed')
+                        return
+            except Exception:
+                pass
+            await asyncio.sleep(1 * (attempt + 1))
+        await stats.inc('failed')
+
+
+async def download_all(items, rtf_dir, workers):
+    stats = Stats(len(items))
+    semaphore = asyncio.Semaphore(workers)
+    connector = aiohttp.TCPConnector(limit=workers, limit_per_host=workers)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        tasks = [download_one(session, did, url, rtf_dir, stats, semaphore) for did, url in items]
+        async def progress():
+            while True:
+                await asyncio.sleep(30)
+                print(f"    {stats.report()}", flush=True)
+        prog_task = asyncio.create_task(progress())
+        batch_size = 500_000
+        for i in range(0, len(tasks), batch_size):
+            batch = tasks[i:i + batch_size]
+            await asyncio.gather(*batch)
+        prog_task.cancel()
+    return stats
+
+
+def process_year(year: int, args):
+    rtf_dir = Path(f"/tmp/edrsr-missing-rtf-{year}")
+    year_filter = f"adjudication_date >= '{year}-01-01' AND adjudication_date < '{year + 1}-01-01'"
+
+    print(f"\n{'='*60}")
+    print(f"  YEAR {year}")
+    print(f"{'='*60}\n")
+
+    rtf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Get missing doc_ids with URLs
+    print(f"  [{year}] Querying missing doc_ids...", flush=True)
+    cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-Atc",
+           f"""SELECT d.doc_id || '|' || d.doc_url
+               FROM edrsr_documents d
+               LEFT JOIN edrsr_fulltext ft ON d.doc_id = ft.doc_id
+               WHERE {year_filter}
+                 AND d.doc_url IS NOT NULL AND d.doc_url != ''
+                 AND ft.doc_id IS NULL
+               ORDER BY d.doc_id;"""]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+
+    items = []
+    for line in r.stdout.strip().split('\n'):
+        if '|' in line:
+            parts = line.split('|', 1)
+            if len(parts) == 2:
+                try:
+                    items.append((int(parts[0]), parts[1]))
+                except ValueError:
+                    pass
+
+    print(f"  [{year}] Missing: {len(items):,}", flush=True)
+    if not items:
+        print(f"  [{year}] Nothing to do!")
+        return
+
+    # Step 2: Filter already on disk
+    to_download = []
+    for doc_id, url in items:
+        p = rtf_dir / f"{doc_id}.rtf"
+        if not p.exists() or p.stat().st_size == 0:
+            to_download.append((doc_id, url))
+    on_disk = len(items) - len(to_download)
+    if on_disk:
+        print(f"  [{year}] Already on disk: {on_disk:,}")
+    print(f"  [{year}] Downloading {len(to_download):,} RTFs ({args.workers} concurrent)...", flush=True)
+
+    # Step 3: Download
+    if to_download:
+        dl_start = time.time()
+        stats = asyncio.run(download_all(to_download, rtf_dir, args.workers))
+        elapsed = time.time() - dl_start
+        rate = stats.downloaded / elapsed if elapsed > 0 else 0
+        print(f"  [{year}] Download: {stats.downloaded:,} ok, {stats.failed:,} failed "
+              f"in {elapsed/60:.1f}m ({rate:.0f}/s)", flush=True)
+
+    # Step 4: Import
+    print(f"  [{year}] Importing ({args.import_workers} workers)...", flush=True)
+    all_doc_ids = []
+    for entry in os.scandir(rtf_dir):
+        if entry.name.endswith('.rtf'):
+            try:
+                all_doc_ids.append(int(entry.name[:-4]))
+            except ValueError:
+                pass
+
+    if not all_doc_ids:
+        print(f"  [{year}] No RTF files!")
+        return
+
+    to_import_files = [f"{rtf_dir}/{did}.rtf" for did in sorted(all_doc_ids)]
+    del all_doc_ids
+    gc.collect()
+
+    total_imported = 0
+    total_batches = (len(to_import_files) + args.batch - 1) // args.batch
+    start = time.time()
+
+    with Pool(processes=args.import_workers) as pool:
+        for batch_idx in range(total_batches):
+            batch_start = batch_idx * args.batch
+            batch_files = to_import_files[batch_start:batch_start + args.batch]
+            results = pool.map(convert_one_file, batch_files, chunksize=50)
+
+            buf = io.StringIO()
+            writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL)
+            converted = 0
+            for res in results:
+                if res is not None:
+                    writer.writerow(res)
+                    converted += 1
+            if converted > 0:
+                total_imported += psql_copy_upsert(buf.getvalue())
+
+            if (batch_idx + 1) % 20 == 0 or batch_idx == total_batches - 1:
+                elapsed = time.time() - start
+                rate = total_imported / elapsed if elapsed > 0 else 0
+                done_f = min(batch_start + len(batch_files), len(to_import_files))
+                pct = 100.0 * done_f / len(to_import_files)
+                print(f"  [{year}] {batch_idx+1}/{total_batches} ({pct:.1f}%) | "
+                      f"{total_imported:,} imported | {rate:.0f}/s", flush=True)
+
+    elapsed = time.time() - start
+    rate = total_imported / elapsed if elapsed > 0 else 0
+    print(f"  [{year}] Done: {total_imported:,} in {elapsed/60:.1f}m ({rate:.0f}/s)", flush=True)
+
+    # Cleanup RTF dir
+    for f in rtf_dir.glob("*.rtf"):
+        f.unlink()
+    try:
+        rtf_dir.rmdir()
+    except OSError:
+        pass
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--year', type=int, required=True)
+    parser.add_argument('--workers', type=int, default=200)
+    parser.add_argument('--import-workers', type=int, default=12)
+    parser.add_argument('--batch', type=int, default=5000)
+    args = parser.parse_args()
+
+    print(f"=== ЄДРСР Missing Fulltext Download & Import ===")
+    print(f"Year: {args.year}, Download: {args.workers} workers, Import: {args.import_workers} workers")
+
+    global_start = time.time()
+    process_year(args.year, args)
+    elapsed = time.time() - global_start
+    print(f"\n=== Year {args.year} complete in {elapsed/60:.1f}m ===")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/import-rtf-fast.py
+++ b/scripts/edrsr/import-rtf-fast.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Minimal RTF→PG import. No asyncio, no large dicts.
+Reads file list from stdin or scans directory.
+
+Usage:
+  python3 import-rtf-fast.py --rtf-dir /tmp/edrsr-rtf-2018-2019 --workers 12 --batch 5000
+"""
+import csv
+import io
+import os
+import re
+import subprocess
+import sys
+import time
+import argparse
+from multiprocessing import Pool
+from pathlib import Path
+
+csv.field_size_limit(sys.maxsize)
+
+CONTAINER = "secondlayer-postgres-local"
+PGUSER = "secondlayer"
+PGDB = "secondlayer_local"
+
+
+def decode_win1251_byte(match):
+    byte_val = int(match.group(1), 16)
+    if byte_val > 127:
+        try:
+            return bytes([byte_val]).decode('windows-1251')
+        except Exception:
+            return chr(byte_val)
+    return chr(byte_val)
+
+
+def decode_unicode(match):
+    code = int(match.group(1))
+    return chr(code) if 0 <= code <= 0x10FFFF else ''
+
+
+def remove_nested_group(text, keyword):
+    idx = text.find('{\\' + keyword)
+    while idx != -1:
+        depth = 0
+        end = idx
+        for i in range(idx, len(text)):
+            if text[i] == '{':
+                depth += 1
+            elif text[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    end = i + 1
+                    break
+        text = text[:idx] + text[end:]
+        idx = text.find('{\\' + keyword)
+    return text
+
+
+MAX_RTF_SIZE = 50 * 1024 * 1024  # 50MB - skip huge files
+
+
+def convert_one(filepath: str) -> tuple[int, str] | None:
+    try:
+        size = os.path.getsize(filepath)
+        if size > MAX_RTF_SIZE:
+            return None
+        raw = Path(filepath).read_bytes()
+    except (IOError, OSError):
+        return None
+    doc_id = int(Path(filepath).stem)
+
+    # Skip non-RTF files (HTML responses from server errors etc)
+    if not raw[:20].startswith(b'{\\rtf'):
+        return None
+
+    text = raw.decode('latin1')
+    for kw in ['fonttbl', 'colortbl', 'stylesheet', 'info', '*\\']:
+        text = remove_nested_group(text, kw)
+    text = re.sub(r'\\rtf1[^\\{]*', '', text)
+    text = re.sub(r'\\par\b', '\n', text)
+    text = re.sub(r'\\line\b', '\n', text)
+    text = re.sub(r'\\tab\b', '\t', text)
+    text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
+    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
+    text = text.replace('{', '').replace('}', '')
+    text = text.replace('\x00', '')
+    text = text.replace('\r\n', '\n')
+    text = re.sub(r'\n{3,}', '\n\n', text)
+    text = text.strip()
+    text = text.encode('utf-8', errors='surrogatepass').decode('utf-8', errors='replace')
+    return (doc_id, text) if text else None
+
+
+def psql_copy(csv_data: str) -> int:
+    lines = []
+    reader = csv.reader(io.StringIO(csv_data))
+    for row in reader:
+        if len(row) == 2:
+            doc_id, text = row
+            text = text.replace('\\', '\\\\').replace('\t', '\\t').replace('\n', '\\n').replace('\r', '')
+            lines.append(f"{doc_id}\t{text}")
+    if not lines:
+        return 0
+    copy_block = '\n'.join(lines)
+    sql = f"""CREATE TEMP TABLE _ft_tmp (doc_id bigint, full_text text);
+COPY _ft_tmp FROM stdin;
+{copy_block}
+\\.
+INSERT INTO edrsr_fulltext(doc_id, full_text)
+SELECT doc_id, full_text FROM _ft_tmp
+ON CONFLICT (doc_id) DO NOTHING;
+DROP TABLE _ft_tmp;
+"""
+    cmd = ["docker", "exec", "-i", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB]
+    r = subprocess.run(cmd, input=sql, capture_output=True, text=True)
+    if r.returncode != 0 and 'ERROR' in r.stderr:
+        print(f"  psql error: {r.stderr[:300]}", file=sys.stderr)
+        return 0
+    for line in r.stdout.strip().split('\n'):
+        if line.startswith('INSERT '):
+            try:
+                return int(line.split()[2])
+            except (IndexError, ValueError):
+                pass
+    return len(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--rtf-dir', required=True)
+    parser.add_argument('--workers', type=int, default=12)
+    parser.add_argument('--batch', type=int, default=5000)
+    args = parser.parse_args()
+
+    rtf_dir = args.rtf_dir
+
+    print(f"=== RTF Import → PG ===")
+    print(f"Workers: {args.workers}, Batch: {args.batch}, Dir: {rtf_dir}")
+    print(flush=True)
+
+    # Scan dir — collect only doc_ids as integers (minimal memory)
+    print("[1/3] Scanning...", flush=True)
+    doc_ids = []
+    for entry in os.scandir(rtf_dir):
+        if entry.name.endswith('.rtf'):
+            try:
+                doc_ids.append(int(entry.name[:-4]))
+            except ValueError:
+                pass
+    print(f"  Files: {len(doc_ids):,}", flush=True)
+
+    # Check existing
+    print("[2/3] Checking DB...", flush=True)
+    min_id, max_id = min(doc_ids), max(doc_ids)
+    cmd = ["docker", "exec", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-Atc",
+           f"SELECT doc_id FROM edrsr_fulltext WHERE doc_id BETWEEN {min_id} AND {max_id};"]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    existing = set()
+    for line in r.stdout.split('\n'):
+        line = line.strip()
+        if line:
+            try:
+                existing.add(int(line))
+            except ValueError:
+                pass
+    print(f"  Existing: {len(existing):,}", flush=True)
+
+    to_import = sorted(set(doc_ids) - existing)
+    # Free memory
+    del doc_ids, existing, r
+    print(f"  To import: {len(to_import):,}", flush=True)
+
+    if not to_import:
+        print("Nothing to import!")
+        return
+
+    # Build minimal file path list
+    files = [f"{rtf_dir}/{did}.rtf" for did in to_import]
+    del to_import
+
+    # Import
+    print(f"[3/3] Importing ({args.workers} workers)...", flush=True)
+    total = 0
+    n_batches = (len(files) + args.batch - 1) // args.batch
+    start = time.time()
+
+    with Pool(args.workers) as pool:
+        for i in range(n_batches):
+            batch = files[i * args.batch : (i + 1) * args.batch]
+
+            # Use apply_async with timeout to avoid hanging on bad files
+            async_results = [pool.apply_async(convert_one, (f,)) for f in batch]
+
+            buf = io.StringIO()
+            writer = csv.writer(buf, quoting=csv.QUOTE_MINIMAL)
+            n = 0
+            skipped = 0
+            for ar in async_results:
+                try:
+                    res = ar.get(timeout=30)  # 30s max per file
+                    if res:
+                        writer.writerow(res)
+                        n += 1
+                except Exception:
+                    skipped += 1
+
+            if n:
+                total += psql_copy(buf.getvalue())
+
+            if (i + 1) % 10 == 0 or i == n_batches - 1:
+                elapsed = time.time() - start
+                rate = total / elapsed if elapsed > 0 else 0
+                done = (i + 1) * args.batch
+                if done > len(files):
+                    done = len(files)
+                pct = 100.0 * done / len(files)
+                rem = len(files) - done
+                eta = rem / rate if rate > 0 else 0
+                print(f"  {i+1}/{n_batches} ({pct:.1f}%) | {total:,} imported | {rate:.0f}/s | ETA {eta/60:.0f}m", flush=True)
+
+    elapsed = time.time() - start
+    rate = total / elapsed if elapsed > 0 else 0
+    print(f"\n=== Done! {total:,} in {elapsed/60:.1f}m ({rate:.0f}/s) ===")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Python scripts for downloading and importing court decisions from ЄДРСР
- Historical imports (2010-2013, 2018-2019), fulltext pipeline, missing records recovery
- Fast RTF parsing for bulk import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a set of scripts to download RTF full texts from ЄДРСР and import them into `edrsr_fulltext`, enabling fast historical backfills and ongoing fills. Uses concurrent downloads, multiprocessing RTF→text, and batched `COPY` upserts.

- **New Features**
  - `scripts/edrsr/download-and-import-2010-2013.py` — async downloader + importer for 2010–2013; per-year runs, skip-download/import flags.
  - `scripts/edrsr/download-and-import-2018-2019.py` — same pipeline for 2018–2019 with batchable downloads.
  - `scripts/edrsr/download-and-import-missing.py` — generic “missing fulltext” recovery for any year; suitable for parallel by-year runs.
  - `scripts/edrsr/download-and-import-fulltext.sh` — shell pipeline for recent years (e.g., 2025–2026) using `curl`/`xargs` and batch `COPY`; includes verification queries.
  - `scripts/edrsr/import-rtf-fast.py` — minimal, fast RTF→PG importer for pre-downloaded files.
  - All import paths use temp tables + `ON CONFLICT DO NOTHING`, skip non-RTF/oversized files, and normalize text (Windows-1251/Unicode handling).

<sup>Written for commit 6f41cac2c9d37755d62fbbd6e1ae5bfad8d7ddc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

