### PR TITLE
fix: stop terminal WS handler from destroying video-signaling connections

### DIFF
--- a/mcp_backend/src/routes/terminal-routes.ts
+++ b/mcp_backend/src/routes/terminal-routes.ts
@@ -112,8 +112,7 @@ export function attachTerminalWebSocket(httpServer: HttpServer, db: IDatabase): 
   httpServer.on('upgrade', (req: IncomingMessage, socket, head) => {
     const url = new URL(req.url || '', `http://${req.headers.host}`);
     if (url.pathname !== '/api/admin/terminal') {
-      socket.destroy();
-      return;
+      return; // Let other upgrade handlers (e.g. video-signaling) handle this path
     }
     wss.handleUpgrade(req, socket, head, (ws) => {
       wss.emit('connection', ws, req);


### PR DESCRIPTION
## Summary
- Terminal WebSocket upgrade handler called `socket.destroy()` for all non-terminal paths, killing video-signaling connections before their handler could process them
- Changed to simple `return` so other upgrade handlers (video-signaling) can process their requests

## Root cause
`attachTerminalWebSocket` registers first on the HTTP server's `upgrade` event. When a video-signaling WebSocket request arrived, the terminal handler saw it wasn't `/api/admin/terminal` and destroyed the socket. The video-signaling handler never got a chance to run.

**nginx error log confirmed:** `upstream prematurely closed connection while reading response header from upstream`

## Test plan
- [ ] Merge and deploy via CI/CD
- [ ] Test video call between two users on legal.org.ua
- [ ] Verify admin terminal still works at `/api/admin/terminal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop destroying non-terminal WebSocket upgrade requests in the terminal handler so video-signaling connections can upgrade normally. This fixes premature connection closes and restores video calls.

- **Bug Fixes**
  - Replaced `socket.destroy()` with an early `return` when the path isn’t `/api/admin/terminal`, allowing the video-signaling handler to process its own upgrades.

<sup>Written for commit 567191750effef8863e49cb1db9fd53d5ae01760. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

