### PR TITLE
fix: qdrant healthcheck timeout — deploy падає двічі

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -159,8 +159,8 @@ services:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/6333'"]
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 15s
+      retries: 10
+      start_period: 60s
     restart: unless-stopped
     networks:
     - secondlayer-prod-network
@@ -171,7 +171,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 2G
+          memory: 4G
         reservations:
           memory: 1G
 


### PR DESCRIPTION
## Summary
- Deploy падав двічі: `container secondlayer-qdrant-prod is unhealthy`
- Qdrant відновлює колекції ~12с, але `start_period` був лише 15с — при рекреації контейнера не вистачає часу
- `start_period`: 15s → 60s
- `retries`: 5 → 10
- `memory limit`: 2G → 4G (колекції ростуть)

## Test plan
- [ ] Deploy повинен пройти без помилок Qdrant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Qdrant healthcheck flakiness that caused deploys to fail as “unhealthy” during startup. Gives Qdrant more time and memory so deploys complete reliably.

- **Bug Fixes**
  - Healthcheck `start_period`: 15s → 60s to allow collection restore.
  - Healthcheck `retries`: 5 → 10 for slower startups.
  - Memory limit: 2G → 4G to support growing collections.

<sup>Written for commit f1b0c9f82b5f88236fdff01cdeb9941b7591679f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

