### PR TITLE
fix(deps): upgrade @anthropic-ai/sdk to ^0.93.0 (CVE-2026-41686)

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,7 @@
     "npm": ">=9.0.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.93.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1005.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",


### PR DESCRIPTION
## Summary
- Upgrades `@anthropic-ai/sdk` from `^0.82.0` to `^0.93.0` in `packages/shared`
- Fixes **Dependabot alert #188** (CVE-2026-41686): Insecure Default File Permissions in Local Filesystem Memory Tool
- Severity: medium

## Test plan
- [ ] CI build passes (shared package type-checks cleanly)
- [ ] Backend services start without import errors
- [ ] Dependabot alert auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `@anthropic-ai/sdk` to ^0.93.0 in `packages/shared` to patch CVE-2026-41686. This fixes insecure default file permissions in the Local Filesystem Memory Tool and removes the vulnerable range (>=0.79.0 <0.91.1).

- **Dependencies**
  - `@anthropic-ai/sdk`: ^0.82.0 → ^0.93.0

<sup>Written for commit 365c3c84a2334965d47a37b0b41fcc65473f9fb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

