### PR TITLE
fix: resolve chat message duplication in consultations

### DIFF
--- a/lexwebapp/src/components/chat/ConsultationChatTab.tsx
+++ b/lexwebapp/src/components/chat/ConsultationChatTab.tsx
@@ -173,8 +173,17 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
       try {
         const message: ConsultationMessage = JSON.parse(event.data);
         setMessages((prev) => {
-          // Avoid duplicates (optimistic send)
+          // Already have this exact message by server ID
           if (prev.some((m) => m.id === message.id)) return prev;
+          // Replace optimistic message if it matches (same sender + content)
+          const optimisticIdx = prev.findIndex(
+            (m) => m.id.startsWith('optimistic-') && m.sender_id === message.sender_id && m.content === message.content
+          );
+          if (optimisticIdx >= 0) {
+            const updated = [...prev];
+            updated[optimisticIdx] = message;
+            return updated;
+          }
           return [...prev, message];
         });
         onUnreadCountChange(0);
@@ -244,13 +253,13 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
     const poll = setInterval(() => {
       consultationService.getMessages(consultationId, { limit: 100 }).then((result) => {
         setMessages(prev => {
-          if (result.messages.length === prev.length) return prev;
-          // Merge: keep all messages, deduplicate by id
-          const ids = new Set(prev.map(m => m.id));
-          const newMsgs = result.messages.filter(m => !ids.has(m.id));
-          if (newMsgs.length === 0) return prev;
-          const merged = [...prev, ...newMsgs];
-          setTimeout(scrollToBottom, 100);
+          // Keep only unresolved optimistic messages (no matching server message yet)
+          const pendingOptimistic = prev.filter(m =>
+            m.id.startsWith('optimistic-') &&
+            !result.messages.some(sm => sm.sender_id === m.sender_id && sm.content === m.content)
+          );
+          const merged = [...result.messages, ...pendingOptimistic];
+          if (merged.length !== prev.length) setTimeout(scrollToBottom, 100);
           return merged;
         });
       }).catch(() => {});
@@ -368,8 +377,15 @@ export function ConsultationChatTab({ consultationId, onUnreadCountChange, disab
         undefined,
         attachment
       );
-      // Replace optimistic with real message
-      setMessages((prev) => prev.map((m) => m.id === optimistic.id ? sent : m));
+      // Replace optimistic with real message (SSE may have already replaced it)
+      setMessages((prev) => {
+        const hasReal = prev.some((m) => m.id === sent.id);
+        if (hasReal) {
+          // SSE already delivered — just remove leftover optimistic if any
+          return prev.filter((m) => m.id !== optimistic.id);
+        }
+        return prev.map((m) => m.id === optimistic.id ? sent : m);
+      });
     } catch {
       // Remove optimistic on failure
       setMessages((prev) => prev.filter((m) => m.id !== optimistic.id));


### PR DESCRIPTION
## Summary
- Fixed race condition between optimistic send, SSE stream, and polling fallback causing messages to appear twice in consultation chat
- SSE handler now detects and replaces optimistic messages instead of adding duplicates
- sendMessage callback checks if SSE already delivered the real message before replacing
- Polling fallback uses server data as source of truth, preserving only unresolved optimistic messages

## Test plan
- [ ] Open consultation chat between two users (lawyer + client)
- [ ] Send messages from both sides — verify no duplicates
- [ ] Send message and verify it appears once even if SSE delivers before API response
- [ ] Wait for 30s polling cycle — verify no duplicates after poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated messages in consultation chats by resolving a race between optimistic sends, SSE delivery, and polling. Messages now appear once and stay in the correct order.

- **Bug Fixes**
  - SSE handler replaces matching optimistic messages (same sender + content) and skips ids already seen.
  - sendMessage removes the optimistic if SSE already delivered the real message; otherwise replaces it.
  - Polling uses server messages as source of truth and keeps only unresolved optimistic messages; scrolls on new data.

<sup>Written for commit 17bd7b2cabf6f515e2f93d77ddeef1675c88c517. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

