### PR TITLE
fix(ci): resolve critical CI/CD issues

### DIFF
--- a/.github/workflows/ci-mobile-release.yml
+++ b/.github/workflows/ci-mobile-release.yml
@@ -217,7 +217,7 @@ jobs:
           echo "Built: $APK_PATH ($(du -sh $APK_PATH | cut -f1))"
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: secondlayer-android-${{ steps.version.outputs.version_name }}
           path: mobile/${{ steps.build.outputs.apk_path }}
@@ -235,7 +235,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download APK artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: secondlayer-android-${{ needs.build-release-apk.outputs.version_name }}
           path: ./release-apk

--- a/.github/workflows/cron-edrsr-sync.yml
+++ b/.github/workflows/cron-edrsr-sync.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Check sync result
         if: always()
         run: |
-          YEAR="${{ inputs.year || '$(date +%Y)' }}"
+          YEAR="${{ inputs.year }}"
+          [ -z "$YEAR" ] && YEAR="$(date +%Y)"
           if [ -f "/tmp/edrsr_sync_${YEAR}.log" ]; then
             echo "=== Sync Log ==="
             cat "/tmp/edrsr_sync_${YEAR}.log"

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -96,7 +96,6 @@
     "minio": "^8.0.6",
     "multer": "^2.1.0",
     "node-cron": "^4.2.1",
-    "node-pty": "^1.1.0",
     "nodemailer": "^8.0.2",
     "openai": "^6.27.0",
     "openid-client": "^5.7.1",
@@ -145,6 +144,9 @@
     "ts-jest": "^29.1.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
+  },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
   },
   "overrides": {
     "fast-xml-parser": ">=5.5.6",

--- a/mcp_backend/src/routes/terminal-routes.ts
+++ b/mcp_backend/src/routes/terminal-routes.ts
@@ -9,7 +9,6 @@
 import { IncomingMessage } from 'http';
 import { Server as WebSocketServer, WebSocket } from 'ws';
 import { WebSocket as WsClient } from 'ws';
-import * as pty from 'node-pty';
 import jwt from 'jsonwebtoken';
 import { logger } from '../utils/logger.js';
 import type { IDatabase } from '../domain/ports/index.js';
@@ -17,6 +16,19 @@ import type { Server as HttpServer } from 'http';
 
 const MAX_SESSIONS_PER_ADMIN = 2;
 const MAX_PTY_INPUT_LENGTH = 4096;
+
+// Lazy-load node-pty (optional native dep — only needed when TERMINAL_SERVICE_URL is not set)
+let pty: typeof import('node-pty') | null = null;
+async function getPty(): Promise<typeof import('node-pty')> {
+  if (!pty) {
+    try {
+      pty = await import('node-pty');
+    } catch {
+      throw new Error('node-pty is not available. Set TERMINAL_SERVICE_URL to use the proxy terminal.');
+    }
+  }
+  return pty;
+}
 
 /**
  * Sanitize PTY input: bound length and ensure only valid terminal data passes through.
@@ -188,9 +200,20 @@ export function attachTerminalWebSocket(httpServer: HttpServer, db: IDatabase): 
       });
     } else {
       // === Fallback: direct node-pty (for environments without terminal-service) ===
+      let ptyModule: typeof import('node-pty');
+      try {
+        ptyModule = await getPty();
+      } catch (err: any) {
+        ws.send(JSON.stringify({ type: 'error', data: err.message }));
+        ws.close(4500, 'node-pty unavailable');
+        sessions.delete(ws);
+        if (sessions.size === 0) activeSessions.delete(admin.id);
+        return;
+      }
+
       const cwd = process.env.TERMINAL_CWD || '/home/vovkes/SecondLayer';
 
-      const ptyProcess = pty.spawn('bash', [], {
+      const ptyProcess = ptyModule.spawn('bash', [], {
         name: 'xterm-256color',
         cols: 120,
         rows: 30,


### PR DESCRIPTION
## Summary
- **node-pty → optionalDependencies + lazy import** — prevents Docker build failures on prod when node-gyp cannot compile (ETIMEDOUT to unofficial-builds.nodejs.org). Prod uses TERMINAL_SERVICE_URL proxy, so node-pty is not needed at runtime.
- **upload/download-artifact@v7/@v8 → @v4** — v7/v8 don't exist, mobile release pipeline would fail on first run.
- **cron-edrsr-sync date fix** — `$(date +%Y)` inside GHA `${{ }}` expression was a literal string, not shell expansion. Now uses proper shell fallback.

## Test plan
- [ ] Backend TypeScript build passes (`tsc --noEmit` ✅ verified locally)
- [ ] CI pipeline passes on this branch
- [ ] Next prod deploy should not fail on node-pty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical CI/CD failures by making `node-pty` optional with lazy loading, correcting artifact action versions, and fixing cron year expansion. Unblocks mobile releases and prevents prod Docker build failures.

- **Bug Fixes**
  - Moved `node-pty` to `optionalDependencies` and lazy-loaded in `terminal-routes.ts`; only used when `TERMINAL_SERVICE_URL` is unset to avoid `node-gyp` build errors.
  - Updated `actions/upload-artifact` and `actions/download-artifact` to `@v4` in the mobile release workflow.
  - Fixed cron EDRSR sync year: use `inputs.year` if set, else compute via shell `date` at runtime.

<sup>Written for commit 134e2dc87c5291961bfc5549a3e4610859652b19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

