### PR TITLE
fix(blog): strip sensitive config params from security audit article

### DIFF
--- a/lexwebapp/src/pages/BlogPage/articles-en.ts
+++ b/lexwebapp/src/pages/BlogPage/articles-en.ts
@@ -50,25 +50,15 @@ gtag('consent', 'default', {
 
 **2. JWT Secret with fallback to a known string**
 
-Three files contained:
-\`\`\`typescript
-const JWT_SECRET = process.env.JWT_SECRET || 'change-this-secret-in-production';
-\`\`\`
+Several files contained a hardcoded fallback value for the JWT secret. If the environment variable wasn't set during deployment, the app would silently operate with a predictable secret, allowing anyone to forge valid JWTs.
 
-If \`JWT_SECRET\` wasn't set during deployment, the app would silently operate with a publicly known secret. Anyone could forge a valid JWT for any user.
+**Fix:** The app now crashes on startup if the JWT secret is not set via environment variable. All fallback values have been removed.
 
-**Fix:** The app now crashes on startup if \`JWT_SECRET\` is missing.
+**3. SQL Injection via parameter interpolation**
 
-**3. SQL Injection via userId interpolation**
+Several places in the code used direct string interpolation for SQL parameters instead of parameterized queries. Combined with #2, this created a direct SQL injection vector.
 
-\`\`\`typescript
-// Before — userId injected directly into SQL string
-const ownerCheck = \` AND user_id = '\${userId}'\`;
-\`\`\`
-
-While \`userId\` comes from JWT, a compromised JWT secret (see #2) would turn this into a direct SQL injection vector.
-
-**Fix:** Parameterized query with \`$N\` placeholder.
+**Fix:** All SQL queries now use parameterized placeholders.
 
 ### High Priority (Fixed)
 
@@ -78,13 +68,13 @@ While \`userId\` comes from JWT, a compromised JWT secret (see #2) would turn th
 
 **6. XSS via dangerouslySetInnerHTML** — 3 components rendered HTML from the database without sanitization. Added DOMPurify.
 
-**7. Dynamic SQL tables without whitelist** — \`lookupName()\` and \`batchLookup()\` accepted table names as parameters. Added an allowlist of permitted tables and columns.
+**7. Dynamic SQL tables without whitelist** — some functions accepted table names as parameters without validation. Added a strict allowlist of permitted tables and columns.
 
-**8. Cleanup functions never ran** — \`cleanupExpiredSessions()\`, \`purge_soft_deleted_documents()\`, and \`cleanup_expired_oauth_data()\` existed but were never scheduled. Added three cron jobs.
+**8. Cleanup functions never ran** — data cleanup functions (expired sessions, soft-deleted documents, expired tokens) existed but were never scheduled. Added automated cron jobs.
 
 **9. Emails logged in plaintext** — 9+ locations in auth controllers. Added \`maskEmail()\`: \`user@example.com\` → \`us***@example.com\`.
 
-**10. OAuth registration without rate limiting** — the \`/oauth/register\` endpoint (RFC 7591) allowed unlimited OAuth client registration. Added rate limit: 5 requests per 15 minutes per IP.
+**10. OAuth registration without rate limiting** — the OAuth client registration endpoint allowed unlimited requests. Added IP-based rate limiting.
 
 ---
 
@@ -121,15 +111,7 @@ All traffic passes through Cloudflare before reaching our servers:
 
 ### Layer 4: Application Security (Express.js)
 
-**Multi-layer rate limiting:**
-
-| Endpoint | Limit | Key |
-|----------|-------|-----|
-| Auth (login, register) | 10 / 15 min | IP |
-| Password reset | 3 / hour | IP |
-| Chat | 60 / min | User ID |
-| Global API | 1500 / min | IP |
-| OAuth registration | 5 / 15 min | IP |
+**Multi-layer rate limiting** — each endpoint type (auth, chat, API, password reset) has separate limits by IP or User ID.
 
 ### Layer 5: Authentication (6 Methods)
 
@@ -143,21 +125,21 @@ All traffic passes through Cloudflare before reaching our servers:
 ### Layer 6: Database Security
 
 - **PgBouncer** with SCRAM-SHA-256 authentication
-- Connection pooling: 500 max clients, 50 pool size
-- Statement timeout: 600s (protection against slow query DoS)
+- Connection pooling with restricted client and pool sizes
+- Statement timeout for protection against slow query DoS
 - Docker bridge network isolates DB from external access
-- Parameterized queries everywhere (PostgreSQL \`$1, $2\` placeholders)
+- Parameterized queries everywhere
 
 ### Layer 7: Data Protection (GDPR)
 
 **Implemented rights:**
 - **Art. 15 (Access)** — full JSON export of all user data
-- **Art. 17 (Erasure)** — cascading deletion from PostgreSQL, Qdrant, MinIO, cost_tracking anonymization
+- **Art. 17 (Erasure)** — cascading deletion from all data stores, tracking anonymization
 - **Art. 20 (Portability)** — machine-readable JSON format
 
 **Cookie Consent:** 4 categories with privacy-by-default. **E2EE for documents:** AES-256-GCM with X25519 ECDH key exchange.
 
-**Automated cleanup:** sessions (every 6 hours), soft-deleted documents (daily, 30-day retention), OAuth tokens (daily).
+**Automated cleanup** — regular purging of expired sessions, soft-deleted documents, and OAuth tokens at configured intervals.
 
 ---
 

--- a/lexwebapp/src/pages/BlogPage/articles-ru.ts
+++ b/lexwebapp/src/pages/BlogPage/articles-ru.ts
@@ -33,13 +33,13 @@ export const ruTranslations: TranslationMap = {
 
 **1. Google Ads загружался ДО cookie consent** — скрипт выполнялся при каждой загрузке страницы до показа баннера. Исправлено: динамическая загрузка только после согласия + Google Consent Mode v2.
 
-**2. JWT Secret с fallback на известную строку** — \`'change-this-secret-in-production'\`. Исправлено: приложение крашится при старте без \`JWT_SECRET\`.
+**2. JWT Secret с fallback на известную строку** — несколько файлов содержали предсказуемый fallback-секрет. Исправлено: приложение крашится при старте без переменной окружения. Fallback удалён.
 
-**3. SQL Injection через интерполяцию userId** — userId вставлялся напрямую в SQL строку. Исправлено: параметризованный запрос.
+**3. SQL Injection через интерполяцию параметров** — параметры вставлялись напрямую в SQL строку. Исправлено: все запросы переведены на параметризованные плейсхолдеры.
 
 ### Высокие (исправлены)
 
-**4–10:** Конверсионный трекинг без consent, Nginx CORS отражал любой Origin, XSS через dangerouslySetInnerHTML (добавлен DOMPurify), динамические SQL таблицы без whitelist, cleanup-функции никогда не запускались (добавлены cron-задачи), email в логах в plaintext (добавлен maskEmail), OAuth регистрация без rate limiting.
+**4–10:** Конверсионный трекинг без consent, Nginx CORS отражал любой Origin (заменён на строгий whitelist), XSS через dangerouslySetInnerHTML (добавлен DOMPurify), динамические SQL таблицы без whitelist (добавлен allowlist), cleanup-функции никогда не запускались (добавлены cron-задачи), email в логах в plaintext (добавлена маскировка), OAuth регистрация без rate limiting (добавлен лимит по IP).
 
 ---
 
@@ -48,7 +48,7 @@ export const ruTranslations: TranslationMap = {
 ### Уровень 1: Cloudflare — DDoS Protection, WAF, Bot Management, Origin CA
 ### Уровень 2: TLS 1.3 — ECDHE Forward Secrecy, HSTS 1 год
 ### Уровень 3: Nginx — Security Headers (HSTS, X-Frame-Options, CSP, Referrer-Policy)
-### Уровень 4: Express.js — Multi-layer rate limiting (от 3/час до 1500/мин)
+### Уровень 4: Express.js — Multi-layer rate limiting по IP и User ID
 ### Уровень 5: Аутентификация — 6 методов (Password, Google OAuth, WebAuthn, Diia, OIDC, API Keys)
 ### Уровень 6: База данных — PgBouncer + SCRAM-SHA-256, Docker network isolation
 ### Уровень 7: GDPR — Export/Delete/Portability, Cookie Consent, E2EE (AES-256-GCM + X25519)

--- a/lexwebapp/src/pages/BlogPage/articles.ts
+++ b/lexwebapp/src/pages/BlogPage/articles.ts
@@ -82,68 +82,34 @@ gtag('consent', 'default', {
 
 **2. JWT Secret з fallback на відомий рядок**
 
-Три файли містили:
-\`\`\`typescript
-const JWT_SECRET = process.env.JWT_SECRET || 'change-this-secret-in-production';
-\`\`\`
+Декілька файлів містили fallback-значення для JWT-секрету. Якщо при деплої змінна оточення не встановлена — додаток тихо працював з передбачуваним секретом, що дозволяло генерувати валідні JWT для будь-якого користувача.
 
-Якщо при деплої \`JWT_SECRET\` не встановлений — додаток тихо працює з публічно відомим секретом. Будь-хто може згенерувати валідний JWT для будь-якого користувача.
+**Виправлення:** Додаток тепер крашиться при старті, якщо JWT-секрет не встановлений через змінну оточення. Fallback-значення повністю видалені.
 
-**Виправлення:** Додаток тепер крашиться при старті, якщо \`JWT_SECRET\` не встановлений:
-\`\`\`typescript
-const _jwtSecret = process.env.JWT_SECRET;
-if (!_jwtSecret) {
-  throw new Error('FATAL: JWT_SECRET environment variable is required');
-}
-\`\`\`
+**3. SQL Injection через інтерполяцію параметрів**
 
-**3. SQL Injection через інтерполяцію userId**
+Кілька місць у коді використовували пряму інтерполяцію параметрів у SQL-рядки замість параметризованих запитів. У поєднанні з п.2 це створювало прямий вектор SQL Injection.
 
-\`\`\`typescript
-// Було — userId вставлявся напряму в SQL рядок
-const ownerCheck = \` AND user_id = '\${userId}'\`;
-\`\`\`
-
-Хоча \`userId\` приходить з JWT, при компрометації JWT-секрету (див. п.2) це ставало прямим вектором SQL Injection.
-
-**Виправлення:** Параметризований запит:
-\`\`\`typescript
-values.push(userId);
-const userParamIdx = values.length;
-// user_id = $N — безпечний параметр
-\`\`\`
+**Виправлення:** Всі SQL-запити переведено на параметризовані плейсхолдери (\`$1, $2, ...\`).
 
 ### Високі (виправлені)
 
 **4. Конверсійний трекінг без перевірки consent** — всі \`gtag('event', 'conversion')\` виклики (реєстрація, оплата, top-up) тепер перевіряють \`consentStore.isAllowed('analytics')\` перед відправкою.
 
-**5. Nginx CORS відображав будь-який Origin** — SSE-ендпоінти використовували \`$http_origin\` напряму, що дозволяло будь-якому сайту робити запити з credentials. Замінено на whitelist:
-\`\`\`nginx
-set $cors_origin "";
-if ($http_origin ~* "^https://(legal\\.org\\.ua|stage\\.legal\\.org\\.ua)$") {
-    set $cors_origin $http_origin;
-}
-\`\`\`
+**5. Nginx CORS відображав будь-який Origin** — SSE-ендпоінти використовували \`$http_origin\` напряму, що дозволяло будь-якому сайту робити запити з credentials. Замінено на строгий whitelist дозволених доменів.
 
 **6. XSS через dangerouslySetInnerHTML** — 3 компоненти рендерили HTML з бази без санітизації. Додано DOMPurify:
 \`\`\`tsx
 dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
 \`\`\`
 
-**7. Динамічні SQL-таблиці без whitelist** — функції \`lookupName()\` і \`batchLookup()\` приймали імена таблиць як параметри. Додано allowlist:
-\`\`\`typescript
-private static readonly ALLOWED_LOOKUP_TABLES: Record<string, Set<string>> = {
-  edrsr_courts: new Set(['court_code']),
-  edrsr_judgment_forms: new Set(['judgment_code']),
-  edrsr_justice_kinds: new Set(['justice_kind']),
-};
-\`\`\`
+**7. Динамічні SQL-таблиці без whitelist** — деякі функції приймали імена таблиць як параметри без валідації. Додано строгий allowlist дозволених таблиць і колонок.
 
-**8. Cleanup-функції ніколи не запускались** — \`cleanupExpiredSessions()\`, \`purge_soft_deleted_documents()\`, \`cleanup_expired_oauth_data()\` існували, але не були прив'язані до cron. Додано три cron-задачі.
+**8. Cleanup-функції ніколи не запускались** — функції очищення застарілих даних (сесії, видалені документи, токени) існували, але не були прив'язані до cron. Додано автоматичні cron-задачі.
 
 **9. Email-адреси логувались у plaintext** — 9+ місць в auth-контролерах. Додано \`maskEmail()\`: \`user@example.com\` → \`us***@example.com\`.
 
-**10. OAuth реєстрація без rate limiting** — ендпоінт \`/oauth/register\` (RFC 7591) дозволяв необмежену реєстрацію OAuth-клієнтів. Додано rate limit: 5 запитів за 15 хвилин на IP.
+**10. OAuth реєстрація без rate limiting** — ендпоінт реєстрації OAuth-клієнтів дозволяв необмежену кількість запитів. Додано rate limiting по IP.
 
 ---
 
@@ -163,14 +129,7 @@ private static readonly ALLOWED_LOOKUP_TABLES: Record<string, Set<string>> = {
 
 ### Рівень 2: TLS 1.3 (Transport Encryption)
 
-\`\`\`
-ssl_protocols TLSv1.2 TLSv1.3;
-ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256
-            :ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
-            :ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305;
-\`\`\`
-
-- TLS 1.0/1.1 вимкнено
+- TLS 1.0/1.1 вимкнено, тільки TLS 1.2/1.3
 - Тільки ECDHE-сюїти (Forward Secrecy)
 - HSTS з 1-річним max-age і includeSubDomains
 - SSL session cache для продуктивності без компромісів
@@ -195,22 +154,9 @@ Nginx — перший сервер, який бачить запит після
 
 ### Рівень 4: Application Security (Express.js)
 
-**Multi-layer rate limiting:**
+**Multi-layer rate limiting** — кожен тип ендпоінту (auth, chat, API, password reset) має окремі ліміти по IP або User ID. При падінні Redis rate limiting працює через in-memory fallback.
 
-| Ендпоінт | Ліміт | Ключ |
-|----------|-------|------|
-| Auth (login, register) | 10 / 15 хв | IP |
-| Password reset | 3 / год | IP |
-| Chat | 60 / хв | User ID |
-| Global API | 1500 / хв | IP |
-| OAuth registration | 5 / 15 хв | IP |
-
-**Fail-safe:** при падінні Redis rate limiting працює через in-memory express-rate-limit як backup.
-
-**CORS:** Express-рівень валідує origins незалежно від Nginx:
-\`\`\`typescript
-const allowedOrigins = ['https://legal.org.ua', 'https://stage.legal.org.ua'];
-\`\`\`
+**CORS** — Express-рівень валідує origins незалежно від Nginx через строгий whitelist дозволених доменів.
 
 ### Рівень 5: Authentication (6 методів)
 
@@ -223,24 +169,21 @@ LEX AI підтримує 6 методів автентифікації:
 5. **OIDC / Authentik** — SSO через Authentik
 6. **API Keys** — для MCP-клієнтів (Claude Desktop, Claude Code), database-backed з audit log
 
-**Dual Auth Middleware** автоматично визначає тип токена:
-- Містить крапку → JWT (user session)
-- Починається з \`mcp_token_\` → OAuth access token
-- Інше → API key
+**Dual Auth Middleware** автоматично визначає тип токена і застосовує відповідну стратегію верифікації для кожного методу автентифікації.
 
 ### Рівень 6: Database Security
 
 - **PgBouncer** з SCRAM-SHA-256 автентифікацією
-- Connection pooling: 500 max clients, 50 pool size
-- Statement timeout: 600с (захист від DOS через повільні запити)
+- Connection pooling з обмеженнями на кількість клієнтів та розмір пулу
+- Statement timeout для захисту від DOS через повільні запити
 - Docker bridge network ізолює БД від зовнішнього доступу
-- Parameterized queries скрізь (PostgreSQL \`$1, $2\` плейсхолдери)
+- Parameterized queries скрізь (PostgreSQL плейсхолдери)
 
 ### Рівень 7: Data Protection (GDPR)
 
 **Реалізовані права:**
 - **Art. 15 (Доступ)** — повний JSON-експорт всіх даних користувача
-- **Art. 17 (Видалення)** — каскадне видалення з PostgreSQL, Qdrant, MinIO, anonymization cost_tracking
+- **Art. 17 (Видалення)** — каскадне видалення з усіх сховищ даних, анонімізація трекінгу
 - **Art. 20 (Портабельність)** — машинно-зчитуваний JSON формат
 
 **Cookie Consent:**
@@ -253,10 +196,7 @@ LEX AI підтримує 6 методів автентифікації:
 - X25519 ECDH key exchange (envelope encryption)
 - Зашифровані документи недоступні для AI-аналізу (by design)
 
-**Автоматичне очищення:**
-- Сесії: кожні 6 годин
-- Soft-deleted документи: щоденно (30-день retention)
-- OAuth токени: щоденно
+**Автоматичне очищення** — регулярне видалення застарілих сесій, soft-deleted документів та OAuth токенів за налаштованими інтервалами.
 
 ---
 


### PR DESCRIPTION
## Summary
- Видалено внутрішні конфігураційні параметри зі статті security-audit-gdpr-owasp
- JWT fallback secret, SQL injection code snippets, точні rate limits, PgBouncer config, token detection logic, CORS whitelist зі stage domain, назви таблиць БД, імена внутрішніх функцій, TLS cipher list
- Замінено на узагальнені описи без конкретних значень
- Застосовано до всіх 3 мовних версій (uk, en, ru)

## Test plan
- [ ] Перевірити що стаття рендериться коректно на /blog
- [ ] Переконатися що зміст статті залишається інформативним без конкретних параметрів

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed sensitive internal configuration details from the security audit blog post and replaced them with generalized descriptions to prevent disclosure. Applied to `uk`, `en`, and `ru` articles without reducing clarity.

- **Bug Fixes**
  - Removed JWT secret fallback mentions and vulnerable SQL code examples; described fixes generically.
  - Hid exact operational values (rate limits, PgBouncer pool sizes/timeouts, TLS cipher list, cleanup schedules).
  - Removed internal specifics (CORS whitelist domains, DB table names, internal function names, token prefix patterns).
  - Kept mitigation explanations and architecture overview while avoiding concrete parameters.

<sup>Written for commit d141298f956d41eea881710b71928b8d78e23bda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

