### PR TITLE
feat(login): donate button with $5/$10/$20 via Monobank

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -23,6 +23,7 @@ import {
   ChevronRight,
   Gift,
   UserPlus,
+  Heart,
 } from 'lucide-react';
 import { startAuthentication } from '@simplewebauthn/browser';
 import { hasRecentArticles } from '../BlogPage/articles';
@@ -222,6 +223,88 @@ function PanelDivider() {
   return (
     <div className="hidden lg:block absolute right-0 top-0 bottom-0 w-px">
       <div className="h-full bg-gradient-to-b from-transparent via-zinc-700/35 to-transparent" />
+    </div>
+  );
+}
+
+const DONATION_AMOUNTS_USD = [5, 10, 20] as const;
+
+function DonateCard() {
+  const [selected, setSelected] = useState<number>(10);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleDonate = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${BASE_URL}/api/donations/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount_usd: selected }),
+      });
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.message || data.error || 'Не вдалося створити донат');
+      }
+
+      window.location.href = data.pageUrl;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Помилка донату';
+      setError(msg);
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full mt-4 px-4 py-4 rounded-lg bg-zinc-900/40 border border-zinc-800/50 hover:border-zinc-700/70 transition-colors duration-150">
+      <div className="flex items-center gap-2 mb-3">
+        <Heart size={11} className="text-rose-500/80" />
+        <span className="text-[9px] font-bold text-zinc-400 tracking-[0.2em] uppercase">
+          Підтримати проект
+        </span>
+      </div>
+      <p className="text-[10px] text-zinc-500 leading-relaxed mb-3">
+        Донат через Monobank допомагає розвивати платформу для всіх.
+      </p>
+      <div className="grid grid-cols-3 gap-1.5 mb-3">
+        {DONATION_AMOUNTS_USD.map((amount) => (
+          <button
+            key={amount}
+            type="button"
+            onClick={() => setSelected(amount)}
+            className={`py-2 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
+              selected === amount
+                ? 'bg-zinc-100 text-zinc-900 border border-zinc-100'
+                : 'bg-zinc-900/60 text-zinc-400 border border-zinc-800/70 hover:border-zinc-700 hover:text-zinc-200'
+            }`}
+          >
+            ${amount}
+          </button>
+        ))}
+      </div>
+      {error && (
+        <p className="text-[10px] text-red-400 mb-2 flex items-center gap-1">
+          <AlertCircle size={10} />
+          {error}
+        </p>
+      )}
+      <button
+        type="button"
+        onClick={handleDonate}
+        disabled={isLoading}
+        className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-md bg-zinc-800/80 hover:bg-zinc-800 border border-zinc-700/70 hover:border-zinc-600 text-zinc-200 text-[11px] font-medium transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {isLoading ? (
+          <Loader2 size={11} className="animate-spin" />
+        ) : (
+          <>
+            <Heart size={11} className="text-rose-500/80" />
+            Задонатити ${selected}
+          </>
+        )}
+      </button>
     </div>
   );
 }
@@ -1213,6 +1296,9 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               className="text-zinc-800 group-hover:text-zinc-600 flex-shrink-0 transition-all duration-200 group-hover:translate-x-0.5"
             />
           </button>
+
+          {/* Donate */}
+          <DonateCard />
 
           {/* Footer legal links */}
           <div className="mt-5 pb-4 sm:pb-0 flex flex-wrap justify-center gap-x-3 gap-y-1.5">

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -477,6 +477,46 @@ class HTTPMCPServer {
       }
     }) as any);
 
+    // Public donation endpoint — no auth, no balance credit.
+    // Creates a Monobank invoice with DONATION- reference. Money lands in the
+    // merchant Monobank account; webhook gracefully ignores (payment_intent
+    // lookup returns empty, handler returns {received:true}).
+    this.app.post('/api/donations/create', (async (req: Request, res: Response) => {
+      try {
+        const { amount_usd, amount_uah, email } = req.body || {};
+
+        let amountUah: number;
+        if (typeof amount_uah === 'number' && amount_uah >= 1) {
+          amountUah = amount_uah;
+        } else if (typeof amount_usd === 'number' && amount_usd >= 1) {
+          const converted = await this.billing.currencyService.convertUsdToUah(amount_usd);
+          amountUah = Math.round(converted.amountUah);
+        } else {
+          return res.status(400).json({
+            error: 'Invalid request',
+            message: 'amount_usd (≥1) or amount_uah (≥1) is required',
+          });
+        }
+
+        if (amountUah > 200000) {
+          return res.status(400).json({
+            error: 'Invalid request',
+            message: 'Максимальна сума донату — 200 000 ₴',
+          });
+        }
+
+        const safeEmail = typeof email === 'string' && email.length < 256 ? email : undefined;
+        const result = await this.billing.monobankService.createDonationInvoice(amountUah, safeEmail);
+        res.json({ ...result, amountUah });
+      } catch (error: any) {
+        logger.error('[DonationAPI] Failed to create donation invoice', { error: error.message });
+        res.status(500).json({
+          error: 'Не вдалося створити рахунок для донату',
+          message: error.message,
+        });
+      }
+    }) as any);
+
     // Billing inline routes (balance, history, topup, settings, statistics, invoices)
     this.app.use('/api/billing', requireJWT as any, createBillingInlineRoutes({
       billingService: this.billing.billingService,

--- a/mcp_backend/src/services/__mocks__/monobank-service-mock.ts
+++ b/mcp_backend/src/services/__mocks__/monobank-service-mock.ts
@@ -49,6 +49,22 @@ export class MockMonobankService extends MonobankService {
     return { invoiceId, pageUrl, paymentIntentId: invoiceId };
   }
 
+  async createDonationInvoice(
+    amountUah: number,
+    email?: string
+  ): Promise<{ invoiceId: string; pageUrl: string }> {
+    if (amountUah < 1) {
+      throw new Error('Мінімальна сума донату — 1 ₴');
+    }
+
+    const invoiceId = `mock-donation-${Date.now()}`;
+    const pageUrl = `${process.env.FRONTEND_URL || 'http://localhost:5173'}/payment/success?mock=true&donation=1&invoiceId=${invoiceId}`;
+
+    logger.info('[MockMonobankService] Created mock donation invoice', { amountUah, invoiceId, email });
+
+    return { invoiceId, pageUrl };
+  }
+
   async handleWebhook(_rawBody: Buffer | string, body: MonobankWebhookBody, _signature: string): Promise<{ received: boolean }> {
     logger.info('[MockMonobankService] Mock webhook received', { invoiceId: body.invoiceId, status: body.status });
 

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -150,6 +150,66 @@ export class MonobankService {
     };
   }
 
+  /**
+   * Create a Monobank donation invoice (no user_id, no balance credit).
+   * Used by the public donation button on the login page.
+   * Reference prefix `DONATION-` lets webhook handlers distinguish donations
+   * from normal top-ups.
+   */
+  async createDonationInvoice(
+    amountUah: number,
+    email?: string
+  ): Promise<{ invoiceId: string; pageUrl: string }> {
+    const key = this.apiKey;
+
+    if (amountUah < 1) {
+      throw new Error('Мінімальна сума донату — 1 ₴');
+    }
+
+    const amountKopecks = Math.round(amountUah * 100);
+    const orderRef = `DONATION-${Date.now()}`;
+    const description = `Донат SecondLayer: ${amountUah.toFixed(0)} ₴`;
+    const redirectBase = this.redirectUrl;
+
+    logger.info('[MonobankService] Creating donation invoice', { amountUah, amountKopecks, orderRef });
+
+    const response = await fetch('https://api.monobank.ua/api/merchant/invoice/create', {
+      method: 'POST',
+      headers: {
+        'X-Token': key,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        amount: amountKopecks,
+        ccy: 980,
+        merchantPaymInfo: {
+          reference: orderRef,
+          destination: description,
+          comment: description,
+        },
+        redirectUrl: `${redirectBase}/payment/success?donation=1`,
+        webHookUrl: `${this.getPublicUrl()}/webhooks/monobank`,
+        validity: 3600,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Monobank API error: ${response.status} ${body}`);
+    }
+
+    const data = (await response.json()) as { invoiceId: string; pageUrl: string };
+
+    logger.info('[MonobankService] Donation invoice created', {
+      invoiceId: data.invoiceId,
+      amountUah,
+      orderRef,
+      email: email ? '[provided]' : '[none]',
+    });
+
+    return { invoiceId: data.invoiceId, pageUrl: data.pageUrl };
+  }
+
   private cachedPubKey: string | null = null;
   private pubKeyFetchedAt = 0;
 


### PR DESCRIPTION
## Summary

- Adds a **Підтримати проект** card on the login page (right panel, below the GDPR badge) with three preset amounts — **\$5 / \$10 / \$20** — that redirects to a Monobank hosted payment page.
- New public endpoint `POST /api/donations/create` (no JWT) — accepts `amount_usd`, converts to UAH via the cached NBU rate, caps at 200 000 ₴, calls Monobank with a `DONATION-<timestamp>` reference, and returns `{pageUrl, invoiceId, amountUah}`.
- New `MonobankService.createDonationInvoice(amountUah, email?)` method — does NOT persist to `payment_intents` and does NOT credit any user balance. The reference prefix distinguishes donations from top-ups.
- Matching `MockMonobankService.createDonationInvoice` for dev mode.

Webhook safety: when a donation invoice succeeds, the existing `handleWebhook` looks up `payment_intents` by `invoiceId`, finds none, logs a warning, and returns `{received:true}` — so no balance is credited and no error is thrown. No code change to the webhook path was needed.

Styled to match the login page's dark zinc aesthetic (`bg-zinc-900/40`, `border-zinc-800/50`, rose heart accent) — no new color tokens introduced.

## Test plan

- [x] Backend `tsc --noEmit` — clean on touched files (pre-existing `node-pty` errors are unrelated).
- [x] Frontend `tsc --noEmit` — clean.
- [x] End-to-end Monobank API test against the **prod** key (payload format identical to `createDonationInvoice`) — invoice created, `pageUrl` returned, `DONATION-` reference preserved, status endpoint returns expected fields. Test invoice auto-expires in 1 hour per `validity:3600`.
- [ ] Post-deploy smoke test: hit https://legal.org.ua/login, click \$5 → confirm redirect to `pay.monobank.ua/<id>` with amount ≈ 5 × current rate.
- [ ] Post-deploy: pay a small donation end-to-end and confirm the webhook no-ops (no balance credited to any user, no errors in backend logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a donation card to the login page with $5/$10/$20 presets that redirect to a Monobank payment page. Introduces a public endpoint to create donation invoices that never credit user balance.

- **New Features**
  - Login page: “Підтримати проект” card with $5/$10/$20; redirects to Monobank `pageUrl`.
  - Public `POST /api/donations/create` (no auth): accepts `amount_usd` or `amount_uah`, converts USD via cached NBU rate, caps at 200 000 ₴, returns `{ pageUrl, invoiceId, amountUah }`.
  - `MonobankService.createDonationInvoice(amountUah, email?)`: uses `DONATION-<timestamp>` reference, 1h validity, sets redirect/webhook URLs; does not create `payment_intents` or credit balance (webhook no-ops).
  - `MockMonobankService.createDonationInvoice` for dev.

<sup>Written for commit c31c7997798718b03dbe4272d1fc75a374f278c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

