### PR TITLE
fix: skip nginx health check when backend not deployed

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -437,7 +437,9 @@ jobs:
           [ "$OPENREYESTR_CHANGED" = "true" ] && wait_healthy "OpenReyestr" "openreyestr-app-local" 120
           [ "$FRONTEND_CHANGED" = "true" ] && wait_healthy "Frontend" "lexwebapp-local" 60
 
-          # Check nginx routes locally (skip public DNS — runner may not resolve it)
-          check_health "Local via nginx" "http://localhost:80/health"
+          # Check nginx routes locally — only when backend is running (nginx proxies /health to backend)
+          if [ "$BACKEND_CHANGED" = "true" ]; then
+            check_health "Local via nginx" "http://localhost:80/health"
+          fi
 
           if [ "$FAILED" = "true" ]; then exit 1; fi


### PR DESCRIPTION
## Summary
- Nginx `/health` endpoint proxies to backend — fails when only frontend is deployed in CI
- Wrap the nginx health check with `BACKEND_CHANGED` condition so it only runs when backend containers are up

## Test plan
- [ ] Merge and verify CI passes on a frontend-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the nginx `/health` check in CI when only the frontend is deployed. The check now runs only if `BACKEND_CHANGED` is true to avoid false failures.

- **Bug Fixes**
  - Guarded the nginx health probe with `BACKEND_CHANGED` since `/health` proxies to the backend.
  - Prevents CI failures on frontend-only changes; backend checks still run when backend containers are up.

<sup>Written for commit 3dfeb02e3ce8257500ec6b2c0c66b98cd8f40f6e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

