### PR TITLE
fix: increase Vitest worker heap to 4GB to prevent OOM

### DIFF
--- a/lexwebapp/vitest.config.ts
+++ b/lexwebapp/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     poolOptions: {
       forks: {
         maxForks: 2,
+        execArgv: ['--max-old-space-size=4096'],
       },
     },
     coverage: {


### PR DESCRIPTION
## Summary
- Previous fix (maxForks: 2) didn't help — OOM happens inside a single fork
- Add `execArgv: ['--max-old-space-size=4096']` to give each worker 4GB heap
- ConsultationChatTab test imports large articles.ts (~4500 lines) causing heap exhaustion

## Test plan
- [ ] CI passes without OOM on ConsultationChatTab test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `vitest` worker heap to 4GB to prevent OOM crashes in the ConsultationChatTab test that imports a large articles.ts file. Each fork now gets more memory, stabilizing CI runs.

- **Bug Fixes**
  - Add `execArgv: ['--max-old-space-size=4096']` to fork pool (keeps `maxForks: 2`).
  - OOM occurred within a single worker due to large import (~4500 lines).

<sup>Written for commit 531d1dc1e02ba577037a1562d7c16c2452139f73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

