### PR TITLE
fix(paper): minor corrections in memory architecture paper (§3 + §7.2)

### DIFF
--- a/docs/arxiv-memory-paper/main.tex
+++ b/docs/arxiv-memory-paper/main.tex
@@ -242,7 +242,7 @@ Long-horizon agentic composition is a regime characterized by three measurable p
 Each new agentic session begins by loading context.
 The agent consumes $T$ input tokens of \texttt{CLAUDE.md} content and system context automatically, then performs $K$ exploratory file reads before beginning productive work.
 Measured across 304 sessions from the companion paper's dataset (Section~\ref{sec:preliminary}): median bootstrap cost is $T = 30{,}115$ input tokens, of which ${\sim}17{,}600$ (59\%) is cache-creation cost for \texttt{CLAUDE.md} alone; median per-session file reads are $K = 14$ (mean 23.1).
-Both quantities grow with project age as \texttt{CLAUDE.md} accumulates conventions and the agent's file-read heuristics expand.
+Both quantities grow approximately linearly with project age as \texttt{CLAUDE.md} accumulates conventions and the agent's file-read heuristics expand (\texttt{CLAUDE.md} growth: 217~chars/day, $R^2 = 0.87$; see Section~\ref{sec:preliminary}).
 
 The relevant subset for any given task is a small fraction of $K$ and $T$.
 Measured across 180 sessions with at least three bootstrap reads: the median \emph{context waste ratio}---files read but never subsequently edited---is 60\%, with source-code reads wasted at 78\% (Section~\ref{sec:preliminary}).
@@ -543,6 +543,7 @@ Across sessions with at least three file reads in the bootstrap phase (first 50~
 The distribution is right-skewed: 66\% of sessions waste more than half their bootstrap reads; only 15\% waste less than 30\%.
 Source-code reads are wasted at 78\%, while memory files (\texttt{.claude/memory/}) are wasted at 66.5\%, suggesting that structured memory retrieval is more targeted than exploratory file reads.
 Waste ratio correlates negatively with session length: short sessions (5--10 turns) waste 68.5\%; longer sessions ($>$50 turns) waste 51.1\%.
+This metric is a conservative proxy: a file may be read for context without subsequent editing, in which case it counts as ``wasted'' even when its content informed the agent's reasoning. The 60\% baseline therefore likely overstates true waste; the gap between read-and-edited and read-and-used is left for future work.
 
 Phase~0 (prompt-commit bridge) has been deployed since May~9, 2026 with negligible performance overhead (15ms per capture); distributional analysis requires 4--6 weeks of collection and will be reported in a revision.
 Full evaluation of the memory layer itself (retrieval accuracy, bootstrap reduction with memory enabled) will be reported after Phase~1.3 deployment.


### PR DESCRIPTION
## Summary
Two minor corrections in `docs/arxiv-memory-paper/main.tex`:

1. **§3 growth slope reference:** "Both quantities grow with project age" → adds explicit "approximately linearly (217 chars/day, R²=0.87; see §7.2)" cross-reference

2. **§7.2 Experiment 3 caveat:** Adds conservative proxy disclaimer for the 60% context waste metric — a file read for context but not edited still counts as "wasted" even when its content informed the agent's reasoning. Pre-empts reviewer objection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies §3 with an explicit linear growth rate for `CLAUDE.md` (217 chars/day, R²=0.87) and adds a cross‑reference to §7.2. Adds a note in §7.2 that the 60% context‑waste metric is a conservative proxy because read‑but‑not‑edited files may still inform reasoning.

<sup>Written for commit 6ce970e23eeeb8a094fd25b055a863c6c9db5fa4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

