### PR TITLE
fix: use UUID type for user FKs in video call migration

### DIFF
--- a/mcp_backend/src/migrations/115_video_call_sessions.sql
+++ b/mcp_backend/src/migrations/115_video_call_sessions.sql
@@ -7,8 +7,8 @@ BEGIN;
 CREATE TABLE IF NOT EXISTS video_call_sessions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   consultation_id UUID NOT NULL REFERENCES consultations(id) ON DELETE CASCADE,
-  caller_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  callee_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  caller_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  callee_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   status VARCHAR(20) NOT NULL DEFAULT 'pending',
   call_type VARCHAR(10) NOT NULL DEFAULT 'video',
   started_at TIMESTAMPTZ,
@@ -56,7 +56,7 @@ END $$;
 CREATE TABLE IF NOT EXISTS call_transcripts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   call_session_id UUID NOT NULL REFERENCES video_call_sessions(id) ON DELETE CASCADE,
-  speaker_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  speaker_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   text TEXT NOT NULL,
   language VARCHAR(5) DEFAULT 'uk',
   is_final BOOLEAN DEFAULT false,


### PR DESCRIPTION
## Summary
- Migration 115 declared `caller_id`, `callee_id`, `speaker_id` as `INTEGER` but `users.id` is `UUID`
- PostgreSQL rejects the FK constraint due to type mismatch — changed all three to `UUID`

## Test plan
- [ ] CI migration step passes on local deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated migration 115 to use UUID for `caller_id`, `callee_id`, and `speaker_id` to match `users.id`. This fixes PostgreSQL foreign key type errors so the migration applies cleanly.

<sup>Written for commit 690fc903883239d35e010cabd3ef4102db8a9025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

