### PR TITLE
test(blog): update read time to verify incremental CI

### DIFF
--- a/lexwebapp/src/pages/BlogPage/articles.ts
+++ b/lexwebapp/src/pages/BlogPage/articles.ts
@@ -9617,7 +9617,7 @@ AWS runners — це не "перехід у хмару заради моди". 
     punchline: 'Кожна нова сесія Claude Code починається з нуля: перечитує файли, накопичує зайвий стейт і втрачає контекст попередніх рішень. На горизонті 6+ тижнів жодне контекстне вікно — навіть 1M токенів — не витримує. Ми проєктуємо тришарову workflow memory layer замість плоских CLAUDE.md дампів.',
     category: 'tech',
     tags: ['AI Architecture', 'Claude Code', 'Workflow Memory', 'RAG', 'Qdrant', 'RLHF', 'Long-Horizon AI'],
-    readTime: '25 хв',
+    readTime: '24 хв',
     publishedAt: '2026-05-09',
     content: `# Workflow Memory Architecture for Long-Horizon Composition
 


### PR DESCRIPTION
## Summary
- Minimal text change in blog article (readTime 25→24 хв) to verify that CI only rebuilds frontend, not all services

## Test plan
- [ ] CI detects only `frontend` changed
- [ ] Backend/rada/openreyestr are NOT rebuilt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update blog article readTime from 25 to 24 хв in `lexwebapp/src/pages/BlogPage/articles.ts`. This verifies incremental CI only rebuilds the frontend (`lexwebapp`) and skips backend services.

<sup>Written for commit 0689560bf9b048286fe6597ea45e1fdb515d0854. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

