### PR TITLE
feat(rlhf): SageMaker DPO training infrastructure

### DIFF
--- a/rlhf-signals/training/sagemaker/eval_dpo.py
+++ b/rlhf-signals/training/sagemaker/eval_dpo.py
@@ -1,0 +1,142 @@
+"""
+Evaluation harness for DPO experiment.
+Compares outputs from 4 conditions using LLM-as-judge win-rate.
+
+Usage:
+  python eval_dpo.py --condition-a output/practitioner/ --condition-b output/rlaif/ \
+    --eval-data data/eval.jsonl --judge bedrock
+"""
+
+import json
+import random
+import argparse
+from pathlib import Path
+from collections import Counter
+
+import boto3
+
+
+JUDGE_SYSTEM = "You are an expert evaluator. Compare two AI assistant responses and determine which is better."
+
+JUDGE_PROMPT = """Given a user request and two assistant responses (A and B), determine which response is better.
+
+Evaluate based on:
+1. Accuracy and correctness
+2. Completeness
+3. Clarity and structure
+4. Relevance to the request
+
+User Request:
+{prompt}
+
+Response A:
+{response_a}
+
+Response B:
+{response_b}
+
+Which response is better? Answer with ONLY one word: "A", "B", or "TIE".
+Verdict:"""
+
+
+def judge_pair_bedrock(client, prompt, response_a, response_b, model_id="us.anthropic.claude-haiku-4-5-20251001-v1:0"):
+    judge_input = JUDGE_PROMPT.format(prompt=prompt, response_a=response_a, response_b=response_b)
+    try:
+        resp = client.converse(
+            modelId=model_id,
+            system=[{"text": JUDGE_SYSTEM}],
+            messages=[{"role": "user", "content": [{"text": judge_input}]}],
+            inferenceConfig={"maxTokens": 5, "temperature": 0.0},
+        )
+        verdict = resp["output"]["message"]["content"][0]["text"].strip().upper()
+        if verdict in ("A", "B", "TIE"):
+            return verdict
+        return "TIE"
+    except Exception as e:
+        print(f"  Judge error: {e}")
+        return "ERROR"
+
+
+def generate_response(client, model_id, prompt, max_tokens=512):
+    """Generate response from a Bedrock model (for stock baseline)."""
+    try:
+        resp = client.converse(
+            modelId=model_id,
+            messages=[{"role": "user", "content": [{"text": prompt}]}],
+            inferenceConfig={"maxTokens": max_tokens, "temperature": 0.7},
+        )
+        return resp["output"]["message"]["content"][0]["text"]
+    except Exception as e:
+        return f"[ERROR: {e}]"
+
+
+def evaluate_win_rate(eval_data, responses_a, responses_b, client, label_a="A", label_b="B"):
+    results = Counter()
+    details = []
+
+    for i, (item, ra, rb) in enumerate(zip(eval_data, responses_a, responses_b)):
+        prompt = item["prompt"]
+
+        # Randomize position to reduce bias
+        if random.random() > 0.5:
+            first, second = ra, rb
+            mapping = {"A": label_a, "B": label_b}
+        else:
+            first, second = rb, ra
+            mapping = {"A": label_b, "B": label_a}
+
+        verdict = judge_pair_bedrock(client, prompt, first, second)
+
+        if verdict in ("A", "B"):
+            winner = mapping[verdict]
+        elif verdict == "TIE":
+            winner = "TIE"
+        else:
+            winner = "ERROR"
+
+        results[winner] += 1
+        details.append({"prompt_idx": i, "verdict": verdict, "winner": winner})
+
+        if (i + 1) % 20 == 0:
+            print(f"  [{i+1}/{len(eval_data)}] judged")
+
+    total = sum(v for k, v in results.items() if k != "ERROR")
+    print(f"\n  Win rate: {label_a}={results[label_a]}/{total} ({100*results[label_a]/total:.1f}%), "
+          f"{label_b}={results[label_b]}/{total} ({100*results[label_b]/total:.1f}%), "
+          f"TIE={results['TIE']}/{total} ({100*results['TIE']/total:.1f}%)")
+
+    return {"counts": dict(results), "details": details, "labels": [label_a, label_b]}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--eval-data", required=True, help="Eval JSONL (prompt/chosen/rejected)")
+    parser.add_argument("--responses-a", help="JSONL with responses from model A")
+    parser.add_argument("--responses-b", help="JSONL with responses from model B")
+    parser.add_argument("--label-a", default="A")
+    parser.add_argument("--label-b", default="B")
+    parser.add_argument("--output", default="eval_results.json")
+    parser.add_argument("--limit", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    eval_data = [json.loads(l) for l in Path(args.eval_data).read_text().splitlines()]
+    if args.limit and len(eval_data) > args.limit:
+        eval_data = random.sample(eval_data, args.limit)
+
+    responses_a = [json.loads(l)["response"] for l in Path(args.responses_a).read_text().splitlines()]
+    responses_b = [json.loads(l)["response"] for l in Path(args.responses_b).read_text().splitlines()]
+
+    client = boto3.client("bedrock-runtime", region_name="us-east-1")
+
+    print(f"Evaluating {len(eval_data)} pairs: {args.label_a} vs {args.label_b}")
+    results = evaluate_win_rate(eval_data, responses_a, responses_b, client, args.label_a, args.label_b)
+
+    Path(args.output).write_text(json.dumps(results, indent=2))
+    print(f"\nSaved: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlhf-signals/training/sagemaker/launch_experiment.py
+++ b/rlhf-signals/training/sagemaker/launch_experiment.py
@@ -1,0 +1,224 @@
+"""
+Launch full DPO experiment on SageMaker.
+Runs 4 conditions × 3 seeds = 9 training jobs (Condition D = no training).
+
+Usage:
+  pip install sagemaker boto3
+  python launch_experiment.py [--dry-run] [--condition a] [--seed 42]
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import boto3
+import sagemaker
+from sagemaker.huggingface import HuggingFace
+
+BUCKET = "secondlayer-rlhf-exp4"
+REGION = "us-west-2"
+ROLE_ARN = None  # Set after IAM setup, or auto-detect
+
+CONDITIONS = {
+    "a": {
+        "name": "practitioner-oversight",
+        "train_prefix": "data/condition_a",
+        "description": "Practitioner edit-trace DPO (24,495 pairs)",
+    },
+    "c": {
+        "name": "rlaif-self-correction",
+        "train_prefix": "data/condition_c",
+        "description": "RLAIF Claude Haiku 4.5 self-correction (24,495 pairs)",
+    },
+    "e": {
+        "name": "public-rlhf-ultrafeedback",
+        "train_prefix": "data/condition_e",
+        "description": "UltraFeedback public RLHF (24,495 sampled pairs)",
+    },
+}
+
+SEEDS = [42, 123, 456]
+
+HYPERPARAMETERS = {
+    "model_name_or_path": "meta-llama/Llama-3.1-8B-Instruct",
+    "num_train_epochs": "1",
+    "per_device_train_batch_size": "2",
+    "gradient_accumulation_steps": "4",
+    "learning_rate": "5e-5",
+    "beta": "0.1",
+    "max_length": "1024",
+    "max_prompt_length": "512",
+    "lora_r": "16",
+    "lora_alpha": "32",
+    "lora_dropout": "0.05",
+}
+
+
+def upload_data(s3_client, local_dir: Path, condition: str):
+    """Upload train/val JSONL to S3 for a condition."""
+    prefix = CONDITIONS[condition]["train_prefix"]
+
+    for filename in ["train.jsonl", "val.jsonl"]:
+        local_path = local_dir / filename
+        if not local_path.exists():
+            print(f"  WARNING: {local_path} not found, skipping")
+            continue
+        s3_key = f"{prefix}/{filename}"
+        print(f"  Uploading {local_path} -> s3://{BUCKET}/{s3_key}")
+        s3_client.upload_file(str(local_path), BUCKET, s3_key)
+
+
+def launch_training_job(condition: str, seed: int, role: str, dry_run: bool = False):
+    """Launch one SageMaker training job."""
+    cond_info = CONDITIONS[condition]
+    job_name = f"dpo-{cond_info['name']}-seed{seed}-{int(time.time())}"
+    s3_train = f"s3://{BUCKET}/{cond_info['train_prefix']}"
+    s3_output = f"s3://{BUCKET}/output/{cond_info['name']}/seed{seed}/"
+
+    hp = {
+        **HYPERPARAMETERS,
+        "condition": condition,
+        "seed": str(seed),
+        "dataset_path": "/opt/ml/input/data/training",
+        "output_dir": "/opt/ml/model",
+    }
+
+    print(f"\n{'='*60}")
+    print(f"Job: {job_name}")
+    print(f"Condition {condition.upper()}: {cond_info['description']}")
+    print(f"Seed: {seed}")
+    print(f"Data: {s3_train}")
+    print(f"Output: {s3_output}")
+
+    if dry_run:
+        print("  [DRY RUN] Would launch SageMaker training job")
+        print(f"  Hyperparameters: {json.dumps(hp, indent=2)}")
+        return None
+
+    estimator = HuggingFace(
+        entry_point="train_dpo.py",
+        source_dir=str(Path(__file__).parent),
+        instance_type="ml.g5.12xlarge",
+        instance_count=1,
+        role=role,
+        transformers_version="4.45",
+        pytorch_version="2.4",
+        py_version="py311",
+        output_path=s3_output,
+        hyperparameters=hp,
+        environment={
+            "HUGGING_FACE_HUB_TOKEN": get_hf_token(),
+        },
+        distribution={"torch_distributed": {"enabled": True}},
+        max_run=6 * 3600,
+        job_name=job_name,
+    )
+
+    estimator.fit({"training": s3_train}, wait=False)
+    print(f"  Launched: {job_name}")
+    return job_name
+
+
+def get_hf_token():
+    """Read HF token from env or file."""
+    import os
+    token = os.environ.get("HUGGING_FACE_HUB_TOKEN", "")
+    if not token:
+        token_path = Path.home() / ".cache" / "huggingface" / "token"
+        if token_path.exists():
+            token = token_path.read_text().strip()
+    return token
+
+
+def create_bucket(s3_client):
+    """Create S3 bucket if it doesn't exist."""
+    try:
+        s3_client.head_bucket(Bucket=BUCKET)
+        print(f"Bucket s3://{BUCKET} exists")
+    except Exception:
+        print(f"Creating bucket s3://{BUCKET} in {REGION}")
+        s3_client.create_bucket(
+            Bucket=BUCKET,
+            CreateBucketConfiguration={"LocationConstraint": REGION},
+        )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch DPO experiment on SageMaker")
+    parser.add_argument("--dry-run", action="store_true", help="Print config without launching")
+    parser.add_argument("--condition", type=str, default=None, help="Run single condition (a/c/e)")
+    parser.add_argument("--seed", type=int, default=None, help="Run single seed")
+    parser.add_argument("--upload-only", action="store_true", help="Only upload data to S3")
+    args = parser.parse_args()
+
+    s3 = boto3.client("s3", region_name=REGION)
+    data_dir = Path(__file__).parent.parent / "data"
+
+    create_bucket(s3)
+
+    # Upload data for each condition
+    condition_files = {
+        "a": {"train.jsonl": data_dir / "train.jsonl", "val.jsonl": data_dir / "val.jsonl"},
+        "c": {"train.jsonl": data_dir / "rlaif_train.jsonl", "val.jsonl": data_dir / "rlaif_val.jsonl"},
+        "e": {"train.jsonl": data_dir / "public_rlhf_train.jsonl", "val.jsonl": data_dir / "public_rlhf_val.jsonl"},
+    }
+
+    conditions_to_run = [args.condition] if args.condition else list(CONDITIONS.keys())
+    seeds_to_run = [args.seed] if args.seed else SEEDS
+
+    print("=== Uploading training data to S3 ===")
+    for cond in conditions_to_run:
+        prefix = CONDITIONS[cond]["train_prefix"]
+        for target_name, source_path in condition_files[cond].items():
+            if source_path.exists():
+                s3_key = f"{prefix}/{target_name}"
+                print(f"  {source_path.name} -> s3://{BUCKET}/{s3_key}")
+                if not args.dry_run:
+                    s3.upload_file(str(source_path), BUCKET, s3_key)
+            else:
+                print(f"  WARNING: {source_path} not found!")
+
+    if args.upload_only:
+        print("\nData uploaded. Use --condition/--seed to launch training.")
+        return
+
+    # Get SageMaker role
+    role = ROLE_ARN
+    if not role:
+        try:
+            sess = sagemaker.Session(boto_session=boto3.Session(region_name=REGION))
+            role = sagemaker.get_execution_role(sagemaker_session=sess)
+        except Exception:
+            print("ERROR: No SageMaker execution role. Set ROLE_ARN or run from SageMaker notebook.")
+            print("Create role: aws iam create-role ... (see README)")
+            return
+
+    # Launch training jobs
+    print(f"\n=== Launching DPO Training ===")
+    print(f"Conditions: {conditions_to_run}")
+    print(f"Seeds: {seeds_to_run}")
+    print(f"Total jobs: {len(conditions_to_run) * len(seeds_to_run)}")
+
+    jobs = []
+    for cond in conditions_to_run:
+        for seed in seeds_to_run:
+            job = launch_training_job(cond, seed, role, dry_run=args.dry_run)
+            if job:
+                jobs.append(job)
+
+    if jobs:
+        print(f"\n=== {len(jobs)} jobs launched ===")
+        print("Monitor: aws sagemaker list-training-jobs --region us-west-2")
+        print("Or: SageMaker console -> Training -> Training jobs")
+
+    # Estimated cost
+    hours_per_job = 6
+    cost_per_hour = 5.67
+    total_jobs = len(conditions_to_run) * len(seeds_to_run)
+    est_cost = total_jobs * hours_per_job * cost_per_hour
+    print(f"\nEstimated cost: {total_jobs} jobs × {hours_per_job}h × ${cost_per_hour}/h = ${est_cost:.0f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/rlhf-signals/training/sagemaker/requirements.txt
+++ b/rlhf-signals/training/sagemaker/requirements.txt
@@ -1,0 +1,5 @@
+trl>=1.0.0
+peft>=0.14.0
+bitsandbytes>=0.45.0
+datasets>=3.0.0
+accelerate>=1.2.0

--- a/rlhf-signals/training/sagemaker/train_dpo.py
+++ b/rlhf-signals/training/sagemaker/train_dpo.py
@@ -1,0 +1,131 @@
+"""
+DPO training script for SageMaker.
+Runs inside HuggingFace DLC container on ml.g5.12xlarge (4x A10G).
+
+Trains Llama 3.1 8B Instruct with QLoRA + DPO on preference pairs.
+SageMaker passes hyperparameters via SM_HP_* env vars, data via /opt/ml/input/data/.
+"""
+
+import os
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from peft import LoraConfig, TaskType
+from trl import DPOConfig, DPOTrainer
+
+
+def get_hp(name, default, cast=str):
+    return cast(os.environ.get(f"SM_HP_{name.upper()}", default))
+
+
+def main():
+    model_name = get_hp("model_name_or_path", "meta-llama/Llama-3.1-8B-Instruct")
+    dataset_path = get_hp("dataset_path", "/opt/ml/input/data/training")
+    output_dir = get_hp("output_dir", "/opt/ml/model")
+    condition = get_hp("condition", "a")
+    seed = get_hp("seed", "42", int)
+
+    num_epochs = get_hp("num_train_epochs", "1", int)
+    batch_size = get_hp("per_device_train_batch_size", "2", int)
+    grad_accum = get_hp("gradient_accumulation_steps", "4", int)
+    lr = get_hp("learning_rate", "5e-5", float)
+    beta = get_hp("beta", "0.1", float)
+    max_length = get_hp("max_length", "1024", int)
+    max_prompt_length = get_hp("max_prompt_length", "512", int)
+
+    lora_r = get_hp("lora_r", "16", int)
+    lora_alpha = get_hp("lora_alpha", "32", int)
+    lora_dropout = get_hp("lora_dropout", "0.05", float)
+
+    print(f"=== DPO Training: Condition {condition}, Seed {seed} ===")
+    print(f"Model: {model_name}")
+    print(f"Data: {dataset_path}")
+    print(f"Hyperparams: lr={lr}, beta={beta}, epochs={num_epochs}, batch={batch_size}x{grad_accum}")
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    bnb_config = BitsAndBytesConfig(
+        load_in_4bit=True,
+        bnb_4bit_quant_type="nf4",
+        bnb_4bit_compute_dtype=torch.bfloat16,
+        bnb_4bit_use_double_quant=True,
+    )
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        quantization_config=bnb_config,
+        attn_implementation="flash_attention_2",
+        torch_dtype=torch.bfloat16,
+    )
+
+    peft_config = LoraConfig(
+        r=lora_r,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        target_modules="all-linear",
+        task_type=TaskType.CAUSAL_LM,
+        bias="none",
+    )
+
+    train_path = os.path.join(dataset_path, "train.jsonl")
+    val_path = os.path.join(dataset_path, "val.jsonl")
+
+    train_dataset = load_dataset("json", data_files=train_path, split="train")
+    eval_dataset = None
+    if os.path.exists(val_path):
+        eval_dataset = load_dataset("json", data_files=val_path, split="train")
+
+    print(f"Train: {len(train_dataset)} pairs, Val: {len(eval_dataset) if eval_dataset else 0}")
+
+    training_args = DPOConfig(
+        output_dir=output_dir,
+        num_train_epochs=num_epochs,
+        per_device_train_batch_size=batch_size,
+        gradient_accumulation_steps=grad_accum,
+        learning_rate=lr,
+        beta=beta,
+        max_length=max_length,
+        max_prompt_length=max_prompt_length,
+        bf16=True,
+        gradient_checkpointing=True,
+        logging_steps=10,
+        save_strategy="epoch",
+        eval_strategy="epoch" if eval_dataset else "no",
+        optim="adamw_torch_fused",
+        warmup_ratio=0.1,
+        lr_scheduler_type="cosine",
+        remove_unused_columns=False,
+        disable_dropout=True,
+        loss_type="sigmoid",
+        ddp_find_unused_parameters=False,
+        dataloader_num_workers=4,
+        seed=seed,
+        run_name=f"dpo-{condition}-seed{seed}",
+    )
+
+    trainer = DPOTrainer(
+        model=model,
+        ref_model=None,
+        args=training_args,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        processing_class=tokenizer,
+        peft_config=peft_config,
+    )
+
+    trainer.train()
+    trainer.save_model(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    metrics = trainer.state.log_history
+    import json
+    with open(os.path.join(output_dir, "training_metrics.json"), "w") as f:
+        json.dump(metrics, f, indent=2)
+
+    print(f"Done. Condition {condition}, seed {seed}. Adapter saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- SageMaker training scripts for DPO Experiment 4 (Llama 3.1 8B + QLoRA + TRL)
- Launch orchestrator: 3 conditions × 3 seeds = 9 training jobs on ml.g5.12xlarge
- Evaluation harness: LLM-as-judge win-rate with position debiasing
- S3 bucket created, all training data uploaded (3 × 24,495 pairs)
- Estimated cost: ~$406 total

## Test plan
- [x] S3 bucket created and data uploaded (us-west-2)
- [x] Training script follows SageMaker HuggingFace DLC conventions
- [ ] Dry-run: `python launch_experiment.py --dry-run`
- [ ] IAM role setup (manual step before first launch)
- [ ] Single-condition test: `--condition a --seed 42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SageMaker infrastructure to run Experiment 4 DPO training on Llama 3.1 8B with QLoRA and TRL, plus a Bedrock-based judge for evaluation. Includes scripts to upload data, launch 3 conditions × 3 seeds on `ml.g5.12xlarge`, and save adapters and metrics to S3.

- **New Features**
  - `train_dpo.py`: DPO with `trl` using QLoRA (4-bit) on `meta-llama/Llama-3.1-8B-Instruct`; configurable via `SM_HP_*`; saves adapter and training metrics.
  - `launch_experiment.py`: uploads datasets to `s3://secondlayer-rlhf-exp4` (us-west-2) and launches conditions `a/c/e` across seeds on `ml.g5.12xlarge`; prints a cost estimate.
  - `eval_dpo.py`: Bedrock judge with position debiasing; compares two response sets and writes win-rate JSON.
  - Dependencies: adds `trl`, `peft`, `bitsandbytes`, `datasets`, `accelerate`.

- **Migration**
  - Ensure a SageMaker execution role is available; set `ROLE_ARN` when not running inside SageMaker.
  - Provide `HUGGING_FACE_HUB_TOKEN` via env or `~/.cache/huggingface/token`.
  - Dry-run: `python launch_experiment.py --dry-run`; single test: `python launch_experiment.py --condition a --seed 42`.

<sup>Written for commit 2ed0eb86b8b80376e7b038e53bdca60a3cefee05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

