### PR TITLE
feat: configure coturn TURN server for WebRTC video calls

### DIFF
--- a/deployment/coturn/turnserver.conf
+++ b/deployment/coturn/turnserver.conf
@@ -4,8 +4,13 @@ tls-listening-port=5349
 fingerprint
 lt-cred-mech
 use-auth-secret
-static-auth-secret=${TURN_SHARED_SECRET}
+# static-auth-secret is passed via command line (--static-auth-secret)
 realm=secondlayer.legal
+# AWS EC2: public IP / private IP mapping
+external-ip=18.192.189.254/172.31.29.20
+# Relay port range
+min-port=49152
+max-port=65535
 total-quota=100
 max-bps=10000000
 stale-nonce=600

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -639,6 +639,9 @@ services:
       NOWPAYMENTS_API_KEY: ${NOWPAYMENTS_API_KEY:-}
       NOWPAYMENTS_IPN_SECRET: ${NOWPAYMENTS_IPN_SECRET:-}
       NOWPAYMENTS_PUBLIC_KEY: ${NOWPAYMENTS_PUBLIC_KEY:-}
+      TURN_SERVER_URL: ${TURN_SERVER_URL:-}
+      TURN_SHARED_SECRET: ${TURN_SHARED_SECRET:-}
+      STUN_SERVER_URL: ${STUN_SERVER_URL:-stun:stun.l.google.com:19302}
 
       LOG_LEVEL: ${LOG_LEVEL:-info}
       TZ: Europe/Kiev
@@ -999,6 +1002,9 @@ services:
       NOWPAYMENTS_API_KEY: ${NOWPAYMENTS_API_KEY:-}
       NOWPAYMENTS_IPN_SECRET: ${NOWPAYMENTS_IPN_SECRET:-}
       NOWPAYMENTS_PUBLIC_KEY: ${NOWPAYMENTS_PUBLIC_KEY:-}
+      TURN_SERVER_URL: ${TURN_SERVER_URL:-}
+      TURN_SHARED_SECRET: ${TURN_SHARED_SECRET:-}
+      STUN_SERVER_URL: ${STUN_SERVER_URL:-stun:stun.l.google.com:19302}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       TZ: Europe/Kiev
     depends_on:
@@ -1413,8 +1419,7 @@ services:
     network_mode: host
     volumes:
       - ./coturn/turnserver.conf:/etc/turnserver.conf:ro
-    environment:
-      - TURN_SHARED_SECRET=${TURN_SHARED_SECRET}
+    command: ["-c", "/etc/turnserver.conf", "--static-auth-secret=${TURN_SHARED_SECRET}"]
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- Coturn TURN server was defined in compose but never configured or started
- Fixed coturn config: external-ip mapping for AWS EC2, relay port range, CLI-based secret passing
- Added TURN/STUN env vars to both blue/green backend services
- Opened AWS Security Group ports: UDP/TCP 3478, UDP 49152-65535 (relay)
- Already deployed and verified on prod

## What was done on prod
1. Generated TURN shared secret and added to `.env.prod`
2. Started coturn container
3. Recreated backend to pick up TURN env vars
4. Opened Security Group ports via AWS API
5. Verified TCP/UDP 3478 reachable externally

## Test plan
- [ ] Test video call between two users on different networks (mobile + desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures and enables the `coturn` TURN server for WebRTC video calls. Adds TURN/STUN env vars and correct AWS networking to ensure reliable connectivity across networks.

- **New Features**
  - Start `coturn` in prod and pass `--static-auth-secret=${TURN_SHARED_SECRET}` via CLI.
  - Set AWS EC2 external-ip mapping and define relay port range 49152–65535.
  - Add TURN/STUN env vars to both blue/green backends: TURN_SERVER_URL, TURN_SHARED_SECRET, STUN_SERVER_URL.

- **Migration**
  - Set TURN_SERVER_URL, TURN_SHARED_SECRET, and STUN_SERVER_URL in the environment.
  - Open Security Group ports: TCP/UDP 3478 and UDP 49152–65535.
  - Redeploy `coturn` and the backends, then verify calls across different networks.

<sup>Written for commit 42c6a6578d8915d6ffacb1c10d3c59dc316b6dcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

