### PR TITLE
fix: prevent session replay payload snowball on large DOM

### DIFF
--- a/lexwebapp/src/hooks/useSessionRecorder.ts
+++ b/lexwebapp/src/hooks/useSessionRecorder.ts
@@ -19,6 +19,7 @@ export function getActiveSessionId(): string | null {
 
 const FLUSH_INTERVAL_MS = 10_000; // 10 seconds
 const MAX_BUFFER_SIZE = 500; // flush early if buffer gets large
+const MAX_CHUNK_BYTES = 5_000_000; // 5MB — stay well under the 10MB body-parser limit
 
 export function useSessionRecorder() {
   const { user, isAuthenticated } = useAuth();
@@ -129,15 +130,51 @@ export function useSessionRecorder() {
 
     const events = [...bufferRef.current];
     bufferRef.current = [];
-    const chunkIndex = chunkIndexRef.current++;
 
-    // Fire-and-forget — don't block UI on network errors
-    sessionReplayApi.sendChunk(sessionId, chunkIndex, events).catch((err) => {
-      console.warn('[SessionRecorder] Failed to send chunk', chunkIndex, err);
-      // Put events back in buffer for retry on next flush
-      bufferRef.current.unshift(...events);
-      chunkIndexRef.current--; // reuse chunk index
-    });
+    // Split events into chunks that fit under the body-parser limit
+    const batches: any[][] = [];
+    let currentBatch: any[] = [];
+    let currentSize = 0;
+
+    for (const event of events) {
+      const eventSize = JSON.stringify(event).length;
+
+      // If a single event exceeds the limit, skip it (e.g. huge FullSnapshot)
+      if (eventSize > MAX_CHUNK_BYTES) {
+        console.warn('[SessionRecorder] Dropping oversized event', event.type, eventSize);
+        continue;
+      }
+
+      if (currentSize + eventSize > MAX_CHUNK_BYTES && currentBatch.length > 0) {
+        batches.push(currentBatch);
+        currentBatch = [];
+        currentSize = 0;
+      }
+
+      currentBatch.push(event);
+      currentSize += eventSize;
+    }
+
+    if (currentBatch.length > 0) {
+      batches.push(currentBatch);
+    }
+
+    // Send each batch as a separate chunk
+    for (const batch of batches) {
+      const chunkIndex = chunkIndexRef.current++;
+
+      sessionReplayApi.sendChunk(sessionId, chunkIndex, batch).catch((err) => {
+        // Only retry on transient errors (5xx, network). Drop on 413/4xx to prevent snowball.
+        const status = err?.response?.status;
+        if (status && status >= 400 && status < 500) {
+          console.warn('[SessionRecorder] Dropping chunk (client error)', chunkIndex, status);
+          return;
+        }
+        console.warn('[SessionRecorder] Failed to send chunk (will retry)', chunkIndex, err);
+        bufferRef.current.unshift(...batch);
+        chunkIndexRef.current--;
+      });
+    }
   }
 
   // Also flush on page unload (best-effort with sendBeacon)


### PR DESCRIPTION
## Summary

- Fixes cascade of `PayloadTooLargeError` (34MB+) from rrweb session recorder that blocked user teosoph@gmail.com
- Root cause: retry logic put failed events back in buffer, new events accumulated each 10s flush → payload grew unboundedly

## Changes

`lexwebapp/src/hooks/useSessionRecorder.ts`:
- Split events into batches ≤5MB before sending (well under 10MB body-parser limit)
- Drop oversized single events (e.g. huge FullSnapshot >5MB)
- Only retry on transient errors (5xx, network failures), NOT on 4xx client errors (413 PayloadTooLarge)

## Test plan

- [x] TypeScript compiles clean
- [ ] Verify session replay still records and sends chunks on pages with small DOM
- [ ] Verify no 413 errors on pages with large DOM (consultation detail with documents)
- [ ] Verify chunks are split correctly when buffer exceeds 5MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents session replay payload snowballing on large DOMs by batching `rrweb` events and skipping retries on client errors. Stops 413 Payload Too Large cascades and rate‑limit spikes.

- **Bug Fixes**
  - Split buffered events into chunks ≤5MB to stay under the `body-parser` 10MB limit.
  - Drop single oversized events (e.g., FullSnapshot >5MB).
  - Retry only on transient errors (5xx or network); drop 4xx (including 413).

<sup>Written for commit beb6d29812c45faf3cdbebde73ab649bb117e591. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

