### PR TITLE
fix(tests): add JWT_SECRET to test env, fix balance-check test

### DIFF
--- a/mcp_backend/jest.setup.js
+++ b/mcp_backend/jest.setup.js
@@ -2,6 +2,11 @@
 // Load environment variables
 require('dotenv').config();
 
+// Provide test-only JWT secret (required by auth modules at import time)
+if (!process.env.JWT_SECRET) {
+  process.env.JWT_SECRET = 'test-jwt-secret-do-not-use-in-production';
+}
+
 // Ensure console output is not buffered
 if (typeof process.stdout.setEncoding === 'function') process.stdout.setEncoding('utf8');
 if (typeof process.stderr.setEncoding === 'function') process.stderr.setEncoding('utf8');

--- a/mcp_backend/src/middleware/__tests__/balance-check.test.ts
+++ b/mcp_backend/src/middleware/__tests__/balance-check.test.ts
@@ -212,7 +212,7 @@ describe('createBalanceCheckMiddleware', () => {
     const freeTools = [
       'list_documents', 'get_document', 'get_document_sections',
       'list_conversations', 'get_conversation',
-      'get_legislation_structure', 'get_legislation_article',
+      'get_legislation_structure',
       'get_legislation_articles', 'get_legislation_section',
     ];
 


### PR DESCRIPTION
## Summary

- Fixes CI/CD failure caused by security hardening in #1224
- `jest.setup.js`: provides test-only `JWT_SECRET` so auth modules can import without throwing
- `balance-check.test.ts`: removes `get_legislation_article` from expected free tools list to match actual `FREE_TOOLS` set

## Test plan
- [x] All 15 test suites pass locally (326/326 tests)
- [ ] CI/CD pipeline passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)