### PR TITLE
fix(deploy): prevent Qdrant recreation during backend deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -515,11 +515,16 @@ jobs:
             [ "${OPENREYESTR_CHANGED}" = "true" ] && { \$DC up migrate-openreyestr-prod || true; }
 
             # --- 3. Start new-color containers alongside old ones ---
+            # Ensure infra services are running WITHOUT recreating them.
+            # Qdrant holds vector indices and may be running long embedding jobs;
+            # recreating it interrupts indexing and takes 10+ min to recover.
+            \$DC up -d --no-recreate qdrant-prod redis-prod pgbouncer-prod
+
             if [ "\$ANY_BACKEND" = "true" ]; then
               if [ "\$NEW_BACKEND" = "green" ]; then
-                \$DC --profile green up -d app-prod-green document-service-prod-green rada-mcp-app-prod-green app-openreyestr-prod-green
+                \$DC --profile green up -d --no-deps app-prod-green document-service-prod-green rada-mcp-app-prod-green app-openreyestr-prod-green
               else
-                \$DC up -d app-prod document-service-prod rada-mcp-app-prod app-openreyestr-prod
+                \$DC up -d --no-deps app-prod document-service-prod rada-mcp-app-prod app-openreyestr-prod
               fi
             fi
             if [ "${FRONTEND_CHANGED}" = "true" ]; then


### PR DESCRIPTION
## Summary

- Add `--no-recreate` for infra services (qdrant, redis, pgbouncer) before starting app containers
- Add `--no-deps` for app containers so compose doesn't touch their dependencies
- Prevents interruption of long-running embedding/indexing jobs on Qdrant

## Context

First deploy attempt for LEXAI-877 failed because Qdrant was recreated and took 15 min to recover (longer than its 600s start_period healthcheck). This also interrupts any active Voyage embedding jobs.

## Test plan

- [ ] Trigger backend deploy, verify Qdrant is NOT recreated (stays running)
- [ ] Verify app containers still start and pass health checks
- [ ] Verify embedding jobs on prod are not interrupted during deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop recreating Qdrant during backend deploys by starting infra with `--no-recreate` and starting apps with `--no-deps` so dependencies aren’t touched. Addresses LEXAI-877 and prevents embedding/indexing interruptions.

- **Bug Fixes**
  - Ensure `qdrant-prod`, `redis-prod`, `pgbouncer-prod` are up with `docker-compose up -d --no-recreate` before app containers.
  - Start app containers (`app-prod*`, `document-service*`, `rada-mcp-app*`, `app-openreyestr*`) with `--no-deps` for both blue/green profiles to avoid restarting infra.

<sup>Written for commit ca800fc0ac71e701062c6667e3a94f4ee0b71e2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

