### PR TITLE
feat: E2EE auto-encrypt documents & chat after one-time key setup

### DIFF
--- a/lexwebapp/src/App.tsx
+++ b/lexwebapp/src/App.tsx
@@ -5,6 +5,7 @@ import { AuthProvider } from './contexts/AuthContext';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { CookieConsent } from './components/CookieConsent';
 import { GeoDetector } from './components/GeoDetector';
+import { EncryptionGuard } from './components/encryption/EncryptionGuard';
 import { router } from './router';
 
 export function App() {
@@ -13,6 +14,7 @@ export function App() {
       <QueryProvider>
         <AuthProvider>
           <GeoDetector />
+          <EncryptionGuard />
           <RouterProvider router={router} />
           <CookieConsent />
         <Toaster

--- a/lexwebapp/src/components/encryption/EncryptionGuard.tsx
+++ b/lexwebapp/src/components/encryption/EncryptionGuard.tsx
@@ -1,0 +1,91 @@
+/**
+ * EncryptionGuard
+ * Auto-checks encryption status after authentication and prompts setup/unlock.
+ * Placed inside AuthProvider so it has access to auth state.
+ *
+ * Flow:
+ * 1. User logs in → checkStatus() called
+ * 2. If no encryption → show setup dialog
+ * 3. If has encryption but locked → try sessionStorage restore first, then show unlock dialog
+ * 4. After unlock → private key persisted in sessionStorage for page-refresh recovery
+ */
+
+import { useEffect, useState } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useEncryptionStore } from '../../stores/encryptionStore';
+import { EncryptionSetupDialog } from './EncryptionSetupDialog';
+
+export function EncryptionGuard() {
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const {
+    hasEncryption,
+    isUnlocked,
+    statusChecked,
+    checkStatus,
+    trySessionRestore,
+  } = useEncryptionStore();
+
+  const [showDialog, setShowDialog] = useState(false);
+  const [dialogMode, setDialogMode] = useState<'setup' | 'unlock'>('setup');
+  // Track if user explicitly dismissed the dialog (don't re-show until next session)
+  const [dismissed, setDismissed] = useState(false);
+
+  // Step 1: After auth is ready, check encryption status + try session restore
+  useEffect(() => {
+    if (authLoading || !isAuthenticated) return;
+
+    const init = async () => {
+      // Try session restore first (instant, no password needed)
+      const restored = await trySessionRestore();
+      if (restored) return;
+
+      // If session restore failed, check server status
+      await checkStatus();
+    };
+
+    init();
+  }, [isAuthenticated, authLoading, checkStatus, trySessionRestore]);
+
+  // Step 2: After status check, decide whether to show dialog
+  useEffect(() => {
+    if (!isAuthenticated || !statusChecked || isUnlocked || dismissed) return;
+
+    if (!hasEncryption) {
+      // New user — prompt to set up encryption
+      setDialogMode('setup');
+      setShowDialog(true);
+    } else {
+      // Returning user with locked keys — prompt to unlock
+      setDialogMode('unlock');
+      setShowDialog(true);
+    }
+  }, [isAuthenticated, statusChecked, hasEncryption, isUnlocked, dismissed]);
+
+  // Auto-hide dialog when unlocked (e.g. after successful setup/unlock)
+  useEffect(() => {
+    if (isUnlocked && showDialog) {
+      setShowDialog(false);
+    }
+  }, [isUnlocked, showDialog]);
+
+  // Reset dismissed state on logout
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setDismissed(false);
+      setShowDialog(false);
+    }
+  }, [isAuthenticated]);
+
+  const handleClose = () => {
+    setDismissed(true);
+    setShowDialog(false);
+  };
+
+  return (
+    <EncryptionSetupDialog
+      isOpen={showDialog}
+      onClose={handleClose}
+      mode={dialogMode}
+    />
+  );
+}

--- a/lexwebapp/src/contexts/AuthContext.tsx
+++ b/lexwebapp/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import { authService } from '../services';
 import { User } from '../types/models';
 import showToast from '../utils/toast';
 import { toastT, toastTDynamic } from '../i18n/toast-i18n';
+import { useEncryptionStore } from '../stores/encryptionStore';
 
 interface AuthContextType {
   user: User | null;
@@ -117,6 +118,9 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     // Clear local storage
     localStorage.removeItem('auth_token');
     localStorage.removeItem('user');
+
+    // Clear encryption state + sessionStorage
+    useEncryptionStore.getState().reset();
 
     // Clear state
     setToken(null);

--- a/lexwebapp/src/services/api/ConversationService.ts
+++ b/lexwebapp/src/services/api/ConversationService.ts
@@ -65,6 +65,7 @@ export interface ConversationMessage {
   citations?: ConversationCitation[];
   tool_calls?: ConversationToolCall[];
   cost_tracking_id?: string;
+  is_encrypted?: boolean;
   created_at: string;
 }
 
@@ -108,12 +109,30 @@ export class ConversationService extends BaseService {
       tool_calls?: ConversationToolCall[];
       cost_tracking_id?: string;
       cost_summary?: ConversationCostSummary;
+      is_encrypted?: boolean;
     }
   ): Promise<ConversationMessage> {
     return this.request(() => this.client.post<ConversationMessage>(
       `/api/conversations/${conversationId}/messages`,
       message
     ));
+  }
+
+  async saveConversationKey(conversationId: string, encryptedDek: string): Promise<void> {
+    return this.requestVoid(() =>
+      this.client.post(`/api/conversations/${conversationId}/encryption-key`, { encrypted_dek: encryptedDek })
+    );
+  }
+
+  async getConversationKey(conversationId: string): Promise<string | null> {
+    try {
+      const result = await this.request(() =>
+        this.client.get<{ encrypted_dek: string }>(`/api/conversations/${conversationId}/encryption-key`)
+      );
+      return result.encrypted_dek;
+    } catch {
+      return null;
+    }
   }
 
 }

--- a/lexwebapp/src/services/api/EncryptionService.ts
+++ b/lexwebapp/src/services/api/EncryptionService.ts
@@ -23,6 +23,7 @@ export interface PublicKeyResponse {
 
 export interface MyKeyResponse {
   encrypted_private_key: string;
+  public_key: string;
   kdf_algorithm: string;
   kdf_params: Record<string, unknown>;
   key_version: number;

--- a/lexwebapp/src/services/crypto/ChatEncryptor.ts
+++ b/lexwebapp/src/services/crypto/ChatEncryptor.ts
@@ -1,0 +1,84 @@
+/**
+ * ChatEncryptor — Encryption at rest for AI chat conversations.
+ *
+ * Each conversation gets its own DEK (Data Encryption Key).
+ * Messages are encrypted client-side before syncing to server.
+ * DEK is wrapped with user's X25519 public key and stored on server.
+ *
+ * Unlike consultation E2EE, this is encryption at rest — the server
+ * sees plaintext during AI processing but stored copies are encrypted.
+ */
+
+import { generateDEK, encryptContent, decryptContent } from './DocumentEncryptor';
+import { wrapDEK, unwrapDEK } from './KeyExchange';
+import { conversationService } from '../api/ConversationService';
+
+// In-memory cache of conversation DEKs (cleared on logout/lock)
+const dekCache = new Map<string, Uint8Array>();
+
+/**
+ * Get or create a DEK for a conversation.
+ * On first call for a conversation, generates a new DEK, wraps it, and stores on server.
+ * On subsequent calls, returns from cache or fetches wrapped DEK from server.
+ */
+export async function getConversationDEK(
+  conversationId: string,
+  publicKey: Uint8Array,
+  privateKey: Uint8Array,
+): Promise<Uint8Array> {
+  // Check cache first
+  const cached = dekCache.get(conversationId);
+  if (cached) return cached;
+
+  // Try to fetch from server
+  const wrappedDek = await conversationService.getConversationKey(conversationId);
+  if (wrappedDek) {
+    const dek = await unwrapDEK(wrappedDek, privateKey);
+    dekCache.set(conversationId, dek);
+    return dek;
+  }
+
+  // Generate new DEK for this conversation
+  const dek = generateDEK();
+  const wrapped = await wrapDEK(dek, publicKey);
+  await conversationService.saveConversationKey(conversationId, wrapped);
+  dekCache.set(conversationId, dek);
+  return dek;
+}
+
+/**
+ * Encrypt a message content for storage.
+ */
+export async function encryptChatMessage(
+  content: string,
+  conversationId: string,
+  publicKey: Uint8Array,
+  privateKey: Uint8Array,
+): Promise<string> {
+  const dek = await getConversationDEK(conversationId, publicKey, privateKey);
+  return encryptContent(content, dek);
+}
+
+/**
+ * Decrypt a message content from storage.
+ */
+export async function decryptChatMessage(
+  encryptedContent: string,
+  conversationId: string,
+  publicKey: Uint8Array,
+  privateKey: Uint8Array,
+): Promise<string> {
+  const dek = await getConversationDEK(conversationId, publicKey, privateKey);
+  return decryptContent(encryptedContent, dek);
+}
+
+/**
+ * Clear all cached DEKs (call on logout/lock).
+ */
+export function clearChatDEKCache() {
+  // Zero out DEKs before clearing
+  for (const dek of dekCache.values()) {
+    dek.fill(0);
+  }
+  dekCache.clear();
+}

--- a/lexwebapp/src/services/crypto/index.ts
+++ b/lexwebapp/src/services/crypto/index.ts
@@ -77,3 +77,10 @@ export {
   generateSafetyNumber,
   generateShortSafetyCode,
 } from './CallVerification';
+
+export {
+  encryptChatMessage,
+  decryptChatMessage,
+  clearChatDEKCache,
+  getConversationDEK,
+} from './ChatEncryptor';

--- a/lexwebapp/src/stores/chatStore.ts
+++ b/lexwebapp/src/stores/chatStore.ts
@@ -8,6 +8,8 @@ import { devtools, persist } from 'zustand/middleware';
 import { Message, ThinkingStep, ExecutionPlan } from '../types/models';
 import { api } from '../utils/api-client';
 import type { ConversationThinkingStep } from '../services/api/ConversationService';
+import { useEncryptionStore } from './encryptionStore';
+import { encryptChatMessage, decryptChatMessage, decodeBase64 } from '../services/crypto';
 
 interface ConversationSummary {
   id: string;
@@ -258,25 +260,51 @@ export const useChatStore = create<ChatState>()(
             // User may have switched again while we were fetching — bail out
             if (get().conversationId !== conversationId) return;
             const data = response.data;
-            const fetchedMessages: Message[] = (data.messages || []).map((m: { id: string; role: 'user' | 'assistant'; content: string; thinking_steps?: ConversationThinkingStep[]; decisions?: Message['decisions']; citations?: Message['citations']; documents?: Message['documents']; cost_summary?: Message['costSummary'] }) => ({
-              id: m.id,
-              role: m.role,
-              content: m.content,
-              thinkingSteps: Array.isArray(m.thinking_steps)
-                ? m.thinking_steps.map((s: ConversationThinkingStep, i: number) => ({
-                    id: `step-${i}`,
-                    title: `✓ ${s.tool || 'tool'}`,
-                    content: typeof s.result === 'string'
-                      ? s.result
-                      : (JSON.stringify(s.result ?? '', null, 2) || ''),
-                    isComplete: true,
-                  }))
-                : undefined,
-              decisions: m.decisions,
-              citations: m.citations,
-              documents: m.documents,
-              costSummary: m.cost_summary ?? undefined,
-            }));
+
+            // Decrypt encrypted messages if E2EE is unlocked
+            const encState = useEncryptionStore.getState();
+            const canDecrypt = encState.isUnlocked && encState.privateKey && encState.publicKey;
+
+            const fetchedMessages: Message[] = await Promise.all(
+              (data.messages || []).map(async (m: { id: string; role: 'user' | 'assistant'; content: string; is_encrypted?: boolean; thinking_steps?: ConversationThinkingStep[]; decisions?: Message['decisions']; citations?: Message['citations']; documents?: Message['documents']; cost_summary?: Message['costSummary'] }) => {
+                let content = m.content;
+                if (m.is_encrypted && canDecrypt) {
+                  try {
+                    const pubKeyBytes = decodeBase64(encState.publicKey!);
+                    content = await decryptChatMessage(
+                      m.content,
+                      conversationId,
+                      pubKeyBytes,
+                      encState.privateKey!,
+                    );
+                  } catch {
+                    content = '[Зашифроване повідомлення — не вдалося розшифрувати]';
+                  }
+                } else if (m.is_encrypted && !canDecrypt) {
+                  content = '[Зашифроване повідомлення — розблокуйте шифрування]';
+                }
+
+                return {
+                  id: m.id,
+                  role: m.role,
+                  content,
+                  thinkingSteps: Array.isArray(m.thinking_steps)
+                    ? m.thinking_steps.map((s: ConversationThinkingStep, i: number) => ({
+                        id: `step-${i}`,
+                        title: `\u2713 ${s.tool || 'tool'}`,
+                        content: typeof s.result === 'string'
+                          ? s.result
+                          : (JSON.stringify(s.result ?? '', null, 2) || ''),
+                        isComplete: true,
+                      }))
+                    : undefined,
+                  decisions: m.decisions,
+                  citations: m.citations,
+                  documents: m.documents,
+                  costSummary: m.cost_summary ?? undefined,
+                };
+              })
+            );
             set((state) => ({
               messages: fetchedMessages,
               conversationCache: { ...state.conversationCache, [conversationId]: fetchedMessages },
@@ -344,25 +372,49 @@ export const useChatStore = create<ChatState>()(
           });
         },
 
-        // Sync message to server (fire-and-forget)
+        // Sync message to server (fire-and-forget, encrypts if E2EE is unlocked)
         syncMessage: (message: Message) => {
           if (!isAuthenticated()) return;
           const { conversationId } = get();
           if (!conversationId) return;
 
-          api.conversations
-            .addMessage(conversationId, {
+          const encState = useEncryptionStore.getState();
+          const shouldEncrypt = encState.isUnlocked && encState.privateKey && encState.publicKey;
+
+          const doSync = async () => {
+            let content = message.content;
+            let isEncrypted = false;
+
+            if (shouldEncrypt && content) {
+              try {
+                const pubKeyBytes = decodeBase64(encState.publicKey!);
+                content = await encryptChatMessage(
+                  content,
+                  conversationId,
+                  pubKeyBytes,
+                  encState.privateKey!,
+                );
+                isEncrypted = true;
+              } catch (err) {
+                console.error('[ChatStore] Message encryption failed, syncing plaintext:', err);
+              }
+            }
+
+            await api.conversations.addMessage(conversationId, {
               role: message.role,
-              content: message.content,
+              content,
               thinking_steps: message.thinkingSteps?.map(s => ({ tool: s.title, result: s.content })),
               decisions: message.decisions,
               citations: message.citations,
               documents: message.documents,
               cost_summary: message.costSummary,
-            })
-            .catch(() => {
-              // Silent fail - localStorage backup remains
+              is_encrypted: isEncrypted,
             });
+          };
+
+          doSync().catch(() => {
+            // Silent fail - localStorage backup remains
+          });
         },
 
       }),

--- a/lexwebapp/src/stores/encryptionStore.ts
+++ b/lexwebapp/src/stores/encryptionStore.ts
@@ -12,9 +12,75 @@ import {
   unlockPrivateKey,
   exportKeyFile,
   clearAllConsultationKeys,
+  clearChatDEKCache,
+  encodeBase64,
+  decodeBase64,
   type EncryptedKeyBundle,
   type KdfParams,
 } from '../services/crypto';
+
+// --- Session persistence helpers ---
+// After unlock, we store the private key encrypted with a random session key
+// in sessionStorage so page refresh doesn't require password re-entry.
+// sessionStorage is cleared when the tab/browser closes.
+
+const SESSION_KEY_NAME = 'e2ee_session_key';
+const SESSION_PK_NAME = 'e2ee_session_pk';
+const SESSION_PUB_NAME = 'e2ee_session_pub';
+
+async function encryptForSession(privateKey: Uint8Array): Promise<{ sessionKey: string; encryptedPk: string }> {
+  const sk = crypto.getRandomValues(new Uint8Array(32));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const cryptoKey = await crypto.subtle.importKey('raw', sk.buffer as ArrayBuffer, 'AES-GCM', false, ['encrypt']);
+  const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, cryptoKey, privateKey.buffer as ArrayBuffer);
+  // Store iv + ciphertext together
+  const combined = new Uint8Array(12 + ct.byteLength);
+  combined.set(iv, 0);
+  combined.set(new Uint8Array(ct), 12);
+  return { sessionKey: encodeBase64(sk), encryptedPk: encodeBase64(combined) };
+}
+
+async function decryptFromSession(sessionKey: string, encryptedPk: string): Promise<Uint8Array> {
+  const sk = decodeBase64(sessionKey);
+  const combined = decodeBase64(encryptedPk);
+  const iv = combined.slice(0, 12);
+  const ct = combined.slice(12);
+  const cryptoKey = await crypto.subtle.importKey('raw', sk.buffer as ArrayBuffer, 'AES-GCM', false, ['decrypt']);
+  const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, cryptoKey, ct.buffer as ArrayBuffer);
+  return new Uint8Array(pt);
+}
+
+function saveToSession(sessionKey: string, encryptedPk: string, publicKey: string) {
+  try {
+    sessionStorage.setItem(SESSION_KEY_NAME, sessionKey);
+    sessionStorage.setItem(SESSION_PK_NAME, encryptedPk);
+    sessionStorage.setItem(SESSION_PUB_NAME, publicKey);
+  } catch {
+    // sessionStorage may be unavailable (private mode in some browsers)
+  }
+}
+
+function clearSession() {
+  try {
+    sessionStorage.removeItem(SESSION_KEY_NAME);
+    sessionStorage.removeItem(SESSION_PK_NAME);
+    sessionStorage.removeItem(SESSION_PUB_NAME);
+  } catch {
+    // Ignore
+  }
+}
+
+function getSessionData(): { sessionKey: string; encryptedPk: string; publicKey: string } | null {
+  try {
+    const sessionKey = sessionStorage.getItem(SESSION_KEY_NAME);
+    const encryptedPk = sessionStorage.getItem(SESSION_PK_NAME);
+    const publicKey = sessionStorage.getItem(SESSION_PUB_NAME);
+    if (sessionKey && encryptedPk && publicKey) return { sessionKey, encryptedPk, publicKey };
+  } catch {
+    // Ignore
+  }
+  return null;
+}
 
 interface EncryptionState {
   /** Whether the user has encryption keys set up on the server */
@@ -29,8 +95,12 @@ interface EncryptionState {
   isLoading: boolean;
   /** Error message from last operation */
   error: string | null;
+  /** Whether status check has been performed */
+  statusChecked: boolean;
   // Actions
   checkStatus: () => Promise<void>;
+  /** Try to restore private key from sessionStorage (no password needed) */
+  trySessionRestore: () => Promise<boolean>;
   setup: (password: string) => Promise<EncryptedKeyBundle>;
   unlock: (password: string) => Promise<void>;
   lock: () => void;
@@ -46,6 +116,7 @@ export const useEncryptionStore = create<EncryptionState>()(
       publicKey: null,
       isLoading: false,
       error: null,
+      statusChecked: false,
 
       /**
        * Check if the current user has encryption set up.
@@ -53,9 +124,32 @@ export const useEncryptionStore = create<EncryptionState>()(
       checkStatus: async () => {
         try {
           const { has_encryption } = await encryptionService.getStatus();
-          set({ hasEncryption: has_encryption });
+          set({ hasEncryption: has_encryption, statusChecked: true });
         } catch {
           // Silently fail — user may not be authenticated yet
+          set({ statusChecked: true });
+        }
+      },
+
+      /**
+       * Try to restore private key from sessionStorage (after page refresh).
+       * Returns true if restoration succeeded.
+       */
+      trySessionRestore: async () => {
+        const data = getSessionData();
+        if (!data) return false;
+        try {
+          const privateKey = await decryptFromSession(data.sessionKey, data.encryptedPk);
+          set({
+            isUnlocked: true,
+            privateKey,
+            publicKey: data.publicKey,
+            hasEncryption: true,
+          });
+          return true;
+        } catch {
+          clearSession();
+          return false;
         }
       },
 
@@ -93,6 +187,11 @@ export const useEncryptionStore = create<EncryptionState>()(
             isLoading: false,
           });
 
+          // Persist to sessionStorage for page-refresh recovery
+          encryptForSession(pk).then(({ sessionKey, encryptedPk }) => {
+            saveToSession(sessionKey, encryptedPk, bundle.publicKey);
+          }).catch(() => {});
+
           return bundle;
         } catch (error: any) {
           set({
@@ -117,15 +216,22 @@ export const useEncryptionStore = create<EncryptionState>()(
             myKey.kdf_algorithm,
           );
 
-          // Also fetch public key
-          const status = await encryptionService.getStatus();
+          const pubKey = myKey.public_key || null;
 
           set({
             isUnlocked: true,
             privateKey,
-            hasEncryption: status.has_encryption,
+            publicKey: pubKey,
+            hasEncryption: true,
             isLoading: false,
           });
+
+          // Persist to sessionStorage for page-refresh recovery
+          if (pubKey) {
+            encryptForSession(privateKey).then(({ sessionKey, encryptedPk }) => {
+              saveToSession(sessionKey, encryptedPk, pubKey);
+            }).catch(() => {});
+          }
         } catch (error: any) {
           set({
             isLoading: false,
@@ -145,6 +251,8 @@ export const useEncryptionStore = create<EncryptionState>()(
           privateKey.fill(0);
         }
         clearAllConsultationKeys();
+        clearChatDEKCache();
+        clearSession();
         set({
           isUnlocked: false,
           privateKey: null,
@@ -158,6 +266,8 @@ export const useEncryptionStore = create<EncryptionState>()(
         const { privateKey } = get();
         if (privateKey) privateKey.fill(0);
         clearAllConsultationKeys();
+        clearChatDEKCache();
+        clearSession();
         set({
           hasEncryption: false,
           isUnlocked: false,
@@ -165,6 +275,7 @@ export const useEncryptionStore = create<EncryptionState>()(
           publicKey: null,
           isLoading: false,
           error: null,
+          statusChecked: false,
         });
       },
     }),

--- a/lexwebapp/src/utils/api/conversations.ts
+++ b/lexwebapp/src/utils/api/conversations.ts
@@ -23,5 +23,10 @@ export const conversationsApi = {
     citations?: ConversationCitation[];
     documents?: ConversationDocument[];
     cost_summary?: ConversationCostSummary;
+    is_encrypted?: boolean;
   }) => apiClient.post(`/api/conversations/${conversationId}/messages`, message),
+  saveConversationKey: (conversationId: string, encryptedDek: string) =>
+    apiClient.post(`/api/conversations/${conversationId}/encryption-key`, { encrypted_dek: encryptedDek }),
+  getConversationKey: (conversationId: string) =>
+    apiClient.get(`/api/conversations/${conversationId}/encryption-key`),
 };

--- a/mcp_backend/src/migrations/121_conversation_encryption.sql
+++ b/mcp_backend/src/migrations/121_conversation_encryption.sql
@@ -1,0 +1,20 @@
+-- Migration 121: Encryption at rest for conversation messages
+-- Each conversation gets a DEK (Data Encryption Key) wrapped with the user's public key.
+-- Message content is encrypted client-side before sync, decrypted on load.
+
+-- Conversation-level encryption keys
+CREATE TABLE IF NOT EXISTS conversation_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  encrypted_dek TEXT NOT NULL,  -- ECDH-wrapped DEK (base64)
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(conversation_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_keys_conv ON conversation_keys(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_conversation_keys_user ON conversation_keys(user_id);
+
+-- Track which messages are encrypted
+ALTER TABLE conversation_messages
+  ADD COLUMN IF NOT EXISTS is_encrypted BOOLEAN DEFAULT FALSE;

--- a/mcp_backend/src/routes/conversation-routes.ts
+++ b/mcp_backend/src/routes/conversation-routes.ts
@@ -97,7 +97,7 @@ export function createConversationRouter(conversationService: ConversationServic
       const userId = req.user?.id;
       if (!userId) return res.status(401).json({ error: 'User not authenticated' });
 
-      const { role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id, cost_summary } = req.body;
+      const { role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id, cost_summary, is_encrypted } = req.body;
       if (!role || !content) return res.status(400).json({ error: 'role and content required' });
 
       const message = await conversationService.addMessage(req.params.id as string, userId, {
@@ -110,6 +110,7 @@ export function createConversationRouter(conversationService: ConversationServic
         tool_calls,
         cost_tracking_id,
         cost_summary,
+        is_encrypted,
       });
 
       if (!message) return res.status(404).json({ error: 'Conversation not found' });
@@ -133,6 +134,39 @@ export function createConversationRouter(conversationService: ConversationServic
       res.json({ messages });
     } catch (error: any) {
       logger.error('[Conversations] Get messages failed', { error: error.message });
+      res.status(500).json({ error: error.message });
+    }
+  }) as any);
+
+  // POST /:id/encryption-key - Save wrapped DEK for conversation
+  router.post('/:id/encryption-key', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const { encrypted_dek } = req.body;
+      if (!encrypted_dek) return res.status(400).json({ error: 'encrypted_dek required' });
+
+      await conversationService.saveConversationKey(req.params.id as string, userId, encrypted_dek);
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('[Conversations] Save encryption key failed', { error: error.message });
+      res.status(500).json({ error: error.message });
+    }
+  }) as any);
+
+  // GET /:id/encryption-key - Get wrapped DEK for conversation
+  router.get('/:id/encryption-key', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const encryptedDek = await conversationService.getConversationKey(req.params.id as string, userId);
+      if (!encryptedDek) return res.status(404).json({ error: 'No encryption key found' });
+
+      res.json({ encrypted_dek: encryptedDek });
+    } catch (error: any) {
+      logger.error('[Conversations] Get encryption key failed', { error: error.message });
       res.status(500).json({ error: error.message });
     }
   }) as any);

--- a/mcp_backend/src/routes/encryption-routes.ts
+++ b/mcp_backend/src/routes/encryption-routes.ts
@@ -117,6 +117,7 @@ export function createEncryptionRoutes(
 
       res.json({
         encrypted_private_key: key.encrypted_private_key,
+        public_key: key.public_key,
         kdf_algorithm: key.kdf_algorithm,
         kdf_params: key.kdf_params,
         key_version: key.key_version,

--- a/mcp_backend/src/services/conversation-service.ts
+++ b/mcp_backend/src/services/conversation-service.ts
@@ -115,6 +115,7 @@ export class ConversationService {
       tool_calls?: any[];
       cost_tracking_id?: string;
       cost_summary?: { total_cost_usd: number; tools_used: string[]; response_id?: string; charged_usd?: number; balance_usd?: number } | null;
+      is_encrypted?: boolean;
     }
   ): Promise<ConversationMessage | null> {
     // Verify ownership
@@ -124,8 +125,8 @@ export class ConversationService {
     const id = uuidv4();
     const result = await this.db.query(
       `INSERT INTO conversation_messages
-         (id, conversation_id, role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id, cost_summary)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+         (id, conversation_id, role, content, thinking_steps, decisions, citations, documents, tool_calls, cost_tracking_id, cost_summary, is_encrypted)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        RETURNING *`,
       [
         id,
@@ -139,6 +140,7 @@ export class ConversationService {
         message.tool_calls ? JSON.stringify(message.tool_calls) : null,
         message.cost_tracking_id || null,
         message.cost_summary ? JSON.stringify(message.cost_summary) : null,
+        message.is_encrypted || false,
       ]
     );
 
@@ -149,6 +151,27 @@ export class ConversationService {
     );
 
     return result.rows[0];
+  }
+
+  // --- Conversation encryption key management ---
+
+  async saveConversationKey(conversationId: string, userId: string, encryptedDek: string): Promise<void> {
+    await this.db.query(
+      `INSERT INTO conversation_keys (conversation_id, user_id, encrypted_dek)
+       VALUES ($1, $2, $3)
+       ON CONFLICT (conversation_id, user_id)
+       DO UPDATE SET encrypted_dek = EXCLUDED.encrypted_dek`,
+      [conversationId, userId, encryptedDek]
+    );
+  }
+
+  async getConversationKey(conversationId: string, userId: string): Promise<string | null> {
+    const result = await this.db.query<{ encrypted_dek: string }>(
+      `SELECT encrypted_dek FROM conversation_keys
+       WHERE conversation_id = $1 AND user_id = $2`,
+      [conversationId, userId]
+    );
+    return result.rows[0]?.encrypted_dek || null;
   }
 
   async getMessages(


### PR DESCRIPTION
## Summary
- **EncryptionGuard** — автоматична перевірка статусу шифрування після логіну: нові юзери отримують setup dialog, існуючі — unlock dialog
- **Session-based auto-unlock** — приватний ключ зберігається в sessionStorage (зашифрований випадковим session key), переживає refresh сторінки, очищується при закритті табу
- **Chat encryption at rest** — кожна розмова отримує свій DEK (AES-256-GCM), загорнутий публічним ключем користувача (X25519 ECDH-ES). Повідомлення шифруються перед sync, дешифруються при завантаженні
- **Migration 121** — таблиця `conversation_keys` + поле `is_encrypted` в `conversation_messages`
- **Backend** — endpoints для ключів розмов, `public_key` в my-key response
- **Cleanup on logout** — encryption reset через AuthContext

## Changed files
| Area | Files |
|------|-------|
| Frontend crypto | `ChatEncryptor.ts` (new), `crypto/index.ts` |
| Frontend stores | `encryptionStore.ts`, `chatStore.ts` |
| Frontend components | `EncryptionGuard.tsx` (new), `App.tsx` |
| Frontend services | `ConversationService.ts`, `EncryptionService.ts`, `conversations.ts` |
| Frontend auth | `AuthContext.tsx` |
| Backend routes | `conversation-routes.ts`, `encryption-routes.ts` |
| Backend services | `conversation-service.ts` |
| Migration | `121_conversation_encryption.sql` |

## Test plan
- [ ] Новий юзер: при логіні з'являється setup dialog, генерація ключа працює
- [ ] Існуючий юзер: при логіні з'являється unlock dialog, розблокування працює
- [ ] Refresh сторінки: ключ автоматично відновлюється без паролю
- [ ] Закриття табу: sessionStorage очищується, при відкритті знову просить пароль
- [ ] Завантаження документа: шифрується автоматично після генерації ключа
- [ ] Чат: повідомлення шифруються при sync, дешифруються при завантаженні історії
- [ ] Logout: encryption state повністю очищується
- [ ] Dismiss dialog: не показується до наступної сесії

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables automatic E2EE for documents and chat after a one-time key setup. Adds session-based auto-unlock and per-conversation chat encryption at rest with full backend support.

- **New Features**
  - EncryptionGuard prompts setup/unlock after login and restores keys from `sessionStorage`; clears on logout/tab close.
  - Chat encryption at rest: per-conversation DEK (AES-256-GCM) wrapped with user X25519 (ECDH-ES); messages encrypt before sync and decrypt on load; `is_encrypted` respected end-to-end.
  - Backend endpoints to save/get conversation encrypted DEK; `my-key` now returns `public_key`.
  - App integration: `EncryptionGuard` mounted; chat store handles encrypt/decrypt; encryption reset via `AuthContext`.

- **Migration**
  - 121: adds `conversation_keys` (unique per conversation/user) to store wrapped DEKs.
  - Adds `is_encrypted` boolean to `conversation_messages`.

<sup>Written for commit 8678d3ff32feeb78be8128048f1814d2dec39ecf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

