### PR TITLE
ci(security): use read-only deploy key for secondlayer-core clone

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -94,12 +94,18 @@ jobs:
       # CI runs TypeScript compilation + unit tests (mocked, no infra needed).
       - name: Overlay proprietary source
         if: needs.detect-changes.outputs.backend == 'true'
+        env:
+          CORE_REPO_SSH_KEY: ${{ secrets.CORE_REPO_SSH_KEY }}
         run: |
           CORE_TMP=$(mktemp -d)
-          gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
+          KEY_FILE=$(mktemp)
+          trap 'shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"; rm -rf "$CORE_TMP"' EXIT
+          printf '%s\n' "$CORE_REPO_SSH_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
+            git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
           cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
-          rm -rf "$CORE_TMP"
 
       - name: Build backend
         if: needs.detect-changes.outputs.backend == 'true'
@@ -335,15 +341,21 @@ jobs:
           node-version: 20
 
       - name: Build dist for changed services
+        env:
+          CORE_REPO_SSH_KEY: ${{ secrets.CORE_REPO_SSH_KEY }}
         run: |
           npm --prefix packages/shared install && npm --prefix packages/shared run build
 
           if [ "$BACKEND_CHANGED" = "true" ]; then
             CORE_TMP=$(mktemp -d)
-            gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
+            KEY_FILE=$(mktemp)
+            trap 'shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"; rm -rf "$CORE_TMP"' EXIT
+            printf '%s\n' "$CORE_REPO_SSH_KEY" > "$KEY_FILE"
+            chmod 600 "$KEY_FILE"
+            GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
+              git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
             cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
             cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
-            rm -rf "$CORE_TMP"
             npm --prefix mcp_backend install && npm --prefix mcp_backend run build
           fi
           if [ "$RADA_CHANGED" = "true" ]; then


### PR DESCRIPTION
## Summary

Replaces the implicit reliance on the runner user's personal PAT (stored in `~/.config/gh/hosts.yml`) with an explicit, read-only SSH deploy key scoped to `overthelex/secondlayer-core`. Removes an over-privileged credential from the CI surface area.

## Why

Before this change, `gh repo clone overthelex/secondlayer-core` in the `Overlay proprietary source` and `Build dist for changed services` steps implicitly used the runner user's authenticated `gh` context. On both host and VM, that was a personal access token with scopes `repo, workflow, read:org, gist` — dramatically more privilege than needed for "clone one private repo, read-only".

Security debt introduced when the VM runner was first set up: the user's personal PAT was copied from host to `/home/ubuntu/.config/gh/hosts.yml` inside the VM, multiplying the blast radius of that credential.

A deploy key is the minimal-privilege GitHub primitive for this exact use case:
- Scoped to exactly one repository
- Explicitly read-only (`read_only: true` at registration)
- Cannot be escalated to any other resource
- Does not expire (unlike PATs with a max 1-year TTL)

## What changed

- `.github/workflows/ci-local-deploy.yml`: both steps that previously ran `gh repo clone overthelex/secondlayer-core` now:
  - Read `CORE_REPO_SSH_KEY` from repo secrets (step-level env, not job-level)
  - Write it to a `mktemp` file with `chmod 600`
  - Register an `EXIT` trap that `shred`s the file and removes the tmp clone dir
  - Use `GIT_SSH_COMMAND` to run `git clone --depth 1 git@github.com:overthelex/secondlayer-core.git` with the key and `StrictHostKeyChecking=accept-new`

Out-of-repo changes already made:
- Generated ed25519 deploy keypair at `~/.ssh/core-repo-deploy` (private key never leaves local machine)
- Public key added to `overthelex/secondlayer-core` as read-only deploy key (id=148847020, title=`ci-deploy-secondlayer`)
- Private key stored as repo secret `CORE_REPO_SSH_KEY` in `overthelex/secondlayer`

## Follow-up (separate PR/commit)

Once this workflow runs green on main:
- `ssh secondlayer_vm 'gh auth logout --hostname github.com' ` to purge the personal PAT from the VM runner's gh config.
- Host runner's gh auth can remain (used by other workflows and interactive work), but the CORE-specific dependency is now severed.

## Test plan

- [ ] Merge → CI triggers.
- [ ] `Overlay proprietary source` step on VM succeeds (clone via SSH + deploy key).
- [ ] `Build dist for changed services` step on host succeeds (same).
- [ ] Subsequent `mcp_backend` build uses the overlayed files correctly.
- [ ] No `gh:` / auth errors in logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches CI cloning of `overthelex/secondlayer-core` from a personal PAT to a read-only SSH deploy key. This reduces credential scope and removes `gh auth` reliance in these steps.

- **Refactors**
  - Uses step-scoped `CORE_REPO_SSH_KEY` secret; writes to a temp key file with `chmod 600`.
  - Clones via SSH with `GIT_SSH_COMMAND`, `StrictHostKeyChecking=accept-new`, and `IdentitiesOnly=yes`; shallow `--depth 1`.
  - Adds an EXIT trap to shred the key and clean the temp directory.
  - Applies to “Overlay proprietary source” and “Build dist for changed services” in `.github/workflows/ci-local-deploy.yml`, enforcing read-only, repo-scoped access.

<sup>Written for commit d4df5b72139b9ff500dab4e0ebf69b7d0d586780. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

