### PR TITLE
fix(tools): accept numeric doc_id in get_citation_graph

### DIFF
--- a/mcp_backend/src/api/tools/legal-advice-tools.ts
+++ b/mcp_backend/src/api/tools/legal-advice-tools.ts
@@ -216,12 +216,14 @@ export class LegalAdviceTools extends BaseToolHandler {
     let caseId = String(args.case_id).trim();
 
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const isUUID = uuidRegex.test(caseId);
+    const isNumericDocId = /^\d+$/.test(caseId);
 
-    if (!uuidRegex.test(caseId)) {
-      // Not a UUID — treat as case_number (e.g. "176/973/26") and resolve to doc_id
+    if (!isUUID && !isNumericDocId) {
+      // Looks like a case_number (e.g. "176/973/26") — resolve to doc_id
       if (!this.db) {
         return this.wrapResponse({
-          error: `Параметр case_id "${caseId}" не є UUID, а БД недоступна для пошуку по номеру справи.`,
+          error: `Параметр case_id "${caseId}" не є UUID/doc_id, а БД недоступна для пошуку по номеру справи.`,
           provided_value: caseId,
         });
       }
@@ -245,6 +247,7 @@ export class LegalAdviceTools extends BaseToolHandler {
       });
     }
 
+    // caseId is now either a UUID, a numeric doc_id, or a resolved doc_id
     const graph = await this.citationValidator.buildCitationGraph(caseId, args.depth || 2);
     return this.wrapResponse({ graph });
   }


### PR DESCRIPTION
## Summary
- `get_citation_graph` now correctly handles numeric `doc_id` (BIGINT) in addition to UUID and case_number
- Previous fix only distinguished UUID vs case_number, but `edrsr_documents.doc_id` is BIGINT — numeric IDs were incorrectly treated as case numbers and failed lookup

## Three accepted formats
| Input | Example | Handling |
|-------|---------|----------|
| UUID | `a1b2c3d4-e5f6-...` | Pass through |
| Numeric doc_id | `12345678` | Pass through as-is |
| Case number | `176/973/26` | Resolve via `cause_num` DB lookup |

## Test plan
- [ ] `get_citation_graph` with numeric doc_id like `"12345678"` works
- [ ] `get_citation_graph` with case_number like `"756/1234/23"` resolves correctly
- [ ] `get_citation_graph` with UUID still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`get_citation_graph` now accepts numeric `doc_id` (BIGINT) alongside UUID and case numbers, fixing lookup failures caused by treating numeric IDs as case numbers. It detects UUIDs, passes numeric strings through as `doc_id`, and only resolves case numbers via DB lookup.

<sup>Written for commit 4da02a37355ca428426d075095da23296c3c9a3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

