### PR TITLE
fix(ci): downgrade setup-node to v4 for runner compatibility

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -181,7 +181,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -330,7 +330,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -164,7 +164,7 @@ jobs:
           fi
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -235,7 +235,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -857,7 +857,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 


### PR DESCRIPTION
## Summary
- Downgrade `actions/setup-node` from v6 to v4 in both CI and prod deploy workflows
- v6 requires `node24` runtime which runner v2.333.1 doesn't support yet, causing all jobs to fail

## Test plan
- [ ] CI pipeline picks up the PR and runs successfully
- [ ] Re-run deploy-prod workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrade `actions/setup-node` to v4 in CI and production deploy workflows to restore compatibility with runner v2.333.1. v6 requires the Node 24 runtime (unsupported on our runner), so jobs were failing; we keep `node-version: 20`.

<sup>Written for commit 442d382876d83feed06cd3f91ccf6efc8b1119a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

