### PR TITLE
fix(ci): use /health/ready for prod health check

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -840,7 +840,7 @@ jobs:
 
           # Health check via docker exec on prod (port 3000 is not exposed on host)
           for i in 1 2 3 4 5; do
-            HEALTH=$($SSH_CMD "docker exec $CONTAINER wget -q -O- --timeout=10 http://127.0.0.1:3000/health 2>/dev/null") && {
+            HEALTH=$($SSH_CMD "docker exec $CONTAINER wget -q -O- --timeout=10 http://127.0.0.1:3000/health/ready 2>/dev/null") && {
               echo "=== Production health (docker exec via SSH) ==="
               echo "$HEALTH" | jq . 2>/dev/null || echo "$HEALTH"
               STATUS=$(echo "$HEALTH" | jq -r '.status' 2>/dev/null)


### PR DESCRIPTION
## Summary
- Switches prod deploy health check from `/health` to `/health/ready`
- `/health` calls Qdrant, MinIO, OpenAI models.list, payout reconciliation — any can hang past wget's 10s timeout
- `/health/ready` is the same lightweight endpoint Docker healthcheck uses (just returns status + uptime)
- Fixes prod deploy failure where container was healthy but health check timed out

## Test plan
- [x] Verified `/health/ready` responds in <1s on prod
- [x] Verified `/health` hangs on prod (wget timeout)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch production deploy health check from /health to /health/ready to avoid wget 10s timeouts and false failures. The new endpoint is a lightweight readiness check (status + uptime) that matches the container’s Docker healthcheck.

<sup>Written for commit 06479378b9d4e8a8284c310875bb54604679c2ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

