### PR TITLE
fix(ci): prevent SIGPIPE exit 141 in detect-changes

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -62,7 +62,7 @@ runs:
         LAST_SHA=""
 
         # Primary: use the requested baseline tag prefix
-        LAST_TAG=$(git tag -l "${BASELINE}-*" --sort=-creatordate | head -1)
+        LAST_TAG=$(git tag -l "${BASELINE}-*" --sort=-creatordate | head -1 || true)
         if [ -n "$LAST_TAG" ]; then
           LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
           echo "Using ${BASELINE} marker tag: $LAST_TAG ($LAST_SHA)"
@@ -75,7 +75,7 @@ runs:
           else
             FALLBACK="ci-local"
           fi
-          LAST_TAG=$(git tag -l "${FALLBACK}-*" --sort=-creatordate | head -1)
+          LAST_TAG=$(git tag -l "${FALLBACK}-*" --sort=-creatordate | head -1 || true)
           if [ -n "$LAST_TAG" ]; then
             LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
             echo "Using ${FALLBACK} marker tag as fallback: $LAST_TAG ($LAST_SHA)"
@@ -84,7 +84,7 @@ runs:
 
         # Fallback: release tags
         if [ -z "$LAST_SHA" ]; then
-          LAST_TAG=$(git tag -l --sort=-creatordate "v*" "fe-v*" | head -1)
+          LAST_TAG=$(git tag -l --sort=-creatordate "v*" "fe-v*" | head -1 || true)
           if [ -n "$LAST_TAG" ]; then
             LAST_SHA=$(git rev-parse "$LAST_TAG" 2>/dev/null || echo "")
             echo "Using release tag as fallback: $LAST_TAG ($LAST_SHA)"


### PR DESCRIPTION
## Summary

- `git tag -l ... | head -1` fails with exit 141 (SIGPIPE) under `set -o pipefail`
- Added `|| true` to 3 occurrences in detect-changes action
- Both recent prod deploy failures were caused by this

## Test plan

- [x] Prod deploy should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CI exit 141 (SIGPIPE) in the `detect-changes` action by absorbing pipe errors from `git tag -l ... | head -1` when `set -o pipefail` is enabled. Adds `|| true` to the three tag-lookup pipelines so deploys stop failing.

<sup>Written for commit 66dcb04dc26d4e3c14a590af80067d48165f20f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

