### PR TITLE
fix: opendata-sync response parsing

### DIFF
--- a/opendata-sync/src/sync-runner.ts
+++ b/opendata-sync/src/sync-runner.ts
@@ -124,7 +124,8 @@ async function triggerBackendImport(
     let message: string;
     try {
       const data = JSON.parse(res.body);
-      message = data?.content?.[0]?.text || data?.result || `HTTP ${res.statusCode}`;
+      const raw = data?.content?.[0]?.text || data?.result || data?.message || `HTTP ${res.statusCode}`;
+      message = typeof raw === 'string' ? raw : JSON.stringify(raw);
     } catch {
       message = `HTTP ${res.statusCode}: ${res.body.slice(0, 200)}`;
     }
@@ -188,7 +189,7 @@ async function triggerOpenreyestrSync(
         success,
         message: success
           ? `NAIS sync triggered via tool: ${source.sourceName}`
-          : `HTTP ${toolRes.statusCode}: ${toolRes.body.slice(0, 200)}`,
+          : `HTTP ${toolRes.statusCode}: ${String(toolRes.body).slice(0, 200)}`,
         durationMs: Date.now() - start,
         startedAt,
       };
@@ -200,7 +201,7 @@ async function triggerOpenreyestrSync(
       success,
       message: success
         ? `NAIS sync OK: ${source.sourceName}`
-        : `HTTP ${res.statusCode}: ${res.body.slice(0, 200)}`,
+        : `HTTP ${res.statusCode}: ${String(res.body).slice(0, 200)}`,
       durationMs: Date.now() - start,
       startedAt,
     };


### PR DESCRIPTION
Fix .slice() on non-string response objects

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix response parsing in `opendata-sync` to handle non-string bodies and object results, preventing .slice() crashes and making status/error messages reliable.

- **Bug Fixes**
  - Ensure message is always a string: prefer content[0].text/result/message; stringify non-strings.
  - Cast response bodies with String(...) before .slice(0, 200) in tool and sync paths.

<sup>Written for commit 7f03f25202e905d460999639ed1687bbe58df273. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

