### PR TITLE
feat(chat): add OSINT category to template questions

### DIFF
--- a/lexwebapp/src/components/EmptyState.tsx
+++ b/lexwebapp/src/components/EmptyState.tsx
@@ -55,6 +55,20 @@ const PROMPT_POOL: SamplePrompt[] = [
   { category: 'Глибокий аналіз', text: 'Набувальна давність (ст. 344 ЦК): земельне та містобудівне законодавство, практика ВС, КС та аналіз патернів' },
   { category: 'Глибокий аналіз', text: 'Компанія «Газпром»: санкції РНБО, пов\'язані юрособи в Україні, судові справи, виконавчі провадження та закупівлі' },
   { category: 'Глибокий аналіз', text: 'Відповідальність директора ТОВ: ст. 89 ГК, ст. 1166 ЦК, практика ВС, банкрутні справи та дані з реєстрів' },
+
+  // ── OSINT (міжнародні бази, кіберрозвідка) ──
+  { category: 'OSINT', text: 'Перевірка санкцій OFAC/EU/UN для Huawei Technologies' },
+  { category: 'OSINT', text: 'Перевір IP 185.220.101.1 на шкідливу активність' },
+  { category: 'OSINT', text: 'Витоки облікових даних для домену @jpmorgan.com' },
+  { category: 'OSINT', text: 'Червоні повідомлення ІНТЕРПОЛУ за шахрайство' },
+  { category: 'OSINT', text: 'Репутація домену suspicious-site.com через VirusTotal' },
+  { category: 'OSINT', text: 'Жертви ransomware у фінансовому секторі' },
+  { category: 'OSINT', text: 'Дебармент Світового банку для консалтингових фірм' },
+  { category: 'OSINT', text: 'Офшорні зв\'язки через ICIJ для shell-компаній' },
+  { category: 'OSINT', text: 'Згадки у медіа та тональність для компанії Wirecard' },
+  { category: 'OSINT', text: 'CVE вразливості Cisco критичного рівня' },
+  { category: 'OSINT', text: 'Витоки API-ключів у GitHub для acme-corp.com' },
+  { category: 'OSINT', text: 'Публікації на darknet-форумах про витоки даних' },
 ];
 
 /**
@@ -64,8 +78,8 @@ const PROMPT_POOL: SamplePrompt[] = [
 const DISPLAY_SLOTS: string[] = [
   'Швидкий пошук',
   'Дослідження',
+  'OSINT',
   'Глибокий аналіз',
-  'Дослідження',
 ];
 
 function pickPrompts(): SamplePrompt[] {


### PR DESCRIPTION
## Summary
- Add 12 OSINT sample prompts to chat empty state (sanctions, INTERPOL, CVE, IP/domain reputation, credential leaks, ransomware, corporate registries, media, GitHub leaks, darknet forums)
- Replace one "Дослідження" display slot with "OSINT" category

## Test plan
- [x] All 12 OSINT tools tested via API -- 11/12 return data, 1 timeout (GDELT media, known slow)
- [ ] Verify OSINT template card appears in chat UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an OSINT category to the chat empty state and seed it with 12 sample prompts (sanctions, INTERPOL, CVEs, IP/domain reputation, credential leaks, ransomware, debarments, ICIJ links, media sentiment, GitHub leaks, darknet). Replace the duplicate "Дослідження" display slot with "OSINT" so the new category appears in the UI.

<sup>Written for commit 60851610bb2c51164d227aee86ea4ffc8d01ae95. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1700?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

