### PR TITLE
fix(prompt): suppress empty results from irrelevant tools (LEXAI-877)

### DIFF
--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -1,4 +1,5 @@
 // Proprietary implementation: @secondlayer/core (private repo)
+// LEXAI-877: suppress empty results from irrelevant tools in answer
 
 export type QueryType =
   | 'case_lookup'


### PR DESCRIPTION
## Summary

- Fix answer leaking internal tool state ("Не знайдено документів у Vault") for unrelated queries
- Narrow the "report empty results" system prompt rule to only key tools for the query

## Context

During LEXAI-877 verification, a legislation-focused query ("Оподаткування нерухомості для ВПО") produced an answer starting with: "Не знайдено документів у Vault..." because `list_documents` was called as a side-effect and the blanket prompt rule told the LLM to report empty results from ANY tool.

Fix is in secondlayer-core PR #10 (merged). This PR triggers CI to pick up the updated prompt.

## Test plan

- [ ] CI passes (shared build + backend build + tests)
- [ ] After deploy: send legislation query, verify answer doesn't mention empty Vault results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress empty-result messages from irrelevant tools in user answers by narrowing the system prompt to report empties only for query-relevant tools. Addresses LEXAI-877 and pulls in the updated prompt from `@secondlayer/core`.

<sup>Written for commit 9e15e2524eab159b3bd727706c598c7f9dd063a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

