### PR TITLE
fix: await checkLimit to catch Redis errors in rate limiter

### DIFF
--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -100,9 +100,9 @@ export function createRateLimiter(options: RateLimitOptions) {
     try {
       if (!rateCache) {
         // Redis unavailable — fall back to in-memory rate limiting
-        return checkLimit(req, res, next, true);
+        return await checkLimit(req, res, next, true);
       }
-      return checkLimit(req, res, next, false);
+      return await checkLimit(req, res, next, false);
     } catch (error) {
       logger.error('[RateLimit] Redis error, falling back to memory', {
         error: (error as Error).message,


### PR DESCRIPTION
## Summary
- Added `await` before `checkLimit()` calls so `try/catch` properly catches Redis errors and falls back to in-memory rate limiting
- Created missing `ci` and `urgent` GitHub labels used by self-heal workflow

## Test plan
- [x] `rate-limit.test.ts` — all 12 tests pass (was 1 failure: "should allow request on cache error")
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await `checkLimit` in the rate limiter so Redis errors are caught, preventing unhandled promise rejections and ensuring a reliable in-memory fallback. Also adds the missing `ci` and `urgent` GitHub labels used by the self-heal workflow.

<sup>Written for commit 3bc1a16a3e4dde7de034a4dd269859337828e39d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

