### PR TITLE
feat(testing): add real-time TUI dashboard for load test

### DIFF
--- a/scripts/testing/load-test-quality.ts
+++ b/scripts/testing/load-test-quality.ts
@@ -11,6 +11,7 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import { randomUUID } from 'crypto';
+import { Dashboard, type ResultEntry } from './tui-dashboard.ts';
 
 dotenv.config({ path: new URL('../../mcp_backend/.env', import.meta.url).pathname });
 
@@ -483,18 +484,27 @@ async function runBatch(
   assignments: QueryAssignment[],
   users: TestUser[],
   pool: pg.Pool,
-  testRunId: string
+  testRunId: string,
+  dashboard: Dashboard | null
 ): Promise<{ succeeded: number; failed: number }> {
-  console.log(`\n  [Batch ${batchNum}] ${assignments.length} queries (${wave})`);
+  if (!dashboard) console.log(`\n  [Batch ${batchNum}] ${assignments.length} queries (${wave})`);
 
   const promises = assignments.map(async (a) => {
     const user = users[a.userIndex % users.length];
     const shortQuery = a.query.length > 60 ? a.query.substring(0, 60) + '...' : a.query;
-    console.log(`    [${user.email.split('@')[0]}] -> ${a.expectedTool}: ${shortQuery}`);
+    if (!dashboard) console.log(`    [${user.email.split('@')[0]}] -> ${a.expectedTool}: ${shortQuery}`);
 
     const result = await sendChatQueryWithRetry(BASE_URL, user.jwt, a.query);
 
     const primaryTool = result.toolsUsed.length > 0 ? result.toolsUsed[0] : null;
+
+    dashboard?.recordResult({
+      tool: a.expectedTool,
+      status: result.status === 'success' ? 'success' : result.status === 'timeout' ? 'timeout' : 'error',
+      timeMs: result.totalMs,
+      cost: result.totalCostUsd,
+      errorMsg: result.errorMessage?.substring(0, 30),
+    });
 
     await insertResult(pool, {
       testRunId,
@@ -519,7 +529,7 @@ async function runBatch(
     });
 
     const icon = result.status === 'success' ? 'OK' : result.status === 'timeout' ? 'TIMEOUT' : 'ERR';
-    console.log(`    [${user.email.split('@')[0]}] ${icon} ${result.totalMs}ms cost=$${result.totalCostUsd.toFixed(4)} tools=[${result.toolsUsed.join(',')}]`);
+    if (!dashboard) console.log(`    [${user.email.split('@')[0]}] ${icon} ${result.totalMs}ms cost=$${result.totalCostUsd.toFixed(4)} tools=[${result.toolsUsed.join(',')}]`);
 
     return result;
   });
@@ -532,7 +542,7 @@ async function runBatch(
     else failed++;
   }
 
-  console.log(`  [Batch ${batchNum}] Done: ${succeeded} ok, ${failed} failed`);
+  if (!dashboard) console.log(`  [Batch ${batchNum}] Done: ${succeeded} ok, ${failed} failed`);
   return { succeeded, failed };
 }
 
@@ -540,11 +550,15 @@ async function runPhase(
   wave: 'simple' | 'complex',
   users: TestUser[],
   pool: pg.Pool,
-  testRunId: string
+  testRunId: string,
+  dashboard: Dashboard | null
 ): Promise<void> {
-  console.log(`\n${'='.repeat(60)}`);
-  console.log(`  PHASE: ${wave.toUpperCase()} (${QUERY_CATALOG.length} queries)`);
-  console.log(`${'='.repeat(60)}`);
+  dashboard?.setWave(wave);
+  if (!dashboard) {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`  PHASE: ${wave.toUpperCase()} (${QUERY_CATALOG.length} queries)`);
+    console.log(`${'='.repeat(60)}`);
+  }
 
   const allAssignments: QueryAssignment[] = QUERY_CATALOG.map((q, i) => ({
     query: wave === 'simple' ? q.simple : q.complex,
@@ -554,15 +568,17 @@ async function runPhase(
 
   const batchSize = wave === 'simple' ? BATCH_SIZE_SIMPLE : BATCH_SIZE_COMPLEX;
   const batchPause = wave === 'simple' ? PAUSE_BETWEEN_BATCHES_MS : PAUSE_BETWEEN_BATCHES_COMPLEX_MS;
+  const totalBatches = Math.ceil(allAssignments.length / batchSize);
 
   let batchNum = 1;
   for (let offset = 0; offset < allAssignments.length; offset += batchSize) {
     const batch = allAssignments.slice(offset, offset + batchSize);
-    await runBatch(batchNum, wave, batch, users, pool, testRunId);
+    dashboard?.setBatch(batchNum, totalBatches, batch.map(a => a.expectedTool));
+    await runBatch(batchNum, wave, batch, users, pool, testRunId, dashboard);
     batchNum++;
 
     if (offset + batchSize < allAssignments.length) {
-      console.log(`  ... pause ${batchPause / 1000}s ...`);
+      if (!dashboard) console.log(`  ... pause ${batchPause / 1000}s ...`);
       await sleep(batchPause);
     }
   }
@@ -907,15 +923,24 @@ async function main() {
   }
 
   const testRunId = `loadtest-${new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').substring(0, 19)}`;
+  const totalQueries = QUERY_CATALOG.length * 2;
 
-  console.log(`${'='.repeat(60)}`);
-  console.log(`  LOAD & QUALITY TEST`);
-  console.log(`  Run ID: ${testRunId}`);
-  console.log(`  Target: ${BASE_URL}`);
-  console.log(`  Queries: ${QUERY_CATALOG.length} tools x 2 = ${QUERY_CATALOG.length * 2}`);
-  console.log(`  Users: ${TEST_USER_COUNT} concurrent`);
-  console.log(`  Budget: ${BUDGET}`);
-  console.log(`${'='.repeat(60)}\n`);
+  const useTui = process.stdout.isTTY && !args.includes('--no-tui');
+  let dashboard: Dashboard | null = null;
+
+  if (useTui) {
+    dashboard = new Dashboard({ testRunId, totalQueries });
+    dashboard.start();
+  } else {
+    console.log(`${'='.repeat(60)}`);
+    console.log(`  LOAD & QUALITY TEST`);
+    console.log(`  Run ID: ${testRunId}`);
+    console.log(`  Target: ${BASE_URL}`);
+    console.log(`  Queries: ${QUERY_CATALOG.length} tools x 2 = ${totalQueries}`);
+    console.log(`  Users: ${TEST_USER_COUNT} concurrent`);
+    console.log(`  Budget: ${BUDGET}`);
+    console.log(`${'='.repeat(60)}\n`);
+  }
 
   const pool = new pg.Pool(DB_CONFIG);
 
@@ -924,14 +949,18 @@ async function main() {
 
     const users = await createTestUsers(pool);
 
+    if (!useTui) console.log('[Preflight] Checking...');
     await preflightCheck(BASE_URL, users[0].jwt);
 
-    await runPhase('simple', users, pool, testRunId);
+    await runPhase('simple', users, pool, testRunId, dashboard);
 
-    console.log(`\n  ... pause ${PAUSE_BETWEEN_PHASES_MS / 1000}s between phases ...`);
+    if (!useTui) console.log(`\n  ... pause ${PAUSE_BETWEEN_PHASES_MS / 1000}s between phases ...`);
     await sleep(PAUSE_BETWEEN_PHASES_MS);
 
-    await runPhase('complex', users, pool, testRunId);
+    await runPhase('complex', users, pool, testRunId, dashboard);
+
+    dashboard?.stop();
+    dashboard = null;
 
     await gradeResults(pool, testRunId);
 
@@ -941,6 +970,7 @@ async function main() {
 
     console.log('\nDone.');
   } catch (error: any) {
+    dashboard?.stop();
     console.error('Fatal error:', error.message);
     console.error(error.stack);
     process.exit(1);

--- a/scripts/testing/tui-dashboard.ts
+++ b/scripts/testing/tui-dashboard.ts
@@ -1,0 +1,217 @@
+import chalk from 'chalk';
+
+export interface ResultEntry {
+  tool: string;
+  status: 'success' | 'error' | 'timeout';
+  timeMs: number;
+  cost: number;
+  errorMsg?: string;
+}
+
+interface DashboardState {
+  testRunId: string;
+  wave: 'simple' | 'complex' | 'idle';
+  batchNum: number;
+  totalBatches: number;
+  currentTools: string[];
+  succeeded: number;
+  failed: number;
+  inProgress: number;
+  totalQueries: number;
+  completed: number;
+  latencies: number[];
+  totalCost: number;
+  recentResults: ResultEntry[];
+}
+
+export class Dashboard {
+  private enabled = false;
+  private state: DashboardState;
+  private renderInterval: ReturnType<typeof setInterval> | null = null;
+  private readonly maxRecent = 10;
+  private readonly cols: number;
+
+  constructor(config: { testRunId: string; totalQueries: number }) {
+    this.cols = Math.min(process.stdout.columns || 80, 120);
+    this.state = {
+      testRunId: config.testRunId,
+      wave: 'idle',
+      batchNum: 0,
+      totalBatches: 0,
+      currentTools: [],
+      succeeded: 0,
+      failed: 0,
+      inProgress: 0,
+      totalQueries: config.totalQueries,
+      completed: 0,
+      latencies: [],
+      totalCost: 0,
+      recentResults: [],
+    };
+  }
+
+  start(): void {
+    this.enabled = true;
+    process.stdout.write('\x1b[?1049h'); // alt screen
+    process.stdout.write('\x1b[?25l');   // hide cursor
+    this.renderInterval = setInterval(() => this.render(), 250);
+    process.on('SIGINT', () => this.cleanup());
+    process.on('SIGTERM', () => this.cleanup());
+    process.on('exit', () => this.cleanup());
+    this.render();
+  }
+
+  stop(): void {
+    this.cleanup();
+  }
+
+  setWave(wave: 'simple' | 'complex'): void {
+    this.state.wave = wave;
+    this.state.batchNum = 0;
+  }
+
+  setBatch(batchNum: number, totalBatches: number, tools: string[]): void {
+    this.state.batchNum = batchNum;
+    this.state.totalBatches = totalBatches;
+    this.state.currentTools = tools;
+    this.state.inProgress = tools.length;
+  }
+
+  addInProgress(tool: string): void {
+    this.state.inProgress++;
+  }
+
+  recordResult(entry: ResultEntry): void {
+    if (entry.status === 'success') {
+      this.state.succeeded++;
+    } else {
+      this.state.failed++;
+    }
+    this.state.completed++;
+    this.state.inProgress = Math.max(0, this.state.inProgress - 1);
+    this.state.latencies.push(entry.timeMs);
+    this.state.totalCost += entry.cost;
+    this.state.recentResults.push(entry);
+    if (this.state.recentResults.length > this.maxRecent) {
+      this.state.recentResults.shift();
+    }
+  }
+
+  private render(): void {
+    if (!this.enabled) return;
+    const s = this.state;
+    const w = this.cols;
+
+    process.stdout.write('\x1b[H'); // cursor home
+
+    const lines: string[] = [];
+
+    // Header
+    const title = ` LOAD TEST ─ ${s.testRunId} `;
+    lines.push(chalk.cyan('┌─' + title + '─'.repeat(Math.max(0, w - title.length - 4)) + '─┐'));
+
+    // Wave + Progress
+    const waveLabel = s.wave === 'idle' ? 'STARTING' : s.wave.toUpperCase();
+    const waveTotal = s.wave === 'idle' ? s.totalQueries : s.totalQueries / 2;
+    const waveCompleted = s.wave === 'simple'
+      ? Math.min(s.completed, waveTotal)
+      : s.completed - s.totalQueries / 2;
+    const progressBar = this.renderProgressBar(Math.max(0, waveCompleted), waveTotal, 30);
+    const batchInfo = s.batchNum > 0 ? `Batch ${s.batchNum}/${s.totalBatches}` : '';
+    lines.push(this.pad(`│ Wave: ${chalk.bold(waveLabel)} ${progressBar}  ${batchInfo}`));
+
+    lines.push(this.pad('│'));
+
+    // Status counters
+    const statusLine = `│ Status:  ${chalk.green('✓ ' + s.succeeded)} succeeded  ${chalk.red('✗ ' + s.failed)} failed  ${chalk.yellow('⟳ ' + s.inProgress)} in-progress  Total: ${s.completed}/${s.totalQueries}`;
+    lines.push(this.pad(statusLine));
+
+    // Latency
+    const lat = this.getLatencyStats();
+    const latLine = `│ Latency: min ${this.fmtTime(lat.min)}  avg ${this.fmtTime(lat.avg)}  max ${this.fmtTime(lat.max)}  p95 ${this.fmtTime(lat.p95)}`;
+    lines.push(this.pad(latLine));
+
+    // Cost
+    lines.push(this.pad(`│ Cost:    ${chalk.green('$' + s.totalCost.toFixed(4))} total LLM`));
+
+    lines.push(this.pad('│'));
+
+    // Current batch tools
+    const toolsStr = s.currentTools.map(t => t.length > 25 ? t.substring(0, 22) + '...' : t).join(', ');
+    const toolsLine = toolsStr.length > w - 20 ? toolsStr.substring(0, w - 23) + '...' : toolsStr;
+    lines.push(this.pad(`│ Tools: ${chalk.dim(toolsLine)}`));
+
+    lines.push(this.pad('│'));
+
+    // Recent results
+    lines.push(this.pad(`│ ${chalk.bold('Recent Results:')}`));
+    const displayResults = s.recentResults.slice(-8);
+    for (const r of displayResults) {
+      const icon = r.status === 'success' ? chalk.green('✓') : r.status === 'timeout' ? chalk.yellow('⏱') : chalk.red('✗');
+      const toolName = r.tool.length > 32 ? r.tool.substring(0, 29) + '...' : r.tool.padEnd(32);
+      const time = this.fmtTime(r.timeMs);
+      const cost = r.cost > 0 ? chalk.dim('$' + r.cost.toFixed(4)) : chalk.dim(r.errorMsg?.substring(0, 20) || '');
+      lines.push(this.pad(`│  ${icon} ${toolName} ${time.padStart(7)}  ${cost}`));
+    }
+    // Fill empty slots
+    for (let i = displayResults.length; i < 8; i++) {
+      lines.push(this.pad('│'));
+    }
+
+    // Footer
+    const successRate = s.completed > 0 ? Math.round(s.succeeded / s.completed * 100) : 0;
+    const footerText = ` Success Rate: ${successRate}% `;
+    const footerColor = successRate >= 95 ? chalk.green : successRate >= 80 ? chalk.yellow : chalk.red;
+    lines.push(chalk.cyan('└─' + footerColor(footerText) + '─'.repeat(Math.max(0, w - footerText.length - 4)) + '─┘'));
+
+    // Write all lines, clear remaining terminal space
+    const output = lines.join('\n') + '\n';
+    process.stdout.write(output);
+    // Clear below
+    process.stdout.write('\x1b[J');
+  }
+
+  private pad(line: string): string {
+    // Strip ANSI for length calculation
+    const stripped = line.replace(/\x1b\[[0-9;]*m/g, '');
+    const padding = Math.max(0, this.cols - stripped.length - 1);
+    return line + ' '.repeat(padding) + chalk.cyan('│');
+  }
+
+  private renderProgressBar(completed: number, total: number, width: number): string {
+    const ratio = total > 0 ? completed / total : 0;
+    const filled = Math.round(ratio * width);
+    const empty = width - filled;
+    const bar = chalk.green('█'.repeat(filled)) + chalk.dim('░'.repeat(empty));
+    const pct = Math.round(ratio * 100);
+    return `[${bar}] ${completed}/${total} (${pct}%)`;
+  }
+
+  private getLatencyStats(): { min: number; avg: number; max: number; p95: number } {
+    const lats = this.state.latencies;
+    if (lats.length === 0) return { min: 0, avg: 0, max: 0, p95: 0 };
+    const sorted = [...lats].sort((a, b) => a - b);
+    const sum = sorted.reduce((a, b) => a + b, 0);
+    const p95idx = Math.floor(sorted.length * 0.95);
+    return {
+      min: sorted[0],
+      avg: Math.round(sum / sorted.length),
+      max: sorted[sorted.length - 1],
+      p95: sorted[Math.min(p95idx, sorted.length - 1)],
+    };
+  }
+
+  private fmtTime(ms: number): string {
+    if (ms === 0) return '-';
+    if (ms < 1000) return `${ms}ms`;
+    return `${(ms / 1000).toFixed(1)}s`;
+  }
+
+  private cleanup(): void {
+    if (!this.enabled) return;
+    this.enabled = false;
+    if (this.renderInterval) clearInterval(this.renderInterval);
+    process.stdout.write('\x1b[?25h');   // show cursor
+    process.stdout.write('\x1b[?1049l'); // exit alt screen
+  }
+}


### PR DESCRIPTION
## Summary
- New `scripts/testing/tui-dashboard.ts` — ANSI-based terminal UI with zero new dependencies (only chalk)
- Live progress bar, success/fail counters, latency stats, cost, recent results
- Auto-detects TTY; plain text fallback for CI/pipes
- `--no-tui` flag to force plain output

## Demo
```
┌─ LOAD TEST ─ loadtest-2026-05-16_23-32-18 ──────────────────────────────┐
│ Wave: SIMPLE [████████████░░░░░░░░░░░░░░░░░░] 22/45 (49%)  Batch 3/5    │
│                                                                          │
│ Status:  ✓ 18 succeeded  ✗ 2 failed  ⟳ 2 in-progress  Total: 22/90      │
│ Latency: min 3.2s  avg 8.4s  max 34.1s  p95 28.5s                       │
│ Cost:    $0.4520 total LLM                                               │
│                                                                          │
│ Recent Results:                                                          │
│  ✓ search_court_decisions              3.2s  $0.0120                     │
│  ✓ get_court_decision                  5.1s  $0.0180                     │
│  ✗ analyze_case_pattern               34.1s  timeout                     │
└─ Success Rate: 90% ─────────────────────────────────────────────────────┘
```

## Test plan
- [x] TUI renders correctly in terminal
- [x] --no-tui flag produces plain text
- [x] --report still outputs markdown (no TUI)
- [x] Alt screen preserved (scroll history intact after test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real-time ANSI TUI dashboard for load tests to visualize progress, latency, and cost. Auto-detects terminals and falls back to plain text for CI or when disabled.

- **New Features**
  - New `scripts/testing/tui-dashboard.ts` with zero new deps (uses `chalk`).
  - Live view: wave progress, batch info, success/failed/in-progress, min/avg/max/p95 latency, total cost, recent results, success rate.
  - Auto TTY detection; plain-text fallback for pipes/CI; `--no-tui` flag to force plain output.
  - Integrated into `scripts/testing/load-test-quality.ts` to track wave/batch and record results; clean start/stop and signal-safe cleanup (scrollback preserved).

<sup>Written for commit e19f8e43079e531c826db087a90a4e75b3318a9b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1711?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

