### PR TITLE
security: harden Redis auth + remove stage fallback URLs

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -101,12 +101,12 @@ services:
     image: redis:7-alpine
     container_name: secondlayer-redis-local
     ports:
-      - "6379:6379"  # Standard Redis port
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_local_data:/data
-    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy noeviction --requirepass ${REDIS_PASSWORD:-local_redis_pass}
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-local_redis_pass}", "ping"]
       interval: 5s
       timeout: 2s
       retries: 5
@@ -240,9 +240,10 @@ services:
       QDRANT_URL: http://qdrant-local:6333
 
       # Cache
-      REDIS_URL: redis://redis-local:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD:-local_redis_pass}@redis-local:6379
       REDIS_HOST: redis-local
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-local_redis_pass}
 
       # OpenAI Configuration
       OPENAI_API_KEY: ${OPENAI_API_KEY:-local-dev-openai-key}
@@ -424,9 +425,10 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_local}
       POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
       DATABASE_URL: postgresql://${RADA_POSTGRES_USER:-rada_mcp}:${RADA_POSTGRES_PASSWORD:-rada_password}@postgres-local:5432/${POSTGRES_DB:-secondlayer_local}
-      REDIS_URL: redis://redis-local:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD:-local_redis_pass}@redis-local:6379
       REDIS_HOST: redis-local
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-local_redis_pass}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-local-dev-openai-key}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
@@ -489,9 +491,10 @@ services:
       QDRANT_URL: http://qdrant-local:6333
 
       # Cache
-      REDIS_URL: redis://redis-local:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD:-local_redis_pass}@redis-local:6379
       REDIS_HOST: redis-local
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-local_redis_pass}
 
       # OpenAI Configuration
       OPENAI_API_KEY: ${OPENAI_API_KEY:-local-dev-openai-key}
@@ -696,9 +699,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-local_dev_password}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_local}
-      REDIS_URL: redis://redis-local:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD:-local_redis_pass}@redis-local:6379
       REDIS_HOST: redis-local
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:-local_redis_pass}
       QDRANT_URL: http://qdrant-local:6333
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -181,11 +181,13 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 2048mb --maxmemory-policy volatile-lru
+    command: redis-server --appendonly yes --maxmemory 2048mb --maxmemory-policy noeviction --requirepass ${REDIS_PASSWORD}
     healthcheck:
       test:
       - CMD
       - redis-cli
+      - -a
+      - ${REDIS_PASSWORD}
       - ping
       interval: 10s
       timeout: 3s
@@ -273,9 +275,10 @@ services:
       POSTGRES_PASSWORD: ${RADA_POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       NODE_ENV: production
       TZ: Europe/Kiev
@@ -309,9 +312,10 @@ services:
       POSTGRES_PASSWORD: ${RADA_POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
@@ -518,9 +522,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
@@ -689,9 +694,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
@@ -899,9 +905,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}
@@ -1031,9 +1038,10 @@ services:
       POSTGRES_PASSWORD: ${RADA_POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       POSTGRES_SCHEMA: ${RADA_POSTGRES_SCHEMA:-rada}
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
@@ -1140,9 +1148,10 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
-      REDIS_URL: redis://redis-prod:6379
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY2: ${OPENAI_API_KEY2:-}
       OPENAI_EMBEDDING_MODEL: ${OPENAI_EMBEDDING_MODEL:-text-embedding-3-small}

--- a/mcp_backend/src/services/remote-service-client.ts
+++ b/mcp_backend/src/services/remote-service-client.ts
@@ -51,11 +51,11 @@ export class RemoteServiceClient {
         apiKey: '',
       },
       rada: {
-        baseUrl: process.env.RADA_MCP_URL || 'http://rada-mcp-app-stage:3001',
+        baseUrl: process.env.RADA_MCP_URL || '',
         apiKey: process.env.RADA_API_KEY || '',
       },
       openreyestr: {
-        baseUrl: process.env.OPENREYESTR_MCP_URL || 'http://app-openreyestr-stage:3005',
+        baseUrl: process.env.OPENREYESTR_MCP_URL || '',
         apiKey: process.env.OPENREYESTR_API_KEY || '',
       },
     };

--- a/mcp_backend/src/services/upload-queue-service.ts
+++ b/mcp_backend/src/services/upload-queue-service.ts
@@ -58,8 +58,9 @@ export class UploadQueueService {
 
     const redisHost = process.env.REDIS_HOST || 'localhost';
     const redisPort = parseInt(process.env.REDIS_PORT || '6379', 10);
+    const redisPassword = process.env.REDIS_PASSWORD || undefined;
 
-    const connection = { host: redisHost, port: redisPort };
+    const connection = { host: redisHost, port: redisPort, password: redisPassword };
 
     this.queue = new Queue(QUEUE_NAME, {
       connection,
@@ -88,7 +89,8 @@ export class UploadQueueService {
   startWorker(): void {
     const redisHost = process.env.REDIS_HOST || 'localhost';
     const redisPort = parseInt(process.env.REDIS_PORT || '6379', 10);
-    const connection = { host: redisHost, port: redisPort };
+    const redisPassword = process.env.REDIS_PASSWORD || undefined;
+    const connection = { host: redisHost, port: redisPort, password: redisPassword };
     const concurrency = DEFAULT_CONCURRENCY;
 
     this.worker = new Worker(


### PR DESCRIPTION
## Summary

- **Redis localhost binding** — local Redis was exposed on `0.0.0.0:6379` (vulnerable to RedisWriteMaster attacks — malicious `backup*` keys were found in local instance). Now bound to `127.0.0.1`
- **Redis authentication** — added `requirepass` to both local and prod Redis. All services now pass `REDIS_PASSWORD` via env vars. BullMQ `upload-queue-service.ts` was missing password in connection config
- **Stage fallback URLs removed** — `remote-service-client.ts` had hardcoded `http://rada-mcp-app-stage:3001` and `http://app-openreyestr-stage:3005` as fallbacks. If env vars were missing in prod, traffic would silently route to stage
- **Eviction policy** — prod Redis changed from `volatile-lru` to `noeviction` (BullMQ requirement — hangs on startup with wrong policy)

## Deployment notes

After merging, add `REDIS_PASSWORD=<generated-password>` to `.env.prod` on the prod server before deploying. The password was already added during the security audit: `LUgw7tDGcMGeIx5OH8a1MVXbAgRE1Wl`

## Test plan

- [ ] Verify local dev starts with `docker compose --env-file .env.local up -d` (Redis requires password)
- [ ] Verify `redis-cli` without password returns `NOAUTH`
- [ ] Verify backend health check passes (postgres, redis, qdrant all OK)
- [ ] Verify BullMQ upload queue connects without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens Redis security by enforcing auth and binding local Redis to localhost, and removes stage fallback URLs to prevent accidental routing. Also fixes `BullMQ` startup by setting the correct eviction policy and passing the Redis password everywhere.

- **Bug Fixes**
  - Bind local Redis to 127.0.0.1 and enforce `requirepass`; healthchecks use auth.
  - Include `REDIS_PASSWORD` in `REDIS_URL` and env for all services; `upload-queue-service.ts` now passes it to `BullMQ`.
  - Switch prod Redis eviction policy to `noeviction` to satisfy `BullMQ`.
  - Remove hardcoded stage base URLs in `remote-service-client.ts` (env-only now).

- **Migration**
  - Set `REDIS_PASSWORD` in prod before deploy; redeploy services.
  - Local dev works with default `local_redis_pass` or a custom `REDIS_PASSWORD`.

<sup>Written for commit 4c96ba0f0beea422faa1a8a0fee0f89b91649e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

