### PR TITLE
fix: remove 500-char truncation from legislation full_text

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -304,7 +304,7 @@ export class LegislationTools extends BaseToolHandler {
             rada_id: resolvedRadaId,
             article_number: a.article_number,
             title: a.title,
-            full_text: a.full_text ? a.full_text.substring(0, 500) + '...' : '',
+            full_text: a.full_text || '',
             url: `https://zakon.rada.gov.ua/laws/show/${resolvedRadaId}#n${a.article_number}`,
           })),
         };
@@ -333,7 +333,7 @@ export class LegislationTools extends BaseToolHandler {
         rada_id: a.rada_id,
         article_number: a.article_number,
         title: a.title,
-        full_text: a.full_text.substring(0, 500) + '...',
+        full_text: a.full_text || '',
         url: a.url,
       })),
     };


### PR DESCRIPTION
## Summary
- Removed `.substring(0, 500) + '...'` truncation from `search_legislation` tool results
- Norm modal in the right panel now displays the complete article text

## Test plan
- [ ] Search legislation and open a norm from the right panel — verify full text is shown
- [ ] Check that long articles display correctly without cutoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 500-character truncation from `search_legislation` article `full_text` so the norm modal and other consumers show the complete text. Long articles now render without being cut off.

- **Bug Fixes**
  - Return `full_text` unchanged (or empty if missing) instead of `.substring(0, 500) + '...'`.
  - Fixes truncated article display in the right-panel norm modal.

<sup>Written for commit 42907f0f816b4851a286bda32129d8235227a9b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

