### PR TITLE
fix(ui): reduce sidebar submenu font size

### DIFF
--- a/lexwebapp/src/components/sidebar/NavItem.tsx
+++ b/lexwebapp/src/components/sidebar/NavItem.tsx
@@ -30,7 +30,7 @@ export function NavItem({ icon: Icon, label, route, onClick, badge }: NavItemPro
   return (
     <button
       onClick={handleClick}
-      className={`w-full text-left pl-3 pr-2.5 py-[7px] rounded-md text-[12.5px] transition-all duration-150 flex items-center gap-2.5 group relative ${
+      className={`w-full text-left pl-3 pr-2.5 py-[7px] rounded-md text-[11px] transition-all duration-150 flex items-center gap-2.5 group relative ${
         isActive
           ? 'bg-white/[0.07] text-white'
           : 'text-zinc-400 hover:bg-white/[0.04] hover:text-zinc-200'

--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -268,7 +268,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                     {conversations.map((conv) => (
                       <div
                         key={conv.id}
-                        className={`group flex items-center gap-2 pl-3 pr-2 py-[7px] rounded-md text-[12.5px] cursor-pointer transition-all duration-150 relative ${
+                        className={`group flex items-center gap-2 pl-3 pr-2 py-[7px] rounded-md text-[11px] cursor-pointer transition-all duration-150 relative ${
                           activeConversationId === conv.id
                             ? 'bg-white/[0.07] text-white'
                             : 'text-zinc-500 hover:bg-white/[0.04] hover:text-zinc-300'
@@ -328,7 +328,7 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                   return (
                     <div
                       key={folder}
-                      className={`relative flex items-center gap-2.5 pl-3 pr-2 py-[7px] rounded-md text-[12.5px] transition-all duration-150 group cursor-pointer ${
+                      className={`relative flex items-center gap-2.5 pl-3 pr-2 py-[7px] rounded-md text-[11px] transition-all duration-150 group cursor-pointer ${
                         isActive
                           ? 'bg-white/[0.07] text-white'
                           : 'text-zinc-500 hover:bg-white/[0.04] hover:text-zinc-300'


### PR DESCRIPTION
## Summary
- Reduced sidebar submenu item font size from 12.5px to 11px for better visual hierarchy
- Applied to NavItem component, vault folder items, and conversation items
- Submenu text now appears visually smaller than section headers (VAULT, СПРАВИ, etc.)

## Test plan
- [ ] Verify sidebar submenu items are visually smaller than section titles
- [ ] Check all sidebar sections render correctly (conversations, vault folders, research, legislation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced sidebar submenu font size from 12.5px to 11px so items read as subordinate to section headers and improve visual hierarchy.
Applied to `NavItem` buttons, conversation items, and vault folder items in the sidebar.

<sup>Written for commit 776717ebb8c950f7fb0c64792011c27516fee468. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

