### PR TITLE
feat(lextreme): remove truncation, add LEXTREME benchmark configs

### DIFF
--- a/scripts/lextreme/build-temporal-splits.py
+++ b/scripts/lextreme/build-temporal-splits.py
@@ -5,15 +5,17 @@ Build HuggingFace dataset with temporal train/val/test splits per epoch.
 Takes per-epoch JSONL files from extract-full-local.py, sorts by adjudication_date,
 and splits chronologically: earliest 80% = train, next 10% = validation, last 10% = test.
 
-Produces three configs for HuggingFace (one per epoch):
-  - pre_war    (2008-2013)
-  - hybrid_war (2014-2021)
-  - full_scale (2022-2026)
+Produces configs for HuggingFace:
+  Full configs (one per epoch):
+    - pre_war, hybrid_war, full_scale
+  LEXTREME benchmark configs (small val/test for fast evaluation):
+    - pre_war_lextreme, hybrid_war_lextreme, full_scale_lextreme
 
 Usage:
     python3 scripts/lextreme/build-temporal-splits.py
     python3 scripts/lextreme/build-temporal-splits.py --balance 20000
     python3 scripts/lextreme/build-temporal-splits.py --epochs hybrid_war full_scale
+    python3 scripts/lextreme/build-temporal-splits.py --lextreme-max 1000
 """
 
 import argparse
@@ -81,11 +83,47 @@ def format_for_hf(record):
     }
 
 
+def subsample_split(records, max_samples, rng):
+    """Subsample records while preserving temporal order and label balance."""
+    if len(records) <= max_samples:
+        return records
+    by_label = {}
+    for r in records:
+        by_label.setdefault(r["label"], []).append(r)
+    per_class = max_samples // len(by_label)
+    sampled = []
+    for label in sorted(by_label.keys()):
+        items = by_label[label]
+        if len(items) > per_class:
+            indices = sorted(rng.sample(range(len(items)), per_class))
+            sampled.extend(items[i] for i in indices)
+        else:
+            sampled.extend(items)
+    sampled.sort(key=lambda r: r.get("adjudication_date") or "")
+    return sampled
+
+
+def write_split(split_data, path, keep_metadata):
+    with open(path, "w", encoding="utf-8") as f:
+        for record in split_data:
+            out = record if keep_metadata else format_for_hf(record)
+            f.write(json.dumps(out, ensure_ascii=False) + "\n")
+
+
+def print_split_info(split_name, split_data):
+    dates = [r["adjudication_date"] for r in split_data if r.get("adjudication_date")]
+    date_range = f"{min(dates)} .. {max(dates)}" if dates else "no dates"
+    dist = Counter(r["label"] for r in split_data)
+    print(f"  {split_name:12s}: {len(split_data):>7,} samples  [{date_range}]  {dict(dist)}")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--epochs", nargs="+", default=EPOCHS, choices=EPOCHS)
     parser.add_argument("--balance", type=int, default=None,
                         help="Balance to N per class per epoch before splitting")
+    parser.add_argument("--lextreme-max", type=int, default=1000,
+                        help="Max val/test size for LEXTREME configs (default: 1000)")
     parser.add_argument("--seed", type=int, default=SEED)
     parser.add_argument("--keep-metadata", action="store_true",
                         help="Keep jurisdiction, adjudication_date, doc_id in output")
@@ -93,10 +131,11 @@ def main():
 
     rng = random.Random(args.seed)
 
-    print("Building temporal splits for LexTreme")
+    print("Building temporal splits for HuggingFace")
     print(f"Epochs: {args.epochs}")
     if args.balance:
         print(f"Balancing to {args.balance} per class per epoch")
+    print(f"LEXTREME val/test cap: {args.lextreme_max}")
     print()
 
     for epoch_name in args.epochs:
@@ -117,29 +156,38 @@ def main():
 
         splits = temporal_split(records)
 
+        # Full config
         epoch_dir = OUTPUT_DIR / epoch_name
         epoch_dir.mkdir(parents=True, exist_ok=True)
 
+        print(f"\n  [Full config: {epoch_name}]")
         for split_name, split_data in splits.items():
-            dates = [r["adjudication_date"] for r in split_data if r.get("adjudication_date")]
-            date_range = f"{min(dates)} .. {max(dates)}" if dates else "no dates"
-            dist = Counter(r["label"] for r in split_data)
+            write_split(split_data, epoch_dir / f"{split_name}.jsonl", args.keep_metadata)
+            print_split_info(split_name, split_data)
 
-            path = epoch_dir / f"{split_name}.jsonl"
-            with open(path, "w", encoding="utf-8") as f:
-                for record in split_data:
-                    out = record if args.keep_metadata else format_for_hf(record)
-                    f.write(json.dumps(out, ensure_ascii=False) + "\n")
+        # LEXTREME config (small val/test)
+        lx_dir = OUTPUT_DIR / f"{epoch_name}_lextreme"
+        lx_dir.mkdir(parents=True, exist_ok=True)
 
-            print(f"  {split_name:12s}: {len(split_data):>7,} samples  [{date_range}]  {dict(dist)}")
+        lx_splits = {
+            "train": splits["train"],
+            "validation": subsample_split(splits["validation"], args.lextreme_max, rng),
+            "test": subsample_split(splits["test"], args.lextreme_max, rng),
+        }
+
+        print(f"\n  [LEXTREME config: {epoch_name}_lextreme]")
+        for split_name, split_data in lx_splits.items():
+            write_split(split_data, lx_dir / f"{split_name}.jsonl", args.keep_metadata)
+            print_split_info(split_name, split_data)
 
     print(f"\n{'='*50}")
     print("Output structure:")
     for epoch_name in args.epochs:
-        epoch_dir = OUTPUT_DIR / epoch_name
-        if epoch_dir.exists():
-            for f in sorted(epoch_dir.glob("*.jsonl")):
-                print(f"  {f.relative_to(OUTPUT_DIR)}")
+        for suffix in ["", "_lextreme"]:
+            d = OUTPUT_DIR / f"{epoch_name}{suffix}"
+            if d.exists():
+                for f in sorted(d.glob("*.jsonl")):
+                    print(f"  {f.relative_to(OUTPUT_DIR)}")
 
     print("\nRun upload-to-hf.py to push to HuggingFace.")
 

--- a/scripts/lextreme/extract-full-local.py
+++ b/scripts/lextreme/extract-full-local.py
@@ -187,8 +187,8 @@ def main():
     conn.set_client_encoding('UTF8')
     conn.set_session(readonly=True)
 
-    # Verify connection
     with conn.cursor() as cur:
+        cur.execute("SET idle_in_transaction_session_timeout = 0")
         cur.execute("SELECT current_database(), count(*) FROM edrsr_documents LIMIT 1")
         db_name, _ = cur.fetchone()
         print(f"Connected to: {db_name}")
@@ -251,8 +251,6 @@ def main():
                         continue
 
                     facts = sections["facts"]
-                    if len(facts) > 10000:
-                        facts = facts[:10000]
 
                     valid += 1
                     epoch_results.append({

--- a/scripts/lextreme/lextreme-config.py
+++ b/scripts/lextreme/lextreme-config.py
@@ -1,13 +1,16 @@
 """
 Config snippet to add to lextreme.py in joelniklaus/lextreme.
 
-Three configs -- one per temporal epoch -- with train/val/test splits
-separated chronologically within each epoch.
+Three configs -- one per temporal epoch -- pointing to *_lextreme configs
+in the source dataset (≤1000 val/test for fast benchmark evaluation).
+
+Full untruncated data lives in pre_war / hybrid_war / full_scale configs
+of the source dataset (overthelex/ukrainian-court-decisions).
 """
 
 _UKRAINIAN_COURT_DECISIONS_BASE = {
     "task_type": "TaskType.SLTC",
-    "hf_hub_name": "secondlayer/ukrainian-court-decisions",
+    "hf_hub_name": "overthelex/ukrainian-court-decisions",
     "language": "uk",
     "input_col": "text",
     "label_col": "label",
@@ -17,35 +20,38 @@ _UKRAINIAN_COURT_DECISIONS_BASE = {
   title={Ukrainian Court Decisions Dataset for Judgment Prediction},
   author={Ovcharov, Volodymyr},
   year={2025},
-  url={https://huggingface.co/datasets/secondlayer/ukrainian-court-decisions},
+  url={https://huggingface.co/datasets/overthelex/ukrainian-court-decisions},
   note={Extracted from the State Court Decisions Registry of Ukraine}
 }""",
 }
 
 _UKRAINIAN_COURT_DECISIONS_PRE_WAR = {
     **_UKRAINIAN_COURT_DECISIONS_BASE,
-    "config_name": "pre_war",
+    "config_name": "pre_war_lextreme",
     "description": (
         "Ukrainian Court Decisions Judgment Prediction (pre-war epoch, 2008-2013). "
-        "Civil and commercial court decisions with temporal train/val/test splits."
+        "Civil and commercial court decisions with temporal train/val/test splits. "
+        "LEXTREME benchmark subset with ≤1000 val/test samples."
     ),
 }
 
 _UKRAINIAN_COURT_DECISIONS_HYBRID_WAR = {
     **_UKRAINIAN_COURT_DECISIONS_BASE,
-    "config_name": "hybrid_war",
+    "config_name": "hybrid_war_lextreme",
     "description": (
         "Ukrainian Court Decisions Judgment Prediction (hybrid war epoch, 2014-2021). "
-        "Civil and commercial court decisions with temporal train/val/test splits."
+        "Civil and commercial court decisions with temporal train/val/test splits. "
+        "LEXTREME benchmark subset with ≤1000 val/test samples."
     ),
 }
 
 _UKRAINIAN_COURT_DECISIONS_FULL_SCALE = {
     **_UKRAINIAN_COURT_DECISIONS_BASE,
-    "config_name": "full_scale",
+    "config_name": "full_scale_lextreme",
     "description": (
         "Ukrainian Court Decisions Judgment Prediction (full-scale war epoch, 2022-2026). "
-        "Civil and commercial court decisions with temporal train/val/test splits."
+        "Civil and commercial court decisions with temporal train/val/test splits. "
+        "LEXTREME benchmark subset with ≤1000 val/test samples."
     ),
 }
 
@@ -70,7 +76,9 @@ print("Configs for lextreme.py PR:")
 print()
 print("1. Add _UKRAINIAN_COURT_DECISIONS_* dicts (3 epochs)")
 print("2. Add 3 LextremeConfig entries to BUILDER_CONFIGS")
-print("3. Test:")
+print("3. LEXTREME configs point to *_lextreme source configs (≤1000 val/test)")
+print("4. Full data available in pre_war / hybrid_war / full_scale source configs")
+print("5. Test:")
 print("   load_dataset('lextreme', 'ukrainian_court_decisions_judgment_pre_war')")
 print("   load_dataset('lextreme', 'ukrainian_court_decisions_judgment_hybrid_war')")
 print("   load_dataset('lextreme', 'ukrainian_court_decisions_judgment_full_scale')")

--- a/scripts/lextreme/upload-to-hf.py
+++ b/scripts/lextreme/upload-to-hf.py
@@ -18,14 +18,16 @@ import argparse
 from pathlib import Path
 
 OUTPUT_DIR = Path(__file__).parent / "output"
-DEFAULT_REPO = "secondlayer/ukrainian-court-decisions"
+DEFAULT_REPO = "overthelex/ukrainian-court-decisions"
 EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+LEXTREME_EPOCHS = [f"{e}_lextreme" for e in EPOCHS]
+ALL_CONFIGS = EPOCHS + LEXTREME_EPOCHS
 
 
 def main():
     parser = argparse.ArgumentParser(description="Upload dataset to HuggingFace Hub")
     parser.add_argument("--repo", default=DEFAULT_REPO, help=f"HF repo ID (default: {DEFAULT_REPO})")
-    parser.add_argument("--epochs", nargs="+", default=EPOCHS, choices=EPOCHS)
+    parser.add_argument("--epochs", nargs="+", default=ALL_CONFIGS, choices=ALL_CONFIGS)
     parser.add_argument("--dry-run", action="store_true", help="Show what would be uploaded")
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- Remove 10K char text truncation from dataset extraction
- Add `*_lextreme` configs with ≤1000 val/test for fast LEXTREME benchmark evaluation
- Source dataset now has 6 configs: 3 full + 3 lextreme
- Updated LEXTREME PR (joelniklaus/lextreme#16) to point to `*_lextreme` configs

Per Joel Niklaus review on HuggingFace.

## Test plan
- [x] Extraction verified: texts up to 194K chars (was capped at 10K)
- [x] All 6 configs uploaded to HF and load correctly
- [x] LEXTREME PR updated and tested with `datasets` 2.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the 10K-character truncation from extraction and adds `*_lextreme` configs with ≤1000 val/test examples for fast LEXTREME evaluation. Updates split and upload scripts to generate and publish both full and benchmark configs under `overthelex/ukrainian-court-decisions`.

- **New Features**
  - Keep full `facts` text during extraction (no truncation).
  - Add `pre_war_lextreme`, `hybrid_war_lextreme`, `full_scale_lextreme` with temporally ordered, label-balanced val/test subsamples (≤1000); train is unchanged.
  - `build-temporal-splits.py`: generates both full and LEXTREME outputs; new `--lextreme-max` flag; improved split stats.
  - `upload-to-hf.py`: default repo is `overthelex/ukrainian-court-decisions`; uploads all six configs by default.
  - `lextreme-config.py`: LEXTREME entries now point to `*_lextreme`; full data remains in `pre_war`, `hybrid_war`, `full_scale`.

- **Migration**
  - Downstream code must handle longer texts (no truncation).
  - Use `*_lextreme` for quick benchmarking; use epoch-only configs for full data.
  - When uploading, pass `--epochs` to restrict which configs are pushed; otherwise all six are uploaded.

<sup>Written for commit 2f7b2078d41f9fc8b583ce474bea85b78398ff07. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1744?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

