### PR TITLE
fix(mcp): SSE format for ChatGPT tool registration

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -109,9 +109,9 @@ export class MCPSSEServer {
       accept: acceptHeader,
       method: req.body?.method || 'unknown',
     });
-    // POST requests are Streamable HTTP — always respond with JSON
-    // GET requests are SSE — respond with event-stream
-    const wantsJson = req.method === 'POST' || (acceptHeader.includes('application/json') && !acceptHeader.includes('text/event-stream'));
+    // Determine response format based on Accept header
+    // ChatGPT MCP client expects text/event-stream for tool registration
+    const wantsJson = acceptHeader.includes('application/json') && !acceptHeader.includes('text/event-stream');
 
     if (wantsJson) {
       // Streamable HTTP mode — respond with JSON


### PR DESCRIPTION
Revert to SSE default - ChatGPT needs it for tools

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default responses from the MCP SSE server now use SSE (`text/event-stream`) so ChatGPT tool registration works again. JSON is returned only when the client explicitly sends `Accept: application/json` without `text/event-stream`.

<sup>Written for commit 9090c872df7e1ca44be04afc9ee52cdd7703a683. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

