### PR TITLE
fix(shared): bedrock-first must not fallback to OpenAI

### DIFF
--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -124,12 +124,16 @@ export class ModelSelector {
       providers.push('bedrock');
     }
 
-    if (process.env.OPENAI_API_KEY) {
-      providers.push('openai');
+    if (this.PROVIDER_STRATEGY === 'bedrock-first' && providers.includes('bedrock')) {
+      return providers;
     }
 
     if (process.env.ANTHROPIC_API_KEY) {
       providers.push('anthropic');
+    }
+
+    if (process.env.OPENAI_API_KEY) {
+      providers.push('openai');
     }
 
     return providers;


### PR DESCRIPTION
## Summary
- When `LLM_PROVIDER_STRATEGY=bedrock-first`, `getAvailableProviders()` now returns only `['bedrock']`
- Prevents `getFallbackProvider()` from routing failed Bedrock calls to OpenAI (429 quota errors)
- Bedrock-internal fallback (Opus → Sonnet via `getBedrockFallbackSelection`) still works

## Test plan
- [ ] Bedrock primary model failure falls back to Bedrock fallback model (not OpenAI)
- [ ] No 429 OpenAI errors in prod logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `bedrock-first` strategy strict so we never fall back to OpenAI/Anthropic. This prevents 429s from OpenAI when it has no quota.

- **Bug Fixes**
  - Updated `packages/shared/src/utils/model-selector.ts`: `ModelSelector.getAvailableProviders()` returns only `['bedrock']` when `LLM_PROVIDER_STRATEGY=bedrock-first` and Bedrock is configured.
  - `getFallbackProvider()` no longer routes Bedrock failures to OpenAI/Anthropic; Bedrock model fallback (e.g., Opus → Sonnet) still applies.

<sup>Written for commit 84d1afaf081a11374b610f27bf30440147d3ed23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

