### PR TITLE
security: harden Redis, Qdrant auth, bind DB ports to localhost

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -28,7 +28,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-local_dev_password}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_local}
     ports:
-      - "5432:5432"  # Standard PostgreSQL port
+      - "127.0.0.1:5432:5432"  # Standard PostgreSQL port
     volumes:
       - postgres_local_data:/var/lib/postgresql/data
     healthcheck:
@@ -75,10 +75,12 @@ services:
     image: qdrant/qdrant:latest
     container_name: secondlayer-qdrant-local
     ports:
-      - "6333:6333"  # HTTP API
-      - "6334:6334"  # gRPC
+      - "127.0.0.1:6333:6333"  # HTTP API
+      - "127.0.0.1:6334:6334"  # gRPC
     volumes:
       - qdrant_local_data:/qdrant/storage
+    environment:
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-local_qdrant_key}
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/6333'"]
       interval: 10s
@@ -104,7 +106,18 @@ services:
       - "127.0.0.1:6379:6379"
     volumes:
       - redis_local_data:/data
-    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy volatile-lru --requirepass ${REDIS_PASSWORD:-local_redis_pass}
+    command: >
+      redis-server
+      --appendonly yes
+      --maxmemory 512mb
+      --maxmemory-policy volatile-lru
+      --requirepass ${REDIS_PASSWORD:-local_redis_pass}
+      --rename-command CONFIG ""
+      --rename-command DEBUG ""
+      --rename-command SLAVEOF ""
+      --rename-command REPLICAOF ""
+      --rename-command FLUSHDB ""
+      --rename-command FLUSHALL ""
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD:-local_redis_pass}", "ping"]
       interval: 5s
@@ -238,6 +251,7 @@ services:
 
       # Vector DB
       QDRANT_URL: http://qdrant-local:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-local_qdrant_key}
 
       # Cache
       REDIS_URL: redis://:${REDIS_PASSWORD:-local_redis_pass}@redis-local:6379
@@ -489,6 +503,7 @@ services:
 
       # Vector DB
       QDRANT_URL: http://qdrant-local:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-local_qdrant_key}
 
       # Cache
       REDIS_URL: redis://:${REDIS_PASSWORD:-local_redis_pass}@redis-local:6379
@@ -571,7 +586,7 @@ services:
       POSTGRES_PASSWORD: ${OPENREYESTR_POSTGRES_PASSWORD:-openreyestr_dev_password}
       POSTGRES_DB: ${OPENREYESTR_POSTGRES_DB:-openreyestr_local}
     ports:
-      - "5437:5432"
+      - "127.0.0.1:5437:5432"
     volumes:
       - postgres_openreyestr_local_data:/var/lib/postgresql/data
     healthcheck:
@@ -704,6 +719,7 @@ services:
       REDIS_PORT: 6379
       REDIS_PASSWORD: ${REDIS_PASSWORD:-local_redis_pass}
       QDRANT_URL: http://qdrant-local:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-local_qdrant_key}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
@@ -739,8 +755,8 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-minioadmin}
       MINIO_PROMETHEUS_AUTH_TYPE: public
     ports:
-      - "9000:9000"   # S3 API
-      - "9001:9001"   # Web console
+      - "127.0.0.1:9000:9000"   # S3 API
+      - "127.0.0.1:9001:9001"   # Web console
     volumes:
       - minio_local_data:/data
     healthcheck:
@@ -785,7 +801,7 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: "nextcloud-local localhost local.legal.org.ua"
       OVERWRITEPROTOCOL: https
     ports:
-      - "8888:80"
+      - "127.0.0.1:8888:80"
     volumes:
       - nextcloud_local_data:/var/www/html
     depends_on:
@@ -917,7 +933,7 @@ services:
       - ./prometheus/rules:/etc/prometheus/rules:ro
       - prometheus_local_data:/prometheus
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     networks:
       - secondlayer-local
     restart: unless-stopped
@@ -939,7 +955,7 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning:ro
       - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
-      - "3100:3000"
+      - "127.0.0.1:3100:3000"
     networks:
       - secondlayer-local
     restart: unless-stopped
@@ -995,7 +1011,7 @@ services:
       POSTGRES_PASSWORD: ${HUDOC_POSTGRES_PASSWORD:-hudoc_local_pass}
       POSTGRES_DB: ${HUDOC_POSTGRES_DB:-hudoc_local}
     ports:
-      - "5436:5432"
+      - "127.0.0.1:5436:5432"
     volumes:
       - ${HUDOC_DATA_PATH:-./hudoc-storage/pgdata}:/var/lib/postgresql/data
     healthcheck:
@@ -1022,7 +1038,7 @@ services:
     environment:
       REDIS_ADDR: "redis://redis-local:6379"
     ports:
-      - "9121:9121"
+      - "127.0.0.1:9121:9121"
     networks:
       - secondlayer-local
     restart: unless-stopped

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -166,6 +166,7 @@ services:
     - secondlayer-prod-network
     environment:
       TZ: Europe/Kiev
+      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
       QDRANT__STORAGE__OPTIMIZERS__MEMMAP_THRESHOLD_KB: "1048576"
     deploy:
       resources:
@@ -181,7 +182,18 @@ services:
     - "127.0.0.1:6383:6379"
     volumes:
     - redis_prod_data:/data
-    command: redis-server --appendonly yes --maxmemory 2048mb --maxmemory-policy volatile-lru --requirepass ${REDIS_PASSWORD}
+    command: >
+      redis-server
+      --appendonly yes
+      --maxmemory 2048mb
+      --maxmemory-policy volatile-lru
+      --requirepass ${REDIS_PASSWORD}
+      --rename-command CONFIG ""
+      --rename-command DEBUG ""
+      --rename-command SLAVEOF ""
+      --rename-command REPLICAOF ""
+      --rename-command FLUSHDB ""
+      --rename-command FLUSHALL ""
     healthcheck:
       test:
       - CMD
@@ -522,6 +534,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -694,6 +707,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -906,6 +920,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -1149,6 +1164,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379

--- a/mcp_backend/src/scripts/batch-embed-court-sessions.ts
+++ b/mcp_backend/src/scripts/batch-embed-court-sessions.ts
@@ -50,7 +50,7 @@ const AWS_CONFIG = {
 // ── Clients ─────────────────────────────────────────────────────────────────
 const s3 = new S3Client(AWS_CONFIG);
 const bedrock = new BedrockClient(AWS_CONFIG);
-const qdrant = new QdrantClient({ url: process.env.QDRANT_URL || 'http://localhost:6333' });
+const qdrant = new QdrantClient({ url: process.env.QDRANT_URL || 'http://localhost:6333', ...(process.env.QDRANT_API_KEY && { apiKey: process.env.QDRANT_API_KEY }) });
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   host: process.env.POSTGRES_HOST || 'localhost',

--- a/mcp_backend/src/scripts/reindex-user-docs.ts
+++ b/mcp_backend/src/scripts/reindex-user-docs.ts
@@ -91,7 +91,7 @@ function splitIntoChunks(text: string): string[] {
 
 async function main() {
   const pool = new pg.Pool({ connectionString: DATABASE_URL });
-  const qdrant = new QdrantClient({ url: QDRANT_URL });
+  const qdrant = new QdrantClient({ url: QDRANT_URL, ...(process.env.QDRANT_API_KEY && { apiKey: process.env.QDRANT_API_KEY }) });
 
   // 1. Get all active docs with text for this user
   const { rows: docs } = await pool.query(

--- a/mcp_backend/src/scripts/vectorize-datasets.ts
+++ b/mcp_backend/src/scripts/vectorize-datasets.ts
@@ -27,7 +27,7 @@ const CHUNK_OVERLAP_WORDS = 50;
 
 // ── Clients ─────────────────────────────────────────────────────────────────
 const voyageClient = new VoyageAIClient(process.env.VOYAGEAI_API_KEY!);
-const qdrant = new QdrantClient({ url: process.env.QDRANT_URL || 'http://localhost:6333' });
+const qdrant = new QdrantClient({ url: process.env.QDRANT_URL || 'http://localhost:6333', ...(process.env.QDRANT_API_KEY && { apiKey: process.env.QDRANT_API_KEY }) });
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
   host: process.env.POSTGRES_HOST || 'localhost',

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -121,7 +121,8 @@ export class EdsrVectorizerService {
     this.voyageClient = new VoyageAIClient(apiKey);
 
     const qdrantUrl = process.env.QDRANT_URL || 'http://localhost:6333';
-    this.qdrant = new QdrantClient({ url: qdrantUrl });
+    const qdrantApiKey = process.env.QDRANT_API_KEY;
+    this.qdrant = new QdrantClient({ url: qdrantUrl, ...(qdrantApiKey && { apiKey: qdrantApiKey }) });
 
     this.concurrency = concurrency;
   }

--- a/mcp_backend/src/services/embedding-service.ts
+++ b/mcp_backend/src/services/embedding-service.ts
@@ -25,7 +25,8 @@ export class EmbeddingService implements IEmbeddingPort {
   constructor() {
 
     const qdrantUrl = process.env.QDRANT_URL || 'http://localhost:6333';
-    this.qdrant = new QdrantClient({ url: qdrantUrl });
+    const qdrantApiKey = process.env.QDRANT_API_KEY;
+    this.qdrant = new QdrantClient({ url: qdrantUrl, ...(qdrantApiKey && { apiKey: qdrantApiKey }) });
   }
 
   /** Register a callback to receive VoyageAI token usage (for cost tracking). */


### PR DESCRIPTION
## Summary

- **Redis**: disable dangerous commands (CONFIG, DEBUG, SLAVEOF, REPLICAOF, FLUSHDB, FLUSHALL) via `rename-command` — prevents RedisWriteMaster cron injection attacks
- **Qdrant**: add API key authentication (`QDRANT__SERVICE__API_KEY`) to both local and prod; update all QdrantClient instances to pass `apiKey`
- **Ports**: bind 9 local services to `127.0.0.1` (PostgreSQL, Qdrant, MinIO, Prometheus, Grafana, Nextcloud, HUDOC, redis-exporter)

## Post-merge actions

1. Add `QDRANT_API_KEY=<generated_key>` to `.env.prod` on the server
2. Rotate Redis, PostgreSQL, JWT, MinIO passwords (new values generated during audit)
3. Rotate external API keys (OpenAI, VoyageAI) via their dashboards

## Test plan

- [ ] Local: `docker compose -f docker-compose.local.yml --env-file .env.local up -d` — verify all services start
- [ ] Verify Qdrant rejects requests without API key
- [ ] Verify Redis rejects CONFIG/FLUSHALL commands
- [ ] Verify all ports bound to 127.0.0.1 (not 0.0.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened infra by disabling risky Redis commands, requiring API key auth for Qdrant, and binding local service ports to 127.0.0.1 to shrink the attack surface.

- **New Features**
  - Redis: disabled `CONFIG`, `DEBUG`, `SLAVEOF`, `REPLICAOF`, `FLUSHDB`, `FLUSHALL` via `rename-command` in local and prod.
  - Qdrant: enabled API key (`QDRANT__SERVICE__API_KEY`); all `QdrantClient` usages now pass `apiKey` from `QDRANT_API_KEY`.
  - Networking: bound local ports to localhost for PostgreSQL, Qdrant, MinIO, Prometheus, Grafana, Nextcloud, HUDOC PG, and `redis-exporter`.

- **Migration**
  - Add `QDRANT_API_KEY` to `.env.prod` before deploy; redeploy Qdrant and dependent services.
  - Rotate Redis, PostgreSQL, JWT, MinIO passwords and external API keys.

<sup>Written for commit 4abcb3774b91edbed679e8368e95f44e1d591c2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

