### PR TITLE
feat(india): S3 mirror + DB import + MCP search tools for Indian courts

### DIFF
--- a/mcp_backend/src/api/tools/india-court-tools.ts
+++ b/mcp_backend/src/api/tools/india-court-tools.ts
@@ -1,0 +1,364 @@
+/**
+ * India Court Tools
+ *
+ * 3 tools for searching Indian court judgments:
+ * - search_india_supreme_court — Supreme Court of India (38K+ judgments, 1950-2026)
+ * - search_india_high_courts   — 25 High Courts (16M+ judgments, 1950-2025)
+ * - india_court_stats          — Aggregate statistics across both courts
+ *
+ * Data source: AWS Open Data Registry (CC-BY-4.0, Dattam Labs)
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+export class IndiaCourtTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'search_india_supreme_court',
+        annotations: { title: 'Supreme Court of India', readOnlyHint: true },
+        description: `Search Indian Supreme Court judgments (38K+ decisions, 1950-2026).
+
+Search by case title, petitioner, respondent, judge, citation, CNR number, disposal type, or year range.
+Available fields: title, petitioner, respondent, judge, author_judge, citation, case_id, cnr, decision_date, disposal_nature, court, available_languages, year.
+
+Examples:
+- Search by petitioner: {"petitioner": "State of Maharashtra"}
+- Search by judge: {"judge": "Chandrachud"}
+- Search by year: {"year_from": 2020, "year_to": 2024}
+- Search by citation: {"citation": "2024 INSC"}
+- Combined: {"judge": "Misra", "disposal_nature": "Dismissed", "year_from": 2015}
+
+Data: CC-BY-4.0 via AWS Open Data (Dattam Labs).`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Free text search across title, petitioner, respondent, and description' },
+            petitioner: { type: 'string', description: 'Petitioner name (partial match)' },
+            respondent: { type: 'string', description: 'Respondent name (partial match)' },
+            judge: { type: 'string', description: 'Judge name (partial match)' },
+            citation: { type: 'string', description: 'Citation reference (e.g. "2024 INSC 735")' },
+            case_id: { type: 'string', description: 'Case ID (e.g. "2024 INSC 735")' },
+            cnr: { type: 'string', description: 'CNR number (exact match)' },
+            disposal_nature: { type: 'string', description: 'Disposal type: Dismissed, Appeal(s) allowed, Disposed off, etc.' },
+            year_from: { type: 'number', description: 'Start year (inclusive)' },
+            year_to: { type: 'number', description: 'End year (inclusive)' },
+            limit: { type: 'number', default: 50, maximum: 200, description: 'Max results (default 50)' },
+            offset: { type: 'number', default: 0, description: 'Offset for pagination' },
+          },
+        },
+      },
+      {
+        name: 'search_india_high_courts',
+        annotations: { title: 'Indian High Courts', readOnlyHint: true },
+        description: `Search Indian High Courts judgments (16M+ decisions across 25 courts, 1950-2025).
+
+25 High Courts: Bombay, Madras, Calcutta, Delhi, Karnataka, Kerala, Allahabad, Patna, Punjab & Haryana, Rajasthan, Gujarat, Madhya Pradesh, Chhattisgarh, Orissa, Jharkhand, Gauhati, Himachal Pradesh, Uttarakhand, Telangana, Andhra Pradesh, Jammu & Kashmir, Tripura, Manipur, Meghalaya, Sikkim.
+
+Search by case title, judge, court name, CNR, disposal type, or year range.
+
+Examples:
+- Search Bombay HC: {"court": "Bombay"}
+- Search by judge in Kerala: {"judge": "Justice Kumar", "court": "Kerala"}
+- Search by year range: {"year_from": 2020, "year_to": 2024, "court": "Delhi"}
+- Combined: {"query": "land acquisition", "court": "Madras", "year_from": 2018}
+
+Data: CC-BY-4.0 via AWS Open Data (Dattam Labs).`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Free text search across title and description' },
+            court: { type: 'string', description: 'Court name (partial match, e.g. "Bombay", "Delhi")' },
+            court_code: { type: 'string', description: 'Court code (e.g. "27~1" for Bombay)' },
+            judge: { type: 'string', description: 'Judge name (partial match)' },
+            cnr: { type: 'string', description: 'CNR number (exact match)' },
+            disposal_nature: { type: 'string', description: 'Disposal type (e.g. "DISPOSED OFF", "ALLOWED")' },
+            bench: { type: 'string', description: 'Bench identifier' },
+            year_from: { type: 'number', description: 'Start year (inclusive)' },
+            year_to: { type: 'number', description: 'End year (inclusive)' },
+            limit: { type: 'number', default: 50, maximum: 200, description: 'Max results (default 50)' },
+            offset: { type: 'number', default: 0, description: 'Offset for pagination' },
+          },
+        },
+      },
+      {
+        name: 'india_court_stats',
+        annotations: { title: 'India Courts Statistics', readOnlyHint: true },
+        description: `Get aggregate statistics for Indian courts: total cases, breakdown by year, court, judge, disposal type.
+
+Use without parameters for a full overview, or filter by court/year for specific stats.
+
+Examples:
+- Full overview: {}
+- Stats for Bombay HC: {"court": "Bombay", "source": "high-courts"}
+- SC stats for 2020-2024: {"source": "supreme-court", "year_from": 2020, "year_to": 2024}`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            source: { type: 'string', enum: ['supreme-court', 'high-courts', 'all'], default: 'all', description: 'Which court system' },
+            court: { type: 'string', description: 'Filter HC stats by court name (partial match)' },
+            year_from: { type: 'number', description: 'Start year' },
+            year_to: { type: 'number', description: 'End year' },
+            group_by: { type: 'string', enum: ['year', 'court', 'judge', 'disposal'], default: 'year', description: 'Group results by field' },
+            limit: { type: 'number', default: 30, maximum: 100, description: 'Max groups to return' },
+          },
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: Record<string, unknown>): Promise<ToolResult | null> {
+    switch (name) {
+      case 'search_india_supreme_court':
+        return this.searchSupremeCourt(args);
+      case 'search_india_high_courts':
+        return this.searchHighCourts(args);
+      case 'india_court_stats':
+        return this.getStats(args);
+      default:
+        return null;
+    }
+  }
+
+  private async searchSupremeCourt(args: Record<string, unknown>): Promise<ToolResult> {
+    const { query, petitioner, respondent, judge, citation, case_id, cnr, disposal_nature, year_from, year_to, limit = 50, offset = 0 } = args as any;
+
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (query) {
+      conditions.push(`(title ILIKE $${pi} OR petitioner ILIKE $${pi} OR respondent ILIKE $${pi} OR description ILIKE $${pi})`);
+      values.push(`%${query}%`);
+      pi++;
+    }
+    if (petitioner) {
+      conditions.push(`petitioner ILIKE $${pi}`);
+      values.push(`%${petitioner}%`);
+      pi++;
+    }
+    if (respondent) {
+      conditions.push(`respondent ILIKE $${pi}`);
+      values.push(`%${respondent}%`);
+      pi++;
+    }
+    if (judge) {
+      conditions.push(`judge ILIKE $${pi}`);
+      values.push(`%${judge}%`);
+      pi++;
+    }
+    if (citation) {
+      conditions.push(`citation ILIKE $${pi}`);
+      values.push(`%${citation}%`);
+      pi++;
+    }
+    if (case_id) {
+      conditions.push(`case_id ILIKE $${pi}`);
+      values.push(`%${case_id}%`);
+      pi++;
+    }
+    if (cnr) {
+      conditions.push(`cnr = $${pi}`);
+      values.push(cnr);
+      pi++;
+    }
+    if (disposal_nature) {
+      conditions.push(`disposal_nature ILIKE $${pi}`);
+      values.push(`%${disposal_nature}%`);
+      pi++;
+    }
+    if (year_from) {
+      conditions.push(`year >= $${pi}`);
+      values.push(Number(year_from));
+      pi++;
+    }
+    if (year_to) {
+      conditions.push(`year <= $${pi}`);
+      values.push(Number(year_to));
+      pi++;
+    }
+
+    if (conditions.length === 0) {
+      return this.wrapResponse('Specify at least one search parameter: query, petitioner, respondent, judge, citation, case_id, cnr, disposal_nature, or year range');
+    }
+
+    const lim = Math.min(Number(limit) || 50, 200);
+    const off = Number(offset) || 0;
+    values.push(lim, off);
+
+    const sql = `
+      SELECT title, petitioner, respondent, judge, author_judge, citation, case_id, cnr,
+             decision_date, disposal_nature, available_languages, year,
+             COUNT(*) OVER() AS _total_count
+      FROM indian_sc_judgments
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY decision_date DESC NULLS LAST
+      LIMIT $${pi} OFFSET $${pi + 1}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('No Supreme Court judgments found matching your query');
+      }
+      return this.wrapSearchResults(result.rows, lim, off);
+    } catch (error: any) {
+      logger.error('search_india_supreme_court error', { error: error.message });
+      return this.wrapError(`Search error: ${error.message}`);
+    }
+  }
+
+  private async searchHighCourts(args: Record<string, unknown>): Promise<ToolResult> {
+    const { query, court, court_code, judge, cnr, disposal_nature, bench, year_from, year_to, limit = 50, offset = 0 } = args as any;
+
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+
+    if (query) {
+      conditions.push(`(title ILIKE $${pi} OR description ILIKE $${pi})`);
+      values.push(`%${query}%`);
+      pi++;
+    }
+    if (court) {
+      conditions.push(`court ILIKE $${pi}`);
+      values.push(`%${court}%`);
+      pi++;
+    }
+    if (court_code) {
+      conditions.push(`court_code = $${pi}`);
+      values.push(court_code);
+      pi++;
+    }
+    if (judge) {
+      conditions.push(`judge ILIKE $${pi}`);
+      values.push(`%${judge}%`);
+      pi++;
+    }
+    if (cnr) {
+      conditions.push(`cnr = $${pi}`);
+      values.push(cnr);
+      pi++;
+    }
+    if (disposal_nature) {
+      conditions.push(`disposal_nature ILIKE $${pi}`);
+      values.push(`%${disposal_nature}%`);
+      pi++;
+    }
+    if (bench) {
+      conditions.push(`bench = $${pi}`);
+      values.push(bench);
+      pi++;
+    }
+    if (year_from) {
+      conditions.push(`year >= $${pi}`);
+      values.push(Number(year_from));
+      pi++;
+    }
+    if (year_to) {
+      conditions.push(`year <= $${pi}`);
+      values.push(Number(year_to));
+      pi++;
+    }
+
+    if (conditions.length === 0) {
+      return this.wrapResponse('Specify at least one search parameter: query, court, judge, cnr, disposal_nature, bench, or year range');
+    }
+
+    const lim = Math.min(Number(limit) || 50, 200);
+    const off = Number(offset) || 0;
+    values.push(lim, off);
+
+    const sql = `
+      SELECT title, court, court_code, judge, cnr, bench,
+             decision_date, disposal_nature, pdf_link, year,
+             COUNT(*) OVER() AS _total_count
+      FROM indian_hc_judgments
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY decision_date DESC NULLS LAST
+      LIMIT $${pi} OFFSET $${pi + 1}`;
+
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('No High Court judgments found matching your query');
+      }
+      return this.wrapSearchResults(result.rows, lim, off);
+    } catch (error: any) {
+      logger.error('search_india_high_courts error', { error: error.message });
+      return this.wrapError(`Search error: ${error.message}`);
+    }
+  }
+
+  private async getStats(args: Record<string, unknown>): Promise<ToolResult> {
+    const { source = 'all', court, year_from, year_to, group_by = 'year', limit = 30 } = args as any;
+    const lim = Math.min(Number(limit) || 30, 100);
+    const stats: any = {};
+
+    try {
+      if (source === 'all' || source === 'supreme-court') {
+        const scConditions: string[] = [];
+        const scValues: any[] = [];
+        let pi = 1;
+        if (year_from) { scConditions.push(`year >= $${pi}`); scValues.push(Number(year_from)); pi++; }
+        if (year_to) { scConditions.push(`year <= $${pi}`); scValues.push(Number(year_to)); pi++; }
+        const where = scConditions.length > 0 ? `WHERE ${scConditions.join(' AND ')}` : '';
+
+        const scTotal = await this.db.query(`SELECT count(*) as total, min(year) as min_year, max(year) as max_year FROM indian_sc_judgments ${where}`, scValues);
+
+        let groupCol = 'year';
+        if (group_by === 'judge') groupCol = 'judge';
+        else if (group_by === 'disposal') groupCol = 'disposal_nature';
+
+        const scGroup = await this.db.query(
+          `SELECT ${groupCol} as group_key, count(*) as cases FROM indian_sc_judgments ${where} GROUP BY ${groupCol} ORDER BY cases DESC LIMIT $${pi}`,
+          [...scValues, lim]
+        );
+
+        stats.supreme_court = {
+          total: Number(scTotal.rows[0].total),
+          year_range: `${scTotal.rows[0].min_year}-${scTotal.rows[0].max_year}`,
+          [`by_${group_by}`]: scGroup.rows,
+        };
+      }
+
+      if (source === 'all' || source === 'high-courts') {
+        const hcConditions: string[] = [];
+        const hcValues: any[] = [];
+        let pi = 1;
+        if (court) { hcConditions.push(`court ILIKE $${pi}`); hcValues.push(`%${court}%`); pi++; }
+        if (year_from) { hcConditions.push(`year >= $${pi}`); hcValues.push(Number(year_from)); pi++; }
+        if (year_to) { hcConditions.push(`year <= $${pi}`); hcValues.push(Number(year_to)); pi++; }
+        const where = hcConditions.length > 0 ? `WHERE ${hcConditions.join(' AND ')}` : '';
+
+        const hcTotal = await this.db.query(`SELECT count(*) as total, count(DISTINCT court) as courts, min(year) as min_year, max(year) as max_year FROM indian_hc_judgments ${where}`, hcValues);
+
+        let groupCol = 'year';
+        if (group_by === 'court') groupCol = 'court';
+        else if (group_by === 'judge') groupCol = 'judge';
+        else if (group_by === 'disposal') groupCol = 'disposal_nature';
+
+        const hcGroup = await this.db.query(
+          `SELECT ${groupCol} as group_key, count(*) as cases FROM indian_hc_judgments ${where} GROUP BY ${groupCol} ORDER BY cases DESC LIMIT $${pi}`,
+          [...hcValues, lim]
+        );
+
+        stats.high_courts = {
+          total: Number(hcTotal.rows[0].total),
+          distinct_courts: Number(hcTotal.rows[0].courts),
+          year_range: `${hcTotal.rows[0].min_year}-${hcTotal.rows[0].max_year}`,
+          [`by_${group_by}`]: hcGroup.rows,
+        };
+      }
+
+      return this.wrapResponse(stats);
+    } catch (error: any) {
+      logger.error('india_court_stats error', { error: error.message });
+      return this.wrapError(`Stats error: ${error.message}`);
+    }
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -41,6 +41,7 @@ import { WorkflowMemoryService } from '../services/workflow-memory-service.js';
 import { WorkflowMemoryPushService } from '../services/workflow-memory-push-service.js';
 import { OsintProxyAdapter } from '../adapters/osint-proxy-adapter.js';
 import { OsintProxyTools } from '../api/tools/osint-proxy-tools.js';
+import { IndiaCourtTools } from '../api/tools/india-court-tools.js';
 import { logger } from '../utils/logger.js';
 import path from 'path';
 
@@ -146,6 +147,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new OpenDataRegistriesTools(coreServices.db));
   toolRegistry.registerHandler(new Tier1OpenDataTools(coreServices.db));
   toolRegistry.registerHandler(new EdsrExtendedTools(coreServices.db));
+  toolRegistry.registerHandler(new IndiaCourtTools(coreServices.db));
   toolRegistry.registerHandler(new DecisionLayerTools(llmAdapter));
 
   // EDRSR unified search (structured + FTS + hybrid + semantic in one tool)

--- a/scripts/india/import-metadata-to-db.py
+++ b/scripts/india/import-metadata-to-db.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+"""
+Import Indian court metadata from parquet files (S3 or local) into PostgreSQL.
+
+Creates tables:
+  - indian_sc_judgments  (Supreme Court)
+  - indian_hc_judgments  (High Courts)
+
+Optimized: COPY via temp table + vectorized pandas ops + concurrent S3 prefetch.
+
+Usage:
+  python import-metadata-to-db.py --source supreme-court --years 2024
+  python import-metadata-to-db.py --source high-courts --years 2024 --courts 27_1
+  python import-metadata-to-db.py --source all
+"""
+
+import argparse
+import csv
+import io
+import logging
+import os
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from queue import Queue, Empty
+from threading import Thread
+
+import boto3
+import pyarrow.parquet as pq
+import numpy as np
+import pandas as pd
+import psycopg2
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("india-import")
+
+SOURCE_REGION = "ap-south-1"
+DEST_REGION = "eu-central-1"
+DEST_BUCKET = "lexai-corpus-india-judgments"
+
+SC_SOURCE_BUCKET = "indian-supreme-court-judgments"
+HC_SOURCE_BUCKET = "indian-high-court-judgments"
+
+SC_TABLE = "indian_sc_judgments"
+HC_TABLE = "indian_hc_judgments"
+
+PREFETCH_WORKERS = 4
+
+CREATE_SC_TABLE = f"""
+CREATE TABLE IF NOT EXISTS {SC_TABLE} (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    petitioner TEXT,
+    respondent TEXT,
+    description TEXT,
+    judge TEXT,
+    author_judge TEXT,
+    citation TEXT,
+    case_id TEXT,
+    cnr TEXT,
+    decision_date DATE,
+    disposal_nature TEXT,
+    court TEXT,
+    available_languages TEXT,
+    path TEXT,
+    nc_display TEXT,
+    scraped_at TIMESTAMPTZ,
+    year INTEGER,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(cnr, case_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_{SC_TABLE}_year ON {SC_TABLE}(year);
+CREATE INDEX IF NOT EXISTS idx_{SC_TABLE}_decision_date ON {SC_TABLE}(decision_date);
+CREATE INDEX IF NOT EXISTS idx_{SC_TABLE}_cnr ON {SC_TABLE}(cnr);
+CREATE INDEX IF NOT EXISTS idx_{SC_TABLE}_judge ON {SC_TABLE}(judge);
+"""
+
+CREATE_HC_TABLE = f"""
+CREATE TABLE IF NOT EXISTS {HC_TABLE} (
+    id SERIAL PRIMARY KEY,
+    court_code TEXT,
+    title TEXT,
+    description TEXT,
+    judge TEXT,
+    pdf_link TEXT,
+    cnr TEXT,
+    date_of_registration DATE,
+    decision_date DATE,
+    disposal_nature TEXT,
+    court TEXT,
+    pdf_exists BOOLEAN,
+    year INTEGER,
+    bench TEXT,
+    imported_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(cnr, court_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_{HC_TABLE}_year ON {HC_TABLE}(year);
+CREATE INDEX IF NOT EXISTS idx_{HC_TABLE}_decision_date ON {HC_TABLE}(decision_date);
+CREATE INDEX IF NOT EXISTS idx_{HC_TABLE}_cnr ON {HC_TABLE}(cnr);
+CREATE INDEX IF NOT EXISTS idx_{HC_TABLE}_court ON {HC_TABLE}(court);
+CREATE INDEX IF NOT EXISTS idx_{HC_TABLE}_court_code ON {HC_TABLE}(court_code);
+"""
+
+SC_COLS = [
+    "title", "petitioner", "respondent", "description", "judge", "author_judge",
+    "citation", "case_id", "cnr", "decision_date", "disposal_nature", "court",
+    "available_languages", "path", "nc_display", "scraped_at", "year",
+]
+
+HC_COLS = [
+    "court_code", "title", "description", "judge", "pdf_link", "cnr",
+    "date_of_registration", "decision_date", "disposal_nature", "court",
+    "pdf_exists", "year", "bench",
+]
+
+
+BULK_MODE = False
+
+
+def get_db_connection():
+    opts = "-c statement_timeout=600000"
+    if BULK_MODE:
+        opts += " -c synchronous_commit=off -c work_mem=256MB -c maintenance_work_mem=512MB"
+    return psycopg2.connect(
+        os.environ["DATABASE_URL"],
+        options=opts,
+        keepalives=1,
+        keepalives_idle=30,
+        keepalives_interval=10,
+        keepalives_count=5,
+    )
+
+
+def get_source_client():
+    from botocore import UNSIGNED
+    from botocore.config import Config
+    return boto3.client("s3", region_name=SOURCE_REGION, config=Config(signature_version=UNSIGNED))
+
+
+def ensure_tables(conn):
+    with conn.cursor() as cur:
+        cur.execute(CREATE_SC_TABLE)
+        cur.execute(CREATE_HC_TABLE)
+    conn.commit()
+    log.info("Tables ensured: %s, %s", SC_TABLE, HC_TABLE)
+
+
+def vectorized_date_parse(series):
+    """Parse dates vectorized -- 100x faster than row-by-row."""
+    if series.dtype == "datetime64[ns]" or pd.api.types.is_datetime64_any_dtype(series):
+        return pd.to_datetime(series, errors="coerce").dt.date
+    result = pd.to_datetime(series, format="%d-%m-%Y", errors="coerce")
+    mask = result.isna() & series.notna()
+    if mask.any():
+        result[mask] = pd.to_datetime(series[mask], format="%Y-%m-%d", errors="coerce")
+    mask2 = result.isna() & series.notna()
+    if mask2.any():
+        result[mask2] = pd.to_datetime(series[mask2], format="%d/%m/%Y", errors="coerce")
+    return result.dt.date
+
+
+def df_to_csv_buffer(df, columns):
+    """Convert DataFrame to CSV StringIO for COPY -- avoids row-by-row iteration."""
+    buf = io.StringIO()
+    subset = df[columns].copy()
+    subset.to_csv(buf, index=False, header=False, na_rep="\\N", quoting=csv.QUOTE_MINIMAL)
+    buf.seek(0)
+    return buf
+
+
+def copy_upsert(conn, df, target_table, columns, conflict_cols, update_cols):
+    """Bulk load via COPY to temp table + INSERT ON CONFLICT. 5-10x faster than execute_values."""
+    tmp_table = f"_tmp_{target_table}_{os.getpid()}"
+    col_defs = ", ".join(columns)
+    conflict_def = ", ".join(conflict_cols)
+    update_set = ", ".join(f"{c} = EXCLUDED.{c}" for c in update_cols)
+
+    buf = df_to_csv_buffer(df, columns)
+
+    with conn.cursor() as cur:
+        cur.execute(f"CREATE TEMP TABLE {tmp_table} (LIKE {target_table} INCLUDING DEFAULTS) ON COMMIT DROP")
+        cur.execute(f"ALTER TABLE {tmp_table} DROP COLUMN IF EXISTS id")
+        cur.execute(f"ALTER TABLE {tmp_table} DROP COLUMN IF EXISTS imported_at")
+
+        cur.copy_expert(
+            f"COPY {tmp_table} ({col_defs}) FROM STDIN WITH (FORMAT csv, NULL '\\N')",
+            buf,
+        )
+
+        cur.execute(f"""
+            INSERT INTO {target_table} ({col_defs})
+            SELECT {col_defs} FROM {tmp_table}
+            ON CONFLICT ({conflict_def}) DO UPDATE SET
+                {update_set},
+                imported_at = NOW()
+        """)
+        inserted = cur.rowcount
+
+    conn.commit()
+    return inserted
+
+
+def prepare_sc_df(parquet_path, year):
+    """Load and prepare SC dataframe -- all vectorized, no iterrows."""
+    df = pd.read_parquet(parquet_path, columns=[c for c in [
+        "title", "petitioner", "respondent", "description", "judge", "author_judge",
+        "citation", "case_id", "cnr", "decision_date", "disposal_nature", "court",
+        "available_languages", "path", "nc_display", "scraped_at", "year",
+    ]])
+
+    if "year" not in df.columns:
+        df["year"] = year
+    df["year"] = pd.to_numeric(df["year"], errors="coerce").fillna(int(year)).astype(int)
+
+    df["decision_date"] = vectorized_date_parse(df["decision_date"])
+    if "scraped_at" in df.columns:
+        df["scraped_at"] = pd.to_datetime(df["scraped_at"], errors="coerce")
+
+    df = df.astype(object).where(df.notna(), None)
+    before = len(df)
+    df = df.drop_duplicates(subset=["cnr", "case_id"], keep="last")
+    if len(df) < before:
+        log.info("SC year=%s: deduplicated %d -> %d", year, before, len(df))
+
+    return df
+
+
+def prepare_hc_df(parquet_path, year, court_code=None, bench=None):
+    """Load and prepare HC dataframe -- all vectorized, no iterrows."""
+    df = pd.read_parquet(parquet_path)
+    if "raw_html" in df.columns:
+        df = df.drop(columns=["raw_html"])
+
+    if "court_code" not in df.columns:
+        df["court_code"] = court_code
+    df["year"] = int(year)
+    df["bench"] = bench
+
+    df["decision_date"] = vectorized_date_parse(df["decision_date"])
+    if "date_of_registration" in df.columns:
+        df["date_of_registration"] = vectorized_date_parse(df["date_of_registration"])
+    else:
+        df["date_of_registration"] = None
+
+    if "pdf_exists" in df.columns:
+        df["pdf_exists"] = df["pdf_exists"].astype(object).where(df["pdf_exists"].notna(), None)
+    else:
+        df["pdf_exists"] = None
+
+    for col in HC_COLS:
+        if col not in df.columns:
+            df[col] = None
+
+    df = df.astype(object).where(df.notna(), None)
+    before = len(df)
+    if "court_code" in df.columns:
+        df = df.drop_duplicates(subset=["cnr", "court_code"], keep="last")
+    if len(df) < before:
+        log.info("HC year=%s court=%s: deduplicated %d -> %d", year, court_code, before, len(df))
+
+    return df
+
+
+def import_sc_parquet(conn, parquet_path, year):
+    t0 = time.time()
+    df = prepare_sc_df(parquet_path, year)
+    log.info("SC year=%s: %d rows (prepared in %.1fs)", year, len(df), time.time() - t0)
+
+    n = copy_upsert(
+        conn, df, SC_TABLE, SC_COLS,
+        conflict_cols=["cnr", "case_id"],
+        update_cols=["title", "decision_date", "disposal_nature", "scraped_at"],
+    )
+    log.info("SC year=%s: upserted %d rows (%.1fs total)", year, n, time.time() - t0)
+    return n
+
+
+def import_hc_parquet(conn, parquet_path, year, court_code=None, bench=None):
+    t0 = time.time()
+    df = prepare_hc_df(parquet_path, year, court_code, bench)
+    log.info("HC year=%s court=%s bench=%s: %d rows (prepared in %.1fs)",
+             year, court_code, bench, len(df), time.time() - t0)
+
+    n = copy_upsert(
+        conn, df, HC_TABLE, HC_COLS,
+        conflict_cols=["cnr", "court_code"],
+        update_cols=["title", "decision_date", "disposal_nature", "pdf_exists"],
+    )
+    log.info("HC year=%s court=%s bench=%s: upserted %d rows (%.1fs total)",
+             year, court_code, bench, n, time.time() - t0)
+    return n
+
+
+def download_parquet(s3_client, bucket, key):
+    tmp = tempfile.NamedTemporaryFile(suffix=".parquet", delete=False)
+    s3_client.download_file(bucket, key, tmp.name)
+    return tmp.name
+
+
+def prefetch_parquets(s3_client, bucket, items, max_workers=PREFETCH_WORKERS):
+    """Download parquets concurrently, yield (local_path, metadata) as they complete."""
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {}
+        for item in items:
+            key = item[0]
+            fut = pool.submit(download_parquet, s3_client, bucket, key)
+            futures[fut] = item
+
+        for fut in as_completed(futures):
+            item = futures[fut]
+            try:
+                local_path = fut.result()
+                yield (local_path, *item)
+            except Exception as e:
+                log.error("Download failed %s: %s", item[0], e)
+
+
+def discover_sc_parquets(s3_client, years=None):
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=SC_SOURCE_BUCKET, Prefix="metadata/parquet/"):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".parquet"):
+                continue
+            year = extract_year_from_key(key)
+            if years and year not in years:
+                continue
+            yield key, year
+
+
+def discover_hc_parquets(s3_client, years=None, courts=None):
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=HC_SOURCE_BUCKET, Prefix="metadata/parquet/"):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if not key.endswith(".parquet"):
+                continue
+            year = extract_year_from_key(key)
+            if years and year not in years:
+                continue
+            court = extract_court_from_key(key)
+            if courts and court not in courts:
+                continue
+            bench = extract_bench_from_key(key)
+            yield key, year, court, bench
+
+
+def extract_year_from_key(key):
+    for part in key.split("/"):
+        if part.startswith("year="):
+            return part.split("=")[1]
+    return None
+
+
+def extract_court_from_key(key):
+    for part in key.split("/"):
+        if part.startswith("court="):
+            return part.split("=")[1]
+    return None
+
+
+def extract_bench_from_key(key):
+    for part in key.split("/"):
+        if part.startswith("bench="):
+            return part.split("=")[1]
+    return None
+
+
+def parse_years(years_str):
+    if not years_str:
+        return None
+    if "-" in years_str:
+        start, end = years_str.split("-", 1)
+        return [str(y) for y in range(int(start), int(end) + 1)]
+    return [years_str]
+
+
+HC_SEARCH_INDEXES = [
+    ("idx_indian_hc_judgments_year", f"CREATE INDEX idx_{{HC_TABLE}}_year ON {HC_TABLE}(year)"),
+    ("idx_indian_hc_judgments_decision_date", f"CREATE INDEX idx_{{HC_TABLE}}_decision_date ON {HC_TABLE}(decision_date)"),
+    ("idx_indian_hc_judgments_cnr", f"CREATE INDEX idx_{{HC_TABLE}}_cnr ON {HC_TABLE}(cnr)"),
+    ("idx_indian_hc_judgments_court", f"CREATE INDEX idx_{{HC_TABLE}}_court ON {HC_TABLE}(court)"),
+    ("idx_indian_hc_judgments_court_code", f"CREATE INDEX idx_{{HC_TABLE}}_court_code ON {HC_TABLE}(court_code)"),
+    ("idx_indian_hc_title_trgm", f"CREATE INDEX idx_indian_hc_title_trgm ON {HC_TABLE} USING gin (title gin_trgm_ops)"),
+    ("idx_indian_hc_judge_trgm", f"CREATE INDEX idx_indian_hc_judge_trgm ON {HC_TABLE} USING gin (judge gin_trgm_ops)"),
+    ("idx_indian_hc_court_trgm", f"CREATE INDEX idx_indian_hc_court_trgm ON {HC_TABLE} USING gin (court gin_trgm_ops)"),
+]
+
+SC_SEARCH_INDEXES = [
+    ("idx_indian_sc_title_trgm", f"CREATE INDEX idx_indian_sc_title_trgm ON {SC_TABLE} USING gin (title gin_trgm_ops)"),
+    ("idx_indian_sc_petitioner_trgm", f"CREATE INDEX idx_indian_sc_petitioner_trgm ON {SC_TABLE} USING gin (petitioner gin_trgm_ops)"),
+    ("idx_indian_sc_respondent_trgm", f"CREATE INDEX idx_indian_sc_respondent_trgm ON {SC_TABLE} USING gin (respondent gin_trgm_ops)"),
+]
+
+
+def drop_search_indexes(conn, table):
+    indexes = HC_SEARCH_INDEXES if table == HC_TABLE else SC_SEARCH_INDEXES
+    with conn.cursor() as cur:
+        for idx_name, _ in indexes:
+            cur.execute(f"DROP INDEX IF EXISTS {idx_name}")
+            log.info("Dropped index %s", idx_name)
+    conn.commit()
+
+
+def rebuild_search_indexes(conn, table):
+    indexes = HC_SEARCH_INDEXES if table == HC_TABLE else SC_SEARCH_INDEXES
+    for idx_name, create_sql in indexes:
+        t0 = time.time()
+        log.info("Creating index %s ...", idx_name)
+        with conn.cursor() as cur:
+            cur.execute(f"SET maintenance_work_mem = '1GB'")
+            cur.execute(f"DROP INDEX IF EXISTS {idx_name}")
+            cur.execute(create_sql)
+        conn.commit()
+        log.info("Created %s in %.1fs", idx_name, time.time() - t0)
+
+
+def main():
+    global BULK_MODE
+    parser = argparse.ArgumentParser(description="Import Indian court metadata into PostgreSQL")
+    parser.add_argument("--source", choices=["supreme-court", "high-courts", "all"], default="all")
+    parser.add_argument("--years", type=str, help="Year or range: 2024 or 2020-2025")
+    parser.add_argument("--courts", type=str, help="Comma-separated court IDs (HC only)")
+    parser.add_argument("--database-url", type=str, help="Override DATABASE_URL env var")
+    parser.add_argument("--prefetch", type=int, default=PREFETCH_WORKERS, help="Concurrent S3 downloads")
+    parser.add_argument("--bulk-mode", action="store_true",
+                        help="Drop indexes before import, rebuild after. 3-5x faster for large imports.")
+    parser.add_argument("--rebuild-indexes-only", action="store_true",
+                        help="Only rebuild search indexes, no import.")
+    args = parser.parse_args()
+
+    if args.database_url:
+        os.environ["DATABASE_URL"] = args.database_url
+
+    if "DATABASE_URL" not in os.environ:
+        log.error("DATABASE_URL not set. Pass --database-url or export DATABASE_URL.")
+        sys.exit(1)
+
+    BULK_MODE = args.bulk_mode
+
+    conn = get_db_connection()
+    ensure_tables(conn)
+    conn.close()
+
+    if args.rebuild_indexes_only:
+        conn = get_db_connection()
+        sources = ["supreme-court", "high-courts"] if args.source == "all" else [args.source]
+        if "high-courts" in sources:
+            rebuild_search_indexes(conn, HC_TABLE)
+        if "supreme-court" in sources:
+            rebuild_search_indexes(conn, SC_TABLE)
+        conn.close()
+        log.info("Index rebuild complete.")
+        return
+
+    if BULK_MODE:
+        conn = get_db_connection()
+        sources_list = ["supreme-court", "high-courts"] if args.source == "all" else [args.source]
+        if "high-courts" in sources_list:
+            log.info("BULK MODE: dropping HC search indexes")
+            drop_search_indexes(conn, HC_TABLE)
+        if "supreme-court" in sources_list:
+            log.info("BULK MODE: dropping SC search indexes")
+            drop_search_indexes(conn, SC_TABLE)
+        conn.close()
+
+    s3 = get_source_client()
+    years = parse_years(args.years)
+    courts = args.courts.split(",") if args.courts else None
+    sources = ["supreme-court", "high-courts"] if args.source == "all" else [args.source]
+
+    total = 0
+    errors = []
+    t_start = time.time()
+
+    if "supreme-court" in sources:
+        log.info("=== Importing Supreme Court metadata ===")
+        items = list(discover_sc_parquets(s3, years))
+        log.info("Found %d SC parquet files", len(items))
+        for local_path, key, year in prefetch_parquets(s3, SC_SOURCE_BUCKET, items, args.prefetch):
+            try:
+                conn = get_db_connection()
+                total += import_sc_parquet(conn, local_path, year)
+                conn.close()
+            except Exception as e:
+                log.error("FAILED %s: %s", key, e)
+                errors.append((key, str(e)))
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            finally:
+                os.unlink(local_path)
+
+    if "high-courts" in sources:
+        log.info("=== Importing High Courts metadata ===")
+        items = list(discover_hc_parquets(s3, years, courts))
+        log.info("Found %d HC parquet files", len(items))
+        for local_path, key, year, court, bench in prefetch_parquets(s3, HC_SOURCE_BUCKET, items, args.prefetch):
+            try:
+                conn = get_db_connection()
+                total += import_hc_parquet(conn, local_path, year, court, bench)
+                conn.close()
+            except Exception as e:
+                log.error("FAILED %s: %s", key, e)
+                errors.append((key, str(e)))
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+            finally:
+                os.unlink(local_path)
+
+    elapsed = time.time() - t_start
+    rate = total / elapsed if elapsed > 0 else 0
+    log.info("=== DONE: %d rows in %.0fs (%.0f rows/s) ===", total, elapsed, rate)
+    if errors:
+        log.error("=== %d ERRORS ===", len(errors))
+        for key, err in errors:
+            log.error("  %s: %s", key, err)
+
+    if BULK_MODE:
+        log.info("BULK MODE: rebuilding search indexes...")
+        conn = get_db_connection()
+        if "high-courts" in sources:
+            rebuild_search_indexes(conn, HC_TABLE)
+        if "supreme-court" in sources:
+            rebuild_search_indexes(conn, SC_TABLE)
+        conn.close()
+        log.info("Index rebuild complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/india/mirror-india-courts.py
+++ b/scripts/india/mirror-india-courts.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""
+Mirror Indian court judgments from public AWS S3 buckets to our S3 bucket.
+
+Sources (CC-BY-4.0, Dattam Labs):
+  - Supreme Court: s3://indian-supreme-court-judgments (ap-south-1)
+  - High Courts:   s3://indian-high-court-judgments   (ap-south-1)
+
+Destination: s3://lexai-corpus-india-judgments (eu-central-1)
+"""
+
+import argparse
+import json
+import sys
+import time
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import boto3
+from botocore import UNSIGNED
+from botocore.config import Config
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("india-mirror")
+
+SOURCE_REGION = "ap-south-1"
+DEST_REGION = "eu-central-1"
+DEST_BUCKET = "lexai-corpus-india-judgments"
+
+SOURCES = {
+    "supreme-court": {
+        "bucket": "indian-supreme-court-judgments",
+        "prefix_map": "supreme-court",
+    },
+    "high-courts": {
+        "bucket": "indian-high-court-judgments",
+        "prefix_map": "high-courts",
+    },
+}
+
+STATE_KEY = "_state/sync-state.json"
+MAX_RETRIES = 5
+
+
+def get_source_client():
+    return boto3.client("s3", region_name=SOURCE_REGION, config=Config(signature_version=UNSIGNED))
+
+
+def get_dest_client():
+    return boto3.client("s3", region_name=DEST_REGION)
+
+
+def load_state(dest_client):
+    try:
+        resp = dest_client.get_object(Bucket=DEST_BUCKET, Key=STATE_KEY)
+        return json.loads(resp["Body"].read())
+    except dest_client.exceptions.NoSuchKey:
+        return {}
+
+
+def save_state(dest_client, state):
+    dest_client.put_object(
+        Bucket=DEST_BUCKET,
+        Key=STATE_KEY,
+        Body=json.dumps(state, indent=2, default=str),
+        ContentType="application/json",
+    )
+
+
+def list_objects(client, bucket, prefix="", year_filter=None, court_filter=None):
+    paginator = client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if year_filter:
+                matched = False
+                for y in year_filter:
+                    if f"year={y}" in key:
+                        matched = True
+                        break
+                if not matched:
+                    continue
+            if court_filter:
+                matched = False
+                for c in court_filter:
+                    if f"court={c}" in key:
+                        matched = True
+                        break
+                if not matched:
+                    continue
+            yield obj
+
+
+def copy_with_retry(source_client, dest_client, src_bucket, src_key, dest_key, storage_class):
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            dest_client.copy_object(
+                Bucket=DEST_BUCKET,
+                Key=dest_key,
+                CopySource={"Bucket": src_bucket, "Key": src_key},
+                StorageClass=storage_class,
+                MetadataDirective="COPY",
+            )
+            return True
+        except Exception as e:
+            if attempt == MAX_RETRIES:
+                log.error("FAILED after %d attempts: %s -> %s: %s", MAX_RETRIES, src_key, dest_key, e)
+                return False
+            wait = 2 ** attempt
+            log.warning("Retry %d/%d for %s (wait %ds): %s", attempt, MAX_RETRIES, src_key, wait, e)
+            time.sleep(wait)
+    return False
+
+
+def storage_class_for_key(key):
+    if key.endswith(".parquet") or key.endswith(".json"):
+        return "STANDARD"
+    return "STANDARD_IA"
+
+
+def sync_source(source_name, years=None, courts=None, dry_run=False, full=False, include_pdf=False):
+    src_cfg = SOURCES[source_name]
+    src_bucket = src_cfg["bucket"]
+    dest_prefix = src_cfg["prefix_map"]
+
+    source_client = get_source_client()
+    dest_client = get_dest_client()
+
+    state = {} if full else load_state(dest_client)
+    source_state = state.setdefault(source_name, {"synced_keys": {}})
+    synced = source_state["synced_keys"]
+
+    prefixes_to_scan = []
+    if not include_pdf and source_name == "high-courts":
+        prefixes_to_scan = ["data/tar/", "metadata/parquet/", "metadata/tar/"]
+    elif not include_pdf and source_name == "supreme-court":
+        prefixes_to_scan = ["data/tar/", "metadata/parquet/", "metadata/tar/"]
+    else:
+        prefixes_to_scan = [""]
+
+    stats = {"copied": 0, "skipped": 0, "errors": 0, "bytes_copied": 0}
+    run_start = datetime.now(timezone.utc)
+
+    for prefix in prefixes_to_scan:
+        log.info("Scanning %s/%s ...", src_bucket, prefix)
+        for obj in list_objects(source_client, src_bucket, prefix, years, courts):
+            src_key = obj["Key"]
+            dest_key = f"{dest_prefix}/{src_key}"
+            etag = obj["ETag"]
+            size = obj["Size"]
+
+            if src_key in synced and synced[src_key].get("etag") == etag:
+                stats["skipped"] += 1
+                continue
+
+            sc = storage_class_for_key(src_key)
+
+            if dry_run:
+                log.info("DRY-RUN | would copy %s (%s bytes, %s)", src_key, size, sc)
+                stats["copied"] += 1
+                stats["bytes_copied"] += size
+                continue
+
+            log.info("COPY | %s | %s | %.2f MB", source_name, src_key, size / 1024 / 1024)
+            ok = copy_with_retry(source_client, dest_client, src_bucket, src_key, dest_key, sc)
+
+            if ok:
+                stats["copied"] += 1
+                stats["bytes_copied"] += size
+                synced[src_key] = {
+                    "etag": etag,
+                    "size": size,
+                    "synced_at": datetime.now(timezone.utc).isoformat(),
+                }
+                if stats["copied"] % 50 == 0:
+                    source_state["last_sync"] = datetime.now(timezone.utc).isoformat()
+                    save_state(dest_client, state)
+            else:
+                stats["errors"] += 1
+
+    if not dry_run:
+        source_state["last_sync"] = datetime.now(timezone.utc).isoformat()
+        save_state(dest_client, state)
+
+    run_end = datetime.now(timezone.utc)
+    run_report = {
+        "started_at": run_start.isoformat(),
+        "finished_at": run_end.isoformat(),
+        "duration_seconds": (run_end - run_start).total_seconds(),
+        "source": source_name,
+        **stats,
+    }
+
+    if not dry_run:
+        run_key = f"_state/runs/{run_start.strftime('%Y%m%dT%H%M%S')}_{source_name}.json"
+        dest_client.put_object(
+            Bucket=DEST_BUCKET,
+            Key=run_key,
+            Body=json.dumps(run_report, indent=2),
+            ContentType="application/json",
+        )
+
+    log.info(
+        "DONE | %s | copied=%d skipped=%d errors=%d bytes=%.2f GB | %.0fs",
+        source_name,
+        stats["copied"],
+        stats["skipped"],
+        stats["errors"],
+        stats["bytes_copied"] / 1024 / 1024 / 1024,
+        run_report["duration_seconds"],
+    )
+    return run_report
+
+
+def show_status():
+    dest_client = get_dest_client()
+    state = load_state(dest_client)
+    if not state:
+        print("No sync state found. Run sync first.")
+        return
+
+    for source_name, sdata in state.items():
+        keys = sdata.get("synced_keys", {})
+        total_bytes = sum(v.get("size", 0) for v in keys.values())
+        print(f"\n{source_name}:")
+        print(f"  Last sync: {sdata.get('last_sync', 'never')}")
+        print(f"  Objects:   {len(keys)}")
+        print(f"  Size:      {total_bytes / 1024 / 1024 / 1024:.2f} GB")
+
+
+def parse_years(years_str):
+    if not years_str:
+        return None
+    if "-" in years_str:
+        start, end = years_str.split("-", 1)
+        return [str(y) for y in range(int(start), int(end) + 1)]
+    return [years_str]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mirror Indian court judgments to our S3")
+    sub = parser.add_subparsers(dest="command")
+
+    sync_p = sub.add_parser("sync", help="Sync data from source to destination")
+    sync_p.add_argument("--source", choices=["supreme-court", "high-courts", "all"], default="all")
+    sync_p.add_argument("--years", type=str, help="Year or range: 2024 or 2020-2025")
+    sync_p.add_argument("--courts", type=str, help="Comma-separated court IDs (HC only)")
+    sync_p.add_argument("--dry-run", action="store_true")
+    sync_p.add_argument("--full", action="store_true", help="Ignore state, re-sync everything")
+    sync_p.add_argument("--include-pdf", action="store_true", help="Also sync individual PDFs")
+
+    sub.add_parser("status", help="Show sync status")
+
+    args = parser.parse_args()
+
+    if args.command == "status":
+        show_status()
+        return
+
+    if args.command == "sync":
+        years = parse_years(args.years)
+        courts = args.courts.split(",") if args.courts else None
+        sources = ["supreme-court", "high-courts"] if args.source == "all" else [args.source]
+
+        for src in sources:
+            if courts and src == "supreme-court":
+                log.warning("--courts ignored for supreme-court source")
+                courts_for_src = None
+            else:
+                courts_for_src = courts
+            sync_source(src, years=years, courts=courts_for_src, dry_run=args.dry_run, full=args.full, include_pdf=args.include_pdf)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **S3 mirror service** (`scripts/india/mirror-india-courts.py`): incremental sync from public AWS buckets (Supreme Court + 25 High Courts) to `s3://lexai-corpus-india-judgments` (eu-central-1) with state tracking, retry, dry-run CLI
- **DB import pipeline** (`scripts/india/import-metadata-to-db.py`): parquet → PostgreSQL bulk import using COPY via temp table, vectorized pandas, concurrent S3 prefetch, `--bulk-mode` for automated index drop/rebuild
- **3 MCP search tools** (`india-court-tools.ts`): `search_india_supreme_court`, `search_india_high_courts`, `india_court_stats` with GIN trigram indexes for fast ILIKE

## Data imported to prod

| Table | Rows | Size | Years |
|-------|------|------|-------|
| `indian_sc_judgments` | 38,269 | 28 MB | 1950–2026 |
| `indian_hc_judgments` | 17,549,056 | 18 GB | 1950–2025 |

Source: AWS Open Data Registry (CC-BY-4.0, Dattam Labs) -- 25 High Courts, Supreme Court of India.

## Test plan

- [x] S3 cross-region server-side copy verified (ap-south-1 → eu-central-1)
- [x] SC smoke test: 2024 year (8 files, 2.14 GB) copied successfully
- [x] SC full metadata import: 38,269 rows, all years
- [x] HC full metadata import: 17.5M rows, all courts/years
- [x] GIN trigram + btree indexes created and verified
- [x] TypeScript build passes (no new errors)
- [ ] MCP tools functional test after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an S3 mirror and a fast parquet→PostgreSQL import for Indian Supreme Court and 25 High Courts, plus 3 MCP search tools backed by trigram indexes. Enables quick search and stats over 17.5M+ High Court and 38K+ Supreme Court judgments.

- **New Features**
  - S3 mirror (`scripts/india/mirror-india-courts.py`): incremental cross-region copy (ap-south-1 → eu-central-1) with state tracking, retry, dry-run; writes to `s3://lexai-corpus-india-judgments`.
  - DB import (`scripts/india/import-metadata-to-db.py`): parquet → PostgreSQL bulk load via COPY + temp table, vectorized pandas, concurrent S3 prefetch, optional `--bulk-mode` index drop/rebuild.
  - Tables and indexes: creates `indian_sc_judgments` and `indian_hc_judgments` with year/date/cnr indexes and GIN trigram indexes for fast ILIKE.
  - MCP tools (`mcp_backend/src/api/tools/india-court-tools.ts`), registered in `tool-services.ts`:
    - `search_india_supreme_court`
    - `search_india_high_courts`
    - `india_court_stats`

- **Migration**
  - Ensure PostgreSQL has `pg_trgm` enabled: `CREATE EXTENSION IF NOT EXISTS pg_trgm;`.
  - Set `DATABASE_URL` and install Python deps: `boto3`, `pyarrow`, `pandas`, `psycopg2`.
  - Optional: start S3 mirror (dry-run first), e.g. `python scripts/india/mirror-india-courts.py sync --source all --dry-run`.
  - Run metadata import (use `--bulk-mode` for large loads), e.g. `python scripts/india/import-metadata-to-db.py --source all --bulk-mode`.
  - Deploy MCP backend to load the new tools.

<sup>Written for commit 7b0ab352ab1403d637ac7264b621cacdca1915e2. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1741?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

