### PR TITLE
fix: raise consultation rate limit from 300 to 600/min

### DIFF
--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -166,10 +166,10 @@ export const passwordResetRateLimit = createRateLimiter({
 });
 
 // Consultation rate limiter — keyed by userId to avoid Cloudflare shared IP issues.
-// 300/min: handles multiple open tabs with polling + SSE reconnects.
+// 600/min: handles multiple open tabs/consultations with polling + SSE reconnects.
 export const consultationRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 300,
+  maxRequests: 600,
   keyPrefix: 'ratelimit:consultation',
   keyByUserId: true,
 });


### PR DESCRIPTION
## Summary
- Users with multiple open consultations hit the 300/min per-user rate limit due to polling every ~15s on detail + messages endpoints
- Raised `consultationRateLimit` from 300 to 600 requests/min

## Test plan
- [ ] Open 2+ consultations simultaneously, verify no rate limit errors
- [ ] Monitor prod logs for `[RateLimit] Limit exceeded` on consultation paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the per-user consultation rate limit from 300 to 600 requests/min to prevent throttling when users have multiple consultations open. This accommodates ~15s polling and SSE reconnects across tabs so consultation pages and messages keep working without rate limit errors.

<sup>Written for commit ec462463505f9f1299dba23a5736838cc7327cb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

