### PR TITLE
fix: add issues:write permission to CI workflow

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
   actions: read
 
 concurrency:


### PR DESCRIPTION
Self-heal step fails with 'Resource not accessible by integration' when creating issues. Added missing `issues: write` permission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `issues: write` to `.github/workflows/ci-local-deploy.yml` so the self-heal step can create GitHub issues on failure. Fixes the "Resource not accessible by integration" error during CI.

<sup>Written for commit 7f16e978a5f4a073df81a81a6cea1835f757a4c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

