### PR TITLE
refactor: remove workflow menu, inline institutional analysis

### DIFF
--- a/lexwebapp/src/components/sidebar/index.tsx
+++ b/lexwebapp/src/components/sidebar/index.tsx
@@ -6,7 +6,7 @@ import { toastT } from '../../i18n/toast-i18n';
 import {
   Plus, MessageSquare, X, Edit3, Trash2,
   ChevronsUpDown, Archive, Folder, FolderOpen,
-  Zap, Briefcase, Users, Search,
+  Briefcase, Users, Search,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../../contexts/AuthContext';
@@ -370,9 +370,6 @@ export function Sidebar({ isOpen, onClose, onLogout }: SidebarProps) {
                 )}
               </Section>
 
-              <div className="mb-2 mt-1">
-                <NavItem icon={Zap} label="Workflows" route={ROUTES.WORKFLOWS} onClick={() => handleNavigation(ROUTES.WORKFLOWS)} />
-              </div>
 
               <Section id="developer" title={appT('nav.section.developer')} collapsed={collapsedSections.has('developer')} onToggle={toggleSection}>
                 {developerSections.map((s) => (

--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -21,6 +21,6 @@ export const QUERY_TYPE_CONFIG: Record<string, QueryTypeConfigEntry> = {
   document_drafting: { defaultBudget: 'standard', requiresGrounding: false, description: '', maxToolCalls: 5, thinkingPrefix: 'Складаю документ', preferredScenarios: ['drafting'] },
   comparative_analysis: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Порівнюю', preferredScenarios: ['comparison'] },
   due_diligence: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Виконую due diligence', preferredScenarios: ['due_diligence'] },
-  institutional_analysis: { defaultBudget: 'standard', requiresGrounding: true, description: '', maxToolCalls: 5, thinkingPrefix: 'Аналізую інституцію', preferredScenarios: ['institutional'] },
+  institutional_analysis: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Аналізую інституцію', preferredScenarios: ['practice_search'] },
   unsupported: { defaultBudget: 'quick', requiresGrounding: false, description: '', maxToolCalls: 0, thinkingPrefix: '', preferredScenarios: [] },
 };


### PR DESCRIPTION
## Summary
- Видалено пункт меню Workflows з бічної панелі
- `institutional_analysis` тепер обробляється напряму в чаті (agentic loop) замість генерації workflows
- Оновлено конфіг: deep budget, 10 maxToolCalls

## Test plan
- [ ] Перевірити що меню Workflows відсутнє в сайдбарі
- [ ] Надіслати institutional запит (напр. "рейтинг суддів Оболонського суду") і переконатися що відповідь приходить в чат

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Workflows menu from the sidebar and now answer `institutional_analysis` requests directly in chat instead of generating workflows. Updated the query config to use a deep budget with up to 10 tool calls for better results.

- **Refactors**
  - Removed the “Workflows” nav item from the sidebar.
  - Updated `institutional_analysis` config: handled inline in chat, `defaultBudget: 'deep'`, `maxToolCalls: 10`, `preferredScenarios: ['practice_search']`.

<sup>Written for commit e5a9d0a380f0ec062805e59c4503ebd5f2ac304f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

