### PR TITLE
feat(backend): separate QDRANT_EDRSR_URL for compute node

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -535,6 +535,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
+      QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -712,6 +714,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
+      QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -928,6 +932,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
+      QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -1176,6 +1182,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
       QDRANT_URL: http://qdrant-prod:6333
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
+      QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
+      QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -120,8 +120,8 @@ export class EdsrVectorizerService {
     }
     this.voyageClient = new VoyageAIClient(apiKey, process.env.VOYAGEAI_API_KEY_2 || '');
 
-    const qdrantUrl = process.env.QDRANT_URL || 'http://localhost:6333';
-    const qdrantApiKey = process.env.QDRANT_API_KEY;
+    const qdrantUrl = process.env.QDRANT_EDRSR_URL || process.env.QDRANT_URL || 'http://localhost:6333';
+    const qdrantApiKey = process.env.QDRANT_EDRSR_API_KEY || process.env.QDRANT_API_KEY;
     this.qdrant = new QdrantClient({ url: qdrantUrl, ...(qdrantApiKey && { apiKey: qdrantApiKey }) });
 
     this.concurrency = concurrency;


### PR DESCRIPTION
## Summary
- EdsrVectorizerService now checks `QDRANT_EDRSR_URL` / `QDRANT_EDRSR_API_KEY` before falling back to `QDRANT_URL`
- docker-compose.prod.yml passes the new env vars to all backend containers
- Enables routing edrsr_decisions queries to dedicated compute EC2 (r6a.xlarge) while other collections stay on prod Qdrant

## Context
EDRSR court decision vectors (258M+ points, 1.6TB) were causing OOM kills on prod Qdrant (40GB limit). Moved vectorization workloads to a dedicated `qdrant-compute` EC2 instance. This PR enables the prod backend to query the compute Qdrant for semantic search.

## Test plan
- [ ] Deploy to prod, verify `QDRANT_EDRSR_URL` is picked up by EdsrVectorizerService
- [ ] Test hybrid/semantic court decision search routes to compute Qdrant
- [ ] Verify other collections (legal_sections, court_sessions) still use local Qdrant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable routing of EDRSR court decision semantic search to the compute Qdrant node via new `QDRANT_EDRSR_URL`/`QDRANT_EDRSR_API_KEY`, with fallback to `QDRANT_URL` for other collections. Updates `EdsrVectorizerService` and `docker-compose.prod.yml` to use the EDRSR-specific connection when set.

<sup>Written for commit 5b11be11ea0f4628b685e4d57f849cce9b17e82c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

