### PR TITLE
fix(opendata-importers): wire json_array imports to real upserts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -54,6 +54,7 @@ config
 # Docker and deployment artifacts
 deployment/backups
 deployment/nginx/certs
+deployment/hudoc-storage
 
 # Misc
 *.md

--- a/mcp_backend/src/migrations/131_json_array_importer_mapping.sql
+++ b/mcp_backend/src/migrations/131_json_array_importer_mapping.sql
@@ -1,0 +1,96 @@
+-- Migration 131: wire json_array importer to actual upserts
+--
+-- Background: runJsonArrayImport previously just downloaded JSON and
+-- reported "completed" without writing to target_table. We now store a
+-- column-level mapping (+ unique_key) inside source_config so the
+-- importer can upsert generically. Tables get unique indexes on the
+-- natural keys declared in unique_key.
+--
+-- Scope: the three daily sources that were demonstrably stale —
+--   mvs_missing_persons, mvs_wanted_vehicles, nazk_corruption.
+
+-- ── Unique indexes backing ON CONFLICT ──────────────────────────────────
+CREATE UNIQUE INDEX IF NOT EXISTS opendata_missing_persons_source_id_uniq
+  ON opendata_missing_persons(source_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS opendata_wanted_vehicles_natural_uniq
+  ON opendata_wanted_vehicles(vehicle_number, body_number);
+
+CREATE UNIQUE INDEX IF NOT EXISTS opendata_corruption_record_id_uniq
+  ON opendata_corruption(record_id);
+
+-- ── mvs_missing_persons ────────────────────────────────────────────────
+UPDATE import_source_catalog
+SET source_config = jsonb_build_object(
+      'format',     'json',
+      'unique_key', jsonb_build_array('source_id'),
+      'mapping', jsonb_build_object(
+        'source_id',     'ID',
+        'ovd',           'OVD',
+        'category',      'CATEGORY',
+        'first_name_u',  'FIRST_NAME_U',
+        'last_name_u',   'LAST_NAME_U',
+        'middle_name_u', 'MIDDLE_NAME_U',
+        'first_name_r',  'FIRST_NAME_R',
+        'last_name_r',   'LAST_NAME_R',
+        'middle_name_r', 'MIDDLE_NAME_R',
+        'first_name_e',  'FIRST_NAME_E',
+        'last_name_e',   'LAST_NAME_E',
+        'middle_name_e', 'MIDDLE_NAME_E',
+        'birth_date',    'BIRTH_DATE',
+        'sex',           'SEX',
+        'lost_date',     'LOST_DATE',
+        'lost_place',    'LOST_PLACE',
+        'article_crim',  'ARTICLE_CRIM',
+        'restraint',     'RESTRAINT',
+        'contact',       'CONTACT',
+        'photo_id',      'PHOTO_ID'
+      )
+    )
+WHERE name = 'mvs_missing_persons';
+
+-- ── mvs_wanted_vehicles ────────────────────────────────────────────────
+UPDATE import_source_catalog
+SET source_config = jsonb_build_object(
+      'format',     'json',
+      'unique_key', jsonb_build_array('vehicle_number', 'body_number'),
+      'mapping', jsonb_build_object(
+        'brand_model',          'brandmodel',
+        'car_type',             'cartype',
+        'color',                'color',
+        'vehicle_number',       'vehiclenumber',
+        'body_number',          'bodynumber',
+        'chassis_number',       'chassisnumber',
+        'engine_number',        'enginenumber',
+        'illegal_seizure_date', 'illegalseizuredate',
+        'organ_unit',           'organunit',
+        'insert_date',          'insertdate'
+      )
+    )
+WHERE name = 'mvs_wanted_vehicles';
+
+-- ── nazk_corruption ────────────────────────────────────────────────────
+-- Fix the target (was opendata_corruption_register, which doesn't exist)
+-- and switch to the live NAZK API (the 2023 snapshot URL was stale).
+UPDATE import_source_catalog
+SET source_url   = 'https://corruptinfo.nazk.gov.ua/ep/1.0/corrupt/getAllData',
+    target_table = 'opendata_corruption',
+    source_config = jsonb_build_object(
+      'format',     'json',
+      'unique_key', jsonb_build_array('record_id'),
+      'mapping', jsonb_build_object(
+        'record_id',         'id',
+        'punishment_type',   'punishmentType.name',
+        'entity_type',       'entityType.name',
+        'last_name',         'indLastNameOnOffenseMoment',
+        'first_name',        'indFirstNameOnOffenseMoment',
+        'patronymic',        'indPatronymicOnOffenseMoment',
+        'offense_name',      'offenseName',
+        'punishment',        'punishment',
+        'court_case_number', 'courtCaseNumber',
+        'sentence_date',     'sentenceDate',
+        'court_name',        'courtName',
+        'codex_articles',    'codexArticles'
+      )
+    )
+WHERE name = 'nazk_corruption';

--- a/mcp_backend/src/services/import-task-service.ts
+++ b/mcp_backend/src/services/import-task-service.ts
@@ -20,6 +20,7 @@ const DEFAULT_IPS = [
 
 const MAX_RETRIES = 5;
 const REQUEST_TIMEOUT = 30_000;
+const JSON_ARRAY_TIMEOUT = 300_000;
 
 interface SourceCatalog {
   id: number;
@@ -350,21 +351,133 @@ export class ImportTaskService {
 
   private async runJsonArrayImport(taskId: number, source: SourceCatalog, ips: string[], signal: AbortSignal): Promise<void> {
     logger.info(`[ImportTask ${taskId}] Downloading JSON array from ${source.source_url}`);
-    const data = await this.fetchJson(source.source_url, null, signal);
+    const data = await this.fetchJson(source.source_url, null, signal, JSON_ARRAY_TIMEOUT);
     if (!data) throw new Error('Cannot download JSON');
 
-    const records = Array.isArray(data) ? data : (data.results || data.data || []);
-    const mem = taskProgress.get(taskId);
-
-    await this.db.query('UPDATE import_tasks SET total_items = $2, total_pages = 1 WHERE id = $1', [taskId, records.length]);
-
-    if (mem) {
-      mem.recordsImported = records.length;
-      mem.pagesDone = 1;
+    const config = source.source_config || {};
+    const rootPath: string | undefined = config.root_path;
+    let records: any[];
+    if (rootPath) {
+      records = this.getJsonPath(data, rootPath) || [];
+    } else {
+      records = Array.isArray(data) ? data : (data.results || data.data || []);
     }
 
-    // TODO: actual upsert into target_table
-    logger.info(`[ImportTask ${taskId}] Downloaded ${records.length} records from JSON array`);
+    const mem = taskProgress.get(taskId);
+    await this.db.query('UPDATE import_tasks SET total_items = $2, total_pages = 1 WHERE id = $1', [taskId, records.length]);
+    logger.info(`[ImportTask ${taskId}] Downloaded ${records.length} records`);
+
+    const mapping = config.mapping as Record<string, string> | undefined;
+    const uniqueKey = (config.unique_key as string[] | undefined) || undefined;
+
+    if (!mapping || !uniqueKey?.length || !source.target_table) {
+      const reason = 'upsert skipped: source_config.mapping / unique_key not configured';
+      logger.warn(`[ImportTask ${taskId}] ${reason}`);
+      if (mem) { mem.recordsImported = records.length; mem.pagesDone = 1; mem.lastError = reason; }
+      return;
+    }
+
+    const { imported, failed } = await this.upsertJsonBatches(
+      taskId, source.target_table, mapping, uniqueKey, records, signal
+    );
+
+    if (mem) {
+      mem.recordsImported = imported;
+      mem.recordsFailed = failed;
+      mem.pagesDone = 1;
+    }
+  }
+
+  private async upsertJsonBatches(
+    taskId: number,
+    table: string,
+    mapping: Record<string, string>,
+    uniqueKey: string[],
+    records: any[],
+    signal: AbortSignal,
+  ): Promise<{ imported: number; failed: number }> {
+    const cols = Object.keys(mapping);
+    const paths = Object.values(mapping);
+
+    // Pre-dedup by unique_key (last record wins) to avoid
+    // "ON CONFLICT DO UPDATE cannot affect row a second time" inside a batch.
+    const seen = new Map<string, any>();
+    for (const rec of records) {
+      const k = uniqueKey.map(col => {
+        const v = this.getJsonPath(rec, mapping[col]);
+        return v == null ? '' : String(v);
+      }).join('\u0001');
+      seen.set(k, rec);
+    }
+    const deduped = Array.from(seen.values());
+    if (deduped.length !== records.length) {
+      logger.info(`[ImportTask ${taskId}] Dedup by ${uniqueKey.join('+')}: ${records.length} → ${deduped.length}`);
+    }
+
+    const updateCols = cols.filter(c => !uniqueKey.includes(c));
+    const updateSet = updateCols.map(c => `${c} = EXCLUDED.${c}`).concat(['imported_at = NOW()']).join(', ');
+    const batchSize = 1000;
+    let imported = 0;
+    let failed = 0;
+
+    for (let i = 0; i < deduped.length; i += batchSize) {
+      if (signal.aborted) break;
+
+      const batch = deduped.slice(i, i + batchSize);
+      const params: any[] = [];
+      const rowsSql: string[] = [];
+
+      for (const rec of batch) {
+        const placeholders = cols.map((_, c) => `$${params.length + c + 1}`).join(',');
+        rowsSql.push(`(${placeholders})`);
+        for (const p of paths) {
+          const raw = this.getJsonPath(rec, p);
+          params.push(this.normalizeValue(raw));
+        }
+      }
+
+      const sql =
+        `INSERT INTO ${table} (${cols.join(',')}) VALUES ${rowsSql.join(',')} ` +
+        `ON CONFLICT (${uniqueKey.join(',')}) DO UPDATE SET ${updateSet}`;
+
+      try {
+        await this.db.query(sql, params);
+        imported += batch.length;
+      } catch (err: any) {
+        failed += batch.length;
+        logger.error(`[ImportTask ${taskId}] Upsert batch failed`, {
+          table, offset: i, size: batch.length, error: err.message,
+        });
+      }
+
+      const mem = taskProgress.get(taskId);
+      if (mem) { mem.recordsImported = imported; mem.recordsFailed = failed; }
+      if ((i / batchSize) % 10 === 0) {
+        await this.db.query(
+          `UPDATE import_tasks SET records_imported = $2, records_failed = $3, last_activity_at = NOW(), updated_at = NOW() WHERE id = $1`,
+          [taskId, imported, failed],
+        ).catch(() => {});
+      }
+    }
+
+    return { imported, failed };
+  }
+
+  private getJsonPath(obj: any, path: string): any {
+    if (!path) return obj;
+    let v: any = obj;
+    for (const part of path.split('.')) {
+      if (v == null) return null;
+      v = (v as any)[part];
+    }
+    return v;
+  }
+
+  private normalizeValue(v: any): any {
+    if (v === undefined || v === null) return null;
+    if (v instanceof Date) return v.toISOString();
+    if (typeof v === 'object') return JSON.stringify(v);
+    return v;
   }
 
   // ---- File Download (ZIP/CSV/XML) ----
@@ -383,12 +496,12 @@ export class ImportTaskService {
 
   // ========================= HTTP Fetcher =========================
 
-  private async fetchJson(url: string, localAddress: string | null, signal: AbortSignal): Promise<any> {
+  private async fetchJson(url: string, localAddress: string | null, signal: AbortSignal, timeoutMs: number = REQUEST_TIMEOUT): Promise<any> {
     for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
       if (signal.aborted) return null;
 
       try {
-        const data = await this.httpGet(url, localAddress, signal);
+        const data = await this.httpGet(url, localAddress, signal, timeoutMs);
         return JSON.parse(data);
       } catch (err: any) {
         if (signal.aborted) return null;
@@ -413,7 +526,7 @@ export class ImportTaskService {
     return null;
   }
 
-  private httpGet(url: string, localAddress: string | null, signal: AbortSignal): Promise<string> {
+  private httpGet(url: string, localAddress: string | null, signal: AbortSignal, timeoutMs: number = REQUEST_TIMEOUT): Promise<string> {
     return new Promise((resolve, reject) => {
       const parsed = new URL(url);
       const isHttps = parsed.protocol === 'https:';
@@ -424,7 +537,7 @@ export class ImportTaskService {
         port: parsed.port || (isHttps ? 443 : 80),
         path: parsed.pathname + parsed.search,
         method: 'GET',
-        timeout: REQUEST_TIMEOUT,
+        timeout: timeoutMs,
         headers: {
           'Accept': 'application/json',
           'User-Agent': 'SecondLayer-Legal-Platform/2.0',
@@ -438,7 +551,7 @@ export class ImportTaskService {
       const req = mod.request(opts, (res) => {
         // Follow redirects
         if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          this.httpGet(res.headers.location, localAddress, signal).then(resolve).catch(reject);
+          this.httpGet(res.headers.location, localAddress, signal, timeoutMs).then(resolve).catch(reject);
           return;
         }
 


### PR DESCRIPTION
## Summary
- `runJsonArrayImport` was a no-op (`TODO: actual upsert into target_table`). The daily cron downloaded NAZK / MVS dumps, reported `completed`, and wrote nothing — `opendata_corruption` drifted weeks behind while tasks showed success.
- Wired up a generic mapping-based upsert driven by `source_config.mapping` + `unique_key`. Batches are pre-deduped on the unique key (needed for `mvs_wanted_vehicles`, which has ~5.3K duplicate `vehicle_number+body_number` pairs that would otherwise trigger "cannot affect row a second time").
- Fixed `nazk_corruption` catalog entry: points at the live NAZK API (`corruptinfo.nazk.gov.ua/ep/1.0/corrupt/getAllData`) instead of the retired 2023 snapshot, and the correct target table `opendata_corruption` (catalog pointed at the non-existent `opendata_corruption_register`).
- Added unique indexes backing the new `ON CONFLICT` clauses and bumped the per-request timeout to 5 min for json_array fetches (NAZK's ~50MB dump routinely exceeded the 30s default).
- Scoped to the three sources with demonstrably stale data: `mvs_missing_persons`, `mvs_wanted_vehicles`, `nazk_corruption`. The other 14 `json_array` sources still lack mappings and stay no-op behind a warning until configured in a follow-up.
- `.dockerignore`: exclude `deployment/hudoc-storage` (root-owned `pgdata` blocks the Docker build context).

## Test plan
- [x] Apply migration `131_json_array_importer_mapping.sql` locally.
- [x] Trigger `start_import` for all three sources; verify `records_imported` matches expected counts post-dedup.
  - `nazk_corruption`: 27,567 upserted, +1 new (live API snapshot).
  - `mvs_missing_persons`: 113,425 upserted, +1,434 new.
  - `mvs_wanted_vehicles`: 72,919 upserted (deduped from 78,219), +61 new.
- [x] Confirm `ON CONFLICT (vehicle_number, body_number)` handles duplicate pairs without erroring.
- [ ] CI/CD: validate local build + deploy; observe the next scheduled 03:00 daily run on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable real upserts for `json_array` imports so daily NAZK/MVS dumps persist to target tables and stay current; also fix the NAZK catalog source and stabilize large fetches.

- **New Features**
  - Add mapping-driven, batched upserts using `source_config.mapping` + `unique_key` with `ON CONFLICT` (supports dot paths, pre-dedups per batch).
  - Create unique indexes for the new conflict keys and raise JSON array fetch timeout to 5 minutes.
  - Scope to `mvs_missing_persons`, `mvs_wanted_vehicles`, and `nazk_corruption`; other `json_array` sources warn and skip until mapped.

- **Bug Fixes**
  - Fix `nazk_corruption` catalog: switch to the live API and point to `opendata_corruption`.
  - `.dockerignore`: exclude `deployment/hudoc-storage` to avoid blocked Docker build contexts.

<sup>Written for commit 0f05137503036550a0419ac00a2bee60489916b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

