### PR TITLE
fix(testing): default load test to Haiku to avoid Bedrock rate limits

### DIFF
--- a/scripts/testing/load-test-quality.ts
+++ b/scripts/testing/load-test-quality.ts
@@ -31,7 +31,8 @@ const DB_CONFIG = {
 const TEST_USER_PASSWORD = 'LoadTest2026!';
 const TEST_USER_COUNT = 10;
 const INITIAL_BALANCE_USD = 100.0;
-const BUDGET = 'standard';
+const BUDGET_ARG = process.argv.find(a => a.startsWith('--budget='))?.split('=')[1];
+const BUDGET = BUDGET_ARG || 'quick';
 const REQUEST_TIMEOUT_MS = 240_000;
 const BATCH_SIZE_SIMPLE = 10;
 const BATCH_SIZE_COMPLEX = 5;


### PR DESCRIPTION
## Summary
- Default budget changed from `standard` (Sonnet) to `quick` (Haiku)
- Haiku has ~10x higher TPD limits on Bedrock and is much cheaper
- Use `--budget=standard` or `--budget=deep` when you need to test with bigger models

## Usage
```bash
# Default: Haiku (cheap, high limits)
npx tsx scripts/testing/load-test-quality.ts

# Sonnet (standard)
npx tsx scripts/testing/load-test-quality.ts --budget=standard
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the load-test script default from standard (Sonnet) to quick (Haiku) to reduce cost and avoid Bedrock TPD limits. Use the --budget flag to opt into larger models when needed.

- **Migration**
  - For Sonnet use `--budget=standard`; for larger models use `--budget=deep`.

<sup>Written for commit bd1ec75be4aa4094973d95450847dfce99bc24a9. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1713?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

