### PR TITLE
feat(chat): add maxBudget ceiling to prevent model escalation

### DIFF
--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -90,7 +90,7 @@ export function createChatInlineRoutes(deps: {
     const requestId = `chat-${uuidv4()}`;
 
     try {
-      const { query, history, budget, conversationId, approvedPlan, planSessionId, allowDeepEscalation, internetEnabled } = req.body;
+      const { query, history, budget, maxBudget, conversationId, approvedPlan, planSessionId, allowDeepEscalation, internetEnabled } = req.body;
 
       if (!query || typeof query !== 'string') {
         return res.status(400).json({ error: 'query is required' });
@@ -173,6 +173,7 @@ export function createChatInlineRoutes(deps: {
         query,
         history,
         budget: (budget || 'standard') as 'quick' | 'standard' | 'deep',
+        maxBudget: maxBudget as 'quick' | 'standard' | 'deep' | undefined,
         conversationId,
         userId,
         requestId,

--- a/scripts/testing/load-test-quality.ts
+++ b/scripts/testing/load-test-quality.ts
@@ -32,7 +32,9 @@ const TEST_USER_PASSWORD = 'LoadTest2026!';
 const TEST_USER_COUNT = 10;
 const INITIAL_BALANCE_USD = 100.0;
 const BUDGET_ARG = process.argv.find(a => a.startsWith('--budget='))?.split('=')[1];
-const BUDGET = BUDGET_ARG || 'quick';
+const BUDGET = BUDGET_ARG || 'standard';
+const MODEL_ARG = process.argv.find(a => a.startsWith('--model='))?.split('=')[1];
+const FORCE_MODEL = MODEL_ARG || '';  // e.g. --model=haiku forces all tiers to Haiku
 const REQUEST_TIMEOUT_MS = 240_000;
 const BATCH_SIZE_SIMPLE = 10;
 const BATCH_SIZE_COMPLEX = 5;
@@ -317,7 +319,7 @@ async function sendChatQuery(baseUrl: string, token: string, query: string): Pro
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
       },
-      body: JSON.stringify({ query, budget: BUDGET }),
+      body: JSON.stringify({ query, budget: BUDGET, ...(FORCE_MODEL ? { maxBudget: FORCE_MODEL } : {}) }),
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary
- New `maxBudget` API parameter — caps effective budget tier regardless of classifier
- Load test `--model=quick` flag sends `maxBudget: 'quick'` forcing all queries to Haiku
- Prevents Bedrock rate limit exhaustion during load testing

## How it works
```
Client sends: { budget: 'standard', maxBudget: 'quick' }
Classifier says: practice_analysis → floor = 'standard'
Effective: min(floor, ceiling) → 'quick' (Haiku)
```

## Test plan
- [ ] `--model=quick` routes all queries through Haiku
- [ ] Without --model, classifier picks as before
- [ ] Deep escalation (8+ step plans) is capped by maxBudget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `maxBudget` ceiling to the chat API and a `--model` flag to the load test to prevent model escalation during testing and protect Bedrock rate limits.

- **New Features**
  - Chat API accepts optional `maxBudget` to cap the effective model tier regardless of classifier.
  - Load test supports `--model=quick`; sends `maxBudget: 'quick'` so all queries route to Haiku.
  - Load test default budget is now `standard`; omitting `--model` keeps classifier behavior unchanged.

<sup>Written for commit 13b2fc918c39063cfbcf0ce89e43cdcdd9e0e51b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1714?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

