### PR TITLE
feat(rlhf-signals): Experiment 1 Phase A — sampling + founder analysis

### DIFF
--- a/rlhf-signals/analysis/exp1_signal_quality.py
+++ b/rlhf-signals/analysis/exp1_signal_quality.py
@@ -1,0 +1,295 @@
+"""
+Experiment 1 Phase A: Signal Quality Analysis
+Founder-side distribution analysis + skeleton for crowd comparison
+
+Usage:
+  cd rlhf-signals
+  pip install -r analysis/requirements.txt
+  python analysis/exp1_signal_quality.py
+
+Output figures saved to: output/experiment1/figures/
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+import pandas as pd
+import psycopg2
+import seaborn as sns
+from dotenv import load_dotenv
+from scipy import stats
+
+ENV_PATH = Path(__file__).resolve().parent.parent / ".env"
+load_dotenv(ENV_PATH)
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgres://secondlayer@localhost:5432/lex_rlhf_signals")
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "output" / "experiment1" / "figures"
+
+plt.style.use("seaborn-v0_8-paper")
+plt.rcParams.update({
+    "figure.dpi": 300,
+    "savefig.dpi": 300,
+    "font.size": 10,
+    "axes.titlesize": 12,
+    "axes.labelsize": 11,
+    "figure.figsize": (8, 5),
+    "savefig.bbox": "tight",
+})
+
+CLASS_ORDER = [
+    "substantive_rewrite",
+    "reorganization",
+    "cosmetic",
+    "rejection",
+    "factual_correction",
+    "tone_adjustment",
+]
+
+CLASS_COLORS = {
+    "substantive_rewrite": "#d62728",
+    "reorganization": "#ff7f0e",
+    "cosmetic": "#2ca02c",
+    "rejection": "#1f77b4",
+    "factual_correction": "#9467bd",
+    "tone_adjustment": "#8c564b",
+}
+
+
+def load_data() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    conn = psycopg2.connect(DATABASE_URL)
+    df_edits = pd.read_sql("""
+        SELECT we.edit_id, we.session_id, we.edit_distance_norm,
+               we.semantic_change_class, we.edit_distance
+        FROM workflow_edits we
+        WHERE we.semantic_change_class IS NOT NULL
+          AND we.edit_distance_norm IS NOT NULL
+    """, conn)
+
+    df_sessions = pd.read_sql("""
+        SELECT session_id, source, created_at, terminal_at
+        FROM workflow_sessions
+    """, conn)
+
+    df_outcomes = pd.read_sql("""
+        SELECT session_id, outcome_type, attribution_confidence
+        FROM workflow_outcomes
+    """, conn)
+
+    conn.close()
+    return df_edits, df_sessions, df_outcomes
+
+
+def fig1_edit_distance_distribution(df: pd.DataFrame):
+    fig, ax1 = plt.subplots()
+    dist = df["edit_distance_norm"].dropna()
+
+    ax1.hist(dist, bins=50, color="#1f77b4", alpha=0.7, edgecolor="white", label="Count")
+    ax1.set_xlabel("Normalized Edit Distance")
+    ax1.set_ylabel("Count", color="#1f77b4")
+    ax1.tick_params(axis="y", labelcolor="#1f77b4")
+
+    ax2 = ax1.twinx()
+    sorted_vals = np.sort(dist.values)
+    cdf = np.arange(1, len(sorted_vals) + 1) / len(sorted_vals)
+    ax2.plot(sorted_vals, cdf, color="#d62728", linewidth=2, label="CDF")
+    ax2.set_ylabel("Cumulative Probability", color="#d62728")
+    ax2.tick_params(axis="y", labelcolor="#d62728")
+
+    mean_val = dist.mean()
+    median_val = dist.median()
+    ax1.axvline(mean_val, color="green", linestyle="--", alpha=0.8, label=f"Mean={mean_val:.3f}")
+    ax1.axvline(median_val, color="orange", linestyle="-.", alpha=0.8, label=f"Median={median_val:.3f}")
+
+    lines1, labels1 = ax1.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax1.legend(lines1 + lines2, labels1 + labels2, loc="upper left", fontsize=8)
+
+    ax1.set_title("Founder Edit Distance Distribution (N={:,})".format(len(dist)))
+    fig.savefig(OUTPUT_DIR / "fig1_edit_distance_distribution.png")
+    plt.close(fig)
+    print(f"  Fig 1: edit distance distribution (N={len(dist):,})")
+
+
+def fig2_semantic_class_breakdown(df: pd.DataFrame):
+    counts = df["semantic_change_class"].value_counts()
+    counts = counts.reindex(CLASS_ORDER).dropna().astype(int)
+    total = counts.sum()
+
+    fig, ax = plt.subplots(figsize=(8, 4))
+    bars = ax.barh(
+        counts.index,
+        counts.values,
+        color=[CLASS_COLORS.get(c, "#999") for c in counts.index],
+    )
+    for bar, count in zip(bars, counts.values):
+        pct = count / total * 100
+        ax.text(bar.get_width() + total * 0.005, bar.get_y() + bar.get_height() / 2,
+                f"{count:,} ({pct:.1f}%)", va="center", fontsize=9)
+
+    ax.set_xlabel("Count")
+    ax.set_title("Semantic Change Class Distribution")
+    ax.invert_yaxis()
+    ax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+    fig.savefig(OUTPUT_DIR / "fig2_semantic_class_breakdown.png")
+    plt.close(fig)
+    print(f"  Fig 2: semantic class breakdown ({len(counts)} classes)")
+
+
+def fig3_edit_distance_per_class(df: pd.DataFrame):
+    fig, ax = plt.subplots(figsize=(10, 5))
+    order = (
+        df.groupby("semantic_change_class")["edit_distance_norm"]
+        .median()
+        .sort_values(ascending=False)
+        .index.tolist()
+    )
+    sns.boxplot(
+        data=df, y="semantic_change_class", x="edit_distance_norm",
+        order=order, palette=CLASS_COLORS, ax=ax, width=0.6,
+    )
+    ax.set_xlabel("Normalized Edit Distance")
+    ax.set_ylabel("")
+    ax.set_title("Edit Distance by Semantic Class")
+    fig.savefig(OUTPUT_DIR / "fig3_edit_distance_per_class.png")
+    plt.close(fig)
+    print(f"  Fig 3: edit distance per class (box plots)")
+
+
+def fig4_source_vs_class(df_edits: pd.DataFrame, df_sessions: pd.DataFrame):
+    merged = df_edits.merge(df_sessions[["session_id", "source"]], on="session_id", how="left")
+    ct = pd.crosstab(merged["source"], merged["semantic_change_class"])
+    ct = ct.reindex(columns=CLASS_ORDER, fill_value=0)
+
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ct.plot(kind="bar", stacked=True, ax=ax,
+            color=[CLASS_COLORS.get(c, "#999") for c in ct.columns])
+    ax.set_xlabel("Session Source")
+    ax.set_ylabel("Edit Count")
+    ax.set_title("Session Source vs Semantic Change Class")
+    ax.legend(title="Edit Class", bbox_to_anchor=(1.02, 1), loc="upper left", fontsize=8)
+    plt.xticks(rotation=30, ha="right")
+    fig.savefig(OUTPUT_DIR / "fig4_source_vs_class.png")
+    plt.close(fig)
+    print(f"  Fig 4: source vs class (stacked bar)")
+
+
+def fig5_summary_table(df: pd.DataFrame):
+    stats_rows = []
+    for cls in CLASS_ORDER:
+        subset = df[df["semantic_change_class"] == cls]["edit_distance_norm"]
+        if len(subset) == 0:
+            continue
+        stats_rows.append({
+            "Class": cls,
+            "Count": f"{len(subset):,}",
+            "%": f"{len(subset) / len(df) * 100:.1f}%",
+            "Mean": f"{subset.mean():.4f}",
+            "Median": f"{subset.median():.4f}",
+            "Std": f"{subset.std():.4f}",
+            "P25": f"{subset.quantile(0.25):.4f}",
+            "P75": f"{subset.quantile(0.75):.4f}",
+        })
+
+    tbl = pd.DataFrame(stats_rows)
+    fig, ax = plt.subplots(figsize=(10, 3))
+    ax.axis("off")
+    table = ax.table(
+        cellText=tbl.values, colLabels=tbl.columns,
+        cellLoc="center", loc="center",
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(9)
+    table.auto_set_column_width(list(range(len(tbl.columns))))
+    for (row, col), cell in table.get_celld().items():
+        if row == 0:
+            cell.set_facecolor("#4472C4")
+            cell.set_text_props(color="white", fontweight="bold")
+
+    ax.set_title("Summary Statistics by Semantic Change Class", pad=20)
+    fig.savefig(OUTPUT_DIR / "fig5_summary_table.png")
+    plt.close(fig)
+    print(f"  Fig 5: summary statistics table")
+
+
+def fig6_monthly_heatmap(df_edits: pd.DataFrame, df_sessions: pd.DataFrame):
+    merged = df_edits.merge(df_sessions[["session_id", "created_at"]], on="session_id", how="left")
+    merged["month"] = pd.to_datetime(merged["created_at"]).dt.to_period("M").astype(str)
+    pivot = merged.pivot_table(
+        index="semantic_change_class", columns="month", values="edit_id",
+        aggfunc="count", fill_value=0,
+    )
+    pivot = pivot.reindex(CLASS_ORDER).dropna(how="all")
+
+    fig, ax = plt.subplots(figsize=(10, 4))
+    sns.heatmap(pivot, annot=True, fmt=",", cmap="YlOrRd", ax=ax, linewidths=0.5)
+    ax.set_title("Edit Volume: Semantic Class x Month")
+    ax.set_ylabel("")
+    ax.set_xlabel("")
+    fig.savefig(OUTPUT_DIR / "fig6_monthly_heatmap.png")
+    plt.close(fig)
+    print(f"  Fig 6: monthly volume heatmap")
+
+
+# --- Crowd comparison skeleton (to be filled when crowd data arrives) ---
+
+def ks_test_founder_vs_crowd(founder_dist: np.ndarray, crowd_dist: np.ndarray) -> dict:
+    """Two-sample Kolmogorov-Smirnov test."""
+    statistic, pvalue = stats.ks_2samp(founder_dist, crowd_dist)
+    return {"ks_statistic": statistic, "p_value": pvalue}
+
+
+def bootstrap_ci(
+    data: np.ndarray,
+    statistic_fn=np.mean,
+    n_bootstrap: int = 10_000,
+    ci: float = 0.95,
+    seed: int = 42,
+) -> tuple[float, float, float]:
+    """Bootstrap confidence interval for a statistic."""
+    rng = np.random.default_rng(seed)
+    boot_stats = np.array([
+        statistic_fn(rng.choice(data, size=len(data), replace=True))
+        for _ in range(n_bootstrap)
+    ])
+    alpha = (1 - ci) / 2
+    lo, hi = np.quantile(boot_stats, [alpha, 1 - alpha])
+    return float(statistic_fn(data)), float(lo), float(hi)
+
+
+def plot_founder_vs_crowd_distributions(
+    founder_df: pd.DataFrame, crowd_df: pd.DataFrame, output_path: Path
+):
+    """Side-by-side histogram/CDF comparison. Fill when crowd data arrives."""
+    pass
+
+
+def krippendorff_alpha(annotations: np.ndarray) -> float:
+    """Krippendorff's alpha for inter-annotator agreement. Fill when crowd data arrives."""
+    pass
+
+
+def main():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"Output directory: {OUTPUT_DIR}")
+    print("Loading data from DB...")
+
+    df_edits, df_sessions, df_outcomes = load_data()
+    print(f"Loaded: {len(df_edits):,} edits, {len(df_sessions):,} sessions, {len(df_outcomes):,} outcomes")
+
+    print("\nGenerating paper figures...")
+    fig1_edit_distance_distribution(df_edits)
+    fig2_semantic_class_breakdown(df_edits)
+    fig3_edit_distance_per_class(df_edits)
+    fig4_source_vs_class(df_edits, df_sessions)
+    fig5_summary_table(df_edits)
+    fig6_monthly_heatmap(df_edits, df_sessions)
+
+    print(f"\nAll figures saved to {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlhf-signals/analysis/requirements.txt
+++ b/rlhf-signals/analysis/requirements.txt
@@ -1,0 +1,7 @@
+psycopg2-binary>=2.9
+pandas>=2.0
+matplotlib>=3.7
+seaborn>=0.13
+scipy>=1.11
+python-dotenv>=1.0
+numpy>=1.24

--- a/rlhf-signals/package.json
+++ b/rlhf-signals/package.json
@@ -17,6 +17,7 @@
     "rlhf:outcome": "tsx src/attribution/manual-outcomes.ts",
     "rlhf:redact": "tsx src/redaction/content-redactor.ts",
     "rlhf:export": "tsx src/export/dataset-builder.ts",
+    "rlhf:experiment1:sample": "tsx src/experiment1/sample-for-crowd.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/rlhf-signals/src/experiment1/sample-for-crowd.ts
+++ b/rlhf-signals/src/experiment1/sample-for-crowd.ts
@@ -1,0 +1,236 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { query, closePool } from '../lib/db';
+import { logger } from '../lib/logger';
+import { detectPII } from '../redaction/pii-detector';
+import type { CrowdSample, CrowdPlatformRow, PopulationRow } from './types';
+
+const TASK_INSTRUCTION =
+  'Edit this output to improve it for use in a professional legal context. ' +
+  'Make any changes you think are necessary — from minor fixes to complete rewrites.';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const get = (flag: string, def: string) => {
+    const idx = args.findIndex((a) => a.startsWith(`--${flag}=`));
+    return idx >= 0 ? args[idx].split('=')[1] : def;
+  };
+  return {
+    n: parseInt(get('n', '200'), 10),
+    seed: get('seed', 'experiment1-phase-a'),
+    outputDir: get('output', 'output/experiment1'),
+    minPerClass: parseInt(get('min-per-class', '10'), 10),
+  };
+}
+
+function mulberry32(seed: number): () => number {
+  let t = seed;
+  return () => {
+    t = (t + 0x6d2b79f5) | 0;
+    let v = Math.imul(t ^ (t >>> 15), t | 1);
+    v ^= v + Math.imul(v ^ (v >>> 7), v | 61);
+    return ((v ^ (v >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function seedFromString(s: string): number {
+  const hash = crypto.createHash('sha256').update(s).digest();
+  return hash.readUInt32BE(0);
+}
+
+function deterministicUUID(seed: string, index: number): string {
+  const hash = crypto.createHash('sha256').update(`${seed}:${index}`).digest('hex');
+  return [
+    hash.slice(0, 8),
+    hash.slice(8, 12),
+    '4' + hash.slice(13, 16),
+    ((parseInt(hash.slice(16, 17), 16) & 0x3) | 0x8).toString(16) + hash.slice(17, 20),
+    hash.slice(20, 32),
+  ].join('-');
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+async function fetchPopulation(): Promise<PopulationRow[]> {
+  const result = await query<PopulationRow>(`
+    SELECT
+      wa.artifact_id,
+      wa.session_id,
+      COALESCE(wa.content_redacted, wa.content_raw) AS llm_content,
+      COALESCE(ta.content_redacted, ta.content_raw) AS edit_content,
+      we.edit_id,
+      we.edit_distance_norm,
+      we.semantic_change_class,
+      ws.source AS session_source
+    FROM workflow_artifacts wa
+    JOIN workflow_edits we ON we.from_artifact_id = wa.artifact_id
+    JOIN workflow_artifacts ta ON ta.artifact_id = we.to_artifact_id
+    JOIN workflow_sessions ws ON ws.session_id = wa.session_id
+    WHERE wa.role = 'llm_output'
+      AND we.semantic_change_class IS NOT NULL
+      AND (wa.content_redacted IS NOT NULL OR wa.content_raw IS NOT NULL)
+      AND (ta.content_redacted IS NOT NULL OR ta.content_raw IS NOT NULL)
+  `);
+  return result.rows;
+}
+
+function allocateStrata(
+  classCounts: Map<string, number>,
+  n: number,
+  minPerClass: number
+): Map<string, number> {
+  const classes = [...classCounts.keys()];
+  const total = [...classCounts.values()].reduce((s, c) => s + c, 0);
+  const allocation = new Map<string, number>();
+
+  let reserved = 0;
+  const needsFloor: string[] = [];
+  for (const cls of classes) {
+    const proportional = Math.round((classCounts.get(cls)! / total) * n);
+    if (proportional < minPerClass) {
+      const available = classCounts.get(cls)!;
+      const actual = Math.min(minPerClass, available);
+      allocation.set(cls, actual);
+      reserved += actual;
+      needsFloor.push(cls);
+    }
+  }
+
+  const remaining = n - reserved;
+  const unfloored = classes.filter((c) => !needsFloor.includes(c));
+  const unflooredTotal = unfloored.reduce((s, c) => s + classCounts.get(c)!, 0);
+
+  let allocated = 0;
+  for (let i = 0; i < unfloored.length; i++) {
+    const cls = unfloored[i];
+    const available = classCounts.get(cls)!;
+    if (i === unfloored.length - 1) {
+      allocation.set(cls, Math.min(remaining - allocated, available));
+    } else {
+      const share = Math.round((classCounts.get(cls)! / unflooredTotal) * remaining);
+      const actual = Math.min(share, available);
+      allocation.set(cls, actual);
+      allocated += actual;
+    }
+  }
+
+  return allocation;
+}
+
+function filterPII(rows: PopulationRow[]): PopulationRow[] {
+  return rows.filter((row) => {
+    const llmPII = detectPII(row.llm_content);
+    const editPII = detectPII(row.edit_content);
+    if (llmPII.length > 0 || editPII.length > 0) {
+      logger.debug('Filtered sample with PII', {
+        artifact_id: row.artifact_id,
+        llm_pii: llmPII.length,
+        edit_pii: editPII.length,
+      });
+      return false;
+    }
+    return true;
+  });
+}
+
+async function main() {
+  const opts = parseArgs();
+  logger.info('Experiment 1: sampling for crowd annotation', opts);
+
+  const population = await fetchPopulation();
+  logger.info(`Population size: ${population.length} eligible LLM output → edit pairs`);
+
+  const clean = filterPII(population);
+  logger.info(`After PII filter: ${clean.length} (removed ${population.length - clean.length})`);
+
+  const byClass = new Map<string, PopulationRow[]>();
+  for (const row of clean) {
+    const cls = row.semantic_change_class;
+    if (!byClass.has(cls)) byClass.set(cls, []);
+    byClass.get(cls)!.push(row);
+  }
+
+  const classCounts = new Map<string, number>();
+  for (const [cls, rows] of byClass) classCounts.set(cls, rows.length);
+
+  logger.info('Population by class:', Object.fromEntries(classCounts));
+
+  const allocation = allocateStrata(classCounts, opts.n, opts.minPerClass);
+  const totalAllocated = [...allocation.values()].reduce((s, v) => s + v, 0);
+  logger.info('Allocation:', Object.fromEntries(allocation));
+  logger.info(`Total allocated: ${totalAllocated}`);
+
+  const rng = mulberry32(seedFromString(opts.seed));
+  const samples: CrowdSample[] = [];
+  let sampleIndex = 0;
+
+  for (const [cls, count] of allocation) {
+    const pool = byClass.get(cls) || [];
+    if (pool.length < count) {
+      logger.warn(`Class '${cls}' has only ${pool.length} samples, requested ${count}`);
+    }
+    const shuffled = shuffle(pool, rng);
+    const selected = shuffled.slice(0, count);
+
+    for (const row of selected) {
+      samples.push({
+        sample_id: deterministicUUID(opts.seed, sampleIndex++),
+        llm_output: row.llm_content,
+        founder_edit: row.edit_content,
+        task_instruction: TASK_INSTRUCTION,
+        metadata: {
+          session_source: row.session_source,
+          edit_class: row.semantic_change_class,
+          edit_distance_norm: row.edit_distance_norm,
+          artifact_id: row.artifact_id,
+          edit_id: row.edit_id,
+          session_id: row.session_id,
+        },
+      });
+    }
+  }
+
+  const outDir = path.resolve(opts.outputDir);
+  fs.mkdirSync(outDir, { recursive: true });
+
+  const fullPath = path.join(outDir, 'crowd-samples.jsonl');
+  const fullStream = fs.createWriteStream(fullPath);
+  for (const s of samples) fullStream.write(JSON.stringify(s) + '\n');
+  fullStream.end();
+  logger.info(`Wrote ${samples.length} full samples to ${fullPath}`);
+
+  const platformPath = path.join(outDir, 'crowd-platform.jsonl');
+  const platformStream = fs.createWriteStream(platformPath);
+  for (const s of samples) {
+    const row: CrowdPlatformRow = {
+      sample_id: s.sample_id,
+      llm_output: s.llm_output,
+      task_instruction: s.task_instruction,
+    };
+    platformStream.write(JSON.stringify(row) + '\n');
+  }
+  platformStream.end();
+  logger.info(`Wrote ${samples.length} platform rows to ${platformPath}`);
+
+  const classSummary: Record<string, number> = {};
+  for (const s of samples) {
+    classSummary[s.metadata.edit_class] = (classSummary[s.metadata.edit_class] || 0) + 1;
+  }
+  logger.info('Final sample distribution:', classSummary);
+
+  await closePool();
+  logger.info('Done');
+}
+
+main().catch((err) => {
+  logger.error('Fatal error', { error: err.message, stack: err.stack });
+  closePool().then(() => process.exit(1));
+});

--- a/rlhf-signals/src/experiment1/types.ts
+++ b/rlhf-signals/src/experiment1/types.ts
@@ -1,0 +1,33 @@
+export interface CrowdSample {
+  sample_id: string;
+  llm_output: string;
+  founder_edit: string;
+  task_instruction: string;
+  metadata: CrowdSampleMetadata;
+}
+
+export interface CrowdSampleMetadata {
+  session_source: string;
+  edit_class: string;
+  edit_distance_norm: number;
+  artifact_id: string;
+  edit_id: string;
+  session_id: string;
+}
+
+export interface CrowdPlatformRow {
+  sample_id: string;
+  llm_output: string;
+  task_instruction: string;
+}
+
+export interface PopulationRow {
+  artifact_id: string;
+  session_id: string;
+  llm_content: string;
+  edit_content: string;
+  edit_id: string;
+  edit_distance_norm: number;
+  semantic_change_class: string;
+  session_source: string;
+}


### PR DESCRIPTION
## Summary
- Stratified sampling script: extracts N=200 LLM outputs with founder edits from `lex_rlhf_signals` DB, stratified by `semantic_change_class` (min 10 per class, seeded PRNG for reproducibility)
- Two JSONL exports: full metadata (`crowd-samples.jsonl`) and platform-ready (`crowd-platform.jsonl`) for Surge AI / Scale AI / Toloka
- Python analysis script: 6 paper-ready figures (300 DPI) for §6.1 of arXiv paper + crowd comparison skeleton (KS test, bootstrap CI, Krippendorff's alpha)

### Key results
- 19,455 eligible samples after PII filtering (from 21,461)
- Founder edit distribution: 80.7% substantive_rewrite, median edit_distance_norm = 0.84
- Sample allocation: substantive=144, cosmetic=15, reorganization=11, rejection=10, factual=10, tone=10

### Files
- `rlhf-signals/src/experiment1/types.ts` — interfaces
- `rlhf-signals/src/experiment1/sample-for-crowd.ts` — sampling + JSONL export
- `rlhf-signals/analysis/exp1_signal_quality.py` — Python analysis + paper figures
- `rlhf-signals/analysis/requirements.txt` — Python deps

## Test plan
- [x] `npm run rlhf:experiment1:sample` produces 200-line JSONL files
- [x] Each semantic class has ≥10 samples
- [x] Deterministic: same seed → identical output (verified via md5sum)
- [x] Platform JSONL contains no founder_edit or metadata fields
- [x] Python script generates 6 PNG figures in `output/experiment1/figures/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Experiment 1 Phase A tooling: a stratified sampler for 200 LLM output → founder edit pairs with PII filtering and a deterministic seed, plus a Python analysis that generates six paper-ready figures for founder-side signal quality.

- **New Features**
  - Sampler `src/experiment1/sample-for-crowd.ts`: stratifies by `semantic_change_class` (≥10 per class), seeded PRNG, exports `crowd-samples.jsonl` (full) and `crowd-platform.jsonl` (platform-ready).
  - NPM script `rlhf:experiment1:sample` added in `package.json`.
  - Analysis `analysis/exp1_signal_quality.py`: produces 6 figures (edit distance, class breakdown, per-class box plots, source vs class, summary table, monthly heatmap) and stubs for KS test, bootstrap CI, and Krippendorff’s alpha.
  - New types in `src/experiment1/types.ts`.

- **Dependencies**
  - Added `analysis/requirements.txt`: `psycopg2-binary`, `pandas`, `matplotlib`, `seaborn`, `scipy`, `python-dotenv`, `numpy`.

<sup>Written for commit 738502ad9b335dcd6f406791679e98e0debc4ff3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

