### PR TITLE
fix(backend): lazy-init VoyageAI client for Bedrock-only envs

### DIFF
--- a/mcp_backend/src/services/embedding-service.ts
+++ b/mcp_backend/src/services/embedding-service.ts
@@ -19,7 +19,13 @@ export type VoyageTokensCallback = (tokens: number, model: string, task: string)
 import type { IEmbeddingPort } from '../domain/ports/index.js';
 
 export class EmbeddingService implements IEmbeddingPort {
-  private voyageClient = new VoyageAIClient(process.env.VOYAGEAI_API_KEY!, process.env.VOYAGEAI_API_KEY_2 || '');
+  private _voyageClient: VoyageAIClient | null = null;
+  private get voyageClient(): VoyageAIClient {
+    if (!this._voyageClient) {
+      this._voyageClient = new VoyageAIClient(process.env.VOYAGEAI_API_KEY!, process.env.VOYAGEAI_API_KEY_2 || '');
+    }
+    return this._voyageClient;
+  }
   private qdrant: QdrantClient;
   private collectionName = 'legal_sections';
   private initialized = false;


### PR DESCRIPTION
## Summary
- VoyageAI client was eagerly initialized, crashing when `VOYAGEAI_API_KEY` is absent
- Changed to lazy getter — only initializes on first Voyage API call
- Bedrock-only environments (`EMBEDDING_PROVIDER=bedrock`) no longer need VoyageAI keys

## Test plan
- [x] 73/73 tests pass
- [x] TypeScript compiles
- [ ] Prod backfill with `EMBEDDING_PROVIDER=bedrock` works without VoyageAI key

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-initialize the `VoyageAIClient` in `EmbeddingService` to prevent crashes when `VOYAGEAI_API_KEY` is missing. Bedrock-only environments (`EMBEDDING_PROVIDER=bedrock`) now run without VoyageAI keys.

- **Bug Fixes**
  - Replaced eager client construction with a private cached getter. The client is created only on first Voyage API call.

<sup>Written for commit 1df31241ffabb53e54072c38ae848ff52cf7e112. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

