### PR TITLE
fix(nginx): add .mjs MIME type for PDF.js worker

### DIFF
--- a/deployment/nginx/includes/frontend-routes.conf
+++ b/deployment/nginx/includes/frontend-routes.conf
@@ -5,7 +5,7 @@
 # Static Assets (with caching)
 # ==========================================
 
-location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+location ~* \.(mjs|js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
     proxy_pass http://stage_frontend;
     proxy_http_version 1.1;
     proxy_set_header Connection "";

--- a/deployment/nginx/includes/preview-server-common.conf
+++ b/deployment/nginx/includes/preview-server-common.conf
@@ -341,7 +341,7 @@ location ^~ /s3/ {
 # Static Assets (with caching)
 # ==========================================
 
-location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+location ~* \.(mjs|js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
     proxy_pass http://preview_frontend;
     proxy_http_version 1.1;
     proxy_set_header Connection "";

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -408,7 +408,7 @@ location ~ /\.(?!well-known) {
 # Static Assets (with caching)
 # ==========================================
 
-location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+location ~* \.(mjs|js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
     proxy_pass $prod_frontend;
     proxy_http_version 1.1;
     proxy_set_header Connection "";

--- a/deployment/nginx/stage.legal.org.ua-fixed.conf
+++ b/deployment/nginx/stage.legal.org.ua-fixed.conf
@@ -259,7 +259,7 @@ server {
     # Frontend Routes
     # ==========================================
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    location ~* \.(mjs|js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         proxy_pass http://localhost:8092;
         proxy_http_version 1.1;
         proxy_set_header Connection "";

--- a/lexwebapp/Dockerfile
+++ b/lexwebapp/Dockerfile
@@ -53,6 +53,9 @@ FROM nginx:alpine
 # Copy built assets from builder stage
 COPY --from=builder /app/lexwebapp/dist /usr/share/nginx/html
 
+# Add .mjs MIME type (ES modules — required for pdf.js worker)
+RUN sed -i 's|application/javascript\s*js;|application/javascript js mjs;|' /etc/nginx/mime.types
+
 # Copy custom nginx configuration
 COPY lexwebapp/nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/lexwebapp/nginx.conf
+++ b/lexwebapp/nginx.conf
@@ -27,7 +27,7 @@ server {
     }
 
     # Cache static assets
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    location ~* \.(mjs|js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
     }


### PR DESCRIPTION
## Summary
- Blog paper pages show "Failed to load PDF" because the PDF.js worker file (`.mjs`) is served with `content-type: application/octet-stream` — browsers reject ES module workers with wrong MIME type
- Added `mjs` to nginx's MIME type mapping in the frontend Dockerfile (`application/javascript js mjs`)
- Added `mjs` to all nginx static asset location regexes (prod, preview, stage, frontend container) so `.mjs` files get proper cache headers

## Root cause
nginx's default `mime.types` doesn't include `.mjs`. The `pdf.worker.min-*.mjs` file was being served correctly (200 OK) but with the wrong Content-Type, causing `react-pdf`'s Document component to fail silently.

## Test plan
- [ ] Verify `curl -sI https://legal.org.ua/assets/pdf.worker.min-*.mjs` returns `content-type: application/javascript`
- [ ] Open https://legal.org.ua/blog/paper-edit-trace-oversight and verify PDF renders
- [ ] Check all 4 academic paper blog posts load PDFs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “Failed to load PDF” on blog paper pages by serving the PDF worker `.mjs` with the correct MIME type. Adds `.mjs` handling and cache headers across all Nginx configs and the frontend Docker image.

- **Bug Fixes**
  - Added `.mjs` to Nginx `mime.types` in the frontend Dockerfile (maps to `application/javascript`).
  - Included `.mjs` in static asset location regexes for prod, preview, stage, and container Nginx so these files get proper cache headers.

<sup>Written for commit 547dbc8360e7402488c4b236ffd2f40e4b470108. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

