### PR TITLE
fix(mcp): support legacy API keys in SSE transport

### DIFF
--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -121,16 +121,23 @@ export function createMCPSSERoutes(deps: {
           clientKey = tokenData.clientId;
         } else {
           clientKey = token;
+          // Try Phase 2 API key (DB) first, then legacy env keys
           const keyInfo = await deps.apiKeyService.validateApiKey(token);
-          if (!keyInfo) {
-            res.setHeader(
-              'WWW-Authenticate',
-              `Bearer error="invalid_token", error_description="Invalid API key", resource_metadata="${resourceMetadataUrl}"`
-            );
-            return res.status(401).json({ error: 'Unauthorized', code: 'INVALID_API_KEY' });
+          if (keyInfo) {
+            userId = keyInfo.userId;
+            deps.apiKeyService.updateUsage(token).catch(() => {});
+          } else {
+            // Fallback: check legacy SECONDARY_LAYER_KEYS
+            const legacyKeys = (process.env.SECONDARY_LAYER_KEYS || '').split(',').map(k => k.trim()).filter(k => k.length > 0);
+            if (!legacyKeys.includes(token)) {
+              res.setHeader(
+                'WWW-Authenticate',
+                `Bearer error="invalid_token", error_description="Invalid API key", resource_metadata="${resourceMetadataUrl}"`
+              );
+              return res.status(401).json({ error: 'Unauthorized', code: 'INVALID_API_KEY' });
+            }
+            logger.debug('[MCP SSE GET] Authenticated with legacy API key');
           }
-          userId = keyInfo.userId;
-          deps.apiKeyService.updateUsage(token).catch(() => {});
         }
       } catch (error) {
         logger.warn('[MCP SSE GET] Authentication failed', { error: (error as Error).message });


### PR DESCRIPTION
## Summary
- GET /sse handler now falls back to SECONDARY_LAYER_KEYS when Phase 2 DB key not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds legacy API key support to MCP SSE GET `/sse` by falling back to `SECONDARY_LAYER_KEYS` when Phase 2 DB validation fails. Restores auth for older clients without affecting new key flow.

- **Bug Fixes**
  - Try DB-backed key first; if missing, accept tokens listed in `SECONDARY_LAYER_KEYS`.
  - Preserve 401 + `WWW-Authenticate` for invalid tokens; update usage only for DB-backed keys.
  - Add debug log when a legacy key is used.

<sup>Written for commit 78ff9eb668c2b10c0ec93b49cbedb91a963d23d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

