### PR TITLE
fix(blog): add title overlay on AttractorBanner

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -122,7 +122,15 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
         {/* Banner */}
         <div className="relative w-full h-60 sm:h-76 overflow-hidden">
           <AttractorBanner seed={article.id} className="absolute inset-0" animate />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10 pointer-events-none" />
+          <div className="absolute inset-0 flex flex-col justify-end p-6 sm:p-8 pointer-events-none">
+            <p className="text-[10px] sm:text-xs font-bold tracking-[0.2em] uppercase text-emerald-400 font-mono mb-2">
+              {article.tags.slice(0, 3).join(' / ')}
+            </p>
+            <h3 className="text-xl sm:text-3xl font-bold text-white font-mono leading-tight">
+              {article.title.split(':')[0]}
+            </h3>
+          </div>
         </div>
 
         {/* Modal content */}

--- a/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
+++ b/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
@@ -166,7 +166,15 @@ export function BlogArticlePage() {
       <div className="relative w-full max-w-3xl mx-auto">
         <div className="relative w-full h-60 sm:h-76 overflow-hidden">
           <AttractorBanner seed={article.id} className="absolute inset-0" animate />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent pointer-events-none" />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10 pointer-events-none" />
+          <div className="absolute inset-0 flex flex-col justify-end p-6 sm:p-8 pointer-events-none">
+            <p className="text-[10px] sm:text-xs font-bold tracking-[0.2em] uppercase text-emerald-400 font-mono mb-2">
+              {article.tags.slice(0, 3).join(' / ')}
+            </p>
+            <h3 className="text-xl sm:text-3xl font-bold text-white font-mono leading-tight">
+              {article.title.split(':')[0]}
+            </h3>
+          </div>
         </div>
       </div>
 

--- a/lexwebapp/src/pages/BlogPage/index.tsx
+++ b/lexwebapp/src/pages/BlogPage/index.tsx
@@ -155,7 +155,15 @@ export function BlogPage() {
             >
               <div className="relative w-full h-52 sm:h-60 overflow-hidden">
                 <AttractorBanner seed={article.id} className="absolute inset-0" />
-                <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-transparent pointer-events-none" />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-black/10 pointer-events-none" />
+                <div className="absolute inset-0 flex flex-col justify-end p-5 sm:p-7 pointer-events-none">
+                  <p className="text-[10px] sm:text-xs font-bold tracking-[0.2em] uppercase text-emerald-400 font-mono mb-2">
+                    {article.tags.slice(0, 3).join(' / ')}
+                  </p>
+                  <h3 className="text-lg sm:text-2xl font-bold text-white font-mono leading-tight line-clamp-2">
+                    {article.title.split(':')[0]}
+                  </h3>
+                </div>
               </div>
               <div className="p-6 sm:p-8">
               <div className="flex items-start gap-4">


### PR DESCRIPTION
## Summary
- Add tags + title text overlay on top of AttractorBanner on all three blog surfaces: listing page, article modal, detail page
- Tags shown as uppercase mono label (e.g. `AI ARCHITECTURE / CLAUDE CODE / WORKFLOW MEMORY`)
- Article title (before the colon) shown as large white mono heading
- Gradient adjusted for better text readability

## Test plan
- [ ] Verify `/blog` listing shows tags + title over fractal banners
- [ ] Verify article modal shows the same overlay
- [ ] Verify article detail page shows the same overlay
- [ ] Check text readability across different article fractals

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tag and title overlays on the fractal banner across the blog list, article modal, and article detail pages to match the old PNG layout. Darker gradient improves readability; shows up to 3 uppercase tags and the title before the colon.

<sup>Written for commit 04c074b8a0b37543b2e37355fd437be30ef1b6ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

