### PR TITLE
fix(nextcloud): remove OVERWRITEWEBROOT causing 404

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -779,7 +779,6 @@ services:
       NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_USER:-admin}
       NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
       NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud-local localhost local.legal.org.ua"
-      OVERWRITEWEBROOT: /nextcloud
       OVERWRITEPROTOCOL: https
     ports:
       - "8888:80"

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -449,8 +449,8 @@ services:
       NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_USER:-admin}
       NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_PASSWORD:-admin}
       NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud-prod localhost legal.org.ua"
-      OVERWRITEWEBROOT: /nextcloud
       OVERWRITEPROTOCOL: https
+      OVERWRITEHOST: nextcloud.legal.org.ua
     ports:
       - "127.0.0.1:8890:80"
     volumes:


### PR DESCRIPTION
## Summary
- Removed `OVERWRITEWEBROOT: /nextcloud` from prod and local docker-compose files
- Added `OVERWRITEHOST: nextcloud.legal.org.ua` to prod for correct URL generation
- Nextcloud runs on its own subdomain (`nextcloud.legal.org.ua`) so no subpath is needed
- The mismatch between nginx (proxying to `/`) and Nextcloud (generating `/nextcloud/` URLs) caused 404 errors

## Test plan
- [x] Verified on prod: `https://nextcloud.legal.org.ua/` now redirects to `/login` correctly
- [x] Login page renders successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix 404s on Nextcloud by removing the `/nextcloud` webroot override and setting the correct host, since the app runs at the root of its own subdomain.

- **Bug Fixes**
  - Removed `OVERWRITEWEBROOT=/nextcloud` in local and prod compose files to align with nginx proxying to `/`.
  - Added `OVERWRITEHOST=nextcloud.legal.org.ua` in prod for correct URL generation.
  - Result: `https://nextcloud.legal.org.ua/` now redirects to `/login` and loads as expected.

<sup>Written for commit ffd0748090c207d0a61e9874a0861f979aa63fe5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

