### PR TITLE
fix(frontend): make /team page publicly accessible

### DIFF
--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -308,6 +308,10 @@ export const router = createBrowserRouter([
     element: S(ProductPage),
   },
   {
+    path: ROUTES.TEAM,
+    element: S(TeamPage),
+  },
+  {
     path: ROUTES.INVESTOR_LETTER,
     element: S(InvestorLetterPage),
   },
@@ -382,10 +386,6 @@ export const router = createBrowserRouter([
                 element: S(BillingSettingsTab),
               },
             ],
-          },
-          {
-            path: ROUTES.TEAM,
-            element: S(TeamPage),
           },
           {
             path: ROUTES.MCP_CONNECT,


### PR DESCRIPTION
## Summary
- `/team` route was inside `AuthGuard`, redirecting unauthenticated visitors to login
- Moved to public routes section alongside `/about` and `/product`

## Test plan
- [ ] Open https://legal.org.ua/team in incognito — should render without login
- [ ] Verify `/about` and `/product` still work publicly
- [ ] Verify authenticated routes still require login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `/team` publicly accessible by moving the route from the authenticated section to the public routes with `/about` and `/product`. Unauthenticated visitors can now view `/team` without a login redirect.

<sup>Written for commit 80125e67a098ca08cdb606961b1a1c83c34bd729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

