### PR TITLE
fix: WebView Google OAuth warning

### DIFF
--- a/lexwebapp/src/i18n/locales.ts
+++ b/lexwebapp/src/i18n/locales.ts
@@ -36,6 +36,7 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     phoneKeyMethod: 'Ключ в телефоні',
     // OAuth
     googleAuth: 'Google',
+    webviewGoogleWarning: 'Google не дозволяє вхід із вбудованого браузера. Відкрийте сайт у Safari або Chrome.',
     diiaAuth: 'Увійти через Дія.Підпис',
     ssoAuth: 'SSO',
     // Errors
@@ -176,6 +177,7 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     hardwareKeyMethod: 'Hardware Key',
     phoneKeyMethod: 'Phone Key',
     googleAuth: 'Google',
+    webviewGoogleWarning: 'Google does not allow sign-in from in-app browsers. Please open the site in Safari or Chrome.',
     diiaAuth: 'Sign in via Diia.Signature',
     ssoAuth: 'SSO',
     enterEmailPassword: 'Enter email and password',
@@ -307,6 +309,7 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     hardwareKeyMethod: 'Hardware-Schlussel',
     phoneKeyMethod: 'Telefon-Schlussel',
     googleAuth: 'Google',
+    webviewGoogleWarning: 'Google erlaubt keine Anmeldung über In-App-Browser. Bitte öffnen Sie die Seite in Safari oder Chrome.',
     diiaAuth: 'Anmelden über Diia.Signature',
     ssoAuth: 'SSO',
     enterEmailPassword: 'E-Mail und Passwort eingeben',
@@ -438,6 +441,7 @@ export const loginTranslations: Record<Locale, Record<string, string>> = {
     hardwareKeyMethod: 'Llave física',
     phoneKeyMethod: 'Llave del teléfono',
     googleAuth: 'Google',
+    webviewGoogleWarning: 'Google no permite iniciar sesión desde navegadores integrados. Abra el sitio en Safari o Chrome.',
     diiaAuth: 'Iniciar sesión vía Diia.Signature',
     ssoAuth: 'SSO',
     enterEmailPassword: 'Introduzca correo electrónico y contraseña',

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -60,6 +60,13 @@ function LanguageSwitcher() {
   );
 }
 
+function isInAppBrowser(): boolean {
+  const ua = navigator.userAgent || '';
+  return /LinkedInApp|FBAN|FBAV|Instagram|Twitter|Line\/|Snapchat|TikTok|Telegram|Viber/i.test(ua)
+    || (/(iPhone|iPod|iPad).*AppleWebKit(?!.*Safari)/i.test(ua))
+    || (/Android.*wv\b/.test(ua));
+}
+
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 const BASE_URL = API_URL.replace(/\/api$/, '');
 
@@ -402,9 +409,15 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
     }
   };
 
+  const [showWebViewWarning, setShowWebViewWarning] = useState(false);
+
   const handleGoogleAuth = () => {
     if (!isLogin && !allConsentsAccepted) {
       setError('Для реєстрації необхідно прийняти всі документи');
+      return;
+    }
+    if (isInAppBrowser()) {
+      setShowWebViewWarning(true);
       return;
     }
     setError(null);
@@ -818,6 +831,13 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
             </svg>
             {t.googleAuth}
           </button>
+
+          {showWebViewWarning && (
+            <div className="flex items-start gap-2 px-3 py-2.5 mb-2 rounded-lg bg-amber-500/10 border border-amber-500/20 text-amber-300 text-[0.78rem] leading-snug">
+              <AlertCircle className="w-4 h-4 mt-0.5 flex-shrink-0" />
+              <span>{t.webviewGoogleWarning}</span>
+            </div>
+          )}
 
           {/* Diia Auth */}
           <button


### PR DESCRIPTION
## Summary
- Detect in-app browsers (LinkedIn, Facebook, Instagram, TikTok, Telegram, etc.) via user-agent
- Show localized warning when user tries Google OAuth from WebView: "Google does not allow sign-in from in-app browsers. Please open the site in Safari or Chrome."
- Translations: UK, EN, DE, ES

## Context
Google blocks OAuth from embedded browsers with `403: disallowed_useragent`. This happens when users open legal.org.ua from LinkedIn chat or similar apps that use WebView instead of the system browser.

## Test plan
- [ ] Open legal.org.ua from LinkedIn iOS chat → tap Google → see warning
- [ ] Open legal.org.ua in Safari/Chrome → tap Google → OAuth works normally
- [ ] Verify warning renders in all 4 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects in-app browsers and shows a localized warning when users try Google sign-in from a WebView. This avoids the 403 disallowed_useragent error and guides users to open the site in Safari or Chrome.

- **Bug Fixes**
  - Detect WebViews via user agent (LinkedIn, Facebook, Instagram, TikTok, Telegram, Viber, Snapchat, Twitter; iOS/Android WebView hints).
  - Prevent Google OAuth redirect in WebViews and show a warning on the Login page.
  - Added translations for the warning: UK, EN, DE, ES.

<sup>Written for commit 2e47f508e51a2438ca77a45c58328186035509fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

