### PR TITLE
fix: add prod safety guard to local CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -334,6 +334,17 @@ jobs:
           ln -sf /home/vovkes/SecondLayer/deployment/.env.local deployment/.env.local
           ln -sf /home/vovkes/SecondLayer/deployment/.env.prod deployment/.env.prod 2>/dev/null || true
 
+      - name: Safety check — prod containers untouched
+        run: |
+          # Verify prod nginx and backend are running before we touch local env
+          for c in nginx-prod secondlayer-app-prod-green secondlayer-app-prod-blue; do
+            STATUS=$(docker inspect --format='{{.State.Status}}' "$c" 2>/dev/null || echo "absent")
+            if [ "$STATUS" = "running" ]; then
+              echo "✓ Prod container $c is running"
+            fi
+          done
+          echo "PROD_NGINX_BEFORE=$(docker inspect --format='{{.State.StartedAt}}' nginx-prod 2>/dev/null || echo none)" >> "$GITHUB_ENV"
+
       - name: Build & restart changed local services
         working-directory: deployment
         run: |
@@ -440,6 +451,18 @@ jobs:
           # Check nginx routes locally — only when backend is running (nginx proxies /health to backend)
           if [ "$BACKEND_CHANGED" = "true" ]; then
             check_health "Local via nginx" "http://localhost:80/health"
+          fi
+
+          # Verify prod was not affected by local deploy
+          PROD_NGINX_NOW=$(docker inspect --format='{{.State.Status}}' nginx-prod 2>/dev/null || echo "absent")
+          PROD_NGINX_STARTED=$(docker inspect --format='{{.State.StartedAt}}' nginx-prod 2>/dev/null || echo none)
+          if [ "$PROD_NGINX_NOW" != "running" ]; then
+            echo "::error::CRITICAL: prod nginx is $PROD_NGINX_NOW after local deploy!"
+            FAILED=true
+          elif [ "$PROD_NGINX_STARTED" != "$PROD_NGINX_BEFORE" ] && [ "$PROD_NGINX_BEFORE" != "none" ]; then
+            echo "::warning::Prod nginx was restarted during local deploy (was: $PROD_NGINX_BEFORE, now: $PROD_NGINX_STARTED)"
+          else
+            echo "✓ Prod nginx untouched"
           fi
 
           if [ "$FAILED" = "true" ]; then exit 1; fi


### PR DESCRIPTION
## Summary
- After incident where manual container ops broke prod nginx (502), adding safety checks to CI
- Pre-deploy: records prod nginx state (container status + start time)
- Post-deploy: verifies prod nginx is still running and wasn't restarted
- Fails with CRITICAL error if prod goes down during local deploy

## Context
Local CI runs on the same self-hosted runner as prod. While local compose uses separate `-local` suffixed services, any accidental cross-contamination would be caught by this guard.

## Test plan
- [ ] CI pipeline passes with new safety checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a production safety guard to the local CI/CD workflow to prevent local deploys from disrupting prod `nginx`. It records prod `nginx` state before deploy and verifies it remains running and untouched after.

- **Bug Fixes**
  - Pre-check records `nginx-prod` StartedAt in `$GITHUB_ENV` and confirms prod containers are running.
  - Post-check compares status and start time; fails with a CRITICAL error if prod `nginx` stops, warns if it restarts.
  - Changes limited to `.github/workflows/ci-local-deploy.yml`.

<sup>Written for commit d23db2d4ff1756b4764f4ed82d548605bed1ea31. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

