### PR TITLE
fix(infra): remove Anthropic/OpenAI fallback — Bedrock only

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -282,8 +282,7 @@ services:
       # LLM Provider Strategy
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-bedrock-first}
 
-      # Anthropic direct (fallback)
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # No Anthropic/OpenAI — Bedrock only
 
       # ZakonOnline API (deprecated, removal pending)
       ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN:-}


### PR DESCRIPTION
## Summary
- Remove ANTHROPIC_API_KEY from docker-compose.local.yml
- Eliminates cross-provider fallback that caused 42 auth errors in load test
- Container now only has `providers: ["bedrock"]`

## Context
When Bedrock rate-limited, LLM manager fell back to Anthropic direct API with an expired key, causing 401 errors instead of proper Bedrock rate-limit handling.

## Test plan
- [x] Container env shows only `LLM_PROVIDER_STRATEGY=bedrock-first`, no ANTHROPIC/OPENAI keys
- [x] `LLM Client Manager initialized {"providers":["bedrock"]}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed Anthropic/OpenAI fallback and enforced Bedrock-only in local Docker to stop 401 auth errors during rate limiting. Deleted `ANTHROPIC_API_KEY` from `deployment/docker-compose.local.yml`; container starts with `LLM_PROVIDER_STRATEGY=bedrock-first` and `providers: ["bedrock"]`.

<sup>Written for commit f41145419e5ee4680cb02cb802610ab1e5a50016. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1712?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

