### PR TITLE
feat(opendata): update landing to 27 jurisdictions

### DIFF
--- a/deployment/static/opendata/index.html
+++ b/deployment/static/opendata/index.html
@@ -58,7 +58,7 @@
           "name": "LEX",
           "url": "https://legal.org.ua",
           "applicationCategory": "LegalService",
-          "description": "AI-powered legal analysis platform for law firms. Semantic search across 110M+ court decisions, case law analysis, legislative monitoring across 12 jurisdictions."
+          "description": "AI-powered legal analysis platform for law firms. Semantic search across 110M+ court decisions, case law analysis, legislative monitoring across 27 jurisdictions."
         }
       },
       {
@@ -252,7 +252,7 @@
       <div class="lbl">Breach records monitored</div>
     </div>
     <div class="stat">
-      <div class="num">12</div>
+      <div class="num">27</div>
       <div class="lbl">Legal jurisdictions</div>
     </div>
   </section>
@@ -268,11 +268,11 @@
           <div class="tag">Legal Technology</div>
           <h3>LEX</h3>
           <div class="url"><a href="https://legal.org.ua">legal.org.ua</a></div>
-          <p>AI-powered legal analysis platform for law firms and corporate counsel. Semantic search across 110M+ court decisions, case law and legal position analysis, legislative monitoring across 12 jurisdictions, and legal positions with cited sources.</p>
+          <p>AI-powered legal analysis platform for law firms and corporate counsel. Semantic search across 110M+ court decisions, case law and legal position analysis, legislative monitoring across 27 jurisdictions, and legal positions with cited sources.</p>
           <ul class="features">
             <li>Semantic search across 110M+ court decisions (EDRSR)</li>
             <li>AI-powered case law and legal position analysis</li>
-            <li>Legislative change monitoring across 12 jurisdictions</li>
+            <li>Legislative change monitoring across 27 jurisdictions</li>
             <li>Legal positions with cited sources</li>
             <li>End-to-end encrypted legal consultations</li>
             <li>Parliament data, deputy voting records, bill tracking</li>


### PR DESCRIPTION
## Summary
- Updated `deployment/static/opendata/index.html` — the static landing at opendata.legal.org.ua
- Changed "12 jurisdictions" → "27 jurisdictions" (12 existing + 15 offshore from NC task 489)
- Updated stats badge, structured data, product description, and feature list

## Test plan
- [ ] Verify opendata.legal.org.ua shows "27" in stats and product descriptions after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Open Data landing to reflect coverage in 27 jurisdictions (12 existing + 15 offshore per NC-489). Updated structured data, stats counter, and feature list text in `deployment/static/opendata/index.html` to match.

<sup>Written for commit 3e623c78a43df5217f9803b6c70418550174a57f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

