### PR TITLE
feat(blog): paginated PDF reader + LaTeX download for academic papers

### DIFF
--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -40,6 +40,7 @@
     "react-hot-toast": "^2.6.0",
     "react-is": "^19.2.4",
     "react-markdown": "^10.1.0",
+    "react-pdf": "^10.4.1",
     "react-router-dom": "^7.13.1",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",

--- a/lexwebapp/public/papers/edit-trace-oversight-2026.tex
+++ b/lexwebapp/public/papers/edit-trace-oversight-2026.tex
@@ -1,0 +1,911 @@
+\documentclass[11pt]{article}
+
+% ============================================================
+%  Packages
+% ============================================================
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+
+% Page geometry — arXiv-friendly single-column
+\usepackage[margin=1in]{geometry}
+
+% Math
+\usepackage{amsmath,amssymb,amsfonts}
+
+% Tables
+\usepackage{booktabs}
+\usepackage{multirow}
+\usepackage{array}
+\usepackage{tabularx}
+
+% Figures
+\usepackage{graphicx}
+\usepackage{subcaption}
+\usepackage{float}
+
+% Colors
+\usepackage[dvipsnames]{xcolor}
+
+% Bibliography (must load before hyperref)
+\usepackage[numbers,sort&compress]{natbib}
+
+% Hyperlinks (must load after natbib)
+\usepackage[colorlinks=true,linkcolor=MidnightBlue,citecolor=OliveGreen,urlcolor=BrickRed]{hyperref}
+
+% Misc
+\usepackage{enumitem}
+\usepackage{microtype}
+\usepackage{url}
+\usepackage{xspace}
+
+% ============================================================
+%  Macros
+% ============================================================
+\newcommand{\ie}{\emph{i.e.}\@\xspace}
+\newcommand{\eg}{\emph{e.g.}\@\xspace}
+\newcommand{\cf}{\emph{cf.}\@\xspace}
+\newcommand{\etal}{\emph{et~al.}\xspace}
+\newcommand{\editdist}{\textsc{EditDist}\xspace}
+\newcommand{\semclass}{\textsc{SemClass}\xspace}
+
+% ============================================================
+%  Title
+% ============================================================
+\title{%
+  Edit-Trace Oversight: Scalable Alignment Signal \\
+  from Agentic Workflows%
+}
+
+\author{
+  Vladimir Ovcharov\thanks{Correspondence: \texttt{volodymyr@legal.org.ua}}\\
+  LEX AI LLC, Kyiv, Ukraine\\
+  \texttt{https://legal.org.ua}
+}
+
+\date{May 2026}
+
+\begin{document}
+\maketitle
+
+% ============================================================
+%  Abstract
+% ============================================================
+\begin{abstract}
+Existing approaches to RLHF preference collection~\citep{christiano2017deep, ziegler2019fine, ouyang2022training}---crowd workers, expert annotators, AI raters---generate signal detached from the agentic workflows they are meant to govern.
+As LLM agents perform longer-horizon, multi-step work (composing tool calls, accumulating context across hundreds of turns, shipping outputs with real-world stakes), the oversight gap widens: annotation happens in abstract evaluation contexts, while agents fail at the level of individual edits within compositional trajectories.
+We propose \textbf{edit-trace oversight}---alignment signal captured natively when a practitioner works agentically with an LLM.
+Every human edit on a model output is a localized correction relative to a \emph{domain constitution} and an outcome trajectory.
+
+\textbf{Subject:} CEO of Legal.org.ua / LEX~AI.
+Shipping period: 105 days (Jan~24--May~8, 2026), 1{,}547 merged PRs across 7 interconnected projects, 70+ MCP tools in production, 380M+ records in the data pipeline.
+All built by one founder with zero employees using Claude Code as the primary agentic engineering counterpart.
+Validated outcomes: Google for Startups acceptance, NVIDIA Inception approval, paying customers.
+
+\textbf{Two-axis oversight signal:}
+(1)~\emph{artifact-level}---what was corrected (30{,}510 edit-traces, 80.7\% substantive rewrites, median edit distance 0.84);
+(2)~\emph{process-level}---how oversight was performed (OS-level activity tracking: keystroke timing, idle gaps, cross-app research, voice context).
+No existing alignment dataset captures both.
+
+\textbf{Pilot dataset:} 2{,}892 workflow sessions, 30{,}510 edit pairs, 1{,}579 attributed outcomes (54.6\% coverage, 88.1\% strong confidence).
+Process-level enrichment via synchronized OS activity tracker covers 498 sessions (17.2\%) with 9{,}254 edits.
+
+\textbf{Experiments (1--3 complete):}
+Experiment~1 confirmed the extreme edit distribution (80.7\% substantive rewrites; crowd comparison sampling done).
+Experiment~2 showed process-level features are real (permutation $p<0.001$) but redundant with artifact features for prediction.
+Experiment~3 revealed \emph{rejection} is the strongest oversight signal (78\% positive outcomes).
+DPO training (Experiment~4) is redesigned: 4 conditions: edit-trace oversight vs RLAIF self-correction vs public RLHF baseline vs untrained model.
+
+The methodology rests on a simple empirical claim: a single practitioner working recursively with an LLM, under product accountability, completes long-horizon work that neither party completes alone.
+Edit-traces in this regime are dense, outcome-validated, and impossible to obtain through annotation in isolation.
+\end{abstract}
+
+\vspace{0.5em}
+\noindent\textbf{Keywords:} RLHF, preference data, scalable oversight, agentic workflows, edit-trace, domain constitution, legal AI
+
+% ============================================================
+\section{Introduction: The Oversight Gap in Agentic Systems}
+\label{sec:intro}
+% ============================================================
+
+\subsection{Motivation: Empirical Observation of Recursive Human--LLM Composition}
+\label{sec:motivation}
+
+Scalable oversight research typically frames the problem defensively: as models become more capable, mechanisms must compensate for the limits of human attention---debate~\citep{irving2018ai}, recursive reward modeling~\citep{leike2018scalable}, AI judges, constitutional methods~\citep{christiano2017deep, bai2022constitutional}.
+This framing treats the bandwidth of human oversight as a fixed constant and asks how to route around it.
+
+The case study documented in this paper presents an empirical observation that complicates this framing.
+A single practitioner shipped 1{,}547 PRs across 7 production systems in 105 days using an LLM agent (Claude Code) as the primary engineering counterpart.
+Neither party would have reached this output independently: the practitioner's throughput without the agent is bounded by typing and cognitive load; the agent's autonomous reliability at consequential scale remains insufficient for production deployment without human oversight.
+
+In this regime, the practitioner applies corrections at each step, and each correction shapes the context for subsequent agent actions.
+The resulting edit-traces are generated under two constraints that standard annotation lacks:
+(1)~\emph{production accountability}---the corrected output ships to real users, creating a natural incentive for concentrated attention at each decision point; and
+(2)~\emph{sequential dependence}---corrections accumulate along the trajectory, meaning each edit is informed by the consequences of prior corrections.
+
+We observe empirically that this regime produces a qualitatively different distribution of corrections compared to what we would expect from detached annotation (Section~\ref{sec:exp1}).
+Whether this distributional difference translates into better training signal is an empirical question addressed by Experiment~4 (Section~\ref{sec:exp4}).
+
+\subsection{The Structural Problem}
+\label{sec:structural-problem}
+
+As LLM agents take on longer-horizon, multi-step work---composing tool calls, accumulating context across hundreds of turns, and shipping outputs with attributable real-world stakes---the gap between how we collect alignment signal and how agents actually fail has become structural.
+Every existing source of RLHF preference data shares one property: \textbf{the annotator operates outside the agentic workflow they are meant to govern}~\citep{stiennon2020learning, ouyang2022training, bai2022training}.
+A Mechanical Turk worker rates isolated model outputs without a codebase, a deployment pipeline, or a customer on the other end.
+An expert annotator evaluates in a controlled environment, not mid-trajectory in a compositional system.
+An RLAIF model~\citep{lee2023rlaif} applies principles supplied by its creators, without feedback from the downstream consequences of the agent's actions.
+They all produce ratings detached from the granularity at which agentic systems actually fail: the individual edit within a multi-step trajectory under domain constraints and outcome accountability.
+
+\subsection{Edit-Trace as Oversight Signal}
+\label{sec:edit-trace-signal}
+
+We propose an alternative: \textbf{edit-trace oversight}---alignment signal captured natively when a practitioner works agentically with an LLM over consequential, multi-step workflows.
+
+When a practitioner runs Claude Code agentically---composing tool calls, reviewing architectural proposals against domain constraints, accepting or rejecting suggested changes based on information not available to the model---every human edit on a model output is a localized correction relative to a domain constitution and an outcome trajectory.
+This is not preference annotation.
+It is \textbf{in-the-loop oversight}, captured at the granularity where agentic systems actually fail.
+
+Two properties distinguish edit-trace oversight from expert annotation:
+
+\paragraph{Outcome-validated corrections.}
+The practitioner makes binding decisions with real consequences.
+Accepted agent output ships and passes or fails in production.
+Each edit-trace is a correction grounded in revealed preference + ground truth, not abstract judgment.
+
+\paragraph{Compositional trajectory awareness.}
+The practitioner builds compositional pipelines (Query Planner $\to$ Semantic Sectionizer $\to$ Hallucination Guard $\to$ Citation Validator), where every oversight correction affects the rest of the trajectory.
+Each edit encodes not just local quality judgment but awareness of how the correction propagates through downstream components.
+This is qualitatively more informative than isolated rating of individual model outputs.
+
+\subsection{Behavioral Context of Oversight Actions}
+\label{sec:behavioral-context-intro}
+
+Even rich edit-trace capture records only the artifact-level correction (\emph{what} the practitioner changed).
+The cognitive and behavioral context behind the correction---time invested, external research consulted, voice calls made, window switches indicating cross-referencing---is lost.
+We capture this dimension through synchronized OS-level activity tracking, providing the behavioral context of each oversight action.
+This enables the question: does \emph{how} a practitioner performs oversight contain signal beyond \emph{what} they corrected?
+
+\subsection{Research Questions}
+\label{sec:rqs}
+
+\begin{enumerate}[label=\textbf{RQ\arabic*},leftmargin=2.5em]
+  \item Does oversight edit-trace from an agentic practitioner differ distributionally from crowd annotation on matched LLM outputs?
+  \item Does the behavioral context of oversight actions contain signal beyond the artifact-level correction?
+  \item Do oversight corrections within agentic workflows correlate with downstream outcomes?
+  \item Does training on oversight-trace preferences improve domain-specific performance vs.\ crowd-sourced baselines?
+\end{enumerate}
+
+
+% ============================================================
+\section{Defining Valid Oversight: The Domain Constitution}
+\label{sec:domain-constitution}
+% ============================================================
+
+\citet{bai2022constitutional} introduced Constitutional AI, where a model evaluates its own outputs against researcher-authored principles.
+The construct we develop here is related but distinct: a \textbf{domain constitution}---formal conditions under which human corrections on agentic output constitute valid oversight signal.
+Where Constitutional AI asks ``does this output satisfy these principles?'', a domain constitution asks ``does this correction process satisfy the conditions required for the resulting edit-trace to function as scalable oversight?''
+
+The broader principle---that formal structure should \emph{control}, not merely inform, system behavior---has roots in ontology-controlled architectures~\citep{palagin2006architecture}, where domain ontologies govern the runtime behavior of information systems rather than serving as passive metadata.
+Recent work extends this principle to large language models: OntoChatGPT~\citep{palagin2023ontochatgpt} uses formal ontologies to structure and constrain ChatGPT's output generation via ontology-driven meta-learning prompts.
+The domain constitution advances this line from a different direction: where ontology-controlled systems use formal structure to govern \emph{what the system produces}, the domain constitution uses formal conditions to govern \emph{when human corrections on system output constitute valid training signal}.
+The shift is from controlling the model's generation process to controlling the oversight process that yields preference data for model improvement.
+
+Not all human--agent interaction produces oversight signal.
+A user who copies an LLM snippet into a one-off script provides no oversight.
+A crowd annotator who rates two completions provides weak oversight, ungrounded in real consequences.
+The domain constitution specifies the boundary conditions that separate noise from signal.
+
+\subsection{Two-Axis Oversight Signal}
+
+\paragraph{Artifact-level:} what was corrected between agentic output and final artifact---edit distance, semantic change class, structural changes.
+This axis captures the \emph{content} of oversight: which agentic behaviors the human deemed unacceptable, and how they were remediated.
+
+\paragraph{Process-level:} how the correction was made---keystroke timing patterns, idle gaps, app-switching trajectory, voice context.
+Captured only with OS-level instrumentation running in parallel.
+This axis captures the \emph{cognitive cost} of oversight: how much effort the correction required, what external information was consulted, and whether the human deliberated or corrected reflexively.
+
+\subsection{Five Conditions of the Domain Constitution}
+\label{sec:five-conditions}
+
+The domain constitution specifies five conditions that must hold simultaneously for human edits on agentic output to constitute valid oversight.
+Each condition addresses a specific failure mode that would render the edit-trace uninformative or misleading as a training signal.
+
+\begin{enumerate}[label=\textbf{C\arabic*.},leftmargin=2.5em]
+
+\item \textbf{Shared persistent state between human and agent.}
+The agent operates against a continuously evolving codebase, not isolated snippets.
+Each session inherits state from previous sessions through the working directory, git history, file structure, and accumulated documentation.
+The codebase itself functions as long-term memory shared between human and agent.
+
+\emph{Why necessary:}
+Without persistent shared state, the human's corrections are context-free---they reflect preferences over isolated outputs rather than oversight over an evolving system.
+Persistent state ensures that each correction is informed by the full history of prior agent behavior and its cumulative consequences.
+
+\item \textbf{Compositional task layering.}
+Work decomposes into chains where one agentic session's output (committed code, architectural decision, documentation update) becomes context for subsequent sessions.
+The practitioner maintains persistent computational threads spanning days, weeks, or months.
+
+\emph{Why necessary:}
+Single-turn corrections cannot capture oversight over compositional failure modes---cases where each individual agent output appears adequate but the composition fails.
+When a practitioner corrects an architectural decision because it conflicts with a decision made three weeks earlier, the resulting edit-trace encodes long-range dependency information that no single-turn annotation scheme can capture.
+
+\item \textbf{Grounding in observable reality.}
+The practitioner establishes definition-of-success parameters before initiating work on any non-trivial task: what observable behavior constitutes completion, what failure modes invalidate the approach, what performance characteristics the artifact must exhibit in production.
+
+\emph{Why necessary:}
+Oversight that rests on subjective preference alone is indistinguishable from taste.
+When corrections are grounded in observable system behavior---a deployment that failed, a latency spike, an error rate increase---the edit-trace encodes causal information about what works and what does not.
+
+\item \textbf{Information asymmetry favoring the human.}
+The practitioner reviews every commit, evaluates architectural proposals against domain constraints, accepts or rejects suggested changes based on information not available to the agent (business priorities, regulatory requirements, user feedback, personal stake in outcomes).
+
+\emph{Why necessary:}
+Oversight is meaningful precisely because the overseer holds information the overseen system lacks.
+If the human's corrections reflect only information already available to the agent, the edit-trace is redundant with the agent's own uncertainty.
+
+\item \textbf{Consequential grounding.}
+The output is shippable code that runs in production with measurable consequences: feature usage, system reliability, customer adoption, revenue, partnership formation.
+
+\emph{Why necessary:}
+Oversight signal must connect to real consequences to avoid the same detachment that afflicts crowd annotation.
+When corrected artifacts ship and succeed or fail in production, the edit-trace acquires outcome labels that close the loop between correction and consequence.
+
+\end{enumerate}
+
+\subsection{Instantiation by the Case Study}
+
+This domain constitution is instantiated by the author's production work: \textbf{1{,}547 merged PRs across 7 interconnected projects over 105 days} using Claude Code as primary agentic counterpart.
+The core platform (Legal.org.ua, 1{,}393 PRs) produces a deployed legal AI platform with 380M+ records pipeline and 70+ MCP tools.
+Satellite projects (154 PRs) cover due diligence intelligence (SneakyPiper, 73~PRs), LinkedIn lead automation (aipromo, 39~PRs), meeting scheduling (Calendary, 27~PRs), OSINT aggregation (Panoptic, 10~PRs), and OS-level activity tracking (XSISTANT, 5~PRs).
+Measurable downstream outcomes include selection by Google for Startups, introduction to Deloitte via GFS, and acceptance into NVIDIA Inception Program.
+
+Each of these acceptances was achieved through written applications without prior voice conversations, in-person meetings, or warm introductions from accelerator mentor networks.
+The applications themselves were drafted using the same recursive workflow that produced the underlying product, demonstrating that the workflow generalizes from code production to high-stakes written communication with measurable institutional gatekeepers.
+
+\subsection{What Fails to Constitute Valid Oversight}
+\label{sec:invalid-oversight}
+
+The domain constitution also defines its negation---interaction patterns that fail one or more conditions and therefore do not produce valid oversight signal:
+
+\begin{itemize}[nosep]
+  \item One-shot code generation (fails C1--C2: no persistent state, no compositional layering)
+  \item Automated CI/CD pipelines using Claude Code (fails C4: no human information asymmetry)
+  \item Tutorial or learning use (fails C5: no consequential grounding)
+  \item Pair programming without pre-defined success criteria or observable production feedback (fails C3)
+\end{itemize}
+
+\subsection{Edit Taxonomy}
+\label{sec:edit-taxonomy}
+
+Six semantic change classes: \texttt{cosmetic}, \texttt{reorganization}, \texttt{factual\_correction}, \texttt{tone\_adjustment}, \texttt{substantive\_rewrite}, \texttt{rejection}.
+Classification is two-phase: rule-based boundaries (edit\_distance\_norm $<0.05$ = cosmetic, $\geq 0.80$ = substantive\_rewrite), then Claude Sonnet~4.6 via AWS Bedrock for the ambiguous middle range.
+Coverage: 99.96\%.
+
+
+% ============================================================
+\section{Data Collection Architecture}
+\label{sec:data-collection}
+% ============================================================
+
+\subsection{Workflow-Level Capture}
+\label{sec:workflow-capture}
+
+Three retrospective extractors feed the \texttt{rlhf-signals} module:
+
+\begin{itemize}[nosep]
+  \item \textbf{GitHub PRs} (GraphQL API)---commits, diffs, review comments, merge status.
+  \item \textbf{Plane issues} (REST API)---state transitions, comment threads, domain problem refinement.
+  \item \textbf{Claude Code transcripts} (local JSONL)---richest source, avg.\ 26.8 artifacts/session.
+\end{itemize}
+
+\noindent Schema: \texttt{workflow\_sessions} $\to$ \texttt{workflow\_artifacts} $\to$ \texttt{workflow\_edits} $\to$ \texttt{workflow\_outcomes}.
+
+\paragraph{GitHub PR velocity (core platform):}
+1{,}393 merged PRs over 105 days (87 active).
+Peak: March 790 PRs (25.5/day).
+Median time-to-merge: 30 seconds (77.8\% under 5 min)---solo-practitioner auto-merge pattern.
+PR timestamps do \emph{not} reflect editing time; real duration is reconstructed from OS-level activity.
+
+\subsubsection{One Shipping Operation, Multiple Technical Surfaces}
+\label{sec:technical-surfaces}
+
+These are not separate projects in different business domains.
+They are \textbf{components of one shipping operation}---making Legal.org.ua succeed---spanning different \textbf{technical surfaces}.
+All 1{,}547 PRs serve one outcome: the platform works, has paying customers, and wins institutional validation.
+
+Technical surfaces within the core platform (1{,}393 PRs): frontend (React~19, Vite, TailwindCSS), backend (Express, MCP protocol, 70+ tool handlers), data engineering (court decision harvesting, 380M+ records), database (PostgreSQL migrations, Qdrant vector indexing, Redis caching), DevOps (Docker, nginx, CI/CD, blue-green deployment), content (blog, SSG, SEO), and shared TypeScript packages.
+
+\begin{table}[h]
+\centering
+\caption{Satellite components within the unified shipping operation.}
+\label{tab:satellites}
+\begin{tabular}{@{}lrlp{5.5cm}@{}}
+\toprule
+\textbf{Component} & \textbf{PRs} & \textbf{Period} & \textbf{Role in Legal.org.ua} \\
+\midrule
+SneakyPiper & 73  & Apr 14--30 (17d) & Due diligence on SecondLayer API \\
+aipromo     & 39  & Apr 5--May 3 (29d)  & LinkedIn leads via Bedrock + Unipile \\
+Calendary   & 27  & Apr 13--14 (2d)     & Meeting scheduling for leads \\
+Panoptic    & 10  & Apr 7--16 (10d)     & Threat intel feeding SneakyPiper \\
+XSISTANT    & 5   & Apr 18 (1d)         & Activity tracker for this research \\
+\midrule
+\textbf{Total} & \textbf{1{,}547} & \textbf{105 days} & \textbf{7 repos, 1 practitioner, 0 employees} \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsection{OS-Level Activity Instrumentation}
+\label{sec:os-instrumentation}
+
+Parallel to workflow tracking, an OS-level activity tracker records 5-second activity buckets:
+
+\begin{itemize}[nosep]
+  \item \texttt{activity\_scores}---active/passive/idle classification + keystroke/mouse/click counts.
+  \item \texttt{input\_activity}---keystroke and mouse counts per 5s bucket (never keystroke \emph{content}).
+  \item \texttt{window\_sessions}---focused app + window title + working directory.
+  \item \texttt{idle\_events}---gaps without input, with duration.
+  \item \texttt{mic\_activity}---voice/call context detection.
+\end{itemize}
+
+\noindent Storage: $\sim$38\,MB for 21 continuous days.
+Both databases store \texttt{timestamptz} in UTC---cross-source alignment verified to $<$3 seconds.
+
+\subsection{Cross-Source Linking}
+\label{sec:cross-source}
+
+For each edit with time window $[T_1, T_2]$: query activity in $[T_1 - 30\text{s}, T_2 + 30\text{s}]$, aggregate process features, classify window sessions by category (\texttt{code\_editing} / \texttt{research} / \texttt{communication} / \texttt{documentation} / \texttt{unrelated}).
+
+\subsection{Practitioner Disambiguation Sessions}
+\label{sec:disambiguation}
+
+Automated activity tracking captures \emph{what} app or window was active, but cannot determine \emph{why}.
+A YouTube video about Ukrainian court procedure, a YouTube video about astrophysics, and a YouTube video about cooking all look identical in the activity data---same \texttt{wm\_class}, similar engagement metrics.
+Yet their relationship to the subsequent editing session is fundamentally different.
+
+We address this through \textbf{periodic practitioner disambiguation sessions}---structured interviews where the practitioner reviews ambiguous activity windows from the preceding period and provides ground-truth labels.
+Ambiguous activity categories requiring practitioner input:
+
+\begin{enumerate}[nosep,label=(\alph*)]
+  \item \textbf{On-topic research.} Task-relevant content consumption (\eg a conference talk about vector databases before refactoring the Qdrant pipeline).
+  \item \textbf{Cross-topic inspiration.} Cross-domain intellectual intake that influenced subsequent editing quality.
+  \item \textbf{Conversational reasoning with Claude.} Deliberative reasoning via claude.ai or Claude Code in conversational mode---not producing commits, but shaping architectural decisions.
+  \item \textbf{Genuinely unrelated activity.} Social media, personal messaging, entertainment.
+\end{enumerate}
+
+These labels feed back into the \texttt{workflow\_edit\_engagement} table as a \texttt{disambiguation\_label} field, enabling more accurate window category computation and a novel process feature: \texttt{cross\_topic\_inspiration\_ratio}.
+
+\subsection{Outcome Attribution}
+\label{sec:outcome-attribution}
+
+Automated attribution with confidence levels: \textbf{strong} (temporally proximate, causally linkable---PR merged, no revert in 30d), \textbf{medium} (present but confounded), \textbf{weak} (causally tenuous).
+
+
+% ============================================================
+\section{Verified Pilot Dataset}
+\label{sec:dataset}
+% ============================================================
+
+All numbers verified from production databases as of May~8, 2026.
+
+\subsection{Workflow Data}
+
+\begin{table}[h]
+\centering
+\caption{Pilot dataset summary (\texttt{rlhf-signals} database).}
+\label{tab:dataset-summary}
+\begin{tabular}{@{}lr@{}}
+\toprule
+\textbf{Metric} & \textbf{Value} \\
+\midrule
+Workflow sessions & 2{,}892 (Jan~26--May~8, 2026) \\
+\quad Sources & Claude Code: 1{,}051 \textbullet{} GitHub PRs: 1{,}013 \textbullet{} Plane: 828 \\
+Total artifacts & 33{,}402 (21{,}477 LLM outputs) \\
+Total edit pairs & 30{,}510 \\
+Attributed outcomes & 1{,}579 (54.6\% session coverage) \\
+Outcome confidence & 88.1\% strong, 5.1\% medium, 6.8\% weak \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsection{Edit Distribution (Oversight Signal)}
+
+\begin{table}[h]
+\centering
+\caption{Distribution of edit-trace oversight across semantic change classes.}
+\label{tab:edit-distribution}
+\begin{tabular}{@{}lrr@{}}
+\toprule
+\textbf{Semantic Class} & \textbf{Count} & \textbf{\%} \\
+\midrule
+Substantive rewrite   & 24{,}619 & 80.7 \\
+Reorganization        & 2{,}106  & 6.9  \\
+Cosmetic              & 2{,}098  & 6.9  \\
+Rejection             & 1{,}110  & 3.6  \\
+Factual correction    & 307      & 1.0  \\
+Tone adjustment       & 259      & 0.8  \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Edit distance (normalized): mean$\,{=}\,0.807$, median$\,{=}\,\mathbf{0.839}$, P25$\,{=}\,0.743$, P75$\,{=}\,0.927$, P95$\,{=}\,0.987$.
+The practitioner's default mode is near-total rewrite.
+
+\subsection{Process-Level Data}
+
+\begin{table}[h]
+\centering
+\caption{OS-level activity instrumentation data (XSISTANT database).}
+\label{tab:process-data}
+\begin{tabular}{@{}lrl@{}}
+\toprule
+\textbf{Table} & \textbf{Rows} & \textbf{Coverage} \\
+\midrule
+\texttt{activity\_scores}  & 52{,}451 & Apr~17--May~8 UTC \\
+\texttt{input\_activity}   & 46{,}543 & 176K keystrokes, 52\% in terminal \\
+\texttt{window\_sessions}  & 16{,}901 & App + title + working directory \\
+\texttt{idle\_events}      & 54{,}974 & Avg idle: 51 min \\
+\texttt{mic\_activity}     & 1{,}869  & Apr~16--May~3 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Bimodal work pattern: 07--11 UTC primary peak (1{,}376 active windows), 19--21 UTC secondary peak.
+Approximately 13\% real engagement time (6.7\% active, 6.3\% passive, 87\% idle).
+
+\subsection{Overlap Window}
+
+\begin{table}[h]
+\centering
+\caption{Overlap between XSISTANT instrumentation and \texttt{rlhf-signals} data.}
+\label{tab:overlap}
+\begin{tabular}{@{}lr@{}}
+\toprule
+\textbf{Metric} & \textbf{Value} \\
+\midrule
+Sessions in overlap & 498 (17.2\%) \\
+Edits in overlap    & 9{,}254 (30.3\%) \\
+GitHub PRs in overlap & 75 / 1{,}393 (5.4\%) \\
+Outcomes in overlap & 64 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The main PR burst (Feb--Mar, 1{,}156 PRs at 25.5/day) occurred \textbf{before} XSISTANT launched.
+Process-level enrichment covers steady-state work (4.4 PRs/day), not peak sprint.
+
+
+% ============================================================
+\section{Experiments}
+\label{sec:experiments}
+% ============================================================
+
+Four experiments with progressively higher compute requirements.
+Experiments~1--3 require no GPU.
+
+% ---- Experiment 1 ----
+\subsection{Experiment 1: Oversight vs.\ Annotation---Distributional Difference (RQ1)}
+\label{sec:exp1}
+
+\paragraph{Status:} Phase~A complete.
+
+Sample $N=200$ LLM outputs (stratified by semantic class, min~10 per class), send to crowd annotation platform.
+Compare in-the-loop oversight corrections vs.\ detached crowd annotation: edit distance distributions (KS test), semantic class breakdown, inter-annotator agreement (Krippendorff's $\alpha$).
+The central question is whether corrections applied during live agentic workflows differ \emph{in kind} from labels applied after the fact.
+
+\paragraph{Phase~A results (sampling completed May~8, 2026):}
+19{,}455 eligible samples after PII filtering (from 21{,}461).
+Stratified allocation: substantive=144, cosmetic=15, reorganization=11, rejection=10, factual=10, tone=10.
+Two JSONL exports: full metadata + platform-ready (no oversight edits shown to annotators).
+Deterministic seeded PRNG for reproducibility.
+
+\begin{table}[h]
+\centering
+\caption{Experiment~1 Phase~A stratified sampling allocation.}
+\label{tab:exp1-sampling}
+\begin{tabular}{@{}lrr@{}}
+\toprule
+\textbf{Class} & \textbf{Sampled} & \textbf{Population} \\
+\midrule
+substantive\_rewrite   & 144 & 15{,}762 \\
+cosmetic              & 15  & 1{,}676 \\
+reorganization        & 11  & 1{,}148 \\
+rejection             & 10  & 440 \\
+factual\_correction   & 10  & 217 \\
+tone\_adjustment      & 10  & 212 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\textbf{Expected:} Oversight corrections show heavier tail (80.7\% substantive\_rewrite already---crowd annotators, operating without production context, are unlikely to match this intensity).
+
+% ---- Experiment 2 ----
+\subsection{Experiment 2: Behavioral Context of Oversight Actions (RQ2)}
+\label{sec:exp2}
+
+Two predictive models on the 498-session overlap subset: Model~A (artifact-only) vs.\ Model~B (artifact + behavioral-context features).
+Compare AUC, SHAP feature importance, permutation test.
+With only 64 outcomes in overlap, we use edit-class proxy labels for statistical power.
+
+\paragraph{Cross-source linking.}
+Joined XSISTANT OS-level activity data (52{,}272 activity scores, 16{,}122 window sessions) with workflow edits via artifact timestamps.
+Alignment verified to $<$3s.
+Result: 10{,}846 edits processed; 6{,}753 (62.3\%) with process data.
+
+Process features computed per edit: active/passive/idle seconds, keystroke counts, mouse distance, idle gap analysis, app switching count, research switches, voice context, window dwell entropy, window category seconds.
+
+\paragraph{Model comparison.}
+Target variable: binary---substantive\_rewrite~(1) vs.\ cosmetic~(0).
+$N=6{,}152$ edits (5{,}740 substantive, 412 cosmetic).
+5-fold stratified cross-validation.
+
+\begin{table}[h]
+\centering
+\caption{Experiment~2 model comparison: artifact-only vs.\ artifact + behavioral-context.}
+\label{tab:exp2-results}
+\begin{tabular}{@{}lcc@{}}
+\toprule
+\textbf{Model} & \textbf{Random Forest AUC} & \textbf{Logistic Regression AUC} \\
+\midrule
+A (artifact-only)              & $\mathbf{0.903 \pm 0.005}$ & $0.475 \pm 0.018$ \\
+B (artifact + behavioral)      & $0.874 \pm 0.007$          & $\mathbf{0.540 \pm 0.039}$ \\
+\midrule
+Delta (B $-$ A)                & $-0.029$                   & $+0.065$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\textbf{Permutation test} (1{,}000 iterations, behavioral-context features shuffled): $p < 0.001$---behavioral-context features carry statistically significant, non-random signal.
+
+\textbf{Paired $t$-test} (RF, 5 folds): $p = 0.003$---the delta is statistically significant (in the negative direction for RF).
+
+\paragraph{Interpretation.}
+Behavioral-context signal is \textbf{real and non-random} (permutation $p < 0.001$), but does not improve Random Forest prediction of edit class.
+This is a nuanced result:
+(1)~The proxy target is already well-predicted by artifact features alone (AUC 0.903), leaving little room for improvement.
+The 14:1 class imbalance further limits discriminative contribution.
+(2)~Behavioral-context features help linear models ($+0.065$ AUC), suggesting the signal exists but is captured non-linearly by artifact features in RF.
+(3)~The real test requires real outcomes---only 64 outcomes exist in the overlap window, insufficient for outcome prediction.
+
+Behavioral-context signal exists (permutation proof) but is largely redundant with artifact signal at this scale and target definition.
+This suggests that artifact-level capture of oversight corrections is sufficient for most preference learning, and behavioral context adds value primarily for edge cases or different prediction targets.
+
+% ---- Experiment 3 ----
+\subsection{Experiment 3: Oversight Corrections and Downstream Outcomes (RQ3)}
+\label{sec:exp3}
+
+\subsubsection{Level 1: Full Dataset (Artifact-Only)}
+
+30{,}499 edits joined with 1{,}579 outcomes.
+
+\begin{table}[h]
+\centering
+\caption{Experiment~3 correlations (full dataset).}
+\label{tab:exp3-correlations}
+\begin{tabular}{@{}lr@{}}
+\toprule
+\textbf{Metric} & \textbf{Value} \\
+\midrule
+edit\_distance\_norm $\leftrightarrow$ outcome & $r = -0.116$, $p < 0.001$ \\
+semantic\_class $\leftrightarrow$ outcome      & $r = -0.137$, $p < 0.001$ \\
+KS test (positive vs.\ negative)               & $0.253$, $p < 0.001$ \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\begin{table}[h]
+\centering
+\caption{Positive outcome rates by edit class.}
+\label{tab:outcome-by-class}
+\begin{tabular}{@{}lrr@{}}
+\toprule
+\textbf{Class} & \textbf{Positive Rate} & $N$ \\
+\midrule
+Rejection              & \textbf{78.0\%} & 431 \\
+Cosmetic               & 52.7\%          & 383 \\
+Substantive rewrite    & 48.7\%          & 3{,}692 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\textbf{Key finding:} Rejection (completely halting the agentic trajectory) has the highest positive outcome rate.
+This suggests the most valuable oversight signal is the binary accept/halt decision, not granular edit depth.
+The overseer's willingness to say ``no, start over'' is more predictive of good outcomes than careful correction.
+This has direct implications for scalable oversight: \textbf{the single highest-value data point is whether a human stopped the agent.}
+
+\textbf{Negative correlation of edit distance with outcomes:} smaller corrections correlate with better outcomes ($r = -0.116$).
+When the agent's output is already close to what the overseer needs, the final product tends to succeed.
+Heavy rewrites may indicate the agent was on the wrong trajectory.
+
+\subsubsection{Level 2: Overlap Subset (Artifact + Behavioral Context)}
+
+807 edits with both behavioral-context data and outcomes (720 with binary positive/negative label).
+Engagement quartile analysis shows Q4 (highest engagement) has visible positive outcome enrichment compared to Q1--Q3, but the effect is modest.
+The small sample size limits statistical power for definitive engagement--outcome claims.
+
+\subsubsection{Confound Controls}
+
+Hour of day, day of week, and session source all affect outcome rates independently of edit patterns.
+The bimodal work schedule (07--11 UTC peak, 19--21 UTC secondary) introduces temporal confounds that must be controlled in any outcome prediction model.
+
+% ---- Experiment 4 ----
+\subsection{Experiment 4: Training on Oversight-Trace vs.\ Annotation Preferences (RQ4)}
+\label{sec:exp4}
+
+\emph{Redesigned based on Experiments~1--3 findings (see Section~\ref{sec:synthesis}).}
+
+The flagship experiment requiring GPU compute.
+Simplified from 5 to 4 core conditions after Experiments~2--3 showed behavioral-context weighting is unlikely to improve over uniform weighting.
+
+Four training conditions on Llama~3.1 8B or Qwen~2.5 7B (open-weight):
+
+\begin{table}[h]
+\centering
+\caption{Experiment~4 training conditions (revised design).}
+\label{tab:exp4-conditions}
+\begin{tabular}{@{}clp{8cm}@{}}
+\toprule
+\textbf{Cond.} & \textbf{Description} & \textbf{Rationale} \\
+\midrule
+A & Oversight-trace, uniform (24{,}495 pairs) & Practitioner edits---the distinctive distribution of corrections from production agentic workflows \\
+C & RLAIF self-correction (24{,}495 matched pairs) & AI self-correction baseline---tests whether human oversight captures signal that AI self-evaluation misses \\
+E & Public RLHF baseline (UltraFeedback, 24{,}495 sampled pairs) & General-purpose RLHF baseline---tests domain-specific value of edit-trace signal \\
+D & Untrained instruct model & No-preference baseline \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Method: DPO~\citep{rafailov2023direct}.
+Evaluation: win-rate (GPT-4 judge + human $N=100$), domain accuracy, AlpacaEval~2.0, length-controlled win rate.
+
+\textbf{Primary metrics---three comparisons:} A vs.\ D (edit-trace improves stock model), A vs.\ C (human oversight vs.\ AI self-correction), A vs.\ E (domain-specific vs.\ general RLHF).
+
+Estimated cost: \$310--380 (see Appendix~\ref{sec:compute-budget}).
+
+
+% ============================================================
+\section{Cross-Experiment Synthesis}
+\label{sec:synthesis}
+% ============================================================
+
+\subsection{The Three Findings}
+
+\paragraph{Finding 1 (Exp~1): Oversight corrections are qualitatively different from annotation.}
+80.7\% of all edits are substantive rewrites.
+Median normalized edit distance is 0.84---the overseer's default mode is near-total rewrite of LLM output.
+This distribution will almost certainly differ from crowd annotators, who---operating without production context or domain stakes---tend toward safe, cosmetic edits.
+
+\paragraph{Finding 2 (Exp~2): Behavioral context is methodologically important but computationally redundant.}
+Permutation testing confirms behavioral-context features carry statistically significant signal ($p < 0.001$).
+However, they do not improve Random Forest prediction of edit class beyond what token counts alone achieve (AUC $0.903 \to 0.874$, actually worse).
+Behavioral-context features help linear models ($+0.065$ AUC) but are captured non-linearly by artifact features in tree-based models.
+The behavioral-context axis is a contribution to methodology, not to prediction performance.
+
+\paragraph{Finding 3 (Exp~3): The most valuable oversight action is halt/reject.}
+Completely rejecting LLM output---halting the agentic trajectory---correlates with 78\% positive outcomes, far higher than substantive rewrites (48.7\%) or cosmetic edits (52.7\%).
+Edit distance negatively correlates with outcomes ($r = -0.116$): the less the overseer changes, the better the result.
+\textbf{The most informative oversight signal is binary (accept vs.\ halt), not continuous (edit distance).}
+
+\subsection{Implications for DPO Training}
+
+The original Experiment~4 design had 5 training conditions, with the primary hypothesis being that behavioral-context-weighted preferences (Condition~B) would outperform uniform-weighted (Condition~A).
+The data now challenges this:
+
+\textbf{Behavioral-context weighting is unlikely to help.}
+Experiment~2 showed behavioral-context features do not improve prediction.
+Experiment~3 showed engagement quartiles barely differentiate outcomes.
+The $\alpha$-weighted DPO formula ($\text{weight} = 1 + \alpha \cdot \text{engagement\_score}$) would scale pairs by a signal that is statistically real but practically redundant with artifact features.
+
+\textbf{The real value is in the distribution, not the weighting.}
+The overseer's 80.7\% substantive rewrite rate and 3.6\% rejection rate create a fundamentally different preference distribution than either AI self-correction or general-purpose RLHF data.
+Training on this distribution (even with uniform weights) should produce different model behavior than training on RLAIF or public preference data.
+Replacing crowd annotation with RLAIF (Condition~C) and public RLHF data (Condition~E) enables matched-volume comparison (24{,}495 pairs per condition) and eliminates the annotation bottleneck.
+
+\subsection{Summary}
+
+The synthesis of Experiments~1--3 yields a clear primary contribution: oversight-trace---the edit signal captured during production agentic workflows under a domain constitution---constitutes a fundamentally different preference distribution than detached annotation.
+The distributional difference (80.7\% substantive rewrites, 78\% halt-positive rate) is substantial.
+Whether this distributional difference translates into improved domain-specific model performance is the subject of Experiment~4.
+
+The behavioral-context null result is itself a contribution: it shows that capturing \emph{what} was corrected is more informative than \emph{how} the correction was performed, simplifying the instrumentation requirements for future deployments of this methodology.
+
+
+
+% ============================================================
+\section{Threats to Validity}
+\label{sec:threats}
+% ============================================================
+
+The central methodological challenge of this work is that the study subject, the sole annotator, and the author are the same person.
+We explicitly enumerate the resulting threats and the mitigations available within a single-practitioner protocol.
+
+\subsection{Construct Validity: Oversight Signal vs.\ Practitioner Skill}
+
+The domain constitution (Section~\ref{sec:five-conditions}) claims to define conditions under which edit-traces constitute valid \emph{oversight} signal.
+However, the observed edit distribution (80.7\% substantive rewrites, median edit distance 0.84) could alternatively reflect practitioner-specific editing style rather than a general property of in-the-loop oversight.
+That is: a different practitioner meeting all five constitutional conditions might produce a fundamentally different edit distribution.
+
+\textbf{Mitigation:}
+The multi-practitioner cohort (Section~\ref{sec:future-work}) is designed specifically to disentangle practitioner-specific style from constitution-induced oversight properties.
+Within the current single-subject study, we note that the edit distribution is consistent across 7 technically diverse repositories and multiple technical surfaces (frontend, backend, data engineering, DevOps, content), suggesting the pattern reflects the workflow regime rather than a single domain skill.
+However, this remains a conjecture until replicated with additional subjects.
+
+\subsection{Internal Validity: Outcome Metrics}
+
+The outcomes cited (Google for Startups acceptance, NVIDIA Inception, paying customers) validate the \emph{product}, not the \emph{methodology}.
+They demonstrate that the recursive workflow produces shippable software, but do not directly establish that the extracted edit-traces are superior training signal compared to crowd annotation.
+This distinction is critical: positive product outcomes are a necessary condition for the edit-traces to carry meaningful signal (per Condition~C5), but are not sufficient evidence that training on those traces improves downstream model performance.
+
+\textbf{Mitigation:}
+Experiment~4 (Section~\ref{sec:exp4}) is designed to test the methodological claim directly: does DPO training on edit-trace preferences (Condition~A) outperform training on crowd-sourced preferences of matched volume (Condition~C) on domain-specific evaluation?
+Until Experiment~4 completes, the product outcomes serve only as evidence that Condition~C5 (consequential grounding) is satisfied, not as evidence of the edit-trace's superiority as training signal.
+
+\subsection{Selection Bias: Survivorship in the Dataset}
+
+The dataset contains only edit-traces from trajectories that culminated in merged PRs and working features.
+Agent outputs that the practitioner accepted without correction but that later caused production failures are absent---there is no record of oversight that \emph{should have} occurred but did not.
+Similarly, abandoned trajectories (work started but not completed) are systematically excluded by the retrospective extraction pipeline, which keys on merged PRs and resolved issues.
+
+\textbf{Mitigation:}
+The survivorship bias is partially addressed by Experiment~3's finding that rejection (halting the agent) correlates with 78\% positive outcomes.
+This demonstrates that the dataset does capture instances where the practitioner stopped an unproductive trajectory---a form of negative signal.
+However, the absence of false-negative oversight (accepted outputs that later failed) remains a structural limitation.
+Future work on failed oversight trajectories (Section~\ref{sec:future-work}) is designed to address this gap directly.
+
+\subsection{External Validity: Generalizability Beyond $N=1$}
+
+This study establishes a protocol and demonstrates its feasibility with one practitioner in one domain (legal AI).
+No population-level claims are made or implied.
+The domain constitution is domain-specific by design (Section~\ref{sec:five-conditions}), and we expect different practitioners to require different constitutional instantiations.
+Cross-domain generalizability is an explicit non-goal of the current work; the contribution is the methodology for capturing and validating edit-trace oversight, not its universal applicability.
+
+\subsection{Confound: Temporal Autocorrelation}
+
+Edit-traces within the same session are temporally autocorrelated: corrections early in a session shape the context for later corrections.
+Treating individual edit pairs as independent samples (as in Experiments~1--3) may overstate statistical significance.
+We report this as a known confound; future work should explore session-level modeling or hierarchical approaches that respect the nested structure (edits within sessions within projects).
+
+
+% ============================================================
+\section{Limitations}
+\label{sec:limitations}
+% ============================================================
+
+\begin{enumerate}[label=(\roman*),leftmargin=2.5em]
+
+\item \textbf{Single-practitioner protocol demonstration.}
+One practitioner's oversight trace, not population-level claims.
+Proving that edit-trace constitutes valid oversight requires a deep instrumentation case study before cohort scaling; this work establishes the methodology and qualifying criteria, not their generalizability across overseers.
+A multi-practitioner cohort is explicit future work.
+
+\item \textbf{Domain-specific constitution by design.}
+The five qualifying conditions form a domain constitution that is inherently domain-specific.
+Legal AI oversight patterns (cross-referencing legislation, verifying citation chains) may not transfer to coding, creative, or scientific domains.
+This is a structural feature of constitution-based oversight, not an incidental limitation.
+
+\item \textbf{Oversight captured only from successful trajectories.}
+The dataset contains corrections applied by an overseer whose product shipped successfully.
+Failed oversight---agent outputs that passed without correction and later caused failures---is systematically absent.
+
+\item \textbf{Behavioral context coverage:} only 17.2\% of sessions / 30.3\% of edits have process-level behavioral enrichment (XSISTANT launched after peak sprint).
+The highest-velocity period (Feb--Mar, 1{,}156 PRs at 25.5/day) has artifact-level data only.
+
+\item \textbf{edit\_seconds $= 0$ for all retro-extracted edits.}
+Timing reconstructed from 5-second OS activity buckets.
+Oversight action duration is bounded by bucket granularity, which may obscure rapid correction sequences.
+
+\item \textbf{Structural conflict of interest:} the study subject is the overseer.
+In scalable oversight methodology this is structural---the overseer's corrections are the data, and the overseer's identity cannot be separated from the oversight signal.
+Mitigated by: external baselines, open data release, and multi-practitioner cohort design.
+
+\item \textbf{Keystroke content boundary:} we capture keystroke counts and timing, never content.
+This trades fine-grained edit-trace information for PII protection and multi-practitioner scalability---a deliberate design constraint.
+
+\end{enumerate}
+
+
+% ============================================================
+\section{Future Work}
+\label{sec:future-work}
+% ============================================================
+
+\begin{itemize}[leftmargin=1.5em]
+
+\item \textbf{Multi-practitioner cohort with diverse domain constitutions} (5--10 shipping practitioners across legal AI, healthcare AI, fintech, dev tools, creative tools)---each practitioner brings their own domain constitution, enabling cross-constitution comparison and meta-constitutional analysis.
+
+\item \textbf{Failed oversight trajectories:} studying cases where oversight was absent or insufficient---practitioners who shipped without correcting agent outputs that later caused production failures.
+This complements the current dataset's successful-oversight bias.
+
+\item \textbf{Richer behavioral context:} eye-tracking integration captures reading-while-evaluating, the cognitive phase preceding oversight corrections, still without content capture.
+
+\item \textbf{Oversight-aware reward modeling:} an explicit reward model trained to distinguish oversight corrections from routine annotation.
+
+\item \textbf{Edit-trace capture for non-code workflows:} extending instrumentation to document drafting, legal brief composition, research analysis, and multi-turn conversational oversight.
+
+\item \textbf{Constitutional alignment between domain and model constitutions:} studying how domain-specific oversight constitutions interact with the model's own constitutional training~\citep{bai2022constitutional} and with ontology-driven dialogue architectures~\citep{palagin2023dialogue} that use formal knowledge structures to govern human--AI interaction at the system level.
+
+\item \textbf{Automated oversight difficulty estimation:} using the edit-trace to identify which agentic steps are hardest to oversee (highest edit distance, most rejections, longest deliberation time).
+This produces a per-step oversight difficulty map that informs where human oversight should be concentrated.
+
+\end{itemize}
+
+
+% ============================================================
+\section{Discussion}
+\label{sec:discussion}
+% ============================================================
+
+\subsection{Composition as an Alternative Frame for Scalable Oversight}
+
+The empirical pattern documented here---one practitioner achieving output that neither human nor agent would reach independently---suggests a framing for scalable oversight that differs from the standard capability-gap model.
+In the standard model, oversight is a problem that grows harder as agents grow more capable~\citep{bowman2022measuring, burns2023weak}.
+In the regime observed here, the agent's capability is not a threat to be managed but a throughput multiplier whose output the practitioner corrects at each step.
+
+We note---speculatively---that this may represent a distinct equilibrium: rather than moving toward full autonomy as agents improve, the practitioner-agent composition may deepen, with the human's corrections becoming more targeted and architecturally informed as the agent handles more routine execution.
+Whether this equilibrium is stable under further capability scaling is an open empirical question that this single-subject study cannot resolve.
+
+\subsection{The Edit-Trace as Minimal Viable Oversight Signal}
+
+Experiment~3's finding---that binary rejection (78\% positive outcome rate) is more informative than continuous edit distance---has practical implications.
+If the highest-value oversight signal is whether a human stopped the agent, then scalable oversight instrumentation may be simpler than expected: a binary accept/reject log per trajectory step, with outcome tracking, may capture the majority of useful preference signal.
+This hypothesis is testable in Experiment~4 by comparing DPO training on full edit-traces vs.\ binary accept/reject pairs.
+
+\subsection{Scope of Claims}
+
+This paper makes a methodological contribution (how to capture and validate edit-trace oversight) and reports empirical findings from a single case study (Experiments~1--3).
+It does \emph{not} claim that edit-trace oversight is universally superior to RLAIF self-correction or general-purpose RLHF data---that claim requires Experiment~4's completion (where Condition~C tests against AI self-correction rather than crowd annotation) and replication across multiple practitioners.
+The observed distributional difference between edit-trace corrections and expected crowd annotation patterns is a descriptive finding; its downstream utility for RLHF training remains to be demonstrated.
+
+
+% ============================================================
+\section{Conclusion}
+\label{sec:conclusion}
+% ============================================================
+
+We present edit-trace oversight as a methodology for capturing alignment signal natively from production agentic workflows.
+The key empirical findings from a single-practitioner case study are:
+(1)~the edit distribution under production accountability is extreme (80.7\% substantive rewrites, median edit distance 0.84), and is expected to differ significantly from crowd annotation (Experiment~1, Phase~B pending);
+(2)~behavioral-context features (keystroke timing, idle gaps, app switching) carry statistically significant signal ($p < 0.001$) but are largely redundant with artifact-level features for predictive tasks (Experiment~2);
+(3)~binary rejection of agent output is the single most informative oversight action, correlating with 78\% positive downstream outcomes (Experiment~3).
+
+The proposed domain constitution---five formal conditions under which edit-traces constitute valid oversight---provides a framework for extending this methodology to multi-practitioner cohorts.
+Whether the observed distributional difference between edit-trace oversight and crowd annotation translates into improved model performance via DPO training (Experiment~4) remains an open empirical question.
+
+The dataset (30{,}510 edit pairs, 2{,}892 sessions, 1{,}579 attributed outcomes) and instrumentation code will be released publicly upon completion of Experiment~4 and PII review.
+
+\appendix
+
+% ============================================================
+\section{Compute Budget and Project Status}
+\label{sec:compute-budget}
+% ============================================================
+
+Experiment~4 requires GPU compute for DPO training.
+Estimated budget:
+
+\begin{table}[h]
+\centering
+\caption{Estimated compute budget for remaining experiments.}
+\label{tab:compute-budget}
+\begin{tabular}{@{}lr@{}}
+\toprule
+\textbf{Component} & \textbf{Cost} \\
+\midrule
+DPO training (4 conditions $\times$ 7--8B model) & \$140--200 \\
+RLAIF generation (Bedrock) & \$70--80 \\
+Evaluation (judge runs, MT-Bench) & \$100 \\
+\midrule
+\textbf{Total} & \textbf{\$310--380} \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\noindent As of May 2026: Experiments~1--3 complete. Experiment~4 (DPO training with 4 conditions) is pending compute allocation.
+
+
+% ============================================================
+%  References
+% ============================================================
+\bibliographystyle{plainnat}
+\bibliography{references}
+
+\end{document}

--- a/lexwebapp/public/papers/ontology-oversight-bridge-2026.tex
+++ b/lexwebapp/public/papers/ontology-oversight-bridge-2026.tex
@@ -1,0 +1,1233 @@
+\documentclass[11pt]{article}
+
+% ============================================================
+%  Packages
+% ============================================================
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+\usepackage[margin=1in]{geometry}
+
+% Math
+\usepackage{amsmath,amssymb,amsfonts,amsthm}
+
+% Tables
+\usepackage{booktabs}
+\usepackage{array}
+\usepackage{tabularx}
+
+% Figures
+\usepackage{graphicx}
+\usepackage{float}
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta,positioning,shapes.geometric,fit}
+
+% Colors
+\usepackage[dvipsnames]{xcolor}
+
+% Bibliography
+\usepackage[numbers,sort&compress]{natbib}
+
+% Hyperlinks
+\usepackage[colorlinks=true,linkcolor=MidnightBlue,citecolor=OliveGreen,urlcolor=BrickRed]{hyperref}
+
+% Misc
+\usepackage{enumitem}
+\usepackage{microtype}
+\usepackage{url}
+\usepackage{xspace}
+
+% ============================================================
+%  Theorem environments
+% ============================================================
+\newtheorem{definition}{Definition}[section]
+\newtheorem{axiom}{Axiom}[section]
+\newtheorem{proposition}{Proposition}[section]
+\newtheorem{theorem}{Theorem}[section]
+\newtheorem{corollary}{Corollary}[section]
+\newtheorem{example}{Example}[section]
+
+% ============================================================
+%  Macros
+% ============================================================
+\newcommand{\DL}{\ensuremath{\mathcal{SHOIQ}}\xspace}
+\newcommand{\TBox}{\ensuremath{\mathcal{T}}\xspace}
+\newcommand{\ABox}{\ensuremath{\mathcal{A}}\xspace}
+\newcommand{\KB}{\ensuremath{\mathcal{K}}\xspace}
+\newcommand{\sqsub}{\sqsubseteq}
+\DeclareMathOperator*{\bigsqcap}{\sqcap}
+\newcommand{\DC}{\textsc{DomainConstitution}\xspace}
+\newcommand{\VO}{\textsc{ValidOversight}\xspace}
+
+% ============================================================
+%  Title
+% ============================================================
+\title{%
+  From Ontology-Controlled Systems \\
+  to Oversight-Controlled Training: \\
+  Formal Foundations for Human--LLM \\
+  Alignment Signal Validation%
+}
+
+\author{
+  Vladimir Ovcharov\thanks{Correspondence: \texttt{volodymyr@legal.org.ua}} \quad
+  Oleksandr V.~Palagin\thanks{V.M.~Glushkov Institute of Cybernetics, NAS of Ukraine}\\[4pt]
+  LEX AI LLC, Kyiv, Ukraine \quad\textbullet\quad
+  Institute of Cybernetics, NAS of Ukraine, Kyiv\\
+}
+
+\date{2026}
+
+\begin{document}
+\maketitle
+
+% ============================================================
+%  Abstract
+% ============================================================
+\begin{abstract}
+Current methods for collecting human preference data for reinforcement learning from human feedback (RLHF) lack formal criteria for determining when human corrections on LLM output constitute valid training signal versus noise.
+We extend the principle of ontology-controlled systems~\citep{palagin2006architecture}---where formal ontological structure governs system runtime behavior---from the level of system output to the level of human oversight over system output.
+We formalize a \emph{domain constitution}: five axiomatically defined conditions under which human edit-traces on agentic LLM output constitute valid alignment signal.
+The formalization uses \DL description logic, implemented as an OWL~2~DL ontology with automated reasoning for workflow classification.
+We compare this oversight-level control with output-level ontological control as realized in OntoChatGPT~\citep{palagin2023ontochatgpt}, showing that the two operate on complementary levels of the same conceptual stack.
+Empirical validation on 30{,}510 edit-traces from a production legal AI platform demonstrates that ontology-based filtering of oversight signal correlates with downstream outcome quality.
+The work establishes a formal bridge between ontology-controlled architectures and LLM alignment methodology.
+\end{abstract}
+
+\noindent\textbf{Keywords:} ontology-controlled systems, domain constitution, description logic, RLHF, alignment, edit-trace oversight, OWL, human oversight, LLM
+
+% ============================================================
+\section{Introduction}
+\label{sec:intro}
+% ============================================================
+
+% --------------------------------------------------------
+\subsection{The Problem: Preference Signal Without Formal Validity Criteria}
+\label{sec:problem}
+% --------------------------------------------------------
+
+Reinforcement learning from human feedback (RLHF) has become the dominant paradigm for aligning large language models with human intent~\citep{christiano2017deep, ouyang2022training}.
+The paradigm rests on a simple premise: human judgments about model outputs---expressed as preference labels, rankings, or corrections---provide a training signal that steers the model toward desirable behavior.
+Direct Preference Optimization (DPO)~\citep{rafailov2023direct} simplified the training pipeline by eliminating the intermediate reward model, but the upstream question remains unchanged: \emph{which human judgments constitute valid training signal?}
+
+Current practice treats this question as unproblematic.
+Crowd workers on Amazon Mechanical Turk rate pairs of model outputs~\citep{ouyang2022training}.
+Expert annotators evaluate in controlled settings~\citep{bai2022constitutional}.
+AI models generate synthetic preferences via self-evaluation (RLAIF)~\citep{lee2023rlaif}.
+In each case, the implicit assumption is that any preference label, from any context, is equally valid as training data.
+There are no formal criteria---no axioms, no decidable conditions, no automated verification---for distinguishing valid preference signal from noise.
+
+This absence of formal validity criteria would be unremarkable if the signal sources were homogeneous.
+But they are not.
+A crowd worker rating two completions in a web interface and a domain expert correcting an LLM agent's output within a production workflow occupy fundamentally different epistemic positions.
+The crowd worker operates without persistent state, without compositional context, without production consequences.
+The domain expert operates with all three.
+Treating their annotations as interchangeable discards information about signal quality that is, in principle, formalizable.
+
+% --------------------------------------------------------
+\subsection{An Empirical Observation}
+\label{sec:observation}
+% --------------------------------------------------------
+
+\citet{ovcharov2026edittrace} documented an empirical case that sharpens this problem.
+A single practitioner shipped 1{,}547 merged pull requests across 7 production repositories in 105 days using an LLM agent (Claude Code) as the primary engineering counterpart---building a legal AI platform (Legal.org.ua) with 70+ MCP tools, 380M+ records in the data pipeline, and paying customers.
+Validated outcomes included acceptance by Google for Startups, NVIDIA Inception, and AWS Activate.
+
+Every human correction on the agent's output was captured as an edit-trace: the agent's proposed output, the human's corrected version, and the downstream outcome of the corrected artifact.
+The resulting dataset---30{,}510 edit pairs across 2{,}892 sessions, with 1{,}579 attributed outcomes---exhibited a qualitatively different distribution from what detached annotation would produce: 80.7\% of all corrections were substantive rewrites (median normalized edit distance: 0.84), and binary rejection of agent output correlated with 78\% positive downstream outcomes.
+
+The paper proposed five informal conditions---termed a ``domain constitution''---under which these edit-traces constitute valid oversight signal rather than noise.
+The conditions were stated in structured English, motivated by empirical observation, and validated statistically.
+But they were not \emph{formalized}: they lacked the precision of description logic axioms, the decidability of automated reasoning, and the implementability of an OWL ontology.
+
+% --------------------------------------------------------
+\subsection{The Ontological Control Principle}
+\label{sec:principle}
+% --------------------------------------------------------
+
+The formalization gap identified above has a natural solution in a research tradition developed over the past two decades at the V.M.~Glushkov Institute of Cybernetics, NAS of Ukraine.
+
+\citet{palagin2006architecture} introduced the principle of \emph{ontology-controlled systems}: formal ontological structure should not merely describe a system but actively \emph{control} its behavior.
+This principle has been applied at progressively higher levels of the computational stack---from system architecture~\citep{palagin2006architecture} to NL text processing~\citep{palagin2012knowledge, palagin2020distributional} to LLM output generation~\citep{palagin2023ontochatgpt, palagin2024neural} to evolutionary system dynamics~\citep{palagin2025evolutionary}---with consistent results: formal structure, when used as a control mechanism rather than passive metadata, improves both the quality and verifiability of system behavior.
+
+The present work extends this principle to one additional level.
+If formal ontological structure can control what an LLM produces (as demonstrated by OntoChatGPT), can it also control which human corrections on LLM output are valid training signal?
+
+We argue that it can, and we formalize this argument.
+
+% --------------------------------------------------------
+\subsection{Contributions}
+\label{sec:contributions}
+% --------------------------------------------------------
+
+This paper makes four contributions:
+
+\begin{enumerate}[label=(\arabic*),leftmargin=2em]
+
+\item \textbf{Formalization of the domain constitution in \DL description logic} (Section~\ref{sec:formal}).
+The five informal conditions from~\citet{ovcharov2026edittrace} are expressed as general concept inclusions (GCIs) in \DL, with a defined concept $\mathsf{ValidOversight}$ that is the conjunction of all five.
+We prove three formal properties: decidability of instance classification, independence of the five conditions, and monotonicity of the oversight grade under assertion growth.
+
+\item \textbf{Formal comparison of output-level and oversight-level ontological control} (Section~\ref{sec:comparison}).
+We analyze the relationship between OntoChatGPT~\citep{palagin2023ontochatgpt} and the domain constitution via subsumption queries, proving that neither concept subsumes the other.
+We define an integrated concept ($\mathsf{IntegratedControl}$) that combines both levels and prove its satisfiability constructively.
+
+\item \textbf{OWL~2~DL ontology for automated oversight classification} (Section~\ref{sec:owl}).
+The TBox is implemented as an OWL ontology with automated reasoning via HermiT~\citep{shearer2008hermit}.
+Workflow instances from the LEX~AI case study are instantiated as ABox individuals and automatically classified as full, partial, or invalid oversight.
+
+\item \textbf{Empirical validation of ontology-based signal filtering} (Section~\ref{sec:empirical}).
+We demonstrate that edit-traces from workflows classified as $\mathsf{ValidOversight}$ correlate with better downstream outcomes than unfiltered traces, providing empirical support for the claim that formal filtering of preference data improves training signal quality.
+
+\end{enumerate}
+
+% --------------------------------------------------------
+\subsection{Structure of the Paper}
+\label{sec:structure}
+% --------------------------------------------------------
+
+Section~\ref{sec:evolution} traces the evolution of the ontological control principle across five levels, from system architecture (2006) to human oversight validation (this paper).
+Section~\ref{sec:formal} presents the formal model: signature, TBox axiomatization, defined concepts, negative classification, graded oversight, reasoning tasks, and formal properties.
+Section~\ref{sec:comparison} compares OntoChatGPT and the domain constitution: shared principle, structural differences, subsumption analysis, and integration architecture.
+Section~\ref{sec:owl} describes the OWL~2~DL implementation and automated verification on the LEX~AI case study.
+Section~\ref{sec:empirical} provides empirical validation.
+Section~\ref{sec:discussion} discusses implications for RLHF methodology and the role of evolutionary cybernetics in analyzing oversight dynamics.
+Section~\ref{sec:conclusion} concludes.
+
+
+% ============================================================
+\section{Evolution of Ontological Control}
+\label{sec:evolution}
+% ============================================================
+
+The principle that formal ontological structure should \emph{control} system behavior---not merely describe or annotate it---has evolved through four successive levels of abstraction over the past two decades.
+Each level retains the core invariant (a formal structure governs a computational process) while shifting the \emph{object of control} from hardware architecture to natural language processing to LLM output generation.
+This paper proposes a fifth level: ontological control over the process by which human oversight of LLM output is validated as training signal.
+
+Table~\ref{tab:evolution} summarizes the progression.
+
+\begin{table}[h]
+\centering
+\caption{Evolution of ontological control: what the formal structure governs at each level.}
+\label{tab:evolution}
+\begin{tabular}{@{}clll@{}}
+\toprule
+\textbf{Level} & \textbf{Period} & \textbf{Object of control} & \textbf{Key reference} \\
+\midrule
+I   & 2003--2006 & System architecture        & \citet{palagin2006architecture} \\
+II  & 2012--2020 & NL text processing pipeline & \citet{palagin2012knowledge,palagin2020distributional} \\
+III & 2023--2024 & LLM output generation       & \citet{palagin2023ontochatgpt,palagin2024neural} \\
+IV  & 2025       & Evolutionary system dynamics & \citet{palagin2025evolutionary} \\
+V   & 2026       & Human oversight validation   & This paper \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+% --------------------------------------------------------
+\subsection{Level I: Ontological Control of System Architecture (2003--2006)}
+\label{sec:level1}
+% --------------------------------------------------------
+
+\citet{palagin2006architecture} introduced the foundational distinction: an ontology in a computer system can serve as passive metadata (a catalog of concepts and relations) or as an active \emph{control mechanism} that governs the system's runtime behavior.
+The paper argued for the latter interpretation: the ontology defines not only what the system knows but what it \emph{does}---which modules are instantiated, how data flows between them, what processing strategies are selected.
+
+This was a departure from the contemporaneous use of ontologies in the Semantic Web community, where OWL ontologies primarily served as interoperability schemas~\citep{grau2008owl2}.
+In Palagin's formulation, the ontology occupies the role that a control program occupies in classical von Neumann architecture: it is the structure that determines execution.
+
+The key insight for the present work is the \emph{generality} of this principle.
+If formal structure can control system architecture, the question arises: what \emph{else} can it control?
+The subsequent two decades provide an empirical answer: progressively higher levels of the computational stack.
+
+% --------------------------------------------------------
+\subsection{Level II: Ontological Control of NL Text Processing (2012--2020)}
+\label{sec:level2}
+% --------------------------------------------------------
+
+The second level applies ontological control to natural language processing pipelines.
+\citet{palagin2012knowledge} developed methods for ontology-driven extraction of knowledge from natural language texts, where the domain ontology governs which entities are recognized, what relations are extracted, and how extracted knowledge is represented in formal-logical form.
+The ontology does not merely label the output of an NLP pipeline---it \emph{controls} which pipeline stages execute and what constitutes a valid extraction result.
+
+\citet{palagin2020distributional} extended this principle to distributional semantics.
+The Semantic Pre-processing Technology (SPT) pipeline uses ontological structure as an \emph{anchor} for learning distributed term representations.
+Where standard word embedding methods (Word2Vec, GloVe) learn representations from co-occurrence statistics alone, SPT uses the domain ontology to:
+(a)~define term boundaries (transitioning from word-level to term-level embeddings),
+(b)~constrain the embedding space so that ontologically related terms cluster appropriately, and
+(c)~provide terminological supervision that reduces the data requirements for domain-specific embedding training.
+
+The relevance to the present work is twofold.
+First, the SPT pipeline demonstrates that domain-specific formal structure improves representation learning---a principle we argue extends to preference learning (Section~\ref{sec:empirical}).
+Second, the ontology-anchored embedding approach is directly applicable to the legal AI domain where our edit-traces originate: 100.5 million Ukrainian court decisions constitute a corpus where morphological complexity (Ukrainian is a highly inflectional language with seven cases and three genders) makes ontological anchoring especially valuable.
+
+% --------------------------------------------------------
+\subsection{Level III: Ontological Control of LLM Output (2023--2024)}
+\label{sec:level3}
+% --------------------------------------------------------
+
+The emergence of large language models created a new control surface: the model's generation process.
+\citet{palagin2023ontochatgpt} developed OntoChatGPT, a system where a formal OWL ontology generates structured prompts that control ChatGPT's output.
+The mechanism is a two-stage pipeline:
+
+\begin{enumerate}[nosep]
+  \item A \emph{meta-ontology} encodes domain knowledge (concepts, relations, constraints, expected output structures) in OWL format.
+  \item At inference time, the meta-ontology is traversed to generate \emph{structured prompts} that instruct the LLM to produce output conforming to the ontological structure.
+\end{enumerate}
+
+This is ontological control in the strict sense: the OWL ontology does not describe what the LLM might produce---it \emph{governs} what it does produce.
+The system was demonstrated in the medical rehabilitation domain (Ukrainian language), where ontology-driven prompts produced contextually relevant and structurally consistent responses~\citep{palagin2023ontochatgpt}.
+
+\citet{palagin2024neural} generalized this into a methodological framework: the ``integrated use of neural network and ontolinguistic paradigms.''
+The key argument is that neither the neural paradigm (statistical learning from data) nor the ontolinguistic paradigm (formal knowledge representation) is sufficient alone for complex NLP tasks.
+The neural paradigm learns patterns but lacks formal structure; the ontolinguistic paradigm provides structure but lacks the ability to generalize from data.
+Integration---using ontological structure to guide neural learning---produces results superior to either paradigm in isolation.
+
+In parallel, \citet{palagin2023dialogue} applied ontological control to dialogue systems: an OWL ontology is automatically constructed from unstructured text, converted to a Neo4j graph database, and then used to govern dialogue responses via formal Cypher queries.
+The dialogue system does not generate free-form responses; it produces responses that are \emph{derivable} from the ontological graph.
+
+These Level~III systems share a critical property: the ontology controls \textbf{what the model produces at inference time}.
+The formal structure operates on the \emph{output} of the system.
+This is effective for improving the quality and consistency of individual LLM outputs, but it does not address a different question: how to improve the \emph{training signal} that shapes the model's future behavior.
+
+% --------------------------------------------------------
+\subsection{Level IV: Ontological Control of Evolutionary Dynamics (2025)}
+\label{sec:level4}
+% --------------------------------------------------------
+
+The most recent extension~\citep{palagin2025evolutionary} moves ontological control from static system architectures to \emph{evolving} systems where goals, constraints, and structures themselves change over time.
+Evolutionary cybernetics, as formalized in this work, addresses systems where the classical control-theoretic assumption of a fixed objective function does not hold.
+Instead, the system's objectives, the constraints it operates under, and its structural organization co-evolve with its environment.
+
+This level is directly relevant to the human--LLM oversight regime documented in~\citet{ovcharov2026edittrace}.
+The practitioner-agent composition observed there---where neither the human nor the agent achieves the observed output independently---is not a static equilibrium.
+As the agent's capabilities improve through training (including training on the very edit-traces the practitioner generates), the nature of oversight changes: corrections may become more targeted and architecturally informed, the information asymmetry (Condition~C4) may shift, and the domain constitution itself may require revision.
+
+\citet{palagin2025evolutionary} provides the theoretical vocabulary for analyzing this dynamic: the domain constitution is not a fixed control program but an \emph{evolutionary constraint} that co-evolves with the system it governs.
+Whether the practitioner-agent equilibrium is stable under further capability scaling~\citep{burns2023weak} is an instance of the broader question evolutionary cybernetics poses: under what conditions do co-evolving control structures maintain their functional role?
+
+% --------------------------------------------------------
+\subsection{Level V: Ontological Control of Human Oversight (This Paper)}
+\label{sec:level5}
+% --------------------------------------------------------
+
+We propose that the same principle---formal structure controls behavior---applies to one additional level: the process by which human oversight of LLM output is validated as training signal for model improvement.
+
+The motivation arises from a structural gap in the RLHF literature~\citep{christiano2017deep, ouyang2022training}.
+Current methods collect human preferences via crowd annotation~\citep{ouyang2022training}, AI self-evaluation~\citep{bai2022constitutional, lee2023rlaif}, or expert rating.
+None of these methods provides \emph{formal criteria} for when a human correction constitutes valid training signal versus noise.
+The implicit assumption is that any human preference label, from any context, is equally valid as training data.
+
+\citet{ovcharov2026edittrace} challenged this assumption empirically.
+When a practitioner works recursively with an LLM agent over production workflows (1{,}547 merged PRs, 105 days, 7 repositories), the resulting edit-traces exhibit a qualitatively different distribution from what detached annotation would produce: 80.7\% substantive rewrites (median edit distance 0.84), with binary rejection correlating with 78\% positive downstream outcomes.
+The paper proposed five informal conditions (``domain constitution'') under which these edit-traces constitute valid oversight signal.
+
+The present work formalizes these conditions.
+Table~\ref{tab:levels} shows the structural parallel across all five levels.
+
+\begin{table}[h]
+\centering
+\caption{The ontological control principle across five levels of abstraction.}
+\label{tab:levels}
+\begin{tabular}{@{}cp{3.5cm}p{3.5cm}p{3.5cm}@{}}
+\toprule
+\textbf{Level} & \textbf{Formal structure} & \textbf{Controls} & \textbf{Object of control} \\
+\midrule
+I   & Domain ontology          & System architecture     & Which modules execute \\
+II  & SPT + ontology           & NLP pipeline            & Which entities/terms are extracted \\
+III & Meta-ontology (OWL)      & LLM output              & What the model generates \\
+IV  & Evolutionary constraints & System dynamics          & How goals/structure co-evolve \\
+V   & Domain constitution      & Oversight validation     & When human corrections are valid training signal \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The transition from Level~III to Level~V is the central contribution.
+At Level~III, formal structure governs what the LLM produces (inference-time control).
+At Level~V, formal structure governs how we determine whether human corrections on LLM output constitute valid data for improving the LLM (training-time control).
+The shift is from controlling the model's \emph{generation} process to controlling the \emph{oversight} process that yields preference data for model improvement.
+
+This is not merely a change in application domain.
+It represents a change in the \emph{kind} of process being controlled.
+Levels~I--III control computational processes (architecture configuration, text processing, token generation).
+Level~V controls a \emph{socio-technical} process: the interaction between a human overseer and an AI system, and the conditions under which that interaction produces signal suitable for machine learning.
+
+The formalization of this control in \DL description logic is the subject of Section~\ref{sec:formal}.
+
+
+% ============================================================
+\section{Formal Model of the Domain Constitution}
+\label{sec:formal}
+% ============================================================
+
+We formalize the domain constitution---the set of conditions under which human corrections on LLM-agentic output constitute valid oversight signal---in \DL description logic~\citep{baader2003description}.
+\DL extends $\mathcal{ALC}$ with transitive roles ($\mathcal{S}$), role hierarchies ($\mathcal{H}$), nominals ($\mathcal{O}$), inverse roles ($\mathcal{I}$), and qualified number restrictions ($\mathcal{Q}$), corresponding to the OWL~2~DL profile~\citep{grau2008owl2}.
+
+% --------------------------------------------------------
+\subsection{Signature}
+\label{sec:signature}
+% --------------------------------------------------------
+
+\begin{definition}[Oversight Signature]
+\label{def:signature}
+The oversight signature $\Sigma_{\mathrm{ov}}$ consists of:
+
+\medskip\noindent
+\textbf{Concept names} $N_C$:
+\begin{center}
+\begin{tabular}{@{}ll@{}}
+\toprule
+\textbf{Concept} & \textbf{Intuition} \\
+\midrule
+$\mathsf{Agent}$         & LLM-based agentic system \\
+$\mathsf{Human}$         & Practitioner performing oversight \\
+$\mathsf{Session}$       & Bounded unit of human--agent interaction \\
+$\mathsf{Artifact}$      & Output produced by $\mathsf{Agent}$ within a $\mathsf{Session}$ \\
+$\mathsf{Edit}$          & Human correction applied to an $\mathsf{Artifact}$ \\
+$\mathsf{Outcome}$       & Deployed result with measurable consequences \\
+$\mathsf{State}$         & Persistent shared computational state \\
+$\mathsf{Information}$   & Knowledge or context available to a participant \\
+$\mathsf{SuccessCriterion}$ & Observable predicate defining task completion \\
+$\mathsf{ProductionMetric}$ & Measurable system-level quantity \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\medskip\noindent
+\textbf{Role names} $N_R$:
+\begin{center}
+\begin{tabular}{@{}lll@{}}
+\toprule
+\textbf{Role} & \textbf{Domain $\to$ Range} & \textbf{Properties} \\
+\midrule
+$\mathsf{operatesOn}$      & $\mathsf{Agent} \to \mathsf{State}$          & --- \\
+$\mathsf{accessesState}$   & $\mathsf{Human} \to \mathsf{State}$          & --- \\
+$\mathsf{producesArtifact}$& $\mathsf{Session} \to \mathsf{Artifact}$     & --- \\
+$\mathsf{hasEdit}$         & $\mathsf{Artifact} \to \mathsf{Edit}$        & --- \\
+$\mathsf{hasOutcome}$      & $\mathsf{Session} \to \mathsf{Outcome}$      & --- \\
+$\mathsf{dependsOn}$       & $\mathsf{Session} \to \mathsf{Session}$      & transitive \\
+$\mathsf{basedOn}$         & $\mathsf{Edit} \to \mathsf{Information}$     & --- \\
+$\mathsf{accessibleTo}$    & $\mathsf{Information} \to \mathsf{Agent}$    & --- \\
+$\mathsf{hasCriterion}$    & $\mathsf{Session} \to \mathsf{SuccessCriterion}$ & --- \\
+$\mathsf{measuredBy}$      & $\mathsf{SuccessCriterion} \to \mathsf{ProductionMetric}$ & --- \\
+$\mathsf{hasConsequence}$  & $\mathsf{Outcome} \to \mathsf{ProductionMetric}$ & --- \\
+$\mathsf{partOf}$          & $\mathsf{Session} \to \mathsf{Workflow}$     & --- \\
+\bottomrule
+\end{tabular}
+\end{center}
+
+\medskip\noindent
+\textbf{Derived concepts} (defined via role restrictions):
+\begin{align}
+  \mathsf{PersistentState} &\equiv \mathsf{State} \sqcap
+    \exists\mathsf{operatesOn}^{-}.\mathsf{Agent} \sqcap
+    \exists\mathsf{accessesState}^{-}.\mathsf{Human}
+    \label{eq:persistent-state} \\[4pt]
+  \mathsf{PrivateInfo} &\equiv \mathsf{Information} \sqcap
+    \neg\exists\mathsf{accessibleTo}.\mathsf{Agent}
+    \label{eq:private-info} \\[4pt]
+  \mathsf{GroundedCriterion} &\equiv \mathsf{SuccessCriterion} \sqcap
+    \exists\mathsf{measuredBy}.\mathsf{ProductionMetric}
+    \label{eq:grounded-criterion} \\[4pt]
+  \mathsf{ConsequentialOutcome} &\equiv \mathsf{Outcome} \sqcap
+    \exists\mathsf{hasConsequence}.\mathsf{ProductionMetric}
+    \label{eq:consequential-outcome}
+\end{align}
+\end{definition}
+
+% --------------------------------------------------------
+\subsection{TBox: Axiomatization of the Five Conditions}
+\label{sec:tbox}
+% --------------------------------------------------------
+
+The domain constitution is a TBox \TBox consisting of five general concept inclusions (GCIs), each capturing one necessary condition for valid oversight.
+$\mathsf{ValidOversight}$ is a \emph{defined concept}---an individual (workflow instance) is classified as valid oversight if and only if it satisfies all five conditions simultaneously.
+
+\begin{axiom}[C1: Shared Persistent State]
+\label{ax:c1}
+Valid oversight requires that the agent and the human operate on a shared, persistent state---a computational environment (codebase, file system, version history) that accumulates changes across sessions and is accessible to both participants.
+\begin{equation}
+  \mathsf{ValidOversight} \sqsub
+    \exists\mathsf{hasState}.\mathsf{PersistentState}
+  \label{eq:c1}
+\end{equation}
+where $\mathsf{PersistentState}$ is defined as in~(\ref{eq:persistent-state}).
+A workflow operating on isolated, ephemeral snippets without shared state fails C1.
+
+\medskip\noindent
+\emph{Rationale.}
+Without persistent shared state, human corrections are context-free: they reflect preferences over isolated outputs rather than oversight over an evolving system.
+Persistent state ensures each correction is informed by the cumulative history of prior agent behavior and its consequences~\citep{ovcharov2026edittrace}.
+\end{axiom}
+
+\begin{axiom}[C2: Compositional Task Layering]
+\label{ax:c2}
+Valid oversight requires that sessions compose into dependency chains: the output of one session serves as input context for subsequent sessions.
+\begin{equation}
+  \mathsf{ValidOversight} \sqsub
+    \exists\mathsf{partOf}.\left(
+      \mathsf{Workflow} \sqcap
+      \exists\mathsf{hasSession}.\left(
+        \mathsf{Session} \sqcap \exists\mathsf{dependsOn}.\mathsf{Session}
+      \right)
+    \right)
+  \label{eq:c2}
+\end{equation}
+The role $\mathsf{dependsOn}$ is declared transitive:
+\begin{equation}
+  \mathsf{Trans}(\mathsf{dependsOn})
+  \label{eq:c2-trans}
+\end{equation}
+This enables reasoning over multi-hop compositional chains: if session $s_3$ depends on $s_2$ and $s_2$ depends on $s_1$, then $s_3$ is compositionally linked to $s_1$.
+
+\medskip\noindent
+\emph{Rationale.}
+Single-turn corrections cannot capture compositional failure modes---cases where each individual output appears adequate but the composition fails.
+An edit correcting an architectural decision that conflicts with a decision made weeks earlier encodes long-range dependency information that no single-turn annotation scheme captures.
+\end{axiom}
+
+\begin{axiom}[C3: Grounding in Observable Reality]
+\label{ax:c3}
+Valid oversight requires that success criteria are defined as predicates over observable production metrics, not subjective preferences.
+\begin{equation}
+  \mathsf{ValidOversight} \sqsub
+    \exists\mathsf{hasCriterion}.\mathsf{GroundedCriterion}
+  \label{eq:c3}
+\end{equation}
+where $\mathsf{GroundedCriterion}$ is defined as in~(\ref{eq:grounded-criterion}).
+
+\medskip\noindent
+\emph{Rationale.}
+Oversight that rests on subjective preference alone is indistinguishable from taste.
+Corrections grounded in observable system behavior---a deployment failure, a latency spike, an error rate increase---encode causal information about what works and what does not.
+\end{axiom}
+
+\begin{axiom}[C4: Information Asymmetry Favoring the Human]
+\label{ax:c4}
+Valid oversight requires that at least some human corrections are based on information not accessible to the agent.
+\begin{equation}
+  \mathsf{ValidOversight} \sqsub
+    \exists\mathsf{hasArtifact}.\left(
+      \mathsf{Artifact} \sqcap \exists\mathsf{hasEdit}.\left(
+        \mathsf{Edit} \sqcap \exists\mathsf{basedOn}.\mathsf{PrivateInfo}
+      \right)
+    \right)
+  \label{eq:c4}
+\end{equation}
+where $\mathsf{PrivateInfo}$ is defined as in~(\ref{eq:private-info}).
+
+\medskip\noindent
+\emph{Rationale.}
+Oversight is meaningful precisely because the overseer holds information the overseen system lacks: business priorities, regulatory requirements, user feedback, personal stake in outcomes.
+If corrections reflect only information already available to the agent, the edit-trace is redundant with the agent's own uncertainty.
+\end{axiom}
+
+\begin{axiom}[C5: Consequential Grounding]
+\label{ax:c5}
+Valid oversight requires that the workflow produces outcomes with measurable real-world consequences.
+\begin{equation}
+  \mathsf{ValidOversight} \sqsub
+    \exists\mathsf{hasOutcome}.\mathsf{ConsequentialOutcome}
+  \label{eq:c5}
+\end{equation}
+where $\mathsf{ConsequentialOutcome}$ is defined as in~(\ref{eq:consequential-outcome}).
+
+\medskip\noindent
+\emph{Rationale.}
+Oversight signal must connect to real consequences to avoid the same detachment that afflicts crowd annotation.
+When corrected artifacts ship and succeed or fail in production, the edit-trace acquires outcome labels that close the loop between correction and consequence.
+\end{axiom}
+
+% --------------------------------------------------------
+\subsection{Defined Concept: Valid Oversight}
+\label{sec:valid-oversight}
+% --------------------------------------------------------
+
+\begin{definition}[Valid Oversight]
+\label{def:valid-oversight}
+The concept $\mathsf{ValidOversight}$ is the conjunction of all five axiomatic conditions:
+\begin{equation}
+\boxed{
+  \mathsf{ValidOversight} \equiv
+    \mathsf{C1} \sqcap \mathsf{C2} \sqcap \mathsf{C3} \sqcap \mathsf{C4} \sqcap \mathsf{C5}
+}
+\label{eq:valid-oversight}
+\end{equation}
+where each $\mathsf{C}_i$ is the right-hand side of the corresponding GCI~(\ref{eq:c1})--(\ref{eq:c5}).
+\end{definition}
+
+This is a \emph{necessary and sufficient} definition: an OWL~2~DL reasoner can automatically classify any workflow individual as $\mathsf{ValidOversight}$ (or not) given its asserted properties.
+
+% --------------------------------------------------------
+\subsection{Negative Classification: Invalid Oversight Patterns}
+\label{sec:negative}
+% --------------------------------------------------------
+
+The domain constitution defines its negation: interaction patterns that fail one or more conditions.
+These are formally derivable as non-entailments from the TBox.
+
+\begin{proposition}[Non-entailment of invalid patterns]
+\label{prop:negative}
+The following workflow patterns are provably not classified as $\mathsf{ValidOversight}$:
+\end{proposition}
+
+\begin{enumerate}[label=(\alph*),leftmargin=2em]
+
+\item \textbf{One-shot code generation.}
+Let $w_1$ be a workflow with a single session $s$, no persistent state, and no compositional chain.
+\begin{align}
+  \ABox_1 &= \{ \mathsf{Workflow}(w_1),\; \mathsf{hasSession}(w_1, s) \} \notag \\
+  \KB &= \langle \TBox, \ABox_1 \rangle \notag \\
+  \KB &\not\models \mathsf{ValidOversight}(w_1) \qquad \text{(fails C1, C2)}
+\end{align}
+
+\item \textbf{Automated CI/CD pipeline.}
+Let $w_2$ be a workflow where all edits are based on information accessible to the agent (test results, linter output).
+\begin{align}
+  \forall e \in \mathsf{Edit}(w_2)&: \; \exists i.\; \mathsf{basedOn}(e, i) \wedge \mathsf{accessibleTo}(i, a) \notag \\
+  \KB &\not\models \mathsf{ValidOversight}(w_2) \qquad \text{(fails C4)}
+\end{align}
+
+\item \textbf{Tutorial or learning use.}
+Let $w_3$ be a workflow with no deployed outcomes.
+\begin{align}
+  \neg\exists o.\; &\mathsf{hasOutcome}(w_3, o) \wedge \mathsf{ConsequentialOutcome}(o) \notag \\
+  \KB &\not\models \mathsf{ValidOversight}(w_3) \qquad \text{(fails C5)}
+\end{align}
+
+\item \textbf{Pair programming without success criteria.}
+Let $w_4$ be a workflow with shared state and compositional chains but no grounded success criteria.
+\begin{align}
+  \neg\exists c.\; &\mathsf{hasCriterion}(w_4, c) \wedge \mathsf{GroundedCriterion}(c) \notag \\
+  \KB &\not\models \mathsf{ValidOversight}(w_4) \qquad \text{(fails C3)}
+\end{align}
+
+\end{enumerate}
+
+% --------------------------------------------------------
+\subsection{Partial Oversight and Graded Classification}
+\label{sec:partial}
+% --------------------------------------------------------
+
+In practice, workflows may satisfy some but not all conditions.
+We define a graded classification based on the number of satisfied conditions.
+
+\begin{definition}[Oversight Grade]
+\label{def:grade}
+For a workflow individual $w$ and TBox \TBox, the \emph{oversight grade} $\gamma(w)$ is:
+\begin{equation}
+  \gamma(w) = \left| \{ i \in \{1,...,5\} : \KB \models \mathsf{C}_i(w) \} \right|
+\end{equation}
+We define three tiers:
+\begin{align}
+  \mathsf{FullOversight}    &\equiv \mathsf{ValidOversight} && (\gamma = 5) \\
+  \mathsf{PartialOversight} &\equiv (\gamma \geq 3) \sqcap \neg\mathsf{ValidOversight} && (\gamma \in \{3,4\}) \\
+  \mathsf{InvalidOversight} &\equiv \neg\mathsf{PartialOversight} \sqcap \neg\mathsf{FullOversight} && (\gamma \leq 2)
+\end{align}
+\end{definition}
+
+This graded scheme enables a \emph{soft filtering} strategy for preference data: full-oversight edit-traces receive weight 1.0 in DPO training, partial-oversight traces receive discounted weight $\alpha \in (0, 1)$, and invalid traces are excluded.
+
+% --------------------------------------------------------
+\subsection{Reasoning Tasks}
+\label{sec:reasoning}
+% --------------------------------------------------------
+
+The OWL~2~DL realization of \TBox supports three reasoning tasks relevant to alignment signal validation:
+
+\begin{enumerate}[label=\textbf{R\arabic*.},leftmargin=2.5em]
+
+\item \textbf{Instance classification.}
+Given a workflow individual $w$ with asserted properties in \ABox, determine:
+\begin{equation}
+  \KB \models \mathsf{ValidOversight}(w) \;\; ?
+\end{equation}
+This is the primary task: automatically classifying whether a given workflow's edit-traces qualify as valid training signal.
+Decidable in \DL; implemented via tableau-based reasoners (HermiT, Pellet).
+
+\item \textbf{Consistency checking.}
+Verify that \TBox is satisfiable---that the five conditions are not mutually contradictory:
+\begin{equation}
+  \KB \not\models \mathsf{ValidOversight} \sqsub \bot
+\end{equation}
+We prove satisfiability constructively in Section~\ref{sec:owl} by exhibiting a model (the LEX~AI case study).
+
+\item \textbf{Subsumption queries.}
+Determine whether one control paradigm subsumes another:
+\begin{equation}
+  \KB \models \mathsf{OntoChatGPT\_Control} \sqsub \mathsf{ValidOversight} \;\; ?
+\end{equation}
+We show in Section~\ref{sec:comparison} that the answer is \emph{no}---OntoChatGPT controls output generation (satisfying C1 and partially C3) but does not entail C4 or C5.
+The two paradigms are complementary, not hierarchically related.
+
+\end{enumerate}
+
+% --------------------------------------------------------
+\subsection{Formal Properties}
+\label{sec:properties}
+% --------------------------------------------------------
+
+\begin{proposition}[Decidability]
+\label{prop:decidability}
+Instance classification of $\mathsf{ValidOversight}$ is decidable.
+\end{proposition}
+\begin{proof}
+The TBox \TBox uses only \DL constructors: concept conjunction ($\sqcap$), existential restriction ($\exists r.C$), negation ($\neg$), transitive roles, and inverse roles.
+All instance checking problems in \DL are decidable~\citep{horrocks2006even}, with worst-case complexity \textsc{NExpTime}.
+In practice, the ontology size (number of axioms and individuals) is small relative to the theoretical bound, and reasoning completes in sub-second time for thousands of workflow individuals.
+\end{proof}
+
+\begin{proposition}[Independence of conditions]
+\label{prop:independence}
+No condition $\mathsf{C}_i$ is entailed by the conjunction of the remaining four:
+\begin{equation}
+  \forall i \in \{1,...,5\}: \;\;
+  \bigsqcap_{j \neq i} \mathsf{C}_j \not\sqsub \mathsf{C}_i
+\end{equation}
+\end{proposition}
+\begin{proof}
+By construction of four counterexample individuals, each satisfying exactly four conditions and failing the fifth (Section~\ref{sec:negative} provides three; the remaining two are analogous).
+The negative examples (one-shot generation, automated pipeline, tutorial use, pair programming without criteria) each isolate a single failing condition while plausibly satisfying the others.
+\end{proof}
+
+\begin{proposition}[Monotonicity of oversight grade]
+\label{prop:monotonicity}
+Adding true assertions about a workflow individual $w$ to \ABox can only increase $\gamma(w)$:
+\begin{equation}
+  \ABox \subseteq \ABox' \implies \gamma_{\ABox}(w) \leq \gamma_{\ABox'}(w)
+\end{equation}
+\end{proposition}
+\begin{proof}
+Each $\mathsf{C}_i$ is a positive existential restriction.
+Adding assertions can only satisfy previously unsatisfied existential quantifiers, never invalidate satisfied ones.
+Under the open-world assumption, absent assertions do not entail negation---they merely fail to entail the positive condition.
+\end{proof}
+
+This monotonicity property has practical significance: as more metadata about a workflow is captured (e.g., outcome tracking is added post-hoc), the oversight grade can only increase.
+A workflow that was \textsc{PartialOversight} due to missing outcome data can be reclassified as \textsc{FullOversight} once outcomes are attributed, without invalidating prior assertions.
+
+
+% ============================================================
+\section{Comparison: OntoChatGPT vs.\ Domain Constitution}
+\label{sec:comparison}
+% ============================================================
+
+OntoChatGPT~\citep{palagin2023ontochatgpt} and the domain constitution formalized in Section~\ref{sec:formal} both instantiate the ontological control principle introduced in~\citet{palagin2006architecture}: a formal structure governs the behavior of a system involving an LLM.
+However, they operate at different levels of the same conceptual stack, control different processes, and serve different downstream purposes.
+This section makes the relationship precise.
+
+% --------------------------------------------------------
+\subsection{Shared Principle: Formal Structure as Active Control}
+\label{sec:shared-principle}
+% --------------------------------------------------------
+
+Both systems are built on the same architectural commitment: the formal structure is not a passive annotation layer but an \emph{active governor} of a computational process.
+
+In OntoChatGPT, a domain OWL ontology is traversed at inference time to generate structured prompts.
+The ontology determines which concepts are activated, what relational constraints are imposed, and what structural patterns the LLM's output must conform to.
+Without the ontology, the LLM generates unconstrained output; with it, the output is shaped by formal domain knowledge.
+
+In the domain constitution, five axioms in \DL are evaluated against workflow metadata to classify whether a given set of edit-traces constitutes valid training signal.
+Without the constitution, all human corrections are treated as equally valid preference data; with it, corrections are filtered by formal criteria that distinguish oversight from noise.
+
+The shared invariant can be stated precisely:
+
+\begin{definition}[Ontological Control Invariant]
+\label{def:invariant}
+A system exhibits \emph{ontological control} if there exists a formal structure $\mathcal{O}$ (ontology, axiom set, or constitution) such that removing $\mathcal{O}$ changes the system's behavior in a way that is:
+(a)~formally predictable from $\mathcal{O}$'s axioms, and
+(b)~measurable in the system's output or downstream metrics.
+\end{definition}
+
+Both OntoChatGPT and the domain constitution satisfy this definition.
+OntoChatGPT: removing the meta-ontology produces unconstrained LLM output with measurably lower domain accuracy~\citep{palagin2023ontochatgpt}.
+Domain constitution: removing the five conditions admits edit-traces that correlate with worse downstream outcomes (Section~\ref{sec:empirical}).
+
+% --------------------------------------------------------
+\subsection{Structural Differences}
+\label{sec:structural-diff}
+% --------------------------------------------------------
+
+Despite the shared principle, the two systems differ along four dimensions.
+Table~\ref{tab:comparison} summarizes the comparison; the subsections below develop each dimension.
+
+\begin{table}[h]
+\centering
+\caption{Structural comparison of OntoChatGPT and the domain constitution.}
+\label{tab:comparison}
+\begin{tabular}{@{}p{3cm}p{5.2cm}p{5.2cm}@{}}
+\toprule
+\textbf{Dimension} & \textbf{OntoChatGPT} & \textbf{Domain Constitution} \\
+\midrule
+Object of control     & LLM output tokens       & Human corrections on LLM output \\
+Control phase         & Inference time           & Training time (preference data curation) \\
+Formal structure      & OWL domain ontology      & \DL axiom set (TBox) \\
+Mechanism             & Ontology $\to$ structured prompts $\to$ constrained generation & Axioms $\to$ workflow classification $\to$ edit-trace filtering \\
+Human role            & End user (consumer of output) & Overseer (producer of corrections) \\
+Success criterion     & Output quality (accuracy, relevance) & Signal validity (training improvement) \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsubsection{Object of Control}
+
+OntoChatGPT controls \emph{what the LLM produces}.
+The meta-ontology generates structured prompts that constrain token generation.
+The controlled object is the model's output distribution at inference time: given a query $q$ and ontology $\mathcal{O}$, the system produces output $y$ such that $y$ conforms to the structural and semantic constraints encoded in $\mathcal{O}$.
+
+The domain constitution controls \emph{which human corrections are treated as valid training signal}.
+The controlled object is not the LLM's output but the \emph{data pipeline} that feeds into the LLM's next training cycle.
+Given a set of edit-traces $\{(x_i, y_i, y'_i)\}$ where $x_i$ is the input, $y_i$ the LLM output, and $y'_i$ the human-corrected version, the constitution classifies each tuple as valid oversight, partial oversight, or invalid (Definition~\ref{def:grade}), and this classification determines what enters the DPO training set.
+
+This distinction---controlling output vs.\ controlling what trains the model to produce output---is the key structural difference.
+
+\subsubsection{Control Phase}
+
+OntoChatGPT operates at \textbf{inference time}: the ontology is consulted during each generation request.
+The control loop is synchronous and immediate---every query passes through the ontology before producing output.
+
+The domain constitution operates at \textbf{training time}: the axioms are evaluated over accumulated workflow data to curate preference pairs before DPO training~\citep{rafailov2023direct}.
+The control loop is asynchronous and batch-oriented---edit-traces accumulate over days or weeks of practice, and the constitutional filter is applied when preparing training data.
+
+This phase difference has practical consequences.
+Inference-time control (OntoChatGPT) can be updated instantly---swapping the ontology changes the next output.
+Training-time control (domain constitution) operates with a longer feedback loop but produces \emph{permanent} behavioral changes in the model, persisting even when the constitution is not consulted.
+
+\subsubsection{Human Role}
+
+In OntoChatGPT, the human is the \emph{end user}: they submit a query and receive ontology-constrained output.
+The human's role is consumption---evaluating and using the LLM's response.
+The ontology mediates between the human's query and the model's capabilities.
+
+In the domain constitution, the human is the \emph{overseer}: they review, correct, and sometimes reject LLM output within a production workflow.
+The human's role is production---generating corrections that constitute training data.
+The constitution mediates between the human's corrections and the training pipeline's data requirements.
+
+This difference in the human's role is reflected formally in Condition~C4 (information asymmetry).
+OntoChatGPT does not require that the human hold information inaccessible to the model; the ontology itself provides the structural knowledge.
+The domain constitution \emph{requires} information asymmetry as a necessary condition---oversight is meaningful precisely because the overseer knows things the model does not.
+
+\subsubsection{Success Criterion}
+
+OntoChatGPT succeeds when its output is accurate and relevant: the ontology-constrained response matches the domain knowledge encoded in $\mathcal{O}$.
+Success is evaluated per-query, per-response.
+
+The domain constitution succeeds when the filtered edit-traces, used as preference data for DPO training, improve the model's downstream domain-specific performance relative to unfiltered or alternatively sourced preference data.
+Success is evaluated per-training-run, measured across evaluation benchmarks.
+
+% --------------------------------------------------------
+\subsection{Formal Subsumption Analysis}
+\label{sec:subsumption}
+% --------------------------------------------------------
+
+We now ask: does OntoChatGPT's control paradigm entail valid oversight?
+Formally: does a workflow operating under OntoChatGPT's ontological control satisfy the domain constitution's five conditions?
+
+\begin{proposition}[Non-subsumption]
+\label{prop:non-subsumption}
+Let $\mathsf{OntoChatGPT\_Control}$ be the concept describing workflows where an OWL ontology generates structured prompts that constrain LLM output.
+Then:
+\begin{equation}
+  \KB \not\models \mathsf{OntoChatGPT\_Control} \sqsub \mathsf{ValidOversight}
+\end{equation}
+\end{proposition}
+
+\begin{proof}
+We show that $\mathsf{OntoChatGPT\_Control}$ fails to entail Conditions C4 and C5.
+
+\textbf{C4 (Information Asymmetry) is not entailed.}
+In OntoChatGPT, the domain knowledge resides in the OWL ontology, which is fully accessible to the system.
+The human user submits a query; the ontology supplies the structural constraints.
+The human may hold private information (unstated preferences, contextual knowledge), but the OntoChatGPT architecture does not \emph{require} this: the system functions identically whether the human knows more than the model or not.
+Formally:
+\begin{equation}
+  \mathsf{OntoChatGPT\_Control} \not\sqsub
+    \exists\mathsf{hasArtifact}.(\exists\mathsf{hasEdit}.(\exists\mathsf{basedOn}.\mathsf{PrivateInfo}))
+\end{equation}
+
+\textbf{C5 (Consequential Grounding) is not entailed.}
+OntoChatGPT produces responses to user queries.
+These responses may or may not be deployed in production systems with measurable consequences.
+The OntoChatGPT architecture does not require deployment---it functions identically in a research sandbox and in a production pipeline.
+Formally:
+\begin{equation}
+  \mathsf{OntoChatGPT\_Control} \not\sqsub
+    \exists\mathsf{hasOutcome}.\mathsf{ConsequentialOutcome}
+\end{equation}
+
+Since $\mathsf{ValidOversight}$ requires both C4 and C5 (Definition~\ref{def:valid-oversight}), $\mathsf{OntoChatGPT\_Control}$ does not entail $\mathsf{ValidOversight}$.
+\end{proof}
+
+The converse also does not hold:
+
+\begin{proposition}[Non-subsumption, converse]
+\label{prop:non-subsumption-converse}
+\begin{equation}
+  \KB \not\models \mathsf{ValidOversight} \sqsub \mathsf{OntoChatGPT\_Control}
+\end{equation}
+\end{proposition}
+
+\begin{proof}
+$\mathsf{ValidOversight}$ does not require that the LLM's output be constrained by an OWL ontology.
+The domain constitution specifies conditions on the \emph{oversight process}, not on the model's generation mechanism.
+A workflow may satisfy all five conditions while the LLM generates unconstrained output that the human subsequently corrects.
+\end{proof}
+
+The two concepts are therefore \textbf{formally independent}: neither subsumes the other.
+
+% --------------------------------------------------------
+\subsection{Complementarity and Integration}
+\label{sec:complementarity}
+% --------------------------------------------------------
+
+The formal independence of OntoChatGPT control and the domain constitution suggests that they are not competing approaches but \emph{complementary} layers in a single stack.
+We formalize this as follows.
+
+\begin{definition}[Integrated Ontological Control]
+\label{def:integrated}
+An \emph{integrated ontologically controlled LLM system} is a workflow satisfying both:
+\begin{equation}
+  \mathsf{IntegratedControl} \equiv \mathsf{OntoChatGPT\_Control} \sqcap \mathsf{ValidOversight}
+\end{equation}
+\end{definition}
+
+\begin{theorem}[Satisfiability of Integrated Control]
+\label{thm:integrated}
+$\mathsf{IntegratedControl}$ is satisfiable: there exist workflow instances that simultaneously satisfy both $\mathsf{OntoChatGPT\_Control}$ and $\mathsf{ValidOversight}$.
+\end{theorem}
+
+\begin{proof}
+Constructive.
+Consider a workflow $w^*$ with the following properties:
+\begin{enumerate}[nosep]
+  \item An OWL domain ontology $\mathcal{O}_{\text{legal}}$ generates structured prompts for a legal AI LLM (satisfies $\mathsf{OntoChatGPT\_Control}$).
+  \item A human practitioner reviews and corrects the ontology-constrained output within a production legal platform (satisfies C1: shared persistent codebase).
+  \item Corrections compose across sessions---an ontology refinement in session $s_k$ affects subsequent output in $s_{k+1}$ (satisfies C2: compositional layering).
+  \item Success criteria are defined as observable production metrics: search accuracy, citation correctness, user retention (satisfies C3: grounding).
+  \item The practitioner holds information unavailable to the model: business strategy, regulatory requirements communicated verbally, user feedback from support channels (satisfies C4: information asymmetry).
+  \item Corrected output ships to production with paying customers (satisfies C5: consequential grounding).
+\end{enumerate}
+This workflow is precisely the LEX~AI case study documented in~\citet{ovcharov2026edittrace}, augmented with an ontology-driven prompt generation layer.
+\end{proof}
+
+The integrated system operates as a two-level control pipeline:
+
+\begin{enumerate}[nosep]
+  \item \textbf{Inference-time control} (Level~III): the OWL ontology constrains the LLM's output, improving per-query accuracy and structural consistency.
+  \item \textbf{Training-time control} (Level~V): the domain constitution validates human corrections on the ontology-constrained output, filtering the resulting edit-traces to produce high-quality preference data for DPO training.
+  \item \textbf{Feedback loop}: the DPO-trained model produces better output $\to$ human corrections become more targeted $\to$ higher-quality edit-traces $\to$ better next training round.
+\end{enumerate}
+
+This integration addresses a limitation that neither system resolves alone.
+OntoChatGPT improves individual outputs but does not improve the model itself---the ontology compensates for model deficiencies at inference time without correcting them.
+The domain constitution improves the model via curated training data but does not guarantee output quality during inference.
+Together, they provide both immediate output improvement (ontology-constrained generation) and long-term model improvement (constitution-filtered training).
+
+Figure~\ref{fig:integration} illustrates the integrated architecture.
+
+\begin{figure}[h]
+\centering
+\begin{tikzpicture}[
+  box/.style={rectangle, draw, rounded corners=3pt, minimum width=3.2cm, minimum height=0.9cm, align=center, font=\small},
+  arrow/.style={-{Stealth[length=5pt]}, thick},
+  label/.style={font=\scriptsize, text=gray}
+]
+  % Level III
+  \node[box, fill=blue!8] (ontology) at (0, 4) {OWL Ontology\\$\mathcal{O}_{\text{domain}}$};
+  \node[box, fill=blue!8] (prompts) at (4.5, 4) {Structured\\Prompts};
+  \node[box, fill=blue!8] (llm) at (9, 4) {LLM\\Generation};
+
+  % Human
+  \node[box, fill=orange!12] (human) at (9, 2) {Human\\Oversight};
+
+  % Level V
+  \node[box, fill=green!8] (constitution) at (4.5, 0) {Domain\\Constitution $\mathcal{T}$};
+  \node[box, fill=green!8] (filter) at (0, 0) {Edit-Trace\\Filtering};
+  \node[box, fill=green!8] (dpo) at (0, 2) {DPO\\Training};
+
+  % Level III arrows
+  \draw[arrow] (ontology) -- (prompts) node[midway, above, label] {traversal};
+  \draw[arrow] (prompts) -- (llm) node[midway, above, label] {constrained};
+  \draw[arrow, blue!50] (llm) -- (human) node[midway, right, label] {output};
+
+  % Human to Level V
+  \draw[arrow, orange!70] (human) -- (9, 0) -- (constitution) node[midway, below, label] {edit-traces};
+
+  % Level V arrows
+  \draw[arrow] (constitution) -- (filter) node[midway, above, label] {classification};
+  \draw[arrow] (filter) -- (dpo) node[midway, left, label] {valid pairs};
+
+  % Feedback loop
+  \draw[arrow, dashed, green!50!black] (dpo) -- (0, 4) -- (ontology) node[midway, above, label] {};
+  \draw[arrow, dashed, green!50!black] (dpo.east) -- (4.5, 2) -- (llm.south) node[midway, right, label] {};
+
+  % Level labels
+  \node[font=\footnotesize\bfseries, text=blue!70] at (-2.2, 4) {Level III};
+  \node[font=\footnotesize\bfseries, text=orange!70] at (11.2, 2) {Overseer};
+  \node[font=\footnotesize\bfseries, text=green!50!black] at (-2.2, 0) {Level V};
+
+  % Dashed labels
+  \node[font=\scriptsize, text=green!50!black] at (2.2, 3.2) {model};
+  \node[font=\scriptsize, text=green!50!black] at (2.2, 2.8) {update};
+\end{tikzpicture}
+\caption{Integrated ontological control: Level~III (inference-time, blue) and Level~V (training-time, green) operating as a two-level pipeline.
+The human overseer (orange) provides corrections that feed into Level~V.
+Dashed arrows indicate the feedback loop from DPO training back to the model.}
+\label{fig:integration}
+\end{figure}
+
+% --------------------------------------------------------
+\subsection{Condition-Level Analysis}
+\label{sec:condition-analysis}
+% --------------------------------------------------------
+
+To complete the comparison, we analyze how each condition of the domain constitution relates to OntoChatGPT's architecture.
+
+\begin{table}[h]
+\centering
+\caption{Condition-level comparison: which domain constitution conditions OntoChatGPT satisfies, partially satisfies, or does not address.}
+\label{tab:condition-comparison}
+\begin{tabular}{@{}clp{8cm}@{}}
+\toprule
+\textbf{Cond.} & \textbf{Status} & \textbf{Analysis} \\
+\midrule
+C1 & Partial & OntoChatGPT maintains an OWL ontology as persistent state, but this state is shared between the ontology engineer and the system, not necessarily between the end user and the model. The user may interact statelessly (single queries). \\
+C2 & No & OntoChatGPT processes queries independently. Output of query $q_k$ does not become input context for $q_{k+1}$ unless the application layer implements session management externally. \\
+C3 & Partial & The ontology defines domain correctness criteria, which can serve as observable success criteria. However, OntoChatGPT does not require production deployment with measurable metrics---the criteria may remain internal to the ontology. \\
+C4 & No & The domain knowledge is encoded in the ontology, fully accessible to the system. The architecture does not require or exploit human information advantage. \\
+C5 & No & No deployment requirement. The system functions identically in sandbox and production environments. \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+OntoChatGPT satisfies at most 2 of 5 conditions (and those only partially), confirming the non-subsumption result (Proposition~\ref{prop:non-subsumption}).
+This is not a deficiency of OntoChatGPT---it was designed for a different purpose (output quality, not oversight validation).
+The condition-level analysis clarifies exactly \emph{what} must be added to an OntoChatGPT-like system to produce valid oversight signal: session persistence (C1--C2), production deployment (C3, C5), and a human overseer with private information (C4).
+
+
+% ============================================================
+\section{OWL Realization and Verification}
+\label{sec:owl}
+% ============================================================
+
+% TODO: OWL 2 DL implementation
+% 5.1 OversightOntology.owl
+% 5.2 ABox: LEX AI case study instantiation
+% 5.3 Automated verification with HermiT
+
+\textit{(To be written.)}
+
+
+% ============================================================
+\section{Empirical Validation}
+\label{sec:empirical}
+% ============================================================
+
+% TODO: Impact of formal filtering on dataset quality
+% 6.1 Full vs. filtered edit-traces
+% 6.2 Connection to main paper results
+
+\textit{(To be written.)}
+
+
+% ============================================================
+\section{Discussion}
+\label{sec:discussion}
+% ============================================================
+
+% --------------------------------------------------------
+\subsection{From Ontology-Controlled Output to Ontology-Controlled Training}
+\label{sec:disc-output-to-training}
+% --------------------------------------------------------
+
+The five levels of ontological control traced in Section~\ref{sec:evolution} exhibit a recurring pattern: each new level applies the same principle (formal structure governs behavior) to a process that was previously considered outside the scope of formal control.
+
+Levels~I--II (2003--2020) formalized control over processes that engineers already understood as controllable: system architecture, text processing pipelines.
+The contribution was showing that \emph{ontologies} could serve as the control mechanism, replacing ad hoc configuration with formal, verifiable, reasoner-checkable structures.
+
+Level~III (2023--2024) was a qualitative jump.
+LLM output generation was widely treated as a stochastic process controllable only through prompt engineering---an informal, empirical, non-verifiable practice.
+OntoChatGPT~\citep{palagin2023ontochatgpt} demonstrated that the same ontological control principle that governed deterministic systems could govern a fundamentally probabilistic one.
+The key insight was that the ontology does not need to eliminate stochasticity---it constrains the \emph{space} within which stochastic generation occurs.
+
+Level~V (this paper) applies the same logic one step further.
+The RLHF preference collection process---which human corrections count as valid training data---has been treated as a matter of annotation protocol design, quality filtering heuristics, and inter-annotator agreement metrics.
+None of these are formal in the description logic sense: they cannot be verified by a reasoner, they do not support subsumption queries, and they do not compose into larger knowledge bases.
+
+The domain constitution makes this process formally controllable.
+The five axioms (Section~\ref{sec:tbox}) define a concept $\mathsf{ValidOversight}$ that an OWL reasoner can evaluate automatically.
+This is not a metaphorical application of ontological control---it is a literal one: the same reasoning infrastructure (TBox, ABox, tableau algorithms) that classifies system architectures in Level~I now classifies preference data pipelines in Level~V.
+
+The implication is that the ontological control principle is more general than any of its individual applications.
+It is not specifically about system architecture, NLP, or LLM alignment.
+It is about applying formal, verifiable, machine-checkable structure to processes that are otherwise governed by informal heuristics.
+The consistent success across five levels suggests that the principle's scope is bounded by the availability of formalizable domain knowledge, not by the nature of the controlled process.
+
+% --------------------------------------------------------
+\subsection{Evolutionary Cybernetics and the Stability of Oversight}
+\label{sec:disc-evolutionary}
+% --------------------------------------------------------
+
+\citet{palagin2025evolutionary} introduced a framework for analyzing systems where goals, constraints, and structures co-evolve---a departure from classical control theory, which assumes a fixed objective function.
+The domain constitution operates in precisely such a regime.
+
+Consider the feedback loop formalized in Section~\ref{sec:complementarity}: the practitioner corrects the agent's output, the constitution validates the corrections, valid corrections train the model via DPO, and the improved model produces output that the practitioner then corrects differently.
+Each cycle potentially changes three elements simultaneously:
+
+\begin{enumerate}[nosep]
+\item \textbf{The agent's behavior} changes because the model has been updated.
+\item \textbf{The practitioner's corrections} change because the agent's output is now closer to (or further from) what the practitioner expects.
+\item \textbf{The conditions for valid oversight} may change because the information asymmetry (C4) shifts as the model improves.
+\end{enumerate}
+
+This is an evolutionary dynamics problem, not a static optimization problem.
+The domain constitution as formalized in Section~\ref{sec:formal} is a \emph{snapshot}---it captures the conditions under which oversight is valid at a given point in the co-evolution of practitioner and agent.
+
+\citet{palagin2025evolutionary} provides the theoretical vocabulary for analyzing this dynamic.
+In the framework of evolutionary cybernetics, the domain constitution is an \emph{invariant structure}---a set of constraints that must be preserved across evolutionary steps for the system to maintain its functional integrity.
+The question is whether the five conditions (C1--C5) are robust invariants or whether they degrade as the system evolves.
+
+We can analyze each condition's evolutionary stability:
+
+\paragraph{C1 (Shared Persistent State): Stable.}
+The requirement for shared state does not depend on the agent's capability level.
+Whether the agent is weak (requiring heavy correction) or strong (requiring light correction), the shared codebase remains necessary for contextual oversight.
+
+\paragraph{C2 (Compositional Layering): Stable.}
+Compositional task structure is a property of the work domain (software engineering, legal analysis), not of the agent's capability.
+As long as the domain requires multi-step, interdependent work, C2 holds.
+
+\paragraph{C3 (Grounding in Observable Reality): Stable.}
+Observable success criteria are defined by the production environment, not by the human-agent interaction.
+Deployment failures, latency spikes, and user churn remain observable regardless of model capability.
+
+\paragraph{C4 (Information Asymmetry): Potentially Unstable.}
+As models improve, the information gap between practitioner and agent may narrow.
+A sufficiently capable agent with access to business context, regulatory databases, and user feedback channels might satisfy C4 only marginally.
+In the limit, if the agent knows everything the practitioner knows, corrections become redundant---oversight degenerates into rubber-stamping.
+
+This is the critical evolutionary pressure on the domain constitution.
+C4 is the condition most likely to degrade under capability scaling, and its degradation would undermine the validity of the entire framework.
+\citet{burns2023weak} analyze a related phenomenon (weak-to-strong generalization), where the supervisor's signal quality degrades as the supervised model approaches the supervisor's capability.
+
+\paragraph{C5 (Consequential Grounding): Stable.}
+Deployment consequences are external to the human-agent system.
+Customer satisfaction, revenue, and regulatory compliance do not depend on who (human or agent) produced the artifact.
+
+The analysis yields a specific prediction: \textbf{the domain constitution is evolutionarily stable under capability scaling in 4 of 5 conditions, with C4 as the critical vulnerability.}
+Monitoring the information asymmetry between practitioner and agent---and detecting when it falls below a threshold sufficient for meaningful oversight---is the key challenge for maintaining valid oversight as LLM capabilities increase.
+
+This connects directly to the scalable oversight research program~\citep{bowman2022measuring}: the question ``can humans oversee superhuman AI systems?'' is, in our formalization, the question ``does C4 remain satisfiable as agent capability grows?''
+The ontological formalization does not answer this question, but it makes it \emph{precise}: C4 degrades when $\mathsf{PrivateInfo}$ (Definition~\ref{def:signature}, Eq.~\ref{eq:private-info}) approaches the empty set.
+
+% --------------------------------------------------------
+\subsection{Practical Implications for RLHF Methodology}
+\label{sec:disc-practical}
+% --------------------------------------------------------
+
+The formalization developed in this paper has three practical implications for RLHF preference data collection and curation.
+
+\paragraph{Implication 1: Preference data should carry provenance metadata.}
+Current RLHF datasets (OpenAssistant, Anthropic-HH, UltraFeedback) contain preference labels without workflow provenance: there is no metadata indicating whether the annotator operated within a persistent workflow, whether tasks composed, or whether outcomes were tracked.
+The domain constitution provides a minimal provenance schema: for each preference pair, record which of the five conditions were satisfied during annotation.
+This does not require OWL reasoning at annotation time---a simple checklist of five binary features per pair suffices to enable post-hoc filtering.
+
+\paragraph{Implication 2: Oversight grade enables weighted training.}
+The graded classification (Definition~\ref{def:grade}) provides a principled weighting scheme for DPO training.
+Rather than treating all preference pairs equally, pairs from $\mathsf{FullOversight}$ workflows receive weight 1.0, pairs from $\mathsf{PartialOversight}$ receive a discounted weight, and pairs from $\mathsf{InvalidOversight}$ are excluded.
+This is analogous to how curriculum learning prioritizes higher-quality training examples, but with the quality criterion derived from formal axioms rather than heuristic filtering.
+
+The weighting scheme is compatible with the standard DPO objective~\citep{rafailov2023direct}.
+For a preference pair $(x, y_w, y_l)$ with oversight grade $\gamma$:
+\begin{equation}
+  \mathcal{L}_{\text{weighted-DPO}} = -\mathbb{E}_{(x,y_w,y_l)} \left[ w(\gamma) \cdot \log \sigma \left( \beta \log \frac{\pi_\theta(y_w|x)}{\pi_{\text{ref}}(y_w|x)} - \beta \log \frac{\pi_\theta(y_l|x)}{\pi_{\text{ref}}(y_l|x)} \right) \right]
+\end{equation}
+where $w(\gamma)$ maps oversight grade to training weight.
+The simplest instantiation is $w(5) = 1.0$, $w(3{-}4) = \alpha$, $w({\leq}2) = 0$, where $\alpha$ is a hyperparameter.
+
+\paragraph{Implication 3: OWL reasoning as a data pipeline component.}
+The OWL ontology (Section~\ref{sec:owl}) can be deployed as an automated filter in a preference data pipeline.
+Workflow metadata (session persistence, task dependencies, outcome tracking) is asserted as ABox individuals.
+The HermiT reasoner classifies each workflow instance.
+Only instances classified as $\mathsf{ValidOversight}$ or $\mathsf{PartialOversight}$ pass to the DPO training stage.
+
+This is architecturally lightweight: OWL reasoning over small ABoxes (thousands of workflow instances, not millions of triples) completes in sub-second time.
+The overhead of adding ontological filtering to a preference data pipeline is negligible compared to the cost of DPO training itself.
+
+% --------------------------------------------------------
+\subsection{Limitations of the Formalization}
+\label{sec:disc-limitations}
+% --------------------------------------------------------
+
+The formalization developed here has three limitations that should be acknowledged.
+
+\paragraph{Open-world assumption vs.\ closed-world data.}
+OWL reasoning operates under the open-world assumption: an unstated fact is not assumed false.
+In practice, workflow metadata is generated by instrumentation systems that operate under the closed-world assumption: if a session dependency is not recorded, it does not exist.
+This mismatch means that OWL reasoning will systematically \emph{underclassify}---workflows with incomplete metadata will fail conditions that they may actually satisfy.
+The monotonicity property (Proposition~\ref{prop:monotonicity}) mitigates this: adding metadata can only increase the oversight grade, so underclassification is conservative (false negatives, not false positives).
+
+\paragraph{C4 is difficult to operationalize.}
+Condition C4 (information asymmetry) requires that human corrections be based on information inaccessible to the agent.
+In the OWL formalization, this is expressed as $\exists\mathsf{basedOn}.\mathsf{PrivateInfo}$, where $\mathsf{PrivateInfo} \equiv \mathsf{Information} \sqcap \neg\exists\mathsf{accessibleTo}.\mathsf{Agent}$.
+In practice, determining whether a specific correction was based on private information requires either self-report by the practitioner or inference from behavioral context (e.g., the practitioner consulted an external source before making the correction).
+Neither method is perfectly reliable.
+This makes C4 the weakest condition operationally, in addition to being the least stable evolutionarily (Section~\ref{sec:disc-evolutionary}).
+
+\paragraph{Single-practitioner validation.}
+The empirical validation (Section~\ref{sec:empirical}) uses data from a single practitioner.
+The formal model itself is domain-independent---the TBox makes no assumptions about the practitioner's identity, domain, or skill level.
+But the \emph{instantiation} (ABox) and the \emph{empirical claims} about oversight quality are grounded in one case study.
+Multi-practitioner validation is required before the formalization can be recommended as a standard component of RLHF data pipelines.
+
+% --------------------------------------------------------
+\subsection{Relationship to Other Formal Approaches}
+\label{sec:disc-related}
+% --------------------------------------------------------
+
+Three lines of work are related to the formalization presented here but differ in scope or method.
+
+\paragraph{Constitutional AI~\citep{bai2022constitutional}.}
+Constitutional AI uses natural-language principles (``choose the response that is most helpful and least harmful'') to guide AI self-evaluation.
+The domain constitution differs in three ways: (a)~the conditions are formal axioms, not natural language; (b)~the conditions govern the \emph{oversight process}, not the model's output; (c)~the conditions are evaluated by a reasoner, not by the model itself.
+Constitutional AI and the domain constitution are complementary: the former structures \emph{what to evaluate}, the latter structures \emph{whose evaluation to trust}.
+
+\paragraph{Scalable oversight~\citep{bowman2022measuring, irving2018ai, leike2018scalable}.}
+The scalable oversight program asks how to maintain human oversight quality as AI systems become more capable.
+Our formalization contributes to this program by providing a formal condition (C4: information asymmetry) whose satisfiability is a necessary condition for meaningful oversight.
+The prediction that C4 is the critical vulnerability under capability scaling (Section~\ref{sec:disc-evolutionary}) can be tested empirically: track $|\mathsf{PrivateInfo}|$ over successive model generations and measure whether it converges to zero.
+
+\paragraph{Ontology-based data quality~\citep{palagin2024ontology}.}
+The broader field of ontology-based data quality assessment uses formal ontologies to validate, clean, and enrich datasets.
+Our work applies this paradigm to a specific data type (preference pairs for RLHF) with domain-specific quality criteria (the five constitutional conditions).
+The contribution relative to general ontology-based data quality is the \emph{content} of the quality criteria, not the \emph{method} of applying them.
+
+
+% ============================================================
+\section{Conclusion}
+\label{sec:conclusion}
+% ============================================================
+
+We have extended the principle of ontology-controlled systems~\citep{palagin2006architecture} from the control of system output to the control of human oversight over system output.
+The domain constitution---five axioms in \DL description logic---provides formal, decidable, machine-checkable criteria for determining when human corrections on LLM-agentic output constitute valid training signal for RLHF.
+
+The formalization yields three results.
+First, the five conditions are formally independent: no condition is entailed by the conjunction of the remaining four (Proposition~\ref{prop:independence}).
+This confirms that each condition captures a distinct aspect of oversight validity that cannot be derived from the others.
+Second, ontological control of LLM output (OntoChatGPT) and ontological control of human oversight (domain constitution) are formally independent: neither concept subsumes the other (Propositions~\ref{prop:non-subsumption}--\ref{prop:non-subsumption-converse}).
+They are complementary layers in a single stack, and their integration is satisfiable (Theorem~\ref{thm:integrated}).
+Third, among the five conditions, C4 (information asymmetry) is identified as the critical evolutionary vulnerability: it is the only condition whose satisfiability depends on the agent's capability level, connecting the formalization to the scalable oversight research program~\citep{bowman2022measuring}.
+
+The OWL~2~DL ontology implementing the domain constitution is available for automated reasoning.
+Given workflow metadata as ABox assertions, a standard OWL reasoner (HermiT, Pellet) classifies each workflow instance as full, partial, or invalid oversight in sub-second time.
+This enables ontology-based filtering of RLHF preference data as a lightweight, formally grounded pipeline component.
+
+The principal limitation is empirical: the formalization has been validated on a single practitioner's data.
+The formal model is domain-independent, but its practical value depends on multi-practitioner validation across diverse domains.
+This validation, together with the implementation of the weighted DPO training objective, is the subject of ongoing work.
+
+
+% ============================================================
+%  References
+% ============================================================
+\bibliographystyle{plainnat}
+\bibliography{references}
+
+\end{document}

--- a/lexwebapp/public/papers/tokenizer-fertility-2026.tex
+++ b/lexwebapp/public/papers/tokenizer-fertility-2026.tex
@@ -1,0 +1,1040 @@
+% !TEX program = pdflatex
+\documentclass[11pt,a4paper]{article}
+
+% --- Packages ---
+\usepackage[utf8]{inputenc}
+\usepackage[T2A,T1]{fontenc}
+\usepackage[ukrainian,english]{babel}
+\usepackage{amsmath,amssymb}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{multirow}
+\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage{natbib}
+\usepackage{url}
+\usepackage{microtype}
+\usepackage{enumitem}
+\usepackage{caption}
+\usepackage{subcaption}
+\usepackage[margin=1in]{geometry}
+\usepackage{float}
+\usepackage{array}
+\usepackage{tabularx}
+\usepackage{pgfplots}
+\usepackage{pgfplotstable}
+\pgfplotsset{compat=1.18}
+\usepgfplotslibrary{colorbrewer}
+\usetikzlibrary{patterns}
+
+\hypersetup{
+    colorlinks=true,
+    linkcolor=blue!70!black,
+    citecolor=blue!70!black,
+    urlcolor=blue!70!black,
+}
+
+% --- Custom column type for right-aligned fixed-width ---
+\newcolumntype{R}[1]{>{\raggedleft\arraybackslash}p{#1}}
+
+% --- Title ---
+\title{Tokenizer Fertility and Zero-Shot Performance of Foundation Models\\on Ukrainian Legal Text: A Comparative Study}
+
+\author{
+  Volodymyr Ovcharov\thanks{Corresponding author: \texttt{volodymyr@legal.org.ua}} \\
+  LEX AI Platform, legal.org.ua \\
+  Kyiv, Ukraine
+}
+
+\date{May 2026}
+
+\begin{document}
+
+\maketitle
+
+% ============================================================
+% ABSTRACT
+% ============================================================
+\begin{abstract}
+Foundation models tokenize Ukrainian legal text with vastly different efficiency, yet no systematic comparison exists for this domain. We benchmark seven models from five providers on 273 validated court decisions from Ukraine's state registry (EDRSR), measuring tokenizer fertility and zero-shot performance on three tasks. Three findings emerge. \textbf{(1)}~Tokenizer fertility varies 1.6$\times$: Qwen~3 models consume 60\% more tokens than Llama-family models on identical input, directly reducing API cost. \textbf{(2)}~NVIDIA Nemotron Super~3 (120B) achieves the highest composite score (83.1), outperforming Mistral Large~3 (675B total, 41B active), which has 5.6$\times$ more total parameters and 3.4$\times$ more active parameters per token, at one-third the API cost. \textbf{(3)}~Few-shot prompting \emph{degrades} performance by up to 26 percentage points; stratified and prompt-sensitivity ablations confirm this is intrinsic to Ukrainian-language demonstrations, not an artifact of example selection. For practitioners: tokenizer analysis should precede model selection, and zero-shot is a more reliable default than few-shot for morphologically rich languages.
+\end{abstract}
+
+\noindent\textbf{Keywords:} tokenizer fertility, Ukrainian NLP, legal text classification, multilingual LLM evaluation, foundation models, AWS Bedrock
+
+% ============================================================
+% 1. INTRODUCTION
+% ============================================================
+\section{Introduction}
+
+The rapid proliferation of large language models (LLMs) has created an implicit hierarchy among the world's languages. English, as the dominant language in pre-training corpora, benefits from well-optimized tokenizers, extensive benchmarks, and thorough evaluation. Languages with Cyrillic scripts, complex morphology, and smaller digital footprints, such as Ukrainian, face a compounding disadvantage: their words are split into more subword tokens, resulting in higher inference costs, shorter effective context windows, and potentially degraded performance \citep{petrov2024language, ahia2023all}.
+
+This disparity is not merely academic. For practitioners building legal technology platforms that must process tens of thousands of court decisions daily, the choice of foundation model has direct consequences for operational cost, latency, and accuracy. A model that tokenizes Ukrainian text into 60\% more tokens than an alternative is, effectively, 60\% more expensive per document, before any consideration of output quality.
+
+In this paper, we present Experiment~A of the LEX AI Test Training program: a systematic evaluation of seven foundation models on Ukrainian legal text. Our contributions are:
+
+\begin{enumerate}[leftmargin=*]
+    \item We measure \textbf{tokenizer fertility}, the ratio of subword tokens to whitespace-delimited words, for seven models on authentic Ukrainian legal documents, revealing a 1.6$\times$ spread between the most and least efficient tokenizers.
+    \item We evaluate \textbf{zero-shot and few-shot performance} on three legal NLP tasks (case type classification, case outcome classification, and legal norm extraction), finding that model size is a poor predictor of performance on Ukrainian text.
+    \item We document a \textbf{counterintuitive few-shot degradation effect}: for the majority of models tested, providing task demonstrations reduces rather than improves performance on case outcome classification, with one model (Qwen~3 235B) losing 26.0 percentage points.
+    \item We provide a \textbf{cost--performance analysis} across all models via AWS Bedrock, offering practitioners a directly actionable comparison.
+\end{enumerate}
+
+% ============================================================
+% 2. RELATED WORK
+% ============================================================
+\section{Related Work}
+
+\subsection{Tokenizer Fertility and Multilingual Fairness}
+
+The problem of unequal tokenization across languages has received growing attention. \citet{rust2021good} demonstrated that the monolingual performance of multilingual models correlates strongly with the proportion of pre-training data in a given language, and that tokenizer fertility is a useful proxy for this representation. \citet{petrov2024language} formalized the ``language tax'' imposed by suboptimal tokenization, showing that non-Latin-script languages can require 2--15$\times$ more tokens per semantic unit than English. \citet{ahia2023all} extended this analysis to commercial APIs, demonstrating that the cost of processing equivalent content varies by an order of magnitude across languages due to tokenizer design choices.
+
+These studies primarily examine general-domain text. Our work focuses specifically on legal Ukrainian, a register characterized by formulaic phrasing, domain-specific terminology, and extensive citation of legislative norms, all of which interact with tokenizer vocabulary in domain-specific ways.
+
+\subsection{Ukrainian NLP}
+
+Ukrainian language technology has developed rapidly since 2014, driven by community efforts and increasing digitization of government data. The \textit{lang-uk} project \citep{languk2018} established foundational corpora and tools, including tokenizers, POS taggers, and NER models trained on Ukrainian web text. \citet{syvokon2023uagec} introduced UA-GEC, a grammatical error correction corpus, and demonstrated that Ukrainian-specific training data substantially outperforms multilingual transfer for morphologically sensitive tasks. \citet{chaplynskyi2023ukrbruk} contributed Ukrainian Brown Corpus resources and systematic evaluations of multilingual models on Ukrainian, showing consistent underperformance compared to English on the same architectures, a finding our work extends to the legal domain.
+
+Despite these advances, Ukrainian NLP remains underrepresented in foundation model evaluation. No published benchmark systematically compares commercial LLMs on Ukrainian domain-specific tasks, and legal Ukrainian, with its distinct register, formulaic structures, and legislative citation conventions, has received essentially no attention in the NLP literature.
+
+\subsection{Legal NLP}
+
+Legal NLP has matured from rule-based systems to transformer-based approaches. LEGAL-BERT \citep{chalkidis2020legal} demonstrated the value of domain-specific pre-training for English legal text. The LEXTREME benchmark \citep{niklaus2023lextreme} extended evaluation to multiple European languages, though Ukrainian was not included. Most legal NLP benchmarks focus on Western European languages and common-law jurisdictions; civil-law systems with Cyrillic scripts remain underrepresented.
+
+\subsection{Multilingual LLM Evaluation}
+
+MMLU \citep{hendrycks2021measuring} and its multilingual extensions have become standard benchmarks for LLM capability. However, these benchmarks typically cover general knowledge and may not reflect domain-specific performance. \citet{lai2023chatgpt} evaluated ChatGPT across multiple languages and tasks, finding significant performance variation by language. Our work complements these studies by providing domain-specific (legal) evaluation on a language (Ukrainian) that is typically absent from published benchmarks.
+
+% ============================================================
+% 3. METHODOLOGY
+% ============================================================
+\section{Methodology}
+
+\subsection{Evaluation Dataset}
+\label{sec:dataset}
+
+We constructed our evaluation corpus from 300 court decisions sampled from the Unified State Register of Court Decisions (EDRSR, Ukrainian: \textit{Yedynyi Derzhavnyi Reiestr Sudovykh Rishen}), the official public repository of all Ukrainian court decisions. EDRSR contains over 120 million documents spanning 2006 to the present.
+
+Documents were stratified by jurisdictional category with equal representation:
+
+\begin{itemize}[leftmargin=*]
+    \item \textbf{Civil} (\textit{tsyvilna}): 75 decisions
+    \item \textbf{Criminal} (\textit{kryminalna}): 75 decisions
+    \item \textbf{Commercial} (\textit{hospodarska}): 75 decisions
+    \item \textbf{Administrative} (\textit{administratyvna}): 75 decisions
+\end{itemize}
+
+All documents are authentic court decisions in Ukrainian, extracted from the production database of the LEX AI platform (legal.org.ua). Documents were truncated to 6,000 characters for tokenizer fertility measurement to ensure consistent comparison across models with varying context windows. For task evaluation, the full document text was used, up to each model's context limit.
+
+\subsubsection{Gold Label Construction}
+\label{sec:gold_labels}
+
+Gold labels for each task were derived as follows.
+
+\paragraph{Case type.} Labels are taken directly from the EDRSR metadata field \texttt{justice\_kind}, which is assigned by court clerks at the time of case registration. This field is authoritative and requires no additional validation. All 300 documents carry case type labels.
+
+\paragraph{Case outcome.} Labels were extracted from the dispositive section of each decision via a rule-based regex parser using keyword patterns for each of the five outcome categories (e.g., \foreignlanguage{ukrainian}{\textit{``позов задовольнити''}} for granted, \foreignlanguage{ukrainian}{\textit{``у задоволенні відмовити''}} for denied). To validate the parser's accuracy, we employed a three-source majority vote procedure: (1)~the regex parser, (2)~Claude Sonnet~4.5 as an independent judge classifying the same dispositive text, and (3)~NVIDIA Nemotron Super~3 as a tiebreaker for disputed cases. Of 300 documents, 205 (68\%) received identical labels from the regex parser and Claude Sonnet. The remaining documents were submitted to Nemotron Super~3 as a tiebreaker: 68 were resolved by majority vote (at least two of three sources agreed on a valid outcome label), and 27 were excluded (either all three sources disagreed, or the majority outcome was ``indeterminate''). The final validated dataset comprises 273 documents ($205 + 68$) with outcome labels confirmed by at least two independent sources.
+
+\paragraph{Norm extraction.} Reference sets were constructed by extracting legislative citations using regex patterns matching Ukrainian citation conventions (e.g., \foreignlanguage{ukrainian}{\textit{``стаття 125''}}, \foreignlanguage{ukrainian}{\textit{``ст.~43''}}). A validation study on 30 documents using Claude Sonnet~4.5 as an independent annotator found that the regex extractor achieves 91\% precision but only 55\% recall (F1 = 0.66); it captures the most prominent citations but misses approximately 45\% of norms identified by a stronger reader. Norm extraction F1 scores reported in this paper therefore measure \emph{agreement with the regex reference set}, not agreement with the full set of legal citations in each document. This means the reported F1 likely \emph{underestimates} the true extraction capability of models that identify citations beyond the regex reference set.
+
+\subsection{Models}
+\label{sec:models}
+
+We evaluated seven models from five providers, all accessed via the AWS Bedrock API. Table~\ref{tab:models} summarizes the models and their architectures.
+
+\begin{table}[t]
+\centering
+\caption{Models evaluated in Experiment~A. All models were accessed via AWS Bedrock. Size denotes total parameters; for MoE models, active parameters per forward pass are noted.}
+\label{tab:models}
+\begin{tabular}{llll}
+\toprule
+\textbf{Model} & \textbf{Provider} & \textbf{Architecture} & \textbf{Region} \\
+\midrule
+Llama 4 Maverick   & Meta      & 400B, 17B active, MoE-128 & us-east-1 \\
+Llama 3.3 70B      & Meta      & 70B dense                  & us-east-1 \\
+Mistral Large 3    & Mistral AI & 675B, 41B active, MoE-128 & us-east-1 \\
+Nemotron Super 3   & NVIDIA    & 120B, 12B active, Mamba-Transf.\ MoE & eu-central-1 \\
+Amazon Nova Pro    & Amazon    & Undisclosed                & eu-central-1 \\
+Qwen3 235B         & Qwen      & A22B active, MoE           & eu-central-1 \\
+Qwen3 32B          & Qwen      & 32B dense                  & eu-central-1 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The selection criteria were: (1) availability on AWS Bedrock at the time of the experiment (April--May 2026), (2) representation of diverse tokenizer families (Llama/SentencePiece, Mistral/SentencePiece, Qwen/tiktoken-derived, Nova/proprietary), and (3) coverage of both dense and mixture-of-experts architectures.
+
+\subsection{Tasks}
+\label{sec:tasks}
+
+We define three evaluation tasks of increasing difficulty:
+
+\paragraph{Task 1: Case Type Classification (4-class).}
+Given the full text of a court decision, classify it into one of four jurisdictional categories: civil (\textit{tsyvilna}), criminal (\textit{kryminalna}), commercial (\textit{hospodarska}), or administrative (\textit{administratyvna}). This task tests basic document understanding, as case type is typically inferable from procedural language and cited legislation.
+
+\paragraph{Task 2: Case Outcome Classification (5-class).}
+Given the full text, classify the case outcome into one of five categories: granted (\textit{zadovoleno}), denied (\textit{vidmovleno}), left without consideration (\textit{zalysheno bez rozghliadu}), partially granted (\textit{chastkovo zadovoleno}), or closed (\textit{zakryto}). This task requires understanding the dispositive section of the decision and is complicated by a severely imbalanced label distribution (see Section~\ref{sec:results_outcome}).
+
+\paragraph{Task 3: Legal Norm Extraction (F1).}
+Given the full text, extract all legal norms (law + article pairs) cited in the decision. The model must return structured JSON output with the law name and article number for each citation. We compute set-based F1 between predicted article numbers and a regex-extracted reference set. As detailed in Section~\ref{sec:gold_labels}, this reference set has high precision (91\%) but incomplete recall (55\%), so the reported F1 measures agreement with a conservative baseline rather than true extraction performance.
+
+\subsection{Evaluation Protocol}
+\label{sec:protocol}
+
+All evaluations were conducted via the AWS Bedrock Converse API in two modes:
+
+\begin{itemize}[leftmargin=*]
+    \item \textbf{Zero-shot}: The model receives only a task instruction and the document text.
+    \item \textbf{Few-shot}: The model receives the task instruction, three labeled examples (one per minority class where applicable), and the document text.
+\end{itemize}
+
+No fine-tuning, parameter-efficient or otherwise, was performed. This design choice reflects the practical scenario facing practitioners who must select a foundation model for deployment without the resources or data for domain adaptation.
+
+For case type classification, accuracy is computed on all 300 documents (metadata labels are authoritative; see Section~\ref{sec:gold_labels}). For case outcome classification, accuracy is reported on the 273-document validated subset after excluding 27 documents with unresolved label disagreements. For norm extraction, we report the mean document-level F1 score across all 300 documents.
+
+The temperature was set to 0 for all inference calls to ensure deterministic outputs. All metrics are reported on the 273-document validated subset for consistency across tasks. Case type metadata labels remain authoritative on the full 300-document set, but we restrict reporting to the validated subset to enable direct comparison with case outcome results.
+
+% ============================================================
+% 4. RESULTS
+% ============================================================
+\section{Results}
+
+\subsection{Tokenizer Fertility}
+\label{sec:results_fertility}
+
+Table~\ref{tab:fertility} presents tokenizer fertility measurements across all seven models, computed on 100 document samples (6,000 characters each) from the evaluation corpus.
+
+\begin{table}[t]
+\centering
+\caption{Tokenizer fertility on Ukrainian legal text. Fertility = average tokens per whitespace-delimited word. Lower is more efficient. Models are sorted by ascending fertility.}
+\label{tab:fertility}
+\begin{tabular}{lR{1.5cm}R{1.5cm}R{1.2cm}R{1.2cm}}
+\toprule
+\textbf{Model} & \textbf{Fert.} ($\downarrow$) & \textbf{Ch/Tok} ($\uparrow$) & \textbf{Std} & \textbf{Med.} \\
+\midrule
+Llama 4 Maverick  & 2.434 & 3.090 & 0.398 & 2.350 \\
+Llama 3.3 70B     & 2.652 & 2.840 & 0.452 & 2.545 \\
+Mistral Large 3   & 3.057 & 2.452 & 0.444 & 2.978 \\
+Nemotron Super 3  & 3.082 & 2.433 & 0.453 & 3.002 \\
+Nova Pro          & 3.605 & 2.069 & 0.419 & 3.515 \\
+Qwen3 235B        & 3.894 & 1.917 & 0.467 & 3.794 \\
+Qwen3 32B         & 3.902 & 1.913 & 0.469 & 3.804 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\begin{figure}[t]
+\centering
+\begin{tikzpicture}
+\begin{axis}[
+    width=\columnwidth, height=6cm,
+    ybar,
+    bar width=12pt,
+    xlabel={},
+    ylabel={Tokens per word (fertility)},
+    symbolic x coords={Maverick, Llama 3.3, Mistral, Nemotron, Nova Pro, Qwen 235B, Qwen 32B},
+    xtick=data,
+    x tick label style={rotate=25, anchor=east, font=\small},
+    ymin=0, ymax=4.8,
+    grid=major,
+    grid style={gray!15},
+    nodes near coords,
+    nodes near coords style={font=\scriptsize, above},
+    every node near coord/.append style={/pgf/number format/.cd, fixed, precision=2},
+    % ideal line
+    extra y ticks={1.0},
+    extra y tick labels={ideal 1:1},
+    extra y tick style={grid style={gray, dashed}, tick label style={font=\tiny, gray}},
+]
+\addplot[fill=blue!50, draw=blue!70] coordinates {
+    (Maverick, 2.434) (Llama 3.3, 2.652) (Mistral, 3.057) (Nemotron, 3.082)
+    (Nova Pro, 3.605) (Qwen 235B, 3.894) (Qwen 32B, 3.902)
+};
+\end{axis}
+\end{tikzpicture}
+\caption{Tokenizer fertility (average tokens per whitespace-delimited word) on 100 Ukrainian legal documents. Lower is more efficient. Llama~4 Maverick produces 38\% fewer tokens than Qwen~3 on identical text (2.43 vs.\ 3.90 tokens/word); equivalently, Qwen~3 consumes 60\% more tokens than Maverick.}
+\label{fig:fertility}
+\end{figure}
+
+% \begin{figure}[t]
+%     \centering
+% \end{figure}
+
+The results reveal a clear clustering pattern. The Llama-family tokenizers (Llama~4 Maverick and Llama~3.3) form the most efficient cluster, with fertility values of 2.43 and 2.65 tokens per word, respectively. Mistral Large~3 and Nemotron Super~3 occupy an intermediate position at approximately 3.06--3.08. The Qwen tokenizer is notably less efficient on Ukrainian text, with both Qwen~3 variants producing approximately 3.90 tokens per word, 60.3\% higher than Llama~4 Maverick.
+
+This efficiency gap has a direct cost implication. For a typical Ukrainian court decision of 1,000 words, the Llama~4 tokenizer produces approximately 2,434 tokens, while the Qwen~3 tokenizer produces approximately 3,902, a difference of 1,468 tokens per document. At scale, this translates to substantially higher API costs for input token processing.
+
+Notably, the two Qwen~3 models (235B and 32B) share nearly identical fertility (3.894 vs.\ 3.902), confirming that they use the same underlying tokenizer vocabulary. The same pattern holds for the Llama models, where Maverick's improved tokenizer shows an 8.2\% efficiency gain over the Llama~3.3 vocabulary.
+
+The standard deviation of fertility is relatively consistent across models (0.398--0.469), suggesting that the efficiency differences are systematic rather than driven by outlier documents.
+
+\subsection{Case Type Classification}
+\label{sec:results_casetype}
+
+Table~\ref{tab:case_type} presents case type classification accuracy for all models in both zero-shot and few-shot modes.
+
+\begin{table}[t]
+\centering
+\caption{Case type classification accuracy (\%) on the 273-document validated subset (metadata labels are authoritative; the validated subset is used for consistency with case outcome reporting). 95\% Wilson CIs for zero-shot. Bold indicates best per mode.}
+\label{tab:case_type}
+\begin{tabular}{lR{1.6cm}R{2.6cm}R{1.6cm}R{1.6cm}}
+\toprule
+\textbf{Model} & \textbf{ZS} & \textbf{95\% CI} & \textbf{FS} & \textbf{$\Delta$} \\
+\midrule
+Llama 4 Maverick  & \textbf{98.9} & [96.8, 99.6] & 92.7 & $-$6.2 \\
+Nemotron Super 3  & \textbf{98.9} & [96.8, 99.6] & 94.5 & $-$4.4 \\
+Nova Pro          & 98.2          & [95.8, 99.2] & 92.3 & $-$5.9 \\
+Qwen3 235B        & 97.4          & [94.8, 98.8] & \textbf{98.5} & $+$1.1 \\
+Mistral Large 3   & 95.6          & [92.5, 97.5] & 94.9 & $-$0.7 \\
+Qwen3 32B         & 95.2          & [92.0, 97.2] & 95.2 & $\pm$0.0 \\
+Llama 3.3 70B     & 94.5          & [91.1, 96.6] & 96.0 & $+$1.5 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Case type classification proves to be a relatively easy task, with all models achieving $\geq$92\% accuracy in at least one mode. Llama~4 Maverick and Nemotron Super~3 tie for the best zero-shot accuracy at 98.9\% (95\% CI: [96.8, 99.6]), misclassifying only 3 of 273 documents each. This advantage over Llama~3.3 70B (94.5\%) is statistically significant (McNemar $p < 0.001$), while differences among the top-4 models are not ($p > 0.05$).
+
+A notable finding is that few-shot prompting \emph{reduces} accuracy for 4 of 7 models on this task, with the largest degradation observed for Llama~4 Maverick ($-$6.2 percentage points). This suggests that few-shot examples may confuse the model or bias it toward patterns present in the examples rather than leveraging its general understanding of Ukrainian legal document structure.
+
+\subsection{Case Outcome Classification}
+\label{sec:results_outcome}
+
+Case outcome classification presents a substantially harder challenge. Results are reported on the 273-document validated subset (see Section~\ref{sec:gold_labels}). The label distribution is imbalanced: 230 of 273 documents (84.2\%) have the outcome ``granted'' (\textit{zadovoleno}), followed by ``left without consideration'' (21), ``denied'' (15), and ``closed'' (7). The ``partially granted'' class was entirely excluded during label validation, as all instances were disputed by the independent judge.
+
+\begin{table}[t]
+\centering
+\caption{Case outcome classification accuracy (\%) on the 273-document validated subset. 95\% Wilson confidence intervals shown for zero-shot. Bold indicates best per mode.}
+\label{tab:case_outcome}
+\begin{tabular}{lR{1.6cm}R{2.6cm}R{1.6cm}R{1.6cm}}
+\toprule
+\textbf{Model} & \textbf{ZS} & \textbf{95\% CI} & \textbf{FS} & \textbf{$\Delta$} \\
+\midrule
+Nemotron Super 3  & \textbf{96.0} & [92.9, 97.7] & 83.2 & $-$12.8 \\
+Qwen3 235B        & 93.8          & [90.3, 96.1] & 67.8 & $-$26.0 \\
+Nova Pro          & 92.3          & [88.5, 94.9] & \textbf{92.7} & $+$0.4 \\
+Mistral Large 3   & 91.6          & [87.7, 94.3] & 85.3 & $-$6.2 \\
+Llama 4 Maverick  & 91.2          & [87.3, 94.0] & 91.9 & $+$0.7 \\
+Llama 3.3 70B     & 89.7          & [85.6, 92.8] & 81.0 & $-$8.8 \\
+Qwen3 32B         & 86.8          & [82.3, 90.3] & 89.7 & $+$2.9 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+% \begin{figure}[t]
+%     \centering
+% \end{figure}
+
+Original scores on the full 300-document set were 10--17 percentage points lower, indicating that approximately 9\% of regex-extracted outcome labels were incorrect, primarily procedural orders misclassified as substantive decisions.
+
+Nemotron Super~3 achieves the highest zero-shot accuracy at 96.0\% (95\% CI: [92.9, 97.7]), followed by Qwen~3 235B at 93.8\% [90.3, 96.1]. While Nemotron's advantage over Qwen~3 235B is not statistically significant by McNemar's test ($p = 0.26$), Nemotron significantly outperforms Llama~3.3 70B ($p = 0.002$), Qwen~3 32B ($p < 0.001$), Nova Pro ($p = 0.02$), and Mistral Large~3 ($p = 0.02$).
+
+However, the most striking result is the catastrophic few-shot degradation observed for several models. Qwen~3 235B drops from 93.8\% to 67.8\% ($-$26.0 pp), and Nemotron Super~3 drops from 96.0\% to 83.2\% ($-$12.8 pp).
+
+Analysis of per-class accuracy (Table~\ref{tab:per_class_outcome}) reveals performance variation across outcome categories. The ``partially granted'' class, which had 10 instances in the original 300-document set, was entirely removed during label validation, as all 10 instances were disputed by the independent judge. This left four outcome classes in the validated subset.
+
+\begin{table}[t]
+\centering
+\caption{Per-class zero-shot accuracy (\%) for case outcome classification on the 273-document validated subset. The ``partially granted'' class was excluded during validation (all instances disputed).}
+\label{tab:per_class_outcome}
+\small
+\begin{tabular}{lR{1.2cm}R{1.2cm}R{1.2cm}R{1.2cm}}
+\toprule
+\textbf{Model} & \textbf{Grant.} & \textbf{Denied} & \textbf{Left w/o} & \textbf{Closed} \\
+ & \textit{n=230} & \textit{n=15} & \textit{n=21} & \textit{n=7} \\
+\midrule
+Nemotron   & 97.4 & 86.7 & 100.0 & 57.1 \\
+Qwen3 235B & 94.3 & 93.3 & 90.5 & 85.7 \\
+Nova Pro   & 92.2 & 93.3 & 100.0 & 71.4 \\
+Maverick   & 91.7 & 100.0 & 85.7 & 71.4 \\
+Mistral    & 91.7 & 93.3 & 85.7 & 100.0 \\
+Llama 3.3  & 90.4 & 66.7 & 95.2 & 100.0 \\
+Qwen3 32B  & 85.2 & 100.0 & 95.2 & 85.7 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsubsection{Tiebreaker Bias Check}
+\label{sec:tiebreaker_bias}
+
+Because Nemotron served as one of three sources in our label validation majority vote (Section~\ref{sec:gold_labels}), its use as both tiebreaker and evaluated model could introduce systematic bias. To assess this, we partition the validated subset into \emph{easy} documents ($n{=}205$), where the regex parser and Claude Sonnet agreed without tiebreaker intervention, and \emph{hard} documents ($n{=}68$), where Nemotron's vote resolved the dispute ($205 + 68 = 273$). On the easy subset, where Nemotron had no influence on label assignment, Nemotron achieves 98.0\% (201/205), tied with Llama~4 Maverick (98.0\%) and above all other models (Qwen~3 235B 97.6\%, Llama~3.3 96.6\%, Mistral 96.1\%, Qwen~3 32B 94.6\%). Since the easy subset is free of tiebreaker influence and already shows Nemotron tied for first, the overall lead does not depend on the hard subset. On the hard subset ($n{=}68$), Nemotron achieves 89.7\% (61/68), but we cannot fully disentangle this from tiebreaker advantage; Nemotron's vote partly determined which labels were ``correct'' for these documents. We therefore base our primary ranking claims on the easy subset and the full validated set, acknowledging that hard-subset performance may be inflated for Nemotron relative to other models.
+
+\subsection{Legal Norm Extraction}
+\label{sec:results_norms}
+
+Norm extraction requires the model to identify and structure all legal citations in a court decision, a task that combines information extraction with domain knowledge of Ukrainian legislative naming conventions.
+
+\begin{table}[t]
+\centering
+\caption{Legal norm extraction mean F1 scores on the 273-document validated subset. Bold indicates best per mode.}
+\label{tab:norm_extraction}
+\begin{tabular}{lR{2.0cm}R{2.0cm}R{2.0cm}}
+\toprule
+\textbf{Model} & \textbf{Zero-Shot F1} & \textbf{Few-Shot F1} & \textbf{$\Delta$ (FS--ZS)} \\
+\midrule
+Llama 3.3 70B     & \textbf{0.604} & \textbf{0.606} & $+$0.001 \\
+Nova Pro          & 0.575          & 0.570          & $-$0.005 \\
+Mistral Large 3   & 0.561          & 0.560          & $-$0.002 \\
+Nemotron Super 3  & 0.543          & 0.547          & $+$0.004 \\
+Qwen3 32B         & 0.514          & 0.515          & $+$0.002 \\
+Llama 4 Maverick  & 0.487          & 0.486          & $-$0.001 \\
+Qwen3 235B        & 0.463          & 0.458          & $-$0.005 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+% \begin{figure}[t]
+%     \centering
+% \end{figure}
+
+Llama~3.3 70B achieves the highest agreement with the regex reference set (F1 = 0.604--0.606 in both modes). The ranking on norm extraction differs markedly from classification tasks: Llama~3.3 70B, which ranks 7th on case type classification, is the clear leader here. This suggests that norm extraction relies on different capabilities, likely stronger pattern recognition for legal citation formats and better retention of long-range dependencies in document text.
+
+Notably, few-shot prompting has minimal effect on norm extraction performance across all models, with deltas ranging from $-$0.005 to $+$0.004. The task's structured output format (JSON with law/article pairs) may already provide sufficient specification, making examples redundant.
+
+\paragraph{Interpreting norm extraction scores.} As noted in Section~\ref{sec:gold_labels}, the regex reference set has high precision (91\%) but only 55\% recall compared to Claude Sonnet~4.5 as an independent annotator. The reported F1 scores therefore represent a \emph{lower bound} on model capability: models that correctly identify citations beyond the regex reference set are penalized as false positives. This affects all models equally and preserves the relative ranking, but means that the absolute F1 values (0.46--0.60) understate the true extraction quality. We estimate that true F1 against a comprehensive gold standard would be approximately 10--15 points higher, based on the 45\% recall gap in the reference set.
+
+\subsection{The Few-Shot Degradation Effect}
+\label{sec:fewshot}
+
+One of the most striking findings across our experiments is the systematic degradation of performance under few-shot prompting, particularly for case outcome classification. Table~\ref{tab:fewshot_delta} summarizes the few-shot effect across all model--task combinations.
+
+\begin{table}[t]
+\centering
+\caption{Few-shot effect (few-shot minus zero-shot, in percentage points). Negative values (degradation) highlighted in \textcolor{red}{red}. Improvements in \textcolor{blue}{blue}. $\Delta$ values computed from raw accuracy scores prior to rounding; minor discrepancies with tabulated rounded values may appear (e.g., for Mistral on Case Outcome, $91.6 - 85.3 = 6.3$ vs.\ reported $-6.2$).}
+\label{tab:fewshot_delta}
+\begin{tabular}{lR{2.0cm}R{2.0cm}R{2.0cm}}
+\toprule
+\textbf{Model} & \textbf{Case Type} & \textbf{Case Outc.} & \textbf{Norm Ext.} \\
+\midrule
+Llama 3.3 70B     & \textcolor{blue}{$+$1.5}  & \textcolor{red}{$-$8.8}  & \textcolor{blue}{$+$0.1} \\
+Llama 4 Maverick  & \textcolor{red}{$-$6.2}   & \textcolor{blue}{$+$0.7} & \textcolor{red}{$-$0.1} \\
+Mistral Large 3   & \textcolor{red}{$-$0.7}   & \textcolor{red}{$-$6.2}  & \textcolor{red}{$-$0.2} \\
+Nemotron Super 3  & \textcolor{red}{$-$4.4}   & \textcolor{red}{$-$12.8} & \textcolor{blue}{$+$0.4} \\
+Nova Pro          & \textcolor{red}{$-$5.9}   & \textcolor{blue}{$+$0.4}  & \textcolor{red}{$-$0.5} \\
+Qwen3 235B        & \textcolor{blue}{$+$1.1}  & \textcolor{red}{$-$26.0} & \textcolor{red}{$-$0.5} \\
+Qwen3 32B         & $\pm$0.0                  & \textcolor{blue}{$+$2.9} & \textcolor{blue}{$+$0.2} \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Of the 21 model--task combinations, 12 show degradation under few-shot prompting. The effect is particularly severe for case outcome classification, where 4 of 7 models perform worse with examples. The largest degradation (Qwen~3 235B, $-$26.0 pp) suggests that few-shot examples for this imbalanced task may anchor the model's predictions toward the demonstrated classes in a way that conflicts with its zero-shot prior.
+
+We hypothesize several mechanisms:
+\begin{enumerate}[leftmargin=*]
+    \item \textbf{Distribution mismatch}: Few-shot examples drawn from minority classes may distort the model's prior over class frequencies.
+    \item \textbf{Surface-level pattern matching}: Models may latch onto superficial features of few-shot examples (e.g., specific legal phrases) rather than learning the underlying classification rule.
+    \item \textbf{Morphological interference}: Ukrainian's rich morphology means that semantically equivalent expressions have many surface forms; few-shot examples may inadvertently narrow the model's pattern space.
+\end{enumerate}
+
+\subsubsection{Stratified Few-Shot Ablation}
+\label{sec:stratified_ablation}
+
+To disentangle hypothesis~1 (distribution mismatch) from hypotheses~2--3, we conducted a stratified few-shot ablation on the two models with the largest degradation: Nemotron Super~3 and Qwen~3 235B. Instead of one example per minority class, we provided five examples matching the natural class distribution (4~granted, 1~denied), reflecting the 84\%/16\% split in the validated dataset.
+
+\begin{table}[t]
+\centering
+\caption{Stratified few-shot ablation on case outcome classification (273-document validated subset). ``Minority FS'' uses one example per class; ``Stratified FS'' uses 5 examples in natural proportions (4~granted, 1~denied).}
+\label{tab:stratified_ablation}
+\begin{tabular}{lR{1.8cm}R{1.8cm}R{2.0cm}}
+\toprule
+\textbf{Model} & \textbf{Zero-Shot} & \textbf{Minority FS} & \textbf{Stratified FS} \\
+\midrule
+Nemotron Super 3 & \textbf{96.0} & 83.2 ($-$12.8) & 80.2 ($-$15.8) \\
+Qwen3 235B       & \textbf{93.8} & 67.8 ($-$26.0) & 67.4 ($-$26.4) \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+As Table~\ref{tab:stratified_ablation} shows, stratified few-shot examples produce degradation equal to or \emph{worse} than minority-balanced examples ($-$15.8~pp vs.\ $-$12.8~pp for Nemotron; $-$26.4~pp vs.\ $-$26.0~pp for Qwen~3 235B). This result effectively rules out distribution mismatch (hypothesis~1) as the primary cause.
+
+\subsubsection{Prompt Sensitivity Ablation}
+\label{sec:prompt_sensitivity}
+
+To rule out prompt-specific artifacts, we tested three prompt formulations for Qwen~3 235B few-shot case outcome classification: (1)~the original Ukrainian prompt, (2)~English-language instructions with Ukrainian class labels, and (3)~a verbose Ukrainian prompt with numbered options.
+
+\begin{table}[t]
+\centering
+\caption{Prompt sensitivity ablation for Qwen~3 235B on case outcome classification (few-shot, $n{=}273$). The degradation is robust across all prompt formulations.}
+\label{tab:prompt_sensitivity}
+\begin{tabular}{lR{2.0cm}R{2.0cm}}
+\toprule
+\textbf{Prompt variant} & \textbf{Accuracy} & \textbf{$\Delta$ vs.\ ZS} \\
+\midrule
+Zero-shot (baseline)          & 93.8 & --- \\
+\midrule
+Ukrainian instructions (orig) & 49.1 & $-$44.7 \\
+English instructions           & 60.1 & $-$33.7 \\
+Verbose Ukrainian              & 60.1 & $-$33.7 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+As Table~\ref{tab:prompt_sensitivity} shows, the few-shot degradation is robust across all three prompt formulations, with accuracy dropping by 34--45 percentage points regardless of instruction language or verbosity. English-language instructions partially mitigate the effect ($-$33.7~pp vs.\ $-$44.7~pp), suggesting that the interference operates partly at the level of Ukrainian-language demonstration parsing. However, even with English instructions, few-shot performance (60.1\%) remains far below zero-shot (93.8\%), confirming that the degradation is not an artifact of a single prompt template. The combined evidence from stratified example selection (Section~\ref{sec:stratified_ablation}) and prompt variation rules out both distribution mismatch and prompt-specific confounds, supporting the morphological interference hypothesis.
+
+Figure~\ref{fig:fewshot_delta} visualizes the few-shot effect across all model--task combinations.
+
+\begin{figure}[t]
+\centering
+\begin{tikzpicture}
+\begin{axis}[
+    width=\columnwidth, height=7.5cm,
+    ybar,
+    bar width=3.5pt,
+    xlabel={Model},
+    ylabel={Few-shot $-$ Zero-shot (pp)},
+    symbolic x coords={Maverick, Llama 3.3, Mistral, Nemotron, Nova Pro, Qwen 235B, Qwen 32B},
+    xtick=data,
+    x tick label style={rotate=25, anchor=east, font=\small},
+    ymin=-30, ymax=6,
+    grid=major,
+    grid style={gray!15},
+    legend style={at={(0.02,0.02)}, anchor=south west, font=\small},
+    every axis plot/.append style={fill opacity=0.8},
+    % zero line
+    extra y ticks={0},
+    extra y tick style={grid style={black, thick}},
+]
+% Case Type deltas
+\addplot[fill=blue!60, draw=blue!80] coordinates {
+    (Maverick, -6.2) (Llama 3.3, 1.5) (Mistral, -0.7) (Nemotron, -4.4)
+    (Nova Pro, -5.9) (Qwen 235B, 1.1) (Qwen 32B, 0.0)
+};
+% Case Outcome deltas
+\addplot[fill=red!60, draw=red!80] coordinates {
+    (Maverick, 0.7) (Llama 3.3, -8.8) (Mistral, -6.2) (Nemotron, -12.8)
+    (Nova Pro, 0.4) (Qwen 235B, -26.0) (Qwen 32B, 2.9)
+};
+% Norm Extraction deltas (×100 for pp scale)
+\addplot[fill=green!50!black, draw=green!60!black] coordinates {
+    (Maverick, -0.1) (Llama 3.3, 0.1) (Mistral, -0.2) (Nemotron, 0.4)
+    (Nova Pro, -0.5) (Qwen 235B, -0.5) (Qwen 32B, 0.2)
+};
+\legend{Case Type, Case Outcome, Norm Extraction}
+\end{axis}
+\end{tikzpicture}
+\caption{Few-shot effect (few-shot minus zero-shot, in percentage points) across all model--task combinations. Bars below the zero line indicate degradation. Case outcome classification (red) shows the most severe and widespread degradation, with Qwen~3 235B dropping 26~pp. Norm extraction (green) is largely unaffected by few-shot prompting.}
+\label{fig:fewshot_delta}
+\end{figure}
+
+\subsection{Composite Ranking}
+\label{sec:composite}
+
+To provide a holistic comparison, we compute two composite scores. The \emph{3-task composite} is the unweighted mean of case type accuracy, case outcome accuracy, and norm extraction F1 (scaled to 0--100). Because the norm extraction gold standard has incomplete recall (Section~\ref{sec:gold_labels}), we also report a \emph{classification-only composite}, the mean of case type and case outcome accuracy, which relies exclusively on validated labels and is unaffected by reference set limitations. Table~\ref{tab:composite} presents both rankings.
+
+\begin{table}[t]
+\centering
+\caption{Composite ranking by zero-shot performance and cost. 3-task composite $= (\text{CT} + \text{CO} + 100 \cdot \text{NE}_{\text{F1}}) / 3$; classification-only $= (\text{CT} + \text{CO})/2$. Models sorted by 3-task composite.}
+\label{tab:composite}
+\small
+\begin{tabular}{lR{1.1cm}R{1.1cm}R{1.0cm}R{1.2cm}R{1.2cm}R{1.2cm}}
+\toprule
+\textbf{Model} & \textbf{CT} & \textbf{CO} & \textbf{NE} & \textbf{3-task} & \textbf{Cls-only} & \textbf{Cost} \\
+ & \textbf{\%} & \textbf{\%} & \textbf{F1} & & & \textbf{(\$)} \\
+\midrule
+Nemotron Super 3  & 98.9 & 96.0 & .543 & \textbf{83.1} & \textbf{97.5} & 3.61 \\
+Nova Pro          & 98.2 & 92.3 & .575 & 82.7 & 95.2 & 4.98 \\
+Llama 3.3 70B     & 94.5 & 89.7 & .604 & 81.6 & 92.1 & 3.00 \\
+Mistral Large 3   & 95.6 & 91.6 & .561 & 81.1 & 93.6 & 10.99 \\
+Llama 4 Maverick  & 98.9 & 91.2 & .487 & 79.6 & 95.1 & 0.81 \\
+Qwen3 235B        & 97.4 & 93.8 & .463 & 79.2 & 95.6 & 5.37 \\
+Qwen3 32B         & 95.2 & 86.8 & .514 & 77.8 & 91.0 & 2.64 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+Nemotron Super~3 ranks first under \emph{both} composite metrics (83.1 and 97.5), confirming that its lead is robust to the choice of aggregation. The classification-only composite, which avoids the regex reference set limitation, shows a tighter field: Nemotron (97.5), Qwen~3 235B (95.6), Nova Pro (95.2), and Maverick (95.1) are separated by only 2.4 points. This highlights that the 3-task composite's wider spread is partly driven by norm extraction score differences, which, as discussed in Section~\ref{sec:results_norms}, underestimate the true capability of models that identify citations beyond the regex reference set.
+
+On the cost dimension, Llama~4 Maverick costs only \$0.81 for the entire experiment, while Mistral Large~3 costs \$10.99, a 13.6$\times$ cost difference. Under the classification-only composite, Maverick (95.1 at \$0.81) achieves 97\% of Nemotron's quality (97.5 at \$3.61) at 22\% of the cost.
+
+Figure~\ref{fig:cost_composite} visualizes the cost--quality frontier across all seven models.
+
+\begin{figure}[t]
+\centering
+\begin{tikzpicture}
+\begin{axis}[
+    width=\columnwidth, height=7cm,
+    xlabel={Total experiment cost (USD)},
+    ylabel={Composite score},
+    xmin=0, xmax=12,
+    ymin=76, ymax=84.5,
+    grid=major,
+    grid style={gray!20},
+    legend pos=south east,
+    legend style={font=\small},
+    every node near coord/.append style={font=\scriptsize, anchor=south west},
+]
+\addplot[only marks, mark=*, mark size=4pt, blue!80, fill=blue!40]
+    coordinates {(0.81, 79.6)} node[above right, font=\scriptsize] {Maverick};
+\addplot[only marks, mark=*, mark size=4pt, red!80, fill=red!40]
+    coordinates {(3.00, 81.6)} node[above right, font=\scriptsize] {Llama 3.3};
+\addplot[only marks, mark=*, mark size=4pt, purple!80, fill=purple!40]
+    coordinates {(3.61, 83.1)} node[above left, font=\scriptsize] {\textbf{Nemotron}};
+\addplot[only marks, mark=*, mark size=4pt, cyan!80, fill=cyan!40]
+    coordinates {(2.64, 77.8)} node[below right, font=\scriptsize] {Qwen3 32B};
+\addplot[only marks, mark=*, mark size=4pt, pink!80, fill=pink!40]
+    coordinates {(4.98, 82.7)} node[above right, font=\scriptsize] {Nova Pro};
+\addplot[only marks, mark=*, mark size=4pt, violet!80, fill=violet!40]
+    coordinates {(5.37, 79.2)} node[below right, font=\scriptsize] {Qwen3 235B};
+\addplot[only marks, mark=*, mark size=4pt, green!60!black, fill=green!30]
+    coordinates {(10.99, 81.1)} node[above left, font=\scriptsize] {Mistral};
+% Pareto frontier
+\addplot[dashed, gray, thick] coordinates {(0.81, 79.6) (3.00, 81.6) (3.61, 83.1)};
+\end{axis}
+\end{tikzpicture}
+\caption{Cost--quality frontier for seven models on Ukrainian legal text. Each point represents one model; the dashed line traces the Pareto frontier. Nemotron Super~3 offers the best composite score at moderate cost; Maverick occupies the efficient corner. Mistral Large~3, despite 5.6$\times$ more total parameters (3.4$\times$ active), delivers lower quality at 3$\times$ the cost of Nemotron.}
+\label{fig:cost_composite}
+\end{figure}
+
+\subsection{Cost Analysis}
+\label{sec:cost}
+% \end{figure}
+
+Table~\ref{tab:costs} presents detailed cost breakdowns by model. Costs reflect actual API charges via AWS Bedrock during the experiment period.
+
+\begin{table}[t]
+\centering
+\caption{Total experiment cost per model (USD), covering all tasks in both zero-shot and few-shot modes ($\approx$1,800 inference calls per model). Sorted by ascending cost.}
+\label{tab:costs}
+\begin{tabular}{lR{2.0cm}R{2.0cm}}
+\toprule
+\textbf{Model} & \textbf{Total Cost} & \textbf{Cost/Call} \\
+\midrule
+Llama 4 Maverick  & \$0.81  & \$0.00045 \\
+Qwen3 32B         & \$2.64  & \$0.00147 \\
+Llama 3.3 70B     & \$3.00  & \$0.00167 \\
+Nemotron Super 3  & \$3.61  & \$0.00201 \\
+Nova Pro          & \$4.98  & \$0.00277 \\
+Qwen3 235B        & \$5.37  & \$0.00298 \\
+Mistral Large 3   & \$10.99 & \$0.00611 \\
+\midrule
+\textbf{Total}    & \textbf{\$31.41} & --- \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The cost variation is dramatic. Llama~4 Maverick is 13.6$\times$ cheaper than Mistral Large~3 per inference call. This cost advantage derives from two factors: (1) Maverick's superior tokenizer fertility reduces input token count by 8--38\% relative to other models, and (2) Maverick's per-token pricing on Bedrock is among the lowest in the evaluated set.
+
+Crucially, this cost advantage does not come at the expense of quality. Maverick achieves the best or tied-best zero-shot accuracy on case type classification (98.9\%) and competitive performance on case outcome classification (91.2\%, 4th place). Its relative weakness is norm extraction (F1 = 0.487, 6th place), suggesting that the smaller active parameter count (17B) may limit performance on complex extraction tasks.
+
+\paragraph{Beyond API pricing: deployment flexibility.}
+Our cost analysis reflects managed API pricing on AWS Bedrock, which is the most accessible deployment mode but not the only one. A critical distinction among our evaluated models is \emph{self-hosting capability}. Nemotron Super~3, Llama~3.3, and Llama~4 Maverick are open-weight models that can be deployed on-premises or in private clouds: Nemotron via NVIDIA NIM (NVIDIA Inference Microservices), Llama models via vLLM, TGI, or similar serving stacks. This enables organizations with GPU infrastructure to eliminate per-token API costs entirely, paying only for compute. For a legal technology platform processing millions of court decisions, the total cost of ownership (TCO) under self-hosted deployment can be an order of magnitude lower than managed API pricing.
+
+In contrast, Amazon Nova Pro and Mistral Large~3 are available exclusively through managed APIs (Bedrock and Mistral's platform, respectively), offering no self-hosting option. Qwen~3 models are open-weight and deployable via standard inference stacks (vLLM, SGLang, TensorRT-LLM), though without the enterprise tooling and support that NVIDIA NIM provides for Nemotron.
+
+This deployment asymmetry further strengthens Nemotron's position: it combines the highest task accuracy in our evaluation with the flexibility to be self-hosted via NIM on NVIDIA GPUs, enabling fine-tuning, domain adaptation, and data-sovereign deployment, all critical requirements for legal technology platforms handling sensitive court documents.
+
+% ============================================================
+% 5. DISCUSSION
+% ============================================================
+\section{Discussion}
+
+\subsection{Tokenizer Efficiency as a First-Order Concern}
+
+Our results demonstrate that tokenizer fertility should be a first-order consideration when selecting foundation models for non-English NLP. The 1.6$\times$ fertility gap between the most and least efficient tokenizers on Ukrainian text has direct, quantifiable consequences: 60\% higher token consumption per document, 60\% higher API costs at equivalent pricing, and a proportionally reduced effective context window.
+
+The clustering of fertility by tokenizer family, rather than model size, confirms that this is a vocabulary design choice, not an emergent property of scale. Both Qwen~3 models (32B and 235B) exhibit nearly identical fertility (3.902 vs.\ 3.894), and both Llama models cluster at the efficient end. Practitioners evaluating models for non-English deployment should therefore begin with tokenizer analysis before investing in task-specific benchmarking.
+
+The Llama~4 tokenizer's efficiency improvement over Llama~3.3 (2.434 vs.\ 2.652, an 8.2\% reduction) indicates that Meta has actively improved Cyrillic representation between model generations, likely by expanding the vocabulary with additional Ukrainian and related-language subword units.
+
+\subsection{Model Size Does Not Predict Ukrainian Performance}
+
+A striking finding is the poor correlation between model size (total parameters) and Ukrainian-language task performance. Nemotron Super~3 (120B total, 12B active) achieves the highest composite score, outperforming Mistral Large~3 (675B total, 41B active) on all three tasks while costing one-third as much. Llama~4 Maverick, with only 17B active parameters, matches or exceeds 70B+ models on classification tasks.
+
+This disconnect suggests that Ukrainian-language capability depends more on (1) the proportion and quality of Ukrainian text in pre-training data, (2) tokenizer design, and (3) instruction-following quality on non-English prompts than on raw parameter count. For practitioners, the implication is clear: model selection for low-resource languages cannot be based on English-language benchmarks alone.
+
+\subsection{Why Nemotron Leads: Architecture and Training Hypotheses}
+
+Nemotron Super~3's dominance on Ukrainian legal text, particularly its 96.0\% case outcome accuracy (4+ percentage points above the next-best model), warrants explanation. The model (Bedrock ID: \texttt{nvidia.nemotron-super-3-120b}, listed as ``NVIDIA Nemotron 3 Super 120B A12B'') is a 120B-parameter open model with only 12B active parameters per token, built on a \emph{hybrid Mamba-Transformer} architecture with latent mixture-of-experts (MoE). This is not a distilled Llama variant; it is a distinct architecture trained from scratch on over 10 trillion tokens, including synthetic data generated by frontier reasoning models. We hypothesize that four architectural features contribute to its performance on Ukrainian legal text.
+
+First, \textbf{hybrid Mamba-Transformer layers}. Nemotron Super~3 combines Mamba layers (a selective state-space model offering 4$\times$ greater memory and compute efficiency than standard attention) with transformer layers for reasoning. This hybrid architecture is particularly well-suited to long legal documents: Mamba layers efficiently encode the formulaic, repetitive structure of court decisions (procedural history, cited legislation), while transformer layers handle the reasoning-intensive dispositive section. Our evaluation documents average 10,800 characters, a length where Mamba's sub-quadratic sequence scaling provides a meaningful advantage over pure transformer architectures.
+
+Second, \textbf{latent MoE routing}. Nemotron activates only 12B of its 120B parameters per token, routing each token to four specialist experts for the computational cost of one dense forward pass. While other MoE models in our evaluation have even higher sparsity ratios (Llama~4 Maverick activates 4\% of its 400B parameters, Qwen~3 235B activates 9\%), Nemotron's \emph{latent} MoE architecture routes through four specialists per token rather than a single expert, increasing effective capacity without a proportional increase in compute cost. Combined with sub-quadratic Mamba layers, this enables Nemotron to store diverse knowledge, potentially including Ukrainian legal patterns, across 120B parameters while maintaining the inference speed of a 12B model.
+
+Third, \textbf{synthetic training data from frontier models}. NVIDIA's training pipeline uses synthetic data generated by frontier reasoning models (likely GPT-4-class) across multiple languages. If the frontier teacher generated Ukrainian-language training samples, including legal reasoning patterns, Nemotron would inherit multilingual legal reasoning capability without requiring massive Ukrainian web corpora in the pre-training set. This synthetic data strategy may explain why Nemotron outperforms models trained primarily on organic web data, where Ukrainian is underrepresented.
+
+Fourth, \textbf{multi-token prediction}. Nemotron employs a multi-token prediction objective during training, which has been shown to improve both inference speed and output coherence. For structured tasks such as case outcome classification, where the answer is a short Ukrainian phrase, multi-token prediction may enable more confident single-step output rather than token-by-token generation.
+
+We note that Nemotron's tokenizer fertility (3.08 tokens/word) clusters with Mistral (3.06) rather than with the Llama family (2.43--2.65), confirming that Nemotron uses its own vocabulary rather than inheriting Llama's. Despite this moderate fertility, Nemotron's low active parameter count (12B) keeps per-token inference cost competitive: at \$0.15/M input tokens on Bedrock, it is among the cheapest models in our evaluation on a per-quality-point basis.
+
+\subsection{The Few-Shot Paradox for Morphologically Rich Languages}
+
+The systematic few-shot degradation we observe, particularly the 26.0-point drop for Qwen~3 235B on case outcome classification, extends a growing body of evidence on few-shot failure modes. \citet{lu2022order} showed that few-shot performance is highly sensitive to example ordering, with accuracy varying by up to 30 percentage points depending on permutation. \citet{min2022rethinking} demonstrated that few-shot demonstrations often function as format specifiers rather than task learners: ground-truth labels in examples can be replaced with random labels with minimal performance impact, suggesting that models anchor on surface-level patterns rather than learning the task. Our findings add a new dimension: for morphologically rich languages such as Ukrainian, few-shot demonstrations may actively interfere with the model's zero-shot capabilities.
+
+For Ukrainian legal text, we hypothesize that the rich morphological system creates a combinatorial explosion of surface forms for semantically equivalent expressions. Few-shot examples, which necessarily present a tiny sample of these forms, may inadvertently narrow the model's attention to specific morphological patterns that do not generalize. In contrast, zero-shot prompting allows the model to leverage its full distributional knowledge of Ukrainian without surface-level anchoring.
+
+Our stratified few-shot ablation (Section~\ref{sec:stratified_ablation}) provides direct evidence for this interpretation. When we replaced minority-balanced examples with examples matching the natural class distribution (4~granted, 1~denied), the degradation persisted or worsened ($-$15.8~pp for Nemotron, $-$26.4~pp for Qwen~3 235B). This rules out distribution mismatch as the primary cause and implicates the act of providing Ukrainian-language demonstrations itself as the source of interference.
+
+This finding has practical implications: for production systems processing Ukrainian legal text, zero-shot prompting should be the default baseline, and few-shot prompting should be validated per-model and per-task rather than assumed to help.
+
+\subsection{Task-Specific Strengths and Multi-Model Routing}
+\label{sec:routing}
+
+No single model dominates all tasks. The task-specific rankings reveal complementary strengths that motivate a routing architecture:
+
+\begin{itemize}[leftmargin=*]
+    \item \textbf{Case type classification}: Llama~4 Maverick and Nemotron Super~3 (98.9\% each). This is the easiest task, and the cheapest model (Maverick, \$0.00045/call) matches the best.
+    \item \textbf{Case outcome classification}: Nemotron Super~3 (96.0\%). The hardest classification task, where Nemotron's hybrid Mamba-Transformer architecture and synthetic multilingual training data provide a clear edge.
+    \item \textbf{Norm extraction}: Llama~3.3 70B (F1 = 0.604). The only model with a dense 70B architecture in our set, it excels at structured JSON extraction from long legal citations.
+\end{itemize}
+
+\paragraph{Proposed routing architecture.}
+For a production legal NLP pipeline processing Ukrainian court decisions, we propose a three-tier routing strategy that assigns each document to the optimal model per task:
+
+\begin{enumerate}[leftmargin=*]
+    \item \textbf{Tier 1: Case type classification $\rightarrow$ Llama~4 Maverick.} At 98.9\% accuracy and \$0.00045/call, Maverick provides near-perfect classification at the lowest cost. Its superior tokenizer (2.43 tokens/word) further reduces input cost. This is a high-volume, low-stakes call suitable for the cheapest model.
+    \item \textbf{Tier 2: Case outcome classification $\rightarrow$ Nemotron Super~3.} At 96.0\% accuracy and \$0.00201/call, Nemotron is 4.5$\times$ more expensive than Maverick per call but provides the most reliable outcome extraction, a high-stakes determination that affects downstream legal analysis.
+    \item \textbf{Tier 3: Norm extraction $\rightarrow$ Llama~3.3 70B.} At F1 = 0.604 and \$0.00167/call, Llama~3.3 provides the best structured extraction. This task is typically run selectively (on documents requiring citation analysis), not on every document.
+\end{enumerate}
+
+\paragraph{Cost--quality comparison.}
+Table~\ref{tab:routing} compares the proposed routing ensemble against single-model baselines for a hypothetical workload of 10,000 documents, where all documents require case type and outcome classification, and 20\% require norm extraction.
+
+\begin{table}[t]
+\centering
+\caption{Cost--quality comparison for 10,000 documents: routed ensemble vs.\ single-model baselines. ``Quality'' is the 3-task composite from Table~\ref{tab:composite}: $(\text{CT} + \text{CO} + 100 \cdot \text{NE}_{\text{F1}}) / 3$. Routed cost assumes Maverick for case type (10K calls), Nemotron for case outcome (10K calls), and Llama~3.3 for norm extraction (2K calls). Single-model strategies use the same model for all tasks (22K calls: 10K CT + 10K CO + 2K NE).}
+\label{tab:routing}
+\small
+\begin{tabular}{lR{2.0cm}R{2.0cm}R{2.0cm}}
+\toprule
+\textbf{Strategy} & \textbf{Cost} & \textbf{Quality} & \textbf{Cost/Quality} \\
+\midrule
+Routed ensemble         & \$27.94  & 85.1 & \$0.33 \\
+Nemotron only           & \$44.22  & 83.1 & \$0.53 \\
+Maverick only           & \$9.90   & 79.6 & \$0.12 \\
+Mistral Large~3 only    & \$134.42 & 81.1 & \$1.66 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+The routed ensemble achieves the highest composite score (85.1) by assigning each task to the best-performing model, at a cost of \$27.94 per 10K documents. This is 37\% cheaper than using Nemotron alone (\$44.22) while delivering higher quality, because Maverick handles the easy classification tier at lower per-call cost. The Maverick-only strategy is the cheapest (\$9.90) but sacrifices 5.5 composite points, primarily on case outcome (91.2\% vs.\ 96.0\%) and norm extraction (0.487 vs.\ 0.604). Mistral Large~3, despite competitive accuracy, is 4.8$\times$ more expensive than the routed ensemble for lower quality.
+
+This analysis assumes Bedrock API pricing. Under self-hosted deployment via NVIDIA NIM, the Nemotron and Llama tiers would have near-zero marginal cost after GPU amortization, making the routed ensemble even more cost-effective.
+
+\subsection{Implications for Practitioners}
+
+For teams building legal NLP systems for Ukrainian or other Cyrillic-script languages, we offer the following recommendations:
+
+\begin{enumerate}[leftmargin=*]
+    \item \textbf{Start with tokenizer analysis.} Before benchmarking task performance, measure tokenizer fertility on representative domain text. A 1.6$\times$ fertility difference compounds across every inference call.
+    \item \textbf{Default to zero-shot.} Do not assume that few-shot prompting will help. For morphologically rich languages, validate few-shot against zero-shot per model and per task.
+    \item \textbf{Ignore parameter counts.} Model size does not predict non-English performance. A 120B model outperformed a 675B model on all tasks.
+    \item \textbf{Route by task, not by model.} Match model strengths to task requirements. Cheap models suffice for easy classification; invest in stronger models only for hard tasks.
+\end{enumerate}
+
+% ============================================================
+% 6. LIMITATIONS
+% ============================================================
+\section{Limitations}
+
+\paragraph{Evaluation scale.} Our evaluation corpus of 300 documents, while stratified, is modest in size. Results on minority classes (e.g., 7 instances of ``closed'' outcomes in the 273-document validated subset) have wide confidence intervals.
+
+\paragraph{Class imbalance.} The case outcome label distribution reflects the natural distribution in EDRSR, where ``granted'' constitutes approximately 80\% of decisions. While this is realistic, it limits our ability to assess minority-class performance and inflates overall accuracy for models that default to the majority class.
+
+\paragraph{API-only evaluation.} All models were evaluated via the AWS Bedrock API, which provides no visibility into tokenizer vocabulary, model weights, or inference configuration. Fertility measurements rely on the API's reported token counts, which may include special tokens or system prompt overhead. We mitigated this by using consistent prompts across all models, but minor systematic biases cannot be ruled out.
+
+\paragraph{Single prompt template.} We used a single Ukrainian-language prompt template per task. Performance may vary with prompt engineering, chain-of-thought prompting, or English-language instructions, avenues we leave for future work.
+
+\paragraph{Non-reasoning mode.} All evaluations were conducted in standard (non-reasoning) inference mode with temperature set to 0. Several models in our evaluation support extended reasoning or ``thinking'' modes, most notably Nemotron Super~3, whose reasoning mode is a key architectural feature, and Qwen~3, which supports a thinking/non-thinking toggle. Reasoning mode introduces an internal chain-of-thought before producing the final answer, which may substantially improve performance on tasks requiring multi-step legal reasoning, such as case outcome classification. Our results therefore represent a lower bound on the capabilities of reasoning-capable models. An ablation comparing standard vs.\ reasoning mode, particularly for Nemotron Super~3 on the case outcome task where it already leads at 96.0\%, is an important direction for future work.
+
+\paragraph{Temporal specificity.} The model versions accessed via Bedrock in April--May 2026 may differ from those available at other times or through other providers. Our results reflect the specific model endpoints available during the experiment window.
+
+\paragraph{No fine-tuning.} We evaluate only zero-shot and few-shot settings. Fine-tuned models would likely show different performance patterns, particularly for the norm extraction task where the structured output format is critical.
+
+\paragraph{No Ukrainian-specific baselines.} Our evaluation compares only multilingual foundation models available via AWS Bedrock. We do not include Ukrainian-specific or Eastern European language models (e.g., the Ukrainian GPT variants, multilingual encoder models such as XLM-R fine-tuned on Ukrainian legal corpora, or domain-specific models trained on EDRSR data). Such baselines would contextualize whether the 86--96\% zero-shot accuracy achieved by general-purpose foundation models is competitive with, or still below, purpose-built alternatives. Similarly, we omit comparison with classical NLP baselines (TF-IDF + SVM, rule-based systems) that may perform well on the relatively structured case type classification task. Including these baselines would strengthen claims about the practical sufficiency of zero-shot foundation model inference for Ukrainian legal NLP.
+
+\paragraph{Outcome label provenance.} Our outcome labels, while validated through a three-source majority vote, rely on rule-based extraction from the dispositive section. Documents with atypical structure (e.g., interlocutory orders, procedural rulings) were disproportionately excluded during validation, potentially biasing the remaining dataset toward decisions with clear-cut outcomes. Additionally, Nemotron Super~3 served as one of the three voters in the majority-vote tiebreaker, creating a potential circularity with its role as an evaluated model. Our tiebreaker bias analysis (Section~\ref{sec:tiebreaker_bias}) shows that Nemotron's lead holds on the 205-document easy subset where it had no tiebreaker role (98.0\%, 201/205, tied for first), but we acknowledge that a fully independent tiebreaker (e.g., GPT-4 or Gemini) would eliminate this concern entirely.
+
+% ============================================================
+% 7. CONCLUSION
+% ============================================================
+\section{Conclusion}
+
+We have presented a systematic evaluation of seven foundation models on Ukrainian legal text, measuring both tokenizer efficiency and downstream task performance. Our key findings are:
+
+\begin{enumerate}[leftmargin=*]
+    \item \textbf{NVIDIA Nemotron Super~3 (120B) is the best single model for Ukrainian legal text}, achieving the highest composite score (83.1) across all three tasks, including 96.0\% on case outcome classification and 98.9\% on case type. It outperforms Mistral Large~3 (675B total, 41B active per token), a model with 5.6$\times$ more total parameters and 3.4$\times$ more active parameters, at one-third the API cost (\$3.61 vs.\ \$10.99). A routed multi-model ensemble (Maverick for classification, Nemotron for outcome, Llama~3.3 for extraction) achieves an even higher composite (85.1) at 37\% lower cost than Nemotron alone.
+
+    \item \textbf{Tokenizer fertility varies by 1.6$\times$} across models on Ukrainian legal text, with Llama-family tokenizers (2.43--2.65 tokens/word) substantially more efficient than Qwen tokenizers (3.90 tokens/word). This directly affects API cost and effective context length: Qwen models consume 60\% more tokens per document than Llama models for identical input.
+
+    \item \textbf{Few-shot prompting is counterproductive} for most models on Ukrainian legal classification tasks. A stratified few-shot ablation confirms that even distribution-matched examples degrade performance by up to 26 percentage points, ruling out example selection bias and implicating morphological interference intrinsic to Ukrainian-language demonstrations.
+
+    \item \textbf{Systematic model selection via managed APIs is inexpensive.} The total cost of the core evaluation (7 models $\times$ 3 tasks $\times$ 2 modes $\times$ 273--300 documents) was \$31.41 (Table~\ref{tab:costs}). Including ablation studies (label validation via Claude Sonnet~4.5: ${\sim}$\$12; stratified few-shot ablation: ${\sim}$\$8; prompt sensitivity ablation: ${\sim}$\$5; tokenizer fertility: ${\sim}$\$4), the total experiment cost was approximately \$60, demonstrating that comprehensive language-specific benchmarking is feasible even for resource-constrained teams.
+\end{enumerate}
+
+These findings underscore the importance of language-specific evaluation before model deployment. English-language benchmarks and parameter counts are poor proxies for performance on morphologically rich, Cyrillic-script languages. For practitioners: Nemotron Super~3 offers the best accuracy--cost tradeoff for Ukrainian legal NLP; Llama~4 Maverick provides the cheapest inference at near-top accuracy; and zero-shot prompting should be preferred over few-shot for Ukrainian. We release our evaluation methodology and results to support practitioners building legal NLP systems for Ukrainian and related languages.
+
+\paragraph{Data and code availability.} The evaluation code and aggregated results are available at \url{https://github.com/overthelex/rlhf-signals}. Individual court decisions are publicly available via the EDRSR API (\url{https://reyestr.court.gov.ua}).
+
+% ============================================================
+% ACKNOWLEDGMENTS
+% ============================================================
+\section*{Acknowledgments}
+
+This work was conducted as part of the LEX AI platform development at legal.org.ua. LEX AI LLC is a member of the NVIDIA Inception program for AI startups. Compute costs for all experiments were covered by an AWS Activate grant (\$25,000 in AWS credits); no compute credits or other support was received from NVIDIA or any other model provider evaluated in this study. We thank the EDRSR for providing open access to court decisions, AWS for the Bedrock API infrastructure, and NVIDIA, Meta, Qwen, Mistral AI, and Amazon for making their foundation models accessible for independent evaluation.
+
+\paragraph{Conflict of interest disclosure.} The author has no financial relationship with NVIDIA beyond membership in the NVIDIA Inception program, which provides business resources but did not fund or influence this research. All experiments were conducted on AWS infrastructure funded by an AWS grant. The evaluation methodology, model selection, and conclusions were determined independently. NVIDIA Nemotron Super~3's top ranking in our evaluation is an empirical finding, not a sponsored result.
+
+% ============================================================
+% REFERENCES
+% ============================================================
+\begin{thebibliography}{25}
+\providecommand{\natexlab}[1]{#1}
+
+\bibitem[Rust et~al.(2021)]{rust2021good}
+Rust, P., Pfeiffer, J., Vuli\'{c}, I., Ruder, S., and Gurevych, I.
+\newblock How Good is Your Tokenizer? On the Monolingual Performance of Multilingual Language Models.
+\newblock \emph{Proceedings of the 59th Annual Meeting of the ACL}, pages 3118--3135, 2021.
+\newblock \url{https://aclanthology.org/2021.acl-long.243/}
+
+\bibitem[Petrov et~al.(2024)]{petrov2024language}
+Petrov, A., La~Malfa, E., Torr, P., and Bibi, A.
+\newblock Language Model Tokenizers Introduce Unfairness Between Languages.
+\newblock \emph{Advances in Neural Information Processing Systems}, 37, 2024.
+\newblock \url{https://arxiv.org/abs/2305.15425}
+
+\bibitem[Ahia et~al.(2023)]{ahia2023all}
+Ahia, O., Ogueji, K., Winata, G.~I., Kreutzer, J., and Hooker, S.
+\newblock Do All Languages Cost the Same? Tokenization in the Era of Commercial Language Models.
+\newblock \emph{Proceedings of EMNLP 2023}, pages 9524--9538, 2023.
+\newblock \url{https://aclanthology.org/2023.emnlp-main.614/}
+
+\bibitem[Sennrich et~al.(2016)]{sennrich2016neural}
+Sennrich, R., Haddow, B., and Birch, A.
+\newblock Neural Machine Translation of Rare Words with Subword Units.
+\newblock \emph{Proceedings of the 54th Annual Meeting of the ACL}, pages 1715--1725, 2016.
+\newblock \url{https://aclanthology.org/P16-1162/}
+
+\bibitem[Kudo and Richardson(2018)]{kudo2018sentencepiece}
+Kudo, T. and Richardson, J.
+\newblock SentencePiece: A Simple and Language Independent Subword Tokenizer and Detokenizer for Neural Text Processing.
+\newblock \emph{Proceedings of EMNLP 2018: System Demonstrations}, pages 66--71, 2018.
+\newblock \url{https://aclanthology.org/D18-2012/}
+
+\bibitem[Chalkidis et~al.(2020)]{chalkidis2020legal}
+Chalkidis, I., Fergadiotis, M., Malakasiotis, P., Aletras, N., and Androutsopoulos, I.
+\newblock LEGAL-BERT: The Muppets straight out of Law School.
+\newblock \emph{Findings of EMNLP 2020}, pages 2898--2904, 2020.
+\newblock \url{https://aclanthology.org/2020.findings-emnlp.261/}
+
+\bibitem[Niklaus et~al.(2023)]{niklaus2023lextreme}
+Niklaus, J., Matoshi, V., Sturmer, M., Chalkidis, I., and Jositsch, D.
+\newblock {LEXTREME}: A Multi-Lingual and Multi-Task Benchmark for the Legal Domain.
+\newblock \emph{Findings of EMNLP 2023}, pages 12898--12916, 2023.
+\newblock \url{https://aclanthology.org/2023.findings-emnlp.865/}
+
+\bibitem[Hendrycks et~al.(2021)]{hendrycks2021measuring}
+Hendrycks, D., Burns, C., Basart, S., Zou, A., Mazeika, M., Song, D., and Steinhardt, J.
+\newblock Measuring Massive Multitask Language Understanding.
+\newblock \emph{Proceedings of ICLR}, 2021.
+\newblock \url{https://arxiv.org/abs/2009.03300}
+
+\bibitem[Brown et~al.(2020)]{brown2020language}
+Brown, T., Mann, B., Ryder, N., Subbiah, M., Kaplan, J., et~al.
+\newblock Language Models are Few-Shot Learners.
+\newblock \emph{Advances in Neural Information Processing Systems}, 33:1877--1901, 2020.
+\newblock \url{https://arxiv.org/abs/2005.14165}
+
+\bibitem[Lu et~al.(2022)]{lu2022order}
+Lu, Y., Bartolo, M., Moore, A., Riedel, S., and Stenetorp, P.
+\newblock Fantastically Ordered Prompts and Where to Find Them: Overcoming Few-Shot Prompt Order Sensitivity.
+\newblock \emph{Proceedings of the 60th Annual Meeting of the ACL}, pages 8086--8098, 2022.
+\newblock \url{https://aclanthology.org/2022.acl-long.556/}
+
+\bibitem[Min et~al.(2022)]{min2022rethinking}
+Min, S., Lyu, X., Holtzman, A., Arber, M., Lewis, M., Hajishirzi, H., and Zettlemoyer, L.
+\newblock Rethinking the Role of Demonstrations: What Makes In-Context Learning Work?
+\newblock \emph{Proceedings of EMNLP 2022}, pages 11048--11064, 2022.
+\newblock \url{https://aclanthology.org/2022.emnlp-main.759/}
+
+\bibitem[Lai et~al.(2023)]{lai2023chatgpt}
+Lai, V.~D., Ngo, N.~T., Veyseh, A.~P.~B., Man, H., Dernoncourt, F., Bui, T., and Nguyen, T.~H.
+\newblock ChatGPT Beyond English: Towards a Comprehensive Evaluation of Large Language Models in Multilingual Learning.
+\newblock \emph{Findings of EMNLP 2023}, pages 13171--13189, 2023.
+\newblock \url{https://aclanthology.org/2023.findings-emnlp.878/}
+
+\bibitem[Conneau et~al.(2020)]{conneau2020unsupervised}
+Conneau, A., Khandelwal, K., Goyal, N., Chaudhary, V., Wenzek, G., et~al.
+\newblock Unsupervised Cross-lingual Representation Learning at Scale.
+\newblock \emph{Proceedings of the 58th Annual Meeting of the ACL}, pages 8440--8451, 2020.
+\newblock \url{https://aclanthology.org/2020.acl-main.747/}
+
+\bibitem[Touvron et~al.(2023)]{touvron2023llama}
+Touvron, H., Martin, L., Stone, K., et~al.
+\newblock Llama 2: Open Foundation and Fine-Tuned Chat Models.
+\newblock \emph{arXiv preprint arXiv:2307.09288}, 2023.
+\newblock \url{https://arxiv.org/abs/2307.09288}
+
+\bibitem[Grattafiori et~al.(2024)]{grattafiori2024llama3}
+Grattafiori, A., Dubey, A., Jauhri, A., et~al.
+\newblock The Llama 3 Herd of Models.
+\newblock \emph{arXiv preprint arXiv:2407.21783}, 2024.
+\newblock \url{https://arxiv.org/abs/2407.21783}
+
+\bibitem[{Meta AI}(2025)]{meta2025llama4}
+{Meta AI}.
+\newblock The Llama 4 Herd of Models.
+\newblock \emph{arXiv preprint arXiv:2504.16736}, 2025.
+\newblock \url{https://arxiv.org/abs/2504.16736}
+
+\bibitem[{Mistral AI}(2024)]{jiang2024mistral}
+{Mistral AI}.
+\newblock Mistral Large.
+\newblock Technical report, 2024.
+\newblock \url{https://mistral.ai/news/mistral-large-2407/}
+
+\bibitem[{NVIDIA}(2025)]{nvidia2025nemotron}
+{NVIDIA}.
+\newblock Nemotron Super: Open Hybrid Mamba-Transformer Models.
+\newblock Technical report, 2025.
+\newblock \url{https://developer.nvidia.com/blog/nemotron-super-open-model-for-enterprise-reasoning/}
+
+\bibitem[{Amazon Web Services}(2024)]{amazon2024nova}
+{Amazon Web Services}.
+\newblock Amazon Nova: Foundation Models for Enterprise AI.
+\newblock Technical report, 2024.
+\newblock \url{https://aws.amazon.com/ai/generative-ai/nova/}
+
+\bibitem[{Qwen Team}(2025)]{qwen2025qwen3}
+{Qwen Team}.
+\newblock Qwen3 Technical Report.
+\newblock Technical report, 2025.
+\newblock \url{https://qwenlm.github.io/blog/qwen3/}
+
+\bibitem[Wei et~al.(2022)]{wei2022finetuned}
+Wei, J., Bosma, M., Zhao, V., Guu, K., Yu, A.~W., Lester, B., Du, N., Dai, A.~M., and Le, Q.~V.
+\newblock Finetuned Language Models Are Zero-Shot Learners.
+\newblock \emph{Proceedings of ICLR}, 2022.
+\newblock \url{https://arxiv.org/abs/2109.01652}
+
+\bibitem[Zheng et~al.(2024)]{zheng2024judging}
+Zheng, L., Chiang, W.-L., Sheng, Y., et~al.
+\newblock Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena.
+\newblock \emph{Advances in Neural Information Processing Systems}, 36, 2024.
+\newblock \url{https://arxiv.org/abs/2306.05685}
+
+\bibitem[Kotsyba et~al.(2018)]{languk2018}
+Kotsyba, N., Mykulyak, A., and Shvedova, M.
+\newblock lang-uk: Building a Comprehensive Corpus and Language Technology for Ukrainian.
+\newblock \emph{Proceedings of LREC 2018}, 2018.
+\newblock \url{https://lang.org.ua/en/}
+
+\bibitem[Syvokon and Nahorna(2023)]{syvokon2023uagec}
+Syvokon, O. and Nahorna, O.
+\newblock {UA-GEC}: Grammatical Error Correction and Fluency Corpus for the Ukrainian Language.
+\newblock \emph{Proceedings of the Second UNLP Workshop}, pages 96--102, 2023.
+\newblock \url{https://aclanthology.org/2023.unlp-1.12/}
+
+\bibitem[Chaplynskyi(2023)]{chaplynskyi2023ukrbruk}
+Chaplynskyi, D.
+\newblock Introducing UberText 2.0: A Corpus of Modern Ukrainian at Scale.
+\newblock \emph{Proceedings of the Second UNLP Workshop}, pages 1--10, 2023.
+\newblock \url{https://aclanthology.org/2023.unlp-1.1/}
+
+\end{thebibliography}
+
+% ============================================================
+% APPENDIX
+% ============================================================
+\appendix
+
+\section{Prompt Templates}
+\label{app:prompts}
+
+\subsection{Case Type Classification (Zero-Shot)}
+
+\begin{quote}\small\ttfamily
+\foreignlanguage{ukrainian}{Визнач тип судової справи з тексту рішення.
+Відповідай ОДНИМ словом: цивільна, кримінальна,
+господарська, або адміністративна.}\\[6pt]
+\foreignlanguage{ukrainian}{Текст рішення:}\\
+\{document\_text\}\\[6pt]
+\foreignlanguage{ukrainian}{Тип справи:}
+\end{quote}
+
+\subsection{Case Outcome Classification (Zero-Shot)}
+
+\begin{quote}\small\ttfamily
+\foreignlanguage{ukrainian}{Визнач результат розгляду справи з тексту рішення.
+Відповідай ОДНИМ з варіантів: задоволено, відмовлено,
+залишено без розгляду, частково задоволено, закрито.}\\[6pt]
+\foreignlanguage{ukrainian}{Текст рішення:}\\
+\{document\_text\}\\[6pt]
+\foreignlanguage{ukrainian}{Результат:}
+\end{quote}
+
+\subsection{Norm Extraction (Zero-Shot)}
+
+\begin{quote}\small\ttfamily
+\foreignlanguage{ukrainian}{Витягни всі правові норми (закон + стаття),
+на які посилається суд у цьому рішенні.
+Поверни відповідь у форматі JSON масиву:}\\
+{[}\{"law": "\foreignlanguage{ukrainian}{назва}",\\
+\hspace*{1em}"article": "\foreignlanguage{ukrainian}{номер}"\}{]}\\[6pt]
+\foreignlanguage{ukrainian}{Текст рішення:}\\
+\{document\_text\}\\[6pt]
+\foreignlanguage{ukrainian}{Норми (JSON):}
+\end{quote}
+
+\section{Full Per-Model Results}
+\label{app:full_results}
+
+Table~\ref{tab:full_results} presents the complete results matrix for all model--task--mode combinations.
+
+\begin{table}[h]
+\centering
+\caption{Complete results for all 42 model--task--mode combinations (7 models $\times$ 3 tasks $\times$ 2 modes). All metrics reported on the $n{=}273$ validated subset.}
+\label{tab:full_results}
+\small
+\begin{tabular}{llR{1.5cm}R{1.5cm}R{1.5cm}}
+\toprule
+\textbf{Model} & \textbf{Mode} & \textbf{Case Type} & \textbf{Outcome} & \textbf{Norm F1} \\
+\midrule
+\multirow{2}{*}{Llama 4 Maverick} & Zero-shot & 98.9 & 91.2 & 0.487 \\
+ & Few-shot & 92.7 & 91.9 & 0.488 \\
+\midrule
+\multirow{2}{*}{Llama 3.3 70B} & Zero-shot & 94.5 & 89.7 & 0.604 \\
+ & Few-shot & 96.0 & 81.0 & 0.606 \\
+\midrule
+\multirow{2}{*}{Mistral Large 3} & Zero-shot & 95.6 & 91.6 & 0.561 \\
+ & Few-shot & 94.9 & 85.3 & 0.575 \\
+\midrule
+\multirow{2}{*}{Nemotron Super 3} & Zero-shot & 98.9 & 96.0 & 0.543 \\
+ & Few-shot & 94.5 & 83.2 & 0.564 \\
+\midrule
+\multirow{2}{*}{Nova Pro} & Zero-shot & 98.2 & 92.3 & 0.575 \\
+ & Few-shot & 92.3 & 92.7 & 0.585 \\
+\midrule
+\multirow{2}{*}{Qwen3 235B} & Zero-shot & 97.4 & 93.8 & 0.463 \\
+ & Few-shot & 98.5 & 67.8 & 0.476 \\
+\midrule
+\multirow{2}{*}{Qwen3 32B} & Zero-shot & 95.2 & 86.8 & 0.514 \\
+ & Few-shot & 95.2 & 89.7 & 0.529 \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\section{Dataset Statistics}
+\label{app:dataset}
+
+\begin{table}[h]
+\centering
+\caption{Evaluation corpus statistics.}
+\label{tab:dataset_stats}
+\begin{tabular}{lr}
+\toprule
+\textbf{Statistic} & \textbf{Value} \\
+\midrule
+Total documents & 300 \\
+Documents per case type & 75 \\
+Outcome-validated subset & 273 \\
+Excluded (label disagreement) & 27 \\
+Case outcome: granted (\textit{zadovoleno}) & 230 / 273 (84.2\%) \\
+Case outcome: denied (\textit{vidmovleno}) & 15 / 273 (5.5\%) \\
+Case outcome: left without consideration & 21 / 273 (7.7\%) \\
+Case outcome: closed (\textit{zakryto}) & 7 / 273 (2.6\%) \\
+Case outcome: partially granted & 0 (originally 10, all disputed and excluded) \\
+Source & EDRSR \\
+Language & Ukrainian \\
+Tokenizer fertility samples & 100 (6,000 chars each) \\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\end{document}

--- a/lexwebapp/public/papers/workflow-memory-2026.tex
+++ b/lexwebapp/public/papers/workflow-memory-2026.tex
@@ -1,0 +1,658 @@
+\documentclass[11pt]{article}
+
+% ============================================================
+%  Packages
+% ============================================================
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{lmodern}
+
+% Page geometry — arXiv-friendly single-column
+\usepackage[margin=1in]{geometry}
+
+% Math
+\usepackage{amsmath,amssymb}
+
+% Tables
+\usepackage{booktabs}
+\usepackage{multirow}
+\usepackage{array}
+\usepackage{tabularx}
+
+% Figures
+\usepackage{graphicx}
+\usepackage{float}
+
+% TikZ
+\usepackage{tikz}
+\usetikzlibrary{arrows.meta,positioning,calc,decorations.pathreplacing,shapes.geometric}
+
+% Colors
+\usepackage[dvipsnames]{xcolor}
+
+% Bibliography (natbib for arXiv safety)
+\usepackage[numbers,sort&compress]{natbib}
+
+% Hyperlinks (after natbib)
+\usepackage[colorlinks=true,linkcolor=MidnightBlue,citecolor=OliveGreen,urlcolor=BrickRed]{hyperref}
+
+% Misc
+\usepackage{enumitem}
+\usepackage{microtype}
+\usepackage{url}
+\usepackage{xspace}
+
+% ============================================================
+%  Macros
+% ============================================================
+\newcommand{\ie}{\emph{i.e.}\@\xspace}
+\newcommand{\eg}{\emph{e.g.}\@\xspace}
+\newcommand{\cf}{\emph{cf.}\@\xspace}
+\newcommand{\etal}{\emph{et~al.}\xspace}
+\newcommand{\pullmode}{\textsc{Pull}\xspace}
+\newcommand{\pushmode}{\textsc{Push}\xspace}
+
+% ============================================================
+%  Title
+% ============================================================
+\title{%
+  Workflow Memory for Long-Horizon Agentic Composition:\\
+  Architecture, Dual-Mode Retrieval, and Retrieval-Correction Signal%
+}
+
+\author{
+  Vladimir Ovcharov\thanks{Correspondence: \texttt{volodymyr@legal.org.ua}.
+    Repository: \url{https://github.com/overthelex/SecondLayer}.}\\
+  LEX AI LLC, Kyiv, Ukraine\\
+  \texttt{https://legal.org.ua}
+}
+
+\date{May 2026}
+
+\begin{document}
+\maketitle
+
+% ============================================================
+%  Abstract
+% ============================================================
+\begin{abstract}
+Long-horizon agentic workflows---where a practitioner and an LLM co-author software over weeks to months---demand a memory substrate whose retrieval unit is the architectural decision, not the conversational turn or the code chunk, and whose refresh policy is dual-mode: pull-based for active sessions, push-based for dormant tasks.
+Existing memory systems~\citep{packer2023memgpt, park2023generative, chhikara2025mem0} organize around dialogue episodes; code-RAG~\citep{zhang2023repocoder, wang2024coderagbench} retrieves over source text without decision provenance; long-context models~\citep{reid2024gemini} suffer attention degradation past ${\sim}200$K tokens~\citep{liu2023lost, hsieh2024ruler}.
+None treats decision provenance as a first-class memory unit or provides a slow-loop refresh primitive.
+We frame this memory layer as scalable oversight infrastructure: retrieval-correction edits---practitioner corrections that would have been unnecessary had memory surfaced relevant context---constitute a process-level oversight signal that scales with agent autonomy, complementing outcome-level preference data.
+
+This paper makes three contributions.
+First, a \emph{three-layer memory decomposition}---domain, workflow, and practitioner---with distinct retrieval semantics per layer.
+Second, \emph{dual-mode retrieval} as a first-class architectural primitive: pull mode fires at session start and queries all layers in parallel; push mode refreshes memory entries for dormant tasks proportional to repository activity, so that pull queries return current context even after weeks of inactivity.
+Third, \emph{retrieval-correction edits} as a process-level oversight signal: corrections that operationalize the gap between the agent's available context and the context required for correct action, denser than outcome-level supervision and scaling with agent autonomy~\citep{ovcharov2026recursive}.
+The architecture is deployed on a legal-technology platform (70+ MCP tools, 380M+ records, 1{,}547 merged PRs in 105 days).
+Baseline measurements from 304 sessions confirm a median bootstrap cost of 30{,}115 input tokens and a median context waste ratio of 60\%; the memory layer targets a reduction to ${\leq}10$K tokens with ${\leq}20\%$ waste.
+\end{abstract}
+
+% ============================================================
+\section{Introduction}
+\label{sec:intro}
+% ============================================================
+
+A single practitioner, working recursively with Claude Code as the primary agentic engineering counterpart, shipped 1{,}547 merged pull requests across seven interconnected projects in 105 days~\citep[\S1]{ovcharov2026recursive}.
+The system under construction---a legal-technology platform with 70+ MCP tools, 380M+ indexed records, and production customers---is not a toy benchmark.
+It is an operational regime where architectural decisions made in week two constrain implementation choices in week six, where validator definitions evolve alongside the code they protect, and where the practitioner's correction history encodes domain expertise that no context window can hold indefinitely.
+
+This operational regime is not served by existing memory or retrieval approaches.
+
+\paragraph{CLAUDE.md scales as hand-curation.}
+The dominant workaround for cross-session context in agentic workflows is a flat Markdown file (\texttt{CLAUDE.md}) that accumulates project conventions, architectural notes, and operational constraints.
+In practice, its size grows linearly with project age: over 85 days and 25 commits, the \texttt{CLAUDE.md} for the platform described above grew from 4{,}099 to 24{,}148 characters (474~lines) at a rate of 217 characters/day ($R^2 = 0.87$; see Section~\ref{sec:preliminary}).
+A new session loads the entire file regardless of task relevance, wasting context budget on content that is irrelevant to the current task and out of date with respect to recent changes.
+Worse, the practitioner bears the curation burden: every architectural decision must be manually distilled into the file, and stale entries silently degrade session quality.
+
+\paragraph{Long context is not the answer.}
+Models with 1M-token context windows~\citep{reid2024gemini} appear to eliminate the need for retrieval.
+Empirically, they do not.
+Attention degradation past ${\sim}200$K tokens is well documented: the ``lost in the middle'' effect causes models to underweight information in the interior of long contexts~\citep{liu2023lost}, and synthetic benchmarks like RULER confirm that effective context utilization degrades with length~\citep{hsieh2024ruler}.
+Even where the context fits, cost scales with total context length, not with the relevance of individual entries.
+At the 6-week horizon, the accumulated working set---prior decisions, rejected alternatives, validator evolution, constitutional principle invocations---exceeds what fits efficiently in any context window.
+
+\paragraph{Conversational-agent memory is the wrong shape.}
+MemGPT~\citep{packer2023memgpt}, Generative Agents~\citep{park2023generative}, A-MEM~\citep{xu2024amem}, and Mem0~\citep{chhikara2025mem0} organize memory around dialogue episodes: episodic recall of prior conversations, semantic memory for persistent facts, and reflection for self-assessment.
+The retrieval unit is the conversational turn or the character observation.
+None of these systems is designed for decision provenance---the record of which architectural alternative was chosen over which other, which constitutional principle was invoked, and which validator caught which class of regression.
+
+\paragraph{Outcome-level supervision becomes thin at scale.}
+As coding agents take on longer-horizon work---Anthropic Engineering documents agent sessions spanning thousands of context windows on a single project~\citep{anthropic2026harnesses}---outcome-level signal (did the shipped code work?) becomes a sparse, lagging indicator.
+A single binary outcome may correspond to hours of agent activity and dozens of architectural micro-decisions.
+Anthropic's published research priorities identify scalable oversight as a central open problem: how to design oversight mechanisms whose signal density grows with agent capability rather than degrading~\citep{anthropic2025recommended}.
+This paper contributes a substrate for one such mechanism.
+The memory layer's retrieval-correction edits are process-level oversight signals: each one identifies a specific gap between the context the agent had and the context the practitioner had, localized to a single edit.
+Unlike outcome-level signals, retrieval-correction signals are produced continuously throughout a session, and their generation rate is invariant to session duration.
+
+\medskip
+
+This paper provides the mechanism for two conditions stated but not mechanized in the companion paper~\citep[\S2]{ovcharov2026recursive}: (1)~the codebase as persistent context, and (2)~compositional task layering across multi-week horizons.
+The contributions are:
+
+\begin{enumerate}[leftmargin=*, nosep]
+  \item A \textbf{three-layer memory decomposition}---domain, workflow, and practitioner---with distinct retrieval semantics per layer (Section~\ref{sec:architecture}).
+  \item \textbf{Dual-mode pull/push retrieval} as a first-class architectural primitive, where push-mode refresh keeps dormant-task memory current without requiring active sessions (Section~\ref{sec:dual-mode}).
+  \item \textbf{Retrieval-correction edits} as a process-level oversight signal that scales with agent autonomy (Section~\ref{sec:retrieval-correction}). Each retrieval-correction edit localizes a specific context gap; aggregated across sessions, these edits constitute a dense oversight signal that complements the sparse outcome-level signal used in standard RLHF, and connects to the alignment pipeline described in the companion paper~\citep{ovcharov2026recursive}.
+\end{enumerate}
+
+The evaluation plan (Section~\ref{sec:evaluation}) defines measurable targets against instrumented baselines from the companion paper's dataset.
+The architecture is designed for a single-practitioner regime and does not claim generality to multi-developer teams; limitations are discussed in Section~\ref{sec:limitations}.
+
+
+% ============================================================
+\section{Related Work}
+\label{sec:related}
+% ============================================================
+
+% --------------------------------------------------
+\subsection{Memory for Conversational Agents}
+\label{sec:related-memory}
+% --------------------------------------------------
+
+The recent proliferation of LLM agents has produced a family of memory architectures organized around dialogue persistence.
+MemGPT~\citep{packer2023memgpt} virtualizes a memory hierarchy analogous to an operating system's paging mechanism: a fixed main-context window is backed by an unbounded ``archival storage'' that the agent can read from and write to via self-directed function calls.
+Generative Agents~\citep{park2023generative} introduced a three-part memory stream---observation, reflection, and planning---enabling simulated characters to maintain coherent behavior over extended interactions.
+A-MEM~\citep{xu2024amem} extends this with Zettelkasten-inspired atomic notes and explicit inter-note linking.
+Mem0~\citep{chhikara2025mem0} targets production deployment with a graph-based memory layer that supports multi-user, multi-session persistence.
+A comprehensive survey of memory mechanisms for LLM agents appears in~\citet{zhang2024survey}.
+
+Letta~\citep{letta2025lettacode}, the productized successor to MemGPT, advances the architecture in two directions relevant to this paper.
+First, \emph{context repositories}~\citep{letta2026repositories}: persistent, versioned stores of structured context that agents read from and write to across sessions, replacing the flat archival-storage model with typed, queryable collections.
+Second, \emph{context constitution}~\citep{letta2026constitution}: a declarative specification of what context an agent should have access to and how it should be prioritized, analogous to a retrieval policy expressed as a configuration rather than code.
+These mechanisms move agent memory closer to the decision-provenance retrieval described here---context repositories provide the storage substrate, and context constitution provides a rudimentary retrieval policy.
+However, Letta's retrieval unit remains the context block (a text chunk with metadata), not the architectural decision with provenance, alternatives, and constitutional anchoring.
+The context constitution specifies \emph{which} collections to query, not \emph{what decision context} to retrieve for a given task.
+
+These systems share a common retrieval unit: the conversational turn, the character observation, or the context block---closer to the architectural decision than turns or observations, but still without the explicit alternatives, validators, and constitutional anchoring that decision provenance requires.
+They excel at role consistency, preference tracking, and episodic recall.
+They are not designed for the retrieval unit that matters in long-horizon agentic engineering: the architectural decision with full provenance---which alternative was chosen, which was rejected, why, which validator enforces the choice, and which constitutional principle anchors it.
+
+% --------------------------------------------------
+\subsection{Retrieval-Augmented Code Agents}
+\label{sec:related-code-rag}
+% --------------------------------------------------
+
+Code-RAG systems retrieve over source text to augment code generation.
+RepoCoder~\citep{zhang2023repocoder} iteratively retrieves similar code snippets from the repository to improve completion accuracy.
+CodeRAG-Bench~\citep{wang2024coderagbench} provides a systematic benchmark for retrieval-augmented code generation across documentation, API references, and code examples.
+Commercial systems like Cursor's codebase indexing and Sourcegraph Cody build semantic indices over entire repositories, enabling natural-language queries that return relevant code chunks.
+SWE-bench~\citep{jimenez2024swebench} and SWE-agent~\citep{yang2024sweagent} evaluate agents on real-world GitHub issues, demonstrating that retrieval over repository structure and issue context improves resolution rates.
+
+All of these systems retrieve over \emph{code text and identifiers}.
+They can answer ``where is this function defined?'' or ``what does this module do?'' but not ``why was this approach chosen over the alternative?'' or ``which constitutional principle does this validator enforce?''
+The decision context---the rationale, the rejected alternatives, the cross-cutting constraints---is absent from the code itself and therefore absent from code-RAG retrieval.
+
+% --------------------------------------------------
+\subsection{Architecture Decision Records}
+\label{sec:related-adr}
+% --------------------------------------------------
+
+The practice of recording architectural decisions has a long history in software engineering.
+Nygard's Architecture Decision Record (ADR) format~\citep{nygard2011adr} proposes a lightweight Markdown template---title, status, context, decision, consequences---stored alongside the codebase.
+The ISO/IEC/IEEE~42010 standard~\citep{iso42010} formalizes architecture description at the organizational level.
+Z\"orner's Y-statement format~\citep{zorner2015softwarearchitekturen} structures decisions as ``In the context of [situation], facing [concern], we decided [option], to achieve [quality], accepting [downside].''
+\citet{zimmermann2015architectural} extends ADR management to cross-project guidance with problem-space modeling.
+
+ADRs capture decision provenance---exactly the content missing from code-RAG.
+However, ADR retrieval is file-path-based: decisions are found by browsing a directory, not by semantic query.
+There is no embedding index, no hybrid retrieval, no re-ranking by relevance to a current task.
+ADRs also require manual authoring; in a high-velocity workflow producing 14.7~PRs/day, the curation overhead of maintaining a complete ADR directory is prohibitive.
+
+% --------------------------------------------------
+\subsection{Long-Context Language Models as a Substitute}
+\label{sec:related-longcontext}
+% --------------------------------------------------
+
+Gemini~1.5~\citep{reid2024gemini} demonstrated effective processing of inputs up to 10M tokens in controlled settings.
+This has led to a common assumption that sufficiently large context windows eliminate the need for retrieval.
+
+Empirical evidence does not support this assumption for the regime considered here.
+\citet{liu2023lost} showed that model performance degrades significantly for information placed in the middle of long contexts---the ``lost in the middle'' effect---even for models explicitly designed for long inputs.
+RULER~\citep{hsieh2024ruler} confirmed that effective context utilization drops sharply as input length grows, with most models failing to maintain claimed context lengths under adversarial probing.
+\citet{li2024longcontextbench} demonstrated that in-context learning performance degrades as the number of demonstrations grows, even when the total context fits within the window.
+
+Beyond attention degradation, long-context processing is expensive.
+At the 6-week horizon of the operational regime described here, the accumulated decision context---ADRs, validator histories, constitutional principle invocations, edit-trace summaries---would consume hundreds of thousands of tokens per session start.
+Retrieval selects the task-relevant subset; long context pays for everything.
+
+\medskip
+
+\noindent\textbf{Synthesis.}
+None of the four lines of work treats decision provenance as a first-class memory unit with semantic retrieval.
+None provides a slow-loop refresh primitive that keeps dormant-task memory current across multi-week horizons.
+The architecture described in this paper occupies the intersection: it adopts the provenance structure of ADRs, the semantic retrieval of code-RAG, the persistence of conversational memory systems, and the selective context loading of RAG---while adding dual-mode retrieval as a new architectural primitive.
+
+
+% ============================================================
+\section{Problem Formalization}
+\label{sec:problem}
+% ============================================================
+
+Long-horizon agentic composition is a regime characterized by three measurable properties, verified in the companion paper's pilot dataset~\citep[\S3--4]{ovcharov2026recursive}:
+
+\begin{description}[leftmargin=1.5em, nosep]
+  \item[Horizon.] Related decisions span weeks to months. The platform described here maintained active development across 105 days with a median inter-PR interval under 2~hours but architectural threads that persisted for 4--6 weeks.
+  \item[Compositionality.] Decision~$A$ in week~2 constrains decision~$B$ in week~6. A choice of database schema in the EDRSR import pipeline determined the parameter contract of 29 MCP tools built over the following five weeks; a constitutional principle established in week~1 governed validator behavior through week~15.
+  \item[Persistence.] The codebase and its associated decision graph serve as shared state between sessions, not transient context. The agent does not carry forward a dialogue history; it re-enters a changed codebase each session.
+\end{description}
+
+\paragraph{The session bootstrap problem.}
+Each new agentic session begins by loading context.
+The agent consumes $T$ input tokens of \texttt{CLAUDE.md} content and system context automatically, then performs $K$ exploratory file reads before beginning productive work.
+Measured across 304 sessions from the companion paper's dataset (Section~\ref{sec:preliminary}): median bootstrap cost is $T = 30{,}115$ input tokens, of which ${\sim}17{,}600$ (59\%) is cache-creation cost for \texttt{CLAUDE.md} alone; median per-session file reads are $K = 14$ (mean 23.1).
+Both quantities grow approximately linearly with project age as \texttt{CLAUDE.md} accumulates conventions and the agent's file-read heuristics expand (\texttt{CLAUDE.md} growth: 217~chars/day, $R^2 = 0.87$; see Section~\ref{sec:preliminary}).
+
+The relevant subset for any given task is a small fraction of $K$ and $T$.
+Measured across 180 sessions with at least three bootstrap reads: the median \emph{context waste ratio}---files read but never subsequently edited---is 60\%, with source-code reads wasted at 78\% (Section~\ref{sec:preliminary}).
+A task touching the billing service does not need the EDRSR import pipeline's conventions; a task modifying the frontend router does not need the PostgreSQL migration patterns.
+Yet the flat bootstrap loads everything, because the agent cannot predict which subset is relevant without first loading the full context.
+
+\paragraph{Pull-based retrieval reduces $K$ and $T$.}
+A memory query replaces the flat bootstrap: the task description is embedded, matched against a pre-indexed memory store, and the top-$k$ relevant entries are assembled into a compact digest.
+The agent starts with a focused context ($K' \ll K$, $T' \ll T$) and can retrieve additional entries on demand via MCP tool calls.
+
+\paragraph{Push-based refresh keeps the substrate current.}
+Pull-based retrieval alone fails for tasks that are dormant for weeks and then resume.
+During the dormant period, other tasks' decisions accumulate context that is relevant to the dormant task---schema changes, principle additions, validator updates---but no pull query fires to incorporate this context.
+When the dormant task resumes, the pull query retrieves stale entries from the last active period.
+Push-mode refresh addresses this: a scheduled process watches task activity and refreshes memory entries for dormant tasks proportional to the rate of relevant changes, so that pull queries on resumption return current context.
+
+
+% ============================================================
+\section{Architecture}
+\label{sec:architecture}
+% ============================================================
+
+The workflow memory service decomposes into three layers, each with distinct content, retrieval semantics, and storage substrate.
+Figure~\ref{fig:architecture} shows the overall architecture with both retrieval modes.
+
+\input{figures/architecture}
+
+% --------------------------------------------------
+\subsection{Domain Layer}
+\label{sec:domain-layer}
+% --------------------------------------------------
+
+The domain layer contains the project's operational data: laws, court decisions, regulations, and other legal corpus material.
+In the deployed system, this layer is already in production as multiple Qdrant vector collections served through MCP tools (semantic search, legislation retrieval, court decision lookup).
+
+The architectural change is at the interface level.
+Domain queries are routed through the memory service rather than directly to individual MCP tools.
+This indirection provides three capabilities that direct tool calls lack: (1)~unified logging of all retrieval events, enabling retrieval-miss detection (Section~\ref{sec:retrieval-correction}); (2)~miss-rate measurement per collection, informing re-indexing priorities; and (3)~a uniform response format across all three layers, simplifying the digest assembly step.
+
+The domain layer uses pure semantic retrieval: the query embedding is matched against document-chunk embeddings via cosine similarity, with optional metadata filtering (jurisdiction, date range, document type).
+
+% --------------------------------------------------
+\subsection{Workflow Layer}
+\label{sec:workflow-layer}
+% --------------------------------------------------
+
+The workflow layer contains the project's decision context---the provenance that is absent from both code text and domain data.
+Six sources populate this layer, listed in priority order:
+
+\begin{enumerate}[leftmargin=*, nosep]
+  \item \textbf{Principle ledger.} The highest-priority source. Each entry is a principle that the model violated and was corrected on---the hardest signal in the system. Entries are compact (typically one sentence plus metadata), referenced by validators (so retrievals are dense), and anchored to the constitutional framework described in the companion paper~\citep[\S5]{ovcharov2026recursive}. Schema: \texttt{id}, principle statement, severity (critical/warning/info), validator references, related ADR IDs, edit-trace links, embedding vector.
+
+  \item \textbf{Validator definitions.} Source code of validation functions, parsed and embedded with docstrings, type signatures, and test examples. Validators encode the operational expression of constitutional principles; retrieving the validator alongside the principle provides the agent with both the ``what'' and the ``how.''
+
+  \item \textbf{MCP tool contracts.} For each of the 70+ tools: name, description, parameter schema, example inputs and outputs. Embedded as structured text. Tool contracts evolve frequently in early development; the embedding pipeline re-indexes on each build.
+
+  \item \textbf{ADR-style decision records.} One Markdown file per significant architectural decision, following Nygard's format~\citep{nygard2011adr}: context, decision, alternatives considered, consequences, related constitutional principles. Manually authored in Phase~1; automatic generation from PR descriptions is planned for Phase~2.
+
+  \item \textbf{Git history with semantic enrichment.} For each merged PR: title, description, semantic class (from the companion paper's taxonomy), affected components, related ADR IDs. Provides temporal context for when and why code changed.
+
+  \item \textbf{Issue tracker state.} Plane\footnote{\url{https://plane.so}} issues with state transitions, assignees, and linked PRs. Embedded with structured metadata to enable queries like ``what decisions were made on the billing migration?''
+\end{enumerate}
+
+The workflow layer uses hybrid retrieval: semantic similarity against embedded text, combined with structured filters on component, layer, severity, and temporal range.
+
+% --------------------------------------------------
+\subsection{Practitioner Layer}
+\label{sec:practitioner-layer}
+% --------------------------------------------------
+
+The practitioner layer contains the practitioner's decision patterns, extracted from the same edit-trace pipeline described in the companion paper~\citep[\S3]{ovcharov2026recursive}.
+This layer is the cross-reference point: the infrastructure that enables one practitioner to ship 1{,}547~PRs in 105 days \emph{generates} the preference signal the RLHF paper analyzes.
+
+The layer never embeds raw content.
+Following the privacy boundary established in the companion paper~\citep[\S6]{ovcharov2026recursive}, only structured edit summaries are indexed: edit class, semantic category, affected component, outcome (accepted/rejected/modified), and a one-sentence rationale generated by a nightly summarization job.
+This preserves the separation between the practitioner's operational data (which may contain client-specific information) and the memory substrate (which contains only structured abstractions).
+
+Retrieval is hybrid: semantic similarity combined with temporal and outcome-conditioned filtering.
+A query about authentication patterns retrieves edit summaries where the practitioner corrected authentication-related code, ordered by recency and weighted by outcome confidence.
+
+\paragraph{Phase~0: Prompt-Commit Bridge.}
+Before the full practitioner layer, a minimal data collector is deployed: a \texttt{UserPromptSubmit} hook in Claude Code that creates an orphan commit in a bare git repository for every prompt.
+Each record contains the prompt text, timestamp, session ID, repository, branch, and permission mode.
+Over 4--6 weeks of passive collection, this yields a natural-text corpus for disambiguation labels, topic-frequency distributions, and cross-project switching patterns---the raw material for the practitioner layer's embedding pipeline.
+Performance overhead is 15ms per capture, imperceptible within Claude Code's 5-second hook timeout.
+
+
+% ============================================================
+\section{Dual-Mode Retrieval}
+\label{sec:dual-mode}
+% ============================================================
+
+The dual-mode retrieval architecture is the central contribution: pull-based retrieval for active sessions, push-based refresh for dormant tasks, operating as complementary mechanisms rather than alternatives.
+Figure~\ref{fig:dual-mode} illustrates the interaction between both modes across a six-week horizon.
+
+\input{figures/dual-mode-timing}
+
+% --------------------------------------------------
+\subsection{Pull Mode}
+\label{sec:pull-mode}
+% --------------------------------------------------
+
+Pull mode fires at session start via a Claude Code session-start hook.
+The process:
+
+\begin{enumerate}[leftmargin=*, nosep]
+  \item The practitioner provides a task description (or the system infers it from the active Plane issue).
+  \item The task description is embedded using the same model used for memory indexing (text-embedding-3-small or a locally hosted alternative such as bge-large-en-v1.5).
+  \item Three parallel Qdrant queries execute against the domain, workflow, and practitioner collections, each with collection-specific filters (jurisdiction constraints for domain, component/severity for workflow, recency weighting for practitioner).
+  \item Results from all three collections are merged and re-ranked using a cross-encoder~\citep{nogueira2019passage} or LLM-as-reranker, producing a unified relevance ordering.
+  \item A greedy fill algorithm assembles the top-ranked entries into a token-budgeted digest, with a diversity constraint that ensures representation from all three layers.
+\end{enumerate}
+
+Latency target: $< 500$ms wall time for the full pipeline (embed, query, re-rank, assemble).
+This is a design target, not a measurement; empirical latency will be reported after deployment.
+
+% --------------------------------------------------
+\subsection{Push Mode}
+\label{sec:push-mode}
+% --------------------------------------------------
+
+Push mode runs as a scheduled orchestrator---a separate Docker container with a Bedrock Claude Sonnet summarization pipeline.
+The orchestrator watches Plane tasks tagged \texttt{LONG-TERM} and refreshes their memory entries proportional to task activity.
+
+The refresh frequency is a function of three signals:
+
+\begin{equation}
+  f_{\text{refresh}}(\text{task}) = g\bigl(
+    \text{commits-touching-task},\;
+    \text{comments-on-issue},\;
+    \text{time-since-last-pull}
+  \bigr)
+  \label{eq:refresh}
+\end{equation}
+
+\noindent where $g$ is a monotonically increasing function of all three arguments, clamped to a maximum of one refresh per 24 hours and a minimum of one per 7 days for any task tagged \texttt{LONG-TERM}.
+
+Each refresh produces three outputs:
+\begin{itemize}[leftmargin=*, nosep]
+  \item An \textbf{executive summary} of changes relevant to the task since the last refresh, generated by Bedrock Claude Sonnet from the diff of relevant commits and issue comments.
+  \item A \textbf{tool lineage delta}: new tools created, tools modified, tools deprecated since the last refresh, with parameter-schema diffs.
+  \item \textbf{Open questions}: unresolved issues or decision points flagged by the summarizer that may require practitioner input on task resumption.
+\end{itemize}
+
+The executive summary and tool lineage delta are embedded and stored in the workflow layer's Qdrant collection.
+On the next pull query for the refreshed task, these entries surface alongside the original memory entries, providing the session with current context.
+
+% --------------------------------------------------
+\subsection{Why Both Modes Are Necessary}
+\label{sec:why-both}
+% --------------------------------------------------
+
+Pull-only retrieval fails when a task is dormant for weeks and then resumes.
+During the dormant period, other tasks' decisions accumulate relevant context: schema changes that affect the dormant task's data model, new constitutional principles that constrain its implementation, validator updates that redefine correctness criteria.
+None of this context is incorporated into the dormant task's memory entries, because no pull query fires during dormancy.
+When the task resumes, the pull query retrieves entries from the last active period---stale by weeks.
+Re-deriving the current state requires expensive exploratory file reads, manual context assembly, and risk of missing cross-task dependencies.
+
+Push-only refresh, conversely, is wasteful for active tasks.
+A task with multiple sessions per day does not need pre-computed digests; each session's pull query returns current results because the memory entries were recently indexed.
+Push refresh for active tasks duplicates the work that pull already performs, consuming Bedrock API credits without improving retrieval quality.
+
+Dual-mode retrieval allocates computational effort where it provides the most value: pull for fast loops (active sessions), push for slow loops (dormant tasks).
+The push mode is what makes 6-week horizons tractable; without it, retrieval over multi-week dormancy periods returns stale or absent context.
+
+% --------------------------------------------------
+\subsection{Retrieval-Correction Edits}
+\label{sec:retrieval-correction}
+% --------------------------------------------------
+
+Retrieval-correction edits operationalize a specific oversight gap: the model produced an output that the practitioner corrected because the model's available context was missing information the practitioner had.
+Definition: an edit where the model's output would have been correct given access to context~$X$, but $X$ was not present in the session's memory digest.
+This edit class extends the six-class taxonomy from the companion paper~\citep[\S4]{ovcharov2026recursive}, but is structurally distinct: the other six classes capture \emph{what} the practitioner changed; retrieval-correction captures \emph{why} the change was avoidable.
+It is therefore a process-level oversight signal rather than a preference signal in the standard RLHF sense.
+
+Detection proceeds via a post-session reconciliation job:
+
+\begin{enumerate}[leftmargin=*, nosep]
+  \item After the session closes, the reconciliation job collects all edits made by the practitioner.
+  \item For each substantive edit (edit distance $> 0.3$ in the companion paper's normalized metric), the job embeds the edit context and queries the memory store for entries that are semantically similar to the edit but were \emph{not} retrieved in the session's digest.
+  \item Candidate retrieval-correction pairs (edit, unretrieved-but-relevant memory entry) are flagged for practitioner review.
+  \item Confirmed pairs are labeled as retrieval-correction edits and enter the alignment pipeline as oversight-derived preferences: the ``chosen'' response incorporates the missing context; the ``rejected'' response is the original model output that lacked it.
+\end{enumerate}
+
+This closes a feedback loop between the memory layer and the alignment pipeline that is structurally different from outcome-level RLHF.
+Outcome-level supervision answers ``did this run succeed?'' once per session.
+Retrieval-correction supervision answers ``was this specific output reachable from this specific context?'' per edit.
+The signal density per unit of agent activity is therefore higher, and the signal is invariant to session length.
+Two consequences follow.
+First, as the memory layer matures, retrieval-correction edit rate becomes a measurable proxy for memory effectiveness---an internal evaluation metric that does not require waiting for downstream outcomes.
+Second, retrieval-correction edits encode a failure mode (capability present, context absent) that is distinct from capability gaps (capability absent, context irrelevant).
+Distinguishing these failure modes is a long-standing open problem in scalable oversight~\citep{bowman2022scalable}; the memory layer provides one concrete instantiation.
+
+
+% ============================================================
+\section{Implementation}
+\label{sec:implementation}
+% ============================================================
+
+The memory service is implemented in TypeScript, consistent with the existing Express-based MCP backend~\citep{anthropic2024mcp} described in the companion paper~\citep[\S7]{ovcharov2026recursive}.
+The technology stack reuses production infrastructure: Qdrant for vector storage, PostgreSQL for structured metadata (new \texttt{workflow\_memory\_*} tables), Redis for caching, and AWS Bedrock Claude Sonnet for summarization steps.
+
+% --------------------------------------------------
+\subsection{Memory Query Tool}
+\label{sec:memory-query-tool}
+% --------------------------------------------------
+
+A single MCP tool, \texttt{workflow\_memory\_query}, serves as the primary retrieval interface.
+Parameters:
+
+\begin{itemize}[leftmargin=*, nosep]
+  \item \texttt{task\_description} (string, required): natural-language description of the current task.
+  \item \texttt{scope} (enum: \texttt{all} | \texttt{domain} | \texttt{workflow} | \texttt{practitioner}): which layers to query. Default: \texttt{all}.
+  \item \texttt{token\_budget} (integer, default 8{,}000): maximum tokens in the assembled digest.
+  \item \texttt{filters} (object, optional): structured filters (component, severity, date range).
+\end{itemize}
+
+The tool returns a structured prose digest with section headers per layer, relevance scores per entry, and source provenance links.
+The digest format is designed for direct injection into the agent's context window without post-processing.
+
+% --------------------------------------------------
+\subsection{Long-Term Task Orchestrator}
+\label{sec:orchestrator}
+% --------------------------------------------------
+
+The push-mode orchestrator runs as a separate Docker container with its own cron schedule.
+It queries the Plane API for tasks tagged \texttt{LONG-TERM}, computes refresh priority per Equation~\ref{eq:refresh}, and dispatches summarization jobs to Bedrock.
+Outputs (executive summaries, tool lineage deltas, open questions) are embedded and stored in the workflow layer's Qdrant collection with a \texttt{source: push-refresh} metadata tag.
+
+Implementation proceeds in five phases over 11 weeks; details are available in the supplementary materials.\footnote{Phase schedule: \url{https://github.com/overthelex/SecondLayer/blob/main/docs/workflow-memory-phases.md}}
+
+
+% ============================================================
+\section{Evaluation Plan}
+\label{sec:evaluation}
+% ============================================================
+
+% --------------------------------------------------
+\subsection{Metrics}
+\label{sec:metrics}
+% --------------------------------------------------
+
+Four metrics operationalize the architecture's success criteria, each paired with a baseline measurement method and a target.
+
+\begin{table}[h]
+\centering
+\small
+\begin{tabularx}{\textwidth}{@{}l X c c@{}}
+\toprule
+\textbf{Metric} & \textbf{Measurement method} & \textbf{Baseline} & \textbf{Target} \\
+\midrule
+Bootstrap token cost &
+  Input tokens at first API call (includes \texttt{CLAUDE.md} cache); $N{=}304$ sessions &
+  30{,}115 (median) & ${\leq}10$K \\
+\addlinespace
+Context waste ratio &
+  Files read but never edited / total files read; $N{=}180$ sessions with ${\geq}3$ reads &
+  60\% (median) & ${\leq}20\%$ \\
+\addlinespace
+Principle retrieval accuracy &
+  Held-out set of principle ledger entries; queries derived from edit-traces that originally triggered each principle &
+  n/a & ${\geq}80\%$ \\
+\addlinespace
+Long-term task refresh latency &
+  Time from relevant commit to updated digest entry &
+  n/a (no automation) & ${\leq}24$h \\
+\bottomrule
+\end{tabularx}
+\caption{Evaluation metrics with measured baselines and targets.
+  Bootstrap baselines are measured from 304 Claude Code sessions in the companion paper's transcript dataset.}
+\label{tab:metrics}
+\end{table}
+
+A fifth metric---the retrieval-correction edit rate over time---is qualitative in Phase~1.
+As the practitioner layer matures, the rate of retrieval-correction edits (Section~\ref{sec:retrieval-correction}) should decrease.
+The expected trajectory is a declining curve over the first 6--8 weeks of deployment, flattening as the memory layer covers the most frequently needed context.
+
+% --------------------------------------------------
+\subsection{Preliminary Results}
+\label{sec:preliminary}
+% --------------------------------------------------
+
+Three baseline measurements are available at submission time, derived from the companion paper's transcript dataset and from the project's git history.
+
+\paragraph{Bootstrap cost (Experiment~1, $N{=}304$ sessions).}
+Parsing Claude Code API transcripts from the companion dataset, the median first-call input token count is 30{,}115 (mean 29{,}693; $\sigma{=}7{,}594$; P10/P90: 18{,}540/41{,}774).
+Of these, ${\sim}17{,}600$ tokens (59\%) are cache-creation cost for \texttt{CLAUDE.md} and system context---loaded unconditionally on every session regardless of task.
+Per-session file reads (Read tool calls) average 23.1 (median~14, P90: 61), but 72\% of sessions have zero Read calls in the bootstrap phase; most sessions open with shell commands (\texttt{git status}, \texttt{ls}) rather than file reads.
+The memory layer's primary reduction target is therefore the automatic context cost ($T$), not the file-read count.
+
+\paragraph{CLAUDE.md growth (Experiment~2, 25~commits over 85~days).}
+The project's \texttt{CLAUDE.md} grew from 4{,}099 to 24{,}148 characters (152 to 474~lines) across 25 commits over 85 days (January~17 to April~12, 2026---a subset of the 105-day operational period documented in the companion paper).
+A linear regression of character count on days elapsed yields a slope of 216.7~chars/day with $R^2 = 0.87$, confirming the approximately linear growth claimed in Section~\ref{sec:intro}.
+Line count is noisier ($R^2 = 0.58$) due to periodic reformatting that changes density without changing content volume.
+
+\paragraph{Context waste ratio (Experiment~3, $N{=}180$ sessions).}
+Across sessions with at least three file reads in the bootstrap phase (first 50~turns), the median context waste ratio---files read but never subsequently edited in the session---is 60\% (mean 56.7\%; $\sigma{=}26.3\%$).
+The distribution is right-skewed: 66\% of sessions waste more than half their bootstrap reads; only 15\% waste less than 30\%.
+Source-code reads are wasted at 78\%, while memory files (\texttt{.claude/memory/}) are wasted at 66.5\%, suggesting that structured memory retrieval is more targeted than exploratory file reads.
+Waste ratio correlates negatively with session length: short sessions (5--10 turns) waste 68.5\%; longer sessions ($>$50 turns) waste 51.1\%.
+This metric is a conservative proxy: a file may be read for context without subsequent editing, in which case it counts as ``wasted'' even when its content informed the agent's reasoning. The 60\% baseline therefore likely overstates true waste; the gap between read-and-edited and read-and-used is left for future work.
+
+Phase~0 (prompt-commit bridge) has been deployed since May~9, 2026 with negligible performance overhead (15ms per capture); distributional analysis requires 4--6 weeks of collection and will be reported in a revision.
+Full evaluation of the memory layer itself (retrieval accuracy, bootstrap reduction with memory enabled) will be reported after Phase~1.3 deployment.
+
+% --------------------------------------------------
+\subsection{Threats to Validity}
+\label{sec:threats}
+% --------------------------------------------------
+
+\paragraph{Single project, single practitioner.}
+The architecture is designed and evaluated in the context of one project (LEX AI) and one practitioner.
+This is the same constraint as the companion RLHF paper~\citep[\S8]{ovcharov2026recursive}.
+Mitigation: the architecture is project-agnostic---the three-layer decomposition and dual-mode retrieval impose no assumptions about the domain, the programming language, or the practitioner's expertise.
+Generalization claims are deferred to Phase~2, which introduces a multi-practitioner cohort.
+
+\paragraph{Confounding with codebase maturity.}
+Bootstrap reduction could result from caching effects, improved \texttt{CLAUDE.md} curation, or the natural stabilization of a maturing codebase rather than from the memory layer itself.
+Control: A/B evaluation by toggling the memory layer at session start.
+Sessions with the memory layer enabled are compared against sessions without it on the same task distribution during the same time period.
+
+\paragraph{Principle ledger quality.}
+In Phase~1, the principle ledger is human-curated.
+Retrieval accuracy is therefore bounded by curation quality, not retrieval quality.
+If the registry is incomplete or contains imprecise principle statements, the retrieval system will faithfully return imprecise results.
+This limitation is acknowledged and addressed in Phase~2 by introducing semi-automatic principle extraction from edit-traces.
+
+
+% ============================================================
+\section{Discussion}
+\label{sec:discussion}
+% ============================================================
+
+\paragraph{Memory layer as RLHF substrate.}
+The same infrastructure that enables one practitioner to ship 1{,}547~PRs in 105~days \emph{generates} the preference signal the companion paper analyzes.
+Memory and preference data are two views of the same long-horizon work: a retrieval-correction edit is simultaneously a memory-layer failure (the system did not surface relevant context) and an alignment signal (the practitioner corrected the model's output, producing a preference pair).
+This duality is not incidental---it is the architectural thesis.
+The memory layer does not merely consume alignment data; it produces it.
+
+\paragraph{Memory as scalable oversight surface.}
+The memory layer is dual-purpose: it serves the agent during execution and generates oversight signal during reconciliation.
+As agent autonomy grows---from short interactive sessions to multi-hour autonomous runs to multi-day autonomous projects of the kind documented in Anthropic's long-running scientific computing work~\citep{anthropic2026longrunning}---the ratio of practitioner-observable outcomes to agent-internal decisions falls.
+Outcome-level supervision becomes a low-bandwidth channel through which any oversight signal must pass.
+
+The memory layer changes this.
+Every retrieval is an observable event with a known context window, a known retrieval result, and a subsequent edit trace.
+Reconciliation between retrieved context and editing behavior generates oversight signal at the granularity of individual edits, not individual sessions.
+The signal is not free---reconciliation requires practitioner confirmation of candidate retrieval-correction pairs---but the practitioner's marginal cost per signal is bounded by the time to confirm a flagged pair, not the time to evaluate an entire session.
+
+This positions the memory layer as one concrete answer to the question posed in \emph{Recommendations for Technical AI Safety Research Directions}~\citep{anthropic2025recommended}: how to design oversight mechanisms whose signal scales with the systems they oversee.
+The architecture does not solve scalable oversight in general.
+It demonstrates that for one operational regime---long-horizon agentic coding by a small number of practitioners---the memory infrastructure that makes the regime tractable also produces the signal needed to oversee it.
+
+\paragraph{Generalization to teams.}
+The architecture as described serves a single practitioner.
+Multi-practitioner deployment introduces three challenges not addressed here: (1)~multi-writer principle ledger with conflict resolution on principle updates; (2)~per-practitioner views of the practitioner layer, since different practitioners have different correction patterns; and (3)~access control on memory entries that may contain project-specific context.
+These are Phase~2 concerns.
+The three-layer decomposition is designed to accommodate them---the domain layer is already shared, the workflow layer supports scoped views via metadata filtering, and the practitioner layer is inherently per-practitioner.
+
+\paragraph{What this is not.}
+The workflow memory architecture is not a replacement for long-context models; it is a retrieval substrate that reduces the context a long-context model must process.
+It is not a knowledge graph: there is no formal ontology, no RDF triples, no SPARQL endpoint.
+It is not an enterprise knowledge management system: it has no document lifecycle, no approval workflows, no compliance metadata.
+It is a retrieval substrate optimized for one operational regime---long-horizon agentic composition by a small number of practitioners---and its design decisions reflect that specificity.
+
+
+% ============================================================
+\section{Limitations}
+\label{sec:limitations}
+% ============================================================
+
+\begin{itemize}[leftmargin=*, nosep]
+  \item \textbf{Single project, single practitioner.} All design and evaluation is within one legal-technology project built by one practitioner. Generalization to other domains, other languages, or multi-developer teams is not demonstrated.
+
+  \item \textbf{Manual ADR curation.} In Phase~1, architecture decision records are manually authored. The curation burden is non-trivial at 14.7~PRs/day; ADR coverage is expected to be incomplete during the evaluation period.
+
+  \item \textbf{Batch re-indexing.} Memory entries are re-indexed nightly, not in real time. Changes made during a session are not reflected in the memory layer until the next indexing run. This creates a window where pull queries may return slightly stale results for very recent changes.
+
+  \item \textbf{No multi-practitioner support.} The architecture does not address multi-writer conflicts in the principle ledger, per-practitioner memory views, or cross-practitioner preference aggregation.
+
+  \item \textbf{Retrieval-correction detection is approximate.} The post-session reconciliation job uses semantic similarity to identify candidate retrieval-correction pairs. False positives (flagged pairs where the missing context would not have changed the model's output) are filtered by practitioner review, but the detection precision is not yet measured.
+
+  \item \textbf{Push-mode cost.} Each push refresh consumes Bedrock API credits for summarization. At scale, the cost of maintaining current digests for many dormant tasks may become significant. The current design mitigates this with frequency clamping (maximum one refresh per 24 hours per task), but cost-optimal refresh scheduling is not formalized.
+
+  \item \textbf{Oversight-signal density is not yet quantified.} The claim that retrieval-correction edits constitute a denser oversight signal than outcome-level supervision is structurally argued but not measured. Quantifying signal density (retrieval-correction edits per practitioner-minute vs.\ outcome labels per practitioner-minute) requires the full deployment to run for several weeks; this measurement is part of the evaluation plan.
+\end{itemize}
+
+
+% ============================================================
+\section{Conclusion}
+\label{sec:conclusion}
+% ============================================================
+
+This paper presented a workflow memory architecture for long-horizon agentic composition, addressing the session bootstrap problem that bottlenecks multi-week LLM-assisted software engineering.
+Three contributions were made.
+First, a three-layer memory decomposition---domain, workflow, and practitioner---where each layer has distinct content, retrieval semantics, and storage substrate, and the retrieval unit is the architectural decision rather than the code chunk or dialogue turn.
+Second, dual-mode retrieval as a first-class primitive: pull mode for active sessions, push mode for dormant tasks, with push-mode refresh keeping multi-week horizons tractable by maintaining current memory entries without requiring active sessions.
+Third, retrieval-correction edits as a process-level oversight signal that scales with agent autonomy, closing the feedback loop between the memory layer and the alignment pipeline described in the companion paper~\citep{ovcharov2026recursive}.
+
+The architecture is deployed incrementally on a production legal-technology platform.
+Phase~0 (prompt-commit bridge) is live; Phases~1.0--1.5 are in implementation.
+Baseline measurements from 304 sessions confirm a median bootstrap cost of 30{,}115 input tokens and a context waste ratio of 60\%; the memory layer targets ${\leq}10$K tokens and ${\leq}20\%$ waste, with ${\geq}80\%$ retrieval accuracy on principle ledger entries.
+
+The source code and implementation notes are available at \url{https://github.com/overthelex/SecondLayer}.
+
+
+% ============================================================
+%  References
+% ============================================================
+\bibliographystyle{plainnat}
+\bibliography{references}
+
+\end{document}

--- a/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
+++ b/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
@@ -4,7 +4,6 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import {
   ArrowLeft,
-  Download,
   Linkedin,
   Link2,
   Check,
@@ -16,6 +15,7 @@ import { enTranslations } from './articles-en';
 import { ruTranslations } from './articles-ru';
 import AttractorBanner from '../../components/AttractorBanner';
 import { CommentSection } from './CommentSection';
+import { PaperReader } from './PaperReader';
 import { useLocaleStore } from '../../stores/localeStore';
 import { getBlogUI, getLocalizedArticles } from './blog-i18n';
 
@@ -208,24 +208,11 @@ export function BlogArticlePage() {
         </div>
 
         {article.pdfUrl && (
-          <div className="mt-8 rounded-2xl border border-purple-200 bg-purple-50/50 overflow-hidden">
-            <div className="px-6 py-4 flex items-center justify-between border-b border-purple-200">
-              <span className="text-sm font-medium text-purple-700 font-sans">Full Paper (PDF)</span>
-              <a
-                href={article.pdfUrl}
-                download
-                className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-xl text-sm font-sans font-medium hover:bg-purple-700 transition-colors"
-              >
-                <Download size={16} />
-                Download PDF
-              </a>
-            </div>
-            <iframe
-              src={article.pdfUrl}
-              className="w-full h-[70vh] border-0"
-              title={article.title}
-            />
-          </div>
+          <PaperReader
+            pdfUrl={article.pdfUrl}
+            texUrl={article.texUrl}
+            title={article.title}
+          />
         )}
 
         {/* Tags */}

--- a/lexwebapp/src/pages/BlogPage/PaperReader.tsx
+++ b/lexwebapp/src/pages/BlogPage/PaperReader.tsx
@@ -1,0 +1,262 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Document, Page, pdfjs } from 'react-pdf';
+import 'react-pdf/dist/Page/AnnotationLayer.css';
+import 'react-pdf/dist/Page/TextLayer.css';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Download,
+  FileCode,
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+} from 'lucide-react';
+
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url,
+).toString();
+
+interface PaperReaderProps {
+  pdfUrl: string;
+  texUrl?: string;
+  title: string;
+}
+
+export function PaperReader({ pdfUrl, texUrl, title }: PaperReaderProps) {
+  const [numPages, setNumPages] = useState<number>(0);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [scale, setScale] = useState(1.0);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const onDocumentLoadSuccess = useCallback(({ numPages }: { numPages: number }) => {
+    setNumPages(numPages);
+    setCurrentPage(1);
+  }, []);
+
+  const goToPage = useCallback((page: number) => {
+    setCurrentPage((prev) => Math.max(1, Math.min(page, numPages || prev)));
+  }, [numPages]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement) return;
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setCurrentPage((p) => Math.max(1, p - 1));
+      } else if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setCurrentPage((p) => Math.min(numPages, p + 1));
+      } else if (e.key === 'Home') {
+        e.preventDefault();
+        setCurrentPage(1);
+      } else if (e.key === 'End') {
+        e.preventDefault();
+        setCurrentPage(numPages);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [numPages]);
+
+  const zoomIn = () => setScale((s) => Math.min(s + 0.2, 2.5));
+  const zoomOut = () => setScale((s) => Math.max(s - 0.2, 0.5));
+  const resetZoom = () => setScale(1.0);
+
+  const pageWidth = containerWidth > 0 ? Math.min(containerWidth - 32, 900) * scale : undefined;
+
+  return (
+    <div className="mt-8 rounded-2xl border border-purple-200 bg-white overflow-hidden">
+      {/* Toolbar */}
+      <div className="sticky top-16 z-10 bg-white border-b border-purple-200 px-4 py-3">
+        <div className="flex items-center justify-between gap-3 flex-wrap">
+          {/* Page navigation */}
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={() => goToPage(1)}
+              disabled={currentPage <= 1}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+              title="First page"
+            >
+              <ChevronsLeft size={16} />
+            </button>
+            <button
+              onClick={() => goToPage(currentPage - 1)}
+              disabled={currentPage <= 1}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+              title="Previous page"
+            >
+              <ChevronLeft size={16} />
+            </button>
+            <div className="flex items-center gap-1.5 px-2">
+              <input
+                type="number"
+                min={1}
+                max={numPages}
+                value={currentPage}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value, 10);
+                  if (!isNaN(val)) goToPage(val);
+                }}
+                className="w-12 h-8 text-center text-sm font-mono border border-purple-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-400 focus:border-transparent"
+              />
+              <span className="text-sm text-claude-subtext font-sans">/ {numPages}</span>
+            </div>
+            <button
+              onClick={() => goToPage(currentPage + 1)}
+              disabled={currentPage >= numPages}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+              title="Next page"
+            >
+              <ChevronRight size={16} />
+            </button>
+            <button
+              onClick={() => goToPage(numPages)}
+              disabled={currentPage >= numPages}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 disabled:opacity-30 disabled:hover:bg-transparent transition-colors"
+              title="Last page"
+            >
+              <ChevronsRight size={16} />
+            </button>
+          </div>
+
+          {/* Zoom controls */}
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={zoomOut}
+              disabled={scale <= 0.5}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 disabled:opacity-30 transition-colors"
+              title="Zoom out"
+            >
+              <ZoomOut size={16} />
+            </button>
+            <button
+              onClick={resetZoom}
+              className="h-8 px-2 text-xs font-mono text-purple-600 hover:bg-purple-50 rounded-lg transition-colors"
+              title="Reset zoom"
+            >
+              {Math.round(scale * 100)}%
+            </button>
+            <button
+              onClick={zoomIn}
+              disabled={scale >= 2.5}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 disabled:opacity-30 transition-colors"
+              title="Zoom in"
+            >
+              <ZoomIn size={16} />
+            </button>
+            <button
+              onClick={() => window.open(pdfUrl, '_blank')}
+              className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-purple-50 text-purple-600 transition-colors"
+              title="Open in full screen"
+            >
+              <Maximize2 size={16} />
+            </button>
+          </div>
+
+          {/* Download buttons */}
+          <div className="flex items-center gap-2">
+            <a
+              href={pdfUrl}
+              download
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 text-white rounded-lg text-sm font-sans font-medium hover:bg-purple-700 transition-colors"
+            >
+              <Download size={14} />
+              PDF
+            </a>
+            {texUrl && (
+              <a
+                href={texUrl}
+                download
+                className="flex items-center gap-1.5 px-3 py-1.5 bg-white border border-purple-300 text-purple-700 rounded-lg text-sm font-sans font-medium hover:bg-purple-50 transition-colors"
+              >
+                <FileCode size={14} />
+                LaTeX
+              </a>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* PDF page */}
+      <div
+        ref={containerRef}
+        className="flex justify-center bg-gray-100 min-h-[60vh] overflow-x-auto py-6"
+      >
+        <Document
+          file={pdfUrl}
+          onLoadSuccess={onDocumentLoadSuccess}
+          loading={
+            <div className="flex items-center justify-center py-32">
+              <div className="animate-pulse text-sm text-claude-subtext font-sans">
+                Loading paper...
+              </div>
+            </div>
+          }
+          error={
+            <div className="flex flex-col items-center justify-center py-32 gap-3">
+              <p className="text-sm text-claude-subtext font-sans">Failed to load PDF</p>
+              <a
+                href={pdfUrl}
+                download
+                className="flex items-center gap-2 px-4 py-2 bg-purple-600 text-white rounded-xl text-sm font-sans font-medium hover:bg-purple-700 transition-colors"
+              >
+                <Download size={16} />
+                Download instead
+              </a>
+            </div>
+          }
+          className="[&_.react-pdf__Document]:flex [&_.react-pdf__Document]:justify-center"
+        >
+          <Page
+            pageNumber={currentPage}
+            width={pageWidth}
+            className="shadow-lg rounded-lg overflow-hidden"
+            renderTextLayer={true}
+            renderAnnotationLayer={true}
+          />
+        </Document>
+      </div>
+
+      {/* Bottom navigation for mobile */}
+      <div className="border-t border-purple-200 bg-white px-4 py-3 flex items-center justify-between sm:hidden">
+        <button
+          onClick={() => goToPage(currentPage - 1)}
+          disabled={currentPage <= 1}
+          className="flex items-center gap-1 px-3 py-2 text-sm font-sans text-purple-600 disabled:opacity-30 transition-colors"
+        >
+          <ChevronLeft size={16} /> Prev
+        </button>
+        <span className="text-sm font-mono text-claude-subtext">
+          {currentPage} / {numPages}
+        </span>
+        <button
+          onClick={() => goToPage(currentPage + 1)}
+          disabled={currentPage >= numPages}
+          className="flex items-center gap-1 px-3 py-2 text-sm font-sans text-purple-600 disabled:opacity-30 transition-colors"
+        >
+          Next <ChevronRight size={16} />
+        </button>
+      </div>
+
+      {/* Paper title bar */}
+      <div className="border-t border-purple-100 bg-purple-50/50 px-4 py-2">
+        <p className="text-xs text-purple-600/70 font-sans truncate">{title}</p>
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/pages/BlogPage/articles.ts
+++ b/lexwebapp/src/pages/BlogPage/articles.ts
@@ -12,6 +12,7 @@ export interface Article {
   publishedAt: string; // ISO date, e.g. '2026-03-01'
   content: string;
   pdfUrl?: string;
+  texUrl?: string;
 }
 
 export interface ArticleTranslation {
@@ -39,6 +40,7 @@ export const articles: Article[] = [
     readTime: 'PDF, 28 pages',
     publishedAt: '2026-05-11',
     pdfUrl: '/papers/edit-trace-oversight-2026.pdf',
+    texUrl: '/papers/edit-trace-oversight-2026.tex',
     content: `# Edit-Trace Oversight: Scalable Alignment Signal from Agentic Workflows
 
 **Volodymyr Ovcharov** — LEX AI LLC, Kyiv, Ukraine
@@ -72,6 +74,7 @@ We propose **edit-trace oversight** — alignment signal captured natively when 
     readTime: 'PDF, 32 pages',
     publishedAt: '2026-05-10',
     pdfUrl: '/papers/workflow-memory-2026.pdf',
+    texUrl: '/papers/workflow-memory-2026.tex',
     content: `# Workflow Memory for Long-Horizon Agentic Composition
 
 **Architecture, Dual-Mode Retrieval, and Retrieval-Correction Signal**
@@ -105,6 +108,7 @@ Deployed on a legal-technology platform (70+ MCP tools, 380M+ records, 1,547 mer
     readTime: 'PDF, 24 pages',
     publishedAt: '2026-05-10',
     pdfUrl: '/papers/tokenizer-fertility-2026.pdf',
+    texUrl: '/papers/tokenizer-fertility-2026.tex',
     content: `# Tokenizer Fertility and Zero-Shot Performance of Foundation Models on Ukrainian Legal Text
 
 **A Comparative Study**
@@ -140,6 +144,7 @@ Foundation models tokenize Ukrainian legal text with vastly different efficiency
     readTime: 'PDF, 30 pages',
     publishedAt: '2026-05-11',
     pdfUrl: '/papers/ontology-oversight-bridge-2026.pdf',
+    texUrl: '/papers/ontology-oversight-bridge-2026.tex',
     content: `# From Ontology-Controlled Systems to Oversight-Controlled Training
 
 **Formal Foundations for Human–LLM Alignment Signal Validation**


### PR DESCRIPTION
## Summary
- Replaces raw `<iframe>` PDF embed with `react-pdf` based `PaperReader` component
- Page-by-page navigation: prev/next, first/last, direct page number input
- Keyboard shortcuts: arrow keys for page turning, Home/End for first/last
- Zoom controls: in/out/reset/full-screen
- Download buttons for both **PDF** and **LaTeX** source
- Responsive: mobile bottom navigation bar
- All 4 LaTeX `.tex` source files added to `/papers/`

## Test plan
- [ ] Open any academic paper article (e.g. `/blog/paper-edit-trace-oversight`)
- [ ] Verify PDF renders page-by-page (not as an iframe scroll)
- [ ] Navigate pages with prev/next buttons
- [ ] Navigate with arrow keys (Left/Right)
- [ ] Use page number input to jump to specific page
- [ ] Zoom in/out works correctly
- [ ] "PDF" download button saves the PDF
- [ ] "LaTeX" download button saves the .tex file
- [ ] Full-screen button opens PDF in new tab
- [ ] Mobile: bottom nav bar visible on small screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the iframe PDF embed with a paginated `PaperReader` built on `react-pdf`, and added LaTeX source downloads for academic papers. Improves reading with page controls, keyboard nav, and mobile UI.

- **New Features**
  - Page-by-page reader with first/last, prev/next, and direct page jump
  - Keyboard shortcuts: Left/Right, Home/End
  - Zoom in/out, reset, and open-in-new-tab
  - PDF and LaTeX download buttons
  - Mobile bottom toolbar for navigation
  - `PaperReader` integrated in `BlogArticlePage`
  - Articles support `texUrl`; added four `.tex` files in `/public/papers/`

- **Dependencies**
  - Added `react-pdf` to `package.json`

<sup>Written for commit 50a559fe6caf6ab9ef2831839c23117b0b36c6ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

