### PR TITLE
refactor: improve WebRTC video/audio call reliability

### DIFF
--- a/lexwebapp/src/hooks/useSpeechTranscription.ts
+++ b/lexwebapp/src/hooks/useSpeechTranscription.ts
@@ -41,20 +41,22 @@ export function useSpeechTranscription(signaling: Signaling) {
       ...(mimeType ? { mimeType } : {}),
     });
 
-    recorder.ondataavailable = async (event) => {
+    recorder.ondataavailable = (event) => {
       if (event.data.size > 0) {
-        try {
-          const buffer = await event.data.arrayBuffer();
-          const bytes = new Uint8Array(buffer);
-          let binary = '';
-          for (let i = 0; i < bytes.byteLength; i++) {
-            binary += String.fromCharCode(bytes[i]);
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          try {
+            // result is "data:<mime>;base64,<data>" — extract the base64 part
+            const dataUrl = reader.result as string;
+            const base64 = dataUrl.split(',')[1];
+            if (base64) {
+              signaling.sendAudioData(base64);
+            }
+          } catch {
+            // ignore encoding errors
           }
-          const base64 = btoa(binary);
-          signaling.sendAudioData(base64);
-        } catch {
-          // ignore encoding errors
-        }
+        };
+        reader.readAsDataURL(event.data);
       }
     };
 

--- a/lexwebapp/src/hooks/useVideoSignaling.ts
+++ b/lexwebapp/src/hooks/useVideoSignaling.ts
@@ -70,21 +70,28 @@ export function useVideoSignaling(consultationId: string | null) {
     } = store.getState();
 
     switch (msg.type) {
-      case 'call-incoming': {
+      case 'incoming-call': {
+        const session = msg.session as any;
         setIncomingCall({
-          sessionId: msg.sessionId as string,
-          callerId: msg.callerId as string,
+          sessionId: session?.id as string,
+          callerId: session?.caller_id as string,
           callerName: msg.callerName as string,
-          callType: msg.callType as 'video' | 'audio',
-          consultationId: msg.consultationId as string,
+          callType: session?.call_type as 'video' | 'audio',
+          consultationId: session?.consultation_id as string,
         });
+        break;
+      }
+
+      case 'call-created': {
+        const session = msg.session as any;
+        setSessionId(session?.id as string);
         break;
       }
 
       case 'call-accepted': {
         setCallState('connecting');
         setSessionId(msg.sessionId as string);
-        setRemoteUser(msg.userId as string, msg.userName as string);
+        setRemoteUser(msg.by as string, null);
         break;
       }
 
@@ -98,12 +105,12 @@ export function useVideoSignaling(consultationId: string | null) {
         break;
       }
 
-      case 'offer': {
+      case 'call-offer': {
         window.dispatchEvent(new CustomEvent('webrtc-offer', { detail: msg }));
         break;
       }
 
-      case 'answer': {
+      case 'call-answer': {
         window.dispatchEvent(new CustomEvent('webrtc-answer', { detail: msg }));
         break;
       }
@@ -143,37 +150,39 @@ export function useVideoSignaling(consultationId: string | null) {
   }, []);
 
   const sendOffer = useCallback((offer: RTCSessionDescriptionInit) => {
-    send({ type: 'offer', sdp: offer.sdp, sdpType: offer.type });
-  }, [send]);
+    const { sessionId } = store.getState();
+    send({ type: 'call-offer', sdp: offer.sdp, sdpType: offer.type, sessionId });
+  }, [send, store]);
 
   const sendAnswer = useCallback((answer: RTCSessionDescriptionInit) => {
-    send({ type: 'answer', sdp: answer.sdp, sdpType: answer.type });
-  }, [send]);
+    const { sessionId } = store.getState();
+    send({ type: 'call-answer', sdp: answer.sdp, sdpType: answer.type, sessionId });
+  }, [send, store]);
 
   const sendIceCandidate = useCallback((candidate: RTCIceCandidateInit) => {
     send({ type: 'ice-candidate', candidate });
   }, [send]);
 
   const initiateCall = useCallback((callType: 'video' | 'audio', calleeId: string) => {
-    send({ type: 'initiate-call', callType, calleeId, consultationId });
+    send({ type: 'call-initiate', callType, calleeId, consultationId });
     store.getState().setCallState('initiating');
     store.getState().setCallType(callType);
   }, [send, consultationId, store]);
 
   const acceptCall = useCallback((sessionId: string) => {
-    send({ type: 'accept-call', sessionId });
+    send({ type: 'call-accept', sessionId });
     store.getState().setCallState('connecting');
     store.getState().setIncomingCall(null);
   }, [send, store]);
 
   const rejectCall = useCallback((sessionId: string) => {
-    send({ type: 'reject-call', sessionId });
+    send({ type: 'call-reject', sessionId });
     store.getState().setIncomingCall(null);
   }, [send, store]);
 
   const hangup = useCallback(() => {
     const { sessionId } = store.getState();
-    send({ type: 'hangup', sessionId });
+    send({ type: 'call-hangup', sessionId });
     store.getState().setCallState('ended');
   }, [send, store]);
 

--- a/lexwebapp/src/hooks/useWebRTC.ts
+++ b/lexwebapp/src/hooks/useWebRTC.ts
@@ -100,6 +100,12 @@ export function useWebRTC(signaling: Signaling) {
       pcRef.current = null;
     }
 
+    // Stop screen share track if active
+    if (originalVideoTrackRef.current) {
+      originalVideoTrackRef.current.stop();
+      originalVideoTrackRef.current = null;
+    }
+
     const { localStream: currentStream } = useVideoCallStore.getState();
     if (currentStream) {
       currentStream.getTracks().forEach((track) => track.stop());

--- a/lexwebapp/src/stores/videoCallStore.ts
+++ b/lexwebapp/src/stores/videoCallStore.ts
@@ -100,23 +100,25 @@ export const useVideoCallStore = create<VideoCallState>((set) => ({
   setLocalStream: (localStream) => set({ localStream }),
   setRemoteStream: (remoteStream) => set({ remoteStream }),
 
-  toggleMute: () => set((state) => {
-    if (state.localStream) {
-      state.localStream.getAudioTracks().forEach((track) => {
-        track.enabled = state.isMuted;
+  toggleMute: () => {
+    const { localStream, isMuted } = useVideoCallStore.getState();
+    if (localStream) {
+      localStream.getAudioTracks().forEach((track) => {
+        track.enabled = isMuted; // isMuted=true means re-enable
       });
     }
-    return { isMuted: !state.isMuted };
-  }),
+    set({ isMuted: !isMuted });
+  },
 
-  toggleVideo: () => set((state) => {
-    if (state.localStream) {
-      state.localStream.getVideoTracks().forEach((track) => {
-        track.enabled = state.isVideoOff;
+  toggleVideo: () => {
+    const { localStream, isVideoOff } = useVideoCallStore.getState();
+    if (localStream) {
+      localStream.getVideoTracks().forEach((track) => {
+        track.enabled = isVideoOff; // isVideoOff=true means re-enable
       });
     }
-    return { isVideoOff: !state.isVideoOff };
-  }),
+    set({ isVideoOff: !isVideoOff });
+  },
 
   toggleScreenSharing: () => set((state) => ({ isScreenSharing: !state.isScreenSharing })),
 

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -30,6 +30,7 @@ import { NewsArticleService } from './services/news-article-service.js';
 import { ERAUCacheService } from './services/erau-cache-service.js';
 import { attachTerminalWebSocket } from './routes/terminal-routes.js';
 import { attachVideoCallSignaling } from './routes/video-call-signaling.js';
+import { SttService } from './services/stt-service.js';
 import { VideoCallService } from './services/video-call-service.js';
 import { createVideoCallRoutes } from './routes/video-call-routes.js';
 import { getConsultationMessageBus } from './services/consultation-message-bus.js';
@@ -965,7 +966,8 @@ class HTTPMCPServer {
     // Attach video call signaling WebSocket
     const messageBus = getConsultationMessageBus();
     const videoCallSvc = new VideoCallService(this.services.db, messageBus);
-    attachVideoCallSignaling(httpServer, this.services.db, videoCallSvc, messageBus);
+    const sttSvc = new SttService(videoCallSvc);
+    attachVideoCallSignaling(httpServer, this.services.db, videoCallSvc, messageBus, sttSvc);
 
     // Listen BEFORE initialize so healthcheck responds during slow startup
     await new Promise<void>((resolve) => httpServer.listen(port, host, resolve));

--- a/mcp_backend/src/migrations/116_video_call_fixes.sql
+++ b/mcp_backend/src/migrations/116_video_call_fixes.sql
@@ -1,0 +1,54 @@
+-- Migration 116: Fix video call constraints and add race condition protection
+-- Date: 2026-03-27
+
+BEGIN;
+
+-- 1. Partial unique index to prevent duplicate active sessions per consultation
+CREATE UNIQUE INDEX IF NOT EXISTS idx_video_call_sessions_one_active_per_consultation
+  ON video_call_sessions(consultation_id)
+  WHERE status IN ('pending', 'ringing', 'connected');
+
+-- 2. Fix status CHECK to include 'rejected' (used by call-reject handler)
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'video_call_sessions_status_check'
+  ) THEN
+    ALTER TABLE video_call_sessions DROP CONSTRAINT video_call_sessions_status_check;
+  END IF;
+  ALTER TABLE video_call_sessions
+    ADD CONSTRAINT video_call_sessions_status_check
+    CHECK (status IN ('pending', 'ringing', 'connected', 'ended', 'failed', 'missed', 'rejected'));
+END $$;
+
+-- 3. Fix end_reason CHECK to include all reasons used in code
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'video_call_sessions_end_reason_check'
+  ) THEN
+    ALTER TABLE video_call_sessions DROP CONSTRAINT video_call_sessions_end_reason_check;
+  END IF;
+  ALTER TABLE video_call_sessions
+    ADD CONSTRAINT video_call_sessions_end_reason_check
+    CHECK (end_reason IN ('hangup', 'timeout', 'error', 'declined', 'disconnect', 'rejected', 'ended_by_user'));
+END $$;
+
+-- 4. Fix call_transcripts: add session_id column alias if missing
+--    (migration 115 uses call_session_id but service code queries session_id)
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'call_transcripts' AND column_name = 'call_session_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'call_transcripts' AND column_name = 'session_id'
+  ) THEN
+    ALTER TABLE call_transcripts RENAME COLUMN call_session_id TO session_id;
+  END IF;
+END $$;
+
+-- 5. Recreate index on renamed column
+DROP INDEX IF EXISTS idx_call_transcripts_call_session_id;
+CREATE INDEX IF NOT EXISTS idx_call_transcripts_session_id
+  ON call_transcripts(session_id);
+
+COMMIT;

--- a/mcp_backend/src/routes/video-call-routes.ts
+++ b/mcp_backend/src/routes/video-call-routes.ts
@@ -1,26 +1,36 @@
-import { Router, Response } from 'express';
+import { Router, Response, NextFunction } from 'express';
 import { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
 import type { VideoCallService } from '../services/video-call-service.js';
 import { logger } from '../utils/logger.js';
 
+function requireCallAccess(videoCallService: VideoCallService) {
+  return (async (req: DualAuthRequest, _res: Response, next: NextFunction): Promise<any> => {
+    if (!req.user?.id) return _res.status(401).json({ error: 'Unauthorized' });
+
+    const consultationId = req.params.consultationId as string;
+    if (!consultationId) return _res.status(400).json({ error: 'consultationId is required' });
+
+    const hasAccess = await videoCallService.verifyCallAccess(consultationId, req.user.id);
+    if (!hasAccess) return _res.status(403).json({ error: 'No access to this consultation' });
+
+    next();
+  }) as any;
+}
+
 export function createVideoCallRoutes(videoCallService: VideoCallService): Router {
   const router = Router({ mergeParams: true });
+
+  // All routes require auth + consultation access
+  router.use(requireCallAccess(videoCallService));
 
   // POST / — initiate a call
   router.post('/', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
-      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-
       const consultationId = req.params.consultationId as string;
-      if (!consultationId) return res.status(400).json({ error: 'consultationId is required' });
-
       const { callType, calleeId } = req.body;
       if (!callType || !calleeId) {
         return res.status(400).json({ error: 'callType and calleeId are required' });
       }
-
-      const hasAccess = await videoCallService.verifyCallAccess(consultationId, req.user.id);
-      if (!hasAccess) return res.status(403).json({ error: 'No access to this consultation' });
 
       // Check for existing active session
       const existing = await videoCallService.getActiveSession(consultationId);
@@ -30,7 +40,7 @@ export function createVideoCallRoutes(videoCallService: VideoCallService): Route
 
       const session = await videoCallService.createSession(
         consultationId,
-        req.user.id,
+        req.user!.id,
         calleeId,
         callType,
       );
@@ -45,14 +55,6 @@ export function createVideoCallRoutes(videoCallService: VideoCallService): Route
   // POST /:sessionId/end — end a call
   router.post('/:sessionId/end', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
-      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-
-      const consultationId = req.params.consultationId as string;
-      if (!consultationId) return res.status(400).json({ error: 'consultationId is required' });
-
-      const hasAccess = await videoCallService.verifyCallAccess(consultationId, req.user.id);
-      if (!hasAccess) return res.status(403).json({ error: 'No access to this consultation' });
-
       const sessionId = req.params.sessionId as string;
       const { reason } = req.body;
 
@@ -68,16 +70,8 @@ export function createVideoCallRoutes(videoCallService: VideoCallService): Route
   }) as any);
 
   // GET /ice-servers — get ICE server configuration
-  router.get('/ice-servers', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+  router.get('/ice-servers', (async (_req: DualAuthRequest, res: Response): Promise<any> => {
     try {
-      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-
-      const consultationId = req.params.consultationId as string;
-      if (!consultationId) return res.status(400).json({ error: 'consultationId is required' });
-
-      const hasAccess = await videoCallService.verifyCallAccess(consultationId, req.user.id);
-      if (!hasAccess) return res.status(403).json({ error: 'No access to this consultation' });
-
       const iceServers = videoCallService.getIceServers();
       res.json({ iceServers });
     } catch (error: any) {
@@ -89,15 +83,11 @@ export function createVideoCallRoutes(videoCallService: VideoCallService): Route
   // GET /history — get call history for a consultation
   router.get('/history', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
-      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-
       const consultationId = req.params.consultationId as string;
-      if (!consultationId) return res.status(400).json({ error: 'consultationId is required' });
-
-      const hasAccess = await videoCallService.verifyCallAccess(consultationId, req.user.id);
-      if (!hasAccess) return res.status(403).json({ error: 'No access to this consultation' });
-
-      const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : 50;
+      const limit = Math.max(1, Math.min(
+        req.query.limit ? parseInt(req.query.limit as string, 10) : 50,
+        500,
+      ));
       const history = await videoCallService.getCallHistory(consultationId, limit);
       res.json(history);
     } catch (error: any) {
@@ -109,14 +99,6 @@ export function createVideoCallRoutes(videoCallService: VideoCallService): Route
   // GET /:sessionId/transcript — get transcript for a session
   router.get('/:sessionId/transcript', (async (req: DualAuthRequest, res: Response): Promise<any> => {
     try {
-      if (!req.user?.id) return res.status(401).json({ error: 'Unauthorized' });
-
-      const consultationId = req.params.consultationId as string;
-      if (!consultationId) return res.status(400).json({ error: 'consultationId is required' });
-
-      const hasAccess = await videoCallService.verifyCallAccess(consultationId, req.user.id);
-      if (!hasAccess) return res.status(403).json({ error: 'No access to this consultation' });
-
       const sessionId = req.params.sessionId as string;
       const transcript = await videoCallService.getTranscript(sessionId);
       res.json(transcript);

--- a/mcp_backend/src/routes/video-call-signaling.ts
+++ b/mcp_backend/src/routes/video-call-signaling.ts
@@ -5,6 +5,7 @@ import { logger } from '../utils/logger.js';
 import type { IDatabase } from '../domain/ports/index.js';
 import type { IConsultationMessageBus } from '../services/consultation-message-bus.js';
 import type { VideoCallService } from '../services/video-call-service.js';
+import type { SttService } from '../services/stt-service.js';
 import type { Server as HttpServer } from 'http';
 
 interface AuthenticatedUser {
@@ -48,6 +49,7 @@ export function attachVideoCallSignaling(
   db: IDatabase,
   videoCallService: VideoCallService,
   messageBus: IConsultationMessageBus,
+  sttService?: SttService,
 ): void {
   const wss = new WebSocketServer({ noServer: true });
 
@@ -268,13 +270,53 @@ export function attachVideoCallSignaling(
           }
 
           case 'audio-data': {
-            // Placeholder for STT integration
-            logger.debug('[VideoSignaling] Received audio data', {
-              sessionId: msg.sessionId,
-              userId: user!.id,
-              language: msg.language,
-              dataLength: msg.data?.length || 0,
-            });
+            if (!sttService) break;
+
+            const activeSession = await videoCallService.getActiveSession(consultationId!);
+            if (!activeSession) break;
+
+            const lang = (msg.language as string) || 'uk';
+
+            // Lazily start transcription for this speaker
+            if (!sttService.hasActiveTranscription(activeSession.id, user!.id)) {
+              sttService.startTranscription(
+                activeSession.id,
+                user!.id,
+                lang,
+                (text: string, isFinal: boolean, timestampMs: number) => {
+                  // Forward transcript to both parties
+                  const transcriptMsg = {
+                    type: 'transcription',
+                    sessionId: activeSession.id,
+                    speakerId: user!.id,
+                    speakerName: user!.name,
+                    segmentId: `${activeSession.id}-${user!.id}-${timestampMs}`,
+                    text,
+                    language: lang,
+                    isFinal,
+                    timestampMs,
+                  };
+
+                  // Send to caller
+                  if (ws.readyState === WebSocket.OPEN) {
+                    ws.send(JSON.stringify(transcriptMsg));
+                  }
+                  // Send to other party
+                  sendToOther(transcriptMsg);
+                },
+              );
+            }
+
+            // Decode base64 audio and forward to Deepgram
+            try {
+              const audioBuffer = Buffer.from(msg.audio as string, 'base64');
+              const handle = sttService.getHandle(activeSession.id, user!.id);
+              if (handle) {
+                handle.sendAudio(audioBuffer);
+              }
+            } catch {
+              // ignore decode errors
+            }
             break;
           }
 
@@ -331,6 +373,16 @@ export function attachVideoCallSignaling(
         if (room.size === 0) {
           rooms.delete(consultationId!);
         }
+      }
+
+      // Stop any active STT transcription for this user
+      try {
+        const sessionForStt = await videoCallService.getActiveSession(consultationId!);
+        if (sessionForStt && sttService) {
+          sttService.stopTranscription(sessionForStt.id, user.id);
+        }
+      } catch {
+        // ignore
       }
 
       // End any active session this user was in

--- a/mcp_backend/src/services/stt-service.ts
+++ b/mcp_backend/src/services/stt-service.ts
@@ -59,6 +59,7 @@ export class SttService {
       },
     });
 
+    const MAX_PENDING_BUFFERS = 20;
     let isOpen = false;
     const pendingBuffers: Buffer[] = [];
 
@@ -131,6 +132,9 @@ export class SttService {
         if (isOpen && dgWs.readyState === WebSocket.OPEN) {
           dgWs.send(audioBuffer);
         } else if (!isOpen) {
+          if (pendingBuffers.length >= MAX_PENDING_BUFFERS) {
+            pendingBuffers.shift(); // drop oldest chunk
+          }
           pendingBuffers.push(audioBuffer);
         }
       },
@@ -150,6 +154,14 @@ export class SttService {
 
     this.activeTranscriptions.set(key, handle);
     return handle;
+  }
+
+  hasActiveTranscription(sessionId: string, speakerId: string): boolean {
+    return this.activeTranscriptions.has(`${sessionId}:${speakerId}`);
+  }
+
+  getHandle(sessionId: string, speakerId: string): DeepgramHandle | undefined {
+    return this.activeTranscriptions.get(`${sessionId}:${speakerId}`);
   }
 
   stopTranscription(sessionId: string, speakerId: string): void {


### PR DESCRIPTION
## Summary

- **Fix signaling mismatch** — frontend now sends correct message types (`call-initiate`, `call-offer`, `call-accept`, `call-reject`, `call-hangup`) matching backend expectations
- **Connect STT pipeline** — `audio-data` handler now wires to Deepgram via SttService with lazy session creation, transcript forwarding to both peers, and cleanup on disconnect
- **Fix race condition** — partial unique index prevents duplicate active sessions per consultation
- **Fix DB constraints** — add missing `rejected` status, `disconnect`/`ended_by_user` end reasons, rename `call_session_id` → `session_id` column
- **Fix screen share track leak** — `endCall()` now stops the screen share track
- **Fix O(n²) base64** — replaced string concatenation loop with `FileReader.readAsDataURL`
- **Extract auth middleware** — `requireCallAccess` eliminates duplicated auth+access checks across 5 endpoints
- **Buffer limits** — SttService caps pending audio buffers at 20 to prevent unbounded memory growth
- **Store side effects** — media track mutations moved out of Zustand `set()` reducer

## Test plan

- [ ] Verify video call initiation between two users in a consultation
- [ ] Verify audio-only call works
- [ ] Test call accept/reject/hangup flows
- [ ] Enable transcription during a call — verify Deepgram transcripts appear for both parties
- [ ] Test screen share start/stop, then end call — verify no browser media indicator remains
- [ ] Run migration 116 on dev DB, verify constraints and index created
- [ ] `npx tsc --noEmit` passes for both `mcp_backend` and `lexwebapp` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves WebRTC call reliability by aligning signaling between app and backend and fixing session/track lifecycle issues. Adds live Deepgram transcription to share captions with both participants.

- **New Features**
  - Live transcription via `SttService` with lazy start/stop; transcripts are sent to both peers.

- **Bug Fixes**
  - Align signaling types and events: `call-initiate`, `call-offer`, `call-answer`, `call-accept`, `call-reject`, `call-hangup`, plus `incoming-call` and `call-created`.
  - Backend: migration enforces one active session per consultation, adds missing statuses/end reasons, and renames transcript column to `session_id`; centralized auth/access with `requireCallAccess`.
  - Media cleanup: stop screen share track on hangup; move media track toggles out of reducers to avoid side effects.
  - Audio pipeline: faster base64 encoding with `FileReader.readAsDataURL`; cap STT pending audio buffers at 20 in `SttService` to prevent memory spikes.

<sup>Written for commit ee4e55a9a972b74753743da479fd64a67924ddb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

