### PR TITLE
chore: gitignore nested mcplane repo and opendata importer checkpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,9 @@ scripts/hudoc/court-sessions-clean.csv
 scripts/hudoc/court-sessions-sample.csv
 scripts/hudoc/*.zip
 scripts/opendata/rnbo/ua_nsdc_sanctions.json
+
+# Nested projects with their own git repos
+mcplane/
+
+# Opendata importer runtime state (resume checkpoints, temp data)
+services/opendata-importers/_data/


### PR DESCRIPTION
## Summary
- `mcplane/` has its own `.git/` — nested repo, shouldn't show up as untracked in the outer repo status
- `services/opendata-importers/_data/` holds runtime state (resume checkpoints, temp data) — not source

## Test plan
- [x] `git status` no longer lists these paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore the nested `mcplane/` repo and `services/opendata-importers/_data/` runtime data. Keeps git status clean and prevents non-source files from being tracked.

<sup>Written for commit 826736e1747bf94e4a7dd00f97c946c48d5fe075. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

