### PR TITLE
fix: add vitest teardownTimeout and explicit run mode

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "preview": "npx vite preview",
     "preview:staging": "npx vite preview --mode staging",
-    "test": "vitest",
+    "test": "vitest run",
     "test:ui": "vitest --ui",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage"

--- a/lexwebapp/vitest.config.ts
+++ b/lexwebapp/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         maxThreads: 2,
       },
     },
+    teardownTimeout: 3000,
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Add `teardownTimeout: 3000` to force worker cleanup after tests
- Change `npm test` to `vitest run` (explicit single-run, no watch)
- Root cause: ConsultationChatTab test leaves unclosed handles preventing graceful worker shutdown

## Test plan
- [ ] CI completes without hanging worker timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI test hangs after completion. Tests now exit reliably.

- **Bug Fixes**
  - Set `teardownTimeout: 3000` in `vitest.config.ts` to force worker cleanup and avoid lingering handles from the ConsultationChatTab test.
  - Updated `npm test` to `vitest run` to ensure a single-run (no watch) execution in CI.

<sup>Written for commit fc790c98ed44f29551722ed932c9a928f423d66e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

