### PR TITLE
fix(tools): prevent UUID cast error in get_citation_graph

### DIFF
--- a/mcp_backend/src/api/tools/legal-advice-tools.ts
+++ b/mcp_backend/src/api/tools/legal-advice-tools.ts
@@ -244,8 +244,8 @@ export class LegalAdviceTools extends BaseToolHandler {
     );
     if (doc.rows.length > 0) return doc.rows[0].id;
 
-    // Fallback: return numeric doc_id as-is (citation_links may not have it, but at least won't crash on UUID cast)
-    return zoId;
+    // No matching UUID in documents table — return null to avoid passing integer as UUID
+    return null;
   }
 
   private async getCitationGraph(args: any): Promise<ToolResult> {
@@ -268,8 +268,9 @@ export class LegalAdviceTools extends BaseToolHandler {
 
     if (!resolvedId) {
       return this.wrapResponse({
-        error: `Справу "${input}" не знайдено в ЄДРСР. Перевірте формат номера або скористайтесь search_legal_precedents для пошуку.`,
+        error: `Справу "${input}" знайдено в ЄДРСР, але вона ще не імпортована до бази цитувань (documents). Граф цитувань поки недоступний для цього рішення.`,
         provided_value: input,
+        hint: 'Використовуйте get_court_decision або get_case_documents_chain для перегляду рішення.',
       });
     }
 


### PR DESCRIPTION
## Summary
The fallback in `resolveToDocumentsUUID` returned the numeric `doc_id` as-is when no matching `documents` record was found. This integer string was then passed to `buildCitationGraph` which queries `citation_links` with `WHERE id = $1` where `id` is UUID type — causing "invalid input syntax for type uuid: 134916442".

Most EDRSR decisions (96M+) only exist in `edrsr_documents`, not in the `documents` table. The fix returns `null` instead of the fallback, and shows a descriptive error.

## Test plan
- [ ] `get_citation_graph` with case_number `"176/973/26"` returns descriptive error (not SQL crash)
- [ ] `get_citation_graph` with valid UUID still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented UUID cast errors in get_citation_graph by removing the fallback that passed a numeric EDRSR doc_id as a UUID. If a case isn’t in the `documents` table, we now return null, show a clear message, and suggest `get_court_decision` or `get_case_documents_chain`.

<sup>Written for commit 940f02de0bd670479d2a2635c07e1d631d4eb9b1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

