### PR TITLE
feat(rlhf-signals): Claude Code transcript extractor for real JSONL format

### DIFF
--- a/rlhf-signals/src/retro/claude-code-history.ts
+++ b/rlhf-signals/src/retro/claude-code-history.ts
@@ -9,16 +9,30 @@ import levenshtein from 'js-levenshtein';
 
 const MAX_ARTIFACT_TOKENS = 50_000;
 
-interface TranscriptMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string | { type: string; text?: string; name?: string }[];
+interface TranscriptLine {
+  type: string;
+  message?: {
+    role?: string;
+    content?: string | ContentBlock[];
+    model?: string;
+    usage?: { input_tokens?: number; output_tokens?: number };
+  };
   timestamp?: string;
+  uuid?: string;
+  sessionId?: string;
 }
 
-function extractTextContent(content: TranscriptMessage['content']): string {
-  if (typeof content === 'string') return content;
-  if (Array.isArray(content)) {
-    return content
+interface ContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+}
+
+export function extractTextContent(message: TranscriptLine['message']): string {
+  if (!message?.content) return '';
+  if (typeof message.content === 'string') return message.content;
+  if (Array.isArray(message.content)) {
+    return message.content
       .filter(c => c.type === 'text' && c.text)
       .map(c => c.text!)
       .join('\n');
@@ -26,9 +40,9 @@ function extractTextContent(content: TranscriptMessage['content']): string {
   return '';
 }
 
-function extractToolNames(content: TranscriptMessage['content']): string[] {
-  if (!Array.isArray(content)) return [];
-  return content
+export function extractToolNames(message: TranscriptLine['message']): string[] {
+  if (!message?.content || !Array.isArray(message.content)) return [];
+  return message.content
     .filter(c => c.type === 'tool_use' && c.name)
     .map(c => c.name!);
 }
@@ -45,8 +59,8 @@ function tokenLevenshtein(a: string, b: string): { distance: number; normalized:
   return { distance, normalized: maxLen > 0 ? distance / maxLen : 0 };
 }
 
-async function parseTranscriptFile(filePath: string): Promise<TranscriptMessage[]> {
-  const messages: TranscriptMessage[] = [];
+async function parseTranscriptFile(filePath: string): Promise<TranscriptLine[]> {
+  const messages: TranscriptLine[] = [];
   const fileStream = fs.createReadStream(filePath);
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
 
@@ -54,8 +68,10 @@ async function parseTranscriptFile(filePath: string): Promise<TranscriptMessage[
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const msg = JSON.parse(trimmed) as TranscriptMessage;
-      if (msg.role) messages.push(msg);
+      const parsed = JSON.parse(trimmed) as TranscriptLine;
+      if (parsed.type === 'user' || parsed.type === 'assistant') {
+        messages.push(parsed);
+      }
     } catch {
       // skip malformed lines
     }
@@ -106,12 +122,16 @@ export async function extractClaudeCodeHistory(): Promise<void> {
 
     await processTranscript(filePath, messages);
     processed++;
+
+    if (processed % 100 === 0) {
+      logger.info(`Progress: ${processed} transcripts processed, ${skipped} skipped`);
+    }
   }
 
   logger.info(`Claude Code extraction complete: ${processed} sessions, ${skipped} skipped`);
 }
 
-async function processTranscript(filePath: string, messages: TranscriptMessage[]): Promise<void> {
+async function processTranscript(filePath: string, messages: TranscriptLine[]): Promise<void> {
   const relativePath = path.relative(config.claudeCodeProjectsDir, filePath);
   const stat = fs.statSync(filePath);
 
@@ -137,23 +157,21 @@ async function processTranscript(filePath: string, messages: TranscriptMessage[]
 
     let seqIdx = 0;
     const artifactIds: string[] = [];
-    let lastUserContent: string | null = null;
+    let hadUserMessage = false;
 
     for (const msg of messages) {
-      if (msg.role === 'system') continue;
-
-      const text = extractTextContent(msg.content);
+      const text = extractTextContent(msg.message);
       if (!text.trim()) continue;
 
       const tokenCount = simpleTokenize(text).length;
       const shouldStore = tokenCount <= MAX_ARTIFACT_TOKENS;
       const storedContent = shouldStore ? text : `[truncated: ${tokenCount} tokens, see file: ${relativePath}]`;
-      const toolNames = extractToolNames(msg.content);
+      const toolNames = extractToolNames(msg.message);
 
       let role: 'prompt' | 'llm_output' | 'edit';
-      if (msg.role === 'user') {
-        role = lastUserContent !== null ? 'edit' : 'prompt';
-        lastUserContent = text;
+      if (msg.type === 'user') {
+        role = !hadUserMessage ? 'prompt' : 'edit';
+        hadUserMessage = true;
       } else {
         role = 'llm_output';
       }
@@ -172,10 +190,10 @@ async function processTranscript(filePath: string, messages: TranscriptMessage[]
       artifactIds.push(id);
     }
 
-    // Add final artifact summarizing session
+    // Add final artifact
     if (artifactIds.length > 0) {
       const lastMsg = messages[messages.length - 1];
-      const lastText = extractTextContent(lastMsg.content);
+      const lastText = extractTextContent(lastMsg.message);
       if (lastText.trim()) {
         const finalContent = lastText.slice(0, 2000);
         const id = await upsertArtifact({
@@ -193,7 +211,7 @@ async function processTranscript(filePath: string, messages: TranscriptMessage[]
       }
     }
 
-    // Edits between consecutive artifacts
+    // Edits between consecutive artifacts (skip truncated)
     for (let i = 1; i < artifactIds.length; i++) {
       const fromResult = await client.query(
         'SELECT content_raw FROM workflow_artifacts WHERE artifact_id = $1',

--- a/rlhf-signals/tests/retro/claude-code-history.test.ts
+++ b/rlhf-signals/tests/retro/claude-code-history.test.ts
@@ -1,48 +1,143 @@
 import { describe, it, expect } from 'vitest';
+import { extractTextContent, extractToolNames } from '../../src/retro/claude-code-history';
 
 describe('Claude Code History Extractor', () => {
-  describe('JSONL parsing', () => {
-    it('should parse valid JSONL messages', () => {
-      const lines = [
-        '{"role":"user","content":"fix the bug"}',
-        '{"role":"assistant","content":"I will fix the bug by..."}',
-      ];
-      const messages = lines.map(l => JSON.parse(l));
-      expect(messages).toHaveLength(2);
-      expect(messages[0].role).toBe('user');
-      expect(messages[1].role).toBe('assistant');
+  describe('extractTextContent', () => {
+    it('extracts string content from user messages', () => {
+      const msg = { role: 'user', content: 'fix the bug' };
+      expect(extractTextContent(msg)).toBe('fix the bug');
     });
 
-    it('should handle complex content arrays', () => {
-      const msg = JSON.parse('{"role":"assistant","content":[{"type":"text","text":"Hello"},{"type":"tool_use","name":"Read"}]}');
-      const textParts = msg.content.filter((c: any) => c.type === 'text');
-      const toolParts = msg.content.filter((c: any) => c.type === 'tool_use');
-      expect(textParts).toHaveLength(1);
-      expect(toolParts).toHaveLength(1);
-      expect(toolParts[0].name).toBe('Read');
+    it('extracts text blocks from assistant messages', () => {
+      const msg = {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', text: 'Let me think...' },
+          { type: 'text', text: 'Here is the fix.' },
+          { type: 'tool_use', name: 'Read' },
+        ],
+      };
+      expect(extractTextContent(msg)).toBe('Here is the fix.');
+    });
+
+    it('joins multiple text blocks', () => {
+      const msg = {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'First part.' },
+          { type: 'text', text: 'Second part.' },
+        ],
+      };
+      expect(extractTextContent(msg)).toBe('First part.\nSecond part.');
+    });
+
+    it('returns empty for undefined message', () => {
+      expect(extractTextContent(undefined)).toBe('');
+    });
+
+    it('returns empty for message with no content', () => {
+      expect(extractTextContent({ role: 'user' })).toBe('');
+    });
+
+    it('returns empty for content array with only tool_use', () => {
+      const msg = {
+        role: 'assistant',
+        content: [{ type: 'tool_use', name: 'Bash' }],
+      };
+      expect(extractTextContent(msg)).toBe('');
+    });
+
+    it('skips thinking blocks', () => {
+      const msg = {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', text: 'internal reasoning' },
+          { type: 'text', text: 'visible output' },
+        ],
+      };
+      expect(extractTextContent(msg)).toBe('visible output');
+    });
+  });
+
+  describe('extractToolNames', () => {
+    it('extracts tool names from content blocks', () => {
+      const msg = {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Reading file' },
+          { type: 'tool_use', name: 'Read' },
+          { type: 'tool_use', name: 'Bash' },
+        ],
+      };
+      expect(extractToolNames(msg)).toEqual(['Read', 'Bash']);
+    });
+
+    it('returns empty for string content', () => {
+      const msg = { role: 'user', content: 'hello' };
+      expect(extractToolNames(msg)).toEqual([]);
+    });
+
+    it('returns empty for no tool_use blocks', () => {
+      const msg = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'no tools' }],
+      };
+      expect(extractToolNames(msg)).toEqual([]);
+    });
+
+    it('returns empty for undefined message', () => {
+      expect(extractToolNames(undefined)).toEqual([]);
     });
   });
 
   describe('role classification', () => {
-    it('should classify first user message as prompt', () => {
-      let lastUserContent: string | null = null;
-      const role = lastUserContent !== null ? 'edit' : 'prompt';
+    it('first user message is prompt', () => {
+      let hadUser = false;
+      const role = !hadUser ? 'prompt' : 'edit';
       expect(role).toBe('prompt');
     });
 
-    it('should classify subsequent user messages as edit', () => {
-      let lastUserContent: string | null = 'previous message';
-      const role = lastUserContent !== null ? 'edit' : 'prompt';
+    it('subsequent user messages are edit', () => {
+      let hadUser = true;
+      const role = !hadUser ? 'prompt' : 'edit';
       expect(role).toBe('edit');
+    });
+
+    it('assistant messages are llm_output', () => {
+      const msgType = 'assistant';
+      const role = msgType === 'user' ? 'prompt' : 'llm_output';
+      expect(role).toBe('llm_output');
     });
   });
 
   describe('token count thresholding', () => {
-    it('should store short content directly', () => {
-      const content = 'short message';
-      const tokens = content.split(/\s+/).length;
+    it('stores short content directly', () => {
+      const tokens = 100;
       const shouldStore = tokens <= 50000;
       expect(shouldStore).toBe(true);
+    });
+
+    it('truncates very long content', () => {
+      const tokens = 60000;
+      const shouldStore = tokens <= 50000;
+      expect(shouldStore).toBe(false);
+    });
+  });
+
+  describe('transcript line filtering', () => {
+    it('includes user and assistant types', () => {
+      const lines = [
+        { type: 'permission-mode' },
+        { type: 'user', message: { role: 'user', content: 'hi' } },
+        { type: 'file-history-snapshot' },
+        { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hello' }] } },
+        { type: 'system' },
+        { type: 'attachment' },
+      ];
+      const filtered = lines.filter(l => l.type === 'user' || l.type === 'assistant');
+      expect(filtered).toHaveLength(2);
+      expect(filtered[0].type).toBe('user');
+      expect(filtered[1].type).toBe('assistant');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Rewrote `retro/claude-code-history.ts` to match actual `~/.claude/projects/` JSONL format
- Transcript lines have top-level `type` field (`user`/`assistant`/`system`/`attachment`/etc.), not flat `{role, content}`
- User messages: `message.content` is a string
- Assistant messages: `message.content` is an array of blocks (`text`, `thinking`, `tool_use`)
- Filters only `user` and `assistant` types, skips system/attachment/permission-mode/etc.
- Exported `extractTextContent` and `extractToolNames` for testing
- Updated tests to 17 cases (was 5) covering real message structures

## Extraction results

| Source | Sessions | Artifacts | Edits |
|--------|----------|-----------|-------|
| GitHub PRs | 1,013 | 3,499 | 2,486 |
| Plane issues | 828 | 1,684 | 856 |
| Claude Code transcripts | 1,051 | 28,219 | 27,168 |
| **Total** | **2,892** | **33,402** | **30,510** |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 98/98 tests pass
- [x] `npm run rlhf:retro --source=claude-code` — 1051/1052 transcripts processed
- [x] Verified artifact roles: 20464 llm_output, 5661 edit, 1051 prompt, 1043 final

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the Claude Code transcript extractor to match the real `~/.claude/projects/` JSONL format. This fixes message parsing and improves text/tool extraction for cleaner artifacts.

- **Refactors**
  - Parse top-level `type` with nested `message.content` (string for `user`, block array for `assistant`).
  - Include only `user` and `assistant` lines; skip system/attachment/permission-mode.
  - Role mapping: first user → `prompt`, subsequent user → `edit`, assistant → `llm_output`.
  - Export `extractTextContent` and `extractToolNames`; expanded tests to cover real structures.
  - Add progress logs every 100 transcripts.

<sup>Written for commit 1031fc74d6fb85fa8fb0ba8d2401440a99b5ec6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

