### PR TITLE
fix: remove unused React import breaking CI build

### DIFF
--- a/lexwebapp/src/components/video-call/__tests__/CallNotification.test.tsx
+++ b/lexwebapp/src/components/video-call/__tests__/CallNotification.test.tsx
@@ -11,7 +11,6 @@
  * used by other component tests in this project.
  */
 
-import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/lexwebapp/src/components/video-call/__tests__/VideoCallControls.test.tsx
+++ b/lexwebapp/src/components/video-call/__tests__/VideoCallControls.test.tsx
@@ -8,7 +8,6 @@
  *   so tests remain resilient to icon changes.
  */
 
-import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';


### PR DESCRIPTION
## Summary
- Removed unused `import React from 'react'` from video-call test files causing TS6133 build failure

## Test plan
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `import React from 'react'` from video-call test files. This resolves TypeScript TS6133 errors and restores the CI build.

<sup>Written for commit afa192be602a8c0fde066ea59fccccef2f609590. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

