### PR TITLE
fix(tests): revert budget expectations to match proprietary overlay

### DIFF
--- a/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
@@ -962,12 +962,12 @@ describe('QueryTypeConfig', () => {
     }
   });
 
-  it('practice_analysis should use deep budget', () => {
-    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('deep');
+  it('practice_analysis should use standard budget', () => {
+    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('standard');
   });
 
-  it('comparative_analysis should use deep budget', () => {
-    expect(QUERY_TYPE_CONFIG.comparative_analysis.defaultBudget).toBe('deep');
+  it('comparative_analysis should use standard budget', () => {
+    expect(QUERY_TYPE_CONFIG.comparative_analysis.defaultBudget).toBe('standard');
   });
 
   it('legislation_lookup should use quick budget', () => {


### PR DESCRIPTION
## Summary
- Revert `practice_analysis` and `comparative_analysis` budget expectations back to `standard` — the proprietary source overlay (`secondlayer-core`) uses `standard`, while the public stub has `deep`
- Previous PR #1702 incorrectly matched the public stub instead of the overlaid config

## Test plan
- [ ] CI pipeline passes (budget tests now match what the proprietary overlay provides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Revert test expectations to use the standard budget for `practice_analysis` and `comparative_analysis` to match the proprietary overlay `secondlayer-core`. This aligns CI with the real config and avoids failures from the public stub’s deep budget.

<sup>Written for commit 3e8dde02910472742da11eb1f3da5ee39118fe78. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1703?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

