### PR TITLE
fix(test): update monobank test for redirect URL validation

### DIFF
--- a/mcp_backend/src/services/__tests__/monobank-service.test.ts
+++ b/mcp_backend/src/services/__tests__/monobank-service.test.ts
@@ -271,10 +271,10 @@ describe('MonobankService — createInvoice', () => {
     });
     global.fetch = mockFetch as any;
 
-    await service.createInvoice('user-abc12345', 100, 'Top-up', 'https://myapp.com/callback');
+    await service.createInvoice('user-abc12345', 100, 'Top-up', 'https://legal.org.ua/payment/custom');
 
     const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(callBody.redirectUrl).toBe('https://myapp.com/callback');
+    expect(callBody.redirectUrl).toBe('https://legal.org.ua/payment/custom');
   });
 
   it('rounds kopecks correctly for fractional amounts', async () => {


### PR DESCRIPTION
## Summary
- Fixes CI failure caused by Phase 1 security fix (redirect_url allowlist)
- Test was using `myapp.com` which is now blocked — updated to `legal.org.ua`

## Test plan
- [ ] CI passes — monobank-service.test.ts no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the Monobank createInvoice test to use an allowlisted redirect URL and satisfy the new redirect_url validation. Replaces https://myapp.com/callback with https://legal.org.ua/payment/custom to fix CI.

<sup>Written for commit ee3d2e9bee9dd165185e43c60f0b0dab6ad2a68f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

