### PR TITLE
fix(deploy-prod): reconcile state + post-switch health check

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -488,6 +488,31 @@ jobs:
             # --- Determine active colors (per service group) ---
             BACKEND_COLOR=\$(grep '^backend=' .active-colors 2>/dev/null | cut -d= -f2 || echo "blue")
             FRONTEND_COLOR=\$(grep '^frontend=' .active-colors 2>/dev/null | cut -d= -f2 || echo "blue")
+
+            # Reality check: if .active-colors disagrees with actual running containers,
+            # trust docker state. Prevents cascading from a stale/half-failed prior deploy.
+            if docker inspect secondlayer-app-prod-green --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+              if ! docker inspect secondlayer-app-prod --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+                [ "\$BACKEND_COLOR" != "green" ] && echo "WARNING: .active-colors=\$BACKEND_COLOR but only -green backend is running — correcting to green"
+                BACKEND_COLOR="green"
+              fi
+            elif docker inspect secondlayer-app-prod --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+              [ "\$BACKEND_COLOR" != "blue" ] && echo "WARNING: .active-colors=\$BACKEND_COLOR but only blue backend is running — correcting to blue"
+              BACKEND_COLOR="blue"
+            fi
+            if docker inspect lexwebapp-prod-green --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+              if ! docker inspect lexwebapp-prod --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+                [ "\$FRONTEND_COLOR" != "green" ] && echo "WARNING: .active-colors=\$FRONTEND_COLOR but only -green frontend is running — correcting to green"
+                FRONTEND_COLOR="green"
+              fi
+            elif docker inspect lexwebapp-prod --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+              [ "\$FRONTEND_COLOR" != "blue" ] && echo "WARNING: .active-colors=\$FRONTEND_COLOR but only blue frontend is running — correcting to blue"
+              FRONTEND_COLOR="blue"
+            fi
+
+            # Persist corrected colors so promote phase (and any rerun) sees consistent state
+            printf 'backend=%s\nfrontend=%s\n' "\$BACKEND_COLOR" "\$FRONTEND_COLOR" > .active-colors
+
             [ "\$BACKEND_COLOR" = "green" ] && NEW_BACKEND="blue" || NEW_BACKEND="green"
             [ "\$FRONTEND_COLOR" = "green" ] && NEW_FRONTEND="blue" || NEW_FRONTEND="green"
 
@@ -768,6 +793,28 @@ jobs:
             # Recreate nginx to pick up new upstreams
             \$DC up -d nginx-prod --force-recreate
             echo "Nginx recreated — production traffic switched to new containers"
+
+            # --- 3b. Verify /health through nginx BEFORE stopping old containers ---
+            # If new color is unreachable, revert upstreams to old color and re-recreate nginx.
+            # Old containers are still running at this point — rollback is zero-downtime.
+            HEALTH_OK=false
+            for i in 1 2 3 4 5 6; do
+              sleep 3
+              if docker exec nginx-prod wget -q -O- --timeout=5 http://127.0.0.1/health --header="Host: legal.org.ua" 2>/dev/null | grep -q '"status":"ok"'; then
+                HEALTH_OK=true; break
+              fi
+            done
+            if [ "\$HEALTH_OK" != "true" ]; then
+              echo "::error::Post-switch /health check failed — rolling back to \$BACKEND_COLOR/\$FRONTEND_COLOR"
+              [ "\$BACKEND_COLOR" = "green" ] && ROLL_BE="secondlayer-app-prod-green" || ROLL_BE="secondlayer-app-prod"
+              [ "\$FRONTEND_COLOR" = "green" ] && ROLL_FE="lexwebapp-prod-green" || ROLL_FE="lexwebapp-prod"
+              printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$ROLL_BE" "\$ROLL_FE" > nginx/includes/prod-upstreams.conf
+              printf '# Backend hostname variables for dynamic DNS resolution\n# Managed by deploy script (blue-green switching)\n\nset \$prod_backend_host %s;\nset \$prod_backend http://\$prod_backend_host:3000;\nset \$prod_frontend_host %s;\nset \$prod_frontend http://\$prod_frontend_host:80;\n' "\$ROLL_BE" "\$ROLL_FE" > nginx/includes/prod-backend-vars.conf
+              \$DC up -d nginx-prod --force-recreate
+              printf 'backend=%s\nfrontend=%s\n' "\$BACKEND_COLOR" "\$FRONTEND_COLOR" > .active-colors
+              exit 1
+            fi
+            echo "✓ Post-switch /health check passed"
 
             # Allow in-flight requests to complete
             sleep 5


### PR DESCRIPTION
## Summary

Prod went down today with 502 on all backend routes. Root cause: a prior deploy left `prod-backend-vars.conf` pointing at `secondlayer-app-prod-green` while `.active-colors=blue` and the `-green` container no longer existed.

Two gaps in `deploy-prod.yml` let this happen:

1. **Preview phase had no drift detection.** It read `.active-colors` blindly and computed `NEW_BACKEND` off whatever was in the file — even if that didn't match running containers.
2. **Promote phase had no post-switch verification.** It wrote new upstreams → force-recreated nginx → immediately stopped old containers, without first confirming that traffic through nginx actually reached a healthy backend. If the new color was broken/missing, the rollback path couldn't help because blue had been killed.

## Changes

- **Preview phase (`Phase 1: Deploy preview`)**: before computing `NEW_BACKEND`/`NEW_FRONTEND`, check actual container state. If `.active-colors` disagrees with reality, correct and persist it. Mirrors the existing reality-check in promote phase (lines 697–717).
- **Promote phase (`Phase 2: Switch production traffic`)**: after `docker compose up -d nginx-prod --force-recreate`, poll `/health` via `docker exec nginx-prod wget` for up to 18s. On failure, revert `prod-upstreams.conf` + `prod-backend-vars.conf` to the old color, re-recreate nginx, write `.active-colors` back to the old color, exit 1. Old-color containers haven't been stopped yet so rollback is zero-downtime.

## Test plan

- [ ] Next deploy should log `Backend: blue → green (changed: true)` (unchanged behavior)
- [ ] If someone manually stops a `-green` container mid-deploy, preview's reality check should detect and correct
- [ ] If the new-color backend is broken after switch, promote should roll back to old color instead of leaving nginx pointing at a dead upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds state reconciliation and a post-switch /health check to `deploy-prod.yml` to prevent 502s from stale blue/green state and enable zero-downtime rollback if the new color is unhealthy.

- **Bug Fixes**
  - Preview: reconcile `.active-colors` with running Docker containers for backend and frontend, persist corrected values, then compute `NEW_BACKEND`/`NEW_FRONTEND`.
  - Promote: after recreating `nginx-prod`, poll `/health` via `docker exec` (18s). On failure, revert `prod-upstreams.conf` and `prod-backend-vars.conf` to the old color, recreate nginx, restore `.active-colors`, and exit before stopping old containers.

<sup>Written for commit 17b9c752b6f1339d77d2ade0a6f4823b7955126e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

