### PR TITLE
docs: add workflow memory phase schedule

### DIFF
--- a/docs/workflow-memory-phases.md
+++ b/docs/workflow-memory-phases.md
@@ -1,0 +1,30 @@
+# Workflow Memory Architecture: Phase Schedule
+
+Supplementary material for the arXiv preprint.
+
+## Phases
+
+| Phase | Weeks | Scope | Status |
+|-------|-------|-------|--------|
+| 0 | 0 (deployed) | Prompt-Commit Bridge: `UserPromptSubmit` hook, bare git repo, GitHub sync, CLI query tool | Complete |
+| 1.0 | 1--2 | Foundation: `workflow_memory_*` PostgreSQL schema, Qdrant collections (domain/workflow/practitioner), basic ingestion pipelines | In progress |
+| 1.1 | 3--4 | Principle ledger population + ADR backfill from existing PRs and design docs | Planned |
+| 1.2 | 5--6 | Practitioner layer bootstrap: nightly summarization of edit-traces into embeddable artifacts | Planned |
+| 1.3 | 7 | Claude Code integration: session-start hook, `workflow_memory_query` MCP tool, thin CLAUDE.md | Planned |
+| 1.4 | 8 | Retrieval-miss instrumentation: post-session reconciliation job, retrieval-correction candidate flagging | Planned |
+| 1.5 | 9--11 | Long-term task orchestrator (push mode): Plane task watcher, Bedrock summarization pipeline, tool lineage delta | Planned |
+
+## Dependencies
+
+- Phase 1.0 requires existing Qdrant and PostgreSQL infrastructure (already in production).
+- Phase 1.1 depends on Phase 1.0 schema.
+- Phase 1.2 depends on the rlhf-signals edit-trace pipeline (already deployed).
+- Phase 1.3 depends on Phase 1.0 (retrieval API must be functional).
+- Phase 1.4 depends on Phase 1.3 (needs session-level retrieval logs).
+- Phase 1.5 is independent of Phases 1.2--1.4 but benefits from principle ledger coverage (Phase 1.1).
+
+## Evaluation checkpoints
+
+- After Phase 1.3: measure session bootstrap (file reads, input tokens) with/without memory layer.
+- After Phase 1.4: measure retrieval-correction edit detection rate and precision.
+- After Phase 1.5: measure long-term task refresh latency (commit-to-digest).


### PR DESCRIPTION
## Summary
- Adds `docs/workflow-memory-phases.md` — phase schedule for the workflow memory arXiv preprint
- Referenced by footnote 2 in the paper; without this file the GitHub link returns 404

## Test plan
- [ ] Verify file renders correctly on GitHub
- [ ] Confirm link resolves: `https://github.com/overthelex/SecondLayer/blob/main/docs/workflow-memory-phases.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `docs/workflow-memory-phases.md`, a phase schedule for the Workflow Memory architecture referenced by footnote 2 in the arXiv preprint. Fixes the 404 from the paper by adding the linked supplementary doc.

<sup>Written for commit 4c3c0528b139b7d5c33ac1db0b179ad41b376775. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

