### PR TITLE
fix: decrypt encrypted vault documents on view (E2EE)

### DIFF
--- a/lexwebapp/src/hooks/useDocumentViewer.ts
+++ b/lexwebapp/src/hooks/useDocumentViewer.ts
@@ -5,6 +5,9 @@ import type { DownloadedDecision } from '../stores/decisionsSearchStore';
 import { STATUS_LABELS, DOC_TYPE_LABELS, SECTION_TYPE_LABELS } from '../components/right-panel/constants';
 import { mcpService } from '../services/api/MCPService';
 import { getErrorMessage } from '../utils/errors';
+import { useEncryptionStore } from '../stores/encryptionStore';
+import { encryptionService } from '../services/api/EncryptionService';
+import { decryptContent, unwrapDEK } from '../services/crypto';
 
 /** Parse MCP tool result wrapper to get the inner JSON payload. */
 function parseToolResult(data: any): any {
@@ -111,17 +114,61 @@ export function useDocumentViewer({ downloadedDecisions }: UseDocumentViewerOpti
     setIsViewerOpen(true);
   }, []);
 
-  const openDocumentModal = useCallback((doc: { id: string; title: string; type: string; uploadedAt?: string; metadata?: Record<string, any> }) => {
+  const openDocumentModal = useCallback(async (doc: { id: string; title: string; type: string; uploadedAt?: string; metadata?: Record<string, any> }) => {
+    const snippet = doc.metadata?.snippet || doc.metadata?.text || doc.metadata?.content || '';
     setViewerItem({
       type: 'document',
       title: doc.title,
       subtitle: doc.uploadedAt ? new Date(doc.uploadedAt).toLocaleDateString('uk-UA') : undefined,
       badge: DOC_TYPE_LABELS[doc.type] || doc.type,
       badgeVariant: 'default',
-      content: doc.metadata?.snippet || doc.metadata?.text || doc.metadata?.content || 'Немає вмісту для перегляду.',
+      content: snippet || 'Завантаження...',
       relevance: doc.metadata?.relevance != null ? Math.round(doc.metadata.relevance * 100) : undefined,
     });
     setIsViewerOpen(true);
+    setIsViewerLoading(true);
+    setViewerError(null);
+
+    try {
+      const result = await mcpService.callTool('get_document', { documentId: doc.id });
+      const parsed = parseToolResult(result);
+
+      let content = parsed?.content || parsed?.text || '';
+      if (!content && parsed?.sections && Array.isArray(parsed.sections) && parsed.sections.length > 0) {
+        content = formatSections(parsed.sections);
+      }
+
+      // Decrypt if document is encrypted
+      const isEncrypted = parsed?.is_encrypted;
+      if (isEncrypted && content) {
+        const { privateKey, isUnlocked } = useEncryptionStore.getState();
+        if (!isUnlocked || !privateKey) {
+          content = '\u{1F512} Сейф заблоковано. Розблокуйте шифрування для перегляду.';
+        } else {
+          try {
+            const keyData = await encryptionService.getDocumentKey(doc.id);
+            const dek = await unwrapDEK(keyData.encrypted_dek, privateKey);
+            content = await decryptContent(content, dek);
+          } catch {
+            content = '\u{1F512} Не вдалося розшифрувати документ. Розблокуйте сейф.';
+          }
+        }
+      }
+
+      if (content) {
+        setViewerItem(prev => prev ? { ...prev, content } : prev);
+      } else {
+        setViewerItem(prev => prev ? { ...prev, content: snippet || 'Немає вмісту для перегляду.' } : prev);
+      }
+    } catch (err: unknown) {
+      console.error('Failed to fetch vault document:', err);
+      // Fall back to snippet if available
+      if (!snippet) {
+        setViewerItem(prev => prev ? { ...prev, content: 'Не вдалося завантажити вміст документа.' } : prev);
+      }
+    } finally {
+      setIsViewerLoading(false);
+    }
   }, []);
 
   return {

--- a/lexwebapp/src/pages/DocumentsPage/useDocumentPreview.ts
+++ b/lexwebapp/src/pages/DocumentsPage/useDocumentPreview.ts
@@ -127,7 +127,18 @@ export function useDocumentPreview(options: UseDocumentPreviewOptions) {
             const parsed = result?.result?.content?.[0]?.text
               ? JSON.parse(result.result.content[0].text)
               : result?.result || result;
-            const rawContent = parsed.content || parsed.text || parsed.sections?.map((s: any) => s.content).join('\n\n') || 'Вміст недоступний';
+            let rawContent = parsed.content || parsed.text || parsed.sections?.map((s: any) => s.content).join('\n\n') || 'Вміст недоступний';
+
+            // Decrypt if document is encrypted
+            const isEncrypted = doc.is_encrypted || parsed.is_encrypted;
+            if (isEncrypted && rawContent && rawContent !== 'Вміст недоступний') {
+              try {
+                rawContent = await decryptDocumentContent(doc.id, rawContent);
+              } catch (decryptErr: any) {
+                rawContent = `\u{1F512} ${decryptErr.message || 'Не вдалося розшифрувати документ. Розблокуйте сейф.'}`;
+              }
+            }
+
             const content = processEmlContent(rawContent);
             setPreviewDoc({
               type: 'document',


### PR DESCRIPTION
## Summary
- **DocumentsPage binary preview fallback**: when `previewUrl` is null for encrypted documents (e.g. `.docx` without MinIO URL), the else block fetched content via `get_document` but displayed raw encrypted base64 text without decryption — now decrypts client-side
- **Chat evidence panel `openDocumentModal`**: clicking vault documents from chat results only showed metadata snippets — now fetches full content via `get_document`, decrypts if `is_encrypted`, and displays plaintext

## Security
Server never sees the private key — all decryption remains client-side (unwrapDEK + AES-256-GCM decrypt via Web Crypto API).

## Test plan
- [ ] Upload encrypted `.docx` document → view from Documents page → should show decrypted text
- [ ] View encrypted document from chat evidence panel → should show decrypted content
- [ ] View encrypted document with vault locked → should show lock message, not encrypted text
- [ ] View non-encrypted document → no regression, displays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes encrypted vault documents showing as raw ciphertext. Content now decrypts client-side when viewed from Documents or the chat evidence panel (E2EE).

- **Bug Fixes**
  - DocumentsPage preview fallback decrypts when `previewUrl` is missing (e.g., binary `.docx` without MinIO URL).
  - Chat evidence panel fetches full content via `get_document` and decrypts when `is_encrypted`.
  - Shows a lock message if the vault is locked and falls back to snippets on errors. Server never sees the private key.

<sup>Written for commit 15ff5be0795dcce76926b0b085b13b199634cb5e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

