### PR TITLE
fix(registry): switch EPA name search to FTS index

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -502,7 +502,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     orderBy: 'fac_name',
     emptyMessage: 'No EPA facilities found matching criteria',
     fields: [
-      { name: 'name', description: 'Facility name', match: 'ilike', columns: ['fac_name'] },
+      { name: 'name', description: 'Facility name', match: 'fts_simple', columns: ['fac_name'] },
       { name: 'state', description: 'State (2-letter code)', match: 'exact', columns: ['fac_state'], transform: 'uppercase' },
       { name: 'city', description: 'City name', match: 'ilike', columns: ['fac_city'] },
       { name: 'zip', description: 'ZIP code', match: 'exact', columns: ['fac_zip'] },


### PR DESCRIPTION
## Summary
- EPA facility name search used ILIKE which scans all state-matching rows (663K for CA alone)
- Switched to `fts_simple` match type to use existing GIN index `idx_us_epa_name_fts`
- EXPLAIN: 541ms → 12ms (45x faster)

## Test plan
- [ ] `us_epa_facilities` name search responds under 1s (was 6.5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch EPA facility name search from ILIKE to `fts_simple` to use GIN index `idx_us_epa_name_fts` for indexed lookups. Query time drops from ~541ms to ~12ms (~45x), bringing responses under 1s (was ~6.5s).

<sup>Written for commit 99c0a4758760db7c0096c19e1d28952820179a21. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1746?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

