### PR TITLE
security: fix critical injection and data exposure vulnerabilities

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -389,8 +389,17 @@ class HTTPMCPServer {
         uptime: Math.round(process.uptime()),
       });
     });
-    // Full health check — detailed dependency info, rate-limited
-    this.app.get('/health', healthCheckRateLimit as any, healthHandler);
+    // Public health check — minimal info only (no infra details)
+    this.app.get('/health', healthCheckRateLimit as any, (_req: any, res: any) => {
+      res.json({
+        status: 'ok',
+        initialized: (this as any)._initialized === true,
+        service: 'secondlayer-mcp-http',
+        uptime: Math.round(process.uptime()),
+      });
+    });
+    // Detailed health check — admin only (exposes dependency statuses)
+    this.app.get('/api/admin/health', requireJWT as any, healthHandler);
 
     // MCP SSE routes (SSE endpoints, OAuth discovery, redirects)
     this.app.use(createMCPSSERoutes({
@@ -518,7 +527,6 @@ class HTTPMCPServer {
         logger.error('[DonationAPI] Failed to create donation invoice', { error: error.message });
         res.status(500).json({
           error: 'Не вдалося створити рахунок для донату',
-          message: error.message,
         });
       }
     }) as any);

--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -83,6 +83,13 @@ function getCallbackURL(req: any): string {
   return `${protocol}://${host}/auth/google/callback`;
 }
 
+function getSafeFrontendUrl(req: any): string {
+  const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
+  const rawHost = (req.headers['x-forwarded-host'] || req.headers.host || '').split(':')[0];
+  const host = ALLOWED_CALLBACK_HOSTS.has(rawHost) ? rawHost : 'legal.org.ua';
+  return `${protocol}://${host}`;
+}
+
 /**
  * @route   POST /auth/google/mobile
  * @desc    Authenticate via Google idToken from mobile SDK
@@ -172,7 +179,7 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
   // On mobile same-device flow the original polling tab is lost,
   // so pass the session ID from cookie so the login page can resume polling.
   router.get('/diia/callback', (_req, res) => {
-    const frontendUrl = `${_req.headers['x-forwarded-proto'] || _req.protocol}://${_req.headers['x-forwarded-host'] || _req.headers.host}`;
+    const frontendUrl = getSafeFrontendUrl(_req);
     const cookieHeader = _req.headers.cookie || '';
     const match = cookieHeader.match(/(?:^|;\s*)diia_session=([^;]+)/);
     const diiaSession = match ? decodeURIComponent(match[1]) : null;
@@ -215,8 +222,7 @@ if (process.env.DIIA_AUTH_ACQUIRER_TOKEN) {
     res.status(501).json({ error: 'Diia auth is not configured' });
   });
   router.get('/diia/callback', (_req, res) => {
-    const frontendUrl = `${_req.headers['x-forwarded-proto'] || _req.protocol}://${_req.headers['x-forwarded-host'] || _req.headers.host}`;
-    res.redirect(`${frontendUrl}/login`);
+    res.redirect(`${getSafeFrontendUrl(_req)}/login`);
   });
   router.get('/diia/status/:sessionId', (_req, res) => {
     res.status(501).json({ error: 'Diia auth is not configured' });

--- a/mcp_backend/src/routes/payment-routes.ts
+++ b/mcp_backend/src/routes/payment-routes.ts
@@ -74,7 +74,7 @@ export function createPaymentRouter(
       logger.error('Failed to create Monobank invoice', { error: error.message });
       return res.status(500).json({
         error: 'Payment creation failed',
-        message: error.message,
+        message: 'An unexpected error occurred',
       });
     }
   });
@@ -188,7 +188,7 @@ export function createPaymentRouter(
       logger.error('Failed to get payment status', { error: error.message });
       return res.status(500).json({
         error: 'Failed to get payment status',
-        message: error.message,
+        message: 'An unexpected error occurred',
       });
     }
   });
@@ -238,7 +238,7 @@ export function createWebhookRouter(
       logger.error('Monobank webhook failed', { error: error.message });
       return res.status(400).json({
         error: 'Webhook processing failed',
-        message: error.message,
+        message: 'An unexpected error occurred',
       });
     }
   });

--- a/mcp_backend/src/services/attorney-profile-service.ts
+++ b/mcp_backend/src/services/attorney-profile-service.ts
@@ -162,7 +162,7 @@ export class AttorneyProfileService {
 
   async getPublicProfile(profileIdOrUserId: string): Promise<AttorneyProfile | null> {
     const result = await this.db.query(
-      `SELECT ap.*, u.name as user_name, u.email as user_email,
+      `SELECT ap.*, u.name as user_name,
               o.name as organization_name, o.org_type
        FROM attorney_profiles ap
        JOIN users u ON u.id = ap.user_id

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -87,7 +87,21 @@ export class MonobankService {
 
     // Amount in kopecks (1 UAH = 100 kopecks)
     const amountKopecks = Math.round(amountUah * 100);
-    const finalRedirectUrl = redirectUrl || `${this.redirectUrl}/payment/success`;
+    const defaultRedirect = `${this.redirectUrl}/payment/success`;
+    let finalRedirectUrl = defaultRedirect;
+    if (redirectUrl) {
+      try {
+        const parsed = new URL(redirectUrl);
+        const ALLOWED_REDIRECT_HOSTS = new Set(['legal.org.ua', 'platform.legal.org.ua']);
+        if (ALLOWED_REDIRECT_HOSTS.has(parsed.hostname)) {
+          finalRedirectUrl = redirectUrl;
+        } else {
+          logger.warn('[MonobankService] Blocked redirect_url with disallowed host', { host: parsed.hostname });
+        }
+      } catch {
+        logger.warn('[MonobankService] Invalid redirect_url, using default');
+      }
+    }
     const orderRef = `SL-${userId.substring(0, 8)}-${Date.now()}`;
 
     logger.info('[MonobankService] Creating invoice', { userId, amountUah, amountKopecks });


### PR DESCRIPTION
## Summary
Phase 1 of security hardening plan triggered by automated scanner (0xsc4nn3r) probe on 01.05.2026.

- **Host header injection** in Diia callback — crafted `Host` header could redirect users to phishing sites after Diia auth. Now validates against `ALLOWED_CALLBACK_HOSTS` allowlist
- **Redirect URL injection** in Monobank payments — user-supplied `redirect_url` passed directly to payment API. Now validates origin against allowlist
- **Health endpoint information disclosure** — `/health` exposed all dependency statuses (Redis, Qdrant, OpenAI, MinIO, DB pool, payout reconciliation) without auth. Detailed check moved to `/api/admin/health` (JWT required)
- **Attorney PII leak** — `getPublicProfile` returned `user_email` without authentication
- **Error message leaks** — payment/donation endpoints returned raw `error.message` to clients

## Test plan
- [ ] `curl -H "Host: evil.com" https://legal.org.ua/auth/diia/callback` → redirect to `legal.org.ua`, not `evil.com`
- [ ] POST `/api/billing/payment/monobank/create` with `redirect_url: "https://evil.com"` → uses default redirect
- [ ] `curl https://legal.org.ua/health` → returns only `{ status, uptime }`, no dependency details
- [ ] `curl https://legal.org.ua/api/admin/health` without JWT → 401
- [ ] `GET /api/attorneys/:id` without auth → no `user_email` in response
- [ ] Trigger payment error → response contains generic message, not stack trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes critical injection and data exposure issues across auth, payments, health checks, and public profiles to block phishing and protect PII. Public `/health` is now minimal; detailed health moved behind JWT.

- **Bug Fixes**
  - Blocked Diia callback host header injection with `ALLOWED_CALLBACK_HOSTS` and a safe URL builder.
  - Validated Monobank `redirect_url` against an allowlist (`legal.org.ua`, `platform.legal.org.ua`) with a safe default fallback.
  - Limited public `/health` to basic status; added `/api/admin/health` (JWT required) for dependency details.
  - Removed `user_email` from `getPublicProfile` to prevent PII exposure.
  - Replaced raw error messages in payment/donation APIs with generic responses.

- **Migration**
  - Update monitors to call `/api/admin/health` with JWT; `/health` now returns minimal info.
  - Custom payment redirects must use allowed hosts or they will fall back to the default.

<sup>Written for commit 9507abc6752eae32fb908f0dc74a02fde0ea5448. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

