### PR TITLE
fix(infra): mount shared dist for local dev hot-reload

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -368,9 +368,8 @@ services:
         condition: service_healthy
 
     volumes:
-      # Mount source code for hot reload (optional - comment out if using Docker image only)
-      # - ../mcp_backend/src:/app/src:ro
-      # - ../mcp_backend/dist:/app/dist:ro
+      - ../mcp_backend/dist:/app/mcp_backend/dist:ro
+      - ../packages/shared/dist:/app/mcp_backend/node_modules/@secondlayer/shared/dist:ro
       - ../mcp_backend/logs:/app/logs
       - app_local_data:/app/data
       # Vision API credentials for OCR


### PR DESCRIPTION
## Summary
- Mount `packages/shared/dist` into app container as read-only volume
- Local `npm run build` in shared/ immediately reflects in running container
- No more stale shared dist after provider strategy changes

## Test plan
- [x] Load test 90/90 (100%) with updated shared dist via mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount `packages/shared/dist` into the app container as a read-only volume so local builds are picked up without rebuilding the image. Also align the `mcp_backend/dist` mount to prevent stale `@secondlayer/shared` code and enable hot reload during local dev.

<sup>Written for commit 0ae35ec4861176c21457378ec6c8c43c31a35703. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1716?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

