### PR TITLE
Citation graph analysis scripts (Exp 1-5, 7)

### DIFF
--- a/scripts/citation-graph/analyze-communities.py
+++ b/scripts/citation-graph/analyze-communities.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""
+Citation Graph Paper — community detection and cross-domain analysis.
+
+Experiment 4: Cross-domain bridging analysis
+  Identifies "bridge articles" — legislation cited across multiple justice domains.
+
+Experiment 5: Temporal ontology evolution via Louvain clustering
+  Builds co-citation graphs per time period, detects communities, tracks evolution.
+
+Usage:
+  python3 analyze-communities.py --exp 4           # cross-domain only
+  python3 analyze-communities.py --exp 5           # temporal clustering only
+  python3 analyze-communities.py --all             # both experiments
+  python3 analyze-communities.py --all --min-citations 100
+
+Designed to run on prod (direct DB access). The co-citation self-join is expensive;
+expect ~10-30 min per time period depending on data volume.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+
+# ── Database connection ──────────────────────────────────────
+
+DB_DSN = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:1xfXUY8y7DM8Sm1w6T2cmBnNsnzfgnNJ2Ajl1Zl11xc@127.0.0.1:5438/secondlayer_prod",
+)
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+JUSTICE_KIND_NAMES = {
+    1: "civil",
+    2: "criminal",
+    3: "commercial",
+    4: "administrative",
+    5: "constitutional",
+}
+
+TIME_PERIODS = [
+    ("2007-2010", 2007, 2010),
+    ("2011-2014", 2011, 2014),
+    ("2015-2018", 2015, 2018),
+    ("2019-2022", 2019, 2022),
+    ("2023-2026", 2023, 2026),
+]
+
+
+def get_conn():
+    return psycopg2.connect(DB_DSN)
+
+
+def ensure_output_dir():
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+# ── Experiment 4: Cross-domain bridging analysis ─────────────
+
+
+def run_experiment_4(min_citations: int):
+    """Identify bridge articles cited significantly across multiple justice domains."""
+    print("\n" + "=" * 70)
+    print("EXPERIMENT 4: Cross-Domain Bridging Analysis")
+    print("=" * 70)
+
+    t0 = time.time()
+    conn = get_conn()
+    cur = conn.cursor()
+
+    # Step 1: Build per-domain citation counts for each (law_number, law_article)
+    print("\n[1/4] Counting per-domain citations (joining with edrsr_fulltext)...")
+
+    cur.execute("""
+        SELECT
+            c.law_number,
+            c.law_article,
+            f.justice_kind,
+            COUNT(*) AS cnt
+        FROM law_court_citations c
+        JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+        WHERE c.law_number IS NOT NULL
+          AND c.law_number != ''
+          AND c.law_article IS NOT NULL
+          AND c.law_article != ''
+          AND f.justice_kind IS NOT NULL
+          AND f.justice_kind BETWEEN 1 AND 5
+        GROUP BY c.law_number, c.law_article, f.justice_kind
+    """)
+
+    # Build nested dict: (law_number, law_article) -> {justice_kind: count}
+    article_domain_counts = defaultdict(lambda: defaultdict(int))
+    total_rows = 0
+    for law_number, law_article, justice_kind, cnt in cur:
+        article_domain_counts[(law_number, law_article)][justice_kind] += cnt
+        total_rows += 1
+
+    print(f"  Loaded {total_rows:,} (article, domain) pairs for "
+          f"{len(article_domain_counts):,} unique articles")
+
+    # Step 2: Compute total citations per article and identify bridge articles
+    print("\n[2/4] Identifying bridge articles (>1000 citations in 3+ domains)...")
+
+    article_stats = []
+    for (law_number, law_article), domain_counts in article_domain_counts.items():
+        total = sum(domain_counts.values())
+        n_domains = len(domain_counts)
+        article_stats.append({
+            "law_number": law_number,
+            "law_article": law_article,
+            "total_citations": total,
+            "n_domains": n_domains,
+            "domain_counts": dict(domain_counts),
+        })
+
+    # Bridge articles: cited >1000 times across 3+ justice_kinds
+    bridge_articles = [
+        a for a in article_stats
+        if a["total_citations"] > 1000 and a["n_domains"] >= 3
+    ]
+
+    # Sort by n_domains desc, then total_citations desc
+    bridge_articles.sort(key=lambda a: (-a["n_domains"], -a["total_citations"]))
+
+    print(f"  Total unique (law, article) pairs: {len(article_stats):,}")
+    print(f"  Bridge articles (>1000 cites, 3+ domains): {len(bridge_articles):,}")
+
+    # Step 3: Report top-30 bridge articles
+    print("\n[3/4] Top-30 bridge articles:")
+    print(f"  {'Rank':<5} {'Law':<45} {'Art':<8} {'Domains':<8} {'Total':<10} "
+          f"{'Civil':<10} {'Crim':<10} {'Comm':<10} {'Admin':<10} {'Const':<10}")
+    print("  " + "-" * 136)
+
+    top30 = bridge_articles[:30]
+    for i, a in enumerate(top30, 1):
+        dc = a["domain_counts"]
+        print(f"  {i:<5} {a['law_number'][:44]:<45} {a['law_article']:<8} "
+              f"{a['n_domains']:<8} {a['total_citations']:<10,} "
+              f"{dc.get(1, 0):<10,} {dc.get(2, 0):<10,} "
+              f"{dc.get(3, 0):<10,} {dc.get(4, 0):<10,} "
+              f"{dc.get(5, 0):<10,}")
+
+    # Step 4: Compute bridge vs domain-specific fraction
+    print("\n[4/4] Computing bridge vs domain-specific fractions...")
+
+    bridge_set = set(
+        (a["law_number"], a["law_article"]) for a in bridge_articles
+    )
+    total_all_citations = sum(a["total_citations"] for a in article_stats)
+    bridge_citations = sum(
+        a["total_citations"] for a in article_stats
+        if (a["law_number"], a["law_article"]) in bridge_set
+    )
+    domain_specific_citations = total_all_citations - bridge_citations
+
+    bridge_pct = (bridge_citations / total_all_citations * 100) if total_all_citations > 0 else 0
+    domain_pct = (domain_specific_citations / total_all_citations * 100) if total_all_citations > 0 else 0
+
+    print(f"  Total citations: {total_all_citations:,}")
+    print(f"  Bridge article citations: {bridge_citations:,} ({bridge_pct:.1f}%)")
+    print(f"  Domain-specific citations: {domain_specific_citations:,} ({domain_pct:.1f}%)")
+
+    elapsed = time.time() - t0
+    print(f"\n  Experiment 4 completed in {elapsed:.1f}s")
+
+    # Save results
+    results = {
+        "experiment": 4,
+        "description": "Cross-domain bridging analysis",
+        "total_unique_articles": len(article_stats),
+        "bridge_article_count": len(bridge_articles),
+        "bridge_threshold_citations": 1000,
+        "bridge_threshold_domains": 3,
+        "total_citations": total_all_citations,
+        "bridge_citations": bridge_citations,
+        "bridge_fraction_pct": round(bridge_pct, 2),
+        "domain_specific_citations": domain_specific_citations,
+        "domain_specific_fraction_pct": round(domain_pct, 2),
+        "top30_bridge_articles": [
+            {
+                "rank": i + 1,
+                "law_number": a["law_number"],
+                "law_article": a["law_article"],
+                "total_citations": a["total_citations"],
+                "n_domains": a["n_domains"],
+                "domain_counts": {
+                    JUSTICE_KIND_NAMES.get(k, str(k)): v
+                    for k, v in sorted(a["domain_counts"].items())
+                },
+            }
+            for i, a in enumerate(top30)
+        ],
+        "elapsed_sec": round(elapsed, 1),
+    }
+
+    ensure_output_dir()
+    out_path = OUTPUT_DIR / "experiment4-bridge-articles.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False)
+    print(f"  Results saved to {out_path}")
+
+    cur.close()
+    conn.close()
+
+    # Generate plot
+    _plot_experiment_4(top30)
+
+    return results
+
+
+def _plot_experiment_4(top30: list[dict]):
+    """Plot stacked bar chart of top-30 bridge articles by domain."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("  [warn] matplotlib not available, skipping plot")
+        return
+
+    if not top30:
+        return
+
+    fig, ax = plt.subplots(figsize=(16, 10))
+
+    labels = [f"{a['law_number'][:25]} ст.{a['law_article']}" for a in top30]
+    x = np.arange(len(labels))
+    width = 0.7
+
+    domain_colors = {
+        1: "#4e79a7",   # civil — blue
+        2: "#e15759",   # criminal — red
+        3: "#59a14f",   # commercial — green
+        4: "#f28e2b",   # administrative — orange
+        5: "#b07aa1",   # constitutional — purple
+    }
+
+    bottom = np.zeros(len(top30))
+    for jk in [1, 2, 3, 4, 5]:
+        values = [a["domain_counts"].get(jk, 0) for a in top30]
+        ax.barh(x, values, width, left=bottom,
+                label=JUSTICE_KIND_NAMES[jk],
+                color=domain_colors[jk])
+        bottom += np.array(values)
+
+    ax.set_yticks(x)
+    ax.set_yticklabels(labels, fontsize=8)
+    ax.invert_yaxis()
+    ax.set_xlabel("Citation count")
+    ax.set_title("Top-30 Bridge Articles: Citations by Justice Domain")
+    ax.legend(loc="lower right")
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "experiment4-bridge-articles.png"
+    plt.savefig(out_path, dpi=150)
+    plt.close()
+    print(f"  Plot saved to {out_path}")
+
+
+# ── Experiment 5: Temporal Louvain clustering ────────────────
+
+
+def run_experiment_5(min_citations: int):
+    """Build co-citation graphs per time period, detect communities, track evolution."""
+    import networkx as nx
+    try:
+        from community import community_louvain
+    except ImportError:
+        print("  [error] python-louvain not installed. Run: pip install python-louvain")
+        sys.exit(1)
+
+    try:
+        from sklearn.metrics import normalized_mutual_info_score
+    except ImportError:
+        print("  [error] scikit-learn not installed. Run: pip install scikit-learn")
+        sys.exit(1)
+
+    print("\n" + "=" * 70)
+    print("EXPERIMENT 5: Temporal Ontology Evolution via Louvain Clustering")
+    print(f"  min_citations = {min_citations}")
+    print("=" * 70)
+
+    t0_total = time.time()
+    period_results = []
+    period_partitions = {}  # label -> {article_key: community_id}
+
+    for label, year_from, year_to in TIME_PERIODS:
+        print(f"\n--- Period: {label} (years {year_from}-{year_to}) ---")
+        t0 = time.time()
+
+        conn = get_conn()
+        cur = conn.cursor()
+
+        # Step 1: Create temp table of articles with >= min_citations in this period
+        print(f"  [1/4] Finding articles with >= {min_citations} citations...")
+        cur.execute("""
+            CREATE TEMP TABLE _freq_articles AS
+            SELECT c.law_number, c.law_article, COUNT(*) AS total_cites
+            FROM law_court_citations c
+            JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+            WHERE f.adj_year BETWEEN %s AND %s
+              AND c.law_number IS NOT NULL AND c.law_number != ''
+              AND c.law_article IS NOT NULL AND c.law_article != ''
+            GROUP BY c.law_number, c.law_article
+            HAVING COUNT(*) >= %s
+        """, (year_from, year_to, min_citations))
+
+        cur.execute("SELECT COUNT(*) FROM _freq_articles")
+        n_articles = cur.fetchone()[0]
+        print(f"    {n_articles:,} articles with >= {min_citations} citations")
+
+        if n_articles < 10:
+            print(f"    Too few articles for clustering, skipping period")
+            cur.execute("DROP TABLE IF EXISTS _freq_articles")
+            cur.close()
+            conn.close()
+            period_results.append({
+                "period": label,
+                "n_articles": n_articles,
+                "skipped": True,
+            })
+            continue
+
+        # Step 2: Build co-citation edge list via SQL self-join
+        print(f"  [2/4] Building co-citation graph (SQL self-join, may take minutes)...")
+
+        cur.execute("""
+            SELECT
+                a.law_number AS law_a, a.law_article AS art_a,
+                b.law_number AS law_b, b.law_article AS art_b,
+                COUNT(DISTINCT a.court_case_id) AS weight
+            FROM law_court_citations a
+            JOIN law_court_citations b ON a.court_case_id = b.court_case_id
+            JOIN edrsr_fulltext f ON a.court_case_id = f.doc_id
+            JOIN _freq_articles fa ON a.law_number = fa.law_number AND a.law_article = fa.law_article
+            JOIN _freq_articles fb ON b.law_number = fb.law_number AND b.law_article = fb.law_article
+            WHERE f.adj_year BETWEEN %s AND %s
+              AND (a.law_number < b.law_number
+                   OR (a.law_number = b.law_number AND a.law_article < b.law_article))
+            GROUP BY a.law_number, a.law_article, b.law_number, b.law_article
+            HAVING COUNT(DISTINCT a.court_case_id) >= 10
+        """, (year_from, year_to))
+
+        edges = cur.fetchall()
+        print(f"    {len(edges):,} co-citation edges (weight >= 10)")
+
+        # Load article citation counts for labeling
+        cur.execute("SELECT law_number, law_article, total_cites FROM _freq_articles")
+        article_cites = {(r[0], r[1]): r[2] for r in cur.fetchall()}
+
+        cur.execute("DROP TABLE IF EXISTS _freq_articles")
+        cur.close()
+        conn.close()
+
+        if len(edges) < 5:
+            print(f"    Too few edges for clustering, skipping period")
+            period_results.append({
+                "period": label,
+                "n_articles": n_articles,
+                "n_edges": len(edges),
+                "skipped": True,
+            })
+            continue
+
+        # Step 3: Build networkx graph and run Louvain
+        print(f"  [3/4] Running Louvain community detection...")
+
+        G = nx.Graph()
+        for law_a, art_a, law_b, art_b, weight in edges:
+            node_a = (law_a, art_a)
+            node_b = (law_b, art_b)
+            G.add_edge(node_a, node_b, weight=weight)
+
+        # Add isolated frequent articles (no co-citation edges but still frequent)
+        for key in article_cites:
+            if key not in G:
+                G.add_node(key)
+
+        print(f"    Graph: {G.number_of_nodes():,} nodes, {G.number_of_edges():,} edges")
+
+        partition = community_louvain.best_partition(G, weight="weight", random_state=42)
+        modularity = community_louvain.modularity(partition, G, weight="weight")
+
+        # Organize communities
+        communities = defaultdict(list)
+        for node, comm_id in partition.items():
+            communities[comm_id].append(node)
+
+        n_communities = len(communities)
+        community_sizes = sorted(
+            [(cid, len(members)) for cid, members in communities.items()],
+            key=lambda x: -x[1],
+        )
+
+        print(f"    Communities: {n_communities}, Modularity: {modularity:.4f}")
+        print(f"    Top-5 community sizes: {[s for _, s in community_sizes[:5]]}")
+
+        # Step 4: Identify dominant law in top-5 communities
+        print(f"  [4/4] Identifying dominant laws in top-5 communities...")
+
+        top5_communities = []
+        for rank, (cid, size) in enumerate(community_sizes[:5], 1):
+            members = communities[cid]
+            law_counter = Counter(node[0] for node in members)
+            dominant_law, dominant_count = law_counter.most_common(1)[0]
+            total_cites_in_comm = sum(article_cites.get(m, 0) for m in members)
+
+            # Top-3 articles by citation count in this community
+            top_articles = sorted(
+                members,
+                key=lambda m: article_cites.get(m, 0),
+                reverse=True,
+            )[:3]
+
+            comm_info = {
+                "rank": rank,
+                "community_id": cid,
+                "size": size,
+                "dominant_law": dominant_law,
+                "dominant_law_fraction": round(dominant_count / size, 3),
+                "total_citations": total_cites_in_comm,
+                "top_articles": [
+                    {
+                        "law_number": a[0],
+                        "law_article": a[1],
+                        "citations": article_cites.get(a, 0),
+                    }
+                    for a in top_articles
+                ],
+            }
+            top5_communities.append(comm_info)
+
+            print(f"    #{rank}: {size} articles, dominant={dominant_law[:50]} "
+                  f"({dominant_count}/{size}={dominant_count/size:.0%}), "
+                  f"total_cites={total_cites_in_comm:,}")
+
+        elapsed = time.time() - t0
+        print(f"  Period {label} completed in {elapsed:.1f}s")
+
+        # Store partition for NMI computation
+        period_partitions[label] = partition
+
+        period_results.append({
+            "period": label,
+            "year_from": year_from,
+            "year_to": year_to,
+            "n_articles": n_articles,
+            "n_edges": len(edges),
+            "n_nodes": G.number_of_nodes(),
+            "n_graph_edges": G.number_of_edges(),
+            "n_communities": n_communities,
+            "modularity": round(modularity, 4),
+            "top5_community_sizes": [s for _, s in community_sizes[:5]],
+            "top5_communities": top5_communities,
+            "elapsed_sec": round(elapsed, 1),
+            "skipped": False,
+        })
+
+    # ── NMI between adjacent periods ──
+    print("\n--- NMI Between Adjacent Periods ---")
+
+    nmi_results = []
+    period_labels = [label for label, _, _ in TIME_PERIODS]
+
+    for i in range(len(period_labels) - 1):
+        label_a = period_labels[i]
+        label_b = period_labels[i + 1]
+
+        if label_a not in period_partitions or label_b not in period_partitions:
+            print(f"  {label_a} -> {label_b}: skipped (missing partition data)")
+            nmi_results.append({
+                "period_a": label_a,
+                "period_b": label_b,
+                "nmi": None,
+                "common_articles": 0,
+            })
+            continue
+
+        part_a = period_partitions[label_a]
+        part_b = period_partitions[label_b]
+
+        # Find common articles
+        common = set(part_a.keys()) & set(part_b.keys())
+        if len(common) < 10:
+            print(f"  {label_a} -> {label_b}: only {len(common)} common articles, skipping NMI")
+            nmi_results.append({
+                "period_a": label_a,
+                "period_b": label_b,
+                "nmi": None,
+                "common_articles": len(common),
+            })
+            continue
+
+        labels_a = [part_a[node] for node in common]
+        labels_b = [part_b[node] for node in common]
+        nmi = normalized_mutual_info_score(labels_a, labels_b)
+
+        stability = "STABLE" if nmi > 0.5 else "CHANGED"
+        print(f"  {label_a} -> {label_b}: NMI={nmi:.4f} ({len(common):,} common articles) [{stability}]")
+
+        nmi_results.append({
+            "period_a": label_a,
+            "period_b": label_b,
+            "nmi": round(nmi, 4),
+            "common_articles": len(common),
+            "stability": stability,
+        })
+
+    total_elapsed = time.time() - t0_total
+    print(f"\nExperiment 5 completed in {total_elapsed:.1f}s")
+
+    # Save results
+    results = {
+        "experiment": 5,
+        "description": "Temporal ontology evolution via Louvain clustering",
+        "min_citations": min_citations,
+        "periods": period_results,
+        "nmi_between_periods": nmi_results,
+        "total_elapsed_sec": round(total_elapsed, 1),
+    }
+
+    ensure_output_dir()
+    out_path = OUTPUT_DIR / "experiment5-temporal-communities.json"
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False)
+    print(f"  Results saved to {out_path}")
+
+    # Generate plots
+    _plot_experiment_5(period_results, nmi_results)
+
+    return results
+
+
+def _plot_experiment_5(period_results: list[dict], nmi_results: list[dict]):
+    """Plot temporal community evolution."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("  [warn] matplotlib not available, skipping plots")
+        return
+
+    active_periods = [p for p in period_results if not p.get("skipped", True)]
+    if len(active_periods) < 2:
+        print("  [warn] Not enough periods for temporal plots")
+        return
+
+    fig, axes = plt.subplots(2, 2, figsize=(16, 12))
+
+    # Plot 1: Number of communities over time
+    ax = axes[0, 0]
+    labels = [p["period"] for p in active_periods]
+    n_comm = [p["n_communities"] for p in active_periods]
+    ax.bar(labels, n_comm, color="#4e79a7")
+    ax.set_title("Number of Communities per Period")
+    ax.set_ylabel("Communities")
+    for i, v in enumerate(n_comm):
+        ax.text(i, v + 0.5, str(v), ha="center", fontsize=9)
+
+    # Plot 2: Modularity over time
+    ax = axes[0, 1]
+    modularity = [p["modularity"] for p in active_periods]
+    ax.plot(labels, modularity, "o-", color="#e15759", linewidth=2, markersize=8)
+    ax.set_title("Modularity Score per Period")
+    ax.set_ylabel("Modularity")
+    ax.set_ylim(0, 1)
+    for i, v in enumerate(modularity):
+        ax.text(i, v + 0.02, f"{v:.3f}", ha="center", fontsize=9)
+
+    # Plot 3: NMI between adjacent periods
+    ax = axes[1, 0]
+    nmi_active = [n for n in nmi_results if n["nmi"] is not None]
+    if nmi_active:
+        nmi_labels = [f"{n['period_a']}\n->\n{n['period_b']}" for n in nmi_active]
+        nmi_values = [n["nmi"] for n in nmi_active]
+        colors = ["#59a14f" if v > 0.5 else "#e15759" for v in nmi_values]
+        ax.bar(nmi_labels, nmi_values, color=colors)
+        ax.set_title("NMI Between Adjacent Periods")
+        ax.set_ylabel("Normalized Mutual Information")
+        ax.set_ylim(0, 1)
+        ax.axhline(y=0.5, color="gray", linestyle="--", alpha=0.5, label="Stability threshold")
+        ax.legend()
+        for i, v in enumerate(nmi_values):
+            ax.text(i, v + 0.02, f"{v:.3f}", ha="center", fontsize=9)
+    else:
+        ax.text(0.5, 0.5, "No NMI data available", ha="center", va="center",
+                transform=ax.transAxes)
+
+    # Plot 4: Top-5 community sizes stacked across periods
+    ax = axes[1, 1]
+    for p in active_periods:
+        sizes = p.get("top5_community_sizes", [])[:5]
+        while len(sizes) < 5:
+            sizes.append(0)
+        bottom = 0
+        comm_colors = ["#4e79a7", "#e15759", "#59a14f", "#f28e2b", "#b07aa1"]
+        for j, s in enumerate(sizes):
+            ax.bar(p["period"], s, bottom=bottom, color=comm_colors[j],
+                   label=f"Community {j+1}" if p == active_periods[0] else "")
+            bottom += s
+    ax.set_title("Top-5 Community Sizes per Period")
+    ax.set_ylabel("Number of Articles")
+    ax.legend(loc="upper right")
+
+    plt.suptitle("Experiment 5: Temporal Ontology Evolution", fontsize=14, y=1.01)
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "experiment5-temporal-communities.png"
+    plt.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"  Plot saved to {out_path}")
+
+
+# ── Main ─────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Citation graph: community detection and cross-domain analysis"
+    )
+    parser.add_argument("--exp", type=int, choices=[4, 5],
+                        help="Run a single experiment (4 or 5)")
+    parser.add_argument("--all", action="store_true",
+                        help="Run both experiments")
+    parser.add_argument("--min-citations", type=int, default=50,
+                        help="Min citations to include an article (default: 50)")
+    args = parser.parse_args()
+
+    if not args.exp and not args.all:
+        parser.error("Specify --exp 4, --exp 5, or --all")
+
+    print(f"=== Citation Graph: Community & Cross-Domain Analysis ===")
+    print(f"Database: {DB_DSN.split('@')[1] if '@' in DB_DSN else DB_DSN}")
+    print(f"Min citations: {args.min_citations}")
+    print(f"Output: {OUTPUT_DIR}")
+
+    ensure_output_dir()
+    all_results = {}
+
+    if args.all or args.exp == 4:
+        all_results["experiment_4"] = run_experiment_4(args.min_citations)
+
+    if args.all or args.exp == 5:
+        all_results["experiment_5"] = run_experiment_5(args.min_citations)
+
+    # Save combined results
+    if args.all:
+        out_path = OUTPUT_DIR / "experiments-4-5-combined.json"
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(all_results, f, indent=2, ensure_ascii=False)
+        print(f"\nCombined results saved to {out_path}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/analyze-degree-centrality.py
+++ b/scripts/citation-graph/analyze-degree-centrality.py
@@ -1,0 +1,812 @@
+#!/usr/bin/env python3
+"""
+Citation Graph Paper — degree centrality analysis of Ukrainian court citation network.
+
+Two experiments:
+  1. Power-law analysis of the degree distribution of cited legislation articles.
+  2. PageRank and HITS centrality on the co-citation graph.
+
+Requirements:
+  pip install psycopg2-binary networkx powerlaw matplotlib scipy numpy
+
+Usage:
+  python3 analyze-degree-centrality.py                     # full dataset
+  python3 analyze-degree-centrality.py --sample-size 500000  # test on subset
+
+Output:
+  scripts/citation-graph/output/  — plots and JSON results
+
+Database:
+  Reads from law_court_citations table via DATABASE_URL env var.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+
+# ── Configuration ───────────────────────────────────────────────
+
+DB_DSN = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:1xfXUY8y7DM8Sm1w6T2cmBnNsnzfgnNJ2Ajl1Zl11xc@127.0.0.1:5438/secondlayer_prod",
+)
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# Minimum citations for an article to be included in the co-citation graph
+CO_CITATION_THRESHOLD = 100
+
+# ── Helpers ─────────────────────────────────────────────────────
+
+
+def get_conn():
+    """Return a psycopg2 connection with sensible defaults."""
+    conn = psycopg2.connect(DB_DSN)
+    conn.set_session(readonly=True, autocommit=True)
+    return conn
+
+
+def fmt_duration(seconds: float) -> str:
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    minutes = int(seconds // 60)
+    secs = seconds % 60
+    return f"{minutes}m {secs:.0f}s"
+
+
+def article_label(law_number: str, law_article: str) -> str:
+    """Short human-readable label for a legislation article."""
+    # Shorten common codex names for display
+    shorts = {
+        "Цивільний кодекс України": "ЦК",
+        "Кримінальний кодекс України": "КК",
+        "Господарський кодекс України": "ГК",
+        "Господарський процесуальний кодекс України": "ГПК",
+        "Кримінальний процесуальний кодекс України": "КПК",
+        "Кодекс адміністративного судочинства України": "КАС",
+        "Цивільний процесуальний кодекс України": "ЦПК",
+        "Кодекс законів про працю України": "КЗпП",
+        "Сімейний кодекс України": "СК",
+        "Земельний кодекс України": "ЗК",
+        "Податковий кодекс України": "ПК",
+        "Митний кодекс України": "МК",
+        "Бюджетний кодекс України": "БК",
+        "Водний кодекс України": "ВК",
+        "Лісовий кодекс України": "ЛК",
+        "Житловий кодекс України": "ЖК",
+        "Конституція України": "КУ",
+    }
+    short = shorts.get(law_number, law_number)
+    # Truncate very long law names
+    if len(short) > 40:
+        short = short[:37] + "..."
+    art = law_article if law_article else "?"
+    return f"ст. {art} {short}"
+
+
+# ── Experiment 1: Power-law analysis ───────────────────────────
+
+
+def run_power_law_analysis(conn, sample_limit: int | None) -> dict[str, Any]:
+    """
+    Query degree distribution (how many court decisions cite each article)
+    and fit power-law, lognormal, exponential distributions.
+    """
+    import powerlaw
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    print("\n" + "=" * 70)
+    print("EXPERIMENT 1: Power-law analysis of citation degree distribution")
+    print("=" * 70)
+
+    t0 = time.time()
+
+    # ── Step 1: Get degree distribution ──
+    print("\n[1/4] Querying degree distribution...")
+
+    # If sample_limit is set, we limit the number of rows read from the table
+    # and then aggregate; otherwise we aggregate the entire table.
+    if sample_limit:
+        query = """
+            SELECT law_number, law_article, COUNT(DISTINCT court_case_id) AS degree
+            FROM (
+                SELECT law_number, law_article, court_case_id
+                FROM law_court_citations
+                WHERE law_number IS NOT NULL
+                  AND law_article IS NOT NULL
+                LIMIT %s
+            ) sub
+            GROUP BY law_number, law_article
+            ORDER BY degree DESC
+        """
+        params = (sample_limit,)
+    else:
+        query = """
+            SELECT law_number, law_article, COUNT(DISTINCT court_case_id) AS degree
+            FROM law_court_citations
+            WHERE law_number IS NOT NULL
+              AND law_article IS NOT NULL
+            GROUP BY law_number, law_article
+            ORDER BY degree DESC
+        """
+        params = None
+
+    cur = conn.cursor()
+    cur.execute(query, params)
+    rows = cur.fetchall()
+    cur.close()
+
+    if not rows:
+        print("ERROR: No citation data found. Is extraction still running?")
+        return {"error": "no_data"}
+
+    articles = [(r[0], r[1]) for r in rows]
+    degrees = np.array([r[2] for r in rows], dtype=np.int64)
+
+    total_articles = len(degrees)
+    total_citations = int(degrees.sum())
+    max_degree = int(degrees.max())
+    median_degree = int(np.median(degrees))
+    mean_degree = float(degrees.mean())
+
+    print(f"    Unique (law_number, law_article) pairs: {total_articles:,}")
+    print(f"    Total citation links: {total_citations:,}")
+    print(f"    Max degree: {max_degree:,}")
+    print(f"    Median degree: {median_degree:,}")
+    print(f"    Mean degree: {mean_degree:,.1f}")
+    print(f"    Query time: {fmt_duration(time.time() - t0)}")
+
+    # Show top-20 most cited articles
+    print("\n    Top-20 most cited articles:")
+    for i in range(min(20, len(rows))):
+        law, art = articles[i]
+        label = article_label(law, art)
+        print(f"      {i+1:3d}. {label:<45s}  {degrees[i]:>10,} decisions")
+
+    # ── Step 2: Fit power law ──
+    print("\n[2/4] Fitting power-law distribution...")
+
+    # powerlaw library expects integer data; filter out zeros if any
+    data = degrees[degrees > 0].astype(float)
+
+    fit = powerlaw.Fit(data, discrete=True, verbose=False)
+
+    alpha = fit.power_law.alpha
+    xmin = fit.power_law.xmin
+    sigma = fit.power_law.sigma  # standard error of alpha
+
+    print(f"    alpha (exponent):    {alpha:.4f} +/- {sigma:.4f}")
+    print(f"    xmin:                {xmin:.0f}")
+
+    # KS distance
+    ks_stat = fit.power_law.KS()
+    print(f"    KS statistic (D):    {ks_stat:.6f}")
+
+    # ── Step 3: Distribution comparison ──
+    print("\n[3/4] Comparing power-law vs alternative distributions...")
+
+    comparisons = {}
+
+    for alt_name in ["lognormal", "exponential", "stretched_exponential", "truncated_power_law"]:
+        try:
+            R, p = fit.distribution_compare("power_law", alt_name, normalized_ratio=True)
+            direction = "power_law" if R > 0 else alt_name
+            comparisons[alt_name] = {
+                "loglikelihood_ratio": float(R),
+                "p_value": float(p),
+                "favored": direction,
+            }
+            print(f"    power_law vs {alt_name:<25s}  R={R:+.4f}  p={p:.4f}  => {direction}")
+        except Exception as e:
+            print(f"    power_law vs {alt_name:<25s}  FAILED: {e}")
+            comparisons[alt_name] = {"error": str(e)}
+
+    # ── Step 4: Comparison with known values ──
+    print("\n[4/4] Comparison with known citation network exponents:")
+    print(f"    Ukrainian court decisions (this study):  alpha = {alpha:.2f}")
+    print(f"    US Supreme Court (Fowler et al., 2007):  alpha ~ 2.1")
+    print(f"    Indian Supreme Court (Kumar et al.):     alpha ~ 1.8")
+    print(f"    EU Court of Justice (Mirshahvalad):      alpha ~ 1.7")
+    print(f"    Random network (Erdos-Renyi):            alpha = N/A (Poisson)")
+
+    if alpha > 2.5:
+        interpretation = "steeper than typical; highly concentrated around few articles"
+    elif alpha > 2.0:
+        interpretation = "comparable to Fowler US Supreme Court network"
+    elif alpha > 1.5:
+        interpretation = "comparable to Kumar Indian / EU networks"
+    else:
+        interpretation = "unusually flat; very broad citation spread"
+    print(f"\n    Interpretation: {interpretation}")
+
+    # ── Plot: log-log degree distribution with power-law fit ──
+    print("\n    Saving log-log plot...")
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 6))
+
+    # Left panel: PDF
+    ax1 = axes[0]
+    fit.plot_pdf(ax=ax1, color="steelblue", linewidth=0, marker="o", markersize=3, label="Empirical PDF")
+    fit.power_law.plot_pdf(ax=ax1, color="crimson", linestyle="--", linewidth=2,
+                           label=f"Power law (alpha={alpha:.2f}, xmin={xmin:.0f})")
+    try:
+        fit.lognormal.plot_pdf(ax=ax1, color="green", linestyle=":", linewidth=2, label="Lognormal fit")
+    except Exception:
+        pass
+    ax1.set_xlabel("Degree (number of citing decisions)", fontsize=12)
+    ax1.set_ylabel("P(k)", fontsize=12)
+    ax1.set_title("Degree Distribution — PDF", fontsize=13)
+    ax1.legend(fontsize=9)
+
+    # Right panel: CCDF
+    ax2 = axes[1]
+    fit.plot_ccdf(ax=ax2, color="steelblue", linewidth=0, marker="o", markersize=3, label="Empirical CCDF")
+    fit.power_law.plot_ccdf(ax=ax2, color="crimson", linestyle="--", linewidth=2,
+                            label=f"Power law (alpha={alpha:.2f})")
+    try:
+        fit.lognormal.plot_ccdf(ax=ax2, color="green", linestyle=":", linewidth=2, label="Lognormal fit")
+    except Exception:
+        pass
+    ax2.set_xlabel("Degree (number of citing decisions)", fontsize=12)
+    ax2.set_ylabel("P(K >= k)", fontsize=12)
+    ax2.set_title("Degree Distribution — CCDF", fontsize=13)
+    ax2.legend(fontsize=9)
+
+    fig.suptitle("Ukrainian Court Citation Network — Degree Distribution", fontsize=15, fontweight="bold")
+    plt.tight_layout()
+
+    plot_path = OUTPUT_DIR / "degree_distribution_powerlaw.png"
+    fig.savefig(plot_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    print(f"    Saved: {plot_path}")
+
+    elapsed = time.time() - t0
+    print(f"\n    Experiment 1 completed in {fmt_duration(elapsed)}")
+
+    return {
+        "total_unique_articles": total_articles,
+        "total_citation_links": total_citations,
+        "max_degree": max_degree,
+        "median_degree": median_degree,
+        "mean_degree": round(mean_degree, 2),
+        "power_law": {
+            "alpha": round(alpha, 4),
+            "alpha_stderr": round(sigma, 4),
+            "xmin": float(xmin),
+            "ks_statistic": round(ks_stat, 6),
+        },
+        "distribution_comparisons": comparisons,
+        "reference_exponents": {
+            "ukraine_this_study": round(alpha, 2),
+            "us_supreme_court_fowler": 2.1,
+            "india_kumar": 1.8,
+            "eu_court_mirshahvalad": 1.7,
+        },
+        "interpretation": interpretation,
+        "top_20_articles": [
+            {
+                "rank": i + 1,
+                "law_number": articles[i][0],
+                "law_article": articles[i][1],
+                "label": article_label(articles[i][0], articles[i][1]),
+                "degree": int(degrees[i]),
+            }
+            for i in range(min(20, len(rows)))
+        ],
+        "elapsed_seconds": round(elapsed, 1),
+    }
+
+
+# ── Experiment 2: PageRank and HITS centrality ─────────────────
+
+
+def run_centrality_analysis(conn, sample_limit: int | None) -> dict[str, Any]:
+    """
+    Build co-citation graph of legislation articles, compute PageRank and HITS.
+    Two articles share an edge if they are cited in the same court decision.
+    """
+    import networkx as nx
+    from scipy.stats import spearmanr
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    print("\n" + "=" * 70)
+    print("EXPERIMENT 2: PageRank and HITS centrality on co-citation graph")
+    print("=" * 70)
+
+    t0 = time.time()
+
+    # ── Step 1: Find articles cited by >= CO_CITATION_THRESHOLD decisions ──
+    print(f"\n[1/5] Finding articles with >= {CO_CITATION_THRESHOLD} citing decisions...")
+
+    cur = conn.cursor()
+
+    if sample_limit:
+        # Use a CTE to first sample rows, then aggregate
+        query_articles = f"""
+            WITH sampled AS (
+                SELECT court_case_id, law_number, law_article
+                FROM law_court_citations
+                WHERE law_number IS NOT NULL
+                  AND law_article IS NOT NULL
+                LIMIT %s
+            )
+            SELECT law_number, law_article, COUNT(DISTINCT court_case_id) AS degree
+            FROM sampled
+            GROUP BY law_number, law_article
+            HAVING COUNT(DISTINCT court_case_id) >= {CO_CITATION_THRESHOLD}
+            ORDER BY degree DESC
+        """
+        cur.execute(query_articles, (sample_limit,))
+    else:
+        query_articles = f"""
+            SELECT law_number, law_article, COUNT(DISTINCT court_case_id) AS degree
+            FROM law_court_citations
+            WHERE law_number IS NOT NULL
+              AND law_article IS NOT NULL
+            GROUP BY law_number, law_article
+            HAVING COUNT(DISTINCT court_case_id) >= {CO_CITATION_THRESHOLD}
+            ORDER BY degree DESC
+        """
+        cur.execute(query_articles)
+
+    article_rows = cur.fetchall()
+
+    if len(article_rows) < 2:
+        print(f"ERROR: Only {len(article_rows)} articles meet the threshold. "
+              f"Need at least 2 for a graph. Try lowering CO_CITATION_THRESHOLD or running more extraction.")
+        cur.close()
+        return {"error": "insufficient_articles", "count": len(article_rows)}
+
+    # Map article keys to degree counts
+    article_keys = set()
+    raw_degree = {}
+    for law_num, law_art, degree in article_rows:
+        key = (law_num, law_art)
+        article_keys.add(key)
+        raw_degree[key] = degree
+
+    print(f"    Articles above threshold: {len(article_keys):,}")
+    print(f"    Query time: {fmt_duration(time.time() - t0)}")
+
+    # ── Step 2: Build co-citation edges ──
+    print("\n[2/5] Building co-citation graph...")
+    t1 = time.time()
+
+    # Strategy: for each court decision, get the set of qualifying articles it cites,
+    # then add edges between all pairs in that set.
+    # We do this with a server-side cursor to avoid loading everything into memory at once.
+
+    # First, build an article-key filter as a set of (law_number, law_article) tuples
+    # We need to query decisions that cite at least one qualifying article.
+
+    # Build a temp table or use IN clause for filtering.
+    # For large article sets, use a VALUES list.
+
+    # Create a list of article key strings for the WHERE clause
+    article_key_list = list(article_keys)
+
+    # Query: for each court_case_id, get the set of (law_number, law_article) it cites
+    # among our qualifying articles. We do this by fetching all relevant rows
+    # grouped by court_case_id.
+
+    # Build VALUES clause for qualifying articles
+    values_str = ",".join(
+        cur.mogrify("(%s,%s)", (ln, la)).decode()
+        for ln, la in article_key_list
+    )
+
+    query_cocitation = f"""
+        SELECT court_case_id, law_number, law_article
+        FROM law_court_citations
+        WHERE (law_number, law_article) IN ({values_str})
+        ORDER BY court_case_id
+    """
+
+    print(f"    Executing co-citation query ({len(article_key_list)} articles)...")
+    cur.execute(query_cocitation)
+
+    # Stream results and build edge weights
+    edge_weights: Counter = Counter()
+    current_case_id = None
+    current_articles: set[tuple[str, str]] = set()
+    decisions_processed = 0
+    total_edges_counted = 0
+
+    batch_size = 100000
+    while True:
+        batch = cur.fetchmany(batch_size)
+        if not batch:
+            break
+        for case_id, law_num, law_art in batch:
+            key = (law_num, law_art)
+            if case_id != current_case_id:
+                # Process the previous decision's article set
+                if len(current_articles) >= 2:
+                    arts = sorted(current_articles)
+                    for i in range(len(arts)):
+                        for j in range(i + 1, len(arts)):
+                            edge_weights[(arts[i], arts[j])] += 1
+                            total_edges_counted += 1
+                current_case_id = case_id
+                current_articles = set()
+                decisions_processed += 1
+                if decisions_processed % 500000 == 0:
+                    print(f"      ... processed {decisions_processed:,} decisions, "
+                          f"{len(edge_weights):,} unique edges so far")
+            current_articles.add(key)
+
+    # Don't forget the last decision
+    if len(current_articles) >= 2:
+        arts = sorted(current_articles)
+        for i in range(len(arts)):
+            for j in range(i + 1, len(arts)):
+                edge_weights[(arts[i], arts[j])] += 1
+        decisions_processed += 1
+
+    cur.close()
+
+    print(f"    Decisions processed: {decisions_processed:,}")
+    print(f"    Unique edges (article pairs): {len(edge_weights):,}")
+    print(f"    Co-citation query time: {fmt_duration(time.time() - t1)}")
+
+    if not edge_weights:
+        print("ERROR: No co-citation edges found. Articles may not co-occur in any decision.")
+        return {"error": "no_edges"}
+
+    # ── Step 3: Build NetworkX graph and compute centrality ──
+    print("\n[3/5] Computing PageRank and HITS...")
+    t2 = time.time()
+
+    G = nx.Graph()
+
+    # Add nodes with degree attribute
+    for key in article_keys:
+        G.add_node(key, degree=raw_degree.get(key, 0))
+
+    # Add weighted edges
+    for (a1, a2), weight in edge_weights.items():
+        G.add_edge(a1, a2, weight=weight)
+
+    print(f"    Graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
+
+    # Remove isolated nodes (articles with no co-citation edges)
+    isolates = list(nx.isolates(G))
+    if isolates:
+        G.remove_nodes_from(isolates)
+        print(f"    Removed {len(isolates)} isolated nodes (no co-citations)")
+        print(f"    Connected graph: {G.number_of_nodes()} nodes, {G.number_of_edges()} edges")
+
+    # PageRank (weighted)
+    print("    Computing PageRank...")
+    pagerank = nx.pagerank(G, weight="weight", max_iter=200, tol=1e-8)
+
+    # HITS (weighted) — for undirected graphs, hub = authority
+    # networkx.hits works on directed graphs; for undirected, we use DiGraph
+    print("    Computing HITS...")
+    DG = G.to_directed()
+    hubs, authorities = nx.hits(DG, max_iter=200, tol=1e-8)
+
+    elapsed_centrality = time.time() - t2
+    print(f"    Centrality computation time: {fmt_duration(elapsed_centrality)}")
+
+    # ── Step 4: Rankings and comparison ──
+    print("\n[4/5] Building rankings and computing correlations...")
+
+    # Get all nodes in the graph
+    nodes = list(G.nodes())
+
+    # Rank by raw citation count
+    by_degree = sorted(nodes, key=lambda n: raw_degree.get(n, 0), reverse=True)
+
+    # Rank by PageRank
+    by_pagerank = sorted(nodes, key=lambda n: pagerank.get(n, 0), reverse=True)
+
+    # Rank by authority score
+    by_authority = sorted(nodes, key=lambda n: authorities.get(n, 0), reverse=True)
+
+    top_n = min(50, len(nodes))
+
+    # Print top-50 tables
+    print(f"\n    Top-{top_n} by RAW CITATION COUNT:")
+    for i in range(top_n):
+        key = by_degree[i]
+        label = article_label(key[0], key[1])
+        pr = pagerank.get(key, 0)
+        auth = authorities.get(key, 0)
+        print(f"      {i+1:3d}. {label:<50s}  deg={raw_degree[key]:>10,}  PR={pr:.6f}  auth={auth:.6f}")
+
+    print(f"\n    Top-{top_n} by PAGERANK:")
+    for i in range(top_n):
+        key = by_pagerank[i]
+        label = article_label(key[0], key[1])
+        pr = pagerank.get(key, 0)
+        deg = raw_degree.get(key, 0)
+        print(f"      {i+1:3d}. {label:<50s}  PR={pr:.6f}  deg={deg:>10,}")
+
+    print(f"\n    Top-{top_n} by AUTHORITY SCORE (HITS):")
+    for i in range(top_n):
+        key = by_authority[i]
+        label = article_label(key[0], key[1])
+        auth = authorities.get(key, 0)
+        hub = hubs.get(key, 0)
+        deg = raw_degree.get(key, 0)
+        print(f"      {i+1:3d}. {label:<50s}  auth={auth:.6f}  hub={hub:.6f}  deg={deg:>10,}")
+
+    # Spearman rank correlations
+    # Build rank arrays for all nodes
+    degree_ranks = {n: rank for rank, n in enumerate(by_degree)}
+    pr_ranks = {n: rank for rank, n in enumerate(by_pagerank)}
+    auth_ranks = {n: rank for rank, n in enumerate(by_authority)}
+
+    deg_arr = np.array([degree_ranks[n] for n in nodes])
+    pr_arr = np.array([pr_ranks[n] for n in nodes])
+    auth_arr = np.array([auth_ranks[n] for n in nodes])
+
+    rho_deg_pr, p_deg_pr = spearmanr(deg_arr, pr_arr)
+    rho_deg_auth, p_deg_auth = spearmanr(deg_arr, auth_arr)
+    rho_pr_auth, p_pr_auth = spearmanr(pr_arr, auth_arr)
+
+    print(f"\n    Spearman rank correlations (N={len(nodes)}):")
+    print(f"      Degree vs PageRank:   rho={rho_deg_pr:.4f}  p={p_deg_pr:.2e}")
+    print(f"      Degree vs Authority:  rho={rho_deg_auth:.4f}  p={p_deg_auth:.2e}")
+    print(f"      PageRank vs Authority: rho={rho_pr_auth:.4f}  p={p_pr_auth:.2e}")
+
+    if rho_deg_pr > 0.9:
+        corr_interpretation = ("PageRank and raw degree are highly correlated (rho > 0.9), "
+                               "suggesting simple citation frequency is a good proxy for centrality "
+                               "in this network.")
+    elif rho_deg_pr > 0.7:
+        corr_interpretation = ("PageRank and raw degree are moderately correlated, "
+                               "indicating that co-citation structure adds information beyond "
+                               "simple frequency.")
+    else:
+        corr_interpretation = ("PageRank and raw degree diverge substantially, "
+                               "suggesting rich co-citation structure where frequently cited articles "
+                               "are not necessarily the most central.")
+
+    print(f"\n    Interpretation: {corr_interpretation}")
+
+    # ── Step 5: Plots ──
+    print("\n[5/5] Saving plots...")
+
+    # Plot 1: PageRank vs Degree scatter
+    fig, axes = plt.subplots(1, 3, figsize=(18, 6))
+
+    pr_values = [pagerank.get(n, 0) for n in nodes]
+    deg_values = [raw_degree.get(n, 0) for n in nodes]
+    auth_values = [authorities.get(n, 0) for n in nodes]
+
+    ax1 = axes[0]
+    ax1.scatter(deg_values, pr_values, alpha=0.4, s=8, color="steelblue")
+    ax1.set_xlabel("Raw Citation Count", fontsize=11)
+    ax1.set_ylabel("PageRank", fontsize=11)
+    ax1.set_title(f"Degree vs PageRank (rho={rho_deg_pr:.3f})", fontsize=12)
+    ax1.set_xscale("log")
+    ax1.set_yscale("log")
+
+    ax2 = axes[1]
+    ax2.scatter(deg_values, auth_values, alpha=0.4, s=8, color="darkorange")
+    ax2.set_xlabel("Raw Citation Count", fontsize=11)
+    ax2.set_ylabel("Authority Score (HITS)", fontsize=11)
+    ax2.set_title(f"Degree vs Authority (rho={rho_deg_auth:.3f})", fontsize=12)
+    ax2.set_xscale("log")
+    ax2.set_yscale("log")
+
+    ax3 = axes[2]
+    ax3.scatter(pr_values, auth_values, alpha=0.4, s=8, color="forestgreen")
+    ax3.set_xlabel("PageRank", fontsize=11)
+    ax3.set_ylabel("Authority Score (HITS)", fontsize=11)
+    ax3.set_title(f"PageRank vs Authority (rho={rho_pr_auth:.3f})", fontsize=12)
+    ax3.set_xscale("log")
+    ax3.set_yscale("log")
+
+    fig.suptitle("Centrality Measure Correlations — Ukrainian Court Citation Network",
+                 fontsize=14, fontweight="bold")
+    plt.tight_layout()
+
+    scatter_path = OUTPUT_DIR / "centrality_correlations.png"
+    fig.savefig(scatter_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    print(f"    Saved: {scatter_path}")
+
+    # Plot 2: Top-30 articles bar chart (3 measures side by side)
+    fig, axes = plt.subplots(3, 1, figsize=(16, 18))
+
+    top_30 = min(30, len(nodes))
+
+    # By degree
+    ax = axes[0]
+    labels_deg = [article_label(by_degree[i][0], by_degree[i][1]) for i in range(top_30)]
+    vals_deg = [raw_degree[by_degree[i]] for i in range(top_30)]
+    y_pos = np.arange(top_30)
+    ax.barh(y_pos, vals_deg, color="steelblue", height=0.7)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels_deg, fontsize=8)
+    ax.invert_yaxis()
+    ax.set_xlabel("Number of Citing Decisions")
+    ax.set_title("Top Articles by Raw Citation Count", fontsize=13, fontweight="bold")
+
+    # By PageRank
+    ax = axes[1]
+    labels_pr = [article_label(by_pagerank[i][0], by_pagerank[i][1]) for i in range(top_30)]
+    vals_pr = [pagerank[by_pagerank[i]] for i in range(top_30)]
+    ax.barh(y_pos, vals_pr, color="crimson", height=0.7)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels_pr, fontsize=8)
+    ax.invert_yaxis()
+    ax.set_xlabel("PageRank Score")
+    ax.set_title("Top Articles by PageRank", fontsize=13, fontweight="bold")
+
+    # By Authority
+    ax = axes[2]
+    labels_auth = [article_label(by_authority[i][0], by_authority[i][1]) for i in range(top_30)]
+    vals_auth = [authorities[by_authority[i]] for i in range(top_30)]
+    ax.barh(y_pos, vals_auth, color="darkorange", height=0.7)
+    ax.set_yticks(y_pos)
+    ax.set_yticklabels(labels_auth, fontsize=8)
+    ax.invert_yaxis()
+    ax.set_xlabel("HITS Authority Score")
+    ax.set_title("Top Articles by HITS Authority", fontsize=13, fontweight="bold")
+
+    fig.suptitle("Top-30 Legislation Articles by Three Centrality Measures",
+                 fontsize=15, fontweight="bold")
+    plt.tight_layout()
+
+    bar_path = OUTPUT_DIR / "top_articles_centrality.png"
+    fig.savefig(bar_path, dpi=200, bbox_inches="tight")
+    plt.close(fig)
+    print(f"    Saved: {bar_path}")
+
+    elapsed = time.time() - t0
+    print(f"\n    Experiment 2 completed in {fmt_duration(elapsed)}")
+
+    # Build results
+    def top_list(ranked, score_fn, score_name, n=50):
+        return [
+            {
+                "rank": i + 1,
+                "law_number": ranked[i][0],
+                "law_article": ranked[i][1],
+                "label": article_label(ranked[i][0], ranked[i][1]),
+                score_name: round(float(score_fn(ranked[i])), 8),
+                "degree": int(raw_degree.get(ranked[i], 0)),
+            }
+            for i in range(min(n, len(ranked)))
+        ]
+
+    return {
+        "graph": {
+            "nodes": G.number_of_nodes(),
+            "edges": G.number_of_edges(),
+            "co_citation_threshold": CO_CITATION_THRESHOLD,
+            "isolated_removed": len(isolates),
+            "decisions_processed": decisions_processed,
+        },
+        "top_50_by_degree": top_list(by_degree, lambda n: raw_degree.get(n, 0), "degree"),
+        "top_50_by_pagerank": top_list(by_pagerank, lambda n: pagerank.get(n, 0), "pagerank"),
+        "top_50_by_authority": top_list(by_authority, lambda n: authorities.get(n, 0), "authority"),
+        "spearman_correlations": {
+            "degree_vs_pagerank": {"rho": round(rho_deg_pr, 4), "p_value": float(p_deg_pr)},
+            "degree_vs_authority": {"rho": round(rho_deg_auth, 4), "p_value": float(p_deg_auth)},
+            "pagerank_vs_authority": {"rho": round(rho_pr_auth, 4), "p_value": float(p_pr_auth)},
+        },
+        "interpretation": corr_interpretation,
+        "elapsed_seconds": round(elapsed, 1),
+    }
+
+
+# ── Main ────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Citation graph degree centrality analysis for Ukrainian court decisions."
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=None,
+        help="Limit the number of citation rows to process (default: all). "
+             "Useful for quick testing on a subset.",
+    )
+    args = parser.parse_args()
+
+    sample_desc = f"{args.sample_size:,} rows" if args.sample_size else "all data"
+    print(f"Citation Graph — Degree Centrality Analysis")
+    print(f"Dataset: {sample_desc}")
+    print(f"Database: {DB_DSN.split('@')[1] if '@' in DB_DSN else DB_DSN}")
+    print(f"Output: {OUTPUT_DIR}")
+
+    # ── Check connectivity and table existence ──
+    print("\nConnecting to database...")
+    try:
+        conn = get_conn()
+    except Exception as e:
+        print(f"ERROR: Cannot connect to database: {e}")
+        print("Set DATABASE_URL environment variable or check connection parameters.")
+        sys.exit(1)
+
+    cur = conn.cursor()
+
+    # Check table exists
+    cur.execute("""
+        SELECT EXISTS (
+            SELECT 1 FROM information_schema.tables
+            WHERE table_name = 'law_court_citations'
+        )
+    """)
+    if not cur.fetchone()[0]:
+        print("ERROR: Table law_court_citations does not exist.")
+        print("Run extract-citations.py first to populate citation data.")
+        sys.exit(1)
+
+    # Get row count estimate (fast)
+    cur.execute("SELECT reltuples::bigint FROM pg_class WHERE relname = 'law_court_citations'")
+    row_estimate = cur.fetchone()
+    est_rows = row_estimate[0] if row_estimate else 0
+    print(f"Table law_court_citations: ~{est_rows:,} rows (estimated)")
+
+    # Get exact count of distinct court cases (might be slow on huge tables)
+    cur.execute("SELECT COUNT(*) FROM law_court_citations")
+    exact_rows = cur.fetchone()[0]
+    print(f"Table law_court_citations: {exact_rows:,} rows (exact)")
+
+    cur.close()
+
+    if exact_rows == 0:
+        print("ERROR: Table is empty. Run extract-citations.py first.")
+        sys.exit(1)
+
+    if args.sample_size and args.sample_size > exact_rows:
+        print(f"NOTE: --sample-size {args.sample_size:,} exceeds table size {exact_rows:,}, "
+              f"using all data.")
+        args.sample_size = None
+
+    # ── Run experiments ──
+    t_total = time.time()
+
+    exp1_results = run_power_law_analysis(conn, args.sample_size)
+    exp2_results = run_centrality_analysis(conn, args.sample_size)
+
+    conn.close()
+
+    # ── Save combined results ──
+    results = {
+        "metadata": {
+            "dataset": sample_desc,
+            "table_rows": exact_rows,
+            "co_citation_threshold": CO_CITATION_THRESHOLD,
+            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        },
+        "experiment_1_power_law": exp1_results,
+        "experiment_2_centrality": exp2_results,
+    }
+
+    json_path = OUTPUT_DIR / "centrality_analysis_results.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    print(f"\nResults saved to: {json_path}")
+
+    total_elapsed = time.time() - t_total
+    print(f"\nTotal analysis time: {fmt_duration(total_elapsed)}")
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/analyze-temporal-dynamics.py
+++ b/scripts/citation-graph/analyze-temporal-dynamics.py
@@ -1,0 +1,800 @@
+#!/usr/bin/env python3
+"""
+Citation Graph Paper — Temporal dynamics analysis.
+
+Experiment 3: Legislative regime change detection
+  - Track codex citation density per year, detect regime transitions (>30% YoY change)
+  - Plot normalized citation trends for major codexes
+
+Experiment 7: Impact of 2022 war on court decision patterns
+  - Decisions per year (showing 2022 drop)
+  - Citation entropy per year (concentration vs dispersion)
+  - Top-20 cited articles comparison: 2021 vs 2023
+  - New post-war legislation detection
+
+Usage:
+  python3 analyze-temporal-dynamics.py
+  python3 analyze-temporal-dynamics.py --year-from 2010 --year-to 2025
+  python3 analyze-temporal-dynamics.py --experiment 3   # run only Experiment 3
+  python3 analyze-temporal-dynamics.py --experiment 7   # run only Experiment 7
+
+Dependencies: psycopg2, matplotlib, numpy, scipy
+Output: plots to scripts/citation-graph/output/, stats to JSON
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import numpy as np
+import psycopg2
+import psycopg2.extras
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+from scipy import stats as scipy_stats
+
+# ── Configuration ───────────────────────────────────────────
+
+DB_DSN = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:1xfXUY8y7DM8Sm1w6T2cmBnNsnzfgnNJ2Ajl1Zl11xc@127.0.0.1:5438/secondlayer_prod",
+)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+OUTPUT_DIR = SCRIPT_DIR / "output"
+
+# Major codexes to track (short abbreviation -> citation law_number substring)
+CODEX_MAP = {
+    "ЦК": "Цивільний кодекс",
+    "КК": "Кримінальний кодекс",
+    "ГК": "Господарський кодекс",
+    "ГПК": "Господарський процесуальний кодекс",
+    "КПК": "Кримінальний процесуальний кодекс",
+    "КАС": "Кодекс адміністративного судочинства",
+    "ЦПК": "Цивільний процесуальний кодекс",
+}
+
+# Known regime transition years for annotation
+KNOWN_TRANSITIONS = {
+    "ЦК": [(2004, "Новий ЦК 2003")],
+    "КПК": [(2013, "Новий КПК 2012")],
+    "КАС": [(2005, "КАС набув чинності"), (2018, "Реформа КАС 2017")],
+    "ГПК": [(2018, "Реформа ГПК 2017")],
+    "ЦПК": [(2018, "Реформа ЦПК 2017")],
+}
+
+REGIME_CHANGE_THRESHOLD = 0.30  # 30% YoY change flags a regime transition
+
+# Plot styling
+plt.rcParams.update({
+    "figure.dpi": 150,
+    "savefig.dpi": 150,
+    "font.size": 10,
+    "axes.titlesize": 12,
+    "axes.labelsize": 11,
+    "legend.fontsize": 8,
+    "figure.facecolor": "white",
+})
+
+
+def get_conn():
+    return psycopg2.connect(DB_DSN)
+
+
+# ── Experiment 3: Legislative regime change detection ───────
+
+def exp3_fetch_codex_citations_per_year(conn, year_from: int, year_to: int) -> dict:
+    """
+    For each major codex, count citations per year.
+    Join law_court_citations with edrsr_fulltext to get adj_year.
+    Returns: {codex_abbr: {year: count}}
+    """
+    cur = conn.cursor()
+
+    # Build CASE expression for codex classification
+    when_clauses = []
+    for abbr, name_fragment in CODEX_MAP.items():
+        when_clauses.append(f"WHEN c.law_number ILIKE '%{name_fragment}%' THEN '{abbr}'")
+    case_expr = "CASE " + " ".join(when_clauses) + " END"
+
+    query = f"""
+        SELECT
+            {case_expr} AS codex,
+            f.adj_year AS year,
+            COUNT(*) AS cnt
+        FROM law_court_citations c
+        JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+        WHERE c.citation_type = 'codex_article'
+          AND f.adj_year BETWEEN %s AND %s
+        GROUP BY codex, f.adj_year
+        HAVING {case_expr} IS NOT NULL
+        ORDER BY codex, year
+    """
+    print("  Fetching codex citations per year...")
+    t0 = time.time()
+    cur.execute(query, (year_from, year_to))
+    rows = cur.fetchall()
+    print(f"  Got {len(rows)} rows in {time.time() - t0:.1f}s")
+    cur.close()
+
+    result = defaultdict(dict)
+    for codex, year, cnt in rows:
+        result[codex][year] = cnt
+    return dict(result)
+
+
+def exp3_fetch_decisions_per_year(conn, year_from: int, year_to: int) -> dict:
+    """Count total decisions per year from edrsr_fulltext for normalization."""
+    cur = conn.cursor()
+    query = """
+        SELECT adj_year, COUNT(*) AS cnt
+        FROM edrsr_fulltext
+        WHERE adj_year BETWEEN %s AND %s
+        GROUP BY adj_year
+        ORDER BY adj_year
+    """
+    print("  Fetching decisions per year...")
+    t0 = time.time()
+    cur.execute(query, (year_from, year_to))
+    rows = cur.fetchall()
+    print(f"  Got {len(rows)} rows in {time.time() - t0:.1f}s")
+    cur.close()
+    return {year: cnt for year, cnt in rows}
+
+
+def exp3_detect_regime_transitions(codex_data: dict, decisions_per_year: dict) -> dict:
+    """
+    Compute YoY change rate for each codex (normalized by decisions).
+    Flag years with >30% change as regime transitions.
+    Returns: {codex: [(year, yoy_change, direction)]}
+    """
+    transitions = {}
+    for codex, year_counts in codex_data.items():
+        years_sorted = sorted(year_counts.keys())
+        codex_transitions = []
+        for i in range(1, len(years_sorted)):
+            y_prev, y_curr = years_sorted[i - 1], years_sorted[i]
+            # Normalize: citations per 1000 decisions
+            dec_prev = decisions_per_year.get(y_prev, 1)
+            dec_curr = decisions_per_year.get(y_curr, 1)
+            rate_prev = year_counts[y_prev] / dec_prev
+            rate_curr = year_counts[y_curr] / dec_curr
+            if rate_prev > 0:
+                yoy_change = (rate_curr - rate_prev) / rate_prev
+            else:
+                yoy_change = float("inf") if rate_curr > 0 else 0.0
+            if abs(yoy_change) > REGIME_CHANGE_THRESHOLD:
+                direction = "surge" if yoy_change > 0 else "decline"
+                codex_transitions.append((y_curr, yoy_change, direction))
+        transitions[codex] = codex_transitions
+    return transitions
+
+
+def exp3_plot_citation_trends(
+    codex_data: dict,
+    decisions_per_year: dict,
+    transitions: dict,
+    year_from: int,
+    year_to: int,
+):
+    """Plot normalized citation trends per codex with regime transition markers."""
+    fig, ax = plt.subplots(figsize=(14, 7))
+
+    all_years = list(range(year_from, year_to + 1))
+    colors = plt.cm.tab10(np.linspace(0, 1, len(CODEX_MAP)))
+
+    for idx, (codex, color) in enumerate(zip(sorted(codex_data.keys()), colors)):
+        year_counts = codex_data[codex]
+        # Normalized: citations per 1000 decisions
+        values = []
+        for y in all_years:
+            cnt = year_counts.get(y, 0)
+            dec = decisions_per_year.get(y, 1)
+            values.append(cnt / dec * 1000)
+        ax.plot(all_years, values, marker="o", markersize=3, label=codex,
+                color=color, linewidth=1.5)
+
+    # Annotate known transitions
+    for codex, events in KNOWN_TRANSITIONS.items():
+        if codex in codex_data:
+            for year, label in events:
+                if year_from <= year <= year_to:
+                    ax.axvline(x=year, color="gray", linestyle="--", alpha=0.4, linewidth=0.8)
+                    ax.annotate(
+                        label, xy=(year, ax.get_ylim()[1] * 0.95),
+                        fontsize=6, rotation=90, ha="right", va="top",
+                        color="gray", alpha=0.7,
+                    )
+
+    # Mark 2022 war
+    if year_from <= 2022 <= year_to:
+        ax.axvline(x=2022, color="red", linestyle="-.", alpha=0.5, linewidth=1.2)
+        ax.annotate("2022 war", xy=(2022, ax.get_ylim()[1] * 0.85),
+                     fontsize=8, color="red", alpha=0.7, ha="left")
+
+    ax.set_xlabel("Year")
+    ax.set_ylabel("Citations per 1,000 decisions")
+    ax.set_title("Experiment 3: Codex Citation Density Over Time (Normalized)")
+    ax.legend(loc="upper left", ncol=2)
+    ax.grid(True, alpha=0.3)
+    ax.set_xlim(year_from - 0.5, year_to + 0.5)
+    ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
+    plt.xticks(rotation=45, fontsize=8)
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "exp3_codex_citation_trends.png"
+    fig.savefig(out_path)
+    plt.close(fig)
+    print(f"  Saved: {out_path}")
+
+
+def exp3_plot_yoy_changes(codex_data: dict, decisions_per_year: dict, year_from: int, year_to: int):
+    """Plot YoY change rates per codex as a heatmap-style chart."""
+    codexes = sorted(codex_data.keys())
+    all_years = list(range(year_from + 1, year_to + 1))
+
+    matrix = np.zeros((len(codexes), len(all_years)))
+
+    for i, codex in enumerate(codexes):
+        year_counts = codex_data[codex]
+        for j, y in enumerate(all_years):
+            y_prev = y - 1
+            dec_prev = decisions_per_year.get(y_prev, 1)
+            dec_curr = decisions_per_year.get(y, 1)
+            rate_prev = year_counts.get(y_prev, 0) / dec_prev
+            rate_curr = year_counts.get(y, 0) / dec_curr
+            if rate_prev > 0:
+                matrix[i, j] = (rate_curr - rate_prev) / rate_prev
+            else:
+                matrix[i, j] = 0
+
+    fig, ax = plt.subplots(figsize=(16, 5))
+    # Clip for visual clarity
+    matrix_clipped = np.clip(matrix, -1.0, 1.0)
+    im = ax.imshow(matrix_clipped, aspect="auto", cmap="RdYlGn", vmin=-1, vmax=1)
+    ax.set_xticks(range(len(all_years)))
+    ax.set_xticklabels(all_years, rotation=45, fontsize=7)
+    ax.set_yticks(range(len(codexes)))
+    ax.set_yticklabels(codexes, fontsize=9)
+    ax.set_title("Experiment 3: Year-over-Year Citation Rate Change by Codex")
+    ax.set_xlabel("Year")
+
+    # Mark cells exceeding threshold
+    for i in range(len(codexes)):
+        for j in range(len(all_years)):
+            val = matrix[i, j]
+            if abs(val) > REGIME_CHANGE_THRESHOLD:
+                ax.text(j, i, f"{val:+.0%}", ha="center", va="center",
+                        fontsize=5, fontweight="bold",
+                        color="white" if abs(val) > 0.6 else "black")
+
+    cbar = plt.colorbar(im, ax=ax, label="YoY change rate", shrink=0.8)
+    cbar.ax.tick_params(labelsize=8)
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "exp3_yoy_change_heatmap.png"
+    fig.savefig(out_path)
+    plt.close(fig)
+    print(f"  Saved: {out_path}")
+
+
+def run_experiment_3(conn, year_from: int, year_to: int) -> dict:
+    """Execute Experiment 3: Legislative regime change detection."""
+    print("\n=== Experiment 3: Legislative Regime Change Detection ===\n")
+
+    decisions_per_year = exp3_fetch_decisions_per_year(conn, year_from, year_to)
+    codex_data = exp3_fetch_codex_citations_per_year(conn, year_from, year_to)
+
+    if not codex_data:
+        print("  No codex citation data found. Skipping plots.")
+        return {"error": "no data"}
+
+    transitions = exp3_detect_regime_transitions(codex_data, decisions_per_year)
+
+    # Print detected transitions
+    print("\n  Detected regime transitions (>30% YoY change):")
+    for codex in sorted(transitions.keys()):
+        events = transitions[codex]
+        if events:
+            print(f"    {codex}:")
+            for year, change, direction in events:
+                print(f"      {year}: {change:+.1%} ({direction})")
+
+    # Generate plots
+    exp3_plot_citation_trends(codex_data, decisions_per_year, transitions, year_from, year_to)
+    exp3_plot_yoy_changes(codex_data, decisions_per_year, year_from, year_to)
+
+    # Build stats
+    stats = {
+        "decisions_per_year": {str(k): v for k, v in sorted(decisions_per_year.items())},
+        "codex_citations_per_year": {
+            codex: {str(y): c for y, c in sorted(years.items())}
+            for codex, years in sorted(codex_data.items())
+        },
+        "regime_transitions": {
+            codex: [
+                {"year": y, "yoy_change": round(ch, 4), "direction": d}
+                for y, ch, d in events
+            ]
+            for codex, events in sorted(transitions.items())
+            if events
+        },
+        "normalized_rates": {},
+    }
+    # Add normalized rates (per 1000 decisions)
+    for codex, year_counts in sorted(codex_data.items()):
+        stats["normalized_rates"][codex] = {
+            str(y): round(year_counts.get(y, 0) / decisions_per_year.get(y, 1) * 1000, 4)
+            for y in range(year_from, year_to + 1)
+        }
+
+    return stats
+
+
+# ── Experiment 7: Impact of 2022 war ───────────────────────
+
+def exp7_fetch_decisions_per_year(conn, year_from: int, year_to: int) -> dict:
+    """Total decisions per year from edrsr_fulltext."""
+    cur = conn.cursor()
+    query = """
+        SELECT adj_year, COUNT(*) AS cnt
+        FROM edrsr_fulltext
+        WHERE adj_year BETWEEN %s AND %s
+        GROUP BY adj_year
+        ORDER BY adj_year
+    """
+    print("  Fetching decisions per year...")
+    t0 = time.time()
+    cur.execute(query, (year_from, year_to))
+    rows = cur.fetchall()
+    print(f"  Got {len(rows)} year buckets in {time.time() - t0:.1f}s")
+    cur.close()
+    return {year: cnt for year, cnt in rows}
+
+
+def exp7_fetch_top_articles(conn, target_year: int, top_n: int = 20) -> list:
+    """
+    Top N cited articles in a given year.
+    Returns list of (law_number, law_article, count).
+    """
+    cur = conn.cursor()
+    query = """
+        SELECT c.law_number, c.law_article, COUNT(*) AS cnt
+        FROM law_court_citations c
+        JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+        WHERE f.adj_year = %s
+          AND c.citation_type IN ('codex_article', 'constitution', 'law_article')
+          AND c.law_article IS NOT NULL
+          AND c.law_article != ''
+        GROUP BY c.law_number, c.law_article
+        ORDER BY cnt DESC
+        LIMIT %s
+    """
+    cur.execute(query, (target_year, top_n))
+    rows = cur.fetchall()
+    cur.close()
+    return [(law, art, cnt) for law, art, cnt in rows]
+
+
+def exp7_fetch_new_post_war_legislation(conn, min_citations: int = 50) -> list:
+    """
+    Articles with zero citations before 2022 but significant citations after.
+    Returns list of (law_number, law_article, post_count).
+    """
+    cur = conn.cursor()
+    query = """
+        WITH post AS (
+            SELECT c.law_number, c.law_article, COUNT(*) AS post_cnt
+            FROM law_court_citations c
+            JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+            WHERE f.adj_year >= 2022
+              AND c.citation_type IN ('codex_article', 'constitution', 'law_article')
+              AND c.law_article IS NOT NULL
+              AND c.law_article != ''
+            GROUP BY c.law_number, c.law_article
+            HAVING COUNT(*) >= %s
+        ),
+        pre AS (
+            SELECT c.law_number, c.law_article, COUNT(*) AS pre_cnt
+            FROM law_court_citations c
+            JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+            WHERE f.adj_year < 2022
+              AND c.citation_type IN ('codex_article', 'constitution', 'law_article')
+              AND c.law_article IS NOT NULL
+              AND c.law_article != ''
+            GROUP BY c.law_number, c.law_article
+        )
+        SELECT post.law_number, post.law_article, post.post_cnt
+        FROM post
+        LEFT JOIN pre ON post.law_number = pre.law_number
+                     AND post.law_article = pre.law_article
+        WHERE pre.pre_cnt IS NULL
+        ORDER BY post.post_cnt DESC
+        LIMIT 30
+    """
+    print("  Fetching new post-war legislation...")
+    t0 = time.time()
+    cur.execute(query, (min_citations,))
+    rows = cur.fetchall()
+    print(f"  Found {len(rows)} new post-war articles in {time.time() - t0:.1f}s")
+    cur.close()
+    return [(law, art, cnt) for law, art, cnt in rows]
+
+
+def exp7_fetch_citation_entropy_per_year(conn, year_from: int, year_to: int) -> dict:
+    """
+    Compute citation entropy per year.
+    H = -sum(p_i * log(p_i)) where p_i = fraction of citations to article i.
+    Returns: {year: entropy}
+    """
+    cur = conn.cursor()
+    # Get citation counts per article per year
+    query = """
+        SELECT f.adj_year, c.law_number, c.law_article, COUNT(*) AS cnt
+        FROM law_court_citations c
+        JOIN edrsr_fulltext f ON c.court_case_id = f.doc_id
+        WHERE f.adj_year BETWEEN %s AND %s
+          AND c.citation_type IN ('codex_article', 'constitution', 'law_article')
+          AND c.law_article IS NOT NULL
+          AND c.law_article != ''
+        GROUP BY f.adj_year, c.law_number, c.law_article
+        ORDER BY f.adj_year
+    """
+    print("  Fetching citation distributions for entropy calculation...")
+    t0 = time.time()
+    cur.execute(query, (year_from, year_to))
+    rows = cur.fetchall()
+    print(f"  Got {len(rows)} article-year buckets in {time.time() - t0:.1f}s")
+    cur.close()
+
+    # Group by year
+    year_distributions = defaultdict(list)
+    for year, law, art, cnt in rows:
+        year_distributions[year].append(cnt)
+
+    entropies = {}
+    for year in sorted(year_distributions.keys()):
+        counts = np.array(year_distributions[year], dtype=np.float64)
+        total = counts.sum()
+        if total == 0:
+            entropies[year] = 0.0
+            continue
+        probs = counts / total
+        # Filter out zeros to avoid log(0)
+        probs = probs[probs > 0]
+        entropy = -np.sum(probs * np.log2(probs))
+        entropies[year] = float(entropy)
+
+    return entropies
+
+
+def exp7_plot_decisions_per_year(decisions_per_year: dict, year_from: int, year_to: int):
+    """Bar chart of decisions per year, highlighting 2022 drop."""
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    years = sorted(decisions_per_year.keys())
+    counts = [decisions_per_year[y] for y in years]
+    colors = ["#d32f2f" if y == 2022 else "#1976d2" for y in years]
+
+    ax.bar(years, counts, color=colors, edgecolor="white", linewidth=0.5)
+
+    # Annotate 2022
+    if 2022 in decisions_per_year:
+        idx_2022 = years.index(2022)
+        ax.annotate(
+            f"2022: {decisions_per_year[2022]:,}\n(war)",
+            xy=(2022, decisions_per_year[2022]),
+            xytext=(2022 + 1.5, decisions_per_year[2022] * 1.15),
+            arrowprops=dict(arrowstyle="->", color="red"),
+            fontsize=9, color="red", fontweight="bold",
+        )
+        # Show percentage drop from 2021
+        if 2021 in decisions_per_year and decisions_per_year[2021] > 0:
+            drop = (decisions_per_year[2021] - decisions_per_year[2022]) / decisions_per_year[2021]
+            ax.annotate(
+                f"{drop:.0%} drop",
+                xy=(2022, decisions_per_year[2022] * 0.5),
+                fontsize=10, color="red", ha="center", fontweight="bold",
+            )
+
+    ax.set_xlabel("Year")
+    ax.set_ylabel("Number of decisions")
+    ax.set_title("Experiment 7a: Court Decisions Per Year")
+    ax.grid(True, axis="y", alpha=0.3)
+    ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
+    plt.xticks(rotation=45, fontsize=8)
+    ax.yaxis.set_major_formatter(mticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "exp7a_decisions_per_year.png"
+    fig.savefig(out_path)
+    plt.close(fig)
+    print(f"  Saved: {out_path}")
+
+
+def exp7_plot_citation_entropy(entropies: dict, year_from: int, year_to: int):
+    """Plot citation entropy over time."""
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    years = sorted(entropies.keys())
+    values = [entropies[y] for y in years]
+
+    ax.plot(years, values, marker="o", markersize=5, color="#1976d2", linewidth=2)
+    ax.fill_between(years, values, alpha=0.1, color="#1976d2")
+
+    # Highlight 2022
+    if 2022 in entropies:
+        ax.plot(2022, entropies[2022], "ro", markersize=10, zorder=5)
+        ax.annotate(
+            f"2022: H={entropies[2022]:.2f}",
+            xy=(2022, entropies[2022]),
+            xytext=(2022 + 1, entropies[2022] - 0.3),
+            arrowprops=dict(arrowstyle="->", color="red"),
+            fontsize=9, color="red", fontweight="bold",
+        )
+
+    ax.set_xlabel("Year")
+    ax.set_ylabel("Shannon Entropy (bits)")
+    ax.set_title("Experiment 7b: Citation Entropy Over Time")
+    ax.grid(True, alpha=0.3)
+    ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
+    plt.xticks(rotation=45, fontsize=8)
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "exp7b_citation_entropy.png"
+    fig.savefig(out_path)
+    plt.close(fig)
+    print(f"  Saved: {out_path}")
+
+
+def exp7_plot_top_articles_shift(top_2021: list, top_2023: list):
+    """
+    Heatmap showing top-20 cited articles in 2021 vs 2023.
+    Rows = union of top articles, columns = [2021, 2023].
+    """
+    # Build article labels and counts
+    label_fn = lambda law, art: f"{_abbreviate_law(law)} ст.{art}"
+    articles_2021 = {(law, art): cnt for law, art, cnt in top_2021}
+    articles_2023 = {(law, art): cnt for law, art, cnt in top_2023}
+
+    # Union of all articles, ordered by combined rank
+    all_articles = []
+    seen = set()
+    for law, art, _ in top_2021:
+        key = (law, art)
+        if key not in seen:
+            all_articles.append(key)
+            seen.add(key)
+    for law, art, _ in top_2023:
+        key = (law, art)
+        if key not in seen:
+            all_articles.append(key)
+            seen.add(key)
+
+    # Limit to top 30 for readability
+    all_articles = all_articles[:30]
+
+    labels = [label_fn(law, art) for law, art in all_articles]
+    counts_2021 = [articles_2021.get(key, 0) for key in all_articles]
+    counts_2023 = [articles_2023.get(key, 0) for key in all_articles]
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+
+    x = np.arange(len(labels))
+    width = 0.35
+
+    bars_2021 = ax.barh(x + width / 2, counts_2021, width, label="2021", color="#1976d2", alpha=0.8)
+    bars_2023 = ax.barh(x - width / 2, counts_2023, width, label="2023", color="#d32f2f", alpha=0.8)
+
+    ax.set_yticks(x)
+    ax.set_yticklabels(labels, fontsize=7)
+    ax.invert_yaxis()
+    ax.set_xlabel("Citation count")
+    ax.set_title("Experiment 7c: Top Cited Articles — 2021 vs 2023")
+    ax.legend()
+    ax.grid(True, axis="x", alpha=0.3)
+    ax.xaxis.set_major_formatter(mticker.FuncFormatter(lambda x, _: f"{x:,.0f}"))
+    plt.tight_layout()
+
+    out_path = OUTPUT_DIR / "exp7c_top_articles_shift.png"
+    fig.savefig(out_path)
+    plt.close(fig)
+    print(f"  Saved: {out_path}")
+
+
+def _abbreviate_law(law_name: str) -> str:
+    """Abbreviate long law names for plot labels."""
+    abbrevs = {
+        "Цивільний кодекс України": "ЦК",
+        "Кримінальний кодекс України": "КК",
+        "Господарський кодекс України": "ГК",
+        "Господарський процесуальний кодекс України": "ГПК",
+        "Кримінальний процесуальний кодекс України": "КПК",
+        "Кодекс адміністративного судочинства України": "КАС",
+        "Цивільний процесуальний кодекс України": "ЦПК",
+        "Кодекс законів про працю України": "КЗпП",
+        "Сімейний кодекс України": "СК",
+        "Земельний кодекс України": "ЗК",
+        "Податковий кодекс України": "ПК",
+        "Митний кодекс України": "МК",
+        "Бюджетний кодекс України": "БК",
+        "Водний кодекс України": "ВК",
+        "Лісовий кодекс України": "ЛК",
+        "Житловий кодекс України": "ЖК",
+        "Кодекс України про адміністративні правопорушення": "КУпАП",
+        "Конституція України": "КУ",
+    }
+    for full, short in abbrevs.items():
+        if law_name == full:
+            return short
+    # Truncate if still long
+    if len(law_name) > 30:
+        return law_name[:27] + "..."
+    return law_name
+
+
+def run_experiment_7(conn, year_from: int, year_to: int) -> dict:
+    """Execute Experiment 7: Impact of 2022 war."""
+    print("\n=== Experiment 7: Impact of 2022 War ===\n")
+
+    # 7a: Decisions per year
+    decisions_per_year = exp7_fetch_decisions_per_year(conn, year_from, year_to)
+    exp7_plot_decisions_per_year(decisions_per_year, year_from, year_to)
+
+    # Print the drop
+    if 2021 in decisions_per_year and 2022 in decisions_per_year:
+        drop = (decisions_per_year[2021] - decisions_per_year[2022]) / decisions_per_year[2021]
+        print(f"\n  2021: {decisions_per_year[2021]:,} decisions")
+        print(f"  2022: {decisions_per_year[2022]:,} decisions")
+        print(f"  Drop: {drop:.1%}")
+        if 2023 in decisions_per_year:
+            recovery = (decisions_per_year[2023] - decisions_per_year[2022]) / decisions_per_year[2022]
+            print(f"  2023: {decisions_per_year[2023]:,} decisions (recovery: {recovery:+.1%})")
+
+    # 7b: Citation entropy
+    print()
+    entropies = exp7_fetch_citation_entropy_per_year(conn, year_from, year_to)
+    exp7_plot_citation_entropy(entropies, year_from, year_to)
+
+    if entropies:
+        print("\n  Citation entropy by year:")
+        for y in sorted(entropies.keys()):
+            marker = " <-- war" if y == 2022 else ""
+            print(f"    {y}: H = {entropies[y]:.4f}{marker}")
+
+    # 7c: Top articles shift (2021 vs 2023)
+    print("\n  Fetching top-20 articles for 2021...")
+    top_2021 = exp7_fetch_top_articles(conn, 2021, top_n=20)
+    print(f"  Got {len(top_2021)} articles for 2021")
+
+    print("  Fetching top-20 articles for 2023...")
+    top_2023 = exp7_fetch_top_articles(conn, 2023, top_n=20)
+    print(f"  Got {len(top_2023)} articles for 2023")
+
+    if top_2021 and top_2023:
+        exp7_plot_top_articles_shift(top_2021, top_2023)
+
+    # Print comparison
+    if top_2021:
+        print("\n  Top-10 cited articles in 2021:")
+        for law, art, cnt in top_2021[:10]:
+            print(f"    {_abbreviate_law(law)} ст.{art}: {cnt:,}")
+    if top_2023:
+        print("\n  Top-10 cited articles in 2023:")
+        for law, art, cnt in top_2023[:10]:
+            print(f"    {_abbreviate_law(law)} ст.{art}: {cnt:,}")
+
+    # 7d: New post-war legislation
+    new_legislation = exp7_fetch_new_post_war_legislation(conn, min_citations=50)
+    if new_legislation:
+        print(f"\n  New legislation appearing after 2022 (0 pre-war citations, >=50 post-war):")
+        for law, art, cnt in new_legislation[:15]:
+            print(f"    {_abbreviate_law(law)} ст.{art}: {cnt:,} citations")
+
+    # Build stats
+    stats = {
+        "decisions_per_year": {str(k): v for k, v in sorted(decisions_per_year.items())},
+        "drop_2022": None,
+        "citation_entropy": {str(k): round(v, 6) for k, v in sorted(entropies.items())},
+        "top_articles_2021": [
+            {"law": law, "article": art, "count": cnt}
+            for law, art, cnt in top_2021
+        ],
+        "top_articles_2023": [
+            {"law": law, "article": art, "count": cnt}
+            for law, art, cnt in top_2023
+        ],
+        "new_post_war_legislation": [
+            {"law": law, "article": art, "post_war_count": cnt}
+            for law, art, cnt in new_legislation
+        ],
+    }
+
+    if 2021 in decisions_per_year and 2022 in decisions_per_year:
+        stats["drop_2022"] = {
+            "decisions_2021": decisions_per_year[2021],
+            "decisions_2022": decisions_per_year[2022],
+            "drop_pct": round(
+                (decisions_per_year[2021] - decisions_per_year[2022])
+                / decisions_per_year[2021],
+                4,
+            ),
+        }
+        if 2023 in decisions_per_year:
+            stats["drop_2022"]["decisions_2023"] = decisions_per_year[2023]
+            stats["drop_2022"]["recovery_pct"] = round(
+                (decisions_per_year[2023] - decisions_per_year[2022])
+                / decisions_per_year[2022],
+                4,
+            )
+
+    return stats
+
+
+# ── Main ────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Temporal dynamics analysis of Ukrainian court citation data"
+    )
+    parser.add_argument(
+        "--year-from", type=int, default=2007,
+        help="Start year (default: 2007)",
+    )
+    parser.add_argument(
+        "--year-to", type=int, default=2026,
+        help="End year (default: 2026)",
+    )
+    parser.add_argument(
+        "--experiment", type=int, choices=[3, 7],
+        help="Run only this experiment (default: run both)",
+    )
+    args = parser.parse_args()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"=== Temporal Dynamics Analysis ===")
+    print(f"Years: {args.year_from}--{args.year_to}")
+    print(f"DB: {DB_DSN.split('@')[1] if '@' in DB_DSN else DB_DSN}")
+    print(f"Output: {OUTPUT_DIR}")
+
+    t_total = time.time()
+    conn = get_conn()
+
+    all_stats = {}
+
+    try:
+        if args.experiment is None or args.experiment == 3:
+            all_stats["experiment_3"] = run_experiment_3(conn, args.year_from, args.year_to)
+
+        if args.experiment is None or args.experiment == 7:
+            all_stats["experiment_7"] = run_experiment_7(conn, args.year_from, args.year_to)
+    finally:
+        conn.close()
+
+    elapsed = time.time() - t_total
+
+    # Save stats to JSON
+    all_stats["meta"] = {
+        "year_from": args.year_from,
+        "year_to": args.year_to,
+        "elapsed_sec": round(elapsed, 2),
+        "experiments_run": [3, 7] if args.experiment is None else [args.experiment],
+    }
+
+    stats_path = OUTPUT_DIR / "temporal-dynamics-stats.json"
+    with open(stats_path, "w", encoding="utf-8") as f:
+        json.dump(all_stats, f, indent=2, ensure_ascii=False)
+    print(f"\nStats saved to {stats_path}")
+
+    print(f"\n=== Done in {elapsed:.1f}s ===")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **analyze-degree-centrality.py**: Exp 1 (power-law fit, compare with Fowler/Kumar) + Exp 2 (PageRank, HITS, Spearman correlations)
- **analyze-temporal-dynamics.py**: Exp 3 (codex citation trends, regime transition detection) + Exp 7 (2022 war impact: decision drop, entropy shift, new legislation)
- **analyze-communities.py**: Exp 4 (cross-domain bridge articles via justice_kind) + Exp 5 (temporal Louvain clustering, NMI between periods)

All scripts use SQL-side aggregation to handle 100M+ rows without loading into memory.
Extraction running on prod (~252K citations so far).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three analysis scripts to analyze the citation graph: centrality, temporal dynamics, and communities (experiments 1–5, 7). They run on prod via `DATABASE_URL`, use SQL-side aggregation for large tables, and save plots/JSON to scripts/citation-graph/output.

- **New Features**
  - `analyze-degree-centrality.py`: Exp 1 power-law fit of article degree; Exp 2 PageRank/HITS on the co-citation graph with Spearman correlations. Supports `--sample-size`.
  - `analyze-temporal-dynamics.py`: Exp 3 codex trends and regime shifts; Exp 7 2022 war impact (decision drop, entropy, top articles, new legislation). Supports `--year-from/--year-to` and `--experiment`.
  - `analyze-communities.py`: Exp 4 bridge articles across justice domains; Exp 5 temporal Louvain communities with NMI across periods. Supports `--min-citations`, `--exp`, `--all`.
  - All scripts query `law_court_citations` joined with `edrsr_fulltext` using SQL aggregation; co-citation self-joins can take minutes per period.

- **Dependencies**
  - Python packages: `psycopg2-binary`, `networkx`, `powerlaw`, `matplotlib`, `scipy`, `scikit-learn`, `python-louvain`.

<sup>Written for commit 380337d8fbc4e820b933cc83aa357085bd552d06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

