### PR TITLE
fix(news): prevent timeout on first article load

### DIFF
--- a/lexwebapp/src/i18n/misc-i18n.ts
+++ b/lexwebapp/src/i18n/misc-i18n.ts
@@ -137,6 +137,12 @@ const miscStrings: Record<string, Record<Locale, string>> = {
     de: 'KI-Analyse',
     es: 'Análisis IA',
   },
+  generatingAnalysis: {
+    uk: 'Генерується AI-аналіз...',
+    en: 'Generating AI analysis...',
+    de: 'KI-Analyse wird erstellt...',
+    es: 'Generando análisis IA...',
+  },
   sourceKmu: {
     uk: 'Джерело: kmu.gov.ua',
     en: 'Source: kmu.gov.ua',

--- a/lexwebapp/src/pages/NewsPage/KmuArticleModal.tsx
+++ b/lexwebapp/src/pages/NewsPage/KmuArticleModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -22,31 +22,70 @@ export function KmuArticleModal({ url, title, onClose }: KmuArticleModalProps) {
   const [data, setData] = useState<ArticleData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [analysisLoading, setAnalysisLoading] = useState(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => {
-    const fetchArticle = async () => {
-      setLoading(true);
-      setError(null);
+  const fetchArticle = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const token = localStorage.getItem('auth_token');
+      const params = new URLSearchParams({ url, title });
+      const response = await fetch(`/api/news/article?${params}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${response.status}`);
+      }
+      const result = await response.json();
+      setData(result);
+      if (result.content && !result.analysis) {
+        pollForAnalysis();
+      }
+    } catch (err: any) {
+      setError(err.message || t('articleLoadError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pollForAnalysis = () => {
+    setAnalysisLoading(true);
+    let attempts = 0;
+    const interval = setInterval(async () => {
+      attempts++;
+      if (attempts > 6) {
+        clearInterval(interval);
+        pollRef.current = null;
+        setAnalysisLoading(false);
+        return;
+      }
       try {
         const token = localStorage.getItem('auth_token');
         const params = new URLSearchParams({ url, title });
         const response = await fetch(`/api/news/article?${params}`, {
           headers: token ? { Authorization: `Bearer ${token}` } : {},
         });
-        if (!response.ok) {
-          const body = await response.json().catch(() => ({}));
-          throw new Error(body.error || `HTTP ${response.status}`);
+        if (response.ok) {
+          const result = await response.json();
+          if (result.analysis) {
+            setData(result);
+            clearInterval(interval);
+            pollRef.current = null;
+            setAnalysisLoading(false);
+          }
         }
-        const result = await response.json();
-        setData(result);
-      } catch (err: any) {
-        setError(err.message || t('articleLoadError'));
-      } finally {
-        setLoading(false);
-      }
-    };
+      } catch { /* ignore polling errors */ }
+    }, 10000);
+    pollRef.current = interval;
+  };
 
+  useEffect(() => {
     fetchArticle();
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
   }, [url, title]);
 
   return (
@@ -122,7 +161,7 @@ export function KmuArticleModal({ url, title, onClose }: KmuArticleModalProps) {
               </div>
 
               {/* AI Analysis */}
-              {data.analysis && (
+              {data.analysis ? (
                 <div className="mt-8 p-5 bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 rounded-xl">
                   <div className="flex items-center gap-2 mb-3">
                     <Sparkles size={18} className="text-amber-600" />
@@ -140,7 +179,14 @@ export function KmuArticleModal({ url, title, onClose }: KmuArticleModalProps) {
                     </ReactMarkdown>
                   </div>
                 </div>
-              )}
+              ) : analysisLoading ? (
+                <div className="mt-8 p-5 bg-gradient-to-br from-amber-50 to-orange-50 border border-amber-200 rounded-xl">
+                  <div className="flex items-center gap-2">
+                    <Loader2 size={16} className="animate-spin text-amber-600" />
+                    <span className="text-sm text-amber-800">{t('generatingAnalysis')}</span>
+                  </div>
+                </div>
+              ) : null}
 
               {/* Source link */}
               <div className="mt-6 pt-4 border-t border-claude-border text-center">

--- a/mcp_backend/src/services/news-article-service.ts
+++ b/mcp_backend/src/services/news-article-service.ts
@@ -24,6 +24,8 @@ export class NewsArticleService {
 
   /**
    * Get article with analysis — from DB cache or scrape + analyze on the fly.
+   * For cache misses, returns content immediately and generates analysis in the background
+   * to avoid Cloudflare/ALB timeouts (~100s) during Playwright scrape + LLM analysis.
    */
   async getArticle(url: string, title: string): Promise<NewsArticleResult> {
     // 1. Check DB cache
@@ -45,20 +47,18 @@ export class NewsArticleService {
           analyzed_at: row.analyzed_at,
         };
       }
-      // If we have content but no analysis, generate analysis
+      // If we have content but no analysis, kick off analysis in background and return content now
       if (row.content && !row.analysis) {
-        logger.info('[NewsArticle] Cache hit (content only), generating analysis', { url });
-        const analysis = await this.generateAnalysis(row.title, row.content);
-        await this.db.query(
-          'UPDATE news_articles SET analysis = $1, analyzed_at = NOW() WHERE url = $2',
-          [analysis, url]
+        logger.info('[NewsArticle] Cache hit (content only), generating analysis in background', { url });
+        this.generateAndSaveAnalysis(url, row.title, row.content).catch(err =>
+          logger.error('[NewsArticle] Background analysis failed', { url, error: err instanceof Error ? err.message : String(err) })
         );
         return {
           title: row.title,
           content: row.content,
-          analysis,
+          analysis: '',
           scraped_at: row.scraped_at,
-          analyzed_at: new Date().toISOString(),
+          analyzed_at: null,
         };
       }
     }
@@ -67,29 +67,38 @@ export class NewsArticleService {
     logger.info('[NewsArticle] Cache miss, scraping', { url });
     const content = await this.scrapeArticle(url);
 
-    // 3. Analyze
-    const analysis = await this.generateAnalysis(title, content);
-
-    // 4. Upsert into DB
+    // 3. Save content immediately (without analysis)
     await this.db.query(
-      `INSERT INTO news_articles (url, title, content, analysis, scraped_at, analyzed_at)
-       VALUES ($1, $2, $3, $4, NOW(), NOW())
+      `INSERT INTO news_articles (url, title, content, scraped_at)
+       VALUES ($1, $2, $3, NOW())
        ON CONFLICT (url) DO UPDATE SET
          title = EXCLUDED.title,
          content = EXCLUDED.content,
-         analysis = EXCLUDED.analysis,
-         scraped_at = NOW(),
-         analyzed_at = NOW()`,
-      [url, title, content, analysis]
+         scraped_at = NOW()`,
+      [url, title, content]
+    );
+
+    // 4. Generate analysis in background — don't block the response
+    this.generateAndSaveAnalysis(url, title, content).catch(err =>
+      logger.error('[NewsArticle] Background analysis failed', { url, error: err instanceof Error ? err.message : String(err) })
     );
 
     return {
       title,
       content,
-      analysis,
+      analysis: '',
       scraped_at: new Date().toISOString(),
-      analyzed_at: new Date().toISOString(),
+      analyzed_at: null,
     };
+  }
+
+  private async generateAndSaveAnalysis(url: string, title: string, content: string): Promise<void> {
+    const analysis = await this.generateAnalysis(title, content);
+    await this.db.query(
+      'UPDATE news_articles SET analysis = $1, analyzed_at = NOW() WHERE url = $2',
+      [analysis, url]
+    );
+    logger.info('[NewsArticle] Background analysis complete', { url });
   }
 
   /**


### PR DESCRIPTION
## Summary
- **Root cause:** KMU news article endpoint ran Playwright scraping (~15s) + Bedrock AI analysis (~20-30s) synchronously. For uncached articles, this exceeded Cloudflare/ALB proxy timeouts (~100s), causing nginx 499 and browser "Failed to fetch" error.
- **Backend fix:** Return scraped content immediately, generate AI analysis in background via fire-and-forget promise. Analysis is saved to DB and served from cache on subsequent requests.
- **Frontend fix:** Show article content instantly with a "Генерується AI-аналіз..." spinner. Polls backend every 10s (up to 60s) until analysis is ready, then renders it in-place.

## Test plan
- [ ] Open /news on prod, click an uncached article → content should load within 10-15s, analysis appears shortly after
- [ ] Click a previously cached article → both content and analysis load instantly
- [ ] Close modal while analysis is polling → no console errors (interval cleanup)
- [ ] Verify backend logs show `[NewsArticle] Background analysis complete` after ~20-30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)