### PR TITLE
fix(mcp): search sanctions by name AND aliases

### DIFF
--- a/mcp_backend/src/api/tools/opendata-tools.ts
+++ b/mcp_backend/src/api/tools/opendata-tools.ts
@@ -287,7 +287,7 @@ export class OpenDataTools extends BaseToolHandler {
     let pi = 1;
 
     if (name) {
-      conditions.push(`name ILIKE $${pi}`);
+      conditions.push(`(name ILIKE $${pi} OR aliases ILIKE $${pi})`);
       values.push(`%${name}%`);
       pi++;
     }


### PR DESCRIPTION
## Summary
- Search `opensanctions_entities` now matches against both `name` and `aliases` columns
- Fixes: Cyrillic queries like "Медведчук" returned 0 results because names are stored in Latin, Cyrillic variants are in `aliases`

## Test plan
- [ ] `search_sanctions(name="Медведчук")` → should return Viktor Medvedchuk
- [ ] `search_sanctions(name="Medvedchuk")` → should still work (Latin)
- [ ] No performance regression (ILIKE on `aliases` uses existing index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)