### PR TITLE
feat(seo): EN/RU blog index pages with translated titles

### DIFF
--- a/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
+++ b/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
@@ -39,13 +39,22 @@ export function BlogArticlePage() {
     [effectiveLang]
   );
 
+  // Handle /blog/en, /blog/ru — slug is actually a language code, show blog index
+  useEffect(() => {
+    if (slug && ['en', 'ru', 'es'].includes(slug) && !lang) {
+      setLanguage(slug as 'en' | 'ru' | 'es');
+      navigate('/blog', { replace: true });
+    }
+  }, [slug, lang, setLanguage, navigate]);
+
   const article = localizedArticles.find((a) => a.id === slug);
 
   useEffect(() => {
-    if (!article) {
+    if (!article && slug && !['en', 'ru', 'es'].includes(slug)) {
       navigate('/blog', { replace: true });
       return;
     }
+    if (!article) return;
     document.title = article.title + ' | LEX Blog';
 
     // Set meta description

--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -418,14 +418,54 @@ function prerenderBlogPlugin(): Plugin {
           ].join('\n    ')
         }
 
-        // --- Generate /blog/index.html (article listing) ---
-        const blogListTitle = 'LEX Blog — AI Legal Tech Articles'
-        const blogListDesc = 'Статті про AI в юриспруденції, юридичні технології, аналіз судових рішень, fine-tuning LLM на судовій практиці та цифрову трансформацію правничої практики.'
-        const articleListHtml = articles
-          .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))
-          .map(a => `
+        // --- Generate /blog/index.html (+ /blog/en/ and /blog/ru/) ---
+        const blogDir = path.resolve(distDir, 'blog')
+        fs.mkdirSync(blogDir, { recursive: true })
+
+        const blogListMeta: Record<string, { title: string, desc: string, heading: string }> = {
+          uk: {
+            title: 'LEX Blog — AI Legal Tech Articles',
+            desc: 'Статті про AI в юриспруденції, юридичні технології, аналіз судових рішень, fine-tuning LLM на судовій практиці та цифрову трансформацію правничої практики.',
+            heading: 'LEX AI Blog',
+          },
+          en: {
+            title: 'LEX Blog — AI Legal Tech Articles',
+            desc: 'Articles on AI in law, legal technology, court decision analysis, fine-tuning LLMs on case law, and digital transformation of legal practice.',
+            heading: 'LEX AI Blog',
+          },
+          ru: {
+            title: 'LEX Blog — AI Legal Tech Articles',
+            desc: 'Статьи об AI в юриспруденции, юридических технологиях, анализе судебных решений, fine-tuning LLM на судебной практике и цифровой трансформации правовой практики.',
+            heading: 'LEX AI Blog',
+          },
+        }
+
+        const sortedArticles = [...articles].sort((a, b) => b.publishedAt.localeCompare(a.publishedAt))
+
+        for (const lang of ['uk', 'en', 'ru'] as const) {
+          const meta = blogListMeta[lang]
+          const langMeta = LANG_META[lang]
+          const langPrefix = lang === 'uk' ? '' : `${lang}/`
+          const blogUrl = `${BASE_URL}/blog${lang === 'uk' ? '' : `/${lang}`}`
+
+          const listArticles = sortedArticles.map(a => {
+            let title = a.title
+            let punchline = a.punchline
+            let readTime = a.readTime
+            if (lang !== 'uk') {
+              const tr = translationMaps[lang]?.[a.id]
+              if (tr?.title) {
+                title = tr.title
+                punchline = tr.punchline || punchline
+                readTime = tr.readTime || readTime
+              }
+            }
+            return { ...a, title, punchline, readTime }
+          })
+
+          const articleListHtml = listArticles.map(a => `
         <article>
-          <h2><a href="/blog/${a.id}">${a.title}</a></h2>
+          <h2><a href="/blog/${langPrefix}${a.id}">${a.title}</a></h2>
           <p>${a.punchline}</p>
           <div>
             <span>${a.category === 'tech' ? 'TECH' : 'LEGAL'}</span>
@@ -435,46 +475,57 @@ function prerenderBlogPlugin(): Plugin {
           <div>${a.tags.map(t => `<span>#${t}</span>`).join(' ')}</div>
         </article>`).join('\n')
 
-        const blogListJsonLd = JSON.stringify({
-          "@context": "https://schema.org",
-          "@type": "Blog",
-          "name": "LEX AI Blog",
-          "description": blogListDesc,
-          "url": `${BASE_URL}/blog`,
-          "publisher": { "@type": "Organization", "name": "SecondLayer", "url": BASE_URL },
-          "blogPost": articles.slice(0, 20).map(a => ({
-            "@type": "BlogPosting",
-            "headline": a.title,
-            "description": a.punchline,
-            "url": `${BASE_URL}/blog/${a.id}`,
-            "datePublished": a.publishedAt,
-            "keywords": a.tags.join(', '),
-          }))
-        })
+          const blogListJsonLd = JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Blog",
+            "name": meta.heading,
+            "description": meta.desc,
+            "url": blogUrl,
+            "inLanguage": langMeta.htmlLang,
+            "publisher": { "@type": "Organization", "name": "SecondLayer", "url": BASE_URL },
+            "blogPost": listArticles.slice(0, 20).map(a => ({
+              "@type": "BlogPosting",
+              "headline": a.title,
+              "description": a.punchline,
+              "url": `${BASE_URL}/blog/${langPrefix}${a.id}`,
+              "datePublished": a.publishedAt,
+              "keywords": a.tags.join(', '),
+            }))
+          })
 
-        let blogListPage = replaceMeta(indexHtml, {
-          title: blogListTitle,
-          description: blogListDesc,
-          ogTitle: blogListTitle,
-          ogDescription: blogListDesc,
-          ogUrl: `${BASE_URL}/blog`,
-          canonical: `${BASE_URL}/blog`,
-        })
-        blogListPage = blogListPage.replace('</head>', `<script type="application/ld+json">${blogListJsonLd}</script>\n  </head>`)
-        blogListPage = blogListPage.replace(
-          '<div id="root"></div>',
-          `<div id="blog-seo" style="max-width:820px;margin:40px auto;font-family:system-ui,sans-serif;padding:0 24px">
-      <h1>LEX AI Blog</h1>
-      <p>${blogListDesc}</p>
+          const blogHreflang = [
+            `<link rel="alternate" hreflang="uk" href="${BASE_URL}/blog" />`,
+            `<link rel="alternate" hreflang="en" href="${BASE_URL}/blog/en" />`,
+            `<link rel="alternate" hreflang="ru" href="${BASE_URL}/blog/ru" />`,
+            `<link rel="alternate" hreflang="x-default" href="${BASE_URL}/blog" />`,
+          ].join('\n    ')
+
+          let blogListPage = replaceMeta(indexHtml, {
+            title: meta.title,
+            description: meta.desc,
+            ogTitle: meta.title,
+            ogDescription: meta.desc,
+            ogUrl: blogUrl,
+            canonical: blogUrl,
+            ogLocale: langMeta.ogLocale,
+            htmlLang: langMeta.htmlLang,
+          })
+          blogListPage = blogListPage.replace('</head>', `    ${blogHreflang}\n  <script type="application/ld+json">${blogListJsonLd}</script>\n  </head>`)
+          blogListPage = blogListPage.replace(
+            '<div id="root"></div>',
+            `<div id="blog-seo" style="max-width:820px;margin:40px auto;font-family:system-ui,sans-serif;padding:0 24px">
+      <h1>${meta.heading}</h1>
+      <p>${meta.desc}</p>
       ${articleListHtml}
     </div>
     <div id="root"></div>
     <script>document.getElementById('blog-seo')?.remove()</script>`
-        )
+          )
 
-        const blogDir = path.resolve(distDir, 'blog')
-        fs.mkdirSync(blogDir, { recursive: true })
-        fs.writeFileSync(path.resolve(blogDir, 'index.html'), blogListPage)
+          const listDir = lang === 'uk' ? blogDir : path.resolve(blogDir, lang)
+          fs.mkdirSync(listDir, { recursive: true })
+          fs.writeFileSync(path.resolve(listDir, 'index.html'), blogListPage)
+        }
 
         // --- Generate /blog/:slug/index.html for each article (all languages) ---
         let articleCount = 0


### PR DESCRIPTION
## Summary
- Generate `/blog/en/index.html` and `/blog/ru/index.html` with translated article titles
- Each index has correct `og:locale`, `html lang`, `hreflang` alternates, and JSON-LD
- SPA handles `/blog/en` and `/blog/ru` URLs — sets language and shows blog page
- Article links in EN/RU indexes point to `/blog/en/{slug}` and `/blog/ru/{slug}`

## Test plan
- [ ] `curl https://legal.org.ua/blog/en/` shows English article titles
- [ ] `curl https://legal.org.ua/blog/ru/` shows Russian article titles  
- [ ] Navigate to `/blog/en` in browser — sets English and shows blog
- [ ] Hreflang tags link between uk/en/ru blog indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-rendered English and Russian blog index pages with translated titles and full SEO metadata. SPA now handles /blog/en and /blog/ru by setting language and showing the blog index with language-scoped links.

- **New Features**
  - Generate /blog/en/index.html and /blog/ru/index.html with translated article titles, correct html lang, og:locale, hreflang alternates, and JSON-LD.
  - Index pages link to /blog/en/{slug} and /blog/ru/{slug}; Ukrainian, English, and Russian indexes cross-link via hreflang.
  - SPA recognizes /blog/en and /blog/ru, sets language, then routes to /blog to display the index.

<sup>Written for commit a82a6083c4c577dda1fef375eff241db8972c3f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

