### PR TITLE
fix: OAuth discovery returns request host instead of PUBLIC_URL

### DIFF
--- a/mcp_backend/src/routes/oauth-routes.ts
+++ b/mcp_backend/src/routes/oauth-routes.ts
@@ -969,7 +969,7 @@ export function createOAuthRouter(oauthService: OAuthService): Router {
   router.get('/.well-known/oauth-authorization-server', (req: Request, res: Response) => {
     const proto = req.headers['x-forwarded-proto'] || req.protocol || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
-    const baseUrl = process.env.PUBLIC_URL || `${proto}://${host}`;
+    const baseUrl = `${proto}://${host}`;
 
     res.json({
       issuer: baseUrl,
@@ -994,7 +994,7 @@ export function createOAuthRouter(oauthService: OAuthService): Router {
   router.get('/.well-known/openid-configuration', (req: Request, res: Response) => {
     const proto = req.headers['x-forwarded-proto'] || req.protocol || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
-    const baseUrl = process.env.PUBLIC_URL || `${proto}://${host}`;
+    const baseUrl = `${proto}://${host}`;
 
     res.json({
       issuer: baseUrl,


### PR DESCRIPTION
## Summary
- OAuth discovery (`.well-known/oauth-authorization-server`) was returning `legal.org.ua` endpoints even when accessed from `mcp.legal.org.ua`
- This caused ChatGPT MCP client to skip OAuth (issuer mismatch) and connect without auth
- Fix: use request host header instead of PUBLIC_URL env var for discovery endpoints

## Test plan
- [ ] `curl https://mcp.legal.org.ua/.well-known/oauth-authorization-server` returns `mcp.legal.org.ua` URLs
- [ ] `curl https://legal.org.ua/.well-known/oauth-authorization-server` still returns `legal.org.ua` URLs
- [ ] ChatGPT MCP connection triggers OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OAuth discovery to return the request host (from `x-forwarded-host`/`host`) instead of `PUBLIC_URL`, so subdomains like `mcp.legal.org.ua` get the correct issuer and endpoints. This prevents issuer mismatches and ensures clients (e.g., ChatGPT MCP) start the OAuth flow.

<sup>Written for commit f1c0a7fa239fb1c89d45e513985e76caf505e3a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

