### PR TITLE
feat(tools): add 8 new MCP tools for open data registries

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -246,6 +246,8 @@ export class ToolRegistry {
       { clientName: 'openreyestr_search_tax_debt', serviceName: 'search_tax_debt' },
       { clientName: 'openreyestr_search_esv_debt', serviceName: 'search_esv_debt' },
       { clientName: 'openreyestr_search_prozorro', serviceName: 'search_prozorro' },
+      { clientName: 'openreyestr_search_termination_started', serviceName: 'search_termination_started' },
+      { clientName: 'openreyestr_search_rnbo_sanctions', serviceName: 'search_rnbo_sanctions' },
     ];
 
     for (const tool of openreyestrTools) {

--- a/mcp_backend/src/api/tools/opendata-tools.ts
+++ b/mcp_backend/src/api/tools/opendata-tools.ts
@@ -1,13 +1,19 @@
 /**
  * Open Data Tools — MCP tools for open data registries on prod
  *
- * 6 tools:
+ * 12 tools:
  * - search_sanctions — OpenSanctions (1.25M entities, 346 datasets)
  * - search_trademarks — UIPV trademarks (182K records)
  * - search_patents — UIPV patents, utility models, designs (119K records)
  * - search_edrnpa — EDRNPA regulatory documents (141K cards + full texts)
  * - search_corruption_register — Єдиний реєстр корупціонерів (58K records)
  * - search_lawyers — Реєстр адвокатів (73K records)
+ * - search_vrp_decisions — Рішення ВРП (16.5K records)
+ * - search_vrp_judges_discipline — Звільнені/відсторонені судді та втручання (738 records)
+ * - search_vkks — ВККС: судді, оцінювання, декларації, вакансії, ефективність (24.6K records)
+ * - search_declaration_checks — Перевірки декларацій (2K records)
+ * - search_wage_debtors — Боржники із зарплати (1.3K records)
+ * - search_large_taxpayers — Великі платники податків (1.3K records)
  */
 
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
@@ -128,6 +134,117 @@ export class OpenDataTools extends BaseToolHandler {
           },
         },
       },
+      {
+        name: 'search_vrp_decisions',
+        description: `Пошук рішень Вищої ради правосуддя (ВРП)
+
+16.5K записів. Пошук за назвою, органом, номером рішення, датою.
+Включає голосування та тексти рішень.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            title: { type: 'string', description: 'Назва рішення (нечіткий пошук)' },
+            authority: { type: 'string', description: 'Орган (наприклад, Пленум ВРП, Дисциплінарна палата)' },
+            decision_num: { type: 'string', description: 'Номер рішення' },
+            date_from: { type: 'string', description: 'Дата від (YYYY-MM-DD)' },
+            date_to: { type: 'string', description: 'Дата до (YYYY-MM-DD)' },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+        },
+      },
+      {
+        name: 'search_vrp_judges_discipline',
+        description: `Пошук дисциплінарних даних суддів з ВРП
+
+Об'єднаний пошук по 3 реєстрах:
+- Звільнені судді (59 записів)
+- Відсторонені судді (236 записів)
+- Повідомлення про втручання (443 записів)
+Пошук за ПІБ судді, назвою суду, типом запису.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            judge_name: { type: 'string', description: 'ПІБ судді (нечіткий пошук)' },
+            court_name: { type: 'string', description: 'Назва суду (нечіткий пошук)' },
+            type: { type: 'string', enum: ['dismissed', 'suspended', 'interference'], description: 'Тип: dismissed (звільнені), suspended (відсторонені), interference (втручання). Без фільтра — всі типи' },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+        },
+      },
+      {
+        name: 'search_vkks',
+        description: `Пошук даних Вищої кваліфікаційної комісії суддів (ВККС)
+
+5 категорій:
+- judges — досьє суддів (4.7K записів)
+- evaluations — оцінювання суддів (3.4K записів)
+- declarations — декларації суддів (4.8K записів)
+- vacancies — вакансії у судах (1K записів)
+- efficiency — ефективність суддів (10.7K записів)
+
+Обов'язковий параметр: category.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            category: { type: 'string', enum: ['judges', 'evaluations', 'declarations', 'vacancies', 'efficiency'], description: 'Категорія даних ВККС (обов\'язково)' },
+            judge_name: { type: 'string', description: 'ПІБ судді (для judges, evaluations, declarations, efficiency)' },
+            court_name: { type: 'string', description: 'Назва суду' },
+            year: { type: 'number', description: 'Рік (для declarations, efficiency)' },
+            region: { type: 'string', description: 'Регіон (для vacancies)' },
+            court_level: { type: 'string', description: 'Рівень суду (для vacancies, efficiency)' },
+            dossier_number: { type: 'string', description: 'Номер досьє (для judges, evaluations)' },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+          required: ['category'],
+        },
+      },
+      {
+        name: 'search_declaration_checks',
+        description: `Пошук результатів перевірок декларацій (НАЗК)
+
+2K записів. Пошук за прізвищем, посадою, статусом перевірки, результатом.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            family_name: { type: 'string', description: 'Прізвище декларанта' },
+            name: { type: 'string', description: 'Ім\'я декларанта' },
+            position: { type: 'string', description: 'Посада' },
+            status: { type: 'string', description: 'Статус перевірки' },
+            result: { type: 'string', description: 'Результат перевірки' },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+        },
+      },
+      {
+        name: 'search_wage_debtors',
+        description: `Пошук боржників із заробітної плати
+
+1.3K записів. Пошук за назвою підприємства, регіоном, формою власності, видом діяльності.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            company_name: { type: 'string', description: 'Назва підприємства' },
+            region: { type: 'string', description: 'Регіон' },
+            ownership_form: { type: 'string', description: 'Форма власності' },
+            economic_activity: { type: 'string', description: 'Вид економічної діяльності' },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+        },
+      },
+      {
+        name: 'search_large_taxpayers',
+        description: `Пошук у реєстрі великих платників податків
+
+1.3K записів. Пошук за ЄДРПОУ або назвою підприємства.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            edrpou: { type: 'string', description: 'Код ЄДРПОУ' },
+            name: { type: 'string', description: 'Назва підприємства' },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+        },
+      },
     ];
   }
 
@@ -139,6 +256,12 @@ export class OpenDataTools extends BaseToolHandler {
       case 'search_edrnpa': return this.searchEdrnpa(args);
       case 'search_corruption_register': return this.searchCorruption(args);
       case 'search_lawyers': return this.searchLawyers(args);
+      case 'search_vrp_decisions': return this.searchVrpDecisions(args);
+      case 'search_vrp_judges_discipline': return this.searchVrpJudgesDiscipline(args);
+      case 'search_vkks': return this.searchVkks(args);
+      case 'search_declaration_checks': return this.searchDeclarationChecks(args);
+      case 'search_wage_debtors': return this.searchWageDebtors(args);
+      case 'search_large_taxpayers': return this.searchLargeTaxpayers(args);
       default: return null;
     }
   }
@@ -367,6 +490,354 @@ export class OpenDataTools extends BaseToolHandler {
       return this.wrapResponse(JSON.stringify(result.rows, null, 2));
     } catch (error: any) {
       logger.error('search_lawyers error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  // ─── VRP Decisions ──────────────────────────────────────────────────
+
+  private async searchVrpDecisions(args: Record<string, unknown>): Promise<ToolResult> {
+    const { title, authority, decision_num, date_from, date_to, limit = 50 } = args as any;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (title) { conditions.push(`title ILIKE $${pi}`); values.push(`%${title}%`); pi++; }
+    if (authority) { conditions.push(`authority = $${pi}`); values.push(authority); pi++; }
+    if (decision_num) { conditions.push(`decision_num = $${pi}`); values.push(decision_num); pi++; }
+    if (date_from) { conditions.push(`date_time >= $${pi}`); values.push(date_from); pi++; }
+    if (date_to) { conditions.push(`date_time <= $${pi}`); values.push(date_to); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть назву, орган, номер або дату для пошуку');
+
+    values.push(Math.min(Number(limit) || 50, 100));
+    const sql = `SELECT id, date_time, authority, title, decision_num, proceeding_ids,
+        voting_title, voting_for, voting_against, voting_type, voting_result, texts
+      FROM vrp_decisions WHERE ${conditions.join(' AND ')}
+      ORDER BY date_time DESC NULLS LAST LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Рішень ВРП не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_vrp_decisions error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  // ─── VRP Judges Discipline ──────────────────────────────────────────
+
+  private async searchVrpJudgesDiscipline(args: Record<string, unknown>): Promise<ToolResult> {
+    const { judge_name, court_name, type, limit = 50 } = args as any;
+    const maxRows = Math.min(Number(limit) || 50, 100);
+    const queries: string[] = [];
+    const allValues: any[][] = [];
+
+    const types = type ? [type] : ['dismissed', 'suspended', 'interference'];
+
+    for (const t of types) {
+      const conditions: string[] = [];
+      const values: any[] = [];
+      let pi = 1;
+
+      if (judge_name) { conditions.push(`judge_name ILIKE $${pi}`); values.push(`%${judge_name}%`); pi++; }
+      if (court_name) { conditions.push(`court_name ILIKE $${pi}`); values.push(`%${court_name}%`); pi++; }
+
+      const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+      values.push(maxRows);
+
+      if (t === 'dismissed') {
+        queries.push(`SELECT 'dismissed' AS type, judge_name, court_name, applicant, reporter,
+            panel_decision_date, panel_decision_num, vrp_decision_date_num, NULL AS suspension_reason,
+            NULL AS suspension_deadline, NULL AS suspension_body, NULL AS received_date,
+            NULL AS case_num, NULL AS check_result, NULL AS reaction
+          FROM vrp_dismissed_judges ${where}
+          ORDER BY panel_decision_date DESC NULLS LAST LIMIT $${pi}`);
+      } else if (t === 'suspended') {
+        queries.push(`SELECT 'suspended' AS type, judge_name, court_name, applicant, reporter,
+            decision_date AS panel_decision_date, decision_num AS panel_decision_num,
+            NULL AS vrp_decision_date_num, suspension_reason, suspension_deadline, suspension_body,
+            NULL AS received_date, NULL AS case_num, NULL AS check_result, NULL AS reaction
+          FROM vrp_suspended_judges ${where}
+          ORDER BY decision_date DESC NULLS LAST LIMIT $${pi}`);
+      } else if (t === 'interference') {
+        queries.push(`SELECT 'interference' AS type, judge_name, court_name, applicant, reporter,
+            NULL AS panel_decision_date, NULL AS panel_decision_num, NULL AS vrp_decision_date_num,
+            NULL AS suspension_reason, NULL AS suspension_deadline, NULL AS suspension_body,
+            received_date, case_num, check_result, reaction
+          FROM vrp_interference_reports ${where}
+          ORDER BY received_date DESC NULLS LAST LIMIT $${pi}`);
+      }
+      allValues.push(values);
+    }
+
+    if (queries.length === 0) return this.wrapResponse('Невідомий тип запису');
+
+    try {
+      const allRows: any[] = [];
+      for (let i = 0; i < queries.length; i++) {
+        const result = await this.db.query(queries[i], allValues[i]);
+        allRows.push(...result.rows);
+      }
+
+      if (allRows.length === 0) return this.wrapResponse('Дисциплінарних записів не знайдено');
+      return this.wrapResponse(JSON.stringify(allRows.slice(0, maxRows), null, 2));
+    } catch (error: any) {
+      logger.error('search_vrp_judges_discipline error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  // ─── VKKS ──────────────────────────────────────────────────────────
+
+  private async searchVkks(args: Record<string, unknown>): Promise<ToolResult> {
+    const { category, judge_name, court_name, year, region, court_level, dossier_number, limit = 50 } = args as any;
+
+    if (!category) return this.wrapResponse('Вкажіть category: judges, evaluations, declarations, vacancies, efficiency');
+
+    const maxRows = Math.min(Number(limit) || 50, 100);
+
+    switch (category) {
+      case 'judges': return this.searchVkksJudges({ judge_name, court_name, dossier_number, limit: maxRows });
+      case 'evaluations': return this.searchVkksEvaluations({ judge_name, court_name, dossier_number, limit: maxRows });
+      case 'declarations': return this.searchVkksDeclarations({ judge_name, court_name, year, limit: maxRows });
+      case 'vacancies': return this.searchVkksVacancies({ court_name, region, court_level, limit: maxRows });
+      case 'efficiency': return this.searchVkksEfficiency({ judge_name, court_name, court_level, year, limit: maxRows });
+      default: return this.wrapResponse('Невідома категорія. Доступні: judges, evaluations, declarations, vacancies, efficiency');
+    }
+  }
+
+  private async searchVkksJudges(args: any): Promise<ToolResult> {
+    const { judge_name, court_name, dossier_number, limit } = args;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (judge_name) { conditions.push(`full_name ILIKE $${pi}`); values.push(`%${judge_name}%`); pi++; }
+    if (court_name) { conditions.push(`court_name ILIKE $${pi}`); values.push(`%${court_name}%`); pi++; }
+    if (dossier_number) { conditions.push(`dossier_number = $${pi}`); values.push(dossier_number); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть ПІБ судді, суд або номер досьє');
+
+    values.push(limit);
+    const sql = `SELECT id, dossier_number, full_name, gender, court_name, source_date
+      FROM vkks_judges WHERE ${conditions.join(' AND ')}
+      ORDER BY full_name LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Суддів у ВККС не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_vkks_judges error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async searchVkksEvaluations(args: any): Promise<ToolResult> {
+    const { judge_name, court_name, dossier_number, limit } = args;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (judge_name) { conditions.push(`judge_name ILIKE $${pi}`); values.push(`%${judge_name}%`); pi++; }
+    if (court_name) { conditions.push(`court_name ILIKE $${pi}`); values.push(`%${court_name}%`); pi++; }
+    if (dossier_number) { conditions.push(`dossier_number = $${pi}`); values.push(dossier_number); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть ПІБ судді, суд або номер досьє');
+
+    values.push(limit);
+    const sql = `SELECT id, dossier_number, judge_name, court_name, collegium_decision_date,
+        collegium_decision_number, total_score, collegium_decision_essence, plenary_decision_date,
+        plenary_decision_number, plenary_decision_essence, evaluation_type, decision_url, notes
+      FROM vkks_evaluations WHERE ${conditions.join(' AND ')}
+      ORDER BY collegium_decision_date DESC NULLS LAST LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Оцінювань суддів не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_vkks_evaluations error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async searchVkksDeclarations(args: any): Promise<ToolResult> {
+    const { judge_name, court_name, year, limit } = args;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (judge_name) { conditions.push(`judge_name ILIKE $${pi}`); values.push(`%${judge_name}%`); pi++; }
+    if (court_name) { conditions.push(`court_name ILIKE $${pi}`); values.push(`%${court_name}%`); pi++; }
+    if (year) { conditions.push(`year = $${pi}`); values.push(Number(year)); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть ПІБ судді, суд або рік');
+
+    values.push(limit);
+    const sql = `SELECT id, judge_name, court_name, declaration_type, year, source
+      FROM vkks_declarations WHERE ${conditions.join(' AND ')}
+      ORDER BY year DESC, judge_name LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Декларацій суддів не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_vkks_declarations error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async searchVkksVacancies(args: any): Promise<ToolResult> {
+    const { court_name, region, court_level, limit } = args;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (court_name) { conditions.push(`court_name ILIKE $${pi}`); values.push(`%${court_name}%`); pi++; }
+    if (region) { conditions.push(`region ILIKE $${pi}`); values.push(`%${region}%`); pi++; }
+    if (court_level) { conditions.push(`court_level ILIKE $${pi}`); values.push(`%${court_level}%`); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть назву суду, регіон або рівень суду');
+
+    values.push(limit);
+    const sql = `SELECT id, court_name, court_level, region, positions_limit, positions_filled,
+        positions_vacant, positions_in_process, report_date
+      FROM vkks_vacancies WHERE ${conditions.join(' AND ')}
+      ORDER BY report_date DESC NULLS LAST LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Вакансій у судах не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_vkks_vacancies error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async searchVkksEfficiency(args: any): Promise<ToolResult> {
+    const { judge_name, court_name, court_level, year, limit } = args;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (judge_name) { conditions.push(`judge_name ILIKE $${pi}`); values.push(`%${judge_name}%`); pi++; }
+    if (court_name) { conditions.push(`court_name ILIKE $${pi}`); values.push(`%${court_name}%`); pi++; }
+    if (court_level) { conditions.push(`court_level ILIKE $${pi}`); values.push(`%${court_level}%`); pi++; }
+    if (year) { conditions.push(`year = $${pi}`); values.push(Number(year)); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть ПІБ судді, суд, рівень або рік');
+
+    values.push(limit);
+    const sql = `SELECT id, judge_name, court_name, court_level, year,
+        workload_total_judge, workload_total_court, workload_total_region,
+        workload_criminal_judge, workload_civil_judge, workload_admin_judge,
+        workload_commercial_judge, workload_offense_judge,
+        annulled_total, changed_total, overdue_cases_total
+      FROM vkks_judge_efficiency WHERE ${conditions.join(' AND ')}
+      ORDER BY year DESC, judge_name LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Даних про ефективність суддів не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_vkks_efficiency error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  // ─── Declaration Checks ─────────────────────────────────────────────
+
+  private async searchDeclarationChecks(args: Record<string, unknown>): Promise<ToolResult> {
+    const { family_name, name, position, status, result: checkResult, limit = 50 } = args as any;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (family_name) { conditions.push(`family_name ILIKE $${pi}`); values.push(`%${family_name}%`); pi++; }
+    if (name) { conditions.push(`name ILIKE $${pi}`); values.push(`%${name}%`); pi++; }
+    if (position) { conditions.push(`position ILIKE $${pi}`); values.push(`%${position}%`); pi++; }
+    if (status) { conditions.push(`status ILIKE $${pi}`); values.push(`%${status}%`); pi++; }
+    if (checkResult) { conditions.push(`result ILIKE $${pi}`); values.push(`%${checkResult}%`); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть прізвище, посаду або статус для пошуку');
+
+    values.push(Math.min(Number(limit) || 50, 100));
+    const sql = `SELECT id, declaration_uid, family_name, name, additional_name, position,
+        position_category, reporting_period, status, result, result_url, measures, completion_year
+      FROM opendata_declaration_checks WHERE ${conditions.join(' AND ')}
+      ORDER BY family_name, name LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Перевірок декларацій не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_declaration_checks error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  // ─── Wage Debtors ───────────────────────────────────────────────────
+
+  private async searchWageDebtors(args: Record<string, unknown>): Promise<ToolResult> {
+    const { company_name, region, ownership_form, economic_activity, limit = 50 } = args as any;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (company_name) { conditions.push(`company_name ILIKE $${pi}`); values.push(`%${company_name}%`); pi++; }
+    if (region) { conditions.push(`region ILIKE $${pi}`); values.push(`%${region}%`); pi++; }
+    if (ownership_form) { conditions.push(`ownership_form ILIKE $${pi}`); values.push(`%${ownership_form}%`); pi++; }
+    if (economic_activity) { conditions.push(`economic_activity ILIKE $${pi}`); values.push(`%${economic_activity}%`); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть назву, регіон або вид діяльності для пошуку');
+
+    values.push(Math.min(Number(limit) || 50, 100));
+    const sql = `SELECT id, region, company_name, ownership_form, economic_activity,
+        debt_2018_01, debt_2019_01, debt_2019_02_25, debt_reason
+      FROM opendata_wage_debtors WHERE ${conditions.join(' AND ')}
+      ORDER BY company_name LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Боржників із зарплати не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_wage_debtors error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  // ─── Large Taxpayers ────────────────────────────────────────────────
+
+  private async searchLargeTaxpayers(args: Record<string, unknown>): Promise<ToolResult> {
+    const { edrpou, name, limit = 50 } = args as any;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (edrpou) { conditions.push(`edrpou = $${pi}`); values.push(edrpou); pi++; }
+    if (name) { conditions.push(`name ILIKE $${pi}`); values.push(`%${name}%`); pi++; }
+
+    if (conditions.length === 0) return this.wrapResponse('Вкажіть ЄДРПОУ або назву для пошуку');
+
+    values.push(Math.min(Number(limit) || 50, 100));
+    const sql = `SELECT id, edrpou, name
+      FROM opendata_large_taxpayers WHERE ${conditions.join(' AND ')}
+      ORDER BY name LIMIT $${pi}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) return this.wrapResponse('Великих платників податків не знайдено');
+      return this.wrapResponse(JSON.stringify(result.rows, null, 2));
+    } catch (error: any) {
+      logger.error('search_large_taxpayers error', { error: error.message });
       return this.wrapError(`Помилка пошуку: ${error.message}`);
     }
   }

--- a/mcp_backend/src/migrations/107_add_new_tool_pricing.sql
+++ b/mcp_backend/src/migrations/107_add_new_tool_pricing.sql
@@ -1,0 +1,17 @@
+-- Migration 107: Add pricing for new MCP tools
+-- 6 backend tools + 2 OpenReyestr tools
+
+INSERT INTO tool_pricing (tool_name, service, description, estimated_cost_usd, notes)
+VALUES
+  ('search_vrp_decisions',          'backend',     'Рішення ВРП',                          0.00300000, '16.5K рішень Вищої ради правосуддя'),
+  ('search_vrp_judges_discipline',  'backend',     'Дисциплінарна практика ВРП',            0.00300000, 'Звільнені, відсторонені судді, втручання'),
+  ('search_vkks',                   'backend',     'Дані ВККС',                             0.00300000, 'Судді, оцінювання, декларації, вакансії, ефективність'),
+  ('search_declaration_checks',     'backend',     'Перевірки декларацій',                   0.00300000, 'Результати перевірок НАЗК'),
+  ('search_wage_debtors',           'backend',     'Боржники із зарплати',                   0.00300000, 'Підприємства з заборгованістю по зарплаті'),
+  ('search_large_taxpayers',        'backend',     'Великі платники податків',                0.00100000, 'Реєстр великих платників податків'),
+  ('openreyestr_search_termination_started', 'openreyestr', 'Припинення юросіб',            0.00300000, '148K записів про початок припинення'),
+  ('openreyestr_search_rnbo_sanctions',      'openreyestr', 'Санкції РНБО',                 0.00300000, '21K записів санкційних списків РНБО')
+ON CONFLICT (tool_name) DO UPDATE SET
+  estimated_cost_usd = EXCLUDED.estimated_cost_usd,
+  description = EXCLUDED.description,
+  notes = EXCLUDED.notes;

--- a/mcp_openreyestr/src/api/mcp-openreyestr-api.ts
+++ b/mcp_openreyestr/src/api/mcp-openreyestr-api.ts
@@ -416,6 +416,64 @@ export class MCPOpenReyestrAPI {
         },
       },
       {
+        name: 'search_nazk_declarations',
+        description: `Пошук декларацій у реєстрі НАЗК (Національне агентство з питань запобігання корупції)
+
+💰 Примерная стоимость: $0.001-$0.005 USD
+322K декларацій. Пошук за ім'ям декларанта, місцем роботи, роком, типом, регіоном, доходом.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            declarant_name: { type: 'string', description: 'Ім\'я декларанта' },
+            declarant_workplace: { type: 'string', description: 'Місце роботи' },
+            declaration_year: { type: 'number', description: 'Рік декларації' },
+            declaration_type: { type: 'number', description: 'Тип: 1=щорічна, 2=перед звільненням, 3=після звільнення, 4=кандидата' },
+            declarant_region: { type: 'string', description: 'Регіон' },
+            min_income: { type: 'number', description: 'Мінімальний задекларований дохід (грн)' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1 },
+            offset: { type: 'number', default: 0 },
+          },
+        },
+      },
+      {
+        name: 'search_exchange_data',
+        description: `Пошук у реєстрі обміну даними з державними органами
+
+💰 Примерная стоимость: $0.001-$0.003 USD
+23.2M записів. Пошук за номером запису суб'єкта, типом (UO/FOP/FSU), типом платника.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            entity_record: { type: 'string', description: 'Номер запису суб\'єкта' },
+            entity_type: { type: 'string', enum: ['UO', 'FOP', 'FSU'], description: 'Тип суб\'єкта' },
+            tax_payer_type: { type: 'string', description: 'Тип платника' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1 },
+            offset: { type: 'number', default: 0 },
+          },
+        },
+      },
+      {
+        name: 'search_arma_seized_assets',
+        description: `Пошук у реєстрі АРМА — активи під арештом у кримінальних провадженнях (OpenReyestr)
+
+💰 Примерная стоимость: $0.001-$0.005 USD
+Пошук за власником, ЄДРПОУ, номером справи, типом активу, судом, статусом.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            owner_name: { type: 'string', description: 'Ім\'я / назва власника' },
+            owner_edrpou: { type: 'string', description: 'ЄДРПОУ власника' },
+            case_number: { type: 'string', description: 'Номер кримінального провадження' },
+            asset_type: { type: 'string', description: 'Тип активу' },
+            status: { type: 'string', description: 'Статус (arrested, transferred, returned)' },
+            court_name: { type: 'string', description: 'Назва суду' },
+            region: { type: 'string', description: 'Регіон' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1 },
+            offset: { type: 'number', default: 0 },
+          },
+        },
+      },
+      {
         name: 'search_prozorro',
         description: `Пошук тендерів у системі ProZorro (публічні закупівлі)
 
@@ -432,6 +490,44 @@ export class MCPOpenReyestrAPI {
             limit: { type: 'number', default: 50, maximum: 100, minimum: 1 },
             offset: { type: 'number', default: 0 },
           },
+        },
+      },
+      {
+        name: 'search_termination_started',
+        description: `Пошук юридичних осіб, щодо яких розпочато процедуру припинення
+
+💰 Примерная стоимость: $0.001-$0.003 USD
+Пошук за назвою/ЄДРПОУ, типом суб'єкта, підписантом або причиною припинення. 148K записів.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Назва або ЄДРПОУ суб\'єкта (пошук по entity_record)' },
+            entity_type: { type: 'string', description: 'Тип суб\'єкта' },
+            signer_name: { type: 'string', description: 'Ім\'я підписанта' },
+            reason: { type: 'string', description: 'Причина припинення' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1, description: 'Максимальна кількість результатів' },
+            offset: { type: 'number', default: 0, description: 'Зміщення для пагінації' },
+          },
+          required: ['query'],
+        },
+      },
+      {
+        name: 'search_rnbo_sanctions',
+        description: `Пошук у санкційних списках РНБО України
+
+💰 Примерная стоимость: $0.001-$0.003 USD
+Пошук санкціонованих осіб/компаній за ім'ям, псевдонімами, ідентифікаторами, типом або країною. 21K записів.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Ім\'я або псевдонім особи/компанії' },
+            schema_type: { type: 'string', description: 'Тип запису (Person, Company тощо)' },
+            country: { type: 'string', description: 'Країна' },
+            identifier: { type: 'string', description: 'Ідентифікатор (ІПН, ЄДРПОУ, паспорт тощо)' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1, description: 'Максимальна кількість результатів' },
+            offset: { type: 'number', default: 0, description: 'Зміщення для пагінації' },
+          },
+          required: ['query'],
         },
       },
     ];
@@ -507,8 +603,23 @@ export class MCPOpenReyestrAPI {
         case 'search_esv_debt':
           result = await this.tools.searchEsvDebt(args);
           break;
+        case 'search_nazk_declarations':
+          result = await this.tools.searchNazkDeclarations(args);
+          break;
+        case 'search_exchange_data':
+          result = await this.tools.searchExchangeData(args);
+          break;
+        case 'search_arma_seized_assets':
+          result = await this.tools.searchArmaSeizedAssets(args);
+          break;
         case 'search_prozorro':
           result = await this.tools.searchProzorro(args);
+          break;
+        case 'search_termination_started':
+          result = await this.tools.searchTerminationStarted(args);
+          break;
+        case 'search_rnbo_sanctions':
+          result = await this.tools.searchRnboSanctions(args);
           break;
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/mcp_openreyestr/src/api/openreyestr-tools.ts
+++ b/mcp_openreyestr/src/api/openreyestr-tools.ts
@@ -1194,6 +1194,222 @@ export class OpenReyestrTools {
     return result.rows;
   }
 
+  /**
+   * Search NAZK declarations (anti-corruption declarations)
+   */
+  async searchNazkDeclarations(params: { declarant_name?: string; declarant_workplace?: string; declaration_year?: number; declaration_type?: number; declarant_region?: string; min_income?: number; limit?: number; offset?: number }): Promise<any[]> {
+    const { declarant_name, declarant_workplace, declaration_year, declaration_type, declarant_region, min_income, limit = 50, offset = 0 } = params;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (declarant_name) { conditions.push(`declarant_name ILIKE $${paramIndex}`); values.push(`%${declarant_name}%`); paramIndex++; }
+    if (declarant_workplace) { conditions.push(`declarant_workplace ILIKE $${paramIndex}`); values.push(`%${declarant_workplace}%`); paramIndex++; }
+    if (declaration_year) { conditions.push(`declaration_year = $${paramIndex}`); values.push(declaration_year); paramIndex++; }
+    if (declaration_type) { conditions.push(`declaration_type = $${paramIndex}`); values.push(declaration_type); paramIndex++; }
+    if (declarant_region) { conditions.push(`declarant_region ILIKE $${paramIndex}`); values.push(`%${declarant_region}%`); paramIndex++; }
+    if (min_income) { conditions.push(`total_income_declared >= $${paramIndex}`); values.push(min_income); paramIndex++; }
+
+    if (conditions.length === 0) {
+      return [{ found: false, message: 'Вкажіть ім\'я декларанта, місце роботи або рік для пошуку' }];
+    }
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    values.push(limit, offset);
+
+    const result = await this.pool.query(
+      `SELECT declaration_id, declarant_name, declarant_position, declarant_workplace,
+        declarant_region, declaration_year, declaration_type, post_type, post_category,
+        corruption_affected, submission_date, has_real_estate, has_vehicles,
+        has_securities, has_corporate_rights, has_income, total_income_declared
+      FROM nazk_declarations ${whereClause}
+      ORDER BY declaration_year DESC, submission_date DESC NULLS LAST
+      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query: declarant_name || declarant_workplace || '', message: 'Декларацій не знайдено' }];
+    }
+    return result.rows;
+  }
+
+  /**
+   * Search exchange data (government agency data exchanges)
+   */
+  async searchExchangeData(params: { entity_record?: string; entity_type?: string; tax_payer_type?: string; limit?: number; offset?: number }): Promise<any[]> {
+    const { entity_record, entity_type, tax_payer_type, limit = 50, offset = 0 } = params;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (entity_record) { conditions.push(`entity_record = $${paramIndex}`); values.push(entity_record); paramIndex++; }
+    if (entity_type) { conditions.push(`entity_type = $${paramIndex}`); values.push(entity_type); paramIndex++; }
+    if (tax_payer_type) { conditions.push(`tax_payer_type ILIKE $${paramIndex}`); values.push(`%${tax_payer_type}%`); paramIndex++; }
+
+    if (conditions.length === 0) {
+      return [{ found: false, message: 'Вкажіть номер запису або тип суб\'єкта для пошуку' }];
+    }
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    values.push(limit, offset);
+
+    const result = await this.pool.query(
+      `SELECT entity_type, entity_record, tax_payer_type, start_date, start_num, end_date, end_num
+      FROM exchange_data ${whereClause}
+      ORDER BY start_date DESC NULLS LAST
+      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query: entity_record || '', message: 'Записів обміну даними не знайдено' }];
+    }
+    return result.rows;
+  }
+
+  /**
+   * Search ARMA seized assets registry
+   */
+  async searchArmaSeizedAssets(params: { owner_name?: string; owner_edrpou?: string; case_number?: string; asset_type?: string; status?: string; court_name?: string; region?: string; limit?: number; offset?: number }): Promise<any[]> {
+    const { owner_name, owner_edrpou, case_number, asset_type, status, court_name, region, limit = 50, offset = 0 } = params;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (owner_name) { conditions.push(`owner_name ILIKE $${paramIndex}`); values.push(`%${owner_name}%`); paramIndex++; }
+    if (owner_edrpou) { conditions.push(`owner_edrpou = $${paramIndex}`); values.push(owner_edrpou); paramIndex++; }
+    if (case_number) { conditions.push(`case_number = $${paramIndex}`); values.push(case_number); paramIndex++; }
+    if (asset_type) { conditions.push(`asset_type ILIKE $${paramIndex}`); values.push(`%${asset_type}%`); paramIndex++; }
+    if (status) { conditions.push(`status ILIKE $${paramIndex}`); values.push(`%${status}%`); paramIndex++; }
+    if (court_name) { conditions.push(`court_name ILIKE $${paramIndex}`); values.push(`%${court_name}%`); paramIndex++; }
+    if (region) { conditions.push(`region ILIKE $${paramIndex}`); values.push(`%${region}%`); paramIndex++; }
+
+    if (conditions.length === 0) {
+      return [{ found: false, message: 'Вкажіть власника, ЄДРПОУ або номер справи для пошуку' }];
+    }
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    values.push(limit, offset);
+
+    const result = await this.pool.query(
+      `SELECT case_number, case_date, court_name, asset_type, asset_description,
+        owner_name, owner_type, owner_edrpou, region, status,
+        arrest_date, transfer_date, manager
+      FROM arma_assets ${whereClause}
+      ORDER BY arrest_date DESC NULLS LAST
+      LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query: owner_name || owner_edrpou || '', message: 'Арештованих активів не знайдено' }];
+    }
+    return result.rows;
+  }
+
+  /**
+   * Search for entities with termination started
+   */
+  async searchTerminationStarted(params: { query: string; entity_type?: string; signer_name?: string; reason?: string; limit?: number; offset?: number }): Promise<any[]> {
+    const { query, entity_type, signer_name, reason, limit = 50, offset = 0 } = params;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (query) {
+      conditions.push(`entity_record ILIKE $${paramIndex}`);
+      values.push(`%${query}%`);
+      paramIndex++;
+    }
+    if (entity_type) {
+      conditions.push(`entity_type = $${paramIndex}`);
+      values.push(entity_type);
+      paramIndex++;
+    }
+    if (signer_name) {
+      conditions.push(`signer_name ILIKE $${paramIndex}`);
+      values.push(`%${signer_name}%`);
+      paramIndex++;
+    }
+    if (reason) {
+      conditions.push(`reason ILIKE $${paramIndex}`);
+      values.push(`%${reason}%`);
+      paramIndex++;
+    }
+
+    if (conditions.length === 0) {
+      return [{ found: false, message: 'Вкажіть параметри пошуку' }];
+    }
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    values.push(limit, offset);
+
+    const result = await this.pool.query(
+      `SELECT id, entity_type, entity_record, op_date, reason, sbj_state, signer_name, creditor_req_end_date, created_at
+       FROM termination_started ${whereClause}
+       ORDER BY id DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query, message: 'Записів про припинення не знайдено' }];
+    }
+    return result.rows;
+  }
+
+  /**
+   * Search RNBO sanctions lists
+   */
+  async searchRnboSanctions(params: { query: string; schema_type?: string; country?: string; identifier?: string; limit?: number; offset?: number }): Promise<any[]> {
+    const { query, schema_type, country, identifier, limit = 50, offset = 0 } = params;
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let paramIndex = 1;
+
+    if (query) {
+      conditions.push(`(name ILIKE $${paramIndex} OR aliases ILIKE $${paramIndex})`);
+      values.push(`%${query}%`);
+      paramIndex++;
+    }
+    if (schema_type) {
+      conditions.push(`schema_type = $${paramIndex}`);
+      values.push(schema_type);
+      paramIndex++;
+    }
+    if (country) {
+      conditions.push(`countries ILIKE $${paramIndex}`);
+      values.push(`%${country}%`);
+      paramIndex++;
+    }
+    if (identifier) {
+      conditions.push(`identifiers ILIKE $${paramIndex}`);
+      values.push(`%${identifier}%`);
+      paramIndex++;
+    }
+
+    if (conditions.length === 0) {
+      return [{ found: false, message: 'Вкажіть параметри пошуку' }];
+    }
+
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+    values.push(limit, offset);
+
+    const result = await this.pool.query(
+      `SELECT id, entity_id, schema_type, name, aliases, birth_date, countries, addresses, identifiers, sanctions, phones, emails, program_ids, dataset, first_seen, last_seen, last_change
+       FROM rnbo_sanctions ${whereClause}
+       ORDER BY last_change DESC NULLS LAST, id DESC
+       LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query, message: 'Санкціонованих осіб не знайдено' }];
+    }
+    return result.rows;
+  }
+
   private async findEntityType(record: string): Promise<'UO' | 'FOP' | 'FSU' | null> {
     const uoResult = await this.pool.query(
       'SELECT 1 FROM legal_entities WHERE record = $1',
@@ -1267,6 +1483,24 @@ export const SearchTaxDebtSchema = z.object({
 export const SearchEsvDebtSchema = z.object({
   query: z.string().optional(),
   tin: z.string().optional(),
+  limit: z.number().min(1).max(100).optional(),
+  offset: z.number().min(0).optional(),
+});
+
+export const SearchTerminationStartedSchema = z.object({
+  query: z.string(),
+  entity_type: z.string().optional(),
+  signer_name: z.string().optional(),
+  reason: z.string().optional(),
+  limit: z.number().min(1).max(100).optional(),
+  offset: z.number().min(0).optional(),
+});
+
+export const SearchRnboSanctionsSchema = z.object({
+  query: z.string(),
+  schema_type: z.string().optional(),
+  country: z.string().optional(),
+  identifier: z.string().optional(),
   limit: z.number().min(1).max(100).optional(),
   offset: z.number().min(0).optional(),
 });


### PR DESCRIPTION
## Summary

### Backend (6 new tools)
| Tool | Table | Records | Description |
|------|-------|---------|-------------|
| `search_vrp_decisions` | vrp_decisions | 16.5K | Рішення Вищої ради правосуддя |
| `search_vrp_judges_discipline` | vrp_dismissed/suspended/interference | 738 | Звільнені, відсторонені судді та втручання (3 таблиці) |
| `search_vkks` | vkks_* | 24.6K | ВККС: судді, оцінювання, декларації, вакансії, ефективність (5 категорій) |
| `search_declaration_checks` | opendata_declaration_checks | 2K | Перевірки декларацій НАЗК |
| `search_wage_debtors` | opendata_wage_debtors | 1.3K | Боржники із зарплати |
| `search_large_taxpayers` | opendata_large_taxpayers | 1.3K | Великі платники податків |

### OpenReyestr (2 new tools)
| Tool | Table | Records | Description |
|------|-------|---------|-------------|
| `search_termination_started` | termination_started | 148K | Юрособи, щодо яких розпочато припинення |
| `search_rnbo_sanctions` | rnbo_sanctions | 21K | Санкційні списки РНБО |

### Also included
- Pricing migration (107) for all 8 tools
- Unified gateway routing for 2 new OpenReyestr tools

## Test plan
- [ ] Backend builds (`npx tsc --noEmit` ✅)
- [ ] OpenReyestr builds (`npx tsc --noEmit` ✅)
- [ ] Deploy and test each tool via `/api/tools/:toolName`
- [ ] Verify unified gateway proxies OpenReyestr tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 8 new MCP search tools for open data registries across `mcp_backend` and `mcp_openreyestr`, plus pricing and gateway routing updates. This expands coverage of justice, compliance, and company registries.

- **New Features**
  - Backend (`mcp_backend`): 6 tools — `search_vrp_decisions`, `search_vrp_judges_discipline`, `search_vkks` (judges/evaluations/declarations/vacancies/efficiency), `search_declaration_checks`, `search_wage_debtors`, `search_large_taxpayers`.
  - OpenReyestr (`mcp_openreyestr`): 2 tools — `search_termination_started` (148K), `search_rnbo_sanctions` (21K).

- **Migration**
  - Added pricing migration `107` for all 8 tools.
  - Registered unified gateway routing for `openreyestr_search_termination_started` and `openreyestr_search_rnbo_sanctions` in the Tool Registry.

<sup>Written for commit def2c79c54e85282e6df7a9e8ec1cf3b34572cd8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

