### PR TITLE
fix(ci): separate baselines for local CI and prod deploy

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,6 +1,12 @@
 name: 'Detect Monorepo Changes'
 description: 'Detects which services changed since the last successful deploy'
 
+inputs:
+  baseline:
+    description: 'Tag prefix to use as baseline: "ci-local" (default, for local CI) or "deploy-prod" (for prod deploy)'
+    required: false
+    default: 'ci-local'
+
 outputs:
   shared:
     description: 'Whether packages/shared changed'
@@ -52,25 +58,31 @@ runs:
       id: last_deploy
       shell: bash
       run: |
+        BASELINE="${{ inputs.baseline }}"
         LAST_SHA=""
 
-        # Priority 1: last successful local CI tag (most granular — one per CI run)
-        LAST_TAG=$(git tag -l "ci-local-*" --sort=-creatordate | head -1)
+        # Primary: use the requested baseline tag prefix
+        LAST_TAG=$(git tag -l "${BASELINE}-*" --sort=-creatordate | head -1)
         if [ -n "$LAST_TAG" ]; then
           LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
-          echo "Using local CI marker tag: $LAST_TAG ($LAST_SHA)"
+          echo "Using ${BASELINE} marker tag: $LAST_TAG ($LAST_SHA)"
         fi
 
-        # Priority 2: last successful prod deploy tag
+        # Fallback: try the other marker type
         if [ -z "$LAST_SHA" ]; then
-          LAST_TAG=$(git tag -l "deploy-prod-*" --sort=-creatordate | head -1)
+          if [ "$BASELINE" = "ci-local" ]; then
+            FALLBACK="deploy-prod"
+          else
+            FALLBACK="ci-local"
+          fi
+          LAST_TAG=$(git tag -l "${FALLBACK}-*" --sort=-creatordate | head -1)
           if [ -n "$LAST_TAG" ]; then
             LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
-            echo "Using prod deploy marker tag: $LAST_TAG ($LAST_SHA)"
+            echo "Using ${FALLBACK} marker tag as fallback: $LAST_TAG ($LAST_SHA)"
           fi
         fi
 
-        # Priority 3: last release tag
+        # Fallback: release tags
         if [ -z "$LAST_SHA" ]; then
           LAST_TAG=$(git tag -l --sort=-creatordate "v*" "fe-v*" | head -1)
           if [ -n "$LAST_TAG" ]; then

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -59,6 +59,8 @@ jobs:
       - name: Auto-detect changes (HEAD vs HEAD~1)
         id: changes
         uses: ./.github/actions/detect-changes
+        with:
+          baseline: deploy-prod
 
       - name: Resolve final change flags
         id: final


### PR DESCRIPTION
## Summary
- PR #1598 (blog banners) was not deployed to prod because prod deploy was using `ci-local-*` tags as baseline — the same tag local CI just created on the same commit
- Added `baseline` input to detect-changes action: `ci-local` (default) for local CI, `deploy-prod` for prod deploy
- Each pipeline now compares against its own marker tags independently

## Test plan
- [ ] After merge: local CI uses `ci-local-*`, prod deploy uses `deploy-prod-*`
- [ ] PR #1598 changes get picked up by prod deploy (diff since last `deploy-prod-*` tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Separate baseline tags for local CI and prod deploy so prod reliably detects changes. Adds a `baseline` input to the `detect-changes` action and configures prod to use `deploy-prod` tags.

- **Bug Fixes**
  - Added `baseline` input to `.github/actions/detect-changes` (default `ci-local`).
  - Updated `.github/workflows/deploy-prod.yml` to pass `baseline: deploy-prod`.
  - Pipelines now compare against their own tags (`ci-local-*` vs `deploy-prod-*`) with fallback, preventing prod from missing changes after local CI runs.

<sup>Written for commit a697f0684405515731bc2db15ca03ae2200b4fa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

