### PR TITLE
fix(lexwebapp): fix vitest hanging on ConsultationChatTab test

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           cd lexwebapp
           # Run vitest with timeout — it often hangs on teardown after tests complete
-          timeout 180 npx vitest run --reporter=verbose 2>&1 | tee /tmp/vitest-output.txt || true
+          timeout 60 npx vitest run --reporter=verbose 2>&1 | tee /tmp/vitest-output.txt || true
           # Determine results: check for explicit failures first, then for any passed tests
           if grep -qE "FAIL\s|Tests.*failed|×|✗" /tmp/vitest-output.txt; then
             echo "::error::Some tests failed"

--- a/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
+++ b/lexwebapp/src/components/chat/__tests__/ConsultationChatTab.test.tsx
@@ -26,6 +26,22 @@ vi.mock('../../../services', () => ({
   },
 }));
 
+// Mock E2EE hook with stable reference to prevent infinite re-render loop
+const stableE2ee = {
+  status: 'locked' as const,
+  error: null,
+  encryptMessage: vi.fn(),
+  decryptMessage: vi.fn(),
+  needsRotation: () => false,
+};
+vi.mock('../../../hooks/useConsultationE2ee', () => ({
+  useConsultationE2ee: () => stableE2ee,
+}));
+
+vi.mock('../../encryption/ConsultationE2eeStatus', () => ({
+  ConsultationE2eeStatus: () => null,
+}));
+
 // Mock consultation store
 vi.mock('../../../stores/consultationStore', () => ({
   useConsultationStore: Object.assign(
@@ -74,7 +90,6 @@ describe('ConsultationChatTab', () => {
   });
 
   afterEach(() => {
-    // Unmount all rendered components to trigger useEffect cleanups (clearInterval)
     cleanup();
     currentMockES.close();
     vi.restoreAllMocks();
@@ -177,7 +192,7 @@ describe('ConsultationChatTab', () => {
         expect(screen.getByText('Test message')).toBeInTheDocument();
       });
 
-      expect(mockSendMessage).toHaveBeenCalledWith('cons-1', 'Test message', undefined, undefined);
+      expect(mockSendMessage).toHaveBeenCalledWith('cons-1', 'Test message', undefined, undefined, undefined);
     });
 
     it('does not send empty messages', async () => {

--- a/lexwebapp/vitest.config.ts
+++ b/lexwebapp/vitest.config.ts
@@ -10,8 +10,13 @@ export default defineConfig({
     environmentOptions: {
       happyDOM: {
         settings: {
+          disableJavaScriptFileLoading: true,
+          disableCSSFileLoading: true,
+          disableIframePageLoading: true,
           navigation: {
+            disableMainFrameNavigation: true,
             disableChildFrameNavigation: true,
+            disableChildPageNavigation: true,
           },
         },
       },
@@ -19,7 +24,7 @@ export default defineConfig({
     setupFiles: ['./src/__tests__/setup.ts'],
     testTimeout: 15000,
     pool: 'forks',
-    teardownTimeout: 10000,
+    teardownTimeout: 5000,
     forks: {
       maxForks: 1,
       execArgv: ['--max-old-space-size=4096'],


### PR DESCRIPTION
## Summary
- **Root cause**: `useConsultationE2ee` was not mocked in `ConsultationChatTab.test.tsx`. The unmocked hook returned a new object on each render, which caused `useCallback` deps to change → `useEffect` re-ran → `setMessages([])` triggered re-render → infinite loop that `act()` could never resolve
- Added stable mock for `useConsultationE2ee` and `ConsultationE2eeStatus`
- Disabled all external resource loading in happy-dom (JS files, CSS files, iframes, navigation)
- Reduced CI vitest timeout from 180s to 60s — tests now complete in ~13s

## Test plan
- [x] `ConsultationChatTab.test.tsx` — 10 tests pass in 636ms (was hanging indefinitely)
- [x] Full test suite — 499 tests pass in 13s (was ~180s+ with timeout kill)
- [ ] CI pipeline completes within 60s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vitest hanging in `ConsultationChatTab.test.tsx` by using a stable mock for `useConsultationE2ee` to stop an infinite re-render loop. Test suite now completes in ~13s; CI `vitest` timeout reduced from 180s to 60s.

- **Bug Fixes**
  - Mocked `useConsultationE2ee` and `ConsultationE2eeStatus` with stable references to prevent re-renders.
  - Updated `sendMessage` assertion to include the new `e2eePayload` argument.
  - Hardened `happy-dom` by disabling JS/CSS/iframe loading and main-frame navigation; lowered `teardownTimeout` to 5s.

<sup>Written for commit 3faab0d0030c7dfed304c8b77af5f47a800c9259. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

