### PR TITLE
fix(ci): incremental change detection via per-CI marker tags

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -52,15 +52,25 @@ runs:
       id: last_deploy
       shell: bash
       run: |
-        # Find the most recent deploy marker tag (created after each successful prod deploy)
         LAST_SHA=""
-        LAST_TAG=$(git tag -l "deploy-prod-*" --sort=-creatordate | head -1)
+
+        # Priority 1: last successful local CI tag (most granular — one per CI run)
+        LAST_TAG=$(git tag -l "ci-local-*" --sort=-creatordate | head -1)
         if [ -n "$LAST_TAG" ]; then
           LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
-          echo "Using deploy marker tag: $LAST_TAG ($LAST_SHA)"
+          echo "Using local CI marker tag: $LAST_TAG ($LAST_SHA)"
         fi
 
-        # Fallback: use the most recent release tag (v* or fe-v*)
+        # Priority 2: last successful prod deploy tag
+        if [ -z "$LAST_SHA" ]; then
+          LAST_TAG=$(git tag -l "deploy-prod-*" --sort=-creatordate | head -1)
+          if [ -n "$LAST_TAG" ]; then
+            LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
+            echo "Using prod deploy marker tag: $LAST_TAG ($LAST_SHA)"
+          fi
+        fi
+
+        # Priority 3: last release tag
         if [ -z "$LAST_SHA" ]; then
           LAST_TAG=$(git tag -l --sort=-creatordate "v*" "fe-v*" | head -1)
           if [ -n "$LAST_TAG" ]; then
@@ -69,7 +79,7 @@ runs:
           fi
         fi
 
-        # Last resort: first parent of HEAD (works correctly for merge commits)
+        # Last resort: first parent of HEAD
         if [ -z "$LAST_SHA" ]; then
           LAST_SHA=$(git rev-parse HEAD~1)
           echo "WARNING: No deploy/release tags found, using HEAD~1 ($LAST_SHA)"

--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -506,3 +506,15 @@ jobs:
           fi
 
           if [ "$FAILED" = "true" ]; then exit 1; fi
+
+      - name: Tag successful CI run
+        run: |
+          TAG="ci-local-$(date +%Y%m%d-%H%M%S)"
+          git tag "$TAG" "${{ github.sha }}"
+          git push origin "$TAG"
+
+          # Keep only the 10 most recent ci-local tags to avoid clutter
+          git tag -l "ci-local-*" --sort=-creatordate | tail -n +11 | while read -r old_tag; do
+            git push origin ":refs/tags/$old_tag" 2>/dev/null || true
+            git tag -d "$old_tag" 2>/dev/null || true
+          done


### PR DESCRIPTION
## Summary
- CI change detection was comparing against the last **prod deploy** tag, so every local CI run rebuilt all services changed since the last prod deploy — not just the current PR's changes
- Now each successful local CI run creates a `ci-local-*` marker tag, and `detect-changes` uses it as the primary baseline
- Old marker tags auto-cleaned (keeps last 10)

## Test plan
- [ ] Merge this PR → CI should create a `ci-local-*` tag after success
- [ ] Next PR with only blog text changes → verify only frontend is rebuilt, not backend/rada/openreyestr
- [ ] Check `git tag -l "ci-local-*"` on runner after a few CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI incremental change detection by diffing against the last successful local CI run instead of the last prod deploy. This stops rebuilding unrelated services during local CI runs.

- **Bug Fixes**
  - `detect-changes` now prioritizes the latest `ci-local-*` tag; falls back to `deploy-prod-*`, then the latest `v*`/`fe-v*`, then `HEAD~1`.
  - `ci-local-deploy.yml` tags successful runs as `ci-local-YYYYMMDD-HHMMSS` and keeps only the 10 newest tags.
  - Logs clearly show which baseline tag is used.

<sup>Written for commit 6c81df39a672bdb0f91bd6f1e512a631a54e190f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

