### PR TITLE
feat(rlhf-signals): outcome attribution — 1411 outcomes + idempotency fix

### DIFF
--- a/rlhf-signals/migrations/006_outcomes_unique_constraint.sql
+++ b/rlhf-signals/migrations/006_outcomes_unique_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workflow_outcomes
+  ADD CONSTRAINT uq_outcomes_session_type_source UNIQUE (session_id, outcome_type, source);

--- a/rlhf-signals/src/attribution/github-outcomes.ts
+++ b/rlhf-signals/src/attribution/github-outcomes.ts
@@ -51,6 +51,7 @@ export async function attributeGitHubOutcomes(): Promise<void> {
     SELECT session_id, external_ref, terminal_at, terminal_action
     FROM workflow_sessions
     WHERE source = 'github_pr' AND terminal_action = 'merged'
+    AND NOT EXISTS (SELECT 1 FROM workflow_outcomes WHERE session_id = workflow_sessions.session_id)
   `);
 
   let attributed = 0;

--- a/rlhf-signals/src/schema/queries.ts
+++ b/rlhf-signals/src/schema/queries.ts
@@ -125,6 +125,11 @@ export async function insertOutcome(
       (session_id, outcome_type, outcome_value, observed_at,
        attribution_window_days, attribution_confidence, source, metadata)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    ON CONFLICT (session_id, outcome_type, source) DO UPDATE SET
+      observed_at = EXCLUDED.observed_at,
+      attribution_window_days = EXCLUDED.attribution_window_days,
+      attribution_confidence = EXCLUDED.attribution_confidence,
+      metadata = EXCLUDED.metadata
     RETURNING outcome_id
   `;
   const params = [


### PR DESCRIPTION
## Summary

- Ran `pnpm rlhf:attribute` — attributed outcomes for GitHub PRs and Plane issues
- Fixed GitHub attribution idempotency: added `NOT EXISTS` filter to skip already-attributed sessions
- Added UNIQUE constraint `(session_id, outcome_type, source)` on `workflow_outcomes` (migration 006)
- Updated `insertOutcome` to use `ON CONFLICT DO UPDATE`

## Outcome distribution

| Type | Count | Confidence |
|------|-------|------------|
| merged_clean | 801 | strong |
| issue_resolved | 508 | strong |
| followup_fix_pr | 70 | medium |
| closed_unmerged | 22 | strong |
| closed_obsolete | 10 | strong |
| **Total** | **1,411** | 96% strong |

## Attribution windows

- 0-7 days: 25
- 8-30 days: 504
- 31-90 days: 877
- 90+ days: 5

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 98/98 tests pass
- [x] Re-run `pnpm rlhf:attribute` produces 0 new outcomes (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfilled 1,411 workflow outcomes for GitHub PRs and Plane issues and made attribution idempotent to prevent duplicates.

- **New Features**
  - Ran `pnpm rlhf:attribute` to attribute 1,411 outcomes: 801 `merged_clean`, 508 `issue_resolved`, 70 `followup_fix_pr`, 22 `closed_unmerged`, 10 `closed_obsolete`.
  - GitHub attribution skips sessions with existing outcomes using `NOT EXISTS`.
  - `insertOutcome` now upserts via `ON CONFLICT (session_id, outcome_type, source) DO UPDATE`.

- **Migration**
  - Adds a UNIQUE constraint on `(session_id, outcome_type, source)` via `006_outcomes_unique_constraint.sql`. Run migrations before deploy.
  - Safe to re-run `pnpm rlhf:attribute`; no new outcomes will be created.

<sup>Written for commit 90a050c124b4b3707d99f97009d2365d20108c67. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

