### PR TITLE
fix(blog): use AttractorBanner on listing page and modal

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -14,6 +14,7 @@ import type { Article } from './articles';
 import { CommentSection } from './CommentSection';
 import { useLocaleStore } from '../../stores/localeStore';
 import { getBlogUI } from './blog-i18n';
+import AttractorBanner from '../../components/AttractorBanner';
 
 interface ArticleModalProps {
   article: Article;
@@ -120,16 +121,8 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
 
         {/* Banner */}
         <div className="relative w-full h-60 sm:h-76 overflow-hidden">
-          <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
-          <img
-            src={`/blog-banners/${article.id}.png`}
-            alt={article.title}
-            width={1200}
-            height={630}
-            loading="lazy"
-            className="relative w-full h-full object-cover object-top"
-            onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-          />
+          <AttractorBanner seed={article.id} className="absolute inset-0" animate />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
         </div>
 
         {/* Modal content */}

--- a/lexwebapp/src/pages/BlogPage/index.tsx
+++ b/lexwebapp/src/pages/BlogPage/index.tsx
@@ -14,6 +14,7 @@ import { articles, type Article } from './articles';
 import { enTranslations } from './articles-en';
 import { ruTranslations } from './articles-ru';
 import { ArticleModal } from './ArticleModal';
+import AttractorBanner from '../../components/AttractorBanner';
 
 import { getBlogUI, getLocalizedArticles } from './blog-i18n';
 
@@ -153,16 +154,8 @@ export function BlogPage() {
               onClick={() => navigate(effectiveBlogLang === 'en' ? `/blog/${article.id}` : `/blog/${effectiveBlogLang}/${article.id}`)}
             >
               <div className="relative w-full h-52 sm:h-60 overflow-hidden">
-                <div className={`absolute inset-0 ${article.category === 'tech' ? 'bg-gradient-to-br from-blue-600 via-blue-500 to-indigo-700' : 'bg-gradient-to-br from-claude-accent via-amber-600 to-orange-700'}`} />
-                <img
-                  src={`/blog-banners/${article.id}.png`}
-                  alt={article.title}
-                  width={1200}
-                  height={630}
-                  loading="lazy"
-                  className="relative w-full h-full object-cover object-top"
-                  onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                />
+                <AttractorBanner seed={article.id} className="absolute inset-0" />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent pointer-events-none" />
               </div>
               <div className="p-6 sm:p-8">
               <div className="flex items-start gap-4">


### PR DESCRIPTION
## Summary
- Replace static PNG banners with `AttractorBanner` on the blog listing page (`index.tsx`) and article modal (`ArticleModal.tsx`)
- Blog article detail page (`BlogArticlePage.tsx`) already used `AttractorBanner` — now all three surfaces are consistent

## Test plan
- [ ] Verify `/blog` listing shows dynamic fractal banners instead of PNG images
- [ ] Verify article modal shows dynamic fractal banner
- [ ] Verify article detail page still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced static PNG banners with `AttractorBanner` on the blog listing page and article modal to unify visuals and remove reliance on static assets. The detail page already used `AttractorBanner`; now all surfaces use seeded fractal banners, with a soft gradient overlay and animation in the modal.

<sup>Written for commit 8f4e163435315acc61da478af8b6da039d6850ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

