### PR TITLE
fix(tools): resolve encoding corruption and data bugs from #1532 review

### DIFF
--- a/lexwebapp/src/pages/DeveloperDocsPage/index.tsx
+++ b/lexwebapp/src/pages/DeveloperDocsPage/index.tsx
@@ -139,13 +139,13 @@ const toolGroups: ToolGroup[] = [
   {
     title: 'Відкриті дані',
     tools: [
-      { name: 'search_registry', description: 'Єдиний інструмент для 22 реєстрів відкритих даних (санкції, адвокати, ТМ, патенти, корупціонери, банки НБУ та ін.)', params: [{ name: 'registry', required: true }, { name: 'filters', required: true }, { name: 'limit' }], cost: '₴0.04' },
+      { name: 'search_registry', description: 'Єдиний інструмент для 22 реєстрів відкритих даних (санкції, адвокати, ТМ, патенти, корупціонери, банки НБУ та ін.)', params: [{ name: 'registry', required: true }, { name: 'filters' }, { name: 'limit' }], cost: '₴0.04' },
       { name: 'search_judges', description: 'Реєстр суддів ВККС (з історією)', params: [{ name: 'full_name' }, { name: 'court_name' }, { name: 'include_history' }, { name: 'limit' }], cost: '₴0.04' },
       { name: 'search_edrnpa', description: 'Реєстр нормативно-правових актів', params: [{ name: 'name' }, { name: 'number' }, { name: 'publisher' }, { name: 'include_text' }, { name: 'limit' }], cost: '₴0.04' },
       { name: 'search_vkks', description: 'Дані ВККС (5 категорій: judges, evaluations, declarations, vacancies, efficiency)', params: [{ name: 'category', required: true }, { name: 'judge_name' }, { name: 'court_name' }, { name: 'limit' }], cost: '₴0.04' },
       { name: 'search_vrp_decisions', description: 'Рішення Вищої ради правосуддя', params: [{ name: 'title' }, { name: 'authority' }, { name: 'decision_num' }, { name: 'limit' }], cost: '₴0.04' },
       { name: 'search_vrp_judges_discipline', description: 'Дисциплінарні дані суддів (звільнені/відсторонені/втручання)', params: [{ name: 'judge_name' }, { name: 'court_name' }, { name: 'type' }, { name: 'limit' }], cost: '₴0.04' },
-      { name: 'search_public_spending', description: '��ошук державних витрат (timeout: 120с)', params: [{ name: 'edrpou' }, { name: 'contractor_name' }, { name: 'contractor_edrpou' }, { name: 'date_from' }, { name: 'date_to' }, { name: 'min_amount' }, { name: 'max_amount' }, { name: 'doc_type' }, { name: 'limit' }], cost: '₴0.04–0.21' },
+      { name: 'search_public_spending', description: 'Пошук державних витрат (timeout: 120с)', params: [{ name: 'edrpou' }, { name: 'contractor_name' }, { name: 'contractor_edrpou' }, { name: 'date_from' }, { name: 'date_to' }, { name: 'min_amount' }, { name: 'max_amount' }, { name: 'doc_type' }, { name: 'limit' }], cost: '₴0.04–0.21' },
       { name: 'search_invalid_passports', description: 'Перевірка недійсних паспортів (МВС)', params: [{ name: 'd_series' }, { name: 'd_number' }, { name: 'limit' }], cost: '₴0.04' },
       { name: 'search_terrorism_list', description: 'Перелік терористів ДСФМУ', params: [{ name: 'name', required: true }, { name: 'limit' }], cost: '₴0.04' },
     ],

--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -230,7 +230,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'ipc_code', description: 'Код МПК (наприклад, A61K)', match: 'array_contains', columns: ['ipc_codes'] },
       { name: 'app_number', description: 'Номер заявки', match: 'exact', columns: ['app_number'] },
       { name: 'registration_number', description: 'Номер патенту', match: 'exact', columns: ['registration_number'] },
-      { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 3=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
+      { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 6=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
     ],
   },
 

--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -83,7 +83,7 @@ ${registryDescriptions}
 
     const maxLimit = def.maxLimit ?? 100;
     const defaultLimit = def.defaultLimit ?? 50;
-    const lim = Math.min(Number(limit) || defaultLimit, maxLimit);
+    const lim = Math.max(1, Math.min(Number(limit) || defaultLimit, maxLimit));
     values.push(lim);
 
     const sql = `SELECT ${def.selectColumns}, COUNT(*) OVER() AS _total_count

--- a/mcp_backend/src/api/tools/tier1-opendata-tools.ts
+++ b/mcp_backend/src/api/tools/tier1-opendata-tools.ts
@@ -21,7 +21,7 @@ export class Tier1OpenDataTools extends BaseToolHandler {
       {
         name: 'search_invalid_passports',
         annotations: { title: 'Недійсні паспорти (МВС)', readOnlyHint: true },
-        description: `Перевірка паспорта у реєстрі ��едійсних документів (МВС)
+        description: `Перевірка паспорта у реєстрі недійсних документів (МВС)
 
 2.9M внутрішніх + 195K закордонних паспортів. Статуси: ВТРАЧЕНО, ВИКРАДЕНО, ВЛАСНИК РОЗШУКУЄТЬСЯ тощо.
 Пошук за серією та номером, або за OВД.`,
@@ -40,9 +40,9 @@ export class Tier1OpenDataTools extends BaseToolHandler {
       {
         name: 'search_terrorism_list',
         annotations: { title: 'Перелік терористів', readOnlyHint: true },
-        description: `Пошук у переліку осіб та організацій пов'язаних з тероризм��м (ДСФМУ)
+        description: `Пошук у переліку осіб та організацій пов'язаних з тероризмом (ДСФМУ)
 
-AML/sanctions screening. Перелік ДСФМУ ��� першоджерело для банків та фінустанов.
+AML/sanctions screening. Перелік ДСФМУ — першоджерело для банків та фінустанов.
 Включає фізосіб під санкціями та терористичні організації.`,
         inputSchema: {
           type: 'object',
@@ -98,7 +98,7 @@ AML/sanctions screening. Перелік ДСФМУ ��� першоджер�
         results.push(...result.rows);
       }
 
-      if (results.length === 0) return this.wrapResponse('Паспорт н�� знайдено у реєстрі недійсних документів');
+      if (results.length === 0) return this.wrapResponse('Паспорт не знайдено у реєстрі недійсних документів');
       const sliced = results.slice(0, lim);
       return this.wrapResponse({ results: sliced, total_count: results.length, has_more: results.length > lim, limit: lim, offset: 0 });
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- Fix corrupted Ukrainian text (encoding artifacts) in `tier1-opendata-tools.ts` and `DeveloperDocsPage/index.tsx`
- Fix wrong `obj_type` code for industrial designs in patent registry catalog (`3` → `6`)
- Add `Math.max(1, ...)` floor clamp for `limit` in `registry-search-tool.ts`
- Remove incorrect `required: true` from `filters` param in developer docs

## Test plan
- [ ] Verify `search_invalid_passports` returns proper Ukrainian text in descriptions and empty-result messages
- [ ] Verify `search_terrorism_list` description renders correctly
- [ ] Verify `search_registry registry=patents filters={"obj_type": 6}` returns industrial designs
- [ ] Verify `search_registry` with negative limit doesn't cause SQL error
- [ ] Verify Developer Docs page renders without broken characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes encoding artifacts in Ukrainian text across open data tools and Developer Docs. Corrects patent registry `obj_type` for industrial designs and clamps invalid `limit` values to prevent SQL errors.

- **Bug Fixes**
  - Restored Ukrainian strings in tool descriptions (`search_invalid_passports`, `search_terrorism_list`) and fixed “Пошук державних витрат”.
  - Updated patents catalog: industrial designs use `obj_type = 6` (was `3`), with corrected field description.
  - Prevented negative limits by clamping with `Math.max(1, ...)`.
  - Made `filters` optional in Developer Docs for `search_registry`.

<sup>Written for commit 24071e3b00b1276e0e67405ac1b2830ad5449a93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

