### PR TITLE
fix(ci): use cp -rf for prompts overlay (subdirectories)

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -96,7 +96,7 @@ jobs:
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
           cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
-          cp -f "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
 
       - name: Build backend
@@ -319,7 +319,7 @@ jobs:
             CORE_TMP=$(mktemp -d)
             gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
             cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
-            cp -f "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+            cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
             rm -rf "$CORE_TMP"
             npm --prefix mcp_backend install && npm --prefix mcp_backend run build
           fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -172,7 +172,7 @@ jobs:
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
           cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
-          cp -f "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
 
       - name: Build & test backend


### PR DESCRIPTION
## Summary
- Prompts dir in private repo has subdirectories (`system-instructions`, `templates`) that `cp -f` skips
- Changed to `cp -rf` in both CI workflows

Fixes CI failure from #1256

## Test plan
- [ ] CI pipeline passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `cp -rf` to copy `src/prompts` recursively in CI so nested folders (`system-instructions`, `templates`) are included, fixing missing prompts and pipeline failures in both `ci-local-deploy.yml` and `deploy-prod.yml`.

<sup>Written for commit eb30eb63af4c86827148e6d29f78e950e04dadff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

