### PR TITLE
fix(ui): fully automatic document upload flow

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/UploadQueuePanel.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/UploadQueuePanel.tsx
@@ -1,10 +1,7 @@
-import React, { useRef, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
-  Upload,
   X,
-  ChevronDown,
-  Tag,
   Pause,
   Play,
   RotateCcw,
@@ -13,24 +10,16 @@ import {
 import { useShallow } from 'zustand/react/shallow';
 import { useUploadStore } from '../../stores/uploadStore';
 import { UploadItemRow } from './UploadItemRow';
-import { DOC_TYPE_LABELS } from './constants';
 import { formatFileSize } from './constants';
-import type { DocType } from './types';
 
 interface UploadQueuePanelProps {
   showUploadPanel: boolean;
   setShowUploadPanel: (show: boolean) => void;
-  defaultDocType: DocType;
-  setDefaultDocType: (type: DocType) => void;
-  onStartUpload: () => void;
 }
 
 export function UploadQueuePanel({
   showUploadPanel,
   setShowUploadPanel,
-  defaultDocType,
-  setDefaultDocType,
-  onStartUpload,
 }: UploadQueuePanelProps) {
   // State values via shallow selector to avoid full-store re-renders
   const {
@@ -42,7 +31,6 @@ export function UploadQueuePanel({
     failedFiles,
     totalBytes,
     uploadedBytes,
-    concurrency,
   } = useUploadStore(useShallow(s => ({
     items: s.items,
     isUploading: s.isUploading,
@@ -52,7 +40,6 @@ export function UploadQueuePanel({
     failedFiles: s.failedFiles,
     totalBytes: s.totalBytes,
     uploadedBytes: s.uploadedBytes,
-    concurrency: s.concurrency,
   })));
 
   // Actions (stable refs)
@@ -65,10 +52,7 @@ export function UploadQueuePanel({
   const removeFile = useUploadStore(s => s.removeFile);
   const clearFinished = useUploadStore(s => s.clearFinished);
   const updateDocType = useUploadStore(s => s.updateDocType);
-  const updateAllDocTypes = useUploadStore(s => s.updateAllDocTypes);
-  const setConcurrency = useUploadStore(s => s.setConcurrency);
 
-  const [showTypeDropdown, setShowTypeDropdown] = React.useState(false);
   const uploadQueueRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll upload queue to the first active item
@@ -111,58 +95,6 @@ export function UploadQueuePanel({
               </span>
             </div>
             <div className="flex items-center gap-2">
-              {/* Concurrent uploads selector */}
-              <div className="flex items-center gap-1.5">
-                <span className="text-[10px] text-claude-subtext/50 font-sans">Потоки:</span>
-                <select
-                  value={concurrency}
-                  onChange={(e) => setConcurrency(Number(e.target.value))}
-                  className="text-xs border border-claude-border rounded-lg px-2 py-1.5 bg-white text-claude-text font-sans focus:outline-none focus:border-claude-subtext/40"
-                >
-                  {[1, 2, 3, 5, 8, 10, 15, 20, 30, 50, 100].map((n) => (
-                    <option key={n} value={n}>{n}</option>
-                  ))}
-                </select>
-              </div>
-
-              {/* Default doc type selector */}
-              <div className="relative">
-                <button
-                  onClick={() => setShowTypeDropdown(!showTypeDropdown)}
-                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-claude-border rounded-lg hover:bg-claude-bg transition-colors font-sans"
-                >
-                  <Tag size={12} />
-                  {DOC_TYPE_LABELS[defaultDocType]}
-                  <ChevronDown size={12} />
-                </button>
-                <AnimatePresence>
-                  {showTypeDropdown && (
-                    <motion.div
-                      initial={{ opacity: 0, y: -4 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={{ opacity: 0, y: -4 }}
-                      className="absolute right-0 top-full mt-1 bg-white border border-claude-border rounded-xl shadow-lg z-20 py-1 min-w-[160px]"
-                    >
-                      {(Object.keys(DOC_TYPE_LABELS) as DocType[]).map((t) => (
-                        <button
-                          key={t}
-                          onClick={() => {
-                            setDefaultDocType(t);
-                            updateAllDocTypes(t);
-                            setShowTypeDropdown(false);
-                          }}
-                          className={`w-full text-left px-3 py-2 text-xs font-medium hover:bg-claude-bg transition-colors font-sans ${
-                            defaultDocType === t ? 'text-claude-accent' : 'text-claude-text'
-                          }`}
-                        >
-                          {DOC_TYPE_LABELS[t]}
-                        </button>
-                      ))}
-                    </motion.div>
-                  )}
-                </AnimatePresence>
-              </div>
-
               {/* Pause/Resume */}
               {isUploading && (
                 <button
@@ -257,19 +189,12 @@ export function UploadQueuePanel({
             ))}
           </div>
 
-          {/* Queue footer */}
+          {/* Queue footer — queued count (upload starts automatically) */}
           {queuedCount > 0 && !isUploading && (
-            <div className="px-5 py-3 border-t border-claude-border/50 flex items-center justify-between">
+            <div className="px-5 py-3 border-t border-claude-border/50">
               <span className="text-xs text-claude-subtext/60 font-sans">
-                {queuedCount} файлів готові до завантаження
+                {queuedCount} файлів в черзі
               </span>
-              <button
-                onClick={onStartUpload}
-                className="inline-flex items-center gap-2 px-4 py-2 bg-claude-text text-white rounded-xl text-sm font-medium hover:bg-claude-text/90 transition-all active:scale-[0.98] shadow-sm font-sans"
-              >
-                <Upload size={14} />
-                Завантажити ({queuedCount})
-              </button>
             </div>
           )}
         </motion.div>

--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -2,12 +2,9 @@ import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useShallow } from 'zustand/react/shallow';
 import { useUploadStore } from '../../stores/uploadStore';
-import { showToast } from '../../utils/toast';
-import { toastTDynamic } from '../../i18n/toast-i18n';
 import { FolderNavigator } from './FolderNavigator';
 import { UploadQueuePanel } from './UploadQueuePanel';
 import { DocumentViewerModal } from '../../components/DocumentViewerModal';
-import { PostUploadDestination } from './PostUploadDestination';
 import { DeleteConfirmModal } from './DeleteConfirmModal';
 import { EditDocumentModal } from './EditDocumentModal';
 import { MoveDocumentModal } from './MoveDocumentModal';
@@ -163,22 +160,18 @@ export function DocumentsPage() {
   });
 
   // Upload state from Zustand store
-  const { items: uploadItems, isUploading, completedFiles, recoveredSessions, showDestinationPicker } = useUploadStore(
+  const { items: uploadItems, isUploading, completedFiles, recoveredSessions } = useUploadStore(
     useShallow(s => ({
       items: s.items,
       isUploading: s.isUploading,
       completedFiles: s.completedFiles,
       recoveredSessions: s.recoveredSessions,
-      showDestinationPicker: s.showDestinationPicker,
     }))
   );
   const addFiles = useUploadStore(s => s.addFiles);
-  const startUpload = useUploadStore(s => s.startUpload);
   const recoverSessions = useUploadStore(s => s.recoverSessions);
   const dismissRecoveredSession = useUploadStore(s => s.dismissRecoveredSession);
   const clearRecoveredSessions = useUploadStore(s => s.clearRecoveredSessions);
-  const dismissDestinationPicker = useUploadStore(s => s.dismissDestinationPicker);
-
   // Undo/redo
   const setOnActionExecuted = useUndoStore((s) => s.setOnActionExecuted);
   useUndoKeyboard();
@@ -194,7 +187,6 @@ export function DocumentsPage() {
   // Local UI state
   const [isDragOver, setIsDragOver] = useState(false);
   const [showUploadPanel, setShowUploadPanel] = useState(false);
-  const [defaultDocType, setDefaultDocType] = useState<DocType>('other');
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
@@ -227,11 +219,6 @@ export function DocumentsPage() {
     if (!folderPath) navigate('/documents');
     else navigate(`/documents/folders/${folderPath.replace(/\/+$/, '')}`);
   }, [navigate]);
-
-  const handleStartUpload = () => {
-    startUpload();
-    showToast.success(toastTDynamic('uploadStarted', uploadItems.filter((i) => i.status === 'queued').length));
-  };
 
   const handleSearch = () => { loadDocuments(); };
 
@@ -277,7 +264,7 @@ export function DocumentsPage() {
             showCompactUpload={showCompactUpload}
             setUploadZoneExpanded={setUploadZoneExpanded}
             currentFolderPath={currentFolderPath}
-            defaultDocType={defaultDocType}
+            defaultDocType="other"
             addFiles={addFiles}
             setShowUploadPanel={setShowUploadPanel}
             dropZoneRef={dropZoneRef}
@@ -288,16 +275,7 @@ export function DocumentsPage() {
           <UploadQueuePanel
             showUploadPanel={showUploadPanel}
             setShowUploadPanel={setShowUploadPanel}
-            defaultDocType={defaultDocType}
-            setDefaultDocType={setDefaultDocType}
-            onStartUpload={handleStartUpload}
           />
-
-          {showDestinationPicker && (
-            <PostUploadDestination
-              onComplete={() => { dismissDestinationPicker(); loadDocuments(); loadStats(); }}
-            />
-          )}
 
           <DocumentSearchBar
             searchQuery={searchQuery}

--- a/lexwebapp/src/stores/uploadStore.ts
+++ b/lexwebapp/src/stores/uploadStore.ts
@@ -97,15 +97,12 @@ export const useUploadStore = create<UploadState>((set) => {
     if (event.type === 'all-completed') {
       set({ ...sync, isUploading: false });
 
-      // Show destination picker so user can choose where to put uploaded docs
+      // Auto-classify completed documents (fire-and-forget, no UI prompt)
       const completedItems = sync.items.filter(i => i.status === 'completed');
       if (completedItems.length >= 1) {
         const knownIds = completedItems.map(i => i.documentId).filter(Boolean) as string[];
 
         if (knownIds.length > 0) {
-          set({ showDestinationPicker: true, pendingDocumentIds: knownIds });
-
-          // Auto-classify new uploads (fire-and-forget)
           import('../utils/api-client').then(({ api }) => {
             api.documents.startClassification({ documentIds: knownIds }).catch(err => {
               console.warn('[UploadStore] Auto-classification failed (non-critical)', err);
@@ -122,9 +119,6 @@ export const useUploadStore = create<UploadState>((set) => {
                     .filter(s => s && s.documentId)
                     .map(s => s!.documentId!) as string[];
                   if (docIds.length > 0) {
-                    set({ showDestinationPicker: true, pendingDocumentIds: docIds });
-
-                    // Auto-classify deferred docs
                     import('../utils/api-client').then(({ api }) => {
                       api.documents.startClassification({ documentIds: docIds }).catch(() => {});
                     });
@@ -194,7 +188,20 @@ export const useUploadStore = create<UploadState>((set) => {
         encrypt: true,
       }));
       uploadManager.addFiles(filesWithEncrypt);
-      set(syncFromManager(uploadManager));
+
+      // Auto-select concurrency based on file count
+      const count = uploadManager.getItems().filter(i => i.status === 'queued').length;
+      let autoConcurrency: number;
+      if (count <= 3) autoConcurrency = 1;
+      else if (count <= 10) autoConcurrency = 3;
+      else if (count <= 50) autoConcurrency = 5;
+      else if (count <= 200) autoConcurrency = 10;
+      else autoConcurrency = 20;
+      uploadManager.setConcurrency(autoConcurrency);
+
+      // Auto-start upload immediately
+      uploadManager.start();
+      set({ isUploading: true, isPaused: false, concurrency: autoConcurrency, ...syncFromManager(uploadManager) });
     },
 
     startUpload: () => {


### PR DESCRIPTION
## Summary
- Upload starts immediately on file selection — no "start" button needed
- Concurrency auto-selected: 1-3 files→1 stream, 4-10→3, 11-50→5, 51-200→10, 200+→20
- Removed doc type selector — AI classification runs automatically after upload
- Removed PostUploadDestination picker — documents stay in current folder
- E2EE one-time key setup button remains on the page

## Test plan
- [ ] Select files → upload starts immediately without clicking "start"
- [ ] No doc type dropdown visible in upload queue
- [ ] No "where to save" dialog after upload completes
- [ ] Auto-classification triggers after upload (check backend logs)
- [ ] E2EE setup prompt still shows for new users without keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make document uploads fully automatic: selecting files starts the upload, concurrency is auto-picked, and new docs are auto-classified. Files stay in the current folder; no extra prompts. E2EE key setup prompt remains.

- **New Features**
  - Upload starts on file selection; removed Start button.
  - Auto concurrency by file count: 1–3→1, 4–10→3, 11–50→5, 51–200→10, 200+→20.
  - Removed doc type and destination pickers; docs auto-classified and saved in the current folder.
  - Removed concurrency selector in the queue; E2EE one-time key setup stays.

<sup>Written for commit a13605dc70958da7937912288e872ce6446cbe35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

