### PR TITLE
fix(ci): detect all changes since last deploy, not just HEAD~1

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -52,17 +52,29 @@ runs:
       id: last_deploy
       shell: bash
       run: |
-        # Try to get the last successful deploy tag; fall back to previous commit
+        # Find the most recent deploy marker tag (created after each successful prod deploy)
         LAST_SHA=""
-        if git tag -l "deploy-prod-*" | tail -1 > /dev/null 2>&1; then
-          LAST_TAG=$(git tag -l "deploy-prod-*" --sort=-creatordate | head -1)
+        LAST_TAG=$(git tag -l "deploy-prod-*" --sort=-creatordate | head -1)
+        if [ -n "$LAST_TAG" ]; then
+          LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
+          echo "Using deploy marker tag: $LAST_TAG ($LAST_SHA)"
+        fi
+
+        # Fallback: use the most recent release tag (v* or fe-v*)
+        if [ -z "$LAST_SHA" ]; then
+          LAST_TAG=$(git tag -l --sort=-creatordate "v*" "fe-v*" | head -1)
           if [ -n "$LAST_TAG" ]; then
             LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
+            echo "Using release tag as fallback: $LAST_TAG ($LAST_SHA)"
           fi
         fi
+
+        # Last resort: first parent of HEAD (works correctly for merge commits)
         if [ -z "$LAST_SHA" ]; then
           LAST_SHA=$(git rev-parse HEAD~1)
+          echo "WARNING: No deploy/release tags found, using HEAD~1 ($LAST_SHA)"
         fi
+
         echo "last_sha=$LAST_SHA" >> "$GITHUB_OUTPUT"
         echo "Comparing changes since: $LAST_SHA"
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1094,3 +1094,13 @@ jobs:
               --notes-file - \
               $LATEST_FLAG
           fi
+
+      - name: Tag deploy marker
+        run: |
+          # Create a lightweight tag marking this commit as successfully deployed to prod.
+          # detect-changes uses this to compare against the next deploy, ensuring no
+          # changes are skipped between deploys.
+          DEPLOY_TAG="deploy-prod-$(date -u +%Y%m%d-%H%M%S)"
+          git tag "$DEPLOY_TAG"
+          git push origin "$DEPLOY_TAG"
+          echo "Created deploy marker tag: $DEPLOY_TAG"


### PR DESCRIPTION
## Summary
- **Bug**: CI change detection used `HEAD~1` as the diff base, which only captures changes from the last merge commit. When multiple PRs merged between prod deploys, intermediate changes were silently skipped (e.g., pitch-deck.html update from PR #1395 was never deployed).
- **Fix**: After each successful prod deploy, a `deploy-prod-<timestamp>` marker tag is created. The next deploy compares against this tag, capturing ALL undeployed changes.
- **Fallback chain**: `deploy-prod-*` tag → latest release tag (`v*`/`fe-v*`) → `HEAD~1`

## Test plan
- [ ] Verify next prod deploy creates a `deploy-prod-*` tag
- [ ] Verify subsequent deploy detects changes from marker tag, not `HEAD~1`
- [ ] Confirm `git tag -l "deploy-prod-*"` shows tags after successful deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI change detection so we diff from the last successful prod deploy, not `HEAD~1`. Adds deploy marker tags to ensure no commits are skipped between releases.

- **Bug Fixes**
  - Create and push `deploy-prod-<timestamp>` tag after each prod deploy.
  - Next deploy diffs from the latest deploy marker; fallbacks: latest `v*`/`fe-v*`, then `HEAD~1`.
  - Logs which base was selected for clarity.

<sup>Written for commit fc284bdf219d7be0e65afd4feac6ee52cd872009. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

