### PR TITLE
fix: increase CI heap to 8GB for frontend tests

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -130,7 +130,7 @@ jobs:
           npm run build
         env:
           VITE_API_URL: https://local.legal.org.ua
-          NODE_OPTIONS: --max-old-space-size=4096
+          NODE_OPTIONS: --max-old-space-size=8192
 
       - name: Build platform
         if: needs.detect-changes.outputs.platform == 'true'


### PR DESCRIPTION
## Summary

- Bump NODE_OPTIONS from 4096 to 8192 MB — self-hosted runner has plenty of RAM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased Node.js heap in CI from 4GB to 8GB to prevent OOMs during frontend builds on the self-hosted runner.
Sets `NODE_OPTIONS: --max-old-space-size=8192` in `.github/workflows/ci-local-deploy.yml`.

<sup>Written for commit 8ba06b40beef101b292c03874f31a763ae81d9e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

