### PR TITLE
fix(deploy): add SNEAKYPIPER env vars to compose

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -293,6 +293,8 @@ services:
       RADA_API_KEY: ${RADA_API_KEY:-test-key-123}
       OPENREYESTR_MCP_URL: ${OPENREYESTR_MCP_URL:-http://openreyestr-app-local:3004}
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-test-key-123}
+      SNEAKYPIPER_API_URL: ${SNEAKYPIPER_API_URL:-}
+      SNEAKYPIPER_API_KEY: ${SNEAKYPIPER_API_KEY:-}
       STAGE_BACKEND_URL: ${STAGE_BACKEND_URL:-https://stage.legal.org.ua}
       STAGE_API_KEY: ${STAGE_API_KEY:-}
 

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -582,6 +582,10 @@ services:
       OPENREYESTR_MCP_URL: http://app-openreyestr-prod:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-}
 
+      # SneakyPiper OSINT Proxy
+      SNEAKYPIPER_API_URL: ${SNEAKYPIPER_API_URL:-}
+      SNEAKYPIPER_API_KEY: ${SNEAKYPIPER_API_KEY:-}
+
       # Stage access for db-compare
       STAGE_BACKEND_URL: ${STAGE_BACKEND_URL:-https://stage.legal.org.ua}
       STAGE_API_KEY: ${STAGE_API_KEY:-}
@@ -972,6 +976,8 @@ services:
       RADA_API_KEY: ${RADA_API_KEY:-}
       OPENREYESTR_MCP_URL: http://app-openreyestr-prod-green:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-}
+      SNEAKYPIPER_API_URL: ${SNEAKYPIPER_API_URL:-}
+      SNEAKYPIPER_API_KEY: ${SNEAKYPIPER_API_KEY:-}
       STAGE_BACKEND_URL: ${STAGE_BACKEND_URL:-https://stage.legal.org.ua}
       STAGE_API_KEY: ${STAGE_API_KEY:-}
       WEBAUTHN_RP_ID: ${WEBAUTHN_RP_ID:-legal.org.ua}


### PR DESCRIPTION
## Summary
- Add `SNEAKYPIPER_API_URL` and `SNEAKYPIPER_API_KEY` to docker compose environment blocks
- Without these, env vars from .env.prod weren't injected into the container

## Test plan
- [x] Verified on prod -- container has env vars, `osint_search_sanctions` returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `SNEAKYPIPER_API_URL` and `SNEAKYPIPER_API_KEY` to Docker Compose so the OSINT proxy config is passed into containers. Fixes missing `.env.prod` values not being injected.

- **Bug Fixes**
  - Added both vars to `deployment/docker-compose.local.yml` and `deployment/docker-compose.prod.yml` env blocks.

- **Migration**
  - Set `SNEAKYPIPER_API_URL` and `SNEAKYPIPER_API_KEY` in your `.env.prod` or deployment secrets, then redeploy.

<sup>Written for commit 51f7b54f1a7d1a2146ad71714c9dc8962b3735e7. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1699?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

