### PR TITLE
infra(nginx): add plane-mcp.legal.org.ua SSE proxy

### DIFF
--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -52,6 +52,11 @@ upstream prod_plane_mcp_docs {
     keepalive 4;
 }
 
+upstream prod_plane_mcp {
+    server plane-mcp:8211;
+    keepalive 4;
+}
+
 # HTTP - plane.legal.org.ua (Plane project management)
 server {
     listen 80;
@@ -77,6 +82,35 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         client_max_body_size 100m;
+    }
+}
+
+# HTTP - plane-mcp.legal.org.ua (Plane MCP SSE Server)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name plane-mcp.legal.org.ua;
+
+    set_real_ip_from 172.31.0.0/16;
+    real_ip_header X-Forwarded-For;
+
+    if ($http_x_forwarded_proto = "") {
+        return 301 https://$host$request_uri;
+    }
+
+    location / {
+        proxy_pass http://prod_plane_mcp;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
     }
 }
 
@@ -233,6 +267,34 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         client_max_body_size 100m;
+    }
+}
+
+# HTTPS - plane-mcp.legal.org.ua (Plane MCP SSE Server)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name plane-mcp.legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+
+    location / {
+        proxy_pass http://prod_plane_mcp;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
     }
 }
 


### PR DESCRIPTION
## Summary
- Add upstream `prod_plane_mcp` and HTTP/HTTPS server blocks for `plane-mcp.legal.org.ua`
- SSE-specific config: `proxy_buffering off`, `proxy_cache off`, 24h read/send timeout, websocket upgrade headers

## Test plan
- [x] SSE endpoint `https://plane-mcp.legal.org.ua/sse` returns `event: endpoint` with session ID
- [x] `list_projects` tool returns 6 projects via MCP
- [x] Docs site `https://plane-mcp-doc.legal.org.ua/` still 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Nginx reverse proxy for the Plane MCP SSE service at plane-mcp.legal.org.ua with SSE-safe settings for long-lived streams. This enables stable event delivery behind our gateway over HTTP/HTTPS.

- **New Features**
  - Added upstream `prod_plane_mcp` to `plane-mcp:8211` with keepalive.
  - Created HTTP/HTTPS server blocks for plane-mcp.legal.org.ua with HTTPS enforcement and forwarded IP headers.
  - Applied SSE settings: `proxy_buffering off`, `proxy_cache off`, 24h read/send timeouts, and Upgrade/Connection headers for long-lived connections.

<sup>Written for commit de50f26bbfeddff1b12d4f469101abac7aebaee0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

