### PR TITLE
fix(mcp): always JSON for POST /sse requests

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -97,17 +97,21 @@ export class MCPSSEServer {
     // Store session context
     this.sessions.set(sessionId, { userId, clientKey });
 
+    // Check Accept header — ChatGPT Streamable HTTP sends Accept: application/json
+    const acceptHeader = req.headers.accept || '';
+
     logger.info('[MCP SSE] New connection', {
       sessionId,
       userId: userId || 'anonymous',
       clientKey: clientKey ? clientKey.substring(0, 8) + '...' : 'none',
       ip: req.ip,
       userAgent: req.headers['user-agent'],
+      accept: acceptHeader,
+      method: req.body?.method || 'unknown',
     });
-
-    // Check Accept header — ChatGPT Streamable HTTP sends Accept: application/json
-    const acceptHeader = req.headers.accept || '';
-    const wantsJson = acceptHeader.includes('application/json') && !acceptHeader.includes('text/event-stream');
+    // POST requests are Streamable HTTP — always respond with JSON
+    // GET requests are SSE — respond with event-stream
+    const wantsJson = req.method === 'POST' || (acceptHeader.includes('application/json') && !acceptHeader.includes('text/event-stream'));
 
     if (wantsJson) {
       // Streamable HTTP mode — respond with JSON


### PR DESCRIPTION
ChatGPT doesn't send Accept header, force JSON for all POST

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always return JSON for POST requests to `/sse` to support Streamable HTTP clients that omit the Accept header. GET requests continue to use SSE.

- **Bug Fixes**
  - Force JSON response for all POST requests; SSE only for GET.
  - Log `Accept` header and request method for debugging.

<sup>Written for commit 55dd25076cbb99827b33a9f8261599fdc04d1eb7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

