### PR TITLE
fix: increase Node.js heap size for frontend tests in CI

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -130,6 +130,7 @@ jobs:
           npm run build
         env:
           VITE_API_URL: https://local.legal.org.ua
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Build platform
         if: needs.detect-changes.outputs.platform == 'true'


### PR DESCRIPTION
## Summary

- Vitest worker OOM (out of memory) crash on self-hosted CI runner
- All 422 tests passed but worker process killed by heap limit during cleanup
- Add `NODE_OPTIONS: --max-old-space-size=4096` to frontend test step

## Test plan

- [ ] CI pipeline passes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Node.js heap to 4 GB in CI to prevent `Vitest` worker OOM crashes on the self-hosted runner. Sets `NODE_OPTIONS=--max-old-space-size=4096` in the frontend workflow step.

<sup>Written for commit 6b28fdc297e5b6cd74ef20cdefc85f5b73af54c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

