### PR TITLE
fix: increase chat request timeouts

### DIFF
--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -120,7 +120,7 @@ export function createChatInlineRoutes(deps: {
       const abortController = new AbortController();
 
       // Absolute wall-clock timeout to prevent runaway agentic loops
-      const timeoutMs = (budget === 'deep') ? 180_000 : 90_000;
+      const timeoutMs = (budget === 'deep') ? 300_000 : 180_000;
       const requestTimeout = setTimeout(() => {
         logger.warn('[ChatService] Request timed out', { requestId, timeoutMs, budget });
         abortController.abort();


### PR DESCRIPTION
## Summary
- Standard budget: 90s → 180s (3 min)
- Deep budget: 180s → 300s (5 min)
- Fixes timeout errors when response is almost fully generated

## Test plan
- [ ] Make a long query on prod and verify it completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase chat request wall-clock timeouts to prevent premature aborts on long responses and stop “Час очікування вичерпано” errors near completion. Standard budget: 90s → 180s; deep budget: 180s → 300s.

<sup>Written for commit 4f3b7131ea4f6c1b0b2cca4057af9374af1dbeb9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

