### PR TITLE
feat(session-replay): rrweb recording + admin replay dashboard

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -42,6 +42,8 @@
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
+    "rrweb": "^2.0.0-alpha.4",
+    "rrweb-player": "^1.0.0-alpha.4",
     "tweetnacl": "^1.0.3",
     "zustand": "^5.0.11"
   },

--- a/lexwebapp/src/components/sidebar/nav-config.ts
+++ b/lexwebapp/src/components/sidebar/nav-config.ts
@@ -3,7 +3,7 @@ import {
   BarChart3, Newspaper,
   Clock, FileText, Search, Activity, Database, Users, DollarSign,
   Server, Boxes, Globe, CreditCard, Settings, Terminal, Tag, Zap,
-  Layers, HardDrive, Gauge, Code,
+  Layers, HardDrive, Gauge, Code, Video,
 } from 'lucide-react';
 import { ROUTES } from '../../router/routes';
 import { appT } from '../../i18n/app-i18n';
@@ -66,6 +66,7 @@ export const getMonitoringSections = () => [
   { id: 'bulk-scrape', label: appT('nav.bulkScrape'), icon: Database, route: ROUTES.ADMIN_BULK_SCRAPE },
   { id: 'pg-monitoring', label: appT('nav.pgMonitoring'), icon: HardDrive, route: ROUTES.ADMIN_PG_MONITORING },
   { id: 'limits', label: appT('nav.limits'), icon: Gauge, route: ROUTES.ADMIN_LIMITS },
+  { id: 'session-replay', label: 'Запис сесій', icon: Video, route: ROUTES.ADMIN_SESSION_REPLAY },
 ];
 
 // Legacy static exports for backward compatibility

--- a/lexwebapp/src/hooks/useSessionRecorder.ts
+++ b/lexwebapp/src/hooks/useSessionRecorder.ts
@@ -1,0 +1,185 @@
+/**
+ * rrweb Session Recorder
+ * Records DOM mutations, mouse movements, clicks, scrolls.
+ * Sends event chunks to backend every 10 seconds.
+ * Injects X-Session-Id header into all API requests for server-side log correlation.
+ */
+
+import { useEffect, useRef } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { sessionReplayApi } from '../utils/api/session-replay';
+import apiClient from '../utils/api/client';
+
+// Module-level session ID (survives re-renders, accessible outside React)
+let activeSessionId: string | null = null;
+
+export function getActiveSessionId(): string | null {
+  return activeSessionId;
+}
+
+const FLUSH_INTERVAL_MS = 10_000; // 10 seconds
+const MAX_BUFFER_SIZE = 500; // flush early if buffer gets large
+
+export function useSessionRecorder() {
+  const { user, isAuthenticated } = useAuth();
+  const stopRef = useRef<(() => void) | null>(null);
+  const bufferRef = useRef<any[]>([]);
+  const chunkIndexRef = useRef(0);
+  const flushTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const interceptorIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !user) return;
+
+    const sessionId = crypto.randomUUID();
+    sessionIdRef.current = sessionId;
+    activeSessionId = sessionId;
+
+    const viewport = `${window.innerWidth}x${window.innerHeight}`;
+
+    // Register session on backend
+    sessionReplayApi.createSession(sessionId, viewport).catch(() => {
+      // Non-critical — recording still works locally, chunks will create session on first store
+    });
+
+    // Add X-Session-Id header to all API requests
+    const interceptorId = apiClient.interceptors.request.use((config) => {
+      if (activeSessionId) {
+        config.headers['X-Session-Id'] = activeSessionId;
+      }
+      return config;
+    });
+    interceptorIdRef.current = interceptorId;
+
+    // Dynamically import rrweb to avoid blocking initial load
+    let mounted = true;
+    import('rrweb').then(({ record }) => {
+      if (!mounted) return;
+
+      const stop = record!({
+        emit: (event) => {
+          bufferRef.current.push(event);
+
+          // Flush early if buffer is large
+          if (bufferRef.current.length >= MAX_BUFFER_SIZE) {
+            flushBuffer(sessionId);
+          }
+        },
+        // Record mouse movements for cursor replay
+        sampling: {
+          mousemove: true,
+          mouseInteraction: true,
+          scroll: 150, // ms throttle for scroll events
+          input: 'last', // capture last input value
+        },
+        // Mask sensitive inputs (passwords, etc.)
+        maskInputOptions: {
+          password: true,
+        },
+        // Record canvas content
+        recordCanvas: false,
+        // Collect fonts for accurate replay
+        collectFonts: true,
+      });
+
+      stopRef.current = stop ?? null;
+    });
+
+    // Periodic flush
+    flushTimerRef.current = setInterval(() => {
+      flushBuffer(sessionId);
+    }, FLUSH_INTERVAL_MS);
+
+    // Cleanup on unmount / logout
+    return () => {
+      mounted = false;
+
+      // Stop rrweb recording
+      if (stopRef.current) {
+        stopRef.current();
+        stopRef.current = null;
+      }
+
+      // Clear flush timer
+      if (flushTimerRef.current) {
+        clearInterval(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+
+      // Remove axios interceptor
+      if (interceptorIdRef.current !== null) {
+        apiClient.interceptors.request.eject(interceptorIdRef.current);
+        interceptorIdRef.current = null;
+      }
+
+      // Final flush + end session
+      if (sessionIdRef.current) {
+        flushBuffer(sessionIdRef.current);
+        sessionReplayApi.endSession(sessionIdRef.current).catch(() => {});
+      }
+
+      activeSessionId = null;
+      sessionIdRef.current = null;
+    };
+  }, [isAuthenticated, user?.id]); // re-init on login/logout
+
+  function flushBuffer(sessionId: string) {
+    if (bufferRef.current.length === 0) return;
+
+    const events = [...bufferRef.current];
+    bufferRef.current = [];
+    const chunkIndex = chunkIndexRef.current++;
+
+    // Fire-and-forget — don't block UI on network errors
+    sessionReplayApi.sendChunk(sessionId, chunkIndex, events).catch((err) => {
+      console.warn('[SessionRecorder] Failed to send chunk', chunkIndex, err);
+      // Put events back in buffer for retry on next flush
+      bufferRef.current.unshift(...events);
+      chunkIndexRef.current--; // reuse chunk index
+    });
+  }
+
+  // Also flush on page unload (best-effort with sendBeacon)
+  useEffect(() => {
+    const handleUnload = () => {
+      if (!sessionIdRef.current || bufferRef.current.length === 0) return;
+
+      const events = bufferRef.current;
+      const chunkIndex = chunkIndexRef.current;
+      const payload = JSON.stringify({
+        chunkIndex,
+        events,
+      });
+
+      // sendBeacon is reliable for unload scenarios
+      const url = `${apiClient.defaults.baseURL}/api/session-replay/sessions/${sessionIdRef.current}/chunks`;
+      const token = localStorage.getItem('auth_token');
+      const blob = new Blob([payload], { type: 'application/json' });
+
+      // sendBeacon can't set custom headers, so we use fetch with keepalive
+      fetch(url, {
+        method: 'POST',
+        body: blob,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        keepalive: true,
+      }).catch(() => {});
+
+      // Also try to end session
+      fetch(`${apiClient.defaults.baseURL}/api/session-replay/sessions/${sessionIdRef.current}/end`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        keepalive: true,
+      }).catch(() => {});
+    };
+
+    window.addEventListener('beforeunload', handleUnload);
+    return () => window.removeEventListener('beforeunload', handleUnload);
+  }, []);
+}

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -17,6 +17,7 @@ import { ROUTES } from '../router/routes';
 import { consultationService } from '../services/api/ConsultationService';
 import showToast from '../utils/toast';
 import { toastTDynamic } from '../i18n/toast-i18n';
+import { useSessionRecorder } from '../hooks/useSessionRecorder';
 
 // Map routes to page titles
 const PAGE_TITLES: Record<string, string> = {
@@ -54,6 +55,7 @@ const PAGE_TITLES: Record<string, string> = {
   [ROUTES.ADMIN_OPEN_DATA_CATALOG]: 'Каталог OpenData',
   [ROUTES.ADMIN_PG_MONITORING]: 'PG Моніторинг',
   [ROUTES.ADMIN_LIMITS]: 'Ліміти системи',
+  [ROUTES.ADMIN_SESSION_REPLAY]: 'Запис сесій',
   [ROUTES.ATTORNEY_CLIENTS]: 'Мої клієнти',
 };
 
@@ -63,6 +65,9 @@ export function MainLayout() {
   const location = useLocation();
   const { logout, user } = useAuth();
   const [showInvitationsModal, setShowInvitationsModal] = useState(false);
+
+  // rrweb session recording — starts on login, stops on logout
+  useSessionRecorder();
   const pendingConsultations = useConsultationStore(s => s.pendingConsultations);
   const connect = useConsultationStore(s => s.connect);
   const disconnect = useConsultationStore(s => s.disconnect);

--- a/lexwebapp/src/pages/AdminSessionReplayPage.tsx
+++ b/lexwebapp/src/pages/AdminSessionReplayPage.tsx
@@ -1,0 +1,391 @@
+/**
+ * Admin Session Replay Page
+ * View and replay user sessions recorded with rrweb.
+ * Shows cursor movements, clicks, scrolling, and correlated server logs.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { Play, Clock, User, Monitor, Database, ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
+import { sessionReplayApi } from '../utils/api/session-replay';
+
+interface SessionRecord {
+  id: string;
+  user_id: string;
+  session_id: string;
+  started_at: string;
+  ended_at: string | null;
+  chunk_count: number;
+  event_count: number;
+  total_size_bytes: number;
+  user_agent: string | null;
+  viewport: string | null;
+  user_email?: string;
+  user_name?: string;
+}
+
+interface ServerLog {
+  timestamp: string;
+  log_type: string;
+  method?: string;
+  path?: string;
+  status_code?: number;
+  duration_ms?: number;
+  error_message?: string;
+}
+
+interface CostLog {
+  tool_name: string;
+  user_query: string;
+  execution_time_ms: number;
+  status: string;
+  total_cost_usd: number;
+  created_at: string;
+}
+
+export function AdminSessionReplayPage() {
+  const [sessions, setSessions] = useState<SessionRecord[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(0);
+  const [selectedSession, setSelectedSession] = useState<SessionRecord | null>(null);
+  const [replayEvents, setReplayEvents] = useState<any[] | null>(null);
+  const [serverLogs, setServerLogs] = useState<ServerLog[]>([]);
+  const [costLogs, setCostLogs] = useState<CostLog[]>([]);
+  const [loadingReplay, setLoadingReplay] = useState(false);
+  const replayerContainerRef = useRef<HTMLDivElement>(null);
+  const replayerRef = useRef<any>(null);
+
+  const PAGE_SIZE = 20;
+
+  const fetchSessions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await sessionReplayApi.listSessions({
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
+      });
+      setSessions(res.data.sessions);
+      setTotal(res.data.total);
+    } catch (err) {
+      console.error('Failed to fetch sessions', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [page]);
+
+  useEffect(() => { fetchSessions(); }, [fetchSessions]);
+
+  const openReplay = async (session: SessionRecord) => {
+    setSelectedSession(session);
+    setLoadingReplay(true);
+    setReplayEvents(null);
+    setServerLogs([]);
+    setCostLogs([]);
+
+    try {
+      const [eventsRes, logsRes] = await Promise.all([
+        sessionReplayApi.getSessionEvents(session.session_id),
+        sessionReplayApi.getSessionLogs(session.session_id),
+      ]);
+
+      setReplayEvents(eventsRes.data.events);
+      setServerLogs(logsRes.data.directLogs || []);
+      setCostLogs(logsRes.data.costLogs || []);
+    } catch (err) {
+      console.error('Failed to load replay data', err);
+    } finally {
+      setLoadingReplay(false);
+    }
+  };
+
+  // Initialize rrweb-player when events are loaded
+  useEffect(() => {
+    if (!replayEvents || replayEvents.length === 0 || !replayerContainerRef.current) return;
+
+    // Clean up previous player
+    if (replayerRef.current) {
+      replayerRef.current = null;
+      if (replayerContainerRef.current) {
+        replayerContainerRef.current.innerHTML = '';
+      }
+    }
+
+    // Dynamic import to avoid SSR issues
+    import('rrweb-player').then((mod) => {
+      const RRWebPlayer = mod.default || mod;
+
+      // Import CSS
+      import('rrweb-player/dist/style.css').catch(() => {});
+
+      if (!replayerContainerRef.current) return;
+
+      const player = new RRWebPlayer({
+        target: replayerContainerRef.current,
+        props: {
+          events: replayEvents,
+          width: 1024,
+          height: 600,
+          autoPlay: false,
+          showController: true,
+          speedOption: [1, 2, 4, 8],
+          // Mouse cursor is shown by default in rrweb-player
+        },
+      });
+
+      replayerRef.current = player;
+    });
+
+    return () => {
+      replayerRef.current = null;
+    };
+  }, [replayEvents]);
+
+  const formatDuration = (startedAt: string, endedAt: string | null) => {
+    if (!endedAt) return 'Активна';
+    const ms = new Date(endedAt).getTime() - new Date(startedAt).getTime();
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.floor((ms % 60000) / 1000);
+    return `${minutes}хв ${seconds}с`;
+  };
+
+  const formatSize = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+  };
+
+  const formatTime = (ts: string) => {
+    return new Date(ts).toLocaleString('uk-UA', {
+      day: '2-digit', month: '2-digit', year: 'numeric',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    });
+  };
+
+  // Replay view
+  if (selectedSession) {
+    return (
+      <div className="min-h-screen bg-gray-950 text-gray-100 p-4">
+        {/* Header */}
+        <div className="flex items-center gap-4 mb-4">
+          <button
+            onClick={() => { setSelectedSession(null); setReplayEvents(null); }}
+            className="flex items-center gap-1 px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded text-sm"
+          >
+            <ChevronLeft className="w-4 h-4" /> Назад
+          </button>
+          <div className="flex-1">
+            <h2 className="text-lg font-semibold">
+              {selectedSession.user_name || selectedSession.user_email || 'Невідомий'}
+            </h2>
+            <div className="text-sm text-gray-400 flex items-center gap-4">
+              <span><Clock className="w-3 h-3 inline mr-1" />{formatTime(selectedSession.started_at)}</span>
+              <span><Monitor className="w-3 h-3 inline mr-1" />{selectedSession.viewport || '?'}</span>
+              <span>{selectedSession.event_count} подій, {formatSize(selectedSession.total_size_bytes)}</span>
+            </div>
+          </div>
+        </div>
+
+        {loadingReplay ? (
+          <div className="flex items-center justify-center h-96">
+            <div className="w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-4">
+            {/* Player */}
+            <div className="xl:col-span-2">
+              <div className="bg-gray-900 rounded-lg p-4">
+                <div ref={replayerContainerRef} className="rrweb-player-container" />
+                {replayEvents && replayEvents.length === 0 && (
+                  <div className="text-center text-gray-500 py-20">Немає подій для відтворення</div>
+                )}
+              </div>
+            </div>
+
+            {/* Server logs panel */}
+            <div className="xl:col-span-1">
+              <div className="bg-gray-900 rounded-lg p-4 max-h-[700px] overflow-y-auto">
+                <h3 className="text-sm font-semibold mb-3 flex items-center gap-2">
+                  <Database className="w-4 h-4" /> Серверні логи
+                </h3>
+
+                {/* Direct server logs */}
+                {serverLogs.length > 0 && (
+                  <div className="mb-4">
+                    <div className="text-xs text-gray-500 mb-2 uppercase tracking-wide">API запити</div>
+                    {serverLogs.map((log, i) => (
+                      <div key={i} className="text-xs mb-2 p-2 bg-gray-800 rounded">
+                        <div className="flex items-center gap-2">
+                          <span className={`font-mono ${
+                            (log.status_code || 0) >= 400 ? 'text-red-400' : 'text-green-400'
+                          }`}>
+                            {log.method} {log.status_code}
+                          </span>
+                          <span className="text-gray-400 truncate flex-1">{log.path}</span>
+                          {log.duration_ms && (
+                            <span className="text-gray-500">{log.duration_ms}ms</span>
+                          )}
+                        </div>
+                        <div className="text-gray-500 mt-1">
+                          {formatTime(log.timestamp)}
+                        </div>
+                        {log.error_message && (
+                          <div className="text-red-400 mt-1">{log.error_message}</div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Cost tracking logs */}
+                {costLogs.length > 0 && (
+                  <div>
+                    <div className="text-xs text-gray-500 mb-2 uppercase tracking-wide">Виконання інструментів</div>
+                    {costLogs.map((log, i) => (
+                      <div key={i} className="text-xs mb-2 p-2 bg-gray-800 rounded">
+                        <div className="flex items-center gap-2">
+                          <span className={`font-semibold ${
+                            log.status === 'error' ? 'text-red-400' : 'text-blue-400'
+                          }`}>
+                            {log.tool_name}
+                          </span>
+                          <span className="text-gray-500 ml-auto">{log.execution_time_ms}ms</span>
+                        </div>
+                        {log.user_query && (
+                          <div className="text-gray-400 mt-1 truncate">{log.user_query}</div>
+                        )}
+                        <div className="flex items-center gap-2 mt-1">
+                          <span className="text-gray-500">{formatTime(log.created_at)}</span>
+                          {log.total_cost_usd > 0 && (
+                            <span className="text-yellow-500">${log.total_cost_usd.toFixed(4)}</span>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {serverLogs.length === 0 && costLogs.length === 0 && (
+                  <div className="text-gray-500 text-sm text-center py-8">
+                    Немає серверних логів для цієї сесії
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Session list view
+  return (
+    <div className="min-h-screen bg-gray-950 text-gray-100 p-4">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-xl font-semibold">Запис сесій користувачів</h1>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={fetchSessions}
+            className="flex items-center gap-1 px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded text-sm"
+          >
+            <RefreshCw className="w-4 h-4" /> Оновити
+          </button>
+        </div>
+      </div>
+
+      {/* Sessions table */}
+      <div className="bg-gray-900 rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-gray-800 text-left text-gray-400">
+              <th className="px-4 py-3">Користувач</th>
+              <th className="px-4 py-3">Початок</th>
+              <th className="px-4 py-3">Тривалість</th>
+              <th className="px-4 py-3">Подій</th>
+              <th className="px-4 py-3">Розмір</th>
+              <th className="px-4 py-3">Екран</th>
+              <th className="px-4 py-3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={7} className="text-center py-12">
+                  <div className="w-6 h-6 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mx-auto" />
+                </td>
+              </tr>
+            ) : sessions.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="text-center py-12 text-gray-500">
+                  Немає записаних сесій
+                </td>
+              </tr>
+            ) : sessions.map(session => (
+              <tr
+                key={session.id}
+                className="border-b border-gray-800/50 hover:bg-gray-800/50 cursor-pointer"
+                onClick={() => openReplay(session)}
+              >
+                <td className="px-4 py-3">
+                  <div className="flex items-center gap-2">
+                    <User className="w-4 h-4 text-gray-500" />
+                    <div>
+                      <div className="font-medium">{session.user_name || 'Невідомий'}</div>
+                      <div className="text-xs text-gray-500">{session.user_email}</div>
+                    </div>
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {formatTime(session.started_at)}
+                </td>
+                <td className="px-4 py-3">
+                  <span className={`${!session.ended_at ? 'text-green-400' : 'text-gray-400'}`}>
+                    {formatDuration(session.started_at, session.ended_at)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {session.event_count.toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-gray-400">
+                  {formatSize(session.total_size_bytes)}
+                </td>
+                <td className="px-4 py-3 text-gray-400 font-mono text-xs">
+                  {session.viewport || '?'}
+                </td>
+                <td className="px-4 py-3">
+                  <button className="text-blue-400 hover:text-blue-300">
+                    <Play className="w-4 h-4" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {total > PAGE_SIZE && (
+        <div className="flex items-center justify-between mt-4">
+          <span className="text-sm text-gray-500">
+            {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} з {total}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPage(p => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded text-sm disabled:opacity-50"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => setPage(p => p + 1)}
+              disabled={(page + 1) * PAGE_SIZE >= total}
+              className="px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded text-sm disabled:opacity-50"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -155,6 +155,7 @@ const AdminBulkScrapePage = lazyWithRetry(() => import('../pages/AdminBulkScrape
 const AdminOpenDataCatalogPage = lazyWithRetry(() => import('../pages/AdminOpenDataCatalogPage').then(m => ({ default: m.AdminOpenDataCatalogPage })));
 const AdminPGMonitoringPage = lazyWithRetry(() => import('../pages/AdminPGMonitoringPage').then(m => ({ default: m.AdminPGMonitoringPage })));
 const AdminLimitsPage = lazyWithRetry(() => import('../pages/AdminLimitsPage').then(m => ({ default: m.AdminLimitsPage })));
+const AdminSessionReplayPage = lazyWithRetry(() => import('../pages/AdminSessionReplayPage').then(m => ({ default: m.AdminSessionReplayPage })));
 
 export const router = createBrowserRouter([
   {
@@ -540,6 +541,10 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.ADMIN_LIMITS,
             element: S(AdminLimitsPage),
+          },
+          {
+            path: ROUTES.ADMIN_SESSION_REPLAY,
+            element: S(AdminSessionReplayPage),
           },
         ],
       },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -134,6 +134,7 @@ export const ROUTES = {
   ADMIN_OPEN_DATA_CATALOG: '/admin/open-data-catalog',
   ADMIN_PG_MONITORING: '/admin/pg-monitoring',
   ADMIN_LIMITS: '/admin/limits',
+  ADMIN_SESSION_REPLAY: '/admin/session-replay',
 } as const;
 
 // Helper function to generate dynamic routes

--- a/lexwebapp/src/utils/api/index.ts
+++ b/lexwebapp/src/utils/api/index.ts
@@ -35,3 +35,4 @@ export { documentsApi } from './documents';
 export { teamApi } from './team';
 export { conversationsApi } from './conversations';
 export { decisionsApi, keysApi, gdprApi, toolsApi } from './misc';
+export { sessionReplayApi } from './session-replay';

--- a/lexwebapp/src/utils/api/session-replay.ts
+++ b/lexwebapp/src/utils/api/session-replay.ts
@@ -1,0 +1,26 @@
+import apiClient from './client';
+
+export const sessionReplayApi = {
+  // Client-facing
+  createSession: (sessionId: string, viewport: string) =>
+    apiClient.post('/api/session-replay/sessions', { sessionId, viewport }),
+
+  sendChunk: (sessionId: string, chunkIndex: number, events: any[]) =>
+    apiClient.post(`/api/session-replay/sessions/${sessionId}/chunks`, { chunkIndex, events }),
+
+  endSession: (sessionId: string) =>
+    apiClient.post(`/api/session-replay/sessions/${sessionId}/end`),
+
+  // Admin
+  listSessions: (params?: { userId?: string; from?: string; to?: string; limit?: number; offset?: number }) =>
+    apiClient.get('/api/admin/session-replay/sessions', { params }),
+
+  getSession: (sessionId: string) =>
+    apiClient.get(`/api/admin/session-replay/sessions/${sessionId}`),
+
+  getSessionEvents: (sessionId: string) =>
+    apiClient.get(`/api/admin/session-replay/sessions/${sessionId}/events`),
+
+  getSessionLogs: (sessionId: string) =>
+    apiClient.get(`/api/admin/session-replay/sessions/${sessionId}/logs`),
+};

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -68,6 +68,8 @@ import { createJudgeAnalyticsRoutes } from './routes/judge-analytics-routes.js';
 import { createReferralRoutes } from './routes/referral-routes.js';
 import { createLegislationMonitoringRoutes } from './routes/legislation-monitoring-routes.js';
 import { createUsageRoutes } from './routes/usage-routes.js';
+import { createSessionReplayRoutes, createAdminSessionReplayRoutes } from './routes/session-replay-routes.js';
+import { SessionReplayService } from './services/session-replay-service.js';
 import rateLimit from 'express-rate-limit';
 import cron from 'node-cron';
 
@@ -648,6 +650,29 @@ class HTTPMCPServer {
     // GET /api/admin/api-keys - List API keys
     // GET /api/admin/settings - Get system settings
     this.app.use('/api/admin', requireJWT as any, createAdminRoutes(this.services.db, this.billing.billingService, this.billing.userPreferencesService, this.billing.prometheusService, this.billing.pricingService, this.billing.subscriptionService, this.app_.configService, this.app_.auditService, this.billing.emailService));
+
+    // Session replay: rrweb recording + admin playback
+    const sessionReplayService = new SessionReplayService(this.services.db, this.tools.minioService);
+    this.app.use('/api/session-replay', requireJWT as any, createSessionReplayRoutes(sessionReplayService));
+    this.app.use('/api/admin/session-replay', requireJWT as any, createAdminSessionReplayRoutes(sessionReplayService));
+    logger.info('Session replay routes registered');
+
+    // Server-side request logging middleware (correlates with session replay)
+    this.app.use('/api', ((req: DualAuthRequest, res: express.Response, next: any) => {
+      const sessionId = req.headers['x-session-id'] as string;
+      if (sessionId && req.user?.id) {
+        const start = Date.now();
+        res.on('finish', () => {
+          sessionReplayService.logServerEvent(sessionId, req.user!.id, 'api_call', {
+            method: req.method,
+            path: req.path,
+            statusCode: res.statusCode,
+            durationMs: Date.now() - start,
+          }).catch(() => {}); // fire-and-forget
+        });
+      }
+      next();
+    }) as any);
 
     // Upload metrics endpoint (admin)
     this.app.get('/api/admin/upload-metrics', requireJWT as any, (async (_req: DualAuthRequest, res: express.Response) => {

--- a/mcp_backend/src/migrations/109_session_replay.sql
+++ b/mcp_backend/src/migrations/109_session_replay.sql
@@ -1,0 +1,72 @@
+-- Session replay: rrweb recording storage
+-- Events stored in MinIO as JSON blobs, metadata in PostgreSQL
+
+CREATE TABLE IF NOT EXISTS session_recordings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  session_id VARCHAR(64) NOT NULL UNIQUE,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  ended_at TIMESTAMPTZ,
+  chunk_count INTEGER DEFAULT 0,
+  event_count INTEGER DEFAULT 0,
+  total_size_bytes BIGINT DEFAULT 0,
+  user_agent TEXT,
+  viewport TEXT,
+  ip_address INET,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_recordings_user ON session_recordings(user_id);
+CREATE INDEX IF NOT EXISTS idx_session_recordings_started ON session_recordings(started_at DESC);
+
+CREATE TABLE IF NOT EXISTS session_recording_chunks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  recording_id UUID NOT NULL REFERENCES session_recordings(id) ON DELETE CASCADE,
+  chunk_index INTEGER NOT NULL,
+  minio_key VARCHAR(500) NOT NULL,
+  event_count INTEGER NOT NULL DEFAULT 0,
+  size_bytes INTEGER NOT NULL DEFAULT 0,
+  first_timestamp BIGINT NOT NULL,
+  last_timestamp BIGINT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(recording_id, chunk_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_recording_chunks_recording ON session_recording_chunks(recording_id);
+
+-- Server-side logs correlated with session recordings
+CREATE TABLE IF NOT EXISTS session_server_logs (
+  id BIGSERIAL PRIMARY KEY,
+  session_id VARCHAR(64) NOT NULL,
+  user_id UUID NOT NULL,
+  timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  log_type VARCHAR(50) NOT NULL,  -- 'api_call', 'tool_execution', 'error', 'navigation'
+  method VARCHAR(10),
+  path TEXT,
+  status_code INTEGER,
+  duration_ms INTEGER,
+  request_body JSONB,
+  response_summary JSONB,
+  error_message TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_server_logs_session ON session_server_logs(session_id);
+CREATE INDEX IF NOT EXISTS idx_session_server_logs_timestamp ON session_server_logs(session_id, timestamp);
+
+-- Cleanup: auto-purge recordings older than 90 days
+CREATE OR REPLACE FUNCTION purge_old_session_recordings(days_old INTEGER DEFAULT 90)
+RETURNS INTEGER AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM session_recordings
+  WHERE started_at < NOW() - (days_old || ' days')::INTERVAL;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  DELETE FROM session_server_logs
+  WHERE timestamp < NOW() - (days_old || ' days')::INTERVAL;
+
+  RETURN deleted_count;
+END;
+$$ LANGUAGE plpgsql;

--- a/mcp_backend/src/routes/session-replay-routes.ts
+++ b/mcp_backend/src/routes/session-replay-routes.ts
@@ -1,0 +1,143 @@
+import { Router, Request, Response } from 'express';
+import { SessionReplayService } from '../services/session-replay-service.js';
+import { logger } from '../utils/logger.js';
+
+/**
+ * Client-facing routes: recording sessions + storing event chunks
+ * Mounted at /api/session-replay
+ */
+export function createSessionReplayRoutes(service: SessionReplayService): Router {
+  const router = Router();
+
+  // Create a new recording session (called once on login)
+  router.post('/sessions', (async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id as string | undefined;
+      if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+
+      const { sessionId, viewport } = req.body;
+      if (!sessionId) { res.status(400).json({ error: 'sessionId required' }); return; }
+
+      const session = await service.createSession(
+        userId,
+        sessionId,
+        req.headers['user-agent'] as string | undefined,
+        viewport,
+        req.ip
+      );
+
+      res.status(201).json(session);
+    } catch (error: any) {
+      logger.error('[SessionReplay] Create session failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to create session' });
+    }
+  }) as any);
+
+  // Store a chunk of rrweb events
+  router.post('/sessions/:sessionId/chunks', (async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id as string | undefined;
+      if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+
+      const sessionId = req.params.sessionId as string;
+      const { chunkIndex, events } = req.body;
+
+      if (!Array.isArray(events) || events.length === 0) {
+        res.status(400).json({ error: 'events array required' });
+        return;
+      }
+
+      const chunk = await service.storeChunk(userId, sessionId, chunkIndex, events);
+      res.status(201).json({ chunkIndex: chunk.chunk_index, eventCount: chunk.event_count });
+    } catch (error: any) {
+      logger.error('[SessionReplay] Store chunk failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to store chunk' });
+    }
+  }) as any);
+
+  // End a recording session
+  router.post('/sessions/:sessionId/end', (async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id as string | undefined;
+      if (!userId) { res.status(401).json({ error: 'Unauthorized' }); return; }
+
+      await service.endSession(req.params.sessionId as string);
+      res.json({ ok: true });
+    } catch (error: any) {
+      logger.error('[SessionReplay] End session failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to end session' });
+    }
+  }) as any);
+
+  return router;
+}
+
+/**
+ * Admin routes: list sessions, replay events, view logs
+ * Mounted at /api/admin/session-replay
+ */
+export function createAdminSessionReplayRoutes(service: SessionReplayService): Router {
+  const router = Router();
+
+  // List all sessions (paginated, filterable)
+  router.get('/sessions', (async (req: Request, res: Response) => {
+    try {
+      const { userId, from, to, limit, offset } = req.query;
+
+      const result = await service.listSessions({
+        userId: userId as string,
+        from: from as string,
+        to: to as string,
+        limit: limit ? parseInt(limit as string, 10) : 50,
+        offset: offset ? parseInt(offset as string, 10) : 0,
+      });
+
+      res.set('X-Total-Count', String(result.total));
+      res.json(result);
+    } catch (error: any) {
+      logger.error('[SessionReplay] List sessions failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to list sessions' });
+    }
+  }) as any);
+
+  // Get session metadata + chunks info
+  router.get('/sessions/:sessionId', (async (req: Request, res: Response) => {
+    try {
+      const session = await service.getSession(req.params.sessionId as string);
+      if (!session) { res.status(404).json({ error: 'Session not found' }); return; }
+      res.json(session);
+    } catch (error: any) {
+      logger.error('[SessionReplay] Get session failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to get session' });
+    }
+  }) as any);
+
+  // Get all rrweb events (for replay)
+  router.get('/sessions/:sessionId/events', (async (req: Request, res: Response) => {
+    try {
+      const events = await service.getSessionEvents(req.params.sessionId as string);
+      res.json({ events, count: events.length });
+    } catch (error: any) {
+      logger.error('[SessionReplay] Get events failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to get events' });
+    }
+  }) as any);
+
+  // Get server logs for a session
+  router.get('/sessions/:sessionId/logs', (async (req: Request, res: Response) => {
+    try {
+      const sid = req.params.sessionId as string;
+      const [directLogs, costLogs] = await Promise.all([
+        service.getSessionLogs(sid),
+        service.getCorrelatedCostLogs(sid),
+      ]);
+
+      res.json({ directLogs, costLogs });
+    } catch (error: any) {
+      logger.error('[SessionReplay] Get logs failed', { error: error.message });
+      res.status(500).json({ error: 'Failed to get logs' });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/session-replay-service.ts
+++ b/mcp_backend/src/services/session-replay-service.ts
@@ -1,0 +1,321 @@
+import { logger } from '../utils/logger.js';
+import { MinioService } from './minio-service.js';
+
+interface IDatabase {
+  query(text: string, params?: any[]): Promise<{ rows: any[]; rowCount: number | null }>;
+}
+
+export interface SessionRecordingMeta {
+  id: string;
+  user_id: string;
+  session_id: string;
+  started_at: string;
+  ended_at: string | null;
+  chunk_count: number;
+  event_count: number;
+  total_size_bytes: number;
+  user_agent: string | null;
+  viewport: string | null;
+  ip_address: string | null;
+  // Joined from users table
+  user_email?: string;
+  user_name?: string;
+}
+
+export interface SessionChunkMeta {
+  id: string;
+  recording_id: string;
+  chunk_index: number;
+  minio_key: string;
+  event_count: number;
+  size_bytes: number;
+  first_timestamp: number;
+  last_timestamp: number;
+}
+
+export interface ServerLogEntry {
+  id: number;
+  session_id: string;
+  user_id: string;
+  timestamp: string;
+  log_type: string;
+  method: string | null;
+  path: string | null;
+  status_code: number | null;
+  duration_ms: number | null;
+  request_body: any;
+  response_summary: any;
+  error_message: string | null;
+}
+
+export class SessionReplayService {
+  constructor(
+    private db: IDatabase,
+    private minio: MinioService
+  ) {}
+
+  /**
+   * Create a new recording session
+   */
+  async createSession(
+    userId: string,
+    sessionId: string,
+    userAgent?: string,
+    viewport?: string,
+    ip?: string
+  ): Promise<SessionRecordingMeta> {
+    const result = await this.db.query(
+      `INSERT INTO session_recordings (user_id, session_id, user_agent, viewport, ip_address)
+       VALUES ($1, $2, $3, $4, $5::inet)
+       ON CONFLICT (session_id) DO UPDATE SET started_at = NOW()
+       RETURNING *`,
+      [userId, sessionId, userAgent || null, viewport || null, ip || null]
+    );
+    logger.info('[SessionReplay] Session created', { userId, sessionId });
+    return result.rows[0];
+  }
+
+  /**
+   * Store a chunk of rrweb events in MinIO
+   */
+  async storeChunk(
+    userId: string,
+    sessionId: string,
+    chunkIndex: number,
+    events: any[]
+  ): Promise<SessionChunkMeta> {
+    // Find recording
+    const recording = await this.db.query(
+      'SELECT id FROM session_recordings WHERE session_id = $1 AND user_id = $2',
+      [sessionId, userId]
+    );
+    if (recording.rows.length === 0) {
+      throw new Error(`Recording not found: ${sessionId}`);
+    }
+    const recordingId = recording.rows[0].id;
+
+    // Serialize events and upload to MinIO
+    const buffer = Buffer.from(JSON.stringify(events));
+    const objectKey = `session-replay/${sessionId}/${chunkIndex}.json`;
+
+    await this.minio.uploadBuffer(userId, objectKey, buffer, 'application/json');
+
+    // Get timestamps from events
+    const timestamps = events.map((e: any) => e.timestamp).filter(Boolean);
+    const firstTimestamp = timestamps.length > 0 ? Math.min(...timestamps) : 0;
+    const lastTimestamp = timestamps.length > 0 ? Math.max(...timestamps) : 0;
+
+    // Insert chunk metadata
+    const result = await this.db.query(
+      `INSERT INTO session_recording_chunks
+       (recording_id, chunk_index, minio_key, event_count, size_bytes, first_timestamp, last_timestamp)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       ON CONFLICT (recording_id, chunk_index) DO UPDATE SET
+         minio_key = EXCLUDED.minio_key,
+         event_count = EXCLUDED.event_count,
+         size_bytes = EXCLUDED.size_bytes,
+         first_timestamp = EXCLUDED.first_timestamp,
+         last_timestamp = EXCLUDED.last_timestamp
+       RETURNING *`,
+      [recordingId, chunkIndex, objectKey, events.length, buffer.length, firstTimestamp, lastTimestamp]
+    );
+
+    // Update recording counters
+    await this.db.query(
+      `UPDATE session_recordings SET
+         chunk_count = chunk_count + 1,
+         event_count = event_count + $1,
+         total_size_bytes = total_size_bytes + $2
+       WHERE id = $3`,
+      [events.length, buffer.length, recordingId]
+    );
+
+    logger.debug('[SessionReplay] Chunk stored', {
+      sessionId, chunkIndex, eventCount: events.length, sizeBytes: buffer.length,
+    });
+
+    return result.rows[0];
+  }
+
+  /**
+   * Mark session as ended
+   */
+  async endSession(sessionId: string): Promise<void> {
+    await this.db.query(
+      'UPDATE session_recordings SET ended_at = NOW() WHERE session_id = $1',
+      [sessionId]
+    );
+    logger.info('[SessionReplay] Session ended', { sessionId });
+  }
+
+  /**
+   * Log a server-side event correlated with a session
+   */
+  async logServerEvent(
+    sessionId: string,
+    userId: string,
+    logType: string,
+    data: {
+      method?: string;
+      path?: string;
+      statusCode?: number;
+      durationMs?: number;
+      requestBody?: any;
+      responseSummary?: any;
+      errorMessage?: string;
+    }
+  ): Promise<void> {
+    await this.db.query(
+      `INSERT INTO session_server_logs
+       (session_id, user_id, log_type, method, path, status_code, duration_ms, request_body, response_summary, error_message)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+      [
+        sessionId, userId, logType,
+        data.method || null, data.path || null, data.statusCode || null,
+        data.durationMs || null, data.requestBody || null,
+        data.responseSummary || null, data.errorMessage || null,
+      ]
+    );
+  }
+
+  // ====== Admin methods ======
+
+  /**
+   * List all sessions (admin) with user info
+   */
+  async listSessions(filters: {
+    userId?: string;
+    from?: string;
+    to?: string;
+    limit?: number;
+    offset?: number;
+  }): Promise<{ sessions: SessionRecordingMeta[]; total: number }> {
+    const conditions: string[] = [];
+    const params: any[] = [];
+    let paramIndex = 1;
+
+    if (filters.userId) {
+      conditions.push(`sr.user_id = $${paramIndex++}`);
+      params.push(filters.userId);
+    }
+    if (filters.from) {
+      conditions.push(`sr.started_at >= $${paramIndex++}`);
+      params.push(filters.from);
+    }
+    if (filters.to) {
+      conditions.push(`sr.started_at <= $${paramIndex++}`);
+      params.push(filters.to);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limit = filters.limit || 50;
+    const offset = filters.offset || 0;
+
+    const countResult = await this.db.query(
+      `SELECT COUNT(*) as total FROM session_recordings sr ${where}`,
+      params
+    );
+
+    const result = await this.db.query(
+      `SELECT sr.*, u.email as user_email, u.name as user_name
+       FROM session_recordings sr
+       LEFT JOIN users u ON u.id = sr.user_id
+       ${where}
+       ORDER BY sr.started_at DESC
+       LIMIT $${paramIndex++} OFFSET $${paramIndex++}`,
+      [...params, limit, offset]
+    );
+
+    return {
+      sessions: result.rows,
+      total: parseInt(countResult.rows[0].total, 10),
+    };
+  }
+
+  /**
+   * Get single session metadata
+   */
+  async getSession(sessionId: string): Promise<{
+    recording: SessionRecordingMeta;
+    chunks: SessionChunkMeta[];
+  } | null> {
+    const recordingResult = await this.db.query(
+      `SELECT sr.*, u.email as user_email, u.name as user_name
+       FROM session_recordings sr
+       LEFT JOIN users u ON u.id = sr.user_id
+       WHERE sr.session_id = $1`,
+      [sessionId]
+    );
+    if (recordingResult.rows.length === 0) return null;
+
+    const chunksResult = await this.db.query(
+      `SELECT * FROM session_recording_chunks
+       WHERE recording_id = $1
+       ORDER BY chunk_index ASC`,
+      [recordingResult.rows[0].id]
+    );
+
+    return {
+      recording: recordingResult.rows[0],
+      chunks: chunksResult.rows,
+    };
+  }
+
+  /**
+   * Get all events for a session (concatenated from all chunks)
+   */
+  async getSessionEvents(sessionId: string): Promise<any[]> {
+    const session = await this.getSession(sessionId);
+    if (!session) throw new Error(`Session not found: ${sessionId}`);
+
+    const allEvents: any[] = [];
+    for (const chunk of session.chunks) {
+      const buffer = await this.minio.getFileBuffer(
+        session.recording.user_id,
+        chunk.minio_key
+      );
+      const events = JSON.parse(buffer.toString('utf-8'));
+      allEvents.push(...events);
+    }
+
+    // Sort by timestamp
+    allEvents.sort((a, b) => a.timestamp - b.timestamp);
+    return allEvents;
+  }
+
+  /**
+   * Get server logs correlated with a session
+   */
+  async getSessionLogs(sessionId: string): Promise<ServerLogEntry[]> {
+    const result = await this.db.query(
+      `SELECT * FROM session_server_logs
+       WHERE session_id = $1
+       ORDER BY timestamp ASC`,
+      [sessionId]
+    );
+    return result.rows;
+  }
+
+  /**
+   * Get server logs from cost_tracking correlated by user+time range
+   */
+  async getCorrelatedCostLogs(sessionId: string): Promise<any[]> {
+    const recording = await this.db.query(
+      'SELECT user_id, started_at, ended_at FROM session_recordings WHERE session_id = $1',
+      [sessionId]
+    );
+    if (recording.rows.length === 0) return [];
+
+    const { user_id, started_at, ended_at } = recording.rows[0];
+    const endTime = ended_at || 'NOW()';
+
+    const result = await this.db.query(
+      `SELECT tool_name, user_query, execution_time_ms, status, total_cost_usd, created_at
+       FROM cost_tracking
+       WHERE user_id = $1 AND created_at >= $2 AND created_at <= $3
+       ORDER BY created_at ASC`,
+      [user_id, started_at, ended_at || new Date()]
+    );
+    return result.rows;
+  }
+}


### PR DESCRIPTION
## Summary
- **rrweb session recording** — автоматично записує DOM, курсор мишки, кліки, скрол з моменту логіну
- **Backend** — чанки подій (кожні 10с) зберігаються в MinIO, метадані в PostgreSQL, серверні логи корелюються через X-Session-Id header
- **Admin dashboard** `/admin/session-replay` — список сесій з пагінацією + rrweb-player для відтворення сесій із серверними логами поруч

## New files
- `mcp_backend/src/migrations/109_session_replay.sql` — 3 таблиці
- `mcp_backend/src/services/session-replay-service.ts` — сервіс зберігання/отримання
- `mcp_backend/src/routes/session-replay-routes.ts` — client + admin endpoints
- `lexwebapp/src/hooks/useSessionRecorder.ts` — rrweb хук
- `lexwebapp/src/pages/AdminSessionReplayPage.tsx` — admin replay UI
- `lexwebapp/src/utils/api/session-replay.ts` — API module

## Test plan
- [ ] Залогінитись — перевірити що POST /api/session-replay/sessions створює сесію
- [ ] Виконати дії на сайті — перевірити що чанки відправляються кожні 10с
- [ ] Відкрити /admin/session-replay — перевірити список сесій
- [ ] Натиснути на сесію — перевірити replay з курсором мишки
- [ ] Перевірити серверні логи поруч з replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add session replay with `rrweb` and an admin dashboard to view replays with server logs, helping debug user issues without reproducing them.

- **New Features**
  - Record DOM, mouse, clicks, and scroll after login with `rrweb`. Flush events every 10s. Add `X-Session-Id` to all API requests for log correlation.
  - Store event chunks in MinIO; keep session metadata in Postgres. Middleware logs API calls linked to the session.
  - Admin page `/admin/session-replay`: paginated session list and `rrweb-player` replay with correlated server and cost logs.
  - Client and admin APIs for session create/chunk/end and for listing sessions, events, and logs.

- **Migration**
  - Run `mcp_backend/src/migrations/109_session_replay.sql`.
  - Ensure MinIO is configured and accessible for `session-replay/...` objects.
  - Optionally schedule `purge_old_session_recordings(90)` to auto-clean old data.

<sup>Written for commit ed1ff507652d675f48a46f402ae8a1e84ec990d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

