### PR TITLE
ci(local): route build-and-test job to isolated VM runner

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -64,7 +64,7 @@ jobs:
   # ─── Step 2: Build & test on local environment ─────────────────────
   build-and-test:
     name: Build & Test on Local
-    runs-on: [self-hosted, local]
+    runs-on: [self-hosted, local-build]
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
     env:


### PR DESCRIPTION
## Summary

Routes the `build-and-test` job of `ci-local-deploy.yml` to a new, dedicated KVM VM runner (`local-runner-vm`, label `local-build`). All other jobs in the workflow continue to run on the host runner (label `local`).

## Why

Six GitHub Actions runners (aipromo, aisisstant, calendary, panoptic, secondlayer, sneakypiper) currently co-locate on a single box (cthulhu, Ryzen 9800X3D). They share one docker daemon, one disk, and 16 threads, which produces resource contention — visible in CI history as occasional 47–73 min runs (vs. the ~10 min median).

`build-and-test` accounts for ~80% of CI wall time (npm install, `tsc -b`, jest, vitest, frontend `vite build`) and is the main beneficiary of isolation.

## What changed

- One-line edit: `runs-on: [self-hosted, local]` → `runs-on: [self-hosted, local-build]` for the `build-and-test` job only.
- VM runner has been registered with GitHub (`local-runner-vm`, id 24) with labels `[self-hosted, Linux, X64, local-build]` and is online.
- Host runner labels unchanged (`[self-hosted, Linux, X64, local]`), so all other jobs and other workflows (`deploy-prod.yml`, `cron-edrsr-sync.yml`) continue to land on host as before.

## Why other jobs stay on host

- `detect-changes`: trivial git diff, staying on host avoids extra checkout on VM.
- `self-heal-build`: currently disabled (`if: false`), safe either way — keeping on host for simplicity.
- `local-deploy-and-test`: deploys to the local Docker environment which lives on the host. It references host path `/home/vovkes/SecondLayer/deployment/.env.local` and interacts with host containers (`nginx-prod`, `secondlayer-app-local`, etc.) via host docker daemon — these cannot be moved into a VM without a much larger refactor.

## VM specs

| Resource | Value |
|---|---|
| CPU | 4 vCPU (host-passthrough, AVX-512 preserved) |
| RAM | 16 GB |
| Disk | 400 GB qcow2 on NVMe, `cache=none,io=native,discard=unmap` |
| Network | libvirt default NAT (`192.168.122.236`, outbound-only) |
| OS | Ubuntu 24.04 LTS + Docker 29.4.0 + Docker Compose v5.1.3 |
| Runner | actions-runner 2.333.1, systemd service |

## Rollback

If VM runner misbehaves, one command restores the previous behavior:

```bash
# Re-add generic 'local' label to VM, letting both runners receive build jobs again
gh api -X PUT repos/overthelex/secondlayer/actions/runners/24/labels \
  -f 'labels[]=local-build' -f 'labels[]=local'

# Or revert this PR
```

## Test plan

- [ ] Merge triggers CI: `detect-changes` lands on host runner; `build-and-test` lands on VM runner; `local-deploy-and-test` lands on host runner.
- [ ] Compare wall time for `build-and-test` job vs. last 5 host-runner runs. Expect comparable or better (VM is uncontended but has 4 vCPU vs. host's 16-thread pool that was shared).
- [ ] Verify local env at https://local.legal.org.ua still updates correctly after merge — deploy job should update host containers as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the `build-and-test` job in `.github/workflows/ci-local-deploy.yml` to a dedicated VM runner labeled `local-build` to isolate the heavy build/test phase and reduce contention. Other jobs remain on the host runner labeled `local`, keeping local deploy behavior unchanged.

<sup>Written for commit c633f5e0ffb1bf2d62e22a7ffee97b3ffb01fa8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

