### PR TITLE
fix(lexwebapp): remove unused userEvent import breaking CI

### DIFF
--- a/lexwebapp/src/components/support/__tests__/ConsultationBookingModal.test.tsx
+++ b/lexwebapp/src/components/support/__tests__/ConsultationBookingModal.test.tsx
@@ -5,7 +5,6 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { ConsultationBookingModal } from '../ConsultationBookingModal';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Remove unused `userEvent` import in `ConsultationBookingModal.test.tsx` that causes `TS6133` error and fails CI build

## Test plan
- [x] `tsc --noEmit` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused `userEvent` import in `ConsultationBookingModal.test.tsx` to resolve TS6133 and restore a passing CI build.

<sup>Written for commit 2496d17eb9feef46b443cfb4b4429e72dbdffa8e. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1510?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

