### PR TITLE
fix(api): increase chat rate limit 60 → 180 req/min

### DIFF
--- a/mcp_backend/src/middleware/rate-limit.ts
+++ b/mcp_backend/src/middleware/rate-limit.ts
@@ -146,7 +146,7 @@ export const webhookRateLimit = createRateLimiter({
 // (Cloudflare proxies all traffic through shared IPs)
 export const chatRateLimit = createRateLimiter({
   windowMs: 60 * 1000,
-  maxRequests: 60,
+  maxRequests: 180,
   keyPrefix: 'ratelimit:chat',
   keyByUserId: true,
 });


### PR DESCRIPTION
## Summary
- Increase chat API rate limit from 60 to 180 requests per minute per user
- Needed for DefectRadar annotation experiments (3 parallel scripts)

## Test plan
- [x] Rate limit is per-user (keyByUserId: true), not per-IP
- [x] Only affects chat endpoint, not auth or webhook limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase chat API rate limit from 60 to 180 requests per minute per user (not per IP). Enables DefectRadar annotation experiments with 3 parallel scripts while leaving auth and webhook limits unchanged.

<sup>Written for commit a3df1c99f563f08de9b5fd606a4a899fde9ec4ed. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1755?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

