### PR TITLE
feat(ci): build Docker images on runner, push to GHCR

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -24,6 +24,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: read
+  packages: write
 
 concurrency:
   group: deploy-prod
@@ -350,14 +351,148 @@ jobs:
             --base main \
             --head "$BRANCH"
 
-  # ─── Step 3a: Deploy Preview (inactive color) ──────────────────────
-  deploy-preview:
-    name: Deploy Preview
+  # ─── Step 2c: Build Docker images and push to GHCR ──────────────────
+  build-and-push-images:
+    name: Build & Push Images to GHCR
     runs-on: [self-hosted, local]
     needs: [detect-changes, pre-deploy-tests]
     if: |
       needs.detect-changes.outputs.has_changes == 'true' &&
       needs.pre-deploy-tests.result == 'success'
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_PREFIX: ghcr.io/overthelex
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+      PLATFORM_CHANGED: ${{ needs.detect-changes.outputs.platform }}
+      OPENDATA_SYNC_CHANGED: ${{ needs.detect-changes.outputs.opendata_sync }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build shared package (needed for document-service context)
+        run: cd packages/shared && npm install --legacy-peer-deps && npm run build
+
+      - name: Overlay proprietary source
+        if: needs.detect-changes.outputs.backend == 'true'
+        run: |
+          CORE_TMP=$(mktemp -d)
+          gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
+          cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          rm -rf "$CORE_TMP"
+
+      - name: Build backend dist (needed for document-service Dockerfile)
+        if: needs.detect-changes.outputs.backend == 'true'
+        run: cd mcp_backend && npm install && npm run build
+
+      - name: Build & push backend image
+        if: needs.detect-changes.outputs.backend == 'true'
+        run: |
+          docker build \
+            -t $IMAGE_PREFIX/sl-backend:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-backend:latest \
+            -f deployment/Dockerfile.mono-backend .
+          docker push $IMAGE_PREFIX/sl-backend:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-backend:latest
+
+      - name: Build & push document-service image
+        if: needs.detect-changes.outputs.backend == 'true'
+        run: |
+          docker build \
+            -t $IMAGE_PREFIX/sl-document-service:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-document-service:latest \
+            -f deployment/Dockerfile.document-service .
+          docker push $IMAGE_PREFIX/sl-document-service:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-document-service:latest
+
+      - name: Build & push RADA image
+        if: needs.detect-changes.outputs.rada == 'true'
+        run: |
+          docker build \
+            -t $IMAGE_PREFIX/sl-rada:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-rada:latest \
+            -f deployment/Dockerfile.mono-rada .
+          docker push $IMAGE_PREFIX/sl-rada:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-rada:latest
+
+      - name: Build & push OpenReyestr image
+        if: needs.detect-changes.outputs.openreyestr == 'true'
+        run: |
+          docker build \
+            -t $IMAGE_PREFIX/sl-openreyestr:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-openreyestr:latest \
+            -f deployment/Dockerfile.mono-openreyestr .
+          docker push $IMAGE_PREFIX/sl-openreyestr:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-openreyestr:latest
+
+      - name: Build & push frontend image
+        if: needs.detect-changes.outputs.frontend == 'true'
+        run: |
+          docker build \
+            --build-arg BUILD_ENV=production \
+            --build-arg VITE_API_URL=https://legal.org.ua \
+            --build-arg VITE_API_KEY=${VITE_API_KEY_PROD:-REDACTED_SL_KEY_PROD} \
+            --build-arg VITE_ENABLE_SSE_STREAMING=true \
+            --build-arg VITE_ENABLE_ALL_MCP_TOOLS=true \
+            --build-arg VITE_SHOW_TOOL_SELECTOR=true \
+            --build-arg VITE_ENABLE_THINKING_STEPS=true \
+            --build-arg VITE_AUTO_EXPAND_THINKING=true \
+            --build-arg GIT_SHA=${{ github.sha }} \
+            --build-arg APP_VERSION=${APP_VERSION:-dev} \
+            --build-arg APP_FRONTEND_VERSION=${APP_FRONTEND_VERSION:-dev} \
+            -t $IMAGE_PREFIX/sl-frontend:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-frontend:latest \
+            -f lexwebapp/Dockerfile .
+          docker push $IMAGE_PREFIX/sl-frontend:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-frontend:latest
+        env:
+          VITE_API_KEY_PROD: ${{ secrets.VITE_API_KEY_PROD }}
+
+      - name: Build & push platform image
+        if: needs.detect-changes.outputs.platform == 'true'
+        run: |
+          docker build \
+            --build-arg BUILD_ENV=production \
+            --build-arg VITE_API_URL=https://platform.legal.org.ua \
+            --build-arg GIT_SHA=${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-platform:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-platform:latest \
+            -f platform/Dockerfile .
+          docker push $IMAGE_PREFIX/sl-platform:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-platform:latest
+
+      - name: Build & push opendata-sync image
+        if: needs.detect-changes.outputs.opendata_sync == 'true'
+        run: |
+          docker build \
+            -t $IMAGE_PREFIX/sl-opendata-sync:${{ github.sha }} \
+            -t $IMAGE_PREFIX/sl-opendata-sync:latest \
+            -f deployment/Dockerfile.opendata-sync .
+          docker push $IMAGE_PREFIX/sl-opendata-sync:${{ github.sha }}
+          docker push $IMAGE_PREFIX/sl-opendata-sync:latest
+
+      - name: Clean up local images
+        if: always()
+        run: docker image prune -f
+
+  # ��── Step 3a: Deploy Preview (inactive color) ──────────────────────
+  deploy-preview:
+    name: Deploy Preview
+    runs-on: [self-hosted, local]
+    needs: [detect-changes, pre-deploy-tests, build-and-push-images]
+    if: |
+      needs.detect-changes.outputs.has_changes == 'true' &&
+      needs.build-and-push-images.result == 'success'
     outputs:
       backend_version: ${{ steps.version.outputs.backend_version }}
       frontend_version: ${{ steps.version.outputs.frontend_version }}
@@ -431,7 +566,7 @@ jobs:
           echo "frontend_version=${FE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Frontend version: ${FE_VERSION}"
 
-      - name: "Phase 1: Build, migrate, start inactive color, enable preview"
+      - name: "Phase 1: Pull images, migrate, start inactive color, enable preview"
         env:
           PROD_SSH_KEY_PATH: ${{ secrets.PROD_SSH_KEY_PATH }}
           BACKEND_VERSION: ${{ steps.version.outputs.backend_version }}
@@ -450,34 +585,30 @@ jobs:
 
           echo "=== Phase 1: Deploy preview (inactive color) ==="
 
-          # Pull latest code and tags
+          # Pull latest code (for compose file, nginx configs, migration scripts)
           $SSH_CMD "git -C ${REMOTE_REPO} fetch origin main --tags && git -C ${REMOTE_REPO} reset --hard origin/main"
 
           # Write VERSION file with both versions
           $SSH_CMD "printf 'BACKEND_VERSION=%s\nFRONTEND_VERSION=%s\n' '${BACKEND_VERSION}' '${FRONTEND_VERSION}' > ${REMOTE_REPO}/VERSION"
 
-          # Build dist on prod
-          $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix packages/shared install && npm --prefix packages/shared run build"
+          # Login to GHCR and pull pre-built images (built on runner, pushed in previous job)
+          $SSH_CMD bash << PULL_SCRIPT
+            set -e
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-          if [ "$BACKEND_CHANGED" = "true" ]; then
-            # Overlay proprietary source from private repo before building
-            CORE_TMP=$(mktemp -d)
-            gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1 2>/dev/null
-            SCP_CMD="scp -i $PROD_SSH_KEY_PATH -o StrictHostKeyChecking=no"
-            $SCP_CMD -r "$CORE_TMP"/src/services/* "${PROD_USER}@${PROD_SERVER}:${REMOTE_REPO}/mcp_backend/src/services/"
-            $SCP_CMD -r "$CORE_TMP"/src/prompts/* "${PROD_USER}@${PROD_SERVER}:${REMOTE_REPO}/mcp_backend/src/prompts/"
-            rm -rf "$CORE_TMP"
+            [ "${BACKEND_CHANGED}" = "true" ] && {
+              docker pull ghcr.io/overthelex/sl-backend:latest
+              docker pull ghcr.io/overthelex/sl-document-service:latest
+            }
+            [ "${RADA_CHANGED}" = "true" ] && docker pull ghcr.io/overthelex/sl-rada:latest
+            [ "${OPENREYESTR_CHANGED}" = "true" ] && docker pull ghcr.io/overthelex/sl-openreyestr:latest
+            [ "${FRONTEND_CHANGED}" = "true" ] && docker pull ghcr.io/overthelex/sl-frontend:latest
+            [ "${PLATFORM_CHANGED}" = "true" ] && docker pull ghcr.io/overthelex/sl-platform:latest
+            [ "${OPENDATA_SYNC_CHANGED}" = "true" ] && docker pull ghcr.io/overthelex/sl-opendata-sync:latest
+            echo "All required images pulled from GHCR"
+          PULL_SCRIPT
 
-            $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_backend install && npm --prefix mcp_backend run build"
-          fi
-          if [ "$RADA_CHANGED" = "true" ]; then
-            $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_rada install && npm --prefix mcp_rada run build"
-          fi
-          if [ "$OPENREYESTR_CHANGED" = "true" ]; then
-            $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build"
-          fi
-
-          # Phase 1: Build images, run migrations, start inactive color, write preview upstreams
+          # Run migrations, start inactive color, write preview upstreams
           $SSH_CMD bash << DEPLOY_SCRIPT
             set -e
             cd ${REMOTE_REPO}/deployment
@@ -499,44 +630,34 @@ jobs:
             echo "Backend: \$BACKEND_COLOR → \$NEW_BACKEND (changed: \$ANY_BACKEND)"
             echo "Frontend: \$FRONTEND_COLOR → \$NEW_FRONTEND (changed: ${FRONTEND_CHANGED})"
 
-            # --- 1. Build images (old containers still serving traffic) ---
-            BUILD=""
-            [ "${BACKEND_CHANGED}" = "true" ] && BUILD="\$BUILD app-prod document-service-prod migrate-prod"
-            [ "${RADA_CHANGED}" = "true" ] && BUILD="\$BUILD rada-mcp-app-prod rada-db-init-prod rada-migrate-prod"
-            [ "${OPENREYESTR_CHANGED}" = "true" ] && BUILD="\$BUILD app-openreyestr-prod migrate-openreyestr-prod"
-            [ "${FRONTEND_CHANGED}" = "true" ] && BUILD="\$BUILD lexwebapp-prod"
-            [ "${PLATFORM_CHANGED}" = "true" ] && BUILD="\$BUILD platform-prod"
-            [ "${OPENDATA_SYNC_CHANGED}" = "true" ] && BUILD="\$BUILD opendata-sync-prod"
-            [ -n "\$BUILD" ] && \$DC build \$BUILD
+            # --- 1. Run migrations (idempotent, safe while old containers serve) ---
+            [ "${BACKEND_CHANGED}" = "true" ] && { \$DC up --no-build migrate-prod || true; }
+            [ "${RADA_CHANGED}" = "true" ] && { \$DC up --no-build rada-db-init-prod || true; \$DC up --no-build rada-migrate-prod || true; }
+            [ "${OPENREYESTR_CHANGED}" = "true" ] && { \$DC up --no-build migrate-openreyestr-prod || true; }
 
-            # --- 2. Run migrations (idempotent, safe while old containers serve) ---
-            [ "${BACKEND_CHANGED}" = "true" ] && { \$DC up migrate-prod || true; }
-            [ "${RADA_CHANGED}" = "true" ] && { \$DC up rada-db-init-prod || true; \$DC up rada-migrate-prod || true; }
-            [ "${OPENREYESTR_CHANGED}" = "true" ] && { \$DC up migrate-openreyestr-prod || true; }
-
-            # --- 3. Start new-color containers alongside old ones ---
+            # --- 2. Start new-color containers alongside old ones (images already pulled) ---
             if [ "\$ANY_BACKEND" = "true" ]; then
               if [ "\$NEW_BACKEND" = "green" ]; then
-                \$DC --profile green up -d app-prod-green document-service-prod-green rada-mcp-app-prod-green app-openreyestr-prod-green
+                \$DC --profile green up -d --no-build app-prod-green document-service-prod-green rada-mcp-app-prod-green app-openreyestr-prod-green
               else
-                \$DC up -d app-prod document-service-prod rada-mcp-app-prod app-openreyestr-prod
+                \$DC up -d --no-build app-prod document-service-prod rada-mcp-app-prod app-openreyestr-prod
               fi
             fi
             if [ "${FRONTEND_CHANGED}" = "true" ]; then
               if [ "\$NEW_FRONTEND" = "green" ]; then
-                \$DC --profile green up -d lexwebapp-prod-green
+                \$DC --profile green up -d --no-build lexwebapp-prod-green
               else
-                \$DC up -d lexwebapp-prod
+                \$DC up -d --no-build lexwebapp-prod
               fi
             fi
             if [ "${PLATFORM_CHANGED}" = "true" ]; then
-              \$DC up -d platform-prod
+              \$DC up -d --no-build platform-prod
             fi
             if [ "${OPENDATA_SYNC_CHANGED}" = "true" ]; then
-              \$DC up -d opendata-sync-prod
+              \$DC up -d --no-build opendata-sync-prod
             fi
 
-            # --- 4. Wait for new containers to be healthy ---
+            # --- 3. Wait for new containers to be healthy ---
             wait_healthy() {
               local container=\$1 max_wait=\${2:-120} elapsed=0
               echo "Waiting for \$container to be healthy..."
@@ -606,7 +727,7 @@ jobs:
               exit 1
             fi
 
-            # --- 5. Write preview upstreams pointing to new (inactive) color ---
+            # --- 4. Write preview upstreams pointing to new (inactive) color ---
             if [ "\$ANY_BACKEND" = "true" ]; then
               [ "\$NEW_BACKEND" = "green" ] && PREVIEW_BE_HOST="secondlayer-app-prod-green" || PREVIEW_BE_HOST="secondlayer-app-prod"
             else

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -221,7 +221,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/Dockerfile.mono-backend
-    image: secondlayer-app-prod:latest
+    image: ${SL_BACKEND_IMAGE:-ghcr.io/overthelex/sl-backend:latest}
     container_name: secondlayer-migrate-prod
     depends_on:
       postgres-prod:
@@ -247,7 +247,7 @@ services:
     - secondlayer-prod-network
 
   seed-admin-prod:
-    image: secondlayer-app-prod:latest
+    image: ${SL_BACKEND_IMAGE:-ghcr.io/overthelex/sl-backend:latest}
     container_name: secondlayer-seed-admin-prod
     depends_on:
       migrate-prod:
@@ -273,7 +273,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/Dockerfile.mono-rada
-    image: rada-mcp-prod:latest
+    image: ${SL_RADA_IMAGE:-ghcr.io/overthelex/sl-rada:latest}
     container_name: rada-mcp-migrate-prod
     depends_on:
       rada-db-init-prod:
@@ -300,7 +300,7 @@ services:
       - secondlayer-prod-network
 
   rada-mcp-app-prod:
-    image: rada-mcp-prod:latest
+    image: ${SL_RADA_IMAGE:-ghcr.io/overthelex/sl-rada:latest}
     container_name: rada-mcp-app-prod
     command: ["node", "--max-old-space-size=1536", "dist/http-server.js"]
     logging:
@@ -356,7 +356,7 @@ services:
           memory: 512M
 
   migrate-openreyestr-prod:
-    image: openreyestr-app-prod:latest
+    image: ${SL_OPENREYESTR_IMAGE:-ghcr.io/overthelex/sl-openreyestr:latest}
     build:
       context: ..
       dockerfile: deployment/Dockerfile.mono-openreyestr
@@ -380,7 +380,7 @@ services:
       - secondlayer-prod-network
 
   app-openreyestr-prod:
-    image: openreyestr-app-prod:latest
+    image: ${SL_OPENREYESTR_IMAGE:-ghcr.io/overthelex/sl-openreyestr:latest}
     container_name: openreyestr-app-prod
     command: ["node", "dist/http-server.js"]
     logging:
@@ -511,7 +511,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/Dockerfile.mono-backend
-    image: secondlayer-app-prod:latest
+    image: ${SL_BACKEND_IMAGE:-ghcr.io/overthelex/sl-backend:latest}
     container_name: secondlayer-app-prod
     command:
     - node
@@ -683,7 +683,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/Dockerfile.document-service
-    image: document-service-prod:latest
+    image: ${SL_DOCSVC_IMAGE:-ghcr.io/overthelex/sl-document-service:latest}
     container_name: document-service-prod
     command: ["node", "--max-old-space-size=2048", "--expose-gc", "dist/document-service.js"]
     logging:
@@ -786,7 +786,7 @@ services:
         - GIT_SHA=${GIT_SHA:-unknown}
         - APP_VERSION=${APP_VERSION:-dev}
         - APP_FRONTEND_VERSION=${APP_FRONTEND_VERSION:-dev}
-    image: lexwebapp-prod:latest
+    image: ${SL_FRONTEND_IMAGE:-ghcr.io/overthelex/sl-frontend:latest}
     container_name: lexwebapp-prod
     ports:
     - "127.0.0.1:8093:80"
@@ -825,7 +825,7 @@ services:
         - BUILD_ENV=production
         - VITE_API_URL=https://platform.legal.org.ua
         - GIT_SHA=${GIT_SHA:-unknown}
-    image: platform-prod:latest
+    image: ${SL_PLATFORM_IMAGE:-ghcr.io/overthelex/sl-platform:latest}
     container_name: platform-prod
     ports:
     - "127.0.0.1:8094:80"
@@ -903,7 +903,7 @@ services:
   # ==========================================
 
   app-prod-green:
-    image: secondlayer-app-prod:latest
+    image: ${SL_BACKEND_IMAGE:-ghcr.io/overthelex/sl-backend:latest}
     container_name: secondlayer-app-prod-green
     profiles: ["green"]
     command:
@@ -1042,7 +1042,7 @@ services:
           memory: 4G
 
   rada-mcp-app-prod-green:
-    image: rada-mcp-prod:latest
+    image: ${SL_RADA_IMAGE:-ghcr.io/overthelex/sl-rada:latest}
     container_name: rada-mcp-app-prod-green
     profiles: ["green"]
     command: ["node", "--max-old-space-size=1536", "dist/http-server.js"]
@@ -1097,7 +1097,7 @@ services:
           memory: 512M
 
   app-openreyestr-prod-green:
-    image: openreyestr-app-prod:latest
+    image: ${SL_OPENREYESTR_IMAGE:-ghcr.io/overthelex/sl-openreyestr:latest}
     container_name: openreyestr-app-prod-green
     profiles: ["green"]
     command: ["node", "dist/http-server.js"]
@@ -1146,7 +1146,7 @@ services:
           memory: 512M
 
   document-service-prod-green:
-    image: document-service-prod:latest
+    image: ${SL_DOCSVC_IMAGE:-ghcr.io/overthelex/sl-document-service:latest}
     container_name: document-service-prod-green
     profiles: ["green"]
     command: ["node", "--max-old-space-size=2048", "--expose-gc", "dist/document-service.js"]
@@ -1233,7 +1233,7 @@ services:
           memory: 512M
 
   lexwebapp-prod-green:
-    image: lexwebapp-prod:latest
+    image: ${SL_FRONTEND_IMAGE:-ghcr.io/overthelex/sl-frontend:latest}
     container_name: lexwebapp-prod-green
     profiles: ["green"]
     environment:
@@ -1433,7 +1433,7 @@ services:
     build:
       context: ..
       dockerfile: deployment/Dockerfile.opendata-sync
-    image: opendata-sync-prod:latest
+    image: ${SL_OPENDATA_IMAGE:-ghcr.io/overthelex/sl-opendata-sync:latest}
     container_name: opendata-sync-prod
     logging:
       driver: json-file


### PR DESCRIPTION
## Summary

- **Build images on runner instead of prod**: Docker images are now built on the self-hosted CI runner (which already runs tests) and pushed to GHCR, instead of building remotely on prod via SSH
- **Pull on prod**: Deploy step now does `docker pull` + `docker compose up --no-build` instead of `npm install` + `npm run build` + `docker compose build`
- **Compose image names**: Updated `docker-compose.prod.yml` to reference `ghcr.io/overthelex/sl-*` with env var fallback (`${SL_BACKEND_IMAGE:-ghcr.io/...}`)

### New pipeline flow
```
pre-deploy-tests → build-and-push-images (GHCR) → deploy-preview (docker pull) → promote-to-prod
```

### Images
| Service | GHCR Image |
|---------|-----------|
| backend | `ghcr.io/overthelex/sl-backend` |
| document-service | `ghcr.io/overthelex/sl-document-service` |
| rada | `ghcr.io/overthelex/sl-rada` |
| openreyestr | `ghcr.io/overthelex/sl-openreyestr` |
| frontend | `ghcr.io/overthelex/sl-frontend` |
| platform | `ghcr.io/overthelex/sl-platform` |
| opendata-sync | `ghcr.io/overthelex/sl-opendata-sync` |

## Test plan

- [ ] Trigger workflow_dispatch with `services: backend` and verify GHCR push + prod pull works
- [ ] Verify local dev still works (`docker compose -f docker-compose.local.yml build`)
- [ ] Check images appear at github.com/overthelex?tab=packages
- [ ] Health check passes after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Docker images on the self-hosted CI runner and push them to `ghcr.io/overthelex/sl-*`. Deploys now pull prebuilt images on prod, cutting build time and load on the server.

- **Refactors**
  - Added `build-and-push-images` job to build and push `ghcr.io/overthelex/sl-*`; enabled `packages: write`.
  - Deploy now logs in to GHCR on prod and runs `docker pull` + `docker compose up --no-build`; removed on-prod builds.
  - Updated `deployment/docker-compose.prod.yml` to reference GHCR images with env var overrides (`${SL_BACKEND_IMAGE}`, `${SL_DOCSVC_IMAGE}`, `${SL_RADA_IMAGE}`, `${SL_OPENREYESTR_IMAGE}`, `${SL_FRONTEND_IMAGE}`, `${SL_PLATFORM_IMAGE}`, `${SL_OPENDATA_IMAGE}`).
  - Builds and pushes only changed services; cleans up images on the runner.

<sup>Written for commit c70d04587662b1644da844d54bf74810e43c0eb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

