### PR TITLE
fix(mcp): skip notifications in JSON mode for ChatGPT

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -613,9 +613,14 @@ export class MCPSSEServer {
       const contentType = res.getHeader('Content-Type') as string || '';
       if (contentType.includes('application/json')) {
         // Plain JSON response (Streamable HTTP mode)
-        res.write(data);
+        // Skip notifications — only send final result (messages with 'id')
+        // Concatenating notifications + result creates invalid JSON
+        if ('id' in message) {
+          res.write(data);
+        }
+        // Notifications are silently dropped in JSON mode
       } else {
-        // SSE format
+        // SSE format — all messages including notifications
         res.write(`event: message\ndata: ${data}\n\n`);
       }
     } catch (error) {


### PR DESCRIPTION
Notifications concat with result = invalid JSON = no tools

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip notifications in Streamable HTTP JSON mode to prevent invalid JSON in ChatGPT. Only the final result (messages with `id`) is sent; SSE still emits all messages.

- **Bug Fixes**
  - For `application/json` responses, drop notifications and write only messages with `id`.
  - Prevents notification+result concatenation that broke JSON parsing and tool use.

<sup>Written for commit e7ac4d413a5c5a4b9583ac7360c90718d5022b68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

