### PR TITLE
fix: explicit cleanup in ConsultationChatTab test

### DIFF
--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 // Mock AuthContext
 const mockUser = { id: 'user-1', name: 'Test User', email: 'test@test.com', role: 'user' as const };
@@ -66,7 +66,6 @@ describe('ConsultationChatTab', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.useFakeTimers({ shouldAdvanceTime: true });
     currentMockES = createMockEventSource();
     mockGetMessages.mockResolvedValue({ messages: [], total: 0 });
     mockConnectMessageStream.mockReturnValue(currentMockES);
@@ -75,8 +74,9 @@ describe('ConsultationChatTab', () => {
   });
 
   afterEach(() => {
+    // Unmount all rendered components to trigger useEffect cleanups (clearInterval)
+    cleanup();
     currentMockES.close();
-    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## Summary
- Root cause: component creates `setInterval(30s)` for polling fallback
- Tests `render()` without `unmount()`, interval handle keeps worker alive
- Added explicit `cleanup()` in `afterEach` before mock restoration
- Removed `vi.useFakeTimers` which conflicted with cleanup order

## Test plan
- [ ] CI passes — worker shuts down cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure ConsultationChatTab test unmounts components to clear the 30s polling interval and prevent hanging workers. Adds explicit `cleanup()` in `afterEach` and removes `vi.useFakeTimers` to avoid timer/cleanup conflicts.

<sup>Written for commit 09275ba8780fe313fce93a2d2d9e75f0dd9e4449. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

