### PR TITLE
fix(deploy): add DNS aliases for opendata-sync after blue-green switch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -793,6 +793,23 @@ jobs:
             # --- 5. Save active colors ---
             printf 'backend=%s\nfrontend=%s\n' "\$BACKEND_COLOR" "\$FRONTEND_COLOR" > .active-colors
 
+            # --- 5a. Add canonical DNS aliases for opendata-sync ---
+            # opendata-sync connects to app-prod:3000 and app-openreyestr-prod:3005
+            # but blue-green containers have color suffixes — add aliases so DNS resolves
+            NETWORK="deployment_secondlayer-prod-network"
+            if [ "\$BACKEND_COLOR" = "green" ]; then
+              BE_CONTAINER="secondlayer-app-prod-green"
+              OR_CONTAINER="openreyestr-app-prod-green"
+            else
+              BE_CONTAINER="secondlayer-app-prod"
+              OR_CONTAINER="openreyestr-app-prod"
+            fi
+            echo "Adding canonical DNS aliases (app-prod, app-openreyestr-prod) to \$BE_CONTAINER, \$OR_CONTAINER"
+            docker network disconnect "\$NETWORK" "\$BE_CONTAINER" 2>/dev/null || true
+            docker network connect --alias app-prod "\$NETWORK" "\$BE_CONTAINER" || true
+            docker network disconnect "\$NETWORK" "\$OR_CONTAINER" 2>/dev/null || true
+            docker network connect --alias app-openreyestr-prod "\$NETWORK" "\$OR_CONTAINER" || true
+
             # Restart monitoring if needed
             if [ "${MONITORING_CHANGED}" = "true" ]; then
               echo "=== Restarting monitoring services ==="


### PR DESCRIPTION
## Summary
- opendata-sync connects to `app-prod:3000` and `app-openreyestr-prod:3005` but after blue-green deploy active containers get color-suffixed DNS names (`app-prod-green`, `app-openreyestr-prod-green`)
- **All 19 open data sources have been failing** with `getaddrinfo EAI_AGAIN` since blue-green was introduced
- Fix: after promoting the new color, reconnect containers to the Docker network with canonical aliases (`app-prod`, `app-openreyestr-prod`)
- Hotfix already applied on prod via manual `docker network` commands — this PR makes it permanent

## Test plan
- [x] Manual alias applied on prod, verified connectivity from opendata-sync to both backends
- [ ] Next cron cycle (03:00 Kyiv) should show successful syncs
- [ ] Future deploys should preserve aliases automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DNS resolution for `opendata-sync` after blue‑green deploys by adding canonical DNS aliases during promotion. Restores connectivity to `app-prod:3000` and `app-openreyestr-prod:3005`, preventing `EAI_AGAIN` failures across all 19 sources.

- **Bug Fixes**
  - In `deploy-prod.yml`, after selecting the active color, disconnect/reconnect the active containers on `deployment_secondlayer-prod-network` with `app-prod` and `app-openreyestr-prod` aliases.
  - Applies whether the active containers are `*-green` or non-suffixed, so future deploys keep the expected hostnames for `opendata-sync`.

<sup>Written for commit ce3022a46f450b3f3f872768750e7a70c7bf2439. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

