### PR TITLE
feat(access): gate chat + upload behind beta-tester or Monobank top-up

### DIFF
--- a/lexwebapp/src/App.tsx
+++ b/lexwebapp/src/App.tsx
@@ -6,6 +6,8 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 import { CookieConsent } from './components/CookieConsent';
 import { GeoDetector } from './components/GeoDetector';
 import { EncryptionGuard } from './components/encryption/EncryptionGuard';
+import { BetaRestrictedModal } from './components/BetaRestrictedModal/BetaRestrictedModal';
+import { AccessGateBootstrap } from './components/BetaRestrictedModal/AccessGateBootstrap';
 import { router } from './router';
 
 export function App() {
@@ -15,7 +17,9 @@ export function App() {
         <AuthProvider>
           <GeoDetector />
           <EncryptionGuard />
+          <AccessGateBootstrap />
           <RouterProvider router={router} />
+          <BetaRestrictedModal />
           <CookieConsent />
         <Toaster
           position="top-right"

--- a/lexwebapp/src/components/BetaRestrictedModal/AccessGateBootstrap.tsx
+++ b/lexwebapp/src/components/BetaRestrictedModal/AccessGateBootstrap.tsx
@@ -1,0 +1,33 @@
+/**
+ * AccessGateBootstrap
+ *
+ * On every transition into an authenticated session, fetches the
+ * beta-restriction status so the modal can show proactively (without
+ * waiting for chat / upload to fail with 403).
+ *
+ * Resets the store on logout so a logged-out user does not retain a stale
+ * "restricted" flag from a previous account.
+ */
+
+import { useEffect } from 'react';
+import { useAuth } from '../../contexts/AuthContext';
+import { useAccessGateStore } from '../../stores/accessGateStore';
+
+export const AccessGateBootstrap: React.FC = () => {
+  const { isAuthenticated, isLoading } = useAuth();
+  const fetchAccessStatus = useAccessGateStore((s) => s.fetchAccessStatus);
+  const reset = useAccessGateStore((s) => s.reset);
+
+  useEffect(() => {
+    if (isLoading) return;
+    if (isAuthenticated) {
+      void fetchAccessStatus();
+    } else {
+      reset();
+    }
+  }, [isAuthenticated, isLoading, fetchAccessStatus, reset]);
+
+  return null;
+};
+
+export default AccessGateBootstrap;

--- a/lexwebapp/src/components/BetaRestrictedModal/BetaRestrictedModal.tsx
+++ b/lexwebapp/src/components/BetaRestrictedModal/BetaRestrictedModal.tsx
@@ -1,0 +1,68 @@
+/**
+ * BetaRestrictedModal
+ *
+ * Shown when the current user is not allowed to use chat / document upload
+ * because they are not a beta tester and have not topped up their balance
+ * via Monobank. The modal is opened by `useAccessGateStore` (proactively on
+ * app load and reactively when chat/upload returns 403 BETA_RESTRICTED).
+ */
+
+import React from 'react';
+import { Modal } from '../ui/Modal/Modal';
+import { Button } from '../ui/Button';
+import { useAccessGateStore } from '../../stores/accessGateStore';
+
+export const BetaRestrictedModal: React.FC = () => {
+  const { modalOpen, closeModal, isBetaTester, isAdministrator } = useAccessGateStore();
+
+  // Defensive: never show the modal to users who are explicitly allowed.
+  if (isBetaTester || isAdministrator) return null;
+
+  const goToBilling = () => {
+    closeModal();
+    window.location.href = '/billing';
+  };
+
+  return (
+    <Modal
+      isOpen={modalOpen}
+      onClose={closeModal}
+      title="Доступ обмежено"
+      size="md"
+      closeOnBackdrop={false}
+      showCloseButton={true}
+    >
+      <div className="space-y-4 text-sm text-gray-700 leading-relaxed">
+        <p>
+          Ця версія застосунку наразі доступна <strong>лише учасникам бета-тестування</strong>.
+        </p>
+        <p>
+          Зовнішні користувачі можуть отримати доступ до чату та завантаження документів
+          після <strong>поповнення балансу через Monobank</strong>. Без поповнення баланс
+          не активовано, тому запити до чату та завантаження файлів заблоковано.
+        </p>
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-amber-900">
+          <p className="font-medium mb-1">Що робити:</p>
+          <ul className="list-disc pl-5 space-y-1">
+            <li>Поповніть баланс через Monobank — доступ відкриється автоматично після зарахування платежу.</li>
+            <li>Або зверніться до команди, щоб вас додали до групи бета-тестування.</li>
+          </ul>
+        </div>
+        <p className="text-xs text-gray-500">
+          Контакт для бета-тестерів: <a className="underline" href="mailto:beta@legal.org.ua">beta@legal.org.ua</a>
+        </p>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button variant="secondary" onClick={closeModal}>
+            Закрити
+          </Button>
+          <Button variant="primary" onClick={goToBilling}>
+            Поповнити баланс
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default BetaRestrictedModal;

--- a/lexwebapp/src/hooks/chat/chat-error-utils.ts
+++ b/lexwebapp/src/hooks/chat/chat-error-utils.ts
@@ -27,7 +27,10 @@ export function handleStreamError(
   let content: string;
   let toastMessage: string;
 
-  if (error.code === 'INSUFFICIENT_BALANCE') {
+  if (error.code === 'BETA_RESTRICTED') {
+    content = `⚠️ **Доступ обмежено**\n\nЦя версія застосунку доступна лише учасникам бета-тестування або користувачам, які поповнили баланс через Monobank. [Поповнити баланс](/billing).`;
+    toastMessage = 'Доступ обмежено для бета-тестування';
+  } else if (error.code === 'INSUFFICIENT_BALANCE') {
     const balance = error.current_balance_usd != null
       ? `$${error.current_balance_usd.toFixed(2)}`
       : '';

--- a/lexwebapp/src/services/api/AccessService.ts
+++ b/lexwebapp/src/services/api/AccessService.ts
@@ -1,0 +1,25 @@
+/**
+ * Access Service
+ *
+ * Reads the beta-restriction status for the current user.
+ */
+
+import { BaseService } from '../base/BaseService';
+import type { AccessReason } from '../../stores/accessGateStore';
+
+export interface AccessStatus {
+  allowed: boolean;
+  reason: AccessReason;
+  is_beta_tester: boolean;
+  is_administrator: boolean;
+  has_monobank_topup: boolean;
+}
+
+export class AccessService extends BaseService {
+  async getStatus(): Promise<AccessStatus> {
+    return this.request(() => this.client.get<AccessStatus>('/api/access/status'));
+  }
+}
+
+const accessService = new AccessService();
+export default accessService;

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -176,6 +176,21 @@ export class MCPService extends BaseService {
 
       if (!response.ok) {
         const errorText = await response.text();
+        // Surface the beta-restricted modal when the chat endpoint blocks
+        // the request because the user has not topped up via Monobank.
+        if (response.status === 403) {
+          try {
+            const parsed = JSON.parse(errorText) as { code?: string; message?: string };
+            if (parsed?.code === 'BETA_RESTRICTED') {
+              const m = await import('../../stores/accessGateStore');
+              m.useAccessGateStore.getState().markRestricted();
+              callbacks.onError?.({ message: parsed.message, code: 'BETA_RESTRICTED' });
+              return controller;
+            }
+          } catch {
+            // Fall through to the generic error path below.
+          }
+        }
         callbacks.onError?.({ message: `API Error: ${response.status} - ${errorText}` });
         return controller;
       }

--- a/lexwebapp/src/stores/accessGateStore.ts
+++ b/lexwebapp/src/stores/accessGateStore.ts
@@ -1,0 +1,86 @@
+/**
+ * Access Gate Store
+ *
+ * Tracks whether the current user is allowed to use the paid features
+ * (chat, upload). The hosted version of the app is restricted to beta
+ * testers and to users who have topped up via Monobank — anyone else gets
+ * the BetaRestrictedModal.
+ *
+ * Two trigger paths populate this store:
+ *   1. Proactive — `fetchAccessStatus()` runs on app load (after login).
+ *   2. Reactive — when chat/upload returns 403 with code `BETA_RESTRICTED`,
+ *      the axios interceptor / chat fetch handler calls `markRestricted()`.
+ */
+
+import { create } from 'zustand';
+import accessService from '../services/api/AccessService';
+
+export type AccessReason =
+  | 'beta_tester'
+  | 'administrator'
+  | 'monobank_topup'
+  | 'no_monobank_topup'
+  | 'unauthenticated'
+  | 'unknown';
+
+interface AccessGateState {
+  allowed: boolean;
+  reason: AccessReason;
+  isBetaTester: boolean;
+  isAdministrator: boolean;
+  hasMonobankTopup: boolean;
+  /** Fetched from the server at least once. */
+  loaded: boolean;
+  /** When true, render BetaRestrictedModal. */
+  modalOpen: boolean;
+
+  fetchAccessStatus: () => Promise<void>;
+  markRestricted: () => void;
+  closeModal: () => void;
+  reset: () => void;
+}
+
+const INITIAL = {
+  allowed: true,
+  reason: 'unknown' as AccessReason,
+  isBetaTester: false,
+  isAdministrator: false,
+  hasMonobankTopup: false,
+  loaded: false,
+  modalOpen: false,
+};
+
+export const useAccessGateStore = create<AccessGateState>((set) => ({
+  ...INITIAL,
+
+  fetchAccessStatus: async () => {
+    try {
+      const status = await accessService.getStatus();
+      set({
+        allowed: status.allowed,
+        reason: status.reason,
+        isBetaTester: status.is_beta_tester,
+        isAdministrator: status.is_administrator,
+        hasMonobankTopup: status.has_monobank_topup,
+        loaded: true,
+        modalOpen: !status.allowed,
+      });
+    } catch (error) {
+      // Silent: if the status call fails (e.g. network), stay permissive
+      // and let the chat/upload 403 path surface the modal reactively.
+      set({ loaded: true });
+    }
+  },
+
+  markRestricted: () =>
+    set({
+      allowed: false,
+      reason: 'no_monobank_topup',
+      modalOpen: true,
+      loaded: true,
+    }),
+
+  closeModal: () => set({ modalOpen: false }),
+
+  reset: () => set(INITIAL),
+}));

--- a/lexwebapp/src/utils/api/client.ts
+++ b/lexwebapp/src/utils/api/client.ts
@@ -181,6 +181,22 @@ apiClient.interceptors.response.use(
       return Promise.reject(error);
     }
 
+    // 403 BETA_RESTRICTED - app is restricted to beta testers and users with a Monobank top-up
+    if (status === 403 && (data as { code?: string } | undefined)?.code === 'BETA_RESTRICTED') {
+      // Lazy import to avoid a hard cycle between api/client and the store.
+      import('../../stores/accessGateStore')
+        .then((m) => m.useAccessGateStore.getState().markRestricted())
+        .catch(() => {
+          // If the store can't load for any reason, surface a toast so the
+          // user still sees a clear message rather than a silent failure.
+          showToast.error(
+            (data as { message?: string } | undefined)?.message ||
+              'Доступ обмежено для бета-тестування'
+          );
+        });
+      return Promise.reject(error);
+    }
+
     // 429 Too Many Requests - rate limit exceeded
     if (status === 429) {
       // Skip toast for upload endpoints — UploadManager handles 429 retry internally

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -4,6 +4,8 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import { logger } from './utils/logger.js';
 import { dualAuth, requireJWT, optionalJWT, AuthenticatedRequest as DualAuthRequest } from './middleware/dual-auth.js';
+import { createAccessGate } from './middleware/access-gate-middleware.js';
+import { createAccessRoutes } from './routes/access-routes.js';
 import authRouter from './routes/auth.js';
 import { setAuthCache } from './controllers/auth.js';
 import { setOidcCache } from './services/oidc-service.js';
@@ -587,14 +589,19 @@ class HTTPMCPServer {
     // GET /api/upload/:uploadId/status - Check status
     // DELETE /api/upload/:uploadId - Cancel
     // GET /api/upload/active - List active sessions
-    this.app.use('/api/upload', requireJWT as any, createUploadRouter(
-      this.tools.uploadService,
-      this.tools.minioService,
-      this.tools.vaultTools,
-      this.services.db,
-      this.app_.uploadQueueService,
-      this.services.documentService
-    ));
+    this.app.use(
+      '/api/upload',
+      requireJWT as any,
+      createAccessGate(this.services.db, { feature: 'upload' }) as any,
+      createUploadRouter(
+        this.tools.uploadService,
+        this.tools.minioService,
+        this.tools.vaultTools,
+        this.services.db,
+        this.app_.uploadQueueService,
+        this.services.documentService
+      )
+    );
     logger.info('Upload routes registered at /api/upload');
 
     // Client-Matter segregation routes (matters, clients, legal holds, audit)
@@ -872,13 +879,22 @@ class HTTPMCPServer {
     }) as any);
     logger.info('KMU RSS Proxy endpoint registered at GET /api/proxy/kmu-rss');
 
+    // Access status — frontend uses this to render the beta-restricted modal proactively
+    this.app.use('/api/access', requireJWT as any, createAccessRoutes(this.services.db));
+    logger.info('Access status routes registered at /api/access');
+
     // Chat routes (plan review + AI chat with SSE streaming)
-    this.app.use('/api/chat', requireJWT as any, createChatInlineRoutes({
-      chatService: this.app_.chatService,
-      billingService: this.billing.billingService,
-      costTracker: this.billing.costTracker,
-      db: this.services.db,
-    }));
+    this.app.use(
+      '/api/chat',
+      requireJWT as any,
+      createAccessGate(this.services.db, { feature: 'chat' }) as any,
+      createChatInlineRoutes({
+        chatService: this.app_.chatService,
+        billingService: this.billing.billingService,
+        costTracker: this.billing.costTracker,
+        db: this.services.db,
+      })
+    );
     logger.info('Chat routes registered at /api/chat');
 
 

--- a/mcp_backend/src/middleware/access-gate-middleware.ts
+++ b/mcp_backend/src/middleware/access-gate-middleware.ts
@@ -1,0 +1,72 @@
+/**
+ * Access Gate Middleware
+ *
+ * Express middleware that blocks chat and upload requests for users who are
+ * not beta testers / administrators and have not topped up via Monobank.
+ *
+ * Returns 403 Forbidden with a structured payload that the frontend can
+ * detect (`code: 'BETA_RESTRICTED'`) to surface the beta-only modal.
+ */
+
+import { Response, NextFunction } from 'express';
+import type { IDatabase } from '../domain/ports/index.js';
+import { logger } from '../utils/logger.js';
+import { AuthenticatedRequest as DualAuthRequest } from './dual-auth.js';
+import { evaluateAccessGate } from '../services/access-gate.js';
+
+export interface AccessGateOptions {
+  /**
+   * Short label used in logs (e.g. 'chat', 'upload').
+   */
+  feature: string;
+}
+
+/**
+ * Build a middleware that denies access unless the request belongs to a beta
+ * tester, an administrator, or a user who has topped up via Monobank.
+ *
+ * API key callers (`req.authType === 'apikey'`) are passed through — they
+ * authenticate as service accounts and are not subject to the beta gate.
+ */
+export function createAccessGate(db: IDatabase, options: AccessGateOptions) {
+  return async (req: DualAuthRequest, res: Response, next: NextFunction): Promise<void> => {
+    if (req.authType === 'apikey') {
+      next();
+      return;
+    }
+
+    const decision = await evaluateAccessGate(db, req.user);
+
+    if (decision.allowed) {
+      next();
+      return;
+    }
+
+    if (decision.reason === 'unauthenticated') {
+      res.status(401).json({
+        error: 'Unauthorized',
+        message: 'User authentication required',
+        code: 'UNAUTHENTICATED',
+      });
+      return;
+    }
+
+    logger.warn('[AccessGate] Blocked request', {
+      feature: options.feature,
+      userId: req.user?.id,
+      email: req.user?.email,
+      reason: decision.reason,
+    });
+
+    res.status(403).json({
+      error: 'Beta access required',
+      code: 'BETA_RESTRICTED',
+      message:
+        'Ця версія застосунку доступна лише учасникам бета-тестування ' +
+        'або користувачам, які поповнили баланс через Monobank. ' +
+        'Поповніть баланс, щоб продовжити роботу.',
+      feature: options.feature,
+      topup_url: '/billing',
+    });
+  };
+}

--- a/mcp_backend/src/migrations/140_add_user_beta_tester.sql
+++ b/mcp_backend/src/migrations/140_add_user_beta_tester.sql
@@ -1,0 +1,21 @@
+-- Migration 140: Restrict chat + upload to users who topped up via Monobank
+-- or who are explicitly enrolled in the beta-tester group.
+--
+-- The application gate (see src/services/access-gate.ts) allows a user to
+-- run paid operations (chat, document upload) only if at least one of the
+-- following holds:
+--   1. users.is_beta_tester = TRUE
+--   2. users.role = 'administrator' (or legacy users.is_admin = TRUE)
+--   3. there exists a successful Monobank top-up in billing_transactions
+--      (type = 'topup', payment_provider = 'monobank', amount_usd > 0)
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS is_beta_tester BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_users_beta_tester
+  ON users (is_beta_tester) WHERE is_beta_tester = TRUE;
+
+-- Helper index for the Monobank top-up lookup performed on every chat /
+-- upload request. Partial index keeps it small.
+CREATE INDEX IF NOT EXISTS idx_billing_tx_monobank_topup
+  ON billing_transactions (user_id)
+  WHERE type = 'topup' AND payment_provider = 'monobank';

--- a/mcp_backend/src/routes/access-routes.ts
+++ b/mcp_backend/src/routes/access-routes.ts
@@ -1,0 +1,40 @@
+/**
+ * Access Routes
+ *
+ * Exposes the beta-restriction status so the frontend can render the
+ * beta-only modal proactively (on app load) instead of waiting for a chat
+ * or upload request to fail with 403.
+ */
+
+import { Router, Response } from 'express';
+import type { IDatabase } from '../domain/ports/index.js';
+import { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+import { evaluateAccessGate, hasMonobankTopup } from '../services/access-gate.js';
+
+export function createAccessRoutes(db: IDatabase): Router {
+  const router = Router();
+
+  router.get('/status', (async (req: DualAuthRequest, res: Response) => {
+    const user = req.user;
+    if (!user || !user.id) {
+      return res.status(401).json({ error: 'Unauthorized', code: 'UNAUTHENTICATED' });
+    }
+
+    const decision = await evaluateAccessGate(db, user);
+    const isBeta = user.is_beta_tester === true;
+    const isAdmin = user.role === 'administrator' || user.is_admin === true;
+    const topup = isBeta || isAdmin
+      ? decision.reason === 'monobank_topup'
+      : await hasMonobankTopup(db, user.id);
+
+    res.json({
+      allowed: decision.allowed,
+      reason: decision.reason,
+      is_beta_tester: isBeta,
+      is_administrator: isAdmin,
+      has_monobank_topup: topup,
+    });
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/__tests__/access-gate.test.ts
+++ b/mcp_backend/src/services/__tests__/access-gate.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Access Gate tests
+ *
+ * Verifies the rule that gates chat / upload behind beta-tester membership
+ * or a successful Monobank top-up.
+ */
+
+import { evaluateAccessGate, hasMonobankTopup } from '../access-gate';
+import type { User } from '../user-service';
+
+function makeDb(rows: any[] = []) {
+  return { query: jest.fn().mockResolvedValue({ rows }) } as any;
+}
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-001',
+    google_id: 'g',
+    email: 'u@example.com',
+    email_verified: true,
+    created_at: new Date(),
+    updated_at: new Date(),
+    role: 'user',
+    is_beta_tester: false,
+    is_admin: false,
+    ...overrides,
+  } as User;
+}
+
+describe('access-gate', () => {
+  describe('evaluateAccessGate', () => {
+    it('denies unauthenticated requests', async () => {
+      const db = makeDb();
+      const decision = await evaluateAccessGate(db, null);
+      expect(decision).toEqual({ allowed: false, reason: 'unauthenticated' });
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('allows beta testers without checking the database', async () => {
+      const db = makeDb();
+      const decision = await evaluateAccessGate(db, makeUser({ is_beta_tester: true }));
+      expect(decision).toEqual({ allowed: true, reason: 'beta_tester' });
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('allows administrators (role)', async () => {
+      const db = makeDb();
+      const decision = await evaluateAccessGate(db, makeUser({ role: 'administrator' }));
+      expect(decision).toEqual({ allowed: true, reason: 'administrator' });
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('allows administrators (legacy is_admin flag)', async () => {
+      const db = makeDb();
+      const decision = await evaluateAccessGate(db, makeUser({ is_admin: true }));
+      expect(decision).toEqual({ allowed: true, reason: 'administrator' });
+      expect(db.query).not.toHaveBeenCalled();
+    });
+
+    it('allows ordinary users with at least one successful Monobank top-up', async () => {
+      const db = makeDb([{ '?column?': 1 }]);
+      const decision = await evaluateAccessGate(db, makeUser());
+      expect(decision).toEqual({ allowed: true, reason: 'monobank_topup' });
+      expect(db.query).toHaveBeenCalledTimes(1);
+      const sql = db.query.mock.calls[0][0] as string;
+      expect(sql).toMatch(/billing_transactions/);
+      expect(sql).toMatch(/payment_provider = 'monobank'/);
+      expect(sql).toMatch(/type = 'topup'/);
+    });
+
+    it('denies ordinary users without a Monobank top-up', async () => {
+      const db = makeDb([]);
+      const decision = await evaluateAccessGate(db, makeUser());
+      expect(decision).toEqual({ allowed: false, reason: 'no_monobank_topup' });
+    });
+
+    it('fails closed when the database lookup throws', async () => {
+      const db = { query: jest.fn().mockRejectedValue(new Error('boom')) } as any;
+      const decision = await evaluateAccessGate(db, makeUser());
+      expect(decision).toEqual({ allowed: false, reason: 'no_monobank_topup' });
+    });
+  });
+
+  describe('hasMonobankTopup', () => {
+    it('returns true when at least one successful top-up exists', async () => {
+      const db = makeDb([{ '?column?': 1 }]);
+      await expect(hasMonobankTopup(db, 'user-001')).resolves.toBe(true);
+    });
+
+    it('returns false when no top-up exists', async () => {
+      const db = makeDb([]);
+      await expect(hasMonobankTopup(db, 'user-001')).resolves.toBe(false);
+    });
+  });
+});

--- a/mcp_backend/src/services/access-gate.ts
+++ b/mcp_backend/src/services/access-gate.ts
@@ -1,0 +1,86 @@
+/**
+ * Access Gate
+ *
+ * The hosted version of the application is currently restricted to internal
+ * beta testers and to users who have demonstrated payment intent by topping
+ * up their balance through Monobank. External users without a Monobank
+ * top-up are blocked from chat and document upload.
+ *
+ * The gate is intentionally narrow:
+ *   - administrators: always allowed
+ *   - users.is_beta_tester = TRUE: always allowed
+ *   - any other user: must have at least one successful Monobank top-up
+ *     recorded in billing_transactions (type = 'topup',
+ *     payment_provider = 'monobank', amount_usd > 0)
+ *
+ * The "balance increased via Monobank" check is intentionally based on the
+ * existence of a successful top-up rather than on the current balance — the
+ * balance can be drained by usage, but the user has still proven access.
+ */
+
+import type { IDatabase } from '../domain/ports/index.js';
+import type { User } from './user-service.js';
+import { logger } from '../utils/logger.js';
+
+export type AccessGateReason =
+  | 'beta_tester'
+  | 'administrator'
+  | 'monobank_topup'
+  | 'no_monobank_topup'
+  | 'unauthenticated';
+
+export interface AccessGateDecision {
+  allowed: boolean;
+  reason: AccessGateReason;
+}
+
+const RESULT_BETA: AccessGateDecision = { allowed: true, reason: 'beta_tester' };
+const RESULT_ADMIN: AccessGateDecision = { allowed: true, reason: 'administrator' };
+const RESULT_TOPUP: AccessGateDecision = { allowed: true, reason: 'monobank_topup' };
+const RESULT_DENIED: AccessGateDecision = { allowed: false, reason: 'no_monobank_topup' };
+const RESULT_UNAUTH: AccessGateDecision = { allowed: false, reason: 'unauthenticated' };
+
+/**
+ * Returns true iff the user has at least one successful Monobank top-up
+ * recorded in billing_transactions.
+ */
+export async function hasMonobankTopup(db: IDatabase, userId: string): Promise<boolean> {
+  const result = await db.query(
+    `SELECT 1
+       FROM billing_transactions
+      WHERE user_id = $1
+        AND type = 'topup'
+        AND payment_provider = 'monobank'
+        AND amount_usd > 0
+      LIMIT 1`,
+    [userId]
+  );
+  return result.rows.length > 0;
+}
+
+/**
+ * Decide whether `user` is allowed to call paid features (chat, upload).
+ */
+export async function evaluateAccessGate(
+  db: IDatabase,
+  user: User | null | undefined
+): Promise<AccessGateDecision> {
+  if (!user || !user.id) return RESULT_UNAUTH;
+
+  if (user.is_beta_tester === true) return RESULT_BETA;
+  if (user.role === 'administrator' || user.is_admin === true) return RESULT_ADMIN;
+
+  try {
+    const ok = await hasMonobankTopup(db, user.id);
+    return ok ? RESULT_TOPUP : RESULT_DENIED;
+  } catch (error: any) {
+    // Fail closed: if the lookup fails we deny access rather than letting
+    // unrestricted external traffic through. The error is logged so we can
+    // diagnose connectivity problems.
+    logger.error('[AccessGate] Failed to check Monobank top-up', {
+      error: error?.message,
+      userId: user.id,
+    });
+    return RESULT_DENIED;
+  }
+}

--- a/mcp_backend/src/services/user-service.ts
+++ b/mcp_backend/src/services/user-service.ts
@@ -24,6 +24,8 @@ export interface User {
   password_hash?: string;
   role: 'user' | 'company' | 'administrator';
   user_type?: 'individual' | 'attorney' | 'company_admin';
+  is_beta_tester?: boolean;
+  is_admin?: boolean;
 }
 
 export interface UserCreate {


### PR DESCRIPTION
## Summary

Restricts chat (`/api/chat`) and document upload (`/api/upload`) to one of:

- users with `users.is_beta_tester = TRUE`
- administrators (`role = 'administrator'` or legacy `is_admin = TRUE`)
- any user who has at least **one successful Monobank top-up** recorded in `billing_transactions` (type=`topup`, payment_provider=`monobank`, amount_usd > 0)

Anyone else gets a **403 `BETA_RESTRICTED`** with a Ukrainian message and the frontend opens a modal pointing to `/billing` for top-up.

## Backend

- `migrations/140_add_user_beta_tester.sql` — adds `users.is_beta_tester` + partial index on Monobank top-ups.
- `services/access-gate.ts` — `evaluateAccessGate()`, `hasMonobankTopup()`. Fails closed on DB error.
- `middleware/access-gate-middleware.ts` — returns 403 `BETA_RESTRICTED` with structured payload (`feature`, `topup_url`, message).
- `routes/access-routes.ts` — `GET /api/access/status` so the frontend can preflight on app load (avoids surfacing the modal only on first chat/upload).
- `http-server.ts` — wires the gate after `requireJWT` on `/api/chat` and `/api/upload`; registers `/api/access`.
- `services/user-service.ts` — `User` type now exposes `is_beta_tester` / `is_admin` (already on the row via `SELECT *`).
- `services/__tests__/access-gate.test.ts` — 9 unit tests covering all branches (beta tester, admin role, legacy is_admin, monobank top-up, no top-up, unauthenticated, DB failure).

API key callers (`req.authType === 'apikey'`) bypass the gate — service accounts are not subject to the beta restriction.

## Frontend

- `stores/accessGateStore.ts` — Zustand store: `fetchAccessStatus`, `markRestricted`, `closeModal`, `reset`.
- `services/api/AccessService.ts` — wraps `GET /api/access/status`.
- `components/BetaRestrictedModal/BetaRestrictedModal.tsx` — uk-UA modal with **Поповнити баланс** action linking to `/billing`.
- `components/BetaRestrictedModal/AccessGateBootstrap.tsx` — fetches status on auth, resets on logout.
- `utils/api/client.ts` — axios interceptor catches 403 `BETA_RESTRICTED` (covers all REST including `/api/upload`) and opens the modal.
- `services/api/MCPService.ts` — same treatment for the `fetch`-based chat stream.
- `hooks/chat/chat-error-utils.ts` — Ukrainian inline message in the chat thread when the chat error code is `BETA_RESTRICTED`.
- `App.tsx` — mounts `<AccessGateBootstrap />` and `<BetaRestrictedModal />`.

## How to enroll a beta tester

```sql
UPDATE users SET is_beta_tester = TRUE WHERE email = '...';
```

A user who tops up via Monobank will pass the gate automatically once the existing webhook writes the `topup` transaction.

## Test plan

- [ ] `npm run migrate` in `mcp_backend` (locally) — migration 140 applies cleanly.
- [ ] As a non-beta, non-topped-up user: `POST /api/chat` returns 403 `BETA_RESTRICTED`; `POST /api/upload/init` returns 403 `BETA_RESTRICTED`; UI shows beta-restricted modal.
- [ ] Mark the user beta tester (`UPDATE users SET is_beta_tester = TRUE`) — chat + upload work, modal does not appear.
- [ ] Run a Monobank test top-up — webhook lands → next chat/upload passes; modal does not appear.
- [ ] Existing 402 `INSUFFICIENT_BALANCE` flow still works for users who topped up and then drained the balance.
- [ ] Backend: `npx jest src/services/__tests__/access-gate.test.ts` — 9 tests pass.
- [ ] Frontend: `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates `/api/chat` and `/api/upload` to beta testers, administrators, or users with at least one successful Monobank top-up. Others get 403 `BETA_RESTRICTED`, and the UI shows a Ukrainian modal linking to `/billing`.

- **New Features**
  - Added access-gate middleware on `/api/chat` and `/api/upload`; returns 403 with `{ code: 'BETA_RESTRICTED', topup_url: '/billing' }`. API key callers bypass the gate.
  - Introduced `GET /api/access/status` so the app can preflight access on login.
  - Frontend: Zustand `accessGateStore`, `BetaRestrictedModal` (uk-UA) with a “Поповнити баланс” action, and an auth bootstrap to prefetch status.
  - Axios and chat-stream handlers detect `BETA_RESTRICTED` and open the modal; chat shows a concise inline error.
  - Added unit tests for the access-gate evaluator (9 scenarios).

- **Migration**
  - Run migration 140 to add `users.is_beta_tester` and the Monobank top-up index.
  - To enroll a tester: `UPDATE users SET is_beta_tester = TRUE WHERE email = '...'`; Monobank top-ups unlock access automatically via the existing webhook.

<sup>Written for commit 09189ed263e39d04fa75248f7c74afe29565b037. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1507?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

