### PR TITLE
chore(scripts): add --corpus-file flag to practitioner backfill

### DIFF
--- a/scripts/backfill-workflow-memory-practitioner.ts
+++ b/scripts/backfill-workflow-memory-practitioner.ts
@@ -26,8 +26,11 @@ import { EmbeddingService } from '../mcp_backend/src/services/embedding-service.
 import { WorkflowMemoryService } from '../mcp_backend/src/services/workflow-memory-service.js';
 // Summarization via local backend API (has LLM access inside Docker)
 
+import fs from 'fs';
+
 const DRY_RUN = process.argv.includes('--dry-run');
 const MIN_PROMPTS = parseInt(process.argv.find(a => a.startsWith('--min-prompts='))?.split('=')[1] ?? '5');
+const CORPUS_FILE = process.argv.find(a => a.startsWith('--corpus-file='))?.split('=')[1];
 
 const CORPUS_DIR = path.join(process.env.HOME ?? '/home/vovkes', '.claude', 'prompt-corpus.git');
 
@@ -55,6 +58,14 @@ interface SessionGroup {
 // ── Extract prompts from git corpus ─────────────────────────
 
 function extractPrompts(): PromptRecord[] {
+  if (CORPUS_FILE) {
+    try {
+      return JSON.parse(fs.readFileSync(CORPUS_FILE, 'utf-8'));
+    } catch (err: any) {
+      console.warn(`⚠ Failed to read corpus file ${CORPUS_FILE}: ${err.message}`);
+      return [];
+    }
+  }
   const hashes = execSync(`git -C "${CORPUS_DIR}" log corpus --format=%H`, { encoding: 'utf-8' })
     .trim().split('\n').filter(Boolean);
 


### PR DESCRIPTION
## Summary
- Adds `--corpus-file=<path>` to read prompt corpus from JSON export
- Enables running on prod where `~/.claude/prompt-corpus.git` doesn't exist

## Test plan
- [x] Ran on prod: 13/13 sessions ingested via `--corpus-file`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--corpus-file=<path>` flag to the practitioner backfill script to load the prompt corpus from a JSON export. This lets the backfill run on servers without `~/.claude/prompt-corpus.git`.

- **New Features**
  - Use JSON corpus when `--corpus-file` is provided; otherwise fall back to the git corpus.
  - Warn and skip if the JSON file can’t be read.

<sup>Written for commit 9d5a78ddd2f522685050d92d73dea94781eb5d7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

