### PR TITLE
fix(lexwebapp): use correct tool name on decisions search page

### DIFF
--- a/lexwebapp/src/i18n/legal-i18n.ts
+++ b/lexwebapp/src/i18n/legal-i18n.ts
@@ -10,7 +10,7 @@ const legalStrings: Record<Locale, Record<string, string>> = {
   uk: {
     // === DecisionsSearchPage ===
     decisionsTitle: 'Пошук судових рішень',
-    decisionsSubtitle: 'Пошук в базі судових рішень України через ZakonOnline',
+    decisionsSubtitle: 'Пошук в базі судових рішень України (ЄДРСР)',
     searchQuery: 'Пошуковий запит',
     searchPlaceholder: 'номер справи, ключові слова, тема спору...',
     advancedFilters: 'Розширені фільтри',
@@ -232,7 +232,7 @@ const legalStrings: Record<Locale, Record<string, string>> = {
 
   en: {
     decisionsTitle: 'Court Decisions Search',
-    decisionsSubtitle: 'Search the database of Ukrainian court decisions via ZakonOnline',
+    decisionsSubtitle: 'Search the database of Ukrainian court decisions (EDRSR)',
     searchQuery: 'Search query',
     searchPlaceholder: 'case number, keywords, dispute topic...',
     advancedFilters: 'Advanced filters',
@@ -439,7 +439,7 @@ const legalStrings: Record<Locale, Record<string, string>> = {
 
   de: {
     decisionsTitle: 'Suche nach Gerichtsentscheidungen',
-    decisionsSubtitle: 'Suche in der Datenbank ukrainischer Gerichtsentscheidungen',
+    decisionsSubtitle: 'Suche in der Datenbank ukrainischer Gerichtsentscheidungen (EDRSR)',
     searchQuery: 'Suchanfrage',
     searchPlaceholder: 'Aktenzeichen, Schlusselworter, Streitgegenstand...',
     advancedFilters: 'Erweiterte Filter',
@@ -646,7 +646,7 @@ const legalStrings: Record<Locale, Record<string, string>> = {
 
   es: {
     decisionsTitle: 'Busqueda de resoluciones judiciales',
-    decisionsSubtitle: 'Busqueda en la base de datos de resoluciones judiciales de Ucrania a traves de ZakonOnline',
+    decisionsSubtitle: 'Búsqueda en la base de datos de resoluciones judiciales de Ucrania (EDRSR)',
     searchQuery: 'Consulta de busqueda',
     searchPlaceholder: 'numero de caso, palabras clave, tema de la disputa...',
     advancedFilters: 'Filtros avanzados',

--- a/lexwebapp/src/pages/DecisionsSearchPage.tsx
+++ b/lexwebapp/src/pages/DecisionsSearchPage.tsx
@@ -125,7 +125,7 @@ export function DecisionsSearchPage() {
         if (filters.dateTo) params.time_range.to = filters.dateTo;
       }
 
-      const response = await mcpService.callTool('search_supreme_court_practice', params);
+      const response = await mcpService.callTool('search_legal_precedents', params);
 
       let parsed: any = null;
       if (response?.result?.content?.[0]?.text) {


### PR DESCRIPTION
## Summary

- Fix 404 on `/decisions` page — frontend called `search_supreme_court_practice` which was never registered in tool-registry definitions (only as alias in `executeTool()` switch)
- Switch to `search_legal_precedents` (canonical registered name)
- Replace deprecated ZakonOnline subtitle with ЄДРСР/EDRSR in all 4 locales

## Test plan

- [x] TypeScript compiles cleanly
- [ ] Open https://legal.org.ua/decisions, search `369/1855/15-ц` — should return results instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)