### PR TITLE
feat(backend): Haiku query reformulation for hybrid search

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -15,6 +15,7 @@ import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handle
 import { logger } from '../../utils/logger.js';
 import { EDRSR_METADATA_SEARCH_ORDER } from '../../services/search-ranking-config.js';
 import type { SearchResultFilter } from '../../services/search-result-filter.js';
+import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
 
@@ -50,6 +51,7 @@ interface FusedHit {
 
 export class EdsrUnifiedSearchTool extends BaseToolHandler {
   private resultFilter?: SearchResultFilter;
+  private queryReformulator?: QueryReformulator;
 
   constructor(
     private db: any,
@@ -61,6 +63,10 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
   setResultFilter(filter: SearchResultFilter): void {
     this.resultFilter = filter;
+  }
+
+  setQueryReformulator(reformulator: QueryReformulator): void {
+    this.queryReformulator = reformulator;
   }
 
   getToolDefinitions(): ToolDefinition[] {
@@ -323,12 +329,18 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       judge: args.judge, date_from: args.date_from, date_to: args.date_to,
     };
 
+    const reformulated = this.queryReformulator
+      ? await this.queryReformulator.reformulate(query).catch(() => null)
+      : null;
+    const ftsQuery = reformulated?.fts || query;
+    const semanticQuery = reformulated?.semantic || query;
+
     const ftsPromise = this.ftsService
-      .searchFulltext(query, this.db, filters, candidateLimit, 0)
+      .searchFulltext(ftsQuery, this.db, filters, candidateLimit, 0)
       .catch((err: any) => { logger.warn('[EdsrUnifiedSearch] FTS leg failed', { error: err.message }); return null; });
 
     const vectorPromise = this.vectorizer
-      ? this.vectorizer.semanticSearch(query, filters as unknown as EdrsrSearchFilters, candidateLimit)
+      ? this.vectorizer.semanticSearch(semanticQuery, filters as unknown as EdrsrSearchFilters, candidateLimit)
           .catch((err: any) => { logger.warn('[EdsrUnifiedSearch] Qdrant leg failed', { error: err.message }); return null; })
       : Promise.resolve(null);
 
@@ -345,6 +357,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
     return this.wrapResponse({
       mode: 'hybrid', query, rrf_k: rrfK, oversample,
+      ...(reformulated ? { reformulated: { fts: reformulated.fts, semantic: reformulated.semantic } } : {}),
       legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length },
       total_fused: fused.length, returned: output.filtered.length,
       results: output.filtered,

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -23,6 +23,7 @@ import { EdsrUnifiedSearchTool } from '../api/tools/edrsr-unified-search-tool.js
 import { EdsrFtsService } from '../services/edrsr-fts-service.js';
 import { EdsrVectorizerService } from '../services/edrsr-vectorizer-service.js';
 import { SearchResultFilter } from '../services/search-result-filter.js';
+import { QueryReformulator } from '../services/query-reformulator.js';
 import { NextcloudService } from '../services/nextcloud-service.js';
 import { NextcloudTools } from '../api/tools/nextcloud-tools.js';
 import { CourtStatusTools } from '../api/tools/court-status-tools.js';
@@ -157,6 +158,7 @@ export function createToolServices(
   }
   const edsrUnifiedSearch = new EdsrUnifiedSearchTool(coreServices.db, edsrFtsService, edsrVectorizer);
   edsrUnifiedSearch.setResultFilter(new SearchResultFilter(llmAdapter));
+  edsrUnifiedSearch.setQueryReformulator(new QueryReformulator(llmAdapter));
   toolRegistry.registerHandler(edsrUnifiedSearch);
   // Import task manager (multi-IP downloads)
   toolRegistry.registerHandler(new ImportTaskTools(coreServices.importTaskService));

--- a/mcp_backend/src/services/__tests__/query-reformulator.test.ts
+++ b/mcp_backend/src/services/__tests__/query-reformulator.test.ts
@@ -1,0 +1,60 @@
+import { QueryReformulator } from '../query-reformulator';
+
+describe('QueryReformulator', () => {
+  it('returns original for short queries', async () => {
+    const llm = { chatCompletion: jest.fn() } as any;
+    const reformulator = new QueryReformulator(llm);
+
+    const result = await reformulator.reformulate('оренда');
+    expect(result.original).toBe('оренда');
+    expect(result.semantic).toBe('оренда');
+    expect(result.fts).toBe('оренда');
+    expect(llm.chatCompletion).not.toHaveBeenCalled();
+  });
+
+  it('reformulates queries via LLM', async () => {
+    const llm = {
+      chatCompletion: jest.fn().mockResolvedValue({
+        content: JSON.stringify({
+          semantic: 'відповідальність за самовільне залишення військової частини в умовах воєнного стану',
+          fts: 'самовільне залишення частини стаття 407 КК воєнний стан',
+          expanded: 'дезертирство ЗЧВП ст.407 ст.408 КК військові злочини',
+        }),
+      }),
+    } as any;
+    const reformulator = new QueryReformulator(llm);
+
+    const result = await reformulator.reformulate('покарання за самоволку під час війни');
+
+    expect(result.original).toBe('покарання за самоволку під час війни');
+    expect(result.semantic).toContain('самовільне залишення');
+    expect(result.fts).toContain('407');
+    expect(result.expanded).toContain('дезертирство');
+    expect(llm.chatCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns original on LLM failure', async () => {
+    const llm = {
+      chatCompletion: jest.fn().mockRejectedValue(new Error('timeout')),
+    } as any;
+    const reformulator = new QueryReformulator(llm);
+
+    const result = await reformulator.reformulate('стягнення боргу за договором оренди');
+    expect(result.original).toBe('стягнення боргу за договором оренди');
+    expect(result.semantic).toBe('стягнення боргу за договором оренди');
+    expect(result.fts).toBe('стягнення боргу за договором оренди');
+  });
+
+  it('handles empty semantic/fts in response', async () => {
+    const llm = {
+      chatCompletion: jest.fn().mockResolvedValue({
+        content: JSON.stringify({ semantic: '', fts: null, expanded: null }),
+      }),
+    } as any;
+    const reformulator = new QueryReformulator(llm);
+
+    const result = await reformulator.reformulate('оподаткування нерухомості ВПО');
+    expect(result.semantic).toBe('оподаткування нерухомості ВПО');
+    expect(result.fts).toBe('оподаткування нерухомості ВПО');
+  });
+});

--- a/mcp_backend/src/services/query-reformulator.ts
+++ b/mcp_backend/src/services/query-reformulator.ts
@@ -1,0 +1,84 @@
+import { logger } from '../utils/logger.js';
+import { withLLMRetry } from '../utils/llm-retry.js';
+import type { ILLMPort } from '../domain/ports/index.js';
+
+const REFORMULATION_PROMPT = `Ти — експерт з українського права та пошукових систем. Твоє завдання — переформулювати запит користувача для покращення пошуку в базі судових рішень.
+
+Створи 2-3 альтернативних формулювання:
+1. **semantic** — концептуальне перефразування для векторного пошуку (синоніми, ширший контекст, юридична термінологія)
+2. **fts** — ключові юридичні терміни для повнотекстового пошуку (точні терміни з кодексів, статті, назви інститутів)
+3. **expanded** (опціонально) — розширений запит з суміжними поняттями, якщо оригінальний запит вузький
+
+ПРАВИЛА:
+- Всі формулювання УКРАЇНСЬКОЮ мовою
+- Використовуй офіційну юридичну термінологію (ЦК, ЦПК, КК, ПКУ тощо)
+- Для fts: тільки ключові слова через пробіл (PostgreSQL plainto_tsquery)
+- Не повторюй оригінальний запит дослівно
+- Не додавай пояснень, тільки JSON
+
+Поверни JSON:
+{"semantic": "...", "fts": "...", "expanded": "..." або null}`;
+
+const MIN_QUERY_LENGTH = 10;
+
+export interface ReformulatedQueries {
+  original: string;
+  semantic: string;
+  fts: string;
+  expanded: string | null;
+}
+
+export class QueryReformulator {
+  constructor(private readonly llm: ILLMPort) {}
+
+  async reformulate(query: string): Promise<ReformulatedQueries> {
+    const trimmed = query.trim();
+
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      return { original: trimmed, semantic: trimmed, fts: trimmed, expanded: null };
+    }
+
+    try {
+      const response = await withLLMRetry(
+        () => this.llm.chatCompletion(
+          {
+            messages: [
+              { role: 'system', content: REFORMULATION_PROMPT },
+              { role: 'user', content: trimmed },
+            ],
+            temperature: 0.2,
+            max_tokens: 400,
+            response_format: { type: 'json_object' },
+          },
+          'quick',
+        ),
+        { operationName: 'QueryReformulator.reformulate', timeoutMs: 8_000 },
+      );
+
+      const content = response.content?.trim() || '{}';
+      const jsonMatch = content.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        return { original: trimmed, semantic: trimmed, fts: trimmed, expanded: null };
+      }
+
+      const parsed = JSON.parse(jsonMatch[0]);
+      const result: ReformulatedQueries = {
+        original: trimmed,
+        semantic: typeof parsed.semantic === 'string' && parsed.semantic.trim() ? parsed.semantic.trim() : trimmed,
+        fts: typeof parsed.fts === 'string' && parsed.fts.trim() ? parsed.fts.trim() : trimmed,
+        expanded: typeof parsed.expanded === 'string' && parsed.expanded.trim() ? parsed.expanded.trim() : null,
+      };
+
+      logger.info('[QueryReformulator] Reformulated query', {
+        original: trimmed.slice(0, 80),
+        semantic: result.semantic.slice(0, 80),
+        fts: result.fts.slice(0, 80),
+      });
+
+      return result;
+    } catch (err: any) {
+      logger.warn('[QueryReformulator] Reformulation failed, using original', { error: err.message });
+      return { original: trimmed, semantic: trimmed, fts: trimmed, expanded: null };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- New `QueryReformulator` service uses Haiku to generate optimized query variants for each search leg:
  - **semantic** — conceptual rephrasing with legal synonyms for Qdrant vector search
  - **fts** — precise Ukrainian legal terms, article numbers, code abbreviations for PostgreSQL FTS
- Applied to `hybrid` mode of `search_court_decisions` — each leg now gets a tailored query
- Response metadata includes `reformulated` field showing what queries were actually used
- Graceful degradation: if Haiku fails, original query is used for both legs

## Example
User query: "покарання за самоволку під час війни"
→ semantic: "відповідальність за самовільне залишення військової частини в умовах воєнного стану"
→ fts: "самовільне залишення частини стаття 407 КК воєнний стан"

## Test plan
- [x] 4 unit tests: short query bypass, LLM reformulation, failure fallback, empty fields handling
- [x] TypeScript compiles clean
- [ ] Verify in local env with real hybrid search queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Haiku-backed query reformulation to the hybrid court decision search. Each leg now gets a tailored query to improve precision and recall, with safe fallback to the original.

- **New Features**
  - `QueryReformulator` generates `semantic` (for Qdrant) and `fts` (for PostgreSQL FTS) variants; optional `expanded`.
  - Integrated into `search_court_decisions` hybrid mode; legs use tailored queries instead of the raw input.
  - Response includes `reformulated` metadata with the used queries.
  - Short queries bypass reformulation; failures fall back to the original.
  - Unit tests cover bypass, successful reformulation, failure fallback, and empty fields handling.

<sup>Written for commit b3bf286970c462e7a39ad31274d5a2a43c4885aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

