### PR TITLE
fix: resolve race condition in KMU RSS proxy causing empty responses

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -789,17 +789,17 @@ class HTTPMCPServer {
           });
           const page = await context.newPage();
 
-          // Intercept the RSS response to get raw body (browser wraps XML in HTML viewer)
-          let rawXml = '';
-          page.on('response', async (resp) => {
-            if (resp.url().includes('/api/rss') && resp.status() === 200) {
-              try {
-                rawXml = await resp.text();
-              } catch { /* ignore */ }
-            }
-          });
+          // Use waitForResponse to properly await the RSS response body before closing
+          const [rssResponse] = await Promise.all([
+            page.waitForResponse(resp => resp.url().includes('/api/rss') && resp.status() === 200, { timeout: 30000 }),
+            page.goto(KMU_RSS_URL, { waitUntil: 'domcontentloaded', timeout: 30000 }),
+          ]);
 
-          await page.goto(KMU_RSS_URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+          let rawXml = '';
+          try {
+            rawXml = await rssResponse.text();
+          } catch { /* ignore */ }
+
           await context.close();
 
           if (!rawXml || (!rawXml.includes('<rss') && !rawXml.includes('<channel>'))) {


### PR DESCRIPTION
## Summary
- KMU news page (`/news`) was showing empty results because the RSS proxy returned empty XML
- Root cause: `page.on('response')` async callback (with `resp.text()`) wasn't completing before `context.close()` was called — race condition
- Fix: replaced event listener with `page.waitForResponse()` + `Promise.all` to properly await the response body before closing the browser context

## Test plan
- [ ] Open https://legal.org.ua/news and verify KMU news items load
- [ ] Check backend logs for successful RSS cache hits after first load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a race condition in the KMU RSS proxy that returned empty XML, causing the /news page to show no items. We now await the RSS response body before closing the browser context to restore KMU news rendering.

- **Bug Fixes**
  - Replaced the response event listener with page.waitForResponse + Promise.all to capture the RSS body reliably.
  - Read response.text() into rawXml before context.close(), with 30s timeouts to avoid hangs.

<sup>Written for commit 8da8eab3b7dcd30ed1d12471171efceaca5faa11. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

