### PR TITLE
fix(billing): enforce strict balance check — block $0 users from all tools

### DIFF
--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -424,7 +424,19 @@ export class MCPSSEServer {
             tool: name,
             error: creditError.message,
           });
-          // On error, allow the request to proceed (fail open)
+          this.sendSSEMessage(res, {
+            jsonrpc: '2.0',
+            id: request.id,
+            error: {
+              code: -32000,
+              message: 'Service temporarily unavailable',
+              data: {
+                code: 'BILLING_UNAVAILABLE',
+                message: 'Credit check system is temporarily unavailable. Please try again later.',
+              },
+            },
+          });
+          return;
         }
       }
 

--- a/mcp_backend/src/middleware/__tests__/balance-check.test.ts
+++ b/mcp_backend/src/middleware/__tests__/balance-check.test.ts
@@ -67,8 +67,8 @@ describe('createBalanceCheckMiddleware', () => {
     });
   });
 
-  test('should skip balance check for API key auth', async () => {
-    const req = createMockReq({ authType: 'apikey' } as any);
+  test('should skip balance check for legacy API key (no user_id)', async () => {
+    const req = createMockReq({ authType: 'apikey', user: undefined } as any);
     const res = createMockRes();
 
     await middleware(req, res, next);
@@ -77,16 +77,38 @@ describe('createBalanceCheckMiddleware', () => {
     expect(mockBillingService.getOrCreateUserBilling).not.toHaveBeenCalled();
   });
 
-  test('should skip balance check for free tools', async () => {
+  test('should check balance for Phase 2 API key (has user_id)', async () => {
     const req = createMockReq({
-      params: { toolName: 'list_documents' },
+      authType: 'apikey',
+      user: { id: 'user-456', email: 'apikey-user@example.com' },
     } as any);
     const res = createMockRes();
 
     await middleware(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(mockBillingService.getOrCreateUserBilling).not.toHaveBeenCalled();
+    expect(mockBillingService.getOrCreateUserBilling).toHaveBeenCalled();
+  });
+
+  test('should return 402 for Phase 2 API key with $0 balance', async () => {
+    mockBillingService.checkBalance.mockResolvedValue({
+      hasBalance: false,
+      currentBalance: 0,
+    });
+
+    const req = createMockReq({
+      authType: 'apikey',
+      user: { id: 'user-456', email: 'apikey-user@example.com' },
+    } as any);
+    const res = createMockRes();
+
+    await middleware(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(402);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'INSUFFICIENT_BALANCE' })
+    );
+    expect(next).not.toHaveBeenCalled();
   });
 
   test('should return 401 when no user in request', async () => {
@@ -124,12 +146,11 @@ describe('createBalanceCheckMiddleware', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  test('should return 402 when insufficient balance and free tier limit exceeded', async () => {
+  test('should return 402 when insufficient balance', async () => {
     mockBillingService.checkBalance.mockResolvedValue({
       hasBalance: false,
       currentBalance: 0,
     });
-    mockBillingService.getDailyRequestCount.mockResolvedValue(5);
 
     const req = createMockReq();
     const res = createMockRes();
@@ -143,19 +164,39 @@ describe('createBalanceCheckMiddleware', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  test('should allow free tier request when under daily limit', async () => {
-    mockBillingService.checkBalance.mockResolvedValue({
-      hasBalance: false,
-      currentBalance: 0,
-    });
-    mockBillingService.getDailyRequestCount.mockResolvedValue(3);
+  test('should check balance for all tools including previously free ones', async () => {
+    const previouslyFreeTools = [
+      'list_documents', 'get_document', 'get_document_sections',
+      'list_conversations', 'get_conversation',
+      'get_legislation_structure',
+      'get_legislation_articles', 'get_legislation_section',
+    ];
 
-    const req = createMockReq();
-    const res = createMockRes();
+    for (const toolName of previouslyFreeTools) {
+      jest.clearAllMocks();
+      mockBillingService.getOrCreateUserBilling.mockResolvedValue({
+        userId: 'user-123',
+        billing_enabled: true,
+        balance_usd: 10,
+      });
+      mockCostTracker.estimateCost.mockResolvedValue({
+        total_estimated_cost_usd: 0.05,
+      });
+      mockBillingService.checkBalance.mockResolvedValue({
+        hasBalance: true,
+        currentBalance: 10,
+      });
+      mockBillingService.checkLimits.mockResolvedValue({
+        withinLimits: true,
+      });
 
-    await middleware(req, res, next);
+      const req = createMockReq({ params: { toolName } } as any);
+      const res = createMockRes();
 
-    expect(next).toHaveBeenCalled();
+      await middleware(req, res, next);
+
+      expect(mockBillingService.getOrCreateUserBilling).toHaveBeenCalled();
+    }
   });
 
   test('should return 429 when daily limit exceeded', async () => {
@@ -196,7 +237,7 @@ describe('createBalanceCheckMiddleware', () => {
     );
   });
 
-  test('should not block on middleware errors (fail open)', async () => {
+  test('should fail closed on middleware errors for authenticated users', async () => {
     mockBillingService.getOrCreateUserBilling.mockRejectedValue(new Error('DB connection failed'));
 
     const req = createMockReq();
@@ -204,27 +245,10 @@ describe('createBalanceCheckMiddleware', () => {
 
     await middleware(req, res, next);
 
-    expect(next).toHaveBeenCalled();
-    expect(res.status).not.toHaveBeenCalled();
-  });
-
-  test('should check all free tool names', async () => {
-    const freeTools = [
-      'list_documents', 'get_document', 'get_document_sections',
-      'list_conversations', 'get_conversation',
-      'get_legislation_structure',
-      'get_legislation_articles', 'get_legislation_section',
-    ];
-
-    for (const toolName of freeTools) {
-      jest.clearAllMocks();
-      const req = createMockReq({ params: { toolName } } as any);
-      const res = createMockRes();
-
-      await middleware(req, res, next);
-
-      expect(next).toHaveBeenCalled();
-      expect(mockBillingService.getOrCreateUserBilling).not.toHaveBeenCalled();
-    }
+    expect(res.status).toHaveBeenCalledWith(503);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ code: 'BILLING_UNAVAILABLE' })
+    );
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/mcp_backend/src/middleware/balance-check.ts
+++ b/mcp_backend/src/middleware/balance-check.ts
@@ -12,39 +12,20 @@ import { AuthenticatedRequest as DualAuthRequest } from './dual-auth.js';
 /**
  * Create balance check middleware
  */
-// Tools that are read-only and incur no cost (no LLM/external API calls)
-const FREE_TOOLS = new Set([
-  'list_documents',
-  'get_document',
-  'get_document_sections',
-  'list_conversations',
-  'get_conversation',
-  'get_legislation_structure',
-  'get_legislation_articles',
-  'get_legislation_section',
-]);
-
-/** Free tier: max requests per day with zero balance */
-const FREE_TIER_DAILY_LIMIT = 5;
-
 export function createBalanceCheckMiddleware(
   billingService: BillingService,
   costTracker: CostTracker
 ) {
   return async (req: DualAuthRequest, res: Response, next: NextFunction) => {
     try {
-      // Skip balance check for API key authentication
-      if (req.authType === 'apikey') {
-        logger.debug('Skipping balance check for API key auth');
+      // Skip balance check for legacy/internal API keys (no user_id)
+      // Phase 2 API keys have user_id and must be subject to balance checks
+      if (req.authType === 'apikey' && !req.user?.id) {
+        logger.debug('Skipping balance check for legacy API key (no user_id)');
         return next();
       }
 
-      // Skip balance check for free read-only tools
       const toolName = req.params.toolName || req.body.toolName || 'unknown';
-      if (FREE_TOOLS.has(toolName)) {
-        logger.debug('Skipping balance check for free tool', { toolName });
-        return next();
-      }
 
       // Reject if no user - all requests must be attributed to an account
       if (!req.user || !req.user.id) {
@@ -91,23 +72,10 @@ export function createBalanceCheckMiddleware(
       );
 
       if (!balanceCheck.hasBalance) {
-        // Free tier: allow up to FREE_TIER_DAILY_LIMIT requests per day with zero balance
-        const dailyCount = await billingService.getDailyRequestCount(userId);
-        if (dailyCount < FREE_TIER_DAILY_LIMIT) {
-          logger.info('Free tier request allowed', {
-            userId,
-            toolName,
-            dailyCount,
-            remaining: FREE_TIER_DAILY_LIMIT - dailyCount - 1,
-          });
-          return next();
-        }
-
         logger.warn('Insufficient balance', {
           userId,
           required: estimatedCost.total_estimated_cost_usd,
           available: balanceCheck.currentBalance,
-          dailyCount,
         });
 
         return res.status(402).json({
@@ -118,11 +86,6 @@ export function createBalanceCheckMiddleware(
             current_usd: balanceCheck.currentBalance,
             required_usd: estimatedCost.total_estimated_cost_usd,
             shortfall_usd: estimatedCost.total_estimated_cost_usd - balanceCheck.currentBalance,
-          },
-          free_tier: {
-            daily_limit: FREE_TIER_DAILY_LIMIT,
-            used_today: dailyCount,
-            remaining: 0,
           },
           topup_url: `${process.env.FRONTEND_URL || 'https://billing.legal.org.ua'}/topup`,
         });
@@ -163,8 +126,17 @@ export function createBalanceCheckMiddleware(
         userId: req.user?.id,
       });
 
-      // Don't block request on middleware errors - log and continue
-      next();
+      // Legacy API keys (no user_id) fail open — they are internal service keys
+      if (req.authType === 'apikey' && !req.user?.id) {
+        return next();
+      }
+
+      // Authenticated users fail closed — don't allow access when billing system is unavailable
+      return res.status(503).json({
+        error: 'Service temporarily unavailable',
+        message: 'Billing system is temporarily unavailable. Please try again later.',
+        code: 'BILLING_UNAVAILABLE',
+      });
     }
   };
 }

--- a/mcp_backend/src/routes/tool-execution-routes.ts
+++ b/mcp_backend/src/routes/tool-execution-routes.ts
@@ -496,7 +496,11 @@ export function createToolExecutionRoutes(deps: {
             tool: toolName,
             error: creditError.message,
           });
-          // On error, allow the request to proceed (fail open)
+          return res.status(503).json({
+            error: 'Service temporarily unavailable',
+            message: 'Credit check system is temporarily unavailable. Please try again later.',
+            code: 'BILLING_UNAVAILABLE',
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

- Remove `FREE_TOOLS` bypass — all tools now require positive balance (previously 8 tools like `list_documents`, `get_legislation_*` were exempt)
- Remove free-tier (5 req/day) allowance for zero-balance users — immediate 402 on insufficient balance
- Narrow API-key bypass to legacy/internal keys only (`SECONDARY_LAYER_KEYS` without `user_id`); Phase 2 API keys with `user_id` are now subject to balance checks
- Switch all 3 billing check points from **fail-open** to **fail-closed** (503 `BILLING_UNAVAILABLE`):
  - `balance-check.ts` middleware
  - `tool-execution-routes.ts` HTTP credit check
  - `mcp-sse-server.ts` MCP SSE credit check

## What's NOT affected

- Legacy `SECONDARY_LAYER_KEYS` (internal service-to-service) — continue to bypass
- MCP stdio (local dev) — no auth, not affected
- Gateway proxy → RADA/OpenReyestr — billing checked before proxying
- Health endpoints, Monobank webhooks — not affected
- `access-gate` middleware — unchanged

## Test plan

- [x] 11 unit tests pass (balance-check middleware)
- [x] 66 total middleware tests pass
- [x] TypeScript compiles (only pre-existing `node-pty` errors)
- [ ] Verify prod API key users with positive balance can still call tools
- [ ] Verify JWT users with $0 balance get 402 on any tool
- [ ] Verify legacy API keys still work for internal processes

🤖 Generated with [Claude Code](https://claude.com/claude-code)