### PR TITLE
feat(login): restore AWS Startups badge on login page

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -649,6 +649,28 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
 
           </div>
 
+          {/* AWS Startups Logo */}
+          <div className="text-center mt-6">
+            <motion.a
+              href="https://aws.amazon.com/startups/showcase/startup-details/aa3724a2-2ad3-429d-a762-4415407bbd86"
+              target="_blank"
+              rel="noopener noreferrer"
+              initial={{ scale: 0.9, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ duration: 0.5, delay: 0.5 }}
+              whileHover={{ scale: 1.03 }}
+              whileTap={{ scale: 0.97 }}
+              className="inline-flex flex-col items-center gap-2 opacity-70 hover:opacity-100 transition-opacity"
+            >
+              <span className="text-[10px] text-claude-subtext tracking-wide uppercase">Backed by AWS Activate</span>
+              <img
+                src="/aws.starups_dark.svg"
+                alt="Backed by AWS Activate — LexApp отримав підтримку від AWS Activate для розвитку масштабованої AI-інфраструктури та обробки великих масивів правових даних"
+                className="h-8 w-auto"
+              />
+            </motion.a>
+          </div>
+
           {/* Bottom navigation */}
           <div className="flex items-center gap-5 flex-wrap">
             <a


### PR DESCRIPTION
## Summary
- Restores the AWS Startups / AWS Activate badge on the login page
- Was removed in commit b0e699a9, bringing it back

## Test plan
- [ ] Verify AWS badge appears on login page below the login form
- [ ] Verify link opens AWS Startups showcase page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restored the AWS Activate badge on the login page. It appears below the login form with a subtle animation and links in a new tab to our AWS Startups showcase.

<sup>Written for commit 756573a67c2ab5d4293d018247c8fbcdac02e951. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

