### PR TITLE
fix(paper): remove orphan label from bridge paper

### DIFF
--- a/docs/bridge-paper-cybernetics/main.tex
+++ b/docs/bridge-paper-cybernetics/main.tex
@@ -854,7 +854,6 @@ OntoChatGPT does not require production deployment---it functions identically in
 
 This result formally confirms the evolutionary lineage: edit-trace oversight is not an independent paradigm but a \textbf{strict extension} of ontology-controlled systems.
 $\mathsf{ValidOversight}$ inherits the foundation that $\mathsf{OntoChatGPT\_Control}$ provides (persistent state, grounded criteria) and adds three conditions specific to oversight validation (compositional layering, information asymmetry, consequential grounding).
-\label{prop:non-subsumption-converse}
 
 % --------------------------------------------------------
 \subsection{Complementarity and Integration}


### PR DESCRIPTION
## Summary
- Remove orphan `\label{prop:non-subsumption-converse}` left after subsumption rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed an orphan `\label{prop:non-subsumption-converse}` from the bridge paper to prevent LaTeX warnings and avoid broken cross-references.

<sup>Written for commit 1660eaaa5eb11f60fa213691eccb27818d35633c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

