### PR TITLE
fix(rada): make FTS index migration idempotent

### DIFF
--- a/mcp_rada/src/migrations/004_fix_fts_language.sql
+++ b/mcp_rada/src/migrations/004_fix_fts_language.sql
@@ -1,18 +1,42 @@
 -- Fix FTS language: 'english' → 'simple' for Ukrainian text
 -- English stemmer provides no benefit for Cyrillic text
+-- Idempotent: only recreates indexes if they use the wrong language config
 
--- bills.title
-DROP INDEX IF EXISTS idx_bills_title;
-CREATE INDEX IF NOT EXISTS idx_bills_title ON bills USING gin(to_tsvector('simple', title));
+DO $$
+BEGIN
+  -- bills.title
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'idx_bills_title'
+    AND indexdef LIKE '%simple%'
+  ) THEN
+    DROP INDEX IF EXISTS idx_bills_title;
+    CREATE INDEX idx_bills_title ON bills USING gin(to_tsvector('simple', title));
+  END IF;
 
--- legislation.title
-DROP INDEX IF EXISTS idx_legislation_title;
-CREATE INDEX IF NOT EXISTS idx_legislation_title ON legislation USING gin(to_tsvector('simple', title));
+  -- legislation.title
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'idx_legislation_title'
+    AND indexdef LIKE '%simple%' AND schemaname = current_schema()
+  ) THEN
+    DROP INDEX IF EXISTS idx_legislation_title;
+    CREATE INDEX idx_legislation_title ON legislation USING gin(to_tsvector('simple', title));
+  END IF;
 
--- legislation.full_text_plain
-DROP INDEX IF EXISTS idx_legislation_fulltext;
-CREATE INDEX IF NOT EXISTS idx_legislation_fulltext ON legislation USING gin(to_tsvector('simple', full_text_plain));
+  -- legislation.full_text_plain
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'idx_legislation_fulltext'
+    AND indexdef LIKE '%simple%'
+  ) THEN
+    DROP INDEX IF EXISTS idx_legislation_fulltext;
+    CREATE INDEX idx_legislation_fulltext ON legislation USING gin(to_tsvector('simple', full_text_plain));
+  END IF;
 
--- voting_records.question_text
-DROP INDEX IF EXISTS idx_voting_question;
-CREATE INDEX IF NOT EXISTS idx_voting_question ON voting_records USING gin(to_tsvector('simple', question_text));
+  -- voting_records.question_text
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes WHERE indexname = 'idx_voting_question'
+    AND indexdef LIKE '%simple%'
+  ) THEN
+    DROP INDEX IF EXISTS idx_voting_question;
+    CREATE INDEX idx_voting_question ON voting_records USING gin(to_tsvector('simple', question_text));
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- FTS index migration (004) was failing on prod with `Connection terminated unexpectedly` because it unconditionally DROP+CREATE'd GIN indexes on large tables, hitting connection timeout
- All 4 indexes already exist on prod with correct `'simple'` config — verified via `pg_indexes`
- Migration now checks if index already uses `'simple'` before attempting recreation, making it safely idempotent

## Test plan
- [ ] Verify rada-mcp-migrate-prod completes without errors on next deploy
- [ ] Confirm FTS indexes unchanged on prod after migration runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make FTS index migration 004 idempotent. We only recreate GIN indexes if they don’t use the `'simple'` config, preventing timeouts on large tables.

- **Bug Fixes**
  - Wraps index updates in a DO block that checks `pg_indexes` (and current schema) for `'simple'`.
  - Skips DROP+CREATE when indexes already match, making reruns safe in prod.

<sup>Written for commit 85d7caf6c8131e65a48eb5796e0b0a5a5be287e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

