### PR TITLE
fix(legislation): recover text for short КМУ regulations (LEXAI-865)

### DIFF
--- a/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-fallback.test.ts
+++ b/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-fallback.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for RadaLegislationAdapter fallback parsers — short regulations without
+ * structured articles or numbered punkts (e.g. КМУ розпорядження).
+ */
+
+import axios from 'axios';
+import { RadaLegislationAdapter } from '../rada-legislation-adapter.js';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// КМУ 265-р від 24.04.2019 — розпорядження з коротким основним текстом
+// та додатком-таблицею КВЕД. Немає жодних <span class=rvts9>Стаття N</span>
+// і немає нумерованих пунктів — обидва попередні парсери дають 0 статей.
+const KMU_265_PRINT_HTML = `
+<!DOCTYPE html><html><head><title>КМУ 265-р</title></head><body>
+<div id="prnpanel"><a href="#" onclick="window.print();return false;">Друкувати</a>
+<button>+збільшити</button><button>−зменшити</button>
+або <kbd>Ctrl</kbd> + mouse wheel</div>
+<div id="article">
+<p class=rvps17><span class=rvts23>КАБІНЕТ МІНІСТРІВ УКРАЇНИ</span>
+<br><span class=rvts64>РОЗПОРЯДЖЕННЯ</span></p>
+<p class=rvps7><span class=rvts9>від 24 квітня 2019 р. № 265-р</span>
+<br><span class=rvts9>Київ</span></p>
+<p class=rvps6><span class=rvts23>Про затвердження видів економічної діяльності, які належать до креативних індустрій</span></p>
+<p class=rvps2>Затвердити перелік видів економічної діяльності, які належать до креативних індустрій, згідно з додатком.</p>
+<p class=rvps4><span class=rvts44>Прем'єр-міністр України</span></p>
+<p class=rvps15><span class=rvts44>В.ГРОЙСМАН</span></p>
+<p class=rvps6><span class=rvts23>ПЕРЕЛІК</span>
+<br><span class=rvts23>видів економічної діяльності, які належать до креативних індустрій</span></p>
+<table><tr><td><p>32.12</p></td><td><p>Виробництво ювелірних і подібних виробів</p></td></tr>
+<tr><td><p>90.02</p></td><td><p>Діяльність із підтримки театральних і музичних заходів</p></td></tr></table>
+</div>
+</body></html>
+`;
+
+describe('RadaLegislationAdapter — fallback_whole_document', () => {
+  let adapter: RadaLegislationAdapter;
+  let mockAxiosInstance: any;
+
+  beforeEach(() => {
+    mockAxiosInstance = { get: jest.fn() };
+    mockedAxios.create = jest.fn().mockReturnValue(mockAxiosInstance);
+    adapter = new RadaLegislationAdapter({} as any);
+  });
+
+  test('extracts whole document as single article when no Стаття / punkts found (LEXAI-865)', async () => {
+    mockAxiosInstance.get.mockResolvedValue({ data: KMU_265_PRINT_HTML });
+
+    const { metadata, articles } = await adapter.fetchLegislation('265-2019-р');
+
+    expect(metadata.rada_id).toBe('265-2019-р');
+    expect(articles).toHaveLength(1);
+
+    const article = articles[0];
+    expect(article.article_number).toBe('1');
+    expect(article.metadata?.extraction_method).toBe('fallback_whole_document');
+
+    // Main regulatory text must be present
+    expect(article.full_text).toContain('Затвердити перелік видів економічної діяльності');
+    // Appendix (КВЕД codes) must be included
+    expect(article.full_text).toContain('32.12');
+    expect(article.full_text).toContain('Виробництво ювелірних');
+    expect(article.full_text).toContain('90.02');
+    // Print-panel chrome must be stripped
+    expect(article.full_text).not.toContain('Друкувати');
+    expect(article.full_text).not.toContain('mouse wheel');
+    expect(article.full_text).not.toContain('збільшити');
+    // byte_size must reflect actual text length
+    expect(article.byte_size).toBeGreaterThan(200);
+  });
+
+  test('does not use whole-document fallback when structured articles exist', async () => {
+    const structuredHtml = `
+<html><body><div id="article">
+<p><span class=rvts9>Стаття 1. Загальні положення</span>
+Цей Закон встановлює основи правового регулювання.</p>
+<p><span class=rvts9>Стаття 2. Сфера дії</span>
+Дія цього Закону поширюється на всіх резидентів України.</p>
+<p><span class=rvts9>Стаття 3. Визначення термінів</span>
+Для цілей цього Закону терміни вживаються в такому значенні.</p>
+<p><span class=rvts9>Стаття 4. Принципи</span>
+Основними принципами є законність, рівність, гласність, незалежність.</p>
+<p><span class=rvts9>Стаття 5. Права та обов'язки</span>
+Кожен має право на судовий захист своїх прав і законних інтересів.</p>
+<p><span class=rvts9>Стаття 6. Відповідальність</span>
+Порушення вимог цього Закону тягне за собою відповідальність згідно з законодавством.</p>
+</div></body></html>`;
+    mockAxiosInstance.get.mockResolvedValue({ data: structuredHtml });
+
+    const { articles } = await adapter.fetchLegislation('test-law');
+
+    expect(articles.length).toBeGreaterThan(1);
+    // None should have been produced by the whole-document fallback
+    for (const a of articles) {
+      expect(a.metadata?.extraction_method).not.toBe('fallback_whole_document');
+    }
+  });
+});

--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -367,6 +367,9 @@ export class RadaLegislationAdapter {
 
   private extractArticlesFallback($: cheerio.CheerioAPI, radaId: string): LegislationArticle[] {
     const articles: LegislationArticle[] = [];
+    // Strip RADA's print-page chrome so we don't capture "Друкувати"/"Допомога"/
+    // keyboard hints when falling back to whole-document extraction.
+    $('#prnpanel, script, style, noscript, header, footer, nav').remove();
     // Cheerio .text() strips newlines between block elements (p, div, br),
     // so we inject newlines before extracting text to preserve paragraph boundaries
     $('p, div, br').each((_i, el) => {
@@ -443,6 +446,31 @@ export class RadaLegislationAdapter {
 
       if (articles.length > 0) {
         logger.info(`Extracted ${articles.length} punkts (not articles) from ${radaId} via fallback`);
+      }
+    }
+
+    // Last-resort fallback: short documents without Стаття/numbered punkts
+    // (КМУ розпорядження, накази, короткі постанови з додатками-таблицями).
+    // Store the whole document body as a single "article" so the text is at
+    // least retrievable instead of yielding total_articles = 0.
+    if (articles.length === 0) {
+      const wholeText = bodyText
+        .replace(/ /g, ' ')
+        .replace(/[ \t]+\n/g, '\n')
+        .replace(/\n{3,}/g, '\n\n')
+        .trim();
+
+      if (wholeText.length > 50) {
+        articles.push({
+          article_number: '1',
+          full_text: wholeText,
+          byte_size: Buffer.byteLength(wholeText, 'utf8'),
+          metadata: {
+            rada_id: radaId,
+            extraction_method: 'fallback_whole_document',
+          },
+        });
+        logger.info(`Extracted whole document as single article for ${radaId} via fallback_whole_document (${wholeText.length} chars)`);
       }
     }
 

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -418,19 +418,18 @@ export class LegislationService {
     radaId = normalizeRadaId(radaId);
     // Case-insensitive lookup — RADA API may return different casing (e.g. 254к/96-ВР vs 254к/96-вр)
     const result = await this.db.query(
-      'SELECT id, rada_id FROM legislation WHERE LOWER(rada_id) = LOWER($1)',
+      'SELECT id, rada_id, total_articles FROM legislation WHERE LOWER(rada_id) = LOWER($1)',
       [radaId]
     );
-    // If found with different case, use the DB version for consistency
     if (result.rows.length > 0) {
-      return true;
-    }
-
-    if (result.rows.length > 0) {
-      // Legislation exists — no need to re-fetch.
-      // Previously we re-fetched when section_number was missing, but some laws
-      // (e.g. Кримінальний кодекс 1618-15) don't have section structure in RADA API,
-      // causing an infinite re-fetch loop on every request.
+      const row = result.rows[0];
+      // If metadata was saved but parser failed to extract any text
+      // (total_articles = 0), retry the fetch. Previously this record
+      // was considered "present" and user got an empty document.
+      if (row.total_articles === 0 || row.total_articles === null) {
+        logger.info(`Legislation ${radaId} exists but has no articles (total_articles=${row.total_articles}), refetching...`);
+        return this.refetchLegislation(radaId);
+      }
       return true;
     }
 


### PR DESCRIPTION
## Summary

- Fixes LEXAI-865: КМУ розпорядження №265-р від 24.04.2019 та інші короткі акти зберігалися в БД з `total_articles=0` і без тексту.
- Корінь: обидва парсери (`extractArticles` і `extractArticlesFallback`) розраховують на `Стаття N` або нумеровані пункти на початку рядка. Розпорядження цього формату не мають — лише абзац + додаток-таблиця.
- Додано третій fallback `fallback_whole_document` + повторний fetch в `ensureLegislationExists` коли `total_articles=0`, щоб існуючі порожні записи самоочистилися при першому запиті після деплою.

## Changes

- `mcp_backend/src/adapters/rada-legislation-adapter.ts`
  - `extractArticlesFallback` видаляє service chrome (`#prnpanel`, `script/style/nav/header/footer`) перед extraction.
  - Додано останній fallback: якщо Стаття/пункт паттерни дали 0 статей — зберегти увесь текст як `article_number='1'` з `extraction_method='fallback_whole_document'`.
- `mcp_backend/src/services/legislation-service.ts`
  - `ensureLegislationExists` повторює fetch якщо запис має `total_articles=0|null`, замість повернення `true`.
- `mcp_backend/src/adapters/__tests__/rada-legislation-adapter-fallback.test.ts` — новий тест: whole-document fallback працює для розпорядження 265-р, і НЕ активується для нормально структурованого закону.

## Test plan

- [x] `npx tsc --noEmit` — без нових помилок
- [x] `jest src/services/__tests__/legislation-service.test.ts src/services/__tests__/legislation-reference.test.ts` — 40/40 passed
- [x] `jest src/adapters/__tests__/rada-legislation-adapter-fallback.test.ts` — 2/2 passed
- [x] Ручна перевірка проти справжнього HTML `zakon.rada.gov.ua/laws/show/265-2019-р/print`: видобувається 2460 символів чистого тексту (заголовок + основна норма + весь перелік КВЕД), без print-panel сміття.

## Після merge

Після автодеплою через CI/CD perевірити:
```
# в prod БД існуючий запис має total_articles=0 — на перший запит tool
# `get_legislation_section` / `search_legislation` для 265-2019-р ensureLegislationExists
# виявить total_articles=0 і повторно вивантажить через fallback_whole_document.
```

Plane: https://plane.legal.org.ua/lexai/browse/LEXAI-865/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore missing text for short KMU regulations by adding a whole-document extraction fallback and self-healing for empty records. Addresses LEXAI-865 so acts like 265‑р are now readable and searchable.

- **Bug Fixes**
  - Added final fallback in `rada-legislation-adapter`: when no "Стаття" or numbered points are found, save the cleaned document as a single article (`article_number='1'`, `extraction_method='fallback_whole_document'`).
  - Stripped print-page chrome before extraction (`#prnpanel`, `script`, `style`, `nav`, `header`, `footer`).
  - Updated `ensureLegislationExists` to refetch when `total_articles` is `0` or `null` to auto-recover empty entries.
  - Added tests for short regulations (e.g., 265‑р) and confirmed fallback is not used for structured laws.

<sup>Written for commit 801b17df56cec2125d5ba4e3a2a226b611a96e02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

