### PR TITLE
fix(scripts): reduce LEFT to 500K chars for UTF-8 safety

### DIFF
--- a/mcp_backend/src/scripts/backfill-tsv.ts
+++ b/mcp_backend/src/scripts/backfill-tsv.ts
@@ -147,7 +147,7 @@ async function worker(id: number, pool: PoolType): Promise<number> {
             FOR UPDATE SKIP LOCKED
           )
           UPDATE ${TABLE} f
-          SET tsv = to_tsvector('simple', LEFT(f.full_text, 900000))
+          SET tsv = to_tsvector('simple', LEFT(f.full_text, 500000))
           FROM batch
           WHERE f.doc_id = batch.doc_id
         `, [BATCH_SIZE]);


### PR DESCRIPTION
Cyrillic UTF-8 = 2 bytes/char. 900K chars exceeded 1MB tsvector limit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the text slice in the `backfill-tsv` script from 900K to 500K characters to keep `to_tsvector('simple', ...)` under the 1MB tsvector limit. This prevents failures with multi-byte UTF-8 content (e.g., Cyrillic).

<sup>Written for commit 2987f00355fcbf37496ff6e3c8e5e7c3f99efc1a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

