### PR TITLE
fix(frontend): remove manual budget selector, auto-escalation only

### DIFF
--- a/lexwebapp/src/components/PlanReviewDisplay.tsx
+++ b/lexwebapp/src/components/PlanReviewDisplay.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo } from 'react';
-import { Target, Zap, Search, Play } from 'lucide-react';
+import { useMemo } from 'react';
+import { Target, Play } from 'lucide-react';
 import { motion } from 'framer-motion';
 import type { ExecutionPlan, PlanStep } from '../types/models/Message';
 import { getToolLabel } from '../hooks/chat/tool-labels';
@@ -12,41 +12,27 @@ interface PlanReviewDisplayProps {
   isLoading?: boolean;
 }
 
-/** Tools that support depth differentiation (search tools with configurable limits) */
-const DEPTH_CAPABLE_TOOLS = new Set([
-  'search_legal_precedents',
-  'search_supreme_court_practice',
-  'find_similar_fact_pattern_cases',
-  'compare_practice_pro_contra',
-  'search_legislation',
-  'find_relevant_law_articles',
-  'search_procedural_norms',
-]);
-
-/** Fallback cost estimates (USD) per single tool call at each budget tier.
- *  standard → Sonnet 4.6, deep → Opus 4.6 (5x more expensive).
- *  Calibrated from production cost_tracking data. */
-const FALLBACK_COST: Record<string, { standard: number; deep: number }> = {
-  search_legal_precedents:         { standard: 0.05, deep: 0.40 },
-  search_supreme_court_practice:   { standard: 0.05, deep: 0.40 },
-  find_similar_fact_pattern_cases: { standard: 0.04, deep: 0.30 },
-  compare_practice_pro_contra:     { standard: 0.05, deep: 0.40 },
-  search_legislation:              { standard: 0.03, deep: 0.25 },
-  find_relevant_law_articles:      { standard: 0.03, deep: 0.25 },
-  search_procedural_norms:         { standard: 0.03, deep: 0.25 },
-  get_court_decision:              { standard: 0.04, deep: 0.30 },
-  get_case_documents_chain:        { standard: 0.05, deep: 0.35 },
-  get_legislation_article:         { standard: 0.02, deep: 0.15 },
-  get_legislation_structure:       { standard: 0.01, deep: 0.10 },
-  load_full_texts:                 { standard: 0.06, deep: 0.50 },
-  semantic_search:                 { standard: 0.03, deep: 0.25 },
-  list_documents:                  { standard: 0.01, deep: 0.10 },
-  count_cases_by_party:            { standard: 0.02, deep: 0.15 },
+/** Fallback cost estimates (USD) per single tool call at standard tier. */
+const FALLBACK_COST: Record<string, number> = {
+  search_legal_precedents:         0.05,
+  search_supreme_court_practice:   0.05,
+  find_similar_fact_pattern_cases: 0.04,
+  compare_practice_pro_contra:     0.05,
+  search_legislation:              0.03,
+  find_relevant_law_articles:      0.03,
+  search_procedural_norms:         0.03,
+  get_court_decision:              0.04,
+  get_case_documents_chain:        0.05,
+  get_legislation_article:         0.02,
+  get_legislation_structure:       0.01,
+  load_full_texts:                 0.06,
+  semantic_search:                 0.03,
+  list_documents:                  0.01,
+  count_cases_by_party:            0.02,
 };
-const FALLBACK_DEFAULT = { standard: 0.04, deep: 0.30 };
-const FALLBACK_OVERHEAD: Record<string, number> = { standard: 0.14, deep: 0.70 };
+const FALLBACK_DEFAULT = 0.04;
+const FALLBACK_OVERHEAD = 0.14;
 
-/** Typical number of tool invocations per plan step (must match backend TYPICAL_CALLS) */
 const FALLBACK_TYPICAL_CALLS: Record<string, number> = {
   get_court_decision:    4,
   load_full_texts:       2,
@@ -59,64 +45,20 @@ function getStepCalls(step: PlanStep): number {
 }
 
 function getStepCost(step: PlanStep): number {
-  const depth = step.depth || 'standard';
   if (step.estimatedCost != null) return step.estimatedCost;
-  // Fallback: per-call cost × typical calls
-  const costs = FALLBACK_COST[step.tool] || FALLBACK_DEFAULT;
-  const calls = getStepCalls(step);
-  return costs[depth] * calls;
+  const cost = FALLBACK_COST[step.tool] || FALLBACK_DEFAULT;
+  return cost * getStepCalls(step);
 }
 
 export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanReviewDisplayProps) {
   const { formatUah } = useCurrencyRate();
-  const [steps, setSteps] = useState<PlanStep[]>(
-    // Use recommendedDepth from backend (LLM-chosen) as the default
-    plan.steps.map(s => ({
-      ...s,
-      depth: s.recommendedDepth || s.depth || 'standard',
-    }))
-  );
-
-  // Recalculate all step costs based on effective budget tier.
-  // Any deep step OR 5+ steps → all iterations use Opus (deep tier).
-  const recalcSteps = (newSteps: PlanStep[]): PlanStep[] => {
-    const hasDeep = newSteps.some(s => s.depth === 'deep');
-    const tier: 'standard' | 'deep' = (hasDeep || newSteps.length >= 5) ? 'deep' : 'standard';
-    return newSteps.map(s => {
-      const costs = FALLBACK_COST[s.tool] || FALLBACK_DEFAULT;
-      const calls = getStepCalls(s);
-      return { ...s, estimatedCost: costs[tier] * calls };
-    });
-  };
-
-  const toggleDepth = (stepId: number) => {
-    setSteps(prev => {
-      const toggled = prev.map(s =>
-        s.id === stepId ? { ...s, depth: (s.depth === 'deep' ? 'standard' : 'deep') as 'standard' | 'deep' } : s
-      );
-      return recalcSteps(toggled);
-    });
-  };
-
-  const setAllDeep = () => {
-    setSteps(prev => recalcSteps(prev.map(s =>
-      DEPTH_CAPABLE_TOOLS.has(s.tool) ? { ...s, depth: 'deep' as const } : s
-    )));
-  };
-
-  const setAllStandard = () => {
-    setSteps(prev => recalcSteps(prev.map(s => ({ ...s, depth: 'standard' as const }))));
-  };
 
   const handleConfirm = () => {
-    onConfirm({ ...plan, steps });
+    onConfirm(plan);
   };
 
-  const deepCount = steps.filter(s => s.depth === 'deep').length;
-  // Effective tier determines overhead + per-step costs
-  const effectiveTier: 'standard' | 'deep' = (deepCount > 0 || steps.length >= 5) ? 'deep' : 'standard';
-  const overheadCost = plan.overheadCost ?? (FALLBACK_OVERHEAD[effectiveTier] || FALLBACK_OVERHEAD.standard);
-  const totalCost = useMemo(() => overheadCost + steps.reduce((sum, s) => sum + getStepCost(s), 0), [steps, overheadCost]);
+  const overheadCost = plan.overheadCost ?? FALLBACK_OVERHEAD;
+  const totalCost = useMemo(() => overheadCost + plan.steps.reduce((sum, s) => sum + getStepCost(s), 0), [plan.steps, overheadCost]);
 
   return (
     <motion.div
@@ -136,122 +78,52 @@ export function PlanReviewDisplay({ plan, onConfirm, onSkip, isLoading }: PlanRe
               {plan.goal}
             </span>
             <p className="text-[10.5px] text-zinc-400 mt-0.5 font-medium">
-              Оберіть глибину аналізу для кожного кроку
+              {plan.steps.length} кроків · ~{formatUah(totalCost)}
             </p>
           </div>
         </div>
       </div>
 
-      {/* Steps — scrollable on mobile when many steps */}
+      {/* Steps */}
       <div className="px-4 py-2 space-y-0.5 overflow-y-auto flex-1 min-h-0 divide-y divide-zinc-100">
-        {steps.map((step) => {
-          const isDepthCapable = DEPTH_CAPABLE_TOOLS.has(step.tool);
-          const isDeep = step.depth === 'deep';
-          const cost = getStepCost(step);
-          const calls = getStepCalls(step);
-          const isRecommended = step.recommendedDepth && step.depth === step.recommendedDepth;
-
-          return (
-            <div
-              key={step.id}
-              className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1.5 sm:gap-3 py-2.5"
-            >
-              <div className="flex items-start gap-2.5 flex-1 min-w-0">
-                <span className="text-[10px] text-zinc-300 font-mono mt-0.5 w-4 flex-shrink-0 text-right tabular-nums">
-                  {step.id}
-                </span>
-                <div className="min-w-0">
-                  <span className="text-[12.5px] text-zinc-800 leading-snug">
-                    {step.purpose}
-                  </span>
-                  <span className="text-[10px] text-zinc-400 ml-1.5 font-medium">
-                    {getToolLabel(step.tool)}
-                  </span>
-                </div>
-              </div>
-
-              {/* Cost + Depth toggle */}
-              <div className="flex items-center gap-2 flex-shrink-0 pl-6 sm:pl-0">
-                <span className="text-[10px] text-zinc-400 font-mono tabular-nums w-[56px] text-right" title={calls > 1 ? `~${calls} викликів` : undefined}>
-                  {formatUah(cost)}{calls > 1 && <span className="text-zinc-300 ml-0.5">×{calls}</span>}
-                </span>
-
-                {isDepthCapable ? (
-                  <button
-                    onClick={() => toggleDepth(step.id)}
-                    className={`flex items-center gap-1 px-2.5 py-1 rounded-md text-[10px] font-semibold tracking-tight transition-all duration-150 min-w-[100px] justify-center border ${
-                      isDeep
-                        ? 'bg-zinc-900 text-white border-zinc-900 hover:bg-zinc-800'
-                        : 'bg-white text-zinc-600 border-zinc-200 hover:border-zinc-300 hover:text-zinc-900'
-                    } ${isRecommended ? 'ring-1 ring-offset-1 ring-zinc-400' : ''}`}
-                  >
-                    {isDeep ? (
-                      <>
-                        <Search size={9} strokeWidth={2.5} />
-                        Глибокий
-                      </>
-                    ) : (
-                      <>
-                        <Zap size={9} strokeWidth={2.5} />
-                        Стандартний
-                      </>
-                    )}
-                  </button>
-                ) : (
-                  <span className="text-[10px] text-zinc-300 min-w-[100px] text-center px-2 font-medium">
-                    фіксований
-                  </span>
-                )}
-              </div>
+        {plan.steps.map((step) => (
+          <div
+            key={step.id}
+            className="flex items-center gap-2.5 py-2.5"
+          >
+            <span className="text-[10px] text-zinc-300 font-mono w-4 flex-shrink-0 text-right tabular-nums">
+              {step.id}
+            </span>
+            <div className="min-w-0 flex-1">
+              <span className="text-[12.5px] text-zinc-800 leading-snug">
+                {step.purpose}
+              </span>
+              <span className="text-[10px] text-zinc-400 ml-1.5 font-medium">
+                {getToolLabel(step.tool)}
+              </span>
             </div>
-          );
-        })}
+          </div>
+        ))}
       </div>
 
-      {/* Footer: bulk actions + total cost + confirm */}
+      {/* Footer */}
       <div className="px-4 py-3 border-t border-zinc-200/60 bg-zinc-50/70 flex-shrink-0">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <button
-              onClick={setAllDeep}
-              className="text-[10.5px] text-zinc-500 hover:text-zinc-900 transition-colors font-medium"
-            >
-              Усі глибокі
-            </button>
-            <span className="text-zinc-300 text-xs">·</span>
-            <button
-              onClick={setAllStandard}
-              className="text-[10.5px] text-zinc-500 hover:text-zinc-900 transition-colors font-medium"
-            >
-              Стандартні
-            </button>
-            {deepCount > 0 && (
-              <span className="text-[10px] text-zinc-500 bg-zinc-100 border border-zinc-200 px-1.5 py-0.5 rounded font-medium">
-                {deepCount} глибоких
-              </span>
-            )}
-          </div>
-
-          <div className="flex items-center gap-3">
-            <span className="text-[11px] text-zinc-500 font-mono tabular-nums font-medium">
-              ~{formatUah(totalCost)}
-            </span>
-            <button
-              onClick={onSkip}
-              disabled={isLoading}
-              className="text-[11px] text-zinc-400 hover:text-zinc-700 transition-colors font-medium px-2 py-1"
-            >
-              Пропустити
-            </button>
-            <button
-              onClick={handleConfirm}
-              disabled={isLoading}
-              className="flex items-center gap-1.5 px-3.5 py-1.5 bg-zinc-900 text-white rounded-md text-[11.5px] font-semibold hover:bg-zinc-800 transition-colors duration-150 disabled:opacity-50"
-            >
-              <Play size={10} strokeWidth={2.5} />
-              {isLoading ? 'Запуск...' : 'Почати аналіз'}
-            </button>
-          </div>
+        <div className="flex items-center justify-end gap-3">
+          <button
+            onClick={onSkip}
+            disabled={isLoading}
+            className="text-[11px] text-zinc-400 hover:text-zinc-700 transition-colors font-medium px-2 py-1"
+          >
+            Пропустити
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isLoading}
+            className="flex items-center gap-1.5 px-3.5 py-1.5 bg-zinc-900 text-white rounded-md text-[11.5px] font-semibold hover:bg-zinc-800 transition-colors duration-150 disabled:opacity-50"
+          >
+            <Play size={10} strokeWidth={2.5} />
+            Виконати
+          </button>
         </div>
       </div>
     </motion.div>

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -7,13 +7,10 @@
 import { useCallback, useRef } from 'react';
 import { useChatStore } from '../../stores';
 import { mcpService } from '../../services';
-import showToast from '../../utils/toast';
-import { toastTDynamic } from '../../i18n/toast-i18n';
 import type { Decision, Citation, VaultDocument, ExecutionPlan, CostSummary } from '../../types/models/Message';
 import { getToolLabel } from './tool-labels';
 import { extractEvidenceFromToolResult } from './evidence-extractor';
 import { extractNormsFromAnswer } from './chat-helpers';
-import { useCurrencyRate } from '../useCurrencyRate';
 import { handleStreamError, autoTitleConversation } from './chat-error-utils';
 
 export interface UseAIChatStreamOptions {
@@ -31,7 +28,6 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
   } = useChatStore();
 
   const { onSuccess, onError } = options;
-  const { formatUah } = useCurrencyRate();
 
   // Accumulate evidence across multiple tool calls in one chat session
   const accumulatedDecisions = useRef<Decision[]>([]);
@@ -63,7 +59,7 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
       assistantMessageId: string,
       approvedPlan?: ExecutionPlan,
       planSessionId?: string,
-      allowDeepEscalation?: boolean,
+      _allowDeepEscalation?: boolean,
       internetEnabled?: boolean
     ) => {
       // Reset accumulators
@@ -125,20 +121,8 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
           });
         },
 
-        onBudgetEscalated: (data) => {
-          if (data.requiresConfirmation) {
-            useChatStore.getState().setPendingBudgetEscalation({
-              reason: data.reason,
-              estimatedCostMin: data.estimatedCost.minUsd,
-              estimatedCostMax: data.estimatedCost.maxUsd,
-              query,
-            });
-          } else {
-            showToast.info(
-              toastTDynamic('budgetEscalated', formatUah(data.estimatedCost.minUsd), formatUah(data.estimatedCost.maxUsd)),
-              6000
-            );
-          }
+        onBudgetEscalated: () => {
+          // Budget escalation is now fully automatic — no UI confirmation needed
         },
 
         onThinking: (data) => {
@@ -425,11 +409,11 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
             setCurrentTool(null);
           }
         },
-      }, 'standard', chatConversationId, approvedPlan, planSessionId, allowDeepEscalation, internetEnabled);
+      }, 'standard', chatConversationId, approvedPlan, planSessionId, true, internetEnabled);
 
       setStreamController(controller);
     },
-    [addThinkingStep, updateMessage, setStreaming, setStreamController, setCurrentTool, onSuccess, onError, formatUah]
+    [addThinkingStep, updateMessage, setStreaming, setStreamController, setCurrentTool, onSuccess, onError]
   );
 
   return { runChatStream };

--- a/lexwebapp/src/pages/ChatPage/index.tsx
+++ b/lexwebapp/src/pages/ChatPage/index.tsx
@@ -5,12 +5,10 @@
  */
 
 import { useCallback, useEffect, useRef } from 'react';
-import { TrendingUp } from 'lucide-react';
 import { ChatInput } from '../../components/ChatInput';
 import { MessageThread } from '../../components/MessageThread';
 import { EmptyState } from '../../components/EmptyState';
 import { PlanReviewDisplay } from '../../components/PlanReviewDisplay';
-import { useCurrencyRate } from '../../hooks/useCurrencyRate';
 import { useChatStore, useSettingsStore } from '../../stores';
 import { useAIChat } from '../../hooks/useMCPTool';
 import showToast from '../../utils/toast';
@@ -26,26 +24,11 @@ export function ChatPage() {
   const isPlanLoading = useChatStore(s => s.isPlanLoading);
   const cancelStream = useChatStore(s => s.cancelStream);
   const removeMessage = useChatStore(s => s.removeMessage);
-  const pendingBudgetEscalation = useChatStore(s => s.pendingBudgetEscalation);
-  const setPendingBudgetEscalation = useChatStore(s => s.setPendingBudgetEscalation);
   const queuedQuery = useChatStore(s => s.queuedQuery);
   const setQueuedQuery = useChatStore(s => s.setQueuedQuery);
 
   // AI Chat hook (agentic mode)
   const { executeChat, confirmPlanAndExecute, skipPlanReview } = useAIChat();
-  const { formatUah } = useCurrencyRate();
-
-  const handleConfirmDeepBudget = useCallback(() => {
-    const esc = useChatStore.getState().pendingBudgetEscalation;
-    if (!esc) return;
-    setPendingBudgetEscalation(null);
-    // Re-send the same query with allowDeepEscalation
-    executeChat(esc.query, undefined, true, internetEnabled);
-  }, [executeChat, setPendingBudgetEscalation, internetEnabled]);
-
-  const handleSkipDeepBudget = useCallback(() => {
-    setPendingBudgetEscalation(null);
-  }, [setPendingBudgetEscalation]);
 
   const handleSend = async (content: string, _toolName?: string, documentIds?: string[]) => {
     // If streaming is active, queue the message for execution after current stream ends
@@ -122,35 +105,6 @@ export function ChatPage() {
             onSkip={skipPlanReview}
             isLoading={isStreaming}
           />
-        </div>
-      )}
-
-      {/* Budget escalation confirmation */}
-      {pendingBudgetEscalation && (
-        <div className="w-full max-w-3xl mx-auto px-4 mb-3">
-          <div className="flex items-center gap-3 p-4 bg-amber-50 border border-amber-200 rounded-xl">
-            <TrendingUp size={20} className="text-amber-600 shrink-0" />
-            <div className="flex-1">
-              <p className="text-sm font-medium text-amber-900">
-                Рекомендовано глибокий аналіз
-              </p>
-              <p className="text-xs text-amber-700 mt-0.5">
-                Орієнтовна вартість: {formatUah(pendingBudgetEscalation.estimatedCostMin)}–{formatUah(pendingBudgetEscalation.estimatedCostMax)}
-              </p>
-            </div>
-            <button
-              onClick={handleSkipDeepBudget}
-              className="px-3 py-1.5 text-xs font-medium text-amber-700 hover:text-amber-900 transition-colors"
-            >
-              Залишити стандартний
-            </button>
-            <button
-              onClick={handleConfirmDeepBudget}
-              className="px-4 py-1.5 text-xs font-medium bg-amber-600 text-white rounded-lg hover:bg-amber-700 transition-colors"
-            >
-              Глибокий аналіз
-            </button>
-          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Remove depth toggle per plan step in PlanReviewDisplay (standard/deep buttons)
- Remove "Рекомендовано глибокий аналіз" confirmation banner from ChatPage
- Always pass `allowDeepEscalation: true` — budget is fully automatic now
- Companion PR: overthelex/secondlayer-core fix/auto-budget-escalation

## Context (LEXAI-877)
Users on `standard` budget were silently escalated to Opus ($15/M tokens) via:
1. `practice_analysis.defaultBudget: 'deep'` config floor
2. Plan step threshold (>=5 steps → deep)

Result: $7-9 per query instead of ~$0.50.

## Test plan
- [ ] Chat page loads without budget escalation banner
- [ ] Plan review shows steps without depth toggles
- [ ] Queries execute on Sonnet (standard) by default
- [ ] Build passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make budget selection fully automatic and remove all manual depth controls in the UI. This aligns with LEXAI-877 by moving budget tier decisions to the backend and reducing surprise costs.

- **Refactors**
  - Removed per-step standard/deep toggles and bulk actions from `PlanReviewDisplay`; simplified cost calc to a single tier and trimmed UI.
  - Dropped the “Рекомендовано глибокий аналіз” banner and related state/handlers from `ChatPage`.
  - Always pass `allowDeepEscalation: true` in `useAIChatStream`; `onBudgetEscalated` is now a no-op (no confirmation/toast).
  - Default runs stay on standard; core escalates automatically when needed.

<sup>Written for commit 94bf9b0bfc13ee8a1a5d0b414ee03089658739b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

