### PR TITLE
security: fix critical/high vulnerabilities from pentest audit

### DIFF
--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -3,17 +3,12 @@
 # CORS origin validation for SSE endpoints
 # Only allow known origins with credentials; MCP clients use Bearer tokens, not cookies
 set $cors_origin "";
-if ($http_origin ~* "^https://(legal\.org\.ua|stage\.legal\.org\.ua|localhost:\d+)$") {
+if ($http_origin ~* "^https://(legal\.org\.ua|stage\.legal\.org\.ua)$") {
     set $cors_origin $http_origin;
 }
 
-# Security Headers
-add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-add_header X-Frame-Options "SAMEORIGIN" always;
-add_header X-Content-Type-Options "nosniff" always;
-add_header X-XSS-Protection "1; mode=block" always;
-add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://legal.org.ua https://accounts.google.com https://cloudflareinsights.com https://api.stripe.com wss://legal.org.ua; frame-src 'self' https://accounts.google.com https://js.stripe.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';" always;
+# Security Headers (server-level — apply to locations without their own add_header)
+include /etc/nginx/includes/security-headers.conf;
 
 # Logging
 access_log /var/log/nginx/legal.org.ua-access.log;
@@ -38,6 +33,9 @@ location /health {
 # ==========================================
 
 location /auth {
+    limit_req zone=auth_limit burst=10 nodelay;
+    limit_req_status 429;
+
     proxy_pass http://prod_mcp_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -71,6 +69,8 @@ location /api/admin/terminal {
 # GET /api/v1/sse  → establish SSE stream (rewrites to /v1/sse on backend)
 # POST /api/v1/sse → route messages to SSE session (rewrites to /v1/sse on backend)
 location /api/v1/sse {
+    limit_conn sse_conn_limit 20;
+
     rewrite ^/api(/v1/sse.*)$ $1 break;
     proxy_pass http://prod_mcp_backend;
     proxy_http_version 1.1;
@@ -88,6 +88,7 @@ location /api/v1/sse {
     proxy_connect_timeout 75s;
     chunked_transfer_encoding on;
 
+    include /etc/nginx/includes/security-headers.conf;
     add_header Access-Control-Allow-Origin "$cors_origin" always;
     add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
     add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control" always;
@@ -110,6 +111,9 @@ location /api/v1/sse {
 # ==========================================
 
 location /api {
+    limit_req zone=api_limit burst=60 nodelay;
+    limit_req_status 429;
+
     proxy_pass http://prod_mcp_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -129,6 +133,9 @@ location /api {
 # ==========================================
 
 location /webhooks {
+    limit_req zone=webhook_limit burst=10 nodelay;
+    limit_req_status 429;
+
     proxy_pass http://prod_mcp_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -145,6 +152,8 @@ location /webhooks {
 
 # MCP SSE for ChatGPT Web / Claude.ai
 location /sse {
+    limit_conn sse_conn_limit 20;
+
     proxy_pass http://prod_mcp_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -160,6 +169,7 @@ location /sse {
     proxy_connect_timeout 75s;
     chunked_transfer_encoding on;
 
+    include /etc/nginx/includes/security-headers.conf;
     add_header Access-Control-Allow-Origin "$cors_origin" always;
     add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
     add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control" always;
@@ -179,6 +189,8 @@ location /sse {
 
 # Standard MCP SSE for Claude Desktop, Claude Code, Jan AI, etc.
 location /v1/sse {
+    limit_conn sse_conn_limit 20;
+
     proxy_pass http://prod_mcp_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
@@ -194,6 +206,7 @@ location /v1/sse {
     proxy_connect_timeout 75s;
     chunked_transfer_encoding on;
 
+    include /etc/nginx/includes/security-headers.conf;
     add_header Access-Control-Allow-Origin "$cors_origin" always;
     add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
     add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control" always;
@@ -318,11 +331,11 @@ location ^~ /s3/ {
     proxy_set_header Connection "";
     proxy_buffering off;
 
-    # Override server-level security headers for S3 content.
-    # Adding add_header here clears inherited server-level headers,
-    # removing the CSP object-src 'none' that blocks Chrome's PDF viewer.
+    # S3 needs relaxed CSP for PDF viewer — keep core security headers
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # Hide MinIO Content-Disposition to allow inline PDF viewing
     proxy_hide_header Content-Disposition;
@@ -337,6 +350,7 @@ location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
     proxy_http_version 1.1;
     proxy_set_header Connection "";
     expires 7d;
+    include /etc/nginx/includes/security-headers.conf;
     add_header Cache-Control "public";
 }
 
@@ -354,6 +368,7 @@ location / {
     proxy_set_header Connection "";
 
     # Prevent caching index.html so browsers always get fresh chunk references after deploy
+    include /etc/nginx/includes/security-headers.conf;
     add_header Cache-Control "no-cache, no-store, must-revalidate";
     add_header Pragma "no-cache";
     add_header Expires "0";

--- a/deployment/nginx/includes/security-headers.conf
+++ b/deployment/nginx/includes/security-headers.conf
@@ -1,0 +1,10 @@
+# Security headers — include in every location that uses add_header
+# (nginx add_header in a location block clears server-level headers)
+
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self)" always;
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://static.cloudflareinsights.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://legal.org.ua https://accounts.google.com https://cloudflareinsights.com https://api.stripe.com wss://legal.org.ua; frame-src 'self' https://accounts.google.com https://js.stripe.com; worker-src 'self' blob:; object-src 'none'; base-uri 'self';" always;

--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -1,6 +1,13 @@
 # Nginx Configuration for legal.org.ua (Production)
 # Runs as a Docker container (nginx-prod) in docker-compose.prod.yml
 
+# Rate limiting zones (must be in http context, before server blocks)
+# Use X-Forwarded-For from Cloudflare/ALB as real client IP
+limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
+limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=1r/s;
+limit_req_zone $binary_remote_addr zone=webhook_limit:10m rate=5r/s;
+limit_conn_zone $binary_remote_addr zone=sse_conn_limit:10m;
+
 # App upstreams — managed by deploy script (blue-green switching)
 include /etc/nginx/includes/prod-upstreams.conf;
 

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -62,7 +62,6 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@secondlayer/core-interfaces": "file:../packages/core-interfaces",
     "@anthropic-ai/sdk": "^0.78.0",
     "@aws-sdk/client-bedrock": "^3.1014.0",
     "@aws-sdk/client-s3": "^3.1005.0",
@@ -70,6 +69,7 @@
     "@google-cloud/vision": "^5.3.4",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@qdrant/js-client-rest": "^1.17.0",
+    "@secondlayer/core-interfaces": "file:../packages/core-interfaces",
     "@secondlayer/shared": "file:../packages/shared",
     "@simplewebauthn/server": "^13.2.3",
     "@types/bcryptjs": "^3.0.0",
@@ -96,7 +96,7 @@
     "minio": "^8.0.6",
     "multer": "^2.1.0",
     "node-cron": "^4.2.1",
-    "nodemailer": "^8.0.2",
+    "nodemailer": "^8.0.4",
     "openai": "^6.27.0",
     "openid-client": "^5.7.1",
     "passport": "^0.7.0",

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -179,8 +179,8 @@ class HTTPMCPServer {
         if (!origin) return callback(null, true);
         // Allow configured origins
         if (allowedOrigins.includes(origin)) return callback(null, true);
-        // Allow localhost in development
-        if (origin.match(/^https?:\/\/localhost(:\d+)?$/)) return callback(null, true);
+        // Allow localhost only in development
+        if (process.env.NODE_ENV !== 'production' && origin.match(/^https?:\/\/localhost(:\d+)?$/)) return callback(null, true);
         callback(new Error(`CORS not allowed for origin: ${origin}`));
       },
       credentials: true,
@@ -369,7 +369,16 @@ class HTTPMCPServer {
       });
     };
 
-    this.app.get('/health/ready', healthHandler);
+    // Lightweight readiness probe for Docker healthcheck — no infra details exposed
+    this.app.get('/health/ready', (_req: any, res: any) => {
+      res.json({
+        status: 'ok',
+        initialized: (this as any)._initialized === true,
+        service: 'secondlayer-mcp-http',
+        uptime: Math.round(process.uptime()),
+      });
+    });
+    // Full health check — detailed dependency info, rate-limited
     this.app.get('/health', healthCheckRateLimit as any, healthHandler);
 
     // MCP SSE routes (SSE endpoints, OAuth discovery, redirects)

--- a/mcp_backend/src/middleware/auth.ts
+++ b/mcp_backend/src/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import { logger } from '../utils/logger.js';
 
 export interface AuthenticatedRequest extends Request {
@@ -42,7 +43,12 @@ export function authenticateClient(
     });
   }
 
-  if (!validKeys.includes(clientKey.trim())) {
+  const trimmedKey = clientKey.trim();
+  const keyMatch = validKeys.some(k => {
+    if (k.length !== trimmedKey.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(k), Buffer.from(trimmedKey));
+  });
+  if (!keyMatch) {
     logger.warn('Unauthorized request - invalid client key', {
       ip: req.ip,
       path: req.path,

--- a/mcp_backend/src/middleware/dual-auth.ts
+++ b/mcp_backend/src/middleware/dual-auth.ts
@@ -4,6 +4,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 import { UserService, User } from '../services/user-service.js';
 import { ApiKeyService } from '../services/api-key-service.js';
@@ -173,7 +174,11 @@ async function authenticateWithAPIKey(req: AuthenticatedRequest, apiKey: string)
   // Fall back to legacy env-based API keys
   const validKeys = getSecondaryLayerKeys();
 
-  if (!validKeys.includes(apiKey)) {
+  const keyMatch = validKeys.some(k => {
+    if (k.length !== apiKey.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(k), Buffer.from(apiKey));
+  });
+  if (!keyMatch) {
     logger.warn('Invalid API key attempt (not found in Phase 2 or legacy keys)', {
       keyPrefix: maskSensitive(apiKey, 8),
       validKeysCount: validKeys.length,

--- a/mcp_backend/src/middleware/oauth-auth.ts
+++ b/mcp_backend/src/middleware/oauth-auth.ts
@@ -4,6 +4,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
+import crypto from 'crypto';
 import { OAuthService } from '../services/oauth-service.js';
 import { logger } from '../utils/logger.js';
 
@@ -127,7 +128,11 @@ export function createHybridAuthMiddleware(oauthService: OAuthService) {
       }
 
       // Try API key authentication
-      if (apiKeys.includes(token)) {
+      const apiKeyMatch = apiKeys.some(k => {
+        if (k.length !== token.length) return false;
+        return crypto.timingSafeEqual(Buffer.from(k), Buffer.from(token));
+      });
+      if (apiKeyMatch) {
         // Valid API key - no user ID attached
         logger.debug('API key authentication successful');
         return next();

--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -9,6 +9,31 @@ export function setRateLimitCache(cache: ICachePort): void {
   rateCache = cache;
 }
 
+// In-memory fallback when Redis is unavailable
+const memoryStore = new Map<string, { count: number; expiresAt: number }>();
+const MEMORY_CLEANUP_INTERVAL = 60_000;
+let lastCleanup = Date.now();
+
+function memoryIncrement(key: string, windowMs: number): number {
+  // Periodic cleanup of expired entries
+  if (Date.now() - lastCleanup > MEMORY_CLEANUP_INTERVAL) {
+    const now = Date.now();
+    for (const [k, v] of memoryStore) {
+      if (v.expiresAt <= now) memoryStore.delete(k);
+    }
+    lastCleanup = now;
+  }
+
+  const existing = memoryStore.get(key);
+  const now = Date.now();
+  if (existing && existing.expiresAt > now) {
+    existing.count++;
+    return existing.count;
+  }
+  memoryStore.set(key, { count: 1, expiresAt: now + windowMs });
+  return 1;
+}
+
 interface RateLimitOptions {
   windowMs: number;
   maxRequests: number;
@@ -25,54 +50,76 @@ export function createRateLimiter(options: RateLimitOptions) {
     keyPrefix = 'ratelimit',
   } = options;
 
+  const checkLimit = async (req: Request, res: Response, next: NextFunction, useMemory: boolean) => {
+    const identifier = options.keyByUserId && (req as any).user?.id
+      ? `user:${(req as any).user.id}`
+      : req.ip || req.socket.remoteAddress || 'unknown';
+
+    // Skip rate limiting for internal/localhost traffic (Prometheus, health monitors)
+    if (identifier === '127.0.0.1' || identifier === '::1' || identifier === '::ffff:127.0.0.1') {
+      return next();
+    }
+
+    const key = keyPrefix + ':' + identifier;
+    let currentCount: number;
+
+    if (useMemory) {
+      currentCount = memoryIncrement(key, windowMs);
+    } else {
+      const current = await rateCache!.get(key);
+      currentCount = current ? parseInt(current, 10) : 0;
+      await rateCache!.increment(key, Math.ceil(windowMs / 1000));
+      currentCount++; // after increment
+    }
+
+    if (currentCount > maxRequests) {
+      logger.warn('[RateLimit] Limit exceeded', {
+        identifier,
+        current: currentCount,
+        max: maxRequests,
+        path: req.path,
+        backend: useMemory ? 'memory' : 'redis',
+      });
+
+      return res.status(429).json({
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded. Maximum ' + maxRequests + ' requests per ' + (windowMs / 1000) + ' seconds',
+        code: 'RATE_LIMIT_EXCEEDED',
+        retryAfter: Math.ceil(windowMs / 1000),
+      });
+    }
+
+    res.setHeader('X-RateLimit-Limit', maxRequests.toString());
+    res.setHeader('X-RateLimit-Remaining', (maxRequests - currentCount).toString());
+    res.setHeader('X-RateLimit-Reset', (Date.now() + windowMs).toString());
+
+    next();
+  };
+
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
       if (!rateCache) {
-        return next(); // Cache unavailable, skip rate limiting
+        // Redis unavailable — fall back to in-memory rate limiting
+        return checkLimit(req, res, next, true);
       }
-      const identifier = options.keyByUserId && (req as any).user?.id
-        ? `user:${(req as any).user.id}`
-        : req.ip || req.socket.remoteAddress || 'unknown';
-
-      // Skip rate limiting for internal/localhost traffic (Prometheus, health monitors)
-      if (identifier === '127.0.0.1' || identifier === '::1' || identifier === '::ffff:127.0.0.1') {
-        return next();
-      }
-
-      const key = keyPrefix + ':' + identifier;
-
-      const current = await rateCache.get(key);
-      const currentCount = current ? parseInt(current, 10) : 0;
-
-      if (currentCount >= maxRequests) {
-        logger.warn('[RateLimit] Limit exceeded', {
-          identifier,
-          current: currentCount,
-          max: maxRequests,
-          path: req.path,
-        });
-
-        return res.status(429).json({
-          error: 'Too Many Requests',
-          message: 'Rate limit exceeded. Maximum ' + maxRequests + ' requests per ' + (windowMs / 1000) + ' seconds',
-          code: 'RATE_LIMIT_EXCEEDED',
-          retryAfter: Math.ceil(windowMs / 1000),
-        });
-      }
-
-      await rateCache.increment(key, Math.ceil(windowMs / 1000));
-
-      res.setHeader('X-RateLimit-Limit', maxRequests.toString());
-      res.setHeader('X-RateLimit-Remaining', (maxRequests - currentCount - 1).toString());
-      res.setHeader('X-RateLimit-Reset', (Date.now() + windowMs).toString());
-
-      next();
+      return checkLimit(req, res, next, false);
     } catch (error) {
-      logger.error('[RateLimit] Cache error, allowing request', {
+      logger.error('[RateLimit] Redis error, falling back to memory', {
         error: (error as Error).message,
         path: req.path,
       });
-      next();
+      // Fall back to in-memory instead of allowing unlimited requests
+      try {
+        return checkLimit(req, res, next, true);
+      } catch (memError) {
+        logger.error('[RateLimit] Memory fallback also failed', {
+          error: (memError as Error).message,
+        });
+        return res.status(503).json({
+          error: 'Service Unavailable',
+          message: 'Rate limiting service temporarily unavailable',
+        });
+      }
     }
   };
 }

--- a/mcp_backend/src/middleware/upload-rate-limit.ts
+++ b/mcp_backend/src/middleware/upload-rate-limit.ts
@@ -16,6 +16,20 @@ interface UserRateLimitOptions {
   keyPrefix: string;
 }
 
+// In-memory fallback for upload rate limiting when Redis is unavailable
+const uploadMemoryStore = new Map<string, { count: number; expiresAt: number }>();
+
+function uploadMemoryIncrement(key: string, windowMs: number): number {
+  const now = Date.now();
+  const existing = uploadMemoryStore.get(key);
+  if (existing && existing.expiresAt > now) {
+    existing.count++;
+    return existing.count;
+  }
+  uploadMemoryStore.set(key, { count: 1, expiresAt: now + windowMs });
+  return 1;
+}
+
 function createUserRateLimiter(options: UserRateLimitOptions) {
   const { windowMs, maxRequests, keyPrefix } = options;
 
@@ -26,15 +40,20 @@ function createUserRateLimiter(options: UserRateLimitOptions) {
         return next(); // Let auth middleware handle unauthenticated requests
       }
 
+      const key = `${keyPrefix}:${userId}`;
+      let currentCount: number;
+
       if (!uploadRateCache) {
-        return next(); // Cache unavailable, skip rate limiting
+        // Redis unavailable — fall back to in-memory rate limiting
+        currentCount = uploadMemoryIncrement(key, windowMs);
+      } else {
+        const current = await uploadRateCache.get(key);
+        currentCount = current ? parseInt(current, 10) : 0;
+        await uploadRateCache.increment(key, Math.ceil(windowMs / 1000));
+        currentCount++;
       }
 
-      const key = `${keyPrefix}:${userId}`;
-      const current = await uploadRateCache.get(key);
-      const currentCount = current ? parseInt(current, 10) : 0;
-
-      if (currentCount >= maxRequests) {
+      if (currentCount > maxRequests) {
         const retryAfter = Math.ceil(windowMs / 1000);
         logger.warn('[UploadRateLimit] User rate limit exceeded', {
           userId,
@@ -52,16 +71,26 @@ function createUserRateLimiter(options: UserRateLimitOptions) {
         });
       }
 
-      await uploadRateCache.increment(key, Math.ceil(windowMs / 1000));
-
       res.setHeader('X-RateLimit-Limit', maxRequests.toString());
-      res.setHeader('X-RateLimit-Remaining', (maxRequests - currentCount - 1).toString());
+      res.setHeader('X-RateLimit-Remaining', (maxRequests - currentCount).toString());
 
       next();
     } catch (error) {
-      logger.error('[UploadRateLimit] Cache error, allowing request', {
+      logger.error('[UploadRateLimit] Redis error, falling back to memory', {
         error: (error as Error).message,
       });
+      // Fall back to memory instead of allowing unlimited
+      const userId = req.user?.id;
+      if (userId) {
+        const key = `${keyPrefix}:${userId}`;
+        const count = uploadMemoryIncrement(key, windowMs);
+        if (count > maxRequests) {
+          return res.status(429).json({
+            error: 'Too Many Requests',
+            code: 'UPLOAD_RATE_LIMIT_EXCEEDED',
+          });
+        }
+      }
       next();
     }
   };

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -69,9 +69,17 @@ router.post('/reset-password', authRateLimit as any, authController.resetPasswor
  * This allows OAuth to work from legal.org.ua, platform.legal.org.ua, etc.
  * Each redirect URI must also be registered in Google Cloud Console.
  */
+const ALLOWED_CALLBACK_HOSTS = new Set([
+  'legal.org.ua',
+  'platform.legal.org.ua',
+  'mcp.legal.org.ua',
+  'preview.legal.org.ua',
+]);
+
 function getCallbackURL(req: any): string {
   const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
-  const host = req.headers['x-forwarded-host'] || req.headers.host;
+  const rawHost = (req.headers['x-forwarded-host'] || req.headers.host || '').split(':')[0];
+  const host = ALLOWED_CALLBACK_HOSTS.has(rawHost) ? rawHost : 'legal.org.ua';
   return `${protocol}://${host}/auth/google/callback`;
 }
 

--- a/mcp_backend/src/routes/oauth-routes.ts
+++ b/mcp_backend/src/routes/oauth-routes.ts
@@ -696,6 +696,33 @@ export function createOAuthRouter(oauthService: OAuthService): Router {
         });
       }
 
+      // Validate each redirect URI: must be a valid URL with https (or http://localhost for dev)
+      for (const uri of redirect_uris) {
+        try {
+          const parsed = new URL(uri);
+          const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+          if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLocalhost)) {
+            return res.status(400).json({
+              error: 'invalid_redirect_uri',
+              error_description: `redirect_uri must use https (or http for localhost): ${uri}`,
+            });
+          }
+        } catch {
+          return res.status(400).json({
+            error: 'invalid_redirect_uri',
+            error_description: `Invalid redirect_uri format: ${uri}`,
+          });
+        }
+      }
+
+      // Limit number of redirect URIs per client
+      if (redirect_uris.length > 10) {
+        return res.status(400).json({
+          error: 'invalid_client_metadata',
+          error_description: 'Maximum 10 redirect_uris allowed per client',
+        });
+      }
+
       // Register the client
       const name = client_name || `MCP Client ${new Date().toISOString().slice(0, 10)}`;
       const client = await oauthService.registerClient({

--- a/mcp_backend/src/routes/rest-api.ts
+++ b/mcp_backend/src/routes/rest-api.ts
@@ -108,16 +108,19 @@ export function createRestAPIRouter(db: IDatabase): Router {
       const userId = req.user?.id;
       const updates = req.body;
 
-      const fields = Object.keys(updates).filter(k => k !== 'id' && k !== 'user_id');
-      const setClause = fields.map((field, idx) => `${field} = $${idx + 2}`).join(', ');
-      const values = [id, ...fields.map(f => updates[f])];
-
+      const ALLOWED_DOCUMENT_COLUMNS = new Set([
+        'type', 'title', 'date', 'full_text', 'full_text_html', 'metadata',
+        'zakononline_id', 'status', 'notes', 'tags'
+      ]);
+      const fields = Object.keys(updates).filter(k => ALLOWED_DOCUMENT_COLUMNS.has(k));
       if (fields.length === 0) {
-        res.status(400).json({ error: 'No fields to update' });
+        res.status(400).json({ error: 'No valid fields to update' });
         return;
       }
+      const setClause = fields.map((field, idx) => `"${field}" = $${idx + 2}`).join(', ');
+      const values = [id, ...fields.map(f => updates[f])];
 
-      // Only allow updating own documents (or public if no userId)
+      // Only allow updating own documents
       if (!userId) {
         res.status(401).json({ error: 'Authentication required' });
         return;
@@ -291,14 +294,18 @@ export function createRestAPIRouter(db: IDatabase): Router {
       const { id } = req.params;
       const updates = req.body;
 
-      const fields = Object.keys(updates).filter(k => k !== 'id');
-      const setClause = fields.map((field, idx) => `${field} = $${idx + 2}`).join(', ');
-      const values = [id, ...fields.map(f => updates[f])];
-
+      const ALLOWED_PATTERN_COLUMNS = new Set([
+        'category', 'subcategory', 'description', 'law_articles',
+        'decision_outcome', 'frequency', 'confidence', 'example_cases',
+        'risk_factors', 'success_arguments', 'anti_patterns'
+      ]);
+      const fields = Object.keys(updates).filter(k => ALLOWED_PATTERN_COLUMNS.has(k));
       if (fields.length === 0) {
-        res.status(400).json({ error: 'No fields to update' });
+        res.status(400).json({ error: 'No valid fields to update' });
         return;
       }
+      const setClause = fields.map((field, idx) => `"${field}" = $${idx + 2}`).join(', ');
+      const values = [id, ...fields.map(f => updates[f])];
 
       const result = await db.query(
         `UPDATE legal_patterns SET ${setClause}, updated_at = NOW() WHERE id = $1 RETURNING *`,

--- a/mcp_backend/src/services/attorney-profile-service.ts
+++ b/mcp_backend/src/services/attorney-profile-service.ts
@@ -238,7 +238,13 @@ export class AttorneyProfileService {
 
     const [result, countResult] = await Promise.all([
       this.db.query(
-        `SELECT ap.*, u.name as user_name, u.email as user_email,
+        `SELECT ap.id, ap.user_id, ap.display_name, ap.bio, ap.specializations,
+                ap.region, ap.city, ap.court_types, ap.languages,
+                ap.years_experience, ap.education, ap.certifications,
+                ap.consultation_fee_uah, ap.free_initial_consultation,
+                ap.serves_remotely, ap.average_rating, ap.review_count,
+                ap.is_available, ap.avatar_url, ap.website,
+                u.name as user_name,
                 o.name as organization_name, o.org_type
          FROM attorney_profiles ap
          JOIN users u ON u.id = ap.user_id

--- a/mcp_backend/src/services/nowpayments-service.ts
+++ b/mcp_backend/src/services/nowpayments-service.ts
@@ -124,7 +124,8 @@ export class NOWPaymentsService {
       .update(sortedBody)
       .digest('hex');
 
-    return expected === signature;
+    if (expected.length !== signature.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
   }
 
   /**

--- a/mcp_backend/src/services/oauth-service.ts
+++ b/mcp_backend/src/services/oauth-service.ts
@@ -109,7 +109,9 @@ export class OAuthService {
       return false;
     }
 
-    return result.rows[0].client_secret === clientSecret;
+    const stored = result.rows[0].client_secret;
+    if (stored.length !== clientSecret.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(stored), Buffer.from(clientSecret));
   }
 
   /**


### PR DESCRIPTION
## Summary

Comprehensive security hardening based on 10-agent parallel penetration testing audit of legal.org.ua.

**Critical fixes:**
- SQL column injection in `rest-api.ts` PATCH handlers — added column allowlists
- Timing-unsafe API key/secret comparisons → `crypto.timingSafeEqual()` in 5 files

**High fixes:**
- HSTS with `preload` + `Permissions-Policy` header + fix nginx `add_header` inheritance
- Nginx rate limiting for prod (`limit_req` for API/auth/webhooks, `limit_conn` for SSE)
- Redis fail-open → in-memory fallback instead of bypassing rate limits entirely
- OAuth redirect URI validation (require https, max 10 per client)
- Host header injection in Google OAuth callback → domain allowlist
- Remove localhost from production CORS whitelist

**Medium fixes:**
- Strip IBAN/email from public attorney search results
- Reduce `/health/ready` to minimal response (no infra dependency details)
- Update nodemailer >=8.0.4 (SMTP command injection)

### Files changed (16)
- `deployment/nginx/includes/security-headers.conf` (new)
- `deployment/nginx/includes/prod-server-common.conf`
- `deployment/nginx/prod.legal.org.ua.conf`
- `mcp_backend/src/routes/rest-api.ts`
- `mcp_backend/src/middleware/auth.ts`, `dual-auth.ts`, `oauth-auth.ts`
- `mcp_backend/src/middleware/rate-limit.ts`, `upload-rate-limit.ts`
- `mcp_backend/src/services/oauth-service.ts`, `nowpayments-service.ts`, `attorney-profile-service.ts`
- `mcp_backend/src/routes/auth.ts`, `oauth-routes.ts`
- `mcp_backend/src/http-server.ts`
- `mcp_backend/package.json`

## Test plan

- [ ] Verify TypeScript builds without new errors (`npx tsc --noEmit`)
- [ ] Test auth with valid/invalid API keys still works
- [ ] Test OAuth flow (Google login) on legal.org.ua
- [ ] Verify nginx rate limiting doesn't block normal usage (30r/s API, 1r/s auth)
- [ ] Verify SSE connections still work with `limit_conn 20`
- [ ] Confirm security headers appear in curl response after deploy
- [ ] Test attorney search no longer returns IBAN/email fields
- [ ] Verify `/health/ready` returns minimal JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security hardening to address critical/high findings from the pentest: added column allowlists, constant‑time secret checks, stricter OAuth/CORS, server security headers, and Nginx rate limiting with safe fallbacks. This reduces attack surface across API and infra without impacting normal use.

- **Bug Fixes**
  - REST API: block SQL column injection by allowlisting and quoting columns in PATCH handlers.
  - Auth and secrets: use `crypto.timingSafeEqual()` for API keys, OAuth client secrets, and NOWPayments signatures.
  - OAuth: validate `redirect_uris` (require https or localhost http), cap at 10 per client, and enforce callback host allowlist.
  - CORS: remove localhost from prod allowlist (kept only in non‑prod).
  - Nginx/security headers: add HSTS with `preload`, `Permissions-Policy`, and centralized `security-headers.conf` include to fix `add_header` inheritance; keep relaxed CSP for S3 PDFs only.
  - Rate limiting: add Nginx zones for API/auth/webhooks and `limit_conn` for SSE; backend rate limiters now fall back to in‑memory instead of failing open; upload limits use the same fallback.
  - Data exposure and health: strip IBAN/email from public attorney search; replace `/health/ready` with a minimal JSON response.

- **Dependencies**
  - Bump `nodemailer` to `^8.0.4` (patches SMTP command injection).

<sup>Written for commit cf85ffe5f42dd72695e71e37d3ce8d7e0bc26e73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

