### PR TITLE
fix(rlhf-signals): make workflow_edits idempotent

### DIFF
--- a/rlhf-signals/migrations/005_edits_unique_constraint.sql
+++ b/rlhf-signals/migrations/005_edits_unique_constraint.sql
@@ -1,0 +1,9 @@
+-- Deduplicate existing edits before adding constraint
+DELETE FROM workflow_edits a USING workflow_edits b
+WHERE a.edit_id > b.edit_id
+  AND a.from_artifact_id = b.from_artifact_id
+  AND a.to_artifact_id = b.to_artifact_id;
+
+-- Add unique constraint to prevent duplicate edits
+ALTER TABLE workflow_edits
+  ADD CONSTRAINT uq_edits_from_to UNIQUE (from_artifact_id, to_artifact_id);

--- a/rlhf-signals/src/schema/queries.ts
+++ b/rlhf-signals/src/schema/queries.ts
@@ -92,6 +92,11 @@ export async function insertEdit(
       (session_id, from_artifact_id, to_artifact_id, edit_distance,
        edit_distance_norm, semantic_change_class, edit_seconds, inferred_class, metadata)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+    ON CONFLICT (from_artifact_id, to_artifact_id) DO UPDATE SET
+      edit_distance = EXCLUDED.edit_distance,
+      edit_distance_norm = EXCLUDED.edit_distance_norm,
+      semantic_change_class = COALESCE(EXCLUDED.semantic_change_class, workflow_edits.semantic_change_class),
+      metadata = EXCLUDED.metadata
     RETURNING edit_id
   `;
   const params = [


### PR DESCRIPTION
## Summary

- Added UNIQUE constraint `(from_artifact_id, to_artifact_id)` on `workflow_edits` table
- Changed `insertEdit` to use `ON CONFLICT DO UPDATE` (preserves existing `semantic_change_class` if not overwritten)
- Migration 005 deduplicates existing rows before adding constraint
- Discovered during Sprint 2 real run: repeated `rlhf:retro --source=github` doubled edit count (2486 → 4972)

## Verified

- Sessions: 1013 (unchanged across 3 runs)
- Artifacts: 3499 (unchanged)
- Edits: 2486 (stable after fix, was doubling before)
- 41/41 tests pass, 0 type errors

## Test plan

- [x] Run extraction 3x, verify all counts stable
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 41/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `workflow_edits` idempotent in `rlhf-signals` to prevent duplicate edits on repeated runs. Running `rlhf:retro --source=github` no longer doubles edit counts.

- **Bug Fixes**
  - Enforced UNIQUE `(from_artifact_id, to_artifact_id)` on `workflow_edits`; migration removes duplicates first.
  - Updated `insertEdit` to `ON CONFLICT DO UPDATE`; refreshes distances/metadata and keeps existing `semantic_change_class` if the new value is null.
  - Verified by running extraction 3x: sessions/artifacts unchanged; edits stable at 2486; all tests pass.

<sup>Written for commit 5d8c818719a21d00a53502e131abeebe8235dd13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

