### PR TITLE
fix(shared): move Bedrock embedding to shared, fix CI build

### DIFF
--- a/mcp_backend/src/services/embedding-service.ts
+++ b/mcp_backend/src/services/embedding-service.ts
@@ -121,24 +121,13 @@ export class EmbeddingService implements IEmbeddingPort {
   private async generateEmbeddingBedrock(text: string, task: string): Promise<number[]> {
     try {
       const bedrock = getBedrockManager();
-      const client = bedrock.getClient();
-      const { InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime');
-      const command = new InvokeModelCommand({
-        modelId: BEDROCK_EMBED_MODEL,
-        contentType: 'application/json',
-        accept: 'application/json',
-        body: new TextEncoder().encode(JSON.stringify({
-          inputText: text.substring(0, 8000),
-          dimensions: EMBEDDING_DIMENSION,
-          normalize: true,
-        })),
+      const { embedding, inputTokens } = await bedrock.generateEmbedding(text, {
+        model: BEDROCK_EMBED_MODEL,
+        dimensions: EMBEDDING_DIMENSION,
       });
-      const response: any = await client.send(command as any);
-      const result = JSON.parse(new TextDecoder().decode(response.body));
-      const inputTokens = result.inputTextTokenCount ?? 0;
       this.tokenUsageCallback?.(inputTokens, BEDROCK_EMBED_MODEL, task);
       await bedrock.trackUsage(BEDROCK_EMBED_MODEL, inputTokens, 0);
-      return result.embedding;
+      return embedding;
     } catch (error) {
       logger.error('Bedrock embedding error:', error);
       throw error;

--- a/packages/shared/src/utils/bedrock-client.ts
+++ b/packages/shared/src/utils/bedrock-client.ts
@@ -1,4 +1,4 @@
-import { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 import { logger } from './logger';
 import { ModelSelector } from './model-selector';
 import { requestContext, CostTrackerInterface } from './openai-client';
@@ -40,6 +40,25 @@ export class BedrockClientManager {
   setCostTracker(tracker: CostTrackerInterface) {
     this.costTracker = tracker;
     logger.debug('Cost tracker attached to Bedrock client manager');
+  }
+
+  async generateEmbedding(text: string, opts: { model?: string; dimensions?: number } = {}): Promise<{ embedding: number[]; inputTokens: number }> {
+    const client = this.getClient();
+    const model = opts.model || process.env.BEDROCK_EMBEDDING_MODEL || 'amazon.titan-embed-text-v2:0';
+    const dimensions = opts.dimensions || 1024;
+    const command = new InvokeModelCommand({
+      modelId: model,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: new TextEncoder().encode(JSON.stringify({
+        inputText: text.substring(0, 8000),
+        dimensions,
+        normalize: true,
+      })),
+    });
+    const response = await client.send(command);
+    const result = JSON.parse(new TextDecoder().decode(response.body));
+    return { embedding: result.embedding, inputTokens: result.inputTextTokenCount ?? 0 };
   }
 
   async trackUsage(model: string, inputTokens: number, outputTokens: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Adds `generateEmbedding()` method to `BedrockClientManager` in `@secondlayer/shared`
- `EmbeddingService` in mcp_backend now calls `bedrock.generateEmbedding()` instead of importing `@aws-sdk/client-bedrock-runtime` directly
- Removes `@aws-sdk/client-bedrock-runtime` from `mcp_backend/package.json` — it's only needed in shared
- Fixes CI failure where `npm --prefix mcp_backend install` couldn't resolve the Bedrock SDK

## Test plan
- [x] `tsc --noEmit` passes in both shared and mcp_backend
- [x] 73/73 unit tests pass
- [ ] CI green (this is the fix for the failing build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved Bedrock embedding logic into `@secondlayer/shared` and updated `mcp_backend` to use it, fixing the CI install failure and simplifying integration. Adds a single `generateEmbedding()` entry point and removes direct Bedrock SDK usage in `mcp_backend`.

- **Refactors**
  - Added `generateEmbedding()` to `BedrockClientManager` in `@secondlayer/shared`.
  - Updated `EmbeddingService` to call `bedrock.generateEmbedding()` and report `inputTokens`.
  - Centralized `@aws-sdk/client-bedrock-runtime` usage in shared with defaults for model and dimensions.

- **Bug Fixes**
  - Removed `@aws-sdk/client-bedrock-runtime` from `mcp_backend` to resolve the isolated `npm --prefix mcp_backend install` failure in CI.

<sup>Written for commit 25dbf67c4d2511cee8265e04eb888cf242ac1257. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

