### PR TITLE
fix(backend): remove hardcoded OpenAI from workflow generator

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -45,7 +45,8 @@
     "load:civil-cases": "npm run build && node dist/scripts/load-civil-property-cases.js",
     "backfill:reyestr": "npm run build && node dist/scripts/backfill-fulltext-reyestr.js",
     "discover:court": "npm run build && node dist/scripts/discover-court-decisions.js",
-    "compute:judge-analytics": "npx tsx src/scripts/compute-judge-analytics.ts"
+    "compute:judge-analytics": "npx tsx src/scripts/compute-judge-analytics.ts",
+    "backfill:tsv": "npx tsx src/scripts/backfill-tsv.ts"
   },
   "keywords": [
     "mcp",

--- a/mcp_backend/src/services/workflow-generator-service.ts
+++ b/mcp_backend/src/services/workflow-generator-service.ts
@@ -152,8 +152,7 @@ ${toolDescriptions}`,
         temperature: 0.3,
         response_format: { type: 'json_object' },
       },
-      'deep',
-      'openai'
+      'deep'
     );
 
     const content = response.content || '{}';

--- a/mcp_backend/tsconfig.json
+++ b/mcp_backend/tsconfig.json
@@ -20,5 +20,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "src/**/__tests__", "src/__tests__", "src/scripts/vectorize-opendata-titan.ts"]
+  "exclude": ["node_modules", "dist", "src/**/__tests__", "src/__tests__", "src/scripts/vectorize-opendata-titan.ts", "src/scripts/backfill-tsv.ts"]
 }


### PR DESCRIPTION
## Summary
- Removed hardcoded `preferredProvider: 'openai'` from `WorkflowGeneratorService`, allowing it to respect `LLM_PROVIDER_STRATEGY=bedrock-first`
- This was the root cause of chat failures when OpenAI quota was exhausted — Bedrock was available but workflow generator bypassed it
- Also fixes pre-existing build error (excludes `backfill-tsv.ts` from tsconfig)

## Context
Diagnosed on prod: Bedrock API works fine (`claude-haiku-4-5` responds correctly), but `WorkflowGeneratorService.generateWorkflows()` was forcing `'openai'` as preferred provider, causing the full fallback chain to fail when OpenAI returned 429.

## Test plan
- [ ] Verify build passes (`npm run build` in mcp_backend)
- [ ] Deploy to prod and test chat query that triggers workflow generation
- [ ] Confirm Bedrock is used as primary provider in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops hardcoding `openai` in the workflow generator so it honors `LLM_PROVIDER_STRATEGY=bedrock-first`, restoring Bedrock fallback when OpenAI is rate-limited. Also fixes a build error by excluding `src/scripts/backfill-tsv.ts` from `tsconfig`.

- **Bug Fixes**
  - Workflow generator now respects the configured provider strategy; Bedrock is selected first when `bedrock-first` is set.
  - Excludes `src/scripts/backfill-tsv.ts` from `tsconfig` to prevent build failures.

- **New Features**
  - Adds `backfill:tsv` npm script in `mcp_backend/package.json`.

<sup>Written for commit 5b3b847bdaa0254af12650bcbcd9c2eb0c34a9ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

