### PR TITLE
fix(router): make /developer/docs public for crawlers

### DIFF
--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -294,6 +294,10 @@ export const router = createBrowserRouter([
     element: S(ReferralLanding),
   },
   {
+    path: ROUTES.DEVELOPER_DOCS,
+    element: S(DeveloperDocsPage),
+  },
+  {
     element: <AuthGuard />,
     children: [
       {
@@ -356,10 +360,6 @@ export const router = createBrowserRouter([
           {
             path: ROUTES.MCP_CONNECT,
             element: S(MCPConnectPage),
-          },
-          {
-            path: ROUTES.DEVELOPER_DOCS,
-            element: S(DeveloperDocsPage),
           },
           {
             path: ROUTES.MY_CONTRACTS,


### PR DESCRIPTION
## Summary
- `/developer/docs` was inside `<AuthGuard />` — crawlers and unauthenticated users got redirected to login
- Moved the route to the public section (alongside blog, investor pages, legal docs)
- Page is self-contained, no auth-dependent data

## Test plan
- [ ] Open `legal.org.ua/developer/docs` in incognito — should render without login
- [ ] Verify authenticated users still see the page normally
- [ ] Check Google crawler can access the page (use Lighthouse or Search Console URL inspection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make /developer/docs publicly accessible by moving DeveloperDocsPage outside <AuthGuard />, so crawlers and logged‑out users can access the docs. Signed‑in behavior is unchanged.

<sup>Written for commit ad277cc9775292e6eddc654d9b16ca6a9a52381a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

