### PR TITLE
feat(chat): add osint_investigation queryType for OSINT routing

### DIFF
--- a/mcp_backend/src/prompts/chat-system-prompt.ts
+++ b/mcp_backend/src/prompts/chat-system-prompt.ts
@@ -14,6 +14,7 @@ export type QueryType =
   | 'comparative_analysis'
   | 'due_diligence'
   | 'institutional_analysis'
+  | 'osint_investigation'
   | 'unsupported';
 
 export const VALID_QUERY_TYPES: Set<QueryType> = new Set([
@@ -29,6 +30,7 @@ export const VALID_QUERY_TYPES: Set<QueryType> = new Set([
   'comparative_analysis',
   'due_diligence',
   'institutional_analysis',
+  'osint_investigation',
   'unsupported',
 ]);
 

--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -22,5 +22,6 @@ export const QUERY_TYPE_CONFIG: Record<string, QueryTypeConfigEntry> = {
   comparative_analysis: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Порівнюю', preferredScenarios: ['comparison'] },
   due_diligence: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Виконую due diligence', preferredScenarios: ['due_diligence'] },
   institutional_analysis: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Аналізую інституцію', preferredScenarios: ['practice_search'] },
+  osint_investigation: { defaultBudget: 'standard', requiresGrounding: true, description: '', maxToolCalls: 5, thinkingPrefix: 'Перевіряю через OSINT-джерела', preferredScenarios: ['osint_entity_screening', 'osint_cyber_check', 'osint_darknet_intel'] },
   unsupported: { defaultBudget: 'quick', requiresGrounding: false, description: '', maxToolCalls: 0, thinkingPrefix: '', preferredScenarios: [] },
 };


### PR DESCRIPTION
## Summary
- Add `osint_investigation` queryType to public type stubs so OSINT queries (IP checks, sanctions, credentials, darknet) route to SneakyPiper tools instead of being rejected as `unsupported`
- Corresponding core logic already pushed to `secondlayer-core` (domain, safety-net regex, queryType coercion, plan generation, tool filtering)
- Fixes the bug where template OSINT questions (e.g. "Перевір IP 185.220.101.1 на шкідливу активність") returned a refusal

## Test plan
- [ ] Send "Перевір IP 185.220.101.1 на шкідливу активність" in chat — should invoke `osint_check_ip_reputation`
- [ ] Send "Санкції OFAC для Huawei" — should invoke `osint_search_sanctions`
- [ ] Send "Яка погода?" — should still return `unsupported`
- [ ] Verify existing legal queries (case lookup, legislation, registry) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `osint_investigation` queryType so OSINT queries (IP reputation, sanctions, credential leaks, darknet intel) route to `SneakyPiper` tools instead of being rejected as `unsupported`. Syncs public type stubs with `secondlayer-core` and adds config for budgets, limits, and scenarios.

- **New Features**
  - Added `osint_investigation` to `QueryType` and `VALID_QUERY_TYPES`.
  - Configured: default budget `standard`, requires grounding, max 5 tool calls; preferred scenarios `osint_entity_screening`, `osint_cyber_check`, `osint_darknet_intel`.

<sup>Written for commit 7750f41c0084d213debedb78c416e95cdefc1f6d. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1701?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

