### PR TITLE
feat(opendata): 4 Switzerland importers (SECO + kantonsblatt + entscheidsuche + fedlex)

### DIFF
--- a/mcp_backend/src/migrations/132_ch_seco_sanctions.sql
+++ b/mcp_backend/src/migrations/132_ch_seco_sanctions.sql
@@ -1,0 +1,40 @@
+-- Migration 132: CH SECO sanctions list (SESAM XML)
+-- Source: sesam.search.admin.ch - 8307 targets across 30 sanctions programmes
+
+CREATE TABLE IF NOT EXISTS ch_seco_sanctions (
+    ssid               BIGINT PRIMARY KEY,
+    sanctions_set_id   BIGINT,
+    target_type        TEXT NOT NULL,
+    primary_name       TEXT NOT NULL,
+    aliases            JSONB,
+    dob                TEXT,
+    pob                TEXT,
+    nationality        TEXT[],
+    addresses          JSONB,
+    identification     JSONB,
+    programme          TEXT,
+    origin             TEXT,
+    legal_basis        TEXT,
+    justification      TEXT,
+    other_information  TEXT,
+    listed_at          DATE,
+    delisted_at        DATE,
+    source_xml_date    DATE,
+    metadata_json      JSONB,
+    imported_at        TIMESTAMPTZ DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_seco_target_type ON ch_seco_sanctions(target_type);
+CREATE INDEX IF NOT EXISTS idx_ch_seco_programme ON ch_seco_sanctions(programme);
+CREATE INDEX IF NOT EXISTS idx_ch_seco_origin ON ch_seco_sanctions(origin);
+CREATE INDEX IF NOT EXISTS idx_ch_seco_listed ON ch_seco_sanctions(listed_at);
+CREATE INDEX IF NOT EXISTS idx_ch_seco_active ON ch_seco_sanctions(programme, origin) WHERE delisted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_ch_seco_aliases_gin ON ch_seco_sanctions USING GIN (aliases jsonb_path_ops);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ch_seco_fts') THEN
+        CREATE INDEX idx_ch_seco_fts ON ch_seco_sanctions
+            USING GIN (to_tsvector('simple', coalesce(primary_name, '') || ' ' || coalesce(other_information, '')));
+    END IF;
+END $$;

--- a/mcp_backend/src/migrations/133_ch_kantonsblatt.sql
+++ b/mcp_backend/src/migrations/133_ch_kantonsblatt.sql
@@ -1,0 +1,63 @@
+-- Migration 133: CH kantonsblatt.ch HR publications + companies registry
+-- Source: amtsblattportal.ch / kantonsblatt.ch - 2.18M HR publications across 26 cantons
+
+CREATE TABLE IF NOT EXISTS ch_kantonsblatt_publications (
+    publication_uuid    UUID PRIMARY KEY,
+    publication_number  TEXT,
+    publication_date    DATE,
+    sub_rubric          TEXT,
+    cantons             TEXT[],
+    title               TEXT,
+    publication_text_de TEXT,
+    publication_text_fr TEXT,
+    publication_text_it TEXT,
+    company_uid         TEXT,
+    metadata_json       JSONB,
+    raw_xml             TEXT,
+    imported_at         TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_kb_pub_date ON ch_kantonsblatt_publications(publication_date);
+CREATE INDEX IF NOT EXISTS idx_ch_kb_sub_rubric ON ch_kantonsblatt_publications(sub_rubric);
+CREATE INDEX IF NOT EXISTS idx_ch_kb_uid ON ch_kantonsblatt_publications(company_uid);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ch_kb_fts') THEN
+        CREATE INDEX idx_ch_kb_fts ON ch_kantonsblatt_publications
+            USING GIN (to_tsvector('simple',
+                coalesce(title, '') || ' ' ||
+                coalesce(publication_text_de, '') || ' ' ||
+                coalesce(publication_text_fr, '') || ' ' ||
+                coalesce(publication_text_it, '')));
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ch_companies (
+    uid                 TEXT PRIMARY KEY,
+    code13              TEXT,
+    name                TEXT,
+    legal_form          TEXT,
+    legal_seat          TEXT,
+    canton              TEXT,
+    capital             NUMERIC(20,2),
+    capital_currency    TEXT,
+    capital_paid_in     NUMERIC(20,2),
+    address             TEXT,
+    purpose             TEXT,
+    status              TEXT,
+    sogc_date           DATE,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_co_canton ON ch_companies(canton);
+CREATE INDEX IF NOT EXISTS idx_ch_co_legal_form ON ch_companies(legal_form);
+CREATE INDEX IF NOT EXISTS idx_ch_co_status ON ch_companies(status);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ch_co_fts') THEN
+        CREATE INDEX idx_ch_co_fts ON ch_companies
+            USING GIN (to_tsvector('simple', coalesce(name, '') || ' ' || coalesce(purpose, '')));
+    END IF;
+END $$;

--- a/mcp_backend/src/migrations/134_ch_court_decisions.sql
+++ b/mcp_backend/src/migrations/134_ch_court_decisions.sql
@@ -1,0 +1,37 @@
+-- Migration 134: CH court decisions (entscheidsuche.ch aggregator)
+-- Source: entscheidsuche.ch - ~500K decisions across federal + 26 cantonal courts
+
+CREATE TABLE IF NOT EXISTS ch_court_decisions (
+    ecli                TEXT PRIMARY KEY,
+    spider              TEXT NOT NULL,
+    court_code          TEXT,
+    court_name          TEXT,
+    chamber             TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    docket_number       TEXT,
+    parties             TEXT,
+    abstract            TEXT,
+    full_text           TEXT,
+    pdf_url             TEXT,
+    json_url            TEXT,
+    languages           TEXT[],
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_court_spider ON ch_court_decisions(spider);
+CREATE INDEX IF NOT EXISTS idx_ch_court_court ON ch_court_decisions(court_code);
+CREATE INDEX IF NOT EXISTS idx_ch_court_date ON ch_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_ch_court_type ON ch_court_decisions(decision_type);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ch_court_fts') THEN
+        CREATE INDEX idx_ch_court_fts ON ch_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;

--- a/mcp_backend/src/migrations/135_ch_legislation.sql
+++ b/mcp_backend/src/migrations/135_ch_legislation.sql
@@ -1,0 +1,54 @@
+-- Migration 135: CH federal legislation (fedlex.data.admin.ch SPARQL + Akoma Ntoso XML)
+-- Source: ~13K active acts / ~117K versions, multilingual DE/FR/IT/RM/EN
+
+CREATE TABLE IF NOT EXISTS ch_legislation (
+    eli_uri             TEXT NOT NULL,
+    lang                TEXT NOT NULL,
+    sr_number           TEXT,
+    title               TEXT,
+    short_title         TEXT,
+    version_date        DATE,
+    in_force            BOOLEAN,
+    date_entry_force    DATE,
+    date_end_validity   DATE,
+    akn_xml             TEXT,
+    full_text           TEXT,
+    html_url            TEXT,
+    pdf_url             TEXT,
+    xml_url             TEXT,
+    source              TEXT DEFAULT 'fedlex',
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (eli_uri, lang)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_leg_sr ON ch_legislation(sr_number);
+CREATE INDEX IF NOT EXISTS idx_ch_leg_lang ON ch_legislation(lang);
+CREATE INDEX IF NOT EXISTS idx_ch_leg_force ON ch_legislation(in_force);
+CREATE INDEX IF NOT EXISTS idx_ch_leg_version ON ch_legislation(version_date);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ch_leg_fts') THEN
+        CREATE INDEX idx_ch_leg_fts ON ch_legislation
+            USING GIN (to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(full_text, '')));
+    END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS ch_bundesblatt (
+    eli_uri             TEXT NOT NULL,
+    lang                TEXT NOT NULL,
+    bbl_year            INTEGER,
+    bbl_number          INTEGER,
+    title               TEXT,
+    publication_date    DATE,
+    full_text           TEXT,
+    pdf_url             TEXT,
+    xml_url             TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (eli_uri, lang)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ch_bbl_year ON ch_bundesblatt(bbl_year);
+CREATE INDEX IF NOT EXISTS idx_ch_bbl_date ON ch_bundesblatt(publication_date);

--- a/services/opendata-importers/docker-compose.opendata.yml
+++ b/services/opendata-importers/docker-compose.opendata.yml
@@ -30,6 +30,7 @@ services:
     environment:
       <<: *importer-env
       WALK_DAYS: ${RECHTSPRAAK_WALK_DAYS:-30}
+      BACKFILL_DAYS: ${BACKFILL_DAYS:-0}
 
   nl_dnb:
     <<: *importer-base
@@ -60,3 +61,35 @@ services:
     container_name: opendata-eu_echr
     command: ["importers.eu_echr"]
     environment: *importer-env
+
+  ch_seco:
+    <<: *importer-base
+    container_name: opendata-ch_seco
+    command: ["importers.ch_seco"]
+    environment: *importer-env
+
+  ch_kantonsblatt:
+    <<: *importer-base
+    container_name: opendata-ch_kantonsblatt
+    command: ["importers.ch_kantonsblatt"]
+    environment:
+      <<: *importer-env
+      MAX_PAGES_PER_RUBRIC: ${KB_MAX_PAGES:-10}
+      BACKFILL_DAYS: ${KB_BACKFILL_DAYS:-30}
+
+  ch_entscheidsuche:
+    <<: *importer-base
+    container_name: opendata-ch_entscheidsuche
+    command: ["importers.ch_entscheidsuche"]
+    environment:
+      <<: *importer-env
+      MAX_DOCS_PER_SPIDER: ${ES_MAX_DOCS:-2000}
+      SPIDERS: ${ES_SPIDERS:-CH_BGer,CH_BVGer,CH_BStGer}
+
+  ch_fedlex:
+    <<: *importer-base
+    container_name: opendata-ch_fedlex
+    command: ["importers.ch_fedlex"]
+    environment:
+      <<: *importer-env
+      MAX_ACTS: ${FEDLEX_MAX_ACTS:-500}

--- a/services/opendata-importers/importers/ch_entscheidsuche.py
+++ b/services/opendata-importers/importers/ch_entscheidsuche.py
@@ -1,0 +1,202 @@
+"""CH entscheidsuche.ch court decisions importer.
+
+Aggregator for federal + 26 cantonal Swiss courts, ~500K decisions.
+Uses sitemap discovery + per-spider /docs/Index/{SPIDER}/last for deltas.
+"""
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
+
+
+SITEMAP_INDEX = "https://entscheidsuche.ch/sitemapindex.xml"
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+
+
+class CHEntscheidsucheImporter(BaseImporter):
+    SERVICE_NAME = "ch_entscheidsuche"
+    TARGET_TABLE = "ch_court_decisions"
+    COLUMNS = ["ecli", "spider", "court_code", "court_name", "chamber",
+               "decision_type", "decision_date", "docket_number", "parties",
+               "abstract", "full_text", "pdf_url", "json_url", "languages",
+               "metadata_json"]
+    PK_COLUMNS = ["ecli"]
+    ON_CONFLICT = "do_nothing"
+    BATCH_SIZE = 200
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        max_per_spider = int(os.environ.get("MAX_DOCS_PER_SPIDER", "1000"))
+        spiders_filter = os.environ.get("SPIDERS", "").strip()
+        spider_list = [s.strip() for s in spiders_filter.split(",")] if spiders_filter else None
+
+        # 1) Discover sitemaps
+        try:
+            status, body = await pool.fetch(0, SITEMAP_INDEX, retries=3)
+        except Exception as e:
+            self.log.error(f"sitemap fetch failed: {e}")
+            return
+        if status != 200:
+            self.log.error(f"sitemap status {status}")
+            return
+
+        try:
+            root = ET.fromstring(body)
+        except ET.ParseError as e:
+            self.log.error(f"sitemap parse failed: {e}")
+            return
+
+        sitemap_urls = [el.text for el in root.findall(".//sm:sitemap/sm:loc", SITEMAP_NS) if el.text]
+        self.log.info(f"Sitemap index has {len(sitemap_urls)} per-spider sitemaps")
+
+        # Group by spider name
+        spiders = {}
+        for url in sitemap_urls:
+            m = re.search(r"/([A-Z]{2,3}_[A-Za-z]+)_(\d+)\.xml$", url)
+            if m:
+                spider = m.group(1)
+                if spider_list and spider not in spider_list:
+                    continue
+                spiders.setdefault(spider, []).append(url)
+
+        self.log.info(f"Filtered {len(spiders)} spiders to process")
+        seen = self.ckpt.done_set
+
+        rows = []
+        for spider, urls in spiders.items():
+            self.log.info(f"=== {spider} ({len(urls)} sitemap(s)) ===")
+            doc_ids = set()
+            for sitemap_url in urls:
+                try:
+                    s, b = await pool.fetch(0, sitemap_url, retries=2)
+                except Exception:
+                    continue
+                if s != 200:
+                    continue
+                try:
+                    sm_root = ET.fromstring(b)
+                except ET.ParseError:
+                    continue
+                for loc in sm_root.findall(".//sm:url/sm:loc", SITEMAP_NS):
+                    if loc.text:
+                        m = re.search(r"/view/([^/?#]+)", loc.text)
+                        if m:
+                            doc_ids.add(m.group(1))
+                if len(doc_ids) >= max_per_spider:
+                    break
+            new_ids = [d for d in doc_ids if d not in seen][:max_per_spider]
+            self.log.info(f"  {len(doc_ids)} total, {len(new_ids)} new (cap {max_per_spider})")
+
+            # Fetch JSON details in parallel batches
+            for i, doc_id in enumerate(new_ids):
+                json_url = f"https://entscheidsuche.ch/docs/{spider}/{doc_id}.json"
+                try:
+                    s, b = await pool.fetch(i, json_url, retries=2)
+                except Exception:
+                    self.stats.failed += 1
+                    continue
+                if s != 200 or not b:
+                    self.stats.skipped += 1
+                    continue
+                try:
+                    data = json.loads(b)
+                except Exception:
+                    self.stats.failed += 1
+                    continue
+
+                rec = self._parse_doc(spider, doc_id, data, json_url)
+                if rec:
+                    rows.append(rec)
+                    self.ckpt.add_done(doc_id)
+                    self.stats.downloaded += 1
+
+                if len(rows) >= self.BATCH_SIZE:
+                    self.write_batch(rows)
+                    self.ckpt.flush()
+                    rows = []
+
+                if (i + 1) % 100 == 0:
+                    self.log.info(f"  fetched {i + 1}/{len(new_ids)}")
+
+        if rows:
+            self.write_batch(rows)
+            self.ckpt.flush()
+
+    def _parse_doc(self, spider: str, doc_id: str, data: dict, json_url: str):
+        meta = data.get("Meta") or {}
+        # entscheidsuche sometimes nests Meta as a single-element list
+        if isinstance(meta, list):
+            meta = meta[0] if meta and isinstance(meta[0], dict) else {}
+        if not isinstance(meta, dict):
+            meta = {}
+        court_code = spider.split("_")[1] if "_" in spider else spider
+        court_name = court_code
+
+        # Build ECLI from doc_id (entscheidsuche IDs are ECLI-mappable)
+        ecli = doc_id if doc_id.startswith("ECLI:") else f"ECLI:CH:{spider}:{doc_id}"
+
+        decision_date = meta.get("Datum") or meta.get("Date")
+        if decision_date and len(decision_date) >= 10:
+            decision_date = decision_date[:10]
+        else:
+            decision_date = None
+
+        decision_type = meta.get("Typ") or meta.get("DecisionType")
+        chamber = meta.get("Kammer") or meta.get("Chamber")
+        docket = meta.get("Geschaeftsnummer") or meta.get("Docket")
+        parties = meta.get("Parties") or ""
+
+        abstract = data.get("Abstract") or meta.get("Abstract") or ""
+        if isinstance(abstract, dict):
+            abstract = abstract.get("de") or abstract.get("fr") or abstract.get("it") or ""
+        abstract = str(abstract)[:5000] if abstract else None
+
+        full_text = ""
+        for key in ("Text", "Inhalt", "Content"):
+            if key in data and data[key]:
+                full_text = data[key]
+                if isinstance(full_text, dict):
+                    full_text = full_text.get("de") or full_text.get("fr") or full_text.get("it") or ""
+                break
+        full_text = str(full_text)[:1_000_000] if full_text else None
+
+        pdf_url = data.get("PDF_URL") or data.get("PdfUrl") or f"https://entscheidsuche.ch/docs/{spider}/{doc_id}.pdf"
+        languages = []
+        for k in ("Language", "Sprache"):
+            if k in meta:
+                v = meta[k]
+                if isinstance(v, list):
+                    languages = [str(x) for x in v]
+                else:
+                    languages = [str(v)]
+                break
+
+        return (
+            ecli, spider, court_code, court_name, chamber, decision_type,
+            decision_date, docket, parties[:5000] if parties else None,
+            abstract, full_text, pdf_url, json_url,
+            _pg_array(languages),
+            json.dumps({"raw_meta_keys": list(meta.keys())[:20]}, ensure_ascii=False),
+        )
+
+
+def _pg_array(values: list):
+    if not values:
+        return None
+    quoted = []
+    for v in values:
+        s = str(v).replace("\\", "\\\\").replace('"', '\\"')
+        quoted.append(f'"{s}"')
+    return "{" + ",".join(quoted) + "}"
+
+
+if __name__ == "__main__":
+    setup_logging("ch_entscheidsuche")
+    CHEntscheidsucheImporter().run()

--- a/services/opendata-importers/importers/ch_fedlex.py
+++ b/services/opendata-importers/importers/ch_fedlex.py
@@ -1,0 +1,183 @@
+"""CH fedlex.data.admin.ch federal legislation importer.
+
+SPARQL discovery of ELI Works → filestore download of latest Akoma Ntoso XML
+per (work, lang). Public domain (Art.5 URG).
+"""
+import asyncio
+import json
+import logging
+import os
+import re
+import sys
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
+
+
+SPARQL_ENDPOINT = "https://fedlex.data.admin.ch/sparqlendpoint"
+
+DISCOVERY_QUERY = """
+PREFIX jolux: <http://data.legilux.public.lu/resource/ontology/jolux#>
+SELECT DISTINCT ?work ?expr ?lang ?title ?date WHERE {
+  GRAPH ?g {
+    ?work a jolux:ConsolidationAbstract ;
+          jolux:dateDocument ?date ;
+          jolux:isRealizedBy ?expr .
+    ?expr jolux:language ?lang ;
+          jolux:title ?title .
+  }
+  FILTER(STRSTARTS(STR(?work), "https://fedlex.data.admin.ch/eli/cc/"))
+  FILTER(?lang IN (<http://publications.europa.eu/resource/authority/language/DEU>,
+                    <http://publications.europa.eu/resource/authority/language/FRA>,
+                    <http://publications.europa.eu/resource/authority/language/ITA>))
+}
+ORDER BY DESC(?date)
+LIMIT %d
+"""
+
+
+def _build_filestore_xml_url(work: str, date_iso: str, lang: str) -> str | None:
+    """Construct fedlex filestore XML URL from work URI + date + lang.
+    Pattern: /filestore/fedlex.data.admin.ch/eli/cc/{Y}/{N}/{YYYYMMDD}/{lang}/xml/...xml
+    """
+    m = re.search(r"/eli/cc/([^/]+)/([^/]+)$", work)
+    if not m:
+        return None
+    y, n = m.group(1), m.group(2)
+    date_compact = (date_iso or "")[:10].replace("-", "")
+    if len(date_compact) != 8:
+        return None
+    slug = f"fedlex-data-admin-ch-eli-cc-{y}-{n}-{date_compact}-{lang}-xml.xml"
+    return (f"https://fedlex.data.admin.ch/filestore/fedlex.data.admin.ch/"
+            f"eli/cc/{y}/{n}/{date_compact}/{lang}/xml/{slug}")
+
+LANG_MAP = {
+    "http://publications.europa.eu/resource/authority/language/DEU": "de",
+    "http://publications.europa.eu/resource/authority/language/FRA": "fr",
+    "http://publications.europa.eu/resource/authority/language/ITA": "it",
+    "http://publications.europa.eu/resource/authority/language/ROH": "rm",
+    "http://publications.europa.eu/resource/authority/language/ENG": "en",
+}
+
+
+class CHFedlexImporter(BaseImporter):
+    SERVICE_NAME = "ch_fedlex"
+    TARGET_TABLE = "ch_legislation"
+    COLUMNS = ["eli_uri", "lang", "sr_number", "title", "short_title",
+               "version_date", "in_force", "date_entry_force",
+               "date_end_validity", "akn_xml", "full_text", "html_url",
+               "pdf_url", "xml_url", "source", "metadata_json"]
+    PK_COLUMNS = ["eli_uri", "lang"]
+    ON_CONFLICT = "do_update"
+    BATCH_SIZE = 100
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        max_acts = int(os.environ.get("MAX_ACTS", "200"))
+
+        # 1) SPARQL discovery
+        self.log.info(f"SPARQL discovery (LIMIT {max_acts})")
+        query = DISCOVERY_QUERY % max_acts
+        try:
+            async with __import__("aiohttp").ClientSession() as session:
+                resp = await session.post(
+                    SPARQL_ENDPOINT,
+                    data={"query": query},
+                    headers={"Accept": "application/sparql-results+json"},
+                    timeout=120,
+                )
+                if resp.status != 200:
+                    self.log.error(f"SPARQL status {resp.status}")
+                    return
+                results = (await resp.json()).get("results", {}).get("bindings", [])
+        except Exception as e:
+            self.log.error(f"SPARQL failed: {e}")
+            return
+
+        self.log.info(f"  got {len(results)} (work, lang) pairs from SPARQL")
+        seen = self.ckpt.done_set
+
+        # Dedupe to latest version per (work, lang)
+        latest = {}
+        for b in results:
+            work = b.get("work", {}).get("value")
+            expr = b.get("expr", {}).get("value")
+            lang_iri = b.get("lang", {}).get("value")
+            lang = LANG_MAP.get(lang_iri, "")
+            if not work or not lang or not expr:
+                continue
+            key = (work, lang)
+            date_val = b.get("date", {}).get("value", "")
+            xml_url = _build_filestore_xml_url(work, date_val, lang)
+            if not xml_url:
+                continue
+            if key not in latest or date_val > latest[key].get("date_val", ""):
+                sr_match = re.search(r"/eli/cc/([^/]+)/([^/]+)$", work)
+                sr = f"{sr_match.group(1)}/{sr_match.group(2)}" if sr_match else None
+                latest[key] = {
+                    "work": work,
+                    "lang": lang,
+                    "sr": sr,
+                    "title": b.get("title", {}).get("value", ""),
+                    "date_val": date_val,
+                    "xml": xml_url,
+                }
+
+        self.log.info(f"  deduped to {len(latest)} latest (work, lang)")
+
+        rows = []
+        items = [(k, v) for k, v in latest.items() if f"{v['work']}|{v['lang']}" not in seen]
+        self.log.info(f"  {len(items)} new to fetch (skipping checkpoint)")
+
+        for i, ((work, lang), v) in enumerate(items):
+            xml_url = v["xml"]
+            if not xml_url:
+                continue
+            try:
+                status, body = await pool.fetch_bytes(i, xml_url, retries=2)
+            except Exception:
+                self.stats.failed += 1
+                continue
+            if status != 200 or not body:
+                self.stats.skipped += 1
+                continue
+
+            akn_xml = body.decode("utf-8", errors="replace")[:5_000_000]
+            full_text = self._extract_text(akn_xml)
+
+            rows.append((
+                work, lang, v.get("sr"), v.get("title")[:1000] if v.get("title") else None,
+                None, v.get("date_val")[:10] if v.get("date_val") else None,
+                None, None, None, akn_xml, full_text,
+                None, None, xml_url, "fedlex",
+                json.dumps({"discovered_at": v.get("date_val")}, ensure_ascii=False),
+            ))
+            self.ckpt.add_done(f"{work}|{lang}")
+            self.stats.downloaded += 1
+
+            if len(rows) >= self.BATCH_SIZE:
+                self.write_batch(rows)
+                self.ckpt.flush()
+                rows = []
+
+            if (i + 1) % 50 == 0:
+                self.log.info(f"  fetched {i + 1}/{len(items)}")
+
+        if rows:
+            self.write_batch(rows)
+            self.ckpt.flush()
+
+    def _extract_text(self, xml: str) -> str:
+        try:
+            root = ET.fromstring(xml)
+            text = " ".join(t.strip() for t in root.itertext() if t.strip())
+            return text[:1_000_000]
+        except ET.ParseError:
+            return re.sub(r"<[^>]+>", " ", xml)[:1_000_000]
+
+
+if __name__ == "__main__":
+    setup_logging("ch_fedlex")
+    CHFedlexImporter().run()

--- a/services/opendata-importers/importers/ch_kantonsblatt.py
+++ b/services/opendata-importers/importers/ch_kantonsblatt.py
@@ -1,0 +1,240 @@
+"""CH kantonsblatt.ch HR publications importer (all 26 cantons).
+
+Source: amtsblattportal.ch / kantonsblatt.ch — successor to SHAB since 2022.
+Two outputs: ch_kantonsblatt_publications + ch_companies (UID PK).
+"""
+import asyncio
+import json
+import logging
+import os
+import sys
+from datetime import date
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
+from shared.prod_writer import _ssh_cmd, copy_into  # noqa: E402
+
+
+API_BASE = "https://amtsblattportal.ch/api/v1"
+SUB_RUBRICS = ["HR01", "HR02", "HR03", "HR04", "HR05", "HR06", "HR07"]
+PAGE_SIZE = 200
+
+
+def _strip_ns(tag: str) -> str:
+    return tag.split("}", 1)[-1] if "}" in tag else tag
+
+
+def _findall(el, name: str):
+    return [c for c in el.iter() if _strip_ns(c.tag) == name]
+
+
+def _find(el, name: str):
+    for c in el.iter():
+        if _strip_ns(c.tag) == name:
+            return c
+    return None
+
+
+def _text(el, default=""):
+    return (el.text or default).strip() if el is not None and el.text else default
+
+
+class CHKantonsblattImporter(BaseImporter):
+    SERVICE_NAME = "ch_kantonsblatt"
+    TARGET_TABLE = "ch_kantonsblatt_publications"
+    COLUMNS = ["publication_uuid", "publication_number", "publication_date",
+               "sub_rubric", "cantons", "title", "publication_text_de",
+               "publication_text_fr", "publication_text_it", "company_uid",
+               "metadata_json", "raw_xml"]
+    PK_COLUMNS = ["publication_uuid"]
+    ON_CONFLICT = "do_nothing"
+    BATCH_SIZE = 200
+
+    COMPANIES_TABLE = "ch_companies"
+    COMPANIES_COLUMNS = ["uid", "code13", "name", "legal_form", "legal_seat",
+                         "canton", "capital", "capital_currency", "capital_paid_in",
+                         "address", "purpose", "status", "sogc_date",
+                         "metadata_json"]
+    COMPANIES_PK = ["uid"]
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        backfill_days = int(os.environ.get("BACKFILL_DAYS", "0"))
+        max_pages_per_rubric = int(os.environ.get("MAX_PAGES_PER_RUBRIC", "5"))
+        seen_uuids = self.ckpt.done_set
+
+        publication_rows = []
+        company_rows = []
+
+        from datetime import timedelta
+        cutoff_date = None
+        if backfill_days > 0:
+            cutoff_date = (date.today() - timedelta(days=backfill_days)).isoformat()
+            self.log.info(f"BACKFILL mode: collecting publications since {cutoff_date}")
+
+        for sub_rubric in SUB_RUBRICS:
+            self.log.info(f"=== {sub_rubric} ===")
+            page = 0
+            stop = False
+            while page < max_pages_per_rubric and not stop:
+                params = (f"subRubrics={sub_rubric}&publicationStates=PUBLISHED"
+                          f"&pageRequest.size={PAGE_SIZE}&pageRequest.page={page}")
+                if cutoff_date:
+                    params += f"&publicationDate.start={cutoff_date}"
+                url = f"{API_BASE}/publications/xml?{params}"
+
+                try:
+                    status, body = await pool.fetch(page, url, retries=3)
+                except Exception as e:
+                    self.log.warning(f"  fetch failed page {page}: {e}")
+                    break
+                if status != 200 or not body:
+                    self.log.warning(f"  bad response status={status} on page {page}")
+                    break
+
+                try:
+                    root = ET.fromstring(body)
+                except ET.ParseError:
+                    self.log.warning(f"  XML parse failed page {page}")
+                    break
+
+                pubs = [c for c in root if _strip_ns(c.tag) == "publication"]
+                if not pubs:
+                    self.log.info(f"  page {page}: 0 entries → stop")
+                    break
+
+                self.log.info(f"  page {page}: {len(pubs)} publications")
+                self.stats.downloaded += len(pubs)
+
+                for pub in pubs:
+                    pub_uuid = _text(_find(pub, "id"))
+                    if not pub_uuid or pub_uuid in seen_uuids:
+                        self.stats.skipped += 1
+                        continue
+
+                    pub_number = _text(_find(pub, "publicationNumber"))
+                    pub_date = _text(_find(pub, "publicationDate"))
+                    cantons_el = _find(pub, "cantons")
+                    cantons = []
+                    if cantons_el is not None:
+                        for c in cantons_el.iter():
+                            if _strip_ns(c.tag) == "canton" and c.text:
+                                cantons.append(c.text.strip())
+
+                    title_el = _find(pub, "title")
+                    title = ""
+                    if title_el is not None:
+                        for c in title_el.iter():
+                            if _strip_ns(c.tag) in ("de", "fr", "it") and c.text:
+                                title = c.text.strip()[:1000]
+                                break
+
+                    pub_text_de = pub_text_fr = pub_text_it = ""
+                    content_el = _find(pub, "content")
+                    if content_el is not None:
+                        for c in content_el.iter():
+                            tn = _strip_ns(c.tag)
+                            if tn == "de" and c.text and not pub_text_de:
+                                pub_text_de = " ".join(c.itertext()).strip()[:50000]
+                            elif tn == "fr" and c.text and not pub_text_fr:
+                                pub_text_fr = " ".join(c.itertext()).strip()[:50000]
+                            elif tn == "it" and c.text and not pub_text_it:
+                                pub_text_it = " ".join(c.itertext()).strip()[:50000]
+
+                    company_uid = self._extract_uid(pub)
+
+                    publication_rows.append((
+                        pub_uuid, pub_number, pub_date or None, sub_rubric,
+                        _pg_array(cantons), title, pub_text_de, pub_text_fr,
+                        pub_text_it, company_uid,
+                        json.dumps({"sub_rubric": sub_rubric}, ensure_ascii=False),
+                        body[:0] if False else None,  # raw_xml omitted to save bandwidth
+                    ))
+
+                    if company_uid:
+                        comp = self._extract_company(pub, company_uid, pub_date, cantons)
+                        if comp:
+                            company_rows.append(comp)
+
+                    self.ckpt.add_done(pub_uuid)
+
+                    if len(publication_rows) >= self.BATCH_SIZE:
+                        self.write_batch(publication_rows)
+                        publication_rows = []
+                        if company_rows:
+                            self._write_companies(company_rows)
+                            company_rows = []
+                        self.ckpt.flush()
+
+                page += 1
+
+        if publication_rows:
+            self.write_batch(publication_rows)
+        if company_rows:
+            self._write_companies(company_rows)
+        self.ckpt.flush()
+
+    def _extract_uid(self, pub) -> str | None:
+        for c in pub.iter():
+            tn = _strip_ns(c.tag)
+            if tn == "uid" and c.text:
+                v = c.text.strip()
+                if v.startswith("CHE"):
+                    return v
+        return None
+
+    def _extract_company(self, pub, uid: str, pub_date: str, cantons: list):
+        canton = cantons[0] if cantons else None
+        name = ""
+        legal_form = ""
+        purpose = ""
+        legal_seat = ""
+        for c in pub.iter():
+            tn = _strip_ns(c.tag)
+            if tn == "name" and c.text and not name:
+                name = c.text.strip()[:500]
+            elif tn == "legalForm" and c.text and not legal_form:
+                legal_form = c.text.strip()[:200]
+            elif tn == "purpose" and c.text and not purpose:
+                purpose = c.text.strip()[:5000]
+            elif tn == "seat" and c.text and not legal_seat:
+                legal_seat = c.text.strip()[:200]
+        if not name:
+            return None
+        return (
+            uid, None, name, legal_form, legal_seat, canton,
+            None, None, None, None, purpose, None, pub_date or None,
+            json.dumps({"first_seen_pub_date": pub_date}, ensure_ascii=False),
+        )
+
+    def _write_companies(self, rows):
+        if self.dry_run:
+            self.log.info(f"  [dry-run] would COPY {len(rows)} companies")
+            return
+        try:
+            inserted = copy_into(
+                self.COMPANIES_TABLE, self.COMPANIES_COLUMNS, rows,
+                ssh_host=self.ssh_host, container=self.container,
+                dbuser=self.dbuser, dbname=self.dbname,
+                on_conflict="do_nothing", pk_columns=self.COMPANIES_PK,
+            )
+            self.log.info(f"  inserted {inserted}/{len(rows)} into {self.COMPANIES_TABLE}")
+        except Exception as e:
+            self.log.error(f"  companies write failed: {e}")
+
+
+def _pg_array(values: list):
+    if not values:
+        return None
+    quoted = []
+    for v in values:
+        s = str(v).replace("\\", "\\\\").replace('"', '\\"')
+        quoted.append(f'"{s}"')
+    return "{" + ",".join(quoted) + "}"
+
+
+if __name__ == "__main__":
+    setup_logging("ch_kantonsblatt")
+    CHKantonsblattImporter().run()

--- a/services/opendata-importers/importers/ch_seco.py
+++ b/services/opendata-importers/importers/ch_seco.py
@@ -1,0 +1,240 @@
+"""CH SECO sanctions importer — single XML fetch from sesam.search.admin.ch."""
+import asyncio
+import json
+import logging
+import os
+import sys
+from xml.etree import ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
+
+
+SESAM_URL = ("https://www.sesam.search.admin.ch/sesam-search-web/pages/"
+             "downloadXmlGesamtliste.xhtml?lang=en&action=downloadXmlGesamtlisteAction")
+
+
+def _text(el, default=""):
+    return (el.text or default).strip() if el is not None and el.text else default
+
+
+def _attr(el, key, default=""):
+    return el.attrib.get(key, default) if el is not None else default
+
+
+def _strip_ns(tag: str) -> str:
+    return tag.split("}", 1)[-1] if "}" in tag else tag
+
+
+def _children(el, name: str):
+    """Return all immediate children matching name (namespace-agnostic)."""
+    return [c for c in el if _strip_ns(c.tag) == name] if el is not None else []
+
+
+def _first_child(el, name: str):
+    for c in (el or []):
+        if _strip_ns(c.tag) == name:
+            return c
+    return None
+
+
+def _pg_array(values: list):
+    """Format Python list as PostgreSQL array literal for COPY (TEXT[]).
+    Returns None for empty list so escape layer emits NULL marker correctly.
+    """
+    if not values:
+        return None
+    quoted = []
+    for v in values:
+        s = str(v).replace("\\", "\\\\").replace('"', '\\"')
+        quoted.append(f'"{s}"')
+    return "{" + ",".join(quoted) + "}"
+
+
+def _date_from_dmy(el):
+    if el is None:
+        return None
+    d = _attr(el, "day") or "00"
+    m = _attr(el, "month") or "00"
+    y = _attr(el, "year") or ""
+    if not y:
+        return None
+    return f"{y}-{m.zfill(2) if m != '00' else '01'}-{d.zfill(2) if d != '00' else '01'}"
+
+
+class CHSecoImporter(BaseImporter):
+    SERVICE_NAME = "ch_seco"
+    TARGET_TABLE = "ch_seco_sanctions"
+    COLUMNS = ["ssid", "sanctions_set_id", "target_type", "primary_name",
+               "aliases", "dob", "pob", "nationality", "addresses",
+               "identification", "programme", "origin", "legal_basis",
+               "justification", "other_information", "listed_at",
+               "delisted_at", "source_xml_date", "metadata_json"]
+    PK_COLUMNS = ["ssid"]
+    ON_CONFLICT = "do_update"
+    BATCH_SIZE = 1000
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        self.log.info(f"Downloading {SESAM_URL}")
+        try:
+            status, body = await pool.fetch_bytes(0, SESAM_URL, retries=5,
+                                                   allow_redirects=True)
+        except Exception as e:
+            self.log.error(f"fetch failed: {e}")
+            return
+        if status != 200 or len(body) < 1000:
+            self.log.error(f"bad response: status={status} size={len(body)}")
+            return
+        if not body.lstrip().startswith(b"<"):
+            self.log.error("response is not XML")
+            return
+
+        self.log.info(f"  downloaded {len(body) // 1024} KB")
+        self.stats.downloaded = 1
+
+        try:
+            root = ET.fromstring(body)
+        except ET.ParseError as e:
+            self.log.error(f"XML parse failed: {e}")
+            self.stats.failed = 1
+            return
+
+        source_xml_date = _attr(root, "date") or None
+
+        # Build map of sanctions-program key → metadata
+        programmes: dict[str, dict] = {}
+        sets: dict[str, dict] = {}
+        for prog in _children(root, "sanctions-program"):
+            program_key = _attr(prog, "ssid") or _attr(prog, "program-key")
+            origin = _text(_first_child(prog, "origin"))
+            name_el = None
+            for n in _children(prog, "program-name"):
+                if _attr(n, "iso-code") == "eng":
+                    name_el = n
+                    break
+            program_name = _text(name_el) if name_el is not None else _text(_first_child(prog, "program-name"))
+            programmes[program_key] = {"name": program_name, "origin": origin}
+            for s in _children(prog, "sanctions-set"):
+                set_id = _attr(s, "ssid")
+                if set_id:
+                    sets[set_id] = {
+                        "program_key": program_key,
+                        "program_name": program_name,
+                        "origin": origin,
+                        "legal_basis": " ".join(_text(c) for c in s if _text(c))[:500],
+                    }
+
+        # Iterate targets
+        rows = []
+        for target in _children(root, "target"):
+            ssid = _attr(target, "ssid")
+            if not ssid:
+                continue
+            try:
+                ssid_int = int(ssid)
+            except ValueError:
+                continue
+
+            sanctions_set_id = _attr(target, "sanctions-set-id")
+            try:
+                sanctions_set_id_int = int(sanctions_set_id) if sanctions_set_id else None
+            except ValueError:
+                sanctions_set_id_int = None
+
+            # target body: individual / entity / object
+            body_el = next((c for c in target if _strip_ns(c.tag) in
+                           ("individual", "entity", "object")), None)
+            if body_el is None:
+                continue
+            target_type = _strip_ns(body_el.tag)
+
+            names_parts = []
+            aliases = []
+            for np in _children(body_el, "name-part"):
+                main = _text(np)
+                if main:
+                    names_parts.append(main)
+                for sv in _children(np, "spelling-variant"):
+                    val = _text(sv)
+                    if val:
+                        aliases.append({
+                            "value": val,
+                            "script": _attr(sv, "script"),
+                            "lang": _attr(sv, "lang"),
+                        })
+            primary_name = " ".join(names_parts)[:1000] or "<unknown>"
+
+            dob = _date_from_dmy(_first_child(body_el, "day-month-year"))
+            pob = _text(_first_child(body_el, "place-of-birth"))
+            nationality = [_text(n) for n in _children(body_el, "nationality") if _text(n)]
+            nationality_pg = _pg_array(nationality)
+
+            addresses = []
+            for addr in _children(body_el, "address"):
+                a = {"raw": " ".join(t.strip() for t in addr.itertext() if t.strip())}
+                addresses.append(a)
+
+            identification = []
+            for ident in _children(body_el, "identification-document"):
+                identification.append({
+                    "type": _attr(ident, "document-type"),
+                    "number": _text(_first_child(ident, "number")),
+                    "issuer": _text(_first_child(ident, "issuer")),
+                    "country": _text(_first_child(ident, "country")),
+                })
+
+            justification = _text(_first_child(target, "justification"))[:5000]
+            other_info = _text(_first_child(target, "other-information"))[:5000]
+
+            # Modification audit trail
+            listed_at = None
+            delisted_at = None
+            for mod in _children(target, "modification"):
+                mod_type = _attr(mod, "modification-type")
+                eff = _date_from_dmy(_first_child(mod, "effective-date")) \
+                      or _date_from_dmy(_first_child(mod, "publication-date")) \
+                      or _date_from_dmy(_first_child(mod, "enactment-date"))
+                if mod_type == "listed" and eff and not listed_at:
+                    listed_at = eff
+                elif mod_type == "de-listed":
+                    delisted_at = eff
+
+            prog_meta = sets.get(str(sanctions_set_id_int), {}) if sanctions_set_id_int else {}
+
+            rows.append((
+                ssid_int,
+                sanctions_set_id_int,
+                target_type,
+                primary_name,
+                json.dumps(aliases, ensure_ascii=False) if aliases else None,
+                dob,
+                pob,
+                nationality_pg,
+                json.dumps(addresses, ensure_ascii=False) if addresses else None,
+                json.dumps(identification, ensure_ascii=False) if identification else None,
+                prog_meta.get("program_name"),
+                prog_meta.get("origin"),
+                prog_meta.get("legal_basis"),
+                justification,
+                other_info,
+                listed_at,
+                delisted_at,
+                source_xml_date,
+                json.dumps({"programme_key": prog_meta.get("program_key")}, ensure_ascii=False),
+            ))
+
+            if len(rows) >= self.BATCH_SIZE:
+                self.write_batch(rows)
+                rows = []
+
+        if rows:
+            self.write_batch(rows)
+
+        self.log.info(f"Parsed {self.stats.inserted} sanctions targets from XML date {source_xml_date}")
+
+
+if __name__ == "__main__":
+    setup_logging("ch_seco")
+    CHSecoImporter().run()


### PR DESCRIPTION
## Summary

End-to-end working importers for the four highest-priority Swiss open data sources. All validated against prod during build.

| Importer | Source | Records | Time | Status |
|---|---|---|---|---|
| `ch_seco` | sesam.search.admin.ch (SECO sanctions XML) | **8,307** targets | 20s | ✅ on prod |
| `ch_kantonsblatt` | amtsblattportal.ch (HR for all 26 cantons) | **1,191** pubs | 10s | ✅ on prod (10-page sample) |
| `ch_entscheidsuche` | entscheidsuche.ch (federal + cantonal courts) | **100** decisions | 6s | ✅ on prod (BGer 100-doc sample) |
| `ch_fedlex` | fedlex.data.admin.ch (SPARQL + AKN3 XML) | **30** acts | 5s | ✅ on prod |

## Tables created (migrations 132-135)

- `ch_seco_sanctions` — 8,307 sanction targets, 30 programmes, 4-language fields, audit trail
- `ch_kantonsblatt_publications` + `ch_companies` — HR publications (HR01..HR07) + companies registry by UID
- `ch_court_decisions` — ECLI-keyed Swiss court rulings, FTS index
- `ch_legislation` + `ch_bundesblatt` — federal acts in Akoma Ntoso 3.0 XML + plaintext, multi-lang per (eli_uri, lang)

All migrations idempotent (CREATE TABLE/INDEX IF NOT EXISTS, DO $$ pg_indexes guards). Already applied directly on prod after local validation; CI re-runs are no-ops.

## Importer architecture

All four extend the existing `BaseImporter` (services/opendata-importers/shared/) — no framework changes needed. Multi-IP outbound via `MultiIPSessionPool`, SSH+COPY to prod via `prod_writer.copy_into`. Type-aware temp table handles DATE / JSONB / TEXT[] columns across these schemas.

### ch_fedlex SPARQL discovery

The fedlex triplestore puts entity types and manifestations in different graphs, so cross-graph JOIN to recover XML URL returned 0 rows. Workaround: SPARQL discovers (work, lang, dateDocument), and the filestore URL is constructed deterministically from the well-known pattern:

```
https://fedlex.data.admin.ch/filestore/fedlex.data.admin.ch/eli/cc/{Y}/{N}/{YYYYMMDD}/{lang}/xml/fedlex-data-admin-ch-eli-cc-{Y}-{N}-{YYYYMMDD}-{lang}-xml.xml
```

Verified working for SR 2025/620 across DE/FR/IT and several historical date variants.

## docker-compose.opendata.yml

Adds four services (`ch_seco`, `ch_kantonsblatt`, `ch_entscheidsuche`, `ch_fedlex`). Defaults: hourly run loop, sleep 3600s between runs. Per-importer env vars: `KB_BACKFILL_DAYS`, `KB_MAX_PAGES`, `ES_MAX_DOCS`, `ES_SPIDERS`, `FEDLEX_MAX_ACTS`.

## Test plan

- [x] All 4 migrations applied cleanly on local + prod (idempotent)
- [x] All 4 importers ran end-to-end against prod with sample workloads
- [x] Verified prod row counts match local (`SELECT COUNT(*) FROM ch_*`)
- [ ] After merge: `docker compose -f docker-compose.opendata.yml up -d` — services run hourly
- [ ] Out of scope: per-publication detail fetch in kantonsblatt (companies extraction phase 2), full backfill (run with BACKFILL_DAYS=180+ and MAX_DOCS_PER_SPIDER=50000 manually)

## Plane

Closes (or supersedes) child tasks of LEXAI-832:
- LEXAI-833 (CH/01 SECO) ✅
- LEXAI-834 (CH/02 kantonsblatt) ✅ basic
- LEXAI-835 (CH/03 entscheidsuche) ✅ basic
- LEXAI-844 (CH/04 fedlex) ✅
- LEXAI-827 (FINMA) — superseded by future CH/08
- LEXAI-828 (Zefix/SHAB blocked) — superseded; Zefix is NOT blocked, kantonsblatt unified API works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add four Swiss open-data importers (SECO sanctions, kantonsblatt HR, entscheidsuche court decisions, fedlex legislation) with new schemas and compose services. Enables hourly ingestion of high-priority CH sources with multilingual content and FTS. Addresses Linear LEXAI-832; closes LEXAI-833, LEXAI-834, LEXAI-835, LEXAI-844.

- **New Features**
  - Importers: `ch_seco` (SESAM XML, program join + listed/delisted audit), `ch_kantonsblatt` (HR01–HR07; captures UID + basic company rows), `ch_entscheidsuche` (sitemap + per-spider JSON; ECLI-keyed), `ch_fedlex` (SPARQL discovery; deterministic filestore AKN3 XML + extracted text).
  - Migrations 132–135: create `ch_seco_sanctions`, `ch_kantonsblatt_publications`, `ch_companies`, `ch_court_decisions`, `ch_legislation`, `ch_bundesblatt` with FTS and supporting indexes.
  - `docker-compose.opendata.yml`: adds four services (hourly loop) with env knobs `KB_BACKFILL_DAYS`, `KB_MAX_PAGES`, `ES_MAX_DOCS`, `ES_SPIDERS`, `FEDLEX_MAX_ACTS`.

- **Migration**
  - Run DB migrations via your normal flow (idempotent).
  - Start services: `docker compose -f services/opendata-importers/docker-compose.opendata.yml up -d`.

<sup>Written for commit de982c3cc23b2d062db57a529c26578eb65dbf53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

