### PR TITLE
hotfix: fix FTS migration column names for prod

### DIFF
--- a/mcp_openreyestr/src/migrations/013_fix_fts_language.sql
+++ b/mcp_openreyestr/src/migrations/013_fix_fts_language.sql
@@ -1,6 +1,7 @@
 -- Fix FTS language: 'russian' → 'simple' for Ukrainian text
 -- Russian stemmer gives incorrect morphological results for Ukrainian words
 -- 'simple' config tokenizes without stemming — works correctly for both UA and RU
+-- Also fixes column name mismatches between local and prod schemas
 
 -- From 001_initial_schema.sql
 DROP INDEX IF EXISTS idx_legal_entities_name;
@@ -12,31 +13,66 @@ CREATE INDEX IF NOT EXISTS idx_individual_entrepreneurs_name ON individual_entre
 DROP INDEX IF EXISTS idx_public_associations_name;
 CREATE INDEX IF NOT EXISTS idx_public_associations_name ON public_associations USING gin(to_tsvector('simple', name));
 
--- From 003_add_notaries_experts_arbitration.sql
+-- From 003_add_notaries_experts_arbitration.sql (prod uses full_name, not name)
 DROP INDEX IF EXISTS idx_notaries_name;
-CREATE INDEX IF NOT EXISTS idx_notaries_name ON notaries USING gin(to_tsvector('simple', name));
+DO $$ BEGIN
+  CREATE INDEX idx_notaries_name ON notaries USING gin(to_tsvector('simple', full_name));
+EXCEPTION WHEN undefined_column THEN
+  CREATE INDEX IF NOT EXISTS idx_notaries_name ON notaries USING gin(to_tsvector('simple', name));
+WHEN duplicate_table THEN NULL;
+END $$;
 
 DROP INDEX IF EXISTS idx_experts_name;
-CREATE INDEX IF NOT EXISTS idx_experts_name ON court_experts USING gin(to_tsvector('simple', name));
+DO $$ BEGIN
+  CREATE INDEX idx_experts_name ON court_experts USING gin(to_tsvector('simple', full_name));
+EXCEPTION WHEN undefined_column THEN
+  CREATE INDEX IF NOT EXISTS idx_experts_name ON court_experts USING gin(to_tsvector('simple', name));
+WHEN duplicate_table THEN NULL;
+END $$;
 
 DROP INDEX IF EXISTS idx_arb_mgr_name;
-CREATE INDEX IF NOT EXISTS idx_arb_mgr_name ON arbitration_managers USING gin(to_tsvector('simple', name));
+DO $$ BEGIN
+  CREATE INDEX idx_arb_mgr_name ON arbitration_managers USING gin(to_tsvector('simple', full_name));
+EXCEPTION WHEN undefined_column THEN
+  CREATE INDEX IF NOT EXISTS idx_arb_mgr_name ON arbitration_managers USING gin(to_tsvector('simple', name));
+WHEN duplicate_table THEN NULL;
+END $$;
 
--- From 004_add_remaining_registries.sql
+-- From 004_add_remaining_registries.sql (prod uses method_name, not name)
 DROP INDEX IF EXISTS idx_forensic_methods_name;
-CREATE INDEX IF NOT EXISTS idx_forensic_methods_name ON forensic_methods USING gin(to_tsvector('simple', name));
+DO $$ BEGIN
+  CREATE INDEX idx_forensic_methods_name ON forensic_methods USING gin(to_tsvector('simple', method_name));
+EXCEPTION WHEN undefined_column THEN
+  CREATE INDEX IF NOT EXISTS idx_forensic_methods_name ON forensic_methods USING gin(to_tsvector('simple', name));
+WHEN duplicate_table THEN NULL;
+END $$;
 
 DROP INDEX IF EXISTS idx_bankruptcy_debtor;
 CREATE INDEX IF NOT EXISTS idx_bankruptcy_debtor ON bankruptcy_cases USING gin(to_tsvector('simple', debtor_name));
 
+-- legal_acts: prod uses act_title, local uses title
 DROP INDEX IF EXISTS idx_legal_acts_title;
-CREATE INDEX IF NOT EXISTS idx_legal_acts_title ON legal_acts USING gin(to_tsvector('simple', title));
+DO $$ BEGIN
+  CREATE INDEX idx_legal_acts_title ON legal_acts USING gin(to_tsvector('simple', act_title));
+EXCEPTION WHEN undefined_column THEN
+  CREATE INDEX IF NOT EXISTS idx_legal_acts_title ON legal_acts USING gin(to_tsvector('simple', title));
+WHEN duplicate_table THEN NULL;
+END $$;
 
-DROP INDEX IF EXISTS idx_admin_units_name;
-CREATE INDEX IF NOT EXISTS idx_admin_units_name ON admin_units USING gin(to_tsvector('simple', name));
+-- admin_units and street_codes may not exist on prod
+DO $$ BEGIN
+  DROP INDEX IF EXISTS idx_admin_units_name;
+  CREATE INDEX idx_admin_units_name ON admin_units USING gin(to_tsvector('simple', name));
+EXCEPTION WHEN undefined_table THEN NULL;
+WHEN duplicate_table THEN NULL;
+END $$;
 
-DROP INDEX IF EXISTS idx_streets_name;
-CREATE INDEX IF NOT EXISTS idx_streets_name ON street_codes USING gin(to_tsvector('simple', street_name));
+DO $$ BEGIN
+  DROP INDEX IF EXISTS idx_streets_name;
+  CREATE INDEX idx_streets_name ON street_codes USING gin(to_tsvector('simple', street_name));
+EXCEPTION WHEN undefined_table THEN NULL;
+WHEN duplicate_table THEN NULL;
+END $$;
 
 DROP INDEX IF EXISTS idx_enforce_debtor;
 CREATE INDEX IF NOT EXISTS idx_enforce_debtor ON enforcement_proceedings USING gin(to_tsvector('simple', debtor_name));
@@ -55,8 +91,14 @@ CREATE INDEX IF NOT EXISTS idx_arma_assets_owner_name ON arma_assets USING gin(t
 DROP INDEX IF EXISTS idx_nazk_declarations_name;
 CREATE INDEX IF NOT EXISTS idx_nazk_declarations_name ON nazk_declarations USING gin(to_tsvector('simple', declarant_name));
 
+-- nazk_declarations: prod uses declarant_workplace, local uses workplace
 DROP INDEX IF EXISTS idx_nazk_declarations_workplace;
-CREATE INDEX IF NOT EXISTS idx_nazk_declarations_workplace ON nazk_declarations USING gin(to_tsvector('simple', workplace));
+DO $$ BEGIN
+  CREATE INDEX idx_nazk_declarations_workplace ON nazk_declarations USING gin(to_tsvector('simple', declarant_workplace));
+EXCEPTION WHEN undefined_column THEN
+  CREATE INDEX IF NOT EXISTS idx_nazk_declarations_workplace ON nazk_declarations USING gin(to_tsvector('simple', workplace));
+WHEN duplicate_table THEN NULL;
+END $$;
 
 -- From 010_rnbo_sanctions_and_prozorro.sql
 DROP INDEX IF EXISTS idx_rnbo_sanctions_name;


### PR DESCRIPTION
## Summary
Migration 013 failed on prod because column names differ between local and prod schemas. Fixed with `DO $$ BEGIN...EXCEPTION` blocks that try prod column name first, fallback to local name.

| Table | Local | Prod |
|-------|-------|------|
| notaries | name | full_name |
| court_experts | name | full_name |
| arbitration_managers | name | full_name |
| forensic_methods | name | method_name |
| legal_acts | title | act_title |
| nazk_declarations | workplace | declarant_workplace |
| admin_units | exists | doesn't exist |
| street_codes | exists | doesn't exist |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Migration 013 failing on prod by making FTS index creation schema-aware and idempotent. We now prefer prod column names, fall back to local names, and safely skip missing tables.

- **Bug Fixes**
  - notaries/court_experts/arbitration_managers: use full_name or name.
  - forensic_methods: use method_name or name.
  - legal_acts: use act_title or title.
  - nazk_declarations: use declarant_workplace or workplace.
  - admin_units/street_codes: handle missing tables; wrap DROP/CREATE and ignore undefined_table/duplicate_table.
  - All indexes use the simple FTS config.

<sup>Written for commit fa1a2f5ab10340a977bb6d3c4c0c089340dacd9d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

