### PR TITLE
fix(lexwebapp): split axios + api utils into vendor chunks (prod white screen fix)

### DIFF
--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -905,6 +905,27 @@ export default defineConfig(({ mode }) => {
     build: {
       outDir: mode === 'staging' ? 'dist-staging' : 'dist',
       sourcemap: mode === 'staging' || mode === 'development',
+      rollupOptions: {
+        output: {
+          // Pin shared libraries and base utilities into dedicated vendor
+          // chunks. Otherwise rolldown places axios + apiClient + BaseService
+          // alongside the main chunk, while service classes that extend
+          // BaseService end up in feature chunks, producing circular imports
+          // (feature -> index -> feature). At module init the imported binding
+          // is undefined and the app crashes ("Cannot read properties of
+          // undefined (reading 'create')", "Class extends value undefined").
+          manualChunks(id: string) {
+            if (id.includes('/node_modules/axios/')) return 'vendor-axios'
+            if (
+              id.includes('/src/utils/api/') ||
+              id.includes('/src/utils/api-client') ||
+              id.includes('/src/services/base/')
+            ) {
+              return 'vendor-api'
+            }
+          },
+        },
+      },
     },
     server: {
       host: true,


### PR DESCRIPTION
## Summary

- Production at https://legal.org.ua/ shows a white screen since the vite 8.0.10 bump (#1498). Headless Chrome console: `Uncaught TypeError: Cannot read properties of undefined (reading 'create')` from `client-*.js` → React never mounts.
- Root cause: rolldown's default chunking placed axios, `apiClient` (= `axios.create(...)`) and `BaseService` inside the main `index` chunk, while feature chunks (api client wrapper, crypto services that `extends BaseService`) ended up in separate chunks that import back from `index`. That created a circular import where module-init code (`axios.create(...)`, `class X extends BaseService`) read bindings before `index` had finished initialising them — so they were `undefined`.
- Fix: pin axios and the api/base utilities into dedicated vendor chunks (`vendor-axios`, `vendor-api`) so the cross-chunk dependency graph is acyclic. No source-code change required, no revert of #1498 / vite 8.0.10, CVE patches stay in place.

## Test plan

- [x] Local production build (`npx vite build`) succeeds, produces `vendor-axios-*.js` and `vendor-api-*.js` chunks.
- [x] `npx tsc --noEmit` passes.
- [x] `npx vite preview` + headless Chrome against the built bundle: no console errors, root `<div id="root">` populated with the login page (Ukrainian copy + canvas + form).
- [ ] After merge: CI/CD builds and deploys to local, then promotes to prod via blue-green pipeline. Verify https://legal.org.ua/ renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the production white screen by moving `axios` and base API utilities into dedicated vendor chunks. This breaks a circular import from `vite` 8.0.10 chunking so the app boots correctly.

- **Bug Fixes**
  - Adds `rollupOptions.output.manualChunks` in `vite.config.ts` to create `vendor-axios` and `vendor-api`.
  - Ensures `axios.create(...)` and `BaseService` initialize before feature chunks, resolving errors like "Cannot read properties of undefined (reading 'create')" and "Class extends value undefined".
  - No source changes required; keeps the `vite` 8.0.10 upgrade and CVE patches.

<sup>Written for commit a536cac08652d9e1687bfbc44185f9af6c57551d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

