### PR TITLE
opendata: raise caps + WORKERS_PER_IP=2 for 5 heavy importers

### DIFF
--- a/services/opendata-importers/docker-compose.opendata.yml
+++ b/services/opendata-importers/docker-compose.opendata.yml
@@ -74,8 +74,9 @@ services:
     command: ["importers.ch_kantonsblatt"]
     environment:
       <<: *importer-env
-      MAX_PAGES_PER_RUBRIC: ${KB_MAX_PAGES:-10}
-      BACKFILL_DAYS: ${KB_BACKFILL_DAYS:-30}
+      WORKERS_PER_IP: "2"
+      MAX_PAGES_PER_RUBRIC: ${KB_MAX_PAGES:-100}
+      BACKFILL_DAYS: ${KB_BACKFILL_DAYS:-365}
 
   ch_entscheidsuche:
     <<: *importer-base
@@ -83,8 +84,9 @@ services:
     command: ["importers.ch_entscheidsuche"]
     environment:
       <<: *importer-env
-      MAX_DOCS_PER_SPIDER: ${ES_MAX_DOCS:-2000}
-      SPIDERS: ${ES_SPIDERS:-CH_BGer,CH_BVGer,CH_BStGer}
+      WORKERS_PER_IP: "2"
+      MAX_DOCS_PER_SPIDER: ${ES_MAX_DOCS:-10000}
+      SPIDERS: ${ES_SPIDERS:-}
 
   ch_fedlex:
     <<: *importer-base
@@ -100,7 +102,8 @@ services:
     command: ["importers.spain_consejo_estado"]
     environment:
       <<: *importer-env
-      CE_MAX_PER_YEAR: ${CE_MAX_PER_YEAR:-500}
+      WORKERS_PER_IP: "2"
+      CE_MAX_PER_YEAR: ${CE_MAX_PER_YEAR:-1500}
       CE_YEARS: ${CE_YEARS:-}
 
   spain_boe_sumarios:
@@ -109,8 +112,9 @@ services:
     command: ["importers.spain_boe_sumarios"]
     environment:
       <<: *importer-env
-      BOE_BACKFILL_DAYS: ${BOE_BACKFILL_DAYS:-0}
-      BOE_MAX_DAYS: ${BOE_MAX_DAYS:-30}
+      WORKERS_PER_IP: "2"
+      BOE_BACKFILL_DAYS: ${BOE_BACKFILL_DAYS:-90}
+      BOE_MAX_DAYS: ${BOE_MAX_DAYS:-90}
 
   spain_contratos:
     <<: *importer-base
@@ -118,7 +122,8 @@ services:
     command: ["importers.spain_contratos"]
     environment:
       <<: *importer-env
-      CONTRATOS_MAX_PAGES: ${CONTRATOS_MAX_PAGES:-10}
+      WORKERS_PER_IP: "2"
+      CONTRATOS_MAX_PAGES: ${CONTRATOS_MAX_PAGES:-200}
       CONTRATOS_SOURCES: ${CONTRATOS_SOURCES:-federal,ccaa,local}
 
   spain_congreso:


### PR DESCRIPTION
## Summary
- Conservative defaults left 9 of 11 opendata importers idle in "caught up" state
- Heavy backfill with default WORKERS_PER_IP=8 saturated prod sshd MaxStartups → OS-level overload (OOM-like state, ICMP/SSH/HTTPS timeouts)
- Per-service overrides: WORKERS_PER_IP=2 + raised caps to mid-range for ch_kantonsblatt, ch_entscheidsuche, spain_consejo_estado, spain_boe_sumarios, spain_contratos

## Verified post-restart
- prod load 5min ~7.8, SSH count 1
- ch_court_decisions: 371,072 → 382,272 (+11K in first cycle, ongoing)
- spain_contratos: 150,489 → 151,911 (+1.4K)
- ch_kantonsblatt: 30,009 → 32,051 (+2K)
- spain_boe_disposiciones: +173, anuncios +248, borme +137
- spain_consejo_estado: +9 (checkpoints already deep)
- All batches insert at controlled 22–85 rows/s via SSH+psql COPY

## Test plan
- [x] YAML validation passes
- [x] All 5 affected containers recreate cleanly with new env
- [x] Image rebuild includes all new importers (ch_kantonsblatt, ch_entscheidsuche, ch_seco, ch_fedlex, spain_*)
- [x] Prod stays reachable during heavy ingest (load < 10, SSH < 3)
- [x] Row counts grow on prod across affected tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce importer concurrency and raise backfill limits for five heavy `opendata` services to keep prod stable and make steady progress. Sets WORKERS_PER_IP=2 and increases caps so each run does meaningful work without flooding SSH/psql.

- **Bug Fixes**
  - ch_kantonsblatt: WORKERS_PER_IP=2; MAX_PAGES_PER_RUBRIC=100; BACKFILL_DAYS=365
  - ch_entscheidsuche: WORKERS_PER_IP=2; MAX_DOCS_PER_SPIDER=10000; SPIDERS unset (use all)
  - spain_consejo_estado: WORKERS_PER_IP=2; CE_MAX_PER_YEAR=1500
  - spain_boe_sumarios: WORKERS_PER_IP=2; BOE_BACKFILL_DAYS=90; BOE_MAX_DAYS=90
  - spain_contratos: WORKERS_PER_IP=2; CONTRATOS_MAX_PAGES=200

<sup>Written for commit 8769e3bdff31e777023655ef87aac931379ac9d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

