### PR TITLE
fix(deploy): increase qdrant healthcheck start_period to 600s

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -157,10 +157,10 @@ services:
     - qdrant_prod_data:/qdrant/storage
     healthcheck:
       test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/6333'"]
-      interval: 10s
+      interval: 30s
       timeout: 5s
       retries: 10
-      start_period: 60s
+      start_period: 600s
     restart: unless-stopped
     networks:
     - secondlayer-prod-network


### PR DESCRIPTION
## Summary
- Qdrant loads 1.4 TB `edrsr_decisions` collection on startup (~10-30 min)
- Previous `start_period: 60s` caused healthcheck failures during deploy
- Increased to `start_period: 600s`, `interval: 30s`

## Test plan
- [ ] Prod deploy completes — qdrant passes healthcheck after loading all collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Qdrant healthcheck start_period to 600s and interval to 30s to prevent deploy failures while it loads the 1.4 TB edrsr_decisions collection (10–30 min). This avoids false healthcheck negatives during startup so deploys can complete.

<sup>Written for commit 546c158f74bc9f4720198b4e46450460849fe631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

