### PR TITLE
feat(tools): add search_public_spending MCP tool

### DIFF
--- a/mcp_backend/src/api/tools/spending-tools.ts
+++ b/mcp_backend/src/api/tools/spending-tools.ts
@@ -1,0 +1,174 @@
+/**
+ * Spending Tools — MCP tools for public spending data (spending.gov.ua)
+ *
+ * 1 tool:
+ * - search_public_spending — Акти, додаткові угоди, пеня, контракти (12.6M+ записів)
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+const TABLE_MAP: Record<string, string> = {
+  acts: 'spending_acts',
+  addendums: 'spending_addendums',
+  peny: 'spending_peny',
+  contracts: 'spending_contracts',
+};
+
+const DOC_TYPE_LABELS: Record<string, string> = {
+  acts: 'Акт виконаних робіт',
+  addendums: 'Додаткова угода',
+  peny: 'Пеня / штраф',
+  contracts: 'Договір',
+};
+
+export class SpendingTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'search_public_spending',
+        description: `Пошук у реєстрі публічних витрат (spending.gov.ua)
+
+12.6M+ записів: акти виконаних робіт (9.45M), додаткові угоди (2.11M), пеня (40K), договори (2.8K).
+Пошук за ЄДРПОУ розпорядника, назвою контрагента, сумою, датою, типом документа.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            edrpou: { type: 'string', description: 'ЄДРПОУ розпорядника бюджетних коштів' },
+            contractor_name: { type: 'string', description: 'Назва контрагента (часткове входження)' },
+            contractor_edrpou: { type: 'string', description: 'ЄДРПОУ контрагента' },
+            date_from: { type: 'string', description: 'Дата підписання від (YYYY-MM-DD)' },
+            date_to: { type: 'string', description: 'Дата підписання до (YYYY-MM-DD)' },
+            min_amount: { type: 'number', description: 'Мін. сума (копійки)' },
+            max_amount: { type: 'number', description: 'Макс. сума (копійки)' },
+            doc_type: {
+              type: 'string',
+              enum: ['acts', 'addendums', 'peny', 'contracts', 'all'],
+              description: 'Тип документа (acts/addendums/peny/contracts/all). За замовчуванням: all',
+            },
+            limit: { type: 'number', default: 50, maximum: 100, description: 'Макс. результатів' },
+          },
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
+    switch (name) {
+      case 'search_public_spending': return this.searchPublicSpending(args);
+      default: return null;
+    }
+  }
+
+  private async searchPublicSpending(args: Record<string, unknown>): Promise<ToolResult> {
+    const {
+      edrpou, contractor_name, contractor_edrpou,
+      date_from, date_to, min_amount, max_amount,
+      doc_type = 'all', limit = 50,
+    } = args as any;
+
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (edrpou) {
+      conditions.push(`edrpou = $${pi}`);
+      values.push(edrpou);
+      pi++;
+    }
+    if (date_from) {
+      conditions.push(`sign_date >= $${pi}`);
+      values.push(date_from);
+      pi++;
+    }
+    if (date_to) {
+      conditions.push(`sign_date <= $${pi}`);
+      values.push(date_to);
+      pi++;
+    }
+    if (min_amount != null) {
+      conditions.push(`amount >= $${pi}`);
+      values.push(min_amount);
+      pi++;
+    }
+    if (max_amount != null) {
+      conditions.push(`amount <= $${pi}`);
+      values.push(max_amount);
+      pi++;
+    }
+
+    // JSONB contractor search
+    let contractorCondition = '';
+    if (contractor_name) {
+      contractorCondition = `EXISTS (SELECT 1 FROM jsonb_array_elements(contractors) AS c WHERE c->>'name' ILIKE $${pi})`;
+      conditions.push(contractorCondition);
+      values.push(`%${contractor_name}%`);
+      pi++;
+    }
+    if (contractor_edrpou) {
+      conditions.push(`EXISTS (SELECT 1 FROM jsonb_array_elements(contractors) AS c WHERE c->>'code' = $${pi})`);
+      values.push(contractor_edrpou);
+      pi++;
+    }
+
+    if (conditions.length === 0) {
+      return this.wrapResponse('Вкажіть хоча б один параметр: edrpou, contractor_name, contractor_edrpou, date_from/date_to, або min_amount/max_amount');
+    }
+
+    const maxRows = Math.min(Number(limit) || 50, 100);
+    const whereClause = conditions.join(' AND ');
+
+    // Determine which tables to query
+    const tables = doc_type === 'all'
+      ? Object.entries(TABLE_MAP)
+      : TABLE_MAP[doc_type]
+        ? [[doc_type, TABLE_MAP[doc_type]]]
+        : Object.entries(TABLE_MAP);
+
+    const allResults: any[] = [];
+
+    for (const [dtype, tableName] of tables) {
+      try {
+        const sql = `SELECT id, edrpou, document_number, document_date, sign_date,
+          amount, currency, pdv_include, pdv_amount,
+          contractors, parent_id
+          FROM ${tableName}
+          WHERE ${whereClause}
+          ORDER BY sign_date DESC NULLS LAST
+          LIMIT ${maxRows}`;
+
+        const result = await this.db.query(sql, values);
+        for (const row of result.rows) {
+          allResults.push({
+            ...row,
+            doc_type: dtype,
+            doc_type_label: DOC_TYPE_LABELS[dtype] || dtype,
+            amount_uah: row.amount ? (Number(row.amount) / 100).toFixed(2) : null,
+          });
+        }
+      } catch (err: any) {
+        logger.warn(`[SpendingTools] Error querying ${tableName}`, { error: err.message });
+      }
+    }
+
+    // Sort merged results by sign_date DESC and trim
+    allResults.sort((a, b) => {
+      const da = a.sign_date ? new Date(a.sign_date).getTime() : 0;
+      const db = b.sign_date ? new Date(b.sign_date).getTime() : 0;
+      return db - da;
+    });
+
+    const trimmed = allResults.slice(0, maxRows);
+
+    return this.wrapResponse(JSON.stringify({
+      query: { edrpou, contractor_name, contractor_edrpou, date_from, date_to, min_amount, max_amount, doc_type },
+      total: allResults.length,
+      returned: trimmed.length,
+      results: trimmed,
+    }, null, 2));
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -27,6 +27,7 @@ import { NextcloudTools } from '../api/tools/nextcloud-tools.js';
 import { StateRegistryTools } from '../api/tools/state-registry-tools.js';
 import { CourtStatusTools } from '../api/tools/court-status-tools.js';
 import { OpenDataTools } from '../api/tools/opendata-tools.js';
+import { SpendingTools } from '../api/tools/spending-tools.js';
 import { OpenDataRegistriesTools } from '../api/tools/opendata-registries-tools.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
 import { DecisionLayerTools } from '../api/tools/decision-layer-tools.js';
@@ -129,6 +130,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new StateRegistryTools(coreServices.db));
   toolRegistry.registerHandler(new CourtStatusTools(coreServices.db));
   toolRegistry.registerHandler(new OpenDataTools(coreServices.db));
+  toolRegistry.registerHandler(new SpendingTools(coreServices.db));
   toolRegistry.registerHandler(new OpenDataRegistriesTools(coreServices.db));
   toolRegistry.registerHandler(new EdsrSearchTools(coreServices.db));
   toolRegistry.registerHandler(new DecisionLayerTools(llmAdapter));


### PR DESCRIPTION
## Summary
- New `search_public_spending` tool for spending.gov.ua data (12.6M+ records)
- Searches across 4 tables: acts (9.45M), addendums (2.11M), peny (40.5K), contracts (2.8K)
- Supports: EDRPOU, contractor name/code (JSONB), date range, amount range, doc_type filter

## Closes GAP from task #415
Previously these 4 tables had no MCP tool coverage.

## Test plan
- [ ] `search_public_spending` with `edrpou` filter
- [ ] `search_public_spending` with `contractor_name` JSONB search
- [ ] `search_public_spending` with `doc_type=acts` filter
- [ ] Verify all existing tools still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `search_public_spending` MCP tool to query spending.gov.ua across acts, addendums, peny, and contracts (12.6M+ records). Addresses #415 by adding MCP coverage for these spending tables.

- **New Features**
  - Queries `spending_acts`, `spending_addendums`, `spending_peny`, `spending_contracts` with optional `doc_type` or `all`.
  - Filters: `edrpou`, contractor name/code (JSONB), `date_from`/`date_to`, `min_amount`/`max_amount`; `limit` up to 100.
  - Merges results, sorts by `sign_date` desc; includes `doc_type` label and computed `amount_uah`.
  - Requires at least one filter; defaults: `doc_type=all`, `limit=50`.
  - Registers `SpendingTools` in the tool registry for availability.

<sup>Written for commit 8043743b3762857bc0a766b06f95b70655c17ed2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

