### PR TITLE
test(tools): unit tests for consolidated tools (LEXAI-881/882/883)

### DIFF
--- a/mcp_backend/src/api/__tests__/analyze-data-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/analyze-data-tool.test.ts
@@ -1,0 +1,332 @@
+/**
+ * AnalyzeDataTool unit tests
+ *
+ * Covers:
+ * - Tool definition
+ * - SQL validation: SELECT-only, forbidden keywords, LIMIT requirement, limit cap
+ * - Table whitelist enforcement
+ * - Read-only transaction setup (BEGIN READ ONLY + statement_timeout)
+ * - Comment stripping (-- and /* *​/ )
+ * - DB error handling (timeout, read-only violation)
+ * - Row cap enforcement
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { AnalyzeDataTool } from '../tools/analyze-data-tool.js';
+
+type QueryCall = { sql: string; params?: any[] };
+
+describe('AnalyzeDataTool', () => {
+  let calls: QueryCall[];
+  let tool: AnalyzeDataTool;
+
+  const makePoolDb = (responder: (sql: string) => any) => ({
+    connect: jest.fn(() => {
+      const client = {
+        query: jest.fn((sql: string, params?: any[]) => {
+          calls.push({ sql, params });
+          return Promise.resolve(responder(sql));
+        }),
+        release: jest.fn(),
+      };
+      return Promise.resolve(client);
+    }),
+  });
+
+  const makeSimpleDb = (responder: (sql: string) => any) => ({
+    query: jest.fn((sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve(responder(sql));
+    }),
+  });
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  describe('tool definition', () => {
+    it('exposes single analyze_data tool', () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+      const defs = tool.getToolDefinitions();
+      expect(defs).toHaveLength(1);
+      expect(defs[0].name).toBe('analyze_data');
+      expect(defs[0].annotations?.readOnlyHint).toBe(true);
+    });
+
+    it('returns null for unknown tool', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+      expect(await tool.executeTool('other', {})).toBeNull();
+    });
+  });
+
+  describe('SQL validation', () => {
+    it('rejects empty sql', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', { sql: '' });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('sql');
+    });
+
+    it('rejects non-SELECT statements', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'INSERT INTO edrsr_documents VALUES (1)',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('SELECT');
+    });
+
+    it('rejects DELETE', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT 1; DELETE FROM edrsr_documents LIMIT 1',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('заборонені операції');
+    });
+
+    it('rejects DROP TABLE', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT 1; DROP TABLE edrsr_documents; LIMIT 1',
+      });
+      expect(result?.isError).toBe(true);
+    });
+
+    it('rejects UPDATE', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: "SELECT 1 FROM edrsr_documents; UPDATE edrsr_documents SET judge = 'x' LIMIT 1",
+      });
+      expect(result?.isError).toBe(true);
+    });
+
+    it('rejects TRUNCATE', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT 1; TRUNCATE edrsr_documents LIMIT 1',
+      });
+      expect(result?.isError).toBe(true);
+    });
+
+    it('requires LIMIT clause', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT count(*) FROM edrsr_documents',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('LIMIT');
+    });
+
+    it('rejects LIMIT > 500', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT * FROM edrsr_documents LIMIT 1000',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('500');
+    });
+
+    it('accepts LIMIT 500', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: [], rowCount: 0, fields: [] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT count(*) FROM edrsr_documents LIMIT 500',
+      });
+      expect(result?.isError).toBeFalsy();
+    });
+
+    it('strips SQL comments before validation', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      // DELETE is inside a comment, shouldn't trigger
+      const result = await tool.executeTool('analyze_data', {
+        sql: "SELECT count(*) FROM edrsr_documents -- DELETE FROM users\nLIMIT 10",
+      });
+      // Should fail on table whitelist or succeed, but NOT on "forbidden keyword"
+      expect(result?.isError).toBeFalsy();
+    });
+  });
+
+  describe('table whitelist', () => {
+    it('allows edrsr tables', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: [{ cnt: 42 }], rowCount: 1, fields: [{ name: 'cnt' }] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT count(*) as cnt FROM edrsr_documents LIMIT 1',
+      });
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.results[0].cnt).toBe(42);
+    });
+
+    it('allows opendata tables', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: [], rowCount: 0, fields: [] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT count(*) FROM opendata_lawyers LIMIT 1',
+      });
+      expect(result?.isError).toBeFalsy();
+    });
+
+    it('blocks user/billing tables', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT * FROM users LIMIT 10',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('users');
+    });
+
+    it('blocks billing tables', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT * FROM user_billing LIMIT 10',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('user_billing');
+    });
+
+    it('blocks sessions/auth tables', async () => {
+      const db = makeSimpleDb(() => ({ rows: [] }));
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT * FROM sessions LIMIT 10',
+      });
+      expect(result?.isError).toBe(true);
+    });
+
+    it('allows JOINs between whitelisted tables', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: [], rowCount: 0, fields: [] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT d.doc_id, c.name FROM edrsr_documents d JOIN edrsr_courts c ON c.court_code = d.court_code LIMIT 10',
+      });
+      expect(result?.isError).toBeFalsy();
+    });
+  });
+
+  describe('read-only transaction', () => {
+    it('sets up BEGIN READ ONLY and statement_timeout with pool', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: [], rowCount: 0, fields: [] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      await tool.executeTool('analyze_data', {
+        sql: 'SELECT count(*) FROM edrsr_documents LIMIT 1',
+      });
+
+      expect(calls.some(c => c.sql.includes('BEGIN TRANSACTION READ ONLY'))).toBe(true);
+      expect(calls.some(c => c.sql.includes('statement_timeout'))).toBe(true);
+      expect(calls.some(c => c.sql.includes('COMMIT'))).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('handles statement timeout', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('SET')) return { rows: [] };
+        if (sql.includes('ROLLBACK')) return { rows: [] };
+        throw new Error('canceling statement due to statement timeout');
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT * FROM edrsr_documents LIMIT 10',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('ліміт часу');
+    });
+
+    it('handles read-only violation', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('SET')) return { rows: [] };
+        if (sql.includes('ROLLBACK')) return { rows: [] };
+        throw new Error('cannot execute INSERT in a read-only transaction');
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: "SELECT count(*) FROM edrsr_documents LIMIT 1",
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('SELECT');
+    });
+  });
+
+  describe('response formatting', () => {
+    it('caps rows at 500', async () => {
+      const bigRows = Array.from({ length: 600 }, (_, i) => ({ id: i }));
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: bigRows, rowCount: 600, fields: [{ name: 'id' }] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT id FROM edrsr_documents LIMIT 500',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.rows_returned).toBe(500);
+      expect(parsed.has_more).toBe(true);
+    });
+
+    it('includes column names in response', async () => {
+      const db = makePoolDb((sql) => {
+        if (sql.includes('BEGIN') || sql.includes('COMMIT') || sql.includes('SET')) return { rows: [] };
+        return { rows: [{ cnt: 42, avg_val: 3.14 }], rowCount: 1, fields: [{ name: 'cnt' }, { name: 'avg_val' }] };
+      });
+      tool = new AnalyzeDataTool(db);
+
+      const result = await tool.executeTool('analyze_data', {
+        sql: 'SELECT count(*) as cnt, avg(share_percent) as avg_val FROM opendata_securities_owners LIMIT 1',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.columns).toEqual(['cnt', 'avg_val']);
+    });
+  });
+});

--- a/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
@@ -1,0 +1,284 @@
+/**
+ * EdsrUnifiedSearchTool unit tests
+ *
+ * Covers:
+ * - Tool definition: single search_court_decisions tool with mode enum
+ * - Mode routing: structured/fulltext/hybrid/semantic
+ * - Structured mode: WHERE clause, military presets, court name resolution, enrichment
+ * - Fulltext mode: delegates to FTS service, enriches results
+ * - Hybrid mode: graceful degradation when one leg fails
+ * - Semantic mode: redirects to fulltext with notice
+ * - Unknown mode rejection
+ * - Required param validation per mode
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { EdsrUnifiedSearchTool } from '../tools/edrsr-unified-search-tool.js';
+
+type QueryCall = { sql: string; params?: any[] };
+
+describe('EdsrUnifiedSearchTool', () => {
+  let db: any;
+  let calls: QueryCall[];
+  let tool: EdsrUnifiedSearchTool;
+  let mockFtsService: any;
+  let mockVectorizer: any;
+
+  const makeDb = (responder: (sql: string, params?: any[]) => any) => ({
+    query: jest.fn((sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve(responder(sql, params));
+    }),
+  });
+
+  beforeEach(() => {
+    calls = [];
+    mockFtsService = {
+      searchFulltext: jest.fn(() => Promise.resolve({
+        query: 'test',
+        total: 1,
+        results: [{
+          doc_id: 12345, cause_num: '756/1234/23', judge: 'Іванов І.І.',
+          court_code: 2605, justice_kind: 1, judgment_code: 3,
+          adjudication_date: '2024-06-15', headline: 'тест <b>match</b>',
+          rank: 0.5,
+        }],
+      })),
+    };
+    mockVectorizer = {
+      semanticSearch: jest.fn(() => Promise.resolve([])),
+    };
+  });
+
+  describe('tool definition', () => {
+    it('exposes single search_court_decisions tool', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+      const defs = tool.getToolDefinitions();
+      expect(defs).toHaveLength(1);
+      expect(defs[0].name).toBe('search_court_decisions');
+    });
+
+    it('mode enum has 4 values', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+      const defs = tool.getToolDefinitions();
+      const modeEnum = defs[0].inputSchema.properties.mode.enum;
+      expect(modeEnum).toEqual(['structured', 'fulltext', 'hybrid', 'semantic']);
+    });
+  });
+
+  describe('mode routing', () => {
+    it('rejects unknown mode', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+
+      const result = await tool.executeTool('search_court_decisions', { mode: 'unknown' });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('Невідомий режим');
+    });
+
+    it('returns null for unknown tool name', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+      const result = await tool.executeTool('other_tool', {});
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('structured mode', () => {
+    it('requires at least one filter', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+
+      const result = await tool.executeTool('search_court_decisions', { mode: 'structured' });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('параметр пошуку');
+    });
+
+    it('searches by cause_num', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('COUNT')) return { rows: [{ total: 1 }] };
+        return { rows: [{
+          doc_id: 123, cause_num: '756/1234/23', judge: 'Петров',
+          court_code: 2605, justice_kind: 1, judgment_code: 3,
+          adjudication_date: '2024-01-15',
+        }] };
+      });
+      tool = new EdsrUnifiedSearchTool(db);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'structured',
+        cause_num: '756/1234/23',
+      });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.mode).toBe('structured');
+      expect(parsed.total).toBe(1);
+    });
+
+    it('applies military preset', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('COUNT')) return { rows: [{ total: 0 }] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db);
+
+      await tool.executeTool('search_court_decisions', {
+        mode: 'structured',
+        military_preset: 'awol',
+      });
+
+      const dataSql = calls.find(c => c.sql.includes('SELECT'));
+      expect(dataSql?.sql).toContain('category_code = ANY');
+      expect(dataSql?.sql).toContain('justice_kind');
+    });
+
+    it('resolves court_name to court_code', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('edrsr_courts') && sql.includes('LIKE')) {
+          return { rows: [{ court_code: 2605 }] };
+        }
+        if (sql.includes('COUNT')) return { rows: [{ total: 0 }] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db);
+
+      await tool.executeTool('search_court_decisions', {
+        mode: 'structured',
+        court_name: 'Оболонський',
+      });
+
+      expect(calls[0].sql).toContain('edrsr_courts');
+      const filterSql = calls.find(c => c.sql.includes('court_code = ANY'));
+      expect(filterSql).toBeTruthy();
+    });
+
+    it('returns empty result when court not found', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('edrsr_courts')) return { rows: [] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'structured',
+        court_name: 'Неіснуючий суд',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.total).toBe(0);
+    });
+  });
+
+  describe('fulltext mode', () => {
+    it('requires query parameter', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      const result = await tool.executeTool('search_court_decisions', { mode: 'fulltext' });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('query');
+    });
+
+    it('returns error when FTS service unavailable', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext',
+        query: 'тест',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('FTS');
+    });
+
+    it('delegates to FTS service and enriches results', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('edrsr_courts')) return { rows: [{ court_code: 2605, name: 'Оболонський' }] };
+        if (sql.includes('edrsr_justice_kinds')) return { rows: [{ justice_kind: 1, name: 'Цивільне' }] };
+        if (sql.includes('edrsr_judgment_forms')) return { rows: [{ judgment_code: 3, name: 'Рішення' }] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext',
+        query: 'тест',
+      });
+
+      expect(mockFtsService.searchFulltext).toHaveBeenCalled();
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.mode).toBe('fulltext');
+      expect(parsed.results).toHaveLength(1);
+      expect(parsed.results[0].court_name).toBe('Оболонський');
+      expect(parsed.results[0].justice_kind_name).toBe('Цивільне');
+    });
+  });
+
+  describe('hybrid mode', () => {
+    it('requires query parameter', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+
+      const result = await tool.executeTool('search_court_decisions', { mode: 'hybrid' });
+      expect(result?.isError).toBe(true);
+    });
+
+    it('returns error when both legs fail', async () => {
+      const failingFts = { searchFulltext: jest.fn(() => Promise.reject(new Error('FTS down'))) };
+      const failingVector = { semanticSearch: jest.fn(() => Promise.reject(new Error('Qdrant down'))) };
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, failingFts as any, failingVector as any);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'hybrid',
+        query: 'тест',
+      });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('недоступні');
+    });
+
+    it('degrades gracefully to FTS-only when vector fails', async () => {
+      const failingVector = { semanticSearch: jest.fn(() => Promise.reject(new Error('Qdrant down'))) };
+      db = makeDb((sql) => {
+        if (sql.includes('edrsr_courts')) return { rows: [] };
+        if (sql.includes('edrsr_justice_kinds')) return { rows: [] };
+        if (sql.includes('edrsr_judgment_forms')) return { rows: [] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, failingVector as any);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'hybrid',
+        query: 'тест',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.legs.fts_available).toBe(true);
+      expect(parsed.legs.vector_available).toBe(false);
+    });
+  });
+
+  describe('semantic mode', () => {
+    it('redirects to fulltext with notice', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('edrsr_courts')) return { rows: [] };
+        if (sql.includes('edrsr_justice_kinds')) return { rows: [] };
+        if (sql.includes('edrsr_judgment_forms')) return { rows: [] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'semantic',
+        query: 'відповідальність директора',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed._notice).toContain('тимчасово недоступний');
+      expect(parsed.mode).toContain('semantic');
+    });
+  });
+});

--- a/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
@@ -1,0 +1,299 @@
+/**
+ * RegistrySearchTool unit tests
+ *
+ * Covers:
+ * - Tool definition: single search_registry tool with correct enum
+ * - Unknown registry rejection
+ * - Empty filters → registry description
+ * - Required field enforcement (financial_statements needs tin)
+ * - WHERE clause generation for all match types (ilike, exact, ilike_multi, exact_multi, gte, lte, array_contains, ilike_cast)
+ * - Transform (uppercase) applied before query
+ * - Limit clamping
+ * - DB error handling
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { RegistrySearchTool } from '../tools/registry-search-tool.js';
+import { REGISTRY_CATALOG } from '../tools/registry-catalog.js';
+
+type QueryCall = { sql: string; params?: any[] };
+
+describe('RegistrySearchTool', () => {
+  let db: any;
+  let calls: QueryCall[];
+  let tool: RegistrySearchTool;
+
+  const makeDb = (responder: (sql: string, params?: any[]) => any) => ({
+    query: jest.fn((sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve(responder(sql, params));
+    }),
+  });
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  describe('tool definition', () => {
+    it('exposes single search_registry tool', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+      const defs = tool.getToolDefinitions();
+      expect(defs).toHaveLength(1);
+      expect(defs[0].name).toBe('search_registry');
+    });
+
+    it('enum includes all catalog keys', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+      const defs = tool.getToolDefinitions();
+      const registryEnum = defs[0].inputSchema.properties.registry.enum;
+      expect(registryEnum).toEqual(Object.keys(REGISTRY_CATALOG));
+    });
+  });
+
+  describe('validation', () => {
+    it('rejects unknown registry', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+
+      const result = await tool.executeTool('search_registry', { registry: 'nonexistent' });
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('nonexistent');
+    });
+
+    it('returns registry description when no filters provided', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+
+      const result = await tool.executeTool('search_registry', { registry: 'sanctions' });
+      expect(result?.isError).toBeFalsy();
+      const text = result?.content[0].text || '';
+      expect(text).toContain('sanctions');
+      expect(text).toContain('Доступні фільтри');
+    });
+
+    it('enforces required fields', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+
+      const result = await tool.executeTool('search_registry', {
+        registry: 'financial_statements',
+        filters: { period_year: 2024 },
+      });
+      expect(result?.isError).toBeFalsy();
+      const text = result?.content[0].text || '';
+      expect(text).toContain('tin');
+    });
+
+    it('returns null for unknown tool name', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+      const result = await tool.executeTool('unknown_tool', {});
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('WHERE clause generation', () => {
+    it('ilike: wraps value with % and uses ILIKE', async () => {
+      db = makeDb(() => ({ rows: [{ name: 'Test', _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'lawyers',
+        filters: { last_name: 'Іваненко' },
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0].sql).toContain('ILIKE');
+      expect(calls[0].params).toContain('%Іваненко%');
+    });
+
+    it('exact: uses = operator without wrapping', async () => {
+      db = makeDb(() => ({ rows: [{ edrpou: '12345678', _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'large_taxpayers',
+        filters: { edrpou: '12345678' },
+      });
+
+      expect(calls[0].sql).toContain('= $');
+      expect(calls[0].params).toContain('12345678');
+    });
+
+    it('ilike_multi: generates OR across multiple columns', async () => {
+      db = makeDb(() => ({ rows: [{ name: 'Test', _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'missing_persons',
+        filters: { last_name: 'Петренко' },
+      });
+
+      const sql = calls[0].sql;
+      expect(sql).toContain('last_name_u ILIKE');
+      expect(sql).toContain('last_name_r ILIKE');
+      expect(sql).toContain('last_name_e ILIKE');
+      expect(sql).toContain(' OR ');
+    });
+
+    it('gte: uses >= operator', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'securities_owners',
+        filters: { min_share_percent: 10 },
+      });
+
+      expect(calls[0].sql).toContain('>= $');
+      expect(calls[0].params).toContain(10);
+    });
+
+    it('lte: uses <= operator', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'vrp_decisions',
+        filters: { date_to: '2025-01-01' },
+      });
+
+      expect(calls[0].sql).toContain('<= $');
+    });
+
+    it('array_contains: uses ANY() syntax', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'trademarks',
+        filters: { nice_class: 25 },
+      });
+
+      expect(calls[0].sql).toContain('ANY(nice_classes)');
+      expect(calls[0].params).toContain(25);
+    });
+
+    it('ilike_cast: casts column to text', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'public_organizations',
+        filters: { founders: 'Іванов' },
+      });
+
+      expect(calls[0].sql).toContain('founders::text ILIKE');
+    });
+
+    it('exact_multi: uses = with OR across columns', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'trademarks',
+        filters: { holder_edrpou: '12345678' },
+      });
+
+      const sql = calls[0].sql;
+      expect(sql).toContain('holder_edrpou = $');
+      expect(sql).toContain('applicant_edrpou = $');
+      expect(sql).toContain(' OR ');
+    });
+  });
+
+  describe('transforms', () => {
+    it('uppercase transform applied to vehicle search', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'vehicle_registrations',
+        filters: { vin: 'wvwzzz3czwe123456' },
+      });
+
+      expect(calls[0].params?.[0]).toBe('WVWZZZ3CZWE123456');
+    });
+  });
+
+  describe('limit handling', () => {
+    it('clamps limit to maxLimit', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'financial_statements',
+        filters: { tin: '12345678' },
+        limit: 999,
+      });
+
+      // financial_statements has maxLimit=50
+      const limitParam = calls[0].params?.[calls[0].params.length - 1];
+      expect(limitParam).toBe(50);
+    });
+
+    it('uses defaultLimit when not specified', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'financial_statements',
+        filters: { tin: '12345678' },
+      });
+
+      // financial_statements has defaultLimit=20
+      const limitParam = calls[0].params?.[calls[0].params.length - 1];
+      expect(limitParam).toBe(20);
+    });
+  });
+
+  describe('response formatting', () => {
+    it('returns empty message when no results', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new RegistrySearchTool(db);
+
+      const result = await tool.executeTool('search_registry', {
+        registry: 'sanctions',
+        filters: { name: 'NonexistentPerson' },
+      });
+
+      const text = result?.content[0].text || '';
+      expect(text).toContain(REGISTRY_CATALOG.sanctions.emptyMessage);
+    });
+
+    it('strips _total_count from results', async () => {
+      db = makeDb(() => ({
+        rows: [{ name: 'Test Corp', schema: 'Company', _total_count: 42 }],
+      }));
+      tool = new RegistrySearchTool(db);
+
+      const result = await tool.executeTool('search_registry', {
+        registry: 'sanctions',
+        filters: { name: 'Test' },
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.total_count).toBe(42);
+      expect(parsed.results[0]._total_count).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('wraps DB errors', async () => {
+      db = {
+        query: jest.fn(() => Promise.reject(new Error('connection refused'))),
+      };
+      tool = new RegistrySearchTool(db);
+
+      const result = await tool.executeTool('search_registry', {
+        registry: 'sanctions',
+        filters: { name: 'test' },
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('connection refused');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add 59 unit tests for the 3 new consolidated tools
- `registry-search-tool.test.ts`: 20 tests — WHERE clause generation, all 8 match types, transforms, limits, validation
- `edrsr-unified-search-tool.test.ts`: 16 tests — mode routing, military presets, FTS delegation, graceful degradation
- `analyze-data-tool.test.ts`: 23 tests — SQL validation, forbidden keywords, table whitelist, read-only enforcement, timeouts

## Test plan
- [x] All 59 tests pass (`npx jest --no-cache <3 files>` → 3 suites, 59 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add 59 Jest unit tests for the consolidated tools to validate behavior, safety, and error handling. Tests cover `search_registry` match types and limit clamping (LEXAI-881), `search_court_decisions` mode routing with fulltext/hybrid and military presets (LEXAI-882), and `analyze_data` SQL validation, read-only transactions, table whitelist, and timeouts (LEXAI-883).

<sup>Written for commit f86b0d8dde5bf734704f9b6a4e6bbe446ce3c7f0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

