### PR TITLE
feat: unify Diia auth and sign callbacks into single endpoint

### DIFF
--- a/mcp_backend/src/controllers/__tests__/diia-auth.test.ts
+++ b/mcp_backend/src/controllers/__tests__/diia-auth.test.ts
@@ -101,7 +101,7 @@ jest.mock('../../utils/logger.js', () => ({
 import {
   setAuthCache,
   diiaAuthInit,
-  diiaAuthCallback,
+  diiaCallback,
   diiaAuthStatus,
 } from '../auth.js';
 
@@ -196,7 +196,7 @@ describe('Diia Auth Flow', () => {
     });
   });
 
-  describe('diiaAuthCallback', () => {
+  describe('diiaCallback', () => {
     beforeEach(async () => {
       // Simulate a prior init that created both keys
       mockCache['diia:session:plain-uuid-abc'] = JSON.stringify({ status: 'pending' });
@@ -212,7 +212,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       // Both keys should be 'complete'
       const plainData = JSON.parse(mockCache['diia:session:plain-uuid-abc']);
@@ -230,7 +230,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(res._json).toEqual({ success: true });
     });
@@ -239,7 +239,7 @@ describe('Diia Auth Flow', () => {
       const req = makeReq({ headers: {} });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(res._status).toBe(400);
       expect(res._json.success).toBe(false);
@@ -253,7 +253,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(fakeUserService.createUser).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -272,7 +272,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(fakeUserService.updateLastLogin).toHaveBeenCalledWith('user-uuid-123');
       expect(fakeUserService.createUser).not.toHaveBeenCalled();
@@ -382,7 +382,7 @@ describe('Diia Auth Flow', () => {
     });
   });
 
-  describe('diiaAuthCallback — edge cases', () => {
+  describe('diiaCallback — edge cases', () => {
     beforeEach(() => {
       mockCache['diia:session:plain-uuid-abc'] = JSON.stringify({ status: 'pending' });
       mockCache['diia:session:hashed-base64-xyz=='] = JSON.stringify({
@@ -399,7 +399,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(res._status).toBe(503);
     });
@@ -412,7 +412,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(fakeUserService.findByEmail).toHaveBeenCalledWith(
         expect.stringMatching(/^diia_.*@diia\.legal\.org\.ua$/),
@@ -426,7 +426,7 @@ describe('Diia Auth Flow', () => {
       });
       const res = makeRes();
 
-      await diiaAuthCallback(req, res);
+      await diiaCallback(req, res);
 
       // Should not crash — webhook must be idempotent
       expect(res._json.success).toBe(true);
@@ -502,7 +502,7 @@ describe('Diia Auth Flow', () => {
         headers: { 'x-document-request-trace-id': 'hashed-base64-xyz==' },
       });
       const callbackRes = makeRes();
-      await diiaAuthCallback(callbackReq, callbackRes);
+      await diiaCallback(callbackReq, callbackRes);
       expect(callbackRes._json).toEqual({ success: true });
 
       // Step 4: Frontend polls again — should get token

--- a/mcp_backend/src/controllers/__tests__/diia-sign.test.ts
+++ b/mcp_backend/src/controllers/__tests__/diia-sign.test.ts
@@ -82,7 +82,7 @@ jest.mock('../../utils/logger.js', () => ({
 import {
   setAuthCache,
   diiaSignInit,
-  diiaSignCallback,
+  diiaCallback,
   diiaSignStatus,
 } from '../auth.js';
 
@@ -241,7 +241,7 @@ describe('Дія.Підпис (Signing) Flow', () => {
     });
   });
 
-  describe('diiaSignCallback', () => {
+  describe('diiaCallback', () => {
     beforeEach(() => {
       mockCache['diia:sign:sign-uuid-abc'] = JSON.stringify({
         status: 'pending',
@@ -262,7 +262,7 @@ describe('Дія.Підпис (Signing) Flow', () => {
       });
       const res = makeRes();
 
-      await diiaSignCallback(req, res);
+      await diiaCallback(req, res);
 
       const plainData = JSON.parse(mockCache['diia:sign:sign-uuid-abc']);
       expect(plainData.status).toBe('complete');
@@ -281,7 +281,7 @@ describe('Дія.Підпис (Signing) Flow', () => {
       });
       const res = makeRes();
 
-      await diiaSignCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(res._json).toEqual({ success: true });
     });
@@ -290,22 +290,24 @@ describe('Дія.Підпис (Signing) Flow', () => {
       const req = makeReq({ headers: {} });
       const res = makeRes();
 
-      await diiaSignCallback(req, res);
+      await diiaCallback(req, res);
 
       expect(res._status).toBe(400);
       expect(res._json.success).toBe(false);
     });
 
-    it('still returns { success: true } even for unknown traceId (no crash)', async () => {
+    it('falls through to auth flow for unknown traceId (no sign session)', async () => {
       const req = makeReq({
         headers: { 'x-document-request-trace-id': 'unknown-trace-id' },
         body: { signed: true },
       });
       const res = makeRes();
 
-      await diiaSignCallback(req, res);
+      await diiaCallback(req, res);
 
-      expect(res._json).toEqual({ success: true });
+      // Unknown traceId with no sign session falls through to auth flow,
+      // which returns 503 when userService is unavailable in this test context
+      expect(res._status).toBe(503);
     });
   });
 
@@ -407,7 +409,7 @@ describe('Дія.Підпис (Signing) Flow', () => {
         body: signedPayload,
       });
       const callbackRes = makeRes();
-      await diiaSignCallback(callbackReq, callbackRes);
+      await diiaCallback(callbackReq, callbackRes);
       expect(callbackRes._json).toEqual({ success: true });
 
       // Step 4: Frontend polls again — should get signed data

--- a/mcp_backend/src/controllers/auth-diia.ts
+++ b/mcp_backend/src/controllers/auth-diia.ts
@@ -82,9 +82,11 @@ export async function diiaAuthInit(req: Request, res: Response): Promise<void> {
 
 /**
  * POST /auth/diia/callback
- * Diia sends the signed auth package to this webhook after user completes auth in the app.
+ * Unified Diia webhook — handles both auth and sign callbacks.
+ * Diia sends the signed package here after user completes auth or signs documents.
+ * Distinguishes auth vs sign by checking which Redis session key exists for the traceId.
  */
-export async function diiaAuthCallback(req: Request, res: Response): Promise<Response> {
+export async function diiaCallback(req: Request, res: Response): Promise<Response> {
   const traceId = (req.headers['x-document-request-trace-id'] as string) || '';
   logger.info('[Diia] Webhook received', { traceId, contentType: req.headers['content-type'] });
 
@@ -93,57 +95,102 @@ export async function diiaAuthCallback(req: Request, res: Response): Promise<Res
       return res.status(400).json({ success: false, error: 'Missing X-Document-Request-Trace-Id' });
     }
 
-    const userService = getUserService();
-    if (!userService) {
-      return res.status(503).json({ success: false, error: 'Service unavailable' });
-    }
-
     const authCache = getAuthCache();
-    const hashedKey = `diia:session:${traceId}`;
-    let sessionData: { status: string; plainRequestId?: string } | null = null;
 
+    // Check if this is a sign session
+    let signSessionRaw: string | null = null;
     if (authCache) {
-      const raw = await authCache.get(hashedKey);
-      if (raw) sessionData = JSON.parse(raw);
+      signSessionRaw = await authCache.get(`diia:sign:${traceId}`);
     }
 
-    const email = `diia_${traceId.substring(0, 16)}@diia.legal.org.ua`;
-    const name = 'Дія Користувач';
-    let user = await userService.findByEmail(email);
-    if (!user) {
-      user = await userService.createUser({
-        googleId: null,
-        email,
-        name,
-        emailVerified: true,
-      });
-      logger.info('[Diia] Created user from webhook', { userId: user.id, traceId });
-      generateBannerAsync(user.id, name);
-      provisionAuthentikUser({ email, name }).catch(() => {});
-      provisionNextcloudUser({ email, name }).catch(() => {});
-    } else {
-      await userService.updateLastLogin(user.id);
-      logger.info('[Diia] Existing user webhook auth', { userId: user.id, traceId });
+    if (signSessionRaw) {
+      // --- Sign callback flow ---
+      return handleSignCallback(req, res, traceId, signSessionRaw);
     }
 
-    if (authCache) {
-      const completeData = JSON.stringify({ status: 'complete', userId: user.id });
-      await authCache.set(hashedKey, completeData, DIIA_SESSION_TTL);
-
-      if (sessionData?.plainRequestId) {
-        await authCache.set(
-          `diia:session:${sessionData.plainRequestId}`,
-          completeData,
-          DIIA_SESSION_TTL,
-        );
-      }
-    }
-
-    return res.json({ success: true });
+    // --- Auth callback flow ---
+    return handleAuthCallback(req, res, traceId);
   } catch (error: any) {
     logger.error('[Diia] Webhook failed:', error);
     return res.json({ success: true });
   }
+}
+
+async function handleAuthCallback(req: Request, res: Response, traceId: string): Promise<Response> {
+  const userService = getUserService();
+  if (!userService) {
+    return res.status(503).json({ success: false, error: 'Service unavailable' });
+  }
+
+  const authCache = getAuthCache();
+  const hashedKey = `diia:session:${traceId}`;
+  let sessionData: { status: string; plainRequestId?: string } | null = null;
+
+  if (authCache) {
+    const raw = await authCache.get(hashedKey);
+    if (raw) sessionData = JSON.parse(raw);
+  }
+
+  const email = `diia_${traceId.substring(0, 16)}@diia.legal.org.ua`;
+  const name = 'Дія Користувач';
+  let user = await userService.findByEmail(email);
+  if (!user) {
+    user = await userService.createUser({
+      googleId: null,
+      email,
+      name,
+      emailVerified: true,
+    });
+    logger.info('[Diia] Created user from webhook', { userId: user.id, traceId });
+    generateBannerAsync(user.id, name);
+    provisionAuthentikUser({ email, name }).catch(() => {});
+    provisionNextcloudUser({ email, name }).catch(() => {});
+  } else {
+    await userService.updateLastLogin(user.id);
+    logger.info('[Diia] Existing user webhook auth', { userId: user.id, traceId });
+  }
+
+  if (authCache) {
+    const completeData = JSON.stringify({ status: 'complete', userId: user.id });
+    await authCache.set(hashedKey, completeData, DIIA_SESSION_TTL);
+
+    if (sessionData?.plainRequestId) {
+      await authCache.set(
+        `diia:session:${sessionData.plainRequestId}`,
+        completeData,
+        DIIA_SESSION_TTL,
+      );
+    }
+  }
+
+  return res.json({ success: true });
+}
+
+async function handleSignCallback(_req: Request, res: Response, traceId: string, signSessionRaw: string): Promise<Response> {
+  const authCache = getAuthCache();
+  const hashedKey = `diia:sign:${traceId}`;
+  const sessionData: { status: string; plainRequestId?: string; files?: DiiaSignFile[] } = JSON.parse(signSessionRaw);
+  const signedData = _req.body;
+
+  if (authCache) {
+    const completeData = JSON.stringify({
+      status: 'complete',
+      signedData,
+      files: sessionData?.files,
+    });
+    await authCache.set(hashedKey, completeData, DIIA_SIGN_SESSION_TTL);
+
+    if (sessionData?.plainRequestId) {
+      await authCache.set(
+        `diia:sign:${sessionData.plainRequestId}`,
+        completeData,
+        DIIA_SIGN_SESSION_TTL,
+      );
+    }
+  }
+
+  logger.info('[Diia] Sign webhook processed', { traceId });
+  return res.json({ success: true });
 }
 
 /**
@@ -214,7 +261,7 @@ export async function diiaSignInit(req: Request, res: Response): Promise<Respons
     const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
     const baseUrl = `${protocol}://${host}`;
-    const callbackUrl = `${baseUrl}/auth/diia/sign/callback`;
+    const callbackUrl = `${baseUrl}/auth/diia/callback`;
     const effectiveReturnUrl = returnUrl || `${baseUrl}/documents`;
 
     const session = await diiaService.initSigningSession(effectiveReturnUrl, files);
@@ -242,56 +289,6 @@ export async function diiaSignInit(req: Request, res: Response): Promise<Respons
     logger.error('[Diia] Sign init failed:', error);
     const errorCode = error instanceof DiiaPermissionError ? 'scope_forbidden' : 'sign_failed';
     return res.status(500).json({ error: errorCode, message: error.message });
-  }
-}
-
-/**
- * POST /auth/diia/sign/callback
- * Diia webhook — called after user signs documents in the app.
- */
-export async function diiaSignCallback(req: Request, res: Response): Promise<Response> {
-  const traceId = (req.headers['x-document-request-trace-id'] as string) || '';
-  logger.info('[Diia] Sign webhook received', { traceId, contentType: req.headers['content-type'] });
-
-  try {
-    if (!traceId) {
-      return res.status(400).json({ success: false, error: 'Missing X-Document-Request-Trace-Id' });
-    }
-
-    const authCache = getAuthCache();
-    const hashedKey = `diia:sign:${traceId}`;
-    let sessionData: { status: string; plainRequestId?: string; files?: DiiaSignFile[] } | null = null;
-
-    if (authCache) {
-      const raw = await authCache.get(hashedKey);
-      if (raw) sessionData = JSON.parse(raw);
-    }
-
-    const signedData = req.body;
-
-    if (authCache) {
-      const completeData = JSON.stringify({
-        status: 'complete',
-        signedData,
-        files: sessionData?.files,
-      });
-      await authCache.set(hashedKey, completeData, DIIA_SIGN_SESSION_TTL);
-
-      if (sessionData?.plainRequestId) {
-        await authCache.set(
-          `diia:sign:${sessionData.plainRequestId}`,
-          completeData,
-          DIIA_SIGN_SESSION_TTL,
-        );
-      }
-    }
-
-    logger.info('[Diia] Sign webhook processed', { traceId });
-
-    return res.json({ success: true });
-  } catch (error: any) {
-    logger.error('[Diia] Sign webhook failed:', error);
-    return res.json({ success: true });
   }
 }
 

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -161,12 +161,12 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
 
   /**
    * @route   POST /auth/diia/callback
-   * @desc    Diia webhook — called after user authenticates in the app
+   * @desc    Unified Diia webhook — handles both auth and sign callbacks
    *          Header: X-Document-Request-Trace-Id = requestId
    *          Must respond { success: true } within 30s
    * @access  Public
    */
-  router.post('/diia/callback', authController.diiaAuthCallback as any);
+  router.post('/diia/callback', authController.diiaCallback as any);
 
   // Diia redirects the user's browser here via GET after auth.
   // On mobile same-device flow the original polling tab is lost,
@@ -202,15 +202,6 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
   router.post('/diia/sign', authController.diiaSignInit as any);
 
   /**
-   * @route   POST /auth/diia/sign/callback
-   * @desc    Diia webhook — called after user signs documents in the app
-   *          Header: X-Document-Request-Trace-Id = hashedRequestId
-   *          Must respond { success: true } within 30s
-   * @access  Public (webhook from Diia)
-   */
-  router.post('/diia/sign/callback', authController.diiaSignCallback as any);
-
-  /**
    * @route   GET /auth/diia/sign/status/:sessionId
    * @desc    Poll for Дія.Підпис signing session completion
    * @access  Protected (JWT required)
@@ -231,9 +222,6 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
     res.status(501).json({ error: 'Diia auth is not configured' });
   });
   router.post('/diia/sign', (_req, res) => {
-    res.status(501).json({ error: 'Diia signing is not configured' });
-  });
-  router.post('/diia/sign/callback', (_req, res) => {
     res.status(501).json({ error: 'Diia signing is not configured' });
   });
   router.get('/diia/sign/status/:sessionId', (_req, res) => {


### PR DESCRIPTION
## Summary
- Diia team requires a single callback endpoint for both auth and signing
- Merged `POST /auth/diia/callback` and `POST /auth/diia/sign/callback` into one unified handler
- Handler distinguishes auth vs sign by checking `diia:sign:*` Redis session key existence
- Updated sign init to send unified callback URL to Diia API

**Production endpoint:** `POST https://legal.org.ua/auth/diia/callback`

## Test plan
- [x] All 41 Diia tests pass
- [ ] Verify auth flow works with Diia test environment
- [ ] Verify sign flow works with Diia test environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Diia auth and signing webhooks into a single POST `/auth/diia/callback`, matching Diia’s requirement and simplifying our integration. The handler auto-detects auth vs sign by checking Redis for `diia:sign:*` session keys.

- **Refactors**
  - Merged `POST /auth/diia/callback` and `POST /auth/diia/sign/callback` into `diiaCallback`.
  - Removed `diiaSignCallback`; added internal `handleAuthCallback` and `handleSignCallback`.
  - Updated signing init to send the unified callback URL.
  - Cleaned up routes and tests; status endpoints remain the same.

- **Migration**
  - Diia should call: `POST https://legal.org.ua/auth/diia/callback`.
  - No frontend changes required.

<sup>Written for commit 0160f746f80a7fd6c83610ad16567b3e4ad00c9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

