### PR TITLE
fix(deploy): add preview nginx volume mounts

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -847,6 +847,8 @@ services:
       - ./nginx/includes/ssl-common.conf:/etc/nginx/includes/ssl-common.conf:ro
       - ./nginx/includes/prod-server-common.conf:/etc/nginx/includes/prod-server-common.conf:ro
       - ./nginx/includes/prod-upstreams.conf:/etc/nginx/includes/prod-upstreams.conf
+      - ./nginx/includes/preview-server-common.conf:/etc/nginx/includes/preview-server-common.conf:ro
+      - ./nginx/includes/preview-upstreams.conf:/etc/nginx/includes/preview-upstreams.conf
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - /var/www/html:/var/www/html:ro
       - nginx_prod_logs:/var/log/nginx


### PR DESCRIPTION
## Summary
- Nginx was crash-looping because `preview-upstreams.conf` and `preview-server-common.conf` were referenced in the nginx config but not bind-mounted into the container
- Added missing volume mounts to `docker-compose.prod.yml`

## Urgency
**Critical** — nginx on prod is currently in restart loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Nginx crash loop in prod by bind-mounting missing preview config files. Adds two volume mounts in `deployment/docker-compose.prod.yml` so included files exist at runtime.

- **Bug Fixes**
  - Mount `./nginx/includes/preview-server-common.conf` to `/etc/nginx/includes/preview-server-common.conf:ro`
  - Mount `./nginx/includes/preview-upstreams.conf` to `/etc/nginx/includes/preview-upstreams.conf`

<sup>Written for commit 3b2e8d57edf9a26e25994268c7d0b7460a61e766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

