### PR TITLE
fix(tests): update chat-intent-classifier tests for OSINT and budget changes

### DIFF
--- a/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
@@ -962,12 +962,12 @@ describe('QueryTypeConfig', () => {
     }
   });
 
-  it('practice_analysis should use standard budget', () => {
-    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('standard');
+  it('practice_analysis should use deep budget', () => {
+    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('deep');
   });
 
-  it('comparative_analysis should use standard budget', () => {
-    expect(QUERY_TYPE_CONFIG.comparative_analysis.defaultBudget).toBe('standard');
+  it('comparative_analysis should use deep budget', () => {
+    expect(QUERY_TYPE_CONFIG.comparative_analysis.defaultBudget).toBe('deep');
   });
 
   it('legislation_lookup should use quick budget', () => {
@@ -1050,16 +1050,16 @@ describe.skip('DOMAIN_TOOL_MAP', () => {
 
 describe('VALID_QUERY_TYPES', () => {
 
-  it('should contain all 13 defined query types', () => {
+  it('should contain all 14 defined query types', () => {
     const expected: QueryType[] = [
       'case_lookup', 'practice_analysis', 'legislation_lookup', 'legal_consultation',
       'registry_lookup', 'parliament_query', 'document_query', 'calculation',
       'document_drafting', 'comparative_analysis', 'due_diligence', 'institutional_analysis',
-      'unsupported',
+      'osint_investigation', 'unsupported',
     ];
     for (const qt of expected) {
       expect(VALID_QUERY_TYPES.has(qt)).toBe(true);
     }
-    expect(VALID_QUERY_TYPES.size).toBe(13);
+    expect(VALID_QUERY_TYPES.size).toBe(14);
   });
 });


### PR DESCRIPTION
## Summary
- Add `osint_investigation` to `VALID_QUERY_TYPES` expected list (14 types, up from 13) after #1701
- Update `practice_analysis` and `comparative_analysis` budget expectations from `standard` to `deep` to match current `query-type-config.ts`

## Test plan
- [x] `npx jest --no-cache src/services/__tests__/chat-intent-classifier.test.ts` passes locally (12 passed, 62 skipped)
- [ ] CI pipeline passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated chat-intent-classifier tests to include the new `osint_investigation` query type and to reflect deep budgets for `practice_analysis` and `comparative_analysis`. This syncs tests with `query-type-config.ts` and updates `VALID_QUERY_TYPES` expectations to 14.

<sup>Written for commit 2d5135744c70f05e9a22a530642cde92f43e38d1. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1702?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

