### PR TITLE
redesign(ui): Apple-style developer documentation page

### DIFF
--- a/lexwebapp/src/pages/DeveloperDocsPage/index.tsx
+++ b/lexwebapp/src/pages/DeveloperDocsPage/index.tsx
@@ -1,332 +1,342 @@
-import { useState } from 'react';
-import { motion } from 'framer-motion';
-import {
-  BookOpen, Code, Terminal, Key, Zap, Server, Globe, Copy, Check,
-  ChevronDown, ChevronRight, ExternalLink, Shield, DollarSign,
-  Search, FileText, Scale, Building2, BarChart3,
-} from 'lucide-react';
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { Copy, Check, ChevronRight, ChevronDown } from 'lucide-react';
 
-type TabId = 'overview' | 'tools' | 'auth' | 'examples' | 'mcp-clients' | 'pricing';
-
-interface ToolInfo {
-  name: string;
-  description: string;
-  params?: string[];
-  cost?: string;
-  badge?: 'new' | 'popular' | 'dev';
-}
-
-interface ToolCategory {
-  title: string;
-  icon: React.ElementType;
-  tools: ToolInfo[];
-}
+/* ================================================================
+   DATA
+   ================================================================ */
 
 const API_BASE = 'https://platform.legal.org.ua/api/tools';
 const MCP_SSE_URL = 'https://mcp.legal.org.ua/api/v1/sse';
 
-export function DeveloperDocsPage() {
-  const [activeTab, setActiveTab] = useState<TabId>('overview');
-
-  const tabs: { id: TabId; label: string; icon: React.ElementType }[] = [
-    { id: 'overview', label: 'Огляд', icon: BookOpen },
-    { id: 'tools', label: 'Інструменти', icon: Zap },
-    { id: 'auth', label: 'Автентифікація', icon: Key },
-    { id: 'examples', label: 'Приклади', icon: Code },
-    { id: 'mcp-clients', label: 'MCP клієнти', icon: Terminal },
-    { id: 'pricing', label: 'Вартість', icon: DollarSign },
-  ];
-
-  return (
-    <div className="flex-1 h-full overflow-y-auto bg-claude-bg">
-      <div className="max-w-4xl mx-auto px-6 py-10">
-        {/* Header */}
-        <div className="flex items-center gap-3 mb-2">
-          <div className="p-2 bg-claude-accent/10 rounded-xl">
-            <BookOpen size={22} className="text-claude-accent" />
-          </div>
-          <div className="flex-1">
-            <h1 className="text-xl font-semibold text-claude-text font-sans tracking-tight">
-              API документація
-            </h1>
-            <p className="text-[13px] text-claude-subtext font-sans">
-              LEX AI Platform &mdash; 56+ MCP інструментів для юридичного аналізу
-            </p>
-          </div>
-          <a
-            href="https://platform.legal.org.ua"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 px-4 py-2 bg-claude-accent text-white rounded-lg text-sm font-medium font-sans hover:bg-[#C66345] transition-colors shrink-0"
-          >
-            <Terminal size={16} />
-            Developer Console
-            <ExternalLink size={14} />
-          </a>
-        </div>
-
-        {/* Tabs */}
-        <div className="flex gap-1 mt-6 mb-8 border-b border-claude-border overflow-x-auto">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center gap-1.5 px-4 py-2.5 text-[13px] font-medium transition-colors whitespace-nowrap border-b-2 -mb-px ${
-                activeTab === tab.id
-                  ? 'text-claude-accent border-claude-accent'
-                  : 'text-claude-subtext border-transparent hover:text-claude-text hover:border-claude-border'
-              }`}
-            >
-              <tab.icon size={14} />
-              {tab.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Tab Content */}
-        <motion.div
-          key={activeTab}
-          initial={{ opacity: 0, y: 8 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.2 }}
-        >
-          {activeTab === 'overview' && <OverviewTab />}
-          {activeTab === 'tools' && <ToolsTab />}
-          {activeTab === 'auth' && <AuthTab />}
-          {activeTab === 'examples' && <ExamplesTab />}
-          {activeTab === 'mcp-clients' && <MCPClientsTab />}
-          {activeTab === 'pricing' && <PricingTab />}
-        </motion.div>
-      </div>
-    </div>
-  );
+interface ToolDef {
+  name: string;
+  description: string;
+  params?: { name: string; required?: boolean }[];
+  cost?: string;
 }
 
-/* ==================== OVERVIEW TAB ==================== */
-
-function OverviewTab() {
-  return (
-    <div className="space-y-6">
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Платформа LEX AI</h2>
-        <p className="text-[13px] text-claude-subtext leading-relaxed mb-4">
-          LEX AI надає API доступ до 56+ інструментів юридичного аналізу через три мікросервіси.
-          Підтримуємо REST API, MCP stdio та SSE streaming.
-        </p>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <ServiceCard
-            icon={Scale}
-            title="mcp_backend"
-            count="36+"
-            description="Судова практика, аналіз, законодавство, парсинг документів"
-          />
-          <ServiceCard
-            icon={Building2}
-            title="mcp_rada"
-            count="4"
-            description="Парламентські дані, законопроекти, депутати, голосування"
-          />
-          <ServiceCard
-            icon={Search}
-            title="mcp_openreyestr"
-            count="22"
-            description="Реєстр юридичних осіб, ФОП, бенефіціари, боржники"
-          />
-        </div>
-      </Card>
-
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Три транспорти</h2>
-        <div className="space-y-3">
-          <TransportRow
-            icon={Globe}
-            title="HTTP REST API"
-            endpoint={`POST ${API_BASE}/:toolName`}
-            description="Для вебдодатків та серверних інтеграцій"
-          />
-          <TransportRow
-            icon={Terminal}
-            title="MCP SSE (v1)"
-            endpoint={MCP_SSE_URL}
-            description="Для Claude Code, Claude Desktop, Cursor, VS Code, Continue.dev"
-          />
-          <TransportRow
-            icon={Server}
-            title="SSE Streaming"
-            endpoint={`POST ${API_BASE}/:toolName/stream`}
-            description="Для тривалих операцій з поточною відповіддю"
-          />
-        </div>
-      </Card>
-
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Швидкий старт</h2>
-        <CodeBlock language="bash" code={`# 1. Отримайте API ключ в Профіль → API токени
-# 2. Зробіть перший запит
-
-curl -X POST ${API_BASE}/search_legal_precedents \\
-  -H "Authorization: Bearer YOUR_API_KEY" \\
-  -H "Content-Type: application/json" \\
-  -d '{"arguments": {"query": "відшкодування збитків ДТП", "limit": 5}}'`} />
-      </Card>
-    </div>
-  );
+interface ToolGroup {
+  title: string;
+  tools: ToolDef[];
 }
 
-/* ==================== TOOLS TAB ==================== */
-
-const toolCategories: ToolCategory[] = [
+const toolGroups: ToolGroup[] = [
   {
     title: 'Пошук судових рішень',
-    icon: Gavel,
     tools: [
-      { name: 'search_legal_precedents', description: 'Пошук юридичних прецедентів із семантичним аналізом', params: ['query', 'domain', 'time_range', 'limit'], cost: '$0.03-$0.10', badge: 'popular' },
-      { name: 'search_supreme_court_practice', description: 'Пошук практики Верховного Суду (ВП/КЦС/КГС/КАС/ККС)', params: ['procedure_code', 'query', 'time_range', 'limit'], cost: '$0.05-$0.15' },
-      { name: 'find_similar_fact_pattern_cases', description: 'Пошук справ за схожими фактами', params: ['procedure_code', 'facts_text', 'time_range', 'limit'], cost: '$0.03-$0.10' },
-      { name: 'compare_practice_pro_contra', description: 'Підбірка практики «за/проти» за тезою', params: ['procedure_code', 'query', 'time_range', 'limit'], cost: '$0.05-$0.15' },
+      { name: 'search_legal_precedents', description: 'Пошук юридичних прецедентів із семантичним аналізом', params: [{ name: 'query', required: true }, { name: 'domain' }, { name: 'time_range' }, { name: 'limit' }], cost: '$0.03–0.10' },
+      { name: 'search_supreme_court_practice', description: 'Пошук практики Верховного Суду (ВП/КЦС/КГС/КАС/ККС)', params: [{ name: 'procedure_code', required: true }, { name: 'query', required: true }, { name: 'time_range' }, { name: 'limit' }], cost: '$0.05–0.15' },
+      { name: 'find_similar_fact_pattern_cases', description: 'Пошук справ за схожими фактами', params: [{ name: 'procedure_code', required: true }, { name: 'facts_text', required: true }, { name: 'time_range' }, { name: 'limit' }], cost: '$0.03–0.10' },
+      { name: 'compare_practice_pro_contra', description: 'Підбірка практики «за/проти» за тезою', params: [{ name: 'procedure_code', required: true }, { name: 'query', required: true }, { name: 'time_range' }, { name: 'limit' }], cost: '$0.05–0.15' },
     ],
   },
   {
     title: 'Аналіз судової практики',
-    icon: BarChart3,
     tools: [
-      { name: 'analyze_case_pattern', description: 'Аналізує патерни: аргументи, ризики, статистика результатів', params: ['intent', 'case_ids'], cost: '$0.02-$0.08' },
-      { name: 'get_similar_reasoning', description: 'Знаходить схожі судові обґрунтування за векторним пошуком', params: ['query', 'section_type', 'date_from', 'date_to'], cost: '$0.01-$0.03' },
-      { name: 'get_citation_graph', description: 'Будує граф цитувань між справами', params: ['case_id', 'depth'], cost: '$0.005-$0.02' },
-      { name: 'check_precedent_status', description: 'Перевіряє актуальність та статус прецеденту', params: ['case_id'], cost: '$0.005-$0.015' },
-      { name: 'get_judge_statistics', description: 'Статистика по судді: кількість справ, результати', params: ['judge_name', 'court', 'time_range'], cost: '$0.01-$0.03' },
-      { name: 'analyze_court_trends', description: 'Аналіз тенденцій судової практики', params: ['query', 'court', 'time_range'], cost: '$0.05-$0.12' },
+      { name: 'analyze_case_pattern', description: 'Аналізує патерни: аргументи, ризики, статистика результатів', params: [{ name: 'intent', required: true }, { name: 'case_ids' }], cost: '$0.02–0.08' },
+      { name: 'get_similar_reasoning', description: 'Знаходить схожі судові обґрунтування за векторним пошуком', params: [{ name: 'query', required: true }, { name: 'section_type' }, { name: 'date_from' }, { name: 'date_to' }], cost: '$0.01–0.03' },
+      { name: 'get_citation_graph', description: 'Будує граф цитувань між справами', params: [{ name: 'case_id', required: true }, { name: 'depth' }], cost: '$0.005–0.02' },
+      { name: 'check_precedent_status', description: 'Перевіряє актуальність та статус прецеденту', params: [{ name: 'case_id', required: true }], cost: '$0.005–0.015' },
+      { name: 'get_judge_statistics', description: 'Статистика по судді: кількість справ, результати', params: [{ name: 'judge_name', required: true }, { name: 'court' }, { name: 'time_range' }], cost: '$0.01–0.03' },
+      { name: 'analyze_court_trends', description: 'Аналіз тенденцій судової практики', params: [{ name: 'query', required: true }, { name: 'court' }, { name: 'time_range' }], cost: '$0.05–0.12' },
     ],
   },
   {
     title: 'Робота з документами',
-    icon: FileText,
     tools: [
-      { name: 'get_court_decision', description: 'Повний текст рішення з секціями: ФАКТИ, ОБҐРУНТУВАННЯ, РІШЕННЯ', params: ['doc_id', 'case_number', 'depth'], cost: '$0.01-$0.04' },
-      { name: 'get_case_documents_chain', description: 'Всі документи справи через усі інстанції', params: ['case_number', 'include_full_text', 'max_docs'], cost: '$0.005-$0.02', badge: 'new' },
-      { name: 'parse_document', description: 'Парсинг PDF/DOCX/HTML з OCR', params: ['fileBase64', 'mimeType', 'filename'], cost: '$0.01-$0.10' },
-      { name: 'extract_key_clauses', description: 'Витяг ключових положень з контракту', params: ['documentText', 'documentId'], cost: '$0.03-$0.10' },
-      { name: 'summarize_document', description: 'Резюме документа (quick/standard/deep)', params: ['documentText', 'detailLevel'], cost: '$0.02-$0.08' },
-      { name: 'compare_documents', description: 'Семантичне порівняння двох версій документа', params: ['oldDocumentText', 'newDocumentText'], cost: '$0.03-$0.12' },
+      { name: 'get_court_decision', description: 'Повний текст рішення з секціями: ФАКТИ, ОБҐРУНТУВАННЯ, РІШЕННЯ', params: [{ name: 'doc_id' }, { name: 'case_number' }, { name: 'depth' }], cost: '$0.01–0.04' },
+      { name: 'get_case_documents_chain', description: 'Всі документи справи через усі інстанції', params: [{ name: 'case_number', required: true }, { name: 'include_full_text' }, { name: 'max_docs' }], cost: '$0.005–0.02' },
+      { name: 'parse_document', description: 'Парсинг PDF/DOCX/HTML з OCR', params: [{ name: 'fileBase64', required: true }, { name: 'mimeType', required: true }, { name: 'filename' }], cost: '$0.01–0.10' },
+      { name: 'extract_key_clauses', description: 'Витяг ключових положень з контракту', params: [{ name: 'documentText', required: true }, { name: 'documentId' }], cost: '$0.03–0.10' },
+      { name: 'summarize_document', description: 'Резюме документа (quick/standard/deep)', params: [{ name: 'documentText', required: true }, { name: 'detailLevel' }], cost: '$0.02–0.08' },
+      { name: 'compare_documents', description: 'Семантичне порівняння двох версій документа', params: [{ name: 'oldDocumentText', required: true }, { name: 'newDocumentText', required: true }], cost: '$0.03–0.12' },
     ],
   },
   {
     title: 'Законодавство',
-    icon: BookOpen,
     tools: [
-      { name: 'get_legislation_article', description: 'Повний текст конкретної статті', params: ['rada_id', 'article_number'], cost: 'мін.' },
-      { name: 'get_legislation_articles', description: 'Декілька статей одночасно', params: ['rada_id', 'article_numbers[]'], cost: 'мін.' },
-      { name: 'search_legislation', description: 'Семантичний пошук по законодавству', params: ['query', 'rada_id', 'limit'], cost: '$0.01-$0.03' },
-      { name: 'get_legislation_structure', description: 'Структура акту: зміст, розділи, глави', params: ['rada_id'], cost: 'мін.' },
-      { name: 'find_relevant_law_articles', description: 'Статті, що часто застосовуються у справах за темою', params: ['intent', 'limit'], cost: '$0.01-$0.02' },
+      { name: 'get_legislation_article', description: 'Повний текст конкретної статті', params: [{ name: 'rada_id', required: true }, { name: 'article_number', required: true }], cost: '<$0.01' },
+      { name: 'get_legislation_articles', description: 'Декілька статей одночасно', params: [{ name: 'rada_id', required: true }, { name: 'article_numbers', required: true }], cost: '<$0.01' },
+      { name: 'search_legislation', description: 'Семантичний пошук по законодавству', params: [{ name: 'query', required: true }, { name: 'rada_id' }, { name: 'limit' }], cost: '$0.01–0.03' },
+      { name: 'get_legislation_structure', description: 'Структура акту: зміст, розділи, глави', params: [{ name: 'rada_id', required: true }], cost: '<$0.01' },
+      { name: 'find_relevant_law_articles', description: 'Статті, що часто застосовуються у справах за темою', params: [{ name: 'intent', required: true }, { name: 'limit' }], cost: '$0.01–0.02' },
     ],
   },
   {
     title: 'Процесуальні інструменти',
-    icon: Scale,
     tools: [
-      { name: 'calculate_procedural_deadlines', description: 'Калькулятор процесуальних строків', params: ['procedure_code', 'event_type', 'event_date'], cost: '$0.02-$0.08' },
-      { name: 'build_procedural_checklist', description: 'Процесуальний чекліст із посиланням на норму', params: ['procedure_code', 'stage', 'case_category'], cost: '$0.01-$0.03' },
-      { name: 'calculate_monetary_claims', description: 'Розрахунки грошових вимог (3% річних тощо)', params: ['amount', 'date_from', 'date_to', 'claim_type'], cost: 'мін.' },
+      { name: 'calculate_procedural_deadlines', description: 'Калькулятор процесуальних строків', params: [{ name: 'procedure_code', required: true }, { name: 'event_type', required: true }, { name: 'event_date', required: true }], cost: '$0.02–0.08' },
+      { name: 'build_procedural_checklist', description: 'Процесуальний чекліст із посиланням на норму', params: [{ name: 'procedure_code', required: true }, { name: 'stage' }, { name: 'case_category' }], cost: '$0.01–0.03' },
+      { name: 'calculate_monetary_claims', description: 'Розрахунки грошових вимог (3% річних тощо)', params: [{ name: 'amount', required: true }, { name: 'date_from', required: true }, { name: 'date_to', required: true }, { name: 'claim_type' }], cost: '<$0.01' },
     ],
   },
   {
     title: 'Комплексний аналіз',
-    icon: Zap,
     tools: [
-      { name: 'get_legal_advice', description: 'Повний юридичний аналіз з перевіркою джерел та антигалюцинацією', params: ['query', 'reasoning_budget'], cost: '$0.10-$0.30', badge: 'popular' },
-      { name: 'classify_intent', description: 'Класифікація запиту для роутингу pipeline', params: ['query'], cost: 'мін.' },
-      { name: 'retrieve_legal_sources', description: 'RAG retrieval: сирі джерела без аналізу', params: ['query'], cost: 'залежить від обсягу' },
-      { name: 'validate_response', description: 'Trust layer: перевірка відповіді на галюцинації', params: ['response', 'sources'], cost: '$0.01-$0.03' },
+      { name: 'get_legal_advice', description: 'Повний юридичний аналіз з перевіркою джерел та антигалюцинацією', params: [{ name: 'query', required: true }, { name: 'reasoning_budget' }], cost: '$0.10–0.30' },
+      { name: 'classify_intent', description: 'Класифікація запиту для роутингу pipeline', params: [{ name: 'query', required: true }], cost: '<$0.01' },
+      { name: 'retrieve_legal_sources', description: 'RAG retrieval: сирі джерела без аналізу', params: [{ name: 'query', required: true }], cost: 'залежить від обсягу' },
+      { name: 'validate_response', description: 'Trust layer: перевірка відповіді на галюцинації', params: [{ name: 'response', required: true }, { name: 'sources', required: true }], cost: '$0.01–0.03' },
     ],
   },
   {
-    title: 'Верховна Рада (RADA)',
-    icon: Building2,
+    title: 'Верховна Рада',
     tools: [
-      { name: 'rada_search_parliament_bills', description: 'Пошук законопроектів ВР', params: ['query', 'status', 'initiator', 'date_from', 'date_to'], cost: '$0.01-$0.05' },
-      { name: 'rada_get_deputy_info', description: 'Інформація про народного депутата', params: ['name', 'rada_id', 'include_voting_record'], cost: '$0.005-$0.01' },
-      { name: 'rada_search_legislation_text', description: 'Пошук у текстах законів з посиланнями на судові рішення', params: ['law_identifier', 'article', 'search_text'], cost: '$0.005-$0.02' },
-      { name: 'rada_analyze_voting_record', description: 'Аналіз голосувань депутата з AI-інсайтами', params: ['deputy_name', 'date_from', 'date_to'], cost: '$0.02-$0.10' },
+      { name: 'rada_search_parliament_bills', description: 'Пошук законопроектів ВР', params: [{ name: 'query', required: true }, { name: 'status' }, { name: 'initiator' }, { name: 'date_from' }, { name: 'date_to' }], cost: '$0.01–0.05' },
+      { name: 'rada_get_deputy_info', description: 'Інформація про народного депутата', params: [{ name: 'name' }, { name: 'rada_id' }, { name: 'include_voting_record' }], cost: '$0.005–0.01' },
+      { name: 'rada_search_legislation_text', description: 'Пошук у текстах законів з посиланнями на судові рішення', params: [{ name: 'law_identifier' }, { name: 'article' }, { name: 'search_text' }], cost: '$0.005–0.02' },
+      { name: 'rada_analyze_voting_record', description: 'Аналіз голосувань депутата з AI-інсайтами', params: [{ name: 'deputy_name', required: true }, { name: 'date_from' }, { name: 'date_to' }], cost: '$0.02–0.10' },
     ],
   },
   {
-    title: 'Реєстри (OpenReyestr)',
-    icon: Building2,
+    title: 'Реєстри',
     tools: [
-      { name: 'openreyestr_search_entities', description: 'Пошук юридичних осіб та ФОП', params: ['query', 'edrpou', 'entityType', 'limit'], cost: '$0.001-$0.005' },
-      { name: 'openreyestr_get_entity_details', description: 'Повна інформація: засновники, бенефіціари, керівники', params: ['record', 'entityType'], cost: '$0.001-$0.003' },
-      { name: 'openreyestr_search_beneficiaries', description: 'Пошук бенефіціарних власників компаній', params: ['query', 'limit'], cost: '$0.002-$0.005' },
-      { name: 'openreyestr_get_by_edrpou', description: 'Швидкий пошук за кодом ЄДРПОУ', params: ['edrpou'], cost: '$0.001' },
-      { name: 'openreyestr_search_debtors', description: 'Пошук боржників', params: ['query', 'limit'], cost: '$0.001-$0.005' },
-      { name: 'openreyestr_search_enforcement_proceedings', description: 'Виконавчі провадження', params: ['query', 'limit'], cost: '$0.001-$0.005' },
-      { name: 'openreyestr_search_bankruptcy_cases', description: 'Справи про банкрутство', params: ['query', 'limit'], cost: '$0.001-$0.005' },
-      { name: 'openreyestr_search_notaries', description: 'Пошук нотаріусів', params: ['query', 'limit'], cost: '$0.001' },
-      { name: 'openreyestr_search_prozorro', description: 'Пошук у системі Prozorro', params: ['query', 'limit'], cost: '$0.001-$0.005' },
+      { name: 'openreyestr_search_entities', description: 'Пошук юридичних осіб та ФОП', params: [{ name: 'query', required: true }, { name: 'edrpou' }, { name: 'entityType' }, { name: 'limit' }], cost: '$0.001–0.005' },
+      { name: 'openreyestr_get_entity_details', description: 'Повна інформація: засновники, бенефіціари, керівники', params: [{ name: 'record', required: true }, { name: 'entityType' }], cost: '$0.001–0.003' },
+      { name: 'openreyestr_search_beneficiaries', description: 'Пошук бенефіціарних власників компаній', params: [{ name: 'query', required: true }, { name: 'limit' }], cost: '$0.002–0.005' },
+      { name: 'openreyestr_get_by_edrpou', description: 'Швидкий пошук за кодом ЄДРПОУ', params: [{ name: 'edrpou', required: true }], cost: '$0.001' },
+      { name: 'openreyestr_search_debtors', description: 'Пошук боржників', params: [{ name: 'query', required: true }, { name: 'limit' }], cost: '$0.001–0.005' },
+      { name: 'openreyestr_search_enforcement_proceedings', description: 'Виконавчі провадження', params: [{ name: 'query', required: true }, { name: 'limit' }], cost: '$0.001–0.005' },
+      { name: 'openreyestr_search_bankruptcy_cases', description: 'Справи про банкрутство', params: [{ name: 'query', required: true }, { name: 'limit' }], cost: '$0.001–0.005' },
+      { name: 'openreyestr_search_notaries', description: 'Пошук нотаріусів', params: [{ name: 'query', required: true }, { name: 'limit' }], cost: '$0.001' },
+      { name: 'openreyestr_search_prozorro', description: 'Пошук у системі Prozorro', params: [{ name: 'query', required: true }, { name: 'limit' }], cost: '$0.001–0.005' },
       { name: 'openreyestr_get_statistics', description: 'Статистика по реєстру', cost: '$0.001' },
     ],
   },
   {
-    title: 'Vault (сховище документів)',
-    icon: Shield,
+    title: 'Vault',
     tools: [
-      { name: 'store_document', description: 'Зберегти документ у vault', params: ['title', 'content', 'metadata', 'tags'], cost: 'мін.' },
-      { name: 'get_document', description: 'Отримати документ із vault за ID', params: ['document_id'], cost: 'мін.' },
-      { name: 'list_documents', description: 'Список документів із фільтрацією', params: ['filters', 'limit', 'offset'], cost: 'мін.' },
-      { name: 'semantic_search', description: 'Семантичний пошук по vault через Qdrant', params: ['query', 'limit', 'filters'], cost: '$0.01-$0.03' },
+      { name: 'store_document', description: 'Зберегти документ у vault', params: [{ name: 'title', required: true }, { name: 'content', required: true }, { name: 'metadata' }, { name: 'tags' }], cost: '<$0.01' },
+      { name: 'get_document', description: 'Отримати документ із vault за ID', params: [{ name: 'document_id', required: true }], cost: '<$0.01' },
+      { name: 'list_documents', description: 'Список документів із фільтрацією', params: [{ name: 'filters' }, { name: 'limit' }, { name: 'offset' }], cost: '<$0.01' },
+      { name: 'semantic_search', description: 'Семантичний пошук по vault через Qdrant', params: [{ name: 'query', required: true }, { name: 'limit' }, { name: 'filters' }], cost: '$0.01–0.03' },
     ],
   },
 ];
 
-function ToolsTab() {
-  const [expandedCategory, setExpandedCategory] = useState<number | null>(0);
+/* ================================================================
+   SIDEBAR NAVIGATION STRUCTURE
+   ================================================================ */
+
+interface NavItem {
+  id: string;
+  label: string;
+  children?: NavItem[];
+}
+
+const navigation: NavItem[] = [
+  { id: 'overview', label: 'Огляд' },
+  {
+    id: 'getting-started', label: 'Початок роботи', children: [
+      { id: 'authentication', label: 'Автентифікація' },
+      { id: 'endpoints', label: 'Ендпоінти' },
+      { id: 'quick-start', label: 'Швидкий старт' },
+    ],
+  },
+  {
+    id: 'tools', label: 'Інструменти', children:
+      toolGroups.map((g, i) => ({ id: `tools-${i}`, label: g.title })),
+  },
+  {
+    id: 'examples', label: 'Приклади коду', children: [
+      { id: 'example-curl', label: 'cURL' },
+      { id: 'example-js', label: 'JavaScript' },
+      { id: 'example-python', label: 'Python' },
+      { id: 'example-sse', label: 'SSE Streaming' },
+    ],
+  },
+  {
+    id: 'mcp-clients', label: 'MCP клієнти', children: [
+      { id: 'mcp-claude-code', label: 'Claude Code' },
+      { id: 'mcp-claude-desktop', label: 'Claude Desktop' },
+      { id: 'mcp-cursor', label: 'Cursor' },
+      { id: 'mcp-vscode', label: 'VS Code' },
+      { id: 'mcp-chatgpt', label: 'ChatGPT' },
+      { id: 'mcp-continue', label: 'Continue.dev' },
+    ],
+  },
+  { id: 'pricing', label: 'Вартість' },
+];
+
+/* ================================================================
+   MAIN COMPONENT
+   ================================================================ */
+
+export function DeveloperDocsPage() {
+  const [activeSection, setActiveSection] = useState('overview');
+  const [expandedNav, setExpandedNav] = useState<Set<string>>(new Set(['getting-started', 'tools', 'examples', 'mcp-clients']));
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const toggleNav = useCallback((id: string) => {
+    setExpandedNav(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const scrollTo = useCallback((id: string) => {
+    setActiveSection(id);
+    setSidebarOpen(false);
+    const el = document.getElementById(id);
+    if (el && contentRef.current) {
+      const top = el.offsetTop - 24;
+      contentRef.current.scrollTo({ top, behavior: 'smooth' });
+    }
+  }, []);
+
+  // Track active section on scroll
+  useEffect(() => {
+    const container = contentRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const sections = container.querySelectorAll('[data-section]');
+      let current = 'overview';
+      for (const section of sections) {
+        const el = section as HTMLElement;
+        if (el.offsetTop - 80 <= container.scrollTop) {
+          current = el.id;
+        }
+      }
+      setActiveSection(current);
+    };
+
+    container.addEventListener('scroll', handleScroll, { passive: true });
+    return () => container.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
-    <div className="space-y-3">
-      <p className="text-[13px] text-claude-subtext mb-4">
-        Повний каталог інструментів. Всі доступні через <code className="text-[12px] bg-claude-bg-secondary px-1.5 py-0.5 rounded">POST /api/tools/:toolName</code>
-      </p>
-      {toolCategories.map((cat, i) => (
-        <div key={i} className="bg-white rounded-xl border border-claude-border overflow-hidden">
-          <button
-            onClick={() => setExpandedCategory(expandedCategory === i ? null : i)}
-            className="w-full flex items-center gap-3 px-5 py-3.5 hover:bg-claude-bg-secondary/50 transition-colors"
-          >
-            <cat.icon size={16} className="text-claude-accent flex-shrink-0" />
-            <span className="text-[14px] font-semibold text-claude-text flex-1 text-left">{cat.title}</span>
-            <span className="text-[11px] text-claude-subtext bg-claude-bg-secondary px-2 py-0.5 rounded-full">
-              {cat.tools.length}
-            </span>
-            {expandedCategory === i ? <ChevronDown size={14} className="text-claude-subtext" /> : <ChevronRight size={14} className="text-claude-subtext" />}
-          </button>
-          {expandedCategory === i && (
-            <div className="border-t border-claude-border divide-y divide-claude-border">
-              {cat.tools.map((tool) => (
-                <ToolRow key={tool.name} tool={tool} />
-              ))}
-            </div>
-          )}
+    <div className="flex h-full bg-white dark:bg-[#1d1d1f]">
+      {/* Mobile sidebar toggle */}
+      <button
+        onClick={() => setSidebarOpen(!sidebarOpen)}
+        className="fixed top-3 left-3 z-50 p-2 rounded-lg bg-white dark:bg-[#2d2d2f] border border-[#d2d2d7] dark:border-[#424245] lg:hidden"
+      >
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+          <path d="M2 4h14M2 9h14M2 14h14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      </button>
+
+      {/* Sidebar */}
+      <aside className={`
+        fixed lg:sticky top-0 left-0 z-40 h-full w-[260px] flex-shrink-0
+        border-r border-[#d2d2d7] dark:border-[#424245]
+        bg-[#fbfbfd] dark:bg-[#1d1d1f]
+        overflow-y-auto overscroll-contain
+        transition-transform lg:transition-none
+        ${sidebarOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'}
+      `}>
+        <div className="px-5 pt-6 pb-3">
+          <div className="text-[11px] font-semibold tracking-wider uppercase text-[#86868b] dark:text-[#a1a1a6]">
+            Документація
+          </div>
+          <div className="text-[15px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7] mt-1">
+            LEX AI Platform
+          </div>
         </div>
-      ))}
+        <nav className="px-3 pb-8">
+          {navigation.map(item => (
+            <SidebarItem
+              key={item.id}
+              item={item}
+              active={activeSection}
+              expanded={expandedNav}
+              onToggle={toggleNav}
+              onNavigate={scrollTo}
+            />
+          ))}
+        </nav>
+      </aside>
+
+      {/* Backdrop for mobile */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/20 lg:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Content */}
+      <main
+        ref={contentRef}
+        className="flex-1 h-full overflow-y-auto overscroll-contain"
+      >
+        <div className="max-w-[820px] mx-auto px-6 lg:px-10 py-10 pb-32">
+          <OverviewSection />
+          <Divider />
+          <GettingStartedSection />
+          <Divider />
+          <ToolsSection />
+          <Divider />
+          <ExamplesSection />
+          <Divider />
+          <MCPClientsSection />
+          <Divider />
+          <PricingSection />
+        </div>
+      </main>
     </div>
   );
 }
 
-function ToolRow({ tool }: { tool: ToolInfo }) {
+/* ================================================================
+   SIDEBAR COMPONENTS
+   ================================================================ */
+
+function SidebarItem({ item, active, expanded, onToggle, onNavigate, depth = 0 }: {
+  item: NavItem;
+  active: string;
+  expanded: Set<string>;
+  onToggle: (id: string) => void;
+  onNavigate: (id: string) => void;
+  depth?: number;
+}) {
+  const hasChildren = item.children && item.children.length > 0;
+  const isExpanded = expanded.has(item.id);
+  const isActive = active === item.id;
+
   return (
-    <div className="px-5 py-3 hover:bg-claude-bg-secondary/30 transition-colors">
-      <div className="flex items-center gap-2 mb-1">
-        <code className="text-[12.5px] font-mono font-semibold text-claude-text">{tool.name}</code>
-        {tool.badge === 'new' && <span className="text-[9px] font-semibold bg-green-100 text-green-700 px-1.5 py-0.5 rounded-full uppercase">new</span>}
-        {tool.badge === 'popular' && <span className="text-[9px] font-semibold bg-blue-100 text-blue-700 px-1.5 py-0.5 rounded-full uppercase">popular</span>}
-        {tool.cost && <span className="text-[11px] text-claude-subtext ml-auto">{tool.cost}</span>}
-      </div>
-      <p className="text-[12px] text-claude-subtext">{tool.description}</p>
-      {tool.params && (
-        <div className="flex flex-wrap gap-1 mt-1.5">
-          {tool.params.map((p) => (
-            <span key={p} className="text-[10.5px] font-mono bg-claude-bg-secondary text-claude-subtext px-1.5 py-0.5 rounded">{p}</span>
+    <div>
+      <button
+        onClick={() => {
+          if (hasChildren) onToggle(item.id);
+          onNavigate(item.id);
+        }}
+        className={`
+          w-full flex items-center gap-1.5 px-2 py-[6px] rounded-md text-left transition-colors
+          ${depth === 0 ? 'text-[13px] font-medium' : 'text-[12.5px]'}
+          ${isActive
+            ? 'bg-[#0071e3]/10 text-[#0071e3] dark:bg-[#0a84ff]/15 dark:text-[#4db8ff]'
+            : 'text-[#1d1d1f] dark:text-[#f5f5f7] hover:bg-[#e8e8ed] dark:hover:bg-[#2d2d2f]'
+          }
+        `}
+        style={{ paddingLeft: `${8 + depth * 12}px` }}
+      >
+        {hasChildren && (
+          <span className="w-3.5 flex-shrink-0">
+            {isExpanded
+              ? <ChevronDown size={11} className="text-[#86868b]" />
+              : <ChevronRight size={11} className="text-[#86868b]" />
+            }
+          </span>
+        )}
+        {!hasChildren && depth > 0 && <span className="w-3.5 flex-shrink-0" />}
+        <span className="truncate">{item.label}</span>
+      </button>
+      {hasChildren && isExpanded && (
+        <div>
+          {item.children!.map(child => (
+            <SidebarItem
+              key={child.id}
+              item={child}
+              active={active}
+              expanded={expanded}
+              onToggle={onToggle}
+              onNavigate={onNavigate}
+              depth={depth + 1}
+            />
           ))}
         </div>
       )}
@@ -334,58 +344,217 @@ function ToolRow({ tool }: { tool: ToolInfo }) {
   );
 }
 
-/* ==================== AUTH TAB ==================== */
+/* ================================================================
+   SECTION: OVERVIEW
+   ================================================================ */
 
-function AuthTab() {
+function OverviewSection() {
   return (
-    <div className="space-y-6">
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Автентифікація</h2>
-        <p className="text-[13px] text-claude-subtext leading-relaxed mb-4">
-          Платформа підтримує два методи автентифікації: Bearer Token (для API клієнтів) та JWT/OAuth (для веб-користувачів).
+    <section id="overview" data-section>
+      <h1 className="text-[28px] font-bold text-[#1d1d1f] dark:text-[#f5f5f7] tracking-tight leading-tight">
+        LEX AI Platform API
+      </h1>
+      <p className="mt-3 text-[15px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed max-w-[640px]">
+        Доступ до 56+ інструментів юридичного аналізу через уніфікований API.
+        Судова практика, законодавство, реєстри, парламентські дані.
+      </p>
+
+      <div className="mt-8 grid grid-cols-1 sm:grid-cols-3 gap-px bg-[#d2d2d7] dark:bg-[#424245] rounded-xl overflow-hidden border border-[#d2d2d7] dark:border-[#424245]">
+        <InfoCell label="Інструменти" value="56+" />
+        <InfoCell label="Мікросервіси" value="3" />
+        <InfoCell label="Транспорти" value="REST, MCP, SSE" />
+      </div>
+
+      <h2 className="mt-10 text-[20px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Сервіси</h2>
+
+      <div className="mt-4 space-y-3">
+        <ServiceRow name="mcp_backend" count={36} description="Судова практика, аналіз, законодавство, парсинг документів, vault" />
+        <ServiceRow name="mcp_rada" count={4} description="Законопроекти, депутати, голосування, тексти законів" />
+        <ServiceRow name="mcp_openreyestr" count={16} description="Юридичні особи, ФОП, бенефіціари, боржники, Prozorro" />
+      </div>
+
+      <h2 className="mt-10 text-[20px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Транспорти</h2>
+
+      <table className="mt-4 w-full text-[13px]">
+        <thead>
+          <tr className="border-b border-[#d2d2d7] dark:border-[#424245] text-left">
+            <Th>Протокол</Th>
+            <Th>Ендпоінт</Th>
+            <Th>Призначення</Th>
+          </tr>
+        </thead>
+        <tbody className="text-[#424245] dark:text-[#a1a1a6]">
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+            <Td>HTTP REST</Td>
+            <Td><Code>POST {API_BASE}/:tool</Code></Td>
+            <Td>Вебдодатки, серверні інтеграції</Td>
+          </tr>
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+            <Td>MCP SSE</Td>
+            <Td><Code>{MCP_SSE_URL}</Code></Td>
+            <Td>Claude, Cursor, VS Code, Continue.dev</Td>
+          </tr>
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+            <Td>SSE Streaming</Td>
+            <Td><Code>POST {API_BASE}/:tool/stream</Code></Td>
+            <Td>Тривалі операції з поточною відповіддю</Td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+/* ================================================================
+   SECTION: GETTING STARTED
+   ================================================================ */
+
+function GettingStartedSection() {
+  return (
+    <section>
+      <div id="getting-started" data-section />
+
+      {/* Authentication */}
+      <div id="authentication" data-section>
+        <h2 className="text-[20px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Автентифікація</h2>
+        <p className="mt-2 text-[14px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+          Всі запити потребують автентифікації через Bearer Token. Згенеруйте API ключ
+          у розділі <strong>Профіль &rarr; API токени</strong>.
         </p>
 
-        <h3 className="text-[14px] font-semibold text-claude-text mt-5 mb-2">Bearer Token</h3>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Отримайте API ключ у розділі <strong>Профіль → API токени</strong>. Передавайте його у заголовку кожного запиту:
-        </p>
-        <CodeBlock language="http" code={`Authorization: Bearer YOUR_API_KEY`} />
+        <CodeBlock lang="http" code={`Authorization: Bearer YOUR_API_KEY`} />
 
-        <h3 className="text-[14px] font-semibold text-claude-text mt-5 mb-2">JWT/OAuth</h3>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Для вебдодатків використовуйте Google OAuth для отримання JWT токена.
-        </p>
+        <h3 className="mt-6 text-[15px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Методи автентифікації</h3>
+        <table className="mt-3 w-full text-[13px]">
+          <thead>
+            <tr className="border-b border-[#d2d2d7] dark:border-[#424245] text-left">
+              <Th>Метод</Th>
+              <Th>Призначення</Th>
+            </tr>
+          </thead>
+          <tbody className="text-[#424245] dark:text-[#a1a1a6]">
+            <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+              <Td>Bearer Token</Td>
+              <Td>API клієнти, MCP клієнти, скрипти</Td>
+            </tr>
+            <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+              <Td>JWT / Google OAuth</Td>
+              <Td>Вебдодатки з інтерактивною авторизацією</Td>
+            </tr>
+          </tbody>
+        </table>
 
-        <h3 className="text-[14px] font-semibold text-claude-text mt-5 mb-2">Ліміти</h3>
-        <div className="bg-claude-bg-secondary rounded-lg p-4 text-[13px] text-claude-subtext space-y-1">
-          <p>Rate limit залежить від вашого тарифного плану</p>
-          <p>Максимальний розмір тіла запиту: 10 MB</p>
-          <p>Timeout: 120 секунд (для SSE streaming — без обмежень)</p>
+        <h3 className="mt-6 text-[15px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Ліміти</h3>
+        <div className="mt-3 text-[13px] text-[#424245] dark:text-[#a1a1a6] space-y-1">
+          <p>Rate limit залежить від тарифного плану.</p>
+          <p>Максимальний розмір тіла запиту: <Code>10 MB</Code></p>
+          <p>Timeout: <Code>120 с</Code> (SSE streaming &mdash; без обмежень)</p>
         </div>
-      </Card>
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Ендпоінти</h2>
-        <div className="space-y-3">
-          <EndpointRow method="POST" path="/api/tools/:toolName" description="Виконати інструмент" />
-          <EndpointRow method="POST" path="/api/tools/:toolName/stream" description="Виконати з SSE streaming" />
-          <EndpointRow method="POST" path="/api/tools/batch" description="Пакетне виконання інструментів" />
-          <EndpointRow method="GET" path="/health" description="Перевірка стану сервісу" />
-          <EndpointRow method="GET" path="/api/tools" description="Список доступних інструментів" />
+      {/* Endpoints */}
+      <div id="endpoints" data-section className="mt-10">
+        <h2 className="text-[20px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Ендпоінти</h2>
+
+        <table className="mt-4 w-full text-[13px]">
+          <thead>
+            <tr className="border-b border-[#d2d2d7] dark:border-[#424245] text-left">
+              <Th>Метод</Th>
+              <Th>Шлях</Th>
+              <Th>Опис</Th>
+            </tr>
+          </thead>
+          <tbody className="text-[#424245] dark:text-[#a1a1a6]">
+            <EndpointTableRow method="POST" path="/api/tools/:toolName" desc="Виконати інструмент" />
+            <EndpointTableRow method="POST" path="/api/tools/:toolName/stream" desc="Виконати з SSE streaming" />
+            <EndpointTableRow method="POST" path="/api/tools/batch" desc="Пакетне виконання" />
+            <EndpointTableRow method="GET" path="/api/tools" desc="Список доступних інструментів" />
+            <EndpointTableRow method="GET" path="/health" desc="Перевірка стану сервісу" />
+          </tbody>
+        </table>
+      </div>
+
+      {/* Quick Start */}
+      <div id="quick-start" data-section className="mt-10">
+        <h2 className="text-[20px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Швидкий старт</h2>
+        <p className="mt-2 text-[14px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+          Отримайте API ключ та зробіть перший запит:
+        </p>
+        <CodeBlock lang="bash" code={`curl -X POST ${API_BASE}/search_legal_precedents \\
+  -H "Authorization: Bearer YOUR_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{"arguments": {"query": "відшкодування збитків ДТП", "limit": 5}}'`} />
+      </div>
+    </section>
+  );
+}
+
+/* ================================================================
+   SECTION: TOOLS
+   ================================================================ */
+
+function ToolsSection() {
+  return (
+    <section id="tools" data-section>
+      <h1 className="text-[24px] font-bold text-[#1d1d1f] dark:text-[#f5f5f7] tracking-tight">Інструменти</h1>
+      <p className="mt-2 text-[14px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+        Всі інструменти доступні через <Code>POST /api/tools/:toolName</Code> з тілом <Code>{`{"arguments": {...}}`}</Code>.
+      </p>
+
+      {toolGroups.map((group, i) => (
+        <div key={i} id={`tools-${i}`} data-section className="mt-8">
+          <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7] pb-2 border-b border-[#d2d2d7] dark:border-[#424245]">
+            {group.title}
+          </h2>
+          <div className="divide-y divide-[#e8e8ed] dark:divide-[#333336]">
+            {group.tools.map(tool => (
+              <ToolEntry key={tool.name} tool={tool} />
+            ))}
+          </div>
         </div>
-      </Card>
+      ))}
+    </section>
+  );
+}
+
+function ToolEntry({ tool }: { tool: ToolDef }) {
+  return (
+    <div className="py-4">
+      <div className="flex items-baseline gap-3">
+        <code className="text-[13px] font-mono font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">
+          {tool.name}
+        </code>
+        {tool.cost && (
+          <span className="text-[11px] text-[#86868b] dark:text-[#6e6e73]">{tool.cost}</span>
+        )}
+      </div>
+      <p className="mt-1 text-[13px] text-[#424245] dark:text-[#a1a1a6]">{tool.description}</p>
+      {tool.params && tool.params.length > 0 && (
+        <div className="mt-2.5 flex flex-wrap gap-x-3 gap-y-1">
+          {tool.params.map(p => (
+            <span key={p.name} className="text-[12px] font-mono text-[#424245] dark:text-[#a1a1a6]">
+              {p.name}{p.required && <span className="text-[#bf5af2] dark:text-[#bf5af2] ml-0.5">*</span>}
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
-/* ==================== EXAMPLES TAB ==================== */
+/* ================================================================
+   SECTION: EXAMPLES
+   ================================================================ */
 
-function ExamplesTab() {
+function ExamplesSection() {
   return (
-    <div className="space-y-6">
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Пошук судових рішень</h2>
-        <CodeBlock language="bash" code={`curl -X POST ${API_BASE}/search_legal_precedents \\
+    <section id="examples" data-section>
+      <h1 className="text-[24px] font-bold text-[#1d1d1f] dark:text-[#f5f5f7] tracking-tight">Приклади коду</h1>
+
+      <div id="example-curl" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">cURL</h2>
+        <h3 className="mt-4 text-[14px] font-medium text-[#1d1d1f] dark:text-[#f5f5f7]">Пошук судових рішень</h3>
+        <CodeBlock lang="bash" code={`curl -X POST ${API_BASE}/search_legal_precedents \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -395,11 +564,9 @@ function ExamplesTab() {
       "time_range": "2023-2024"
     }
   }'`} />
-      </Card>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Комплексний юридичний аналіз</h2>
-        <CodeBlock language="bash" code={`curl -X POST ${API_BASE}/get_legal_advice \\
+        <h3 className="mt-6 text-[14px] font-medium text-[#1d1d1f] dark:text-[#f5f5f7]">Юридичний аналіз</h3>
+        <CodeBlock lang="bash" code={`curl -X POST ${API_BASE}/get_legal_advice \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
   -d '{
@@ -408,44 +575,27 @@ function ExamplesTab() {
       "reasoning_budget": "standard"
     }
   }'`} />
-      </Card>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Отримати статтю закону</h2>
-        <CodeBlock language="bash" code={`curl -X POST ${API_BASE}/get_legislation_article \\
+        <h3 className="mt-6 text-[14px] font-medium text-[#1d1d1f] dark:text-[#f5f5f7]">Стаття закону</h3>
+        <CodeBlock lang="bash" code={`curl -X POST ${API_BASE}/get_legislation_article \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{
-    "arguments": {
-      "rada_id": "435-15",
-      "article_number": "625"
-    }
-  }'`} />
-        <p className="text-[12px] text-claude-subtext mt-2">
-          Популярні rada_id: <code className="bg-claude-bg-secondary px-1 py-0.5 rounded text-[11px]">254к/96-вр</code> (Конституція),
-          <code className="bg-claude-bg-secondary px-1 py-0.5 rounded text-[11px] ml-1">435-15</code> (ЦК),
-          <code className="bg-claude-bg-secondary px-1 py-0.5 rounded text-[11px] ml-1">2341-14</code> (ККУ),
-          <code className="bg-claude-bg-secondary px-1 py-0.5 rounded text-[11px] ml-1">1618-15</code> (ЦПК)
-        </p>
-      </Card>
+  -d '{"arguments": {"rada_id": "435-15", "article_number": "625"}}'`} />
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Пошук у реєстрі</h2>
-        <CodeBlock language="bash" code={`curl -X POST ${API_BASE}/openreyestr_search_entities \\
+        <div className="mt-3 text-[12px] text-[#86868b] dark:text-[#6e6e73]">
+          Поширені <Code>rada_id</Code>: <Code>254к/96-вр</Code> (Конституція), <Code>435-15</Code> (ЦК), <Code>2341-14</Code> (ККУ), <Code>1618-15</Code> (ЦПК)
+        </div>
+
+        <h3 className="mt-6 text-[14px] font-medium text-[#1d1d1f] dark:text-[#f5f5f7]">Пошук у реєстрі</h3>
+        <CodeBlock lang="bash" code={`curl -X POST ${API_BASE}/openreyestr_search_entities \\
   -H "Authorization: Bearer YOUR_API_KEY" \\
   -H "Content-Type: application/json" \\
-  -d '{
-    "arguments": {
-      "query": "Приватбанк",
-      "entityType": "UO",
-      "limit": 5
-    }
-  }'`} />
-      </Card>
+  -d '{"arguments": {"query": "Приватбанк", "entityType": "UO", "limit": 5}}'`} />
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">JavaScript / TypeScript</h2>
-        <CodeBlock language="typescript" code={`const response = await fetch('${API_BASE}/search_legal_precedents', {
+      <div id="example-js" data-section className="mt-10">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">JavaScript / TypeScript</h2>
+        <CodeBlock lang="typescript" code={`const response = await fetch('${API_BASE}/search_legal_precedents', {
   method: 'POST',
   headers: {
     'Authorization': 'Bearer YOUR_API_KEY',
@@ -461,11 +611,11 @@ function ExamplesTab() {
 
 const data = await response.json();
 console.log(data.result);`} />
-      </Card>
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Python</h2>
-        <CodeBlock language="python" code={`import requests
+      <div id="example-python" data-section className="mt-10">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Python</h2>
+        <CodeBlock lang="python" code={`import requests
 
 response = requests.post(
     '${API_BASE}/search_legal_precedents',
@@ -482,11 +632,14 @@ response = requests.post(
 )
 
 print(response.json()['result'])`} />
-      </Card>
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">SSE Streaming</h2>
-        <CodeBlock language="typescript" code={`const response = await fetch('${API_BASE}/get_legal_advice/stream', {
+      <div id="example-sse" data-section className="mt-10">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">SSE Streaming</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+          Для тривалих операцій використовуйте SSE endpoint. Відповідь надходить потоком подій.
+        </p>
+        <CodeBlock lang="typescript" code={`const response = await fetch('${API_BASE}/get_legal_advice/stream', {
   method: 'POST',
   headers: {
     'Authorization': 'Bearer YOUR_API_KEY',
@@ -504,7 +657,6 @@ while (true) {
   const { done, value } = await reader.read();
   if (done) break;
   const chunk = decoder.decode(value);
-  // Парсимо SSE events: "data: {...}\\n\\n"
   for (const line of chunk.split('\\n')) {
     if (line.startsWith('data: ')) {
       const event = JSON.parse(line.slice(6));
@@ -512,321 +664,249 @@ while (true) {
     }
   }
 }`} />
-      </Card>
-    </div>
+      </div>
+    </section>
   );
 }
 
-/* ==================== MCP CLIENTS TAB ==================== */
+/* ================================================================
+   SECTION: MCP CLIENTS
+   ================================================================ */
 
-function MCPClientsTab() {
+function MCPClientsSection() {
+  const mcpConfig = `{
+  "mcpServers": {
+    "secondlayer": {
+      "type": "sse",
+      "url": "${MCP_SSE_URL}",
+      "headers": {
+        "Authorization": "Bearer YOUR_API_TOKEN"
+      }
+    }
+  }
+}`;
+
   return (
-    <div className="space-y-6">
-      <Card>
-        <div className="flex items-center gap-2 mb-3">
-          <h2 className="text-[16px] font-semibold text-claude-text">Claude Code</h2>
-          <span className="px-1.5 py-0.5 bg-emerald-500/10 text-emerald-600 text-[10px] font-semibold rounded tracking-wide uppercase">рекомендовано</span>
-        </div>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Додайте до <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">~/.claude/settings.json</code> або <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">.mcp.json</code> в корені проєкту:
-        </p>
-        <CodeBlock language="json" code={`{
-  "mcpServers": {
-    "secondlayer": {
-      "type": "sse",
-      "url": "${MCP_SSE_URL}",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_TOKEN"
-      }
-    }
-  }
-}`} />
-        <p className="text-[12px] text-claude-subtext mt-3">
-          Згенеруйте API-токен у <a href="/profile" className="text-claude-accent hover:underline">Профілі → MCP Access Tokens</a>. Після додавання перезапустіть Claude Code або виконайте <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">/mcp</code> для перепідключення.
-        </p>
-      </Card>
+    <section id="mcp-clients" data-section>
+      <h1 className="text-[24px] font-bold text-[#1d1d1f] dark:text-[#f5f5f7] tracking-tight">MCP клієнти</h1>
+      <p className="mt-2 text-[14px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+        LEX AI підтримує MCP SSE транспорт. Згенеруйте токен у <a href="/profile" className="text-[#0071e3] dark:text-[#4db8ff] hover:underline">Профілі &rarr; MCP Access Tokens</a>.
+      </p>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Claude Desktop</h2>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Додайте до <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">claude_desktop_config.json</code>:
+      <div id="mcp-claude-code" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Claude Code</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6]">
+          Додайте до <Code>~/.claude/settings.json</Code> або <Code>.mcp.json</Code> в корені проєкту:
         </p>
-        <CodeBlock language="json" code={`{
-  "mcpServers": {
-    "secondlayer": {
-      "type": "sse",
-      "url": "${MCP_SSE_URL}",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_TOKEN"
-      }
-    }
-  }
-}`} />
-      </Card>
+        <CodeBlock lang="json" code={mcpConfig} />
+        <p className="mt-2 text-[12px] text-[#86868b] dark:text-[#6e6e73]">
+          Після додавання перезапустіть Claude Code або виконайте <Code>/mcp</Code> для перепідключення.
+        </p>
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Cursor</h2>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Збережіть як <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">.cursor/mcp.json</code> в корені проєкту:
+      <div id="mcp-claude-desktop" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Claude Desktop</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6]">
+          Додайте до <Code>claude_desktop_config.json</Code>:
         </p>
-        <CodeBlock language="json" code={`{
-  "mcpServers": {
-    "secondlayer": {
-      "type": "sse",
-      "url": "${MCP_SSE_URL}",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_TOKEN"
-      }
-    }
-  }
-}`} />
-      </Card>
+        <CodeBlock lang="json" code={mcpConfig} />
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">VS Code</h2>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Збережіть як <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">.vscode/mcp.json</code>. Увімкніть: <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">chat.mcp.discovery.enabled: true</code>
+      <div id="mcp-cursor" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Cursor</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6]">
+          Збережіть як <Code>.cursor/mcp.json</Code> в корені проєкту:
         </p>
-        <CodeBlock language="json" code={`{
-  "mcpServers": {
-    "secondlayer": {
-      "type": "sse",
-      "url": "${MCP_SSE_URL}",
-      "headers": {
-        "Authorization": "Bearer YOUR_API_TOKEN"
-      }
-    }
-  }
-}`} />
-      </Card>
+        <CodeBlock lang="json" code={mcpConfig} />
+      </div>
 
-      <Card>
-        <div className="flex items-center gap-2 mb-3">
-          <h2 className="text-[16px] font-semibold text-claude-text">ChatGPT</h2>
-        </div>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          ChatGPT підтримує MCP через SSE (Server-Sent Events) транспорт. Це дозволяє використовувати всі інструменти LEX AI безпосередньо у веб-інтерфейсі ChatGPT.
+      <div id="mcp-vscode" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">VS Code</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6]">
+          Збережіть як <Code>.vscode/mcp.json</Code>. Увімкніть: <Code>chat.mcp.discovery.enabled: true</Code>
         </p>
-        <div className="space-y-3">
-          <div>
-            <p className="text-[12px] font-medium text-claude-text mb-1.5">1. Відкрийте налаштування ChatGPT</p>
-            <p className="text-[12.5px] text-claude-subtext">
-              <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">Settings → Features → MCP Servers → Add</code>
-            </p>
-          </div>
-          <div>
-            <p className="text-[12px] font-medium text-claude-text mb-1.5">2. Додайте SSE endpoint</p>
-            <CodeBlock language="text" code={`Server URL: https://mcp.legal.org.ua/sse
-Label: LEX AI — Ukrainian Legal Platform`} />
-          </div>
-          <div>
-            <p className="text-[12px] font-medium text-claude-text mb-1.5">3. Автентифікація</p>
-            <p className="text-[12.5px] text-claude-subtext mb-2">
-              Згенеруйте API-токен у <a href="/profile" className="text-claude-accent hover:underline">Профілі → MCP Access Tokens</a>, потім додайте як Bearer токен:
-            </p>
-            <CodeBlock language="text" code={`Header: Authorization
-Value: Bearer YOUR_API_TOKEN`} />
-          </div>
-          <div>
-            <p className="text-[12px] font-medium text-claude-text mb-1.5">4. Готово</p>
-            <p className="text-[12.5px] text-claude-subtext">
-              Після підключення ChatGPT матиме доступ до всіх інструментів: пошук судових рішень, аналіз законодавства, реєстри, моніторинг — прямо в чаті.
-            </p>
-          </div>
-        </div>
-        <div className="mt-4 p-3 bg-amber-500/5 border border-amber-500/15 rounded-lg">
-          <p className="text-[12px] text-amber-600">
-            <strong>Примітка:</strong> MCP у ChatGPT доступний для Plus/Team/Enterprise підписок. Перевірте доступність у вашому акаунті.
-          </p>
-        </div>
-      </Card>
+        <CodeBlock lang="json" code={mcpConfig} />
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Continue.dev</h2>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          Збережіть як <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">.continue/mcpServers/secondlayer.yaml</code>:
+      <div id="mcp-chatgpt" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">ChatGPT</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+          ChatGPT підтримує MCP через SSE транспорт (Plus/Team/Enterprise).
         </p>
-        <CodeBlock language="yaml" code={`name: secondlayer
+        <ol className="mt-3 text-[13px] text-[#424245] dark:text-[#a1a1a6] space-y-2 list-decimal list-inside">
+          <li>Відкрийте <Code>Settings &rarr; Features &rarr; MCP Servers &rarr; Add</Code></li>
+          <li>Server URL: <Code>https://mcp.legal.org.ua/sse</Code></li>
+          <li>Authorization header: <Code>Bearer YOUR_API_TOKEN</Code></li>
+        </ol>
+      </div>
+
+      <div id="mcp-continue" data-section className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Continue.dev</h2>
+        <p className="mt-2 text-[13px] text-[#424245] dark:text-[#a1a1a6]">
+          Збережіть як <Code>.continue/mcpServers/secondlayer.yaml</Code>:
+        </p>
+        <CodeBlock lang="yaml" code={`name: secondlayer
 type: sse
 url: ${MCP_SSE_URL}
 
 headers:
   Authorization: "Bearer YOUR_API_TOKEN"`} />
-      </Card>
+      </div>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">API Версіонування</h2>
-        <p className="text-[13px] text-claude-subtext mb-3">
-          MCP SSE API використовує версіоновані ендпоінти для забезпечення зворотної сумісності.
-        </p>
-        <div className="space-y-2">
-          <div className="flex items-center gap-3 p-2.5 bg-claude-bg-secondary rounded-lg">
-            <code className="text-[12px] font-mono font-semibold text-claude-accent">v1</code>
-            <span className="text-[12px] text-claude-subtext flex-1">Поточна стабільна версія — SSE транспорт (MCP SDK)</span>
-            <span className="px-1.5 py-0.5 bg-emerald-500/10 text-emerald-600 text-[10px] font-semibold rounded">stable</span>
-          </div>
-        </div>
-        <div className="mt-3 text-[12px] text-claude-subtext space-y-1">
-          <p><strong>Base URL:</strong> <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">https://mcp.legal.org.ua/api/v1/sse</code></p>
-          <p><strong>Протокол:</strong> SSE (Server-Sent Events) — GET для підключення, POST для повідомлень</p>
-          <p><strong>Автентифікація:</strong> Bearer Token в заголовку <code className="bg-claude-bg-secondary px-1.5 py-0.5 rounded text-[11px]">Authorization</code></p>
-        </div>
-      </Card>
-    </div>
+      <div className="mt-8">
+        <h2 className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Версіонування</h2>
+        <table className="mt-3 w-full text-[13px]">
+          <thead>
+            <tr className="border-b border-[#d2d2d7] dark:border-[#424245] text-left">
+              <Th>Версія</Th>
+              <Th>URL</Th>
+              <Th>Статус</Th>
+            </tr>
+          </thead>
+          <tbody className="text-[#424245] dark:text-[#a1a1a6]">
+            <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+              <Td>v1</Td>
+              <Td><Code>{MCP_SSE_URL}</Code></Td>
+              <Td>Stable</Td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
   );
 }
 
-/* ==================== PRICING TAB ==================== */
+/* ================================================================
+   SECTION: PRICING
+   ================================================================ */
 
-function PricingTab() {
+function PricingSection() {
   return (
-    <div className="space-y-6">
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Вартість за категоріями</h2>
-        <p className="text-[13px] text-claude-subtext mb-4">
-          Вартість залежить від складності інструменту та обсягу AI обробки.
-        </p>
+    <section id="pricing" data-section>
+      <h1 className="text-[24px] font-bold text-[#1d1d1f] dark:text-[#f5f5f7] tracking-tight">Вартість</h1>
+      <p className="mt-2 text-[14px] text-[#424245] dark:text-[#a1a1a6] leading-relaxed">
+        Вартість залежить від складності інструменту та обсягу AI обробки.
+        Включає OpenAI API виклики, векторний пошук, зовнішні API запити та кешування.
+      </p>
 
-        <div className="space-y-4">
-          <PricingTier
-            title="Мінімальна (<$0.01)"
-            color="green"
-            tools={[
-              'get_legislation_article', 'get_legislation_structure', 'openreyestr_get_by_edrpou',
-              'openreyestr_get_statistics', 'openreyestr_search_entities', 'check_precedent_status',
-              'classify_intent', 'store_document', 'get_document', 'list_documents',
-            ]}
-          />
-          <PricingTier
-            title="Середня ($0.01-$0.05)"
-            color="blue"
-            tools={[
-              'search_legal_precedents', 'get_court_decision', 'search_legislation',
-              'rada_search_parliament_bills', 'get_similar_reasoning', 'get_judge_statistics',
-            ]}
-          />
-          <PricingTier
-            title="Висока ($0.05-$0.15)"
-            color="amber"
-            tools={[
-              'search_supreme_court_practice', 'compare_practice_pro_contra',
-              'rada_analyze_voting_record', 'extract_key_clauses', 'analyze_court_trends',
-            ]}
-          />
-          <PricingTier
-            title="Максимальна (>$0.15)"
-            color="red"
-            tools={['get_legal_advice — $0.10-$0.30 (комплексний аналіз)']}
-          />
-        </div>
-      </Card>
+      <table className="mt-6 w-full text-[13px]">
+        <thead>
+          <tr className="border-b border-[#d2d2d7] dark:border-[#424245] text-left">
+            <Th>Категорія</Th>
+            <Th>Діапазон</Th>
+            <Th>Приклади</Th>
+          </tr>
+        </thead>
+        <tbody className="text-[#424245] dark:text-[#a1a1a6]">
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336] align-top">
+            <Td>Мінімальна</Td>
+            <Td>&lt;$0.01</Td>
+            <Td>get_legislation_article, classify_intent, store_document, openreyestr_*</Td>
+          </tr>
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336] align-top">
+            <Td>Середня</Td>
+            <Td>$0.01–0.05</Td>
+            <Td>search_legal_precedents, get_court_decision, search_legislation</Td>
+          </tr>
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336] align-top">
+            <Td>Висока</Td>
+            <Td>$0.05–0.15</Td>
+            <Td>search_supreme_court_practice, compare_practice_pro_contra, analyze_court_trends</Td>
+          </tr>
+          <tr className="border-b border-[#e8e8ed] dark:border-[#333336] align-top">
+            <Td>Максимальна</Td>
+            <Td>$0.10–0.30</Td>
+            <Td>get_legal_advice (комплексний аналіз з антигалюцинацією)</Td>
+          </tr>
+        </tbody>
+      </table>
 
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Що входить у вартість</h2>
-        <div className="text-[13px] text-claude-subtext space-y-2">
-          <p>Вартість включає:</p>
-          <ul className="list-disc list-inside space-y-1 ml-2">
-            <li>OpenAI API виклики (embeddings + LLM аналіз)</li>
-            <li>Векторний пошук у Qdrant</li>
-            <li>Зовнішні API запити (RADA, реєстри)</li>
-            <li>Кешування результатів (RADA: 7-30 днів, Backend: Redis + PostgreSQL)</li>
-          </ul>
-        </div>
-      </Card>
-
-      <Card>
-        <h2 className="text-[16px] font-semibold text-claude-text mb-3">Правові документи</h2>
-        <div className="space-y-2">
-          <a href="/ua/developer-offer" target="_blank" rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[13px] text-claude-accent hover:underline">
-            <ExternalLink size={13} />
-            Оферта розробника
-          </a>
-          <a href="/en/api-terms" target="_blank" rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[13px] text-claude-accent hover:underline">
-            <ExternalLink size={13} />
-            API Terms of Use (EN)
-          </a>
-          <a href="/ua/privacy" target="_blank" rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[13px] text-claude-accent hover:underline">
-            <ExternalLink size={13} />
-            Політика конфіденційності
-          </a>
-          <a href="/ua/dpa" target="_blank" rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[13px] text-claude-accent hover:underline">
-            <ExternalLink size={13} />
-            DPA (обробка даних)
-          </a>
-        </div>
-      </Card>
-    </div>
+      <h2 className="mt-8 text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7]">Правові документи</h2>
+      <div className="mt-3 space-y-1.5 text-[13px]">
+        <DocLink href="/ua/developer-offer" label="Оферта розробника" />
+        <DocLink href="/en/api-terms" label="API Terms of Use (EN)" />
+        <DocLink href="/ua/privacy" label="Політика конфіденційності" />
+        <DocLink href="/ua/dpa" label="DPA (обробка даних)" />
+      </div>
+    </section>
   );
 }
 
-/* ==================== SHARED COMPONENTS ==================== */
+/* ================================================================
+   SHARED UI PRIMITIVES
+   ================================================================ */
 
-function Card({ children }: { children: React.ReactNode }) {
+function Divider() {
+  return <hr className="my-12 border-[#d2d2d7] dark:border-[#424245]" />;
+}
+
+function Th({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-white rounded-xl border border-claude-border p-5">
+    <th className="pb-2 pr-4 text-[12px] font-semibold text-[#86868b] dark:text-[#6e6e73] uppercase tracking-wider">
       {children}
-    </div>
+    </th>
   );
 }
 
-function ServiceCard({ icon: Icon, title, count, description }: { icon: React.ElementType; title: string; count: string; description: string }) {
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="py-2.5 pr-4">{children}</td>;
+}
+
+function Code({ children }: { children: React.ReactNode }) {
   return (
-    <div className="bg-claude-bg-secondary rounded-lg p-4">
-      <div className="flex items-center gap-2 mb-2">
-        <Icon size={16} className="text-claude-accent" />
-        <span className="text-[13px] font-semibold text-claude-text">{title}</span>
-        <span className="text-[11px] font-semibold text-claude-accent bg-claude-accent/10 px-1.5 py-0.5 rounded-full">{count}</span>
-      </div>
-      <p className="text-[12px] text-claude-subtext">{description}</p>
-    </div>
+    <code className="text-[12px] font-mono bg-[#f5f5f7] dark:bg-[#2d2d2f] text-[#1d1d1f] dark:text-[#f5f5f7] px-1.5 py-0.5 rounded">
+      {children}
+    </code>
   );
 }
 
-function TransportRow({ icon: Icon, title, endpoint, description }: { icon: React.ElementType; title: string; endpoint: string; description: string }) {
+function InfoCell({ label, value }: { label: string; value: string }) {
   return (
-    <div className="flex items-start gap-3 p-3 bg-claude-bg-secondary rounded-lg">
-      <Icon size={16} className="text-claude-accent mt-0.5 flex-shrink-0" />
-      <div className="flex-1 min-w-0">
-        <div className="text-[13px] font-semibold text-claude-text">{title}</div>
-        <code className="text-[11px] text-claude-accent font-mono">{endpoint}</code>
-        <p className="text-[12px] text-claude-subtext mt-0.5">{description}</p>
-      </div>
+    <div className="bg-[#fbfbfd] dark:bg-[#2d2d2f] px-5 py-4">
+      <div className="text-[11px] font-medium text-[#86868b] dark:text-[#6e6e73] uppercase tracking-wider">{label}</div>
+      <div className="text-[17px] font-semibold text-[#1d1d1f] dark:text-[#f5f5f7] mt-1">{value}</div>
     </div>
   );
 }
 
-function EndpointRow({ method, path, description }: { method: string; path: string; description: string }) {
-  const color = method === 'GET' ? 'bg-green-100 text-green-700' : 'bg-blue-100 text-blue-700';
+function ServiceRow({ name, count, description }: { name: string; count: number; description: string }) {
   return (
-    <div className="flex items-center gap-3">
-      <span className={`text-[10px] font-bold ${color} px-2 py-0.5 rounded uppercase w-12 text-center`}>{method}</span>
-      <code className="text-[12px] font-mono text-claude-text flex-1">{path}</code>
-      <span className="text-[12px] text-claude-subtext">{description}</span>
+    <div className="flex items-baseline gap-4 py-2">
+      <code className="text-[13px] font-mono font-semibold text-[#1d1d1f] dark:text-[#f5f5f7] w-[160px] flex-shrink-0">{name}</code>
+      <span className="text-[12px] text-[#86868b] dark:text-[#6e6e73] w-[36px] flex-shrink-0">{count}+</span>
+      <span className="text-[13px] text-[#424245] dark:text-[#a1a1a6]">{description}</span>
     </div>
   );
 }
 
-function PricingTier({ title, color, tools }: { title: string; color: string; tools: string[] }) {
-  const bgColor = color === 'green' ? 'bg-green-50 border-green-200' : color === 'blue' ? 'bg-blue-50 border-blue-200' : color === 'amber' ? 'bg-amber-50 border-amber-200' : 'bg-red-50 border-red-200';
-  const textColor = color === 'green' ? 'text-green-700' : color === 'blue' ? 'text-blue-700' : color === 'amber' ? 'text-amber-700' : 'text-red-700';
-
+function EndpointTableRow({ method, path, desc }: { method: string; path: string; desc: string }) {
   return (
-    <div className={`rounded-lg border p-4 ${bgColor}`}>
-      <h3 className={`text-[13px] font-semibold ${textColor} mb-2`}>{title}</h3>
-      <div className="flex flex-wrap gap-1.5">
-        {tools.map((t) => (
-          <span key={t} className="text-[11px] font-mono bg-white/70 text-claude-subtext px-2 py-0.5 rounded">{t}</span>
-        ))}
-      </div>
-    </div>
+    <tr className="border-b border-[#e8e8ed] dark:border-[#333336]">
+      <Td>
+        <span className={`text-[11px] font-mono font-semibold ${method === 'GET' ? 'text-[#248a3d]' : 'text-[#0071e3]'}`}>
+          {method}
+        </span>
+      </Td>
+      <Td><Code>{path}</Code></Td>
+      <Td>{desc}</Td>
+    </tr>
   );
 }
 
-function CodeBlock({ code, language }: { code: string; language: string }) {
+function DocLink({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block text-[#0071e3] dark:text-[#4db8ff] hover:underline"
+    >
+      {label}
+    </a>
+  );
+}
+
+function CodeBlock({ code, lang }: { code: string; lang: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
@@ -836,24 +916,20 @@ function CodeBlock({ code, language }: { code: string; language: string }) {
   };
 
   return (
-    <div className="relative group">
-      <div className="flex items-center justify-between bg-[#1a1a1a] rounded-t-lg px-4 py-2 border border-b-0 border-[#333]">
-        <span className="text-[10px] text-zinc-500 uppercase tracking-wider font-mono">{language}</span>
+    <div className="mt-3 rounded-lg border border-[#d2d2d7] dark:border-[#424245] overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-1.5 bg-[#f5f5f7] dark:bg-[#2d2d2f] border-b border-[#d2d2d7] dark:border-[#424245]">
+        <span className="text-[10px] font-mono text-[#86868b] dark:text-[#6e6e73] uppercase tracking-wider">{lang}</span>
         <button
           onClick={handleCopy}
-          className="flex items-center gap-1 text-[11px] text-zinc-500 hover:text-zinc-300 transition-colors"
+          className="flex items-center gap-1 text-[11px] text-[#86868b] dark:text-[#6e6e73] hover:text-[#1d1d1f] dark:hover:text-[#f5f5f7] transition-colors"
         >
-          {copied ? <Check size={12} /> : <Copy size={12} />}
+          {copied ? <Check size={11} /> : <Copy size={11} />}
           {copied ? 'Скопійовано' : 'Копіювати'}
         </button>
       </div>
-      <pre className="bg-[#111] border border-[#333] rounded-b-lg p-4 overflow-x-auto">
-        <code className="text-[12px] font-mono text-zinc-300 leading-relaxed whitespace-pre">{code}</code>
+      <pre className="px-4 py-3.5 bg-[#fafafa] dark:bg-[#1d1d1f] overflow-x-auto">
+        <code className="text-[12.5px] font-mono text-[#1d1d1f] dark:text-[#e5e5e5] leading-relaxed whitespace-pre">{code}</code>
       </pre>
     </div>
   );
-}
-
-function Gavel(props: any) {
-  return <Scale {...props} />;
 }


### PR DESCRIPTION
## Summary
- Redesigned `/developer/docs` from marketing-style tabbed layout to Apple Developer Documentation style
- Left sidebar with collapsible navigation tree and scroll-based active section tracking
- Clean reference layout: tables for endpoints/transports/pricing, monochrome palette, dark mode
- Mobile responsive with hamburger sidebar toggle
- Removed framer-motion animations and marketing badges (new/popular)

## Test plan
- [ ] Verify page renders at `/developer/docs`
- [ ] Check sidebar navigation scrolls to correct sections
- [ ] Test mobile responsive sidebar (toggle open/close)
- [ ] Verify dark mode colors
- [ ] Check all code blocks copy-to-clipboard works
- [ ] Confirm all tool names and parameters are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt `/developer/docs` into an Apple-style reference page with a left sidebar, scroll tracking, and structured tables to improve navigation, readability, and mobile support.

- **New Features**
  - Collapsible left sidebar with scroll-synced active section; mobile hamburger toggle.
  - Structured tables for transports, endpoints, versioning, and pricing; required params marked with *.
  - Unified code blocks with copy-to-clipboard; examples for cURL, JS/TS, Python, and SSE streaming.
  - MCP client setup guides (Claude Code/Desktop, Cursor, VS Code, ChatGPT, Continue.dev); dark mode with a monochrome palette.

- **Refactors**
  - Replaced tabbed marketing UI with a single-page sectioned layout; removed `framer-motion` usage on this page.
  - Consolidated tool metadata into `toolGroups`; added lightweight UI primitives (sidebar items, code blocks, table cells).
  - Removed marketing badges; standardized cost ranges and simplified copy.

<sup>Written for commit cbf4ac28275c298e320c6680bce822cf011b8099. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

