### PR TITLE
fix(security): resolve all Dependabot alerts (#165-174)

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -27,7 +27,7 @@
     "@xterm/xterm": "^6.0.0",
     "@xyflow/react": "^12.10.1",
     "argon2-browser": "^1.18.0",
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "date-fns": "^4.1.0",
     "docx": "^9.6.1",
     "dompurify": "^3.3.3",

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -3328,9 +3328,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4175,9 +4175,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4613,9 +4613,9 @@
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- **axios** 1.14.0 → 1.15.0 in lexwebapp (alerts #168, #174)
- **picomatch** 2.3.1 → 2.3.2, 4.0.3 → 4.0.4 in platform (alerts #170-173)
- **vite** already at 8.0.8 (alerts #165-167 resolved by prior update)

## Test plan

- [x] `lexwebapp` builds successfully
- [x] `platform` builds successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update security-sensitive dependencies to resolve Dependabot alerts #165–#174. Bumps `axios` and `picomatch`; `vite` alerts were already resolved.

- **Dependencies**
  - `lexwebapp`: `axios` 1.14.0 → 1.15.0 (fixes header injection chain and SSRF via NO_PROXY bypass).
  - `platform`: `picomatch` 2.3.1 → 2.3.2 and 4.0.3 → 4.0.4 (fixes ReDoS and method injection in POSIX classes).
  - `vite` stays at 8.0.8; related alerts already addressed, no change needed.

<sup>Written for commit 2b89809685740ad8101eb179bca05a7aa7e2e5a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

