### PR TITLE
fix(nginx): add missing security-headers.conf mount

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -852,6 +852,7 @@ services:
       - ./nginx/prod.legal.org.ua.conf:/etc/nginx/conf.d/default.conf:ro
       - ./nginx/includes/ssl-common.conf:/etc/nginx/includes/ssl-common.conf:ro
       - ./nginx/includes/prod-server-common.conf:/etc/nginx/includes/prod-server-common.conf:ro
+      - ./nginx/includes/security-headers.conf:/etc/nginx/includes/security-headers.conf:ro
       - ./nginx/includes/prod-upstreams.conf:/etc/nginx/includes/prod-upstreams.conf
       - ./nginx/includes/preview-server-common.conf:/etc/nginx/includes/preview-server-common.conf:ro
       - ./nginx/includes/preview-upstreams.conf:/etc/nginx/includes/preview-upstreams.conf


### PR DESCRIPTION
## Summary
- Додано volume mount для `security-headers.conf` в nginx контейнер
- Файл включається з `prod-server-common.conf`, але не був замонтований
- Після CI/CD rebuild nginx крашився в restart loop → 502

## Test plan
- [x] Nginx піднявся після хотфіксу на проді
- [ ] Наступний деплой не зламає nginx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing volume mount for `./nginx/includes/security-headers.conf` in `docker-compose.prod.yml` so the include from `prod-server-common.conf` is available. This stops Nginx crash loops and 502s after CI/CD rebuilds.

<sup>Written for commit 225cc8bf5751cb6bb3badf085f2dfb7ef8800072. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

