### PR TITLE
security: auth hardening — JWT pinning, terminal env, PKCE

### DIFF
--- a/mcp_backend/src/controllers/auth-common.ts
+++ b/mcp_backend/src/controllers/auth-common.ts
@@ -106,7 +106,7 @@ export function generateToken(user: User): string {
       googleId: user.google_id,
     },
     JWT_SECRET,
-    { expiresIn: JWT_EXPIRES_IN }
+    { expiresIn: JWT_EXPIRES_IN, algorithm: 'HS256' }
   );
 }
 

--- a/mcp_backend/src/controllers/auth-profile.ts
+++ b/mcp_backend/src/controllers/auth-profile.ts
@@ -352,7 +352,7 @@ export async function refreshToken(req: Request, res: Response): Promise<Respons
     const token = authHeader.replace('Bearer ', '');
 
     // Verify existing token
-    const decoded = jwt.verify(token, JWT_SECRET) as any;
+    const decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }) as any;
 
     // Create new token with same payload but fresh expiry
     const newToken = jwt.sign(
@@ -362,7 +362,7 @@ export async function refreshToken(req: Request, res: Response): Promise<Respons
         googleId: decoded.googleId,
       },
       JWT_SECRET,
-      { expiresIn: JWT_EXPIRES_IN }
+      { expiresIn: JWT_EXPIRES_IN, algorithm: 'HS256' }
     );
 
     logger.info('Token refreshed', { userId: decoded.userId });

--- a/mcp_backend/src/middleware/dual-auth.ts
+++ b/mcp_backend/src/middleware/dual-auth.ts
@@ -81,7 +81,7 @@ export function getWebAuthnService(): WebAuthnService {
 async function authenticateWithJWT(req: AuthenticatedRequest, token: string): Promise<void> {
   try {
     // Verify JWT signature and expiry
-    const decoded = jwt.verify(token, JWT_SECRET) as any;
+    const decoded = jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] }) as any;
 
     // Fetch user from database
     if (!userService) {

--- a/mcp_backend/src/middleware/jwt-auth.ts
+++ b/mcp_backend/src/middleware/jwt-auth.ts
@@ -61,7 +61,7 @@ export function authenticateJWT(req: AuthenticatedRequest, res: Response, next: 
 
   try {
     // Verify and decode JWT token
-    const decoded = jwt.verify(token, jwtSecret) as JWTPayload;
+    const decoded = jwt.verify(token, jwtSecret, { algorithms: ['HS256'] }) as JWTPayload;
 
     // Attach JWT payload to request
     req.jwt = decoded;

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -180,7 +180,7 @@ export function createMCPSSERoutes(deps: {
           const jwt = await import('jsonwebtoken');
           const jwtSecret = process.env.JWT_SECRET;
           if (!jwtSecret) throw new Error('JWT_SECRET not configured');
-          const decoded = jwt.verify(token, jwtSecret) as any;
+          const decoded = jwt.verify(token, jwtSecret, { algorithms: ['HS256'] }) as any;
           userId = decoded.userId;
           logger.debug('[MCP SSE] Authenticated with JWT', { userId });
         } else if (token.startsWith('mcp_token_')) {
@@ -318,7 +318,7 @@ export function createMCPSSERoutes(deps: {
           const jwt = await import('jsonwebtoken');
           const jwtSecret = process.env.JWT_SECRET;
           if (!jwtSecret) throw new Error('JWT_SECRET not configured');
-          const decoded = jwt.verify(token, jwtSecret) as any;
+          const decoded = jwt.verify(token, jwtSecret, { algorithms: ['HS256'] }) as any;
           userId = decoded.userId;
           logger.debug('[MCP v1/sse] Authenticated with JWT', { userId });
         } else {

--- a/mcp_backend/src/routes/terminal-routes.ts
+++ b/mcp_backend/src/routes/terminal-routes.ts
@@ -48,24 +48,15 @@ function sanitizePtyInput(raw: string): string {
 // Track active sessions per admin
 const activeSessions = new Map<string, Set<WebSocket>>();
 
-const SENSITIVE_ENV_VARS = [
-  'OPENAI_API_KEY',
-  'SECONDARY_LAYER_KEYS',
-  'ZAKONONLINE_API_TOKEN',
-  'JWT_SECRET',
-  'POSTGRES_PASSWORD',
-  'REDIS_PASSWORD',
-  'ANTHROPIC_API_KEY',
-];
+const SENSITIVE_PATTERN = /SECRET|PASSWORD|KEY|TOKEN|CREDENTIALS|PASS/i;
 
 function buildPtyEnv(): Record<string, string> {
   const env: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (!SENSITIVE_ENV_VARS.includes(key) && value !== undefined) {
+    if (!SENSITIVE_PATTERN.test(key) && value !== undefined) {
       env[key] = value;
     }
   }
-  // Ensure sensible terminal defaults
   env.TERM = 'xterm-256color';
   env.COLORTERM = 'truecolor';
   return env;
@@ -79,7 +70,7 @@ async function verifyAdminFromToken(
     const secret = process.env.JWT_SECRET;
     if (!secret) return null;
 
-    const decoded = jwt.verify(token, secret) as any;
+    const decoded = jwt.verify(token, secret, { algorithms: ['HS256'] }) as any;
     const userId = decoded?.id || decoded?.userId || decoded?.sub;
     if (!userId) return null;
 
@@ -210,7 +201,7 @@ export function attachTerminalWebSocket(httpServer: HttpServer, db: IDatabase): 
         return;
       }
 
-      const cwd = process.env.TERMINAL_CWD || '/home/vovkes/SecondLayer';
+      const cwd = process.env.TERMINAL_CWD || process.cwd();
 
       const ptyProcess = ptyModule.spawn('bash', [], {
         name: 'xterm-256color',

--- a/mcp_backend/src/routes/video-call-signaling.ts
+++ b/mcp_backend/src/routes/video-call-signaling.ts
@@ -22,7 +22,7 @@ async function verifyUserFromToken(
     const secret = process.env.JWT_SECRET;
     if (!secret) return null;
 
-    const decoded = jwt.verify(token, secret) as any;
+    const decoded = jwt.verify(token, secret, { algorithms: ['HS256'] }) as any;
     const userId = decoded?.id || decoded?.userId || decoded?.sub;
     if (!userId) return null;
 

--- a/mcp_backend/src/services/oauth-service.ts
+++ b/mcp_backend/src/services/oauth-service.ts
@@ -448,15 +448,11 @@ export class OAuthService {
     codeChallengeMethod: string
   ): boolean {
     if (codeChallengeMethod === 'S256') {
-      // SHA256 hash of code_verifier, base64url encoded
       const hash = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
       return hash === codeChallenge;
-    } else if (codeChallengeMethod === 'plain') {
-      // Plain comparison
-      return codeVerifier === codeChallenge;
     }
 
-    logger.warn('Unsupported PKCE code_challenge_method', {
+    logger.warn('Rejected PKCE method (only S256 allowed)', {
       method: codeChallengeMethod,
     });
     return false;


### PR DESCRIPTION
## Summary
Phase 3 of security hardening — authentication layer.

- **JWT algorithm pinning** — all 9 `jwt.verify()`/`jwt.sign()` call sites now explicitly specify `HS256`. Prevents algorithm confusion attacks where attacker switches to `alg: "none"`
- **Terminal env var filtering** — replaced hardcoded 7-entry blocklist with pattern-based regex `/SECRET|PASSWORD|KEY|TOKEN|CREDENTIALS|PASS/i`. Catches all ~30+ sensitive vars (MONOBANK_*, AWS_*, VOYAGEAI_*, DIIA_*, etc.)
- **Terminal CWD** — removed hardcoded `/home/vovkes/SecondLayer`, uses `process.cwd()` to avoid leaking directory structure
- **PKCE plain method removed** — only S256 allowed per RFC 7636 security best practices

## Test plan
- [ ] JWT with `alg: "none"` → 401
- [ ] Admin terminal: `env | grep -i key` → empty, `env | grep -i password` → empty
- [ ] Terminal opens in container WORKDIR, not developer home dir
- [ ] OAuth flow with `code_challenge_method=plain` → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthens auth and the admin terminal by pinning JWT to `HS256`, enforcing PKCE `S256`, filtering sensitive env vars by pattern, and removing the hardcoded terminal CWD. Blocks alg:none token abuse, reduces env leaks, and stops exposing local paths.

- **Refactors**
  - Pin `HS256` for all `jsonwebtoken` `verify`/`sign` calls.
  - Replace the terminal env allowlist with regex filtering: `/SECRET|PASSWORD|KEY|TOKEN|CREDENTIALS|PASS/i`.
  - Use `process.cwd()` for terminal CWD (no hardcoded dev path).
  - PKCE: reject `plain`; accept only `S256` and log rejections.

<sup>Written for commit 25f93776aabba81da415d7ed37fb3997698ff6b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

