### PR TITLE
fix(deploy): entrypoint must pass through CMD for migrations

### DIFF
--- a/deployment/Dockerfile.mono-backend
+++ b/deployment/Dockerfile.mono-backend
@@ -113,3 +113,4 @@ HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3000/health/ready', (r) => { let d=''; r.on('data', c => d+=c); r.on('end', () => { if (r.statusCode !== 200) { process.stderr.write(d); process.exit(1); } process.exit(0); }); }).on('error', e => { process.stderr.write(e.message); process.exit(1); })"
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["node", "--max-old-space-size=2048", "dist/http-server.js"]

--- a/deployment/scripts/backend-entrypoint.sh
+++ b/deployment/scripts/backend-entrypoint.sh
@@ -9,4 +9,4 @@ for dir in $DIRS; do
   chown nodejs:nodejs "$dir"
 done
 
-exec su-exec nodejs node --max-old-space-size=2048 dist/http-server.js
+exec su-exec nodejs "$@"


### PR DESCRIPTION
## Summary
- Entrypoint hardcoded `dist/http-server.js`, ignoring CMD override from docker-compose
- `migrate-local` container loaded http-server.js → imported dual-auth.js → crashed on missing JWT_SECRET
- Now entrypoint uses `"$@"` to pass through CMD, with default CMD in Dockerfile for http-server

## Test plan
- [ ] CI local deploy passes (migrate-local exits 0)
- [ ] Backend container starts normally (http-server)
- [ ] Seed containers work (also use command override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix entrypoint to respect container CMD so migrations and seeds run their own commands. Adds a default CMD for the http server to preserve current behavior.

- **Bug Fixes**
  - Entrypoint now executes `"$@"` instead of hardcoding `dist/http-server.js`.
  - Dockerfile sets default CMD to run the http server with `--max-old-space-size=2048`.
  - Prevents `migrate-local` from starting the server and crashing on missing `JWT_SECRET`; docker-compose overrides now work.

<sup>Written for commit 0687f692e62dee2beb66ead9c5d53cb282376724. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

