### PR TITLE
chore(scripts): add --pr-file flag to backfill script

### DIFF
--- a/scripts/backfill-workflow-memory-principles.ts
+++ b/scripts/backfill-workflow-memory-principles.ts
@@ -28,6 +28,7 @@ import { WorkflowMemoryService, PrincipleInput } from '../mcp_backend/src/servic
 
 const DRY_RUN = process.argv.includes('--dry-run');
 const SKIP_PRS = process.argv.includes('--skip-prs');
+const PR_FILE = process.argv.find(a => a.startsWith('--pr-file='))?.split('=')[1];
 
 // ── Tag inference ────────────────────────────────────────────
 
@@ -296,6 +297,14 @@ interface PRData {
 }
 
 function fetchMergedPRs(limit = 50): PRData[] {
+  if (PR_FILE) {
+    try {
+      return JSON.parse(fs.readFileSync(PR_FILE, 'utf-8')).slice(0, limit);
+    } catch (err: any) {
+      console.warn(`⚠ Failed to read PR file ${PR_FILE}: ${err.message}`);
+      return [];
+    }
+  }
   try {
     const raw = execSync(
       `gh pr list --state merged --limit ${limit} --json number,title,body,mergedAt,url`,


### PR DESCRIPTION
## Summary
- Adds `--pr-file=<path>` flag to read merged PR data from JSON file instead of `gh` CLI
- Enables running backfill on servers without `gh` installed (e.g. prod)

## Test plan
- [x] Ran on prod with `--pr-file=/tmp/merged-prs.json`: 170/170 ingested, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--pr-file=<path>` flag to the backfill script to load merged PRs from a JSON file instead of `gh`. This lets us run the backfill on servers without `gh` (e.g., prod).

- **New Features**
  - When `--pr-file` is set, reads and slices PRs from the JSON file.
  - Falls back to `gh` when the flag isn’t provided; warns and returns no PRs if the file read fails.

- **Migration**
  - Example: `npx tsx scripts/backfill-workflow-memory-principles.ts --pr-file=/tmp/merged-prs.json`

<sup>Written for commit 121f262c68aa914dbf5df407a7012634f3ffe3dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

