### PR TITLE
fix(ui): code blocks visibility in LexNews and chat

### DIFF
--- a/lexwebapp/src/components/message/MarkdownContent.tsx
+++ b/lexwebapp/src/components/message/MarkdownContent.tsx
@@ -143,6 +143,8 @@ export const MarkdownContent = React.memo(function MarkdownContent({ content, is
       prose-headings:font-sans prose-headings:text-claude-text prose-headings:tracking-tight
       prose-p:leading-[1.72] prose-p:my-2
       prose-code:before:content-none prose-code:after:content-none
+      prose-pre:bg-gray-900 prose-pre:rounded-xl prose-pre:text-gray-100
+      [&_pre_code]:text-gray-100 [&_pre_code]:bg-transparent [&_pre_code]:p-0
       prose-a:text-claude-text prose-a:underline prose-a:decoration-claude-subtext/30 hover:prose-a:decoration-claude-text
       prose-strong:text-claude-text prose-strong:font-semibold
     ">

--- a/lexwebapp/src/pages/LexNewsPage/index.tsx
+++ b/lexwebapp/src/pages/LexNewsPage/index.tsx
@@ -118,7 +118,9 @@ function ArticleModal({ article, onClose }: { article: NewsArticle; onClose: () 
             prose-p:text-claude-text prose-p:font-sans prose-p:leading-relaxed
             prose-li:text-claude-text prose-li:font-sans
             prose-strong:text-claude-text
-            prose-code:text-claude-accent prose-code:bg-claude-accent/5 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm
+            prose-code:text-claude-accent prose-code:bg-claude-accent/5 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none
+            prose-pre:bg-gray-900 prose-pre:rounded-xl prose-pre:text-gray-100
+            [&_pre_code]:text-gray-100 [&_pre_code]:bg-transparent [&_pre_code]:p-0
             prose-blockquote:border-claude-accent prose-blockquote:bg-claude-accent/5 prose-blockquote:rounded-r-xl
             prose-a:text-claude-accent prose-a:no-underline hover:prose-a:underline
             prose-table:font-sans


### PR DESCRIPTION
## Summary
- Fix dark-on-dark text in code blocks for LexNewsPage and chat MarkdownContent
- Same pattern as #1231 (ArticleModal fix): `prose-pre:text-gray-100` + `[&_pre_code]` overrides

## Test plan
- [ ] LexNews articles with code — text visible on dark bg
- [ ] Chat messages with code blocks — text visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)