### PR TITLE
fix: show E2EE badge immediately after upload encryption

### DIFF
--- a/lexwebapp/src/pages/DocumentsPage/index.tsx
+++ b/lexwebapp/src/pages/DocumentsPage/index.tsx
@@ -160,12 +160,13 @@ export function DocumentsPage() {
   });
 
   // Upload state from Zustand store
-  const { items: uploadItems, isUploading, completedFiles, recoveredSessions } = useUploadStore(
+  const { items: uploadItems, isUploading, completedFiles, recoveredSessions, encryptionDoneCounter } = useUploadStore(
     useShallow(s => ({
       items: s.items,
       isUploading: s.isUploading,
       completedFiles: s.completedFiles,
       recoveredSessions: s.recoveredSessions,
+      encryptionDoneCounter: s.encryptionDoneCounter,
     }))
   );
   const addFiles = useUploadStore(s => s.addFiles);
@@ -213,6 +214,13 @@ export function DocumentsPage() {
       loadStats();
     }
   }, [completedFiles, isUploading]);
+
+  // Reload docs when post-upload encryption finishes (E2EE badges)
+  useEffect(() => {
+    if (encryptionDoneCounter > 0) {
+      loadDocuments();
+    }
+  }, [encryptionDoneCounter]);
 
   // Navigation helpers
   const navigateToFolder = useCallback((folderPath: string) => {

--- a/lexwebapp/src/stores/uploadStore.ts
+++ b/lexwebapp/src/stores/uploadStore.ts
@@ -43,6 +43,9 @@ interface UploadState {
   recoveredSessions: RecoveredSession[];
   isRecovering: boolean;
 
+  // Bumped when post-upload encryption finishes (signals list reload)
+  encryptionDoneCounter: number;
+
   // Post-upload destination picker
   showDestinationPicker: boolean;
   pendingDocumentIds: string[];
@@ -146,6 +149,8 @@ export const useUploadStore = create<UploadState>((set) => {
             if (failed > 0) {
               showToast.error(toastTDynamic('encryptionFailed', failed));
             }
+            // Signal DocumentsPage to reload (E2EE badges now visible)
+            set(state => ({ encryptionDoneCounter: state.encryptionDoneCounter + 1 }));
           }).catch(err => {
             console.warn('[UploadStore] Post-upload encryption failed', err);
           });
@@ -177,6 +182,7 @@ export const useUploadStore = create<UploadState>((set) => {
     isThrottled: false,
     recoveredSessions: [],
     isRecovering: false,
+    encryptionDoneCounter: 0,
     showDestinationPicker: false,
     pendingDocumentIds: [],
     dismissDestinationPicker: () => set({ showDestinationPicker: false, pendingDocumentIds: [] }),


### PR DESCRIPTION
## Summary
- Post-upload encryption runs async after `isUploading` becomes false, but `loadDocuments()` fired immediately — before encryption finished
- Documents appeared without the E2EE badge until manual page refresh
- Added `encryptionDoneCounter` to uploadStore that bumps when encryption completes, triggering a second `loadDocuments()` reload

## Test plan
- [ ] Upload a document with E2EE enabled → badge should appear without page refresh
- [ ] Upload multiple documents → all badges should appear after encryption finishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delayed E2EE badge display after uploads by reloading the documents list when post-upload encryption completes. Badges now show without a manual refresh, including for multi-file uploads.

- **Bug Fixes**
  - Added `encryptionDoneCounter` in `uploadStore`, incremented when encryption finishes.
  - `DocumentsPage` watches `encryptionDoneCounter` and triggers `loadDocuments()`.
  - Prevents documents from briefly showing without the E2EE badge.

<sup>Written for commit e4cf79ab8aa3faf04bc27dd467c8b90e61ec3cd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

