### PR TITLE
feat: add opendata-sync scheduler service

### DIFF
--- a/deployment/Dockerfile.opendata-sync
+++ b/deployment/Dockerfile.opendata-sync
@@ -1,0 +1,26 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files and install all deps (including devDeps for build)
+COPY opendata-sync/package.json ./
+RUN npm install
+
+# Copy source and build
+COPY opendata-sync/tsconfig.json ./
+COPY opendata-sync/src/ ./src/
+RUN npx tsc
+
+# --- Production stage ---
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY opendata-sync/package.json ./
+RUN npm install --production
+
+COPY --from=builder /app/dist/ ./dist/
+
+EXPOSE 3010
+
+CMD ["node", "dist/index.js"]

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1422,6 +1422,47 @@ services:
     command: ["-c", "/etc/turnserver.conf", "--static-auth-secret=${TURN_SHARED_SECRET}"]
     restart: unless-stopped
 
+  # OpenData Sync — cron scheduler for government data sources
+  opendata-sync-prod:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.opendata-sync
+    image: opendata-sync-prod:latest
+    container_name: opendata-sync-prod
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
+    depends_on:
+      app-prod:
+        condition: service_healthy
+      app-openreyestr-prod:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      BACKEND_URL: http://app-prod:3000
+      BACKEND_API_KEY: ${SECONDARY_LAYER_KEYS:-}
+      OPENREYESTR_URL: http://app-openreyestr-prod:3005
+      OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEYS:-}
+      HEALTH_PORT: "3010"
+      TZ: Europe/Kiev
+    healthcheck:
+      test: ["CMD", "node", "-e", "require('http').get('http://127.0.0.1:3010/health', r => { process.exit(r.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+
 volumes:
   postgres_prod_data:
     driver: local

--- a/mcp_openreyestr/src/http-server.ts
+++ b/mcp_openreyestr/src/http-server.ts
@@ -425,6 +425,148 @@ class HTTPOpenReyestrServer {
       }
     }) as any);
 
+    // Admin: trigger NAIS registry sync (called by opendata-sync scheduler)
+    this.app.post('/api/admin/sync-registry', requireAPIKey as any, (async (req: AuthenticatedRequest, res: Response) => {
+      const { registry } = req.body;
+      if (!registry || typeof registry !== 'string') {
+        res.status(400).json({ error: 'Missing "registry" parameter' });
+        return;
+      }
+
+      logger.info('Admin sync-registry triggered', { registry, clientKey: req.clientKey?.substring(0, 8) });
+
+      try {
+        // Import and run sync for the specified registry
+        const { REGISTRIES } = await import('./config/registries');
+        const config = REGISTRIES[registry];
+        if (!config) {
+          res.status(404).json({ error: `Unknown registry: ${registry}`, available: Object.keys(REGISTRIES) });
+          return;
+        }
+
+        // Run sync in background — return immediately with 202
+        res.status(202).json({
+          status: 'accepted',
+          message: `Sync started for ${config.title} (${registry})`,
+          registry,
+        });
+
+        // Execute sync after responding
+        const { Pool } = await import('pg');
+        const pool = new Pool({
+          host: process.env.POSTGRES_HOST || 'localhost',
+          port: parseInt(process.env.POSTGRES_PORT || '5432'),
+          user: process.env.POSTGRES_USER || 'openreyestr',
+          password: process.env.POSTGRES_PASSWORD,
+          database: process.env.POSTGRES_DB || 'openreyestr_prod',
+        });
+
+        try {
+          const { importXml } = await import('./services/generic-xml-importer');
+          const { importCsv } = await import('./services/csv-importer');
+          const fs = await import('fs');
+          const path = await import('path');
+          const https = await import('https');
+          const http = await import('http');
+
+          const dataDir = process.env.NAIS_DATA_DIR || '/tmp/nais-sync';
+          const registryDir = path.join(dataDir, registry);
+          fs.mkdirSync(registryDir, { recursive: true });
+          const zipPath = path.join(dataDir, `${registry}.zip`);
+
+          // Download
+          logger.info(`Downloading ${registry} from ${config.datasetUrl}`);
+          await new Promise<void>((resolve, reject) => {
+            const proto = config.datasetUrl.startsWith('https') ? https : http;
+            const doGet = (url: string) => {
+              (proto as any).get(url, { timeout: 30 * 60 * 1000 }, (response: any) => {
+                if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {
+                  doGet(response.headers.location.startsWith('http') ? response.headers.location : new URL(response.headers.location, url).href);
+                  return;
+                }
+                if (response.statusCode !== 200) { reject(new Error(`HTTP ${response.statusCode}`)); return; }
+                const ws = fs.createWriteStream(zipPath);
+                response.pipe(ws);
+                ws.on('finish', () => { ws.close(); resolve(); });
+                ws.on('error', reject);
+              }).on('error', reject);
+            };
+            doGet(config.datasetUrl);
+          });
+
+          // Extract
+          const { execFileSync } = await import('child_process');
+          try {
+            execFileSync('unzip', ['-o', '-q', zipPath, '-d', registryDir], { timeout: 10 * 60 * 1000 });
+          } catch { /* fallback handled by sync-all-registries */ }
+
+          // Find data file
+          const ext = config.format === 'csv' ? '.csv' : '.xml';
+          const files = fs.readdirSync(registryDir);
+          const dataFile = config.innerFileName
+            ? files.find((f: string) => f.includes(config.innerFileName))
+            : files.find((f: string) => f.toLowerCase().endsWith(ext));
+
+          if (!dataFile) {
+            logger.error(`No ${ext} file found for ${registry}`);
+            return;
+          }
+
+          const dataFilePath = path.join(registryDir, dataFile);
+
+          // Log import
+          await pool.query(
+            `INSERT INTO import_log (registry_name, file_name, status) VALUES ($1, $2, 'in_progress')`,
+            [registry, dataFile],
+          );
+
+          // Import
+          let imported = 0;
+          let errors = 0;
+          if (config.format === 'xml') {
+            const stats = await importXml(pool, config, dataFilePath, dataFile);
+            imported = stats.imported;
+            errors = stats.errors;
+          } else {
+            const stats = await importCsv(pool, config, dataFilePath, dataFile);
+            imported = stats.imported;
+            errors = stats.errors;
+          }
+
+          // Update metadata
+          await pool.query(
+            `UPDATE registry_metadata SET last_update_date = CURRENT_DATE, updated_at = CURRENT_TIMESTAMP WHERE registry_name = $1`,
+            [registry],
+          );
+          await pool.query(
+            `UPDATE import_log SET import_completed_at = CURRENT_TIMESTAMP, records_imported = $1, records_failed = $2, status = 'completed' WHERE registry_name = $3 AND status = 'in_progress'`,
+            [imported, errors, registry],
+          );
+
+          // Cleanup
+          try { fs.unlinkSync(zipPath); } catch { /* ok */ }
+          try { fs.rmSync(registryDir, { recursive: true, force: true }); } catch { /* ok */ }
+
+          logger.info(`Sync complete: ${registry} — ${imported} imported, ${errors} errors`);
+        } catch (syncErr: any) {
+          logger.error(`Sync failed for ${registry}:`, syncErr);
+          try {
+            await pool.query(
+              `UPDATE import_log SET import_completed_at = CURRENT_TIMESTAMP, status = 'failed', error_message = $1 WHERE registry_name = $2 AND status = 'in_progress'`,
+              [syncErr.message, registry],
+            );
+          } catch { /* ok */ }
+        } finally {
+          await pool.end();
+        }
+      } catch (err: any) {
+        if (!res.headersSent) {
+          res.status(500).json({ error: err.message });
+        }
+        logger.error('sync-registry error:', err);
+      }
+    }) as any);
+
     // 404 handler
     this.app.use((req, res) => {
       res.status(404).json({

--- a/opendata-sync/package.json
+++ b/opendata-sync/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "opendata-sync",
+  "version": "1.0.0",
+  "description": "Scheduled sync service for Ukrainian government open data sources",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx src/index.ts",
+    "run-once": "node dist/index.js --run-once"
+  },
+  "dependencies": {
+    "node-cron": "^3.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/node-cron": "^3.0.11",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/opendata-sync/src/config.ts
+++ b/opendata-sync/src/config.ts
@@ -1,0 +1,220 @@
+/**
+ * Open Data Sync Configuration
+ *
+ * Defines all data sources, their sync frequencies, and target services.
+ * Frequencies use node-cron syntax: second(opt) minute hour day month weekday
+ */
+
+export type SyncTarget = 'backend' | 'openreyestr';
+
+export interface DataSourceSchedule {
+  name: string;
+  title: string;
+  /** node-cron expression */
+  cron: string;
+  /** Which service handles the import */
+  target: SyncTarget;
+  /** For backend: source_name from import_source_catalog. For openreyestr: registry name */
+  sourceName: string;
+  /** Whether this source is enabled */
+  enabled: boolean;
+}
+
+// ─── Backend data sources (import via /api/tools/start_import) ──────────
+
+const backendDailySources: DataSourceSchedule[] = [
+  {
+    name: 'mvs_wanted_persons',
+    title: 'МВС — Особи в розшуку',
+    cron: '0 3 * * *', // 03:00 daily
+    target: 'backend',
+    sourceName: 'mvs_wanted_persons',
+    enabled: true,
+  },
+  {
+    name: 'mvs_missing_persons',
+    title: 'МВС — Безвісно зниклі',
+    cron: '0 3 * * *', // 03:00 daily
+    target: 'backend',
+    sourceName: 'mvs_missing_persons',
+    enabled: true,
+  },
+  {
+    name: 'mvs_wanted_vehicles',
+    title: 'МВС — Транспорт у розшуку',
+    cron: '0 3 * * *', // 03:00 daily
+    target: 'backend',
+    sourceName: 'mvs_wanted_vehicles',
+    enabled: true,
+  },
+  {
+    name: 'nazk_corruption',
+    title: 'НАЗК — Корупціонери',
+    cron: '30 3 * * *', // 03:30 daily
+    target: 'backend',
+    sourceName: 'nazk_corruption',
+    enabled: true,
+  },
+];
+
+const backendWeeklySources: DataSourceSchedule[] = [
+  {
+    name: 'nipo_trademarks',
+    title: 'УІПВ — Торгові марки',
+    cron: '0 2 * * 0', // Sunday 02:00
+    target: 'backend',
+    sourceName: 'nipo_trademarks',
+    enabled: true,
+  },
+  {
+    name: 'nipo_patents',
+    title: 'УІПВ — Патенти на винаходи',
+    cron: '0 2 * * 0', // Sunday 02:00
+    target: 'backend',
+    sourceName: 'nipo_patents',
+    enabled: true,
+  },
+  {
+    name: 'nipo_utility_models',
+    title: 'УІПВ — Корисні моделі',
+    cron: '30 2 * * 0', // Sunday 02:30
+    target: 'backend',
+    sourceName: 'nipo_utility_models',
+    enabled: true,
+  },
+  {
+    name: 'nipo_designs',
+    title: 'УІПВ — Промислові зразки',
+    cron: '0 4 * * 0', // Sunday 04:00
+    target: 'backend',
+    sourceName: 'nipo_designs',
+    enabled: true,
+  },
+];
+
+// ─── OpenReyestr NAIS registries (sync via HTTP trigger) ────────────
+
+const naisDailySources: DataSourceSchedule[] = [
+  {
+    name: 'nais_arbitration_managers',
+    title: 'НАІС — Арбітражні керуючі',
+    cron: '0 4 * * *', // 04:00 daily
+    target: 'openreyestr',
+    sourceName: 'arbitration_managers',
+    enabled: true,
+  },
+  {
+    name: 'nais_bankruptcy_cases',
+    title: 'НАІС — Банкрутство',
+    cron: '15 4 * * *', // 04:15 daily
+    target: 'openreyestr',
+    sourceName: 'bankruptcy_cases',
+    enabled: true,
+  },
+  {
+    name: 'nais_enforcement',
+    title: 'НАІС — Виконавчі провадження (АСВП)',
+    cron: '30 4 * * *', // 04:30 daily
+    target: 'openreyestr',
+    sourceName: 'enforcement_proceedings',
+    enabled: true,
+  },
+  {
+    name: 'nais_debtors',
+    title: 'НАІС — Єдиний реєстр боржників',
+    cron: '0 5 * * *', // 05:00 daily
+    target: 'openreyestr',
+    sourceName: 'debtors',
+    enabled: true,
+  },
+];
+
+const naisWeeklySources: DataSourceSchedule[] = [
+  {
+    name: 'nais_notaries',
+    title: 'НАІС — Нотаріуси',
+    cron: '0 2 * * 1', // Monday 02:00
+    target: 'openreyestr',
+    sourceName: 'notaries',
+    enabled: true,
+  },
+  {
+    name: 'nais_court_experts',
+    title: 'НАІС — Судові експерти',
+    cron: '15 2 * * 1', // Monday 02:15
+    target: 'openreyestr',
+    sourceName: 'court_experts',
+    enabled: true,
+  },
+  {
+    name: 'nais_special_forms',
+    title: 'НАІС — Спеціальні бланки',
+    cron: '30 2 * * 1', // Monday 02:30
+    target: 'openreyestr',
+    sourceName: 'special_forms',
+    enabled: true,
+  },
+  {
+    name: 'nais_forensic_methods',
+    title: 'НАІС — Методики експертиз',
+    cron: '45 2 * * 1', // Monday 02:45
+    target: 'openreyestr',
+    sourceName: 'forensic_methods',
+    enabled: true,
+  },
+  {
+    name: 'nais_legal_acts',
+    title: 'НАІС — ЄДРНПА',
+    cron: '0 3 * * 1', // Monday 03:00
+    target: 'openreyestr',
+    sourceName: 'legal_acts',
+    enabled: true,
+  },
+  {
+    name: 'nais_administrative_units',
+    title: 'НАІС — Адмін. одиниці',
+    cron: '30 3 * * 1', // Monday 03:30
+    target: 'openreyestr',
+    sourceName: 'administrative_units',
+    enabled: true,
+  },
+  {
+    name: 'nais_streets',
+    title: 'НАІС — Вулиці',
+    cron: '0 5 * * 1', // Monday 05:00
+    target: 'openreyestr',
+    sourceName: 'streets',
+    enabled: true,
+  },
+];
+
+// ─── All sources ───────────────────────────────────────────────────
+
+export const ALL_SOURCES: DataSourceSchedule[] = [
+  ...backendDailySources,
+  ...backendWeeklySources,
+  ...naisDailySources,
+  ...naisWeeklySources,
+];
+
+// ─── Environment config ────────────────────────────────────────────
+
+export interface ServiceConfig {
+  backendUrl: string;
+  backendApiKey: string;
+  openreyestrUrl: string;
+  openreyestrApiKey: string;
+  healthPort: number;
+  timezone: string;
+}
+
+export function loadConfig(): ServiceConfig {
+  return {
+    backendUrl: process.env.BACKEND_URL || 'http://app-prod:3000',
+    backendApiKey: process.env.BACKEND_API_KEY || '',
+    openreyestrUrl: process.env.OPENREYESTR_URL || 'http://app-openreyestr-prod:3005',
+    openreyestrApiKey: process.env.OPENREYESTR_API_KEY || '',
+    healthPort: parseInt(process.env.HEALTH_PORT || '3010', 10),
+    timezone: process.env.TZ || 'Europe/Kiev',
+  };
+}

--- a/opendata-sync/src/index.ts
+++ b/opendata-sync/src/index.ts
@@ -1,0 +1,164 @@
+/**
+ * OpenData Sync Service
+ *
+ * Lightweight cron scheduler that triggers data imports from Ukrainian
+ * government open data sources at configured frequencies.
+ *
+ * Architecture:
+ * - Backend data sources (MVS, NAZK, UIPV): triggers via backend /api/tools/start_import
+ * - NAIS registries (11 sources): triggers via openreyestr /api/admin/sync-registry
+ *
+ * Runs as a Docker container alongside the main services.
+ * Does NOT download data itself — delegates to existing import infrastructure.
+ */
+
+import cron from 'node-cron';
+import http from 'http';
+import { ALL_SOURCES, loadConfig, type DataSourceSchedule } from './config.js';
+import { runSync, runAllOnce, getSyncHistory, getLastSync } from './sync-runner.js';
+
+const config = loadConfig();
+const scheduledJobs: cron.ScheduledTask[] = [];
+
+// ─── Health endpoint ───────────────────────────────────────────────
+
+function startHealthServer(): void {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/health' || req.url === '/health/ready') {
+      const history = getSyncHistory();
+      const recentFails = history.slice(-20).filter((h) => !h.success).length;
+
+      const body = JSON.stringify({
+        status: 'ok',
+        service: 'opendata-sync',
+        uptime: process.uptime(),
+        scheduledSources: ALL_SOURCES.filter((s) => s.enabled).length,
+        totalSyncsRun: history.length,
+        recentFailures: recentFails,
+        lastSync: history[history.length - 1] || null,
+      });
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    if (req.url === '/status') {
+      const enabledSources = ALL_SOURCES.filter((s) => s.enabled);
+      const sourceStatus = enabledSources.map((s) => {
+        const last = getLastSync(s.name);
+        return {
+          name: s.name,
+          title: s.title,
+          cron: s.cron,
+          target: s.target,
+          lastRun: last
+            ? {
+                success: last.success,
+                message: last.message,
+                durationMs: last.durationMs,
+                at: last.startedAt,
+              }
+            : null,
+        };
+      });
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ sources: sourceStatus }, null, 2));
+      return;
+    }
+
+    if (req.url === '/history') {
+      const history = getSyncHistory().slice(-100);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(history, null, 2));
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  server.listen(config.healthPort, '0.0.0.0', () => {
+    console.log(`[HEALTH] Сервер здоров'я запущено на порті ${config.healthPort}`);
+  });
+}
+
+// ─── Schedule all sources ──────────────────────────────────────────
+
+function scheduleAll(): void {
+  const enabled = ALL_SOURCES.filter((s) => s.enabled);
+  console.log(`\n[SCHEDULER] Планування ${enabled.length} джерел даних:`);
+
+  for (const source of enabled) {
+    if (!cron.validate(source.cron)) {
+      console.error(`[SCHEDULER] Невалідний cron: ${source.cron} для ${source.name}`);
+      continue;
+    }
+
+    const job = cron.schedule(
+      source.cron,
+      async () => {
+        try {
+          await runSync(config, source);
+        } catch (error: any) {
+          console.error(`[SCHEDULER] Необроблена помилка для ${source.name}: ${error.message}`);
+        }
+      },
+      { timezone: config.timezone },
+    );
+
+    scheduledJobs.push(job);
+    console.log(`  ${source.cron.padEnd(15)} ${source.title} → ${source.target}`);
+  }
+
+  console.log('');
+}
+
+// ─── Main ──────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log('  OpenData Sync Service v1.0');
+  console.log('  Автоматичне оновлення державних реєстрів');
+  console.log('═══════════════════════════════════════════════════════════');
+  console.log(`  Backend:      ${config.backendUrl}`);
+  console.log(`  OpenReyestr:  ${config.openreyestrUrl}`);
+  console.log(`  Health port:  ${config.healthPort}`);
+  console.log(`  Timezone:     ${config.timezone}`);
+  console.log(`  Джерел:       ${ALL_SOURCES.filter((s) => s.enabled).length} активних`);
+
+  // --run-once mode: trigger all sources immediately and exit
+  if (process.argv.includes('--run-once')) {
+    console.log('\n[MODE] Разовий запуск (--run-once)');
+    const results = await runAllOnce(config, ALL_SOURCES);
+    const ok = results.filter((r) => r.success).length;
+    const fail = results.filter((r) => !r.success).length;
+    console.log(`\n[DONE] Завершено: ${ok} успішних, ${fail} невдалих`);
+    process.exit(fail > 0 ? 1 : 0);
+  }
+
+  // Normal mode: schedule + health endpoint
+  startHealthServer();
+  scheduleAll();
+
+  console.log('[SCHEDULER] Сервіс запущено. Очікування за розкладом...\n');
+}
+
+// Graceful shutdown
+process.on('SIGTERM', () => {
+  console.log('[SHUTDOWN] Отримано SIGTERM, зупинка...');
+  for (const job of scheduledJobs) job.stop();
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  console.log('[SHUTDOWN] Отримано SIGINT, зупинка...');
+  for (const job of scheduledJobs) job.stop();
+  process.exit(0);
+});
+
+main().catch((error) => {
+  console.error('[FATAL]', error);
+  process.exit(1);
+});

--- a/opendata-sync/src/sync-runner.ts
+++ b/opendata-sync/src/sync-runner.ts
@@ -1,0 +1,279 @@
+/**
+ * Sync Runner — executes data source syncs via HTTP calls to backend/openreyestr.
+ *
+ * Backend sources: triggers start_import via /api/tools/start_import
+ * OpenReyestr sources: triggers registry sync via /api/admin/sync-registry/:name
+ */
+
+import http from 'http';
+import https from 'https';
+import { DataSourceSchedule, ServiceConfig } from './config.js';
+
+export interface SyncResult {
+  source: string;
+  success: boolean;
+  message: string;
+  durationMs: number;
+  startedAt: string;
+}
+
+const syncHistory: SyncResult[] = [];
+const MAX_HISTORY = 500;
+
+export function getSyncHistory(): SyncResult[] {
+  return syncHistory;
+}
+
+export function getLastSync(sourceName: string): SyncResult | undefined {
+  for (let i = syncHistory.length - 1; i >= 0; i--) {
+    if (syncHistory[i].source === sourceName) return syncHistory[i];
+  }
+  return undefined;
+}
+
+function httpRequest(
+  url: string,
+  method: string,
+  body: string | null,
+  headers: Record<string, string>,
+  timeoutMs = 30_000,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const parsed = new URL(url);
+    const proto = parsed.protocol === 'https:' ? https : http;
+    const req = proto.request(
+      {
+        hostname: parsed.hostname,
+        port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+        path: parsed.pathname + parsed.search,
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          ...headers,
+          ...(body ? { 'Content-Length': Buffer.byteLength(body).toString() } : {}),
+        },
+        timeout: timeoutMs,
+      },
+      (res) => {
+        let data = '';
+        res.on('data', (chunk: Buffer) => (data += chunk));
+        res.on('end', () => resolve({ statusCode: res.statusCode || 0, body: data }));
+      },
+    );
+    req.on('error', reject);
+    req.on('timeout', () => {
+      req.destroy();
+      reject(new Error('Request timeout'));
+    });
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+/**
+ * Trigger a backend import via the import task system.
+ * Calls POST /api/tools/start_import with source_name.
+ */
+async function triggerBackendImport(
+  config: ServiceConfig,
+  source: DataSourceSchedule,
+): Promise<SyncResult> {
+  const start = Date.now();
+  const startedAt = new Date().toISOString();
+
+  try {
+    // First check if there's already a running import for this source
+    const statusRes = await httpRequest(
+      `${config.backendUrl}/api/tools/get_import_status`,
+      'POST',
+      JSON.stringify({ name: 'get_import_status', arguments: { status: 'running' } }),
+      { Authorization: `Bearer ${config.backendApiKey}` },
+    );
+
+    if (statusRes.statusCode === 200) {
+      try {
+        const statusData = JSON.parse(statusRes.body);
+        const content = statusData?.content?.[0]?.text || statusData?.result || '';
+        if (typeof content === 'string' && content.includes(source.sourceName)) {
+          return {
+            source: source.name,
+            success: true,
+            message: `Пропущено: імпорт ${source.sourceName} вже виконується`,
+            durationMs: Date.now() - start,
+            startedAt,
+          };
+        }
+      } catch {
+        // Status check failed, proceed with import anyway
+      }
+    }
+
+    // Trigger the import
+    const res = await httpRequest(
+      `${config.backendUrl}/api/tools/start_import`,
+      'POST',
+      JSON.stringify({
+        name: 'start_import',
+        arguments: { source_name: source.sourceName },
+      }),
+      { Authorization: `Bearer ${config.backendApiKey}` },
+      60_000, // 60s timeout for import trigger
+    );
+
+    const success = res.statusCode >= 200 && res.statusCode < 300;
+    let message: string;
+    try {
+      const data = JSON.parse(res.body);
+      message = data?.content?.[0]?.text || data?.result || `HTTP ${res.statusCode}`;
+    } catch {
+      message = `HTTP ${res.statusCode}: ${res.body.slice(0, 200)}`;
+    }
+
+    return {
+      source: source.name,
+      success,
+      message: success ? `Запущено: ${message.slice(0, 200)}` : `Помилка: ${message.slice(0, 200)}`,
+      durationMs: Date.now() - start,
+      startedAt,
+    };
+  } catch (error: any) {
+    return {
+      source: source.name,
+      success: false,
+      message: `Помилка з'єднання: ${error.message}`,
+      durationMs: Date.now() - start,
+      startedAt,
+    };
+  }
+}
+
+/**
+ * Trigger an OpenReyestr NAIS registry sync.
+ * Calls POST /api/admin/sync-registry with registry name.
+ * Falls back to POST /api/tools/sync_nais_registries if admin endpoint not available.
+ */
+async function triggerOpenreyestrSync(
+  config: ServiceConfig,
+  source: DataSourceSchedule,
+): Promise<SyncResult> {
+  const start = Date.now();
+  const startedAt = new Date().toISOString();
+
+  try {
+    // Try the admin sync endpoint
+    const res = await httpRequest(
+      `${config.openreyestrUrl}/api/admin/sync-registry`,
+      'POST',
+      JSON.stringify({ registry: source.sourceName }),
+      { Authorization: `Bearer ${config.openreyestrApiKey}` },
+      300_000, // 5 min timeout — NAIS syncs can be slow
+    );
+
+    if (res.statusCode === 404) {
+      // Admin endpoint doesn't exist, try MCP tool endpoint
+      const toolRes = await httpRequest(
+        `${config.openreyestrUrl}/api/tools/sync_nais_registries`,
+        'POST',
+        JSON.stringify({
+          name: 'sync_nais_registries',
+          arguments: { registries: source.sourceName },
+        }),
+        { Authorization: `Bearer ${config.openreyestrApiKey}` },
+        300_000,
+      );
+
+      const success = toolRes.statusCode >= 200 && toolRes.statusCode < 300;
+      return {
+        source: source.name,
+        success,
+        message: success
+          ? `NAIS sync triggered via tool: ${source.sourceName}`
+          : `HTTP ${toolRes.statusCode}: ${toolRes.body.slice(0, 200)}`,
+        durationMs: Date.now() - start,
+        startedAt,
+      };
+    }
+
+    const success = res.statusCode >= 200 && res.statusCode < 300;
+    return {
+      source: source.name,
+      success,
+      message: success
+        ? `NAIS sync OK: ${source.sourceName}`
+        : `HTTP ${res.statusCode}: ${res.body.slice(0, 200)}`,
+      durationMs: Date.now() - start,
+      startedAt,
+    };
+  } catch (error: any) {
+    return {
+      source: source.name,
+      success: false,
+      message: `Помилка з'єднання з openreyestr: ${error.message}`,
+      durationMs: Date.now() - start,
+      startedAt,
+    };
+  }
+}
+
+/**
+ * Run a single source sync.
+ */
+export async function runSync(
+  config: ServiceConfig,
+  source: DataSourceSchedule,
+): Promise<SyncResult> {
+  console.log(`[SYNC] Запуск: ${source.title} (${source.name})`);
+
+  let result: SyncResult;
+  if (source.target === 'backend') {
+    result = await triggerBackendImport(config, source);
+  } else {
+    result = await triggerOpenreyestrSync(config, source);
+  }
+
+  // Store in history
+  syncHistory.push(result);
+  if (syncHistory.length > MAX_HISTORY) {
+    syncHistory.splice(0, syncHistory.length - MAX_HISTORY);
+  }
+
+  const status = result.success ? 'OK' : 'FAIL';
+  console.log(
+    `[SYNC] ${status}: ${source.title} — ${result.message} (${result.durationMs}ms)`,
+  );
+
+  return result;
+}
+
+/**
+ * Run all enabled sources (for --run-once mode).
+ */
+export async function runAllOnce(
+  config: ServiceConfig,
+  sources: DataSourceSchedule[],
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+
+  // Group by target to avoid overwhelming a single service
+  const backendSources = sources.filter((s) => s.target === 'backend' && s.enabled);
+  const openreyestrSources = sources.filter((s) => s.target === 'openreyestr' && s.enabled);
+
+  console.log(`[SYNC] Разовий запуск: ${backendSources.length} backend + ${openreyestrSources.length} openreyestr джерел`);
+
+  // Run backend sources sequentially (they create background tasks anyway)
+  for (const source of backendSources) {
+    const result = await runSync(config, source);
+    results.push(result);
+    // Small delay between triggers
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+
+  // Run openreyestr sources sequentially (they are resource-heavy)
+  for (const source of openreyestrSources) {
+    const result = await runSync(config, source);
+    results.push(result);
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+
+  return results;
+}

--- a/opendata-sync/tsconfig.json
+++ b/opendata-sync/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- New `opendata-sync` service — lightweight cron scheduler that automatically updates government open data at configured frequencies
- **Daily (03:00-05:00 Kyiv):** MVS wanted persons/vehicles/missing, NAZK corruption, NAIS daily registries (arbitration managers, bankruptcy, enforcement, debtors)
- **Weekly (Sun/Mon 02:00-05:00):** UIPV trademarks/patents, NAIS weekly registries (notaries, court experts, special forms, forensic methods, legal acts, admin units, streets)
- Delegates to existing import infrastructure: backend `start_import` + new openreyestr `sync-registry` admin endpoint
- Monitoring: `/health`, `/status`, `/history` endpoints
- `--run-once` mode for manual triggers

## Changes
- `opendata-sync/` — new TypeScript service with `node-cron` scheduler
- `deployment/Dockerfile.opendata-sync` — multi-stage Docker build
- `deployment/docker-compose.prod.yml` — new `opendata-sync-prod` container (256MB limit)
- `mcp_openreyestr/src/http-server.ts` — added `POST /api/admin/sync-registry` endpoint for scheduler to trigger NAIS syncs

## Test plan
- [ ] Verify Docker build: `cd deployment && docker compose -f docker-compose.prod.yml build opendata-sync-prod`
- [ ] Check health endpoint: `curl localhost:3010/health`
- [ ] Check status endpoint: `curl localhost:3010/status`
- [ ] Test `--run-once` mode manually
- [ ] Verify NAIS sync-registry endpoint responds on openreyestr
- [ ] Monitor logs after deploy for first scheduled sync trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `opendata-sync`, a lightweight cron service that auto-triggers daily/weekly imports of Ukrainian government datasets via existing systems. Includes a new OpenReyestr admin endpoint to run NAIS syncs and simple health endpoints.

- **New Features**
  - New `opendata-sync` TypeScript service using `node-cron` with Kyiv TZ schedules:
    - Daily (03:00–05:00): MVS wanted/missing/vehicles, NAZK corruption, NAIS daily registries.
    - Weekly (Sun/Mon 02:00–05:00): UIPV trademarks/patents, NAIS weekly registries.
  - Delegates imports to existing infra:
    - Backend via `/api/tools/start_import`.
    - OpenReyestr via new `POST /api/admin/sync-registry`.
  - Monitoring: `/health`, `/status`, `/history`; supports `--run-once`.
  - Dockerized: `deployment/Dockerfile.opendata-sync` and `opendata-sync-prod` in compose (256MB limit, healthcheck).

- **Migration**
  - Deploy the new `opendata-sync-prod` service and set env vars: `BACKEND_URL`, `BACKEND_API_KEY`, `OPENREYESTR_URL`, `OPENREYESTR_API_KEY`, `HEALTH_PORT`, `TZ`.
  - Verify `GET /health` on port 3010 and that OpenReyestr exposes `POST /api/admin/sync-registry`.

<sup>Written for commit b7a39fc108e33f1e396930312519f5c63e5e03c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

