### PR TITLE
fix(edrsr): anti-join in fulltext worker — skip filled docs

### DIFF
--- a/services/edrsr-fulltext-worker/worker.py
+++ b/services/edrsr-fulltext-worker/worker.py
@@ -370,47 +370,32 @@ async def create_pool() -> asyncpg.Pool:
 
 
 async def get_missing_batch(pool: asyncpg.Pool, year: int, limit: int, after_doc_id: int = 0) -> tuple[list[tuple], int]:
-    """Fetch a batch of doc_ids missing fulltext using two lightweight queries
-    instead of a single heavy anti-join.
+    """Fetch a batch of doc_ids missing fulltext via direct anti-join.
+    Skips straight to missing docs without scanning filled ones.
     Returns (list of (doc_id, adj_year, url), last_doc_id_checked)."""
 
-    # Step 1: Get candidate doc_ids (fast — uses date index + PK order)
-    # Fetch more than limit because some will already have fulltext
-    fetch_size = limit * 3
-    candidates_sql = """
+    sql = """
         SELECT d.doc_id, extract(year from d.adjudication_date)::int, d.doc_url
         FROM edrsr_documents d
         WHERE d.adjudication_date >= $1
           AND d.adjudication_date < $2
           AND d.doc_url IS NOT NULL AND d.doc_url != ''
           AND d.doc_id > $3
+          AND NOT EXISTS (SELECT 1 FROM edrsr_fulltext f WHERE f.doc_id = d.doc_id)
+          AND NOT EXISTS (SELECT 1 FROM edrsr_fulltext_failed ff WHERE ff.doc_id = d.doc_id)
         ORDER BY d.doc_id
         LIMIT $4
     """
     rows = await pool.fetch(
-        candidates_sql, date(year, 1, 1), date(year + 1, 1, 1), after_doc_id, fetch_size
+        sql, date(year, 1, 1), date(year + 1, 1, 1), after_doc_id, limit
     )
     if not rows:
         return [], after_doc_id
 
-    candidates = [(r[0], r[1], r[2]) for r in rows]
-    last_doc_id = candidates[-1][0]
+    missing = [(r[0], r[1], r[2]) for r in rows]
+    last_doc_id = missing[-1][0]
 
-    # Step 2: Check which doc_ids already have fulltext or are known-failed (fast — PK lookup)
-    doc_ids = [c[0] for c in candidates]
-    existing_sql = "SELECT doc_id FROM edrsr_fulltext WHERE doc_id = ANY($1::bigint[])"
-    failed_sql = "SELECT doc_id FROM edrsr_fulltext_failed WHERE doc_id = ANY($1::bigint[])"
-    existing_rows = await pool.fetch(existing_sql, doc_ids)
-    try:
-        failed_rows = await pool.fetch(failed_sql, doc_ids)
-    except asyncpg.UndefinedTableError:
-        failed_rows = []
-    exclude_set = {r[0] for r in existing_rows} | {r[0] for r in failed_rows}
-
-    # Filter to only missing ones
-    missing = [(d, y, u) for d, y, u in candidates if d not in exclude_set]
-
-    return missing[:limit], last_doc_id
+    return missing, last_doc_id
 
 
 async def insert_batch(pool: asyncpg.Pool, rows: list[tuple]) -> int:


### PR DESCRIPTION
## Summary

- Replace two-step scan in `get_missing_batch()` with direct SQL anti-join
- Old: fetch 9000 candidates → check edrsr_fulltext in Python → filter
- New: `NOT EXISTS` subquery skips directly to missing docs
- Eliminates scanning through millions of filled doc_ids per year
- Fixes 2026 gap: 75K docs unreachable because worker scanned 2.1M filled docs first

## Impact

Before: worker scans ~233 batches of filled docs per year before finding gaps
After: worker jumps directly to first missing doc_id

## Test plan

- [x] Verified 75,662 genuinely missing docs for 2026 via direct SQL
- [ ] Monitor worker logs after deploy — should start downloading immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a direct SQL anti-join in the EDRSR fulltext worker to fetch only missing documents. This skips filled/failed doc_ids and unblocks the 2026 backlog (~75k docs).

- **Bug Fixes**
  - Replace two-step candidate scan + Python filter with NOT EXISTS against `edrsr_fulltext` and `edrsr_fulltext_failed`.
  - Avoids scanning millions of filled doc_ids and immediately returns the next missing batch.

<sup>Written for commit 1b1060677c49cd862031f36dc65c61757a244d5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

