### PR TITLE
fix(registry): use FTS indexes for large US data tables

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -17,7 +17,9 @@ export type MatchType =
   | 'gte'           // col >= $N
   | 'lte'           // col <= $N
   | 'array_contains' // $N = ANY(col)
-  | 'ilike_cast';    // col::text ILIKE $N  (%val%)
+  | 'ilike_cast'    // col::text ILIKE $N  (%val%)
+  | 'fts'           // to_tsvector('english', col) @@ plainto_tsquery('english', $N)
+  | 'fts_simple';   // to_tsvector('simple', col) @@ plainto_tsquery('simple', $N)
 
 export interface FieldDef {
   name: string;
@@ -417,7 +419,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     defaultLimit: 20,
     maxLimit: 50,
     fields: [
-      { name: 'query', description: 'Full-text search in opinion text (English)', match: 'ilike', columns: ['text_preview'] },
+      { name: 'query', description: 'Full-text search in opinion text (English)', match: 'fts', columns: ['text_preview'] },
       { name: 'reporter', description: 'Reporter series (e.g. f2d, f3d, us, s-ct for Supreme Court)', match: 'exact', columns: ['reporter_series'] },
       { name: 'author', description: 'Author or URL containing court/jurisdiction info', match: 'ilike', columns: ['author'] },
     ],
@@ -467,7 +469,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     maxLimit: 100,
     requiredFields: ['donor'],
     fields: [
-      { name: 'donor', description: 'Contributor name (LAST, FIRST format)', match: 'ilike', columns: ['contributor_name'] },
+      { name: 'donor', description: 'Contributor name (LAST, FIRST format)', match: 'fts_simple', columns: ['contributor_name'] },
       { name: 'employer', description: 'Employer of contributor', match: 'ilike', columns: ['employer'] },
       { name: 'state', description: 'Donor state (2-letter code)', match: 'exact', columns: ['state'], transform: 'uppercase' },
       { name: 'committee', description: 'Recipient committee ID (e.g. C00401224)', match: 'exact', columns: ['committee_id'] },
@@ -520,7 +522,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     defaultLimit: 30,
     requiredFields: ['company'],
     fields: [
-      { name: 'company', description: 'Company name (bank, lender, servicer)', match: 'ilike', columns: ['company'] },
+      { name: 'company', description: 'Company name (bank, lender, servicer)', match: 'fts_simple', columns: ['company'] },
       { name: 'product', description: 'Product: Credit reporting, Mortgage, Bank account, Credit card / prepaid, Debt collection, etc.', match: 'exact', columns: ['product_normalized'] },
       { name: 'state', description: 'Consumer state (2-letter code)', match: 'exact', columns: ['state'], transform: 'uppercase' },
       { name: 'issue', description: 'Issue description', match: 'ilike', columns: ['issue'] },

--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -165,6 +165,18 @@ ${registryDescriptions}
           values.push(`%${val}%`);
           pi++;
           break;
+
+        case 'fts':
+          conditions.push(`to_tsvector('english', ${field.columns[0]}) @@ plainto_tsquery('english', $${pi})`);
+          values.push(val);
+          pi++;
+          break;
+
+        case 'fts_simple':
+          conditions.push(`to_tsvector('simple', ${field.columns[0]}) @@ plainto_tsquery('simple', $${pi})`);
+          values.push(val);
+          pi++;
+          break;
       }
     }
 


### PR DESCRIPTION
## Summary
- **us_court_opinions** (62 GB / 6.9M rows) was timing out on prod (>60s) because `ILIKE` can't use the existing GIN FTS index
- **us_fec_contributions** (18 GB / 58M rows) took 31s per query for the same reason
- **us_cfpb_complaints** (18 GB / 15M rows) took 39s per query

Added `fts` and `fts_simple` match types to the registry search tool that generate `to_tsvector() @@ plainto_tsquery()` SQL, which leverages the existing GIN indexes (`idx_us_court_opinions_fts`, `idx_us_fec_contrib_name_fts`, `idx_us_cfpb_company_fts`).

## Test plan
- [ ] Verify `us_court_opinions` search completes under 5s (was timing out at 60s)
- [ ] Verify `us_fec_contributions` search completes under 5s (was 31s)
- [ ] Verify `us_cfpb_complaints` search completes under 5s (was 39s)
- [ ] Verify other US registries still work (SEC, OSHA, EPA, FDA, sanctions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches US registry search from ILIKE to full‑text search to use existing GIN indexes and stop timeouts on large tables. Adds FTS match types for faster queries on court opinions, FEC contributions, and CFPB complaints.

- **Bug Fixes**
  - Added `fts` and `fts_simple` match types using to_tsvector @@ plainto_tsquery with `english` and `simple` configs.
  - Updated catalog: court opinions `query` → `fts` on `text_preview`; FEC `donor` → `fts_simple` on `contributor_name`; CFPB `company` → `fts_simple` on `company`.
  - Expected performance: under 5s vs 31–60s+.

<sup>Written for commit c0ac888e464597ce850e665187ee68b43ae65496. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1742?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

