### PR TITLE
test(backend): workflow memory unit tests (73 tests)

### DIFF
--- a/mcp_backend/src/api/__tests__/workflow-memory-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/workflow-memory-tools.test.ts
@@ -1,0 +1,565 @@
+/**
+ * WorkflowMemoryTools unit tests
+ *
+ * Covers:
+ * - getToolDefinitions: returns 3 tool defs with correct names/annotations
+ * - executeTool: dispatches correctly, returns null for unknown tool
+ * - workflow_memory_query: formats results, handles empty results, caps top_k at 20
+ * - workflow_memory_ingest: principle (with/without key), pattern defaults, practitioner, unknown layer
+ * - workflow_memory_stats: formatted response
+ * - Error handling: wraps errors with isError: true
+ */
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { WorkflowMemoryTools } from '../tools/workflow-memory-tools';
+
+// ---------------------------------------------------------------------------
+// Helper: build a mock of WorkflowMemoryService using explicit jest.Mock<any>
+// ---------------------------------------------------------------------------
+
+interface MockService {
+  initialize: jest.Mock<any>;
+  query: jest.Mock<any>;
+  ingestPrinciple: jest.Mock<any>;
+  ingestPattern: jest.Mock<any>;
+  ingestPractitioner: jest.Mock<any>;
+  getStats: jest.Mock<any>;
+}
+
+function makeMockService(): MockService {
+  return {
+    initialize: jest.fn() as jest.Mock<any>,
+    query: jest.fn() as jest.Mock<any>,
+    ingestPrinciple: jest.fn() as jest.Mock<any>,
+    ingestPattern: jest.fn() as jest.Mock<any>,
+    ingestPractitioner: jest.fn() as jest.Mock<any>,
+    getStats: jest.fn() as jest.Mock<any>,
+  };
+}
+
+// Convenience: parse the text payload of a ToolResult
+function parseResult(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+// ---------------------------------------------------------------------------
+
+describe('WorkflowMemoryTools', () => {
+  let svc: MockService;
+  let handler: WorkflowMemoryTools;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    svc = makeMockService();
+    handler = new WorkflowMemoryTools(svc as any);
+  });
+
+  // ── getToolDefinitions ─────────────────────────────────────────────────────
+
+  describe('getToolDefinitions', () => {
+    it('returns exactly 3 tool definitions', () => {
+      const defs = handler.getToolDefinitions();
+      expect(defs).toHaveLength(3);
+    });
+
+    it('returns workflow_memory_query with required "query" field', () => {
+      const defs = handler.getToolDefinitions();
+      const queryTool = defs.find(d => d.name === 'workflow_memory_query');
+      expect(queryTool).toBeDefined();
+      expect(queryTool!.inputSchema.required).toContain('query');
+      expect(queryTool!.annotations?.readOnlyHint).toBe(true);
+    });
+
+    it('returns workflow_memory_ingest with required fields', () => {
+      const defs = handler.getToolDefinitions();
+      const ingestTool = defs.find(d => d.name === 'workflow_memory_ingest');
+      expect(ingestTool).toBeDefined();
+      expect(ingestTool!.inputSchema.required).toContain('layer');
+      expect(ingestTool!.inputSchema.required).toContain('title');
+      expect(ingestTool!.inputSchema.required).toContain('body');
+    });
+
+    it('returns workflow_memory_stats with readOnlyHint and idempotentHint', () => {
+      const defs = handler.getToolDefinitions();
+      const statsTool = defs.find(d => d.name === 'workflow_memory_stats');
+      expect(statsTool).toBeDefined();
+      expect(statsTool!.annotations?.readOnlyHint).toBe(true);
+      expect(statsTool!.annotations?.idempotentHint).toBe(true);
+    });
+
+    it('handles() returns true for all three tool names', () => {
+      expect(handler.handles('workflow_memory_query')).toBe(true);
+      expect(handler.handles('workflow_memory_ingest')).toBe(true);
+      expect(handler.handles('workflow_memory_stats')).toBe(true);
+    });
+
+    it('handles() returns false for unknown tool name', () => {
+      expect(handler.handles('workflow_memory_unknown')).toBe(false);
+    });
+  });
+
+  // ── executeTool dispatch ───────────────────────────────────────────────────
+
+  describe('executeTool', () => {
+    it('returns null for an unrecognised tool name', async () => {
+      const result = await handler.executeTool('totally_unknown', {});
+      expect(result).toBeNull();
+    });
+
+    it('dispatches to handleQuery for workflow_memory_query', async () => {
+      svc.query.mockResolvedValue({ hits: [], queryTokens: 0, layers_searched: ['principle'] });
+      const result = await handler.executeTool('workflow_memory_query', { query: 'test' });
+      expect(result).not.toBeNull();
+      expect(svc.query).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches to handleIngest for workflow_memory_ingest', async () => {
+      svc.ingestPrinciple.mockResolvedValue(1);
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'principle',
+        title: 'T',
+        body: 'B',
+        principle_key: 'k',
+      });
+      expect(result).not.toBeNull();
+      expect(svc.ingestPrinciple).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches to handleStats for workflow_memory_stats', async () => {
+      svc.getStats.mockResolvedValue({ principles: 0, patterns: 0, practitioner: 0, retrievals: 0 });
+      const result = await handler.executeTool('workflow_memory_stats', {});
+      expect(result).not.toBeNull();
+      expect(svc.getStats).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── workflow_memory_query ──────────────────────────────────────────────────
+
+  describe('workflow_memory_query', () => {
+    it('returns "nothing found" message when hits array is empty', async () => {
+      svc.query.mockResolvedValue({
+        hits: [],
+        queryTokens: 0,
+        layers_searched: ['principle', 'pattern', 'practitioner'],
+      });
+
+      const result = await handler.executeTool('workflow_memory_query', { query: 'anything' });
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = parseResult(result);
+      expect(parsed.message).toMatch(/нічого не знайдено/i);
+      expect(parsed.layers_searched).toBeDefined();
+    });
+
+    it('formats hits correctly with rounded score', async () => {
+      svc.query.mockResolvedValue({
+        hits: [
+          {
+            layer: 'principle',
+            id: 1,
+            title: 'Deploy blue-green',
+            body: 'Use blue-green deploy strategy',
+            score: 0.876543,
+            tags: ['deploy'],
+            source: 'adr',
+            metadata: { version: 2 },
+          },
+        ],
+        queryTokens: 0,
+        layers_searched: ['principle'],
+      });
+
+      const result = await handler.executeTool('workflow_memory_query', { query: 'deploy' });
+
+      const parsed = parseResult(result);
+      expect(parsed.count).toBe(1);
+      expect(parsed.hits[0].layer).toBe('principle');
+      expect(parsed.hits[0].title).toBe('Deploy blue-green');
+      expect(parsed.hits[0].score).toBe(0.877); // rounded to 3 dp
+      expect(parsed.hits[0].source).toBe('adr');
+      expect(parsed.hits[0].metadata).toEqual({ version: 2 });
+    });
+
+    it('omits source field from hit when source is not present', async () => {
+      svc.query.mockResolvedValue({
+        hits: [
+          {
+            layer: 'pattern',
+            id: 2,
+            title: 'T',
+            body: 'B',
+            score: 0.7,
+            tags: [],
+            source: undefined,
+            metadata: undefined,
+          },
+        ],
+        queryTokens: 0,
+        layers_searched: ['pattern'],
+      });
+
+      const result = await handler.executeTool('workflow_memory_query', { query: 'x' });
+      const parsed = parseResult(result);
+      expect(Object.prototype.hasOwnProperty.call(parsed.hits[0], 'source')).toBe(false);
+    });
+
+    it('omits metadata field from hit when metadata is empty object', async () => {
+      svc.query.mockResolvedValue({
+        hits: [
+          {
+            layer: 'practitioner',
+            id: 3,
+            title: 'T',
+            body: 'B',
+            score: 0.7,
+            tags: [],
+            source: undefined,
+            metadata: {},
+          },
+        ],
+        queryTokens: 0,
+        layers_searched: ['practitioner'],
+      });
+
+      const result = await handler.executeTool('workflow_memory_query', { query: 'x' });
+      const parsed = parseResult(result);
+      expect(Object.prototype.hasOwnProperty.call(parsed.hits[0], 'metadata')).toBe(false);
+    });
+
+    it('caps top_k at 20 even when caller passes a larger value', async () => {
+      svc.query.mockResolvedValue({ hits: [], queryTokens: 0, layers_searched: ['principle'] });
+
+      await handler.executeTool('workflow_memory_query', { query: 'x', top_k: 100 });
+
+      expect(svc.query).toHaveBeenCalledWith(
+        expect.objectContaining({ topK: 20 }),
+      );
+    });
+
+    it('uses default top_k=5 when not provided', async () => {
+      svc.query.mockResolvedValue({ hits: [], queryTokens: 0, layers_searched: ['principle'] });
+
+      await handler.executeTool('workflow_memory_query', { query: 'x' });
+
+      expect(svc.query).toHaveBeenCalledWith(
+        expect.objectContaining({ topK: 5 }),
+      );
+    });
+
+    it('passes layers, tags and session_id through to service', async () => {
+      svc.query.mockResolvedValue({ hits: [], queryTokens: 0, layers_searched: ['principle'] });
+
+      await handler.executeTool('workflow_memory_query', {
+        query: 'test',
+        layers: ['principle', 'pattern'],
+        tags: ['billing'],
+        session_id: 'sess-1',
+        top_k: 3,
+      });
+
+      expect(svc.query).toHaveBeenCalledWith({
+        query: 'test',
+        layers: ['principle', 'pattern'],
+        tags: ['billing'],
+        topK: 3,
+        sessionId: 'sess-1',
+      });
+    });
+
+    it('wraps service errors with isError: true', async () => {
+      svc.query.mockRejectedValue(new Error('Qdrant connection refused'));
+
+      const result = await handler.executeTool('workflow_memory_query', { query: 'x' });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('Qdrant connection refused');
+    });
+  });
+
+  // ── workflow_memory_ingest — principle ─────────────────────────────────────
+
+  describe('workflow_memory_ingest — principle layer', () => {
+    it('returns error when principle_key is missing', async () => {
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'principle',
+        title: 'T',
+        body: 'B',
+        // no principle_key
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('principle_key');
+    });
+
+    it('calls ingestPrinciple with correct arguments and returns success', async () => {
+      svc.ingestPrinciple.mockResolvedValue(42);
+
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'principle',
+        title: 'Blue-green deploy',
+        body: 'Deploy to inactive colour',
+        principle_key: 'deploy.blue_green',
+        source: 'adr',
+        source_ref: 'docs/adr/001.md',
+        tags: ['deploy', 'infra'],
+      });
+
+      expect(result?.isError).toBeFalsy();
+      expect(svc.ingestPrinciple).toHaveBeenCalledWith({
+        principleKey: 'deploy.blue_green',
+        title: 'Blue-green deploy',
+        body: 'Deploy to inactive colour',
+        source: 'adr',
+        sourceRef: 'docs/adr/001.md',
+        tags: ['deploy', 'infra'],
+      });
+
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.id).toBe(42);
+      expect(parsed.layer).toBe('principle');
+    });
+
+    it('wraps service error with isError: true', async () => {
+      svc.ingestPrinciple.mockRejectedValue(new Error('DB connection lost'));
+
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'principle',
+        title: 'T',
+        body: 'B',
+        principle_key: 'k',
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('DB connection lost');
+    });
+  });
+
+  // ── workflow_memory_ingest — pattern ───────────────────────────────────────
+
+  describe('workflow_memory_ingest — pattern layer', () => {
+    it('calls ingestPattern and returns success', async () => {
+      svc.ingestPattern.mockResolvedValue(55);
+
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'pattern',
+        title: 'Read-Edit-Build cycle',
+        body: 'Always read before editing, run build after',
+        tags: ['workflow'],
+      });
+
+      expect(result?.isError).toBeFalsy();
+      expect(svc.ingestPattern).toHaveBeenCalledTimes(1);
+      const parsed = parseResult(result);
+      expect(parsed.id).toBe(55);
+      expect(parsed.layer).toBe('pattern');
+    });
+
+    it('uses "edit_trace" as default pattern_type when not provided', async () => {
+      svc.ingestPattern.mockResolvedValue(1);
+
+      await handler.executeTool('workflow_memory_ingest', {
+        layer: 'pattern',
+        title: 'T',
+        body: 'B',
+      });
+
+      expect(svc.ingestPattern).toHaveBeenCalledWith(
+        expect.objectContaining({ patternType: 'edit_trace' }),
+      );
+    });
+
+    it('wraps session_id into sessionIds array', async () => {
+      svc.ingestPattern.mockResolvedValue(1);
+
+      await handler.executeTool('workflow_memory_ingest', {
+        layer: 'pattern',
+        title: 'T',
+        body: 'B',
+        session_id: 'sess-77',
+      });
+
+      expect(svc.ingestPattern).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionIds: ['sess-77'] }),
+      );
+    });
+
+    it('uses empty sessionIds when session_id absent', async () => {
+      svc.ingestPattern.mockResolvedValue(1);
+
+      await handler.executeTool('workflow_memory_ingest', {
+        layer: 'pattern',
+        title: 'T',
+        body: 'B',
+      });
+
+      expect(svc.ingestPattern).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionIds: [] }),
+      );
+    });
+
+    it('passes pattern_data to ingestPattern', async () => {
+      svc.ingestPattern.mockResolvedValue(1);
+      const patternData = { steps: ['Read', 'Edit'] };
+
+      await handler.executeTool('workflow_memory_ingest', {
+        layer: 'pattern',
+        title: 'T',
+        body: 'B',
+        pattern_data: patternData,
+      });
+
+      expect(svc.ingestPattern).toHaveBeenCalledWith(
+        expect.objectContaining({ patternData }),
+      );
+    });
+  });
+
+  // ── workflow_memory_ingest — practitioner ──────────────────────────────────
+
+  describe('workflow_memory_ingest — practitioner layer', () => {
+    it('calls ingestPractitioner and returns success', async () => {
+      svc.ingestPractitioner.mockResolvedValue(77);
+
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'practitioner',
+        title: 'Session recap',
+        body: 'Implemented billing fix in 3 files.',
+        knowledge_type: 'session_summary',
+        session_id: 'sess-42',
+        commit_range: 'abc..def',
+        files_touched: ['billing.ts'],
+        tools_used: ['Read', 'Edit'],
+        tags: ['billing'],
+      });
+
+      expect(result?.isError).toBeFalsy();
+      expect(svc.ingestPractitioner).toHaveBeenCalledWith({
+        knowledgeType: 'session_summary',
+        title: 'Session recap',
+        body: 'Implemented billing fix in 3 files.',
+        sessionId: 'sess-42',
+        commitRange: 'abc..def',
+        filesTouched: ['billing.ts'],
+        toolsUsed: ['Read', 'Edit'],
+        tags: ['billing'],
+      });
+
+      const parsed = parseResult(result);
+      expect(parsed.ok).toBe(true);
+      expect(parsed.id).toBe(77);
+      expect(parsed.layer).toBe('practitioner');
+    });
+
+    it('uses "session_summary" as default knowledge_type when not provided', async () => {
+      svc.ingestPractitioner.mockResolvedValue(1);
+
+      await handler.executeTool('workflow_memory_ingest', {
+        layer: 'practitioner',
+        title: 'T',
+        body: 'B',
+      });
+
+      expect(svc.ingestPractitioner).toHaveBeenCalledWith(
+        expect.objectContaining({ knowledgeType: 'session_summary' }),
+      );
+    });
+  });
+
+  // ── workflow_memory_ingest — unknown layer ─────────────────────────────────
+
+  describe('workflow_memory_ingest — unknown layer', () => {
+    it('returns isError: true for an unrecognised layer', async () => {
+      const result = await handler.executeTool('workflow_memory_ingest', {
+        layer: 'bogus_layer',
+        title: 'T',
+        body: 'B',
+      });
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('bogus_layer');
+    });
+
+    it('does not call any ingest method for unknown layer', async () => {
+      await handler.executeTool('workflow_memory_ingest', {
+        layer: 'ghost',
+        title: 'T',
+        body: 'B',
+      });
+
+      expect(svc.ingestPrinciple).not.toHaveBeenCalled();
+      expect(svc.ingestPattern).not.toHaveBeenCalled();
+      expect(svc.ingestPractitioner).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── workflow_memory_stats ──────────────────────────────────────────────────
+
+  describe('workflow_memory_stats', () => {
+    it('formats stats correctly', async () => {
+      svc.getStats.mockResolvedValue({
+        principles: 10,
+        patterns: 25,
+        practitioner: 5,
+        retrievals: 100,
+      });
+
+      const result = await handler.executeTool('workflow_memory_stats', {});
+
+      expect(result?.isError).toBeFalsy();
+      const parsed = parseResult(result);
+      expect(parsed.layers.principles).toBe(10);
+      expect(parsed.layers.patterns).toBe(25);
+      expect(parsed.layers.practitioner).toBe(5);
+      expect(parsed.total_entries).toBe(40);
+      expect(parsed.total_retrievals).toBe(100);
+    });
+
+    it('computes total_entries as sum of principles + patterns + practitioner', async () => {
+      svc.getStats.mockResolvedValue({
+        principles: 3,
+        patterns: 7,
+        practitioner: 2,
+        retrievals: 0,
+      });
+
+      const result = await handler.executeTool('workflow_memory_stats', {});
+      const parsed = parseResult(result);
+      expect(parsed.total_entries).toBe(12);
+    });
+
+    it('wraps getStats error with isError: true', async () => {
+      svc.getStats.mockRejectedValue(new Error('DB timeout'));
+
+      const result = await handler.executeTool('workflow_memory_stats', {});
+
+      expect(result?.isError).toBe(true);
+      expect(result?.content[0].text).toContain('DB timeout');
+    });
+  });
+
+  // ── wrapResponse shape ─────────────────────────────────────────────────────
+
+  describe('response shape (wrapResponse)', () => {
+    it('always returns content as an array with at least one text item', async () => {
+      svc.query.mockResolvedValue({ hits: [], queryTokens: 0, layers_searched: ['principle'] });
+      const result = await handler.executeTool('workflow_memory_query', { query: 'x' });
+
+      expect(Array.isArray(result?.content)).toBe(true);
+      expect(result?.content.length).toBeGreaterThan(0);
+      expect(result?.content[0].type).toBe('text');
+      expect(typeof result?.content[0].text).toBe('string');
+    });
+
+    it('result text is valid JSON for successful responses', async () => {
+      svc.getStats.mockResolvedValue({ principles: 1, patterns: 2, practitioner: 3, retrievals: 4 });
+      const result = await handler.executeTool('workflow_memory_stats', {});
+
+      expect(() => JSON.parse(result!.content[0].text)).not.toThrow();
+    });
+  });
+});

--- a/mcp_backend/src/services/__tests__/workflow-memory-service.test.ts
+++ b/mcp_backend/src/services/__tests__/workflow-memory-service.test.ts
@@ -1,0 +1,651 @@
+/**
+ * WorkflowMemoryService unit tests
+ *
+ * Covers:
+ * - initialize: creates missing Qdrant collections, skips existing ones, runs only once
+ * - query: embedding, per-layer search, merge+sort by score, topK trim, tag filter,
+ *          sessionId logRetrieval, no logging when sessionId absent
+ * - ingestPrinciple: PG upsert + Qdrant domain collection
+ * - ingestPattern: PG insert + Qdrant workflow collection
+ * - ingestPractitioner: PG insert + Qdrant practitioner collection
+ * - getStats: counts from all 4 tables
+ * - collectionForLayer: correct mapping per layer
+ */
+
+// --- Module-level mocks MUST come before imports ---
+// The mock variables are set up in beforeEach to avoid TypeScript inference issues
+// with module-level mockResolvedValue calls.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetCollections: jest.Mock<any> = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateCollection: jest.Mock<any> = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSearch: jest.Mock<any> = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpsert: jest.Mock<any> = jest.fn();
+
+jest.mock('@qdrant/js-client-rest', () => ({
+  QdrantClient: jest.fn().mockImplementation(() => ({
+    getCollections: mockGetCollections,
+    createCollection: mockCreateCollection,
+    search: mockSearch,
+    upsert: mockUpsert,
+  })),
+}));
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+}));
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { WorkflowMemoryService } from '../workflow-memory-service';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const FAKE_EMBEDDING = new Array(1024).fill(0.1);
+
+function makeDb(responder?: (sql: string) => any) {
+  return {
+    query: jest.fn((sql: string, _params?: any[]) => {
+      if (responder) return Promise.resolve(responder(sql));
+      return Promise.resolve({ rows: [] });
+    }),
+  };
+}
+
+function makeEmbeddingService() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mock: jest.Mock<any> = jest.fn();
+  mock.mockResolvedValue(FAKE_EMBEDDING);
+  return { generateEmbedding: mock } as any;
+}
+
+function makeService(db = makeDb(), emb = makeEmbeddingService()) {
+  return new WorkflowMemoryService(db, emb);
+}
+
+// Default: all three collections already exist so initialize() is a no-op
+function allCollectionsExist() {
+  mockGetCollections.mockResolvedValue({
+    collections: [
+      { name: 'wm_domain' },
+      { name: 'wm_workflow' },
+      { name: 'wm_practitioner' },
+    ],
+  });
+}
+
+function noCollectionsExist() {
+  mockGetCollections.mockResolvedValue({ collections: [] });
+}
+
+// ---------------------------------------------------------------------------
+
+describe('WorkflowMemoryService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset default resolved values
+    mockCreateCollection.mockResolvedValue({});
+    mockUpsert.mockResolvedValue({});
+    allCollectionsExist();
+  });
+
+  // ── initialize ─────────────────────────────────────────────────────────────
+
+  describe('initialize', () => {
+    it('skips createCollection when all three collections already exist', async () => {
+      const svc = makeService();
+      await svc.initialize();
+      expect(mockCreateCollection).not.toHaveBeenCalled();
+    });
+
+    it('creates each missing collection with correct vector config', async () => {
+      noCollectionsExist();
+      const svc = makeService();
+      await svc.initialize();
+
+      expect(mockCreateCollection).toHaveBeenCalledTimes(3);
+      const names = mockCreateCollection.mock.calls.map((c: any[]) => c[0]);
+      expect(names).toContain('wm_domain');
+      expect(names).toContain('wm_workflow');
+      expect(names).toContain('wm_practitioner');
+
+      for (const call of mockCreateCollection.mock.calls as any[]) {
+        expect(call[1]).toEqual({ vectors: { size: 1024, distance: 'Cosine' } });
+      }
+    });
+
+    it('creates only the missing collection when two of three exist', async () => {
+      mockGetCollections.mockResolvedValue({
+        collections: [{ name: 'wm_domain' }, { name: 'wm_workflow' }],
+      });
+      const svc = makeService();
+      await svc.initialize();
+
+      expect(mockCreateCollection).toHaveBeenCalledTimes(1);
+      expect(mockCreateCollection).toHaveBeenCalledWith('wm_practitioner', expect.any(Object));
+    });
+
+    it('is idempotent — second call does not query Qdrant again', async () => {
+      const svc = makeService();
+      await svc.initialize();
+      await svc.initialize();
+
+      expect(mockGetCollections).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── query ──────────────────────────────────────────────────────────────────
+
+  describe('query', () => {
+    it('calls generateEmbedding with the query text', async () => {
+      const emb = makeEmbeddingService();
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService(makeDb(), emb);
+
+      await svc.query({ query: 'deployment conventions' });
+
+      expect(emb.generateEmbedding).toHaveBeenCalledWith('deployment conventions', 'wm_query');
+    });
+
+    it('searches all three layers by default', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+
+      const result = await svc.query({ query: 'test' });
+
+      expect(mockSearch).toHaveBeenCalledTimes(3);
+      const searchedCollections = mockSearch.mock.calls.map((c: any[]) => c[0]);
+      expect(searchedCollections).toContain('wm_domain');
+      expect(searchedCollections).toContain('wm_workflow');
+      expect(searchedCollections).toContain('wm_practitioner');
+      expect(result.layers_searched).toEqual(
+        expect.arrayContaining(['principle', 'pattern', 'practitioner']),
+      );
+    });
+
+    it('searches only specified layers', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+
+      const result = await svc.query({ query: 'test', layers: ['principle'] });
+
+      expect(mockSearch).toHaveBeenCalledTimes(1);
+      expect(mockSearch).toHaveBeenCalledWith('wm_domain', expect.any(Object));
+      expect(result.layers_searched).toEqual(['principle']);
+    });
+
+    it('merges results from multiple layers and sorts by score descending', async () => {
+      mockSearch
+        .mockResolvedValueOnce([
+          { score: 0.7, payload: { pg_id: 1, title: 'A', body: 'body-a', tags: [] } },
+        ])
+        .mockResolvedValueOnce([
+          { score: 0.9, payload: { pg_id: 2, title: 'B', body: 'body-b', tags: [] } },
+        ])
+        .mockResolvedValueOnce([
+          { score: 0.5, payload: { pg_id: 3, title: 'C', body: 'body-c', tags: [] } },
+        ]);
+
+      const svc = makeService();
+      const result = await svc.query({ query: 'test', topK: 10 });
+
+      expect(result.hits).toHaveLength(3);
+      expect(result.hits[0].score).toBe(0.9);
+      expect(result.hits[1].score).toBe(0.7);
+      expect(result.hits[2].score).toBe(0.5);
+    });
+
+    it('trims merged hits to topK', async () => {
+      const makeHit = (score: number, pg_id: number) => ({
+        score,
+        payload: { pg_id, title: `title-${pg_id}`, body: 'body', tags: [] },
+      });
+      mockSearch
+        .mockResolvedValueOnce([makeHit(0.9, 1), makeHit(0.8, 2)])
+        .mockResolvedValueOnce([makeHit(0.75, 3), makeHit(0.6, 4)])
+        .mockResolvedValueOnce([makeHit(0.55, 5), makeHit(0.4, 6)]);
+
+      const svc = makeService();
+      const result = await svc.query({ query: 'test', topK: 3 });
+
+      expect(result.hits).toHaveLength(3);
+      expect(result.hits[0].score).toBe(0.9);
+    });
+
+    it('passes tag filter to Qdrant when tags provided', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+
+      await svc.query({ query: 'test', tags: ['billing', 'auth'] });
+
+      for (const call of mockSearch.mock.calls as any[]) {
+        expect(call[1].filter).toEqual({
+          must: [{ key: 'tags', match: { any: ['billing', 'auth'] } }],
+        });
+      }
+    });
+
+    it('does NOT pass filter when tags array is empty', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+
+      await svc.query({ query: 'test', tags: [] });
+
+      for (const call of mockSearch.mock.calls as any[]) {
+        expect(call[1].filter).toBeUndefined();
+      }
+    });
+
+    it('does NOT pass filter when tags not provided', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+
+      await svc.query({ query: 'test' });
+
+      for (const call of mockSearch.mock.calls as any[]) {
+        expect(call[1].filter).toBeUndefined();
+      }
+    });
+
+    it('logs retrieval when sessionId is provided', async () => {
+      mockSearch
+        .mockResolvedValueOnce([
+          { score: 0.8, payload: { pg_id: 10, title: 'T', body: 'B', tags: [] } },
+        ])
+        .mockResolvedValue([]);
+
+      const db = makeDb();
+      const svc = makeService(db);
+
+      await svc.query({ query: 'test', layers: ['principle'], sessionId: 'sess-123' });
+
+      const insertCalls = (db.query.mock.calls as any[]).filter((c) =>
+        c[0].includes('workflow_memory_retrievals'),
+      );
+      expect(insertCalls).toHaveLength(1);
+      expect(insertCalls[0][1]).toContain('sess-123');
+    });
+
+    it('does NOT log retrieval when sessionId is absent', async () => {
+      mockSearch.mockResolvedValue([]);
+      const db = makeDb();
+      const svc = makeService(db);
+
+      await svc.query({ query: 'test' });
+
+      const insertCalls = (db.query.mock.calls as any[]).filter((c) =>
+        c[0].includes('workflow_memory_retrievals'),
+      );
+      expect(insertCalls).toHaveLength(0);
+    });
+
+    it('maps hit fields correctly from Qdrant payload', async () => {
+      mockSearch
+        .mockResolvedValueOnce([
+          {
+            score: 0.88,
+            payload: {
+              pg_id: 42,
+              title: 'Blue-green deploy',
+              body: 'Deploy to inactive color first',
+              source: 'adr',
+              tags: ['deploy', 'infra'],
+              metadata: { adv: true },
+            },
+          },
+        ])
+        .mockResolvedValue([]);
+
+      const svc = makeService();
+      const result = await svc.query({ query: 'deploy', layers: ['principle'] });
+
+      expect(result.hits[0]).toMatchObject({
+        layer: 'principle',
+        id: 42,
+        title: 'Blue-green deploy',
+        body: 'Deploy to inactive color first',
+        score: 0.88,
+        source: 'adr',
+        tags: ['deploy', 'infra'],
+        metadata: { adv: true },
+      });
+    });
+
+    it('uses default topK=5 when topK not specified', async () => {
+      const makeHit = (score: number, pg_id: number) => ({
+        score,
+        payload: { pg_id, title: `t${pg_id}`, body: 'b', tags: [] },
+      });
+      // Each layer returns 4 hits; total = 12, but topK=5 slices to 5
+      mockSearch.mockResolvedValue(
+        Array.from({ length: 4 }, (_, i) => makeHit(0.9 - i * 0.05, i + 1)),
+      );
+      const svc = makeService();
+      const result = await svc.query({ query: 'test' });
+
+      expect(result.hits.length).toBeLessThanOrEqual(5);
+    });
+
+    it('passes score_threshold to Qdrant', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+
+      await svc.query({ query: 'test', minScore: 0.6 });
+
+      for (const call of mockSearch.mock.calls as any[]) {
+        expect(call[1].score_threshold).toBe(0.6);
+      }
+    });
+  });
+
+  // ── ingestPrinciple ────────────────────────────────────────────────────────
+
+  describe('ingestPrinciple', () => {
+    it('inserts into workflow_memory_principles and returns the new id', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 7 }] }));
+      const svc = makeService(db);
+
+      const id = await svc.ingestPrinciple({
+        principleKey: 'deploy.blue_green',
+        title: 'Blue-green deploy',
+        body: 'Always deploy to inactive colour first.',
+        source: 'adr',
+        tags: ['deploy'],
+      });
+
+      expect(id).toBe(7);
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_principles'),
+      );
+      expect(pgCall).toBeDefined();
+      expect(pgCall[1]).toContain('deploy.blue_green');
+    });
+
+    it('uses ON CONFLICT DO UPDATE (upsert) semantics', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 3 }] }));
+      const svc = makeService(db);
+      await svc.ingestPrinciple({ principleKey: 'k', title: 'T', body: 'B' });
+
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_principles'),
+      );
+      expect(pgCall[0]).toMatch(/ON CONFLICT.*DO UPDATE/s);
+    });
+
+    it('upserts into Qdrant wm_domain collection', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 5 }] }));
+      const svc = makeService(db);
+
+      await svc.ingestPrinciple({ principleKey: 'k', title: 'T', body: 'B' });
+
+      expect(mockUpsert).toHaveBeenCalledTimes(1);
+      const [collection, payload] = mockUpsert.mock.calls[0] as any[];
+      expect(collection).toBe('wm_domain');
+      expect(payload.points[0].id).toBe(5);
+      expect(payload.points[0].vector).toEqual(FAKE_EMBEDDING);
+    });
+
+    it('uses defaults for optional fields', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 1 }] }));
+      const svc = makeService(db);
+      await svc.ingestPrinciple({ principleKey: 'k', title: 'T', body: 'B' });
+
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_principles'),
+      );
+      // confidence defaults to 1.0
+      expect(pgCall[1]).toContain(1.0);
+      // source defaults to null
+      expect(pgCall[1]).toContain(null);
+    });
+
+    it('generates embedding from title + body concatenated', async () => {
+      const emb = makeEmbeddingService();
+      const db = makeDb(() => ({ rows: [{ id: 1 }] }));
+      const svc = makeService(db, emb);
+
+      await svc.ingestPrinciple({ principleKey: 'k', title: 'MyTitle', body: 'MyBody' });
+
+      expect(emb.generateEmbedding).toHaveBeenCalledWith(
+        'MyTitle\nMyBody',
+        'wm_ingest_principle',
+      );
+    });
+  });
+
+  // ── ingestPattern ──────────────────────────────────────────────────────────
+
+  describe('ingestPattern', () => {
+    it('inserts into workflow_memory_patterns and returns id', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 20 }] }));
+      const svc = makeService(db);
+
+      const id = await svc.ingestPattern({
+        patternType: 'tool_sequence',
+        description: 'Read → Edit → Build',
+        tags: ['tools'],
+      });
+
+      expect(id).toBe(20);
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_patterns'),
+      );
+      expect(pgCall).toBeDefined();
+      expect(pgCall[1]).toContain('tool_sequence');
+    });
+
+    it('upserts into Qdrant wm_workflow collection', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 21 }] }));
+      const svc = makeService(db);
+
+      await svc.ingestPattern({ patternType: 'edit_trace', description: 'Desc' });
+
+      const [collection] = mockUpsert.mock.calls[0] as any[];
+      expect(collection).toBe('wm_workflow');
+    });
+
+    it('serialises patternData to JSON string for PG', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 22 }] }));
+      const svc = makeService(db);
+      const patternData = { steps: ['a', 'b'], count: 2 };
+
+      await svc.ingestPattern({ patternType: 'pt', description: 'D', patternData });
+
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_patterns'),
+      );
+      expect(pgCall[1]).toContain(JSON.stringify(patternData));
+    });
+
+    it('generates embedding from description text', async () => {
+      const emb = makeEmbeddingService();
+      const db = makeDb(() => ({ rows: [{ id: 1 }] }));
+      const svc = makeService(db, emb);
+
+      await svc.ingestPattern({ patternType: 'pt', description: 'Step by step' });
+
+      expect(emb.generateEmbedding).toHaveBeenCalledWith('Step by step', 'wm_ingest_pattern');
+    });
+  });
+
+  // ── ingestPractitioner ─────────────────────────────────────────────────────
+
+  describe('ingestPractitioner', () => {
+    it('inserts into workflow_memory_practitioner and returns id', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 99 }] }));
+      const svc = makeService(db);
+
+      const id = await svc.ingestPractitioner({
+        knowledgeType: 'session_summary',
+        title: 'Session recap',
+        body: 'Fixed billing bug.',
+        sessionId: 's-1',
+        tags: ['billing'],
+      });
+
+      expect(id).toBe(99);
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_practitioner'),
+      );
+      expect(pgCall).toBeDefined();
+      expect(pgCall[1]).toContain('session_summary');
+    });
+
+    it('upserts into Qdrant wm_practitioner collection', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 100 }] }));
+      const svc = makeService(db);
+
+      await svc.ingestPractitioner({ knowledgeType: 'correction', title: 'T', body: 'B' });
+
+      const [collection] = mockUpsert.mock.calls[0] as any[];
+      expect(collection).toBe('wm_practitioner');
+    });
+
+    it('generates embedding from title + body concatenated', async () => {
+      const emb = makeEmbeddingService();
+      const db = makeDb(() => ({ rows: [{ id: 1 }] }));
+      const svc = makeService(db, emb);
+
+      await svc.ingestPractitioner({ knowledgeType: 'correction', title: 'TT', body: 'BB' });
+
+      expect(emb.generateEmbedding).toHaveBeenCalledWith('TT\nBB', 'wm_ingest_practitioner');
+    });
+
+    it('stores optional arrays with defaults', async () => {
+      const db = makeDb(() => ({ rows: [{ id: 1 }] }));
+      const svc = makeService(db);
+
+      await svc.ingestPractitioner({ knowledgeType: 'session_summary', title: 'T', body: 'B' });
+
+      const pgCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_practitioner'),
+      );
+      const params = pgCall[1] as any[];
+      // params: [knowledgeType, title, body, sessionId, commitRange, filesTouched, toolsUsed, tags]
+      expect(params[5]).toEqual([]); // filesTouched
+      expect(params[6]).toEqual([]); // toolsUsed
+      expect(params[7]).toEqual([]); // tags
+    });
+  });
+
+  // ── getStats ───────────────────────────────────────────────────────────────
+
+  describe('getStats', () => {
+    it('returns counts from all four tables', async () => {
+      let callIndex = 0;
+      const counts = [12, 34, 56, 78];
+      const db = makeDb(() => ({ rows: [{ cnt: counts[callIndex++] }] }));
+      const svc = makeService(db);
+
+      const stats = await svc.getStats();
+
+      expect(stats.principles).toBe(12);
+      expect(stats.patterns).toBe(34);
+      expect(stats.practitioner).toBe(56);
+      expect(stats.retrievals).toBe(78);
+    });
+
+    it('issues four COUNT(*) queries', async () => {
+      const db = makeDb(() => ({ rows: [{ cnt: 0 }] }));
+      const svc = makeService(db);
+
+      await svc.getStats();
+
+      expect(db.query).toHaveBeenCalledTimes(4);
+      const sqls = (db.query.mock.calls as any[]).map((c) => c[0]);
+      expect(sqls.some((s: string) => s.includes('workflow_memory_principles'))).toBe(true);
+      expect(sqls.some((s: string) => s.includes('workflow_memory_patterns'))).toBe(true);
+      expect(sqls.some((s: string) => s.includes('workflow_memory_practitioner'))).toBe(true);
+      expect(sqls.some((s: string) => s.includes('workflow_memory_retrievals'))).toBe(true);
+    });
+
+    it('converts COUNT() string result to number', async () => {
+      const db = makeDb(() => ({ rows: [{ cnt: '42' }] }));
+      const svc = makeService(db);
+
+      const stats = await svc.getStats();
+
+      expect(typeof stats.principles).toBe('number');
+      expect(stats.principles).toBe(42);
+    });
+  });
+
+  // ── collectionForLayer (via query) ─────────────────────────────────────────
+
+  describe('layer → collection mapping', () => {
+    it('principle maps to wm_domain', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+      await svc.query({ query: 'x', layers: ['principle'] });
+      expect(mockSearch).toHaveBeenCalledWith('wm_domain', expect.any(Object));
+    });
+
+    it('pattern maps to wm_workflow', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+      await svc.query({ query: 'x', layers: ['pattern'] });
+      expect(mockSearch).toHaveBeenCalledWith('wm_workflow', expect.any(Object));
+    });
+
+    it('practitioner maps to wm_practitioner', async () => {
+      mockSearch.mockResolvedValue([]);
+      const svc = makeService();
+      await svc.query({ query: 'x', layers: ['practitioner'] });
+      expect(mockSearch).toHaveBeenCalledWith('wm_practitioner', expect.any(Object));
+    });
+  });
+
+  // ── logRetrieval (indirectly via query) ────────────────────────────────────
+
+  describe('logRetrieval (via query with sessionId)', () => {
+    it('groups hits by layer and inserts one row per layer that has hits', async () => {
+      mockSearch
+        .mockResolvedValueOnce([
+          { score: 0.9, payload: { pg_id: 1, title: 'T1', body: 'B1', tags: [] } },
+          { score: 0.8, payload: { pg_id: 2, title: 'T2', body: 'B2', tags: [] } },
+        ])
+        .mockResolvedValueOnce([
+          { score: 0.7, payload: { pg_id: 3, title: 'T3', body: 'B3', tags: [] } },
+        ])
+        .mockResolvedValue([]);
+
+      const db = makeDb();
+      const svc = makeService(db);
+
+      await svc.query({
+        query: 'test',
+        layers: ['principle', 'pattern', 'practitioner'],
+        sessionId: 'my-session',
+      });
+
+      const retrievalInserts = (db.query.mock.calls as any[]).filter((c) =>
+        c[0].includes('workflow_memory_retrievals'),
+      );
+      // principle has 2 hits → 1 insert; pattern has 1 hit → 1 insert; practitioner has 0 → no insert
+      expect(retrievalInserts).toHaveLength(2);
+    });
+
+    it('passes correct session_id and query_text to retrieval log', async () => {
+      mockSearch
+        .mockResolvedValueOnce([
+          { score: 0.85, payload: { pg_id: 5, title: 'T', body: 'B', tags: [] } },
+        ])
+        .mockResolvedValue([]);
+
+      const db = makeDb();
+      const svc = makeService(db);
+
+      await svc.query({ query: 'my-query', layers: ['principle'], sessionId: 'sid-42' });
+
+      const insertCall = (db.query.mock.calls as any[]).find((c) =>
+        c[0].includes('workflow_memory_retrievals'),
+      );
+      expect(insertCall[1][0]).toBe('sid-42');
+      expect(insertCall[1][1]).toBe('my-query');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 38 unit tests for `WorkflowMemoryService` — covers initialize, query (layers, tags, scoring, sessionId logging), ingest (principle/pattern/practitioner), getStats, logRetrieval
- 35 unit tests for `WorkflowMemoryTools` handler — covers tool definitions, dispatch, validation (principle_key required), top_k cap at 20, error wrapping, response formatting
- All mocks (Qdrant, EmbeddingService, DB) are self-contained, no external deps needed

## Test plan
- [x] `npx jest --no-cache src/services/__tests__/workflow-memory-service.test.ts` — 38 passed
- [x] `npx jest --no-cache src/api/__tests__/workflow-memory-tools.test.ts` — 35 passed
- [ ] CI pipeline validates on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 73 unit tests for `WorkflowMemoryService` and `WorkflowMemoryTools` to lock in initialization, querying, ingestion, stats, and error handling behavior. Tests run fully in-process with mocks and no external dependencies.

- **Test Coverage**
  - Service: idempotent init (Qdrant collections), query merge/sort with layers/tags/minScore/topK, sessionId retrieval logging, ingest for principle/pattern/practitioner (PG insert/upsert + Qdrant upsert + embeddings), getStats, and layer→collection mapping.
  - Tools: tool definitions and dispatch, query result formatting and empty-state, top_k cap at 20 (default 5), ingest validation (`principle_key` required) and defaults, stats formatting, error wrapping, and consistent JSON text response shape.
  - Mocks: Qdrant client (`@qdrant/js-client-rest`), embedding service, and DB are mocked to avoid external deps.

<sup>Written for commit 03b66695b47af37e132dcd41b0ce0a9c5b009338. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

