### PR TITLE
fix: executive_power — uppercase/lowercase key mismatch

### DIFF
--- a/mcp_openreyestr/src/services/database-importer.ts
+++ b/mcp_openreyestr/src/services/database-importer.ts
@@ -358,10 +358,14 @@ export class DatabaseImporter {
     }
 
     if (entity.executive_power) {
-      await client.query(
-        'INSERT INTO executive_power (entity_record, name, code) VALUES ($1, $2, $3)',
-        [entity.record, entity.executive_power.name, entity.executive_power.code]
-      );
+      const epName = entity.executive_power.NAME || entity.executive_power.name;
+      const epCode = entity.executive_power.CODE || entity.executive_power.code;
+      if (epName || epCode) {
+        await client.query(
+          'INSERT INTO executive_power (entity_record, name, code) VALUES ($1, $2, $3)',
+          [entity.record, epName, epCode]
+        );
+      }
     }
 
     if (entity.termination_started) {

--- a/mcp_openreyestr/src/services/streaming-xml-parser.ts
+++ b/mcp_openreyestr/src/services/streaming-xml-parser.ts
@@ -265,7 +265,10 @@ export class StreamingXMLParser {
       termination_cancel_info: subject.TERMINATION_CANCEL_INFO,
     };
 
-    if (subject.EXECUTIVE_POWER) entity.executive_power = subject.EXECUTIVE_POWER;
+    if (subject.EXECUTIVE_POWER) {
+      const ep = subject.EXECUTIVE_POWER;
+      entity.executive_power = { name: ep.NAME || ep.name, code: ep.CODE || ep.code };
+    }
     if (subject.FOUNDERS?.FOUNDER) entity.founders = subject.FOUNDERS.FOUNDER;
     if (subject.BENEFICIARIES?.BENEFICIARY) entity.beneficiaries = subject.BENEFICIARIES.BENEFICIARY;
     if (subject.SIGNERS?.SIGNER) entity.signers = subject.SIGNERS.SIGNER;


### PR DESCRIPTION
## Summary
- XML-парсер зберігав ключі EXECUTIVE_POWER як `NAME`/`CODE` (uppercase з XML тегів), а database-importer читав `.name`/`.code` (lowercase) → всі 19,623 записів на проді порожні
- Нормалізовано ключі до lowercase в `streaming-xml-parser.ts`
- Додано fallback uppercase→lowercase в `database-importer.ts` + skip порожніх записів

## Test plan
- [ ] Переімпортувати ЄДР XML і перевірити, що executive_power має заповнені name/code
- [ ] Перевірити browse-data.py — записи повинні показувати реальні дані

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty `executive_power` name/code by resolving an XML key casing mismatch. Keys are normalized during parsing, with a fallback in the importer to handle existing data safely.

- **Bug Fixes**
  - Map `EXECUTIVE_POWER.NAME/CODE` to `name`/`code` in the XML parser.
  - Add uppercase→lowercase fallback in the database importer.
  - Skip inserts when both name and code are missing to prevent empty rows.

- **Migration**
  - Re-import the EDR XML to backfill `executive_power` name/code.
  - Verify records via your data browsing script.

<sup>Written for commit e9a06e1d21629fa16cd1d88e4f5e196d2aae918e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

