### PR TITLE
ui: remove cost from thinking step titles

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -138,10 +138,9 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             }
           }
 
-          const costSuffix = data.cost_usd ? ` · ${formatUah(data.cost_usd)}` : '';
           addThinkingStep(assistantMessageId, {
             id: `step-${data.step}`,
-            title: (data.description || `${getToolLabel(data.tool)}`) + costSuffix,
+            title: (data.description || `${getToolLabel(data.tool)}`),
             content: JSON.stringify(data.params, null, 2),
             isComplete: false,
           });
@@ -152,10 +151,9 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             ? data.result
             : JSON.stringify(data.result, null, 2);
 
-          const costSuffix = data.cost_usd ? ` · ${formatUah(data.cost_usd)}` : '';
           addThinkingStep(assistantMessageId, {
             id: `result-${data.tool}`,
-            title: `${getToolLabel(data.tool)}` + costSuffix,
+            title: `${getToolLabel(data.tool)}`,
             content: toolPreview,
             isComplete: true,
           });


### PR DESCRIPTION
## Summary

- Remove per-tool cost display (`· 1.23 ₴`) from thinking step titles in chat
- Overall CostSummary component at the bottom of the message remains unchanged

## Test plan

- [ ] Verify thinking steps show tool names without cost suffix
- [ ] Verify CostSummary still shows total cost at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove per-tool cost (e.g., "· 1.23 ₴") from thinking step titles in chat to reduce noise. The total CostSummary at the bottom of the message remains unchanged.

<sup>Written for commit fc41a6e62b71f31dde77bc508ebc996c34a391eb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

