### PR TITLE
fix(mcp): limit tools to 15 for ChatGPT

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -317,10 +317,15 @@ export class MCPSSEServer {
    * Handle tools/list request
    */
   private async handleToolsList(res: Response, request: MCPRequest): Promise<void> {
-    const tools = this.getAllTools();
+    const allTools = this.getAllTools();
+
+    // Limit tools for ChatGPT compatibility — large tool lists may fail to register
+    const MAX_TOOLS = 15;
+    const tools = allTools.slice(0, MAX_TOOLS);
 
     logger.info('[MCP SSE] Tools list requested', {
       count: tools.length,
+      total: allTools.length,
     });
 
     this.sendSSEMessage(res, {


### PR DESCRIPTION
Test if 88 tools overloads ChatGPT MCP

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limit the tools/list SSE response to the first 15 tools to avoid ChatGPT MCP registration failures with large tool sets. Log both returned count and total available to help debugging.

<sup>Written for commit bc51676f5fecd11360d0d31225931fa5c5e65b9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

