### PR TITLE
fix: switch Vitest to threads pool to prevent OOM

### DIFF
--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -62,13 +62,22 @@ function createMockEventSource() {
 
 describe('ConsultationChatTab', () => {
   const mockOnUnreadCountChange = vi.fn();
+  let currentMockES: ReturnType<typeof createMockEventSource>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    currentMockES = createMockEventSource();
     mockGetMessages.mockResolvedValue({ messages: [], total: 0 });
-    mockConnectMessageStream.mockReturnValue(createMockEventSource());
+    mockConnectMessageStream.mockReturnValue(currentMockES);
     mockMarkMessagesRead.mockResolvedValue(undefined);
     mockGetGlobalUnreadCount.mockResolvedValue({ count: 0 });
+  });
+
+  afterEach(() => {
+    currentMockES.close();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   describe('Empty state', () => {

--- a/lexwebapp/vitest.config.ts
+++ b/lexwebapp/vitest.config.ts
@@ -8,11 +8,10 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
-    pool: 'forks',
+    pool: 'threads',
     poolOptions: {
-      forks: {
-        maxForks: 2,
-        execArgv: ['--max-old-space-size=4096'],
+      threads: {
+        maxThreads: 2,
       },
     },
     coverage: {


### PR DESCRIPTION
## Summary
- Switch from `forks` to `threads` pool — worker_threads share memory with main process, drastically reducing memory footprint
- Fix ConsultationChatTab test: add afterEach cleanup for SSE mocks and fake timers
- Previous fixes (maxForks, execArgv heap) didn't help because OOM happens during V8 error stack capture at teardown

## Test plan
- [ ] CI passes without OOM
- [ ] All 422 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch tests to the `vitest` threads pool to reduce memory and prevent OOM crashes. Also fixes SSE test cleanup in ConsultationChatTab to avoid leaks and hanging timers.

- **Bug Fixes**
  - Use `pool: 'threads'` with `maxThreads: 2` in `vitest` config to share memory and lower footprint.
  - Add afterEach cleanup: close the mock EventSource, restore timers and mocks; use fake timers to prevent hanging intervals.

<sup>Written for commit eede34bca90a8b80d241b758bba3129c1801a93d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

