### PR TITLE
fix(paper): correct LexTreme citation authors

### DIFF
--- a/docs/arxiv-tokenizer-fertility/main.tex
+++ b/docs/arxiv-tokenizer-fertility/main.tex
@@ -815,7 +815,7 @@ Chalkidis, I., Fergadiotis, M., Malakasiotis, P., Aletras, N., and Androutsopoul
 \newblock \url{https://aclanthology.org/2020.findings-emnlp.261/}
 
 \bibitem[Niklaus et~al.(2023)]{niklaus2023lextreme}
-Niklaus, J., Matoshi, V., Sturmer, M., Chalkidis, I., and Jositsch, D.
+Niklaus, J., Matoshi, V., Rani, P., Galassi, A., St{\"u}rmer, M., and Chalkidis, I.
 \newblock {LEXTREME}: A Multi-Lingual and Multi-Task Benchmark for the Legal Domain.
 \newblock \emph{Findings of EMNLP 2023}, pages 12898--12916, 2023.
 \newblock \url{https://aclanthology.org/2023.findings-emnlp.865/}

--- a/docs/arxiv-tokenizer-fertility/references.bib
+++ b/docs/arxiv-tokenizer-fertility/references.bib
@@ -99,7 +99,7 @@
 
 @article{niklaus2023lextreme,
   title={{LEXTREME}: A Multi-Lingual and Multi-Task Benchmark for the Legal Domain},
-  author={Niklaus, Joel and Matoshi, Veton and Sturmer, Matthias and Chalkidis, Ilias and Jositsch, Daniel},
+  author={Niklaus, Joel and Matoshi, Veton and Rani, Pooja and Galassi, Andrea and St{\"u}rmer, Matthias and Chalkidis, Ilias},
   journal={Findings of the Association for Computational Linguistics: EMNLP 2023},
   pages={12898--12916},
   year={2023}


### PR DESCRIPTION
## Summary
- Fix Niklaus et al. (2023) citation: add Rani, Galassi; remove Jositsch; fix Stürmer umlaut

## Test plan
- [x] Verified correct authors against https://aclanthology.org/2023.findings-emnlp.865/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the LEXTREME (Niklaus et al., 2023) citation to match the ACL Anthology: add Pooja Rani and Andrea Galassi, remove Daniel Jositsch, and correct the umlaut in Matthias Stürmer. Updates `docs/arxiv-tokenizer-fertility/main.tex` and `docs/arxiv-tokenizer-fertility/references.bib` to ensure accurate authorship and proper rendering.

<sup>Written for commit b1f004390bb776adb462fd5a997cec0fcdfb4ddf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

