### PR TITLE
fix(deps): upgrade axios to ^1.16.0 in platform (13 CVEs)

### DIFF
--- a/platform/package-lock.json
+++ b/platform/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/typography": "0.5.19",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "date-fns": "4.1.0",
         "lucide-react": "0.577.0",
         "react": "19.2.4",
@@ -897,12 +897,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/platform/package.json
+++ b/platform/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tailwindcss/typography": "0.5.19",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "date-fns": "4.1.0",
     "lucide-react": "0.577.0",
     "react": "19.2.4",


### PR DESCRIPTION
## Summary
- Upgrades `axios` from `^1.15.0` to `^1.16.0` in `platform/`
- Closes **13 Dependabot alerts** (#189–#201): 4 high, 8 medium, 1 low
- Key fixes: Prototype Pollution, Header Injection, SSRF via NO_PROXY bypass, CRLF Injection, DoS, Auth Bypass

## Test plan
- [ ] CI build passes
- [ ] Platform type-checks (`tsc --noEmit` clean)
- [ ] All 13 Dependabot alerts auto-close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `axios` to `^1.16.0` in the platform to resolve 13 Dependabot security alerts (#189–#201). Fixes prototype pollution, header injection, SSRF via NO_PROXY bypass, CRLF injection, DoS, and auth bypass.

- **Dependencies**
  - Bump `axios` from `^1.15.0` to `^1.16.0`.
  - Transitive: `follow-redirects` from `^1.15.11` to `^1.16.0`.

<sup>Written for commit 258bb096491fee0253fbb0ae46cc676b406412d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

