### PR TITLE
fix(ci): harden CI/CD workflows

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -227,6 +227,27 @@ jobs:
             echo "::warning::Claude Code did not produce a fix"
           fi
 
+      - name: Create issue if no fix produced
+        if: steps.guard.outputs.skip == 'false' && steps.check-fix.outputs.has_fix == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "CI build failure needs manual fix ($(date +%Y-%m-%d))" \
+            --body "$(cat <<EOF
+          ## CI build failure — auto-fix failed
+
+          The self-heal agent could not produce a code fix for this build failure.
+
+          **Failed run:** $RUN_URL
+          **Commit:** ${GITHUB_SHA:0:7}
+
+          Please investigate manually.
+          EOF
+          )" \
+            --label "bug,ci"
+
       - name: Push branch and create PR
         if: steps.guard.outputs.skip == 'false' && steps.check-fix.outputs.has_fix == 'true'
         env:
@@ -331,9 +352,9 @@ jobs:
           [ -n "$STOP" ] && $DC rm -f $STOP 2>/dev/null || true
           [ -n "$BUILD" ] && $DC build $BUILD
 
-          [ "$BACKEND_CHANGED" = "true" ] && { $DC up migrate-local || true; }
-          [ "$RADA_CHANGED" = "true" ] && { $DC up rada-db-init-local || true; $DC up rada-migrate-local || true; }
-          [ "$OPENREYESTR_CHANGED" = "true" ] && { $DC up migrate-openreyestr-local || true; }
+          [ "$BACKEND_CHANGED" = "true" ] && { timeout 120 $DC up --abort-on-container-exit migrate-local || true; }
+          [ "$RADA_CHANGED" = "true" ] && { timeout 120 $DC up --abort-on-container-exit rada-db-init-local || true; timeout 120 $DC up --abort-on-container-exit rada-migrate-local || true; }
+          [ "$OPENREYESTR_CHANGED" = "true" ] && { timeout 120 $DC up --abort-on-container-exit migrate-openreyestr-local || true; }
 
           [ -n "$START" ] && $DC up -d $START
 

--- a/.github/workflows/ci-mobile-release.yml
+++ b/.github/workflows/ci-mobile-release.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FLUTTER_VERSION: '3.41.4'
+  FLUTTER_VERSION: '3.29.3'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -270,6 +270,27 @@ jobs:
             echo "::warning::Claude Code did not produce a fix"
           fi
 
+      - name: Create issue if no fix produced
+        if: steps.guard.outputs.skip == 'false' && steps.check-fix.outputs.has_fix == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Pre-deploy test failure needs manual fix ($(date +%Y-%m-%d))" \
+            --body "$(cat <<EOF
+          ## Pre-deploy test failure — auto-fix failed
+
+          The self-heal agent could not produce a code fix for this test failure.
+
+          **Failed run:** $RUN_URL
+          **Commit:** ${GITHUB_SHA:0:7}
+
+          Please investigate manually.
+          EOF
+          )" \
+            --label "bug,ci"
+
       - name: Push branch and create PR
         if: steps.guard.outputs.skip == 'false' && steps.check-fix.outputs.has_fix == 'true'
         env:
@@ -308,8 +329,8 @@ jobs:
       backend_version: ${{ steps.version.outputs.backend_version }}
       frontend_version: ${{ steps.version.outputs.frontend_version }}
     env:
-      PROD_SERVER: '18.192.189.254'
-      PROD_USER: 'ubuntu'
+      PROD_SERVER: ${{ secrets.PROD_SERVER_IP }}
+      PROD_USER: ${{ secrets.PROD_USER || 'ubuntu' }}
       BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
       RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
       OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
@@ -382,6 +403,14 @@ jobs:
           BACKEND_VERSION: ${{ steps.version.outputs.backend_version }}
           FRONTEND_VERSION: ${{ steps.version.outputs.frontend_version }}
         run: |
+          if [ -z "$PROD_SSH_KEY_PATH" ]; then
+            echo "::error::PROD_SSH_KEY_PATH secret is not set"
+            exit 1
+          fi
+          if [ -z "$PROD_SERVER" ]; then
+            echo "::error::PROD_SERVER_IP secret is not set"
+            exit 1
+          fi
           SSH_CMD="ssh -i $PROD_SSH_KEY_PATH -o StrictHostKeyChecking=no ${PROD_USER}@${PROD_SERVER}"
           REMOTE_REPO="/home/${PROD_USER}/SecondLayer"
 
@@ -637,8 +666,8 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_REGION: eu-central-1
-      PROD_SERVER: '18.192.189.254'
-      PROD_USER: 'ubuntu'
+      PROD_SERVER: ${{ secrets.PROD_SERVER_IP }}
+      PROD_USER: ${{ secrets.PROD_USER || 'ubuntu' }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
@@ -749,6 +778,27 @@ jobs:
             echo "has_fix=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Claude Code did not produce a fix — manual intervention needed"
           fi
+
+      - name: Create issue if no fix produced
+        if: steps.guard.outputs.skip == 'false' && steps.check-fix.outputs.has_fix == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue create \
+            --title "Deploy failure needs manual fix ($(date +%Y-%m-%d))" \
+            --body "$(cat <<EOF
+          ## Production deploy failure — auto-fix failed
+
+          The self-heal agent could not produce a code fix for this deploy failure.
+
+          **Failed run:** $RUN_URL
+          **Commit:** ${GITHUB_SHA:0:7}
+
+          > Production may be in a degraded state. Investigate promptly.
+          EOF
+          )" \
+            --label "bug,ci,urgent"
 
       - name: Push branch and create PR
         if: steps.guard.outputs.skip == 'false' && steps.check-fix.outputs.has_fix == 'true'


### PR DESCRIPTION
## Summary
- **Flutter version** — 3.41.4 doesn't exist, fixed to 3.29.3 (latest stable)
- **Prod IP → secret** — moved hardcoded `18.192.189.254` to `PROD_SERVER_IP` secret (already created)
- **SSH validation** — early fail with clear error if `PROD_SSH_KEY_PATH` or `PROD_SERVER_IP` secrets are missing
- **Migrate timeouts** — added `timeout 120` + `--abort-on-container-exit` to prevent migrate containers from hanging indefinitely
- **Self-heal issue creation** — all 3 self-heal agents (ci-local, pre-deploy, deploy) now create a GitHub issue when they can't produce a code fix, instead of silently failing

## Test plan
- [ ] CI pipeline passes
- [ ] Verify `PROD_SERVER_IP` and `PROD_USER` secrets are set (`gh secret list`)
- [ ] Next deploy uses secrets instead of hardcoded IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI/CD for reliability and security. Fixes invalid Flutter version, moves prod server IP to secrets with validation, adds migration timeouts, and auto-creates issues when self-heal can’t fix failures.

- **Bug Fixes**
  - Use Flutter 3.29.3 (previous 3.41.4 was invalid).
  - Replace hardcoded prod IP with secrets and default prod user; early fail if required secrets are missing.
  - Add 120s timeouts with --abort-on-container-exit to migration containers to stop hangs.

- **Migration**
  - Ensure secrets are set: PROD_SERVER_IP, PROD_SSH_KEY_PATH, PROD_USER (optional, defaults to ubuntu).

<sup>Written for commit fe37059e9ac08ac712b25d4ed14ae40cd4128e53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

