### PR TITLE
fix(infra): PG config for m6i.4xlarge (64GB)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -6,7 +6,7 @@ services:
       postgres
       -c max_connections=300
       -c shared_buffers=16GB
-      -c effective_cache_size=96GB
+      -c effective_cache_size=48GB
       -c work_mem=256MB
       -c maintenance_work_mem=4GB
       -c wal_buffers=64MB
@@ -46,7 +46,7 @@ services:
       resources:
         limits:
           cpus: "12"
-          memory: 64G
+          memory: 48G
         reservations:
           memory: 16G
 


### PR DESCRIPTION
Adjust effective_cache_size and memory limits for actual 64GB RAM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Right-size Postgres memory settings for the m6i.4xlarge host (64GB RAM) to avoid over-allocation and potential OOMs. Set effective_cache_size to 48GB and the container memory limit to 48G.

<sup>Written for commit 6f77e2560ce5f169253aeabfdf49efd8908d3e89. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

