### PR TITLE
fix(test): align workflow memory tests with Phase 1.4

### DIFF
--- a/mcp_backend/src/api/__tests__/workflow-memory-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/workflow-memory-tools.test.ts
@@ -28,6 +28,7 @@ interface MockService {
   ingestPattern: jest.Mock<any>;
   ingestPractitioner: jest.Mock<any>;
   getStats: jest.Mock<any>;
+  reconcileSession: jest.Mock<any>;
 }
 
 function makeMockService(): MockService {
@@ -38,6 +39,7 @@ function makeMockService(): MockService {
     ingestPattern: jest.fn() as jest.Mock<any>,
     ingestPractitioner: jest.fn() as jest.Mock<any>,
     getStats: jest.fn() as jest.Mock<any>,
+    reconcileSession: jest.fn() as jest.Mock<any>,
   };
 }
 
@@ -61,9 +63,9 @@ describe('WorkflowMemoryTools', () => {
   // ── getToolDefinitions ─────────────────────────────────────────────────────
 
   describe('getToolDefinitions', () => {
-    it('returns exactly 3 tool definitions', () => {
+    it('returns exactly 4 tool definitions', () => {
       const defs = handler.getToolDefinitions();
-      expect(defs).toHaveLength(3);
+      expect(defs).toHaveLength(4);
     });
 
     it('returns workflow_memory_query with required "query" field', () => {
@@ -91,10 +93,11 @@ describe('WorkflowMemoryTools', () => {
       expect(statsTool!.annotations?.idempotentHint).toBe(true);
     });
 
-    it('handles() returns true for all three tool names', () => {
+    it('handles() returns true for all four tool names', () => {
       expect(handler.handles('workflow_memory_query')).toBe(true);
       expect(handler.handles('workflow_memory_ingest')).toBe(true);
       expect(handler.handles('workflow_memory_stats')).toBe(true);
+      expect(handler.handles('workflow_memory_reconcile')).toBe(true);
     });
 
     it('handles() returns false for unknown tool name', () => {
@@ -130,7 +133,7 @@ describe('WorkflowMemoryTools', () => {
     });
 
     it('dispatches to handleStats for workflow_memory_stats', async () => {
-      svc.getStats.mockResolvedValue({ principles: 0, patterns: 0, practitioner: 0, retrievals: 0 });
+      svc.getStats.mockResolvedValue({ principles: 0, patterns: 0, practitioner: 0, retrievals: 0, reconciliations: 0 });
       const result = await handler.executeTool('workflow_memory_stats', {});
       expect(result).not.toBeNull();
       expect(svc.getStats).toHaveBeenCalledTimes(1);
@@ -506,6 +509,7 @@ describe('WorkflowMemoryTools', () => {
         patterns: 25,
         practitioner: 5,
         retrievals: 100,
+        reconciliations: 3,
       });
 
       const result = await handler.executeTool('workflow_memory_stats', {});
@@ -517,6 +521,7 @@ describe('WorkflowMemoryTools', () => {
       expect(parsed.layers.practitioner).toBe(5);
       expect(parsed.total_entries).toBe(40);
       expect(parsed.total_retrievals).toBe(100);
+      expect(parsed.total_reconciliations).toBe(3);
     });
 
     it('computes total_entries as sum of principles + patterns + practitioner', async () => {
@@ -525,6 +530,7 @@ describe('WorkflowMemoryTools', () => {
         patterns: 7,
         practitioner: 2,
         retrievals: 0,
+        reconciliations: 0,
       });
 
       const result = await handler.executeTool('workflow_memory_stats', {});
@@ -556,7 +562,7 @@ describe('WorkflowMemoryTools', () => {
     });
 
     it('result text is valid JSON for successful responses', async () => {
-      svc.getStats.mockResolvedValue({ principles: 1, patterns: 2, practitioner: 3, retrievals: 4 });
+      svc.getStats.mockResolvedValue({ principles: 1, patterns: 2, practitioner: 3, retrievals: 4, reconciliations: 0 });
       const result = await handler.executeTool('workflow_memory_stats', {});
 
       expect(() => JSON.parse(result!.content[0].text)).not.toThrow();

--- a/mcp_backend/src/services/__tests__/workflow-memory-service.test.ts
+++ b/mcp_backend/src/services/__tests__/workflow-memory-service.test.ts
@@ -535,9 +535,9 @@ describe('WorkflowMemoryService', () => {
   // ── getStats ───────────────────────────────────────────────────────────────
 
   describe('getStats', () => {
-    it('returns counts from all four tables', async () => {
+    it('returns counts from all five tables', async () => {
       let callIndex = 0;
-      const counts = [12, 34, 56, 78];
+      const counts = [12, 34, 56, 78, 3];
       const db = makeDb(() => ({ rows: [{ cnt: counts[callIndex++] }] }));
       const svc = makeService(db);
 
@@ -547,20 +547,22 @@ describe('WorkflowMemoryService', () => {
       expect(stats.patterns).toBe(34);
       expect(stats.practitioner).toBe(56);
       expect(stats.retrievals).toBe(78);
+      expect(stats.reconciliations).toBe(3);
     });
 
-    it('issues four COUNT(*) queries', async () => {
+    it('issues five COUNT(*) queries', async () => {
       const db = makeDb(() => ({ rows: [{ cnt: 0 }] }));
       const svc = makeService(db);
 
       await svc.getStats();
 
-      expect(db.query).toHaveBeenCalledTimes(4);
+      expect(db.query).toHaveBeenCalledTimes(5);
       const sqls = (db.query.mock.calls as any[]).map((c) => c[0]);
       expect(sqls.some((s: string) => s.includes('workflow_memory_principles'))).toBe(true);
       expect(sqls.some((s: string) => s.includes('workflow_memory_patterns'))).toBe(true);
       expect(sqls.some((s: string) => s.includes('workflow_memory_practitioner'))).toBe(true);
       expect(sqls.some((s: string) => s.includes('workflow_memory_retrievals'))).toBe(true);
+      expect(sqls.some((s: string) => s.includes('workflow_memory_reconciliations'))).toBe(true);
     });
 
     it('converts COUNT() string result to number', async () => {


### PR DESCRIPTION
## Summary
- `getStats` test: 4 → 5 COUNT queries (added `workflow_memory_reconciliations`)
- Tool definitions test: 3 → 4 tools (added `workflow_memory_reconcile`)
- Mock service: added `reconcileSession` method
- All mock stats now include `reconciliations` field

Fixes CI failure introduced by PR #1642 (Phase 1.4 reconciliation).

## Test plan
- [x] 73/73 tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns workflow memory tests with Phase 1.4 reconciliation changes so CI passes. Tests now expect 5 COUNT queries (including `workflow_memory_reconciliations`) and expose 4 tools (adds `workflow_memory_reconcile`).

- **Bug Fixes**
  - Service tests: `getStats` returns `reconciliations` and runs 5 COUNT(*) queries, including `workflow_memory_reconciliations`.
  - API tool tests: tool definitions increased to 4; `handles()` covers `workflow_memory_reconcile`; stats output includes `reconciliations` and `total_reconciliations`.
  - Mocks: added `reconcileSession`; all mock stats now include `reconciliations`.

<sup>Written for commit b7c139985c5e4eebc5bd488a15cbe297ec582c47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

