### PR TITLE
fix(migrations): reorder migration 150 — CREATE before ALTER

### DIFF
--- a/mcp_backend/src/migrations/150_us_opendata_quality_fixes.sql
+++ b/mcp_backend/src/migrations/150_us_opendata_quality_fixes.sql
@@ -1,16 +1,69 @@
 -- US Open Data quality fixes: indexes, normalization, new columns, enrichment tracking
 
--- 1. OpenSanctions: FTS index on name (was missing — critical for screening queries)
-CREATE INDEX IF NOT EXISTS idx_opensanctions_name_fts ON opensanctions_entities USING gin(to_tsvector('simple', name));
+-- ── Tables first (needed on local/fresh installs) ──────────────────
 
--- 2. Court opinions: reporter_series column + index (created_at was useless — same timestamp for all 6.9M rows)
-ALTER TABLE us_court_opinions ADD COLUMN IF NOT EXISTS reporter_series TEXT;
-DROP INDEX IF EXISTS idx_us_court_opinions_created;
--- Populate in migration (split_part is fast for new/empty installs; prod already populated via manual UPDATE)
-UPDATE us_court_opinions SET reporter_series = split_part(id, '/', 1) WHERE reporter_series IS NULL;
+-- OSHA enforcement table
+CREATE TABLE IF NOT EXISTS us_osha_enforcement (
+    employer_id TEXT PRIMARY KEY,
+    employer_name TEXT,
+    city TEXT, state TEXT, zip5 TEXT,
+    naics_code TEXT, naics_description TEXT, parent_name TEXT,
+    citation_count INTEGER, inspection_count INTEGER,
+    penalties_initial_total NUMERIC, penalties_current_total NUMERIC,
+    willful_count INTEGER, repeat_count INTEGER, serious_count INTEGER,
+    other_count INTEGER, severe_count INTEGER,
+    earliest_citation DATE, latest_citation DATE,
+    max_gravity INTEGER,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_us_osha_enf_name_fts ON us_osha_enforcement USING gin(to_tsvector('simple', employer_name));
+CREATE INDEX IF NOT EXISTS idx_us_osha_enf_state ON us_osha_enforcement(state);
+CREATE INDEX IF NOT EXISTS idx_us_osha_enf_naics ON us_osha_enforcement(naics_code);
+CREATE INDEX IF NOT EXISTS idx_us_osha_enf_penalties ON us_osha_enforcement(penalties_current_total);
+
+-- SEC filers table
+CREATE TABLE IF NOT EXISTS us_sec_filers (
+    cik TEXT PRIMARY KEY,
+    entity_name TEXT, entity_type TEXT, sic TEXT, sic_description TEXT,
+    ticker TEXT, exchanges TEXT, ein TEXT, state_of_incorporation TEXT,
+    fiscal_year_end TEXT, filing_count INTEGER, category TEXT,
+    phone TEXT, state TEXT, city TEXT, zip TEXT,
+    insider_transaction_count INTEGER,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_us_sec_name_fts ON us_sec_filers USING gin(to_tsvector('simple', entity_name));
+CREATE INDEX IF NOT EXISTS idx_us_sec_ticker ON us_sec_filers(ticker);
+CREATE INDEX IF NOT EXISTS idx_us_sec_sic ON us_sec_filers(sic);
+CREATE INDEX IF NOT EXISTS idx_us_sec_ein ON us_sec_filers(ein) WHERE ein IS NOT NULL;
+
+-- Court opinions table
+CREATE TABLE IF NOT EXISTS us_court_opinions (
+    id TEXT PRIMARY KEY,
+    source TEXT,
+    created_at TIMESTAMPTZ,
+    url TEXT,
+    author TEXT,
+    text_preview TEXT,
+    full_text TEXT,
+    text_length INTEGER,
+    reporter_series TEXT,
+    imported_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_us_court_opinions_fts ON us_court_opinions USING gin(to_tsvector('english', text_preview));
+CREATE INDEX IF NOT EXISTS idx_us_court_opinions_length ON us_court_opinions(text_length);
 CREATE INDEX IF NOT EXISTS idx_us_court_opinions_reporter ON us_court_opinions(reporter_series);
 
--- 3. CFPB: normalized product taxonomy (pre/post 2017 labels merged)
+-- ── Fixes (run after tables exist) ─────────────────────────────────
+
+-- 1. OpenSanctions: FTS index on name
+CREATE INDEX IF NOT EXISTS idx_opensanctions_name_fts ON opensanctions_entities USING gin(to_tsvector('simple', name));
+
+-- 2. Court opinions: reporter_series column + populate
+ALTER TABLE us_court_opinions ADD COLUMN IF NOT EXISTS reporter_series TEXT;
+DROP INDEX IF EXISTS idx_us_court_opinions_created;
+UPDATE us_court_opinions SET reporter_series = split_part(id, '/', 1) WHERE reporter_series IS NULL;
+
+-- 3. CFPB: normalized product taxonomy
 ALTER TABLE us_cfpb_complaints ADD COLUMN IF NOT EXISTS product_normalized TEXT;
 UPDATE us_cfpb_complaints SET product_normalized = CASE
     WHEN product IN ('Credit reporting, credit repair services, or other personal consumer reports',
@@ -31,59 +84,8 @@ END
 WHERE product_normalized IS NULL;
 CREATE INDEX IF NOT EXISTS idx_us_cfpb_product_norm ON us_cfpb_complaints(product_normalized);
 
--- 4. FEC candidates: fix garbled election years (2032-2929 typos)
+-- 4. FEC candidates: fix garbled election years
 UPDATE us_fec_candidates SET election_year = NULL WHERE election_year > 2030;
 
--- 5. OFAC standalone: deprecate in catalog (opensanctions_entities is richer)
+-- 5. OFAC standalone: deprecate in catalog
 UPDATE import_source_catalog SET enabled = false WHERE name = 'us_ofac_sdn';
-
--- 6. OSHA enforcement table (created on prod, needs migration for CI/CD)
-CREATE TABLE IF NOT EXISTS us_osha_enforcement (
-    employer_id TEXT PRIMARY KEY,
-    employer_name TEXT,
-    city TEXT, state TEXT, zip5 TEXT,
-    naics_code TEXT, naics_description TEXT, parent_name TEXT,
-    citation_count INTEGER, inspection_count INTEGER,
-    penalties_initial_total NUMERIC, penalties_current_total NUMERIC,
-    willful_count INTEGER, repeat_count INTEGER, serious_count INTEGER,
-    other_count INTEGER, severe_count INTEGER,
-    earliest_citation DATE, latest_citation DATE,
-    max_gravity INTEGER,
-    imported_at TIMESTAMPTZ DEFAULT NOW()
-);
-CREATE INDEX IF NOT EXISTS idx_us_osha_enf_name_fts ON us_osha_enforcement USING gin(to_tsvector('simple', employer_name));
-CREATE INDEX IF NOT EXISTS idx_us_osha_enf_state ON us_osha_enforcement(state);
-CREATE INDEX IF NOT EXISTS idx_us_osha_enf_naics ON us_osha_enforcement(naics_code);
-CREATE INDEX IF NOT EXISTS idx_us_osha_enf_penalties ON us_osha_enforcement(penalties_current_total);
-
--- 7. SEC filers table (created on prod, needs migration for CI/CD)
-CREATE TABLE IF NOT EXISTS us_sec_filers (
-    cik TEXT PRIMARY KEY,
-    entity_name TEXT, entity_type TEXT, sic TEXT, sic_description TEXT,
-    ticker TEXT, exchanges TEXT, ein TEXT, state_of_incorporation TEXT,
-    fiscal_year_end TEXT, filing_count INTEGER, category TEXT,
-    phone TEXT, state TEXT, city TEXT, zip TEXT,
-    insider_transaction_count INTEGER,
-    imported_at TIMESTAMPTZ DEFAULT NOW()
-);
-CREATE INDEX IF NOT EXISTS idx_us_sec_name_fts ON us_sec_filers USING gin(to_tsvector('simple', entity_name));
-CREATE INDEX IF NOT EXISTS idx_us_sec_ticker ON us_sec_filers(ticker);
-CREATE INDEX IF NOT EXISTS idx_us_sec_sic ON us_sec_filers(sic);
-CREATE INDEX IF NOT EXISTS idx_us_sec_ein ON us_sec_filers(ein) WHERE ein IS NOT NULL;
-
--- 8. Court opinions table (created on prod, needs migration for CI/CD)
-CREATE TABLE IF NOT EXISTS us_court_opinions (
-    id TEXT PRIMARY KEY,
-    source TEXT,
-    created_at TIMESTAMPTZ,
-    url TEXT,
-    author TEXT,
-    text_preview TEXT,
-    full_text TEXT,
-    text_length INTEGER,
-    reporter_series TEXT,
-    imported_at TIMESTAMPTZ DEFAULT NOW()
-);
-CREATE INDEX IF NOT EXISTS idx_us_court_opinions_fts ON us_court_opinions USING gin(to_tsvector('english', text_preview));
-CREATE INDEX IF NOT EXISTS idx_us_court_opinions_length ON us_court_opinions(text_length);
-CREATE INDEX IF NOT EXISTS idx_us_court_opinions_reporter ON us_court_opinions(reporter_series);


### PR DESCRIPTION
## Summary
Fix CI failure: migration 150 tried to ALTER TABLE us_court_opinions before CREATE TABLE.
Reordered: CREATE TABLE blocks first, then ALTER/UPDATE/INDEX fixes.

## Test plan
- [ ] CI passes (migrate-local succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered migration 150 to run CREATE TABLE statements before any ALTER/UPDATE/INDEX, fixing CI failures on fresh installs. Ensures `us_court_opinions`, `us_osha_enforcement`, and `us_sec_filers` exist before downstream fixes.

- **Bug Fixes**
  - Moved table creation to the top; follow-up steps run after tables exist.
  - Kept existing fixes intact: OpenSanctions FTS index, `reporter_series` add/backfill, CFPB product normalization, FEC year cleanup, and disabling `us_ofac_sdn`.

<sup>Written for commit 1f8611ad946698212937bb3111f0ec54daf37867. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1730?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

