### PR TITLE
fix: EDRSR cron sync OOM — ON CONFLICT замість LEFT JOIN

### DIFF
--- a/scripts/edrsr/sync-edrsr-incremental.sh
+++ b/scripts/edrsr/sync-edrsr-incremental.sh
@@ -68,9 +68,8 @@ CREATE TEMP TABLE edrsr_import (LIKE edrsr_documents INCLUDING DEFAULTS);
 COPY edrsr_import(doc_id, court_code, judgment_code, justice_kind, category_code, cause_num, adjudication_date, receipt_date, judge, doc_url, status, date_publ)
   FROM '/tmp/import.csv' WITH (FORMAT csv, DELIMITER E'\t', QUOTE '"', NULL '');
 INSERT INTO edrsr_documents
-  SELECT i.* FROM edrsr_import i
-  LEFT JOIN edrsr_documents d ON d.doc_id = i.doc_id AND d.adjudication_date = i.adjudication_date
-  WHERE d.doc_id IS NULL;
+  SELECT * FROM edrsr_import
+  ON CONFLICT (doc_id) DO NOTHING;
 DROP TABLE edrsr_import;
 SQLEOF
     ssh -T "$SSH_HOST" "docker cp ${sql_file} secondlayer-postgres-prod:/tmp/import.sql && rm -f ${sql_file}"


### PR DESCRIPTION
## Summary
- Cron `sync-edrsr-incremental.sh` падав з OOM kill на проді (exit code 2)
- Причина: `LEFT JOIN edrsr_import (2M rows) × edrsr_documents (125M rows)` — потребував більше RAM ніж ліміт контейнера
- Фікс: замінено на `INSERT ... ON CONFLICT (doc_id) DO NOTHING` — та ж логіка, без join
- Також збільшено ліміт RAM postgres контейнера з 12G → 24G (shared_buffers=16G не поміщався)

## Test plan
- [ ] Дочекатись наступного cron run о 04:00 або запустити вручну
- [ ] Перевірити що postgres не падає з OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the heavy LEFT JOIN in the EDRSR incremental sync with INSERT ... ON CONFLICT to skip duplicates and prevent Postgres OOM during cron runs.

- **Bug Fixes**
  - Use `INSERT ... ON CONFLICT (doc_id) DO NOTHING` in `scripts/edrsr/sync-edrsr-incremental.sh`.
  - Avoids joining a 2M temp table with a 125M table, reducing memory use and stabilizing the cron.

<sup>Written for commit 6de09e0c0f7f2d48cea033f088f623f4f218abba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

