### PR TITLE
fix(test): increase vitest testTimeout to 15s for CI stability

### DIFF
--- a/lexwebapp/vitest.config.ts
+++ b/lexwebapp/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     globals: true,
     environment: 'happy-dom',
     setupFiles: ['./src/__tests__/setup.ts'],
+    testTimeout: 15000,
     pool: 'forks',
     teardownTimeout: 10000,
     forks: {


### PR DESCRIPTION
## Summary
- Adds `testTimeout: 15000` to `vitest.config.ts` to prevent flaky timeouts on the self-hosted CI runner
- Fixes 3 test timeouts (AdminMonitoringPage, LegalCodesLibraryPage, OrganizationSetupModal) that caused the latest prod deploy to fail
- The ConsultationChatTab worker crash was a cascade from the fork pool being exhausted by the timeout failures

## Test plan
- [x] AdminMonitoringPage and OrganizationSetupModal tests pass locally with new timeout
- [ ] CI pipeline passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase `vitest` testTimeout to 15s in `vitest.config.ts` to stabilize CI on slower self‑hosted runners. Fixes flaky timeouts in AdminMonitoringPage, LegalCodesLibraryPage, and OrganizationSetupModal, and prevents fork pool exhaustion that crashed the ConsultationChatTab worker.

<sup>Written for commit 1bd2dde7843cb8a7b843efbdb968bab81208f265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

