### PR TITLE
fix(backend): resolve Bedrock embedding type conflict

### DIFF
--- a/mcp_backend/src/services/embedding-service.ts
+++ b/mcp_backend/src/services/embedding-service.ts
@@ -2,7 +2,6 @@ import { QdrantClient } from '@qdrant/js-client-rest';
 import { EmbeddingChunk, SectionType, PrecedentStatusType } from '../types/index.js';
 import { logger } from '../utils/logger.js';
 import { VoyageAIClient } from '../utils/voyage-client.js';
-import { InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 import { getBedrockManager } from '@secondlayer/shared';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -123,18 +122,18 @@ export class EmbeddingService implements IEmbeddingPort {
     try {
       const bedrock = getBedrockManager();
       const client = bedrock.getClient();
-      const body = JSON.stringify({
-        inputText: text.substring(0, 8000),
-        dimensions: EMBEDDING_DIMENSION,
-        normalize: true,
-      });
+      const { InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime');
       const command = new InvokeModelCommand({
         modelId: BEDROCK_EMBED_MODEL,
         contentType: 'application/json',
         accept: 'application/json',
-        body: new TextEncoder().encode(body),
+        body: new TextEncoder().encode(JSON.stringify({
+          inputText: text.substring(0, 8000),
+          dimensions: EMBEDDING_DIMENSION,
+          normalize: true,
+        })),
       });
-      const response = await client.send(command);
+      const response: any = await client.send(command as any);
       const result = JSON.parse(new TextDecoder().decode(response.body));
       const inputTokens = result.inputTextTokenCount ?? 0;
       this.tokenUsageCallback?.(inputTokens, BEDROCK_EMBED_MODEL, task);


### PR DESCRIPTION
## Summary
- Dynamic import for `InvokeModelCommand` instead of static — avoids `@smithy/types` version mismatch between mcp_backend and shared
- `any` cast on `client.send()` response — bypasses deep generic incompatibility
- Fixes CI build failure from PR #1644

## Test plan
- [x] `tsc --noEmit` passes (only pre-existing terminal-routes error)
- [x] 73/73 unit tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Bedrock embedding type mismatches that broke CI by dynamically importing `InvokeModelCommand` and relaxing the response type. Restores successful builds and keeps embedding requests working.

- **Bug Fixes**
  - Dynamically import `InvokeModelCommand` from `@aws-sdk/client-bedrock-runtime` to avoid `@smithy/types` version conflicts between `mcp_backend` and `@secondlayer/shared`.
  - Cast the `client.send()` response to `any` to bypass deep generic incompatibilities without changing runtime behavior.

<sup>Written for commit f7b14c7e5d17bd5dae3c12cd56ea6797d4b627d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

