### PR TITLE
feat(edrsr): add edrsr_hybrid_search — dense + sparse via RRF

### DIFF
--- a/mcp_backend/src/api/__tests__/edrsr-hybrid-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-hybrid-tools.test.ts
@@ -1,0 +1,325 @@
+/**
+ * EdsrHybridTools unit tests — RRF merge, dedup, one-leg-down resilience.
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { EdsrHybridTools } from '../tools/edrsr-hybrid-tools.js';
+
+describe('EdsrHybridTools', () => {
+  let db: any;
+  let ftsService: any;
+  let vectorizer: any;
+  let tool: EdsrHybridTools;
+
+  beforeEach(() => {
+    db = { query: jest.fn(() => Promise.resolve({ rows: [] })) };
+    ftsService = { searchFulltext: jest.fn() };
+    vectorizer = { semanticSearch: jest.fn() };
+    tool = new EdsrHybridTools(db, ftsService, vectorizer);
+  });
+
+  const makeFts = (docIds: number[], opts: { headline?: string } = {}) => ({
+    query: 'test',
+    total: docIds.length,
+    returned: docIds.length,
+    offset: 0,
+    has_more: false,
+    results: docIds.map((doc_id, i) => ({
+      doc_id,
+      rank: 0.9 - i * 0.1,
+      headline: opts.headline || `…fts match ${doc_id}…`,
+      adjudication_date: '2025-10-01',
+      cause_num: `case/${doc_id}`,
+      judge: 'Test Judge',
+      court_code: 2605,
+      justice_kind: 4,
+      judgment_code: 3,
+    })),
+  });
+
+  const makeVec = (entries: Array<{ doc_id: number; score: number; chunk?: number; text?: string }>) =>
+    entries.map((e, i) => ({
+      id: `vec-${i}`,
+      score: e.score,
+      text: e.text || `chunk text for ${e.doc_id}`,
+      doc_id: e.doc_id,
+      chunk_index: e.chunk ?? 0,
+      metadata: {
+        court_code: 2605,
+        judge: 'Test Judge',
+        cause_num: `case/${e.doc_id}`,
+        justice_kind: 4,
+        adjudication_date: '2025-10-01',
+        judgment_code: 3,
+        category_code: undefined,
+      },
+    }));
+
+  describe('validation', () => {
+    it('requires query', async () => {
+      const result = await tool.executeTool('edrsr_hybrid_search', {});
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('query');
+    });
+
+    it('returns null for unknown tool', async () => {
+      const result = await tool.executeTool('other_tool', { query: 'x' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('RRF fusion', () => {
+    it('top result is doc present in both legs at rank 1', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([100, 200, 300]));
+      vectorizer.semanticSearch.mockResolvedValue(
+        makeVec([
+          { doc_id: 100, score: 0.9 },
+          { doc_id: 400, score: 0.8 },
+        ])
+      );
+
+      const result = await tool.executeTool('edrsr_hybrid_search', {
+        query: 'ТЦК повістка',
+      });
+      const payload = JSON.parse(result!.content[0].text);
+
+      expect(payload.results[0].doc_id).toBe(100);
+      // doc 100: RRF = 1/(60+1) + 1/(60+1) = 2/61 ≈ 0.03279
+      expect(payload.results[0].rrf_score).toBeCloseTo(2 / 61, 5);
+      expect(payload.results[0].fts_position).toBe(1);
+      expect(payload.results[0].qdrant_position).toBe(1);
+    });
+
+    it('FTS-only doc has null qdrant fields', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([500]));
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      const result = await tool.executeTool('edrsr_hybrid_search', {
+        query: 'rare term',
+      });
+      const payload = JSON.parse(result!.content[0].text);
+
+      expect(payload.results[0].doc_id).toBe(500);
+      expect(payload.results[0].qdrant_score).toBeNull();
+      expect(payload.results[0].qdrant_position).toBeNull();
+      expect(payload.results[0].fts_position).toBe(1);
+    });
+
+    it('Qdrant-only doc has null fts fields', async () => {
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'test', total: 0, returned: 0, offset: 0, has_more: false, results: [],
+      });
+      vectorizer.semanticSearch.mockResolvedValue(makeVec([{ doc_id: 700, score: 0.77 }]));
+
+      const result = await tool.executeTool('edrsr_hybrid_search', {
+        query: 'semantic only',
+      });
+      const payload = JSON.parse(result!.content[0].text);
+
+      expect(payload.results[0].doc_id).toBe(700);
+      expect(payload.results[0].fts_position).toBeNull();
+      expect(payload.results[0].fts_rank).toBeNull();
+      expect(payload.results[0].qdrant_score).toBeCloseTo(0.77, 5);
+    });
+
+    it('Qdrant chunks of same doc dedup — second chunk only bumps qdrant_score if higher', async () => {
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'test', total: 0, returned: 0, offset: 0, has_more: false, results: [],
+      });
+      vectorizer.semanticSearch.mockResolvedValue(
+        makeVec([
+          { doc_id: 100, score: 0.7, chunk: 0, text: 'first chunk' },
+          { doc_id: 100, score: 0.9, chunk: 2, text: 'better chunk' },
+          { doc_id: 100, score: 0.5, chunk: 5, text: 'weaker chunk' },
+          { doc_id: 200, score: 0.6 },
+        ])
+      );
+
+      const result = await tool.executeTool('edrsr_hybrid_search', {
+        query: 'chunked',
+      });
+      const payload = JSON.parse(result!.content[0].text);
+
+      const hit100 = payload.results.find((r: any) => r.doc_id === 100);
+      expect(hit100).toBeDefined();
+      expect(hit100.qdrant_best_chunk_text).toBe('better chunk');
+      expect(hit100.qdrant_best_chunk_index).toBe(2);
+      expect(hit100.qdrant_score).toBeCloseTo(0.9, 5);
+      // doc 100 contributes RRF of its first occurrence (rank 1)
+      expect(hit100.rrf_score).toBeCloseTo(1 / 61, 5);
+
+      // doc 200 is at vector rank 2 (chunks 2-3 of doc 100 were dedup, so doc 200 bumps to position 2)
+      const hit200 = payload.results.find((r: any) => r.doc_id === 200);
+      expect(hit200.qdrant_position).toBe(2);
+    });
+
+    it('sorts descending by rrf_score', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([10, 20, 30, 40]));
+      vectorizer.semanticSearch.mockResolvedValue(
+        makeVec([
+          { doc_id: 50, score: 0.9 },
+          { doc_id: 30, score: 0.8 },
+          { doc_id: 10, score: 0.7 },
+        ])
+      );
+
+      const result = await tool.executeTool('edrsr_hybrid_search', {
+        query: 'ordering',
+        limit: 10,
+      });
+      const payload = JSON.parse(result!.content[0].text);
+
+      const scores = payload.results.map((r: any) => r.rrf_score);
+      const sorted = [...scores].sort((a, b) => b - a);
+      expect(scores).toEqual(sorted);
+    });
+
+    it('custom rrf_k affects scoring', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([100]));
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      const result = await tool.executeTool('edrsr_hybrid_search', {
+        query: 'k-test',
+        rrf_k: 10,
+      });
+      const payload = JSON.parse(result!.content[0].text);
+
+      // Only FTS, rank 1, k=10 → 1/11 ≈ 0.0909
+      expect(payload.results[0].rrf_score).toBeCloseTo(1 / 11, 5);
+      expect(payload.rrf_k).toBe(10);
+    });
+  });
+
+  describe('resilience', () => {
+    it('returns results if FTS leg throws', async () => {
+      ftsService.searchFulltext.mockRejectedValue(new Error('FTS down'));
+      vectorizer.semanticSearch.mockResolvedValue(makeVec([{ doc_id: 100, score: 0.9 }]));
+
+      const result = await tool.executeTool('edrsr_hybrid_search', { query: 'x' });
+      expect(result?.isError).toBeFalsy();
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.legs.fts_available).toBe(false);
+      expect(payload.legs.vector_available).toBe(true);
+      expect(payload.results[0].doc_id).toBe(100);
+    });
+
+    it('returns results if Qdrant leg throws', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([100]));
+      vectorizer.semanticSearch.mockRejectedValue(new Error('Qdrant down'));
+
+      const result = await tool.executeTool('edrsr_hybrid_search', { query: 'x' });
+      expect(result?.isError).toBeFalsy();
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.legs.fts_available).toBe(true);
+      expect(payload.legs.vector_available).toBe(false);
+      expect(payload.results[0].doc_id).toBe(100);
+    });
+
+    it('returns error if both legs throw', async () => {
+      ftsService.searchFulltext.mockRejectedValue(new Error('FTS down'));
+      vectorizer.semanticSearch.mockRejectedValue(new Error('Qdrant down'));
+
+      const result = await tool.executeTool('edrsr_hybrid_search', { query: 'x' });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('Обидва джерела');
+    });
+  });
+
+  describe('parameters', () => {
+    it('clamps limit to MAX_LIMIT (50)', async () => {
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'x', total: 0, returned: 0, offset: 0, has_more: false, results: [],
+      });
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      await tool.executeTool('edrsr_hybrid_search', { query: 'x', limit: 999 });
+
+      const ftsCall = ftsService.searchFulltext.mock.calls[0];
+      // candidateLimit = limit * oversample = 50 * 3 = 150
+      expect(ftsCall[3]).toBe(150);
+    });
+
+    it('passes oversample through to candidate limit', async () => {
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'x', total: 0, returned: 0, offset: 0, has_more: false, results: [],
+      });
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      await tool.executeTool('edrsr_hybrid_search', {
+        query: 'x',
+        limit: 10,
+        oversample: 5,
+      });
+
+      const ftsCall = ftsService.searchFulltext.mock.calls[0];
+      expect(ftsCall[3]).toBe(50); // 10 * 5
+    });
+
+    it('forwards filters to both legs', async () => {
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'x', total: 0, returned: 0, offset: 0, has_more: false, results: [],
+      });
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      await tool.executeTool('edrsr_hybrid_search', {
+        query: 'ТЦК',
+        court_code: 2605,
+        justice_kind: 4,
+        date_from: '2025-01-01',
+      });
+
+      const ftsCall = ftsService.searchFulltext.mock.calls[0];
+      expect(ftsCall[2]).toEqual({
+        court_code: 2605,
+        justice_kind: 4,
+        judge: undefined,
+        date_from: '2025-01-01',
+        date_to: undefined,
+      });
+      const vecCall = vectorizer.semanticSearch.mock.calls[0];
+      expect(vecCall[1]).toEqual({
+        court_code: 2605,
+        justice_kind: 4,
+        judge: undefined,
+        date_from: '2025-01-01',
+        date_to: undefined,
+      });
+    });
+  });
+
+  describe('enrichment', () => {
+    it('enriches with court_name from edrsr_courts', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([100]));
+      vectorizer.semanticSearch.mockResolvedValue([]);
+      db.query = jest.fn((sql: string) => {
+        if (sql.includes('edrsr_courts')) {
+          return Promise.resolve({ rows: [{ court_code: 2605, name: 'Оболонський районний суд' }] });
+        }
+        if (sql.includes('edrsr_justice_kinds')) {
+          return Promise.resolve({ rows: [{ justice_kind: 4, name: 'Адміністративне' }] });
+        }
+        if (sql.includes('edrsr_judgment_forms')) {
+          return Promise.resolve({ rows: [{ judgment_code: 3, name: 'Рішення' }] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const result = await tool.executeTool('edrsr_hybrid_search', { query: 'x' });
+      const payload = JSON.parse(result!.content[0].text);
+
+      expect(payload.results[0].court_name).toBe('Оболонський районний суд');
+      expect(payload.results[0].justice_kind_name).toBe('Адміністративне');
+      expect(payload.results[0].judgment_form).toBe('Рішення');
+      expect(payload.results[0].external_url).toBe('https://reyestr.court.gov.ua/Review/100');
+    });
+  });
+
+  describe('getToolDefinitions', () => {
+    it('returns single tool with required query', () => {
+      const defs = tool.getToolDefinitions();
+      expect(defs.length).toBe(1);
+      expect(defs[0].name).toBe('edrsr_hybrid_search');
+      expect(defs[0].inputSchema.required).toEqual(['query']);
+    });
+  });
+});

--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -29,6 +29,7 @@ const TOOL_TIMEOUT_OVERRIDES: Record<string, number> = {
   search_edrsr_fulltext: 120_000,
   edrsr_court_decisions_by_court: 90_000,
   edrsr_get_decision_dispositive: 15_000,
+  edrsr_hybrid_search: 120_000,
   build_legal_decision: 120_000,
   search_public_spending: 120_000,
 };

--- a/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
@@ -1,0 +1,376 @@
+/**
+ * EDRSR Hybrid Search — dense vectors (Qdrant/Voyage-3) + sparse FTS (tsvector) via RRF.
+ *
+ * 1 tool:
+ * - edrsr_hybrid_search — паралельний виклик FTS + семантичного пошуку в Qdrant,
+ *   мердж через Reciprocal Rank Fusion, дедуплікація по doc_id (Qdrant повертає
+ *   per-chunk результати), збагачення метаданими суду.
+ *
+ * Чому RRF, не weighted sum score: cosine (Qdrant) і ts_rank_cd (PG FTS) мають
+ * різні шкали. RRF оперує рангами, тому склейка коректна без калібрування.
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsResult } from '../../services/edrsr-fts-service.js';
+import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+const DEFAULT_RRF_K = 60;
+const DEFAULT_OVERSAMPLE = 3;
+const MAX_OVERSAMPLE = 5;
+
+interface FusedHit {
+  doc_id: number;
+  rrf_score: number;
+  fts_rank: number | null;
+  fts_position: number | null;
+  fts_headline: string | null;
+  qdrant_score: number | null;
+  qdrant_position: number | null;
+  qdrant_best_chunk_text: string | null;
+  qdrant_best_chunk_index: number | null;
+  metadata: {
+    cause_num?: string;
+    judge?: string;
+    court_code?: number;
+    justice_kind?: number;
+    judgment_code?: number;
+    category_code?: number;
+    adjudication_date?: string;
+  };
+}
+
+export class EdsrHybridTools extends BaseToolHandler {
+  constructor(
+    private db: any,
+    private ftsService: EdsrFtsService,
+    private vectorizer: EdsrVectorizerService
+  ) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'edrsr_hybrid_search',
+        description: `Гібридний пошук судових рішень ЄДРСР: семантика (Qdrant, ~88M векторів, Voyage-3-large 1024-dim)
++ лексика (PG tsvector FTS) з мерджем через Reciprocal Rank Fusion.
+
+Коли використовувати:
+- запит містить і семантику, і рідкісні токени (номери статей, прізвища, назви установ);
+- потрібен максимальний recall без жертви precision;
+- pure FTS пропускає перефразування, pure semantic — точні матчі кодексів.
+
+Повертає топ-K документів з rrf_score та провенансом обох сторін (fts_rank, qdrant_score,
+snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant повертає per-chunk).`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Пошуковий запит українською. Натуральна мова + точні токени одночасно (напр., "ст. 210-1 КУпАП ТЦК неналежне оповіщення")',
+            },
+            court_code: {
+              type: 'number',
+              description: 'Опційно: код суду для звуження пошуку (edrsr_courts.court_code)',
+            },
+            justice_kind: {
+              type: 'number',
+              description: 'Опційно: 1=Цивільне, 2=Кримінальне, 3=Господарське, 4=Адміністративне, 5=Адмінправопорушення',
+            },
+            judge: {
+              type: 'string',
+              description: 'Опційно: ПІБ судді або частина',
+            },
+            date_from: {
+              type: 'string',
+              description: 'Опційно: дата ухвалення ВІД (YYYY-MM-DD)',
+            },
+            date_to: {
+              type: 'string',
+              description: 'Опційно: дата ухвалення ДО (YYYY-MM-DD)',
+            },
+            limit: {
+              type: 'number',
+              default: 10,
+              maximum: 50,
+              description: 'Максимальна кількість фінальних результатів (1-50)',
+            },
+            oversample: {
+              type: 'number',
+              default: 3,
+              maximum: 5,
+              description: 'Скільки кандидатів брати з кожної сторони перед мерджем (limit × oversample). Більше — кращий recall, повільніше.',
+            },
+            rrf_k: {
+              type: 'number',
+              default: 60,
+              description: 'Параметр RRF (стандарт 60). Менше — сильніше впливає топ-1, більше — плавніше.',
+            },
+          },
+          required: ['query'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    if (name !== 'edrsr_hybrid_search') return null;
+    return await this.hybridSearch(args);
+  }
+
+  private async hybridSearch(args: any): Promise<ToolResult> {
+    const query = (args.query || '').trim();
+    if (!query) return this.wrapError('query є обовʼязковим параметром');
+
+    const limit = Math.min(Math.max(Number(args.limit) || DEFAULT_LIMIT, 1), MAX_LIMIT);
+    const oversample = Math.min(Math.max(Number(args.oversample) || DEFAULT_OVERSAMPLE, 1), MAX_OVERSAMPLE);
+    const rrfK = Math.max(Number(args.rrf_k) || DEFAULT_RRF_K, 1);
+    const candidateLimit = limit * oversample;
+
+    const ftsFilters: EdsrFtsFilters = {
+      court_code: args.court_code,
+      justice_kind: args.justice_kind,
+      judge: args.judge,
+      date_from: args.date_from,
+      date_to: args.date_to,
+    };
+
+    const qdrantFilters: EdrsrSearchFilters = {
+      court_code: args.court_code,
+      justice_kind: args.justice_kind,
+      judge: args.judge,
+      date_from: args.date_from,
+      date_to: args.date_to,
+    };
+
+    const ftsPromise = this.ftsService
+      .searchFulltext(query, this.db, ftsFilters, candidateLimit, 0)
+      .catch((err: any) => {
+        logger.warn('[EdsrHybridTools] FTS leg failed, continuing with vector-only', { error: err.message });
+        return null;
+      });
+
+    const vectorPromise = this.vectorizer
+      .semanticSearch(query, qdrantFilters, candidateLimit)
+      .catch((err: any) => {
+        logger.warn('[EdsrHybridTools] Qdrant leg failed, continuing with FTS-only', { error: err.message });
+        return null;
+      });
+
+    const [ftsResponse, vectorResults] = await Promise.all([ftsPromise, vectorPromise]);
+
+    if (!ftsResponse && !vectorResults) {
+      return this.wrapError('Обидва джерела пошуку недоступні');
+    }
+
+    const ftsResults: EdsrFtsResult[] = ftsResponse?.results || [];
+    const vectorHits: EdrsrSearchResult[] = vectorResults || [];
+
+    const fused = this.fuseRRF(ftsResults, vectorHits, rrfK);
+    const top = fused.slice(0, limit);
+    const enriched = await this.enrich(top);
+
+    logger.info('[EdsrHybridTools] edrsr_hybrid_search', {
+      query,
+      fts_candidates: ftsResults.length,
+      vector_candidates: vectorHits.length,
+      fused_docs: fused.length,
+      returned: enriched.length,
+    });
+
+    return this.wrapResponse({
+      query,
+      filters: {
+        court_code: args.court_code,
+        justice_kind: args.justice_kind,
+        judge: args.judge,
+        date_from: args.date_from,
+        date_to: args.date_to,
+      },
+      rrf_k: rrfK,
+      oversample,
+      legs: {
+        fts_available: ftsResponse !== null,
+        vector_available: vectorResults !== null,
+        fts_candidates: ftsResults.length,
+        vector_candidates: vectorHits.length,
+      },
+      total_fused: fused.length,
+      returned: enriched.length,
+      results: enriched,
+    });
+  }
+
+  private fuseRRF(
+    ftsResults: EdsrFtsResult[],
+    vectorHits: EdrsrSearchResult[],
+    k: number
+  ): FusedHit[] {
+    const byDocId = new Map<number, FusedHit>();
+
+    // FTS leg — 1 doc = 1 result.
+    ftsResults.forEach((r, idx) => {
+      if (!r.doc_id) return;
+      const docId = Number(r.doc_id);
+      const rank = idx + 1;
+      const hit: FusedHit = {
+        doc_id: docId,
+        rrf_score: 1 / (k + rank),
+        fts_rank: typeof r.rank === 'number' ? r.rank : Number(r.rank) || 0,
+        fts_position: rank,
+        fts_headline: r.headline || null,
+        qdrant_score: null,
+        qdrant_position: null,
+        qdrant_best_chunk_text: null,
+        qdrant_best_chunk_index: null,
+        metadata: {
+          cause_num: r.cause_num,
+          judge: r.judge,
+          court_code: r.court_code,
+          justice_kind: r.justice_kind,
+          judgment_code: r.judgment_code,
+          adjudication_date: r.adjudication_date,
+        },
+      };
+      byDocId.set(docId, hit);
+    });
+
+    // Qdrant leg — several chunks per doc. Keep best chunk per doc_id, rank by first occurrence.
+    const seenVectorDocs = new Set<number>();
+    let vectorRank = 0;
+    for (const v of vectorHits) {
+      if (!v.doc_id) continue;
+      const docId = Number(v.doc_id);
+
+      if (seenVectorDocs.has(docId)) {
+        // Same doc, different chunk — bump score only if this chunk is stronger.
+        const existing = byDocId.get(docId);
+        if (existing && (existing.qdrant_score === null || v.score > existing.qdrant_score)) {
+          existing.qdrant_score = v.score;
+          existing.qdrant_best_chunk_text = v.text || existing.qdrant_best_chunk_text;
+          existing.qdrant_best_chunk_index = v.chunk_index;
+        }
+        continue;
+      }
+
+      seenVectorDocs.add(docId);
+      vectorRank += 1;
+      const rrfContribution = 1 / (k + vectorRank);
+
+      const existing = byDocId.get(docId);
+      if (existing) {
+        existing.rrf_score += rrfContribution;
+        existing.qdrant_score = v.score;
+        existing.qdrant_position = vectorRank;
+        existing.qdrant_best_chunk_text = v.text || null;
+        existing.qdrant_best_chunk_index = v.chunk_index;
+        if (v.metadata) {
+          existing.metadata.cause_num = existing.metadata.cause_num || v.metadata.cause_num;
+          existing.metadata.judge = existing.metadata.judge || v.metadata.judge;
+          existing.metadata.court_code = existing.metadata.court_code ?? v.metadata.court_code;
+          existing.metadata.justice_kind = existing.metadata.justice_kind ?? v.metadata.justice_kind;
+          existing.metadata.judgment_code = existing.metadata.judgment_code ?? v.metadata.judgment_code;
+          existing.metadata.category_code = existing.metadata.category_code ?? v.metadata.category_code;
+          existing.metadata.adjudication_date = existing.metadata.adjudication_date || v.metadata.adjudication_date;
+        }
+      } else {
+        byDocId.set(docId, {
+          doc_id: docId,
+          rrf_score: rrfContribution,
+          fts_rank: null,
+          fts_position: null,
+          fts_headline: null,
+          qdrant_score: v.score,
+          qdrant_position: vectorRank,
+          qdrant_best_chunk_text: v.text || null,
+          qdrant_best_chunk_index: v.chunk_index,
+          metadata: {
+            cause_num: v.metadata?.cause_num,
+            judge: v.metadata?.judge,
+            court_code: v.metadata?.court_code,
+            justice_kind: v.metadata?.justice_kind,
+            judgment_code: v.metadata?.judgment_code,
+            category_code: v.metadata?.category_code,
+            adjudication_date: v.metadata?.adjudication_date,
+          },
+        });
+      }
+    }
+
+    return Array.from(byDocId.values()).sort((a, b) => b.rrf_score - a.rrf_score);
+  }
+
+  private async enrich(hits: FusedHit[]): Promise<any[]> {
+    if (hits.length === 0) return [];
+
+    const courtCodes = new Set<number>();
+    const justiceKinds = new Set<number>();
+    const judgmentCodes = new Set<number>();
+    for (const h of hits) {
+      if (h.metadata.court_code) courtCodes.add(h.metadata.court_code);
+      if (h.metadata.justice_kind) justiceKinds.add(h.metadata.justice_kind);
+      if (h.metadata.judgment_code) judgmentCodes.add(h.metadata.judgment_code);
+    }
+
+    const [courtsMap, justiceMap, judgmentMap] = await Promise.all([
+      this.batchLookup('edrsr_courts', 'court_code', Array.from(courtCodes)),
+      this.batchLookup('edrsr_justice_kinds', 'justice_kind', Array.from(justiceKinds)),
+      this.batchLookup('edrsr_judgment_forms', 'judgment_code', Array.from(judgmentCodes)),
+    ]);
+
+    return hits.map((h) => ({
+      doc_id: h.doc_id,
+      cause_num: h.metadata.cause_num || null,
+      judge: h.metadata.judge || null,
+      court_code: h.metadata.court_code ?? null,
+      court_name: h.metadata.court_code ? courtsMap.get(h.metadata.court_code) || null : null,
+      justice_kind: h.metadata.justice_kind ?? null,
+      justice_kind_name: h.metadata.justice_kind ? justiceMap.get(h.metadata.justice_kind) || null : null,
+      judgment_code: h.metadata.judgment_code ?? null,
+      judgment_form: h.metadata.judgment_code ? judgmentMap.get(h.metadata.judgment_code) || null : null,
+      category_code: h.metadata.category_code ?? null,
+      adjudication_date: h.metadata.adjudication_date || null,
+      rrf_score: Number(h.rrf_score.toFixed(6)),
+      fts_position: h.fts_position,
+      fts_rank: h.fts_rank,
+      fts_headline: h.fts_headline,
+      qdrant_position: h.qdrant_position,
+      qdrant_score: h.qdrant_score !== null ? Number(h.qdrant_score.toFixed(6)) : null,
+      qdrant_best_chunk_index: h.qdrant_best_chunk_index,
+      qdrant_best_chunk_text: h.qdrant_best_chunk_text,
+      external_url: `https://reyestr.court.gov.ua/Review/${h.doc_id}`,
+    }));
+  }
+
+  private static readonly ALLOWED_LOOKUP_TABLES: Record<string, Set<string>> = {
+    edrsr_courts: new Set(['court_code']),
+    edrsr_justice_kinds: new Set(['justice_kind']),
+    edrsr_judgment_forms: new Set(['judgment_code']),
+  };
+
+  private async batchLookup(
+    table: string,
+    idColumn: string,
+    ids: number[]
+  ): Promise<Map<number, string>> {
+    const map = new Map<number, string>();
+    if (ids.length === 0) return map;
+    const allowed = EdsrHybridTools.ALLOWED_LOOKUP_TABLES[table];
+    if (!allowed || !allowed.has(idColumn)) return map;
+    try {
+      const result = await this.db.query(
+        `SELECT ${idColumn}, name FROM ${table} WHERE ${idColumn} = ANY($1)`,
+        [ids]
+      );
+      for (const row of result.rows) {
+        map.set(row[idColumn], row.name);
+      }
+    } catch {
+      // non-critical
+    }
+    return map;
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -21,6 +21,7 @@ import { ECHRPracticeTools } from '../api/tools/echr-practice-tools.js';
 import { EdsrSearchTools } from '../api/tools/edrsr-search-tools.js';
 import { EdsrExtendedTools } from '../api/tools/edrsr-extended-tools.js';
 import { EdsrSemanticTools } from '../api/tools/edrsr-semantic-tools.js';
+import { EdsrHybridTools } from '../api/tools/edrsr-hybrid-tools.js';
 import { EdsrFtsService } from '../services/edrsr-fts-service.js';
 import { EdsrVectorizerService } from '../services/edrsr-vectorizer-service.js';
 import { NextcloudService } from '../services/nextcloud-service.js';
@@ -155,6 +156,7 @@ export function createToolServices(
   }
   if (edsrVectorizer) {
     toolRegistry.registerHandler(new EdsrSemanticTools(coreServices.db, edsrFtsService, edsrVectorizer));
+    toolRegistry.registerHandler(new EdsrHybridTools(coreServices.db, edsrFtsService, edsrVectorizer));
   }
   // Import task manager (multi-IP downloads)
   toolRegistry.registerHandler(new ImportTaskTools(coreServices.importTaskService));


### PR DESCRIPTION
## Summary

New MCP tool `edrsr_hybrid_search` combining the two retrieval legs we already run on prod:

- **Dense:** Qdrant collection `edrsr_decisions` — ~88M points, 1024-dim, Voyage-3-large
- **Sparse:** Postgres `edrsr_fulltext.tsv` — GIN-indexed tsvector, 'simple' config
- **Merge:** Reciprocal Rank Fusion, `k=60` default, on doc_id

Addresses real feedback from a blog comment ("Спробуйте використати Hybrid Search") — the infra was already in place but the merge tool was missing.

## Why RRF, not weighted score

Cosine (Qdrant) and `ts_rank_cd` (PG FTS) have incompatible scales. Weighted sum requires per-query calibration; RRF operates on ranks, so it Just Works. `k=60` is the Vespa/Elastic default.

## Resilience

- If FTS leg fails → returns vector-only results
- If Qdrant leg fails → returns FTS-only results
- If both fail → returns error
- Response always includes `legs.{fts_available, vector_available, fts_candidates, vector_candidates}` for observability.

## Dedup

Qdrant stores per-chunk (same doc_id can appear multiple times). The fusion keeps:
- RRF contribution from first occurrence rank
- The **best-scoring chunk** (text + index) for LLM context

## Files

- `mcp_backend/src/api/tools/edrsr-hybrid-tools.ts` — new, 376 LOC
- `mcp_backend/src/factories/tool-services.ts` — register (guarded by edsrVectorizer, same as EdsrSemanticTools)
- `mcp_backend/src/api/tool-registry.ts` — 120s timeout (Qdrant search on 88M + FTS in parallel)
- `mcp_backend/src/api/__tests__/edrsr-hybrid-tools.test.ts` — 16 tests

## Response shape

```json
{
  "query": "...",
  "rrf_k": 60,
  "legs": { "fts_available": true, "vector_available": true, ... },
  "results": [
    {
      "doc_id": 133858563,
      "court_name": "Оболонський районний суд міста Києва",
      "rrf_score": 0.032787,
      "fts_position": 1, "fts_rank": 0.91, "fts_headline": "…ТЦК…",
      "qdrant_position": 1, "qdrant_score": 0.847,
      "qdrant_best_chunk_text": "…",
      "external_url": "https://reyestr.court.gov.ua/Review/133858563"
    }
  ]
}
```

## Test plan

- [x] `tsc --noEmit` — clean (pre-existing node-pty warnings unrelated)
- [x] Jest: **16/16 passed** in 4.8s — covers RRF math, dedup, fallback, clamping, enrichment
- [ ] After merge: smoke test on prod with query that exercises both legs (e.g., "ст. 210-1 КУпАП ТЦК розшук")
- [ ] Verify tool appears in `/api/tools/definitions` after deploy

## Follow-ups (not in this PR)

- Remove stale `TEMP: Redirect to FTS while Qdrant DB is being populated` comment in `edrsr-semantic-tools.ts` — that redirect should go, Qdrant is populated (88M points)
- (Optional) Voyage rerank or Cohere rerank on top-20 before returning top-K — ~20 LOC addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `edrsr_hybrid_search`, a hybrid EDRSR search that fuses Qdrant dense vectors and Postgres FTS via RRF with per-doc dedup and robust fallbacks. Improves recall while keeping exact-token matches across the 88M-chunk vector collection.

- **New Features**
  - New MCP tool `edrsr_hybrid_search` using Reciprocal Rank Fusion (k=60, tunable), with `limit` and `oversample`.
  - Dense: Qdrant `edrsr_decisions` (88M, Voyage-3-large 1024-d). Sparse: Postgres tsvector FTS.
  - Dedup by `doc_id`; keeps best-scoring chunk text/index from Qdrant.
  - Returns provenance fields (`fts_*`, `qdrant_*`), `rrf_score`, core metadata, and `legs.*` observability; includes `external_url`.
  - Resilience: falls back to single-leg results if the other fails; errors only if both fail.
  - Registered when `edsrVectorizer` is available; adds 120s timeout override.
  - 16 Jest tests cover RRF math, dedup, filter forwarding, clamping, and fallback paths.

<sup>Written for commit dba5a632b4e53a692d3e151f989904ac3919bc73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

