### PR TITLE
fix(shared): restore provider fallback when Bedrock fails

### DIFF
--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -200,6 +200,9 @@ export class LLMClientManager {
     if (selection.provider === 'bedrock') {
       return await this.executeBedrockChatCompletion(request, selection.model);
     }
+    if (selection.provider === 'anthropic') {
+      return await this.executeAnthropicChatCompletion(request, selection.model);
+    }
     return await this.executeOpenAIChatCompletion(request, selection.model);
   }
 
@@ -426,6 +429,8 @@ export class LLMClientManager {
     try {
       if (selection.provider === 'bedrock') {
         yield* this.executeBedrockStreamCompletion(request, selection.model, signal);
+      } else if (selection.provider === 'anthropic') {
+        yield* this.executeAnthropicStreamCompletion(request, selection.model, signal);
       } else {
         yield* this.executeOpenAIStreamCompletion(request, selection.model, signal);
       }
@@ -460,6 +465,8 @@ export class LLMClientManager {
         try {
           if (fallbackSelection.provider === 'bedrock') {
             yield* this.executeBedrockStreamCompletion(request, fallbackSelection.model, signal);
+          } else if (fallbackSelection.provider === 'anthropic') {
+            yield* this.executeAnthropicStreamCompletion(request, fallbackSelection.model, signal);
           } else {
             yield* this.executeOpenAIStreamCompletion(request, fallbackSelection.model, signal);
           }

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -124,12 +124,16 @@ export class ModelSelector {
       providers.push('bedrock');
     }
 
-    if (process.env.OPENAI_API_KEY) {
-      providers.push('openai');
+    if (this.PROVIDER_STRATEGY === 'bedrock-first' && providers.includes('bedrock')) {
+      return providers;
     }
 
     if (process.env.ANTHROPIC_API_KEY) {
       providers.push('anthropic');
+    }
+
+    if (process.env.OPENAI_API_KEY) {
+      providers.push('openai');
     }
 
     return providers;

--- a/packages/shared/src/utils/model-selector.ts
+++ b/packages/shared/src/utils/model-selector.ts
@@ -124,16 +124,12 @@ export class ModelSelector {
       providers.push('bedrock');
     }
 
-    if (this.PROVIDER_STRATEGY === 'bedrock-first' && providers.includes('bedrock')) {
-      return providers;
+    if (process.env.OPENAI_API_KEY) {
+      providers.push('openai');
     }
 
     if (process.env.ANTHROPIC_API_KEY) {
       providers.push('anthropic');
-    }
-
-    if (process.env.OPENAI_API_KEY) {
-      providers.push('openai');
     }
 
     return providers;


### PR DESCRIPTION
## Summary
- Removes early return in `getAvailableProviders()` that made `bedrock-first` strategy return only `['bedrock']` — zero fallback to OpenAI/Anthropic when Bedrock fails
- Routes `anthropic` provider to its dedicated `executeAnthropicChatCompletion` / `executeAnthropicStreamCompletion` instead of incorrectly sending Claude models through OpenAI SDK
- Restores original provider order: `['bedrock', 'openai', 'anthropic']`

## Context
Prod Bedrock returning `ValidationException: Operation not allowed` intermittently. With only `['bedrock']` in available providers, `getFallbackProvider()` returned `null` and the error propagated to users with no recovery.

## Test plan
- [ ] Build shared package (`cd packages/shared && npm run build`)
- [ ] Verify fallback chain: Bedrock fail → OpenAI → Anthropic
- [ ] Deploy via CI/CD and verify chat works on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the provider fallback chain so requests recover when Bedrock fails, and routes Anthropic traffic through its correct client for both normal and streaming calls.

- **Bug Fixes**
  - Reinstates fallback order: bedrock → openai → anthropic (including streaming).
  - Routes `anthropic` to `executeAnthropicChatCompletion` and `executeAnthropicStreamCompletion` instead of the OpenAI SDK in `packages/shared`.

<sup>Written for commit 62adb313edc1d768745173e7e5c7e65d440e1809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

