### PR TITLE
fix(billing): zero out balances for 6 inactive accounts

### DIFF
--- a/mcp_backend/src/migrations/143_zero_inactive_user_balances.sql
+++ b/mcp_backend/src/migrations/143_zero_inactive_user_balances.sql
@@ -1,0 +1,17 @@
+-- Migration 143: Zero out balances for inactive/test accounts (2026-04-30).
+-- These accounts were manually credited but never actively used the platform.
+-- Balances zeroed to prevent accidental restoration via seed scripts.
+
+UPDATE user_billing
+SET balance_uah = 0, balance_usd = 0, updated_at = NOW()
+FROM users u
+WHERE user_billing.user_id = u.id
+  AND u.email IN (
+    'happiest.day@icloud.com',
+    'test@legal.org.ua',
+    'alehina@legal.org.ua',
+    'gladilina_elena@ukr.net',
+    'test_user@legal.org.ua',
+    'ruslanyuryst@gmail.com'
+  )
+  AND (user_billing.balance_uah != 0 OR user_billing.balance_usd != 0);


### PR DESCRIPTION
## Summary
- Adds migration 143 to zero out balances for 6 inactive/test accounts
- Accounts: happiest.day@icloud.com, test@legal.org.ua, alehina@legal.org.ua, gladilina_elena@ukr.net, test_user@legal.org.ua, ruslanyuryst@gmail.com
- Idempotent — skips if balances already zero

## Test plan
- [ ] Migration applies without errors
- [ ] Balances remain zero after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Zeroed balances for six inactive/test accounts to prevent accidental restoration. Adds an idempotent SQL migration that only updates non-zero balances.

- **Migration**
  - Adds migration 143 to set `balance_uah` and `balance_usd` to 0 for the specified accounts.
  - Joins on `users` by email and skips rows already at zero; safe to re-run.

<sup>Written for commit 24f4fd329a74133ec7bb3930fd95e5aa33f167cf. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1511?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

