### PR TITLE
feat(tools): proxy 3 missing openreyestr tools

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -248,6 +248,9 @@ export class ToolRegistry {
       { clientName: 'openreyestr_search_prozorro', serviceName: 'search_prozorro' },
       { clientName: 'openreyestr_search_termination_started', serviceName: 'search_termination_started' },
       { clientName: 'openreyestr_search_rnbo_sanctions', serviceName: 'search_rnbo_sanctions' },
+      { clientName: 'openreyestr_search_arma_seized_assets', serviceName: 'search_arma_seized_assets' },
+      { clientName: 'openreyestr_search_nazk_declarations', serviceName: 'search_nazk_declarations' },
+      { clientName: 'openreyestr_search_exchange_data', serviceName: 'search_exchange_data' },
     ];
 
     for (const tool of openreyestrTools) {


### PR DESCRIPTION
## Summary
- Add proxy routes for 3 openreyestr tools missing from unified gateway:
  - `openreyestr_search_arma_seized_assets` — ARMA seized assets (725K)
  - `openreyestr_search_nazk_declarations` — NAZK declarations (322K)
  - `openreyestr_search_exchange_data` — exchange data registry

## Context
These tools existed in mcp_openreyestr but were never registered in the backend proxy map, making them inaccessible via the unified gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose three missing OpenReyestr tools through the unified gateway by adding proxy routes in the backend. These tools existed in `mcp_openreyestr` but were not registered: `openreyestr_search_arma_seized_assets`, `openreyestr_search_nazk_declarations`, `openreyestr_search_exchange_data`.

<sup>Written for commit af1b0c1698c596f6ae6e1e30a016b98f741fe780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

