### PR TITLE
fix(ci): make docker image prune non-fatal

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -421,7 +421,7 @@ jobs:
           [ -n "$START" ] && $DC up -d $START
 
           $DC restart nginx-local
-          docker image prune -f
+          docker image prune -f || true
 
       - name: Wait for local services to become healthy
         run: |


### PR DESCRIPTION
## Summary
- Add `|| true` to `docker image prune -f` so concurrent prune operations don't fail the deploy step

## Context
CI run #25847901565 failed because another prune was already running — all containers were healthy but the pipeline reported failure, blocking prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Docker image pruning in CI non-fatal to prevent deploy failures when another prune is running. Adds `|| true` to `docker image prune -f` in the local deploy workflow so concurrent prunes don't block healthy deployments.

<sup>Written for commit 9d28415f585163ce908872bb75a79ea1347a254e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

