### PR TITLE
fix(platform): deterministic builds to prevent recurring /usage crashes

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -106,14 +106,14 @@ runs:
           OPENREYESTR=true
         fi
 
-        # If deployment infra changed (Dockerfiles, compose, nginx), rebuild everything
+        # If deployment infra changed (Dockerfiles, compose, nginx), rebuild backend services
         # Monitoring-only changes (grafana, prometheus) don't require service rebuilds
+        # Platform is a static SPA — only rebuild when platform/ source actually changes
         if [ "$DEPLOY_INFRA" = "true" ]; then
           BACKEND=true
           RADA=true
           OPENREYESTR=true
           FRONTEND=true
-          PLATFORM=true
         fi
 
         ANY_BACKEND=false

--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -4,11 +4,11 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app/platform
 
-# Copy package files
-COPY platform/package.json platform/package-lock.json* ./
+# Copy package files (lock file required for deterministic builds)
+COPY platform/package.json platform/package-lock.json ./
 
-# Install dependencies
-RUN npm install --legacy-peer-deps
+# Install dependencies deterministically from lock file
+RUN npm ci
 
 # Accept build arguments
 ARG BUILD_ENV=production

--- a/platform/package.json
+++ b/platform/package.json
@@ -11,18 +11,18 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@tailwindcss/typography": "^0.5.19",
-    "axios": "^1.13.6",
-    "date-fns": "^4.1.0",
+    "@tailwindcss/typography": "0.5.19",
+    "axios": "1.13.6",
+    "date-fns": "4.1.0",
     "lucide-react": "0.577.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
-    "react-hot-toast": "^2.6.0",
-    "react-is": "^19.2.4",
-    "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.13.1",
-    "recharts": "^3.8.0",
-    "remark-gfm": "^4.0.1"
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "react-hot-toast": "2.6.0",
+    "react-is": "19.2.4",
+    "react-markdown": "10.1.0",
+    "react-router-dom": "7.13.1",
+    "recharts": "3.8.0",
+    "remark-gfm": "4.0.1"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",


### PR DESCRIPTION
## Summary
- Pin all platform dependencies to exact versions (no `^` caret ranges) — prevents npm from pulling different minor/patch versions on each rebuild
- Switch Dockerfile from `npm install --legacy-peer-deps` to `npm ci` — guarantees deterministic installs from lock file
- Remove platform from `DEPLOY_INFRA` rebuild trigger — deployment/ changes no longer cause unnecessary platform rebuilds

## Context
The platform /usage page has broken 5 times. Root cause: every backend deploy triggers a platform rebuild via CI change detection, and `npm install` with caret ranges pulls different dependency versions each time. Recharts + React 19 is particularly fragile to version drift.

## Test plan
- [ ] `npm ci && npm run build` passes locally
- [ ] Platform container builds successfully in CI
- [ ] /usage page renders correctly after deploy
- [ ] Backend-only deploys no longer rebuild platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make platform builds deterministic to stop recurring /usage crashes caused by dependency drift. Pins exact versions and switches Docker installs to `npm ci`; CI no longer rebuilds platform on infra-only changes.

- **Dependencies**
  - Pin all `platform` dependencies to exact versions (remove `^`).
  - Switch Dockerfile to `npm ci` to install from `package-lock.json`.
  - Stabilizes `react` + `recharts` combo to avoid version drift issues.

- **Refactors**
  - Update `.github/actions/detect-changes` so deployment infra changes rebuild backend services only; platform rebuilds only when `platform/` changes.

<sup>Written for commit 9363d71c504b665b45a6e1a9a27c0b91859c2147. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

