### PR TITLE
fix(registry): replace COUNT(*) OVER() with parallel count query

### DIFF
--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -84,18 +84,27 @@ ${registryDescriptions}
     const maxLimit = def.maxLimit ?? 100;
     const defaultLimit = def.defaultLimit ?? 50;
     const lim = Math.max(1, Math.min(Number(limit) || defaultLimit, maxLimit));
+
+    const countValues = [...values];
     values.push(lim);
 
-    const sql = `SELECT ${def.selectColumns}, COUNT(*) OVER() AS _total_count
+    const dataSql = `SELECT ${def.selectColumns}
       FROM ${def.table}
       WHERE ${whereClause}
       ORDER BY ${def.orderBy}
       LIMIT $${paramIndex}`;
 
+    const countSql = `SELECT COUNT(*) AS total FROM ${def.table} WHERE ${whereClause}`;
+
     try {
-      const result = await this.db.query(sql, values);
-      if (result.rows.length === 0) return this.wrapResponse(def.emptyMessage);
-      return this.wrapSearchResults(result.rows, lim);
+      const [dataResult, countResult] = await Promise.all([
+        this.db.query(dataSql, values),
+        this.db.query(countSql, countValues),
+      ]);
+      if (dataResult.rows.length === 0) return this.wrapResponse(def.emptyMessage);
+      const totalCount = parseInt(countResult.rows[0]?.total ?? '0', 10);
+      dataResult.rows.forEach((r: any) => { r._total_count = totalCount; });
+      return this.wrapSearchResults(dataResult.rows, lim);
     } catch (error: any) {
       logger.error(`search_registry[${registry}] error`, { error: error.message });
       return this.wrapError(`Помилка пошуку: ${error.message}`);


### PR DESCRIPTION
## Summary
- `COUNT(*) OVER()` window function forced PostgreSQL to read ALL matching rows before returning LIMIT results
- For `us_court_opinions` (62 GB, text_preview up to 558 KB per row), 13K matching rows = timeout
- For `us_cfpb_complaints` (18 GB), 167K matches = 26s response time
- Split into two parallel queries: data query (uses index + LIMIT) and count query (only counts, no wide columns)

## Test plan
- [ ] `us_court_opinions` search completes (was timing out at 60s)
- [ ] `us_cfpb_complaints` responds faster (was 26s)
- [ ] All other registries still return correct total_count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `COUNT(*) OVER()` with parallel data and count queries to avoid full scans and speed up registry search. Large datasets now return limited rows quickly while still providing an accurate `total_count`.

- **Performance**
  - Split into two queries: data (`SELECT ... ORDER BY ... LIMIT`) and count (`SELECT COUNT(*) ...`) using the same WHERE.
  - Execute both in parallel and inject `_total_count` into returned rows.
  - Fixes timeouts on `us_court_opinions` and cuts response time for `us_cfpb_complaints` (was ~26s).

<sup>Written for commit b78ba766ef8142434de3315f52b9288d41878c8f. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1745?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

