### PR TITLE
feat(infra): deploy LegalIntern multi-agent consultation

### DIFF
--- a/deployment/Dockerfile.legal-intern
+++ b/deployment/Dockerfile.legal-intern
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV TZ=Europe/Kiev
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN git clone https://github.com/overthelex/secondlayer-agents.git /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 7860
+
+ENV GRADIO_SERVER_NAME=0.0.0.0
+ENV GRADIO_SERVER_PORT=7860
+
+CMD ["python", "app.py"]

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1529,6 +1529,30 @@ services:
         reservations:
           memory: 64M
 
+  legal-intern-prod:
+    build:
+      context: ..
+      dockerfile: deployment/Dockerfile.legal-intern
+    image: legal-intern-prod:latest
+    container_name: legal-intern-prod
+    restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "3"
+    environment:
+      - GRADIO_SERVER_NAME=0.0.0.0
+      - GRADIO_SERVER_PORT=7860
+    networks:
+      - secondlayer-prod-network
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+        reservations:
+          memory: 128M
+
 volumes:
   postgres_prod_data:
     driver: local

--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -658,3 +658,37 @@ server {
         add_header Cache-Control "public, immutable";
     }
 }
+
+# agents.legal.org.ua — LegalIntern multi-agent consultation demo
+server {
+    listen 80;
+    server_name agents.legal.org.ua;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name agents.legal.org.ua;
+
+    include /etc/nginx/includes/ssl-common.conf;
+
+    location / {
+        proxy_pass http://legal-intern-prod:7860;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Dockerfile.legal-intern` — Python 3.12 container cloning `secondlayer-agents` from GitHub
- Adds `legal-intern-prod` service to `docker-compose.prod.yml` (Gradio on port 7860, 512M mem limit)
- Adds `agents.legal.org.ua` HTTP→HTTPS + reverse proxy server blocks to nginx config

## Related
- Repo: https://github.com/overthelex/secondlayer-agents
- HF Space: https://huggingface.co/spaces/overthelex/legal-intern
- Plane: LEXAI-1093

## Remaining after merge
- [ ] Cloudflare DNS: add `agents.legal.org.ua` A record → prod IP
- [ ] SSL: verify wildcard cert covers `agents.legal.org.ua` or issue new cert
- [ ] Deploy: CI/CD will build and start the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys the LegalIntern multi-agent consultation service with Docker and Nginx, exposing a `Gradio` app at agents.legal.org.ua. Aligns with LEXAI-1093 requirements.

- **New Features**
  - Added `deployment/Dockerfile.legal-intern`: clones `secondlayer-agents`, installs deps, runs `Gradio` on 7860.
  - Added `legal-intern-prod` service in `docker-compose.prod.yml` with restart policy and 512M memory limit.
  - Added Nginx HTTP→HTTPS and reverse proxy for agents.legal.org.ua (WebSocket headers, 300s timeouts).

- **Migration**
  - Add Cloudflare DNS A record for agents.legal.org.ua → prod IP.
  - Ensure wildcard cert covers the subdomain or issue a new cert.
  - Trigger CI/CD to build and start the container.

<sup>Written for commit 493349f06616a4018b8ba6be7c170e73aeb81e2d. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1762?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

