### PR TITLE
feat(edrsr): multi-IP + Review HTML fallback for fulltext gap download

### DIFF
--- a/deployment/systemd/secondary-ips.service
+++ b/deployment/systemd/secondary-ips.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Assign AWS-secondary private IPs to ens5
+After=network-online.target cloud-final.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/sbin/secondary-ips.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/systemd/secondary-ips.sh
+++ b/deployment/systemd/secondary-ips.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Add all secondary private IPs of ens5 from EC2 IMDSv2 to the OS interface.
+# Runs on boot to persist AWS-assigned secondary IPs.
+set -euo pipefail
+
+IFACE=ens5
+MAC=$(cat /sys/class/net/$IFACE/address)
+TOKEN=$(curl -sS -X PUT 'http://169.254.169.254/latest/api/token' \
+    -H 'X-aws-ec2-metadata-token-ttl-seconds: 60')
+SUBNET_CIDR=$(curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" \
+    "http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/subnet-ipv4-cidr-block")
+MASK=${SUBNET_CIDR##*/}
+
+PRIMARY=$(ip -o -4 addr show $IFACE | awk '{print $4}' | head -1 | cut -d/ -f1)
+
+IPS=$(curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" \
+    "http://169.254.169.254/latest/meta-data/network/interfaces/macs/$MAC/local-ipv4s")
+
+for IP in $IPS; do
+    [ "$IP" = "$PRIMARY" ] && continue
+    if ! ip -o -4 addr show $IFACE | awk '{print $4}' | cut -d/ -f1 | grep -qx "$IP"; then
+        ip addr add "$IP/$MASK" dev $IFACE
+        echo "Added $IP/$MASK to $IFACE"
+    fi
+done

--- a/scripts/edrsr/download-fulltext-gap-prod.py
+++ b/scripts/edrsr/download-fulltext-gap-prod.py
@@ -27,11 +27,16 @@ import aiofiles
 import aiohttp
 
 ALL_SOURCE_IPS = [
-    "172.31.29.20",
-    "172.31.21.255",
-    "172.31.31.40",
-    "172.31.22.206",
-    "172.31.28.109",
+    "172.31.21.255",   # 0: working
+    "172.31.31.40",    # 1: working
+    "172.31.22.206",   # 2: working
+    "172.31.27.31",    # 3: working (new EIP)
+    "172.31.19.142",   # 4: working (new EIP)
+    "172.31.19.20",    # 5: working (new EIP)
+    "172.31.17.145",   # 6: working (new EIP)
+    "172.31.16.240",   # 7: working (new EIP)
+    "172.31.29.20",    # 8: EDRSR-blocked (do not use)
+    "172.31.28.109",   # 9: no public IP (do not use)
 ]
 
 RTF_DIR_BASE = Path("/home/ubuntu/edrsr-rtf-gaps")
@@ -189,35 +194,57 @@ class Stats:
         )
 
 
+REVIEW_URL_TEMPLATE = "https://reyestr.court.gov.ua/Review/{doc_id}"
+
+
+async def _fetch(session, url, timeout=REQUEST_TIMEOUT):
+    """Single GET; returns (status, bytes). Returns (-1, None) on exception."""
+    try:
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout)) as resp:
+            if resp.status == 200:
+                return 200, await resp.read()
+            return resp.status, None
+    except Exception:
+        return -1, None
+
+
 async def download_one(session, doc_id, url, rtf_dir, stats, semaphore, source_ip):
     outpath = rtf_dir / f"{doc_id}.rtf"
     if outpath.exists() and outpath.stat().st_size > 0:
         await stats.inc('skipped')
         return
+    review_url = REVIEW_URL_TEMPLATE.format(doc_id=doc_id)
     async with semaphore:
         for attempt in range(MAX_RETRIES):
-            try:
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)) as resp:
-                    if resp.status == 200:
-                        data = await resp.read()
-                        if len(data) > 100:
-                            async with aiofiles.open(outpath, 'wb') as f:
-                                await f.write(data)
-                            await stats.inc('downloaded', source_ip)
-                            return
-                        await stats.inc('failed')
-                        return
-                    elif resp.status == 429:
-                        await asyncio.sleep(min(60, 5 * (2 ** attempt)))
-                        continue
-                    elif resp.status >= 500:
-                        await asyncio.sleep(min(30, 2 * (2 ** attempt)))
-                        continue
-                    else:
-                        await stats.inc('failed')
-                        return
-            except Exception:
+            # 1) Try RTF file URL
+            status, data = await _fetch(session, url)
+            if status == 200 and data and len(data) > 100:
+                async with aiofiles.open(outpath, 'wb') as f:
+                    await f.write(data)
+                await stats.inc('downloaded', source_ip)
+                return
+            if status == 429:
+                await asyncio.sleep(min(60, 5 * (2 ** attempt)))
+                continue
+            if status >= 500:
+                await asyncio.sleep(min(30, 2 * (2 ** attempt)))
+                continue
+            # 2) On 404/non-200/exception: fallback to Review HTML endpoint
+            hstatus, hdata = await _fetch(session, review_url)
+            if hstatus == 200 and hdata and len(hdata) > 1000:
+                async with aiofiles.open(outpath, 'wb') as f:
+                    await f.write(hdata)
+                await stats.inc('downloaded', source_ip)
+                return
+            if hstatus == 429:
+                await asyncio.sleep(min(60, 5 * (2 ** attempt)))
+                continue
+            if hstatus == -1 or hstatus >= 500:
                 await asyncio.sleep(min(15, 2 * (2 ** attempt)))
+                continue
+            # definitive failure (e.g. both endpoints 404) — stop retrying
+            await stats.inc('failed')
+            return
         await stats.inc('failed')
 
 


### PR DESCRIPTION
## Summary

- **Multi-IP downloader**: expand `ALL_SOURCE_IPS` from 5 → 10 entries (8 usable). 5 new EIPs were allocated on AWS and associated with fresh secondary private IPs on the prod ENI to bypass the EDRSR block on 2 of the original IPs.
- **Review HTML fallback**: when the canonical RTF URL (`od.reyestr.court.gov.ua/files/…`) returns 404 — which is the case for the overwhelming majority of missing docs — fall back to `reyestr.court.gov.ua/Review/{doc_id}`. The existing `rtf_to_text()` already sniffs HTML and routes to `html_to_text()`, so no changes are needed on the import side.
- **systemd helper**: `deployment/systemd/secondary-ips.{sh,service}` queries EC2 IMDSv2 on boot and re-attaches every secondary private IP of the ENI to `ens5`. AWS preserves EIP associations through reboots, but the OS loses the `ip addr` state — without this helper we end up with EIPs pointing to private IPs the kernel doesn't own.

## Context

- Original gap download used the 4 pre-existing secondary IPs (`172.31.29.20`, `21.255`, `31.40`, `22.206`, `28.109`). EDRSR rate-limited all 4 working IPs within a few hours and the block is persistent (not a TTL'd rate-limit). `28.109` never had a public IP associated, so it was silently nonfunctional.
- With the new setup, 2019 gap download went from ~15 doc/s (3 IPs × 3 threads) to 58 doc/s (8 IPs × 3 threads) and stayed at `fail=0`.

## Test plan

- [x] Verified all 5 new EIPs return 200 on `https://reyestr.court.gov.ua/Review/{doc_id}` from prod
- [x] Re-ran `edrsr-queue.sh 0,1,2,3,4,5,6,7 3 2019` on prod; downloader writes to `/home/ubuntu/edrsr-rtf-gaps/rtf2019/` with no failures
- [x] `secondary-ips.service` installed on prod; `systemctl status` reports `active (exited)`; rerunning it is a no-op (skips existing addresses)
- [ ] Reboot prod some quiet Sunday to confirm the systemd unit re-adds the secondary IPs end-to-end (not urgent — the association on AWS survives reboot regardless)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-IP support and an HTML Review fallback to the EDRSR fulltext gap downloader to increase throughput and reduce failures. Adds a boot-time `systemd` helper to reattach AWS secondary IPs for stable networking.

- **New Features**
  - Multi-IP: expanded `ALL_SOURCE_IPS` from 5→10 (8 usable) with 5 new EIPs; boosted throughput from ~15 to ~58 docs/s with stable `fail=0`.
  - Fallback: when the RTF URL 404s/non-200, try `https://reyestr.court.gov.ua/Review/{doc_id}`; existing `rtf_to_text()` already routes HTML to `html_to_text()`.
  - Boot persistence: `deployment/systemd/secondary-ips.{sh,service}` re-adds all secondary private IPs to `ens5` via EC2 IMDSv2 after reboot.

- **Migration**
  - Install and enable `secondary-ips.service` on prod; no reboot required, but it will auto-readd IPs on boot.

<sup>Written for commit eeca4990345e9775352b4b516d2a1bf5f32e50dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

