### PR TITLE
feat: add RFC 9728 oauth-protected-resource for ChatGPT MCP

### DIFF
--- a/deployment/nginx/includes/oauth-endpoints.conf
+++ b/deployment/nginx/includes/oauth-endpoints.conf
@@ -38,6 +38,22 @@ location = /.well-known/openid-configuration {
     add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept" always;
 }
 
+# OAuth Protected Resource Metadata (RFC 9728)
+# Required for ChatGPT MCP integration
+location = /.well-known/oauth-protected-resource {
+    proxy_pass http://stage_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Connection "";
+
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Methods "GET, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept" always;
+}
+
 # ==========================================
 # OAuth Authorization Flow
 # ==========================================

--- a/deployment/nginx/includes/preview-server-common.conf
+++ b/deployment/nginx/includes/preview-server-common.conf
@@ -250,6 +250,16 @@ location = /.well-known/oauth-authorization-server {
     proxy_set_header Connection "";
 }
 
+location = /.well-known/oauth-protected-resource {
+    proxy_pass http://preview_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header Connection "";
+}
+
 # ==========================================
 # OAuth Routes (authorize, token, register)
 # ==========================================

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -274,6 +274,17 @@ location = /.well-known/oauth-authorization-server {
     proxy_set_header Connection "";
 }
 
+# RFC 9728 — OAuth Protected Resource Metadata (required for ChatGPT MCP)
+location = /.well-known/oauth-protected-resource {
+    proxy_pass http://prod_mcp_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header Connection "";
+}
+
 # ==========================================
 # OAuth Routes (authorize, token, register)
 # ==========================================

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -93,6 +93,18 @@ export function createMCPSSERoutes(deps: {
     });
   });
 
+  // GET /sse/.well-known/oauth-protected-resource - RFC 9728 Protected Resource Metadata
+  // ChatGPT checks this FIRST to discover the OAuth authorization server
+  router.get('/sse/.well-known/oauth-protected-resource', (req: Request, res: Response) => {
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      resource: `${baseUrl}/sse`,
+      authorization_servers: [baseUrl],
+      scopes_supported: ['mcp'],
+      bearer_methods_supported: ['header'],
+    });
+  });
+
   // GET /sse/.well-known/oauth-authorization-server - RFC 8414 OAuth metadata
   router.get('/sse/.well-known/oauth-authorization-server', (req: Request, res: Response) => {
     res.json(oauthMetadata(getBaseUrl(req)));
@@ -575,6 +587,17 @@ export function createMCPSSERoutes(deps: {
 
   router.get('/.well-known/openid-configuration', (req: Request, res: Response) => {
     res.json(oauthMetadata(getBaseUrl(req)));
+  });
+
+  // RFC 9728 Protected Resource Metadata (root-level)
+  router.get('/.well-known/oauth-protected-resource', (req: Request, res: Response) => {
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      resource: `${baseUrl}/sse`,
+      authorization_servers: [baseUrl],
+      scopes_supported: ['mcp'],
+      bearer_methods_supported: ['header'],
+    });
   });
 
   // Redirect /register to /oauth/register (MCP client compatibility)


### PR DESCRIPTION
## Summary
- ChatGPT checks `/.well-known/oauth-protected-resource` (RFC 9728) **before** looking for OAuth authorization server metadata
- This endpoint was missing, causing ChatGPT to report "MCP server does not implement OAuth"
- Added endpoint to backend (`mcp-sse-routes.ts`) and all nginx configs (prod, preview, stage)

## Test plan
- [ ] `curl https://mcp.legal.org.ua/.well-known/oauth-protected-resource` returns JSON with `resource`, `authorization_servers`
- [ ] `curl https://mcp.legal.org.ua/sse/.well-known/oauth-protected-resource` also works
- [ ] ChatGPT MCP connection to `https://mcp.legal.org.ua/sse` initiates OAuth flow
- [ ] Existing OAuth discovery endpoints still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RFC 9728 OAuth Protected Resource metadata so ChatGPT MCP can discover our auth server and start OAuth. Adds backend routes and Nginx proxy rules across prod, preview, and stage.

- **New Features**
  - Serve `/.well-known/oauth-protected-resource` at root and `/sse/.well-known/` with `resource`, `authorization_servers`, `scopes_supported`, and `bearer_methods_supported`.
  - Add Nginx locations to proxy this path to the MCP backend in prod, preview, and stage (with CORS headers where applicable).
  - Existing OAuth discovery endpoints remain unchanged.

<sup>Written for commit 3ba924f77b677531dd0dfee5032e0a681c51ead0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

