### PR TITLE
fix: prod safety guard — skip when nginx-prod absent

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -476,11 +476,14 @@ jobs:
 
           # Verify prod was not affected by local deploy
           PROD_NGINX_NOW=$(docker inspect --format='{{.State.Status}}' nginx-prod 2>/dev/null || echo "absent")
-          PROD_NGINX_STARTED=$(docker inspect --format='{{.State.StartedAt}}' nginx-prod 2>/dev/null || echo none)
-          if [ "$PROD_NGINX_NOW" != "running" ]; then
-            echo "::error::CRITICAL: prod nginx is $PROD_NGINX_NOW after local deploy!"
+          PROD_NGINX_STARTED=$(docker inspect --format='{{.State.StartedAt}}' nginx-prod 2>/dev/null || echo "none")
+          if [ "$PROD_NGINX_BEFORE" = "none" ] || [ "$PROD_NGINX_BEFORE" = "" ]; then
+            # Prod nginx wasn't running before deploy — nothing to protect
+            echo "✓ Prod nginx not present on this runner — skipping safety check"
+          elif [ "$PROD_NGINX_NOW" != "running" ]; then
+            echo "::error::CRITICAL: prod nginx was running before deploy but is now $PROD_NGINX_NOW!"
             FAILED=true
-          elif [ "$PROD_NGINX_STARTED" != "$PROD_NGINX_BEFORE" ] && [ "$PROD_NGINX_BEFORE" != "none" ]; then
+          elif [ "$PROD_NGINX_STARTED" != "$PROD_NGINX_BEFORE" ]; then
             echo "::warning::Prod nginx was restarted during local deploy (was: $PROD_NGINX_BEFORE, now: $PROD_NGINX_STARTED)"
           else
             echo "✓ Prod nginx untouched"


### PR DESCRIPTION
## Summary
- Prod safety guard in `ci-local-deploy.yml` incorrectly fails with CRITICAL when `nginx-prod` container doesn't exist on the runner
- When `PROD_NGINX_BEFORE=none` (container was already absent), skip the check entirely instead of treating it as a failure
- Fixes the false-positive failure seen in CI run #1319

## Test plan
- [ ] CI pipeline passes without false CRITICAL error
- [ ] If nginx-prod IS running, safety check still protects it (status change = error, restart = warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the prod safety guard in `ci-local-deploy.yml` when `nginx-prod` is absent, preventing false CRITICAL failures on runners without the container. Normal protection remains when prod is present.

- **Bug Fixes**
  - If `PROD_NGINX_BEFORE` is `none` or empty, skip the check; otherwise still error if status changes and warn on restart.

<sup>Written for commit 50a06815aeceef1fa1e31a07e2e65ac4a1183580. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

