### PR TITLE
fix: limit Vitest forks to 2 to prevent OOM in CI

### DIFF
--- a/lexwebapp/vitest.config.ts
+++ b/lexwebapp/vitest.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        maxForks: 2,
+      },
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- ConsultationChatTab test worker hitting V8 heap OOM on self-hosted runner (pre-existing, 3 consecutive failures)
- Limit `maxForks: 2` in vitest.config.ts to reduce peak memory usage

## Test plan
- [ ] CI passes without OOM
- [ ] All 422 frontend tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit `vitest` to 2 forked workers in `lexwebapp/vitest.config.ts` to reduce peak memory use and prevent V8 heap OOM on self-hosted CI.

<sup>Written for commit dc76a79c842d92737273829bb63646a532e37775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

