### PR TITLE
fix: billing audit — add missing cost tracking to batch, stream, plan endpoints

### DIFF
--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -12,6 +12,7 @@ import { BillingService } from '../services/billing-service.js';
 import { CostTracker } from '../services/cost-tracker.js';
 import { Database } from '../database/database.js';
 import { v4 as uuidv4 } from 'uuid';
+import { requestContext } from '../utils/openai-client.js';
 
 export function createChatInlineRoutes(deps: {
   chatService: ChatService;
@@ -25,6 +26,7 @@ export function createChatInlineRoutes(deps: {
   router.post('/plan', chatRateLimit as any, (async (req: DualAuthRequest, res: Response) => {
     const userId = req.user?.id;
     const requestId = `plan-${uuidv4()}`;
+    const startTime = Date.now();
 
     try {
       const { query, budget, internetEnabled } = req.body;
@@ -33,12 +35,30 @@ export function createChatInlineRoutes(deps: {
         return res.status(400).json({ error: 'query is required' });
       }
 
-      const result = await deps.chatService.generatePlanForReview(
-        query,
-        budget || 'standard',
+      await deps.costTracker.createTrackingRecord({
+        requestId,
+        toolName: 'chat_plan',
+        clientKey: undefined,
         userId,
-        requestId
+        userQuery: query.substring(0, 500),
+        queryParams: { budget, internetEnabled },
+      });
+
+      const result = await requestContext.run(
+        { requestId, task: 'chat_plan' },
+        () => deps.chatService.generatePlanForReview(
+          query,
+          budget || 'standard',
+          userId,
+          requestId
+        )
       );
+
+      await deps.costTracker.completeTrackingRecord({
+        requestId,
+        executionTimeMs: Date.now() - startTime,
+        status: 'completed',
+      });
 
       if (!result) {
         return res.json({ plan: null, planSessionId: null, message: 'Simple query — no plan needed' });
@@ -50,6 +70,16 @@ export function createChatInlineRoutes(deps: {
       });
     } catch (error: any) {
       logger.error('[ChatPlan] Endpoint error', { error: error.message, requestId });
+      try {
+        await deps.costTracker.completeTrackingRecord({
+          requestId,
+          executionTimeMs: Date.now() - startTime,
+          status: 'failed',
+          errorMessage: error.message,
+        });
+      } catch (_trackErr) {
+        logger.error('[ChatPlan] Failed to record error in cost tracking', { requestId });
+      }
       res.status(500).json({ error: 'Plan generation failed', message: error.message });
     }
   }) as any);

--- a/mcp_backend/src/routes/tool-execution-routes.ts
+++ b/mcp_backend/src/routes/tool-execution-routes.ts
@@ -37,6 +37,7 @@ async function handleStreamingProxyCall(
   requestId: string,
   deps: {
     serviceProxy: ServiceProxy;
+    costTracker: CostTracker;
   }
 ): Promise<void> {
   // Validate service is not backend
@@ -65,13 +66,58 @@ async function handleStreamingProxyCall(
       acceptHeader: 'text/event-stream',
     });
 
+    // Parse SSE events to extract cost_tracking from 'complete' event
+    let extractedCostUsd = 0;
+    let extractedCostDetails: any = null;
+    let sseBuffer = '';
+
     // Forward SSE events from remote service to client
     stream.on('data', (chunk: Buffer) => {
+      const chunkStr = chunk.toString();
       res.write(chunk);
+
+      // Buffer SSE data to parse complete events for cost extraction
+      sseBuffer += chunkStr;
+      const events = sseBuffer.split('\n\n');
+      sseBuffer = events.pop() || ''; // Keep incomplete event in buffer
+
+      for (const event of events) {
+        if (event.includes('event: complete') || event.includes('event:complete')) {
+          const dataMatch = event.match(/data:\s*(.+)/);
+          if (dataMatch) {
+            try {
+              const parsed = JSON.parse(dataMatch[1]);
+              const costData = parsed?.cost_tracking?.actual_cost;
+              if (costData) {
+                extractedCostUsd = costData.totals?.cost_usd || costData.total_cost_usd || 0;
+                extractedCostDetails = costData;
+              }
+            } catch { /* ignore parse errors */ }
+          }
+        }
+      }
     });
 
-    stream.on('end', () => {
+    stream.on('end', async () => {
       logger.info('[Gateway SSE] Stream completed', { requestId, service });
+
+      // Record extracted cost from remote SSE stream
+      if (extractedCostUsd > 0) {
+        try {
+          await deps.costTracker.recordRemoteServiceCall({
+            requestId,
+            service: service as 'rada' | 'openreyestr',
+            toolName: serviceName,
+            costUsd: extractedCostUsd,
+            details: extractedCostDetails,
+          });
+        } catch (costErr: any) {
+          logger.error('[Gateway SSE] Failed to record stream cost', {
+            requestId, error: costErr.message,
+          });
+        }
+      }
+
       res.end();
     });
 
@@ -257,28 +303,61 @@ export function createToolExecutionRoutes(deps: {
 
       const results = await Promise.all(
         calls.map(async (call: { name: string; arguments?: any }) => {
+          const callRequestId = `batch-${uuidv4()}`;
+          const callStartTime = Date.now();
+
           try {
-            const result = await deps.toolRegistry.executeTool(
-              call.name,
-              call.arguments || {}
+            await deps.costTracker.createTrackingRecord({
+              requestId: callRequestId,
+              toolName: call.name,
+              clientKey: req.clientKey,
+              userId: req.user?.id,
+              userQuery: JSON.stringify(call.arguments || {}),
+              queryParams: call.arguments || {},
+            });
+
+            const result = await requestContext.run(
+              { requestId: callRequestId, task: call.name },
+              () => deps.toolRegistry.executeTool(call.name, call.arguments || {})
             );
+
+            const breakdown = await deps.costTracker.completeTrackingRecord({
+              requestId: callRequestId,
+              executionTimeMs: Date.now() - callStartTime,
+              status: result !== null && result !== undefined ? 'completed' : 'failed',
+              errorMessage: result === null || result === undefined ? `No handler registered for tool: ${call.name}` : undefined,
+            });
+
             if (result === null || result === undefined) {
               return {
                 tool: call.name,
                 success: false,
                 error: `No handler registered for tool: ${call.name}`,
+                cost_tracking: { request_id: callRequestId, actual_cost: breakdown },
               };
             }
             return {
               tool: call.name,
               success: true,
               result,
+              cost_tracking: { request_id: callRequestId, actual_cost: breakdown },
             };
           } catch (error: any) {
+            try {
+              await deps.costTracker.completeTrackingRecord({
+                requestId: callRequestId,
+                executionTimeMs: Date.now() - callStartTime,
+                status: 'failed',
+                errorMessage: error.message,
+              });
+            } catch (_trackErr) {
+              logger.error('Failed to record batch call error in cost tracking', { callRequestId });
+            }
             return {
               tool: call.name,
               success: false,
               error: error.message,
+              cost_tracking: { request_id: callRequestId },
             };
           }
         })
@@ -299,6 +378,9 @@ export function createToolExecutionRoutes(deps: {
 
   // POST /:toolName/stream — Dedicated SSE streaming endpoint
   router.post('/:toolName/stream', dualAuth as any, balanceCheckMiddleware as any, (async (req: DualAuthRequest, res: Response) => {
+    const streamRequestId = `stream-${uuidv4()}`;
+    const streamStartTime = Date.now();
+
     try {
       const toolName = Array.isArray(req.params.toolName) ? req.params.toolName[0] : req.params.toolName;
       if (!toolName) {
@@ -307,16 +389,45 @@ export function createToolExecutionRoutes(deps: {
       const args = req.body.arguments || req.body;
 
       logger.info('Streaming tool call request', {
+        requestId: streamRequestId,
         tool: toolName,
         clientKey: req.clientKey?.substring(0, 8) + '...',
       });
 
-      await handleStreamingToolCall(req, res, toolName, args, {
-        toolRegistry: deps.toolRegistry,
-        batchDocumentTools: deps.batchDocumentTools,
+      await deps.costTracker.createTrackingRecord({
+        requestId: streamRequestId,
+        toolName,
+        clientKey: req.clientKey,
+        userId: req.user?.id,
+        userQuery: args.query || JSON.stringify(args),
+        queryParams: args,
+      });
+
+      await requestContext.run(
+        { requestId: streamRequestId, task: toolName },
+        () => handleStreamingToolCall(req, res, toolName, args, {
+          toolRegistry: deps.toolRegistry,
+          batchDocumentTools: deps.batchDocumentTools,
+        })
+      );
+
+      await deps.costTracker.completeTrackingRecord({
+        requestId: streamRequestId,
+        executionTimeMs: Date.now() - streamStartTime,
+        status: 'completed',
       });
     } catch (error: any) {
       logger.error('Streaming tool call error:', error);
+      try {
+        await deps.costTracker.completeTrackingRecord({
+          requestId: streamRequestId,
+          executionTimeMs: Date.now() - streamStartTime,
+          status: 'failed',
+          errorMessage: error.message,
+        });
+      } catch (_trackErr) {
+        logger.error('Failed to record stream error in cost tracking', { streamRequestId });
+      }
       if (!res.headersSent) {
         res.status(500).json({
           error: 'Tool execution failed',
@@ -436,7 +547,7 @@ export function createToolExecutionRoutes(deps: {
             route.serviceName,
             args,
             requestId,
-            { serviceProxy: deps.serviceProxy }
+            { serviceProxy: deps.serviceProxy, costTracker: deps.costTracker }
           );
         }
 

--- a/packages/shared/src/services/base-cost-tracker.ts
+++ b/packages/shared/src/services/base-cost-tracker.ts
@@ -196,6 +196,20 @@ export abstract class BaseCostTracker {
         ]
       );
 
+      // Record in monthly aggregates
+      const now = new Date();
+      const yearMonth = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+      await this.db.query(
+        `INSERT INTO monthly_api_usage (year_month, anthropic_total_tokens, anthropic_total_cost_usd)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (year_month) DO UPDATE
+         SET anthropic_total_tokens = monthly_api_usage.anthropic_total_tokens + $2,
+             anthropic_total_cost_usd = monthly_api_usage.anthropic_total_cost_usd + $3,
+             updated_at = NOW()`,
+        [yearMonth, params.totalTokens, params.costUsd]
+      );
+
       logger.debug('Anthropic call recorded', {
         requestId: params.requestId,
         model: params.model,
@@ -241,8 +255,7 @@ export abstract class BaseCostTracker {
           `UPDATE cost_tracking
            SET voyage_total_tokens = voyage_total_tokens + $1,
                voyage_cost_usd = voyage_cost_usd + $2,
-               voyage_calls = voyage_calls || $3::jsonb,
-               total_cost_usd = total_cost_usd + $2
+               voyage_calls = voyage_calls || $3::jsonb
            WHERE request_id = $4`,
           [params.totalTokens, costUsd, JSON.stringify([callRecord]), params.requestId]
         );
@@ -380,13 +393,14 @@ export abstract class BaseCostTracker {
 
     const openaiCostUsd = Number(record.openai_cost_usd || 0);
     const anthropicCostUsd = Number(record.anthropic_cost_usd || 0);
+    const voyageCostUsd = Number(record.voyage_cost_usd || 0);
     const secondlayerCostUsd = Number(record.secondlayer_cost_usd || 0);
 
     // Get server-specific additional costs
     const { additionalCostUsd, additionalBreakdownSections } =
       await this.calculateAdditionalCosts(record);
 
-    const totalCostUsd = openaiCostUsd + anthropicCostUsd + secondlayerCostUsd + additionalCostUsd;
+    const totalCostUsd = openaiCostUsd + anthropicCostUsd + voyageCostUsd + secondlayerCostUsd + additionalCostUsd;
 
     await this.db.query(
       `UPDATE cost_tracking
@@ -420,6 +434,15 @@ export abstract class BaseCostTracker {
       // Merge server-specific breakdown sections
       ...additionalBreakdownSections,
     };
+
+    // Add voyage section if data exists
+    if (voyageCostUsd > 0 || (record.voyage_total_tokens || 0) > 0) {
+      breakdown.voyage = {
+        total_tokens: record.voyage_total_tokens || 0,
+        total_cost_usd: voyageCostUsd,
+        calls: record.voyage_calls || [],
+      };
+    }
 
     // Add anthropic section if enabled and data exists
     if (this.config.enableAnthropic || Number(record.anthropic_cost_usd || 0) > 0) {

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -93,6 +93,12 @@ export interface CostBreakdown {
     calls: AnthropicCallRecord[];
   };
 
+  voyage?: {
+    total_tokens: number;
+    total_cost_usd: number;
+    calls: VoyageCallRecord[];
+  };
+
   zakononline?: {
     total_calls: number;
     monthly_total_before: number;


### PR DESCRIPTION
## Summary

Аудит системи біллінгу виявив кілька критичних прогалин у трекінгу вартості. Цей PR закриває їх:

- **VoyageAI виключено з total_cost_usd**: `completeTrackingRecord` рахував `openai + anthropic + secondlayer`, пропускаючи `voyage_cost_usd`. Також `recordVoyageCall` писав `total_cost_usd` напряму, що потім перезаписувалось — подвійний конфлікт
- **Anthropic без місячної агрегації**: `recordAnthropicCall` не писав у `monthly_api_usage` (на відміну від OpenAI) — місячна статистика по Anthropic була завжди 0
- **POST /tools/batch — нуль трекінгу**: виконував масив інструментів без жодного `createTrackingRecord`/`completeTrackingRecord`
- **POST /tools/:toolName/stream — нуль трекінгу**: SSE streaming endpoint не мав жодної інструментації
- **POST /chat/plan — нуль трекінгу**: генерація плану з LLM-викликами була безкоштовною
- **SSE streaming proxy**: при проксуванні SSE на RADA/OpenReyestr cost extraction пропускався повністю — тепер парсить `complete` event зі стріму

### Файли

| Файл | Зміни |
|------|-------|
| `packages/shared/src/services/base-cost-tracker.ts` | VoyageAI в total, Anthropic monthly, voyage breakdown |
| `packages/shared/src/types/cost.ts` | Додано `voyage` секцію до `CostBreakdown` |
| `mcp_backend/src/routes/tool-execution-routes.ts` | batch + stream tracking, SSE proxy cost parsing |
| `mcp_backend/src/routes/chat-inline-routes.ts` | Plan generation tracking |

## Test plan

- [ ] Перевірити що `POST /tools/batch` створює окремий `cost_tracking` record для кожного tool call
- [ ] Перевірити що `POST /tools/:toolName/stream` створює та завершує tracking record
- [ ] Перевірити що `POST /chat/plan` записує cost_tracking з toolName `chat_plan`
- [ ] Перевірити що VoyageAI cost входить у total_cost_usd після `completeTrackingRecord`
- [ ] Перевірити що Anthropic calls пишуться в `monthly_api_usage`
- [ ] Перевірити що SSE proxy до RADA/OpenReyestr записує cost із стріму
- [ ] TypeScript build проходить без помилок (✅ перевірено)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds missing cost tracking to batch tools, streaming tools, and chat plan, and fixes totals/monthly aggregates so billing reflects real usage. Streaming proxies now capture costs from SSE to ensure accurate charges.

- **Bug Fixes**
  - Include VoyageAI in `total_cost_usd`; remove direct total writes in Voyage calls to prevent double counting.
  - Write Anthropic usage into `monthly_api_usage` aggregates.
  - Parse `complete` SSE events in remote proxies (RADA/OpenReyestr) and record extracted costs.

- **New Features**
  - Cost tracking for `POST /tools/batch`: each call creates/completes its own record and returns `cost_tracking` with `request_id` and `actual_cost`.
  - Cost tracking for `POST /tools/:toolName/stream`: wraps the stream with create/complete; propagates `requestId` via `requestContext`.
  - Cost tracking for `POST /chat/plan` as tool `chat_plan`.
  - Add VoyageAI section to `CostBreakdown` (tokens, cost, calls).

<sup>Written for commit f9e002baf3ca1a13bdbd71ee01978731ee9f1fbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

