### PR TITLE
feat(nginx): plane-mcp-igor.legal.org.ua endpoint (PLANE-6)

### DIFF
--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -57,6 +57,11 @@ upstream prod_plane_mcp {
     keepalive 4;
 }
 
+upstream prod_plane_mcp_igor {
+    server plane-mcp-igor:8211;
+    keepalive 4;
+}
+
 # HTTP - plane.legal.org.ua (Plane project management)
 server {
     listen 80;
@@ -100,6 +105,35 @@ server {
 
     location / {
         proxy_pass http://prod_plane_mcp;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+}
+
+# HTTP - plane-mcp-igor.legal.org.ua (Plane MCP SSE Server — Igor's personal token)
+server {
+    listen 80;
+    listen [::]:80;
+    server_name plane-mcp-igor.legal.org.ua;
+
+    set_real_ip_from 172.31.0.0/16;
+    real_ip_header X-Forwarded-For;
+
+    if ($http_x_forwarded_proto = "") {
+        return 301 https://$host$request_uri;
+    }
+
+    location / {
+        proxy_pass http://prod_plane_mcp_igor;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -284,6 +318,34 @@ server {
 
     location / {
         proxy_pass http://prod_plane_mcp;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $forwarded_proto;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 86400s;
+        proxy_send_timeout 86400s;
+    }
+}
+
+# HTTPS - plane-mcp-igor.legal.org.ua (Plane MCP SSE Server — Igor's personal token)
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name plane-mcp-igor.legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+
+    location / {
+        proxy_pass http://prod_plane_mcp_igor;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Adds HTTP+HTTPS server blocks and upstream for `plane-mcp-igor.legal.org.ua` pointing to a new `plane-mcp-igor` container on prod that runs the Plane MCP server with Igor's personal API key.
- Fixes PLANE-6: work items created through the shared `plane-mcp.legal.org.ua` endpoint were always attributed to Vladimir because `plane-mcp-server` (upstream pip package) is single-tenant — it reads `PLANE_API_KEY` from env at startup and ignores any per-client Authorization header. `mcp-proxy` doesn't forward Authorization into the stdio child either.
- Pragmatic fix: one container per user, each with its own token. Igor reconfigures his MCP client to `https://plane-mcp-igor.legal.org.ua/sse`.

## Out-of-scope (already done on prod)
- Cloudflare CNAME for `plane-mcp-igor.legal.org.ua` → ALB
- `/home/ubuntu/mcplane/` docker-compose: added `plane-mcp-igor` service + `.env.plane-mcp-igor`
- Container is up and SSE-listening on :8212 (host) / :8211 (container)

Nginx deploy via CI/CD will wire it up.

## Test plan
- [ ] After CI deploy, `curl -I https://plane-mcp-igor.legal.org.ua/sse` returns SSE headers (event-stream)
- [ ] Igor reconfigures his MCP client, creates a test task → `created_by` is Igor, not Vladimir
- [ ] Existing `plane-mcp.legal.org.ua` endpoint unchanged for Vladimir

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dedicated `plane-mcp-igor.legal.org.ua` endpoint that proxies to a new per-user upstream so Igor’s tasks are created under his own identity. Fixes PLANE-6 by isolating tokens for the single-tenant `plane-mcp-server`.

- **New Features**
  - Added `upstream prod_plane_mcp_igor` -> `plane-mcp-igor:8211`.
  - Added HTTP/HTTPS server blocks for `plane-mcp-igor.legal.org.ua` with SSE-friendly proxy settings (no buffering, long timeouts).

- **Bug Fixes**
  - PLANE-6: Work items created via Igor now attribute to Igor by routing to a dedicated container with his `PLANE_API_KEY`. Existing `plane-mcp.legal.org.ua` remains unchanged for Vladimir.

<sup>Written for commit 4b94d4f07494dbe9afab7c900fd17730060f435d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

