### PR TITLE
fix(vault): add DEFAULT_VAULT_USER_ID fallback for API key auth

### DIFF
--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -406,7 +406,8 @@ export function createMCPSSERoutes(deps: {
               // Route to appropriate tool handler via centralized registry
               // Inject userId for all vault tools (user isolation)
               const VAULT_TOOLS = new Set(['store_document', 'get_document', 'list_documents', 'semantic_search', 'list_folders', 'delete_document', 'update_document']);
-              const toolArgs = VAULT_TOOLS.has(toolName) ? { ...args, userId } : args;
+              const vaultUserId = userId || process.env.DEFAULT_VAULT_USER_ID;
+              const toolArgs = VAULT_TOOLS.has(toolName) ? { ...args, userId: vaultUserId } : args;
               const registryResult = await deps.toolRegistry.executeTool(toolName, toolArgs);
               if (registryResult) {
                 return registryResult;

--- a/mcp_backend/src/routes/tool-execution-routes.ts
+++ b/mcp_backend/src/routes/tool-execution-routes.ts
@@ -472,7 +472,8 @@ export function createToolExecutionRoutes(deps: {
           { requestId, task: toolName },
           async () => {
             const VAULT_TOOLS = new Set(['store_document', 'get_document', 'list_documents', 'semantic_search', 'list_folders', 'delete_document', 'update_document']);
-            const httpToolArgs = VAULT_TOOLS.has(toolName) ? { ...args, userId: req.user?.id } : args;
+            const vaultUserId = req.user?.id || process.env.DEFAULT_VAULT_USER_ID;
+            const httpToolArgs = VAULT_TOOLS.has(toolName) ? { ...args, userId: vaultUserId } : args;
             return await deps.toolRegistry.executeTool(toolName, httpToolArgs);
           }
         );


### PR DESCRIPTION
## Summary
- Legacy API keys don't carry user context, so vault tools (list_documents, store_document, etc.) returned empty results
- Added `DEFAULT_VAULT_USER_ID` env var fallback in both HTTP and SSE routes
- On prod set to `advocat@legal.org.ua` (7be91480-b8f9-449e-b025-493e8dd95c64)

## Test plan
- [x] Verified vault tools return empty via MCP with legacy API key
- [ ] After deploy: `list_documents` via MCP should return advocat's 564 documents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty vault results for legacy API keys by falling back to a default vault user. MCP clients using API keys can now access the configured user's documents.

- **Bug Fixes**
  - If no user context, set `userId` from `DEFAULT_VAULT_USER_ID` in SSE and HTTP routes.
  - Applies to vault tools: store_document, get_document, list_documents, semantic_search, list_folders, delete_document, update_document.
  - No change for requests with an authenticated user.

<sup>Written for commit 35015e7d3178f1bfb2051a00c249fbdb2c941d02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

