### PR TITLE
feat(login): donate in UAH (200/400 ₴ + custom amount)

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -227,21 +227,32 @@ function PanelDivider() {
   );
 }
 
-const DONATION_AMOUNTS_USD = [5, 10, 20] as const;
+const DONATION_AMOUNTS_UAH = [200, 400] as const;
+const DONATION_MAX_UAH = 200000;
 
 function DonateCard() {
-  const [selected, setSelected] = useState<number>(10);
+  const [selected, setSelected] = useState<number | 'custom'>(200);
+  const [customAmount, setCustomAmount] = useState<string>('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const amountUah = selected === 'custom'
+    ? Math.floor(parseFloat(customAmount) || 0)
+    : selected;
+  const canDonate = amountUah >= 1 && amountUah <= DONATION_MAX_UAH;
+
   const handleDonate = async () => {
+    if (!canDonate) {
+      setError(amountUah < 1 ? 'Мінімум 1 ₴' : `Максимум ${DONATION_MAX_UAH.toLocaleString('uk-UA')} ₴`);
+      return;
+    }
     setIsLoading(true);
     setError(null);
     try {
       const response = await fetch(`${BASE_URL}/api/donations/create`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount_usd: selected }),
+        body: JSON.stringify({ amount_uah: amountUah }),
       });
 
       const data = await response.json();
@@ -268,22 +279,49 @@ function DonateCard() {
       <p className="text-[10px] text-zinc-500 leading-relaxed mb-3">
         Донат через Monobank допомагає розвивати платформу для всіх.
       </p>
-      <div className="grid grid-cols-3 gap-1.5 mb-3">
-        {DONATION_AMOUNTS_USD.map((amount) => (
+      <div className="grid grid-cols-3 gap-1.5 mb-2">
+        {DONATION_AMOUNTS_UAH.map((amount) => (
           <button
             key={amount}
             type="button"
-            onClick={() => setSelected(amount)}
+            onClick={() => { setSelected(amount); setError(null); }}
             className={`py-2 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
               selected === amount
                 ? 'bg-zinc-100 text-zinc-900 border border-zinc-100'
                 : 'bg-zinc-900/60 text-zinc-400 border border-zinc-800/70 hover:border-zinc-700 hover:text-zinc-200'
             }`}
           >
-            ${amount}
+            {amount} ₴
           </button>
         ))}
+        <button
+          type="button"
+          onClick={() => { setSelected('custom'); setError(null); }}
+          className={`py-2 rounded-md text-[11px] font-medium tracking-wide transition-all duration-150 ${
+            selected === 'custom'
+              ? 'bg-zinc-100 text-zinc-900 border border-zinc-100'
+              : 'bg-zinc-900/60 text-zinc-400 border border-zinc-800/70 hover:border-zinc-700 hover:text-zinc-200'
+          }`}
+        >
+          Своя
+        </button>
       </div>
+      {selected === 'custom' && (
+        <div className="relative mb-3">
+          <input
+            type="number"
+            min="1"
+            max={DONATION_MAX_UAH}
+            step="1"
+            inputMode="numeric"
+            value={customAmount}
+            onChange={(e) => { setCustomAmount(e.target.value); setError(null); }}
+            placeholder="Введіть суму"
+            className="block w-full pl-3 pr-8 py-2 bg-zinc-900/60 border border-zinc-800/70 rounded-md text-[12px] text-zinc-200 placeholder-zinc-600 focus:outline-none focus:ring-1 focus:ring-zinc-600 focus:border-zinc-600 transition-all"
+          />
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[11px] text-zinc-500 pointer-events-none">₴</span>
+        </div>
+      )}
       {error && (
         <p className="text-[10px] text-red-400 mb-2 flex items-center gap-1">
           <AlertCircle size={10} />
@@ -293,7 +331,7 @@ function DonateCard() {
       <button
         type="button"
         onClick={handleDonate}
-        disabled={isLoading}
+        disabled={isLoading || !canDonate}
         className="w-full flex items-center justify-center gap-2 px-3 py-2 rounded-md bg-zinc-800/80 hover:bg-zinc-800 border border-zinc-700/70 hover:border-zinc-600 text-zinc-200 text-[11px] font-medium transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed"
       >
         {isLoading ? (
@@ -301,7 +339,7 @@ function DonateCard() {
         ) : (
           <>
             <Heart size={11} className="text-rose-500/80" />
-            Задонатити ${selected}
+            {canDonate ? `Задонатити ${amountUah} ₴` : 'Задонатити'}
           </>
         )}
       </button>


### PR DESCRIPTION
## Summary

- Donate presets switched from USD (\$5/\$10/\$20) → **UAH: 200 ₴, 400 ₴, + Своя (custom)**.
- Custom amount input appears when "Своя" is selected. Accepts integer UAH in range 1 — 200 000 ₴ (same cap the backend enforces).
- Frontend now sends `amount_uah` to `POST /api/donations/create` — the endpoint already supports both `amount_uah` and `amount_usd`, so no backend change is needed.
- Submit button is disabled until a valid amount is entered; label reflects the current amount (e.g. "Задонатити 200 ₴").

## Test plan

- [x] Frontend `tsc --noEmit` — clean.
- [ ] Post-deploy: 200 ₴ preset → redirects to pay.monobank.ua with 200 ₴.
- [ ] Post-deploy: Своя → 777 ₴ → redirects with 777 ₴.
- [ ] Post-deploy: Своя → empty/0 → button disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Login page donation flow from USD presets to UAH, adding 200 ₴, 400 ₴, and a custom amount with validation and clear errors. Frontend now sends `amount_uah` to `POST /api/donations/create`.

- **New Features**
  - UAH presets: 200 ₴, 400 ₴, plus "Своя" (custom).
  - Custom input accepts whole UAH from 1 to 200,000.
  - Submit disabled until valid; inline min/max errors; button shows selected amount.
  - Sends `amount_uah`; backend endpoint already supports UAH/USD, so no backend changes.

<sup>Written for commit c63c601fce529956617198e5977d4d85dc818963. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

