### PR TITLE
fix(backend): rebuild with court practice tools in callable set

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
Triggers backend rebuild with secondlayer-core PR #13 fix.

## What changed in secondlayer-core
Preferred scenario tools (from queryType config) were only used for sorting priority, not added to the callable tool set. When intent classifier didn't assign 'court' domain (e.g. tax question), court practice tools were excluded entirely.

Now: `search_edrsr_fulltext`, `get_case_documents_chain`, `search_supreme_court_practice` are always callable for `legal_consultation` and `practice_analysis` queries.

LEXAI-877

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the backend to include the `secondlayer-core` fix that keeps court practice tools callable for legal queries. Addresses LEXAI-877 to avoid missed results when the classifier doesn’t pick the court domain.

- **Bug Fixes**
  - For `legal_consultation` and `practice_analysis`, `search_edrsr_fulltext`, `get_case_documents_chain`, and `search_supreme_court_practice` are now always in the callable set, not just preferred for sorting.

- **Dependencies**
  - Bumps `secondlayer-mcp` to 1.0.2 and rebuilds against `secondlayer-core` PR #13.

<sup>Written for commit b2cc0d8d0e422ae50bf4869bbbcfc0d71e23631f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

