### PR TITLE
fix(tests): tool name mismatch in LegalCodesLibraryPage test

### DIFF
--- a/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
@@ -413,7 +413,7 @@ describe('LegalCodesLibraryPage', () => {
       );
       await user.click(articleBtns[0]);
 
-      expect(mockCallTool).toHaveBeenCalledWith('get_legislation_article', {
+      expect(mockCallTool).toHaveBeenCalledWith('get_legislation_section', {
         rada_id: '435-15',
         article_number: '1',
       });
@@ -470,7 +470,7 @@ describe('LegalCodesLibraryPage', () => {
         expect(screen.getByText('ЗМІСТ')).toBeInTheDocument();
       });
 
-      // Second call: get_legislation_article
+      // Second call: get_legislation_section
       mockCallTool.mockResolvedValueOnce(
         makeToolResult({
           rada_id: '435-15',


### PR DESCRIPTION
## Summary
- Fix pre-existing test failure: `get_legislation_article` was renamed to `get_legislation_section` but test wasn't updated

## Test plan
- [x] `CI=1 npx vitest run LegalCodesLibraryPage.test.tsx` — 28 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)