### PR TITLE
feat(blog): AttractorBanner for all articles (like sneakypiper.com)

### DIFF
--- a/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
+++ b/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
@@ -165,22 +165,8 @@ export function BlogArticlePage() {
       {/* Banner */}
       <div className="relative w-full max-w-3xl mx-auto">
         <div className="relative w-full h-60 sm:h-76 overflow-hidden">
-          {article.id === 'recursive-workflow-signals-rlhf' ? (
-            <>
-              <AttractorBanner seed={article.id} className="absolute inset-0" animate />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
-            </>
-          ) : (
-            <>
-              <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
-              <img
-                src={`/blog-banners/${article.id}.png`}
-                alt={article.title}
-                className="relative w-full h-full object-cover object-top"
-                onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-              />
-            </>
-          )}
+          <AttractorBanner seed={article.id} className="absolute inset-0" animate />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Replace per-article PNG banners with procedural AttractorBanner component for ALL blog articles. Each article gets a unique deterministic fractal banner seeded by article ID — same approach as sneakypiper.com/blog.

Removes 14 lines of conditional PNG fallback logic.

## Test plan
- [x] TypeScript build passes
- [ ] Visit /blog/workflow-memory-architecture — should show fractal banner instead of PNG
- [ ] Visit /blog/recursive-workflow-signals-rlhf — still shows fractal (unchanged)
- [ ] All blog articles render banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply procedural `AttractorBanner` to all blog articles. Each post now gets a deterministic fractal banner seeded by its ID.

- **Refactors**
  - Replace PNG banner and fallback logic with a single `AttractorBanner` render.
  - Remove the RLHF-only special case.
  - Preserve the gradient overlay for readability.

<sup>Written for commit f9f752215ddb7dc592a49d4ad1a90edf0d8c8aab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

