### PR TITLE
fix: AdminMonitoringPage refresh test flaky assertion

### DIFF
--- a/lexwebapp/src/pages/__tests__/AdminMonitoringPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/AdminMonitoringPage.test.tsx
@@ -233,12 +233,21 @@ describe('AdminMonitoringPage', () => {
     await waitFor(() => {
       expect(screen.getAllByText('Оновити').length).toBeGreaterThanOrEqual(1);
     });
-    // Initial load calls getDataSources for backend/rada/openreyestr
-    const initialCalls = mockGetDataSources.mock.calls.length;
+    // Wait for initial load to complete
+    await waitFor(() => {
+      expect(mockGetDataSources.mock.calls.length).toBeGreaterThanOrEqual(3);
+    });
+    // Reset mock to track only new calls after refresh
+    mockGetDataSources.mockClear();
+    mockGetDataSources.mockImplementation((section?: string) => {
+      if (section === 'backend') return Promise.resolve({ data: mockBackendData });
+      if (section === 'rada') return Promise.resolve({ data: mockRadaData });
+      return Promise.resolve({ data: { tables: {}, dbSizeMb: 0 } });
+    });
     // Click the first "Оновити" (header refresh button)
     fireEvent.click(screen.getAllByText('Оновити')[0]);
     await waitFor(() => {
-      expect(mockGetDataSources.mock.calls.length).toBeGreaterThan(initialCalls);
+      expect(mockGetDataSources.mock.calls.length).toBeGreaterThanOrEqual(1);
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixed flaky `refresh button re-fetches all data` test
- Was asserting `calls.length > 3` but got exactly 3 (mocks resolve synchronously)
- Now clears mock after initial load and checks for new calls after refresh click

## Test plan
- [x] AdminMonitoringPage tests: 18 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky AdminMonitoringPage refresh test by waiting for the initial load, clearing `mockGetDataSources`, and asserting new calls after clicking "Оновити". This stabilizes the test by avoiding comparing the same synchronous call count before and after refresh.

<sup>Written for commit a69ce560ddef7ffc0e15e16a39b684b536bfb4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

