### PR TITLE
feat(opendata-sync): add 13 missing datasets to automatic sync

### DIFF
--- a/mcp_backend/src/migrations/125_add_missing_sync_sources.sql
+++ b/mcp_backend/src/migrations/125_add_missing_sync_sources.sql
@@ -1,0 +1,98 @@
+-- Migration 125: Add import catalog entries for datasets that exist on prod
+-- but don't have automatic sync configured yet.
+-- Sources: data.gov.ua JSON APIs, XLSX/CSV downloads
+
+-- ═══ Daily JSON API sources ═══
+
+-- Недійсні паспорти (щоденне оновлення на data.gov.ua)
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('invalid_passports', 'МВС — Недійсні паспорти', 'json_array',
+  'https://data.gov.ua/dataset/ab09ed00-4f51-4f6c-a2f7-1b2fb118be0f/resource/74681fa4-ca64-4127-8e7f-53e8f27003eb/download/',
+  '{"format": "json"}', 'opendata_invalid_passports', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- Недійсні закордонні паспорти
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('invalid_passports_foreign', 'МВС — Недійсні закордонні паспорти', 'json_array',
+  'https://data.gov.ua/dataset/b465b821-db5d-4b8b-8131-12682fab2203/resource/bc236a5c-5765-4856-94d5-efba65929e83/download/',
+  '{"format": "json"}', 'opendata_invalid_passports_foreign', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- ДСФМУ — Перелік терористів (рідко оновлюється, але треба перевіряти)
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('dsfmu_terrorism', 'ДСФМУ — Перелік терористів', 'json_array',
+  'https://data.gov.ua/dataset/a140de93-d9e1-47ca-b29a-29c7fdc4c3a5/resource/159e6cdf-7f3e-4637-86ea-4f50e4dd0e3b/download/',
+  '{"format": "json"}', 'opendata_terrorism_persons', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- Реєстр люстрованих осіб
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('lustration', 'Мін''юст — Реєстр люстрованих', 'json_array',
+  'https://data.gov.ua/dataset/8faa71c1-3a54-45e8-8f6e-06c92b1ff8bc/resource/e9ef4571-1574-4b38-bb5c-0b4747d308be/download/',
+  '{"format": "json"}', 'opendata_lustration', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- Держдопомога АМКУ
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('state_aid', 'АМКУ — Реєстр держдопомоги', 'json_array',
+  'https://data.gov.ua/dataset/16fcf128-1a28-41d5-8081-3dfffe68b397/resource/91bb54fa-dbce-4248-97e6-8ab85af81bc7/download/',
+  '{"format": "json"}', 'opendata_state_aid', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- НАЗК — Перевірки декларацій
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('nazk_declaration_checks', 'НАЗК — Перевірки декларацій', 'json_array',
+  'https://data.gov.ua/dataset/e2c9de23-8c02-4465-b4bf-d68fc7a28a0c/resource/aeec4bfb-32f0-4ad5-adbd-b4d403e62267/download/',
+  '{"format": "json"}', 'opendata_declaration_checks', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- НАЗК — Корупційні правопорушники
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('nazk_corruption_offenders', 'НАЗК — Корупційні правопорушники', 'json_array',
+  'https://data.gov.ua/dataset/1fba0e89-3a34-4a1b-b3e3-dbb78cdfbb20/resource/a44de7e5-a9b5-4dfa-801d-1e4db2fd0e1a/download/',
+  '{"format": "json"}', 'opendata_corruption_offenders', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- Мін'юст — Адвокати (ЄРАУ)
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('advocates', 'Мін''юст — Реєстр адвокатів (ЄРАУ)', 'json_array',
+  'https://data.gov.ua/dataset/2cfac59e-f849-406c-a826-02de0afe4602/resource/cb39caea-14fa-4f42-a9ff-5bda3d5ce94f/download/',
+  '{"format": "json"}', 'opendata_advocates', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- ═══ Weekly/monthly large dataset sources ═══
+
+-- Стан справ у судах (court.gov.ua)
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('court_case_status', 'Судова влада — Стан розгляду справ', 'json_array',
+  'https://data.gov.ua/dataset/af2a2498-60a2-4c6d-a436-b0e0e052abec/resource/4e5c1e2d-a553-41ac-ae5c-e6ad5e6b13c8/download/',
+  '{"format": "json"}', 'opendata_court_case_status', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- Розклад засідань
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('court_schedule', 'Судова влада — Розклад засідань', 'json_array',
+  'https://data.gov.ua/dataset/710bab18-d34f-4a49-92e3-86c4624a7e70/resource/9d2afb46-67dd-4e56-8cd6-adee289aa66e/download/',
+  '{"format": "json"}', 'opendata_court_schedule', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- ДПС — Великі платники податків
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('large_taxpayers', 'ДПС — Великі платники податків', 'json_array',
+  'https://data.gov.ua/dataset/bcb85244-91fc-4b80-926f-b1fce0bfbb54/resource/b979cbac-c015-4073-b9db-fe11e3b5c7b2/download/',
+  '{"format": "json"}', 'opendata_large_taxpayers', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- ДПС — Боржники по зарплаті
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('wage_debtors', 'Держпраці — Боржники по зарплаті', 'json_array',
+  'https://data.gov.ua/dataset/38a06a08-4e5c-4e7b-9e71-c3a5b0b6d02d/resource/0c3ce3a1-67d2-41a4-8e90-eee6fa96ca81/download/',
+  '{"format": "json"}', 'opendata_wage_debtors', 0)
+ON CONFLICT (name) DO NOTHING;
+
+-- ВККС — Кандидати на посади суддів
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, rate_limit_ms)
+VALUES ('judge_candidates', 'ВККС — Кандидати на посади суддів', 'json_array',
+  'https://data.gov.ua/dataset/77c21a3f-12e7-47c7-8e4b-a8e4d1ea26ab/resource/88ef2d14-c4ff-44a6-b07f-afe2a5f33b0c/download/',
+  '{"format": "json"}', 'opendata_judge_candidates', 0)
+ON CONFLICT (name) DO NOTHING;

--- a/opendata-sync/src/config.ts
+++ b/opendata-sync/src/config.ts
@@ -55,6 +55,38 @@ const backendDailySources: DataSourceSchedule[] = [
     sourceName: 'nazk_corruption',
     enabled: true,
   },
+  {
+    name: 'invalid_passports',
+    title: 'МВС — Недійсні паспорти',
+    cron: '0 4 * * *', // 04:00 daily
+    target: 'backend',
+    sourceName: 'invalid_passports',
+    enabled: true,
+  },
+  {
+    name: 'invalid_passports_foreign',
+    title: 'МВС — Недійсні закордонні паспорти',
+    cron: '15 4 * * *', // 04:15 daily
+    target: 'backend',
+    sourceName: 'invalid_passports_foreign',
+    enabled: true,
+  },
+  {
+    name: 'nazk_corruption_offenders',
+    title: 'НАЗК — Корупційні правопорушники',
+    cron: '45 3 * * *', // 03:45 daily
+    target: 'backend',
+    sourceName: 'nazk_corruption_offenders',
+    enabled: true,
+  },
+  {
+    name: 'nazk_declaration_checks',
+    title: 'НАЗК — Перевірки декларацій',
+    cron: '0 6 * * *', // 06:00 daily
+    target: 'backend',
+    sourceName: 'nazk_declaration_checks',
+    enabled: true,
+  },
 ];
 
 const backendWeeklySources: DataSourceSchedule[] = [
@@ -88,6 +120,78 @@ const backendWeeklySources: DataSourceSchedule[] = [
     cron: '0 4 * * 0', // Sunday 04:00
     target: 'backend',
     sourceName: 'nipo_designs',
+    enabled: true,
+  },
+  {
+    name: 'dsfmu_terrorism',
+    title: 'ДСФМУ — Перелік терористів',
+    cron: '0 6 * * 0', // Sunday 06:00
+    target: 'backend',
+    sourceName: 'dsfmu_terrorism',
+    enabled: true,
+  },
+  {
+    name: 'lustration',
+    title: 'Мін\'юст — Реєстр люстрованих',
+    cron: '15 6 * * 0', // Sunday 06:15
+    target: 'backend',
+    sourceName: 'lustration',
+    enabled: true,
+  },
+  {
+    name: 'state_aid',
+    title: 'АМКУ — Реєстр держдопомоги',
+    cron: '30 6 * * 0', // Sunday 06:30
+    target: 'backend',
+    sourceName: 'state_aid',
+    enabled: true,
+  },
+  {
+    name: 'advocates',
+    title: 'Мін\'юст — Реєстр адвокатів (ЄРАУ)',
+    cron: '45 6 * * 0', // Sunday 06:45
+    target: 'backend',
+    sourceName: 'advocates',
+    enabled: true,
+  },
+  {
+    name: 'court_case_status',
+    title: 'Судова влада — Стан розгляду справ',
+    cron: '0 7 * * 0', // Sunday 07:00
+    target: 'backend',
+    sourceName: 'court_case_status',
+    enabled: true,
+  },
+  {
+    name: 'court_schedule',
+    title: 'Судова влада — Розклад засідань',
+    cron: '30 7 * * 0', // Sunday 07:30
+    target: 'backend',
+    sourceName: 'court_schedule',
+    enabled: true,
+  },
+  {
+    name: 'large_taxpayers',
+    title: 'ДПС — Великі платники податків',
+    cron: '0 8 * * 0', // Sunday 08:00
+    target: 'backend',
+    sourceName: 'large_taxpayers',
+    enabled: true,
+  },
+  {
+    name: 'wage_debtors',
+    title: 'Держпраці — Боржники по зарплаті',
+    cron: '15 8 * * 0', // Sunday 08:15
+    target: 'backend',
+    sourceName: 'wage_debtors',
+    enabled: true,
+  },
+  {
+    name: 'judge_candidates',
+    title: 'ВККС — Кандидати на посади суддів',
+    cron: '30 8 * * 0', // Sunday 08:30
+    target: 'backend',
+    sourceName: 'judge_candidates',
     enabled: true,
   },
 ];


### PR DESCRIPTION
## Summary
- Add 13 new data sources to opendata-sync cron: passports, terrorism, lustration, state aid, advocates, court status, court schedule, declaration checks, corruption offenders, large taxpayers, wage debtors, judge candidates
- Total automatic sync sources: 19 → 32
- Migration 125 adds `import_source_catalog` entries for all new sources
- All use existing `json_array` import pipeline — no new code needed

## Not covered (separate task needed)
- `opendata_vehicle_registrations` (19.5M rows, CSV/ZIP) — needs file_download pipeline
- `opendata_financial_statements` (504K rows, XML/ZIP) — needs file_download pipeline  
- `opendata_securities_owners`, `opendata_public_organizations` — specific formats

## Test plan
- [ ] Run migration 125 on prod
- [ ] Rebuild opendata-sync container
- [ ] Check `/status` endpoint shows 32 sources
- [ ] Run `--run-once` to verify new sources trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 13 missing data.gov.ua JSON datasets to automatic sync, increasing sources from 19 to 32. Migration 125 registers the sources and `opendata-sync` schedules daily/weekly crons using the existing `json_array` pipeline.

- **New Features**
  - Daily: invalid passports, foreign passports, NAPK corruption offenders, declaration checks.
  - Weekly (Sun): terrorism list, lustration, state aid, advocates, court case status, court schedule, large taxpayers, wage debtors, judge candidates.
  - Excludes large ZIP/XML datasets; to be added later via `file_download`.

- **Migration**
  - Apply migration 125 to add `import_source_catalog` rows.
  - Redeploy `opendata-sync` to load new cron config.
  - Verify `/status` shows 32 sources; optionally run `--run-once` to backfill.

<sup>Written for commit 9891d0636892cdb48c09b69fde6b54a6c325a34e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

