### PR TITLE
fix: email-service test type mismatch breaking CI

### DIFF
--- a/mcp_backend/src/services/__tests__/email-service.test.ts
+++ b/mcp_backend/src/services/__tests__/email-service.test.ts
@@ -115,7 +115,7 @@ describe('EmailService', () => {
     });
 
     it('should skip when user preferences disable notifications', async () => {
-      service.setPreferenceFetcher(async () => ({
+      service.setPreferenceFetcher(async (): Promise<any> => ({
         payment_receipts: true,
         low_balance_alerts: true,
         monthly_summary: true,
@@ -140,7 +140,7 @@ describe('EmailService', () => {
     });
 
     it('should skip when payment success notifications disabled', async () => {
-      service.setPreferenceFetcher(async () => ({
+      service.setPreferenceFetcher(async (): Promise<any> => ({
         payment_receipts: true,
         low_balance_alerts: true,
         monthly_summary: true,
@@ -221,7 +221,7 @@ describe('EmailService', () => {
     });
 
     it('should skip if balance above custom threshold', async () => {
-      service.setPreferenceFetcher(async () => ({
+      service.setPreferenceFetcher(async (): Promise<any> => ({
         payment_receipts: true,
         low_balance_alerts: true,
         monthly_summary: true,


### PR DESCRIPTION
## Summary
- Fixed TS2322 error in `email-service.test.ts` where mock preference objects didn't match proprietary `EmailPreferences` type
- Uses `Promise<any>` return type to decouple test from proprietary type definitions
- **This was blocking all deploys** — CI failure caused deploy pipeline to skip

## Test plan
- [x] email-service tests: 21 passed
- [x] Full suite: 39 suites, 844 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures in email-service tests by loosening the mock preference fetcher return type. Mocks now return Promise<any>, so they no longer need to match `EmailPreferences`, resolving TS2322 and unblocking deploys.

<sup>Written for commit 21ca5815af88fc5c4f508bdbba4203f87daa26b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

