### PR TITLE
fix(infra): resolve /blog redirect loop behind Cloudflare + WAF skip for Plane API

### DIFF
--- a/deployment/cloudflare/waf-rules.sh
+++ b/deployment/cloudflare/waf-rules.sh
@@ -124,6 +124,16 @@ build_waf_rules() {
       "enabled": true
     },
     {
+      "description": "SKIP: Plane API requests (own auth, WAF false positives on HTML body)",
+      "expression": "(http.host eq \"plane.legal.org.ua\" and http.request.uri.path contains \"/api/\")",
+      "action": "skip",
+      "action_parameters": {
+        "ruleset": "current"
+      },
+      "logging": { "enabled": true },
+      "enabled": true
+    },
+    {
       "description": "BLOCK: Known bad bots and scanners",
       "expression": "(cf.client.bot) or (http.user_agent contains \"sqlmap\") or (http.user_agent contains \"nikto\") or (http.user_agent contains \"nmap\") or (http.user_agent contains \"masscan\") or (http.user_agent contains \"dirbuster\") or (http.user_agent contains \"gobuster\") or (http.user_agent contains \"nuclei\") or (http.user_agent contains \"zgrab\") or (http.user_agent contains \"httpx\") or (http.user_agent contains \"semrush\") or (http.user_agent contains \"ahref\") or (http.user_agent contains \"dotbot\") or (http.user_agent contains \"mj12bot\") or (http.user_agent eq \"\")",
       "action": "block",
@@ -578,14 +588,15 @@ print_summary() {
     echo ""
     echo -e "  ${CYAN}Custom WAF Rules:${NC}"
     echo "    1. Skip all rules for allowlisted IPs"
-    echo "    2. Block known bad bots & scanners"
-    echo "    3. Challenge high threat score (>25)"
-    echo "    4. Block SQL injection patterns"
-    echo "    5. Block XSS patterns"
-    echo "    6. Block path traversal & CMS probing"
-    echo "    7. Block suspicious HTTP methods"
-    echo "    8. Challenge non-UA/EU on auth/chat/admin"
-    echo "    9. Monitor /metrics and /health access"
+    echo "    2. Skip WAF for Plane API (own auth layer)"
+    echo "    3. Block known bad bots & scanners"
+    echo "    4. Challenge high threat score (>25)"
+    echo "    5. Block SQL injection patterns"
+    echo "    6. Block XSS patterns"
+    echo "    7. Block path traversal & CMS probing"
+    echo "    8. Block suspicious HTTP methods"
+    echo "    9. Challenge non-UA/EU on auth/chat/admin"
+    echo "   10. Monitor /metrics and /health access"
     echo ""
     echo -e "  ${CYAN}Rate Limits:${NC}"
     echo "    Auth endpoints:   10 req/min per IP"

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -18,8 +18,9 @@ if ($http_origin ~* "^https://(legal\.org\.ua|stage\.legal\.org\.ua)$") {
 
 # Remove trailing slashes (SEO — canonical URLs without trailing slash)
 # Safe pattern: if + return only, no proxy/rewrite inside if block
+# Use $forwarded_proto (not $scheme) so redirects preserve HTTPS behind Cloudflare/ALB
 if ($request_uri ~ ^(.+)/$) {
-    return 301 $1;
+    return 301 $forwarded_proto://$host$1;
 }
 
 # Security Headers (server-level — apply to locations without their own add_header)

--- a/lexwebapp/nginx.conf
+++ b/lexwebapp/nginx.conf
@@ -4,6 +4,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Prevent nginx from generating absolute redirects with http:// scheme
+    # when behind a reverse proxy (Cloudflare/ALB terminates TLS)
+    absolute_redirect off;
+
     # Enable gzip compression
     gzip on;
     gzip_vary on;
@@ -15,9 +19,11 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # SPA routing - serve index.html for all routes
+    # SPA routing — serve prerendered pages or fall back to SPA index.html
+    # Use $uri/index.html instead of $uri/ to avoid nginx auto-redirecting to add trailing slash
+    # (which causes redirect loops behind Cloudflare/reverse proxy)
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/index.html /index.html;
     }
 
     # Cache static assets


### PR DESCRIPTION
## Summary

- **Redirect loop on /blog**: `try_files $uri $uri/` caused nginx to auto-redirect to `/blog/` (directory exists for prerendered pages), while prod nginx stripped trailing slash — infinite 301 loop. Fixed by using `try_files $uri $uri/index.html /index.html` and scheme-aware redirect with `$forwarded_proto`.
- **Cloudflare WAF 403 on Plane API**: OWASP managed ruleset blocked POST/PATCH with HTML body containing URL-like strings. Added WAF skip rule for `plane.legal.org.ua/api/*`.
- **waf-rules.sh updated** with Plane API skip rule so future WAF deploys include it.

## Files changed

| File | Change |
|------|--------|
| `lexwebapp/nginx.conf` | `try_files $uri $uri/index.html /index.html` + `absolute_redirect off` |
| `deployment/nginx/includes/prod-server-common.conf` | Trailing slash redirect uses `$forwarded_proto://$host$1` |
| `deployment/cloudflare/waf-rules.sh` | Added Plane API skip rule + updated summary |

## Test plan

- [x] `curl -sI https://legal.org.ua/blog` → 200 (was redirect loop)
- [x] `curl -sI https://legal.org.ua/blog/ai-changes-lawyer-work-2026` → 200
- [x] `curl -sI https://legal.org.ua/` → 200 (SPA still works)
- [x] `curl -sI https://legal.org.ua/chat` → 200 (SPA fallback)
- [x] Prerendered HTML with SEO meta tags served for blog pages
- [x] Plane MCP PATCH with HTML body → 200 (was 403)

> Hotfixed on prod (docker cp + nginx reload). This PR persists the fix for future CI/CD deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /blog redirect loop behind Cloudflare and prevents WAF 403s on Plane API requests. Updates nginx for scheme-aware redirects and serves prerendered pages reliably.

- **Bug Fixes**
  - Nginx: switch to `try_files $uri $uri/index.html /index.html`, set `absolute_redirect off`, and use `$forwarded_proto://$host$1` for trailing slash redirects to avoid 301 loops and wrong-scheme redirects (`lexwebapp/nginx.conf`, `deployment/nginx/includes/prod-server-common.conf`).
  - Cloudflare WAF: add a skip rule for `plane.legal.org.ua/api/*` to prevent false positives on HTML bodies; update `deployment/cloudflare/waf-rules.sh` summary.

<sup>Written for commit 2074b58226381838935d5a62a582f48965321dec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

