### PR TITLE
fix: SSE OAuth discovery must return request host, not PUBLIC_URL

### DIFF
--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -37,10 +37,11 @@ export function createMCPSSERoutes(deps: {
   const router = Router();
 
   // Helper: compute base URL from request headers
+  // Use request host (not PUBLIC_URL) so mcp.legal.org.ua returns correct OAuth URLs
   function getBaseUrl(req: Request): string {
     const proto = req.headers['x-forwarded-proto'] || req.protocol || 'https';
     const host = req.headers['x-forwarded-host'] || req.headers.host;
-    return process.env.PUBLIC_URL || `${proto}://${host}`;
+    return `${proto}://${host}`;
   }
 
   // Helper: build standard OAuth metadata JSON


### PR DESCRIPTION
## Summary
- Companion fix to #1347 — `mcp-sse-routes.ts` still used `PUBLIC_URL` in `getBaseUrl()`, causing OAuth discovery at `/sse/.well-known/oauth-authorization-server` to return `legal.org.ua` URLs when ChatGPT connects via `mcp.legal.org.ua`
- This issuer mismatch prevented ChatGPT from initiating the OAuth flow, resulting in unauthenticated SSE requests (401)

## Test plan
- [ ] Verify `curl https://mcp.legal.org.ua/sse/.well-known/oauth-authorization-server` returns `mcp.legal.org.ua` URLs
- [ ] Verify `curl https://legal.org.ua/.well-known/oauth-authorization-server` still returns `legal.org.ua` URLs
- [ ] Test ChatGPT MCP connection via `mcp.legal.org.ua/sse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SSE OAuth discovery to return URLs based on the incoming request host, not `PUBLIC_URL`. This aligns the issuer with the accessed subdomain (e.g., mcp.legal.org.ua) so ChatGPT can start OAuth and avoid 401s.

- **Bug Fixes**
  - Updated `getBaseUrl()` in `mcp-sse-routes.ts` to use `${proto}://${host}` from `x-forwarded-*` headers.
  - `/sse/.well-known/oauth-authorization-server` now returns host-accurate URLs; root domain discovery remains correct.

<sup>Written for commit b5c74e6d19bcb3d038f429181235dc30ec7512af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

