### PR TITLE
fix: KMU news article timeout (networkidle→domcontentloaded)

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -799,7 +799,7 @@ class HTTPMCPServer {
             }
           });
 
-          await page.goto(KMU_RSS_URL, { waitUntil: 'networkidle', timeout: 30000 });
+          await page.goto(KMU_RSS_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
           await context.close();
 
           if (!rawXml || (!rawXml.includes('<rss') && !rawXml.includes('<channel>'))) {

--- a/mcp_backend/src/services/news-article-service.ts
+++ b/mcp_backend/src/services/news-article-service.ts
@@ -109,7 +109,7 @@ export class NewsArticleService {
       });
       const page = await context.newPage();
 
-      await page.goto(url, { waitUntil: 'networkidle', timeout: 30000 });
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30000 });
       const html = await page.content();
       await context.close();
 


### PR DESCRIPTION
## Summary
- Playwright timed out (30s) scraping kmu.gov.ua articles — heavy tracking scripts prevent `networkidle` from resolving
- Changed `waitUntil` from `networkidle` to `domcontentloaded` in both article scraper and RSS proxy
- Article HTML is in the initial DOM, no need to wait for all network requests

## Test plan
- [ ] Open https://legal.org.ua/news and click any article — should load without error
- [ ] Verify RSS feed loads on the news page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched KMU news article and RSS scraping from waiting on network idle to DOMContentLoaded to stop 30s Playwright timeouts. Pages now load reliably since the article HTML is present in the initial DOM.

- **Bug Fixes**
  - Changed `waitUntil` to `domcontentloaded` in `mcp_backend/src/services/news-article-service.ts` and `mcp_backend/src/http-server.ts`.
  - Avoids hangs caused by tracking scripts preventing `networkidle` from resolving.

<sup>Written for commit 37da9440e78b98d26dee727a90f8114799130cff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

