### PR TITLE
fix(ui): use white logo on dark backgrounds

### DIFF
--- a/lexwebapp/src/pages/InvestorDeckPage.tsx
+++ b/lexwebapp/src/pages/InvestorDeckPage.tsx
@@ -103,7 +103,7 @@ export function InvestorDeckPage() {
       <Slide dark>
         <div className="text-center">
           <FadeIn>
-            <img src="/Image.jpg" alt="LEX" className="h-20 md:h-28 w-auto mx-auto mb-8 brightness-0 invert" />
+            <img src="/logo-white.png" alt="LEX" className="h-20 md:h-28 w-auto mx-auto mb-8" />
           </FadeIn>
           <FadeIn delay={0.15}>
             <h1 className="text-5xl md:text-7xl font-serif font-bold tracking-tight mb-6">

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -574,7 +574,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
 
           {/* Logo */}
           <div>
-            <img src="/Image.jpg" alt="SecondLayer" className="h-9 w-auto opacity-90" />
+            <img src="/logo-white.png" alt="SecondLayer" className="h-9 w-auto opacity-90" />
           </div>
 
           {/* Value proposition */}
@@ -682,7 +682,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
 
         {/* Mobile logo */}
         <div className="lg:hidden mb-10 self-start relative z-10">
-          <img src="/Image.jpg" alt="SecondLayer" className="h-8 w-auto opacity-90" />
+          <img src="/logo-white.png" alt="SecondLayer" className="h-8 w-auto opacity-90" />
         </div>
 
         <motion.div


### PR DESCRIPTION
## Summary
- LoginPage (desktop + mobile): `Image.jpg` → `logo-white.png` on dark `#080808` background
- InvestorDeckPage dark slide: `Image.jpg` → `logo-white.png`, removed `brightness-0 invert` CSS hack
- All light background pages keep `Image.jpg` unchanged

## Test plan
- [ ] Login page shows white logo on dark background
- [ ] Investor deck dark slide shows white logo without CSS filter
- [ ] Light pages (blog, news, investor letter, etc.) still show dark logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the logo to white on dark backgrounds to improve contrast and readability. Replaced the CSS filter hack with the correct asset; light pages are unchanged.

- **Bug Fixes**
  - LoginPage (desktop and mobile): use `logo-white.png` on `#080808` background.
  - InvestorDeckPage dark slide: use `logo-white.png`; remove `brightness-0 invert`.
  - Light pages: continue using `Image.jpg`.

<sup>Written for commit 2409359641eae82f6f055ea452deed52fcba1ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

