### PR TITLE
fix(backend): update budget test assertions for standard defaults

### DIFF
--- a/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
@@ -962,12 +962,12 @@ describe('QueryTypeConfig', () => {
     }
   });
 
-  it('practice_analysis should use deep budget', () => {
-    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('deep');
+  it('practice_analysis should use standard budget', () => {
+    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('standard');
   });
 
-  it('comparative_analysis should use deep budget', () => {
-    expect(QUERY_TYPE_CONFIG.comparative_analysis.defaultBudget).toBe('deep');
+  it('comparative_analysis should use standard budget', () => {
+    expect(QUERY_TYPE_CONFIG.comparative_analysis.defaultBudget).toBe('standard');
   });
 
   it('legislation_lookup should use quick budget', () => {


### PR DESCRIPTION
## Summary
Fix failing tests after secondlayer-core budget changes.

Tests expected `deep` for `practice_analysis` and `comparative_analysis` but these were changed to `standard` in secondlayer-core PR #12.

LEXAI-877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update chat-intent-classifier tests to expect the standard default budget for `practice_analysis` and `comparative_analysis`, matching `secondlayer-core` updates. Fixes failing tests after the deep → standard switch; aligns with LEXAI-877.

<sup>Written for commit e31c88dea939902c60ef6063d77bda2ee7f2a3bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

