### PR TITLE
feat: allow sending new query while streaming response

### DIFF
--- a/lexwebapp/src/components/ChatInput.tsx
+++ b/lexwebapp/src/components/ChatInput.tsx
@@ -13,6 +13,7 @@ interface ChatInputProps {
   onSend: (message: string, toolName?: string, documentIds?: string[]) => void;
   disabled?: boolean;
   isStreaming?: boolean;
+  hasQueuedQuery?: boolean;
   onCancel?: () => void;
 }
 
@@ -20,6 +21,7 @@ export function ChatInput({
   onSend,
   disabled,
   isStreaming,
+  hasQueuedQuery,
   onCancel,
 }: ChatInputProps) {
   const [input, setInput] = useState('');
@@ -43,7 +45,7 @@ export function ChatInput({
   }, [input]);
 
   const handleSubmit = async () => {
-    if ((!input.trim() && files.length === 0) || disabled || isStreaming) return;
+    if ((!input.trim() && files.length === 0) || disabled) return;
 
     let documentIds: string[] = [];
 
@@ -132,7 +134,7 @@ export function ChatInput({
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Напишіть повідомлення..."
-            disabled={disabled || isStreaming}
+            disabled={disabled}
             rows={1}
             className="flex-1 py-2.5 px-1 bg-transparent border-none resize-none focus:ring-0 focus:outline-none text-zinc-900 placeholder:text-zinc-400 font-sans text-[14px] leading-[1.6] max-h-[200px] overflow-hidden"
             style={{
@@ -141,7 +143,7 @@ export function ChatInput({
           />
 
           <div className="flex items-center gap-1.5 flex-shrink-0 pb-0.5">
-            {isStreaming ? (
+            {isStreaming && (
               <button
                 type="button"
                 onClick={onCancel}
@@ -151,27 +153,35 @@ export function ChatInput({
               >
                 <Square size={14} strokeWidth={2} fill="currentColor" />
               </button>
-            ) : (
-              <button
-                onClick={handleSubmit}
-                disabled={(!input.trim() && files.length === 0) || disabled || isUploadingFiles}
-                className={`p-2 rounded-xl transition-all duration-150 ${
-                  (input.trim() || files.length > 0) && !disabled && !isUploadingFiles
-                    ? 'bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95 shadow-sm'
-                    : 'bg-zinc-100 text-zinc-300 cursor-not-allowed'
-                }`}
-                aria-label="Надіслати повідомлення"
-              >
-                {isUploadingFiles ? (
-                  <Loader2 size={14} strokeWidth={2} className="animate-spin" />
-                ) : (
-                  <Send size={14} strokeWidth={2} />
-                )}
-              </button>
             )}
+            <button
+              onClick={handleSubmit}
+              disabled={(!input.trim() && files.length === 0) || disabled || isUploadingFiles}
+              className={`p-2 rounded-xl transition-all duration-150 ${
+                (input.trim() || files.length > 0) && !disabled && !isUploadingFiles
+                  ? 'bg-zinc-900 text-white hover:bg-zinc-700 active:scale-95 shadow-sm'
+                  : 'bg-zinc-100 text-zinc-300 cursor-not-allowed'
+              }`}
+              aria-label={isStreaming ? 'Додати в чергу' : 'Надіслати повідомлення'}
+              title={isStreaming ? 'Буде виконано після поточної відповіді' : undefined}
+            >
+              {isUploadingFiles ? (
+                <Loader2 size={14} strokeWidth={2} className="animate-spin" />
+              ) : (
+                <Send size={14} strokeWidth={2} />
+              )}
+            </button>
           </div>
         </div>
       </div>
+
+      {/* Queued query indicator */}
+      {hasQueuedQuery && (
+        <div className="mt-1.5 px-3 py-1 text-[11px] text-zinc-500 flex items-center gap-1.5">
+          <Loader2 size={10} className="animate-spin" />
+          <span>Запит в черзі — буде виконано після поточної відповіді</span>
+        </div>
+      )}
     </div>
     </>
   );

--- a/lexwebapp/src/pages/ChatPage/index.tsx
+++ b/lexwebapp/src/pages/ChatPage/index.tsx
@@ -4,7 +4,7 @@
  * Now using MCP streaming with all 43 tools support
  */
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { TrendingUp } from 'lucide-react';
 import { ChatInput } from '../../components/ChatInput';
 import { MessageThread } from '../../components/MessageThread';
@@ -28,6 +28,8 @@ export function ChatPage() {
   const removeMessage = useChatStore(s => s.removeMessage);
   const pendingBudgetEscalation = useChatStore(s => s.pendingBudgetEscalation);
   const setPendingBudgetEscalation = useChatStore(s => s.setPendingBudgetEscalation);
+  const queuedQuery = useChatStore(s => s.queuedQuery);
+  const setQueuedQuery = useChatStore(s => s.setQueuedQuery);
 
   // AI Chat hook (agentic mode)
   const { executeChat, confirmPlanAndExecute, skipPlanReview } = useAIChat();
@@ -46,6 +48,11 @@ export function ChatPage() {
   }, [setPendingBudgetEscalation]);
 
   const handleSend = async (content: string, _toolName?: string, documentIds?: string[]) => {
+    // If streaming is active, queue the message for execution after current stream ends
+    if (isStreaming || isPlanLoading) {
+      setQueuedQuery({ content, documentIds });
+      return;
+    }
     try {
       await executeChat(content, documentIds, undefined, internetEnabled);
     } catch (error: unknown) {
@@ -53,6 +60,24 @@ export function ChatPage() {
       showToast.error(getErrorMessage(error));
     }
   };
+
+  // Auto-execute queued query when streaming ends
+  const executingQueueRef = useRef(false);
+  useEffect(() => {
+    if (!isStreaming && !isPlanLoading && queuedQuery && !executingQueueRef.current) {
+      executingQueueRef.current = true;
+      const { content, documentIds } = queuedQuery;
+      setQueuedQuery(null);
+      executeChat(content, documentIds, undefined, internetEnabled)
+        .catch((error: unknown) => {
+          console.error('Queued chat execution error:', error);
+          showToast.error(getErrorMessage(error));
+        })
+        .finally(() => {
+          executingQueueRef.current = false;
+        });
+    }
+  }, [isStreaming, isPlanLoading, queuedQuery, setQueuedQuery, executeChat, internetEnabled]);
 
   const handleRegenerate = useCallback((userQuery: string) => {
     // Find the last assistant message and remove it
@@ -132,8 +157,9 @@ export function ChatPage() {
       <div className="w-full bg-claude-bg pt-3 pb-5 z-20 border-t border-claude-border/60">
         <ChatInput
           onSend={handleSend}
-          disabled={isStreaming || isPlanLoading || !!pendingPlanReview}
+          disabled={!!pendingPlanReview}
           isStreaming={isStreaming || isPlanLoading}
+          hasQueuedQuery={!!queuedQuery}
           onCancel={cancelStream}
         />
         <p className="text-center text-[11px] text-zinc-400 mt-2.5 font-sans">

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -45,6 +45,9 @@ interface ChatState {
   // Budget escalation state
   pendingBudgetEscalation: PendingBudgetEscalation | null;
 
+  // Query queue — holds next query to execute after current stream ends
+  queuedQuery: { content: string; documentIds?: string[] } | null;
+
   // Conversation state
   conversationId: string | null;
   conversations: ConversationSummary[];
@@ -74,6 +77,9 @@ interface ChatState {
   // Budget escalation actions
   setPendingBudgetEscalation: (escalation: PendingBudgetEscalation | null) => void;
 
+  // Queue actions
+  setQueuedQuery: (query: { content: string; documentIds?: string[] } | null) => void;
+
   // Conversation actions
   loadConversations: () => Promise<void>;
   createConversation: (title?: string) => Promise<string>;
@@ -101,6 +107,7 @@ export const useChatStore = create<ChatState>()(
         pendingPlanReview: null,
         isPlanLoading: false,
         pendingBudgetEscalation: null,
+        queuedQuery: null,
         conversationId: null,
         conversations: [],
         conversationsLoading: false,
@@ -163,6 +170,7 @@ export const useChatStore = create<ChatState>()(
         setPendingPlanReview: (review) => set({ pendingPlanReview: review }),
         setIsPlanLoading: (loading) => set({ isPlanLoading: loading }),
         setPendingBudgetEscalation: (escalation) => set({ pendingBudgetEscalation: escalation }),
+        setQueuedQuery: (query) => set({ queuedQuery: query }),
 
         // Cancel active stream
         cancelStream: () => {
@@ -173,6 +181,7 @@ export const useChatStore = create<ChatState>()(
               streamController: null,
               isStreaming: false,
               currentTool: null,
+              queuedQuery: null,
             });
           }
         },
@@ -241,6 +250,7 @@ export const useChatStore = create<ChatState>()(
             currentTool: null,
             pendingPlanReview: null,
             isPlanLoading: false,
+            queuedQuery: null,
           });
 
           try {
@@ -330,6 +340,7 @@ export const useChatStore = create<ChatState>()(
             currentTool: null,
             pendingPlanReview: null,
             isPlanLoading: false,
+            queuedQuery: null,
           });
         },
 


### PR DESCRIPTION
## Summary
- Unlock chat textarea and send button during active streaming
- New query is queued and auto-executes after current stream completes
- Visual indicator shows "Запит в черзі" when a query is pending
- Queue cleared on stream cancel, conversation switch, and new conversation

Closes #455

## Test plan
- [ ] Start a chat query, verify input stays active during streaming
- [ ] Send a second query during streaming — verify queue indicator appears
- [ ] After first stream completes, verify queued query auto-executes
- [ ] Cancel stream — verify queue is cleared
- [ ] Switch conversation during streaming — verify queue is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable sending a new query while a response is streaming. The message is queued and auto-executes when the current stream finishes. Closes #455.

- **New Features**
  - Keep input and Send active during streaming; Send enqueues the message.
  - Auto-run queued query after stream; clear queue on cancel, conversation switch, or new conversation.
  - Show “Запит в черзі” indicator with tooltip when a message is queued.
  - Add `queuedQuery` and `setQueuedQuery` to the store; process queued messages in `ChatPage` when streaming ends.

<sup>Written for commit b56dc5552e008d41ee630556ab8dfb67eea93a4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

