### PR TITLE
security: payment verification, rate limiting, upload validation

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -49,7 +49,7 @@ import { createTemplateRoutes } from './routes/template-routes.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { createOAuthRouter } from './routes/oauth-routes.js';
 // createHybridAuthMiddleware available from './middleware/oauth-auth.js' if needed
-import { healthCheckRateLimit, webhookRateLimit, globalApiRateLimit, consultationRateLimit } from './middleware/rate-limit.js';
+import { healthCheckRateLimit, webhookRateLimit, globalApiRateLimit, consultationRateLimit, publicSearchRateLimit } from './middleware/rate-limit.js';
 import { createUploadRouter } from './routes/upload-routes.js';
 import { createConversationRouter } from './routes/conversation-routes.js';
 import { createEvidenceRoutes } from './routes/evidence-routes.js';
@@ -663,7 +663,7 @@ class HTTPMCPServer {
 
     // ERAU proxy - Ukrainian Bar Registry (public, no auth required)
     const erauCacheService = new ERAUCacheService(this.services.db);
-    this.app.use('/api/erau', optionalJWT as any, createERAUProxyRoutes(erauCacheService, this.services.db));
+    this.app.use('/api/erau', publicSearchRateLimit as any, optionalJWT as any, createERAUProxyRoutes(erauCacheService, this.services.db));
     logger.info('ERAU proxy routes registered at /api/erau');
 
     // Worker heartbeat (uses dualAuth so EC2 workers can auth with SECONDARY_LAYER_KEYS)
@@ -690,7 +690,7 @@ class HTTPMCPServer {
     logger.info('Usage analytics routes registered at /api/usage');
 
     // Attorney routes - search is public (optionalJWT), profile management requires JWT
-    this.app.use('/api/attorneys', optionalJWT as any, createAttorneyRoutes(this.app_.attorneyProfileService));
+    this.app.use('/api/attorneys', publicSearchRateLimit as any, optionalJWT as any, createAttorneyRoutes(this.app_.attorneyProfileService));
     logger.info('Attorney routes registered at /api/attorneys');
 
     // E2EE encryption key management routes - all require JWT

--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -181,3 +181,9 @@ export const globalApiRateLimit = createRateLimiter({
   maxRequests: 3000,
   keyPrefix: 'ratelimit:global-api',
 });
+
+export const publicSearchRateLimit = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 30,
+  keyPrefix: 'ratelimit:public-search',
+});

--- a/mcp_backend/src/routes/upload-routes.ts
+++ b/mcp_backend/src/routes/upload-routes.ts
@@ -179,6 +179,14 @@ export function createUploadRouter(
         });
       }
 
+      if (relativePath && (typeof relativePath !== 'string' || relativePath.includes('..') || relativePath.startsWith('/') || relativePath.includes('\0'))) {
+        return res.status(400).json({ error: 'Invalid relativePath' });
+      }
+
+      if (metadata && (typeof metadata !== 'object' || Array.isArray(metadata))) {
+        return res.status(400).json({ error: 'Invalid metadata — must be an object' });
+      }
+
       // Force encryption for JWT consumer uploads — prevent plaintext bypass via API
       const isJwtConsumer = req.authType === 'jwt';
       const effectiveEncrypt = isJwtConsumer ? true : encrypt === true;

--- a/mcp_backend/src/services/monobank-service.ts
+++ b/mcp_backend/src/services/monobank-service.ts
@@ -343,8 +343,19 @@ export class MonobankService {
       ['succeeded', pi.id]
     );
 
-    // Credit user balance (both UAH and USD equivalent)
-    const amountUah = parseFloat(pi.amount_uah) || (body.amount / 100);
+    // Verify amount matches stored invoice
+    const storedAmountUah = parseFloat(pi.amount_uah);
+    const webhookAmountUah = body.amount / 100;
+    if (storedAmountUah > 0 && Math.abs(storedAmountUah - webhookAmountUah) > 0.01) {
+      logger.error('[MonobankService] Amount mismatch in webhook', {
+        stored: storedAmountUah, webhook: webhookAmountUah, invoiceId: body.invoiceId,
+      });
+      await this.db.query(
+        "UPDATE payment_intents SET metadata = metadata || $1::jsonb WHERE id = $2",
+        [JSON.stringify({ amount_mismatch: true, webhook_amount: webhookAmountUah }), pi.id]
+      );
+    }
+    const amountUah = storedAmountUah > 0 ? storedAmountUah : webhookAmountUah;
     let amountUsd = 0;
     if (this.currencyService) {
       try {


### PR DESCRIPTION
## Summary
Phase 4 of security hardening — payment security and input validation.

- **Payment amount verification** — webhook handler now compares Monobank webhook amount with stored invoice amount. Mismatches are flagged in `payment_intent.metadata` for audit review
- **Public search rate limiting** — `/api/erau` (Bar Registry) and `/api/attorneys` now limited to 30 req/min per IP to prevent mass enumeration
- **Upload metadata validation** — rejects path traversal (`..`, absolute paths, null bytes) in `relativePath`, enforces `metadata` is a plain object

## Test plan
- [ ] Payment webhook with matching amount → normal processing
- [ ] 31 requests to `/api/attorneys` in 60s → 429 on 31st
- [ ] Upload init with `relativePath: "../../etc/passwd"` → 400
- [ ] Upload init with `metadata: [1,2,3]` → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens payments and public search endpoints. Verifies Monobank webhook amounts, adds 30 req/min/IP rate limits, and blocks unsafe upload paths and metadata.

- **Security**
  - Verify Monobank webhook amount against stored invoice; flag mismatches in payment intent metadata and log for audit.
  - Add `publicSearchRateLimit` (30 req/min/IP) to `/api/erau` and `/api/attorneys` to curb enumeration.
  - Reject dangerous `relativePath` values (`..`, leading `/`, null bytes) and require `metadata` to be a plain object.

<sup>Written for commit ea3f82615b0706720b3da7c1d9449e9c4d194852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

