### PR TITLE
fix(seo): dynamic og:locale based on user language

### DIFF
--- a/lexwebapp/index.html
+++ b/lexwebapp/index.html
@@ -25,7 +25,7 @@
     <meta property="og:image" content="https://legal.org.ua/og-image.png" />
     <meta property="og:url" content="https://legal.org.ua" />
     <meta property="og:site_name" content="LEX by SecondLayer" />
-    <meta property="og:locale" content="en_US" />
+    <meta property="og:locale" content="uk_UA" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />

--- a/lexwebapp/src/hooks/useDocumentMeta.ts
+++ b/lexwebapp/src/hooks/useDocumentMeta.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useLocaleStore } from '../stores/localeStore';
 
 interface DocumentMeta {
   title: string;
@@ -8,10 +9,18 @@ interface DocumentMeta {
   ogDescription?: string;
   ogImage?: string;
   ogUrl?: string;
+  ogLocale?: string;
   canonical?: string;
 }
 
 const BASE_URL = 'https://legal.org.ua';
+
+const LANG_TO_OG_LOCALE: Record<string, string> = {
+  uk: 'uk_UA',
+  en: 'en_US',
+  ru: 'ru_RU',
+  es: 'es_ES',
+};
 
 function getOrCreateMeta(attr: 'name' | 'property', value: string): HTMLMetaElement {
   const selector = `meta[${attr}="${value}"]`;
@@ -37,6 +46,7 @@ function getOrCreateLink(rel: string): HTMLLinkElement {
 
 export function useDocumentMeta(meta: DocumentMeta) {
   const location = useLocation();
+  const language = useLocaleStore((s) => s.language);
   const originalTitle = useRef(document.title);
   const originalValues = useRef<Map<string, string | null>>(new Map());
 
@@ -60,6 +70,9 @@ export function useDocumentMeta(meta: DocumentMeta) {
 
     const ogUrlEl = document.querySelector<HTMLMetaElement>('meta[property="og:url"]');
     stored.set('og:url', ogUrlEl?.getAttribute('content') ?? null);
+
+    const ogLocaleEl = document.querySelector<HTMLMetaElement>('meta[property="og:locale"]');
+    stored.set('og:locale', ogLocaleEl?.getAttribute('content') ?? null);
 
     const canonicalEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
     stored.set('canonical', canonicalEl?.getAttribute('href') ?? null);
@@ -87,6 +100,10 @@ export function useDocumentMeta(meta: DocumentMeta) {
     const url = meta.ogUrl || meta.canonical || `${BASE_URL}${location.pathname}`;
     getOrCreateMeta('property', 'og:url').setAttribute('content', url);
 
+    const ogLocale = meta.ogLocale || LANG_TO_OG_LOCALE[language] || 'uk_UA';
+    document.documentElement.lang = language;
+    getOrCreateMeta('property', 'og:locale').setAttribute('content', ogLocale);
+
     const canonical = meta.canonical || `${BASE_URL}${location.pathname}`;
     getOrCreateLink('canonical').setAttribute('href', canonical);
 
@@ -113,6 +130,7 @@ export function useDocumentMeta(meta: DocumentMeta) {
       restoreMeta('property', 'og:description');
       restoreMeta('property', 'og:image');
       restoreMeta('property', 'og:url');
+      restoreMeta('property', 'og:locale');
 
       const canonicalOrig = orig.get('canonical');
       const linkEl = document.querySelector<HTMLLinkElement>('link[rel="canonical"]');
@@ -124,5 +142,5 @@ export function useDocumentMeta(meta: DocumentMeta) {
         }
       }
     };
-  }, [meta.title, meta.description, meta.ogTitle, meta.ogDescription, meta.ogImage, meta.ogUrl, meta.canonical, location.pathname]);
+  }, [meta.title, meta.description, meta.ogTitle, meta.ogDescription, meta.ogImage, meta.ogUrl, meta.ogLocale, meta.canonical, location.pathname, language]);
 }


### PR DESCRIPTION
## Summary
- Fixed `og:locale` hardcoded as `en_US` in `index.html` — changed default to `uk_UA`
- `useDocumentMeta` now dynamically sets `og:locale` based on localeStore language (uk→uk_UA, en→en_US, ru→ru_RU, es→es_ES)
- Also syncs `<html lang>` attribute on every page render

## Test plan
- [ ] Verify `og:locale` is `uk_UA` for Ukrainian users
- [ ] Switch language to EN and verify `og:locale` changes to `en_US`
- [ ] Check `<html lang>` attribute updates on language switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `og:locale` dynamic based on the current app language and sync the `<html lang>` attribute for accurate SEO and social previews.

- **Bug Fixes**
  - Default `og:locale` in `index.html` set to `uk_UA`.
  - `useDocumentMeta` now derives `og:locale` from `useLocaleStore` (uk→uk_UA, en→en_US, ru→ru_RU, es→es_ES).
  - `<html lang>` now updates with the selected language on each render.

<sup>Written for commit 47f50fec61e7cfb045f652073e527d4f8b27686e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

