### PR TITLE
fix(blog): replace em dashes with en dashes in renderer

### DIFF
--- a/lexwebapp/src/pages/BlogPage/clean-latex.ts
+++ b/lexwebapp/src/pages/BlogPage/clean-latex.ts
@@ -46,5 +46,8 @@ export function cleanLatex(raw: string): string {
   s = s.replace(/ сесії\)\.\}/g, ' сесій).**');
   s = s.replace(/ сесій\)\.\}/g, ' сесій).**');
   s = s.replace(/\n{4,}/g, '\n\n\n');
+  // Em dashes → space-surrounded en dash
+  s = s.replace(/—/g, ' – ');
+  s = s.replace(/  +/g, ' ');
   return s;
 }


### PR DESCRIPTION
## Summary
- Add em dash (—) → en dash (–) replacement in `cleanLatex()` renderer
- Prevents double spaces after replacement

## Test plan
- [ ] Open any article with em dashes and verify they render as en dashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced em dashes (—) with space‑surrounded en dashes (–) in `cleanLatex()` to match our style and improve readability. Also normalized multiple spaces to a single space to prevent double-spacing after replacements.

<sup>Written for commit 27229881cf570a3d3baef1c9791a963f616686e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

