### PR TITLE
feat(seo): multilingual blog SSG with hreflang

### DIFF
--- a/lexwebapp/public/sitemap.xml
+++ b/lexwebapp/public/sitemap.xml
@@ -62,10 +62,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/rag-vs-training-legal-heterogeneity</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/rag-vs-training-legal-heterogeneity</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/deepseek-v3-860b-ukrainian-law</loc>
     <lastmod>2026-04-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/deepseek-v3-860b-ukrainian-law</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/deepseek-v3-860b-ukrainian-law</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/edrsr-vectorization-voyage</loc>
@@ -74,10 +98,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/edrsr-vectorization-voyage</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/edrsr-vectorization-voyage</loc>
+    <lastmod>2026-04-18</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/sneakypiper-due-diligence-platform</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/sneakypiper-due-diligence-platform</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/sneakypiper-due-diligence-platform</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/ml-engineer-competencies</loc>
@@ -86,10 +134,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/ml-engineer-competencies</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ml-engineer-competencies</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/tasks-for-independent-contributors</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/tasks-for-independent-contributors</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/tasks-for-independent-contributors</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/open-source-welcome-engineers</loc>
@@ -98,10 +170,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/open-source-welcome-engineers</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/open-source-welcome-engineers</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/distributed-monolith</loc>
     <lastmod>2026-04-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/distributed-monolith</loc>
+    <lastmod>2026-04-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/distributed-monolith</loc>
+    <lastmod>2026-04-01</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/opendata-sync-pipeline-engineering</loc>
@@ -110,10 +206,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/opendata-sync-pipeline-engineering</loc>
+    <lastmod>2026-03-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/opendata-sync-pipeline-engineering</loc>
+    <lastmod>2026-03-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/ci-cd-blue-green-self-healing-tests</loc>
     <lastmod>2026-03-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/ci-cd-blue-green-self-healing-tests</loc>
+    <lastmod>2026-03-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ci-cd-blue-green-self-healing-tests</loc>
+    <lastmod>2026-03-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/court-practice-analysis-march-2026</loc>
@@ -122,10 +242,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/court-practice-analysis-march-2026</loc>
+    <lastmod>2026-03-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/court-practice-analysis-march-2026</loc>
+    <lastmod>2026-03-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/security-audit-gdpr-owasp</loc>
     <lastmod>2026-03-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/security-audit-gdpr-owasp</loc>
+    <lastmod>2026-03-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/security-audit-gdpr-owasp</loc>
+    <lastmod>2026-03-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/open-data-340m-production</loc>
@@ -134,10 +278,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/open-data-340m-production</loc>
+    <lastmod>2026-03-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/open-data-340m-production</loc>
+    <lastmod>2026-03-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/attorney-marketplace</loc>
     <lastmod>2026-03-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/attorney-marketplace</loc>
+    <lastmod>2026-03-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/attorney-marketplace</loc>
+    <lastmod>2026-03-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/mcp-tokens-claude-desktop</loc>
@@ -146,10 +314,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/mcp-tokens-claude-desktop</loc>
+    <lastmod>2026-03-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/mcp-tokens-claude-desktop</loc>
+    <lastmod>2026-03-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/round-robin-llm</loc>
     <lastmod>2026-02-28</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/round-robin-llm</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/round-robin-llm</loc>
+    <lastmod>2026-02-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/mcp-server-architecture</loc>
@@ -158,10 +350,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/mcp-server-architecture</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/mcp-server-architecture</loc>
+    <lastmod>2026-02-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/semantic-search-legislation</loc>
     <lastmod>2026-02-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/semantic-search-legislation</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/semantic-search-legislation</loc>
+    <lastmod>2026-02-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/hallucination-guard</loc>
@@ -170,10 +386,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/hallucination-guard</loc>
+    <lastmod>2026-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/hallucination-guard</loc>
+    <lastmod>2026-02-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/monolith-to-mcp</loc>
     <lastmod>2026-02-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/monolith-to-mcp</loc>
+    <lastmod>2026-02-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/monolith-to-mcp</loc>
+    <lastmod>2026-02-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/diia-digital-identity</loc>
@@ -182,10 +422,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/diia-digital-identity</loc>
+    <lastmod>2026-02-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/diia-digital-identity</loc>
+    <lastmod>2026-02-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/mcp-connect-open-data</loc>
     <lastmod>2026-01-30</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/mcp-connect-open-data</loc>
+    <lastmod>2026-01-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/mcp-connect-open-data</loc>
+    <lastmod>2026-01-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/ai-wont-replace-lawyers</loc>
@@ -194,10 +458,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/ai-wont-replace-lawyers</loc>
+    <lastmod>2026-01-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ai-wont-replace-lawyers</loc>
+    <lastmod>2026-01-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/semantic-vs-keyword-search</loc>
     <lastmod>2026-01-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/semantic-vs-keyword-search</loc>
+    <lastmod>2026-01-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/semantic-vs-keyword-search</loc>
+    <lastmod>2026-01-20</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/ai-analyzes-millions</loc>
@@ -206,10 +494,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/ai-analyzes-millions</loc>
+    <lastmod>2026-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ai-analyzes-millions</loc>
+    <lastmod>2026-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/due-diligence-ai</loc>
     <lastmod>2026-01-10</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/due-diligence-ai</loc>
+    <lastmod>2026-01-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/due-diligence-ai</loc>
+    <lastmod>2026-01-10</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/data-privacy-ai</loc>
@@ -218,10 +530,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/data-privacy-ai</loc>
+    <lastmod>2026-01-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/data-privacy-ai</loc>
+    <lastmod>2026-01-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/gcp-cloud-scaling</loc>
     <lastmod>2026-03-08</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/gcp-cloud-scaling</loc>
+    <lastmod>2026-03-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/gcp-cloud-scaling</loc>
+    <lastmod>2026-03-08</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/edrsr-fulltext-pipeline</loc>
@@ -230,10 +566,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/edrsr-fulltext-pipeline</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/edrsr-fulltext-pipeline</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/chat-latency-optimization</loc>
     <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/chat-latency-optimization</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/chat-latency-optimization</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/bedrock-llm-fallback</loc>
@@ -242,10 +602,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/bedrock-llm-fallback</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/bedrock-llm-fallback</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/erb-nbu-due-diligence</loc>
     <lastmod>2026-03-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/erb-nbu-due-diligence</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/erb-nbu-due-diligence</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/server-side-evidence</loc>
@@ -254,10 +638,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/server-side-evidence</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/server-side-evidence</loc>
+    <lastmod>2026-03-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/developer-platform-api</loc>
     <lastmod>2026-03-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/developer-platform-api</loc>
+    <lastmod>2026-03-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/developer-platform-api</loc>
+    <lastmod>2026-03-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/military-lawyer-ai</loc>
@@ -266,10 +674,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/military-lawyer-ai</loc>
+    <lastmod>2026-03-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/military-lawyer-ai</loc>
+    <lastmod>2026-03-21</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/nais-41m-open-data</loc>
     <lastmod>2026-03-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/nais-41m-open-data</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/nais-41m-open-data</loc>
+    <lastmod>2026-03-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/ai-changes-lawyer-work-2026</loc>
@@ -278,10 +710,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/ai-changes-lawyer-work-2026</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ai-changes-lawyer-work-2026</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/spain-legal-expansion</loc>
     <lastmod>2026-03-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/spain-legal-expansion</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/spain-legal-expansion</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/developer-docs-api-guide</loc>
@@ -290,10 +746,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/developer-docs-api-guide</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/developer-docs-api-guide</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/diia-integration-challenges</loc>
     <lastmod>2026-03-24</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/diia-integration-challenges</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/diia-integration-challenges</loc>
+    <lastmod>2026-03-24</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/sample-queries-86-tools</loc>
@@ -302,10 +782,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/sample-queries-86-tools</loc>
+    <lastmod>2026-03-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/sample-queries-86-tools</loc>
+    <lastmod>2026-03-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/ai-safety-open-registries</loc>
     <lastmod>2026-04-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/ai-safety-open-registries</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ai-safety-open-registries</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/rlhf-longtail-problem</loc>
@@ -314,10 +818,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/rlhf-longtail-problem</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/rlhf-longtail-problem</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/constitutional-rlhf</loc>
     <lastmod>2026-04-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/constitutional-rlhf</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/constitutional-rlhf</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/ai-experimental-court</loc>
@@ -326,10 +854,34 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/ai-experimental-court</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/ai-experimental-court</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/legaltech-llm-constitution</loc>
     <lastmod>2026-04-02</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/legaltech-llm-constitution</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/legaltech-llm-constitution</loc>
+    <lastmod>2026-04-02</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/blog/claude-code-building-startups</loc>
@@ -338,16 +890,52 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/claude-code-building-startups</loc>
+    <lastmod>2026-04-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/claude-code-building-startups</loc>
+    <lastmod>2026-04-12</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/opus-rag-vs-finetuned-llm</loc>
     <lastmod>2026-04-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://legal.org.ua/blog/en/opus-rag-vs-finetuned-llm</loc>
+    <lastmod>2026-04-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/opus-rag-vs-finetuned-llm</loc>
+    <lastmod>2026-04-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://legal.org.ua/blog/fast-builds-aws</loc>
     <lastmod>2026-04-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/en/fast-builds-aws</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://legal.org.ua/blog/ru/fast-builds-aws</loc>
+    <lastmod>2026-04-17</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://legal.org.ua/en/offer</loc>

--- a/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
+++ b/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
@@ -20,14 +20,23 @@ import { getBlogUI, getLocalizedArticles } from './blog-i18n';
 const translationMaps = { en: enTranslations, ru: ruTranslations };
 
 export function BlogArticlePage() {
-  const { slug } = useParams<{ slug: string }>();
+  const { slug, lang } = useParams<{ slug: string; lang?: string }>();
   const navigate = useNavigate();
   const [copied, setCopied] = useState(false);
   const language = useLocaleStore((s) => s.language);
-  const ui = getBlogUI(language);
+  const setLanguage = useLocaleStore((s) => s.setLanguage);
+
+  useEffect(() => {
+    if (lang && ['en', 'ru', 'es'].includes(lang) && lang !== language) {
+      setLanguage(lang as 'en' | 'ru' | 'es');
+    }
+  }, [lang, language, setLanguage]);
+
+  const effectiveLang = (lang && ['en', 'ru', 'es', 'uk'].includes(lang)) ? lang as 'en' | 'ru' | 'es' | 'uk' : language;
+  const ui = getBlogUI(effectiveLang);
   const localizedArticles = useMemo(
-    () => getLocalizedArticles(articles, language, translationMaps),
-    [language]
+    () => getLocalizedArticles(articles, effectiveLang, translationMaps),
+    [effectiveLang]
   );
 
   const article = localizedArticles.find((a) => a.id === slug);

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -280,6 +280,10 @@ export const router = createBrowserRouter([
     element: S(AbuseReportPage),
   },
   {
+    path: ROUTES.BLOG_ARTICLE_LANG,
+    element: S(BlogArticlePage),
+  },
+  {
     path: ROUTES.BLOG_ARTICLE,
     element: S(BlogArticlePage),
   },

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -79,6 +79,7 @@ export const ROUTES = {
   // Blog
   BLOG: '/blog',
   BLOG_ARTICLE: '/blog/:slug',
+  BLOG_ARTICLE_LANG: '/blog/:lang/:slug',
 
   // Career
   CAREER: '/career',

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -50,6 +50,8 @@ function sitemapPlugin(): Plugin {
         const blogArticles: Entry[] = []
         for (let i = 0; i < count; i++) {
           blogArticles.push({ loc: `/blog/${ids[i]}`, changefreq: 'monthly', priority: '0.8', lastmod: dates[i] })
+          blogArticles.push({ loc: `/blog/en/${ids[i]}`, changefreq: 'monthly', priority: '0.7', lastmod: dates[i] })
+          blogArticles.push({ loc: `/blog/ru/${ids[i]}`, changefreq: 'monthly', priority: '0.7', lastmod: dates[i] })
         }
 
         const legalSlugs = ['offer', 'terms', 'privacy', 'dpa', 'ai-usage', 'ai-transparency', 'refund-policy', 'attorney-offer', 'developer-offer', 'marketplace-rules']
@@ -266,12 +268,15 @@ function prerenderBlogPlugin(): Plugin {
         const root = path.resolve(__dirname)
         const distDir = path.resolve(root, 'dist')
         const indexHtml = fs.readFileSync(path.resolve(distDir, 'index.html'), 'utf-8')
-        const articlesPath = path.resolve(root, 'src/pages/BlogPage/articles.ts')
-        const src = fs.readFileSync(articlesPath, 'utf-8')
 
         const BASE_URL = 'https://legal.org.ua'
 
-        // Parse articles from source via regex (same approach as sitemap plugin)
+        const LANG_META: Record<string, { ogLocale: string, htmlLang: string, backLabel: string }> = {
+          uk: { ogLocale: 'uk_UA', htmlLang: 'uk', backLabel: '← Всі статті' },
+          en: { ogLocale: 'en_US', htmlLang: 'en', backLabel: '← All articles' },
+          ru: { ogLocale: 'ru_RU', htmlLang: 'ru', backLabel: '← Все статьи' },
+        }
+
         interface ParsedArticle {
           id: string
           title: string
@@ -283,59 +288,104 @@ function prerenderBlogPlugin(): Plugin {
           content: string
         }
 
-        const articles: ParsedArticle[] = []
+        // --- Parse articles from a TS source file via regex ---
+        function parseArticlesFile(filePath: string, isTranslation: boolean): ParsedArticle[] | Record<string, Partial<ParsedArticle>> {
+          const src = fs.readFileSync(filePath, 'utf-8')
 
-        // Split by article object boundaries
-        const articleBlocks = src.split(/\n  \{[\s]*\n/).slice(1) // skip before first article
-        for (const block of articleBlocks) {
-          const get = (key: string) => {
-            const m = block.match(new RegExp(`${key}:\\s*'([^']*)'`))
-            return m ? m[1] : ''
+          if (isTranslation) {
+            // Translation files: { 'slug': { title, punchline, content, readTime } }
+            const map: Record<string, Partial<ParsedArticle>> = {}
+            // Match each slug entry
+            const slugPattern = /['"]([a-z0-9-]+)['"]\s*:\s*\{/g
+            let match
+            while ((match = slugPattern.exec(src)) !== null) {
+              const slug = match[1]
+              const startIdx = match.index + match[0].length
+              // Find the content boundaries for this slug
+              const remaining = src.slice(startIdx)
+              const titleMatch = remaining.match(/title:\s*'((?:[^'\\]|\\.)*)'/)
+              const punchlineMatch = remaining.match(/punchline:\s*'((?:[^'\\]|\\.)*)'/)
+              const readTimeMatch = remaining.match(/readTime:\s*'((?:[^'\\]|\\.)*)'/)
+              const contentMatch = remaining.match(/content:\s*`((?:\\[\s\S]|[^`])*)`/)
+
+              if (titleMatch) {
+                map[slug] = {
+                  title: titleMatch[1].replace(/\\'/g, "'"),
+                  punchline: punchlineMatch ? punchlineMatch[1].replace(/\\'/g, "'") : '',
+                  readTime: readTimeMatch ? readTimeMatch[1] : '',
+                  content: contentMatch
+                    ? contentMatch[1].replace(/\\`/g, '`').replace(/\\\$/g, '$').replace(/\\\\/g, '\\')
+                    : '',
+                }
+              }
+            }
+            return map
           }
-          const id = get('id')
-          const title = get('title')
-          const punchline = get('punchline')
-          const category = get('category')
-          const readTime = get('readTime')
-          const publishedAt = get('publishedAt')
 
-          // Extract tags array
-          const tagsMatch = block.match(/tags:\s*\[([^\]]*)\]/)
-          const tags = tagsMatch
-            ? tagsMatch[1].match(/'([^']+)'/g)?.map(t => t.replace(/'/g, '')) || []
-            : []
+          // Main articles file
+          const articles: ParsedArticle[] = []
+          const articleBlocks = src.split(/\n  \{[\s]*\n/).slice(1)
+          for (const block of articleBlocks) {
+            const get = (key: string) => {
+              const m = block.match(new RegExp(`${key}:\\s*'([^']*)'`))
+              return m ? m[1] : ''
+            }
+            const id = get('id')
+            const title = get('title')
+            const punchline = get('punchline')
+            const category = get('category')
+            const readTime = get('readTime')
+            const publishedAt = get('publishedAt')
 
-          // Extract content (between backticks).
-          // Articles contain markdown with escaped backticks (\`code\`) and \`\`\`code fences\`\`\`.
-          // A naive non-greedy match /content:\s*`([\s\S]*?)`/ stops at the first backtick —
-          // including escaped ones — and truncates every technical article to ~1400 chars.
-          // The pattern below consumes escape sequences (\`, \$, \\, \\n, etc.) before any
-          // backtick, so the regex only terminates on a real closing backtick.
-          const contentMatch = block.match(/content:\s*`((?:\\[\s\S]|[^`])*)`/)
-          // Unescape the template-literal escape sequences we just preserved.
-          const content = contentMatch
-            ? contentMatch[1]
-                .replace(/\\`/g, '`')
-                .replace(/\\\$/g, '$')
-                .replace(/\\\\/g, '\\')
-            : ''
+            const tagsMatch = block.match(/tags:\s*\[([^\]]*)\]/)
+            const tags = tagsMatch
+              ? tagsMatch[1].match(/'([^']+)'/g)?.map(t => t.replace(/'/g, '')) || []
+              : []
 
-          if (id && title) {
-            articles.push({ id, title, punchline, category, tags, readTime, publishedAt, content })
+            const contentMatch = block.match(/content:\s*`((?:\\[\s\S]|[^`])*)`/)
+            const content = contentMatch
+              ? contentMatch[1]
+                  .replace(/\\`/g, '`')
+                  .replace(/\\\$/g, '$')
+                  .replace(/\\\\/g, '\\')
+              : ''
+
+            if (id && title) {
+              articles.push({ id, title, punchline, category, tags, readTime, publishedAt, content })
+            }
           }
+          return articles
         }
+
+        // Parse all language versions
+        const articles = parseArticlesFile(
+          path.resolve(root, 'src/pages/BlogPage/articles.ts'), false
+        ) as ParsedArticle[]
+
+        const enMap = parseArticlesFile(
+          path.resolve(root, 'src/pages/BlogPage/articles-en.ts'), true
+        ) as Record<string, Partial<ParsedArticle>>
+
+        const ruMap = parseArticlesFile(
+          path.resolve(root, 'src/pages/BlogPage/articles-ru.ts'), true
+        ) as Record<string, Partial<ParsedArticle>>
 
         if (articles.length === 0) {
           console.warn('[prerender-blog] No articles parsed, skipping')
           return
         }
 
+        const translationMaps: Record<string, Record<string, Partial<ParsedArticle>>> = {
+          en: enMap,
+          ru: ruMap,
+        }
+
         // Helper to replace meta tags in the HTML shell
         function replaceMeta(html: string, opts: {
           title: string, description: string, ogTitle: string, ogDescription: string,
-          ogUrl: string, ogImage?: string, canonical: string
+          ogUrl: string, ogImage?: string, canonical: string, ogLocale?: string, htmlLang?: string
         }): string {
-          return html
+          let result = html
             .replace(/<title>[^<]*<\/title>/, `<title>${opts.title}</title>`)
             .replace(/<meta name="description" content="[^"]*"\s*\/?>/, `<meta name="description" content="${opts.description.replace(/"/g, '&quot;')}" />`)
             .replace(/<meta property="og:title" content="[^"]*"\s*\/?>/, `<meta property="og:title" content="${opts.ogTitle.replace(/"/g, '&quot;')}" />`)
@@ -344,9 +394,28 @@ function prerenderBlogPlugin(): Plugin {
             .replace(/<meta name="twitter:title" content="[^"]*"\s*\/?>/, `<meta name="twitter:title" content="${opts.ogTitle.replace(/"/g, '&quot;')}" />`)
             .replace(/<meta name="twitter:description" content="[^"]*"\s*\/?>/, `<meta name="twitter:description" content="${opts.ogDescription.replace(/"/g, '&quot;')}" />`)
             .replace(/<link rel="canonical" href="[^"]*"\s*\/?>/, `<link rel="canonical" href="${opts.canonical}" />`)
-            // Update og:image if provided
             .replace(/<meta property="og:image" content="[^"]*"\s*\/?>/, `<meta property="og:image" content="${opts.ogImage || `${BASE_URL}/og-image.png`}" />`)
             .replace(/<meta name="twitter:image" content="[^"]*"\s*\/?>/, `<meta name="twitter:image" content="${opts.ogImage || `${BASE_URL}/og-image.png`}" />`)
+          if (opts.ogLocale) {
+            result = result.replace(/<meta property="og:locale" content="[^"]*"\s*\/?>/, `<meta property="og:locale" content="${opts.ogLocale}" />`)
+          }
+          if (opts.htmlLang) {
+            result = result.replace(/<html lang="[^"]*"/, `<html lang="${opts.htmlLang}"`)
+          }
+          return result
+        }
+
+        // Helper to generate hreflang link tags for a given article slug
+        function hreflangTags(slug: string): string {
+          const ukUrl = `${BASE_URL}/blog/${slug}`
+          const enUrl = `${BASE_URL}/blog/en/${slug}`
+          const ruUrl = `${BASE_URL}/blog/ru/${slug}`
+          return [
+            `<link rel="alternate" hreflang="uk" href="${ukUrl}" />`,
+            `<link rel="alternate" hreflang="en" href="${enUrl}" />`,
+            `<link rel="alternate" hreflang="ru" href="${ruUrl}" />`,
+            `<link rel="alternate" hreflang="x-default" href="${ukUrl}" />`,
+          ].join('\n    ')
         }
 
         // --- Generate /blog/index.html (article listing) ---
@@ -407,84 +476,107 @@ function prerenderBlogPlugin(): Plugin {
         fs.mkdirSync(blogDir, { recursive: true })
         fs.writeFileSync(path.resolve(blogDir, 'index.html'), blogListPage)
 
-        // --- Generate /blog/:slug/index.html for each article ---
+        // --- Generate /blog/:slug/index.html for each article (all languages) ---
         let articleCount = 0
+        const languages = ['uk', 'en', 'ru'] as const
+
         for (const article of articles) {
-          const articleUrl = `${BASE_URL}/blog/${article.id}`
-          const ogImage = `${BASE_URL}/blog-banners/${article.id}.png`
-          const truncatedPunchline = article.punchline.length > 200
-            ? article.punchline.slice(0, 197) + '...'
-            : article.punchline
+          for (const lang of languages) {
+            // Resolve translated content
+            let title = article.title
+            let punchline = article.punchline
+            let content = article.content
+            let readTime = article.readTime
 
-          let articlePage = replaceMeta(indexHtml, {
-            title: `${article.title} | LEX Blog`,
-            description: truncatedPunchline,
-            ogTitle: article.title,
-            ogDescription: truncatedPunchline,
-            ogUrl: articleUrl,
-            ogImage,
-            canonical: articleUrl,
-          })
+            if (lang !== 'uk') {
+              const translation = translationMaps[lang]?.[article.id]
+              if (!translation?.title) continue // skip if no translation exists
+              title = translation.title || title
+              punchline = translation.punchline || punchline
+              content = translation.content || content
+              readTime = translation.readTime || readTime
+            }
 
-          // Add og:type article
-          articlePage = articlePage.replace(
-            '<meta property="og:type" content="website" />',
-            '<meta property="og:type" content="article" />'
-          )
+            const langMeta = LANG_META[lang]
+            const slugPath = lang === 'uk' ? article.id : `${lang}/${article.id}`
+            const articleUrl = `${BASE_URL}/blog/${slugPath}`
+            const ogImage = `${BASE_URL}/blog-banners/${article.id}.png`
+            const truncatedPunchline = punchline.length > 200
+              ? punchline.slice(0, 197) + '...'
+              : punchline
 
-          // JSON-LD BlogPosting
-          const articleJsonLd = JSON.stringify({
-            "@context": "https://schema.org",
-            "@type": "BlogPosting",
-            "headline": article.title,
-            "description": article.punchline,
-            "url": articleUrl,
-            "image": ogImage,
-            "datePublished": article.publishedAt,
-            "keywords": article.tags.join(', '),
-            "articleSection": article.category === 'tech' ? 'Technology' : 'Legal',
-            "inLanguage": "uk",
-            "publisher": { "@type": "Organization", "name": "SecondLayer", "url": BASE_URL },
-            "mainEntityOfPage": { "@type": "WebPage", "@id": articleUrl }
-          })
+            let articlePage = replaceMeta(indexHtml, {
+              title: `${title} | LEX Blog`,
+              description: truncatedPunchline,
+              ogTitle: title,
+              ogDescription: truncatedPunchline,
+              ogUrl: articleUrl,
+              ogImage,
+              canonical: articleUrl,
+              ogLocale: langMeta.ogLocale,
+              htmlLang: langMeta.htmlLang,
+            })
 
-          articlePage = articlePage.replace('</head>', `<script type="application/ld+json">${articleJsonLd}</script>\n  </head>`)
+            articlePage = articlePage.replace(
+              '<meta property="og:type" content="website" />',
+              '<meta property="og:type" content="article" />'
+            )
 
-          // Convert markdown content to HTML for crawlers
-          let contentHtml = ''
-          try {
-            contentHtml = marked.parse(article.content) as string
-          } catch {
-            contentHtml = `<pre>${article.content.replace(/</g, '&lt;')}</pre>`
-          }
+            // Add hreflang tags
+            articlePage = articlePage.replace('</head>', `    ${hreflangTags(article.id)}\n  </head>`)
 
-          const semanticArticle = `<article id="blog-article-seo" style="max-width:820px;margin:40px auto;font-family:system-ui,sans-serif;padding:0 24px">
+            const articleJsonLd = JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "BlogPosting",
+              "headline": title,
+              "description": punchline,
+              "url": articleUrl,
+              "image": ogImage,
+              "datePublished": article.publishedAt,
+              "keywords": article.tags.join(', '),
+              "articleSection": article.category === 'tech' ? 'Technology' : 'Legal',
+              "inLanguage": langMeta.htmlLang,
+              "publisher": { "@type": "Organization", "name": "SecondLayer", "url": BASE_URL },
+              "mainEntityOfPage": { "@type": "WebPage", "@id": articleUrl }
+            })
+
+            articlePage = articlePage.replace('</head>', `<script type="application/ld+json">${articleJsonLd}</script>\n  </head>`)
+
+            let contentHtml = ''
+            try {
+              contentHtml = marked.parse(content) as string
+            } catch {
+              contentHtml = `<pre>${content.replace(/</g, '&lt;')}</pre>`
+            }
+
+            const semanticArticle = `<article id="blog-article-seo" style="max-width:820px;margin:40px auto;font-family:system-ui,sans-serif;padding:0 24px">
       <header>
         <span>${article.category === 'tech' ? 'TECH' : 'LEGAL'}</span>
         <time datetime="${article.publishedAt}">${article.publishedAt}</time>
-        <span>${article.readTime}</span>
+        <span>${readTime}</span>
       </header>
-      <h1>${article.title}</h1>
-      <p><em>${article.punchline}</em></p>
+      <h1>${title}</h1>
+      <p><em>${punchline}</em></p>
       ${contentHtml}
       <footer>
         <div>${article.tags.map(t => `<span>#${t}</span>`).join(' ')}</div>
-        <nav><a href="/blog">← Всі статті</a></nav>
+        <nav><a href="/blog">${langMeta.backLabel}</a></nav>
       </footer>
     </article>`
 
-          articlePage = articlePage.replace(
-            '<div id="root"></div>',
-            `${semanticArticle}\n    <div id="root"></div>\n    <script>document.getElementById('blog-article-seo')?.remove()</script>`
-          )
+            articlePage = articlePage.replace(
+              '<div id="root"></div>',
+              `${semanticArticle}\n    <div id="root"></div>\n    <script>document.getElementById('blog-article-seo')?.remove()</script>`
+            )
 
-          const articleDir = path.resolve(blogDir, article.id)
-          fs.mkdirSync(articleDir, { recursive: true })
-          fs.writeFileSync(path.resolve(articleDir, 'index.html'), articlePage)
-          articleCount++
+            const articleDir = path.resolve(blogDir, slugPath)
+            fs.mkdirSync(articleDir, { recursive: true })
+            fs.writeFileSync(path.resolve(articleDir, 'index.html'), articlePage)
+            articleCount++
+          }
         }
 
-        console.log(`[prerender-blog] Generated blog/index.html + ${articleCount} article pages`)
+        console.log(`[prerender-blog] Generated blog/index.html + ${articleCount} article pages (uk/en/ru)`)
       } catch (err) {
         console.error('[prerender-blog] Failed to generate blog pages:', err)
       }


### PR DESCRIPTION
## Summary
- Blog prerender plugin now generates EN (`/blog/en/{slug}`) and RU (`/blog/ru/{slug}`) static HTML pages alongside Ukrainian defaults
- Each language version has correct `og:locale`, `<html lang>`, `og:title`, `og:description` in the target language
- All blog pages include `hreflang` alternate links (uk, en, ru, x-default)
- JSON-LD `inLanguage` set per language version
- Frontend router handles `/blog/:lang/:slug` and auto-sets locale
- Sitemap updated with EN/RU blog URLs

Fixes the issue where crawlers (Facebook, Twitter, LinkedIn) only saw Ukrainian meta tags regardless of language.

## Test plan
- [ ] `curl https://legal.org.ua/blog/en/claude-code-building-startups` shows English og:title + og:locale en_US
- [ ] `curl https://legal.org.ua/blog/ru/claude-code-building-startups` shows Russian og:title + og:locale ru_RU
- [ ] Default `/blog/slug` still shows Ukrainian
- [ ] All pages have hreflang alternates
- [ ] SPA navigation to `/blog/en/slug` auto-switches language

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multilingual static generation for blog posts with EN and RU URLs, correct per-language meta, and `hreflang` alternates. Improves crawler previews and SEO; sitemap lists EN/RU pages and the client auto-sets locale from the URL.

- **New Features**
  - Generate `/blog/en/:slug` and `/blog/ru/:slug` static pages alongside UA defaults.
  - Set `<html lang>`, `og:locale`, `og:title`, `og:description`, and JSON-LD `inLanguage` per language.
  - Add `hreflang` alternates for `uk`, `en`, `ru`, and `x-default` on all blog pages.
  - Update sitemap to include EN/RU blog URLs.
  - Router supports `/blog/:lang/:slug` and auto-sets locale on navigation.

- **Bug Fixes**
  - Social crawlers now see the correct language meta tags instead of always Ukrainian.

<sup>Written for commit 5b5c1f1b2e065824755e082d8db8091e92bf6265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

