### PR TITLE
fix: ACADEMIC category in prerender + bedrock-runtime CI fix

### DIFF
--- a/lexwebapp/vite.config.ts
+++ b/lexwebapp/vite.config.ts
@@ -603,7 +603,7 @@ function prerenderBlogPlugin(): Plugin {
 
             const semanticArticle = `<article id="blog-article-seo" style="max-width:820px;margin:40px auto;font-family:system-ui,sans-serif;padding:0 24px">
       <header>
-        <span>${article.category === 'tech' ? 'TECH' : 'LEGAL'}</span>
+        <span>${article.category === 'tech' ? 'TECH' : article.category === 'academic' ? 'ACADEMIC' : 'LEGAL'}</span>
         <time datetime="${article.publishedAt}">${article.publishedAt}</time>
         <span>${readTime}</span>
       </header>

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -62,6 +62,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@aws-sdk/client-bedrock": "^3.1014.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1014.0",
     "@aws-sdk/client-s3": "^3.1005.0",
     "@aws-sdk/client-sqs": "^3.1005.0",
     "@google-cloud/vision": "^5.3.4",


### PR DESCRIPTION
## Summary
- **vite.config.ts**: article prerender shows "ACADEMIC" instead of "LEGAL" for `paper-*` articles (line 606 — blog list page already handled this on line 472)
- **mcp_backend/package.json**: add `@aws-sdk/client-bedrock-runtime` as direct dep — import exists in `embedding-service.ts` but only listed in `packages/shared`, causing TS2307 on local CI and `@smithy/types` version mismatch on prod deploy

## Test plan
- [ ] CI passes (backend TS build no longer fails on bedrock-runtime)
- [ ] Frontend build produces correct "ACADEMIC" label in prerendered paper pages
- [ ] Prod deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prerendered blog articles now display ACADEMIC for academic papers instead of LEGAL. Added `@aws-sdk/client-bedrock-runtime` to the backend to fix CI build errors and deployment type mismatches.

- **Bug Fixes**
  - Academic article pages now render the ACADEMIC label; previously showed LEGAL (list page already correct).

- **Dependencies**
  - Added `@aws-sdk/client-bedrock-runtime` to `mcp_backend` to resolve TS2307 and `@smithy/types` version mismatch in CI/prod.

<sup>Written for commit 706dd784c280a2ef10265f6e98c50836ec8d6d84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

