### PR TITLE
fix(nginx): dynamic DNS resolution for container restarts

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -740,6 +740,9 @@ jobs:
 
             printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-upstreams.conf
 
+            # --- 1b. Update dynamic DNS vars (resolver-based, no restart needed) ---
+            printf '# Backend hostname variables for dynamic DNS resolution\n# Managed by deploy script (blue-green switching)\n\nset \$prod_backend_host %s;\nset \$prod_backend http://\$prod_backend_host:3000;\nset \$prod_frontend_host %s;\nset \$prod_frontend http://\$prod_frontend_host:80;\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-backend-vars.conf
+
             # --- 2. Reset preview upstreams to placeholder ---
             printf '# Preview upstreams — managed by deploy script\n# Points to inactive color containers for pre-production preview\n# DO NOT EDIT MANUALLY\n\nupstream preview_mcp_backend {\n    server 127.0.0.1:1;  # placeholder — returns 502 when no preview is active\n}\n\nupstream preview_frontend {\n    server 127.0.0.1:1;  # placeholder — returns 502 when no preview is active\n}\n' > nginx/includes/preview-upstreams.conf
 
@@ -759,6 +762,7 @@ jobs:
                 FE_HOST="lexwebapp-prod"
               fi
               printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-upstreams.conf
+              printf '# Backend hostname variables for dynamic DNS resolution\n# Managed by deploy script (blue-green switching)\n\nset \$prod_backend_host %s;\nset \$prod_backend http://\$prod_backend_host:3000;\nset \$prod_frontend_host %s;\nset \$prod_frontend http://\$prod_frontend_host:80;\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-backend-vars.conf
             fi
 
             # Recreate nginx to pick up new upstreams

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -873,6 +873,7 @@ services:
       - ./nginx/includes/prod-server-common.conf:/etc/nginx/includes/prod-server-common.conf:ro
       - ./nginx/includes/security-headers.conf:/etc/nginx/includes/security-headers.conf:ro
       - ./nginx/includes/prod-upstreams.conf:/etc/nginx/includes/prod-upstreams.conf
+      - ./nginx/includes/prod-backend-vars.conf:/etc/nginx/includes/prod-backend-vars.conf
       - ./nginx/includes/preview-server-common.conf:/etc/nginx/includes/preview-server-common.conf:ro
       - ./nginx/includes/preview-upstreams.conf:/etc/nginx/includes/preview-upstreams.conf
       - /etc/letsencrypt:/etc/letsencrypt:ro

--- a/deployment/nginx/includes/prod-backend-vars.conf
+++ b/deployment/nginx/includes/prod-backend-vars.conf
@@ -1,0 +1,8 @@
+# Backend hostname variables for dynamic DNS resolution
+# Managed by deploy script (blue-green switching)
+# Using variables forces nginx to re-resolve DNS via resolver directive
+
+set $prod_backend_host secondlayer-app-prod-green;
+set $prod_backend http://$prod_backend_host:3000;
+set $prod_frontend_host lexwebapp-prod;
+set $prod_frontend http://$prod_frontend_host:80;

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -1,5 +1,14 @@
 # Shared server block settings for production (legal.org.ua)
 
+# Dynamic DNS resolution for Docker container hostnames
+# Without this, nginx caches DNS at startup and breaks when containers restart
+resolver 127.0.0.11 valid=10s ipv6=off;
+resolver_timeout 5s;
+
+# Backend hostname variables — using variables forces nginx to re-resolve DNS
+# via resolver directive on each request (unlike static upstream blocks)
+include /etc/nginx/includes/prod-backend-vars.conf;
+
 # CORS origin validation for SSE endpoints
 # Only allow known origins with credentials; MCP clients use Bearer tokens, not cookies
 set $cors_origin "";
@@ -28,7 +37,7 @@ client_max_body_size 50M;
 # ==========================================
 
 location /health {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Connection "";
     access_log off;
@@ -42,7 +51,7 @@ location /auth {
     limit_req zone=auth_limit burst=10 nodelay;
     limit_req_status 429;
 
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -56,7 +65,7 @@ location /auth {
 # ==========================================
 
 location /api/admin/terminal {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -70,7 +79,7 @@ location /api/admin/terminal {
 
 # Video call signaling WebSocket
 location /api/ws/video-signaling {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -93,7 +102,7 @@ location /api/v1/sse {
     limit_conn sse_conn_limit 20;
 
     rewrite ^/api(/v1/sse.*)$ $1 break;
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -135,7 +144,7 @@ location /api {
     limit_req zone=api_limit burst=120 nodelay;
     limit_req_status 429;
 
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -157,7 +166,7 @@ location /webhooks {
     limit_req zone=webhook_limit burst=10 nodelay;
     limit_req_status 429;
 
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -175,7 +184,7 @@ location /webhooks {
 location /sse {
     limit_conn sse_conn_limit 20;
 
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -212,7 +221,7 @@ location /sse {
 location /v1/sse {
     limit_conn sse_conn_limit 20;
 
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -246,7 +255,7 @@ location /v1/sse {
 }
 
 location /messages {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -261,7 +270,7 @@ location /messages {
 # ==========================================
 
 location = /.well-known/openid-configuration {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -271,7 +280,7 @@ location = /.well-known/openid-configuration {
 }
 
 location = /.well-known/oauth-authorization-server {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -283,7 +292,7 @@ location = /.well-known/oauth-authorization-server {
 # RFC 9728 — OAuth Protected Resource Metadata (required for ChatGPT MCP)
 # Prefix match (not exact) so /sse suffix is also routed to backend per RFC 9728
 location /.well-known/oauth-protected-resource {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -297,7 +306,7 @@ location /.well-known/oauth-protected-resource {
 # ==========================================
 
 location /oauth {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -308,7 +317,7 @@ location /oauth {
 
 # Root-level redirects for MCP client compatibility
 location = /authorize {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -318,7 +327,7 @@ location = /authorize {
 }
 
 location = /token {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -328,7 +337,7 @@ location = /token {
 }
 
 location = /register {
-    proxy_pass http://prod_mcp_backend;
+    proxy_pass $prod_backend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -379,7 +388,7 @@ location ^~ /s3/ {
 # ==========================================
 
 location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
-    proxy_pass http://prod_frontend;
+    proxy_pass $prod_frontend;
     proxy_http_version 1.1;
     proxy_set_header Connection "";
     expires 7d;
@@ -392,7 +401,7 @@ location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
 # ==========================================
 
 location / {
-    proxy_pass http://prod_frontend;
+    proxy_pass $prod_frontend;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

- Adds `resolver 127.0.0.11 valid=10s` to nginx for Docker DNS
- Replaces static `proxy_pass http://prod_mcp_backend` with variable-based `proxy_pass $prod_backend`
- Variables force nginx to re-resolve DNS on each request instead of caching at startup
- Deploy script now writes `prod-backend-vars.conf` alongside `prod-upstreams.conf`

## Root Cause

Nginx caches upstream DNS resolution at startup. When containers restart during blue-green deploy, they get new Docker IPs, but nginx keeps proxying to old IPs → 502 Bad Gateway. Required manual `--force-recreate nginx-prod` every time.

## Test plan

- [ ] Deploy to prod
- [ ] Restart backend container without restarting nginx
- [ ] Verify requests still work (no 502)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dynamic DNS in nginx so it re-resolves Docker hostnames on each request, preventing 502s during blue‑green switches and container restarts. Switches to variable-based proxying with a deploy-managed vars file so host changes apply without restarting nginx.

- **Bug Fixes**
  - Added Docker DNS resolver (127.0.0.11, valid=10s, ipv6=off, 5s timeout) and included `prod-backend-vars.conf` to define `$prod_backend`/`$prod_frontend`.
  - Replaced static upstreams with variable-based `proxy_pass` throughout the prod server config.
  - Updated deploy workflow to write `prod-backend-vars.conf` and docker-compose to mount it, enabling blue‑green host flips without recreating nginx.

<sup>Written for commit bbac73ee4c4a87247eb6bafc1dc81846a982c4fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

