### PR TITLE
fix: video call notification not delivered to callee

### DIFF
--- a/lexwebapp/src/components/video-call/VideoCallOverlay.tsx
+++ b/lexwebapp/src/components/video-call/VideoCallOverlay.tsx
@@ -1,28 +1,28 @@
 import React, { useEffect, useRef } from 'react';
 import { useVideoCallStore } from '../../stores/videoCallStore';
-import { useVideoSignaling } from '../../hooks/useVideoSignaling';
 import { useWebRTC } from '../../hooks/useWebRTC';
 import { useSpeechTranscription } from '../../hooks/useSpeechTranscription';
 import { VideoCallControls } from './VideoCallControls';
 import { TranscriptionPanel } from './TranscriptionPanel';
-import { CallNotification } from './CallNotification';
+import type { useVideoSignaling } from '../../hooks/useVideoSignaling';
 
-export const VideoCallOverlay: React.FC = () => {
+interface VideoCallOverlayProps {
+  signaling: ReturnType<typeof useVideoSignaling>;
+}
+
+export const VideoCallOverlay: React.FC<VideoCallOverlayProps> = ({ signaling }) => {
   const {
     callState,
     callType,
-    consultationId,
     localStream,
     remoteStream,
     remoteUserName,
     callDuration,
     transcriptionEnabled,
-    incomingCall,
     incrementDuration,
   } = useVideoCallStore();
 
-  // Wire up signaling, WebRTC, and transcription hooks
-  const signaling = useVideoSignaling(consultationId);
+  // Wire up WebRTC and transcription hooks (signaling comes from parent)
   useWebRTC(signaling);
   useSpeechTranscription(signaling);
 
@@ -71,12 +71,7 @@ export const VideoCallOverlay: React.FC = () => {
     return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
   };
 
-  // Render incoming call notification
-  if (incomingCall && callState === 'idle') {
-    return <CallNotification />;
-  }
-
-  // Don't render overlay when idle
+  // Don't render overlay when idle (incoming call notification is handled by parent)
   if (callState === 'idle') {
     return null;
   }

--- a/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
+++ b/lexwebapp/src/pages/ConsultationDetailPage/index.tsx
@@ -12,7 +12,9 @@ import { SharedDocumentsSection } from '../../components/consultation/SharedDocu
 import { ConfirmModal } from '../../components/ui/ConfirmModal';
 import { useConsultationStore } from '../../stores/consultationStore';
 import { VideoCallOverlay } from '../../components/video-call/VideoCallOverlay';
+import { CallNotification } from '../../components/video-call/CallNotification';
 import { useVideoCallStore } from '../../stores/videoCallStore';
+import { useVideoSignaling } from '../../hooks/useVideoSignaling';
 
 const STATUS_STEPS = ['pending', 'accepted', 'paid', 'in_progress', 'completed'];
 const STATUS_LABELS: Record<string, string> = {
@@ -36,6 +38,7 @@ export function ConsultationDetailPage() {
   const [activeModal, setActiveModal] = useState<'decline' | 'complete' | 'cancel' | null>(null);
 
   const callState = useVideoCallStore(s => s.callState);
+  const incomingCall = useVideoCallStore(s => s.incomingCall);
   const setConsultationIdForCall = useVideoCallStore(s => s.setConsultationId);
 
   // Set consultation ID in video call store
@@ -43,6 +46,43 @@ export function ConsultationDetailPage() {
     if (id) setConsultationIdForCall(id);
     return () => setConsultationIdForCall(null);
   }, [id, setConsultationIdForCall]);
+
+  // Always connect signaling WebSocket when viewing a consultation
+  const signaling = useVideoSignaling(id || null);
+
+  // When caller clicks call button and state goes to 'initiating', send the call-initiate message
+  const prevCallStateRef = useRef(callState);
+  useEffect(() => {
+    if (prevCallStateRef.current === 'idle' && callState === 'initiating' && consultation) {
+      const { remoteUserId, callType } = useVideoCallStore.getState();
+      if (remoteUserId && signaling.isConnected) {
+        signaling.initiateCall(callType, remoteUserId);
+      }
+    }
+    prevCallStateRef.current = callState;
+  }, [callState, consultation, signaling, signaling.isConnected]);
+
+  // Handle accept/reject events from CallNotification
+  useEffect(() => {
+    const handleAccept = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.sessionId) {
+        signaling.acceptCall(detail.sessionId);
+      }
+    };
+    const handleReject = (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (detail?.sessionId) {
+        signaling.rejectCall(detail.sessionId);
+      }
+    };
+    window.addEventListener('video-call-accept', handleAccept);
+    window.addEventListener('video-call-reject', handleReject);
+    return () => {
+      window.removeEventListener('video-call-accept', handleAccept);
+      window.removeEventListener('video-call-reject', handleReject);
+    };
+  }, [signaling]);
 
   const handleStartVideoCall = () => {
     if (!consultation || !id) return;
@@ -607,9 +647,14 @@ export function ConsultationDetailPage() {
         </div>
       )}
 
-      {/* Video/Audio call overlay */}
+      {/* Incoming call notification (shown even when idle) */}
+      {incomingCall && callState === 'idle' && (
+        <CallNotification />
+      )}
+
+      {/* Video/Audio call overlay (active call) */}
       {id && callState !== 'idle' && (
-        <VideoCallOverlay />
+        <VideoCallOverlay signaling={signaling} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- **Bug:** Callee never received incoming call notification because the signaling WebSocket was only created inside `VideoCallOverlay`, which only rendered when a call was already active (`callState !== 'idle'`)
- **Fix:** Move `useVideoSignaling` to `ConsultationDetailPage` so it stays connected while viewing any consultation. Wire up `initiateCall()` on caller state change and handle accept/reject events from `CallNotification`
- Also fixed: caller's `call-initiate` message was never sent to the backend after clicking the call button

## Test plan
- [ ] Open a consultation as User A, click call button — verify call-initiate is sent via WebSocket
- [ ] Open the same consultation as User B — verify incoming call notification appears
- [ ] Accept the call as User B — verify call connects
- [ ] Reject the call as User B — verify call is properly rejected
- [ ] Verify auto-dismiss after 30s works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing incoming call notifications by connecting the signaling WebSocket when the consultation page loads. Also ensures the caller sends call-initiate and accept/reject actions are handled correctly.

- **Bug Fixes**
  - Moved `useVideoSignaling` from `VideoCallOverlay` to `ConsultationDetailPage` to keep the socket connected while viewing a consultation.
  - Sent `call-initiate` when state transitions from `idle` to `initiating`.
  - Listened to `CallNotification` accept/reject events and forwarded them to signaling.
  - Passed `signaling` into `VideoCallOverlay` and rendered `CallNotification` at the page level so notifications show when idle.

<sup>Written for commit 34c4162777823939a1613633ca7606f73a4bb135. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

