### PR TITLE
fix(chat): render fabricated-case-number citation warnings (LEXAI-637)

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -165,32 +165,54 @@ export function AssistantMessage({
 
           {citationWarnings && citationWarnings.length > 0 && (
             <div className="space-y-1.5 mt-4">
-              {citationWarnings.map((warning, idx) => (
-                <motion.div
-                  key={`cw-${idx}`}
-                  initial={{ opacity: 0, y: -4 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.25, delay: idx * 0.08 }}
-                  className={`flex items-start gap-3 px-3.5 py-3 rounded-lg border ${
-                    warning.status === 'explicitly_overruled'
-                      ? 'bg-red-50/70 border-red-200/60'
-                      : 'bg-zinc-50 border-zinc-200/60'
-                  }`}
-                >
-                  <div className="flex-1 min-w-0">
-                    <p className={`text-[13px] leading-relaxed ${
+              {citationWarnings.map((warning, idx) => {
+                if (warning.kind === 'fabricated') {
+                  return (
+                    <motion.div
+                      key={`cw-${idx}`}
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.25, delay: idx * 0.08 }}
+                      className="flex items-start gap-3 px-3.5 py-3 rounded-lg border bg-amber-50/70 border-amber-200/60"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[13px] leading-relaxed text-amber-800">
+                          {warning.message}
+                        </p>
+                        <p className="text-[11px] text-amber-700/80 mt-1 font-mono">
+                          Не підтверджено пошуком: {warning.fabricated.join(', ')}
+                        </p>
+                      </div>
+                    </motion.div>
+                  );
+                }
+                return (
+                  <motion.div
+                    key={`cw-${idx}`}
+                    initial={{ opacity: 0, y: -4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.25, delay: idx * 0.08 }}
+                    className={`flex items-start gap-3 px-3.5 py-3 rounded-lg border ${
                       warning.status === 'explicitly_overruled'
-                        ? 'text-red-700'
-                        : 'text-zinc-700'
-                    }`}>
-                      {warning.message}
-                    </p>
-                    <p className="text-[11px] text-zinc-400 mt-1 font-mono">
-                      {warning.status === 'explicitly_overruled' ? 'Скасовано вищою інстанцією' : 'Частково змінено'} · впевненість: {Math.round(warning.confidence * 100)}%
-                    </p>
-                  </div>
-                </motion.div>
-              ))}
+                        ? 'bg-red-50/70 border-red-200/60'
+                        : 'bg-zinc-50 border-zinc-200/60'
+                    }`}
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className={`text-[13px] leading-relaxed ${
+                        warning.status === 'explicitly_overruled'
+                          ? 'text-red-700'
+                          : 'text-zinc-700'
+                      }`}>
+                        {warning.message}
+                      </p>
+                      <p className="text-[11px] text-zinc-400 mt-1 font-mono">
+                        {warning.status === 'explicitly_overruled' ? 'Скасовано вищою інстанцією' : 'Частково змінено'} · впевненість: {Math.round(warning.confidence * 100)}%
+                      </p>
+                    </div>
+                  </motion.div>
+                );
+              })}
             </div>
           )}
 

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -267,16 +267,18 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             (m) => m.id === assistantMessageId
           );
           const existing = currentMsg?.citationWarnings || [];
+          const normalized: import('../../types/models/Message').CitationWarning =
+            data.reason === 'fabricated_case_numbers'
+              ? { kind: 'fabricated', fabricated: data.fabricated, message: data.message }
+              : {
+                  kind: 'overruled',
+                  case_number: data.case_number,
+                  status: data.status,
+                  confidence: data.confidence,
+                  message: data.message,
+                };
           updateMessage(assistantMessageId, {
-            citationWarnings: [
-              ...existing,
-              {
-                case_number: data.case_number,
-                status: data.status,
-                confidence: data.confidence,
-                message: data.message,
-              },
-            ],
+            citationWarnings: [...existing, normalized],
           });
         },
 

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -11,13 +11,21 @@ import { transformToolResultToMessage } from './mcp/response-transformers';
 import type { Message } from '../../types/models';
 import { StreamingCallbacks } from '../../types/api/sse';
 
-export interface CitationWarning {
-  case_number: string;
-  status: 'explicitly_overruled' | 'limited';
-  confidence: number;
-  affecting_decisions: Array<{ doc_id: string; instance: string; court: string; date?: string; outcome: string; effect: string }>;
-  message: string;
-}
+/** Raw SSE shape — backend emits either shape under the same event type. */
+export type CitationWarning =
+  | {
+      reason?: undefined;
+      case_number: string;
+      status: 'explicitly_overruled' | 'limited';
+      confidence: number;
+      affecting_decisions?: Array<{ doc_id: string; instance: string; court: string; date?: string; outcome: string; effect: string }>;
+      message: string;
+    }
+  | {
+      reason: 'fabricated_case_numbers';
+      fabricated: string[];
+      message: string;
+    };
 
 import type { Decision, Citation, VaultDocument } from '../../types/models/Message';
 

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -2,12 +2,27 @@
  * Message Domain Model
  */
 
-export interface CitationWarning {
-  case_number: string;
-  status: 'explicitly_overruled' | 'limited';
-  confidence: number;
-  message: string;
-}
+/**
+ * Per-message warning about one of two distinct problems:
+ * - `overruled`: shepardization found the cited case was overruled/modified
+ *   by a higher court (legacy path, emitted by ShepardizationService).
+ * - `fabricated`: LEXAI-637 — the model cited a case number that never
+ *   appeared in any tool result of the current turn. Pulled from prior
+ *   messages' context or from training memory.
+ */
+export type CitationWarning =
+  | {
+      kind: 'overruled';
+      case_number: string;
+      status: 'explicitly_overruled' | 'limited';
+      confidence: number;
+      message: string;
+    }
+  | {
+      kind: 'fabricated';
+      fabricated: string[];
+      message: string;
+    };
 
 export interface CostSummary {
   tools_used: string[];


### PR DESCRIPTION
## Summary

Pairs with [secondlayer-core#5](https://github.com/overthelex/secondlayer-core/pull/5). The backend now emits a `citation_warning` event when the LLM answer contains case numbers that never appeared in any tool result of the current turn. The wire shape is `{ reason: 'fabricated_case_numbers', fabricated: string[], message }`.

Before this patch the frontend silently dropped those events because its `CitationWarning` type matched only the legacy shepardization shape (`{ case_number, status, confidence, … }`). So the guard fired in production, the warning was logged, but the user never saw anything.

### Change

- `types/models/Message.ts` — `CitationWarning` is now a discriminated union on `kind: 'overruled' | 'fabricated'`.
- `services/api/MCPService.ts` — SSE parser accepts either wire shape (legacy shepardization or new `reason: 'fabricated_case_numbers'`).
- `hooks/chat/useAIChatStream.ts` — normalize at the stream boundary into the tagged union before pushing into message state.
- `components/message/AssistantMessage.tsx` — render a distinct amber banner for `kind: 'fabricated'` listing the unverified numbers. Red/zinc rendering for overruled warnings is unchanged.

### Test plan

- [ ] Repro LEXAI-637 (chat `chat-6b66b19f-2e4d-4a27-bbff-3b6ef1446eac` flow) — assistant message shows amber banner: _«Деякі номери справ у відповіді не знайдені в результатах пошуку цього запиту…»_ with `160/8324/19` listed.
- [ ] Regular judicial-practice query with tool-verified citations — no banner.
- [ ] Legacy overruled-precedent case (if shepardization still fires) — red banner renders as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show fabricated-case-number citation warnings in chat and stop dropping them. Addresses LEXAI-637 by parsing the new `citation_warning` SSE shape and rendering an amber banner listing unverified case numbers.

- **Bug Fixes**
  - Made `CitationWarning` a discriminated union (`kind: 'overruled' | 'fabricated'`).
  - `MCPService` and `useAIChatStream` accept the legacy shape and `reason: 'fabricated_case_numbers'`, then normalize to the union.
  - `AssistantMessage` renders an amber banner for fabricated numbers; overruled styling remains the same.

<sup>Written for commit 2b0085d72b23a63bf9c29869dd5dc1f49a3d122c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

