### PR TITLE
fix(deploy): add entrypoint to fix volume-mounted dir ownership

### DIFF
--- a/deployment/Dockerfile.mono-backend
+++ b/deployment/Dockerfile.mono-backend
@@ -98,16 +98,18 @@ COPY --from=builder /app/mcp_backend/scripts ./scripts
 COPY --from=builder /app/mcp_backend/assets ./assets
 COPY --from=builder /app/mcp_backend/src/migrations ./src/migrations
 
-RUN mkdir -p /app/data && \
+RUN apk add --no-cache su-exec && \
+    mkdir -p /app/data /app/data/uploads /app/data/uploads/multer-tmp && \
     addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001 && \
     chown -R nodejs:nodejs /app
 
-USER nodejs
+COPY deployment/scripts/backend-entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 3000
 
 HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3000/health/ready', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); })"
 
-CMD ["node", "--max-old-space-size=2048", "dist/http-server.js"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/deployment/scripts/backend-entrypoint.sh
+++ b/deployment/scripts/backend-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Entrypoint: fix volume-mounted directory ownership, then drop to nodejs user.
+# Docker named volumes are created as root; the app runs as nodejs (uid 1001).
+
+DIRS="/app/data /app/data/uploads /app/data/uploads/multer-tmp /app/mcp_backend/logs"
+
+for dir in $DIRS; do
+  mkdir -p "$dir"
+  chown nodejs:nodejs "$dir"
+done
+
+exec su-exec nodejs node --max-old-space-size=2048 dist/http-server.js


### PR DESCRIPTION
## Summary
- Docker named volumes (`/app/data`) are created with root ownership, but the backend runs as `nodejs` (uid 1001)
- This caused `POST /api/upload/init` to return 500 — `fs.mkdir()` failed with EACCES when creating session dirs in `/app/data/uploads/`
- Adds `backend-entrypoint.sh` that runs as root, fixes ownership of volume-mounted dirs, then drops privileges to `nodejs` via `su-exec`

## Root cause
User `teosoph@gmail.com` reported upload failures. Investigation showed 4 upload sessions stuck in `pending` with 0 chunks uploaded. Nginx logs confirmed `/api/upload/init` returning HTTP 500. The container's `/app/data/uploads/` was owned by root (Docker volume mount behavior), preventing the nodejs process from creating session directories.

## Test plan
- [ ] Build image locally: `docker compose -f docker-compose.prod.yml build backend-blue`
- [ ] Verify entrypoint logs "fixing ownership" on first start with fresh volume
- [ ] Verify upload init succeeds (returns 201) after deploy
- [ ] Verify healthcheck passes (node process runs as nodejs, not root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes upload failures by ensuring Docker volume directories are writable by `nodejs`. Adds a root entrypoint that sets correct ownership, then starts the server as `nodejs`.

- **Bug Fixes**
  - Add `backend-entrypoint.sh` to create/chown `/app/data`, `/app/data/uploads`, `/app/data/uploads/multer-tmp`, and `/app/mcp_backend/logs`.
  - Install `su-exec` and switch to `ENTRYPOINT` so the script runs, then drops privileges to `nodejs`.
  - Resolves EACCES on `fs.mkdir()` that caused `POST /api/upload/init` to return 500 on fresh volumes.

<sup>Written for commit 11ccd77fe39c48f436fb3d4f70c5862e2b9d49f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

