### PR TITLE
feat(lextreme): full local extraction script (150K samples)

### DIFF
--- a/scripts/lextreme/DATASET_CARD.md
+++ b/scripts/lextreme/DATASET_CARD.md
@@ -8,7 +8,7 @@ task_ids:
 - multi-class-classification
 pretty_name: Ukrainian Court Decisions (Judgment Prediction)
 size_categories:
-- 10K<n<100K
+- 100K<n<1M
 tags:
 - legal
 - court-decisions
@@ -31,16 +31,16 @@ dataset_info:
     dtype: string
   splits:
   - name: train
-    num_bytes: 93721699
-    num_examples: 8214
+    num_bytes: 1298904607
+    num_examples: 120000
   - name: validation
-    num_bytes: 11990934
-    num_examples: 1027
+    num_bytes: 162035703
+    num_examples: 15000
   - name: test
-    num_bytes: 11569921
-    num_examples: 1027
-  download_size: 45561448
-  dataset_size: 117282554
+    num_bytes: 162965763
+    num_examples: 15000
+  download_size: 660000000
+  dataset_size: 1623906073
 ---
 
 # Ukrainian Court Decisions — Judgment Prediction
@@ -82,10 +82,12 @@ We extract text between the ВСТАНОВИВ marker and the ВИРІШИВ mar
 
 ## Data Quality
 
+- 150,000 samples total (120K train / 15K validation / 15K test)
+- Perfectly balanced: 50,000 per class (approved / dismissed / partial)
 - Minimum 200 characters in facts section
 - Maximum 10,000 characters (truncated for very long decisions)
 - Full text length between 500 and 200,000 characters
-- Class-balanced sampling
+- Sampled from 596,538 valid extractions out of 802,189 court decisions
 - Random 80/10/10 train/validation/test split
 
 ## Usage

--- a/scripts/lextreme/extract-full-local.py
+++ b/scripts/lextreme/extract-full-local.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""
+Full extraction of Ukrainian court decisions from local DB for LexTreme.
+
+Connects directly via psycopg2 to local PostgreSQL.
+Processes ALL available decisions (not just a sample).
+
+Usage:
+    python3 scripts/lextreme/extract-full-local.py
+    python3 scripts/lextreme/extract-full-local.py --target-per-class 10000
+"""
+
+import argparse
+import json
+import random
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+
+DB_CONFIG = {
+    "host": "localhost",
+    "port": 5432,
+    "dbname": "secondlayer_local",
+    "user": "secondlayer",
+    "password": "local_dev_password",
+}
+
+BATCH_SIZE = 10000
+SEED = 42
+
+FACTS_RE = re.compile(
+    r'[ВУ]\s*[СС]\s*Т\s*А\s*Н\s*О\s*В\s*И\s*В\s*:',
+    re.IGNORECASE
+)
+DISP_RE = re.compile(
+    r'(?:В\s*И\s*Р\s*І\s*Ш\s*И\s*В|У\s*Х\s*В\s*А\s*Л\s*И\s*В|П\s*О\s*С\s*Т\s*А\s*Н\s*О\s*В\s*И\s*В)\s*:',
+    re.IGNORECASE
+)
+
+
+def normalize_text(text):
+    return re.sub(r'\s+', ' ', text)
+
+
+def extract_facts(text):
+    text_norm = normalize_text(text)
+    m = FACTS_RE.search(text_norm)
+    if not m:
+        return None
+    facts_start = m.end()
+
+    dm = DISP_RE.search(text_norm, facts_start)
+    if not dm:
+        return None
+
+    facts = text_norm[facts_start:dm.start()].strip()
+    if len(facts) < 200:
+        return None
+    if len(facts) > 10000:
+        facts = facts[:10000]
+    return facts
+
+
+def extract_outcome(text):
+    text_norm = normalize_text(text)
+    matches = list(DISP_RE.finditer(text_norm))
+    if not matches:
+        section = text_norm[int(len(text_norm) * 0.8):]
+    else:
+        section = text_norm[matches[-1].start():]
+
+    s = section.lower()
+    if "частков" in s:
+        return "partial"
+    if "задовольн" in s:
+        return "approved"
+    if "відмов" in s:
+        return "dismissed"
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target-per-class", type=int, default=None,
+                        help="Target per class (default: use all)")
+    parser.add_argument("--seed", type=int, default=SEED)
+    args = parser.parse_args()
+
+    random.seed(args.seed)
+
+    conn = psycopg2.connect(**DB_CONFIG)
+    conn.set_session(readonly=True)
+
+    print("🇺🇦 Full extraction from local DB")
+
+    # Count available
+    with conn.cursor() as cur:
+        for jk, name in [(1, "Цивільне"), (3, "Господарське")]:
+            cur.execute("""
+                SELECT COUNT(*) FROM edrsr_documents d
+                JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+                    AND f.adj_year IN (2013, 2014)
+                WHERE d.judgment_code = 3 AND d.justice_kind = %s
+                  AND d.adjudication_date >= '2013-01-01'
+                  AND d.adjudication_date < '2015-01-01'
+                  AND f.text_length BETWEEN 500 AND 200000
+            """, (jk,))
+            count = cur.fetchone()[0]
+            print(f"  {name}: {count:,}")
+
+    all_results = []
+
+    for jk, jk_name in [(1, "civil"), (3, "commercial")]:
+        print(f"\n📋 {jk_name.upper()} (justice_kind={jk}):")
+
+        with conn.cursor(name=f"lextreme_{jk_name}", cursor_factory=psycopg2.extras.DictCursor) as cur:
+            cur.itersize = BATCH_SIZE
+            cur.execute("""
+                SELECT d.doc_id, f.full_text
+                FROM edrsr_documents d
+                JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+                    AND f.adj_year IN (2013, 2014)
+                WHERE d.judgment_code = 3
+                  AND d.justice_kind = %s
+                  AND d.adjudication_date >= '2013-01-01'
+                  AND d.adjudication_date < '2015-01-01'
+                  AND f.text_length BETWEEN 500 AND 200000
+            """, (jk,))
+
+            processed = 0
+            valid = 0
+            skipped = Counter()
+
+            for row in cur:
+                processed += 1
+                text = row["full_text"]
+
+                facts = extract_facts(text)
+                if not facts:
+                    skipped["no_facts"] += 1
+                    continue
+
+                outcome = extract_outcome(text)
+                if not outcome:
+                    skipped["no_outcome"] += 1
+                    continue
+
+                valid += 1
+                all_results.append({
+                    "text": facts,
+                    "label": outcome,
+                    "language": "uk",
+                    "justice_kind": jk_name,
+                    "doc_id": str(row["doc_id"]),
+                })
+
+                if processed % 50000 == 0:
+                    dist = Counter(r["label"] for r in all_results if r["justice_kind"] == jk_name)
+                    print(f"  ... {processed:,} processed, {valid:,} valid  {dict(dist)}")
+
+        dist = Counter(r["label"] for r in all_results if r["justice_kind"] == jk_name)
+        print(f"  Done: {processed:,} processed, {valid:,} valid")
+        print(f"  Skipped: {dict(skipped)}")
+        print(f"  Distribution: {dict(dist)}")
+
+    conn.close()
+
+    print(f"\n📊 Combined: {len(all_results):,} samples")
+    combined_dist = Counter(r["label"] for r in all_results)
+    print(f"  {dict(combined_dist)}")
+
+    # Balance if requested
+    if args.target_per_class:
+        by_label = {}
+        for item in all_results:
+            by_label.setdefault(item["label"], []).append(item)
+
+        balanced = []
+        for label in sorted(by_label.keys()):
+            items = by_label[label]
+            random.shuffle(items)
+            n = min(len(items), args.target_per_class)
+            balanced.extend(items[:n])
+            print(f"  {label}: {n:,} of {len(items):,} sampled")
+
+        random.shuffle(balanced)
+        data = balanced
+    else:
+        random.shuffle(all_results)
+        data = all_results
+
+    total = len(data)
+    print(f"\n⚖️  Final: {total:,} samples")
+    final_dist = Counter(d["label"] for d in data)
+    print(f"  {dict(final_dist)}")
+
+    # Split 80/10/10
+    train_end = int(total * 0.8)
+    val_end = int(total * 0.9)
+    splits = {
+        "train": data[:train_end],
+        "validation": data[train_end:val_end],
+        "test": data[val_end:],
+    }
+
+    # Save
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    for split_name, items in splits.items():
+        path = OUTPUT_DIR / f"lextreme-ukr-{split_name}.jsonl"
+        with open(path, "w", encoding="utf-8") as f:
+            for item in items:
+                row = {"text": item["text"], "label": item["label"], "language": item["language"]}
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        dist = Counter(i["label"] for i in items)
+        print(f"  {split_name}: {len(items):,} → {path}  {dict(dist)}")
+
+    print(f"\n✅ Done!")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `extract-full-local.py` — connects directly to local PostgreSQL via psycopg2, processes all 802K decisions
- Update dataset card to reflect 150K balanced samples (50K per class)

## Test plan
- [x] Extracted 596,538 valid samples from 802K decisions
- [x] Balanced to 150K (50K approved / 50K dismissed / 50K partial)
- [x] Uploaded and verified on HuggingFace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full local extractor that reads all eligible court decisions from a local PostgreSQL via `psycopg2` and writes train/val/test JSONL. Updates the dataset card to reflect a balanced 150K dataset and new split sizes.

- **New Features**
  - New `scripts/lextreme/extract-full-local.py`: streams 2013–2014 civil/commercial judgments, extracts facts/outcome, enforces length limits, and writes JSONL splits (80/10/10) to `scripts/lextreme/output/`.
  - CLI: `--target-per-class` for balanced sampling and `--seed` for reproducibility.
  - Updated `DATASET_CARD.md`: new size category, split counts/bytes, and data quality notes.

<sup>Written for commit d8c997030c1ab0cab519c47abcdf542248b13fa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

