### PR TITLE
fix(registry): switch sanctions, OSHA, FDA to FTS indexes

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -433,7 +433,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     orderBy: 'last_seen DESC NULLS LAST',
     emptyMessage: 'No sanctioned entities found matching criteria',
     fields: [
-      { name: 'name', description: 'Person or entity name (fuzzy search)', match: 'ilike', columns: ['name'] },
+      { name: 'name', description: 'Person or entity name (fuzzy search)', match: 'fts_simple', columns: ['name'] },
       { name: 'aliases', description: 'Search in aliases/alternate names', match: 'ilike', columns: ['aliases'] },
       { name: 'schema', description: 'Entity type: Person, Company, LegalEntity, Organization, Vessel, CryptoWallet', match: 'exact', columns: ['schema'] },
       { name: 'countries', description: 'Country code (e.g. us, ru, ir, cn)', match: 'ilike', columns: ['countries'] },
@@ -486,7 +486,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     orderBy: 'penalties_current_total DESC NULLS LAST',
     emptyMessage: 'No OSHA enforcement records found for this employer',
     fields: [
-      { name: 'employer', description: 'Employer name', match: 'ilike', columns: ['employer_name'] },
+      { name: 'employer', description: 'Employer name', match: 'fts_simple', columns: ['employer_name'] },
       { name: 'parent', description: 'Parent company name', match: 'ilike', columns: ['parent_name'] },
       { name: 'state', description: 'State (2-letter code)', match: 'exact', columns: ['state'], transform: 'uppercase' },
       { name: 'naics', description: 'NAICS industry code', match: 'exact', columns: ['naics_code'] },
@@ -537,8 +537,8 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     orderBy: 'recall_initiation_date DESC NULLS LAST',
     emptyMessage: 'No FDA enforcement actions found',
     fields: [
-      { name: 'firm', description: 'Recalling firm name', match: 'ilike', columns: ['recalling_firm'] },
-      { name: 'product', description: 'Product description keywords', match: 'ilike', columns: ['product_description'] },
+      { name: 'firm', description: 'Recalling firm name', match: 'fts_simple', columns: ['recalling_firm'] },
+      { name: 'product', description: 'Product description keywords', match: 'fts_simple', columns: ['product_description'] },
       { name: 'reason', description: 'Reason for recall keywords', match: 'ilike', columns: ['reason_for_recall'] },
       { name: 'classification', description: 'Risk class: Class I (dangerous), Class II (may cause harm), Class III (unlikely harm)', match: 'exact', columns: ['classification'] },
       { name: 'state', description: 'State (2-letter code)', match: 'exact', columns: ['state'], transform: 'uppercase' },


### PR DESCRIPTION
## Summary
- Sanctions name search: 1073ms → 1.6ms (670x) -- was doing parallel seq scan on 1.26M rows
- OSHA employer search: switch to existing `idx_us_osha_enf_name_fts`
- FDA firm + product search: switch to existing `idx_us_fda_firm_fts`, `idx_us_fda_product_fts`

All had GIN FTS indexes sitting unused because the catalog specified `ilike`.

## Test plan
- [ ] `us_sanctions_screening` name search under 100ms
- [ ] `us_osha_enforcement` employer search still works
- [ ] `us_fda_enforcement` firm and product search still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch sanctions, OSHA, and FDA text searches from ILIKE to Postgres FTS to use existing GIN indexes and remove seq scans. Sanctions name lookup drops from ~1073ms to ~1.6ms.

- **Refactors**
  - Sanctions `name` now `fts_simple` on `name`.
  - OSHA `employer` now `fts_simple` on `employer_name` (uses `idx_us_osha_enf_name_fts`).
  - FDA `firm` and `product` now `fts_simple` on `recalling_firm` and `product_description` (uses `idx_us_fda_firm_fts`, `idx_us_fda_product_fts`).

<sup>Written for commit 9aea76fe56a9871ea531d1c2fe330f3c2f2be6b5. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1748?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

