### PR TITLE
fix(mcp): downgrade CORS rejection from error to warn

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -191,7 +191,8 @@ class HTTPMCPServer {
         if (allowedOrigins.includes(origin)) return callback(null, true);
         // Allow localhost only in development
         if (process.env.NODE_ENV !== 'production' && origin.match(/^https?:\/\/localhost(:\d+)?$/)) return callback(null, true);
-        callback(new Error(`CORS not allowed for origin: ${origin}`));
+        logger.warn(`CORS blocked origin: ${origin}`);
+        callback(null, false);
       },
       credentials: true,
       exposedHeaders: ['X-Upload-Queue-Depth', 'X-Upload-Throttle', 'Retry-After', 'X-Total-Count'],


### PR DESCRIPTION
## Summary
- CORS blocked origins now log at `warn` instead of `error` level
- Replaced `callback(new Error(...))` with `callback(null, false)` to silently reject without throwing through Express error handler
- Reduces log noise from pentest scans and automated security probes

## Test plan
- [ ] Deploy to local, send request with fake Origin header, verify `warn` log instead of `error`
- [ ] Verify legitimate CORS requests from legal.org.ua still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded CORS rejections to warn and now silently reject blocked origins with `callback(null, false)` instead of throwing. This reduces noisy error logs from expected probes while keeping valid CORS behavior unchanged.

<sup>Written for commit 4f34fdd59522f0deff1e9bfb7208bba285024e7c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

