### PR TITLE
feat(dataset): temporal splits + 3 epoch configs for LEXTREME

### DIFF
--- a/scripts/lextreme/DATASET_CARD.md
+++ b/scripts/lextreme/DATASET_CARD.md
@@ -15,7 +15,33 @@ tags:
 - ukraine
 - judgment-prediction
 - legal-nlp
+- temporal-split
 source_datasets: []
+configs:
+- config_name: pre_war
+  data_files:
+  - split: train
+    path: pre_war/train.jsonl
+  - split: validation
+    path: pre_war/validation.jsonl
+  - split: test
+    path: pre_war/test.jsonl
+- config_name: hybrid_war
+  data_files:
+  - split: train
+    path: hybrid_war/train.jsonl
+  - split: validation
+    path: hybrid_war/validation.jsonl
+  - split: test
+    path: hybrid_war/test.jsonl
+- config_name: full_scale
+  data_files:
+  - split: train
+    path: full_scale/train.jsonl
+  - split: validation
+    path: full_scale/validation.jsonl
+  - split: test
+    path: full_scale/test.jsonl
 dataset_info:
   features:
   - name: text
@@ -29,27 +55,38 @@ dataset_info:
           '2': partial
   - name: language
     dtype: string
-  splits:
-  - name: train
-    num_bytes: 1298904607
-    num_examples: 120000
-  - name: validation
-    num_bytes: 162035703
-    num_examples: 15000
-  - name: test
-    num_bytes: 162965763
-    num_examples: 15000
-  download_size: 660000000
-  dataset_size: 1623906073
 ---
 
-# Ukrainian Court Decisions — Judgment Prediction
+# Ukrainian Court Decisions -- Judgment Prediction
 
-A dataset of Ukrainian court decisions for **case outcome prediction**, extracted from the [State Court Decisions Registry (ЄДРСР)](https://reyestr.court.gov.ua/).
+A dataset of Ukrainian court decisions for **case outcome prediction**, extracted from the [State Court Decisions Registry](https://reyestr.court.gov.ua/).
+
+## Configs (Temporal Epochs)
+
+The dataset is split into three configs corresponding to distinct epochs in Ukrainian legal history. Within each config, train/validation/test splits are **temporal** (chronological), not random -- earlier decisions are in train, later ones in test.
+
+| Config | Period | Context |
+|--------|--------|---------|
+| `pre_war` | 2008--2013 | Baseline period before armed conflict |
+| `hybrid_war` | 2014--2021 | Hybrid warfare (Crimea annexation, Donbas conflict) |
+| `full_scale` | 2022--2026 | Full-scale Russian invasion |
+
+### Why temporal splits?
+
+Following the recommendation from [Niklaus et al. (2021)](https://arxiv.org/abs/2110.00976), we use **temporal splits** for more realistic evaluation. Random splits allow the model to memorize patterns from contemporaneous decisions that appear in both train and test. Temporal splits simulate real deployment: the model trains on past decisions and predicts outcomes for future ones.
+
+### Why separate epochs?
+
+The three epochs differ substantially in judicial practice:
+- **Pre-war**: Stable legal environment, established precedent patterns
+- **Hybrid war**: Martial law in parts of territory, displaced courts, evolving jurisprudence
+- **Full-scale**: Nationwide martial law, new legal regimes, dramatic shifts in case composition
+
+Separate configs allow measuring how well models generalize within vs. across these regimes.
 
 ## Task
 
-Given the **facts section** (ВСТАНОВИВ) of a court decision, predict the judgment outcome:
+Given the **facts section** of a court decision, predict the judgment outcome:
 
 | Label | Ukrainian | Description |
 |-------|-----------|-------------|
@@ -59,46 +96,40 @@ Given the **facts section** (ВСТАНОВИВ) of a court decision, predict th
 
 ## Data Description
 
-- **Source**: State Court Decisions Registry of Ukraine (Єдиний державний реєстр судових рішень, ЄДРСР)
+- **Source**: State Court Decisions Registry of Ukraine (ЄДРСР)
 - **Language**: Ukrainian (uk)
 - **Jurisdiction**: Ukraine
 - **Court types**: Civil and commercial courts
-- **Decision form**: "Рішення" (substantive decisions, judgment_code=3)
-- **Time period**: 2003–2025
+- **Decision form**: Substantive decisions (judgment_code=3)
 
 ### Why facts only?
 
-Following [Niklaus et al. (2021)](https://arxiv.org/abs/2110.00976), we provide only the **facts section** (ВСТАНОВИВ/УСТАНОВИВ) as input, excluding the court's reasoning and the dispositive (ruling) section. Including the full text would make the task trivially solvable since the ruling contains the answer directly.
+Following [Niklaus et al. (2021)](https://arxiv.org/abs/2110.00976), we provide only the **facts section** as input, excluding the court's reasoning and the dispositive (ruling) section. Including the full text would make the task trivially solvable since the ruling contains the answer directly.
 
 ### Section extraction
 
 Ukrainian court decisions follow a standard structure:
-1. **Header** — court name, case number, date, parties
-2. **ВСТАНОВИВ/УСТАНОВИВ** — established facts and circumstances
-3. **Reasoning** — court's legal analysis (sometimes merged with facts)
-4. **ВИРІШИВ/УХВАЛИВ** — the ruling (dispositive section)
+1. **Header** -- court name, case number, date, parties
+2. **ВСТАНОВИВ/УСТАНОВИВ** -- established facts and circumstances
+3. **Reasoning** -- court's legal analysis
+4. **ВИРІШИВ/УХВАЛИВ** -- the ruling (dispositive section)
 
-We extract text between the ВСТАНОВИВ marker and the ВИРІШИВ marker. The outcome label is derived from the dispositive section using keyword matching (задовольнити → approved, відмовити → dismissed, частково → partial).
-
-## Data Quality
-
-- 150,000 samples total (120K train / 15K validation / 15K test)
-- Perfectly balanced: 50,000 per class (approved / dismissed / partial)
-- Minimum 200 characters in facts section
-- Maximum 10,000 characters (truncated for very long decisions)
-- Full text length between 500 and 200,000 characters
-- Sampled from 596,538 valid extractions out of 802,189 court decisions
-- Random 80/10/10 train/validation/test split
+We extract text between the ВСТАНОВИВ marker and the ВИРІШИВ marker. The outcome label is derived from the dispositive section using keyword matching.
 
 ## Usage
 
 ```python
 from datasets import load_dataset
 
-dataset = load_dataset("secondlayer/ukrainian-court-decisions")
+# Load a specific epoch
+dataset = load_dataset("secondlayer/ukrainian-court-decisions", "hybrid_war")
 
 # Or load via LexTreme
-dataset = load_dataset("joelniklaus/lextreme", "ukrainian_court_decisions_judgment")
+dataset = load_dataset("joelniklaus/lextreme", "ukrainian_court_decisions_judgment_hybrid_war")
+
+# Cross-epoch evaluation: train on pre_war, test on full_scale
+train = load_dataset("secondlayer/ukrainian-court-decisions", "pre_war", split="train")
+test = load_dataset("secondlayer/ukrainian-court-decisions", "full_scale", split="test")
 ```
 
 ## Citation
@@ -109,7 +140,7 @@ dataset = load_dataset("joelniklaus/lextreme", "ukrainian_court_decisions_judgme
   author={Ovcharov, Volodymyr},
   year={2025},
   url={https://huggingface.co/datasets/secondlayer/ukrainian-court-decisions},
-  note={Extracted from the State Court Decisions Registry of Ukraine (ЄДРСР)}
+  note={Extracted from the State Court Decisions Registry of Ukraine}
 }
 ```
 
@@ -119,6 +150,6 @@ CC-BY-4.0. The source data is published by the State Court Administration of Ukr
 
 ## Links
 
-- [ЄДРСР (State Court Decisions Registry)](https://reyestr.court.gov.ua/)
+- [State Court Decisions Registry](https://reyestr.court.gov.ua/)
 - [LexTreme Benchmark](https://huggingface.co/datasets/joelniklaus/lextreme)
 - [SecondLayer Legal AI Platform](https://legal.org.ua)

--- a/scripts/lextreme/WORKFLOW.md
+++ b/scripts/lextreme/WORKFLOW.md
@@ -1,61 +1,80 @@
 # LexTreme Dataset Contribution Workflow
 
+## Prerequisites
+
+```bash
+pip install psycopg2-binary datasets huggingface_hub pyarrow
+huggingface-cli login
+```
+
 ## Steps
 
-### 1. Extract data (on prod server)
+### 1. Ensure SSH tunnel to prod DB
 
 ```bash
-scp scripts/lextreme/extract-server-side.py prod:/tmp/extract-lextreme.py
-ssh prod "python3 /tmp/extract-lextreme.py"
+# Check if tunnel is already running:
+ss -tlnp | grep 5438
+
+# If not, start it:
+ssh -fNL 5438:localhost:5432 prod
 ```
 
-### 2. Download results
+### 2. Extract data from prod
 
 ```bash
-mkdir -p scripts/lextreme/output
-scp prod:/tmp/lextreme-ukr-*.jsonl scripts/lextreme/output/
+# Set prod DB password
+export PGPASSWORD='...'   # from .env.prod PROD_DB_PASSWORD
+
+# Extract all epochs (may take a while on full_scale due to less fulltext data)
+python3 scripts/lextreme/extract-full-local.py --prod
+
+# Or specific epochs with balancing:
+python3 scripts/lextreme/extract-full-local.py --prod --target-per-class 20000 --epochs hybrid_war pre_war
+
+# Or pass password directly:
+python3 scripts/lextreme/extract-full-local.py --prod --password '...'
 ```
 
-### 3. Convert to parquet and upload to HuggingFace
+Output: `scripts/lextreme/output/lextreme-ukr-{pre_war,hybrid_war,full_scale}.jsonl`
+
+### 3. Build temporal splits
 
 ```bash
-pip install datasets huggingface_hub pyarrow
-huggingface-cli login
+python3 scripts/lextreme/build-temporal-splits.py
+
+# With balancing (equal per class per epoch):
+python3 scripts/lextreme/build-temporal-splits.py --balance 20000
+```
+
+Output: `scripts/lextreme/output/{epoch}/{train,validation,test}.jsonl`
+
+Each split is chronological -- train contains earliest decisions, test contains latest.
+
+### 4. Upload to HuggingFace
+
+```bash
+# Dry run first:
+python3 scripts/lextreme/upload-to-hf.py --dry-run
+
+# Upload all configs:
 python3 scripts/lextreme/upload-to-hf.py
 ```
 
-### 4. Fork and PR to LexTreme
+### 5. Fork and PR to LexTreme
 
 ```bash
 # Fork joelniklaus/lextreme on HuggingFace
-# Clone your fork
 git clone https://huggingface.co/datasets/YOUR_USERNAME/lextreme
 cd lextreme
-
-# Edit lextreme.py — add the config from lextreme-config.py
-# Commit and push
-# Create PR on HuggingFace
+# Edit lextreme.py -- add the 3 configs from lextreme-config.py
+# Commit and push, create PR on HuggingFace
 ```
 
-### 5. Reply to Joel
+## Data availability notes
 
-Subject: Ukrainian Court Decisions subset for LexTreme
+Fulltext data on prod is uneven:
+- **pre_war** (2008-2013): ~11M fulltext records, solid coverage
+- **hybrid_war** (2014-2021): ~56M fulltext records, best coverage
+- **full_scale** (2022-2026): ~791K fulltext records, limited (import in progress)
 
-```
-Hi Joel,
-
-Thanks for the endorsement! I've prepared a Ukrainian court decisions dataset
-for LexTreme — case outcome prediction (approved/dismissed/partial) based on
-the facts section only.
-
-Source: State Court Decisions Registry (ЄДРСР) — 100M+ decisions.
-We extracted ~15K balanced samples from civil and commercial courts (2018-2025).
-
-Dataset: https://huggingface.co/datasets/secondlayer/ukrainian-court-decisions
-PR: [link to PR]
-
-Let me know if anything needs adjusting!
-
-Best,
-Volodymyr
-```
+Use `--target-per-class` to balance across epochs if full_scale is too small.

--- a/scripts/lextreme/build-temporal-splits.py
+++ b/scripts/lextreme/build-temporal-splits.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Build HuggingFace dataset with temporal train/val/test splits per epoch.
+
+Takes per-epoch JSONL files from extract-full-local.py, sorts by adjudication_date,
+and splits chronologically: earliest 80% = train, next 10% = validation, last 10% = test.
+
+Produces three configs for HuggingFace (one per epoch):
+  - pre_war    (2008-2013)
+  - hybrid_war (2014-2021)
+  - full_scale (2022-2026)
+
+Usage:
+    python3 scripts/lextreme/build-temporal-splits.py
+    python3 scripts/lextreme/build-temporal-splits.py --balance 20000
+    python3 scripts/lextreme/build-temporal-splits.py --epochs hybrid_war full_scale
+"""
+
+import argparse
+import json
+import random
+from collections import Counter
+from pathlib import Path
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+SEED = 42
+TRAIN_RATIO = 0.8
+VAL_RATIO = 0.1
+
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+LABELS = ["approved", "dismissed", "partial"]
+
+
+def load_epoch(epoch_name):
+    path = OUTPUT_DIR / f"lextreme-ukr-{epoch_name}.jsonl"
+    if not path.exists():
+        print(f"  Missing: {path}")
+        return []
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            records.append(json.loads(line))
+    return records
+
+
+def temporal_split(records):
+    records.sort(key=lambda r: r.get("adjudication_date") or "")
+
+    n = len(records)
+    train_end = int(n * TRAIN_RATIO)
+    val_end = train_end + int(n * VAL_RATIO)
+
+    train = records[:train_end]
+    val = records[train_end:val_end]
+    test = records[val_end:]
+
+    return {"train": train, "validation": val, "test": test}
+
+
+def balance_per_class(records, target_per_class, rng):
+    by_label = {}
+    for r in records:
+        by_label.setdefault(r["label"], []).append(r)
+
+    balanced = []
+    for label in sorted(by_label.keys()):
+        items = by_label[label]
+        rng.shuffle(items)
+        n = min(len(items), target_per_class)
+        balanced.extend(items[:n])
+
+    balanced.sort(key=lambda r: r.get("adjudication_date") or "")
+    return balanced
+
+
+def format_for_hf(record):
+    return {
+        "text": record["text"],
+        "label": record["label"],
+        "language": record["language"],
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epochs", nargs="+", default=EPOCHS, choices=EPOCHS)
+    parser.add_argument("--balance", type=int, default=None,
+                        help="Balance to N per class per epoch before splitting")
+    parser.add_argument("--seed", type=int, default=SEED)
+    parser.add_argument("--keep-metadata", action="store_true",
+                        help="Keep jurisdiction, adjudication_date, doc_id in output")
+    args = parser.parse_args()
+
+    rng = random.Random(args.seed)
+
+    print("Building temporal splits for LexTreme")
+    print(f"Epochs: {args.epochs}")
+    if args.balance:
+        print(f"Balancing to {args.balance} per class per epoch")
+    print()
+
+    for epoch_name in args.epochs:
+        print(f"{'='*50}")
+        print(f"Config: {epoch_name}")
+
+        records = load_epoch(epoch_name)
+        if not records:
+            continue
+
+        dist = Counter(r["label"] for r in records)
+        print(f"  Raw: {len(records):,} samples  {dict(dist)}")
+
+        if args.balance:
+            records = balance_per_class(records, args.balance, rng)
+            dist = Counter(r["label"] for r in records)
+            print(f"  Balanced: {len(records):,} samples  {dict(dist)}")
+
+        splits = temporal_split(records)
+
+        epoch_dir = OUTPUT_DIR / epoch_name
+        epoch_dir.mkdir(parents=True, exist_ok=True)
+
+        for split_name, split_data in splits.items():
+            dates = [r["adjudication_date"] for r in split_data if r.get("adjudication_date")]
+            date_range = f"{min(dates)} .. {max(dates)}" if dates else "no dates"
+            dist = Counter(r["label"] for r in split_data)
+
+            path = epoch_dir / f"{split_name}.jsonl"
+            with open(path, "w", encoding="utf-8") as f:
+                for record in split_data:
+                    out = record if args.keep_metadata else format_for_hf(record)
+                    f.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+            print(f"  {split_name:12s}: {len(split_data):>7,} samples  [{date_range}]  {dict(dist)}")
+
+    print(f"\n{'='*50}")
+    print("Output structure:")
+    for epoch_name in args.epochs:
+        epoch_dir = OUTPUT_DIR / epoch_name
+        if epoch_dir.exists():
+            for f in sorted(epoch_dir.glob("*.jsonl")):
+                print(f"  {f.relative_to(OUTPUT_DIR)}")
+
+    print("\nRun upload-to-hf.py to push to HuggingFace.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lextreme/extract-full-local.py
+++ b/scripts/lextreme/extract-full-local.py
@@ -1,17 +1,24 @@
 #!/usr/bin/env python3
 """
-Full extraction of Ukrainian court decisions from local DB for LexTreme.
+Full extraction of Ukrainian court decisions for LexTreme.
 
-Connects directly via psycopg2 to local PostgreSQL.
-Processes ALL available decisions (not just a sample).
+Extracts decisions across three temporal epochs:
+  - pre_war:    2008-2013
+  - hybrid_war: 2014-2021
+  - full_scale: 2022-2026
+
+Each record includes adjudication_date for temporal train/val/test splitting.
 
 Usage:
-    python3 scripts/lextreme/extract-full-local.py
-    python3 scripts/lextreme/extract-full-local.py --target-per-class 10000
+    python3 scripts/lextreme/extract-full-local.py                    # local DB
+    python3 scripts/lextreme/extract-full-local.py --prod             # prod via SSH tunnel (port 5438)
+    python3 scripts/lextreme/extract-full-local.py --prod --target-per-class 20000
+    python3 scripts/lextreme/extract-full-local.py --prod --epochs full_scale hybrid_war
 """
 
 import argparse
 import json
+import os
 import random
 import re
 import sys
@@ -23,7 +30,7 @@ import psycopg2.extras
 
 OUTPUT_DIR = Path(__file__).parent / "output"
 
-DB_CONFIG = {
+DB_LOCAL = {
     "host": "localhost",
     "port": 5432,
     "dbname": "secondlayer_local",
@@ -31,196 +38,281 @@ DB_CONFIG = {
     "password": "local_dev_password",
 }
 
+DB_PROD = {
+    "host": "127.0.0.1",
+    "port": int(os.environ.get("PROD_DB_PORT", "15438")),
+    "dbname": "secondlayer_prod",
+    "user": "secondlayer",
+    "password": os.environ.get("PGPASSWORD", ""),
+}
+
 BATCH_SIZE = 10000
 SEED = 42
 
-FACTS_RE = re.compile(
-    r'[ВУ]\s*[СС]\s*Т\s*А\s*Н\s*О\s*В\s*И\s*В\s*:',
+EPOCHS = {
+    "pre_war":    {"start": "2008-01-01", "end": "2014-01-01"},
+    "hybrid_war": {"start": "2014-01-01", "end": "2022-01-01"},
+    "full_scale": {"start": "2022-01-01", "end": "2027-01-01"},
+}
+
+# --- Section extraction ---
+
+FACTS_START = re.compile(
+    r'[вВуУ]\s*[сС]\s*[тТ]\s*[аА]\s*[нН]\s*[оО]\s*[вВ]\s*[иИі]\s*[вВлЛ]\s*:',
     re.IGNORECASE
 )
-DISP_RE = re.compile(
-    r'(?:В\s*И\s*Р\s*І\s*Ш\s*И\s*В|У\s*Х\s*В\s*А\s*Л\s*И\s*В|П\s*О\s*С\s*Т\s*А\s*Н\s*О\s*В\s*И\s*В)\s*:',
+DISPOSITIVE_START = re.compile(
+    r'[вВ]\s*[иИі]\s*[рР]\s*[іІ]\s*[шШ]\s*[иИі]\s*[вВ]\s*:|'
+    r'[пП]\s*[оО]\s*[сС]\s*[тТ]\s*[аА]\s*[нН]\s*[оО]\s*[вВ]\s*[иИі]\s*[вВ]\s*:|'
+    r'[уУ]\s*[хХ]\s*[вВ]\s*[аА]\s*[лЛ]\s*[иИі]\s*[вВ]\s*:',
     re.IGNORECASE
+)
+GUIDED_BY = re.compile(r'[Кк]еруючись', re.IGNORECASE)
+
+# --- Outcome classification ---
+
+OUTCOME_PARTIAL = re.compile(
+    r'задовольнити\s+частково|'
+    r'частково\s+задовольнити|'
+    r'позов(?:ні вимоги)?\s.*?задовольнити\s+частково',
+    re.IGNORECASE | re.DOTALL
+)
+OUTCOME_GRANTED = re.compile(
+    r'позов(?:ні вимоги|ну заяву)?\s.*?задовол(?:ь|і)нити(?!\s+частково)|'
+    r'позов\s.*?підлягає\s+задоволенню(?!\s+частково)|'
+    r'задовол(?:ь|і)нити\s+позов|'
+    r'[Зз]аяву\s.*?задовол(?:ь|і)нити|'
+    r'задовол(?:ь|і)нити\s.*?заяву|'
+    r'позов\s.*?задовол(?:ь|і)нити|'
+    r'[Аа]дміністративний\s+позов\s*[-—–]\s*задовол(?:ь|і)нити|'
+    r'[Сс]тягнути\s+з\s|'
+    r'[Вв]ідшкодувати\s|'
+    r'[Вв]изнати\s+протиправн',
+    re.IGNORECASE | re.DOTALL
+)
+OUTCOME_DENIED = re.compile(
+    r'(?:у|в)\s+задоволенні\s.*?відмовити|'
+    r'позов(?:ні вимоги)?\s.*?відмовити|'
+    r'відмовити\s+(?:у|в)\s+задоволенні|'
+    r'позов\s.*?не\s+підлягає\s+задоволенню|'
+    r'залишити\s.*?без\s+задоволення|'
+    r'[ВвУу]\s+позові\s+відмовити|'
+    r'відмовити\s+повністю',
+    re.IGNORECASE | re.DOTALL
 )
 
 
-def normalize_text(text):
-    return re.sub(r'\s+', ' ', text)
+def extract_sections(text):
+    facts_match = None
+    for m in FACTS_START.finditer(text):
+        before = text[max(0, m.start()-5):m.start()].strip()
+        if not before or before.endswith((',', '-', '\n', ' ')):
+            facts_match = m
+            break
+
+    dispositive_match = DISPOSITIVE_START.search(text)
+    guided_match = GUIDED_BY.search(text)
+
+    facts = ""
+    dispositive = ""
+
+    if facts_match:
+        facts_start = facts_match.end()
+        facts_end = guided_match.start() if guided_match else (dispositive_match.start() if dispositive_match else len(text))
+        facts = text[facts_start:facts_end].strip()
+
+    if dispositive_match:
+        dispositive = text[dispositive_match.end():].strip()
+        boilerplate = re.search(
+            r'Рішення\s+(?:може бути оскаржене|суду\s+набирає\s+законної\s+сили)',
+            dispositive, re.IGNORECASE
+        )
+        if boilerplate:
+            dispositive = dispositive[:boilerplate.start()].strip()
+
+    return {"facts": facts, "dispositive": dispositive}
 
 
-def extract_facts(text):
-    text_norm = normalize_text(text)
-    m = FACTS_RE.search(text_norm)
-    if not m:
+def classify_outcome(dispositive):
+    if not dispositive:
         return None
-    facts_start = m.end()
-
-    dm = DISP_RE.search(text_norm, facts_start)
-    if not dm:
-        return None
-
-    facts = text_norm[facts_start:dm.start()].strip()
-    if len(facts) < 200:
-        return None
-    if len(facts) > 10000:
-        facts = facts[:10000]
-    return facts
-
-
-def extract_outcome(text):
-    text_norm = normalize_text(text)
-    matches = list(DISP_RE.finditer(text_norm))
-    if not matches:
-        section = text_norm[int(len(text_norm) * 0.8):]
-    else:
-        section = text_norm[matches[-1].start():]
-
-    s = section.lower()
-    if "частков" in s:
+    if OUTCOME_PARTIAL.search(dispositive):
         return "partial"
-    if "задовольн" in s:
+    if OUTCOME_GRANTED.search(dispositive):
         return "approved"
-    if "відмов" in s:
+    if OUTCOME_DENIED.search(dispositive):
         return "dismissed"
     return None
 
 
+def clean_text(text):
+    text = re.sub(r'\s+', ' ', text)
+    text = re.sub(r'ОСОБА_\d+', '[PERSON]', text)
+    text = re.sub(r'АДРЕСА_\d+', '[ADDRESS]', text)
+    text = re.sub(r'НОМЕР_\d+', '[NUMBER]', text)
+    text = re.sub(r'ІНФОРМАЦІЯ_\d+', '[INFO]', text)
+    return text.strip()
+
+
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--prod", action="store_true",
+                        help="Connect to prod DB via SSH tunnel (port 5438). "
+                             "Set PGPASSWORD env var or pass --password")
+    parser.add_argument("--password", default=None,
+                        help="DB password (overrides PGPASSWORD env var)")
     parser.add_argument("--target-per-class", type=int, default=None,
-                        help="Target per class (default: use all)")
+                        help="Target per class per epoch (default: use all)")
+    parser.add_argument("--epochs", nargs="+", default=list(EPOCHS.keys()),
+                        choices=list(EPOCHS.keys()),
+                        help="Which epochs to extract (default: all)")
     parser.add_argument("--seed", type=int, default=SEED)
     args = parser.parse_args()
 
     random.seed(args.seed)
 
-    conn = psycopg2.connect(**DB_CONFIG)
+    if args.prod:
+        db_config = DB_PROD.copy()
+        if args.password:
+            db_config["password"] = args.password
+        if not db_config["password"]:
+            print("ERROR: Set PGPASSWORD env var or use --password for prod DB")
+            sys.exit(1)
+        print("Connecting to PROD DB (127.0.0.1:5438 via SSH tunnel)")
+    else:
+        db_config = DB_LOCAL.copy()
+        print("Connecting to LOCAL DB (localhost:5432)")
+
+    conn = psycopg2.connect(**db_config)
+    conn.set_client_encoding('UTF8')
     conn.set_session(readonly=True)
 
-    print("🇺🇦 Full extraction from local DB")
-
-    # Count available
+    # Verify connection
     with conn.cursor() as cur:
-        for jk, name in [(1, "Цивільне"), (3, "Господарське")]:
-            cur.execute("""
-                SELECT COUNT(*) FROM edrsr_documents d
-                JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
-                    AND f.adj_year IN (2013, 2014)
-                WHERE d.judgment_code = 3 AND d.justice_kind = %s
-                  AND d.adjudication_date >= '2013-01-01'
-                  AND d.adjudication_date < '2015-01-01'
-                  AND f.text_length BETWEEN 500 AND 200000
-            """, (jk,))
-            count = cur.fetchone()[0]
-            print(f"  {name}: {count:,}")
+        cur.execute("SELECT current_database(), count(*) FROM edrsr_documents LIMIT 1")
+        db_name, _ = cur.fetchone()
+        print(f"Connected to: {db_name}")
+
+    print(f"Epochs: {args.epochs}")
+    if args.target_per_class:
+        print(f"Target per class per epoch: {args.target_per_class}")
 
     all_results = []
 
-    for jk, jk_name in [(1, "civil"), (3, "commercial")]:
-        print(f"\n📋 {jk_name.upper()} (justice_kind={jk}):")
+    for epoch_name in args.epochs:
+        epoch_cfg = EPOCHS[epoch_name]
+        epoch_results = []
 
-        with conn.cursor(name=f"lextreme_{jk_name}", cursor_factory=psycopg2.extras.DictCursor) as cur:
-            cur.itersize = BATCH_SIZE
-            cur.execute("""
-                SELECT d.doc_id, f.full_text
-                FROM edrsr_documents d
-                JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
-                    AND f.adj_year IN (2013, 2014)
-                WHERE d.judgment_code = 3
-                  AND d.justice_kind = %s
-                  AND d.adjudication_date >= '2013-01-01'
-                  AND d.adjudication_date < '2015-01-01'
-                  AND f.text_length BETWEEN 500 AND 200000
-            """, (jk,))
+        for jk, jk_name in [(1, "civil"), (3, "commercial")]:
+            print(f"\n  {epoch_name} / {jk_name} (justice_kind={jk}):")
 
-            processed = 0
-            valid = 0
-            skipped = Counter()
+            cursor_name = f"lx_{epoch_name}_{jk_name}"
+            with conn.cursor(name=cursor_name,
+                             cursor_factory=psycopg2.extras.DictCursor) as cur:
+                cur.itersize = BATCH_SIZE
+                # text_length is NULL in many partitions, so filter by length() in Python
+                cur.execute("""
+                    SELECT d.doc_id,
+                           d.adjudication_date::text as adj_date,
+                           f.full_text
+                    FROM edrsr_documents d
+                    JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+                        AND f.adj_year = EXTRACT(YEAR FROM d.adjudication_date)::int
+                    WHERE d.judgment_code = 3
+                      AND d.justice_kind = %s
+                      AND d.adjudication_date >= %s
+                      AND d.adjudication_date < %s
+                    ORDER BY d.adjudication_date
+                """, (jk, epoch_cfg["start"], epoch_cfg["end"]))
 
-            for row in cur:
-                processed += 1
-                text = row["full_text"]
+                processed = 0
+                valid = 0
+                skipped = Counter()
 
-                facts = extract_facts(text)
-                if not facts:
-                    skipped["no_facts"] += 1
-                    continue
+                for row in cur:
+                    processed += 1
+                    text = row["full_text"]
 
-                outcome = extract_outcome(text)
-                if not outcome:
-                    skipped["no_outcome"] += 1
-                    continue
+                    if not text or len(text) < 500 or len(text) > 200000:
+                        skipped["text_length"] += 1
+                        continue
 
-                valid += 1
-                all_results.append({
-                    "text": facts,
-                    "label": outcome,
-                    "language": "uk",
-                    "justice_kind": jk_name,
-                    "doc_id": str(row["doc_id"]),
-                })
+                    sections = extract_sections(text)
+                    if not sections["facts"] or len(sections["facts"]) < 200:
+                        skipped["no_facts"] += 1
+                        continue
+                    if not sections["dispositive"] or len(sections["dispositive"]) < 50:
+                        skipped["no_dispositive"] += 1
+                        continue
 
-                if processed % 50000 == 0:
-                    dist = Counter(r["label"] for r in all_results if r["justice_kind"] == jk_name)
-                    print(f"  ... {processed:,} processed, {valid:,} valid  {dict(dist)}")
+                    outcome = classify_outcome(sections["dispositive"])
+                    if not outcome:
+                        skipped["no_outcome"] += 1
+                        continue
 
-        dist = Counter(r["label"] for r in all_results if r["justice_kind"] == jk_name)
-        print(f"  Done: {processed:,} processed, {valid:,} valid")
-        print(f"  Skipped: {dict(skipped)}")
+                    facts = sections["facts"]
+                    if len(facts) > 10000:
+                        facts = facts[:10000]
+
+                    valid += 1
+                    epoch_results.append({
+                        "text": clean_text(facts),
+                        "label": outcome,
+                        "language": "uk",
+                        "jurisdiction": jk_name,
+                        "adjudication_date": row["adj_date"][:10] if row["adj_date"] else None,
+                        "doc_id": str(row["doc_id"]),
+                    })
+
+                    if processed % 50000 == 0:
+                        print(f"    ... {processed:,} processed, {valid:,} valid", flush=True)
+
+            dist = Counter(r["label"] for r in epoch_results if r["jurisdiction"] == jk_name)
+            print(f"    Done: {processed:,} processed, {valid:,} valid  {dict(dist)}")
+            print(f"    Skipped: {dict(skipped)}")
+
+        dist = Counter(r["label"] for r in epoch_results)
+        print(f"\n  {epoch_name} total: {len(epoch_results):,} samples")
         print(f"  Distribution: {dict(dist)}")
+
+        if args.target_per_class:
+            by_label = {}
+            for item in epoch_results:
+                by_label.setdefault(item["label"], []).append(item)
+
+            balanced = []
+            for label in sorted(by_label.keys()):
+                items = by_label[label]
+                random.shuffle(items)
+                n = min(len(items), args.target_per_class)
+                balanced.extend(items[:n])
+                print(f"    {label}: {n:,} of {len(items):,} sampled")
+
+            epoch_results = balanced
+
+        all_results.extend([(epoch_name, r) for r in epoch_results])
 
     conn.close()
 
-    print(f"\n📊 Combined: {len(all_results):,} samples")
-    combined_dist = Counter(r["label"] for r in all_results)
-    print(f"  {dict(combined_dist)}")
+    print(f"\n{'='*50}")
+    print(f"Total extracted: {len(all_results):,} samples")
+    for epoch_name in args.epochs:
+        epoch_items = [r for e, r in all_results if e == epoch_name]
+        dist = Counter(r["label"] for r in epoch_items)
+        print(f"  {epoch_name}: {len(epoch_items):,}  {dict(dist)}")
 
-    # Balance if requested
-    if args.target_per_class:
-        by_label = {}
-        for item in all_results:
-            by_label.setdefault(item["label"], []).append(item)
-
-        balanced = []
-        for label in sorted(by_label.keys()):
-            items = by_label[label]
-            random.shuffle(items)
-            n = min(len(items), args.target_per_class)
-            balanced.extend(items[:n])
-            print(f"  {label}: {n:,} of {len(items):,} sampled")
-
-        random.shuffle(balanced)
-        data = balanced
-    else:
-        random.shuffle(all_results)
-        data = all_results
-
-    total = len(data)
-    print(f"\n⚖️  Final: {total:,} samples")
-    final_dist = Counter(d["label"] for d in data)
-    print(f"  {dict(final_dist)}")
-
-    # Split 80/10/10
-    train_end = int(total * 0.8)
-    val_end = int(total * 0.9)
-    splits = {
-        "train": data[:train_end],
-        "validation": data[train_end:val_end],
-        "test": data[val_end:],
-    }
-
-    # Save
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    for split_name, items in splits.items():
-        path = OUTPUT_DIR / f"lextreme-ukr-{split_name}.jsonl"
-        with open(path, "w", encoding="utf-8") as f:
-            for item in items:
-                row = {"text": item["text"], "label": item["label"], "language": item["language"]}
-                f.write(json.dumps(row, ensure_ascii=False) + "\n")
-        dist = Counter(i["label"] for i in items)
-        print(f"  {split_name}: {len(items):,} → {path}  {dict(dist)}")
+    for epoch_name in args.epochs:
+        epoch_items = [r for e, r in all_results if e == epoch_name]
+        epoch_items.sort(key=lambda r: r["adjudication_date"] or "")
 
-    print(f"\n✅ Done!")
+        path = OUTPUT_DIR / f"lextreme-ukr-{epoch_name}.jsonl"
+        with open(path, "w", encoding="utf-8") as f:
+            for item in epoch_items:
+                f.write(json.dumps(item, ensure_ascii=False) + "\n")
+        print(f"  {epoch_name}: {len(epoch_items):,} -> {path}")
+
+    print("\nDone! Run build-temporal-splits.py next.")
 
 
 if __name__ == "__main__":

--- a/scripts/lextreme/lextreme-config.py
+++ b/scripts/lextreme/lextreme-config.py
@@ -1,27 +1,18 @@
 """
 Config snippet to add to lextreme.py in joelniklaus/lextreme.
 
-This defines the Ukrainian court decisions subset for the LexTreme benchmark.
-Copy the _UKRAINIAN_COURT_DECISIONS_JUDGMENT dict and the LextremeConfig line
-into the appropriate places in lextreme.py.
+Three configs -- one per temporal epoch -- with train/val/test splits
+separated chronologically within each epoch.
 """
 
-# --- Add this dict alongside other dataset configs ---
-
-_UKRAINIAN_COURT_DECISIONS_JUDGMENT = {
+_UKRAINIAN_COURT_DECISIONS_BASE = {
     "task_type": "TaskType.SLTC",
     "hf_hub_name": "secondlayer/ukrainian-court-decisions",
     "language": "uk",
-    "config_name": "default",
     "input_col": "text",
     "label_col": "label",
     "url": "https://reyestr.court.gov.ua/",
-    "description": (
-        "Ukrainian Court Decisions Judgment Prediction dataset. "
-        "Contains facts sections (ВСТАНОВИВ) of civil and commercial court decisions "
-        "from the State Court Decisions Registry of Ukraine (ЄДРСР). "
-        "The task is to predict the judgment outcome: approved, dismissed, or partial."
-    ),
+    "label_classes": ["approved", "dismissed", "partial"],
     "citation": """@misc{ovcharov2025ukrainian,
   title={Ukrainian Court Decisions Dataset for Judgment Prediction},
   author={Ovcharov, Volodymyr},
@@ -29,18 +20,57 @@ _UKRAINIAN_COURT_DECISIONS_JUDGMENT = {
   url={https://huggingface.co/datasets/secondlayer/ukrainian-court-decisions},
   note={Extracted from the State Court Decisions Registry of Ukraine}
 }""",
-    "label_classes": ["approved", "dismissed", "partial"],
 }
 
-# --- Add this line to BUILDER_CONFIGS list ---
+_UKRAINIAN_COURT_DECISIONS_PRE_WAR = {
+    **_UKRAINIAN_COURT_DECISIONS_BASE,
+    "config_name": "pre_war",
+    "description": (
+        "Ukrainian Court Decisions Judgment Prediction (pre-war epoch, 2008-2013). "
+        "Civil and commercial court decisions with temporal train/val/test splits."
+    ),
+}
+
+_UKRAINIAN_COURT_DECISIONS_HYBRID_WAR = {
+    **_UKRAINIAN_COURT_DECISIONS_BASE,
+    "config_name": "hybrid_war",
+    "description": (
+        "Ukrainian Court Decisions Judgment Prediction (hybrid war epoch, 2014-2021). "
+        "Civil and commercial court decisions with temporal train/val/test splits."
+    ),
+}
+
+_UKRAINIAN_COURT_DECISIONS_FULL_SCALE = {
+    **_UKRAINIAN_COURT_DECISIONS_BASE,
+    "config_name": "full_scale",
+    "description": (
+        "Ukrainian Court Decisions Judgment Prediction (full-scale war epoch, 2022-2026). "
+        "Civil and commercial court decisions with temporal train/val/test splits."
+    ),
+}
+
+# --- Add these lines to BUILDER_CONFIGS list ---
 # LextremeConfig(
-#     name="ukrainian_court_decisions_judgment",
-#     description=_UKRAINIAN_COURT_DECISIONS_JUDGMENT["description"],
-#     **_UKRAINIAN_COURT_DECISIONS_JUDGMENT,
+#     name="ukrainian_court_decisions_judgment_pre_war",
+#     description=_UKRAINIAN_COURT_DECISIONS_PRE_WAR["description"],
+#     **_UKRAINIAN_COURT_DECISIONS_PRE_WAR,
+# ),
+# LextremeConfig(
+#     name="ukrainian_court_decisions_judgment_hybrid_war",
+#     description=_UKRAINIAN_COURT_DECISIONS_HYBRID_WAR["description"],
+#     **_UKRAINIAN_COURT_DECISIONS_HYBRID_WAR,
+# ),
+# LextremeConfig(
+#     name="ukrainian_court_decisions_judgment_full_scale",
+#     description=_UKRAINIAN_COURT_DECISIONS_FULL_SCALE["description"],
+#     **_UKRAINIAN_COURT_DECISIONS_FULL_SCALE,
 # ),
 
-print("Config for lextreme.py PR:")
+print("Configs for lextreme.py PR:")
 print()
-print("1. Add _UKRAINIAN_COURT_DECISIONS_JUDGMENT dict (see above)")
-print("2. Add LextremeConfig entry to BUILDER_CONFIGS list")
-print("3. Test: load_dataset('lextreme', 'ukrainian_court_decisions_judgment')")
+print("1. Add _UKRAINIAN_COURT_DECISIONS_* dicts (3 epochs)")
+print("2. Add 3 LextremeConfig entries to BUILDER_CONFIGS")
+print("3. Test:")
+print("   load_dataset('lextreme', 'ukrainian_court_decisions_judgment_pre_war')")
+print("   load_dataset('lextreme', 'ukrainian_court_decisions_judgment_hybrid_war')")
+print("   load_dataset('lextreme', 'ukrainian_court_decisions_judgment_full_scale')")

--- a/scripts/lextreme/upload-to-hf.py
+++ b/scripts/lextreme/upload-to-hf.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """
-Upload the extracted Ukrainian court decisions dataset to HuggingFace Hub.
+Upload Ukrainian court decisions dataset to HuggingFace Hub.
+
+Supports multi-config upload (one config per epoch) with temporal splits.
 
 Prerequisites:
     pip install huggingface_hub datasets pyarrow
@@ -9,6 +11,7 @@ Prerequisites:
 Usage:
     python3 scripts/lextreme/upload-to-hf.py
     python3 scripts/lextreme/upload-to-hf.py --repo secondlayer/ukrainian-court-decisions
+    python3 scripts/lextreme/upload-to-hf.py --epochs hybrid_war full_scale
 """
 
 import argparse
@@ -16,66 +19,70 @@ from pathlib import Path
 
 OUTPUT_DIR = Path(__file__).parent / "output"
 DEFAULT_REPO = "secondlayer/ukrainian-court-decisions"
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
 
 
 def main():
     parser = argparse.ArgumentParser(description="Upload dataset to HuggingFace Hub")
     parser.add_argument("--repo", default=DEFAULT_REPO, help=f"HF repo ID (default: {DEFAULT_REPO})")
-    parser.add_argument("--dry-run", action="store_true", help="Show what would be uploaded without uploading")
+    parser.add_argument("--epochs", nargs="+", default=EPOCHS, choices=EPOCHS)
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be uploaded")
     args = parser.parse_args()
 
     try:
         from datasets import Dataset, DatasetDict
+        from huggingface_hub import HfApi
     except ImportError:
-        print("❌ datasets not installed. Run: pip install datasets huggingface_hub pyarrow")
+        print("Install deps: pip install datasets huggingface_hub pyarrow")
         return
 
-    splits = {}
-    for split_name in ["train", "validation", "test"]:
-        candidates = [
-            OUTPUT_DIR / f"{split_name}.parquet",
-            OUTPUT_DIR / f"{split_name}.jsonl",
-            OUTPUT_DIR / f"lextreme-ukr-{split_name}.jsonl",
-        ]
+    configs = {}
+    for epoch_name in args.epochs:
+        epoch_dir = OUTPUT_DIR / epoch_name
+        if not epoch_dir.exists():
+            print(f"  Missing: {epoch_dir} -- run build-temporal-splits.py first")
+            continue
 
-        found = None
-        for path in candidates:
-            if path.exists():
-                found = path
-                break
+        splits = {}
+        for split_name in ["train", "validation", "test"]:
+            path = epoch_dir / f"{split_name}.jsonl"
+            if not path.exists():
+                print(f"  Missing: {path}")
+                continue
+            splits[split_name] = Dataset.from_json(str(path))
 
-        if not found:
-            print(f"❌ Не знайдено файл для {split_name}: шукав {[str(c) for c in candidates]}")
-            return
+        if splits:
+            configs[epoch_name] = DatasetDict(splits)
 
-        if found.suffix == ".parquet":
-            splits[split_name] = Dataset.from_parquet(str(found))
-        else:
-            splits[split_name] = Dataset.from_json(str(found))
+    if not configs:
+        print("No data found. Run extract-full-local.py then build-temporal-splits.py first.")
+        return
 
-    dataset_dict = DatasetDict(splits)
-
-    print(f"📊 Датасет:")
-    for name, ds in dataset_dict.items():
-        print(f"  {name}: {len(ds):,} записів")
-
-    print(f"\n  Колонки: {dataset_dict['train'].column_names}")
-    print(f"  Приклад:")
-    sample = dataset_dict["train"][0]
-    print(f"    label: {sample['label']}")
-    print(f"    language: {sample['language']}")
-    print(f"    text: {sample['text'][:200]}...")
+    print(f"Dataset: {args.repo}")
+    print(f"Configs: {list(configs.keys())}")
+    for config_name, dataset_dict in configs.items():
+        print(f"\n  {config_name}:")
+        for split_name, ds in dataset_dict.items():
+            print(f"    {split_name}: {len(ds):,} samples")
+        print(f"    Columns: {dataset_dict['train'].column_names}")
+        sample = dataset_dict["train"][0]
+        print(f"    Example label: {sample['label']}")
+        print(f"    Example text: {sample['text'][:100]}...")
 
     if args.dry_run:
-        print(f"\n🔍 Dry run — не завантажую. Репо: {args.repo}")
+        print(f"\nDry run -- not uploading.")
         return
 
-    print(f"\n⬆️  Завантаження на HuggingFace: {args.repo}")
-    dataset_dict.push_to_hub(
-        args.repo,
-        private=False,
-    )
-    print(f"✅ Готово! https://huggingface.co/datasets/{args.repo}")
+    for config_name, dataset_dict in configs.items():
+        print(f"\nUploading config '{config_name}' to {args.repo}...")
+        dataset_dict.push_to_hub(
+            args.repo,
+            config_name=config_name,
+            private=False,
+        )
+        print(f"  Done: {config_name}")
+
+    print(f"\nhttps://huggingface.co/datasets/{args.repo}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Implements Joel Niklaus' recommendation from joelniklaus/lextreme#16: temporal splits + separate epoch configs
- Three HF configs: `pre_war` (2008-2013), `hybrid_war` (2014-2021), `full_scale` (2022-2026)
- Chronological train/val/test splits within each epoch (80/10/10 by date, not random)
- Fixed `text_length IS NULL` issue in prod fulltext partitions (filter in Python instead of SQL)
- New `build-temporal-splits.py` script, updated extraction, upload, dataset card, and lextreme config

## Files
- `scripts/lextreme/extract-full-local.py` -- `--prod` flag, all 3 epochs, adjudication_date in output
- `scripts/lextreme/build-temporal-splits.py` -- new: temporal splits per epoch
- `scripts/lextreme/upload-to-hf.py` -- multi-config upload (one per epoch)
- `scripts/lextreme/lextreme-config.py` -- 3 LextremeConfig entries for PR to joelniklaus/lextreme
- `scripts/lextreme/DATASET_CARD.md` -- documents temporal splits, epoch descriptions
- `scripts/lextreme/WORKFLOW.md` -- updated workflow with prod instructions

## Test plan
- [x] Extraction running on prod (pre_war 543K, hybrid_war 4.2M extracted, full_scale in progress)
- [ ] Run build-temporal-splits.py on extracted data
- [ ] Upload to HuggingFace as secondlayer/ukrainian-court-decisions
- [ ] Update PR to joelniklaus/lextreme

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds temporal, chronological train/val/test splits and three epoch configs (`pre_war`, `hybrid_war`, `full_scale`) for the Ukrainian court decisions dataset to enable realistic LexTreme evaluation. Also adds scripts to extract by epoch with `adjudication_date`, build splits, upload multi-configs to HF, and updates docs; fixes missing `text_length` handling in prod.

- New Features
  - Temporal 80/10/10 splits within each epoch; three HF configs: `pre_war` (2008–2013), `hybrid_war` (2014–2021), `full_scale` (2022–2026).
  - New `build-temporal-splits.py`; `extract-full-local.py` now supports prod via SSH tunnel, per-epoch extraction, optional class balancing, improved section parsing/outcome classification, and includes `adjudication_date`.
  - `upload-to-hf.py` now uploads one config per epoch and supports `--dry-run`.
  - Updated `DATASET_CARD.md` and `WORKFLOW.md`; added three LexTreme configs in `lextreme-config.py`.

- Bug Fixes
  - Avoids relying on `text_length` in prod partitions by filtering length in Python to prevent missing fulltext rows.

<sup>Written for commit 3260b7c9b03c7d0b55742d43aac91cc17772a6c6. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1733?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

