### PR TITLE
feat(opendata): add Fiscalía v2 + CSSF v2 importers (replace broken originals)

### DIFF
--- a/scripts/opendata/offshore/import-cssf-v2.py
+++ b/scripts/opendata/offshore/import-cssf-v2.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Luxembourg CSSF fund identifiers importer v2.
+Handles UTF-16 LE BOM + TAB-separated fixed-width files from cssf.lu.
+
+Sources (4 ZIPs):
+  1. OPC_COMP_TP_TOUS_OUVERTS.zip                    — UCITS open funds
+  2. OPC_FIS_SICAR_COMP_TP_TOUS_NON_FERMES.zip       — SIF/SICAR open funds
+  3. IDENTIFIANTS_AIFM.zip                            — AIFM identifiers
+  4. NUMERO_SIGNALETIQUE_SOCIETE_DE_GESTION.zip      — Management companies
+
+Usage:
+    PG_CONTAINER=secondlayer-postgres-prod PGDB=secondlayer_prod \
+    python3 import-cssf-v2.py
+"""
+
+import io
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import zipfile
+from datetime import datetime
+from urllib.request import Request, urlopen
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+CONTAINER = os.environ.get("PG_CONTAINER", "secondlayer-postgres-prod")
+PGUSER = os.environ.get("PGUSER", "secondlayer")
+PGDB = os.environ.get("PGDB", "secondlayer_prod")
+USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) SecondLayer/1.0"
+
+CSSF_FILES = [
+    ("https://www.cssf.lu/wp-content/uploads/OPC_COMP_TP_TOUS_OUVERTS.zip", "ucits", "UCITS"),
+    ("https://www.cssf.lu/wp-content/uploads/OPC_FIS_SICAR_COMP_TP_TOUS_NON_FERMES.zip", "sif_sicar", "SIF/SICAR"),
+    ("https://www.cssf.lu/wp-content/uploads/IDENTIFIANTS_AIFM.zip", "aifm", "AIFM"),
+    ("https://www.cssf.lu/wp-content/uploads/NUMERO_SIGNALETIQUE_SOCIETE_DE_GESTION.zip", "mgmt_co", "MGMT_CO"),
+]
+
+
+def fetch(url: str) -> bytes:
+    req = Request(url, headers={"User-Agent": USER_AGENT})
+    with urlopen(req, timeout=120) as r:
+        return r.read()
+
+
+def decode_csv(raw: bytes) -> list[list[str]]:
+    """Decode UTF-16 LE BOM, split TAB-separated, strip cells."""
+    if raw.startswith(b"\xff\xfe"):
+        text = raw.decode("utf-16-le", errors="replace")
+    elif raw.startswith(b"\xfe\xff"):
+        text = raw.decode("utf-16-be", errors="replace")
+    else:
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            text = raw.decode("cp1252", errors="replace")
+    # First char may be BOM remnant \ufeff after decode
+    text = text.lstrip("\ufeff")
+    rows = []
+    for line in text.splitlines():
+        if not line.strip() or line.startswith("\x00"):
+            continue
+        cells = [c.strip() for c in line.split("\t")]
+        rows.append(cells)
+    return rows
+
+
+def parse_date(s: str) -> str | None:
+    s = s.strip()
+    if not s or s in ("-", "00/00/0000"):
+        return None
+    for fmt in ("%d/%m/%Y", "%Y-%m-%d", "%d-%m-%Y"):
+        try:
+            return datetime.strptime(s, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_ucits_or_sif(rows: list[list[str]], fund_type: str) -> list[dict]:
+    """
+    Headers: E NNNNNNNN ISIN NOMOPC CCCCCCCC NOMCOMPARTIMENT
+             AGREEMENTCOMP DEVISECOMP PPPP NOMTYPEPART
+    """
+    out = []
+    if len(rows) < 3:
+        return out
+    # Skip header (row 0) + separator (row 1)
+    for r in rows[2:]:
+        if len(r) < 10:
+            continue
+        status_raw = r[0]
+        status = "Open" if status_raw == "O" else ("Closed" if status_raw == "F" else status_raw)
+        rec = {
+            "fund_id": r[1],
+            "isin": r[2] or None,
+            "fund_name": r[3],
+            "fund_type": fund_type,
+            "compartment_id": r[4],
+            "compartment_name": r[5],
+            "launch_date": parse_date(r[6]),
+            "currency": r[7],
+            "share_class_id": r[8],
+            "share_class": r[9],
+            "management_company": None,
+            "status": status,
+            "cssf_code": r[1],
+        }
+        out.append(rec)
+    return out
+
+
+def parse_aifm(rows: list[list[str]]) -> list[dict]:
+    """
+    Headers: A NNNNNNNN AIFM_NAME STATUS F MMMMMMMM AIF_NAME CCCCCCCC AIF_SUBFUND_NAME
+             STARTING_MANAGEMENT_DATE_OF_THE_AIF ENDING_MANAGEMENT_DATE_OF_THE_AIF
+             REGISTRATION_DATE_OR_INCEPTION_DATE_OF_THE_SUBFUND_OR_AIF CLOSING_DATE_OF_THE_SUBFUND_OR_AIF
+    """
+    out = []
+    if len(rows) < 3:
+        return out
+    for r in rows[2:]:
+        if len(r) < 9:
+            continue
+        rec = {
+            "fund_id": r[1],                  # AIFM ID
+            "isin": None,
+            "fund_name": r[2],                 # AIFM name
+            "fund_type": "AIFM",
+            "compartment_id": r[5] if len(r) > 5 else "",
+            "compartment_name": r[6] if len(r) > 6 else "",
+            "launch_date": parse_date(r[11]) if len(r) > 11 else None,
+            "currency": None,
+            "share_class_id": r[7] if len(r) > 7 else "",
+            "share_class": r[8] if len(r) > 8 else "",
+            "management_company": r[2],
+            "status": r[3] if len(r) > 3 else "",
+            "cssf_code": r[1],
+        }
+        out.append(rec)
+    return out
+
+
+def parse_mgmt_co(rows: list[list[str]]) -> list[dict]:
+    """
+    Headers: ID_TYPE_ENTITE ID_ENTITE NOM_COURRIER ID_STATUT_SURV
+    """
+    out = []
+    if len(rows) < 3:
+        return out
+    for r in rows[2:]:
+        if len(r) < 4:
+            continue
+        rec = {
+            "fund_id": r[1],
+            "isin": None,
+            "fund_name": r[2],
+            "fund_type": "MGMT_CO",
+            "compartment_id": "",
+            "compartment_name": "",
+            "launch_date": None,
+            "currency": None,
+            "share_class_id": "",
+            "share_class": "",
+            "management_company": r[2],
+            "status": r[3],
+            "cssf_code": r[1],
+        }
+        out.append(rec)
+    return out
+
+
+def import_to_db(records: list[dict]):
+    # Dedupe by (fund_id, compartment_name, share_class) — keep last occurrence
+    deduped = {}
+    for r in records:
+        key = (r["fund_id"], r.get("compartment_name") or "", r.get("share_class") or "")
+        deduped[key] = r
+    records = list(deduped.values())
+    log.info(f"Importing {len(records)} records to {CONTAINER}/{PGDB}...")
+    lines = []
+    for r in records:
+        def clean(v):
+            if v is None or v == "":
+                return r"\N"
+            return str(v).replace("\\", "\\\\").replace("\t", " ").replace("\n", " ").replace("\r", " ")
+        meta = json.dumps({
+            "compartment_id": r["compartment_id"],
+            "share_class_id": r["share_class_id"],
+            "currency": r["currency"],
+            "source": "cssf.lu",
+        }, ensure_ascii=False)
+        lines.append("\t".join([
+            clean(r["fund_id"]),
+            clean(r["fund_name"]),
+            clean(r["fund_type"]),
+            clean(r["compartment_name"]),
+            clean(r["share_class"]),
+            clean(r["management_company"]),
+            clean(r["status"]),
+            clean(r["launch_date"]),
+            clean(r["cssf_code"]),
+            clean(r["isin"]),
+            clean(meta),
+        ]))
+    payload = "\n".join(lines) + "\n"
+
+    sql = """
+BEGIN;
+CREATE TEMP TABLE _stage_cssf (
+    fund_id TEXT, fund_name TEXT, fund_type TEXT, compartment_name TEXT, share_class TEXT,
+    management_company TEXT, status TEXT, launch_date DATE, cssf_code TEXT, isin TEXT, metadata_json JSONB
+) ON COMMIT DROP;
+COPY _stage_cssf FROM STDIN WITH (FORMAT text, NULL '\\N');
+"""
+    upsert = """
+INSERT INTO lu_cssf_funds
+    (fund_id, fund_name, fund_type, compartment_name, share_class,
+     management_company, status, launch_date, cssf_code, isin, metadata_json)
+SELECT fund_id, fund_name, fund_type, COALESCE(compartment_name, ''), COALESCE(share_class, ''),
+       management_company, status, launch_date, cssf_code, isin, metadata_json
+FROM _stage_cssf
+WHERE fund_id IS NOT NULL AND fund_id <> ''
+ON CONFLICT (fund_id, compartment_name, share_class) DO NOTHING;
+COMMIT;
+"""
+    full = sql + payload + "\\.\n" + upsert
+    proc = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-v", "ON_ERROR_STOP=1"],
+        input=full, capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        log.error(f"psql failed: {proc.stderr[-2000:]}")
+        sys.exit(1)
+    for line in proc.stdout.strip().splitlines()[-5:]:
+        log.info(f"  psql: {line}")
+
+
+def main():
+    all_records = []
+    for url, label, fund_type in CSSF_FILES:
+        log.info(f"Downloading {label}: {url}")
+        try:
+            raw_zip = fetch(url)
+        except Exception as e:
+            log.error(f"Fetch failed {label}: {e}")
+            continue
+        log.info(f"  {len(raw_zip) // 1024} KB")
+
+        with zipfile.ZipFile(io.BytesIO(raw_zip)) as zf:
+            csv_names = [n for n in zf.namelist() if n.lower().endswith(".csv")]
+            if not csv_names:
+                log.warning(f"  No CSV in {label}")
+                continue
+            with zf.open(csv_names[0]) as f:
+                raw = f.read()
+
+        rows = decode_csv(raw)
+        log.info(f"  Parsed {len(rows)} rows including headers")
+
+        if label == "ucits":
+            recs = parse_ucits_or_sif(rows, "UCITS")
+        elif label == "sif_sicar":
+            recs = parse_ucits_or_sif(rows, "SIF/SICAR")
+        elif label == "aifm":
+            recs = parse_aifm(rows)
+        elif label == "mgmt_co":
+            recs = parse_mgmt_co(rows)
+        else:
+            recs = []
+        log.info(f"  {label}: {len(recs)} records")
+        all_records.extend(recs)
+
+    log.info(f"Total: {len(all_records)} records")
+    if not all_records:
+        log.error("No records parsed; aborting")
+        return
+
+    # Import in batches of 5000
+    for i in range(0, len(all_records), 5000):
+        import_to_db(all_records[i:i+5000])
+
+    log.info("All done")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/spain/download-fiscalia-v2.py
+++ b/scripts/opendata/spain/download-fiscalia-v2.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+Spanish Fiscalía General del Estado downloader v2.
+Scrapes BOE pagination correctly (accion=Mas&id_busqueda=...-offset-limit),
+extracts FIS-{type}-{year}-{num} IDs, downloads HTML, parses, inserts to spain_fiscalia.
+
+Usage:
+    PG_CONTAINER=secondlayer-postgres-prod PGDB=secondlayer_prod \
+    python3 download-fiscalia-v2.py
+"""
+
+import asyncio
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import logging
+from pathlib import Path
+
+import aiohttp
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+BASE = "https://www.boe.es"
+DOC_URL = f"{BASE}/buscar/doc.php"
+SEARCH_URL = f"{BASE}/buscar/fiscalia.php"
+DATA_DIR = Path(os.environ.get("DATA_DIR", "/tmp/fiscalia"))
+CONTENT_DIR = DATA_DIR / "content"
+CONTAINER = os.environ.get("PG_CONTAINER", "secondlayer-postgres-prod")
+PGUSER = os.environ.get("PGUSER", "secondlayer")
+PGDB = os.environ.get("PGDB", "secondlayer_prod")
+USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/131.0.0.0 Safari/537.36"
+TIMEOUT = aiohttp.ClientTimeout(total=60)
+THREADS = 8
+
+# Letter prefixes — only C (Circular) and I (Instrucción) actually exist; Q (Consulta) returns 404
+TYPE_LABELS = {"C": "Circular", "I": "Instruccion"}
+
+
+async def scrape_index(session: aiohttp.ClientSession) -> list[str]:
+    """Walk pagination for each type, collect FIS-* IDs."""
+    all_ids = set()
+    for type_letter in TYPE_LABELS:
+        log.info(f"Scraping type={type_letter}")
+        params = f"campo%5B0%5D=TIPO.ID&dato%5B0%5D=&accion=Buscar"
+        # First page uses TIPO.ID with single letter dato
+        first_url = f"{SEARCH_URL}?campo%5B0%5D=TIPO.ID&dato%5B0%5D={type_letter}&accion=Buscar"
+        async with session.get(first_url, timeout=TIMEOUT) as r:
+            html = await r.text()
+        ids = set(re.findall(r"FIS-[A-Z]-\d+-\d+", html))
+        all_ids |= ids
+        log.info(f"  page 1: {len(ids)} ids; total so far: {len(all_ids)}")
+
+        # Extract id_busqueda token for pagination
+        m = re.search(r"id_busqueda=([A-Za-z0-9+/=]+)", html)
+        if not m:
+            continue
+        busq = m.group(1)
+        offset = 50
+        page = 2
+        while True:
+            url = f"{SEARCH_URL}?accion=Mas&id_busqueda={busq}-{offset}-50"
+            async with session.get(url, timeout=TIMEOUT) as r:
+                html = await r.text()
+            new_ids = set(re.findall(r"FIS-[A-Z]-\d+-\d+", html)) - all_ids
+            if not new_ids:
+                break
+            all_ids |= new_ids
+            log.info(f"  page {page} (offset {offset}): +{len(new_ids)} ids; total: {len(all_ids)}")
+            offset += 50
+            page += 1
+            if page > 50:  # sanity cap
+                break
+    return sorted(all_ids)
+
+
+async def download_one(session, doc_id: str, sem: asyncio.Semaphore, stats: dict):
+    path = CONTENT_DIR / f"{doc_id}.html"
+    if path.exists() and path.stat().st_size > 5000:
+        stats["skipped"] += 1
+        return
+    async with sem:
+        url = f"{DOC_URL}?id={doc_id}"
+        for attempt in range(3):
+            try:
+                async with session.get(url, allow_redirects=True, timeout=TIMEOUT) as r:
+                    text = await r.text()
+                    if r.url.path.endswith("documentNotFound.php"):
+                        stats["not_found"] += 1
+                        return
+                    if "textoxslt" not in text or len(text) < 5000:
+                        stats["empty"] += 1
+                        return
+                    path.write_text(text, encoding="utf-8")
+                    stats["downloaded"] += 1
+                    return
+            except Exception:
+                await asyncio.sleep(2 * (attempt + 1))
+        stats["failed"] += 1
+
+
+def parse_html(html: str, doc_id: str) -> dict:
+    """Extract titulo, tipo, fecha, full_text from BOE HTML."""
+    type_letter = doc_id.split("-")[1]
+    tipo = TYPE_LABELS.get(type_letter, type_letter)
+
+    # Title from <title> tag or <h3 class="documento-tit">
+    m = re.search(r"<h[1-6][^>]*class=\"documento-tit\"[^>]*>(.*?)</h", html, re.DOTALL)
+    titulo = m.group(1).strip() if m else ""
+    if not titulo:
+        m = re.search(r"<title>(.*?)</title>", html, re.DOTALL)
+        titulo = m.group(1).strip() if m else doc_id
+    titulo = re.sub(r"\s+", " ", re.sub(r"<[^>]+>", " ", titulo))[:1000]
+
+    # Date: id format FIS-X-YYYY-NNNNN, default to YYYY-01-01
+    fecha = None
+    parts = doc_id.split("-")
+    if len(parts) >= 3 and parts[2].isdigit():
+        fecha = f"{parts[2]}-01-01"
+    # Try to find more precise fecha in metadata
+    m = re.search(r"Fecha de publicaci[óo]n:\s*</[^>]+>\s*<[^>]+>([0-9/]+)", html)
+    if m:
+        try:
+            d, mo, y = m.group(1).split("/")
+            fecha = f"{y}-{mo}-{d}"
+        except Exception:
+            pass
+
+    # Body: extract text from id="textoxslt"
+    body = ""
+    m = re.search(r'<div[^>]*id="textoxslt"[^>]*>(.*?)</div>\s*(?:<div|</div>\s*</div>)', html, re.DOTALL)
+    if m:
+        body = m.group(1)
+    body = re.sub(r"<style[^>]*>.*?</style>", "", body, flags=re.DOTALL)
+    body = re.sub(r"<script[^>]*>.*?</script>", "", body, flags=re.DOTALL)
+    body = re.sub(r"<[^>]+>", " ", body)
+    body = body.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">").replace("&nbsp;", " ")
+    body = re.sub(r"\s+", " ", body).strip()
+
+    return {"id": doc_id, "tipo": tipo, "titulo": titulo, "fecha": fecha, "full_text": body}
+
+
+def import_to_db(records: list[dict]):
+    """Bulk insert via psql COPY."""
+    log.info(f"Importing {len(records)} records to {CONTAINER}/{PGDB}...")
+    # COPY from stdin: id\ttipo\ttitulo\tfecha\tfull_text\tmetadata
+    lines = []
+    for r in records:
+        def clean(v):
+            if v is None or v == "":
+                return r"\N"
+            return str(v).replace("\\", "\\\\").replace("\t", " ").replace("\n", " ").replace("\r", " ")
+        meta = json.dumps({"source": "boe_fiscalia"}, ensure_ascii=False)
+        lines.append(f"{clean(r['id'])}\t{clean(r['tipo'])}\t{clean(r['titulo'])}\t{clean(r['fecha'])}\t{clean(r['full_text'])}\t{clean(meta)}")
+    payload = "\n".join(lines) + "\n"
+
+    # Stage to a temp table, then upsert
+    sql = """
+BEGIN;
+CREATE TEMP TABLE _stage_fiscalia (id TEXT, tipo TEXT, titulo TEXT, fecha DATE, full_text TEXT, metadata_json JSONB) ON COMMIT DROP;
+COPY _stage_fiscalia FROM STDIN WITH (FORMAT text, NULL '\\N');
+"""
+    upsert = """
+INSERT INTO spain_fiscalia (id, tipo, titulo, fecha, full_text, metadata_json)
+SELECT id, tipo, titulo, fecha, full_text, metadata_json FROM _stage_fiscalia
+ON CONFLICT (id) DO UPDATE SET
+    tipo=EXCLUDED.tipo, titulo=EXCLUDED.titulo, fecha=EXCLUDED.fecha,
+    full_text=EXCLUDED.full_text, metadata_json=EXCLUDED.metadata_json;
+COMMIT;
+"""
+    full = sql + payload + "\\.\n" + upsert
+    proc = subprocess.run(
+        ["docker", "exec", "-i", CONTAINER, "psql", "-U", PGUSER, "-d", PGDB, "-v", "ON_ERROR_STOP=1"],
+        input=full, capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        log.error(f"psql failed: {proc.stderr[-2000:]}")
+    else:
+        # Print last few lines (INSERT count)
+        for line in proc.stdout.strip().splitlines()[-5:]:
+            log.info(f"  psql: {line}")
+
+
+async def main():
+    CONTENT_DIR.mkdir(parents=True, exist_ok=True)
+    connector = aiohttp.TCPConnector(limit=THREADS, limit_per_host=THREADS)
+    async with aiohttp.ClientSession(
+        connector=connector,
+        headers={"User-Agent": USER_AGENT},
+    ) as session:
+        log.info("Phase 1: Scrape index")
+        ids = await scrape_index(session)
+        log.info(f"Total unique IDs: {len(ids)}")
+
+        if not ids:
+            log.error("No IDs found — aborting")
+            return
+
+        log.info(f"Phase 2: Download {len(ids)} documents to {CONTENT_DIR}")
+        sem = asyncio.Semaphore(THREADS)
+        stats = {"downloaded": 0, "skipped": 0, "not_found": 0, "empty": 0, "failed": 0}
+        tasks = [download_one(session, doc_id, sem, stats) for doc_id in ids]
+        for i in range(0, len(tasks), 50):
+            await asyncio.gather(*tasks[i:i+50])
+            log.info(f"  progress {i+50}/{len(tasks)}: {stats}")
+
+    log.info(f"Download done: {stats}")
+
+    log.info("Phase 3: Parse + import to DB")
+    records = []
+    for path in CONTENT_DIR.glob("FIS-*.html"):
+        try:
+            html = path.read_text(encoding="utf-8")
+            records.append(parse_html(html, path.stem))
+        except Exception as e:
+            log.warning(f"Parse fail {path.name}: {e}")
+    log.info(f"Parsed {len(records)} records")
+
+    if records:
+        # Insert in batches of 200
+        for i in range(0, len(records), 200):
+            import_to_db(records[i:i+200])
+
+    log.info("All done")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Two standalone importers built and validated against prod during 2026-04-17 session.

### `scripts/opendata/spain/download-fiscalia-v2.py`
- Replaces `download-fiscalia.py` whose `tipo_doc=Circular` query pattern returned 0 results from BOE
- Uses correct form: `buscar/fiscalia.php?campo[0]=TIPO.ID&dato[0]=C/I&accion=Buscar` then walks `accion=Mas&id_busqueda={base64}-offset-50` pagination
- Discovers `FIS-{C,I}-{YYYY}-{NNNNN}` doc IDs (Q/Consulta type does not exist on BOE despite the form dropdown)
- Downloads HTML, parses `textoxslt` body, batches via COPY+upsert into `spain_fiscalia`

**Result: 266 documents on local + prod (111 Circular + 155 Instrucción, 1979–2025)**

### `scripts/opendata/offshore/import-cssf-v2.py`
- Replaces the CSSF pipeline in `import-luxembourg-opendata.py` which silently inserted 0 rows because:
  1. cssf.lu CSVs are **UTF-16 LE BOM**, not UTF-8 → decode produced mojibake → CSV parser fell through silent `except Exception: continue`
  2. Headers are fixed-width pseudo-CSV (`NNNNNNNN`, `ISIN`, `NOMOPC`, `CCCCCCCC`, `NOMCOMPARTIMENT`, `AGREEMENTCOMP`, `DEVISECOMP`, `PPPP`, `NOMTYPEPART`) — none matched the original script's `row.get('Code OPC')` guesses → `fund_id` always empty → ON CONFLICT collapsed everything
- Bespoke parser per file format (UCITS / SIF/SICAR / AIFM / MGMT_CO), TAB-split with strip per cell
- ON CONFLICT DO NOTHING — UCITS imported first to preserve its 149K records (UCITS and SIF/SICAR share the OPC code namespace, so upsert-style merge would have overwritten UCITS)

**Result: 195,890 funds on local + prod (UCITS 149,010 + SIF/SICAR 28,419 + AIFM 17,977 + MGMT_CO 484)**

## Test plan

- [x] Both scripts run end-to-end against `secondlayer-postgres-local` without errors
- [x] Both scripts run end-to-end against `secondlayer-postgres-prod` (deployed via SCP to `/home/ubuntu/`) — counts match local exactly
- [x] DB row counts verified post-import on prod
- [ ] Add scripts to deployment automation if these become recurring jobs (out of scope for this PR — currently one-shot bulk loaders)

## Notes

- Original `import-luxembourg-opendata.py` and `download-fiscalia.py` are not modified — both remain untracked in repo (the entire `scripts/opendata/` tree is untracked) and are kept as-is for now.
- These v2 scripts are intentionally standalone (single-file, stdlib + aiohttp) so they can be SCP'd to prod and run directly without the full repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds v2 importers for Spain Fiscalía and Luxembourg CSSF to replace the broken originals. Correctly scrapes BOE and parses CSSF UTF‑16 files to load 266 Fiscalía docs and 195,890 CSSF fund records.

- New Features
  - Fiscalía v2: uses the TIPO.ID C/I search with proper pagination (accion=Mas + id_busqueda), discovers FIS-{C,I}-{YYYY}-{NNNNN} IDs, parses the textoxslt body, and bulk loads into spain_fiscalia with COPY + upsert.
  - CSSF v2: decodes UTF‑16 LE BOM, parses TAB‑separated fixed‑width files with format-specific parsers (UCITS, SIF/SICAR, AIFM, MGMT_CO), dedupes, and bulk loads with COPY using ON CONFLICT DO NOTHING to preserve UCITS records.

<sup>Written for commit d359f24e6aa6d55b0ef90e426cc794b90f76e74e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

