### PR TITLE
fix(blog): polish RLHF article — author block, references, numbers

### DIFF
--- a/lexwebapp/src/pages/BlogPage/articles-en.ts
+++ b/lexwebapp/src/pages/BlogPage/articles-en.ts
@@ -7081,6 +7081,7 @@ Registration: [legal.org.ua](https://legal.org.ua)`,
 **A Methodology Proposal**
 
 *Vladimir Ovcharov, Founder & CEO, LEX AI LLC*
+*[LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *May 2026*
 
 ---
@@ -7239,9 +7240,20 @@ This methodology builds directly on prior contributions:
 
 **Constitutional RLHF on Ukrainian Civil Law** (LEX AI, 2026). Demonstrates RLHF methodology thinking applied to specific jurisdiction \\u2014 provides foundation for understanding how preferences interact with constitutional principles.
 
-**Production-scale recursive workflow** (LEX AI, 2026). Documented case of 735 commits in 25 days using Claude Code, 340M+ records pipeline, 70 MCP tools in production \\u2014 demonstrates infrastructure capacity for data collection at meaningful scale.
+**Production-scale recursive workflow** (LEX AI, 2026). Documented case of 1,200+ commits in 50 days using Claude Code, 380M+ records pipeline, 70+ MCP tools in production \\u2014 demonstrates infrastructure capacity for data collection at meaningful scale.
 
 **Open-source MCP infrastructure.** Existing toolchain provides natural instrumentation points for the data collection protocol described in Section 3.
+
+---
+
+## 7.1 Academic References
+
+- Christiano, P., Leike, J., Brown, T., Marber, M., Lowe, S., & Amodei, D. (2017). Deep reinforcement learning from human preferences. *Advances in Neural Information Processing Systems*, 30.
+- Ouyang, L., Wu, J., Jiang, X., et al. (2022). Training language models to follow instructions with human feedback. *Advances in Neural Information Processing Systems*, 35.
+- Bai, Y., Jones, A., Ndousse, K., et al. (2022). Training a helpful and harmless assistant with reinforcement learning from human feedback. *arXiv preprint arXiv:2204.05862*.
+- Bai, Y., Kadavath, S., Kundu, S., et al. (2022). Constitutional AI: Harmlessness from AI feedback. *arXiv preprint arXiv:2212.08073*.
+- Rafailov, R., Sharma, A., Mitchell, E., et al. (2023). Direct preference optimization: Your language model is secretly a reward model. *Advances in Neural Information Processing Systems*, 36.
+- Ziegler, D. M., Stiennon, N., Wu, J., et al. (2019). Fine-tuning language models from human preferences. *arXiv preprint arXiv:1909.08593*.
 
 ---
 
@@ -7286,6 +7298,7 @@ Timeline assumes initiation after current commitments stabilize (Q3 2026), with 
 
 ---
 
+*Vladimir Ovcharov — [LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *LEX AI LLC, Kyiv, Ukraine*
 
 Registration: [legal.org.ua](https://legal.org.ua)`,

--- a/lexwebapp/src/pages/BlogPage/articles.ts
+++ b/lexwebapp/src/pages/BlogPage/articles.ts
@@ -42,6 +42,7 @@ export const articles: Article[] = [
 **A Methodology Proposal**
 
 *Vladimir Ovcharov, Founder & CEO, LEX AI LLC*
+*[LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *May 2026*
 
 ---
@@ -200,9 +201,20 @@ This methodology builds directly on prior contributions:
 
 **Constitutional RLHF on Ukrainian Civil Law** (LEX AI, 2026). Demonstrates RLHF methodology thinking applied to specific jurisdiction — provides foundation for understanding how preferences interact with constitutional principles.
 
-**Production-scale recursive workflow** (LEX AI, 2026). Documented case of 735 commits in 25 days using Claude Code, 340M+ records pipeline, 70 MCP tools in production — demonstrates infrastructure capacity for data collection at meaningful scale.
+**Production-scale recursive workflow** (LEX AI, 2026). Documented case of 1,200+ commits in 50 days using Claude Code, 380M+ records pipeline, 70+ MCP tools in production — demonstrates infrastructure capacity for data collection at meaningful scale.
 
 **Open-source MCP infrastructure.** Existing toolchain provides natural instrumentation points for the data collection protocol described in Section 3.
+
+---
+
+## 7.1 Academic References
+
+- Christiano, P., Leike, J., Brown, T., Marber, M., Lowe, S., & Amodei, D. (2017). Deep reinforcement learning from human preferences. *Advances in Neural Information Processing Systems*, 30.
+- Ouyang, L., Wu, J., Jiang, X., et al. (2022). Training language models to follow instructions with human feedback. *Advances in Neural Information Processing Systems*, 35.
+- Bai, Y., Jones, A., Ndousse, K., et al. (2022). Training a helpful and harmless assistant with reinforcement learning from human feedback. *arXiv preprint arXiv:2204.05862*.
+- Bai, Y., Kadavath, S., Kundu, S., et al. (2022). Constitutional AI: Harmlessness from AI feedback. *arXiv preprint arXiv:2212.08073*.
+- Rafailov, R., Sharma, A., Mitchell, E., et al. (2023). Direct preference optimization: Your language model is secretly a reward model. *Advances in Neural Information Processing Systems*, 36.
+- Ziegler, D. M., Stiennon, N., Wu, J., et al. (2019). Fine-tuning language models from human preferences. *arXiv preprint arXiv:1909.08593*.
 
 ---
 
@@ -247,6 +259,7 @@ Timeline assumes initiation after current commitments stabilize (Q3 2026), with 
 
 ---
 
+*Vladimir Ovcharov — [LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *LEX AI LLC, Kyiv, Ukraine*
 
 Registration: [legal.org.ua](https://legal.org.ua)`,


### PR DESCRIPTION
## Summary
- Add author contact info (LinkedIn + email) to byline and footer of RLHF methodology article
- Add Section 7.1 "Academic References" with 6 foundational papers (Christiano 2017, Ouyang 2022, Bai 2022a/b, Rafailov 2023, Ziegler 2019)
- Sync production numbers: 735→1,200+ commits, 340M→380M+ records, 70→70+ MCP tools
- Meta description already works per-article via punchline — no change needed

## Test plan
- [ ] Verify /blog/recursive-workflow-signals-rlhf renders author LinkedIn + email as clickable links
- [ ] Verify references section renders correctly with italics
- [ ] Check updated numbers in Section 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the RLHF methodology article for accuracy and completeness. Added author LinkedIn and email to the byline and footer, added Section 7.1 with six academic references, and updated production numbers to 1,200+ commits, 380M+ records, and 70+ MCP tools.

<sup>Written for commit 8076e4badd4e2a2274073d0ef2271cc8dce6b0bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

