### PR TITLE
ci: add opendata-sync to deploy pipeline

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -26,6 +26,9 @@ outputs:
   platform:
     description: 'Whether platform/ developer console changed'
     value: ${{ steps.changes.outputs.platform }}
+  opendata_sync:
+    description: 'Whether opendata-sync scheduler changed'
+    value: ${{ steps.changes.outputs.opendata_sync }}
   any_backend:
     description: 'Whether any backend service changed (shared/backend/rada/openreyestr)'
     value: ${{ steps.changes.outputs.any_backend }}
@@ -82,6 +85,8 @@ runs:
         MOBILE=false
         PLATFORM=false
 
+        OPENDATA_SYNC=false
+
         DEPLOY_INFRA=false  # Dockerfiles, compose files, nginx — triggers full rebuild
         DEPLOY_MONITORING=false  # Grafana, prometheus — deploy-only, no rebuild
 
@@ -96,6 +101,7 @@ runs:
             deployment/*) DEPLOY_INFRA=true; DEPLOYMENT=true ;;
             mobile/*) MOBILE=true ;;
             platform/*) PLATFORM=true ;;
+            opendata-sync/*) OPENDATA_SYNC=true ;;
           esac
         done <<< "$CHANGED_FILES"
 
@@ -147,6 +153,10 @@ runs:
           BUILD_LIST="${BUILD_LIST}\"platform\","
           DEPLOY_LIST="${DEPLOY_LIST}\"platform\","
         fi
+        if [ "$OPENDATA_SYNC" = "true" ]; then
+          BUILD_LIST="${BUILD_LIST}\"opendata-sync\","
+          DEPLOY_LIST="${DEPLOY_LIST}\"opendata-sync\","
+        fi
 
         # Remove trailing comma and wrap in array
         BUILD_LIST="${BUILD_LIST%,}"
@@ -163,6 +173,7 @@ runs:
         echo "monitoring=$DEPLOY_MONITORING" >> "$GITHUB_OUTPUT"
         echo "mobile=$MOBILE" >> "$GITHUB_OUTPUT"
         echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+        echo "opendata_sync=$OPENDATA_SYNC" >> "$GITHUB_OUTPUT"
         echo "any_backend=$ANY_BACKEND" >> "$GITHUB_OUTPUT"
         echo "services_to_build=$SERVICES_TO_BUILD" >> "$GITHUB_OUTPUT"
         echo "services_to_deploy=$SERVICES_TO_DEPLOY" >> "$GITHUB_OUTPUT"
@@ -178,5 +189,6 @@ runs:
         echo "  monitoring:  $DEPLOY_MONITORING"
         echo "  mobile:      $MOBILE"
         echo "  platform:    $PLATFORM"
+        echo "  opendata_sync: $OPENDATA_SYNC"
         echo "  services_to_build: $SERVICES_TO_BUILD"
         echo "  services_to_deploy: $SERVICES_TO_DEPLOY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       services:
-        description: 'Services to deploy (comma-separated: backend,rada,openreyestr,frontend,platform,monitoring). Leave empty to auto-detect from latest changes.'
+        description: 'Services to deploy (comma-separated: backend,rada,openreyestr,frontend,platform,opendata-sync,monitoring). Leave empty to auto-detect from latest changes.'
         required: false
         default: ''
         type: string
@@ -49,6 +49,7 @@ jobs:
       services_to_deploy: ${{ steps.final.outputs.services_to_deploy }}
       monitoring: ${{ steps.final.outputs.monitoring }}
       platform: ${{ steps.final.outputs.platform }}
+      opendata_sync: ${{ steps.final.outputs.opendata_sync }}
       has_changes: ${{ steps.final.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v4
@@ -68,7 +69,7 @@ jobs:
             # Manual override: parse comma-separated service names
             echo "Using manual service selection: $INPUT_SERVICES"
 
-            BACKEND=false RADA=false OPENREYESTR=false FRONTEND=false PLATFORM=false MONITORING=false
+            BACKEND=false RADA=false OPENREYESTR=false FRONTEND=false PLATFORM=false MONITORING=false OPENDATA_SYNC=false
             IFS=',' read -ra SVCS <<< "$INPUT_SERVICES"
             for svc in "${SVCS[@]}"; do
               svc=$(echo "$svc" | xargs)  # trim whitespace
@@ -79,6 +80,7 @@ jobs:
                 frontend) FRONTEND=true ;;
                 platform) PLATFORM=true ;;
                 monitoring) MONITORING=true ;;
+                opendata-sync) OPENDATA_SYNC=true ;;
                 *) echo "::warning::Unknown service: $svc" ;;
               esac
             done
@@ -88,6 +90,7 @@ jobs:
             echo "openreyestr=$OPENREYESTR" >> "$GITHUB_OUTPUT"
             echo "frontend=$FRONTEND" >> "$GITHUB_OUTPUT"
             echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+            echo "opendata_sync=$OPENDATA_SYNC" >> "$GITHUB_OUTPUT"
             echo "monitoring=$MONITORING" >> "$GITHUB_OUTPUT"
             echo "shared=${{ steps.changes.outputs.shared }}" >> "$GITHUB_OUTPUT"
             echo "deployment=${{ steps.changes.outputs.deployment }}" >> "$GITHUB_OUTPUT"
@@ -106,6 +109,7 @@ jobs:
             [ "$OPENREYESTR" = "true" ] && SERVICES_LIST="${SERVICES_LIST:+$SERVICES_LIST,}\"openreyestr\""
             [ "$FRONTEND" = "true" ] && SERVICES_LIST="${SERVICES_LIST:+$SERVICES_LIST,}\"frontend\""
             [ "$PLATFORM" = "true" ] && SERVICES_LIST="${SERVICES_LIST:+$SERVICES_LIST,}\"platform\""
+            [ "$OPENDATA_SYNC" = "true" ] && SERVICES_LIST="${SERVICES_LIST:+$SERVICES_LIST,}\"opendata-sync\""
             echo "services_to_build=[${SERVICES_LIST}]" >> "$GITHUB_OUTPUT"
             echo "services_to_deploy=[${SERVICES_LIST}]" >> "$GITHUB_OUTPUT"
 
@@ -123,6 +127,7 @@ jobs:
             echo "openreyestr=${{ steps.changes.outputs.openreyestr }}" >> "$GITHUB_OUTPUT"
             echo "frontend=${{ steps.changes.outputs.frontend }}" >> "$GITHUB_OUTPUT"
             echo "platform=${{ steps.changes.outputs.platform }}" >> "$GITHUB_OUTPUT"
+            echo "opendata_sync=${{ steps.changes.outputs.opendata_sync }}" >> "$GITHUB_OUTPUT"
             echo "monitoring=${{ steps.changes.outputs.monitoring }}" >> "$GITHUB_OUTPUT"
             echo "shared=${{ steps.changes.outputs.shared }}" >> "$GITHUB_OUTPUT"
             echo "deployment=${{ steps.changes.outputs.deployment }}" >> "$GITHUB_OUTPUT"
@@ -351,6 +356,7 @@ jobs:
       OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
       FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
       PLATFORM_CHANGED: ${{ needs.detect-changes.outputs.platform }}
+      OPENDATA_SYNC_CHANGED: ${{ needs.detect-changes.outputs.opendata_sync }}
       MONITORING_CHANGED: ${{ needs.detect-changes.outputs.monitoring }}
     steps:
       - uses: actions/checkout@v4
@@ -487,6 +493,7 @@ jobs:
             [ "${OPENREYESTR_CHANGED}" = "true" ] && BUILD="\$BUILD app-openreyestr-prod migrate-openreyestr-prod"
             [ "${FRONTEND_CHANGED}" = "true" ] && BUILD="\$BUILD lexwebapp-prod"
             [ "${PLATFORM_CHANGED}" = "true" ] && BUILD="\$BUILD platform-prod"
+            [ "${OPENDATA_SYNC_CHANGED}" = "true" ] && BUILD="\$BUILD opendata-sync-prod"
             [ -n "\$BUILD" ] && \$DC build \$BUILD
 
             # --- 2. Run migrations (idempotent, safe while old containers serve) ---
@@ -511,6 +518,9 @@ jobs:
             fi
             if [ "${PLATFORM_CHANGED}" = "true" ]; then
               \$DC up -d platform-prod
+            fi
+            if [ "${OPENDATA_SYNC_CHANGED}" = "true" ]; then
+              \$DC up -d opendata-sync-prod
             fi
 
             # --- 4. Wait for new containers to be healthy ---
@@ -646,6 +656,7 @@ jobs:
       OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
       FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
       PLATFORM_CHANGED: ${{ needs.detect-changes.outputs.platform }}
+      OPENDATA_SYNC_CHANGED: ${{ needs.detect-changes.outputs.opendata_sync }}
       MONITORING_CHANGED: ${{ needs.detect-changes.outputs.monitoring }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `opendata-sync` service to change detection and deploy workflow
- Enables auto-deploy when `opendata-sync/` files change
- Supports manual trigger via `opendata-sync` in services list

## Test plan
- [ ] Verify detect-changes recognizes opendata-sync/ paths
- [ ] Trigger manual deploy with `opendata-sync` service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `opendata-sync` to the CI/CD deploy pipeline. Changes in `opendata-sync/` now auto-trigger build and blue-green deployment, with manual deploy support via the `services` input.

- **New Features**
  - Detects `opendata-sync/` changes and exposes an `opendata_sync` output.
  - Allows manual selection by adding `opendata-sync` to the `services` input in `deploy-prod`.
  - Builds and deploys the `opendata-sync-prod` container when changes are detected.

<sup>Written for commit e5cee5aa9ab1127dcbe6e7186456b07fb489a2d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

