### PR TITLE
fix(seo): URL language takes priority over geo-detection

### DIFF
--- a/lexwebapp/src/stores/localeStore.ts
+++ b/lexwebapp/src/stores/localeStore.ts
@@ -101,6 +101,12 @@ export const useLocaleStore = create<LocaleState>()(
                 return { ...defaults, language: chosen, geoDetected: true, cfCountry };
               }
             }
+            // Respect language from URL path (e.g. /blog/en/..., /blog/ru/...)
+            const pathLangMatch = window.location.pathname.match(/^\/blog\/(en|ru|es)\b/);
+            if (pathLangMatch) {
+              const urlLang = pathLangMatch[1] as AppLanguage;
+              return { ...defaults, language: urlLang, geoDetected: true, cfCountry };
+            }
             // Auto-set locale based on IP
             try { localStorage.setItem('lex_locale', defaults.language); } catch { /* ignore */ }
             return { ...defaults, geoDetected: true, cfCountry };


### PR DESCRIPTION
## Summary
- `applyGeoDefaults` in localeStore was overwriting language set from URL path
- Now `/blog/(en|ru|es)` paths preserve the URL language over IP-based geo-detection
- Fixes: Ukrainian user opening `/blog/en/article` was seeing Ukrainian instead of English

## Test plan
- [ ] Open `/blog/en/claude-code-building-startups` from Ukrainian IP — should stay English
- [ ] Open `/blog/` from non-UA IP — should still auto-detect language from geo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make URL path language take priority over IP geo-detection for blog routes. Updated `localeStore` so `/blog/(en|ru|es)/...` keeps the URL language; if absent, we still auto-detect by IP.

<sup>Written for commit c174208741d595e80b2466b40e034a953fe24c0b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

