### PR TITLE
feat(billing): credit 430 UAH welcome bonus to all new users

### DIFF
--- a/mcp_backend/src/config/passport.ts
+++ b/mcp_backend/src/config/passport.ts
@@ -11,6 +11,7 @@ import { BannerService } from '../services/banner-service.js';
 import { logger } from '../utils/logger.js';
 import { provisionAuthentikUser } from '../services/authentik-service.js';
 import { provisionNextcloudUser } from '../services/nextcloud-provisioning.js';
+import { creditWelcomeBonus } from '../controllers/auth-common.js';
 
 let passportBannerService: BannerService | null = null;
 
@@ -104,6 +105,8 @@ export function configurePassport(db: Database): typeof passport {
               logger.error('[Banner] Async generation failed for OAuth user', { userId: user.id, error: err.message });
             });
           }
+
+          creditWelcomeBonus(user.id);
 
           return done(null, user);
         } catch (error: any) {

--- a/mcp_backend/src/controllers/auth-common.ts
+++ b/mcp_backend/src/controllers/auth-common.ts
@@ -149,3 +149,37 @@ export function generateBannerAsync(userId: string, name: string): void {
     logger.error('[Banner] Async generation failed', { userId, error: err.message });
   });
 }
+
+// ---------------------------------------------------------------------------
+// Welcome bonus for new users
+// ---------------------------------------------------------------------------
+
+const WELCOME_BONUS_UAH = 430;
+
+/**
+ * Credit welcome bonus (430 UAH / ~$10 USD) to a newly registered user.
+ * Fire-and-forget — logs errors but never throws.
+ */
+export function creditWelcomeBonus(userId: string): void {
+  const billingService = authBillingService;
+  if (!billingService) {
+    logger.warn('[WelcomeBonus] Billing service not available', { userId });
+    return;
+  }
+
+  (async () => {
+    await billingService.getOrCreateUserBilling(userId);
+    const amountUsd = await billingService.convertFromUah(WELCOME_BONUS_UAH);
+    await billingService.topUpBalance({
+      userId,
+      amountUsd,
+      amountUah: WELCOME_BONUS_UAH,
+      description: 'Вітальний бонус — 430 грн',
+      paymentProvider: 'adjustment',
+      paymentId: `welcome-${userId}`,
+    });
+    logger.info('[WelcomeBonus] Credited', { userId, amountUah: WELCOME_BONUS_UAH, amountUsd });
+  })().catch((err: any) => {
+    logger.warn('[WelcomeBonus] Failed to credit', { userId, error: err.message });
+  });
+}

--- a/mcp_backend/src/controllers/auth-diia.ts
+++ b/mcp_backend/src/controllers/auth-diia.ts
@@ -11,6 +11,7 @@ import { provisionNextcloudUser } from '../services/nextcloud-provisioning.js';
 import {
   generateToken,
   generateBannerAsync,
+  creditWelcomeBonus,
   getAuthCache,
 } from './auth-common.js';
 
@@ -145,6 +146,7 @@ async function handleAuthCallback(req: Request, res: Response, traceId: string):
     generateBannerAsync(user.id, name);
     provisionAuthentikUser({ email, name }).catch(() => {});
     provisionNextcloudUser({ email, name }).catch(() => {});
+    creditWelcomeBonus(user.id);
   } else {
     await userService.updateLastLogin(user.id);
     logger.info('[Diia] Existing user webhook auth', { userId: user.id, traceId });

--- a/mcp_backend/src/controllers/auth-google.ts
+++ b/mcp_backend/src/controllers/auth-google.ts
@@ -13,6 +13,7 @@ import {
   type AuthenticatedRequest,
   generateToken,
   generateBannerAsync,
+  creditWelcomeBonus,
   FRONTEND_URL,
 } from './auth-common.js';
 
@@ -129,6 +130,7 @@ export async function googleMobileAuth(req: Request, res: Response): Promise<Res
         provisionAuthentikUser({ email, name }).catch(() => {});
         provisionNextcloudUser({ email, name }).catch(() => {});
         generateBannerAsync(user.id, user.name || user.email);
+        creditWelcomeBonus(user.id);
       }
     }
 

--- a/mcp_backend/src/controllers/auth-oidc.ts
+++ b/mcp_backend/src/controllers/auth-oidc.ts
@@ -10,6 +10,7 @@ import { provisionNextcloudUser } from '../services/nextcloud-provisioning.js';
 import {
   generateToken,
   generateBannerAsync,
+  creditWelcomeBonus,
 } from './auth-common.js';
 
 /**
@@ -85,6 +86,7 @@ export async function oidcAuthCallback(req: Request, res: Response): Promise<voi
 
       generateBannerAsync(user.id, user.name || user.email);
       provisionNextcloudUser({ email: userInfo.email, name: userInfo.name }).catch(() => {});
+      creditWelcomeBonus(user.id);
     }
 
     const token = generateToken(user);
@@ -142,6 +144,7 @@ export async function oidcLoginWithPassword(req: Request, res: Response): Promis
 
       generateBannerAsync(user.id, user.name || user.email);
       provisionNextcloudUser({ email: userInfo.email, name: userInfo.name }).catch(() => {});
+      creditWelcomeBonus(user.id);
     }
 
     const token = generateToken(user);

--- a/mcp_backend/src/controllers/auth-password.ts
+++ b/mcp_backend/src/controllers/auth-password.ts
@@ -12,9 +12,9 @@ import { provisionNextcloudUser } from '../services/nextcloud-provisioning.js';
 import {
   generateToken,
   generateBannerAsync,
+  creditWelcomeBonus,
   validatePassword,
   validateEmail,
-  getAuthBillingService,
   getAuthEmailService,
   getAuthReferralService,
   JWT_EXPIRES_IN,
@@ -177,34 +177,14 @@ export async function registerWithPassword(req: Request, res: Response): Promise
         if (referrerId) {
           await authReferralService.linkReferral(referrerId, user.id);
           logger.info('Referral linked on registration', { referrerId, referredId: user.id, referralCode });
-
-          // Welcome bonus for beta testers (referral code 'beta2026')
-          const billingService = getAuthBillingService();
-          if (billingService && referralCode === 'beta2026') {
-            try {
-              const WELCOME_BONUS_UAH = 400;
-              // Ensure billing account exists before top-up
-              await billingService.getOrCreateUserBilling(user.id);
-              // Convert UAH to USD using billing service's currency conversion
-              const amountUsd = await billingService.convertFromUah(WELCOME_BONUS_UAH);
-              await billingService.topUpBalance({
-                userId: user.id,
-                amountUsd,
-                amountUah: WELCOME_BONUS_UAH,
-                description: 'Бонус бетатестера — 400 грн',
-                paymentProvider: 'adjustment',
-                paymentId: `beta-welcome-${user.id}`,
-              });
-              logger.info('Beta welcome bonus credited', { userId: user.id, amountUah: WELCOME_BONUS_UAH, amountUsd });
-            } catch (bonusErr: any) {
-              logger.warn('Failed to credit welcome bonus', { userId: user.id, error: bonusErr.message });
-            }
-          }
         }
       } catch (refErr: any) {
         logger.warn('Failed to link referral on registration', { referralCode, error: refErr.message });
       }
     }
+
+    // Welcome bonus for all new users
+    creditWelcomeBonus(user.id);
 
     // Create verification token and send email
     const verificationToken = await userService.createVerificationToken(user.id);

--- a/mcp_backend/src/services/__tests__/access-gate.test.ts
+++ b/mcp_backend/src/services/__tests__/access-gate.test.ts
@@ -1,15 +1,22 @@
 /**
  * Access Gate tests
  *
- * Verifies the rule that gates chat / upload behind beta-tester membership
- * or a successful Monobank top-up.
+ * Verifies the rule that gates chat / upload behind:
+ * beta-tester membership, admin role, positive balance, or a successful Monobank top-up.
  */
 
-import { evaluateAccessGate, hasMonobankTopup } from '../access-gate';
+import { evaluateAccessGate, hasMonobankTopup, hasPositiveBalance } from '../access-gate';
 import type { User } from '../user-service';
 
-function makeDb(rows: any[] = []) {
-  return { query: jest.fn().mockResolvedValue({ rows }) } as any;
+function makeDb(queryResults: any[][] = [[]]) {
+  let callIndex = 0;
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const rows = queryResults[callIndex] || [];
+      callIndex++;
+      return Promise.resolve({ rows });
+    }),
+  } as any;
 }
 
 function makeUser(overrides: Partial<User> = {}): User {
@@ -57,38 +64,59 @@ describe('access-gate', () => {
       expect(db.query).not.toHaveBeenCalled();
     });
 
-    it('allows ordinary users with at least one successful Monobank top-up', async () => {
-      const db = makeDb([{ '?column?': 1 }]);
+    it('allows users with positive balance (welcome bonus)', async () => {
+      // First query (balance check) returns a row
+      const db = makeDb([[{ '?column?': 1 }]]);
       const decision = await evaluateAccessGate(db, makeUser());
-      expect(decision).toEqual({ allowed: true, reason: 'monobank_topup' });
+      expect(decision).toEqual({ allowed: true, reason: 'has_balance' });
       expect(db.query).toHaveBeenCalledTimes(1);
       const sql = db.query.mock.calls[0][0] as string;
-      expect(sql).toMatch(/billing_transactions/);
-      expect(sql).toMatch(/payment_provider = 'monobank'/);
-      expect(sql).toMatch(/type = 'topup'/);
+      expect(sql).toMatch(/user_billing/);
+      expect(sql).toMatch(/balance_usd > 0 OR balance_uah > 0/);
     });
 
-    it('denies ordinary users without a Monobank top-up', async () => {
-      const db = makeDb([]);
+    it('allows ordinary users with Monobank top-up when balance is zero', async () => {
+      // First query (balance) returns empty, second (topup) returns a row
+      const db = makeDb([[], [{ '?column?': 1 }]]);
       const decision = await evaluateAccessGate(db, makeUser());
-      expect(decision).toEqual({ allowed: false, reason: 'no_monobank_topup' });
+      expect(decision).toEqual({ allowed: true, reason: 'monobank_topup' });
+      expect(db.query).toHaveBeenCalledTimes(2);
+    });
+
+    it('denies ordinary users without balance or top-up', async () => {
+      // Both queries return empty
+      const db = makeDb([[], []]);
+      const decision = await evaluateAccessGate(db, makeUser());
+      expect(decision).toEqual({ allowed: false, reason: 'no_balance' });
     });
 
     it('fails closed when the database lookup throws', async () => {
       const db = { query: jest.fn().mockRejectedValue(new Error('boom')) } as any;
       const decision = await evaluateAccessGate(db, makeUser());
-      expect(decision).toEqual({ allowed: false, reason: 'no_monobank_topup' });
+      expect(decision).toEqual({ allowed: false, reason: 'no_balance' });
+    });
+  });
+
+  describe('hasPositiveBalance', () => {
+    it('returns true when user has positive balance', async () => {
+      const db = makeDb([[{ '?column?': 1 }]]);
+      await expect(hasPositiveBalance(db, 'user-001')).resolves.toBe(true);
+    });
+
+    it('returns false when user has no balance', async () => {
+      const db = makeDb([[]]);
+      await expect(hasPositiveBalance(db, 'user-001')).resolves.toBe(false);
     });
   });
 
   describe('hasMonobankTopup', () => {
     it('returns true when at least one successful top-up exists', async () => {
-      const db = makeDb([{ '?column?': 1 }]);
+      const db = makeDb([[{ '?column?': 1 }]]);
       await expect(hasMonobankTopup(db, 'user-001')).resolves.toBe(true);
     });
 
     it('returns false when no top-up exists', async () => {
-      const db = makeDb([]);
+      const db = makeDb([[]]);
       await expect(hasMonobankTopup(db, 'user-001')).resolves.toBe(false);
     });
   });

--- a/mcp_backend/src/services/access-gate.ts
+++ b/mcp_backend/src/services/access-gate.ts
@@ -1,21 +1,12 @@
 /**
  * Access Gate
  *
- * The hosted version of the application is currently restricted to internal
- * beta testers and to users who have demonstrated payment intent by topping
- * up their balance through Monobank. External users without a Monobank
- * top-up are blocked from chat and document upload.
- *
- * The gate is intentionally narrow:
+ * Controls access to paid features (chat, document upload).
+ * A user is allowed if ANY of these conditions is true:
  *   - administrators: always allowed
  *   - users.is_beta_tester = TRUE: always allowed
- *   - any other user: must have at least one successful Monobank top-up
- *     recorded in billing_transactions (type = 'topup',
- *     payment_provider = 'monobank', amount_usd > 0)
- *
- * The "balance increased via Monobank" check is intentionally based on the
- * existence of a successful top-up rather than on the current balance — the
- * balance can be drained by usage, but the user has still proven access.
+ *   - has positive balance (from welcome bonus or top-up)
+ *   - has at least one successful top-up in billing_transactions
  */
 
 import type { IDatabase } from '../domain/ports/index.js';
@@ -25,7 +16,9 @@ import { logger } from '../utils/logger.js';
 export type AccessGateReason =
   | 'beta_tester'
   | 'administrator'
+  | 'has_balance'
   | 'monobank_topup'
+  | 'no_balance'
   | 'no_monobank_topup'
   | 'unauthenticated';
 
@@ -36,9 +29,25 @@ export interface AccessGateDecision {
 
 const RESULT_BETA: AccessGateDecision = { allowed: true, reason: 'beta_tester' };
 const RESULT_ADMIN: AccessGateDecision = { allowed: true, reason: 'administrator' };
+const RESULT_BALANCE: AccessGateDecision = { allowed: true, reason: 'has_balance' };
 const RESULT_TOPUP: AccessGateDecision = { allowed: true, reason: 'monobank_topup' };
-const RESULT_DENIED: AccessGateDecision = { allowed: false, reason: 'no_monobank_topup' };
+const RESULT_DENIED: AccessGateDecision = { allowed: false, reason: 'no_balance' };
 const RESULT_UNAUTH: AccessGateDecision = { allowed: false, reason: 'unauthenticated' };
+
+/**
+ * Returns true iff the user has a positive balance in user_billing.
+ */
+export async function hasPositiveBalance(db: IDatabase, userId: string): Promise<boolean> {
+  const result = await db.query(
+    `SELECT 1
+       FROM user_billing
+      WHERE user_id = $1
+        AND (balance_usd > 0 OR balance_uah > 0)
+      LIMIT 1`,
+    [userId]
+  );
+  return result.rows.length > 0;
+}
 
 /**
  * Returns true iff the user has at least one successful Monobank top-up
@@ -71,13 +80,11 @@ export async function evaluateAccessGate(
   if (user.role === 'administrator' || user.is_admin === true) return RESULT_ADMIN;
 
   try {
+    if (await hasPositiveBalance(db, user.id)) return RESULT_BALANCE;
     const ok = await hasMonobankTopup(db, user.id);
     return ok ? RESULT_TOPUP : RESULT_DENIED;
   } catch (error: any) {
-    // Fail closed: if the lookup fails we deny access rather than letting
-    // unrestricted external traffic through. The error is logged so we can
-    // diagnose connectivity problems.
-    logger.error('[AccessGate] Failed to check Monobank top-up', {
+    logger.error('[AccessGate] Failed to check access', {
       error: error?.message,
       userId: user.id,
     });


### PR DESCRIPTION
## Summary
- Transition from beta to production: every new user receives **430 UAH (~$10 USD)** welcome bonus on registration
- Welcome bonus is credited regardless of auth method (password, Google, OIDC, Diia)
- Access gate updated to allow users with positive balance (no longer requires Monobank topup or beta flag)
- Removed beta-only `beta2026` referral code logic

## Test plan
- [x] TypeScript compiles without errors
- [x] Access gate tests pass (12/12)
- [ ] Register new user via password — verify 430 UAH credited
- [ ] Register new user via Google — verify 430 UAH credited
- [ ] New user can access chat immediately after registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Give every new user a 430 UAH (~$10) welcome bonus on signup and unlock chat based on positive balance. The access gate now checks balance first, then Monobank top-up; admins and beta testers remain always allowed.

- New Features
  - 430 UAH welcome bonus on registration across password, Google, OIDC, and Diia via `creditWelcomeBonus`.
  - Access gate allows users with positive balance; falls back to Monobank top-up if balance is zero.

- Refactors
  - Removed beta-only `beta2026` referral bonus path.
  - Updated access gate tests for balance-first logic.

<sup>Written for commit c8e581b29e4b06b2daa9e32e3e63d002016ca650. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1704?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

