### PR TITLE
fix: attorney search 500 — align SQL with DB schema

### DIFF
--- a/mcp_backend/src/services/attorney-profile-service.ts
+++ b/mcp_backend/src/services/attorney-profile-service.ts
@@ -238,12 +238,12 @@ export class AttorneyProfileService {
 
     const [result, countResult] = await Promise.all([
       this.db.query(
-        `SELECT ap.id, ap.user_id, ap.display_name, ap.bio, ap.specializations,
+        `SELECT ap.id, ap.user_id, ap.bio, ap.specializations,
                 ap.region, ap.city, ap.court_types, ap.languages,
-                ap.years_experience, ap.education, ap.certifications,
+                ap.years_experience, ap.education,
                 ap.consultation_fee_uah, ap.free_initial_consultation,
-                ap.serves_remotely, ap.average_rating, ap.review_count,
-                ap.is_available, ap.avatar_url, ap.website,
+                ap.serves_remotely, ap.average_rating, ap.rating_count,
+                ap.is_available, ap.photo_url,
                 u.name as user_name,
                 o.name as organization_name, o.org_type
          FROM attorney_profiles ap


### PR DESCRIPTION
## Summary
- Fixed `column ap.display_name does not exist` error on `/api/attorneys`
- Replaced non-existent columns (`display_name`, `certifications`, `avatar_url`, `website`, `review_count`) with actual DB columns (`photo_url`, `rating_count`)

## Test plan
- [ ] Visit `/attorneys` page on prod — verify attorneys load without 500 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 500 errors on attorney search by aligning the SELECT columns with the current DB schema. The `/api/attorneys` endpoint now returns results reliably.

- **Bug Fixes**
  - Matched SQL in `AttorneyProfileService` to actual schema to stop 500s on `/api/attorneys`.
  - Column changes: `review_count` → `rating_count`, `avatar_url` → `photo_url`; removed `display_name`, `certifications`, `website`.

<sup>Written for commit 2b0a9755977ee2d36d1ee04bf9b0548ac49d64ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

