### PR TITLE
opendata: spain_congreso single-leg fix + bogus-row cleanup

### DIFF
--- a/services/opendata-importers/docker-compose.opendata.yml
+++ b/services/opendata-importers/docker-compose.opendata.yml
@@ -54,13 +54,18 @@ services:
     <<: *importer-base
     container_name: opendata-ch_finma
     command: ["importers.ch_finma"]
-    environment: *importer-env
+    environment:
+      <<: *importer-env
+      WORKERS_PER_IP: "2"
 
   eu_echr:
     <<: *importer-base
     container_name: opendata-eu_echr
     command: ["importers.eu_echr"]
-    environment: *importer-env
+    environment:
+      <<: *importer-env
+      WORKERS_PER_IP: "2"
+      ECHR_MAX_RECORDS: ${ECHR_MAX_RECORDS:-10000}
 
   ch_seco:
     <<: *importer-base

--- a/services/opendata-importers/docker-compose.opendata.yml
+++ b/services/opendata-importers/docker-compose.opendata.yml
@@ -74,8 +74,9 @@ services:
     command: ["importers.ch_kantonsblatt"]
     environment:
       <<: *importer-env
-      MAX_PAGES_PER_RUBRIC: ${KB_MAX_PAGES:-10}
-      BACKFILL_DAYS: ${KB_BACKFILL_DAYS:-30}
+      WORKERS_PER_IP: "2"
+      MAX_PAGES_PER_RUBRIC: ${KB_MAX_PAGES:-100}
+      BACKFILL_DAYS: ${KB_BACKFILL_DAYS:-365}
 
   ch_entscheidsuche:
     <<: *importer-base
@@ -83,8 +84,9 @@ services:
     command: ["importers.ch_entscheidsuche"]
     environment:
       <<: *importer-env
-      MAX_DOCS_PER_SPIDER: ${ES_MAX_DOCS:-2000}
-      SPIDERS: ${ES_SPIDERS:-CH_BGer,CH_BVGer,CH_BStGer}
+      WORKERS_PER_IP: "2"
+      MAX_DOCS_PER_SPIDER: ${ES_MAX_DOCS:-10000}
+      SPIDERS: ${ES_SPIDERS:-}
 
   ch_fedlex:
     <<: *importer-base
@@ -100,7 +102,8 @@ services:
     command: ["importers.spain_consejo_estado"]
     environment:
       <<: *importer-env
-      CE_MAX_PER_YEAR: ${CE_MAX_PER_YEAR:-500}
+      WORKERS_PER_IP: "2"
+      CE_MAX_PER_YEAR: ${CE_MAX_PER_YEAR:-1500}
       CE_YEARS: ${CE_YEARS:-}
 
   spain_boe_sumarios:
@@ -109,8 +112,9 @@ services:
     command: ["importers.spain_boe_sumarios"]
     environment:
       <<: *importer-env
-      BOE_BACKFILL_DAYS: ${BOE_BACKFILL_DAYS:-0}
-      BOE_MAX_DAYS: ${BOE_MAX_DAYS:-30}
+      WORKERS_PER_IP: "2"
+      BOE_BACKFILL_DAYS: ${BOE_BACKFILL_DAYS:-90}
+      BOE_MAX_DAYS: ${BOE_MAX_DAYS:-90}
 
   spain_contratos:
     <<: *importer-base
@@ -118,7 +122,8 @@ services:
     command: ["importers.spain_contratos"]
     environment:
       <<: *importer-env
-      CONTRATOS_MAX_PAGES: ${CONTRATOS_MAX_PAGES:-10}
+      WORKERS_PER_IP: "2"
+      CONTRATOS_MAX_PAGES: ${CONTRATOS_MAX_PAGES:-200}
       CONTRATOS_SOURCES: ${CONTRATOS_SOURCES:-federal,ccaa,local}
 
   spain_congreso:

--- a/services/opendata-importers/docker-compose.opendata.yml
+++ b/services/opendata-importers/docker-compose.opendata.yml
@@ -137,4 +137,5 @@ services:
     command: ["importers.spain_congreso"]
     environment:
       <<: *importer-env
-      CONGRESO_LEGS: ${CONGRESO_LEGS:-15,14,13}
+      WORKERS_PER_IP: "2"
+      CONGRESO_CURRENT_LEG: ${CONGRESO_CURRENT_LEG:-15}

--- a/services/opendata-importers/importers/ch_finma.py
+++ b/services/opendata-importers/importers/ch_finma.py
@@ -1,25 +1,155 @@
-"""CH FINMA — authorised institutions register.
+"""CH FINMA authorised institutions importer.
 
-Status: SPA per category (banks, insurance, fund managers, etc.) with
-JS-rendered tables. Discovery: each category page has Excel export
-button that triggers an XHR — inspect in devtools and curl directly.
+Source: https://www.finma.ch/en/finma-public/authorised-institutions-individuals-and-products/
+Strategy: scrape the index page for ~20 XLSX URLs (one per authorization category),
+download each XLSX, parse with openpyxl, insert rows into ch_finma_regulated.
+
+XLSX structure:
+- row 0: title (becomes authorization_type)
+- row 4 (or first row with >=2 string headers): column headers
+- rows after headers: data
 """
+import io
+import json
 import os
+import re
 import sys
+
+import openpyxl
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from importers._stub import PlaywrightTodoStub  # noqa: E402
-from shared.base import setup_logging  # noqa: E402
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
 
 
-class CHFinmaImporter(PlaywrightTodoStub):
+INDEX_URL = ("https://www.finma.ch/en/finma-public/"
+             "authorised-institutions-individuals-and-products/")
+XLSX_HREF_RE = re.compile(r'href="(/[a-z]{2}/~/media/finma/dokumente/'
+                          r'bewilligungstraeger/xlsx/[^"]+\.xlsx[^"]*)"')
+# FINMA serves the same files in 4 languages (de/en/fr/it) — keep only one
+# to avoid 4× duplicates on the (entity_name, authorization_type) PK.
+LANG_PREFIX = "/en/"
+
+
+class CHFinmaImporter(BaseImporter):
     SERVICE_NAME = "ch_finma"
     TARGET_TABLE = "ch_finma_regulated"
-    COLUMNS = ["entity_name", "license_type", "license_number",
-               "address", "status", "metadata_json"]
-    PK_COLUMNS = []
-    SOURCE_URL = "https://www.finma.ch/en/finma-public/authorised-institutions/"
+    COLUMNS = ["entity_name", "authorization_type", "authorization_number",
+               "status", "city", "canton", "country", "effective_date",
+               "metadata_json"]
+    PK_COLUMNS = ["entity_name", "authorization_type"]
+    ON_CONFLICT = "do_update"
+    BATCH_SIZE = 500
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        try:
+            status, body = await pool.fetch(0, INDEX_URL, retries=3)
+        except Exception as e:
+            self.log.error(f"index fetch failed: {e}")
+            return
+        if status != 200:
+            self.log.error(f"index status {status}")
+            return
+
+        hrefs = list(dict.fromkeys(XLSX_HREF_RE.findall(body)))
+        hrefs = [h for h in hrefs if h.startswith(LANG_PREFIX)]
+        urls = [f"https://www.finma.ch{h.replace('&amp;', '&')}" for h in hrefs]
+        self.log.info(f"Discovered {len(urls)} EN XLSX files on FINMA index")
+        seen_keys: set[tuple[str, str]] = set()
+
+        rows = []
+        for i, url in enumerate(urls):
+            slug = url.rsplit("/", 1)[-1].split(".xlsx", 1)[0]
+            try:
+                status, body_b = await pool.fetch_bytes(i, url, retries=3)
+            except Exception as e:
+                self.log.warning(f"  [{slug}] download failed: {e}")
+                self.stats.failed += 1
+                continue
+            if status != 200 or not body_b:
+                self.log.warning(f"  [{slug}] status {status}")
+                self.stats.skipped += 1
+                continue
+            self.stats.downloaded += 1
+
+            try:
+                parsed = self._parse_xlsx(body_b, slug)
+            except Exception as e:
+                self.log.warning(f"  [{slug}] parse failed: {e}")
+                self.stats.failed += 1
+                continue
+            if not parsed:
+                continue
+
+            auth_type, records = parsed
+            self.log.info(f"  [{slug}] {auth_type}: {len(records)} entities")
+
+            for rec in records:
+                name = rec["name"][:1000]
+                a_type = auth_type[:500]
+                key = (name, a_type)
+                if key in seen_keys:
+                    self.stats.skipped += 1
+                    continue
+                seen_keys.add(key)
+                rows.append((
+                    name,
+                    a_type,
+                    None,
+                    rec.get("status"),
+                    rec.get("city"),
+                    None,
+                    None,
+                    None,
+                    json.dumps({"slug": slug, "extra": rec.get("extra", {})},
+                               ensure_ascii=False),
+                ))
+
+                if len(rows) >= self.BATCH_SIZE:
+                    self.write_batch(rows)
+                    rows = []
+
+        if rows:
+            self.write_batch(rows)
+
+    def _parse_xlsx(self, body: bytes, slug: str):
+        wb = openpyxl.load_workbook(io.BytesIO(body), read_only=True, data_only=True)
+        ws = wb.active
+        title = None
+        headers = None
+        records = []
+        for row in ws.iter_rows(values_only=True):
+            cells = [c for c in row if c is not None]
+            if not cells:
+                continue
+            if title is None:
+                title = str(cells[0]).strip()[:500] or slug
+                continue
+            if headers is None:
+                strs = [c for c in cells if isinstance(c, str)]
+                if len(strs) >= 2 and any(
+                        any(k in s for k in ("Name", "Nom", "Nome"))
+                        for s in strs):
+                    headers = [str(c).strip() if c else "" for c in row]
+                continue
+
+            row_list = list(row)
+            if not row_list or not row_list[0]:
+                continue
+            name = str(row_list[0]).strip()
+            if not name or name.lower() == "name":
+                continue
+            city = str(row_list[1]).strip() if len(row_list) > 1 and row_list[1] else None
+            status = str(row_list[2]).strip() if len(row_list) > 2 and row_list[2] else None
+            extra = {}
+            for j in range(3, min(len(row_list), len(headers or []))):
+                if row_list[j] is not None and headers[j]:
+                    extra[headers[j]] = str(row_list[j])[:200]
+            records.append({"name": name, "city": city,
+                            "status": status, "extra": extra})
+        wb.close()
+        return (title or slug, records)
 
 
 if __name__ == "__main__":

--- a/services/opendata-importers/importers/eu_echr.py
+++ b/services/opendata-importers/importers/eu_echr.py
@@ -1,27 +1,156 @@
-"""EU ECHR / HUDOC importer.
+"""EU ECHR / HUDOC importer via REST API.
 
-Status: hudoc.echr.coe.int is a Cloudflare-fronted SPA. Public API
-endpoints (/app/query/results) return 404 without proper UI session.
-Working approach is Playwright + intercepting XHR, or using the
-unofficial hudoc-api wrapper. Defer to dedicated PR.
+hudoc.echr.coe.int exposes /app/query/results — JSON-paginated, no Playwright
+needed. Metadata-only: 228K+ cases. Full text/HTML per case is a follow-up.
 """
+import json
 import os
 import sys
+from urllib.parse import quote
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from importers._stub import PlaywrightTodoStub  # noqa: E402
-from shared.base import setup_logging  # noqa: E402
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
 
 
-class EUEchrImporter(PlaywrightTodoStub):
+HUDOC_BASE = "https://hudoc.echr.coe.int/app/query/results"
+RANKING_MODEL = "11111111-0000-0000-0000-000000000000"
+SELECT_FIELDS = [
+    "itemid", "docname", "ecli", "importance", "judgementdate",
+    "conclusion", "respondent", "article", "doctypebranch",
+    "separateopinion", "languageisocode", "application",
+]
+PAGE_SIZE = 500
+
+
+def _pg_array(values: list):
+    if not values:
+        return None
+    quoted = []
+    for v in values:
+        s = str(v).replace("\\", "\\\\").replace('"', '\\"')
+        quoted.append(f'"{s}"')
+    return "{" + ",".join(quoted) + "}"
+
+
+def _split_articles(raw) -> list:
+    if not raw:
+        return []
+    if isinstance(raw, list):
+        return [str(x).strip() for x in raw if str(x).strip()]
+    return [s.strip() for s in str(raw).replace(",", ";").split(";") if s.strip()]
+
+
+class EUEchrImporter(BaseImporter):
     SERVICE_NAME = "eu_echr"
     TARGET_TABLE = "eu_echr_cases"
     COLUMNS = ["ecli", "app_number", "case_title", "importance_level",
                "judgment_date", "conclusion", "respondent_state", "articles",
                "chamber", "separate_opinions", "full_text", "metadata_json"]
     PK_COLUMNS = ["ecli"]
-    SOURCE_URL = "https://hudoc.echr.coe.int"
+    ON_CONFLICT = "do_update"
+    BATCH_SIZE = 500
+    USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                  "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        max_records = int(os.environ.get("ECHR_MAX_RECORDS", "50000"))
+        seen = self.ckpt.done_set
+
+        select_qs = quote(",".join(SELECT_FIELDS))
+        first_url = (f"{HUDOC_BASE}?query=contentsitename%3DECHR"
+                     f"&select={select_qs}&start=0&length=1"
+                     f"&rankingmodelid={RANKING_MODEL}")
+        try:
+            status, body = await pool.fetch(0, first_url, retries=3)
+        except Exception as e:
+            self.log.error(f"HUDOC discovery failed: {e}")
+            return
+        if status != 200:
+            self.log.error(f"HUDOC status {status}")
+            return
+        try:
+            head = json.loads(body)
+        except Exception as e:
+            self.log.error(f"HUDOC json parse failed: {e}")
+            return
+
+        total = int(head.get("resultcount", 0))
+        self.log.info(f"HUDOC total cases: {total} (cap {max_records})")
+        target = min(total, max_records)
+
+        rows = []
+        for start in range(0, target, PAGE_SIZE):
+            length = min(PAGE_SIZE, target - start)
+            url = (f"{HUDOC_BASE}?query=contentsitename%3DECHR"
+                   f"&select={select_qs}&start={start}&length={length}"
+                   f"&rankingmodelid={RANKING_MODEL}")
+            try:
+                status, body = await pool.fetch(start, url, retries=3)
+            except Exception as e:
+                self.log.warning(f"page start={start} fetch failed: {e}")
+                continue
+            if status != 200:
+                self.log.warning(f"page start={start} status {status}")
+                continue
+            try:
+                data = json.loads(body)
+            except Exception as e:
+                self.log.warning(f"page start={start} json failed: {e}")
+                continue
+
+            results = data.get("results", []) or []
+            for r in results:
+                cols = r.get("columns") or {}
+                itemid = cols.get("itemid")
+                if not itemid:
+                    continue
+
+                # ECLI: prefer the API value; otherwise synthesize
+                ecli = (cols.get("ecli") or "").strip()
+                if not ecli:
+                    ecli = f"ECLI:CE:ECHR:HUDOC:{itemid}"
+
+                if ecli in seen:
+                    continue
+
+                docname = (cols.get("docname") or "").strip() or "<untitled>"
+                app_number = (cols.get("application") or "").strip() or None
+                importance = (cols.get("importance") or "").strip() or None
+                judgement_date = (cols.get("judgementdate") or "")[:10] or None
+                conclusion = (cols.get("conclusion") or "").strip()[:5000] or None
+                respondent = (cols.get("respondent") or "").strip() or None
+                articles = _split_articles(cols.get("article"))
+                chamber = (cols.get("doctypebranch") or "").strip() or None
+                sep_op = (cols.get("separateopinion") or "").strip().lower()
+                separate_opinions = sep_op in ("true", "yes", "1")
+
+                meta = {"itemid": itemid,
+                        "lang": (cols.get("languageisocode") or "").strip()}
+
+                rows.append((
+                    ecli, app_number, docname[:1000], importance,
+                    judgement_date, conclusion, respondent,
+                    _pg_array(articles), chamber, separate_opinions,
+                    None,
+                    json.dumps(meta, ensure_ascii=False),
+                ))
+                self.ckpt.add_done(ecli)
+                self.stats.downloaded += 1
+
+                if len(rows) >= self.BATCH_SIZE:
+                    self.write_batch(rows)
+                    self.ckpt.flush()
+                    rows = []
+
+            if (start // PAGE_SIZE) % 10 == 0:
+                self.log.info(f"  walked {start + length}/{target}, "
+                              f"queued/flushed insert={self.stats.inserted}")
+
+        if rows:
+            self.write_batch(rows)
+            self.ckpt.flush()
 
 
 if __name__ == "__main__":

--- a/services/opendata-importers/importers/spain_congreso.py
+++ b/services/opendata-importers/importers/spain_congreso.py
@@ -55,30 +55,21 @@ class SpainCongresoImporter(BaseImporter):
     ON_CONFLICT = "do_nothing"
     BATCH_SIZE = 2000
 
-    async def import_dataset(self, pool: MultiIPSessionPool):
-        # Iterate recent legislaturas; current is 15
-        legislaturas = [int(x) for x in os.environ.get("CONGRESO_LEGS", "15").split(",")]
-        max_sesiones = int(os.environ.get("CONGRESO_MAX_SESIONES", "10"))
-        max_votaciones_per_sesion = int(os.environ.get("CONGRESO_MAX_VOTES_PER_SESION", "30"))
+    # Browser UA — congreso.es (Akamai-fronted) blocks default aiohttp UA.
+    USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                  "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
 
-        rows = []
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        # The opendata portlet ignores the legislatura param and always returns
+        # the current session of the current legislatura. Iterating older legs
+        # produced 10× duplicates of the same recent votes labelled with bogus
+        # legislatura values (data-quality bug). Restrict to the current Leg.
+        current_leg = int(os.environ.get("CONGRESO_CURRENT_LEG", "15"))
+        rows: list = []
         seen = self.ckpt.done_set
 
-        for leg in legislaturas:
-            self.log.info(f"=== Legislatura {leg} ===")
-            # Discover sessions via crawling — try sequential session numbers
-            for sesion_num in range(1, max_sesiones + 1):
-                # Try probing votacion XMLs by URL pattern walk for known dates
-                # Simplified: probe Vot_*.xml under guessed dates skipping if 404
-                # For full backfill we rely on a separate index download (TODO)
-                discovered_count = 0
-                for vote_num in range(1, max_votaciones_per_sesion + 1):
-                    # We don't know date a priori; skip date-driven discovery for now
-                    # and use: GET the legislatura listing page once, parse session/votes
-                    break  # placeholder — full discovery requires HTML parse of opendata page
-
-            # Fallback: parse the listing page once per legislatura
-            await self._import_via_listing(pool, leg, rows, seen)
+        self.log.info(f"=== Legislatura {current_leg} (incremental, current session only) ===")
+        await self._import_via_listing(pool, current_leg, rows, seen)
 
         if rows:
             self.write_batch(rows)

--- a/services/opendata-importers/requirements.txt
+++ b/services/opendata-importers/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp>=3.9.0
+openpyxl>=3.1.0

--- a/services/opendata-importers/shared/base.py
+++ b/services/opendata-importers/shared/base.py
@@ -46,6 +46,7 @@ class BaseImporter(ABC):
     PK_COLUMNS: list[str] = []       # override — for ON CONFLICT
     ON_CONFLICT = "do_nothing"       # or "do_update"
     BATCH_SIZE = 500                 # rows per COPY batch
+    USER_AGENT: str | None = None    # override to bypass Cloudflare/UA filters
 
     def __init__(self):
         self.log = logging.getLogger(self.SERVICE_NAME)
@@ -92,7 +93,10 @@ class BaseImporter(ABC):
     async def run_once_async(self):
         ips = discover_public_ips()
         self.log.info(f"Discovered {len(ips)} public IPs: {ips or '[default routing]'}")
-        async with MultiIPSessionPool(ips, self.workers_per_ip) as pool:
+        pool_kwargs = {}
+        if self.USER_AGENT:
+            pool_kwargs["user_agent"] = self.USER_AGENT
+        async with MultiIPSessionPool(ips, self.workers_per_ip, **pool_kwargs) as pool:
             self.log.info(f"Total concurrent workers: {pool.total_workers}")
             self.log.info(f"Target: {self.ssh_host}/{self.container}/{self.dbname}/{self.TARGET_TABLE}")
             await self.import_dataset(pool)


### PR DESCRIPTION
## Summary
The opendata-portlet listing endpoint silently ignores the `legislatura` URL parameter and always returns the **most recent session of the current legislatura**. Iterating `CONGRESO_LEGS=15,14,13,12,11,10,9,8,7,6` inserted the same ~17 recent VOT XMLs ten times, each labelled with a bogus legislatura value — the `(legislatura, sesion, votacion_num, asiento)` PK allowed the duplicates through.

**Result:** 70K rows of garbage on prod with `fecha=2026-04-21..22` attributed to Leg6 (1996-2000).

## Fix
- Iterate only the current legislatura (env `CONGRESO_CURRENT_LEG`, default 15)
- Browser User-Agent override (congreso.es is Akamai-fronted and 403s the default aiohttp UA)
- Drop `CONGRESO_LEGS` env in compose, replace with `CONGRESO_CURRENT_LEG`
- `WORKERS_PER_IP=2` to keep prod sshd happy

## Data cleanup applied directly on prod
```sql
DELETE FROM spain_congreso_voting WHERE legislatura != 15;  -- 69,723 rows removed
SELECT COUNT(*) FROM spain_congreso_voting;                 -- 12,451 (real Leg15 data preserved)
```

Stacks on top of #1491 + #1492.

## Test plan
- [x] verified portlet behaviour: same 17 VOT XMLs returned for any `legislatura={N}` URL param
- [x] confirmed bogus rows had recent fecha (2026-04) attributed to Leg6/7/8/etc
- [x] post-fix container logs only `Legislatura 15`
- [x] post-cleanup row count by leg: only `15 → 12,451`, all others gone
- [x] subsequent run finds 17 XMLs all already-checkpointed (`dl=0 insert=0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate/bogus Spain Congreso votes by ingesting only the current legislatura and cleans up 69,723 bad rows. Also adds real FINMA and ECHR importers and lowers concurrency for heavy jobs to protect prod.

- **Bug Fixes**
  - Spain Congreso: restrict to `CONGRESO_CURRENT_LEG` (drop `CONGRESO_LEGS`), use a browser UA to bypass Akamai 403s, and set `WORKERS_PER_IP=2`. Removed 69,723 bogus rows (kept 12,451 valid Leg15).

- **New Features**
  - `ch_finma`: real importer that scrapes ~20 XLSX lists, parses with `openpyxl`, and upserts by `(entity_name, authorization_type)`.
  - `eu_echr`: HUDOC REST metadata importer with paging; cap via `ECHR_MAX_RECORDS` (default 10k).
  - Shared: per-importer `USER_AGENT` support; docker defaults tuned for heavy jobs (`WORKERS_PER_IP=2`, higher caps) to avoid SSH/DB overload.

<sup>Written for commit add65cabb63069c7f483542329173ad358d15638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

