### PR TITLE
infra(nginx): add plane-mcp-doc.legal.org.ua proxy config

### DIFF
--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -47,6 +47,11 @@ upstream prod_plane {
     keepalive 16;
 }
 
+upstream prod_plane_mcp_docs {
+    server plane-mcp-docs:80;
+    keepalive 4;
+}
+
 # HTTP - plane.legal.org.ua (Plane project management)
 server {
     listen 80;
@@ -72,6 +77,29 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         client_max_body_size 100m;
+    }
+}
+
+# HTTP - plane-mcp-doc.legal.org.ua (Plane MCP Documentation)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name plane-mcp-doc.legal.org.ua;
+
+    set_real_ip_from 172.31.0.0/16;
+    real_ip_header X-Forwarded-For;
+
+    if ($http_x_forwarded_proto = "") {
+        return 301 https://$host$request_uri;
+    }
+
+    location / {
+        proxy_pass http://prod_plane_mcp_docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_http_version 1.1;
     }
 }
 
@@ -205,6 +233,28 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         client_max_body_size 100m;
+    }
+}
+
+# HTTPS - plane-mcp-doc.legal.org.ua (Plane MCP Documentation)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name plane-mcp-doc.legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+
+    location / {
+        proxy_pass http://prod_plane_mcp_docs;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_http_version 1.1;
     }
 }
 


### PR DESCRIPTION
## Summary
- Add upstream `prod_plane_mcp_docs` and HTTP/HTTPS server blocks for `plane-mcp-doc.legal.org.ua`
- Ensures the Plane MCP documentation site remains accessible after CI/CD nginx recreates

## Test plan
- [x] Verified `https://plane-mcp-doc.legal.org.ua/` returns 200 on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `nginx` upstream `prod_plane_mcp_docs` and HTTP/HTTPS server blocks for `plane-mcp-doc.legal.org.ua` to serve the Plane MCP docs behind the proxy. Forces HTTP→HTTPS and forwards to `plane-mcp-docs:80` so the site stays up across CI/CD reloads.

<sup>Written for commit cd9e2097b9c50d1f7bd8367ef0f2f50dfff8985b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

