### PR TITLE
fix(infra): increase prod postgres memory to match shared_buffers config

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -28,7 +28,7 @@ services:
       TZ: Europe/Kiev
     ports:
     - "127.0.0.1:5438:5432"
-    shm_size: '4g'
+    shm_size: '16g'
     volumes:
     - postgres_prod_data:/var/lib/postgresql/data
     healthcheck:
@@ -46,9 +46,9 @@ services:
       resources:
         limits:
           cpus: "6"
-          memory: 12G
+          memory: 24G
         reservations:
-          memory: 4G
+          memory: 8G
 
   pgbouncer-prod:
     image: edoburu/pgbouncer:latest


### PR DESCRIPTION
## Summary
- **Root cause**: `shared_buffers=16GB` but container memory limit was only `12G` — PostgreSQL could never fully allocate its shared memory, causing OOM kills during full-table scans on `edrsr_fulltext` (89M+ rows, 1.2TB)
- Container memory limit: `12G` → `24G` (16GB shared_buffers + work_mem/maintenance_work_mem headroom + OS overhead)
- Memory reservation: `4G` → `8G`
- `shm_size`: `4g` → `16g` (POSIX shared memory must be >= `shared_buffers`)

## Test plan
- [ ] Verify postgres container starts and allocates full 16GB shared_buffers (`SHOW shared_buffers;`)
- [ ] Run `ANALYZE` on edrsr_fulltext without OOM
- [ ] Monitor `docker stats secondlayer-postgres-prod` during peak load
- [ ] Confirm host has sufficient RAM (need ~24GB free for postgres alone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase prod Postgres memory and shared memory to align with 16GB `shared_buffers`, preventing OOM during large queries (e.g., full scans on `edrsr_fulltext`).

- **Bug Fixes**
  - Increase container memory limit: 12G → 24G
  - Increase memory reservation: 4G → 8G
  - Set `shm_size`: 4g → 16g

<sup>Written for commit d31d535650f0a4d85c3914748a5d6d1bae54fc01. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

