### PR TITLE
fix(frontend): keep /team behind auth, /about/team is public

### DIFF
--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -308,10 +308,6 @@ export const router = createBrowserRouter([
     element: S(ProductPage),
   },
   {
-    path: ROUTES.TEAM,
-    element: S(TeamPage),
-  },
-  {
     path: ROUTES.INVESTOR_LETTER,
     element: S(InvestorLetterPage),
   },
@@ -386,6 +382,10 @@ export const router = createBrowserRouter([
                 element: S(BillingSettingsTab),
               },
             ],
+          },
+          {
+            path: ROUTES.TEAM,
+            element: S(TeamPage),
           },
           {
             path: ROUTES.MCP_CONNECT,


### PR DESCRIPTION
## Summary
- Reverts #1528 which incorrectly made `/team` (internal team management) public
- `/team` is now back inside AuthGuard (requires login)
- `/about/team` (public founders page) was already public and unaffected

## Test plan
- [ ] `/about/team` opens without login — shows founders info
- [ ] `/team` redirects to login when not authenticated
- [ ] `/team` works normally when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `/team` back behind the auth guard to keep the internal team management page private. `/about/team` remains the public founders page and is unchanged.

<sup>Written for commit 9823e33abcf7c213ea576edd0b455b2dee60b013. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

