### PR TITLE
fix(mcp): POST=JSON GET=SSE for ChatGPT

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -109,9 +109,9 @@ export class MCPSSEServer {
       accept: acceptHeader,
       method: req.body?.method || 'unknown',
     });
-    // Determine response format based on Accept header
-    // ChatGPT MCP client expects text/event-stream for tool registration
-    const wantsJson = acceptHeader.includes('application/json') && !acceptHeader.includes('text/event-stream');
+    // POST = Streamable HTTP = always JSON response
+    // GET = SSE transport = event-stream
+    const wantsJson = req.method === 'POST';
 
     if (wantsJson) {
       // Streamable HTTP mode — respond with JSON


### PR DESCRIPTION
POST was returning SSE, ChatGPT needs JSON

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure POST returns JSON and GET uses SSE in the MCP SSE server so ChatGPT Streamable HTTP works correctly. Switches from Accept-header negotiation to method-based selection.

- **Bug Fixes**
  - `POST` now always responds with JSON; `GET` responds with `text/event-stream` in `mcp_backend`.

<sup>Written for commit ddf6e259f72ffaa04ede877eb7d8901a563e5821. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

