### PR TITLE
fix(blog): strip LaTeX artifacts at render time

### DIFF
--- a/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
+++ b/lexwebapp/src/pages/BlogPage/ArticleModal.tsx
@@ -13,6 +13,7 @@ import {
 import type { Article } from './articles';
 import { CommentSection } from './CommentSection';
 import { useLocaleStore } from '../../stores/localeStore';
+import { cleanLatex } from './clean-latex';
 import { getBlogUI } from './blog-i18n';
 import AttractorBanner from '../../components/AttractorBanner';
 
@@ -157,7 +158,7 @@ export function ArticleModal({ article, onClose }: ArticleModalProps) {
             prose-hr:border-claude-border
           ">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {article.content}
+              {cleanLatex(article.content)}
             </ReactMarkdown>
           </div>
 

--- a/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
+++ b/lexwebapp/src/pages/BlogPage/BlogArticlePage.tsx
@@ -22,6 +22,7 @@ import { CommentSection } from './CommentSection';
 import { PaperReader } from './PaperReader';
 import { useLocaleStore } from '../../stores/localeStore';
 import { getBlogUI, getLocalizedArticles } from './blog-i18n';
+import { cleanLatex } from './clean-latex';
 
 const translationMaps = { en: enTranslations, ru: ruTranslations };
 
@@ -433,7 +434,7 @@ export function BlogArticlePage() {
             [&>p:first-of-type::first-letter]:text-5xl [&>p:first-of-type::first-letter]:font-serif [&>p:first-of-type::first-letter]:font-bold [&>p:first-of-type::first-letter]:text-gray-900 [&>p:first-of-type::first-letter]:float-left [&>p:first-of-type::first-letter]:mr-2 [&>p:first-of-type::first-letter]:mt-1 [&>p:first-of-type::first-letter]:leading-none
           ">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>
-              {article.content}
+              {cleanLatex(article.content)}
             </ReactMarkdown>
           </div>
         </div>

--- a/lexwebapp/src/pages/BlogPage/clean-latex.ts
+++ b/lexwebapp/src/pages/BlogPage/clean-latex.ts
@@ -1,0 +1,50 @@
+const re = (literal: string) => new RegExp(literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+
+export function cleanLatex(raw: string): string {
+  let s = raw;
+  s = s.replace(/^% .*\n/gm, '');
+  s = s.replace(/^\[(?:nosep|leftmargin[^\]]*|label[^\]]*)\]\n/gm, '');
+  s = s.replace(re('"='), '-');
+  s = s.replace(/\s*\((?:[a-z]+\d{4}[a-z]*(?:,\s*[a-z]+\d{4}[a-z]*)*)\)/g, '');
+  s = s.replace(
+    /(?<![a-zA-Z])([a-z]+)(20[12]\d)([a-z]*)\b/g,
+    (match, author: string) => {
+      const common =
+        /^(push|pull|text|code|time|long|last|cross|task|self|zero|full|half|best|meta|auto|para|post|over|left|item|mono|main|type|mini|data|deep|comp|base|test|next|prev|open|send|real|like|info|cost|core|drop|flat|true|dual|down|case|fine|from|mark|back|well|used|less|also|into|just|then|much|each|more|some|here|when|with|what|only|will|been|have|does|made|most|them|than|this|that|line|file|such|very|good|make|work|first|total|upper|lower|model|input|state|point|right|block|multi|large|batch|index|level|class|store|query|token|about|after|being|every|still|above|while|their|where|these|other|shall|should|could|would|which)$/i;
+      if (common.test(author)) return match;
+      return '';
+    },
+  );
+  s = s.replace(re('{\\sim}'), '~');
+  s = s.replace(re('\\longrightarrow'), '→');
+  s = s.replace(re('\\leq'), '≤');
+  s = s.replace(re('\\geq'), '≥');
+  s = s.replace(re('\\ll'), '≪');
+  s = s.replace(re('\\to'), '→');
+  s = s.replace(re('\\alpha'), 'α');
+  s = s.replace(re('\\cdot'), '·');
+  s = s.replace(re('\\sigma'), 'σ');
+  s = s.replace(re('\\times'), '×');
+  s = s.replace(re('\\approx'), '≈');
+  s = s.replace(/\\mathrm\{([^}]+)\}/g, '$1');
+  s = s.replace(/\\text\{([^}]+)\}/g, '$1');
+  s = s.replace(re('\\bigl('), '(');
+  s = s.replace(re('\\bigr)'), ')');
+  s = s.replace(/f_\{\\text\{([^}]+)\}\}/g, 'f_$1');
+  s = s.replace(re('<<'), '«');
+  s = s.replace(re('>>'), '»');
+  s = s.replace(re('{,}'), ',');
+  s = s.replace(re('{=}'), '=');
+  s = s.replace(/N\{=\*\*(\d+)/g, 'N=$1');
+  s = s.replace(re('R^2'), 'R²');
+  s = s.replace(/\\\[[\s\S]*?\\\]/g, (m) => {
+    const inner = m.slice(2, -2).trim().replace(/\s+/g, ' ');
+    return `\n\n*${inner}*\n\n`;
+  });
+  s = s.replace(/\\foreignlanguage\{[^}]+\}\{([^}]+)\}/g, '$1');
+  s = s.replace(/^ - \[([^\]]+)\.?\]/gm, ' - **$1.**');
+  s = s.replace(/ сесії\)\.\}/g, ' сесій).**');
+  s = s.replace(/ сесій\)\.\}/g, ' сесій).**');
+  s = s.replace(/\n{4,}/g, '\n\n\n');
+  return s;
+}


### PR DESCRIPTION
## Summary
- Add `cleanLatex()` preprocessor that strips raw LaTeX markup before ReactMarkdown rendering
- Handles: `%` comments, `[nosep]` directives, citation keys, `"=` hyphens, math symbols, `\\mathrm{}`, `\\text{}`, `<<>>` guillemets, and more
- Applied in both `BlogArticlePage` and `ArticleModal` — fixes all 5 academic paper articles at once without touching content files

## Test plan
- [ ] Open any paper article (e.g. /blog/paper-edit-trace-oversight) and verify no raw LaTeX visible
- [ ] Verify non-paper articles render unchanged
- [ ] Check ArticleModal rendering as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip raw LaTeX artifacts from blog articles at render time so readers see clean text. Adds a `cleanLatex()` preprocessor used in `BlogArticlePage` and `ArticleModal` before `ReactMarkdown`, fixing paper posts without touching content files.

- **Bug Fixes**
  - Removes `%` comments, `[nosep]` list directives, citation keys (e.g., Smith2021), and stray LaTeX (`\alpha`, `\leq`, `\mathrm{}`, `<< >>`, `"=`).
  - Converts common math to symbols (→, ≤, ≥, ×, ≈, R²) and flattens `\text{}`/`\mathrm{}` blocks.
  - No changes to non-paper posts.

<sup>Written for commit a43ac72af1beaa9b6768e2cd2dbc713f88832259. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

