### PR TITLE
Phase 1.4 — retrieval-miss instrumentation

### DIFF
--- a/docs/workflow-memory-phases.md
+++ b/docs/workflow-memory-phases.md
@@ -11,7 +11,7 @@ Supplementary material for the arXiv preprint.
 | 1.1 | 3--4 | Principle ledger population + ADR backfill from existing PRs and design docs | Complete |
 | 1.2 | 5--6 | Practitioner layer bootstrap: nightly summarization of edit-traces into embeddable artifacts | Planned |
 | 1.3 | 7 | Claude Code integration: session-start hook, `workflow_memory_query` MCP tool, thin CLAUDE.md | Complete |
-| 1.4 | 8 | Retrieval-miss instrumentation: post-session reconciliation job, retrieval-correction candidate flagging | Planned |
+| 1.4 | 8 | Retrieval-miss instrumentation: post-session reconciliation job, retrieval-correction candidate flagging | Complete |
 | 1.5 | 9--11 | Long-term task orchestrator (push mode): Plane task watcher, Bedrock summarization pipeline, tool lineage delta | Planned |
 
 ## Dependencies

--- a/mcp_backend/src/api/tools/workflow-memory-tools.ts
+++ b/mcp_backend/src/api/tools/workflow-memory-tools.ts
@@ -102,6 +102,47 @@ export class WorkflowMemoryTools extends BaseToolHandler {
         },
       },
       {
+        name: 'workflow_memory_reconcile',
+        annotations: { title: 'Reconciliation сесії workflow memory' },
+        description: `Post-session reconciliation: порівнює, що було знайдено в workflow memory під час сесії з тим, що реально використано.
+
+Запускайте після завершення сесії або PR. Визначає:
+- retrieval misses — принципи, релевантні до змінених файлів, але не знайдені
+- spurious retrievals — знайдені, але не використані принципи
+- precision / recall метрики якості retrieval
+- кандидати на нові принципи
+
+Потрібен session_id та список змінених файлів.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            session_id: {
+              type: 'string',
+              description: 'ID сесії для reconciliation',
+            },
+            files_touched: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Список файлів, змінених у сесії',
+            },
+            commit_range: {
+              type: 'string',
+              description: 'Діапазон комітів (first..last)',
+            },
+            tools_used: {
+              type: 'array',
+              items: { type: 'string' },
+              description: 'Інструменти, використані в сесії',
+            },
+            prompts_count: {
+              type: 'number',
+              description: 'Кількість промптів у сесії',
+            },
+          },
+          required: ['session_id', 'files_touched'],
+        },
+      },
+      {
         name: 'workflow_memory_stats',
         annotations: { title: 'Статистика workflow memory', readOnlyHint: true, idempotentHint: true },
         description: 'Кількість записів у кожному шарі workflow memory та загальна статистика.',
@@ -117,6 +158,8 @@ export class WorkflowMemoryTools extends BaseToolHandler {
           return await this.handleQuery(args);
         case 'workflow_memory_ingest':
           return await this.handleIngest(args);
+        case 'workflow_memory_reconcile':
+          return await this.handleReconcile(args);
         case 'workflow_memory_stats':
           return await this.handleStats();
         default:
@@ -210,6 +253,30 @@ export class WorkflowMemoryTools extends BaseToolHandler {
     return this.wrapResponse({ ok: true, layer, id, message: `Запис додано до ${layer} (id=${id})` });
   }
 
+  private async handleReconcile(args: any): Promise<ToolResult> {
+    const result = await this.wmService.reconcileSession({
+      sessionId: args.session_id,
+      filesTouched: args.files_touched ?? [],
+      commitRange: args.commit_range,
+      toolsUsed: args.tools_used,
+      promptsCount: args.prompts_count,
+    });
+
+    return this.wrapResponse({
+      reconciliation_id: result.reconciliationId,
+      retrieved: result.retrievedCount,
+      relevant: result.relevantCount,
+      missed: result.missedCount,
+      spurious: result.spuriousCount,
+      precision: result.precision !== null ? Math.round(result.precision * 1000) / 1000 : null,
+      recall: result.recall !== null ? Math.round(result.recall * 1000) / 1000 : null,
+      candidates: result.candidates,
+      message: result.missedCount > 0
+        ? `Знайдено ${result.missedCount} retrieval miss(es) — принципи, які могли бути корисними, але не були знайдені.`
+        : 'Усі релевантні принципи були знайдені під час сесії.',
+    });
+  }
+
   private async handleStats(): Promise<ToolResult> {
     const stats = await this.wmService.getStats();
     return this.wrapResponse({
@@ -220,6 +287,7 @@ export class WorkflowMemoryTools extends BaseToolHandler {
       },
       total_entries: stats.principles + stats.patterns + stats.practitioner,
       total_retrievals: stats.retrievals,
+      total_reconciliations: stats.reconciliations ?? 0,
     });
   }
 }

--- a/mcp_backend/src/migrations/145_workflow_memory_reconciliation.sql
+++ b/mcp_backend/src/migrations/145_workflow_memory_reconciliation.sql
@@ -1,0 +1,31 @@
+-- Migration 145: Workflow Memory Phase 1.4 — retrieval-miss instrumentation
+-- Post-session reconciliation: compare retrieved principles vs actual session work,
+-- flag retrieval misses as correction-signal candidates.
+
+CREATE TABLE IF NOT EXISTS workflow_memory_reconciliations (
+  id              SERIAL PRIMARY KEY,
+  session_id      TEXT NOT NULL,
+  commit_range    TEXT,                         -- first..last commit in session
+  files_touched   TEXT[] DEFAULT '{}',
+  tools_used      TEXT[] DEFAULT '{}',
+  prompts_count   INTEGER DEFAULT 0,
+
+  -- Retrieval quality metrics
+  retrieved_ids   INTEGER[] DEFAULT '{}',       -- principle IDs that were retrieved
+  relevant_ids    INTEGER[] DEFAULT '{}',       -- principle IDs that SHOULD have been retrieved
+  missed_ids      INTEGER[] DEFAULT '{}',       -- relevant - retrieved (retrieval misses)
+  spurious_ids    INTEGER[] DEFAULT '{}',       -- retrieved - relevant (false positives)
+
+  precision       REAL,                         -- |retrieved ∩ relevant| / |retrieved|
+  recall          REAL,                         -- |retrieved ∩ relevant| / |relevant|
+
+  -- Candidate new principles discovered from session
+  candidate_principles JSONB DEFAULT '[]',      -- [{title, body, source_ref, reason}]
+
+  status          TEXT DEFAULT 'pending',        -- 'pending', 'completed', 'skipped'
+  created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_wmrc_session ON workflow_memory_reconciliations(session_id);
+CREATE INDEX IF NOT EXISTS idx_wmrc_status ON workflow_memory_reconciliations(status);
+CREATE INDEX IF NOT EXISTS idx_wmrc_created ON workflow_memory_reconciliations(created_at DESC);

--- a/mcp_backend/src/services/workflow-memory-service.ts
+++ b/mcp_backend/src/services/workflow-memory-service.ts
@@ -69,6 +69,17 @@ export interface PractitionerInput {
   tags?: string[];
 }
 
+export interface ReconciliationResult {
+  reconciliationId: number;
+  retrievedCount: number;
+  relevantCount: number;
+  missedCount: number;
+  spuriousCount: number;
+  precision: number | null;
+  recall: number | null;
+  candidates: Array<{ id: number; title: string; reason: string }>;
+}
+
 export class WorkflowMemoryService {
   private qdrant: QdrantClient;
   private initialized = false;
@@ -264,20 +275,164 @@ export class WorkflowMemoryService {
     }
   }
 
+  // ── Reconciliation (Phase 1.4) ─────────────────────────────
+
+  async reconcileSession(opts: {
+    sessionId: string;
+    commitRange?: string;
+    filesTouched: string[];
+    toolsUsed?: string[];
+    promptsCount?: number;
+  }): Promise<ReconciliationResult> {
+    await this.initialize();
+
+    // 1. Get what was retrieved during this session
+    const retrievalRows = await this.db.query(
+      `SELECT DISTINCT UNNEST(result_ids) AS pid FROM workflow_memory_retrievals WHERE session_id = $1`,
+      [opts.sessionId],
+    );
+    const retrievedIds = new Set<number>(retrievalRows.rows.map((r: any) => r.pid));
+
+    // 2. Find principles relevant to files touched — match by tags inferred from paths
+    const fileTags = this.inferTagsFromPaths(opts.filesTouched);
+    let relevantIds = new Set<number>();
+
+    if (fileTags.length > 0) {
+      const tagRes = await this.db.query(
+        `SELECT id FROM workflow_memory_principles WHERE tags && $1`,
+        [fileTags],
+      );
+      relevantIds = new Set<number>(tagRes.rows.map((r: any) => r.id));
+    }
+
+    // Also check keyword overlap: principles whose body mentions touched file paths
+    if (opts.filesTouched.length > 0) {
+      const pathFragments = opts.filesTouched
+        .map(f => f.split('/').pop()?.replace(/\.[^.]+$/, ''))
+        .filter(Boolean)
+        .slice(0, 20);
+
+      if (pathFragments.length > 0) {
+        const pattern = pathFragments.join('|');
+        const keywordRes = await this.db.query(
+          `SELECT id FROM workflow_memory_principles WHERE body ~* $1 LIMIT 50`,
+          [pattern],
+        );
+        for (const r of keywordRes.rows) relevantIds.add(r.id);
+      }
+    }
+
+    // 3. Compute precision / recall / misses
+    const intersection = new Set([...retrievedIds].filter(id => relevantIds.has(id)));
+    const missedIds = new Set([...relevantIds].filter(id => !retrievedIds.has(id)));
+    const spuriousIds = new Set([...retrievedIds].filter(id => !relevantIds.has(id)));
+
+    const precision = retrievedIds.size > 0 ? intersection.size / retrievedIds.size : null;
+    const recall = relevantIds.size > 0 ? intersection.size / relevantIds.size : null;
+
+    // 4. Mark retrieval rows as useful/not-useful
+    if (retrievedIds.size > 0) {
+      const usefulIds = [...intersection];
+      const notUsefulIds = [...spuriousIds];
+
+      if (usefulIds.length > 0) {
+        await this.db.query(
+          `UPDATE workflow_memory_retrievals SET was_useful = true
+           WHERE session_id = $1 AND result_ids && $2`,
+          [opts.sessionId, usefulIds],
+        );
+      }
+      if (notUsefulIds.length > 0) {
+        await this.db.query(
+          `UPDATE workflow_memory_retrievals SET was_useful = false
+           WHERE session_id = $1 AND NOT (result_ids && $2)`,
+          [opts.sessionId, usefulIds.length > 0 ? usefulIds : [0]],
+        );
+      }
+    }
+
+    // 5. Build candidate principles from missed principles (for review)
+    const candidates: Array<{ id: number; title: string; reason: string }> = [];
+    if (missedIds.size > 0) {
+      const missedRes = await this.db.query(
+        `SELECT id, title, tags FROM workflow_memory_principles WHERE id = ANY($1)`,
+        [[...missedIds]],
+      );
+      for (const r of missedRes.rows) {
+        candidates.push({
+          id: r.id,
+          title: r.title,
+          reason: `Relevant to files touched but not retrieved (tags: ${(r.tags || []).join(', ')})`,
+        });
+      }
+    }
+
+    // 6. Store reconciliation record
+    const res = await this.db.query(
+      `INSERT INTO workflow_memory_reconciliations
+         (session_id, commit_range, files_touched, tools_used, prompts_count,
+          retrieved_ids, relevant_ids, missed_ids, spurious_ids,
+          precision, recall, candidate_principles, status)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'completed')
+       RETURNING id`,
+      [
+        opts.sessionId, opts.commitRange ?? null,
+        opts.filesTouched, opts.toolsUsed ?? [],
+        opts.promptsCount ?? 0,
+        [...retrievedIds], [...relevantIds], [...missedIds], [...spuriousIds],
+        precision, recall,
+        JSON.stringify(candidates),
+      ],
+    );
+
+    return {
+      reconciliationId: res.rows[0].id,
+      retrievedCount: retrievedIds.size,
+      relevantCount: relevantIds.size,
+      missedCount: missedIds.size,
+      spuriousCount: spuriousIds.size,
+      precision,
+      recall,
+      candidates,
+    };
+  }
+
+  private inferTagsFromPaths(files: string[]): string[] {
+    const tags = new Set<string>();
+    for (const f of files) {
+      if (f.includes('deployment/') || f.includes('docker') || f.includes('Dockerfile')) tags.add('deployment').add('docker');
+      if (f.includes('ci-') || f.includes('.github/')) tags.add('ci-cd');
+      if (f.includes('nginx')) tags.add('deployment');
+      if (f.includes('migration')) tags.add('infrastructure');
+      if (f.includes('mcp_backend/')) tags.add('architecture');
+      if (f.includes('mcp_rada/')) tags.add('architecture');
+      if (f.includes('lexwebapp/')) tags.add('frontend');
+      if (f.includes('.test.') || f.includes('__tests__')) tags.add('testing');
+      if (f.includes('package.json') || f.includes('tsconfig')) tags.add('typescript');
+      if (f.includes('auth') || f.includes('oauth') || f.includes('diia')) tags.add('auth');
+      if (f.includes('billing') || f.includes('monobank') || f.includes('payment')) tags.add('billing');
+      if (f.includes('git') || f.includes('.github')) tags.add('git');
+      if (f.includes('script')) tags.add('workflow');
+    }
+    return [...tags];
+  }
+
   // ── Stats ──────────────────────────────────────────────────
 
   async getStats(): Promise<Record<string, number>> {
-    const [principles, patterns, practitioner, retrievals] = await Promise.all([
+    const [principles, patterns, practitioner, retrievals, reconciliations] = await Promise.all([
       this.db.query('SELECT COUNT(*) AS cnt FROM workflow_memory_principles'),
       this.db.query('SELECT COUNT(*) AS cnt FROM workflow_memory_patterns'),
       this.db.query('SELECT COUNT(*) AS cnt FROM workflow_memory_practitioner'),
       this.db.query('SELECT COUNT(*) AS cnt FROM workflow_memory_retrievals'),
+      this.db.query('SELECT COUNT(*) AS cnt FROM workflow_memory_reconciliations').catch(() => ({ rows: [{ cnt: 0 }] })),
     ]);
     return {
       principles: Number(principles.rows[0].cnt),
       patterns: Number(patterns.rows[0].cnt),
       practitioner: Number(practitioner.rows[0].cnt),
       retrievals: Number(retrievals.rows[0].cnt),
+      reconciliations: Number(reconciliations.rows[0].cnt),
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `workflow_memory_reconciliations` table (migration 145) for post-session reconciliation results
- Add `reconcileSession()` method to `WorkflowMemoryService` — computes precision/recall of retrieval vs actual files touched
- Add `workflow_memory_reconcile` MCP tool — triggers reconciliation, returns missed/spurious principles
- Tag-based + keyword-based relevance matching from file paths to principles
- Updates `was_useful` on retrieval log entries based on reconciliation results
- Stats tool now includes reconciliation count

## How it works
1. After a session, call `workflow_memory_reconcile` with `session_id` and `files_touched`
2. Service fetches all principles retrieved during that session from `workflow_memory_retrievals`
3. Infers relevant principles by matching file path tags and keywords against principle tags/body
4. Computes: precision = |retrieved ∩ relevant| / |retrieved|, recall = |retrieved ∩ relevant| / |relevant|
5. Flags missed principles as correction-signal candidates

## Test plan
- [x] TypeScript compiles (only pre-existing node-pty errors)
- [x] Deployed to local Docker, migration 145 applied
- [x] Tested reconciliation on `test-session-001`: precision=1.0, recall=0.009, 112 misses identified
- [x] Stats tool returns reconciliation count

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds post-session reconciliation for workflow memory to measure retrieval quality and flag missed principles. Compares what was retrieved in a session to the files actually changed, computes precision/recall, and stores results.

- New Features
  - New table `workflow_memory_reconciliations` (migration 145) to store reconciliation records and metrics.
  - New `reconcileSession()` in `WorkflowMemoryService` to infer relevant principles (tag + keyword matching), compute precision/recall, and build candidates.
  - New MCP tool `workflow_memory_reconcile` to trigger reconciliation; returns counts, precision/recall, missed/spurious IDs, and candidates.
  - Retrieval logs now update `was_useful` based on reconciliation.
  - `workflow_memory_stats` now includes reconciliation count.

- Migration
  - Run DB migration 145.
  - Deploy backend; no config changes required.
  - After each session, call `workflow_memory_reconcile` with `session_id` and `files_touched`.

<sup>Written for commit 21399dc7d0c3723fbde91380379c2a3bd50658f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

