### PR TITLE
fix(lexwebapp): dedup get_legislation_section requests on rapid TOC clicks

### DIFF
--- a/lexwebapp/src/pages/LegalCodesLibraryPage/useLegalCodes.ts
+++ b/lexwebapp/src/pages/LegalCodesLibraryPage/useLegalCodes.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { mcpService } from '../../services';
 import { showToast } from '../../utils/toast';
 import { toastT } from '../../i18n/toast-i18n';
@@ -35,6 +35,10 @@ export function useLegalCodes() {
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searchLoading, setSearchLoading] = useState(false);
   const [searchTotal, setSearchTotal] = useState(0);
+
+  // Tracks the article number currently being fetched, so duplicate clicks
+  // (and any stale re-renders) don't fire a second request for the same article.
+  const inFlightArticleRef = useRef<string | null>(null);
 
   // Favorites
   const [favorites, setFavorites] = useState<Set<string>>(loadFavorites);
@@ -161,6 +165,9 @@ export function useLegalCodes() {
 
   const fetchArticle = useCallback(async (articleNumber: string) => {
     if (!selectedCode) return;
+    if (inFlightArticleRef.current === articleNumber) return;
+
+    inFlightArticleRef.current = articleNumber;
     setLoadingArticle(true);
     setSelectedArticleNumber(articleNumber);
     setShowComment(false);
@@ -169,6 +176,7 @@ export function useLegalCodes() {
         rada_id: selectedCode,
         article_number: articleNumber,
       });
+      if (inFlightArticleRef.current !== articleNumber) return;
       const data = parseToolResult(result);
       if (data.error) {
         showToast.error(data.error);
@@ -177,10 +185,14 @@ export function useLegalCodes() {
         setCurrentArticle(data);
       }
     } catch (err: unknown) {
+      if (inFlightArticleRef.current !== articleNumber) return;
       showToast.error(getErrorMessage(err));
       setCurrentArticle(null);
     } finally {
-      setLoadingArticle(false);
+      if (inFlightArticleRef.current === articleNumber) {
+        inFlightArticleRef.current = null;
+        setLoadingArticle(false);
+      }
     }
   }, [selectedCode]);
 

--- a/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
+++ b/lexwebapp/src/pages/__tests__/LegalCodesLibraryPage.test.tsx
@@ -423,6 +423,46 @@ describe('LegalCodesLibraryPage', () => {
       });
     });
 
+    it('does not fire a duplicate request when the same article is clicked while loading', async () => {
+      const user = await openCodeViewer();
+
+      let resolveSection: (v: unknown) => void = () => {};
+      mockCallTool.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSection = resolve;
+          })
+      );
+
+      const articleBtns = screen
+        .getAllByRole('button')
+        .filter((btn) => btn.textContent?.includes('Ст. 1. Перша стаття'));
+
+      const callsBefore = mockCallTool.mock.calls.length;
+      await user.click(articleBtns[0]);
+      await user.click(articleBtns[0]);
+      await user.click(articleBtns[0]);
+
+      const sectionCalls = mockCallTool.mock.calls
+        .slice(callsBefore)
+        .filter(([toolName]) => toolName === 'get_legislation_section');
+      expect(sectionCalls).toHaveLength(1);
+
+      resolveSection(
+        makeToolResult({
+          rada_id: '435-15',
+          article_number: '1',
+          title: 'Перша стаття',
+          full_text: 'Текст',
+          url: 'https://example.com/article/1',
+        })
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Текст')).toBeInTheDocument();
+      });
+    });
+
     it('navigates back to listing on back button', async () => {
       const user = await openCodeViewer();
 


### PR DESCRIPTION
## Summary

- `LegalCodesLibraryPage.useLegalCodes.fetchArticle` had no dedup, no race-safe state updates, and no debouncing. A rapid double/triple click on a TOC entry — or any re-render path that calls it twice — fired N parallel `POST /api/v1/tools/get_legislation_section` requests, each landing as its own row in `cost_tracking`.
- Prod telemetry for one user showed bursts like 11 identical calls to ст. 1000 ЦК in 9s and 8 calls to ст. 105 Конституції in 1.3s (every 130–150 ms) — clearly programmatic/spammy, not deliberate.
- Fix tracks the in-flight article number in a ref. Repeated calls for the same article are skipped while one is in flight, and stale responses (article changed mid-fetch) are dropped on return.

## Test plan

- [x] `npx tsc --noEmit` clean for `lexwebapp`
- [x] `CI=1 npx vitest run src/pages/__tests__/LegalCodesLibraryPage.test.tsx` → 29 passed, 1 skipped (pre-existing flaky), 0 failed
- [x] New test: clicking the same TOC button 3× while the request is pending only fires `get_legislation_section` once
- [ ] Manual: open ЦК у бібліотеці, спам-клік на одній статті — у Network має бути 1 запит, не N
- [ ] Manual: швидкий перехід між двома статтями — рендериться остання, не race-condition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate article fetches on rapid TOC clicks in `LegalCodesLibraryPage`. Tracks the in-flight article and drops stale responses to prevent race conditions and extra API costs.

- **Bug Fixes**
  - Dedupes `POST /api/v1/tools/get_legislation_section` when the same article is already loading.
  - Discards responses if the selected article changed mid-fetch; only the latest updates state.
  - Adds a test to ensure 1 request when clicking the same article 3× while loading.

<sup>Written for commit cc198b0ae5bc423be80f5d0faed2a50de296b89a. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

