### PR TITLE
feat: add prod database status utility

### DIFF
--- a/scripts/edrsr/db-status.py
+++ b/scripts/edrsr/db-status.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+Prod DB Status — огляд усіх баз даних на проді з часом останнього оновлення.
+
+Підключається через SSH (ssh prod), читає pg_class + pg_stat для швидких результатів.
+
+Usage:
+    python3 scripts/edrsr/db-status.py
+    python3 scripts/edrsr/db-status.py --format csv
+    python3 scripts/edrsr/db-status.py --format json
+    python3 scripts/edrsr/db-status.py --page-size 40
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# ── Connection config ──
+
+DATABASES = {
+    "secondlayer": {
+        "container": "secondlayer-postgres-prod",
+        "user": "secondlayer",
+        "db": "secondlayer_prod",
+        "label": "SecondLayer (основна)",
+    },
+    "openreyestr": {
+        "container": "openreyestr-postgres-prod",
+        "user": "openreyestr",
+        "db": "openreyestr_prod",
+        "label": "OpenReyestr (реєстри)",
+    },
+}
+
+# ── Tables to exclude ──
+
+EXCLUDE_PREFIXES = ("edrsr_", "spain_")
+EXCLUDE_TABLES = {
+    "schema_migrations", "migrations", "billing_migration_log",
+    "system_config", "tool_usage_stats",
+}
+
+# ── Queries ──
+
+Q_TABLE_STATS = """
+SELECT
+  c.relname,
+  c.reltuples::bigint,
+  pg_total_relation_size(c.oid),
+  COALESCE(s.last_autoanalyze, s.last_analyze),
+  s.n_tup_ins,
+  s.n_tup_upd,
+  s.n_tup_del
+FROM pg_class c
+JOIN pg_stat_user_tables s ON s.relname = c.relname
+WHERE c.relkind = 'r'
+ORDER BY pg_total_relation_size(c.oid) DESC;
+"""
+
+Q_DB_SIZE = """
+SELECT pg_database_size(current_database());
+"""
+
+Q_IMPORT_TASKS = """
+SELECT DISTINCT ON (source_name)
+  source_name, status, records_imported, completed_at, elapsed_ms, last_error
+FROM import_tasks
+ORDER BY source_name, completed_at DESC NULLS LAST;
+"""
+
+Q_IMPORT_LOG = """
+SELECT DISTINCT ON (registry_name)
+  registry_name, status, records_imported, import_completed_at
+FROM import_log
+ORDER BY registry_name, import_completed_at DESC NULLS LAST;
+"""
+
+
+def prod_psql(container: str, user: str, db: str, sql: str) -> str:
+    flat_sql = " ".join(sql.strip().split())
+    shell_cmd = f'docker exec {container} psql -U {user} -d {db} -t -A -c "{flat_sql}"'
+    cmd = ["ssh", "prod", shell_cmd]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if r.returncode != 0:
+        return ""
+    return r.stdout.strip()
+
+
+def psql(db_key: str, sql: str) -> str:
+    cfg = DATABASES[db_key]
+    return prod_psql(cfg["container"], cfg["user"], cfg["db"], sql)
+
+
+def fmt_num(n: int) -> str:
+    if n < 0:
+        return "—"
+    return f"{n:,}".replace(",", " ")
+
+
+def fmt_size(b: int) -> str:
+    if b < 0:
+        return "—"
+    if b < 1024:
+        return f"{b} B"
+    elif b < 1024 ** 2:
+        return f"{b / 1024:.0f} KB"
+    elif b < 1024 ** 3:
+        return f"{b / 1024**2:.0f} MB"
+    else:
+        return f"{b / 1024**3:.1f} GB"
+
+
+def _normalize_ts(ts_str: str) -> str:
+    """Normalize postgres timestamp: +02 → +02:00 for Python parsing."""
+    import re
+    ts_str = ts_str.strip()
+    # Fix short timezone offset: +02 → +02:00, -05 → -05:00
+    ts_str = re.sub(r'([+-]\d{2})$', r'\1:00', ts_str)
+    return ts_str
+
+
+def _parse_ts(ts_str: str) -> datetime | None:
+    """Parse postgres timestamp string into datetime."""
+    if not ts_str:
+        return None
+    ts_str = _normalize_ts(ts_str)
+    for fmt in (
+        "%Y-%m-%d %H:%M:%S.%f%z",
+        "%Y-%m-%d %H:%M:%S%z",
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%Y-%m-%d %H:%M:%S",
+    ):
+        try:
+            dt = datetime.strptime(ts_str, fmt)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except ValueError:
+            continue
+    return None
+
+
+def time_ago(ts_str: str) -> str:
+    """Convert timestamp string to human-readable 'time ago'."""
+    if not ts_str:
+        return "невідомо"
+    try:
+        dt = _parse_ts(ts_str)
+        if not dt:
+            return ts_str[:16]
+
+        now = datetime.now(timezone.utc)
+        delta = now - dt
+        total_sec = int(delta.total_seconds())
+
+        if total_sec < 0:
+            return "щойно"
+        elif total_sec < 60:
+            return f"{total_sec}с тому"
+        elif total_sec < 3600:
+            return f"{total_sec // 60}хв тому"
+        elif total_sec < 86400:
+            h = total_sec // 3600
+            return f"{h}год тому"
+        elif total_sec < 86400 * 30:
+            d = total_sec // 86400
+            return f"{d}д тому"
+        else:
+            m = total_sec // (86400 * 30)
+            return f"{m}міс тому"
+    except Exception:
+        return ts_str[:16]
+
+
+def freshness_icon(ts_str: str) -> str:
+    """Return icon based on how fresh data is."""
+    if not ts_str:
+        return "⚪"
+    dt = _parse_ts(ts_str)
+    if not dt:
+        return "⚪"
+
+    days = (datetime.now(timezone.utc) - dt).total_seconds() / 86400
+
+    if days < 1:
+        return "🟢"
+    elif days < 7:
+        return "🟡"
+    elif days < 30:
+        return "🟠"
+    else:
+        return "🔴"
+
+
+def wait_for_key():
+    print("  ─── ПРОБІЛ/ENTER — далі, q — вихід ───", end="", flush=True)
+    try:
+        import tty
+        import termios
+        fd = sys.stdin.fileno()
+        old = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old)
+        print("\r" + " " * 60 + "\r", end="")
+        if ch in ("q", "Q"):
+            print()
+            sys.exit(0)
+    except (ImportError, termios.error, ValueError, EOFError):
+        print("\r" + " " * 60 + "\r", end="")
+
+
+def parse_table_stats(raw: str, exclude_prefixes=(), exclude_tables=None):
+    """Parse table stats output into list of dicts."""
+    exclude_tables = exclude_tables or set()
+    rows = []
+    seen = set()
+    for line in raw.split("\n"):
+        if not line or "|" not in line:
+            continue
+        parts = line.split("|")
+        if len(parts) < 7:
+            continue
+        name = parts[0]
+        if name in seen:
+            continue
+        if name in exclude_tables:
+            continue
+        if any(name.startswith(p) for p in exclude_prefixes):
+            continue
+        seen.add(name)
+
+        row_est = int(parts[1]) if parts[1] else 0
+        size_bytes = int(parts[2]) if parts[2] else 0
+        last_activity = parts[3] if parts[3] else ""
+        n_ins = int(parts[4]) if parts[4] else 0
+        n_upd = int(parts[5]) if parts[5] else 0
+        n_del = int(parts[6]) if parts[6] else 0
+
+        rows.append({
+            "table": name,
+            "rows": max(row_est, 0),
+            "size_bytes": size_bytes,
+            "last_activity": last_activity,
+            "n_ins": n_ins,
+            "n_upd": n_upd,
+            "n_del": n_del,
+        })
+    return rows
+
+
+def parse_import_tasks(raw: str) -> dict:
+    """Parse import_tasks into {source_name: {...}}."""
+    result = {}
+    for line in raw.split("\n"):
+        if not line or "|" not in line:
+            continue
+        parts = line.split("|")
+        result[parts[0]] = {
+            "status": parts[1],
+            "records_imported": int(parts[2]) if parts[2] else 0,
+            "completed_at": parts[3] if len(parts) > 3 else "",
+            "elapsed_ms": int(parts[4]) if len(parts) > 4 and parts[4] else 0,
+            "last_error": parts[5] if len(parts) > 5 else "",
+        }
+    return result
+
+
+def parse_import_log(raw: str) -> dict:
+    result = {}
+    for line in raw.split("\n"):
+        if not line or "|" not in line:
+            continue
+        parts = line.split("|")
+        result[parts[0]] = {
+            "status": parts[1],
+            "records_imported": int(parts[2]) if parts[2] else 0,
+            "completed_at": parts[3] if len(parts) > 3 else "",
+        }
+    return result
+
+
+def print_db_section(db_key: str, label: str, tables: list, import_info: dict,
+                     db_size: int, page_size: int, fmt: str):
+    """Print one database section."""
+    total_rows = sum(r["rows"] for r in tables)
+    total_size = sum(r["size_bytes"] for r in tables)
+
+    if fmt == "csv":
+        print(f"\n# {label}")
+        print("table,rows,size,last_activity,time_ago,writes_total")
+        for r in tables:
+            imp = import_info.get(r["table"], {})
+            last = imp.get("completed_at", "") or r["last_activity"]
+            writes = r["n_ins"] + r["n_upd"]
+            print(f"{r['table']},{r['rows']},{r['size_bytes']},{last},{time_ago(last)},{writes}")
+        return
+
+    W = 100
+    print()
+    print(f"  {'═' * W}")
+    print(f"  📦 {label}  —  {len(tables)} таблиць, {fmt_size(db_size)} загалом")
+    print(f"  {'═' * W}")
+    print(f"  {'#':<4} {'Таблиця':<38} {'Рядків':>12} {'Розмір':>9} {'Записів':>10}  {'Давність':>14} {'':>2}")
+    print(f"  {'─' * W}")
+
+    for i, r in enumerate(tables):
+        imp = import_info.get(r["table"], {})
+        last_ts = imp.get("completed_at", "") or r["last_activity"]
+        writes = r["n_ins"] + r["n_upd"]
+        ago = time_ago(last_ts)
+        icon = freshness_icon(last_ts)
+        row_str = fmt_num(r["rows"]) if r["rows"] > 0 else "—"
+        writes_str = fmt_num(writes) if writes > 0 else "—"
+
+        # Show import status if failed
+        imp_status = ""
+        if imp.get("status") == "failed":
+            imp_status = " ⛔"
+        elif imp.get("status") == "running":
+            imp_status = " 🔄"
+
+        print(f"  {i + 1:<4} {r['table']:<38} {row_str:>12} {fmt_size(r['size_bytes']):>9} {writes_str:>10}  {ago:>14} {icon}{imp_status}")
+
+        if (i + 1) % page_size == 0 and i + 1 < len(tables):
+            remaining = len(tables) - i - 1
+            print(f"  {'─' * W}")
+            print(f"  ... ще {remaining} таблиць")
+            wait_for_key()
+            print(f"  {'─' * W}")
+            print(f"  {'#':<4} {'Таблиця':<38} {'Рядків':>12} {'Розмір':>9} {'Записів':>10}  {'Давність':>14} {'':>2}")
+            print(f"  {'─' * W}")
+
+    print(f"  {'─' * W}")
+    print(f"  {'':4} {'РАЗОМ: ' + str(len(tables)) + ' таблиць':<38} {fmt_num(total_rows):>12} {fmt_size(total_size):>9}")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Prod DB status: all databases overview")
+    parser.add_argument("--format", choices=["table", "csv", "json"], default="table")
+    parser.add_argument("--page-size", type=int, default=35, help="rows per page (default: 35)")
+    args = parser.parse_args()
+
+    print("⏳ Сканування прод-баз...", file=sys.stderr)
+
+    # ── 1. SecondLayer DB ──
+    print("  → secondlayer_prod...", file=sys.stderr)
+    sl_raw = psql("secondlayer", Q_TABLE_STATS)
+    sl_size_raw = psql("secondlayer", Q_DB_SIZE)
+    sl_import_raw = psql("secondlayer", Q_IMPORT_TASKS)
+
+    sl_tables = parse_table_stats(sl_raw, EXCLUDE_PREFIXES, EXCLUDE_TABLES)
+    sl_db_size = int(sl_size_raw.strip()) if sl_size_raw.strip() else 0
+    sl_imports = parse_import_tasks(sl_import_raw)
+
+    # Map import source → target table for lookup
+    src_catalog_raw = psql("secondlayer",
+        "SELECT name, target_table FROM import_source_catalog;")
+    src_to_table = {}
+    for line in src_catalog_raw.split("\n"):
+        if "|" in line:
+            parts = line.split("|")
+            src_to_table[parts[0]] = parts[1]
+
+    # Build import info keyed by table name
+    sl_import_by_table = {}
+    for src_name, info in sl_imports.items():
+        tbl = src_to_table.get(src_name, src_name)
+        # Keep the most recent entry per table
+        if tbl not in sl_import_by_table or (info.get("completed_at", "") > sl_import_by_table[tbl].get("completed_at", "")):
+            sl_import_by_table[tbl] = info
+
+    # ── 2. OpenReyestr DB ──
+    print("  → openreyestr_prod...", file=sys.stderr)
+    or_raw = psql("openreyestr", Q_TABLE_STATS)
+    or_size_raw = psql("openreyestr", Q_DB_SIZE)
+    or_import_raw = psql("openreyestr", Q_IMPORT_LOG)
+
+    or_tables = parse_table_stats(or_raw, exclude_tables=EXCLUDE_TABLES)
+    or_db_size = int(or_size_raw.strip()) if or_size_raw.strip() else 0
+    or_imports = parse_import_log(or_import_raw)
+
+    # Map import log registry_name → table
+    or_import_by_table = {}
+    for reg_name, info in or_imports.items():
+        or_import_by_table[reg_name] = info
+
+    # ── 3. EDRSR summary (special) ──
+    edrsr_docs_raw = psql("secondlayer",
+        "SELECT SUM(reltuples::bigint) FROM pg_class WHERE relname LIKE 'edrsr_documents_p_%%' AND relkind = 'r';")
+    edrsr_ft_raw = psql("secondlayer",
+        "SELECT SUM(reltuples::bigint) FROM pg_class WHERE relname LIKE 'edrsr_fulltext_p_%%' AND relkind = 'r';")
+    edrsr_size_raw = psql("secondlayer",
+        "SELECT SUM(pg_total_relation_size(c.oid)) FROM pg_class c WHERE c.relname LIKE 'edrsr_%%' AND c.relkind = 'r';")
+
+    edrsr_docs = int(edrsr_docs_raw) if edrsr_docs_raw else 0
+    edrsr_ft = int(edrsr_ft_raw) if edrsr_ft_raw else 0
+    edrsr_size = int(edrsr_size_raw) if edrsr_size_raw else 0
+    edrsr_pct = round(edrsr_ft / edrsr_docs * 100, 1) if edrsr_docs > 0 else 0
+
+    # ── Output ──
+    if args.format == "json":
+        out = {
+            "edrsr": {
+                "docs": edrsr_docs, "fulltext": edrsr_ft,
+                "coverage_pct": edrsr_pct, "size": fmt_size(edrsr_size),
+            },
+            "secondlayer": {
+                "db_size": fmt_size(sl_db_size),
+                "tables": [{
+                    "table": r["table"], "rows": r["rows"],
+                    "size": fmt_size(r["size_bytes"]),
+                    "last_activity": r["last_activity"],
+                    "writes": r["n_ins"] + r["n_upd"],
+                } for r in sl_tables],
+            },
+            "openreyestr": {
+                "db_size": fmt_size(or_db_size),
+                "tables": [{
+                    "table": r["table"], "rows": r["rows"],
+                    "size": fmt_size(r["size_bytes"]),
+                    "last_activity": r["last_activity"],
+                    "writes": r["n_ins"] + r["n_upd"],
+                } for r in or_tables],
+            },
+        }
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+        return
+
+    # ── EDRSR summary banner ──
+    if args.format == "table":
+        W = 100
+        print()
+        print(f"  {'═' * W}")
+        print(f"  ⚖️  ЄДРСР (судові рішення)  —  окрема партиціонована структура")
+        print(f"  {'═' * W}")
+        print(f"  Документів:     {fmt_num(edrsr_docs):>14}")
+        print(f"  Повних текстів: {fmt_num(edrsr_ft):>14}  ({edrsr_pct}% покриття)")
+        print(f"  Розмір:         {fmt_size(edrsr_size):>14}")
+        print(f"  👉 Детально: python3 scripts/edrsr/edrsr-stats.py")
+        print()
+        wait_for_key()
+
+    # ── SecondLayer tables ──
+    print_db_section("secondlayer", DATABASES["secondlayer"]["label"],
+                     sl_tables, sl_import_by_table, sl_db_size,
+                     args.page_size, args.format)
+
+    if args.format == "table":
+        wait_for_key()
+
+    # ── OpenReyestr tables ──
+    print_db_section("openreyestr", DATABASES["openreyestr"]["label"],
+                     or_tables, or_import_by_table, or_db_size,
+                     args.page_size, args.format)
+
+    # ── Legend ──
+    if args.format == "table":
+        print(f"  📋 Легенда: 🟢 <24год  🟡 <7д  🟠 <30д  🔴 >30д  ⛔ імпорт failed  🔄 running")
+        print(f"  📋 Записів = кількість INSERT + UPDATE з моменту запуску PostgreSQL")
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- New utility `scripts/edrsr/db-status.py` — single command to see all prod databases status
- Shows 3 sections: EDRSR summary, SecondLayer DB (160 tables), OpenReyestr DB (40 tables)
- Each table: row count, disk size, total writes (INS+UPD), time since last update, freshness icon
- Freshness indicators: 🟢 <24h, 🟡 <7d, 🟠 <30d, 🔴 >30d, ⛔ import failed, 🔄 running
- Interactive pagination with space/enter/q, `--page-size` control
- Supports `--format table/csv/json`

## Test plan
- [x] Verified output with live prod data (both databases)
- [x] Verified timezone parsing (PostgreSQL +02 format)
- [x] Verified pagination and non-TTY fallback
- [x] Verified JSON and CSV output modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `scripts/edrsr/db-status.py`, a CLI to check prod database health and data freshness at a glance. It shows an EDRSR coverage summary and lists SecondLayer and OpenReyestr tables with size, rows, writes, and last update.

- **New Features**
  - One command to view prod DB status across EDRSR, SecondLayer (~160 tables), and OpenReyestr (~40 tables).
  - Per-table metrics: row count, disk size, total writes (INS+UPD), time since last update, and freshness icon.
  - Import status indicators: ⛔ failed, 🔄 running.
  - Pagination (space/enter/q) with `--page-size`.
  - Output formats: `--format table|csv|json`.

<sup>Written for commit f666c945dcc9877092b200a85755cb734af07bcc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

