### PR TITLE
fix(mcp): JSON response for ChatGPT Streamable HTTP

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -105,11 +105,20 @@ export class MCPSSEServer {
       userAgent: req.headers['user-agent'],
     });
 
-    // Set SSE headers
-    res.setHeader('Content-Type', 'text/event-stream');
-    res.setHeader('Cache-Control', 'no-cache, no-transform');
-    res.setHeader('Connection', 'keep-alive');
-    res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+    // Check Accept header — ChatGPT Streamable HTTP sends Accept: application/json
+    const acceptHeader = req.headers.accept || '';
+    const wantsJson = acceptHeader.includes('application/json') && !acceptHeader.includes('text/event-stream');
+
+    if (wantsJson) {
+      // Streamable HTTP mode — respond with JSON
+      res.setHeader('Content-Type', 'application/json');
+    } else {
+      // SSE mode
+      res.setHeader('Content-Type', 'text/event-stream');
+      res.setHeader('Cache-Control', 'no-cache, no-transform');
+      res.setHeader('Connection', 'keep-alive');
+      res.setHeader('X-Accel-Buffering', 'no');
+    }
     res.setHeader('Mcp-Session-Id', sessionId); // Required by MCP Streamable HTTP transport
 
     // Don't send server/initialized notification here
@@ -598,8 +607,17 @@ export class MCPSSEServer {
   private sendSSEMessage(res: Response, message: MCPResponse | MCPNotification): void {
     try {
       const data = JSON.stringify(message);
-      // MCP Streamable HTTP requires 'event: message' prefix for SSE events
-      res.write(`event: message\ndata: ${data}\n\n`);
+
+      // Check if client prefers JSON (Streamable HTTP) vs SSE
+      // ChatGPT sends Accept: application/json and expects plain JSON-RPC response
+      const contentType = res.getHeader('Content-Type') as string || '';
+      if (contentType.includes('application/json')) {
+        // Plain JSON response (Streamable HTTP mode)
+        res.write(data);
+      } else {
+        // SSE format
+        res.write(`event: message\ndata: ${data}\n\n`);
+      }
     } catch (error) {
       logger.error('[MCP SSE] Error sending message', { error });
     }


### PR DESCRIPTION
ChatGPT sends Accept: application/json, we returned SSE - tools invisible

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Accept header for MCP Streamable HTTP: return JSON when clients send Accept: application/json, fixing missing tools in ChatGPT. SSE behavior remains unchanged for SSE-native clients.

- **Bug Fixes**
  - Detect `Accept: application/json` (without `text/event-stream`) and respond with `application/json` by writing plain JSON-RPC.
  - Default to SSE: set SSE headers and send `event: message` frames for clients expecting `text/event-stream`.

<sup>Written for commit 10d2fbab7d64a794577fdc86663d186a7de0c7a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

