### PR TITLE
fix(deploy): correct pgbouncer image tag

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -51,7 +51,7 @@ services:
           memory: 8G
 
   pgbouncer-prod:
-    image: edoburu/pgbouncer:1.24.0
+    image: edoburu/pgbouncer:v1.24.0-p1
     container_name: secondlayer-pgbouncer-prod
     ports:
     - "127.0.0.1:5439:5432"


### PR DESCRIPTION
## Summary
- Fixes prod deploy failure: `edoburu/pgbouncer:1.24.0` doesn't exist
- Correct tag format is `v1.24.0-p1` (v-prefix + patch suffix)

## Test plan
- [ ] Prod deploy succeeds — pgbouncer image pulls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production deploy failures by using the correct `edoburu/pgbouncer` image tag. Switches from `edoburu/pgbouncer:1.24.0` to `edoburu/pgbouncer:v1.24.0-p1` so the image pulls successfully.

<sup>Written for commit 6c597c2094ad431e2e6ed3d3fe792f9238fd0193. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

