### PR TITLE
fix(frontend): remove lex-news page

### DIFF
--- a/lexwebapp/src/components/sidebar/nav-config.ts
+++ b/lexwebapp/src/components/sidebar/nav-config.ts
@@ -21,7 +21,6 @@ export const getLegislationSections = () => [
   { id: 'legislation-db', label: appT('nav.legislationDb'), icon: BookOpen, route: ROUTES.LEGISLATION_MONITORING },
   { id: 'codes', label: appT('nav.codes'), icon: Scale, route: ROUTES.LEGAL_CODES_LIBRARY },
   { id: 'news', label: appT('nav.newsKmu'), icon: Newspaper, route: ROUTES.NEWS },
-  { id: 'lex-news', label: appT('nav.newsLex'), icon: Globe, route: ROUTES.LEX_NEWS },
 ];
 
 export function getMattersSections(isAttorney: boolean) {

--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -16,7 +16,6 @@ import {
   EyeOff,
   User,
   BookOpen,
-  Newspaper,
   X,
   TrendingUp,
   FileText,
@@ -818,14 +817,6 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
               {hasRecentArticles() && (
                 <span className="w-1 h-1 rounded-full bg-zinc-600 inline-block" />
               )}
-            </a>
-            <a
-              href="/lex-news"
-              className="inline-flex items-center gap-1.5 text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors duration-200 tracking-wide"
-            >
-              <Newspaper size={10} />
-              <span>{t.newsLink}</span>
-              <span className="w-1 h-1 rounded-full bg-emerald-700/70 inline-block" />
             </a>
             <a
               href="/investor"

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -123,7 +123,6 @@ const LegalCodesLibraryPage = lazyWithRetry(() => import('../pages/LegalCodesLib
 
 // -- News --
 const NewsPage = lazyWithRetry(() => import('../pages/NewsPage').then(m => ({ default: m.NewsPage })));
-const LexNewsPage = lazyWithRetry(() => import('../pages/LexNewsPage').then(m => ({ default: m.LexNewsPage })));
 
 // -- MCP Connect --
 const MCPConnectPage = lazyWithRetry(() => import('../pages/MCPConnectPage').then(m => ({ default: m.MCPConnectPage })));
@@ -296,10 +295,6 @@ export const router = createBrowserRouter([
   {
     path: ROUTES.BLOG,
     element: S(BlogPage),
-  },
-  {
-    path: ROUTES.LEX_NEWS,
-    element: S(LexNewsPage),
   },
   {
     path: ROUTES.CAREER,

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -110,7 +110,6 @@ export const ROUTES = {
 
   // News
   NEWS: '/news',
-  LEX_NEWS: '/lex-news',
 
   // History
   HISTORY: '/history',

--- a/lexwebapp/src/utils/api/client.ts
+++ b/lexwebapp/src/utils/api/client.ts
@@ -52,7 +52,6 @@ const PUBLIC_ROUTE_PATTERNS: RegExp[] = [
   /^\/[a-z]{2}\/(offer|attorney-offer|developer-offer|marketplace-rules|terms|privacy|dpa|ai-usage|ai-transparency|refund-policy|data-sources)/,
   /^\/eu\/comparison/,
   /^\/blog(\/|$)/,
-  /^\/lex-news/,
   /^\/news$/,
   /^\/career(\/|$)/,
   /^\/investor(\/|$)/,


### PR DESCRIPTION
## Summary
- Remove /lex-news route, navigation entry, and login page link
- Page component left in place (dead code) for potential future use

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Lex News page: dropped `ROUTES.LEX_NEWS`, its router entry, sidebar nav item, login link, and the public-route whitelist so /lex-news is no longer accessible. The `LexNewsPage` component remains in the repo but is unused.

<sup>Written for commit 598a3b0024a57b086ba0487c75f57d8d2762e341. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1705?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

