### PR TITLE
fix: strip null bytes from PDF text before PostgreSQL insert

### DIFF
--- a/mcp_backend/src/routes/rest-api.ts
+++ b/mcp_backend/src/routes/rest-api.ts
@@ -91,7 +91,7 @@ export function createRestAPIRouter(db: IDatabase): Router {
         `INSERT INTO documents (zakononline_id, type, title, date, full_text, full_text_html, metadata, user_id)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
          RETURNING *`,
-        [zakononline_id, type, title, date, full_text, full_text_html, metadata || {}, userId || null]
+        [zakononline_id, type, title, date, full_text?.replace(/\0/g, '') || null, full_text_html?.replace(/\0/g, '') || null, metadata || {}, userId || null]
       );
 
       res.status(201).json(result.rows[0]);

--- a/mcp_backend/src/services/document-service.ts
+++ b/mcp_backend/src/services/document-service.ts
@@ -29,6 +29,12 @@ export interface Document {
   updated_at?: Date;
 }
 
+/** Strip null bytes that PostgreSQL TEXT columns reject */
+function sanitizeText(value: string | undefined | null): string | null {
+  if (!value) return null;
+  return value.replace(/\0/g, '');
+}
+
 export class DocumentService {
   constructor(private db: IDatabase) {}
 
@@ -73,7 +79,7 @@ export class DocumentService {
         id,
         doc.zakononline_id,
         doc.type,
-        doc.title || null,
+        sanitizeText(doc.title),
         doc.date || null,
         doc.case_number || null,
         doc.court || null,
@@ -81,8 +87,8 @@ export class DocumentService {
         doc.dispute_category || null,
         doc.outcome || null,
         doc.deviation_flag ?? null,
-        doc.full_text || null,
-        doc.full_text_html || null,
+        sanitizeText(doc.full_text),
+        sanitizeText(doc.full_text_html),
         JSON.stringify(doc.metadata || {}),
         doc.user_id || null,
         doc.matter_id || null,
@@ -240,7 +246,7 @@ export class DocumentService {
          SET full_text = $1, updated_at = NOW() 
          WHERE zakononline_id = $2
          RETURNING id`,
-        [full_text, zakononline_id]
+        [sanitizeText(full_text), zakononline_id]
       );
 
       if (result.rows.length === 0) {
@@ -388,7 +394,7 @@ export class DocumentService {
               uuidv4(),
               documentId,
               section.type,
-              section.text,
+              sanitizeText(section.text),
               section.start_index || null,
               section.end_index || null,
               section.confidence || 0.0,

--- a/mcp_backend/src/services/upload-processor.ts
+++ b/mcp_backend/src/services/upload-processor.ts
@@ -232,7 +232,7 @@ export async function processUploadFile(
         documentId,
         session.docType || 'other',
         session.fileName.replace(/\.[^/.]+$/, ''),
-        fullText,
+        fullText ? fullText.replace(/\0/g, '') : null,
         JSON.stringify({
           ...session.metadata,
           originalFilename: session.fileName,


### PR DESCRIPTION
## Summary
- PDF text extraction via pdfjs-dist can produce null bytes (`\0`) which PostgreSQL TEXT columns reject with `invalid byte sequence for encoding "UTF8": 0x00`
- Added `sanitizeText()` helper in `document-service.ts` that strips null bytes from `title`, `full_text`, `full_text_html`, and section `text` before DB insert
- Also patched direct SQL inserts in `upload-processor.ts` and `rest-api.ts`

## Test plan
- [ ] Upload the Invoice-8JSBBAOF-0005.pdf on prod after deploy
- [ ] Verify document stores successfully without encoding error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip null bytes from PDF-extracted text before inserting into PostgreSQL to prevent invalid UTF-8 (0x00) errors. Applies to document titles, full_text, full_text_html, and section text across all insert paths.

- **Bug Fixes**
  - Added sanitizeText in `document-service` and used in document insert/update and section creation.
  - Patched direct SQL inserts in `rest-api` and `upload-processor` to strip `\0` (source: `pdfjs-dist`).

<sup>Written for commit 76f3ecc19dd3e5c50df26c6b719f8e78319ef8a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

