### PR TITLE
fix(chat): prevent UI freeze when backend stream ends without answer

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -321,6 +321,19 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             costSummary: costSummaryRef.current as CostSummary,
           });
         },
+
+        onStreamEnd: () => {
+          // Safety net: if the stream ended without an 'answer' event
+          // (e.g. backend timeout, abort, or crash), reset the UI streaming state
+          // so the chat input is not permanently disabled.
+          if (useChatStore.getState().isStreaming) {
+            console.warn('[AIChat] Stream ended without answer event — resetting streaming state');
+            updateMessage(assistantMessageId, { isStreaming: false });
+            setStreaming(false);
+            setStreamController(null);
+            setCurrentTool(null);
+          }
+        },
       }, 'standard', chatConversationId, approvedPlan, planSessionId, allowDeepEscalation);
 
       setStreamController(controller);

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -40,6 +40,8 @@ export interface ChatStreamCallbacks {
   onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
   onBudgetEscalated?: (data: { reason: string; estimatedCost: { minUsd: number; maxUsd: number }; requiresConfirmation?: boolean }) => void;
   onError?: (data: { message?: string; code?: string; current_balance_usd?: number }) => void;
+  /** Called when the SSE stream ends (reader done), regardless of whether an answer was received */
+  onStreamEnd?: () => void;
 }
 
 export class MCPService extends BaseService {
@@ -213,6 +215,10 @@ export class MCPService extends BaseService {
           if (!isAbortError(err)) {
             callbacks.onError?.({ message: getErrorMessage(err) });
           }
+        } finally {
+          // Always notify that the stream has ended so the UI can reset streaming state,
+          // even if the stream ended without an 'answer' event (e.g. backend timeout/abort)
+          callbacks.onStreamEnd?.();
         }
       };
 

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -168,6 +168,14 @@ export function createChatInlineRoutes(deps: {
           res.write(`event: ${event.type}\n`);
           res.write(`data: ${JSON.stringify(event.data)}\n\n`);
         }
+
+        // If aborted (timeout) and no answer was sent, emit an error event
+        // so the frontend knows to reset streaming state
+        if (abortController.signal.aborted && !chatCompleted && !res.writableEnded) {
+          logger.warn('[ChatService] Sending timeout error to client', { requestId });
+          res.write(`event: error\n`);
+          res.write(`data: ${JSON.stringify({ message: 'Час очікування вичерпано. Спробуйте уточнити запит.' })}\n\n`);
+        }
       } finally {
         clearTimeout(requestTimeout);
         clearInterval(heartbeat);

--- a/packages/shared/src/database/base-database.ts
+++ b/packages/shared/src/database/base-database.ts
@@ -11,6 +11,8 @@ export interface DatabaseConfig {
   max?: number;
   idleTimeoutMillis?: number;
   connectionTimeoutMillis?: number;
+  /** PostgreSQL statement_timeout in ms (default: 60000). Prevents indefinite slow queries. */
+  statementTimeoutMs?: number;
 }
 
 /**
@@ -44,10 +46,12 @@ export class BaseDatabase {
       connectionTimeoutMillis: config.connectionTimeoutMillis ?? 2000,
     };
 
-    if (config.schema) {
-      const safeSchema = sanitizeIdentifier(config.schema);
-      poolConfig.options = `-c search_path=${safeSchema},public`;
-    }
+    // Prevent indefinite slow queries (e.g. full table scans on large tables)
+    const statementTimeout = config.statementTimeoutMs ?? 60000;
+    const searchPathOption = config.schema
+      ? `-c search_path=${sanitizeIdentifier(config.schema)},public`
+      : '';
+    poolConfig.options = `${searchPathOption} -c statement_timeout=${statementTimeout}`.trim();
 
     this.pool = new Pool(poolConfig);
 


### PR DESCRIPTION
## Summary
- **Frontend**: added `onStreamEnd` callback that resets `isStreaming` when SSE stream closes without an `answer` event — prevents permanent chat input freeze
- **Backend**: emit `error` event to client on request timeout/abort so the UI shows "Час очікування вичерпано"
- **Database**: added `statement_timeout=60s` to PostgreSQL pool config to kill runaway queries on large tables (e.g. 96M+ row `edrsr_fulltext`)

## Root cause
When a slow query (like searching court decisions by "ТОВ «Нова Пошта»") causes the 90s backend timeout, `Promise.allSettled` blocks until queries finish, the abort fires, no `answer` event is yielded, and `isStreaming` stays `true` forever → chat frozen.

## Test plan
- [ ] Send "Знайди судові рішення де відповідач ТОВ «Нова Пошта»" — chat should not freeze
- [ ] Verify normal queries still work end-to-end
- [ ] Verify timeout shows error message instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)