### PR TITLE
feat(email): admin credit invitation email

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -616,7 +616,7 @@ class HTTPMCPServer {
     // GET /api/admin/analytics/usage - Usage analytics
     // GET /api/admin/api-keys - List API keys
     // GET /api/admin/settings - Get system settings
-    this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, this.billing.billingService, this.billing.userPreferencesService, this.billing.prometheusService, this.billing.pricingService, this.billing.subscriptionService, this.app_.configService, this.app_.auditService));
+    this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, this.billing.billingService, this.billing.userPreferencesService, this.billing.prometheusService, this.billing.pricingService, this.billing.subscriptionService, this.app_.configService, this.app_.auditService, this.billing.emailService));
 
     // Upload metrics endpoint (admin)
     this.app.get('/api/admin/upload-metrics', requireJWT as any, (async (_req: DualAuthRequest, res: express.Response) => {

--- a/mcp_backend/src/routes/admin-routes.ts
+++ b/mcp_backend/src/routes/admin-routes.ts
@@ -13,6 +13,7 @@ import { PricingService } from '../services/pricing-service.js';
 import { SubscriptionService } from '../services/subscription-service.js';
 import { ConfigService } from '../services/config-service.js';
 import type { AuditService } from '../services/audit-service.js';
+import type { EmailService } from '../services/email-service.js';
 
 import {
   createRequireAdmin,
@@ -38,6 +39,7 @@ export function createAdminRoutes(
   subscriptions: SubscriptionService,
   configService?: ConfigService,
   auditService?: AuditService,
+  emailService?: EmailService,
 ): express.Router {
   const router = express.Router();
 
@@ -48,7 +50,7 @@ export function createAdminRoutes(
 
   // Mount all domain sub-routers (no path prefix — handlers define their own paths)
   router.use(createAdminStatsRoutes(db, logAdminAction));
-  router.use(createAdminUsersRoutes(db, logAdminAction));
+  router.use(createAdminUsersRoutes(db, logAdminAction, emailService));
   router.use(createAdminTransactionsRoutes(db, logAdminAction, auditService));
   router.use(createAdminBillingRoutes(db, logAdminAction, pricing, subscriptions));
   router.use(createAdminConfigRoutes(db, logAdminAction, preferencesService, pricing, configService));

--- a/mcp_backend/src/routes/admin/admin-users.ts
+++ b/mcp_backend/src/routes/admin/admin-users.ts
@@ -10,10 +10,12 @@ import crypto from 'crypto';
 import type { IDatabase } from '../../domain/ports/index.js';
 import { logger } from '../../utils/logger.js';
 import { getStringParam, type LogAdminAction } from './admin-middleware.js';
+import type { EmailService } from '../../services/email-service.js';
 
 export function createAdminUsersRoutes(
   db: IDatabase,
   logAdminAction: LogAdminAction,
+  emailService?: EmailService,
 ): Router {
   const router = Router();
 
@@ -405,6 +407,29 @@ export function createAdminUsersRoutes(
         reason,
         admin: (req as any).user?.id
       });
+
+      // Send email notification for positive balance adjustments
+      if (amount > 0 && emailService) {
+        try {
+          const userRow = await db.query(
+            'SELECT email, name FROM users WHERE id = $1',
+            [userId]
+          );
+          if (userRow.rows.length > 0 && userRow.rows[0].email) {
+            const user = userRow.rows[0];
+            await emailService.sendAdminCredit({
+              email: user.email,
+              name: user.name || user.email,
+              amount,
+              currency: 'USD',
+              newBalance: balanceAfter,
+            });
+            logger.info('Admin balance adjustment email sent', { userId, email: user.email });
+          }
+        } catch (emailErr: any) {
+          logger.warn('Failed to send admin balance adjustment email', { userId, error: emailErr.message });
+        }
+      }
 
       res.json({
         success: true,

--- a/mcp_backend/src/services/email-service.ts
+++ b/mcp_backend/src/services/email-service.ts
@@ -41,6 +41,14 @@ export interface PaymentFailureParams {
   reason: string;
 }
 
+export interface AdminCreditParams {
+  email: string;
+  name: string;
+  amount: number;
+  currency: string;
+  newBalance: number;
+}
+
 export interface LowBalanceParams {
   email: string;
   name: string;
@@ -200,6 +208,50 @@ export class EmailService {
       });
     } catch (error: any) {
       logger.error('Failed to send payment success email', {
+        email: maskSensitive(params.email, 4),
+        error: error.message,
+      });
+    }
+  }
+
+  /**
+   * Send admin credit notification (test account invitation)
+   */
+  async sendAdminCredit(params: AdminCreditParams): Promise<void> {
+    try {
+      const html = this.generateAdminCreditTemplate(params);
+
+      const attachments: nodemailer.SendMailOptions['attachments'] = [];
+      if (this.logoBuffer) {
+        attachments.push({
+          filename: 'logolex.png',
+          content: this.logoBuffer,
+          cid: 'lexlogo@legal.org.ua',
+        });
+      }
+      if (this.fractalBuffer) {
+        attachments.push({
+          filename: 'email-header-fractal.png',
+          content: this.fractalBuffer,
+          cid: 'fractal-header@legal.org.ua',
+        });
+      }
+
+      await this.transporter.sendMail({
+        from: `"${this.config.fromName}" <${this.config.from}>`,
+        to: params.email,
+        subject: `LEX — Вам надано тестовий доступ: ${params.currency} ${params.amount.toFixed(2)}`,
+        html,
+        attachments,
+      });
+
+      logger.info('Admin credit email sent', {
+        email: maskSensitive(params.email, 4),
+        amount: params.amount,
+        currency: params.currency,
+      });
+    } catch (error: any) {
+      logger.error('Failed to send admin credit email', {
         email: maskSensitive(params.email, 4),
         error: error.message,
       });
@@ -911,6 +963,107 @@ export class EmailService {
         </div>
       </div>
     `;
+  }
+
+  /**
+   * Generate admin credit (test account) email template
+   */
+  private generateAdminCreditTemplate(params: AdminCreditParams): string {
+    const logoImg = this.logoBuffer
+      ? '<img src="cid:lexlogo@legal.org.ua" alt="LEX" width="50" height="50" style="display:inline-block;vertical-align:middle;margin-right:8px;" />'
+      : '<span style="font-size:26px;font-weight:bold;color:#1e293b;letter-spacing:3px;vertical-align:middle;">LEX</span>';
+
+    const headerBgStyle = this.fractalBuffer
+      ? 'background:#e8effa url(cid:fractal-header@legal.org.ua) no-repeat center center;background-size:cover;'
+      : 'background:#e8effa;';
+
+    return `
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body { font-family: 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #1e293b; margin: 0; padding: 0; background: #f1f5f9; }
+    .wrapper { max-width: 600px; margin: 0 auto; padding: 20px; }
+    .card { background: #ffffff; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 6px rgba(0,0,0,0.07); }
+    .content { padding: 30px; }
+    .invite-badge { display: inline-block; background: #3b82f6; color: #fff; padding: 5px 16px; border-radius: 20px; font-size: 13px; font-weight: 600; }
+    .amount-block { text-align: center; margin: 24px 0; padding: 20px; background: #eff6ff; border-radius: 10px; }
+    .amount { font-size: 36px; font-weight: 700; color: #1e40af; }
+    .amount-label { font-size: 13px; color: #64748b; margin-top: 4px; }
+    .details-table { width: 100%; border-collapse: collapse; margin: 20px 0; }
+    .details-table td { padding: 10px 0; border-bottom: 1px solid #e2e8f0; font-size: 14px; }
+    .details-table td:first-child { color: #64748b; }
+    .details-table td:last-child { text-align: right; font-weight: 600; color: #1e293b; }
+    .details-table tr:last-child td { border-bottom: none; }
+    .btn { display: inline-block; background: #1e293b; color: #ffffff; padding: 14px 32px; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 14px; }
+    .btn-center { text-align: center; margin: 24px 0; }
+    .features { background: #f8fafc; border-radius: 10px; padding: 20px; margin: 20px 0; }
+    .features h3 { margin: 0 0 12px; font-size: 15px; color: #1e293b; }
+    .features ul { margin: 0; padding-left: 20px; }
+    .features li { font-size: 14px; color: #475569; margin-bottom: 6px; }
+    .divider { border: none; border-top: 1px solid #e2e8f0; margin: 24px 0; }
+    .footer { text-align: center; padding: 20px; font-size: 12px; color: #94a3b8; }
+    .footer a { color: #64748b; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="card">
+      <div class="header" style="${headerBgStyle}padding:28px 30px 24px;text-align:left;">
+        <div style="margin-bottom:14px;">${logoImg}</div>
+        <h1 style="color:#1e293b;font-size:21px;margin:0 0 12px;font-weight:700;">Запрошення до тестування платформи</h1>
+        <div class="invite-badge">Тестовий акаунт</div>
+      </div>
+      <div class="content">
+        <p>Вітаємо, ${params.name}!</p>
+        <p>Вас запрошено до тестування юридичної AI-платформи <strong>LEX</strong>. Це не поповнення рахунку — для вас створено тестовий акаунт з балансом для ознайомлення з можливостями системи.</p>
+
+        <div class="amount-block">
+          <div class="amount">${params.currency} ${params.amount.toFixed(2)}</div>
+          <div class="amount-label">тестовий баланс</div>
+        </div>
+
+        <table class="details-table">
+          <tr>
+            <td>Баланс акаунту</td>
+            <td>$${Number(params.newBalance).toFixed(2)} USD</td>
+          </tr>
+          <tr>
+            <td>Дата</td>
+            <td>${new Date().toLocaleDateString('uk-UA', { day: 'numeric', month: 'long', year: 'numeric' })}</td>
+          </tr>
+        </table>
+
+        <div class="features">
+          <h3>Що можна протестувати:</h3>
+          <ul>
+            <li>Пошук судових рішень з AI-аналізом</li>
+            <li>Аналіз законодавства та нормативних актів</li>
+            <li>Семантичний пошук по правовій базі</li>
+            <li>Робота з документами та витягами</li>
+          </ul>
+        </div>
+
+        <div class="btn-center">
+          <a href="${this.frontendUrl}/dashboard" class="btn">Перейти до платформи</a>
+        </div>
+
+        <hr class="divider" />
+        <p style="font-size:13px; color:#64748b; text-align:center;">
+          Якщо у вас виникли питання — напишіть нам на <a href="mailto:support@legal.org.ua" style="color:#1e293b;">support@legal.org.ua</a>
+        </p>
+      </div>
+      <div class="footer">
+        <p>&copy; ${new Date().getFullYear()} LEX Legal Platform. Усі права захищено.</p>
+        <p><a href="${this.frontendUrl}">legal.org.ua</a></p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+    `.trim();
   }
 
   /**


### PR DESCRIPTION
## Summary
- When admin tops up user balance from `/admin/users`, user receives a dedicated "test account invitation" email
- New `sendAdminCredit` method + Ukrainian template with blue branding, feature list, and clear messaging that this is NOT a payment but a test account
- EmailService plumbed through admin-routes → admin-users

## Test plan
- [ ] Top up a user from admin panel, verify email arrives
- [ ] Verify email content: Ukrainian text, "тестовий акаунт", feature list, correct amount/balance
- [ ] Verify negative adjustments do NOT trigger email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a Ukrainian “test account invitation” email when an admin tops up a user’s balance, making clear it’s not a payment confirmation. Adds `sendAdminCredit` and wires `EmailService` through admin routes.

- **New Features**
  - Emails trigger only for positive adjustments from `/admin/users`.
  - Adds `sendAdminCredit(params)` with a branded UA template, logo/fractal attachments, and subject including currency and amount.
  - Passes `emailService` into admin routes; the users route fetches the recipient and sends the email with amount and `newBalance`.
  - Logs success and warns on failure without blocking the response.

<sup>Written for commit addd4d66ff253605c78f6eb5a8ab03f3ed05536a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

