### PR TITLE
feat(rlhf-signals): link Claude Code transcripts to PRs — coverage 0%→16%, pairs +101%

### DIFF
--- a/rlhf-signals/migrations/007_session_links.sql
+++ b/rlhf-signals/migrations/007_session_links.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS session_links (
+  link_id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_session  UUID NOT NULL REFERENCES workflow_sessions(session_id) ON DELETE CASCADE,
+  target_session  UUID NOT NULL REFERENCES workflow_sessions(session_id) ON DELETE CASCADE,
+  link_type       TEXT NOT NULL CHECK (link_type IN ('temporal_proximity', 'file_overlap', 'explicit_ref', 'manual')),
+  confidence      TEXT NOT NULL CHECK (confidence IN ('strong', 'medium', 'weak')),
+  hours_apart     NUMERIC(8,2),
+  metadata        JSONB DEFAULT '{}',
+  UNIQUE (source_session, target_session)
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_links_source ON session_links(source_session);
+CREATE INDEX IF NOT EXISTS idx_session_links_target ON session_links(target_session);

--- a/rlhf-signals/package.json
+++ b/rlhf-signals/package.json
@@ -12,6 +12,7 @@
     "rlhf:attribute": "tsx scripts/attribute-outcomes.ts",
     "rlhf:feasibility": "tsx scripts/generate-feasibility.ts",
     "rlhf:classify": "tsx scripts/classify-edits.ts",
+    "rlhf:link": "tsx scripts/link-transcripts.ts",
     "rlhf:ingest": "tsx src/capture/manual-ingest.ts",
     "rlhf:outcome": "tsx src/attribution/manual-outcomes.ts",
     "rlhf:redact": "tsx src/redaction/content-redactor.ts",

--- a/rlhf-signals/scripts/link-transcripts.ts
+++ b/rlhf-signals/scripts/link-transcripts.ts
@@ -1,0 +1,14 @@
+import { logger } from '../src/lib/logger';
+import { closePool } from '../src/lib/db';
+import { linkTranscriptsToPRs } from '../src/attribution/transcript-pr-linker';
+
+async function main() {
+  logger.info('Linking Claude Code transcripts to GitHub PRs...');
+  await linkTranscriptsToPRs();
+  await closePool();
+}
+
+main().catch(err => {
+  logger.error('Linking failed', { error: err.message });
+  process.exit(1);
+});

--- a/rlhf-signals/src/attribution/transcript-pr-linker.ts
+++ b/rlhf-signals/src/attribution/transcript-pr-linker.ts
@@ -1,0 +1,129 @@
+import { query } from '../lib/db';
+import { logger } from '../lib/logger';
+
+interface LinkCandidate {
+  transcript_id: string;
+  pr_id: string;
+  pr_number: string;
+  hours_apart: number;
+  [key: string]: unknown;
+}
+
+function classifyConfidence(hoursApart: number): 'strong' | 'medium' | 'weak' {
+  if (hoursApart < 1) return 'strong';
+  if (hoursApart < 4) return 'medium';
+  return 'weak';
+}
+
+export async function linkTranscriptsToPRs(): Promise<void> {
+  // Find best temporal match for each SecondLayer transcript
+  const matches = await query<LinkCandidate>(`
+    WITH secondlayer_transcripts AS (
+      SELECT session_id, created_at, terminal_at
+      FROM workflow_sessions
+      WHERE source = 'claude_code_transcript'
+      AND external_ref LIKE '-home-vovkes-SecondLayer%'
+    ),
+    ranked AS (
+      SELECT
+        t.session_id as transcript_id,
+        pr.session_id as pr_id,
+        pr.external_ref as pr_number,
+        ABS(EXTRACT(EPOCH FROM (t.created_at - pr.created_at))) / 3600 as hours_apart,
+        ROW_NUMBER() OVER (
+          PARTITION BY t.session_id
+          ORDER BY ABS(EXTRACT(EPOCH FROM (t.created_at - pr.created_at)))
+        ) as rn
+      FROM secondlayer_transcripts t
+      JOIN workflow_sessions pr ON pr.source = 'github_pr'
+      WHERE t.created_at BETWEEN pr.created_at - interval '4 hours'
+        AND COALESCE(pr.terminal_at, pr.created_at) + interval '1 hour'
+    )
+    SELECT transcript_id, pr_id, pr_number, hours_apart
+    FROM ranked
+    WHERE rn = 1
+  `);
+
+  logger.info(`Found ${matches.rows.length} transcript-PR temporal matches`);
+
+  let linked = 0;
+  let outcomesPropagated = 0;
+
+  for (const match of matches.rows) {
+    const confidence = classifyConfidence(match.hours_apart);
+
+    // Insert link
+    await query(`
+      INSERT INTO session_links (source_session, target_session, link_type, confidence, hours_apart, metadata)
+      VALUES ($1, $2, 'temporal_proximity', $3, $4, $5)
+      ON CONFLICT (source_session, target_session) DO UPDATE SET
+        confidence = EXCLUDED.confidence,
+        hours_apart = EXCLUDED.hours_apart
+    `, [
+      match.transcript_id,
+      match.pr_id,
+      confidence,
+      match.hours_apart,
+      JSON.stringify({ pr_number: match.pr_number }),
+    ]);
+    linked++;
+
+    // Propagate outcomes from PR to transcript (if transcript has none)
+    const existingOutcomes = await query(
+      'SELECT count(*) as cnt FROM workflow_outcomes WHERE session_id = $1',
+      [match.transcript_id]
+    );
+
+    if (Number(existingOutcomes.rows[0]?.cnt) === 0) {
+      const prOutcomes = await query(
+        'SELECT outcome_type, outcome_value, observed_at, attribution_window_days, attribution_confidence, metadata FROM workflow_outcomes WHERE session_id = $1',
+        [match.pr_id]
+      );
+
+      for (const outcome of prOutcomes.rows) {
+        await query(`
+          INSERT INTO workflow_outcomes
+            (session_id, outcome_type, outcome_value, observed_at,
+             attribution_window_days, attribution_confidence, source, metadata)
+          VALUES ($1, $2, $3, $4, $5, $6, 'linked_pr', $7)
+          ON CONFLICT (session_id, outcome_type, source) DO NOTHING
+        `, [
+          match.transcript_id,
+          outcome.outcome_type,
+          outcome.outcome_value,
+          outcome.observed_at,
+          outcome.attribution_window_days,
+          confidence === 'strong' ? outcome.attribution_confidence : 'weak',
+          JSON.stringify({
+            ...(typeof outcome.metadata === 'object' ? outcome.metadata : {}),
+            linked_from_pr: match.pr_number,
+            hours_apart: match.hours_apart,
+            link_confidence: confidence,
+          }),
+        ]);
+        outcomesPropagated++;
+      }
+    }
+  }
+
+  // Stats
+  const linkStats = await query(`
+    SELECT confidence, count(*) as cnt
+    FROM session_links
+    GROUP BY confidence
+    ORDER BY cnt DESC
+  `);
+
+  const transcriptOutcomes = await query(`
+    SELECT count(DISTINCT session_id) as cnt
+    FROM workflow_outcomes
+    WHERE session_id IN (
+      SELECT session_id FROM workflow_sessions WHERE source = 'claude_code_transcript'
+    )
+  `);
+
+  logger.info(`Linked ${linked} transcripts to PRs`);
+  logger.info(`Propagated ${outcomesPropagated} outcomes to transcripts`);
+  logger.info(`Link confidence: ${linkStats.rows.map(r => `${r.confidence}=${r.cnt}`).join(', ')}`);
+  logger.info(`Claude Code transcripts with outcomes: ${transcriptOutcomes.rows[0]?.cnt}`);
+}


### PR DESCRIPTION
## Summary

Links Claude Code transcripts to GitHub PRs via temporal proximity, propagating PR outcomes to matched transcripts.

**Algorithm:** For each SecondLayer transcript, find the nearest PR where `transcript.created_at` falls within `PR.created_at - 4h` to `PR.terminal_at + 1h`. Confidence: <1h = strong, <4h = medium, else weak.

## Impact

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Claude Code outcome coverage | 0.0% | **16.0%** | +16pp |
| Usable preference pairs | 2,668 | **5,354** | **+101%** |
| Deep edit sessions with outcomes | 146 | **276** | **+89%** |
| Total outcomes | 1,411 | **1,579** | +168 |

## Link quality

| Confidence | Count |
|-----------|-------|
| Strong (<1h) | 252 |
| Medium (1-4h) | 133 |
| Weak (4h+) | 83 |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 108/108
- [x] Re-run produces 0 new outcomes (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Link Claude Code transcripts to GitHub PRs via temporal proximity and propagate PR outcomes to matched transcripts. Outcome coverage rises from 0% to 16%, and usable preference pairs increase by 101%.

- **New Features**
  - Add `session_links` table to store session links with type, confidence, and `hours_apart`.
  - Implement `linkTranscriptsToPRs` to match SecondLayer transcripts to nearest PR within [-4h, +1h]; confidence: <1h strong, <4h medium, else weak.
  - Propagate PR `workflow_outcomes` to linked transcripts when none exist, adjusting confidence and storing PR metadata.
  - Add `rlhf:link` script to run the linker and log stats.

- **Migration**
  - Apply `007_session_links.sql`.
  - Run `rlhf:link` in `rlhf-signals` (idempotent).

<sup>Written for commit b53053e231fa63c45f96a79f3844d4d93e514891. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

