### PR TITLE
fix(evidence): resolve empty summary in court documents panel

### DIFF
--- a/lexwebapp/src/hooks/chat/evidence/court.ts
+++ b/lexwebapp/src/hooks/chat/evidence/court.ts
@@ -15,11 +15,17 @@ function extractSummary(c: ToolResultData): string {
   if (typeof c.text === 'string' && c.text.length > 0) return c.text.slice(0, 500);
   if (typeof c.content === 'string' && c.content.length > 0) return c.content.slice(0, 500);
   if (c.snippet) return String(c.snippet);
+  if (typeof c.full_text === 'string' && c.full_text.length > 0) return c.full_text.slice(0, 300);
   // Try to build from document type + case number
-  const docType = c.doc_type || c.document_type || c.judgment_form || c.judgment_code || '';
+  const docType = c.doc_type || c.document_type || c.judgment_form || c.judgment_form_name || '';
   const caseNum = c.cause_num || c.case_number || '';
   if (docType && caseNum) return `${docType} у справі ${caseNum}`;
   if (docType) return String(docType);
+  // Last resort: use classified document type
+  const classified = classifyDocumentType(c);
+  if (classified && caseNum) return `${classified} у справі ${caseNum}`;
+  if (classified) return classified;
+  if (caseNum) return `Документ у справі ${caseNum}`;
   return '';
 }
 


### PR DESCRIPTION
## Summary
- Court documents (Ухвала, Окрема думка) in right panel "Доказова база" showed "Немає тексту." because backend tools return `document_type` while evidence extractor looked for `judgment_form`
- Added fallback chain in frontend `extractSummary()`: `full_text`, `judgment_form_name`, `document_type`, `classifyDocumentType()` + case number
- Now procedural docs display meaningful text like "Ухвала у справі 910/1234/24" instead of empty placeholder
- Companion fix in `secondlayer-core` evidence-extractor covers the server-side (persisted evidence hydration path)

## Test plan
- [ ] Open a chat with court case search results containing Ухвала/Окрема думка documents
- [ ] Verify documents tab shows document type + case number instead of "Немає тексту."
- [ ] Reload page and verify hydrated evidence still shows correct summary
- [ ] Verify regular Рішення/Вирок/Постанова still display their summary correctly

Closes NC #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty summaries in the "Доказова база" court documents panel by expanding the summary fallback to use backend fields, so procedural docs show a meaningful type + case number instead of "Немає тексту." Closes NC #487.

- **Bug Fixes**
  - Expanded `extractSummary()` fallback: checks `full_text`, `judgment_form_name`, `document_type`, `doc_type`, `judgment_form`, then `classifyDocumentType()` with case number.
  - Builds summaries like "Ухвала у справі 910/1234/24" or case-only when needed.
  - Aligns with backend tools returning `document_type`; hydrated evidence now shows correct summaries without affecting decisions (Рішення/Вирок/Постанова).

<sup>Written for commit 7e770335bd114f90f2e5a348ee7429dc99c51716. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

