### PR TITLE
cleanup(db): drop duplicate opendata tables from main DB

### DIFF
--- a/mcp_backend/src/migrations/106_drop_duplicate_opendata_tables.sql
+++ b/mcp_backend/src/migrations/106_drop_duplicate_opendata_tables.sql
@@ -1,0 +1,14 @@
+-- Migration 106: Drop duplicate opendata tables from main DB
+-- These tables are duplicated in mcp_openreyestr which has proper MCP tools.
+-- No backend code references these tables — they were imported manually.
+--
+-- OpenReyestr equivalents:
+--   opendata_notaries             -> openreyestr.notaries             (search_notaries tool)
+--   opendata_court_experts        -> openreyestr.court_experts        (search_court_experts tool)
+--   opendata_arbitration_managers -> openreyestr.arbitration_managers (search_arbitration_managers tool)
+--   opendata_bankruptcy_cases     -> openreyestr.bankruptcy_cases     (search_bankruptcy_cases tool)
+
+DROP TABLE IF EXISTS opendata_notaries;
+DROP TABLE IF EXISTS opendata_court_experts;
+DROP TABLE IF EXISTS opendata_arbitration_managers;
+DROP TABLE IF EXISTS opendata_bankruptcy_cases;


### PR DESCRIPTION
## Summary
- Drop 4 tables from main DB that are duplicated in OpenReyestr:
  - `opendata_notaries` (5,799 rows) → `openreyestr.notaries` + `search_notaries` tool
  - `opendata_court_experts` (79,956 rows) → `openreyestr.court_experts` + `search_court_experts` tool
  - `opendata_arbitration_managers` (3,420 rows) → `openreyestr.arbitration_managers` + `search_arbitration_managers` tool
  - `opendata_bankruptcy_cases` (74,754 rows) → `openreyestr.bankruptcy_cases` + `search_bankruptcy_cases` tool
- No code references these tables — they were imported manually and are dead weight
- OpenReyestr has proper MCP tools, import scripts, and weekly/daily sync for all of them

## Test plan
- [x] Verified no code references these tables (`grep` across entire repo = 0 hits)
- [x] Verified OpenReyestr has equivalent data and MCP tools
- [ ] Migration runs on prod after merge + deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove four duplicate OpenData tables from the main DB and rely on OpenReyestr as the source of truth. Dropped `opendata_notaries`, `opendata_court_experts`, `opendata_arbitration_managers`, and `opendata_bankruptcy_cases`; use `openreyestr.notaries`, `openreyestr.court_experts`, `openreyestr.arbitration_managers`, `openreyestr.bankruptcy_cases` and their `search_*` tools instead.

<sup>Written for commit fd1f83fbbd927f5e927d58c501fc0d67369971e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

