### PR TITLE
fix: remove stale dist overlay from backend Dockerfile

### DIFF
--- a/deployment/Dockerfile.mono-backend
+++ b/deployment/Dockerfile.mono-backend
@@ -54,12 +54,9 @@ RUN cd mcp_backend \
   && npm run build \
   && npm prune --omit=dev
 
-# Overwrite stub-compiled dist with pre-built dist from host context.
-# The CI pipeline runs preserve-proprietary-dist.sh (backup → build → restore)
-# before Docker build, so mcp_backend/dist/ in the context contains the real
-# proprietary implementations. This COPY overlays them on top of the tsc output,
-# replacing any stubs that tsc compiled from the public source.
-COPY mcp_backend/dist mcp_backend/dist
+# NOTE: CI overlays proprietary .ts sources into mcp_backend/src/ BEFORE
+# Docker build, so tsc above already compiles real implementations.
+# No need to copy host dist/ — that caused stale files to overwrite fresh builds.
 
 # Replace file: symlink for @secondlayer/shared with a real directory so runtime doesn't need ../packages/shared
 # Must be done AFTER npm prune to prevent symlink recreation


### PR DESCRIPTION
## Summary
- `Dockerfile.mono-backend` line 62 `COPY mcp_backend/dist mcp_backend/dist` overwrote freshly compiled TypeScript with stale host dist files
- This caused newly added routes/endpoints to be missing from deployed containers — had to rebuild with `--no-cache` and manually delete stale dist
- **Root cause**: Legacy from when CI overlaid compiled `.js` files. CI now overlays proprietary `.ts` sources before Docker build, so tsc inside Docker already compiles real implementations
- `Dockerfile.document-service` still uses host dist (no builder stage) — unaffected by this change

## Test plan
- [ ] Deploy backend via CI/CD — verify new endpoints appear without manual intervention
- [ ] Verify proprietary services (chat, billing) still work after deploy
- [ ] `curl https://mcp.legal.org.ua/.well-known/oauth-protected-resource` returns JSON (not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `COPY mcp_backend/dist mcp_backend/dist` step from `Dockerfile.mono-backend` to prevent stale host artifacts from overwriting fresh TypeScript builds. Containers now ship new routes/endpoints without `--no-cache` rebuilds or manual cleanup.

- **Bug Fixes**
  - CI already overlays proprietary `.ts` sources before Docker build, so `tsc` compiles the real implementations inside the image.
  - `Dockerfile.document-service` is unchanged and still uses host `dist/`.

<sup>Written for commit e35030c59c3fb0038135427030c6048706481395. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

