### PR TITLE
chore(backend): trigger rebuild with secondlayer-core budget fix

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Version bump to force CI backend rebuild
- Previous empty commit (#1549) didn't trigger backend rebuild because detect-changes saw no mcp_backend/ changes

## What gets deployed
secondlayer-core budget escalation fixes:
- `practice_analysis` / `comparative_analysis` defaultBudget: `deep` → `standard`
- Plan step threshold: `5` → `8`

LEXAI-877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `secondlayer-mcp` to 1.0.1 to force a backend rebuild and deploy `secondlayer-core` budget fixes. Addresses LEXAI-877.

- **Bug Fixes**
  - Set defaultBudget for `practice_analysis` and `comparative_analysis` from deep to standard.
  - Increase plan step threshold from 5 to 8.

<sup>Written for commit 4c0f4b7ea9684472f1fea3cb318f7b8cb3f62b9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

