### PR TITLE
fix(security): patch Dependabot CVEs — dompurify, nodemailer

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -30,7 +30,7 @@
     "axios": "^1.15.0",
     "date-fns": "^4.1.0",
     "docx": "^9.6.1",
-    "dompurify": "^3.3.3",
+    "dompurify": "^3.4.0",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.35.2",
     "jspdf": "^4.2.0",

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -96,7 +96,7 @@
     "minio": "^8.0.6",
     "multer": "^2.1.0",
     "node-cron": "^4.2.1",
-    "nodemailer": "^8.0.4",
+    "nodemailer": "^8.0.5",
     "openai": "^6.27.0",
     "openid-client": "^5.7.1",
     "passport": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "picomatch": ">=2.3.2",
     "undici": ">=6.24.0",
     "@tootallnate/once": ">=3.0.1",
-    "dompurify": ">=3.3.3"
+    "dompurify": ">=3.4.0"
   },
   "dependencies": {
     "@withgraphite/graphite-cli": "^1.7.20"


### PR DESCRIPTION
## Summary
- **dompurify** `^3.3.3` → `^3.4.0` — fixes ADD_TAGS bypass of FORBID_TAGS (alert #179, medium)
- **nodemailer** `^8.0.4` → `^8.0.5` — fixes SMTP command injection via CRLF in EHLO/HELO (moderate)
- **dompurify** override in root `package.json` bumped to `>=3.4.0`

The remaining Dependabot alerts (axios #177/#178, follow-redirects #175/#176, vite #165/#166/#167) already had patched version ranges in `package.json` — the lock file (gitignored) resolves them to safe versions. These alerts should auto-close once Dependabot re-scans after merge.

## Test plan
- [ ] CI passes (build + tests for affected workspaces)
- [ ] `npm audit` shows 0 vulnerabilities
- [ ] Dependabot alerts page clears after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Patch security alerts by upgrading `dompurify` to ^3.4.0 and `nodemailer` to ^8.0.5. Also updates the root `dompurify` override; remaining Dependabot alerts should clear after a rescan.

- **Dependencies**
  - `lexwebapp`: `dompurify` ^3.3.3 → ^3.4.0 (fixes ADD_TAGS bypass of FORBID_TAGS)
  - `mcp_backend`: `nodemailer` ^8.0.4 → ^8.0.5 (fixes SMTP command injection in EHLO/HELO)
  - Root: `dompurify` override set to >=3.4.0

<sup>Written for commit 81d478d330bcb5d24eef12196489ba062e60cfa6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

