### PR TITLE
fix(blog): correct LinkedIn URL

### DIFF
--- a/lexwebapp/src/pages/BlogPage/articles-en.ts
+++ b/lexwebapp/src/pages/BlogPage/articles-en.ts
@@ -7081,7 +7081,7 @@ Registration: [legal.org.ua](https://legal.org.ua)`,
 **Working Paper — arXiv Preprint Forthcoming**
 
 *Vladimir Ovcharov, Founder & CEO, LEX AI LLC*
-*[LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
+*[LinkedIn](https://www.linkedin.com/in/vladimir-ovcharov/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *May 2026*
 
 ---
@@ -7618,7 +7618,7 @@ This is actually a **stronger** narrative because:
 
 ---
 
-*Vladimir Ovcharov — [LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
+*Vladimir Ovcharov — [LinkedIn](https://www.linkedin.com/in/vladimir-ovcharov/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *LEX AI LLC, Kyiv, Ukraine*
 
 Registration: [legal.org.ua](https://legal.org.ua)`,

--- a/lexwebapp/src/pages/BlogPage/articles.ts
+++ b/lexwebapp/src/pages/BlogPage/articles.ts
@@ -42,7 +42,7 @@ export const articles: Article[] = [
 **A Methodology Proposal**
 
 *Vladimir Ovcharov, Founder & CEO, LEX AI LLC*
-*[LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
+*[LinkedIn](https://www.linkedin.com/in/vladimir-ovcharov/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *May 2026*
 
 ---
@@ -351,7 +351,7 @@ Timeline assumes initiation after current commitments stabilize (Q3 2026), with 
 
 ---
 
-*Vladimir Ovcharov — [LinkedIn](https://www.linkedin.com/in/overthelex/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
+*Vladimir Ovcharov — [LinkedIn](https://www.linkedin.com/in/vladimir-ovcharov/) | [volodymyr@legal.org.ua](mailto:volodymyr@legal.org.ua)*
 *LEX AI LLC, Kyiv, Ukraine*
 
 Registration: [legal.org.ua](https://legal.org.ua)`,


### PR DESCRIPTION
Fix LinkedIn link from /in/overthelex/ to /in/vladimir-ovcharov/ in UA and EN articles.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated LinkedIn links in EN and UA blog articles to point to the correct author profile. Replaced /in/overthelex/ with /in/vladimir-ovcharov/.

<sup>Written for commit dfcd8d69a9684a96d4a453e52a98b021897534c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

