### PR TITLE
fix: postgres-prod cpus 12→6 (сервер має 8 CPU)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -45,10 +45,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "12"
-          memory: 48G
+          cpus: "6"
+          memory: 12G
         reservations:
-          memory: 16G
+          memory: 4G
 
   pgbouncer-prod:
     image: edoburu/pgbouncer:latest


### PR DESCRIPTION
## Summary
- Deploy падав: `range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available`
- postgres-prod мав `cpus: "12"` та `memory: 48G` — більше ніж є на сервері
- Змінено на `cpus: "6"`, `memory: 12G`, `reservations.memory: 4G`

## Test plan
- [ ] CI/CD deploy повинен пройти успішно після мержу

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced `postgres-prod` CPU and memory limits to match the 8‑CPU host, fixing the deployment failure caused by over-allocation.

- **Bug Fixes**
  - Set `postgres-prod` limits to `cpus: "6"` and `memory: 12G`; reservations to `memory: 4G`.
  - Resolves error: "range of CPUs is from 0.01 to 8.00, as there are only 8 CPUs available".

<sup>Written for commit dd46d50939361e5581a569d7c938db797e043f05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

