### PR TITLE
feat(arch): Open Core architecture — Phase 1-3

### DIFF
--- a/docs/OPEN_CORE_MIGRATION.md
+++ b/docs/OPEN_CORE_MIGRATION.md
@@ -1,0 +1,124 @@
+# Open Core Migration Guide
+
+## Architecture
+
+```
+@secondlayer/core-interfaces (open, Apache 2.0)
+       ↑                ↑
+@secondlayer/shared    @secondlayer/core (private, proprietary)
+       ↑                ↑
+  mcp_backend (open, optionally loads core via core-loader.ts)
+```
+
+## Current State (Phase 1-3 complete)
+
+- ✅ `packages/core-interfaces/` — interface package with all type contracts
+- ✅ `mcp_backend/src/services/noop/` — NoOp fallbacks for all core services
+- ✅ `mcp_backend/src/factories/core-loader.ts` — dynamic import with fallback
+- ✅ Build passes with zero errors
+
+## Phase 4: Create Private Repo (when ready to go public)
+
+```bash
+# 1. Create secondlayer-core repo on GitHub (private)
+gh repo create overthelex/secondlayer-core --private
+
+# 2. Copy closed files (WITHOUT git history)
+mkdir secondlayer-core && cd secondlayer-core
+git init
+
+# Copy services
+mkdir -p src/services src/prompts/system-instructions src/prompts/templates
+cp ../mcp_backend/src/services/chat-service.ts src/services/
+cp ../mcp_backend/src/services/chat-intent-classifier.ts src/services/
+cp ../mcp_backend/src/services/chat-context-builder.ts src/services/
+cp ../mcp_backend/src/services/chat-result-compactor.ts src/services/
+cp ../mcp_backend/src/services/chat-search-cache-service.ts src/services/
+cp ../mcp_backend/src/services/chat-constants.ts src/services/
+cp ../mcp_backend/src/services/query-planner.ts src/services/
+cp ../mcp_backend/src/services/semantic-sectionizer.ts src/services/
+cp ../mcp_backend/src/services/hallucination-guard.ts src/services/
+cp ../mcp_backend/src/services/citation-validator.ts src/services/
+cp ../mcp_backend/src/services/legal-pattern-store.ts src/services/
+cp ../mcp_backend/src/services/evidence-extractor.ts src/services/
+cp ../mcp_backend/src/services/shepardization-service.ts src/services/
+cp ../mcp_backend/src/services/thinking-descriptions.ts src/services/
+cp ../mcp_backend/src/services/billing-service.ts src/services/
+cp ../mcp_backend/src/services/pricing-service.ts src/services/
+cp ../mcp_backend/src/services/subscription-service.ts src/services/
+cp ../mcp_backend/src/services/credit-service.ts src/services/
+
+# Copy prompts
+cp ../mcp_backend/src/prompts/chat-system-prompt.ts src/prompts/
+cp ../mcp_backend/src/prompts/query-type-config.ts src/prompts/
+cp ../mcp_backend/src/prompts/tool-registry-catalog.ts src/prompts/
+cp -r ../mcp_backend/src/prompts/system-instructions/* src/prompts/system-instructions/
+cp -r ../mcp_backend/src/prompts/templates/* src/prompts/templates/
+
+# 3. Add package.json, tsconfig, LICENSE (proprietary)
+# 4. Export createCoreServices() from src/index.ts
+# 5. Push to private repo
+```
+
+## Phase 5: Remove from Public Repo (when ready)
+
+```bash
+# Delete proprietary files from public repo
+rm mcp_backend/src/services/chat-service.ts
+rm mcp_backend/src/services/chat-intent-classifier.ts
+# ... (full list in task #417)
+
+# Update core-services.ts factory to use core-loader.ts
+# Update http-server.ts /api/chat route to check isProprietaryLoaded()
+
+# Verify no broken imports
+git grep -l "from.*chat-service" mcp_backend/src/
+git grep -l "from.*query-planner" mcp_backend/src/
+```
+
+## Phase 6: CI/CD
+
+Add to `.github/workflows/ci-local-deploy.yml`:
+
+```yaml
+- name: Install proprietary core (prod only)
+  if: github.ref == 'refs/heads/main'
+  run: npm install @secondlayer/core
+  env:
+    NPM_TOKEN_CORE: ${{ secrets.NPM_TOKEN_CORE }}
+```
+
+## Files to move to @secondlayer/core
+
+### Chat Pipeline (8 files)
+- chat-service.ts
+- chat-intent-classifier.ts
+- chat-context-builder.ts
+- chat-result-compactor.ts
+- chat-search-cache-service.ts
+- chat-constants.ts
+- query-planner.ts
+- thinking-descriptions.ts
+
+### Legal AI Quality (6 files)
+- semantic-sectionizer.ts
+- hallucination-guard.ts
+- citation-validator.ts
+- legal-pattern-store.ts
+- evidence-extractor.ts
+- shepardization-service.ts
+
+### Prompts (3 files + 2 directories)
+- prompts/chat-system-prompt.ts
+- prompts/query-type-config.ts
+- prompts/tool-registry-catalog.ts
+- prompts/system-instructions/
+- prompts/templates/
+
+### Billing (4 files)
+- billing-service.ts
+- pricing-service.ts
+- subscription-service.ts
+- credit-service.ts
+
+**Total: 21 files + 2 directories**

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -69,6 +69,7 @@
     "@google-cloud/vision": "^5.3.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@qdrant/js-client-rest": "^1.17.0",
+    "@secondlayer/core-interfaces": "file:../packages/core-interfaces",
     "@secondlayer/shared": "file:../packages/shared",
     "@simplewebauthn/server": "^13.2.3",
     "@types/bcryptjs": "^3.0.0",

--- a/mcp_backend/src/factories/core-loader.ts
+++ b/mcp_backend/src/factories/core-loader.ts
@@ -1,0 +1,58 @@
+/**
+ * Core Loader — Dynamic import of @secondlayer/core (proprietary)
+ *
+ * Attempts to load the proprietary AI pipeline package.
+ * Falls back to NoOp implementations for open-source deployments.
+ *
+ * Open deployment: all 45 MCP tools work, /api/chat returns 501
+ * Production: full AI assistant with chat pipeline
+ */
+
+import type { CoreServices } from '@secondlayer/core-interfaces';
+import { createNoOpCoreServices } from '../services/noop/index.js';
+import { logger } from '@secondlayer/shared';
+
+let _coreServices: CoreServices | null = null;
+let _isProprietaryLoaded = false;
+
+export async function loadCoreServices(dependencies?: Record<string, unknown>): Promise<CoreServices> {
+  if (_coreServices) return _coreServices;
+
+  try {
+    // Try to load proprietary @secondlayer/core
+    // @ts-expect-error — @secondlayer/core is an optional proprietary package
+    const core = await import('@secondlayer/core');
+
+    if (typeof core.createCoreServices === 'function') {
+      _coreServices = await core.createCoreServices(dependencies);
+      _isProprietaryLoaded = true;
+      logger.info('[@secondlayer/core] Proprietary AI pipeline loaded successfully');
+    } else {
+      throw new Error('@secondlayer/core found but createCoreServices() not exported');
+    }
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (message.includes('Cannot find module') || message.includes('MODULE_NOT_FOUND')) {
+      logger.info('[core-loader] @secondlayer/core not installed — using open-source NoOp fallbacks');
+    } else {
+      logger.warn(`[core-loader] Failed to load @secondlayer/core: ${message} — falling back to NoOp`);
+    }
+
+    _coreServices = createNoOpCoreServices();
+    _isProprietaryLoaded = false;
+  }
+
+  return _coreServices!;
+}
+
+export function isProprietaryLoaded(): boolean {
+  return _isProprietaryLoaded;
+}
+
+export function getCoreServices(): CoreServices {
+  if (!_coreServices) {
+    throw new Error('Core services not initialized. Call loadCoreServices() first.');
+  }
+  return _coreServices;
+}

--- a/mcp_backend/src/services/noop/index.ts
+++ b/mcp_backend/src/services/noop/index.ts
@@ -1,0 +1,371 @@
+/**
+ * NoOp implementations of @secondlayer/core-interfaces.
+ *
+ * These are used when @secondlayer/core (proprietary) is not installed.
+ * Open deployments get full MCP tool access but no AI chat pipeline.
+ */
+
+import type {
+  IChatService,
+  IQueryPlanner,
+  IIntentClassifier,
+  ISemanticSectionizer,
+  IHallucinationGuard,
+  ICitationValidator,
+  ILegalPatternStore,
+  IShepardizationService,
+  IEvidenceExtractor,
+  IContextBuilder,
+  IResultCompactor,
+  IThinkingDescriptions,
+  IBillingService,
+  IPricingService,
+  ISubscriptionService,
+  ICreditService,
+  IChatSearchCache,
+  ChatRequest,
+  ChatEvent,
+  ChatPlanRequest,
+  ChatPlan,
+  QueryIntent,
+  ChatIntentClassification,
+  ToolDefinition,
+  DocumentSection,
+  ValidationResult,
+  CitationLink,
+  PrecedentStatus,
+  LegalPattern,
+  ShepardizationResult,
+  ExtractedEvidence,
+  SimpleCitation,
+  BudgetLimits,
+  BudgetKey,
+  UserBilling,
+  UserBalance,
+  PriceCalculation,
+  PricingConfig,
+  PricingTier,
+  CreditDeduction,
+  CreditAddition,
+  CoreServices,
+} from '@secondlayer/core-interfaces';
+
+// ============================================================
+// Chat Pipeline — returns 501
+// ============================================================
+
+export class NoOpChatService implements IChatService {
+  async *chat(_request: ChatRequest): AsyncIterable<ChatEvent> {
+    yield {
+      type: 'error',
+      data: { message: 'Chat pipeline not available in open-source build. Install @secondlayer/core for full AI assistant.' },
+    };
+    yield { type: 'done', data: {} };
+  }
+
+  async generatePlanForReview(_request: ChatPlanRequest): Promise<ChatPlan> {
+    return {
+      query_type: 'unsupported',
+      budget: 'quick',
+      domains: [],
+      tools: [],
+      steps: [],
+    };
+  }
+}
+
+// ============================================================
+// Query Planner — keyword-based fallback
+// ============================================================
+
+export class NoOpQueryPlanner implements IQueryPlanner {
+  async classifyIntent(query: string, _budget?: BudgetKey): Promise<QueryIntent> {
+    const q = query.toLowerCase();
+    let domain = 'general';
+    if (q.includes('суд') || q.includes('рішен') || q.includes('справ')) domain = 'court_cases';
+    else if (q.includes('закон') || q.includes('стаття') || q.includes('кодекс')) domain = 'legislation';
+    else if (q.includes('єдрпоу') || q.includes('компані') || q.includes('підприємств')) domain = 'registry';
+    else if (q.includes('депутат') || q.includes('рада') || q.includes('законопроєкт')) domain = 'parliament';
+
+    return { primary_domain: domain, query_type: 'case_lookup', confidence: 0.3 };
+  }
+
+  async generateOptimizedSearchQuery(userQuery: string): Promise<string> {
+    return userQuery;
+  }
+
+  buildQueryParams(intent: QueryIntent): unknown {
+    return { domain: intent.primary_domain };
+  }
+
+  selectEndpoints(intent: QueryIntent): string[] {
+    return [intent.primary_domain];
+  }
+}
+
+// ============================================================
+// Intent Classifier — returns unsupported
+// ============================================================
+
+export class NoOpIntentClassifier implements IIntentClassifier {
+  async classify(_query: string): Promise<ChatIntentClassification> {
+    return {
+      queryType: 'unsupported',
+      domains: [],
+      slots: {},
+      confidence: 0,
+      suggestedTools: [],
+    };
+  }
+
+  async filterTools(_domains: string[]): Promise<ToolDefinition[]> {
+    return [];
+  }
+}
+
+// ============================================================
+// Legal AI Quality — pass-through / no validation
+// ============================================================
+
+export class NoOpSectionizer implements ISemanticSectionizer {
+  async extractSections(text: string): Promise<DocumentSection[]> {
+    return [{ type: 'unknown', title: '', content: text, startIndex: 0, endIndex: text.length }];
+  }
+}
+
+export class NoOpHallucinationGuard implements IHallucinationGuard {
+  async validateResponse(): Promise<ValidationResult> {
+    return { isValid: true, confidence: 0, unsupportedClaims: [] };
+  }
+
+  async verifyClaim(): Promise<boolean> {
+    return true;
+  }
+}
+
+export class NoOpCitationValidator implements ICitationValidator {
+  async extractCitations(): Promise<CitationLink[]> {
+    return [];
+  }
+
+  async validatePrecedentStatus(): Promise<PrecedentStatus> {
+    return { status: 'unknown', confidence: 0, affectingDecisions: [] };
+  }
+
+  async buildCitationGraph(): Promise<unknown> {
+    return {};
+  }
+
+  async saveCitations(): Promise<void> {}
+}
+
+export class NoOpPatternStore implements ILegalPatternStore {
+  async extractPatterns(): Promise<LegalPattern | null> {
+    return null;
+  }
+
+  async savePattern(): Promise<void> {}
+
+  async findPatterns(): Promise<LegalPattern[]> {
+    return [];
+  }
+
+  async matchPatterns(): Promise<LegalPattern[]> {
+    return [];
+  }
+}
+
+export class NoOpShepardizationService implements IShepardizationService {
+  async analyze(identifier: string): Promise<ShepardizationResult> {
+    return {
+      case_number: identifier,
+      status: 'unknown',
+      confidence: 0,
+      affecting_decisions: [],
+      chain_length: 0,
+      check_source: 'local',
+      checked_at: new Date().toISOString(),
+    };
+  }
+
+  async quickCheck(): Promise<ShepardizationResult | null> {
+    return null;
+  }
+
+  async batchAnalyze(caseNumbers: string[]): Promise<ShepardizationResult[]> {
+    return caseNumbers.map((cn) => ({
+      case_number: cn,
+      status: 'unknown' as const,
+      confidence: 0,
+      affecting_decisions: [],
+      chain_length: 0,
+      check_source: 'local' as const,
+      checked_at: new Date().toISOString(),
+    }));
+  }
+}
+
+// ============================================================
+// Evidence & Context — no-op
+// ============================================================
+
+export class NoOpEvidenceExtractor implements IEvidenceExtractor {
+  extractFromToolResult(): ExtractedEvidence {
+    return { decisions: [], citations: [], vault_documents: [] };
+  }
+
+  extractNormsFromAnswer(): SimpleCitation[] {
+    return [];
+  }
+
+  extractAllEvidence(): ExtractedEvidence {
+    return { decisions: [], citations: [], vault_documents: [] };
+  }
+}
+
+export class NoOpContextBuilder implements IContextBuilder {
+  async build(
+    history: Array<{ role: 'user' | 'assistant'; content: string }>,
+    query: string,
+  ): Promise<Array<{ role: string; content: string }>> {
+    const messages: Array<{ role: string; content: string }> = [];
+    for (const h of history.slice(-4)) {
+      messages.push({ role: h.role, content: h.content });
+    }
+    messages.push({ role: 'user', content: query });
+    return messages;
+  }
+}
+
+export class NoOpResultCompactor implements IResultCompactor {
+  summarize(result: unknown): unknown {
+    return result;
+  }
+
+  async ragCompact(
+    _query: string,
+    toolResults: Array<{ tool: string; content: string }>,
+  ): Promise<Array<{ tool: string; content: string }>> {
+    return toolResults;
+  }
+}
+
+export class NoOpThinkingDescriptions implements IThinkingDescriptions {
+  generate(toolName: string): string {
+    return `Виконую ${toolName}...`;
+  }
+}
+
+// ============================================================
+// Billing — free tier only
+// ============================================================
+
+export class NoOpBillingService implements IBillingService {
+  async getOrCreateUserBilling(userId: string): Promise<UserBilling> {
+    return { userId, tier: 'free', balanceUsd: 0 };
+  }
+
+  async checkBalance(): Promise<UserBalance> {
+    return { hasCredits: true, currentBalance: 999999, reason: 'Open source build — no billing' };
+  }
+
+  async charge(): Promise<void> {}
+}
+
+export class NoOpPricingService implements IPricingService {
+  calculatePrice(costUsd: number): PriceCalculation {
+    return { cost_usd: costUsd, markup_percentage: 0, markup_amount_usd: 0, price_usd: costUsd, tier: 'free' };
+  }
+
+  getTierConfig(tier: PricingTier): PricingConfig {
+    return { tier, markup_percentage: 0, description: 'Open source', features: [] };
+  }
+
+  getAllTiers(): PricingConfig[] {
+    return [this.getTierConfig('free')];
+  }
+
+  getRecommendedTier(): PricingTier {
+    return 'free';
+  }
+
+  isValidTier(tier: string): boolean {
+    return tier === 'free';
+  }
+}
+
+export class NoOpSubscriptionService implements ISubscriptionService {
+  async list(): Promise<{ subscriptions: unknown[]; total: number }> {
+    return { subscriptions: [], total: 0 };
+  }
+
+  async get(): Promise<unknown | null> {
+    return null;
+  }
+
+  async create(): Promise<unknown> {
+    return {};
+  }
+
+  async cancel(): Promise<unknown | null> {
+    return null;
+  }
+
+  async getUserSubscription(): Promise<unknown | null> {
+    return null;
+  }
+}
+
+export class NoOpCreditService implements ICreditService {
+  async checkBalance(): Promise<UserBalance> {
+    return { hasCredits: true, currentBalance: 999999, reason: 'Open source build' };
+  }
+
+  async deductCredits(): Promise<CreditDeduction> {
+    return { success: true, newBalance: 999999, transactionId: null };
+  }
+
+  async addCredits(): Promise<CreditAddition> {
+    return { success: true, newBalance: 999999, transactionId: 'noop' };
+  }
+
+  async getBalanceStatus(): Promise<unknown | null> {
+    return null;
+  }
+}
+
+export class NoOpChatSearchCache implements IChatSearchCache {
+  async getCachedResult(): Promise<unknown | null> {
+    return null;
+  }
+
+  async cacheResult(): Promise<void> {}
+
+  async invalidate(): Promise<void> {}
+}
+
+// ============================================================
+// Factory: create all NoOp services
+// ============================================================
+
+export function createNoOpCoreServices(): CoreServices {
+  return {
+    chatService: new NoOpChatService(),
+    queryPlanner: new NoOpQueryPlanner(),
+    intentClassifier: new NoOpIntentClassifier(),
+    sectionizer: new NoOpSectionizer(),
+    hallucinationGuard: new NoOpHallucinationGuard(),
+    citationValidator: new NoOpCitationValidator(),
+    patternStore: new NoOpPatternStore(),
+    shepardizationService: new NoOpShepardizationService(),
+    evidenceExtractor: new NoOpEvidenceExtractor(),
+    contextBuilder: new NoOpContextBuilder(),
+    resultCompactor: new NoOpResultCompactor(),
+    thinkingDescriptions: new NoOpThinkingDescriptions(),
+    billingService: new NoOpBillingService(),
+    pricingService: new NoOpPricingService(),
+    subscriptionService: new NoOpSubscriptionService(),
+    creditService: new NoOpCreditService(),
+    chatSearchCache: new NoOpChatSearchCache(),
+  };
+}

--- a/packages/core-interfaces/LICENSE
+++ b/packages/core-interfaces/LICENSE
@@ -1,0 +1,17 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+   Copyright 2024-2026 SecondLayer (legal.org.ua)

--- a/packages/core-interfaces/package.json
+++ b/packages/core-interfaces/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@secondlayer/core-interfaces",
+  "version": "1.0.0",
+  "description": "TypeScript interfaces for SecondLayer core services (Open Core boundary)",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/packages/core-interfaces/src/index.ts
+++ b/packages/core-interfaces/src/index.ts
@@ -1,0 +1,392 @@
+/**
+ * @secondlayer/core-interfaces
+ *
+ * TypeScript interfaces defining the boundary between open-source
+ * infrastructure and the proprietary AI chat pipeline.
+ *
+ * These interfaces are implemented by @secondlayer/core (private)
+ * and consumed by mcp_backend (public). The open repo provides
+ * NoOp fallbacks when @secondlayer/core is not installed.
+ */
+
+// ============================================================
+// Chat Pipeline
+// ============================================================
+
+export interface IChatService {
+  chat(request: ChatRequest): AsyncIterable<ChatEvent>;
+  generatePlanForReview(request: ChatPlanRequest): Promise<ChatPlan>;
+}
+
+export interface ChatRequest {
+  query: string;
+  conversationId?: string;
+  userId?: string;
+  budget?: BudgetKey;
+  history?: Array<{ role: 'user' | 'assistant'; content: string }>;
+  requestId?: string;
+}
+
+export interface ChatPlanRequest {
+  query: string;
+  conversationId?: string;
+  userId?: string;
+  budget?: BudgetKey;
+  history?: Array<{ role: 'user' | 'assistant'; content: string }>;
+}
+
+export interface ChatPlan {
+  query_type: QueryType;
+  budget: BudgetKey;
+  domains: string[];
+  tools: string[];
+  steps: Array<{ tool: string; params: Record<string, unknown>; reason: string }>;
+  estimated_cost_usd?: number;
+}
+
+export interface ChatEvent {
+  type: 'thinking' | 'text' | 'tool_call' | 'tool_result' | 'evidence' | 'plan' | 'error' | 'done' | 'cost';
+  data: unknown;
+}
+
+// ============================================================
+// Query Planning & Intent Classification
+// ============================================================
+
+export interface IQueryPlanner {
+  classifyIntent(query: string, budget?: BudgetKey): Promise<QueryIntent>;
+  generateOptimizedSearchQuery(userQuery: string, intent: QueryIntent, budget?: BudgetKey): Promise<string>;
+  buildQueryParams(intent: QueryIntent, searchQuery?: string): unknown;
+  selectEndpoints(intent: QueryIntent): string[];
+}
+
+export interface IIntentClassifier {
+  classify(query: string, requestId?: string): Promise<ChatIntentClassification>;
+  filterTools(domains: string[], slots?: Record<string, unknown>, queryType?: QueryType): Promise<ToolDefinition[]>;
+}
+
+export interface QueryIntent {
+  primary_domain: string;
+  sub_domain?: string;
+  query_type: string;
+  confidence: number;
+  entities?: Record<string, unknown>;
+}
+
+export interface ChatIntentClassification {
+  queryType: QueryType;
+  domains: string[];
+  slots: Record<string, unknown>;
+  confidence: number;
+  suggestedTools: string[];
+}
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export type QueryType =
+  | 'case_lookup'
+  | 'practice_analysis'
+  | 'legislation_lookup'
+  | 'legal_consultation'
+  | 'registry_lookup'
+  | 'parliament_query'
+  | 'document_query'
+  | 'calculation'
+  | 'document_drafting'
+  | 'comparative_analysis'
+  | 'due_diligence'
+  | 'institutional_analysis'
+  | 'unsupported';
+
+// ============================================================
+// Budget System
+// ============================================================
+
+export type BudgetKey = 'quick' | 'standard' | 'deep';
+
+export interface BudgetLimits {
+  maxResultChars: number;
+  maxContextChars: number;
+  maxTokens: number;
+  maxToolCalls: number;
+  resolutionSlice: number;
+}
+
+// ============================================================
+// Legal AI Quality Services
+// ============================================================
+
+export interface ISemanticSectionizer {
+  extractSections(text: string, useLLM?: boolean): Promise<DocumentSection[]>;
+}
+
+export interface DocumentSection {
+  type: SectionType;
+  title: string;
+  content: string;
+  startIndex: number;
+  endIndex: number;
+  metadata?: Record<string, unknown>;
+}
+
+export type SectionType =
+  | 'article'
+  | 'part'
+  | 'chapter'
+  | 'section'
+  | 'paragraph'
+  | 'preamble'
+  | 'conclusion'
+  | 'header'
+  | 'unknown';
+
+export interface IHallucinationGuard {
+  validateResponse(response: unknown, sources: string[]): Promise<ValidationResult>;
+  verifyClaim(claim: string, sources: string[]): Promise<boolean>;
+}
+
+export interface ValidationResult {
+  isValid: boolean;
+  confidence: number;
+  unsupportedClaims: string[];
+  suggestedCorrections?: string[];
+}
+
+export interface ICitationValidator {
+  extractCitations(text: string, caseId: string): Promise<CitationLink[]>;
+  validatePrecedentStatus(caseId: string, caseNumber?: string): Promise<PrecedentStatus>;
+  buildCitationGraph(caseId: string, depth?: number): Promise<unknown>;
+  saveCitations(citations: CitationLink[]): Promise<void>;
+}
+
+export interface CitationLink {
+  sourceDocId: string;
+  targetDocId: string;
+  citationType: string;
+  confidence: number;
+}
+
+export type PrecedentStatusType = 'active' | 'overruled' | 'modified' | 'questioned' | 'unknown';
+
+export interface PrecedentStatus {
+  status: PrecedentStatusType;
+  confidence: number;
+  affectingDecisions: AffectingDecision[];
+}
+
+export interface AffectingDecision {
+  doc_id: string;
+  instance: string;
+  court: string;
+  date?: string;
+  outcome: string;
+  effect: 'upheld' | 'modified' | 'overruled' | 'remanded' | 'closed';
+}
+
+export interface ILegalPatternStore {
+  extractPatterns(caseIds: string[], intent: string): Promise<LegalPattern | null>;
+  savePattern(pattern: LegalPattern): Promise<void>;
+  findPatterns(intent: string, minConfidence?: number): Promise<LegalPattern[]>;
+  matchPatterns(queryEmbedding: number[], intent: string): Promise<LegalPattern[]>;
+}
+
+export interface LegalPattern {
+  id?: string;
+  intent: string;
+  description: string;
+  confidence: number;
+  caseIds: string[];
+  embedding?: number[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface IShepardizationService {
+  analyze(identifier: string): Promise<ShepardizationResult>;
+  quickCheck(caseNumber: string): Promise<ShepardizationResult | null>;
+  batchAnalyze(caseNumbers: string[]): Promise<ShepardizationResult[]>;
+}
+
+export interface ShepardizationResult {
+  case_number: string;
+  target_doc_id?: string;
+  status: PrecedentStatusType;
+  confidence: number;
+  affecting_decisions: AffectingDecision[];
+  chain_length: number;
+  check_source: 'redis' | 'pg' | 'zo_api' | 'local';
+  checked_at: string;
+}
+
+// ============================================================
+// Evidence Extraction
+// ============================================================
+
+export interface IEvidenceExtractor {
+  extractFromToolResult(toolName: string, rawResult: unknown): ExtractedEvidence;
+  extractNormsFromAnswer(answerText: string): SimpleCitation[];
+  extractAllEvidence(
+    thinkingSteps: Array<{ tool: string; params: unknown; result: unknown }>,
+    answerText?: string
+  ): ExtractedEvidence;
+}
+
+export interface ExtractedEvidence {
+  decisions: Array<{ id: string; number: string; court: string; date: string; summary: string }>;
+  citations: SimpleCitation[];
+  vault_documents: Array<{ id: string; name: string; type: string }>;
+}
+
+export interface SimpleCitation {
+  law: string;
+  article: string;
+  text?: string;
+}
+
+// ============================================================
+// Context Building & Result Compaction
+// ============================================================
+
+export interface IContextBuilder {
+  build(
+    history: Array<{ role: 'user' | 'assistant'; content: string }>,
+    query: string,
+    classifiedDomains?: string[],
+    plan?: unknown,
+    maxContextChars?: number,
+    conversationId?: string,
+    requestId?: string,
+    queryType?: QueryType
+  ): Promise<Array<{ role: string; content: string }>>;
+}
+
+export interface IResultCompactor {
+  summarize(result: unknown, limits: BudgetLimits): unknown;
+  ragCompact(
+    query: string,
+    toolResults: Array<{ tool: string; content: string }>,
+    maxChars: number
+  ): Promise<Array<{ tool: string; content: string }>>;
+}
+
+// ============================================================
+// Thinking Descriptions
+// ============================================================
+
+export interface IThinkingDescriptions {
+  generate(toolName: string, params: Record<string, unknown>): string;
+}
+
+// ============================================================
+// Billing & Pricing
+// ============================================================
+
+export type PricingTier = 'free' | 'startup' | 'business' | 'enterprise' | 'internal' | 'attorney';
+
+export interface IBillingService {
+  getOrCreateUserBilling(userId: string): Promise<UserBilling>;
+  checkBalance(userId: string): Promise<UserBalance>;
+  charge(userId: string, requestId: string, costUsd: number): Promise<void>;
+}
+
+export interface UserBilling {
+  userId: string;
+  tier: PricingTier;
+  balanceUsd: number;
+}
+
+export interface UserBalance {
+  hasCredits: boolean;
+  currentBalance: number;
+  reason: string;
+}
+
+export interface IPricingService {
+  calculatePrice(costUsd: number, tier?: PricingTier): PriceCalculation;
+  getTierConfig(tier: PricingTier): PricingConfig;
+  getAllTiers(): PricingConfig[];
+  getRecommendedTier(monthlySpendingUsd: number): PricingTier;
+  isValidTier(tier: string): boolean;
+}
+
+export interface PricingConfig {
+  tier: PricingTier;
+  markup_percentage: number;
+  description: string;
+  features: string[];
+  monthly_price_usd?: number;
+  is_active?: boolean;
+  display_name?: string;
+}
+
+export interface PriceCalculation {
+  cost_usd: number;
+  markup_percentage: number;
+  markup_amount_usd: number;
+  price_usd: number;
+  tier: PricingTier;
+}
+
+export interface ISubscriptionService {
+  list(filters?: Record<string, unknown>): Promise<{ subscriptions: unknown[]; total: number }>;
+  get(id: string): Promise<unknown | null>;
+  create(input: unknown): Promise<unknown>;
+  cancel(id: string, reason: string): Promise<unknown | null>;
+  getUserSubscription(userId: string): Promise<unknown | null>;
+}
+
+export interface ICreditService {
+  checkBalance(userId: string, requiredCredits?: number): Promise<UserBalance>;
+  deductCredits(userId: string, amount: number, toolName: string, costTrackingId?: string, description?: string): Promise<CreditDeduction>;
+  addCredits(userId: string, amount: number, transactionType: string, source: string, sourceId?: string, description?: string): Promise<CreditAddition>;
+  getBalanceStatus(userId: string): Promise<unknown | null>;
+}
+
+export interface CreditDeduction {
+  success: boolean;
+  newBalance: number;
+  transactionId: string | null;
+}
+
+export interface CreditAddition {
+  success: boolean;
+  newBalance: number;
+  transactionId: string;
+}
+
+// ============================================================
+// Search Cache
+// ============================================================
+
+export interface IChatSearchCache {
+  getCachedResult(toolName: string, params: Record<string, unknown>): Promise<unknown | null>;
+  cacheResult(toolName: string, params: Record<string, unknown>, result: unknown): Promise<void>;
+  invalidate(conversationId: string): Promise<void>;
+}
+
+// ============================================================
+// Aggregate: all core services
+// ============================================================
+
+export interface CoreServices {
+  chatService: IChatService;
+  queryPlanner: IQueryPlanner;
+  intentClassifier: IIntentClassifier;
+  sectionizer: ISemanticSectionizer;
+  hallucinationGuard: IHallucinationGuard;
+  citationValidator: ICitationValidator;
+  patternStore: ILegalPatternStore;
+  shepardizationService: IShepardizationService;
+  evidenceExtractor: IEvidenceExtractor;
+  contextBuilder: IContextBuilder;
+  resultCompactor: IResultCompactor;
+  thinkingDescriptions: IThinkingDescriptions;
+  billingService: IBillingService;
+  pricingService: IPricingService;
+  subscriptionService: ISubscriptionService;
+  creditService: ICreditService;
+  chatSearchCache: IChatSearchCache;
+}

--- a/packages/core-interfaces/tsconfig.json
+++ b/packages/core-interfaces/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- **Phase 1**: `@secondlayer/core-interfaces` package — 17 interfaces, 25+ types defining the open/closed boundary
- **Phase 2**: NoOp fallback implementations for all core services (open deployment gets full MCP tools, chat returns 501)
- **Phase 3**: `core-loader.ts` — dynamic import of proprietary `@secondlayer/core` with graceful fallback

## Architecture
```
@secondlayer/core-interfaces (open, Apache 2.0)
       ↑                ↑
@secondlayer/shared    @secondlayer/core (private, future)
       ↑                ↑
  mcp_backend (open, optionally loads core)
```

## What this enables
- Open source fork: `docker compose up` → 45 MCP tools work, `/api/chat` → 501
- Production: CI installs `@secondlayer/core` → full AI assistant

## Migration guide
See `docs/OPEN_CORE_MIGRATION.md` for Phase 4-6 (private repo creation, file removal, CI/CD).

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `@secondlayer/core-interfaces` builds independently
- [x] NoOp services implement all interfaces
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Open Core architecture (Phases 1–3) with a stable interface package, NoOp fallbacks, and a dynamic loader. Open deployments run all MCP tools while chat returns 501; production loads `@secondlayer/core` for full assistant.

- **New Features**
  - Added `@secondlayer/core-interfaces` package defining interfaces for chat pipeline, legal quality, billing, and caching.
  - Implemented NoOp fallbacks and `mcp_backend/src/factories/core-loader.ts` to dynamically import `@secondlayer/core` with graceful fallback.
  - Included `docs/OPEN_CORE_MIGRATION.md` and added `@secondlayer/core-interfaces` to `mcp_backend` dependencies.

- **Bug Fixes**
  - Reduced TSV slice to 500k chars in `backfill-tsv.ts` to stay under PostgreSQL `tsvector` 1MB limit.

<sup>Written for commit ee026a4891566886ccb92656b67b0cf8f8d90164. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

