### PR TITLE
fix: postcss + follow-redirects (Dependabot medium #175, #176, #187)

### DIFF
--- a/lexwebapp/package-lock.json
+++ b/lexwebapp/package-lock.json
@@ -3501,9 +3501,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -26,7 +26,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.27",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.10",
         "tailwindcss": "^3.4.19",
         "typescript": "^5.5.4",
         "vite": "^8.0.8",
@@ -1622,9 +1622,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3358,9 +3358,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/platform/package.json
+++ b/platform/package.json
@@ -29,7 +29,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.27",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.19",
     "typescript": "^5.5.4",
     "vite": "^8.0.8",


### PR DESCRIPTION
## Summary
- `platform/package.json`: `postcss` `^8.5.8` → `^8.5.10` (closes #187 — XSS in CSS Stringify)
- `platform/package-lock.json`: refresh pulls `follow-redirects` `1.15.11` → `1.16.0` via `axios`'s caret range (closes #176 — header leak on cross-domain redirect)
- `lexwebapp/package-lock.json`: same refresh, same fix (closes #175)

## Notes
- Only `platform/package.json` needed a manifest bump; `follow-redirects` is transitive via axios — `npm update` was enough since axios already pins `^1.15.11`.
- `lexwebapp/package-lock.json` is committed (Dockerfile uses it standalone), `platform/package-lock.json` is committed (it's whitelisted in `.gitignore`).
- Local `npm audit` still shows `picomatch` (high) and `brace-expansion` (moderate) inside lexwebapp — both already `fixed`/`dismissed` in Dependabot's view, leaving alone.

## Test plan
- [x] `lexwebapp` build passes (`npm run build`)
- [x] `platform` build passes (`npm run build`)
- [ ] CI green
- [ ] Dependabot alerts #175, #176, #187 auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `postcss` to ^8.5.10 and refreshes lockfiles to pull `follow-redirects` 1.16.0 via `axios`. This patches the `postcss` XSS and the cross-domain redirect header leak (fixes #187, #176, #175).

- **Dependencies**
  - `platform/package.json`: `postcss` ^8.5.8 → ^8.5.10.
  - `platform/package-lock.json` and `lexwebapp/package-lock.json`: refreshed to pick up `follow-redirects` 1.16.0 via `axios`.
  - Builds pass for `platform` and `lexwebapp`.

<sup>Written for commit b3ae963c6272562dd82009cc6e040fe5d50d30b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

