### PR TITLE
fix(tests): remove unused vi imports

### DIFF
--- a/lexwebapp/src/stores/__tests__/localeStore.test.ts
+++ b/lexwebapp/src/stores/__tests__/localeStore.test.ts
@@ -2,7 +2,7 @@
  * localeStore Unit Tests
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { useLocaleStore } from '../localeStore';
 
 describe('localeStore', () => {

--- a/lexwebapp/src/stores/__tests__/uiStore.test.ts
+++ b/lexwebapp/src/stores/__tests__/uiStore.test.ts
@@ -2,7 +2,7 @@
  * uiStore Unit Tests
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 // Mock window.innerWidth before importing the store
 Object.defineProperty(window, 'innerWidth', { value: 1440, writable: true });


### PR DESCRIPTION
## Summary
- Remove unused `vi` import from `localeStore.test.ts` and `uiStore.test.ts`
- Fixes CI failure: `TS6133: 'vi' is declared but its value is never read`

## Test plan
- [x] `npx tsc --noEmit` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `vi` from `vitest` imports in `lexwebapp/src/stores/__tests__/localeStore.test.ts` and `lexwebapp/src/stores/__tests__/uiStore.test.ts`.
Resolves TS6133 (“declared but never read”) and fixes the CI TypeScript check.

<sup>Written for commit 2a63fe02d7ca5280628046f581fae3b8e31c7d6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

