### PR TITLE
fix(lexwebapp): keep /career and other public routes accessible with stale tokens

### DIFF
--- a/lexwebapp/src/utils/api/client.ts
+++ b/lexwebapp/src/utils/api/client.ts
@@ -41,10 +41,36 @@ function processQueue(error: unknown, token: string | null = null) {
   failedQueue = [];
 }
 
+// Public routes that must remain accessible even when a stored token is invalid.
+// Keep in sync with the non-AuthGuard branch of router/index.tsx.
+const PUBLIC_ROUTE_PATTERNS: RegExp[] = [
+  /^\/login$/,
+  /^\/verify-email/,
+  /^\/reset-password/,
+  /^\/payment\//,
+  /^\/oferta$/,
+  /^\/[a-z]{2}\/(offer|attorney-offer|developer-offer|marketplace-rules|terms|privacy|dpa|ai-usage|ai-transparency|refund-policy|data-sources)/,
+  /^\/eu\/comparison/,
+  /^\/blog(\/|$)/,
+  /^\/lex-news/,
+  /^\/news$/,
+  /^\/career(\/|$)/,
+  /^\/investor(\/|$)/,
+  /^\/uk_investor/,
+  /^\/r\//,
+  /^\/developer\/docs/,
+];
+
+function isPublicRoute(pathname: string): boolean {
+  return PUBLIC_ROUTE_PATTERNS.some((p) => p.test(pathname));
+}
+
 function forceLogout() {
   localStorage.removeItem('auth_token');
   localStorage.removeItem('user');
-  window.location.href = '/login';
+  if (!isPublicRoute(window.location.pathname)) {
+    window.location.href = '/login';
+  }
 }
 
 // Create axios instance
@@ -137,7 +163,9 @@ apiClient.interceptors.response.use(
         return apiClient(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);
-        showToast.error(toastT('sessionExpired'));
+        if (!isPublicRoute(window.location.pathname)) {
+          showToast.error(toastT('sessionExpired'));
+        }
         forceLogout();
         return Promise.reject(refreshError);
       } finally {

--- a/mcp_backend/src/api/__tests__/edrsr-hybrid-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-hybrid-tools.test.ts
@@ -287,6 +287,124 @@ describe('EdsrHybridTools', () => {
     });
   });
 
+  describe('metadata backfill', () => {
+    it('backfills missing metadata from edrsr_documents when FTS returns only doc_id/headline/rank', async () => {
+      // FTS service returns only minimal fields (happens when no metadata filter is passed —
+      // service skips JOIN for speed).
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'x',
+        total: 2,
+        returned: 2,
+        offset: 0,
+        has_more: false,
+        results: [
+          { doc_id: 100, headline: 'h1', rank: 0.9 },
+          { doc_id: 200, headline: 'h2', rank: 0.8 },
+        ],
+      });
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      db.query = jest.fn((sql: string, params?: any[]) => {
+        if (sql.includes('FROM edrsr_documents') && sql.includes('doc_id = ANY')) {
+          return Promise.resolve({
+            rows: [
+              {
+                doc_id: 100,
+                court_code: 2605,
+                cause_num: 'case/100',
+                judge: 'Ткаченко',
+                justice_kind: 4,
+                judgment_code: 3,
+                category_code: null,
+                adjudication_date: '2025-10-20T00:00:00.000Z',
+              },
+              {
+                doc_id: 200,
+                court_code: 2605,
+                cause_num: 'case/200',
+                judge: 'Тихонова',
+                justice_kind: 4,
+                judgment_code: 3,
+                category_code: null,
+                adjudication_date: '2025-12-19T00:00:00.000Z',
+              },
+            ],
+          });
+        }
+        if (sql.includes('edrsr_courts')) {
+          return Promise.resolve({
+            rows: [{ court_code: 2605, name: 'Оболонський районний суд м. Києва' }],
+          });
+        }
+        if (sql.includes('edrsr_justice_kinds')) {
+          return Promise.resolve({ rows: [{ justice_kind: 4, name: 'Адміністративне' }] });
+        }
+        if (sql.includes('edrsr_judgment_forms')) {
+          return Promise.resolve({ rows: [{ judgment_code: 3, name: 'Рішення' }] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const result = await tool.executeTool('edrsr_hybrid_search', { query: 'test' });
+      const payload = JSON.parse(result!.content[0].text);
+
+      expect(payload.results[0].doc_id).toBe(100);
+      expect(payload.results[0].court_code).toBe(2605);
+      expect(payload.results[0].court_name).toBe('Оболонський районний суд м. Києва');
+      expect(payload.results[0].cause_num).toBe('case/100');
+      expect(payload.results[0].judge).toBe('Ткаченко');
+      expect(payload.results[0].justice_kind_name).toBe('Адміністративне');
+      expect(payload.results[0].judgment_form).toBe('Рішення');
+
+      expect(payload.results[1].court_name).toBe('Оболонський районний суд м. Києва');
+      expect(payload.results[1].cause_num).toBe('case/200');
+    });
+
+    it('skips backfill query when metadata is already present from FTS', async () => {
+      ftsService.searchFulltext.mockResolvedValue(makeFts([100])); // makeFts returns full metadata
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      const queryCalls: string[] = [];
+      db.query = jest.fn((sql: string) => {
+        queryCalls.push(sql);
+        if (sql.includes('edrsr_courts')) {
+          return Promise.resolve({ rows: [{ court_code: 2605, name: 'Suit' }] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      await tool.executeTool('edrsr_hybrid_search', { query: 'x' });
+
+      // No backfill query should have fired — FTS already provided court_code + cause_num
+      const backfillCalls = queryCalls.filter((s) =>
+        s.includes('FROM edrsr_documents') && s.includes('doc_id = ANY')
+      );
+      expect(backfillCalls.length).toBe(0);
+    });
+
+    it('handles backfill query failure gracefully (returns without metadata)', async () => {
+      ftsService.searchFulltext.mockResolvedValue({
+        query: 'x', total: 1, returned: 1, offset: 0, has_more: false,
+        results: [{ doc_id: 100, headline: 'h', rank: 0.5 }],
+      });
+      vectorizer.semanticSearch.mockResolvedValue([]);
+
+      db.query = jest.fn((sql: string) => {
+        if (sql.includes('FROM edrsr_documents')) {
+          return Promise.reject(new Error('DB down'));
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const result = await tool.executeTool('edrsr_hybrid_search', { query: 'x' });
+      expect(result?.isError).toBeFalsy();
+      const payload = JSON.parse(result!.content[0].text);
+      expect(payload.results[0].doc_id).toBe(100);
+      expect(payload.results[0].court_name).toBeNull();
+      expect(payload.results[0].cause_num).toBeNull();
+    });
+  });
+
   describe('enrichment', () => {
     it('enriches with court_name from edrsr_courts', async () => {
       ftsService.searchFulltext.mockResolvedValue(makeFts([100]));

--- a/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
@@ -306,6 +306,30 @@ snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant �
   private async enrich(hits: FusedHit[]): Promise<any[]> {
     if (hits.length === 0) return [];
 
+    // Backfill missing metadata from edrsr_documents.
+    // EdsrFtsService returns only {doc_id, headline, rank} when no metadata filter
+    // is present (it skips the JOIN for speed). Qdrant returns metadata in payload,
+    // but falls over when its collection is still indexing. So we top up from DB
+    // unconditionally — it's one indexed ANY($1) query, ~5-10ms for 10-20 docs.
+    const docsNeedingMetadata = hits
+      .filter((h) => !h.metadata.court_code && !h.metadata.cause_num)
+      .map((h) => h.doc_id);
+    if (docsNeedingMetadata.length > 0) {
+      const docMetaMap = await this.fetchDocumentMetadata(docsNeedingMetadata);
+      for (const h of hits) {
+        const meta = docMetaMap.get(h.doc_id);
+        if (!meta) continue;
+        h.metadata.cause_num = h.metadata.cause_num || meta.cause_num;
+        h.metadata.judge = h.metadata.judge || meta.judge;
+        h.metadata.court_code = h.metadata.court_code ?? meta.court_code;
+        h.metadata.justice_kind = h.metadata.justice_kind ?? meta.justice_kind;
+        h.metadata.judgment_code = h.metadata.judgment_code ?? meta.judgment_code;
+        h.metadata.category_code = h.metadata.category_code ?? meta.category_code;
+        h.metadata.adjudication_date =
+          h.metadata.adjudication_date || meta.adjudication_date;
+      }
+    }
+
     const courtCodes = new Set<number>();
     const justiceKinds = new Set<number>();
     const judgmentCodes = new Set<number>();
@@ -343,6 +367,43 @@ snippet з FTS, найкращий chunk з Qdrant). Dedup по doc_id (Qdrant �
       qdrant_best_chunk_text: h.qdrant_best_chunk_text,
       external_url: `https://reyestr.court.gov.ua/Review/${h.doc_id}`,
     }));
+  }
+
+  private async fetchDocumentMetadata(
+    docIds: number[]
+  ): Promise<Map<number, FusedHit['metadata']>> {
+    const map = new Map<number, FusedHit['metadata']>();
+    if (docIds.length === 0) return map;
+    try {
+      const result = await this.db.query(
+        `SELECT doc_id, court_code, cause_num, judge, justice_kind, judgment_code,
+                category_code, adjudication_date
+         FROM edrsr_documents
+         WHERE doc_id = ANY($1)`,
+        [docIds]
+      );
+      for (const row of result.rows) {
+        map.set(Number(row.doc_id), {
+          cause_num: row.cause_num ?? undefined,
+          judge: row.judge ?? undefined,
+          court_code: row.court_code ?? undefined,
+          justice_kind: row.justice_kind ?? undefined,
+          judgment_code: row.judgment_code ?? undefined,
+          category_code: row.category_code ?? undefined,
+          adjudication_date: row.adjudication_date
+            ? (typeof row.adjudication_date === 'string'
+                ? row.adjudication_date
+                : row.adjudication_date.toISOString())
+            : undefined,
+        });
+      }
+    } catch (err: any) {
+      logger.warn('[EdsrHybridTools] fetchDocumentMetadata failed (continuing with partial metadata)', {
+        error: err.message,
+        doc_count: docIds.length,
+      });
+    }
+    return map;
   }
 
   private static readonly ALLOWED_LOOKUP_TABLES: Record<string, Set<string>> = {


### PR DESCRIPTION
## Summary

- Bug: visitors to `/career`, `/blog`, `/investor`, etc. with a stale `auth_token` in localStorage were bounced to `/login` because `forceLogout()` in the api-client unconditionally did `window.location.href = '/login'` on refresh failure.
- Fix: `forceLogout()` now checks the current pathname against a `PUBLIC_ROUTE_PATTERNS` list (mirrors the non-AuthGuard branch of `router/index.tsx`). On public routes it clears tokens silently; protected routes keep existing redirect behavior.
- Also suppresses the `sessionExpired` toast on public routes.

## Test plan

- [ ] Open `/career` in an incognito window → renders without auth.
- [ ] Log in, let token expire / invalidate it, visit `/career` → page renders, no redirect, no "session expired" toast.
- [ ] With invalid token, visit `/chat` → still redirects to `/login` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes public route access with stale tokens and restores court metadata in hybrid search results. Users can browse `/career`, `/blog`, etc. without redirects, and search results reliably show court info.

- **Bug Fixes**
  - `lexwebapp`: `forceLogout()` respects public route patterns. On public pages, it clears tokens without redirect and suppresses the session-expired toast; protected pages still redirect to `/login`.
  - `mcp_backend`: Hybrid search backfills missing metadata (e.g., `court_code`, `cause_num`) from `edrsr_documents` in one `ANY($1)` query. Skips when present, handles failures gracefully, and adds tests for backfill behavior.

<sup>Written for commit b306462c137e1d9cd7684d37509e9d0fc1826e71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

