### PR TITLE
fix(mcp): return 401 on GET /sse to trigger ChatGPT OAuth flow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -793,6 +793,23 @@ jobs:
             # --- 5. Save active colors ---
             printf 'backend=%s\nfrontend=%s\n' "\$BACKEND_COLOR" "\$FRONTEND_COLOR" > .active-colors
 
+            # --- 5a. Add canonical DNS aliases for opendata-sync ---
+            # opendata-sync connects to app-prod:3000 and app-openreyestr-prod:3005
+            # but blue-green containers have color suffixes — add aliases so DNS resolves
+            NETWORK="deployment_secondlayer-prod-network"
+            if [ "\$BACKEND_COLOR" = "green" ]; then
+              BE_CONTAINER="secondlayer-app-prod-green"
+              OR_CONTAINER="openreyestr-app-prod-green"
+            else
+              BE_CONTAINER="secondlayer-app-prod"
+              OR_CONTAINER="openreyestr-app-prod"
+            fi
+            echo "Adding canonical DNS aliases (app-prod, app-openreyestr-prod) to \$BE_CONTAINER, \$OR_CONTAINER"
+            docker network disconnect "\$NETWORK" "\$BE_CONTAINER" 2>/dev/null || true
+            docker network connect --alias app-prod "\$NETWORK" "\$BE_CONTAINER" || true
+            docker network disconnect "\$NETWORK" "\$OR_CONTAINER" 2>/dev/null || true
+            docker network connect --alias app-openreyestr-prod "\$NETWORK" "\$OR_CONTAINER" || true
+
             # Restart monitoring if needed
             if [ "${MONITORING_CHANGED}" = "true" ]; then
               echo "=== Restarting monitoring services ==="

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -77,7 +77,23 @@ export function createMCPSSERoutes(deps: {
   // GET /sse - Returns OAuth configuration as JSON
   router.get('/sse', (req: Request, res: Response) => {
     const baseUrl = getBaseUrl(req);
+    const resourceMetadataUrl = `${baseUrl}/.well-known/oauth-protected-resource`;
 
+    // If no Authorization header, return 401 to trigger OAuth flow (RFC 6750 + MCP spec)
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      res.setHeader(
+        'WWW-Authenticate',
+        `Bearer resource_metadata="${resourceMetadataUrl}"`
+      );
+      return res.status(401).json({
+        error: 'Unauthorized',
+        message: 'Authorization required. Use OAuth 2.0 to obtain an access token.',
+        code: 'MISSING_AUTH',
+      });
+    }
+
+    // With valid auth header, return capabilities info
     res.json({
       protocol: 'mcp',
       version: '1.0',
@@ -125,7 +141,10 @@ export function createMCPSSERoutes(deps: {
       const authHeader = req.headers.authorization;
       if (!authHeader || !authHeader.startsWith('Bearer ')) {
         logger.warn('[MCP SSE] Missing or invalid Authorization header');
-        res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadataUrl}"`);
+        res.setHeader(
+          'WWW-Authenticate',
+          `Bearer error="missing_token", error_description="Authorization required", resource_metadata="${resourceMetadataUrl}"`
+        );
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'Authorization header with Bearer token is required',
@@ -155,7 +174,10 @@ export function createMCPSSERoutes(deps: {
             logger.warn('[MCP SSE] Invalid OAuth token', {
               tokenPrefix: maskSensitive(token, 15),
             });
-            res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadataUrl}"`);
+            res.setHeader(
+              'WWW-Authenticate',
+              `Bearer error="invalid_token", error_description="Invalid or expired OAuth access token", resource_metadata="${resourceMetadataUrl}"`
+            );
             return res.status(401).json({
               error: 'Unauthorized',
               message: 'Invalid or expired OAuth access token',
@@ -179,7 +201,10 @@ export function createMCPSSERoutes(deps: {
             logger.warn('[MCP SSE] Invalid API key', {
               keyPrefix: maskSensitive(token, 12),
             });
-            res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadataUrl}"`);
+            res.setHeader(
+              'WWW-Authenticate',
+              `Bearer error="invalid_token", error_description="Invalid API key", resource_metadata="${resourceMetadataUrl}"`
+            );
             return res.status(401).json({
               error: 'Unauthorized',
               message: 'Invalid API key',
@@ -220,7 +245,10 @@ export function createMCPSSERoutes(deps: {
       } catch (error) {
         // Auth failed - return 401
         logger.warn('[MCP SSE] Authentication failed', { error: (error as Error).message });
-        res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadataUrl}"`);
+        res.setHeader(
+          'WWW-Authenticate',
+          `Bearer error="invalid_token", error_description="Authentication failed", resource_metadata="${resourceMetadataUrl}"`
+        );
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'Authentication failed: ' + (error as Error).message,


### PR DESCRIPTION
## Summary

- `GET /sse` without auth now returns **401** with `WWW-Authenticate` header instead of 200 with JSON
- ChatGPT was connecting to `/sse`, getting 200, and never starting OAuth flow — showing "Looked for available tools" but never calling any
- All `WWW-Authenticate` headers now include `error` and `error_description` params per RFC 6750

## Root Cause

ChatGPT MCP client expects 401 from the SSE endpoint to trigger OAuth authorization. Our server returned 200 with capabilities JSON, so ChatGPT assumed no auth was needed and silently failed to use tools.

## Test plan

- [ ] Deploy to prod
- [ ] Verify `curl https://mcp.legal.org.ua/sse` returns 401 with WWW-Authenticate header
- [ ] Test ChatGPT MCP connection — should trigger OAuth popup
- [ ] Verify existing Claude Desktop / API key connections still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
GET /sse without auth now returns 401 with an RFC 6750-compliant WWW-Authenticate header to trigger the ChatGPT OAuth flow; with auth, it still returns capabilities. The deploy workflow also adds canonical Docker network aliases to restore `opendata-sync` connectivity after blue‑green switches.

- Bug Fixes
  - SSE: return 401 on missing/invalid Bearer token and include `error`, `error_description`, and `resource_metadata` in `WWW-Authenticate` so ChatGPT starts OAuth instead of stalling.
  - Deploy: after promoting a color, attach DNS aliases `app-prod` and `app-openreyestr-prod` to the active containers to prevent EAI_AGAIN errors and keep `opendata-sync` resolving expected hosts.

<sup>Written for commit 832c04da14fed04823104f37adc76be2e6f1ba34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

