### PR TITLE
fix: CI safety check GITHUB_ENV format error

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -344,7 +344,8 @@ jobs:
               echo "✓ Prod container $c is running"
             fi
           done
-          echo "PROD_NGINX_BEFORE=$(docker inspect --format='{{.State.StartedAt}}' nginx-prod 2>/dev/null || echo none)" >> "$GITHUB_ENV"
+          NGINX_STARTED=$(docker inspect --format='{{.State.StartedAt}}' nginx-prod 2>/dev/null || true)
+          echo "PROD_NGINX_BEFORE=${NGINX_STARTED:-none}" >> "$GITHUB_ENV"
 
       - name: Build & restart changed local services
         working-directory: deployment


### PR DESCRIPTION
## Summary
- Safety check step failed with `Invalid format 'none'` when writing to GITHUB_ENV
- Split docker inspect into a variable first, then write to GITHUB_ENV with fallback default

## Test plan
- [ ] CI pipeline passes on this PR
- [ ] Deploy step proceeds past safety check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI safety check by safely exporting the prod nginx start timestamp to `GITHUB_ENV`. Prevents the "Invalid format 'none'" error so deploy can proceed.

- **Bug Fixes**
  - Capture `docker inspect` output in `NGINX_STARTED`, then write `PROD_NGINX_BEFORE=${NGINX_STARTED:-none}` to `GITHUB_ENV` instead of inlining the fallback.

<sup>Written for commit 391323c6628468da2940eeec02c0b82199780d5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

