### PR TITLE
fix(db): renumber opendata migrations 121-125 → 126-130

### DIFF
--- a/mcp_backend/src/migrations/126_spain_legal_data.sql
+++ b/mcp_backend/src/migrations/126_spain_legal_data.sql
@@ -1,0 +1,78 @@
+-- Migration 121: Spanish legal open data — align existing tables + add missing columns/indexes
+-- Tables already exist from prior schema; this migration adds missing columns and FTS indexes.
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. BOE — add missing columns (full_text_xml, analysis_json, url_html_consolidada)
+-- Existing schema uses: id (serial), boe_id, title, metadata (jsonb)
+-- ═══════════════════════════════════════════════════════════════
+ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS full_text_xml TEXT;
+ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS analysis_json JSONB;
+ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS url_html_consolidada TEXT;
+ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS diario TEXT;
+ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS diario_numero TEXT;
+ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS fecha_actualizacion TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_spain_boe_rango ON spain_boe_legislation(rango);
+CREATE INDEX IF NOT EXISTS idx_spain_boe_fecha_pub ON spain_boe_legislation(fecha_publicacion);
+CREATE INDEX IF NOT EXISTS idx_spain_boe_estado ON spain_boe_legislation(estado_consolidacion);
+CREATE INDEX IF NOT EXISTS idx_spain_boe_ambito ON spain_boe_legislation(ambito);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spain_boe_boe_id ON spain_boe_legislation(boe_id);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. EUR-Lex — already matches, ensure indexes
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_eurlex_type ON spain_eurlex_legislation(doc_type);
+CREATE INDEX IF NOT EXISTS idx_spain_eurlex_date ON spain_eurlex_legislation(doc_date);
+CREATE INDEX IF NOT EXISTS idx_spain_eurlex_force ON spain_eurlex_legislation(in_force);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. Tribunal Constitucional — actual columns are tipo/fecha (not tipo_resolucion/fecha_registro)
+-- Indexes idx_tc_tipo and idx_tc_fecha already exist; create idempotent aliases.
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_tc_tipo ON spain_tribunal_constitucional(tipo);
+CREATE INDEX IF NOT EXISTS idx_spain_tc_fecha ON spain_tribunal_constitucional(fecha);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 4. BORME Section C — already matches, ensure indexes
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_borme_fecha ON spain_borme_section_c(fecha_publicacion);
+CREATE INDEX IF NOT EXISTS idx_spain_borme_tipo ON spain_borme_section_c(tipo_anuncio);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 5. Consejo de Estado — already matches, ensure indexes
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_ce_fecha ON spain_consejo_estado(fecha_aprobacion);
+CREATE INDEX IF NOT EXISTS idx_spain_ce_procedencia ON spain_consejo_estado(procedencia);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 6. AEAT — already matches, ensure indexes
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_aeat_fecha ON spain_aeat_consultas(fecha);
+CREATE INDEX IF NOT EXISTS idx_spain_aeat_impuesto ON spain_aeat_consultas(impuesto);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 7. Fiscalía — already matches, ensure indexes
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_tipo ON spain_fiscalia(tipo);
+CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_fecha ON spain_fiscalia(fecha);
+
+-- ═══════════════════════════════════════════════════════════════
+-- Full-text search indexes (tsvector, Spanish config)
+-- ═══════════════════════════════════════════════════════════════
+CREATE INDEX IF NOT EXISTS idx_spain_boe_fts ON spain_boe_legislation
+    USING gin(to_tsvector('spanish', COALESCE(title, '') || ' ' || COALESCE(full_text, '')));
+
+CREATE INDEX IF NOT EXISTS idx_spain_eurlex_fts ON spain_eurlex_legislation
+    USING gin(to_tsvector('spanish', COALESCE(title, '') || ' ' || COALESCE(full_text, '')));
+
+CREATE INDEX IF NOT EXISTS idx_spain_tc_fts ON spain_tribunal_constitucional
+    USING gin(to_tsvector('spanish', COALESCE(full_text, '')));
+
+CREATE INDEX IF NOT EXISTS idx_spain_ce_fts ON spain_consejo_estado
+    USING gin(to_tsvector('spanish', COALESCE(full_text, '')));
+
+CREATE INDEX IF NOT EXISTS idx_spain_aeat_fts ON spain_aeat_consultas
+    USING gin(to_tsvector('spanish', COALESCE(cuestion, '') || ' ' || COALESCE(contestacion, '')));
+
+CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_fts ON spain_fiscalia
+    USING gin(to_tsvector('spanish', COALESCE(titulo, '') || ' ' || COALESCE(full_text, '')));

--- a/mcp_backend/src/migrations/127_spain_cendoj_penal.sql
+++ b/mcp_backend/src/migrations/127_spain_cendoj_penal.sql
@@ -1,0 +1,30 @@
+-- Migration 122: Spanish criminal court decisions from CENDOJ
+-- Tribunal Supremo (Sala Penal) + Audiencia Nacional (Sala Penal) decisions
+
+CREATE TABLE IF NOT EXISTS spain_cendoj_penal (
+    id SERIAL PRIMARY KEY,
+    roj TEXT NOT NULL,
+    ecli TEXT,
+    tribunal TEXT,
+    sala TEXT,
+    ponente TEXT,
+    fecha_resolucion DATE,
+    fecha_publicacion DATE,
+    tipo_resolucion TEXT,
+    numero_resolucion TEXT,
+    numero_recurso TEXT,
+    resumen TEXT,
+    full_text TEXT,
+    reference_id TEXT,
+    document_hash TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    CONSTRAINT uq_spain_cendoj_roj UNIQUE (roj)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spain_cendoj_fecha ON spain_cendoj_penal(fecha_resolucion);
+CREATE INDEX IF NOT EXISTS idx_spain_cendoj_tribunal ON spain_cendoj_penal(tribunal);
+CREATE INDEX IF NOT EXISTS idx_spain_cendoj_ecli ON spain_cendoj_penal(ecli);
+CREATE INDEX IF NOT EXISTS idx_spain_cendoj_tipo ON spain_cendoj_penal(tipo_resolucion);
+CREATE INDEX IF NOT EXISTS idx_spain_cendoj_fts ON spain_cendoj_penal
+    USING gin(to_tsvector('spanish', COALESCE(full_text, '')));

--- a/mcp_backend/src/migrations/128_eu_common_legal_data.sql
+++ b/mcp_backend/src/migrations/128_eu_common_legal_data.sql
@@ -1,0 +1,145 @@
+-- Migration 123: EU common open data — legislation, court cases, sanctions
+-- Sources: EUR-Lex (CELLAR), CURIA (CJEU), HUDOC (ECHR), EU Sanctions
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. EUR-Lex Legislation (regulations, directives, decisions)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS eu_eurlex_legislation (
+    celex TEXT PRIMARY KEY,
+    title TEXT,
+    title_en TEXT,
+    doc_type TEXT,                     -- REG, DIR, DEC, RECO, etc.
+    doc_number TEXT,                   -- e.g. "2016/679" for GDPR
+    doc_date DATE,
+    date_document DATE,
+    date_entry_into_force DATE,
+    date_end_validity DATE,
+    in_force BOOLEAN DEFAULT TRUE,
+    eli TEXT,                          -- European Legislation Identifier
+    cellar_uri TEXT,
+    author TEXT,                       -- issuing institution
+    subject_matter TEXT[],             -- eurovoc descriptors
+    directory_codes TEXT[],            -- EUR-Lex directory classification
+    full_text TEXT,
+    full_text_html TEXT,
+    languages_available TEXT[],
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eu_eurlex_type ON eu_eurlex_legislation(doc_type);
+CREATE INDEX IF NOT EXISTS idx_eu_eurlex_date ON eu_eurlex_legislation(doc_date);
+CREATE INDEX IF NOT EXISTS idx_eu_eurlex_force ON eu_eurlex_legislation(in_force);
+CREATE INDEX IF NOT EXISTS idx_eu_eurlex_number ON eu_eurlex_legislation(doc_number);
+CREATE INDEX IF NOT EXISTS idx_eu_eurlex_eli ON eu_eurlex_legislation(eli);
+
+-- FTS index (English + generic)
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_eu_eurlex_fts') THEN
+        CREATE INDEX idx_eu_eurlex_fts ON eu_eurlex_legislation
+            USING GIN (to_tsvector('english', coalesce(title_en, '') || ' ' || coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. CURIA — Court of Justice of the EU (CJEU + General Court)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS eu_curia_cases (
+    ecli TEXT PRIMARY KEY,             -- ECLI identifier
+    case_number TEXT NOT NULL,         -- e.g. "C-131/12"
+    case_name TEXT,
+    court TEXT,                        -- CJ (Court of Justice) / GC (General Court)
+    chamber TEXT,
+    decision_type TEXT,                -- judgment, opinion, order
+    decision_date DATE,
+    subject_matter TEXT[],
+    parties TEXT,
+    advocate_general TEXT,
+    judge_rapporteur TEXT,
+    procedure_type TEXT,               -- preliminary ruling, direct action, appeal
+    celex_links TEXT[],                -- related EUR-Lex documents
+    full_text TEXT,
+    full_text_html TEXT,
+    languages_available TEXT[],
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eu_curia_case ON eu_curia_cases(case_number);
+CREATE INDEX IF NOT EXISTS idx_eu_curia_court ON eu_curia_cases(court);
+CREATE INDEX IF NOT EXISTS idx_eu_curia_date ON eu_curia_cases(decision_date);
+CREATE INDEX IF NOT EXISTS idx_eu_curia_type ON eu_curia_cases(decision_type);
+CREATE INDEX IF NOT EXISTS idx_eu_curia_procedure ON eu_curia_cases(procedure_type);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_eu_curia_fts') THEN
+        CREATE INDEX idx_eu_curia_fts ON eu_curia_cases
+            USING GIN (to_tsvector('english', coalesce(case_name, '') || ' ' || coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. ECHR / HUDOC — European Court of Human Rights
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS eu_echr_cases (
+    ecli TEXT PRIMARY KEY,
+    app_number TEXT,                   -- application number (e.g. "21906/04")
+    case_title TEXT NOT NULL,
+    importance_level TEXT,             -- 1 (key), 2 (high), 3 (medium), 4 (low)
+    judgment_date DATE,
+    conclusion TEXT,                   -- violation / no violation / struck out
+    respondent_state TEXT,             -- country code
+    articles TEXT[],                   -- Convention articles (e.g. ["Art. 6", "Art. 8"])
+    chamber TEXT,
+    separate_opinions BOOLEAN DEFAULT FALSE,
+    full_text TEXT,
+    full_text_html TEXT,
+    languages_available TEXT[],
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eu_echr_app ON eu_echr_cases(app_number);
+CREATE INDEX IF NOT EXISTS idx_eu_echr_date ON eu_echr_cases(judgment_date);
+CREATE INDEX IF NOT EXISTS idx_eu_echr_state ON eu_echr_cases(respondent_state);
+CREATE INDEX IF NOT EXISTS idx_eu_echr_importance ON eu_echr_cases(importance_level);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_eu_echr_fts') THEN
+        CREATE INDEX idx_eu_echr_fts ON eu_echr_cases
+            USING GIN (to_tsvector('english', coalesce(case_title, '') || ' ' || coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 4. EU Sanctions (Consolidated list)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS eu_sanctions (
+    entity_id TEXT PRIMARY KEY,        -- EU reference number
+    entity_type TEXT NOT NULL,          -- person / entity
+    name TEXT NOT NULL,
+    name_aliases TEXT[],
+    birth_date TEXT,
+    birth_place TEXT,
+    citizenship TEXT[],
+    addresses TEXT[],
+    identifications JSONB,             -- passport numbers, etc.
+    regulation_basis TEXT,              -- legal basis (regulation CELEX)
+    listing_date DATE,
+    programme TEXT,                     -- sanctions programme name
+    remark TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eu_sanctions_type ON eu_sanctions(entity_type);
+CREATE INDEX IF NOT EXISTS idx_eu_sanctions_programme ON eu_sanctions(programme);
+CREATE INDEX IF NOT EXISTS idx_eu_sanctions_date ON eu_sanctions(listing_date);
+
+-- FTS on name only (name_aliases stored as array, not suitable for expression index)
+CREATE INDEX IF NOT EXISTS idx_eu_sanctions_fts ON eu_sanctions
+    USING GIN (to_tsvector('simple', coalesce(name, '')));

--- a/mcp_backend/src/migrations/129_offshore_jurisdictions_data.sql
+++ b/mcp_backend/src/migrations/129_offshore_jurisdictions_data.sql
@@ -1,0 +1,360 @@
+-- Migration 124: Offshore jurisdictions open data
+-- Sources: Netherlands (Rechtspraak, DNB, AFM), Switzerland (Zefix, SHAB, FINMA),
+--          Ireland (CRO, Property Prices, Central Bank), ICIJ Offshore Leaks
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. Netherlands — Rechtspraak court decisions (500K+)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS nl_rechtspraak_decisions (
+    ecli TEXT PRIMARY KEY,
+    case_number TEXT,
+    court_code TEXT,
+    court_name TEXT,
+    decision_date DATE,
+    decision_type TEXT,
+    procedure_type TEXT,
+    subject_areas TEXT[],
+    parties TEXT,
+    summary TEXT,
+    full_text TEXT,
+    full_text_xml TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_recht_court ON nl_rechtspraak_decisions(court_code);
+CREATE INDEX IF NOT EXISTS idx_nl_recht_date ON nl_rechtspraak_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_nl_recht_type ON nl_rechtspraak_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_nl_recht_procedure ON nl_rechtspraak_decisions(procedure_type);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_nl_recht_fts') THEN
+        CREATE INDEX idx_nl_recht_fts ON nl_rechtspraak_decisions
+            USING GIN (to_tsvector('simple', coalesce(parties, '') || ' ' || coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. Netherlands — DNB regulated entities
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS nl_dnb_regulated_entities (
+    id SERIAL PRIMARY KEY,
+    entity_name TEXT NOT NULL,
+    trade_name TEXT,
+    license_type TEXT,
+    license_number TEXT,
+    lei_code TEXT,
+    address TEXT,
+    registration_number TEXT,
+    status TEXT,
+    country TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(entity_name, license_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_dnb_name ON nl_dnb_regulated_entities(entity_name);
+CREATE INDEX IF NOT EXISTS idx_nl_dnb_license ON nl_dnb_regulated_entities(license_type);
+CREATE INDEX IF NOT EXISTS idx_nl_dnb_regno ON nl_dnb_regulated_entities(registration_number);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. Netherlands — AFM registers
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS nl_afm_registers (
+    id SERIAL PRIMARY KEY,
+    entity_name TEXT NOT NULL,
+    register_type TEXT,
+    registration_number TEXT,
+    status TEXT,
+    address TEXT,
+    effective_date DATE,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(entity_name, register_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_afm_name ON nl_afm_registers(entity_name);
+CREATE INDEX IF NOT EXISTS idx_nl_afm_type ON nl_afm_registers(register_type);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 4. Netherlands — Insolventieregister
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS nl_insolvency (
+    id SERIAL PRIMARY KEY,
+    case_number TEXT,
+    court_code TEXT,
+    debtor_name TEXT,
+    debtor_type TEXT,
+    insolvency_type TEXT,
+    publication_date DATE,
+    status TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(case_number, court_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_insol_name ON nl_insolvency(debtor_name);
+CREATE INDEX IF NOT EXISTS idx_nl_insol_date ON nl_insolvency(publication_date);
+CREATE INDEX IF NOT EXISTS idx_nl_insol_type ON nl_insolvency(insolvency_type);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 5. Switzerland — Zefix company registry (~900K)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS ch_zefix_companies (
+    uid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    legal_form TEXT,
+    legal_seat TEXT,
+    register_office TEXT,
+    status TEXT,
+    purpose TEXT,
+    capital NUMERIC,
+    capital_currency TEXT,
+    address TEXT,
+    canton TEXT,
+    chid TEXT,
+    ehraid INTEGER,
+    shab_pub_date DATE,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_zefix_name ON ch_zefix_companies(name);
+CREATE INDEX IF NOT EXISTS idx_ch_zefix_canton ON ch_zefix_companies(canton);
+CREATE INDEX IF NOT EXISTS idx_ch_zefix_form ON ch_zefix_companies(legal_form);
+CREATE INDEX IF NOT EXISTS idx_ch_zefix_status ON ch_zefix_companies(status);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ch_zefix_fts') THEN
+        CREATE INDEX idx_ch_zefix_fts ON ch_zefix_companies
+            USING GIN (to_tsvector('simple', coalesce(name, '') || ' ' || coalesce(purpose, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 6. Switzerland — SHAB gazette publications
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS ch_shab_publications (
+    id SERIAL PRIMARY KEY,
+    shab_id TEXT UNIQUE,
+    publication_date DATE,
+    publication_type TEXT,
+    rubric TEXT,
+    sub_rubric TEXT,
+    company_uid TEXT,
+    company_name TEXT,
+    canton TEXT,
+    content TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_shab_date ON ch_shab_publications(publication_date);
+CREATE INDEX IF NOT EXISTS idx_ch_shab_uid ON ch_shab_publications(company_uid);
+CREATE INDEX IF NOT EXISTS idx_ch_shab_type ON ch_shab_publications(publication_type);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 7. Switzerland — FINMA regulated entities
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS ch_finma_regulated (
+    id SERIAL PRIMARY KEY,
+    entity_name TEXT NOT NULL,
+    authorization_type TEXT,
+    authorization_number TEXT,
+    status TEXT,
+    city TEXT,
+    canton TEXT,
+    country TEXT,
+    effective_date DATE,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(entity_name, authorization_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_finma_name ON ch_finma_regulated(entity_name);
+CREATE INDEX IF NOT EXISTS idx_ch_finma_type ON ch_finma_regulated(authorization_type);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 8. Ireland — CRO companies
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS ie_cro_companies (
+    company_number TEXT PRIMARY KEY,
+    company_name TEXT NOT NULL,
+    company_type TEXT,
+    status TEXT,
+    registration_date DATE,
+    address TEXT,
+    activity_code TEXT,
+    last_annual_return_date DATE,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ie_cro_name ON ie_cro_companies(company_name);
+CREATE INDEX IF NOT EXISTS idx_ie_cro_status ON ie_cro_companies(status);
+CREATE INDEX IF NOT EXISTS idx_ie_cro_type ON ie_cro_companies(company_type);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ie_cro_fts') THEN
+        CREATE INDEX idx_ie_cro_fts ON ie_cro_companies
+            USING GIN (to_tsvector('english', coalesce(company_name, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 9. Ireland — Property Price Register
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS ie_property_prices (
+    id SERIAL PRIMARY KEY,
+    sale_date DATE,
+    address TEXT,
+    address_hash TEXT,
+    county TEXT,
+    price NUMERIC,
+    not_full_market_price BOOLEAN DEFAULT FALSE,
+    vat_exclusive BOOLEAN DEFAULT FALSE,
+    property_description TEXT,
+    property_size TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(sale_date, address_hash)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ie_prop_date ON ie_property_prices(sale_date);
+CREATE INDEX IF NOT EXISTS idx_ie_prop_county ON ie_property_prices(county);
+CREATE INDEX IF NOT EXISTS idx_ie_prop_price ON ie_property_prices(price);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 10. Ireland — Central Bank registers
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS ie_central_bank_registers (
+    id SERIAL PRIMARY KEY,
+    entity_name TEXT NOT NULL,
+    register_type TEXT,
+    reference_number TEXT,
+    status TEXT,
+    country TEXT,
+    address TEXT,
+    authorization_date DATE,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(entity_name, register_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ie_cb_name ON ie_central_bank_registers(entity_name);
+CREATE INDEX IF NOT EXISTS idx_ie_cb_type ON ie_central_bank_registers(register_type);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 11. ICIJ Offshore Leaks — entities
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS icij_entities (
+    node_id TEXT PRIMARY KEY,
+    name TEXT,
+    jurisdiction TEXT,
+    jurisdiction_description TEXT,
+    incorporation_date DATE,
+    inactivation_date DATE,
+    struck_off_date DATE,
+    status TEXT,
+    service_provider TEXT,
+    country_codes TEXT[],
+    source_id TEXT,
+    address TEXT,
+    note TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_icij_ent_name ON icij_entities(name);
+CREATE INDEX IF NOT EXISTS idx_icij_ent_jurisdiction ON icij_entities(jurisdiction);
+CREATE INDEX IF NOT EXISTS idx_icij_ent_status ON icij_entities(status);
+CREATE INDEX IF NOT EXISTS idx_icij_ent_source ON icij_entities(source_id);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_icij_ent_fts') THEN
+        CREATE INDEX idx_icij_ent_fts ON icij_entities
+            USING GIN (to_tsvector('simple', coalesce(name, '') || ' ' || coalesce(address, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 12. ICIJ Offshore Leaks — officers
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS icij_officers (
+    node_id TEXT PRIMARY KEY,
+    name TEXT,
+    country_codes TEXT[],
+    source_id TEXT,
+    note TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_icij_off_name ON icij_officers(name);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_icij_off_fts') THEN
+        CREATE INDEX idx_icij_off_fts ON icij_officers
+            USING GIN (to_tsvector('simple', coalesce(name, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 13. ICIJ Offshore Leaks — intermediaries
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS icij_intermediaries (
+    node_id TEXT PRIMARY KEY,
+    name TEXT,
+    country_codes TEXT[],
+    status TEXT,
+    source_id TEXT,
+    address TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_icij_int_name ON icij_intermediaries(name);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 14. ICIJ Offshore Leaks — addresses
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS icij_addresses (
+    node_id TEXT PRIMARY KEY,
+    address TEXT,
+    country_codes TEXT[],
+    source_id TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_icij_addr_country ON icij_addresses USING GIN (country_codes);
+
+-- ═══════════════════════════════════════════════════════════════
+-- 15. ICIJ Offshore Leaks — relationships (edges)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS icij_relationships (
+    id SERIAL PRIMARY KEY,
+    node_id_start TEXT NOT NULL,
+    node_id_end TEXT NOT NULL,
+    rel_type TEXT,
+    link TEXT,
+    start_date DATE,
+    end_date DATE,
+    source_id TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(node_id_start, node_id_end, rel_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_icij_rel_start ON icij_relationships(node_id_start);
+CREATE INDEX IF NOT EXISTS idx_icij_rel_end ON icij_relationships(node_id_end);
+CREATE INDEX IF NOT EXISTS idx_icij_rel_type ON icij_relationships(rel_type);

--- a/mcp_backend/src/migrations/130_luxembourg_opendata.sql
+++ b/mcp_backend/src/migrations/130_luxembourg_opendata.sql
@@ -1,0 +1,135 @@
+-- Migration 125: Luxembourg open data
+-- Sources: Centrale des Bilans (company financials), Court decisions, CSSF funds, GLEIF LEI
+
+-- ═══════════════════════════════════════════════════════════════
+-- 1. Centrale des Bilans — company annual accounts (XML dumps)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS lu_company_accounts (
+    id SERIAL PRIMARY KEY,
+    rcs_number TEXT,
+    company_name TEXT,
+    fiscal_year_end DATE,
+    deposit_date DATE,
+    quarter TEXT,
+    total_assets NUMERIC,
+    total_equity NUMERIC,
+    total_revenue NUMERIC,
+    net_profit NUMERIC,
+    employees INTEGER,
+    legal_form TEXT,
+    nace_code TEXT,
+    address TEXT,
+    raw_xml TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(rcs_number, fiscal_year_end)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lu_acc_rcs ON lu_company_accounts(rcs_number);
+CREATE INDEX IF NOT EXISTS idx_lu_acc_name ON lu_company_accounts(company_name);
+CREATE INDEX IF NOT EXISTS idx_lu_acc_year ON lu_company_accounts(fiscal_year_end);
+CREATE INDEX IF NOT EXISTS idx_lu_acc_deposit ON lu_company_accounts(deposit_date);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_lu_acc_fts') THEN
+        CREATE INDEX idx_lu_acc_fts ON lu_company_accounts
+            USING GIN (to_tsvector('simple', coalesce(company_name, '') || ' ' || coalesce(rcs_number, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 2. Luxembourg court decisions (data.public.lu)
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS lu_court_decisions (
+    id SERIAL PRIMARY KEY,
+    resource_id TEXT UNIQUE,
+    dataset_id TEXT,
+    court TEXT,
+    chamber TEXT,
+    title TEXT,
+    decision_date DATE,
+    file_url TEXT,
+    file_format TEXT,
+    file_size INTEGER,
+    full_text TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lu_court_court ON lu_court_decisions(court);
+CREATE INDEX IF NOT EXISTS idx_lu_court_chamber ON lu_court_decisions(chamber);
+CREATE INDEX IF NOT EXISTS idx_lu_court_date ON lu_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_lu_court_dataset ON lu_court_decisions(dataset_id);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_lu_court_fts') THEN
+        CREATE INDEX idx_lu_court_fts ON lu_court_decisions
+            USING GIN (to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 3. CSSF regulated funds / entities
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS lu_cssf_funds (
+    id SERIAL PRIMARY KEY,
+    fund_id TEXT,
+    fund_name TEXT,
+    fund_type TEXT,
+    compartment_name TEXT,
+    share_class TEXT,
+    management_company TEXT,
+    status TEXT,
+    launch_date DATE,
+    cssf_code TEXT,
+    isin TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(fund_id, compartment_name, share_class)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lu_cssf_name ON lu_cssf_funds(fund_name);
+CREATE INDEX IF NOT EXISTS idx_lu_cssf_type ON lu_cssf_funds(fund_type);
+CREATE INDEX IF NOT EXISTS idx_lu_cssf_isin ON lu_cssf_funds(isin);
+CREATE INDEX IF NOT EXISTS idx_lu_cssf_mgmt ON lu_cssf_funds(management_company);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_lu_cssf_fts') THEN
+        CREATE INDEX idx_lu_cssf_fts ON lu_cssf_funds
+            USING GIN (to_tsvector('simple', coalesce(fund_name, '') || ' ' || coalesce(management_company, '')));
+    END IF;
+END $$;
+
+-- ═══════════════════════════════════════════════════════════════
+-- 4. GLEIF LEI — Luxembourg entities
+-- ═══════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS lu_gleif_lei (
+    lei TEXT PRIMARY KEY,
+    legal_name TEXT,
+    legal_form TEXT,
+    jurisdiction TEXT,
+    entity_status TEXT,
+    registration_date DATE,
+    last_update DATE,
+    address_line TEXT,
+    city TEXT,
+    postal_code TEXT,
+    country TEXT,
+    parent_lei TEXT,
+    ultimate_parent_lei TEXT,
+    managing_lou TEXT,
+    metadata_json JSONB,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lu_lei_name ON lu_gleif_lei(legal_name);
+CREATE INDEX IF NOT EXISTS idx_lu_lei_status ON lu_gleif_lei(entity_status);
+CREATE INDEX IF NOT EXISTS idx_lu_lei_parent ON lu_gleif_lei(parent_lei);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_lu_lei_fts') THEN
+        CREATE INDEX idx_lu_lei_fts ON lu_gleif_lei
+            USING GIN (to_tsvector('simple', coalesce(legal_name, '') || ' ' || coalesce(lei, '')));
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

Five opendata migrations (`121_spain_legal_data.sql`, `122_spain_cendoj_penal.sql`, `123_eu_common_legal_data.sql`, `124_offshore_jurisdictions_data.sql`, `125_luxembourg_opendata.sql`) collided with already-applied migrations on both local and prod (`121_conversation_encryption.sql`, `125_add_missing_sync_sources.sql`). The `schema_migrations` table uses `filename` as PRIMARY KEY, so the runner saw the conflicting numbers as already applied and skipped them — yet the tables exist with data, having been created out-of-band.

This PR renames them to the next free range `126-130` so `npm run migrate` actually picks them up. All five files are idempotent (`CREATE TABLE/INDEX IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, `DO $$ ... pg_indexes` lookups), so applying against existing populated databases is safe — schema is a no-op, only `schema_migrations` bookkeeping is updated.

### Bug fix bundled in `126_spain_legal_data.sql`

The original file referenced columns that never existed on `spain_tribunal_constitucional`:

- Removed three indexes on `anno_resolucion` / `tipo_resolucion` / `fecha_registro` (real columns are `tipo` / `fecha`)
- Fixed `idx_spain_eurlex_fts` expression: `titulo` → `title`

These bugs would have caused the migration to fail outright on first run.

### Practical effect after merge

CI/CD applies `128_eu_common_legal_data.sql` to prod, creating the four EU pack tables (`eu_eurlex_legislation`, `eu_curia_cases`, `eu_echr_cases`, `eu_sanctions`). After deploy, a separate sync step will copy local rows (35K Curia, 46K EUR-Lex, 5.8K Sanctions) to prod.

## Test plan

- [x] All five renumbered migrations apply cleanly via `psql -v ON_ERROR_STOP=1` against the local DB (confirmed in dev session)
- [x] No `ERROR` lines in any migration's output; only `NOTICE: ... already exists, skipping` (expected for idempotent re-runs)
- [ ] CI pipeline `ci-local-deploy.yml` succeeds — runs `npm run migrate` against local DB
- [ ] `deploy-prod.yml` succeeds — runs `npm run migrate` against prod DB during blue-green deploy
- [ ] After deploy, verify `\d eu_curia_cases` / `\d eu_eurlex_legislation` / `\d eu_echr_cases` / `\d eu_sanctions` exist on prod
- [ ] Verify `schema_migrations` on prod contains all of `126_*` … `130_*`
- [ ] Manual data sync (separate step): `pg_dump` local EU pack tables, restore to prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renumbered five opendata migrations to 126–130 to resolve filename collisions so `npm run migrate` runs them. Also fixed invalid indexes in the Spain migration to avoid first-run failures.

- **Migration**
  - Renumbered 121–125 → 126–130; `schema_migrations.filename` PK had caused skips.
  - All five files are idempotent, so applying on existing DBs is safe; updates `schema_migrations` only if schema exists.
  - On deploy, `128_eu_common_legal_data.sql` creates `eu_eurlex_legislation`, `eu_curia_cases`, `eu_echr_cases`, `eu_sanctions` on prod.

- **Bug Fixes**
  - Removed indexes on nonexistent `spain_tribunal_constitucional` columns; kept valid `tipo`/`fecha` indexes.
  - Corrected Spain EUR-Lex FTS index to use `title`.

<sup>Written for commit 40ed9e5d3ecd7120b5f1d89e19e38aa15c195253. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

