### PR TITLE
feat(lexwebapp): floating support widget (LEXAI-869)

### DIFF
--- a/lexwebapp/src/components/support/ConsultationBookingModal.tsx
+++ b/lexwebapp/src/components/support/ConsultationBookingModal.tsx
@@ -1,0 +1,49 @@
+/**
+ * Consultation booking modal — "Записатись на консультацію".
+ * Embeds the public Calendary booking page for legal-org-ua / 30-min.
+ */
+
+import { ExternalLink } from 'lucide-react';
+import { Modal } from '../ui/Modal';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const CALENDARY_URL = 'https://calendary.biz/b/legal-org-ua/30-min';
+
+export function ConsultationBookingModal({ isOpen, onClose }: Props) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Записатись на консультацію" size="xl">
+      <div className="space-y-3">
+        <p className="text-sm text-zinc-600">
+          Оберіть зручний час для 30-хвилинної демо-консультації. Деталі зустрічі прийдуть на ваш email.
+        </p>
+
+        <div className="rounded-lg overflow-hidden border border-zinc-200 bg-zinc-50">
+          <iframe
+            src={CALENDARY_URL}
+            title="Запис на консультацію через Calendary"
+            className="w-full h-[640px] border-0 bg-white"
+            loading="lazy"
+            referrerPolicy="no-referrer-when-downgrade"
+          />
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-zinc-500">
+          <span>Якщо віджет не завантажується — відкрийте сторінку в новій вкладці:</span>
+          <a
+            href={CALENDARY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-claude-text hover:underline font-medium"
+          >
+            calendary.biz
+            <ExternalLink size={12} />
+          </a>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/lexwebapp/src/components/support/FeedbackModal.tsx
+++ b/lexwebapp/src/components/support/FeedbackModal.tsx
@@ -1,0 +1,24 @@
+/**
+ * Feedback modal — "Написати зауваження".
+ */
+
+import { SupportContactForm } from './SupportContactForm';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function FeedbackModal({ isOpen, onClose }: Props) {
+  return (
+    <SupportContactForm
+      isOpen={isOpen}
+      onClose={onClose}
+      type="feedback"
+      title="Написати зауваження"
+      helpText="Опишіть проблему або баг. Що сталося, на якій сторінці, що ви очікували побачити? Чим детальніше — тим швидше виправимо."
+      placeholder="Наприклад: на сторінці «Адвокати» не відкривається фільтр за містом…"
+      submitLabel="Надіслати зауваження"
+    />
+  );
+}

--- a/lexwebapp/src/components/support/QuestionModal.tsx
+++ b/lexwebapp/src/components/support/QuestionModal.tsx
@@ -1,0 +1,24 @@
+/**
+ * Question modal — "Написати питання".
+ */
+
+import { SupportContactForm } from './SupportContactForm';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function QuestionModal({ isOpen, onClose }: Props) {
+  return (
+    <SupportContactForm
+      isOpen={isOpen}
+      onClose={onClose}
+      type="question"
+      title="Написати питання"
+      helpText="Поставте питання нашій команді — про функціонал, тарифи, інтеграції чи юридичні нюанси платформи. Відповімо на email вашого профілю."
+      placeholder="Наприклад: чи можна підключити мою колегію до спільного робочого простору?"
+      submitLabel="Надіслати питання"
+    />
+  );
+}

--- a/lexwebapp/src/components/support/SupportContactForm.tsx
+++ b/lexwebapp/src/components/support/SupportContactForm.tsx
@@ -1,0 +1,123 @@
+/**
+ * Shared contact form used by FeedbackModal and QuestionModal.
+ * Posts to /api/support/contact and shows a success state on submit.
+ */
+
+import { useEffect, useState } from 'react';
+import { Modal } from '../ui/Modal';
+import { supportService, type SupportContactType } from '../../services/api/SupportService';
+import { showToast } from '../../utils/toast';
+import { getErrorMessage } from '../../utils/errors';
+
+interface Props {
+  isOpen: boolean;
+  onClose: () => void;
+  type: SupportContactType;
+  title: string;
+  placeholder: string;
+  helpText: string;
+  submitLabel: string;
+}
+
+const MAX_LEN = 5000;
+
+export function SupportContactForm({
+  isOpen,
+  onClose,
+  type,
+  title,
+  placeholder,
+  helpText,
+  submitLabel,
+}: Props) {
+  const [message, setMessage] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  // Reset state whenever the modal opens fresh
+  useEffect(() => {
+    if (isOpen) {
+      setMessage('');
+      setSubmitted(false);
+      setSubmitting(false);
+    }
+  }, [isOpen]);
+
+  const handleSubmit = async () => {
+    const trimmed = message.trim();
+    if (trimmed.length < 3) {
+      showToast.error('Будь ласка, опишіть детальніше');
+      return;
+    }
+    if (trimmed.length > MAX_LEN) {
+      showToast.error(`Повідомлення задовге (макс. ${MAX_LEN} символів)`);
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await supportService.sendContact(type, trimmed);
+      setSubmitted(true);
+      showToast.success('Повідомлення надіслано — дякуємо!');
+    } catch (err) {
+      showToast.error(getErrorMessage(err) || 'Не вдалося надіслати повідомлення');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={title} size="md">
+      {submitted ? (
+        <div className="py-4 text-center">
+          <p className="text-base font-medium text-zinc-900">Дякуємо!</p>
+          <p className="mt-1 text-sm text-zinc-600">
+            Ми отримали ваше повідомлення і відповімо на email, вказаний у профілі.
+          </p>
+          <button
+            type="button"
+            onClick={onClose}
+            className="mt-5 px-5 py-2 rounded-lg bg-claude-text text-white text-sm font-medium hover:opacity-90"
+          >
+            Закрити
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-zinc-600">{helpText}</p>
+          <textarea
+            value={message}
+            onChange={e => setMessage(e.target.value)}
+            placeholder={placeholder}
+            rows={6}
+            maxLength={MAX_LEN}
+            disabled={submitting}
+            className="w-full px-3 py-2 border border-zinc-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-claude-text/20 focus:border-claude-text/40 resize-none disabled:bg-zinc-50"
+            autoFocus
+          />
+          <div className="flex items-center justify-between text-xs text-zinc-500">
+            <span>{message.length} / {MAX_LEN}</span>
+          </div>
+          <div className="flex gap-3 pt-1">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="flex-1 py-2.5 border border-zinc-300 rounded-lg text-sm font-medium text-zinc-700 hover:bg-zinc-50 disabled:opacity-50"
+            >
+              Скасувати
+            </button>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={submitting || message.trim().length < 3}
+              className="flex-1 py-2.5 bg-claude-text text-white rounded-lg text-sm font-medium hover:opacity-90 disabled:opacity-50"
+            >
+              {submitting ? 'Надсилаємо…' : submitLabel}
+            </button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/lexwebapp/src/components/support/SupportWidget.tsx
+++ b/lexwebapp/src/components/support/SupportWidget.tsx
@@ -1,0 +1,147 @@
+/**
+ * Support Widget (Floating Action Button)
+ * LEXAI-869 — bottom-right FAB that opens a drop-up menu with three actions:
+ *   1. Написати зауваження    → FeedbackModal
+ *   2. Написати питання       → QuestionModal
+ *   3. Записатись на консультацію → ConsultationBookingModal (calendary.biz)
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CalendarClock, HelpCircle, LifeBuoy, MessageSquareWarning, X } from 'lucide-react';
+import { useAuth } from '../../contexts/AuthContext';
+import { FeedbackModal } from './FeedbackModal';
+import { QuestionModal } from './QuestionModal';
+import { ConsultationBookingModal } from './ConsultationBookingModal';
+
+type ActiveModal = null | 'feedback' | 'question' | 'consultation';
+
+export function SupportWidget() {
+  const { isAuthenticated } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [active, setActive] = useState<ActiveModal>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close drop-up on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    window.addEventListener('mousedown', handler);
+    return () => window.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  // Close drop-up on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open]);
+
+  // Hide widget for unauthenticated users — feedback API requires login.
+  if (!isAuthenticated) return null;
+
+  const items = [
+    {
+      key: 'feedback' as const,
+      label: 'Написати зауваження',
+      icon: MessageSquareWarning,
+      iconClass: 'text-amber-600 bg-amber-50',
+    },
+    {
+      key: 'question' as const,
+      label: 'Написати питання',
+      icon: HelpCircle,
+      iconClass: 'text-sky-600 bg-sky-50',
+    },
+    {
+      key: 'consultation' as const,
+      label: 'Записатись на консультацію',
+      icon: CalendarClock,
+      iconClass: 'text-emerald-600 bg-emerald-50',
+    },
+  ];
+
+  return (
+    <>
+      <div
+        ref={containerRef}
+        className="fixed bottom-5 right-5 z-[1000] flex flex-col items-end gap-3"
+      >
+        <AnimatePresence>
+          {open && (
+            <motion.div
+              key="menu"
+              initial={{ opacity: 0, y: 8, scale: 0.96 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: 8, scale: 0.96 }}
+              transition={{ duration: 0.15 }}
+              className="w-[260px] rounded-xl bg-white shadow-xl border border-zinc-200 overflow-hidden"
+              role="menu"
+              aria-label="Опції підтримки"
+            >
+              {items.map(({ key, label, icon: Icon, iconClass }) => (
+                <button
+                  key={key}
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setActive(key);
+                    setOpen(false);
+                  }}
+                  className="w-full flex items-center gap-3 px-4 py-3 text-left text-sm text-zinc-800 hover:bg-zinc-50 transition-colors border-b last:border-b-0 border-zinc-100"
+                >
+                  <span className={`shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${iconClass}`}>
+                    <Icon size={16} strokeWidth={2} />
+                  </span>
+                  <span className="font-medium">{label}</span>
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={open ? 'Закрити меню підтримки' : 'Відкрити меню підтримки'}
+          className="w-14 h-14 rounded-full bg-claude-text text-white shadow-lg hover:shadow-xl active:scale-95 flex items-center justify-center transition-all"
+        >
+          <AnimatePresence mode="wait" initial={false}>
+            {open ? (
+              <motion.span
+                key="x"
+                initial={{ rotate: -45, opacity: 0 }}
+                animate={{ rotate: 0, opacity: 1 }}
+                exit={{ rotate: 45, opacity: 0 }}
+                transition={{ duration: 0.12 }}
+              >
+                <X size={22} strokeWidth={2.2} />
+              </motion.span>
+            ) : (
+              <motion.span
+                key="help"
+                initial={{ rotate: 45, opacity: 0 }}
+                animate={{ rotate: 0, opacity: 1 }}
+                exit={{ rotate: -45, opacity: 0 }}
+                transition={{ duration: 0.12 }}
+              >
+                <LifeBuoy size={22} strokeWidth={2} />
+              </motion.span>
+            )}
+          </AnimatePresence>
+        </button>
+      </div>
+
+      <FeedbackModal isOpen={active === 'feedback'} onClose={() => setActive(null)} />
+      <QuestionModal isOpen={active === 'question'} onClose={() => setActive(null)} />
+      <ConsultationBookingModal isOpen={active === 'consultation'} onClose={() => setActive(null)} />
+    </>
+  );
+}

--- a/lexwebapp/src/components/support/index.ts
+++ b/lexwebapp/src/components/support/index.ts
@@ -1,0 +1,4 @@
+export { SupportWidget } from './SupportWidget';
+export { FeedbackModal } from './FeedbackModal';
+export { QuestionModal } from './QuestionModal';
+export { ConsultationBookingModal } from './ConsultationBookingModal';

--- a/lexwebapp/src/layouts/MainLayout.tsx
+++ b/lexwebapp/src/layouts/MainLayout.tsx
@@ -11,6 +11,7 @@ import { RightPanel } from '../components/right-panel';
 import { TimeTrackerWidget } from '../components/time/TimeTrackerWidget';
 import { OnboardingTour } from '../components/onboarding/OnboardingTour';
 import { PendingInvitationsModal } from '../components/attorney/PendingInvitationsModal';
+import { SupportWidget } from '../components/support';
 import { useAuth } from '../contexts/AuthContext';
 import { useUIStore, useConsultationStore } from '../stores';
 import { ROUTES } from '../router/routes';
@@ -262,6 +263,9 @@ export function MainLayout() {
 
       {/* Onboarding Tour */}
       <OnboardingTour />
+
+      {/* Support Widget — floating help/feedback FAB (LEXAI-869) */}
+      <SupportWidget />
 
       {/* Pending Invitations Modal for attorneys */}
       <PendingInvitationsModal

--- a/lexwebapp/src/services/api/SupportService.ts
+++ b/lexwebapp/src/services/api/SupportService.ts
@@ -1,0 +1,22 @@
+/**
+ * Support Service
+ * Submits feedback and questions from the in-app SupportWidget (FAB).
+ */
+
+import { BaseService } from '../base/BaseService';
+
+export type SupportContactType = 'feedback' | 'question';
+
+export class SupportService extends BaseService {
+  async sendContact(type: SupportContactType, message: string): Promise<void> {
+    return this.request(() =>
+      this.client.post('/api/support/contact', {
+        type,
+        message,
+        pageUrl: typeof window !== 'undefined' ? window.location.href : undefined,
+      })
+    );
+  }
+}
+
+export const supportService = new SupportService();

--- a/lexwebapp/src/services/index.ts
+++ b/lexwebapp/src/services/index.ts
@@ -35,3 +35,6 @@ export { ConsultationService, consultationService } from './api/ConsultationServ
 
 // Encryption service (E2EE)
 export { EncryptionService, encryptionService } from './api/EncryptionService';
+
+// Support widget (in-app feedback/questions)
+export { SupportService, supportService } from './api/SupportService';

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -71,6 +71,7 @@ import { createJudgesRoutes } from './routes/judges-routes.js';
 import { JudgeAnalyticsService } from './services/judge-analytics-service.js';
 import { createJudgeAnalyticsRoutes } from './routes/judge-analytics-routes.js';
 import { createReferralRoutes } from './routes/referral-routes.js';
+import { createSupportRoutes } from './routes/support-routes.js';
 import { createLegislationMonitoringRoutes } from './routes/legislation-monitoring-routes.js';
 import { createUsageRoutes } from './routes/usage-routes.js';
 import { createSessionReplayRoutes, createAdminSessionReplayRoutes } from './routes/session-replay-routes.js';
@@ -610,6 +611,10 @@ class HTTPMCPServer {
     // Referral system routes
     this.app.use('/api/referral', createReferralRoutes(this.billing.referralService));
     logger.info('Referral routes registered at /api/referral');
+
+    // Support widget (FAB) — feedback / question submissions
+    this.app.use('/api/support', createSupportRoutes(this.billing.emailService, this.services.db));
+    logger.info('Support widget routes registered at /api/support');
 
     // Legislation monitoring routes - subscriptions, changes, notifications
     this.app.use('/api/legislation/monitoring', requireJWT as any, createLegislationMonitoringRoutes(this.app_.legislationMonitoringService));

--- a/mcp_backend/src/routes/support-routes.ts
+++ b/mcp_backend/src/routes/support-routes.ts
@@ -1,0 +1,75 @@
+/**
+ * Support Widget Routes
+ * Receives feedback/question submissions from the in-app SupportWidget (FAB)
+ * and forwards them to the support inbox via email.
+ */
+
+import { Router, Request, Response } from 'express';
+import type { EmailService } from '../services/email-service.js';
+import type { BaseDatabase } from '@secondlayer/shared';
+import { requireJWT } from '../middleware/dual-auth.js';
+import { logger } from '../utils/logger.js';
+
+const MAX_MESSAGE_LENGTH = 5000;
+
+export function createSupportRoutes(
+  emailService: EmailService,
+  db: BaseDatabase
+): Router {
+  const router = Router();
+
+  /**
+   * POST /api/support/contact
+   * Body: { type: 'feedback' | 'question', message: string, pageUrl?: string }
+   */
+  router.post('/contact', requireJWT as any, async (req: Request, res: Response) => {
+    try {
+      const userId = (req as any).user?.id;
+      if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+      const { type, message, pageUrl } = req.body || {};
+
+      if (type !== 'feedback' && type !== 'question') {
+        return res.status(400).json({ error: 'Невалідний тип звернення' });
+      }
+      if (!message || typeof message !== 'string') {
+        return res.status(400).json({ error: 'Повідомлення обов’язкове' });
+      }
+      const trimmed = message.trim();
+      if (trimmed.length < 3) {
+        return res.status(400).json({ error: 'Повідомлення занадто коротке' });
+      }
+      if (trimmed.length > MAX_MESSAGE_LENGTH) {
+        return res.status(400).json({ error: `Повідомлення задовге (макс. ${MAX_MESSAGE_LENGTH} символів)` });
+      }
+
+      const userResult = await db.query(
+        'SELECT email, name FROM users WHERE id = $1',
+        [userId]
+      );
+      const userRow = userResult.rows[0] as { email: string; name: string | null } | undefined;
+      if (!userRow?.email) {
+        return res.status(400).json({ error: 'У вашому профілі не вказано email' });
+      }
+
+      await emailService.sendSupportMessage({
+        type,
+        message: trimmed,
+        fromEmail: userRow.email,
+        fromName: userRow.name || userRow.email,
+        userId,
+        pageUrl: typeof pageUrl === 'string' ? pageUrl.slice(0, 500) : undefined,
+        userAgent: typeof req.headers['user-agent'] === 'string'
+          ? (req.headers['user-agent'] as string).slice(0, 300)
+          : undefined,
+      });
+
+      return res.json({ ok: true });
+    } catch (err: any) {
+      logger.error('Support contact submit failed', { error: err.message });
+      return res.status(500).json({ error: 'Не вдалося відправити повідомлення' });
+    }
+  });
+
+  return router;
+}

--- a/mcp_backend/src/services/email-service.ts
+++ b/mcp_backend/src/services/email-service.ts
@@ -1212,4 +1212,66 @@ export class EmailService {
 </html>
     `.trim();
   }
+
+  // ─── Support Widget (FAB) ───────────────────────────────
+
+  /**
+   * Send a support widget message (feedback or question) from a logged-in user
+   * to the support inbox.
+   */
+  async sendSupportMessage(params: {
+    type: 'feedback' | 'question';
+    message: string;
+    fromEmail: string;
+    fromName: string;
+    userId: string;
+    pageUrl?: string;
+    userAgent?: string;
+  }): Promise<void> {
+    const supportInbox = process.env.SUPPORT_EMAIL || 'info@legal.org.ua';
+    const typeLabel = params.type === 'feedback' ? 'Зауваження' : 'Питання';
+    const subject = `LEX — ${typeLabel} від ${params.fromName || params.fromEmail}`;
+
+    const escape = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    const messageHtml = escape(params.message).replace(/\n/g, '<br>');
+
+    const html = `
+<!DOCTYPE html>
+<html lang="uk">
+<head><meta charset="utf-8"></head>
+<body style="font-family: 'Segoe UI', Arial, sans-serif; color: #1e293b; background: #f1f5f9; margin: 0; padding: 20px;">
+  <div style="max-width:600px; margin: 0 auto; background:#fff; border-radius:12px; padding:24px;">
+    <h2 style="margin-top:0; color:#1e293b;">${typeLabel} з Support Widget</h2>
+    <table style="width:100%; font-size:13px; color:#475569; border-collapse:collapse;">
+      <tr><td style="padding:4px 0; width:130px;"><b>Користувач:</b></td><td>${escape(params.fromName)} &lt;${escape(params.fromEmail)}&gt;</td></tr>
+      <tr><td style="padding:4px 0;"><b>User ID:</b></td><td>${escape(params.userId)}</td></tr>
+      ${params.pageUrl ? `<tr><td style="padding:4px 0;"><b>Сторінка:</b></td><td>${escape(params.pageUrl)}</td></tr>` : ''}
+      ${params.userAgent ? `<tr><td style="padding:4px 0;"><b>User-Agent:</b></td><td style="font-family:monospace;font-size:11px;">${escape(params.userAgent)}</td></tr>` : ''}
+    </table>
+    <hr style="border:none;border-top:1px solid #e2e8f0;margin:16px 0;">
+    <div style="white-space:pre-wrap; line-height:1.6; font-size:14px; color:#1e293b;">${messageHtml}</div>
+    <hr style="border:none;border-top:1px solid #e2e8f0;margin:16px 0;">
+    <p style="font-size:12px;color:#94a3b8;margin:0;">
+      Reply directly to this email to respond to ${escape(params.fromEmail)}.
+    </p>
+  </div>
+</body>
+</html>`.trim();
+
+    await this.transporter.sendMail({
+      from: `"${this.config.fromName}" <${this.config.from}>`,
+      to: supportInbox,
+      replyTo: params.fromEmail,
+      subject,
+      html,
+    });
+
+    logger.info('Support message sent', {
+      type: params.type,
+      userId: params.userId,
+      to: supportInbox,
+    });
+  }
 }


### PR DESCRIPTION
## Summary

Adds a floating support FAB (bottom-right, fixed, z-1000) to LEX webapp with a drop-up menu containing three actions, per [LEXAI-869](https://plane.legal.org.ua/lexai/browse/LEXAI-869/):

- **Написати зауваження** → modal posts to new `POST /api/support/contact` (`type: 'feedback'`) → email to support inbox
- **Написати питання** → same endpoint, `type: 'question'`
- **Записатись на консультацію** → embeds `calendary.biz/b/legal-org-ua/30-min` (our self-hosted Calendly alternative) in an iframe with a fallback link

The widget is mounted in `MainLayout` and is hidden for unauthenticated users (the contact API requires JWT).

## Backend

- `EmailService.sendSupportMessage()` — emails `SUPPORT_EMAIL` (defaults to `info@legal.org.ua`) with `reply-to` set to the user's email so the team can respond directly.
- `routes/support-routes.ts` — single `POST /api/support/contact` endpoint, JWT-protected, validates type + length (3..5000).

## Frontend

- `components/support/SupportWidget.tsx` — FAB + drop-up with click-outside / Esc to close.
- `components/support/{FeedbackModal,QuestionModal,ConsultationBookingModal}.tsx` — three modals, each its own logic.
- `components/support/SupportContactForm.tsx` — shared form used by feedback/question modals.
- `services/api/SupportService.ts` — typed client for the contact endpoint.

## Test plan

- [ ] Local: log in → see FAB at bottom-right on every authenticated page
- [ ] Click FAB → drop-up appears with 3 items; click outside or Esc closes it
- [ ] "Написати зауваження" → fill text → submit → success toast + thank-you state; email lands at SUPPORT_EMAIL with reply-to = user
- [ ] "Написати питання" → same flow with question framing
- [ ] "Записатись на консультацію" → modal shows iframe of calendary.biz/b/legal-org-ua/30-min; fallback link opens in new tab
- [ ] Logged out: widget is not rendered
- [ ] `tsc --noEmit` clean for both `lexwebapp` and `mcp_backend` (terminal-routes node-pty errors are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a floating support widget (bottom-right FAB) with feedback, question, and consultation booking, plus a new backend contact endpoint that emails the support inbox. Implements LEXAI-869 and shows the widget only to authenticated users.

- **New Features**
  - Floating FAB in `MainLayout` opens a drop-up with 3 actions: feedback, question, consultation.
  - Feedback/Question modals share a contact form and submit via `SupportService` to `POST /api/support/contact`.
  - New JWT-protected `POST /api/support/contact` validates input and emails `SUPPORT_EMAIL` via `EmailService.sendSupportMessage()` (reply-to = user).
  - Consultation modal embeds `https://calendary.biz/b/legal-org-ua/30-min` in an iframe with a fallback link.

<sup>Written for commit 694cae2b3b61f75c90d6d1b48b503de2f81a5649. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

