### PR TITLE
fix(blog): add missing readTime to mission memory paper EN translation

### DIFF
--- a/lexwebapp/src/pages/BlogPage/articles-en.ts
+++ b/lexwebapp/src/pages/BlogPage/articles-en.ts
@@ -7189,6 +7189,7 @@ The work establishes a formal bridge between ontology-controlled architectures a
   'paper-mission-memory': {
     title: 'Persistent Memory Architecture for Long-Horizon Autonomous Missions with Operator Rotation',
     punchline: 'Three-level memory decomposition (domain / workflow / operator) with dual-mode retrieval for maintaining control continuity in UAV and situation center operations during operator handoff.',
+    readTime: '17 min',
     content: `# Persistent Memory Architecture for Long-Horizon Autonomous Missions with Operator Rotation
 
 **Dual-Mode Retrieval and Correction Signal**


### PR DESCRIPTION
## Summary
- Add missing `readTime: '17 min'` property to `paper-mission-memory` in `articles-en.ts`
- Fixes TS2741 error from PR #1634 that broke CI

## Test plan
- [x] `tsc --noEmit` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing readTime ('17 min') to the 'paper-mission-memory' entry in articles-en.ts. Fixes TS2741 and restores CI.

<sup>Written for commit 9413ad73e4e28a7c30ccf2f7241026efbf55e52f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

