### PR TITLE
feat(edrsr): court-scoped FTS + dispositive-only extraction tools

### DIFF
--- a/mcp_backend/src/api/__tests__/edrsr-extended-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-extended-tools.test.ts
@@ -1,0 +1,339 @@
+/**
+ * EdsrExtendedTools unit tests
+ *
+ * Covers:
+ * - edrsr_court_decisions_by_court: required-param validation, date format, SQL shape, enrichment
+ * - edrsr_get_decision_dispositive: marker detection, fallback path, missing doc
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { EdsrExtendedTools } from '../tools/edrsr-extended-tools.js';
+
+type QueryCall = { sql: string; params?: any[] };
+
+describe('EdsrExtendedTools', () => {
+  let db: any;
+  let calls: QueryCall[];
+  let tool: EdsrExtendedTools;
+
+  const makeDb = (responder: (sql: string, params?: any[]) => any) => ({
+    query: jest.fn((sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      const result = responder(sql, params);
+      return Promise.resolve(result);
+    }),
+  });
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  describe('edrsr_court_decisions_by_court', () => {
+    it('returns error when court_code missing', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_court_decisions_by_court', {
+        fts_query: 'ТЦК',
+        date_from: '2025-01-01',
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('court_code');
+    });
+
+    it('returns error when fts_query missing', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_court_decisions_by_court', {
+        court_code: 2605,
+        date_from: '2025-01-01',
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('fts_query');
+    });
+
+    it('returns error when date_from missing (partition pruning safety)', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_court_decisions_by_court', {
+        court_code: 2605,
+        fts_query: 'ТЦК',
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('date_from');
+    });
+
+    it('rejects malformed date', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_court_decisions_by_court', {
+        court_code: 2605,
+        fts_query: 'ТЦК',
+        date_from: '2025/01/01',
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('YYYY-MM-DD');
+    });
+
+    it('builds partitioned FTS query with adj_year bounds and returns enriched rows', async () => {
+      db = makeDb((sql: string) => {
+        if (sql.includes('FROM edrsr_courts')) {
+          return { rows: [{ name: 'Оболонський районний суд міста Києва' }] };
+        }
+        if (sql.includes('COUNT(*)')) {
+          return { rows: [{ total: 2 }] };
+        }
+        if (sql.includes('ts_rank_cd')) {
+          return {
+            rows: [
+              {
+                doc_id: 100,
+                cause_num: '756/10500/25',
+                adjudication_date: '2025-10-20',
+                judge: 'Ткаченко М.М.',
+                court_code: 2605,
+                justice_kind: 4,
+                judgment_code: 3,
+                category_code: null,
+                doc_url: null,
+                rank: 0.5,
+                snippet: '…ТЦК…',
+              },
+              {
+                doc_id: 101,
+                cause_num: '756/13083/24',
+                adjudication_date: '2025-12-19',
+                judge: 'Тихонова О.О.',
+                court_code: 2605,
+                justice_kind: 4,
+                judgment_code: 3,
+                category_code: null,
+                doc_url: null,
+                rank: 0.3,
+                snippet: '…повістка…',
+              },
+            ],
+          };
+        }
+        if (sql.includes('edrsr_justice_kinds')) {
+          return { rows: [{ justice_kind: 4, name: 'Адміністративне' }] };
+        }
+        if (sql.includes('edrsr_judgment_forms')) {
+          return { rows: [{ judgment_code: 3, name: 'Рішення' }] };
+        }
+        return { rows: [] };
+      });
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_court_decisions_by_court', {
+        court_code: 2605,
+        fts_query: 'ТЦК повістка розшук',
+        date_from: '2025-01-01',
+        date_to: '2026-03-31',
+        limit: 10,
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const payload = JSON.parse(result!.content[0].text);
+
+      expect(payload.total).toBe(2);
+      expect(payload.returned).toBe(2);
+      expect(payload.has_more).toBe(false);
+      expect(payload.query.court_name).toBe('Оболонський районний суд міста Києва');
+      expect(payload.results[0].doc_id).toBe(100);
+      expect(payload.results[0].court_name).toBe('Оболонський районний суд міста Києва');
+      expect(payload.results[0].justice_kind_name).toBe('Адміністративне');
+      expect(payload.results[0].judgment_form).toBe('Рішення');
+      expect(payload.results[0].external_url).toContain('/Review/100');
+
+      const dataCall = calls.find((c) => c.sql.includes('ts_rank_cd'));
+      expect(dataCall).toBeDefined();
+      expect(dataCall!.sql).toContain("plainto_tsquery('simple'");
+      expect(dataCall!.sql).toContain('f.adj_year BETWEEN');
+      expect(dataCall!.sql).toContain('ORDER BY d.adjudication_date DESC');
+      expect(dataCall!.params).toEqual([
+        2605,
+        '2025-01-01',
+        '2026-03-31',
+        2025,
+        2026,
+        'ТЦК повістка розшук',
+        10,
+        0,
+      ]);
+    });
+
+    it('clamps limit above MAX_LIMIT (100)', async () => {
+      db = makeDb((sql: string) => {
+        if (sql.includes('FROM edrsr_courts')) return { rows: [] };
+        if (sql.includes('COUNT(*)')) return { rows: [{ total: 0 }] };
+        return { rows: [] };
+      });
+      tool = new EdsrExtendedTools(db);
+
+      await tool.executeTool('edrsr_court_decisions_by_court', {
+        court_code: 2605,
+        fts_query: 'test',
+        date_from: '2025-01-01',
+        limit: 500,
+      });
+
+      const dataCall = calls.find((c) => c.sql.includes('ts_rank_cd'));
+      expect(dataCall!.params![6]).toBe(100);
+    });
+  });
+
+  describe('edrsr_get_decision_dispositive', () => {
+    it('returns error when doc_id missing', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {});
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('doc_id');
+    });
+
+    it('returns error when doc not found', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {
+        doc_id: 999999,
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('не знайдено');
+    });
+
+    it('extracts ВИРІШИВ: section when present', async () => {
+      const fullText =
+        'Шапка справи.\n\nВСТАНОВИВ: обставини справи тут.\n\n' +
+        'ВИРІШИВ:\n1. Скасувати постанову.\n2. Закрити провадження.\n3. Стягнути судовий збір.';
+      db = makeDb(() => ({
+        rows: [{ full_text: fullText, text_length: fullText.length }],
+      }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {
+        doc_id: 12345,
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.marker).toBe('ВИРІШИВ:');
+      expect(payload.marker_position).toBe(fullText.indexOf('ВИРІШИВ:'));
+      expect(payload.is_fallback).toBe(false);
+      expect(payload.dispositive).toContain('Скасувати постанову');
+      expect(payload.text_length).toBe(fullText.length);
+      expect(payload.external_url).toBe('https://reyestr.court.gov.ua/Review/12345');
+    });
+
+    it('picks earliest marker when multiple present', async () => {
+      const fullText = 'УХВАЛИВ: попередня ухвала.\nВИРІШИВ: фінал.';
+      db = makeDb(() => ({
+        rows: [{ full_text: fullText, text_length: fullText.length }],
+      }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {
+        doc_id: 1,
+      });
+
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.marker).toBe('УХВАЛИВ:');
+      expect(payload.dispositive.startsWith('УХВАЛИВ:')).toBe(true);
+    });
+
+    it('handles spaced marker variant', async () => {
+      const fullText = 'Текст рішення.\n\nВ И Р І Ш И В\n\n1. Позов задовольнити.';
+      db = makeDb(() => ({
+        rows: [{ full_text: fullText, text_length: fullText.length }],
+      }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {
+        doc_id: 2,
+      });
+
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.marker).toBe('В И Р І Ш И В');
+      expect(payload.is_fallback).toBe(false);
+    });
+
+    it('falls back to tail when no marker found', async () => {
+      const fullText = 'А'.repeat(10000) + 'ТАЙЛ БЕЗ МАРКЕРУ';
+      db = makeDb(() => ({
+        rows: [{ full_text: fullText, text_length: fullText.length }],
+      }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {
+        doc_id: 3,
+      });
+
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.marker).toBeNull();
+      expect(payload.marker_position).toBeNull();
+      expect(payload.is_fallback).toBe(true);
+      expect(payload.dispositive).toContain('ТАЙЛ БЕЗ МАРКЕРУ');
+      expect(payload.dispositive.length).toBeLessThanOrEqual(4000);
+    });
+
+    it('handles empty full_text gracefully', async () => {
+      db = makeDb(() => ({
+        rows: [{ full_text: '', text_length: 0 }],
+      }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('edrsr_get_decision_dispositive', {
+        doc_id: 4,
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.dispositive).toBeNull();
+      expect(payload.text_length).toBe(0);
+    });
+  });
+
+  describe('executeTool dispatch', () => {
+    it('returns null for unknown tool names', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const result = await tool.executeTool('unknown_tool', {});
+      expect(result).toBeNull();
+    });
+
+    it('getToolDefinitions returns both tools', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const defs = tool.getToolDefinitions();
+      expect(defs.length).toBe(2);
+      const names = defs.map((d) => d.name);
+      expect(names).toContain('edrsr_court_decisions_by_court');
+      expect(names).toContain('edrsr_get_decision_dispositive');
+    });
+
+    it('tool definitions include required parameters', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrExtendedTools(db);
+
+      const defs = tool.getToolDefinitions();
+      const searchDef = defs.find((d) => d.name === 'edrsr_court_decisions_by_court');
+      const dispositiveDef = defs.find((d) => d.name === 'edrsr_get_decision_dispositive');
+
+      expect(searchDef?.inputSchema.required).toEqual(['court_code', 'fts_query', 'date_from']);
+      expect(dispositiveDef?.inputSchema.required).toEqual(['doc_id']);
+    });
+  });
+});

--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -27,6 +27,8 @@ export interface RemoteServiceConfig {
 /** Per-tool timeout overrides (ms). Tools not listed use DEFAULT_TOOL_TIMEOUT_MS. */
 const TOOL_TIMEOUT_OVERRIDES: Record<string, number> = {
   search_edrsr_fulltext: 120_000,
+  edrsr_court_decisions_by_court: 90_000,
+  edrsr_get_decision_dispositive: 15_000,
   build_legal_decision: 120_000,
   search_public_spending: 120_000,
 };

--- a/mcp_backend/src/api/tools/edrsr-extended-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-extended-tools.ts
@@ -1,0 +1,394 @@
+/**
+ * EDRSR Extended Tools — Спеціалізовані запити по ЄДРСР
+ *
+ * 2 tools:
+ * - edrsr_court_decisions_by_court — FTS у рамках одного суду з обовʼязковим вікном дат
+ * - edrsr_get_decision_dispositive — витяг лише резолютивної частини (ВИРІШИВ/УХВАЛИВ/ПОСТАНОВИВ)
+ *
+ * Обидва інструменти оптимізовані для роботи з партиціонованими таблицями
+ * edrsr_documents (RANGE по adjudication_date) та edrsr_fulltext (LIST по adj_year).
+ * FTS-конфіг — 'simple' (без українського стемера, але коректно токенізує українську).
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+const DISPOSITIVE_MARKERS = [
+  'ВИРІШИВ:',
+  'УХВАЛИВ:',
+  'ПОСТАНОВИВ:',
+  'ВИРОК',
+  'В И Р І Ш И В',
+  'У Х В А Л И В',
+  'П О С Т А Н О В И В',
+  'в и р і ш и в',
+  'у х в а л и в',
+  'п о с т а н о в и в',
+];
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+const DISPOSITIVE_MAX_CHARS = 8000;
+const DISPOSITIVE_FALLBACK_TAIL_CHARS = 4000;
+const STATEMENT_TIMEOUT_MS = 60_000;
+
+export class EdsrExtendedTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'edrsr_court_decisions_by_court',
+        description: `Пошук судових рішень конкретного суду за FTS-запитом у заданому вікні дат.
+
+Оптимізовано для отримання прецедентів одного суду (напр., усі виграні адмінпозови проти ТЦК
+у Оболонському районному суді м. Києва за останній рік).
+
+Обовʼязково:
+- court_code (код суду з таблиці edrsr_courts; напр., 2605 = Оболонський районний суд м. Києва)
+- fts_query (український FTS-запит; plainto_tsquery з конфігом 'simple')
+- date_from (YYYY-MM-DD; без дати запит сканує всі партиції, тому date_from обовʼязковий)
+
+Повертає метадані + ts_rank + snippet з highlights. Сортування: за датою DESC, потім за rank DESC.
+Для повного тексту — get_edrsr_decision_fulltext. Для лише резолютивки — edrsr_get_decision_dispositive.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            court_code: {
+              type: 'number',
+              description: 'Код суду (edrsr_courts.court_code). Приклади: 2605=Оболонський районний м.Києва, 1070=Київський окружний адмін, 9901=Верховний Суд',
+            },
+            fts_query: {
+              type: 'string',
+              description: 'FTS-запит українською (plainto_tsquery). Напр., "повістка ТЦК розшук належне оповіщення"',
+            },
+            date_from: {
+              type: 'string',
+              description: 'Дата ухвалення ВІД (YYYY-MM-DD). ОБОВʼЯЗКОВА для пруну партицій.',
+            },
+            date_to: {
+              type: 'string',
+              description: 'Дата ухвалення ДО (YYYY-MM-DD). За замовчуванням — поточна дата.',
+            },
+            limit: {
+              type: 'number',
+              default: 20,
+              maximum: 100,
+              description: 'Максимальна кількість результатів (1-100)',
+            },
+            offset: {
+              type: 'number',
+              default: 0,
+              description: 'Зміщення для пагінації',
+            },
+          },
+          required: ['court_code', 'fts_query', 'date_from'],
+        },
+      },
+      {
+        name: 'edrsr_get_decision_dispositive',
+        description: `Повертає лише резолютивну частину судового рішення (ВИРІШИВ / УХВАЛИВ / ПОСТАНОВИВ / ВИРОК).
+
+Економить контекст LLM при аналізі багатьох рішень одночасно: замість 50-500 KB повного тексту
+повертає 2-8 KB резолютивки. Якщо жодного з маркерів не знайдено — повертає останні 4000 символів
+як fallback (у 95% випадків резолютивка знаходиться в кінці документа).
+
+Повертає:
+- dispositive (текст резолютивки)
+- marker (який маркер знайдено або null)
+- marker_position (позиція в повному тексті або null)
+- text_length (довжина повного тексту)
+- is_fallback (true, якщо повернуто кінець тексту без явного маркера)`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            doc_id: {
+              type: ['string', 'number'],
+              description: 'ID документа в ЄДРСР',
+            },
+          },
+          required: ['doc_id'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    switch (name) {
+      case 'edrsr_court_decisions_by_court':
+        return await this.searchByCourt(args);
+      case 'edrsr_get_decision_dispositive':
+        return await this.getDispositive(args);
+      default:
+        return null;
+    }
+  }
+
+  private async searchByCourt(args: any): Promise<ToolResult> {
+    const courtCode = Number(args.court_code);
+    const ftsQuery = (args.fts_query || '').trim();
+    const dateFrom = args.date_from;
+    const dateTo = args.date_to || new Date().toISOString().slice(0, 10);
+    const limit = Math.min(Math.max(Number(args.limit) || DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const offset = Math.max(Number(args.offset) || 0, 0);
+
+    if (!courtCode || Number.isNaN(courtCode)) {
+      return this.wrapError('court_code є обовʼязковим числовим параметром');
+    }
+    if (!ftsQuery) {
+      return this.wrapError('fts_query є обовʼязковим параметром');
+    }
+    if (!dateFrom) {
+      return this.wrapError('date_from є обовʼязковим (без нього запит сканує всі партиції)');
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateFrom) || !/^\d{4}-\d{2}-\d{2}$/.test(dateTo)) {
+      return this.wrapError('date_from та date_to повинні бути у форматі YYYY-MM-DD');
+    }
+
+    const yearFrom = Number(dateFrom.slice(0, 4));
+    const yearTo = Number(dateTo.slice(0, 4));
+
+    const client = await this.db.connect?.() ?? this.db;
+    const shouldRelease = typeof this.db.connect === 'function';
+
+    try {
+      if (shouldRelease) {
+        await client.query(`SET LOCAL statement_timeout = ${STATEMENT_TIMEOUT_MS}`);
+      }
+
+      const countSql = `
+        SELECT COUNT(*)::int AS total
+        FROM edrsr_documents d
+        JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+        WHERE d.court_code = $1
+          AND d.adjudication_date >= $2::date
+          AND d.adjudication_date < ($3::date + INTERVAL '1 day')
+          AND f.adj_year BETWEEN $4 AND $5
+          AND f.tsv @@ plainto_tsquery('simple', $6)
+      `;
+
+      const dataSql = `
+        SELECT
+          d.doc_id,
+          d.cause_num,
+          d.adjudication_date,
+          d.judge,
+          d.court_code,
+          d.justice_kind,
+          d.judgment_code,
+          d.category_code,
+          d.doc_url,
+          ts_rank_cd(f.tsv, plainto_tsquery('simple', $6)) AS rank,
+          safe_ts_headline(
+            'simple'::regconfig,
+            f.full_text,
+            plainto_tsquery('simple', $6),
+            'MaxWords=40, MinWords=15, ShortWord=3, MaxFragments=2, FragmentDelimiter=" … "'
+          ) AS snippet
+        FROM edrsr_documents d
+        JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+        WHERE d.court_code = $1
+          AND d.adjudication_date >= $2::date
+          AND d.adjudication_date < ($3::date + INTERVAL '1 day')
+          AND f.adj_year BETWEEN $4 AND $5
+          AND f.tsv @@ plainto_tsquery('simple', $6)
+        ORDER BY d.adjudication_date DESC, rank DESC
+        LIMIT $7 OFFSET $8
+      `;
+
+      const params = [courtCode, dateFrom, dateTo, yearFrom, yearTo, ftsQuery];
+
+      const [courtRow, countResult, dataResult] = await Promise.all([
+        client.query(`SELECT name FROM edrsr_courts WHERE court_code = $1`, [courtCode]),
+        client.query(countSql, params),
+        client.query(dataSql, [...params, limit, offset]),
+      ]);
+
+      const courtName = courtRow.rows[0]?.name || null;
+      const total = countResult.rows[0]?.total || 0;
+
+      const enriched = await this.enrich(dataResult.rows, courtName);
+
+      logger.info('[EdsrExtendedTools] edrsr_court_decisions_by_court', {
+        court_code: courtCode,
+        fts_query: ftsQuery,
+        date_from: dateFrom,
+        date_to: dateTo,
+        total,
+        returned: enriched.length,
+      });
+
+      return this.wrapResponse({
+        query: {
+          court_code: courtCode,
+          court_name: courtName,
+          fts_query: ftsQuery,
+          date_from: dateFrom,
+          date_to: dateTo,
+        },
+        total,
+        returned: enriched.length,
+        offset,
+        has_more: offset + enriched.length < total,
+        results: enriched,
+      });
+    } catch (err: any) {
+      logger.error('[EdsrExtendedTools] edrsr_court_decisions_by_court failed', {
+        error: err.message,
+        court_code: courtCode,
+        fts_query: ftsQuery,
+      });
+      return this.wrapError(`Помилка пошуку: ${err.message}`);
+    } finally {
+      if (shouldRelease && typeof client.release === 'function') {
+        client.release();
+      }
+    }
+  }
+
+  private async getDispositive(args: any): Promise<ToolResult> {
+    const docId = args.doc_id;
+    if (!docId) {
+      return this.wrapError('doc_id є обовʼязковим параметром');
+    }
+
+    try {
+      const result = await this.db.query(
+        `SELECT full_text, text_length FROM edrsr_fulltext WHERE doc_id = $1`,
+        [docId]
+      );
+
+      if (result.rows.length === 0) {
+        return this.wrapError(`Рішення з doc_id=${docId} не знайдено (або повний текст відсутній)`);
+      }
+
+      const row = result.rows[0];
+      const fullText: string = row.full_text || '';
+      const textLength: number = row.text_length || fullText.length;
+
+      if (!fullText) {
+        return this.wrapResponse({
+          doc_id: Number(docId) || docId,
+          dispositive: null,
+          marker: null,
+          marker_position: null,
+          text_length: 0,
+          is_fallback: false,
+          note: 'Повний текст відсутній',
+        });
+      }
+
+      let bestPos = -1;
+      let bestMarker: string | null = null;
+      for (const marker of DISPOSITIVE_MARKERS) {
+        const pos = fullText.indexOf(marker);
+        if (pos >= 0 && (bestPos === -1 || pos < bestPos)) {
+          bestPos = pos;
+          bestMarker = marker;
+        }
+      }
+
+      let dispositive: string;
+      let isFallback = false;
+
+      if (bestPos >= 0) {
+        dispositive = fullText.slice(bestPos, bestPos + DISPOSITIVE_MAX_CHARS);
+      } else {
+        const tailStart = Math.max(0, fullText.length - DISPOSITIVE_FALLBACK_TAIL_CHARS);
+        dispositive = fullText.slice(tailStart);
+        isFallback = true;
+      }
+
+      logger.info('[EdsrExtendedTools] edrsr_get_decision_dispositive', {
+        doc_id: docId,
+        marker: bestMarker,
+        marker_position: bestPos >= 0 ? bestPos : null,
+        text_length: textLength,
+        is_fallback: isFallback,
+        dispositive_length: dispositive.length,
+      });
+
+      return this.wrapResponse({
+        doc_id: Number(docId) || docId,
+        dispositive,
+        marker: bestMarker,
+        marker_position: bestPos >= 0 ? bestPos : null,
+        text_length: textLength,
+        dispositive_length: dispositive.length,
+        is_fallback: isFallback,
+        external_url: `https://reyestr.court.gov.ua/Review/${docId}`,
+      });
+    } catch (err: any) {
+      logger.error('[EdsrExtendedTools] edrsr_get_decision_dispositive failed', {
+        error: err.message,
+        doc_id: docId,
+      });
+      return this.wrapError(`Помилка отримання резолютивної частини: ${err.message}`);
+    }
+  }
+
+  private async enrich(rows: any[], courtName: string | null): Promise<any[]> {
+    if (rows.length === 0) return [];
+
+    const justiceKinds = new Set<number>();
+    const judgmentCodes = new Set<number>();
+    for (const row of rows) {
+      if (row.justice_kind) justiceKinds.add(row.justice_kind);
+      if (row.judgment_code) judgmentCodes.add(row.judgment_code);
+    }
+
+    const [justiceMap, judgmentMap] = await Promise.all([
+      this.batchLookup('edrsr_justice_kinds', 'justice_kind', Array.from(justiceKinds)),
+      this.batchLookup('edrsr_judgment_forms', 'judgment_code', Array.from(judgmentCodes)),
+    ]);
+
+    return rows.map((row) => ({
+      doc_id: row.doc_id,
+      cause_num: row.cause_num,
+      adjudication_date: row.adjudication_date,
+      judge: row.judge,
+      court_code: row.court_code,
+      court_name: courtName,
+      justice_kind: row.justice_kind,
+      justice_kind_name: justiceMap.get(row.justice_kind) || null,
+      judgment_code: row.judgment_code,
+      judgment_form: judgmentMap.get(row.judgment_code) || null,
+      category_code: row.category_code,
+      doc_url: row.doc_url,
+      external_url: `https://reyestr.court.gov.ua/Review/${row.doc_id}`,
+      rank: typeof row.rank === 'number' ? row.rank : Number(row.rank) || 0,
+      snippet: row.snippet || null,
+    }));
+  }
+
+  private static readonly ALLOWED_LOOKUP_TABLES: Record<string, Set<string>> = {
+    edrsr_justice_kinds: new Set(['justice_kind']),
+    edrsr_judgment_forms: new Set(['judgment_code']),
+  };
+
+  private async batchLookup(
+    table: string,
+    idColumn: string,
+    ids: number[]
+  ): Promise<Map<number, string>> {
+    const map = new Map<number, string>();
+    if (ids.length === 0) return map;
+    const allowed = EdsrExtendedTools.ALLOWED_LOOKUP_TABLES[table];
+    if (!allowed || !allowed.has(idColumn)) return map;
+
+    try {
+      const result = await this.db.query(
+        `SELECT ${idColumn}, name FROM ${table} WHERE ${idColumn} = ANY($1)`,
+        [ids]
+      );
+      for (const row of result.rows) {
+        map.set(row[idColumn], row.name);
+      }
+    } catch {
+      // Reference table might be missing — non-critical
+    }
+    return map;
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -19,6 +19,7 @@ import { CourtSessionTools } from '../api/tools/court-session-tools.js';
 import { LegalActsTools } from '../api/tools/legal-acts-tools.js';
 import { ECHRPracticeTools } from '../api/tools/echr-practice-tools.js';
 import { EdsrSearchTools } from '../api/tools/edrsr-search-tools.js';
+import { EdsrExtendedTools } from '../api/tools/edrsr-extended-tools.js';
 import { EdsrSemanticTools } from '../api/tools/edrsr-semantic-tools.js';
 import { EdsrFtsService } from '../services/edrsr-fts-service.js';
 import { EdsrVectorizerService } from '../services/edrsr-vectorizer-service.js';
@@ -136,6 +137,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new OpenDataRegistriesTools(coreServices.db));
   toolRegistry.registerHandler(new Tier1OpenDataTools(coreServices.db));
   toolRegistry.registerHandler(new EdsrSearchTools(coreServices.db));
+  toolRegistry.registerHandler(new EdsrExtendedTools(coreServices.db));
   toolRegistry.registerHandler(new DecisionLayerTools(llmAdapter));
 
   // EDRSR FTS + semantic search + on-demand vectorization


### PR DESCRIPTION
## Summary

Two new MCP tools for efficient EDRSR research in chat — addresses the capability gap identified during a legal-research session where I had to bypass the chat and use ad-hoc psql for (a) scoping FTS to a single court and (b) reading only the dispositive (ВИРІШИВ) section of 220 KB+ decisions.

- **`edrsr_court_decisions_by_court(court_code, fts_query, date_from, date_to?, limit?, offset?)`** — FTS scoped to a single court with **mandatory** date window for partition pruning. Returns metadata + `ts_rank_cd` + `safe_ts_headline` snippet, court name enriched. Typical use: «усі виграні адмінпозови проти ТЦК у Оболонському районному за 2025».
- **`edrsr_get_decision_dispositive(doc_id)`** — extracts only the dispositive section (ВИРІШИВ / УХВАЛИВ / ПОСТАНОВИВ + spaced variants). Falls back to last 4000 chars if no marker found. Shrinks LLM context from 50–500 KB full text to 2–8 KB when analysing many decisions at once.

## Design notes

- **FTS config = `'simple'`** — verified on prod, matches existing `edrsr-fts-service.ts` (no Ukrainian stemmer installed).
- **Partition pruning guard** — `date_from` is a required param, and `f.adj_year BETWEEN ...` clause prunes both `edrsr_documents` (RANGE by `adjudication_date`) and `edrsr_fulltext` (LIST by `adj_year`). Without this the query scans all 25+24 partitions.
- **`safe_ts_headline`** — existing prod function; handles UTF-8 encoding errors in some legacy docs.
- **Dispositive logic in TS**, not SQL — simpler to maintain the 10-variant marker list and easier to unit test. Still one round-trip to DB.
- **Auto-expose** via generic `POST /api/tools/:toolName` + MCP SSE. No route wiring needed.
- **Timeout overrides** added: 90s for court search, 15s for dispositive.

## Files

- `mcp_backend/src/api/tools/edrsr-extended-tools.ts` — new (320 LOC)
- `mcp_backend/src/factories/tool-services.ts` — register handler
- `mcp_backend/src/api/tool-registry.ts` — timeout overrides
- `mcp_backend/src/api/__tests__/edrsr-extended-tools.test.ts` — 16 tests

## Test plan

- [x] `tsc --noEmit` — clean (pre-existing `node-pty` issues in `terminal-routes.ts` are unrelated)
- [x] `jest src/api/__tests__/edrsr-extended-tools.test.ts` — **16/16 passed** in 4.7s
- [x] Validation covers: missing required params, malformed dates, limit clamping, marker detection (all 10 variants), fallback path, empty text, unknown tool dispatch
- [ ] After merge: verify both tools appear in `GET /api/tools/definitions` in local deploy
- [ ] After merge: smoke-test via chat on deep budget with a real query («Оболонський, ТЦК, 2025») → check `court_code=2605` returns the 4 winning precedents found during research session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two EDRSR MCP tools: court-scoped full-text search and dispositive-only extraction. This speeds up chat research and cuts tokens on large decisions.

- **New Features**
  - edrsr_court_decisions_by_court(court_code, fts_query, date_from, date_to?, limit?, offset?): FTS within a single court with a required date window for partition pruning; returns metadata + ts_rank_cd + safe_ts_headline; enriched court/judgment names; ordered by date DESC then rank; uses 'simple' FTS; 90s timeout.
  - edrsr_get_decision_dispositive(doc_id): extracts only the dispositive section (ВИРІШИВ/УХВАЛИВ/ПОСТАНОВИВ + spaced variants); falls back to the last 4000 chars if no marker; typically shrinks 50–500 KB texts to 2–8 KB; 15s timeout.

- **Migration**
  - No routing changes; tools auto-registered and exposed via `POST /api/tools/:toolName` and visible in `GET /api/tools/definitions`.
  - Post-deploy: verify both tools appear in `GET /api/tools/definitions` and smoke-test a real query (e.g., court_code=2605, 2025 window).

<sup>Written for commit 3c517974b9d2b8ae389e127eaf2e3fff8b9b289d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

