### PR TITLE
fix(legislation): deterministic article lookup + self-consistent response (LEXAI-823)

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -640,11 +640,14 @@ export class RadaLegislationAdapter {
   }
 
   async getArticleByNumber(radaId: string, articleNumber: string): Promise<LegislationArticle | null> {
+    // Deterministic pick of the latest version when duplicate rows exist
+    // (see LEXAI-823: multiple is_current rows per article caused random body/title mismatch).
     const result = await this.db.query(
-      `SELECT la.* 
+      `SELECT la.*
        FROM legislation_articles la
        JOIN legislation l ON la.legislation_id = l.id
        WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.is_current = true
+       ORDER BY la.version_date DESC NULLS LAST, la.id DESC
        LIMIT 1`,
       [radaId, articleNumber]
     );

--- a/mcp_backend/src/services/__tests__/legislation-service.test.ts
+++ b/mcp_backend/src/services/__tests__/legislation-service.test.ts
@@ -289,6 +289,28 @@ describe('LegislationService', () => {
       expect(result).toBeNull();
     });
 
+    it('should return actual article_number from DB row (LEXAI-823)', async () => {
+      // Simulates the data bug where the adapter returns a row whose article_number
+      // differs from the input (e.g. "33-5" stored under article_number "33-5" but
+      // requested as "33"). The response must reflect the real row so the header
+      // and body stay consistent.
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: 1, rada_id: '435-15' }],
+        rowCount: 1,
+      });
+      mockAdapter.getArticleByNumber.mockResolvedValueOnce({
+        article_number: '33-5',
+        title: 'Real title of 33-5',
+        full_text: 'Real text of article 33-5',
+      });
+
+      const result = await service.getArticle('435-15', '33');
+
+      expect(result?.article_number).toBe('33-5');
+      expect(result?.url).toBe('https://zakon.rada.gov.ua/laws/show/435-15#n33-5');
+      expect(result?.title).toBe('Real title of 33-5');
+    });
+
     it('should resolve KMU: pattern before fetching article', async () => {
       mockDb.query
         .mockResolvedValueOnce({ rows: [{ rada_id: '1388-93-п' }], rowCount: 1 }) // resolveKmuRadaId

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -474,13 +474,17 @@ export class LegislationService {
     );
     const npaTitle = legResult.rows[0]?.title || undefined;
 
+    // Use the actual article_number from the DB row, not the input arg —
+    // header and body must come from the same record (LEXAI-823).
+    const actualArticleNumber = article.article_number || articleNumber;
+
     return {
       rada_id: radaId,
-      article_number: articleNumber,
+      article_number: actualArticleNumber,
       title: article.title,
       full_text: article.full_text,
       full_text_html: article.full_text_html,
-      url: `https://zakon.rada.gov.ua/laws/show/${radaId}#n${articleNumber}`,
+      url: `https://zakon.rada.gov.ua/laws/show/${radaId}#n${actualArticleNumber}`,
       metadata: article.metadata,
       npa_title: npaTitle,
       section_number: article.section_number,
@@ -493,11 +497,13 @@ export class LegislationService {
   async getMultipleArticles(radaId: string, articleNumbers: string[]): Promise<LegislationReference[]> {
     await this.ensureLegislationExists(radaId);
 
+    // DISTINCT ON picks the latest version per article when duplicate rows exist (LEXAI-823).
     const result = await this.db.query(
-      `SELECT la.*, l.rada_id, l.title as npa_title
+      `SELECT DISTINCT ON (la.article_number) la.*, l.rada_id, l.title as npa_title
        FROM legislation_articles la
        JOIN legislation l ON la.legislation_id = l.id
-       WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.is_current = true`,
+       WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.is_current = true
+       ORDER BY la.article_number, la.version_date DESC NULLS LAST, la.id DESC`,
       [radaId, articleNumbers]
     );
 


### PR DESCRIPTION
## Summary
- `getArticleByNumber` now does `ORDER BY version_date DESC, id DESC LIMIT 1` — no more random row selection when duplicate `is_current=true` versions exist.
- `getMultipleArticles` switched to `DISTINCT ON (article_number)` with the same ordering so each requested article returns its latest version once.
- `getArticle` now returns `article.article_number` and a URL derived from it instead of echoing the input argument, guaranteeing header and body come from the same DB row.
- Added a regression test that mocks the exact data shape behind LEXAI-823 (row with differing `article_number`).

## Root cause
Prod DB has 3110 articles with duplicate `is_current=true` rows (67 with genuinely different bodies — e.g. КПК ст. 483 has 20 distinct versions). Combined with a `LIMIT 1` / no `ORDER BY` and the service overriding `article_number` with the input arg, the card header showed "ст. X" while the body belonged to a different version.

The data cleanup (remaining `is_current` duplicates, sub-article numbers mis-imported as `title = '-N'`) will follow as a separate migration PR — this PR stabilizes serving behavior first.

## Test plan
- [x] `mcp_backend` Jest suite for `legislation-service` (31/31)
- [ ] Local smoke: open a norm card for КПК ст. 483 / Кодексу про адмінпорушення ст. 33 — header and body should match.
- [ ] After merge to main, verify on local.legal.org.ua, then blue-green to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LEXAI-823 by making article lookup deterministic and returning the real `article_number` and URL from the DB row so headers and bodies always match. This prevents random mismatches when multiple `is_current=true` versions exist.

- **Bug Fixes**
  - `getArticleByNumber`: added `ORDER BY version_date DESC NULLS LAST, id DESC` to pick the latest version.
  - `getMultipleArticles`: used `DISTINCT ON (article_number)` with the same ordering to return one latest row per article.
  - `getArticle`: now returns `article.article_number` from the fetched row and derives the URL from it.
  - Added a regression test mirroring the mismatched `article_number` case.

<sup>Written for commit 7eb95def5b56fd06c01b4d1bcae03740354bf97d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

