### PR TITLE
fix(ci): use cp -rf for prompts overlay (subdirectories)

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -96,7 +96,7 @@ jobs:
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
           cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
-          cp -f "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
 
       - name: Build backend
@@ -319,7 +319,7 @@ jobs:
             CORE_TMP=$(mktemp -d)
             gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
             cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
-            cp -f "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+            cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
             rm -rf "$CORE_TMP"
             npm --prefix mcp_backend install && npm --prefix mcp_backend run build
           fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -172,7 +172,7 @@ jobs:
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
           cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
-          cp -f "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
 
       - name: Build & test backend


### PR DESCRIPTION
## Summary

- Fix `cp -f` → `cp -rf` for prompts overlay in CI and deploy workflows
- prompts/ contains subdirectories (system-instructions, templates) that require `-r` flag
- Without it, CI fails with exit code 1: `cp: -r not specified; omitting directory`

## Test plan

- [ ] CI build passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the prompts overlay copy recursive in CI and prod deploy so subdirectories are included and the workflows stop failing. Fixes the “cp: -r not specified; omitting directory” error.

- **Bug Fixes**
  - Replaced `cp -f` with `cp -rf` when copying `src/prompts` to include nested dirs (system-instructions, templates).
  - Applied in `.github/workflows/ci-local-deploy.yml` and `.github/workflows/deploy-prod.yml` to unblock builds and deploys.

<sup>Written for commit 04b5de19fb71d538cfc4685fb7ecc903b4e1d65e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

