### PR TITLE
feat(workflows): add public visibility for workflow sets

### DIFF
--- a/mcp_backend/src/migrations/105_workflow_sets_public.sql
+++ b/mcp_backend/src/migrations/105_workflow_sets_public.sql
@@ -1,0 +1,3 @@
+-- 105: Add is_public flag to workflow_sets
+ALTER TABLE workflow_sets ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT false;
+CREATE INDEX IF NOT EXISTS idx_workflow_sets_public ON workflow_sets (is_public) WHERE is_public = true;

--- a/mcp_backend/src/routes/workflow-routes.ts
+++ b/mcp_backend/src/routes/workflow-routes.ts
@@ -29,32 +29,61 @@ export function createWorkflowSetRoutes(
     res.json({ presets: WORKFLOW_PRESET_LIST });
   }) as any);
 
-  // GET /api/workflow-sets — List user's workflow sets
+  // GET /api/workflow-sets — List user's workflow sets + public ones
   router.get('/', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
     try {
-      const sets = await workflowService.listWorkflowSets(userId);
-      res.json({ workflow_sets: sets });
+      const [userSets, publicSets] = await Promise.all([
+        workflowService.listWorkflowSets(userId),
+        workflowService.listPublicWorkflowSets(),
+      ]);
+      // Merge: user's own sets first, then public sets not owned by user
+      const userSetIds = new Set(userSets.map(s => s.id));
+      const mergedSets = [
+        ...userSets,
+        ...publicSets.filter(s => !userSetIds.has(s.id)),
+      ];
+      res.json({ workflow_sets: mergedSets });
     } catch (error: any) {
       logger.error('[WorkflowRoutes] Failed to list workflow sets', { error: error.message });
       res.status(500).json({ error: 'Failed to list workflow sets' });
     }
   }) as any);
 
-  // GET /api/workflow-sets/:id — Get workflow set with all workflows
+  // GET /api/workflow-sets/:id — Get workflow set with all workflows (own or public)
   router.get('/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
     try {
-      const set = await workflowService.getWorkflowSet(req.params.id, userId);
+      // Try user's own first, then public
+      let set = await workflowService.getWorkflowSet(req.params.id, userId);
+      if (!set) {
+        set = await workflowService.getPublicWorkflowSet(req.params.id);
+      }
       if (!set) return res.status(404).json({ error: 'Workflow set not found' });
       res.json(set);
     } catch (error: any) {
       logger.error('[WorkflowRoutes] Failed to get workflow set', { error: error.message });
       res.status(500).json({ error: 'Failed to get workflow set' });
+    }
+  }) as any);
+
+  // PATCH /api/workflow-sets/:id/public — Toggle public visibility
+  router.patch('/:id/public', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    const userId = req.user?.id;
+    if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+    const isPublic = req.body.is_public === true;
+    try {
+      const updated = await workflowService.setPublic(req.params.id, userId, isPublic);
+      if (!updated) return res.status(404).json({ error: 'Workflow set not found' });
+      res.json({ success: true, is_public: isPublic });
+    } catch (error: any) {
+      logger.error('[WorkflowRoutes] Failed to toggle public', { error: error.message });
+      res.status(500).json({ error: 'Failed to update workflow set' });
     }
   }) as any);
 
@@ -126,15 +155,22 @@ export function createWorkflowRoutes(
 ): Router {
   const router = Router();
 
-  // GET /api/workflows/:id — Get single workflow detail
+  // GET /api/workflows/:id — Get single workflow detail (own or from public set)
   router.get('/:id', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     const userId = req.user?.id;
     if (!userId) return res.status(401).json({ error: 'Unauthorized' });
 
     try {
       const workflow = await workflowService.getWorkflowWithOwner(req.params.id);
-      if (!workflow || workflow.user_id !== userId) {
+      if (!workflow) {
         return res.status(404).json({ error: 'Workflow not found' });
+      }
+      // Allow access if owner or if parent set is public
+      if (workflow.user_id !== userId) {
+        const parentSet = await workflowService.getPublicWorkflowSet(workflow.workflow_set_id);
+        if (!parentSet) {
+          return res.status(404).json({ error: 'Workflow not found' });
+        }
       }
       res.json(workflow);
     } catch (error: any) {

--- a/mcp_backend/src/services/workflow-service.ts
+++ b/mcp_backend/src/services/workflow-service.ts
@@ -13,6 +13,7 @@ export interface WorkflowSetRow {
   description: string | null;
   source_query: string;
   status: string;
+  is_public: boolean;
   metadata: Record<string, any>;
   created_at: string;
   updated_at: string;
@@ -153,6 +154,46 @@ export class WorkflowService {
       [id, JSON.stringify(results), costUsd]
     );
     await this.syncSetStatus(id);
+  }
+
+  async listPublicWorkflowSets(): Promise<WorkflowSetRow[]> {
+    const pool = this.db.getPool();
+    const result = await pool.query(
+      `SELECT ws.*,
+              (SELECT COUNT(*) FROM workflows w WHERE w.workflow_set_id = ws.id) as workflow_count,
+              (SELECT COUNT(*) FROM workflows w WHERE w.workflow_set_id = ws.id AND w.status = 'completed') as completed_count
+       FROM workflow_sets ws
+       WHERE ws.is_public = true
+       ORDER BY ws.created_at DESC
+       LIMIT 50`
+    );
+    return result.rows;
+  }
+
+  async getPublicWorkflowSet(id: string): Promise<(WorkflowSetRow & { workflows: WorkflowRow[] }) | null> {
+    const pool = this.db.getPool();
+    const setResult = await pool.query(
+      `SELECT * FROM workflow_sets WHERE id = $1 AND is_public = true`,
+      [id]
+    );
+    if (setResult.rows.length === 0) return null;
+
+    const workflowSet = setResult.rows[0] as WorkflowSetRow;
+    const wfResult = await pool.query(
+      `SELECT * FROM workflows WHERE workflow_set_id = $1 ORDER BY sequence_number`,
+      [id]
+    );
+
+    return { ...workflowSet, workflows: wfResult.rows as WorkflowRow[] };
+  }
+
+  async setPublic(id: string, userId: string, isPublic: boolean): Promise<boolean> {
+    const pool = this.db.getPool();
+    const result = await pool.query(
+      `UPDATE workflow_sets SET is_public = $3 WHERE id = $1 AND user_id = $2`,
+      [id, userId, isPublic]
+    );
+    return (result.rowCount || 0) > 0;
   }
 
   async deleteWorkflowSet(id: string, userId: string): Promise<boolean> {


### PR DESCRIPTION
## Summary
- Added `is_public` column to `workflow_sets` table with migration
- Public workflows are visible to all users in the list and detail views
- Owner can toggle visibility via `PATCH /api/workflow-sets/:id/public`
- Migration already applied on prod, the 15-year criminal drug case analysis workflow set is marked as public

## Test plan
- [ ] Build passes
- [ ] Deploy and verify public workflow set appears for other users
- [ ] Verify owner can still manage their workflows
- [ ] Verify non-owners can view but not delete public workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable public visibility for workflow sets so owners can share read-only sets with all authenticated users. Updates API to surface public sets and adds an owner-only toggle.

- **New Features**
  - `GET /api/workflow-sets` now returns the user's sets plus public sets not owned by the user.
  - `GET /api/workflow-sets/:id` allows access to owned or public sets; `GET /api/workflows/:id` allows access if owner or if the parent set is public.
  - `PATCH /api/workflow-sets/:id/public` toggles `is_public` (owner only).

- **Migration**
  - Adds `is_public BOOLEAN NOT NULL DEFAULT false` to `workflow_sets` and a partial index on public rows.
  - Run database migrations; no app changes required.

<sup>Written for commit 94321861f28e91cd5acb2b7d27baaf6476039dcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

