### PR TITLE
fix(scripts): range-based TSV backfill (no full scan)

### DIFF
--- a/mcp_backend/src/scripts/backfill-tsv.ts
+++ b/mcp_backend/src/scripts/backfill-tsv.ts
@@ -1,21 +1,22 @@
 /**
  * backfill-tsv.ts — Populate edrsr_fulltext.tsv column using all available CPU cores.
  *
- * Strategy (hybrid Plan A+B):
- *  1. DROP the GIN index (eliminates index maintenance overhead during UPDATE)
- *  2. Run N parallel workers, each doing batch UPDATEs with FOR UPDATE SKIP LOCKED
- *  3. Recreate GIN index with max parallel workers
- *  4. VACUUM ANALYZE
+ * Strategy: Range-based parallel UPDATE.
+ *  1. Get min/max doc_id
+ *  2. Split into N ranges (one per worker)
+ *  3. Each worker UPDATEs its range in batches — no locking contention
+ *  4. Optionally create GIN index after all workers finish
  *
  * Usage:
- *   WORKERS=14 BATCH_SIZE=5000 DATABASE_URL=postgres://... npx ts-node src/scripts/backfill-tsv.ts
+ *   WORKERS=14 BATCH_SIZE=5000 DATABASE_URL=postgres://... npx tsx src/scripts/backfill-tsv.ts
  *
  * Env vars:
- *   DATABASE_URL   — Direct PG connection (NOT through PgBouncer!)
- *   WORKERS        — Number of parallel workers (default: 14)
- *   BATCH_SIZE     — Rows per UPDATE batch (default: 5000)
- *   DRY_RUN        — If "true", only show progress without modifying (default: false)
- *   SKIP_DROP_INDEX — If "true", skip dropping/recreating GIN index (default: false)
+ *   DATABASE_URL     — Direct PG connection (NOT through PgBouncer!)
+ *   WORKERS          — Number of parallel workers (default: 14)
+ *   BATCH_SIZE       — Rows per UPDATE batch (default: 5000)
+ *   DRY_RUN          — If "true", only show progress without modifying (default: false)
+ *   SKIP_DROP_INDEX  — If "true", skip dropping/recreating GIN index (default: false)
+ *   CREATE_INDEX_ONLY — If "true", only create the GIN index (default: false)
  */
 
 import { Pool } from 'pg';
@@ -27,15 +28,17 @@ const WORKERS = parseInt(process.env.WORKERS || '14', 10);
 const BATCH_SIZE = Math.min(Math.max(parseInt(process.env.BATCH_SIZE || '5000', 10), 100), 50000);
 const DRY_RUN = process.env.DRY_RUN === 'true';
 const SKIP_DROP_INDEX = process.env.SKIP_DROP_INDEX === 'true';
+const CREATE_INDEX_ONLY = process.env.CREATE_INDEX_ONLY === 'true';
 const INDEX_NAME = 'idx_edrsr_fulltext_tsv';
 const TABLE = 'edrsr_fulltext';
-const PROGRESS_INTERVAL_MS = 10_000; // log progress every 10s
+const PROGRESS_INTERVAL_MS = 30_000; // log progress every 30s (COUNT is slow on 60M rows)
 
 // ─── State ─────────────────────────────────────────────────────────────────
 let totalIndexed = 0;
 let workersActive = 0;
 let startTime = 0;
 let allDone = false;
+let totalRemaining = 0;
 
 function log(msg: string) {
   const elapsed = startTime ? ((Date.now() - startTime) / 1000).toFixed(0) : '0';
@@ -62,28 +65,11 @@ function createPool(): PoolType {
   }
   return new Pool({
     connectionString: DATABASE_URL,
-    max: WORKERS + 2, // workers + admin queries
+    max: WORKERS + 2,
     idleTimeoutMillis: 60_000,
     connectionTimeoutMillis: 10_000,
-    statement_timeout: 0, // no timeout for long-running UPDATEs
+    statement_timeout: 0,
   } as any);
-}
-
-// ─── Get progress from DB ──────────────────────────────────────────────────
-async function getProgress(pool: PoolType): Promise<{ total: number; indexed: number; remaining: number }> {
-  const result = await pool.query(`
-    SELECT
-      COUNT(*)::bigint AS total,
-      COUNT(tsv)::bigint AS indexed,
-      (COUNT(*) FILTER (WHERE tsv IS NULL AND full_text IS NOT NULL))::bigint AS remaining
-    FROM ${TABLE}
-  `);
-  const row = result.rows[0];
-  return {
-    total: Number(row.total),
-    indexed: Number(row.indexed),
-    remaining: Number(row.remaining),
-  };
 }
 
 // ─── Check if GIN index exists ─────────────────────────────────────────────
@@ -115,9 +101,9 @@ async function createIndex(pool: PoolType): Promise<void> {
   log(`Creating GIN index ${INDEX_NAME} with max_parallel_maintenance_workers...`);
   const indexStart = Date.now();
 
-  // Increase parallel workers for index creation
   const client = await pool.connect();
   try {
+    await client.query(`SET statement_timeout = 0`);
     await client.query(`SET max_parallel_maintenance_workers = 8`);
     await client.query(`SET maintenance_work_mem = '4GB'`);
     await client.query(`CREATE INDEX ${INDEX_NAME} ON ${TABLE} USING gin(tsv)`);
@@ -129,43 +115,41 @@ async function createIndex(pool: PoolType): Promise<void> {
   log(`Index created in ${elapsed} minutes`);
 }
 
-// ─── Worker: process batches until none remain ─────────────────────────────
-async function worker(id: number, pool: PoolType): Promise<number> {
+// ─── Range-based worker ────────────────────────────────────────────────────
+async function worker(id: number, pool: PoolType, rangeStart: number, rangeEnd: number): Promise<number> {
   let workerTotal = 0;
   workersActive++;
+  let offset = rangeStart;
 
-  let consecutiveErrors = 0;
+  log(`Worker ${id}: doc_id range [${rangeStart}, ${rangeEnd}]`);
+
   try {
-    while (!allDone) {
-      try {
-        const result = await pool.query(`
-          WITH batch AS (
-            SELECT doc_id
-            FROM ${TABLE}
-            WHERE tsv IS NULL AND full_text IS NOT NULL
-            LIMIT $1
-            FOR UPDATE SKIP LOCKED
-          )
-          UPDATE ${TABLE} f
-          SET tsv = to_tsvector('simple', LEFT(f.full_text, 500000))
-          FROM batch
-          WHERE f.doc_id = batch.doc_id
-        `, [BATCH_SIZE]);
+    const client = await pool.connect();
+    try {
+      await client.query(`SET statement_timeout = 0`);
+      await client.query(`SET synchronous_commit = off`);
 
-        const count = result.rowCount || 0;
-        if (count === 0) break;
+      while (offset < rangeEnd) {
+        const batchEnd = Math.min(offset + BATCH_SIZE, rangeEnd);
+        try {
+          const result = await client.query(`
+            UPDATE ${TABLE}
+            SET tsv = to_tsvector('simple', LEFT(full_text, 500000))
+            WHERE doc_id >= $1 AND doc_id < $2
+              AND tsv IS NULL AND full_text IS NOT NULL
+          `, [offset, batchEnd]);
 
-        workerTotal += count;
-        totalIndexed += count;
-        consecutiveErrors = 0;
-      } catch (err: any) {
-        consecutiveErrors++;
-        log(`Worker ${id} batch error (${consecutiveErrors}): ${err.message}`);
-        if (consecutiveErrors >= 5) {
-          log(`Worker ${id} giving up after ${consecutiveErrors} consecutive errors`);
-          break;
+          const count = result.rowCount || 0;
+          workerTotal += count;
+          totalIndexed += count;
+        } catch (err: any) {
+          log(`Worker ${id} error at offset ${offset}: ${err.message}`);
+          // Continue to next batch instead of dying
         }
+        offset = batchEnd;
       }
+    } finally {
+      client.release();
     }
   } catch (err: any) {
     log(`Worker ${id} fatal error: ${err.message}`);
@@ -173,80 +157,84 @@ async function worker(id: number, pool: PoolType): Promise<number> {
     workersActive--;
   }
 
+  log(`Worker ${id} done: ${workerTotal.toLocaleString()} rows indexed`);
   return workerTotal;
 }
 
-// ─── Progress reporter ─────────────────────────────────────────────────────
-async function progressReporter(pool: PoolType): Promise<void> {
+// ─── Progress reporter (uses in-memory counter, no slow COUNT) ─────────────
+async function progressReporter(): Promise<void> {
   while (!allDone) {
     await new Promise(resolve => setTimeout(resolve, PROGRESS_INTERVAL_MS));
     if (allDone) break;
 
-    try {
-      const elapsedMs = Date.now() - startTime;
-      const ratePerSec = totalIndexed / (elapsedMs / 1000);
-      const { total, indexed, remaining } = await getProgress(pool);
-      const pct = total > 0 ? ((indexed / total) * 100).toFixed(2) : '0';
-      const eta = formatEta(remaining, ratePerSec);
+    const elapsedMs = Date.now() - startTime;
+    const ratePerSec = totalIndexed / (elapsedMs / 1000);
+    const remaining = totalRemaining - totalIndexed;
+    const pct = totalRemaining > 0 ? ((totalIndexed / totalRemaining) * 100).toFixed(2) : '0';
+    const eta = formatEta(remaining > 0 ? remaining : 0, ratePerSec);
 
-      log(
-        `Progress: ${indexed.toLocaleString()} / ${total.toLocaleString()} (${pct}%) | ` +
-        `Rate: ${formatRate(totalIndexed, elapsedMs)} rows/sec | ` +
-        `Remaining: ${remaining.toLocaleString()} | ETA: ${eta} | ` +
-        `Workers: ${workersActive}/${WORKERS}`
-      );
-    } catch {
-      // ignore progress query errors
-    }
+    log(
+      `Progress: ${totalIndexed.toLocaleString()} / ${totalRemaining.toLocaleString()} (${pct}%) | ` +
+      `Rate: ${formatRate(totalIndexed, elapsedMs)} rows/sec | ` +
+      `ETA: ${eta} | Workers: ${workersActive}/${WORKERS}`
+    );
   }
 }
 
 // ─── Main ──────────────────────────────────────────────────────────────────
 async function main(): Promise<void> {
-  log('=== EDRSR TSV Backfill ===');
+  log('=== EDRSR TSV Backfill (range-based) ===');
   log(`Workers: ${WORKERS} | Batch size: ${BATCH_SIZE} | Dry run: ${DRY_RUN}`);
-  log(`Skip drop index: ${SKIP_DROP_INDEX}`);
 
   const pool = createPool();
 
   try {
-    // 1. Show initial state
-    const initial = await getProgress(pool);
-    log(`Initial state: ${initial.indexed.toLocaleString()} indexed / ${initial.total.toLocaleString()} total`);
-    log(`Remaining: ${initial.remaining.toLocaleString()} rows to process`);
-
-    if (initial.remaining === 0) {
-      log('Nothing to do — all rows are indexed!');
+    // Create index only mode
+    if (CREATE_INDEX_ONLY) {
+      await createIndex(pool);
       return;
     }
+
+    // 1. Get doc_id range
+    const rangeResult = await pool.query(`SELECT MIN(doc_id)::bigint AS min_id, MAX(doc_id)::bigint AS max_id FROM ${TABLE}`);
+    const minId = Number(rangeResult.rows[0].min_id);
+    const maxId = Number(rangeResult.rows[0].max_id);
+    log(`Doc ID range: ${minId} to ${maxId} (span: ${(maxId - minId).toLocaleString()})`);
+
+    // 2. Quick estimate of remaining (sample-based, not full COUNT)
+    const estResult = await pool.query(`
+      SELECT reltuples::bigint AS est_total FROM pg_class WHERE relname = '${TABLE}'
+    `);
+    const estTotal = Number(estResult.rows[0]?.est_total || 60000000);
+    log(`Estimated total rows (pg_class): ${estTotal.toLocaleString()}`);
 
     if (DRY_RUN) {
       log('DRY_RUN=true — exiting without changes');
       return;
     }
 
-    // 2. Drop GIN index (if not skipped)
+    // 3. Drop GIN index (if not skipped)
     if (!SKIP_DROP_INDEX) {
       await dropIndex(pool);
     }
 
-    // 3. Tune session-level PG settings for bulk writes
-    log('Setting checkpoint/WAL params for bulk operation...');
-    // These are session-level hints; global settings come from docker-compose
-    try {
-      await pool.query(`SET synchronous_commit = off`); // faster, safe for backfill
-    } catch {
-      log('Could not set synchronous_commit (non-critical)');
-    }
+    // 4. Split range into worker chunks
+    const rangeSpan = maxId - minId + 1;
+    const chunkSize = Math.ceil(rangeSpan / WORKERS);
+    totalRemaining = estTotal; // rough estimate for ETA
 
-    // 4. Launch workers
+    // 5. Launch workers
     startTime = Date.now();
-    log(`Launching ${WORKERS} workers...`);
+    log(`Launching ${WORKERS} workers with chunk size ~${chunkSize.toLocaleString()} doc_ids each...`);
 
-    const progressPromise = progressReporter(pool);
-    const workerPromises = Array.from({ length: WORKERS }, (_, i) => worker(i, pool));
+    const progressPromise = progressReporter();
+    const workerPromises = Array.from({ length: WORKERS }, (_, i) => {
+      const rangeStart = minId + i * chunkSize;
+      const rangeEnd = Math.min(minId + (i + 1) * chunkSize, maxId + 1);
+      return worker(i, pool, rangeStart, rangeEnd);
+    });
+
     const results = await Promise.all(workerPromises);
-
     allDone = true;
     await progressPromise;
 
@@ -255,21 +243,23 @@ async function main(): Promise<void> {
     log(`All workers done. Total indexed: ${totalDone.toLocaleString()} in ${(elapsedMs / 1000 / 60).toFixed(1)} minutes`);
     log(`Average rate: ${formatRate(totalDone, elapsedMs)} rows/sec`);
 
-    // 5. Recreate GIN index
+    // 6. Recreate GIN index
     if (!SKIP_DROP_INDEX) {
       await createIndex(pool);
     }
 
-    // 6. VACUUM ANALYZE
+    // 7. VACUUM ANALYZE
     log('Running VACUUM ANALYZE...');
     const vacStart = Date.now();
-    await pool.query(`VACUUM ANALYZE ${TABLE}`);
+    const vacClient = await pool.connect();
+    try {
+      await vacClient.query(`SET statement_timeout = 0`);
+      await vacClient.query(`VACUUM ANALYZE ${TABLE}`);
+    } finally {
+      vacClient.release();
+    }
     log(`VACUUM ANALYZE done in ${((Date.now() - vacStart) / 1000 / 60).toFixed(1)} minutes`);
 
-    // 7. Final state
-    const final = await getProgress(pool);
-    log(`Final state: ${final.indexed.toLocaleString()} indexed / ${final.total.toLocaleString()} total`);
-    log(`Remaining: ${final.remaining.toLocaleString()}`);
     log('=== Done ===');
   } finally {
     await pool.end();


### PR DESCRIPTION
Replaces FOR UPDATE SKIP LOCKED with doc_id range splitting. Fixes stalled backfill on partially indexed table.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch TSV backfill to range-based workers that split the `doc_id` space, removing full-table scans and lock contention. This fixes stalled backfills on partially indexed tables and speeds up processing on ~60M rows.

- **Bug Fixes**
  - Replaced `FOR UPDATE SKIP LOCKED` with per-worker `doc_id` ranges to avoid sequential scans and contention.
  - Unblocks backfill on partially indexed tables by preventing repeated full scans.

- **Refactors**
  - Added `CREATE_INDEX_ONLY=true` mode to build the GIN index separately.
  - In-memory progress and ETA (no `COUNT(*)`); logs every 30s.
  - Per-session `SET statement_timeout = 0`; workers use `synchronous_commit = off`.
  - VACUUM ANALYZE runs with no statement timeout.
  - Updated usage example to `npx tsx src/scripts/backfill-tsv.ts`.

<sup>Written for commit 9bb28288ce9c1fc66c447ced570f317a994b9489. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

