### PR TITLE
security: container and nginx infrastructure hardening

### DIFF
--- a/deployment/Dockerfile.mono-backend
+++ b/deployment/Dockerfile.mono-backend
@@ -98,6 +98,13 @@ COPY --from=builder /app/mcp_backend/scripts ./scripts
 COPY --from=builder /app/mcp_backend/assets ./assets
 COPY --from=builder /app/mcp_backend/src/migrations ./src/migrations
 
+RUN mkdir -p /app/data && \
+    addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001 && \
+    chown -R nodejs:nodejs /app
+
+USER nodejs
+
 EXPOSE 3000
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \

--- a/deployment/Dockerfile.mono-rada
+++ b/deployment/Dockerfile.mono-rada
@@ -62,6 +62,12 @@ COPY --from=builder /app/mcp_rada/dist ./dist
 COPY --from=builder /app/mcp_rada/scripts ./scripts
 COPY --from=builder /app/mcp_rada/src/migrations ./src/migrations
 
+RUN addgroup -g 1001 -S nodejs && \
+    adduser -S nodejs -u 1001 && \
+    chown -R nodejs:nodejs /app
+
+USER nodejs
+
 EXPOSE 3001
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -51,7 +51,7 @@ services:
           memory: 8G
 
   pgbouncer-prod:
-    image: edoburu/pgbouncer:latest
+    image: edoburu/pgbouncer:1.24.0
     container_name: secondlayer-pgbouncer-prod
     ports:
     - "127.0.0.1:5439:5432"
@@ -148,7 +148,7 @@ services:
           memory: 2G
 
   qdrant-prod:
-    image: qdrant/qdrant:latest
+    image: qdrant/qdrant:v1.17.0
     container_name: secondlayer-qdrant-prod
     ports:
     - "127.0.0.1:6339:6333"
@@ -485,7 +485,7 @@ services:
       - secondlayer-prod-network
 
   minio-prod:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: minio-prod
     command: server /data --console-address ":9001"
     environment:
@@ -857,7 +857,7 @@ services:
           memory: 64M
 
   nginx-prod:
-    image: nginx:alpine
+    image: nginx:1.27-alpine
     container_name: nginx-prod
     logging:
       driver: json-file

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -131,6 +131,9 @@ location /api/v1/sse {
         add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control" always;
         add_header Access-Control-Allow-Credentials "true" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Content-Length 0;
         add_header Content-Type text/plain;
         return 204;
@@ -153,10 +156,9 @@ location /api {
     proxy_set_header X-Forwarded-Proto $forwarded_proto;
     proxy_set_header Connection "";
 
-    # SSE support
     proxy_buffering off;
     proxy_cache off;
-    proxy_read_timeout 86400s;
+    proxy_read_timeout 300s;
 }
 
 # ==========================================
@@ -212,6 +214,9 @@ location /sse {
         add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control" always;
         add_header Access-Control-Allow-Credentials "true" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Content-Length 0;
         add_header Content-Type text/plain;
         return 204;
@@ -249,6 +254,9 @@ location /v1/sse {
         add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control" always;
         add_header Access-Control-Allow-Credentials "true" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Content-Length 0;
         add_header Content-Type text/plain;
         return 204;
@@ -379,6 +387,7 @@ location ^~ /s3/ {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(self)" always;
 
     # Hide MinIO Content-Disposition to allow inline PDF viewing
     proxy_hide_header Content-Disposition;


### PR DESCRIPTION
## Summary
Phase 2 of security hardening — infrastructure layer.

- **Non-root containers** — backend and RADA Dockerfiles now run as `nodejs` user (UID 1001), matching OpenReyestr pattern
- **Nginx security headers** — fixed inheritance bug where OPTIONS blocks in SSE locations cleared HSTS, X-Frame-Options, X-Content-Type-Options. Added Permissions-Policy to /s3/ location
- **Pinned images** — pgbouncer 1.24.0, qdrant v1.17.0, minio RELEASE.2025-09-07, nginx 1.27-alpine (was :latest)
- **API timeout** — reduced /api proxy_read_timeout from 86400s to 300s (SSE endpoints keep 3600s)

## Test plan
- [ ] `docker exec secondlayer-app-prod whoami` → `nodejs`
- [ ] `docker exec rada-mcp-prod whoami` → `nodejs`
- [ ] `curl -I https://legal.org.ua/api/v1/sse -X OPTIONS` → contains `Strict-Transport-Security`
- [ ] `docker compose config | grep "image:"` → no `:latest` on pgbouncer/qdrant/minio/nginx
- [ ] Upload and general API still work with 300s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens container and nginx infrastructure: run backend services as non‑root, restore missing security headers in SSE `OPTIONS`, pin infra images, and set safer API timeouts.

- **Bug Fixes**
  - Restored `Strict-Transport-Security`, `X-Frame-Options`, and `X-Content-Type-Options` in SSE `OPTIONS` responses; added `Permissions-Policy` on `/s3/`.

- **Refactors**
  - Run backend and RADA containers as `nodejs` (UID 1001) instead of root.
  - Pin infra images: `edoburu/pgbouncer:1.24.0`, `qdrant/qdrant:v1.17.0`, `minio/minio:RELEASE.2025-09-07T16-13-09Z`, `nginx:1.27-alpine`.
  - Reduce `/api` `proxy_read_timeout` to 300s; SSE locations keep 3600s.

<sup>Written for commit 8e73d6fde41166520a2e4959c9c4a908b206848f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

