### PR TITLE
feat(research): MLflow experiment tracking for SageMaker

### DIFF
--- a/scripts/lextreme/sagemaker/dpo-code/mlflow_logger.py
+++ b/scripts/lextreme/sagemaker/dpo-code/mlflow_logger.py
@@ -1,0 +1,115 @@
+"""
+MLflow integration for SageMaker training jobs.
+
+Drop-in logger: import and call at the start/end of any training script.
+
+Usage in train.py:
+    from mlflow_logger import start_run, log_metrics, end_run
+
+    run = start_run("attention-analysis", {"model": "qwen3-32b", "experiment": 1})
+    # ... training ...
+    log_metrics({"accuracy": 0.85, "dar": 0.42})
+    end_run()
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+MLFLOW_AVAILABLE = False
+try:
+    import mlflow
+    MLFLOW_AVAILABLE = True
+except ImportError:
+    pass
+
+CONFIG_PATH = Path(__file__).parent / "mlflow_config.json"
+_active_run = None
+
+
+def _load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
+    if tracking_uri:
+        return {"mlflow_tracking_uri": tracking_uri}
+    return None
+
+
+def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> bool:
+    global _active_run
+    if not MLFLOW_AVAILABLE:
+        print("[mlflow_logger] mlflow not installed, logging to local JSON only")
+        return False
+
+    config = _load_config()
+    if not config:
+        print("[mlflow_logger] No MLflow config found, logging to local JSON only")
+        return False
+
+    try:
+        mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
+        mlflow.set_experiment(experiment_name)
+
+        run_tags = {
+            "project": "secondlayer",
+            "launched_from": os.environ.get("SM_TRAINING_JOB_NAME", "local"),
+        }
+        if tags:
+            run_tags.update(tags)
+
+        _active_run = mlflow.start_run(tags=run_tags)
+
+        if params:
+            mlflow.log_params(params)
+
+        sagemaker_job = os.environ.get("SM_TRAINING_JOB_NAME")
+        if sagemaker_job:
+            mlflow.log_param("sagemaker_job_name", sagemaker_job)
+            mlflow.log_param("instance_type", os.environ.get("SM_RESOURCE_CONFIG", "unknown"))
+
+        print(f"[mlflow_logger] Run started: {_active_run.info.run_id}")
+        return True
+    except Exception as e:
+        print(f"[mlflow_logger] Failed to connect to MLflow: {e}")
+        _active_run = None
+        return False
+
+
+def log_metrics(metrics: dict, step: int = None):
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.log_metrics(metrics, step=step)
+        except Exception as e:
+            print(f"[mlflow_logger] Metric logging failed: {e}")
+
+    output_dir = Path(os.environ.get("SM_MODEL_DIR", "/opt/ml/model"))
+    if not output_dir.exists():
+        output_dir = Path(".")
+    metrics_file = output_dir / "mlflow_metrics.jsonl"
+    with open(metrics_file, "a") as f:
+        entry = {"timestamp": time.time(), "metrics": metrics}
+        if step is not None:
+            entry["step"] = step
+        f.write(json.dumps(entry) + "\n")
+
+
+def log_artifact(local_path: str):
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.log_artifact(local_path)
+        except Exception as e:
+            print(f"[mlflow_logger] Artifact logging failed: {e}")
+
+
+def end_run(status: str = "FINISHED"):
+    global _active_run
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.end_run(status=status)
+            print(f"[mlflow_logger] Run ended: {status}")
+        except Exception as e:
+            print(f"[mlflow_logger] End run failed: {e}")
+    _active_run = None

--- a/scripts/lextreme/sagemaker/dpo-code/requirements.txt
+++ b/scripts/lextreme/sagemaker/dpo-code/requirements.txt
@@ -1,0 +1,9 @@
+trl>=0.12.0,<1.0.0
+peft>=0.13.0,<0.15.0
+bitsandbytes>=0.44.0
+datasets>=3.0.0
+accelerate>=1.0.0,<1.3.0
+deepspeed>=0.14.0
+mlflow>=2.14.0
+psycopg2-binary>=2.9.0
+boto3>=1.34.0

--- a/scripts/lextreme/sagemaker/dpo-code/train_dpo.py
+++ b/scripts/lextreme/sagemaker/dpo-code/train_dpo.py
@@ -1,0 +1,202 @@
+"""
+DPO training script for SageMaker.
+DeepSpeed ZeRO-3 + LoRA on ml.g5.12xlarge (4x A10G).
+LoRA means no separate ref_model needed — frozen base IS the reference.
+"""
+
+import os
+import json
+import time
+import torch
+from huggingface_hub import login
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig
+from mlflow_logger import start_run, log_metrics, log_artifact, end_run
+
+hf_token = os.environ.get("HUGGING_FACE_HUB_TOKEN", "")
+if hf_token:
+    os.environ["HF_TOKEN"] = hf_token
+    os.environ["HUGGING_FACE_HUB_TOKEN"] = hf_token
+    print(f"HF token set via env")
+
+try:
+    from trl import DPOConfig, DPOTrainer
+except ImportError:
+    from trl import DPOTrainer
+    DPOConfig = None
+
+
+def get_hp(name, default, cast=str):
+    return cast(os.environ.get(f"SM_HP_{name.upper()}", default))
+
+
+def main():
+    model_name = get_hp("model_name_or_path", "meta-llama/Llama-3.1-8B-Instruct")
+    dataset_path = get_hp("dataset_path", "/opt/ml/input/data/training")
+    output_dir = get_hp("output_dir", "/opt/ml/model")
+    condition = get_hp("condition", "a")
+    seed = get_hp("seed", "42", int)
+
+    num_epochs = get_hp("num_train_epochs", "1", int)
+    batch_size = get_hp("per_device_train_batch_size", "2", int)
+    grad_accum = get_hp("gradient_accumulation_steps", "4", int)
+    lr = get_hp("learning_rate", "2e-4", float)
+    beta = get_hp("beta", "0.1", float)
+    max_length = get_hp("max_length", "1024", int)
+    max_prompt_length = get_hp("max_prompt_length", "512", int)
+
+    print(f"=== DPO Training (LoRA): Condition {condition}, Seed {seed} ===")
+    print(f"Model: {model_name}")
+    print(f"Data: {dataset_path}")
+    print(f"GPUs: {torch.cuda.device_count()}")
+    print(f"Hyperparams: lr={lr}, beta={beta}, epochs={num_epochs}, batch={batch_size}x{grad_accum}")
+
+    start_run("dpo-edit-trace-oversight", {
+        "model": model_name, "condition": condition, "seed": seed,
+        "num_epochs": num_epochs, "batch_size": batch_size,
+        "grad_accum": grad_accum, "lr": lr, "beta": beta,
+        "max_length": max_length, "lora_r": 16, "lora_alpha": 32,
+    }, tags={"experiment_type": "dpo", "condition": condition})
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name,
+        torch_dtype=torch.bfloat16,
+    )
+
+    peft_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        lora_dropout=0.05,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+        bias="none",
+        task_type="CAUSAL_LM",
+    )
+
+    train_path = os.path.join(dataset_path, "train.jsonl")
+    val_path = os.path.join(dataset_path, "val.jsonl")
+
+    train_dataset = load_dataset("json", data_files=train_path, split="train")
+    eval_dataset = None
+    if os.path.exists(val_path):
+        eval_dataset = load_dataset("json", data_files=val_path, split="train")
+
+    print(f"Train: {len(train_dataset)} pairs, Val: {len(eval_dataset) if eval_dataset else 0}")
+
+    ds_config = os.path.join(os.path.dirname(os.path.abspath(__file__)), "ds_zero3.json")
+    if not os.path.exists(ds_config):
+        ds_config = "ds_zero3.json"
+    if not os.path.exists(ds_config):
+        ds_config = None
+        print("WARNING: ds_zero3.json not found")
+    else:
+        print(f"DeepSpeed config: {ds_config}")
+
+    from transformers import TrainingArguments
+
+    common_args = dict(
+        output_dir=output_dir,
+        num_train_epochs=num_epochs,
+        per_device_train_batch_size=batch_size,
+        gradient_accumulation_steps=grad_accum,
+        learning_rate=lr,
+        bf16=True,
+        gradient_checkpointing=True,
+        logging_steps=10,
+        save_strategy="steps",
+        save_steps=100,
+        save_total_limit=2,
+        optim="adamw_torch",
+        warmup_ratio=0.1,
+        lr_scheduler_type="cosine",
+        remove_unused_columns=False,
+        dataloader_num_workers=4,
+        seed=seed,
+        run_name=f"dpo-{condition}-seed{seed}",
+        deepspeed=ds_config,
+    )
+
+    if DPOConfig is not None:
+        training_args = DPOConfig(
+            **common_args,
+            beta=beta,
+            max_length=max_length,
+            max_prompt_length=max_prompt_length,
+            eval_strategy="epoch" if eval_dataset else "no",
+        )
+        trainer = DPOTrainer(
+            model=model,
+            ref_model=None,
+            args=training_args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            processing_class=tokenizer,
+            peft_config=peft_config,
+        )
+    else:
+        training_args = TrainingArguments(
+            **common_args,
+            evaluation_strategy="epoch" if eval_dataset else "no",
+        )
+        trainer = DPOTrainer(
+            model=model,
+            ref_model=None,
+            args=training_args,
+            beta=beta,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            tokenizer=tokenizer,
+            max_length=max_length,
+            max_prompt_length=max_prompt_length,
+            peft_config=peft_config,
+        )
+
+    t0 = time.time()
+    trainer.train()
+    train_time = time.time() - t0
+
+    trainer.save_model(output_dir)
+    tokenizer.save_pretrained(output_dir)
+
+    metrics_path = os.path.join(output_dir, "training_metrics.json")
+    with open(metrics_path, "w") as f:
+        json.dump(trainer.state.log_history, f, indent=2)
+
+    final_metrics = {}
+    for entry in reversed(trainer.state.log_history):
+        if "loss" in entry and "loss" not in final_metrics:
+            final_metrics["final_loss"] = entry["loss"]
+        if "eval_loss" in entry and "eval_loss" not in final_metrics:
+            final_metrics["eval_loss"] = entry["eval_loss"]
+        if "rewards/accuracies" in entry:
+            final_metrics["final_accuracy"] = entry["rewards/accuracies"]
+    final_metrics["train_time_seconds"] = train_time
+    final_metrics["total_steps"] = trainer.state.global_step
+
+    log_metrics(final_metrics)
+    log_artifact(metrics_path)
+    end_run()
+
+    print(f"Done. Condition {condition}, seed {seed}. Time: {train_time:.0f}s")
+
+
+if __name__ == "__main__":
+    if "LOCAL_RANK" not in os.environ:
+        import subprocess
+        import sys
+        num_gpus = torch.cuda.device_count()
+        print(f"No distributed env detected. Relaunching via deepspeed with {num_gpus} GPUs...")
+        cmd = [
+            sys.executable, "-m", "deepspeed.launcher.runner",
+            "--num_gpus", str(num_gpus),
+            "--no_local_rank",
+            sys.argv[0],
+        ]
+        result = subprocess.run(cmd)
+        sys.exit(result.returncode)
+    else:
+        main()

--- a/scripts/lextreme/sagemaker/td-code/batch_train.py
+++ b/scripts/lextreme/sagemaker/td-code/batch_train.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Batch launcher: run up to 4 experiments in parallel, 1 per GPU.
+Designed for ml.g5.12xlarge (4x A10G, 24GB each).
+
+Base models (278M) fit on 1 GPU with batch_size=16, max_seq_len=512.
+Large models (560M) fit on 1 GPU with batch_size=8.
+
+Usage:
+  # All 36 training runs (base models: 4 parallel, large: 2 parallel)
+  python batch_train.py
+
+  # Only one model, all epochs×seeds
+  python batch_train.py --model xlm-roberta-base
+
+  # Only base models
+  python batch_train.py --base-only
+
+  # Continual learning
+  python batch_train.py --continual
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent / "train_temporal.py"
+SM_MODEL_DIR = Path(os.environ.get("SM_MODEL_DIR", "/opt/ml/model"))
+
+MODELS = ["xlm-roberta-base", "xlm-roberta-large",
+          "legal-xlm-roberta-base", "legal-xlm-roberta-large"]
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+SEEDS = [42, 123, 456]
+
+BASE_MODELS = [m for m in MODELS if "large" not in m]
+LARGE_MODELS = [m for m in MODELS if "large" in m]
+
+
+def run_experiment(gpu_id, model, epoch, seed, extra_args=None, n_gpus_per_job=1, master_port=29500):
+    env = os.environ.copy()
+
+    if isinstance(gpu_id, (list, tuple)):
+        env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_id)
+        gpu_label = f"GPU {gpu_id[0]}-{gpu_id[-1]}"
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+        gpu_label = f"GPU {gpu_id}"
+
+    script_args = [
+        "--model", model,
+        "--epoch", epoch,
+        "--seed", str(seed),
+    ]
+    if extra_args:
+        script_args.extend(extra_args)
+
+    if n_gpus_per_job > 1:
+        cmd = [
+            sys.executable, "-m", "torch.distributed.run",
+            "--nproc_per_node", str(n_gpus_per_job),
+            "--master_port", str(master_port),
+            str(SCRIPT),
+        ] + script_args
+    else:
+        cmd = [sys.executable, str(SCRIPT)] + script_args
+
+    label = f"[{gpu_label}] {model} / {epoch} / s{seed}"
+    print(f"START: {label}", flush=True)
+    t0 = time.time()
+
+    result = subprocess.run(cmd, env=env, text=True)
+
+    elapsed = time.time() - t0
+    status = "OK" if result.returncode == 0 else "FAIL"
+    print(f"{status}: {label} ({elapsed:.0f}s)", flush=True)
+
+    if result.returncode != 0:
+        err_lines = result.stderr.strip().split("\n")[-5:]
+        print(f"  ERROR: {' | '.join(err_lines)}", flush=True)
+
+    return {
+        "model": model, "epoch": epoch, "seed": seed,
+        "gpu": gpu_id, "status": status, "elapsed": round(elapsed),
+        "returncode": result.returncode,
+    }
+
+
+def run_continual(gpu_id, model, direction, seed, n_gpus_per_job=1, master_port=29500):
+    env = os.environ.copy()
+
+    if isinstance(gpu_id, (list, tuple)):
+        env["CUDA_VISIBLE_DEVICES"] = ",".join(str(g) for g in gpu_id)
+        gpu_label = f"GPU {gpu_id[0]}-{gpu_id[-1]}"
+    else:
+        env["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+        gpu_label = f"GPU {gpu_id}"
+
+    script_args = [
+        "--model", model,
+        "--continual", direction,
+        "--seed", str(seed),
+    ]
+
+    if n_gpus_per_job > 1:
+        cmd = [
+            sys.executable, "-m", "torch.distributed.run",
+            "--nproc_per_node", str(n_gpus_per_job),
+            "--master_port", str(master_port),
+            str(SCRIPT),
+        ] + script_args
+    else:
+        cmd = [sys.executable, str(SCRIPT)] + script_args
+
+    label = f"[{gpu_label}] continual {direction} / {model} / s{seed}"
+    print(f"START: {label}", flush=True)
+    t0 = time.time()
+
+    result = subprocess.run(cmd, env=env, text=True)
+
+    elapsed = time.time() - t0
+    status = "OK" if result.returncode == 0 else "FAIL"
+    print(f"{status}: {label} ({elapsed:.0f}s)", flush=True)
+
+    if result.returncode != 0:
+        err_lines = result.stderr.strip().split("\n")[-5:]
+        print(f"  ERROR: {' | '.join(err_lines)}", flush=True)
+
+    return {
+        "model": model, "direction": direction, "seed": seed,
+        "gpu": gpu_id, "status": status, "elapsed": round(elapsed),
+    }
+
+
+def build_job_queue(args):
+    jobs = []
+
+    models = MODELS
+    if args.model:
+        models = [args.model]
+    elif args.base_only:
+        models = BASE_MODELS
+
+    if args.continual:
+        for model in models:
+            for seed in SEEDS:
+                for direction in ["forward", "backward"]:
+                    jobs.append(("continual", model, direction, seed))
+    else:
+        for model in models:
+            for epoch in EPOCHS:
+                for seed in SEEDS:
+                    jobs.append(("train", model, epoch, seed))
+
+    return jobs
+
+
+def max_parallel_for(model):
+    if "large" in model:
+        return 2  # 560M on 24GB GPU, leave headroom
+    return 4  # 278M easily fits
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", choices=MODELS)
+    parser.add_argument("--base-only", action="store_true")
+    parser.add_argument("--continual", action="store_true")
+    parser.add_argument("--embeddings", action="store_true")
+    args = parser.parse_args()
+
+    n_gpus = 4
+    try:
+        import torch
+        n_gpus = torch.cuda.device_count() or 1
+    except ImportError:
+        pass
+
+    jobs = build_job_queue(args)
+    print(f"=== {len(jobs)} experiments, {n_gpus} GPUs ===\n", flush=True)
+
+    extra = ["--embeddings"] if args.embeddings else None
+
+    # Group jobs by model size for optimal parallelism
+    results = []
+    # Process base models first (4 parallel), then large (2 parallel)
+    base_jobs = [j for j in jobs if "large" not in j[1]]
+    large_jobs = [j for j in jobs if "large" in j[1]]
+
+    # Base: 1 GPU per job, 4 parallel
+    # Large: 2 GPUs per job (DDP), 2 parallel -- same wall clock density, 2x faster per run
+    GPU_PAIRS = [[0, 1], [2, 3]]
+
+    for group_name, group_jobs, parallelism, gpus_per_job in [
+        ("base", base_jobs, min(n_gpus, 4), 1),
+        ("large", large_jobs, 2, 2),
+    ]:
+        if not group_jobs:
+            continue
+
+        mode = f"{gpus_per_job} GPU/job, DDP" if gpus_per_job > 1 else f"1 GPU/job"
+        print(f"\n{'='*60}")
+        print(f"  {group_name} models: {len(group_jobs)} jobs, {parallelism} parallel ({mode})")
+        print(f"{'='*60}\n", flush=True)
+
+        with ProcessPoolExecutor(max_workers=parallelism) as pool:
+            futures = {}
+            slot_cycle = 0
+
+            for job in group_jobs:
+                if gpus_per_job > 1:
+                    gpu_id = GPU_PAIRS[slot_cycle % len(GPU_PAIRS)]
+                    master_port = 29500 + (slot_cycle % len(GPU_PAIRS))
+                else:
+                    gpu_id = slot_cycle % n_gpus
+                    master_port = 29500
+                slot_cycle += 1
+
+                if job[0] == "continual":
+                    _, model, direction, seed = job
+                    f = pool.submit(run_continual, gpu_id, model, direction, seed,
+                                    gpus_per_job, master_port)
+                else:
+                    _, model, epoch, seed = job
+                    f = pool.submit(run_experiment, gpu_id, model, epoch, seed, extra,
+                                    gpus_per_job, master_port)
+
+                futures[f] = job
+
+            for f in as_completed(futures):
+                results.append(f.result())
+
+    # Summary
+    ok = sum(1 for r in results if r["status"] == "OK")
+    fail = sum(1 for r in results if r["status"] == "FAIL")
+    total_time = sum(r["elapsed"] for r in results)
+
+    print(f"\n{'='*60}")
+    print(f"  DONE: {ok} OK, {fail} FAIL, {len(results)} total")
+    print(f"  Wall time of individual jobs: {total_time}s ({total_time/3600:.1f}h)")
+    print(f"{'='*60}\n", flush=True)
+
+    # Save manifest
+    manifest_path = SM_MODEL_DIR / "batch_manifest.json" if SM_MODEL_DIR.exists() else Path("scripts/lextreme/results/batch_manifest.json")
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(manifest_path, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"Manifest: {manifest_path}")
+
+    if fail > 0:
+        print("\nFailed jobs:")
+        for r in results:
+            if r["status"] == "FAIL":
+                print(f"  {r}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lextreme/sagemaker/td-code/entry_continual.py
+++ b/scripts/lextreme/sagemaker/td-code/entry_continual.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Generic entry point for continual learning jobs.
+Reads model, direction, seed from SM_HP_* env vars."""
+import subprocess, sys, os
+
+model = os.environ.get("SM_HP_MODEL", "xlm-roberta-base")
+direction = os.environ.get("SM_HP_DIRECTION", "forward")
+seed = os.environ.get("SM_HP_SEED", "42")
+
+print(f"=== Continual: {model} {direction} seed={seed} ===")
+sys.exit(subprocess.run([
+    sys.executable, "train_temporal.py",
+    "--continual", direction,
+    "--model", model,
+    "--seed", seed,
+]).returncode)

--- a/scripts/lextreme/sagemaker/td-code/mlflow_config.json
+++ b/scripts/lextreme/sagemaker/td-code/mlflow_config.json
@@ -1,0 +1,4 @@
+{
+  "mlflow_tracking_uri": "http://35.84.222.41:5000",
+  "artifact_bucket": "secondlayer-mlflow-artifacts"
+}

--- a/scripts/lextreme/sagemaker/td-code/mlflow_logger.py
+++ b/scripts/lextreme/sagemaker/td-code/mlflow_logger.py
@@ -1,0 +1,115 @@
+"""
+MLflow integration for SageMaker training jobs.
+
+Drop-in logger: import and call at the start/end of any training script.
+
+Usage in train.py:
+    from mlflow_logger import start_run, log_metrics, end_run
+
+    run = start_run("attention-analysis", {"model": "qwen3-32b", "experiment": 1})
+    # ... training ...
+    log_metrics({"accuracy": 0.85, "dar": 0.42})
+    end_run()
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+MLFLOW_AVAILABLE = False
+try:
+    import mlflow
+    MLFLOW_AVAILABLE = True
+except ImportError:
+    pass
+
+CONFIG_PATH = Path(__file__).parent / "mlflow_config.json"
+_active_run = None
+
+
+def _load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
+    if tracking_uri:
+        return {"mlflow_tracking_uri": tracking_uri}
+    return None
+
+
+def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> bool:
+    global _active_run
+    if not MLFLOW_AVAILABLE:
+        print("[mlflow_logger] mlflow not installed, logging to local JSON only")
+        return False
+
+    config = _load_config()
+    if not config:
+        print("[mlflow_logger] No MLflow config found, logging to local JSON only")
+        return False
+
+    try:
+        mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
+        mlflow.set_experiment(experiment_name)
+
+        run_tags = {
+            "project": "secondlayer",
+            "launched_from": os.environ.get("SM_TRAINING_JOB_NAME", "local"),
+        }
+        if tags:
+            run_tags.update(tags)
+
+        _active_run = mlflow.start_run(tags=run_tags)
+
+        if params:
+            mlflow.log_params(params)
+
+        sagemaker_job = os.environ.get("SM_TRAINING_JOB_NAME")
+        if sagemaker_job:
+            mlflow.log_param("sagemaker_job_name", sagemaker_job)
+            mlflow.log_param("instance_type", os.environ.get("SM_RESOURCE_CONFIG", "unknown"))
+
+        print(f"[mlflow_logger] Run started: {_active_run.info.run_id}")
+        return True
+    except Exception as e:
+        print(f"[mlflow_logger] Failed to connect to MLflow: {e}")
+        _active_run = None
+        return False
+
+
+def log_metrics(metrics: dict, step: int = None):
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.log_metrics(metrics, step=step)
+        except Exception as e:
+            print(f"[mlflow_logger] Metric logging failed: {e}")
+
+    output_dir = Path(os.environ.get("SM_MODEL_DIR", "/opt/ml/model"))
+    if not output_dir.exists():
+        output_dir = Path(".")
+    metrics_file = output_dir / "mlflow_metrics.jsonl"
+    with open(metrics_file, "a") as f:
+        entry = {"timestamp": time.time(), "metrics": metrics}
+        if step is not None:
+            entry["step"] = step
+        f.write(json.dumps(entry) + "\n")
+
+
+def log_artifact(local_path: str):
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.log_artifact(local_path)
+        except Exception as e:
+            print(f"[mlflow_logger] Artifact logging failed: {e}")
+
+
+def end_run(status: str = "FINISHED"):
+    global _active_run
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.end_run(status=status)
+            print(f"[mlflow_logger] Run ended: {status}")
+        except Exception as e:
+            print(f"[mlflow_logger] End run failed: {e}")
+    _active_run = None

--- a/scripts/lextreme/sagemaker/td-code/requirements.txt
+++ b/scripts/lextreme/sagemaker/td-code/requirements.txt
@@ -1,0 +1,12 @@
+torch>=2.2.0
+transformers>=4.52.0
+accelerate>=1.1.0
+datasets>=2.18.0
+numpy>=1.26.0
+scikit-learn>=1.4.0
+huggingface_hub>=0.23.0
+sentencepiece>=0.2.0
+protobuf>=4.25.0
+mlflow>=2.14.0
+psycopg2-binary>=2.9.0
+boto3>=1.34.0

--- a/scripts/lextreme/sagemaker/td-code/train_temporal.py
+++ b/scripts/lextreme/sagemaker/td-code/train_temporal.py
@@ -1,0 +1,672 @@
+#!/usr/bin/env python3
+"""
+Temporal drift experiment: fine-tune encoder models on each epoch, evaluate cross-epoch.
+
+SageMaker-compatible (ml.g5.12xlarge, 4x A10G) or local execution.
+Runs ONE (model, epoch, seed) triple per invocation for atomic SageMaker jobs.
+
+Usage:
+  # Single run
+  python train_temporal.py --model xlm-roberta-base --epoch pre_war --seed 42
+
+  # All runs (local)
+  python train_temporal.py --all
+
+  # Cross-epoch evaluation only (after training)
+  python train_temporal.py --eval-only --model xlm-roberta-base --epoch pre_war --seed 42
+
+  # Continual learning (Exp 3)
+  python train_temporal.py --continual forward --model xlm-roberta-base --seed 42
+"""
+
+import argparse
+import json
+import os
+import time
+from collections import defaultdict
+from pathlib import Path
+
+os.environ["HF_HOME"] = "/tmp/hf_cache"
+os.environ["TRANSFORMERS_CACHE"] = "/tmp/hf_cache/transformers"
+os.environ["HF_DATASETS_CACHE"] = "/tmp/hf_cache/datasets"
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+import numpy as np
+import torch
+
+from mlflow_logger import start_run, log_metrics, log_artifact, end_run
+
+
+def is_main_process():
+    return int(os.environ.get("LOCAL_RANK", 0)) == 0
+from datasets import Dataset
+from sklearn.metrics import (
+    accuracy_score,
+    classification_report,
+    confusion_matrix,
+    f1_score,
+)
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+    EarlyStoppingCallback,
+    Trainer,
+    TrainingArguments,
+)
+
+SM_MODEL_DIR = Path(os.environ.get("SM_MODEL_DIR", "/opt/ml/model"))
+SM_DATA_DIR = os.environ.get("SM_CHANNEL_DATA", "")
+
+if SM_DATA_DIR:
+    DATA_DIR = Path(SM_DATA_DIR)
+    RESULTS_DIR = SM_MODEL_DIR / "results"
+else:
+    DATA_DIR = Path(__file__).parent / "output"
+    RESULTS_DIR = Path(__file__).parent / "results"
+RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+LABELS = ["approved", "dismissed", "partial"]
+LABEL2ID = {l: i for i, l in enumerate(LABELS)}
+ID2LABEL = {i: l for i, l in enumerate(LABELS)}
+SEEDS = [42, 123, 456]
+
+MODELS = {
+    "xlm-roberta-base": "xlm-roberta-base",
+    "xlm-roberta-large": "xlm-roberta-large",
+    "legal-xlm-roberta-base": "joelniklaus/legal-xlm-roberta-base",
+    "legal-xlm-roberta-large": "joelniklaus/legal-xlm-roberta-large",
+}
+
+TRAINING_DEFAULTS = {
+    "base": {
+        "learning_rate": 2e-5,
+        "per_device_train_batch_size": 16,
+        "per_device_eval_batch_size": 32,
+        "gradient_accumulation_steps": 1,
+    },
+    "large": {
+        "learning_rate": 1e-5,
+        "per_device_train_batch_size": 8,
+        "per_device_eval_batch_size": 16,
+        "gradient_accumulation_steps": 2,
+    },
+}
+
+
+def get_training_config(model_key):
+    if "large" in model_key:
+        return TRAINING_DEFAULTS["large"]
+    return TRAINING_DEFAULTS["base"]
+
+
+def load_split(epoch, split):
+    path = DATA_DIR / epoch / f"{split}.jsonl"
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            r = json.loads(line)
+            records.append({"text": r["text"], "label": LABEL2ID[r["label"]]})
+    return Dataset.from_list(records)
+
+
+def tokenize_dataset(dataset, tokenizer, max_length=512):
+    def tokenize_fn(examples):
+        return tokenizer(
+            examples["text"],
+            truncation=True,
+            max_length=max_length,
+            padding="max_length",
+        )
+
+    return dataset.map(tokenize_fn, batched=True, remove_columns=["text"])
+
+
+def compute_metrics(eval_pred):
+    logits, labels = eval_pred
+    preds = np.argmax(logits, axis=-1)
+    macro_f1 = f1_score(labels, preds, average="macro")
+    per_class_f1 = f1_score(labels, preds, average=None)
+    acc = accuracy_score(labels, preds)
+    return {
+        "accuracy": acc,
+        "macro_f1": macro_f1,
+        "f1_approved": per_class_f1[0],
+        "f1_dismissed": per_class_f1[1],
+        "f1_partial": per_class_f1[2],
+    }
+
+
+def run_name(model_key, epoch, seed):
+    return f"{model_key}_{epoch}_s{seed}"
+
+
+def output_dir_for(model_key, epoch, seed):
+    return RESULTS_DIR / "models" / run_name(model_key, epoch, seed)
+
+
+def train_single(model_key, epoch, seed, max_train_samples=None):
+    hf_id = MODELS[model_key]
+    cfg = get_training_config(model_key)
+    name = run_name(model_key, epoch, seed)
+    out_dir = output_dir_for(model_key, epoch, seed)
+
+    if (out_dir / "eval_results.json").exists():
+        print(f"SKIP {name}: already trained (eval_results.json exists)")
+        return json.loads((out_dir / "eval_results.json").read_text())
+
+    print(f"\n{'='*60}")
+    print(f"Training: {name}")
+    print(f"  Model: {hf_id}")
+    print(f"  Epoch: {epoch}")
+    print(f"  Seed: {seed}")
+    print(f"{'='*60}\n")
+
+    start_run("temporal-drift-exp1", {
+        "model": model_key, "hf_id": hf_id, "epoch": epoch, "seed": seed,
+        "experiment": "single_epoch",
+    }, tags={"experiment_type": "single_epoch"})
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_id)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        hf_id,
+        num_labels=len(LABELS),
+        label2id=LABEL2ID,
+        id2label=ID2LABEL,
+        torch_dtype=torch.float32,
+    )
+
+    train_ds = load_split(epoch, "train")
+    val_ds = load_split(epoch, "validation")
+
+    if max_train_samples and len(train_ds) > max_train_samples:
+        train_ds = train_ds.shuffle(seed=seed).select(range(max_train_samples))
+
+    train_ds = tokenize_dataset(train_ds, tokenizer)
+    val_ds = tokenize_dataset(val_ds, tokenizer)
+
+    n_gpus = torch.cuda.device_count() or 1
+    effective_batch = cfg["per_device_train_batch_size"] * n_gpus * cfg["gradient_accumulation_steps"]
+    total_steps = (len(train_ds) // effective_batch) * 5
+    warmup_steps = int(total_steps * 0.1)
+
+    training_args = TrainingArguments(
+        output_dir=str(out_dir),
+        num_train_epochs=5,
+        per_device_train_batch_size=cfg["per_device_train_batch_size"],
+        per_device_eval_batch_size=cfg["per_device_eval_batch_size"],
+        gradient_accumulation_steps=cfg["gradient_accumulation_steps"],
+        learning_rate=cfg["learning_rate"],
+        weight_decay=0.01,
+        warmup_steps=warmup_steps,
+        eval_strategy="steps",
+        eval_steps=500,
+        save_strategy="steps",
+        save_steps=500,
+        save_total_limit=2,
+        load_best_model_at_end=True,
+        metric_for_best_model="macro_f1",
+        greater_is_better=True,
+        logging_steps=100,
+        seed=seed,
+        bf16=torch.cuda.is_available(),
+        dataloader_num_workers=4,
+        report_to="none",
+        ddp_find_unused_parameters=False if n_gpus > 1 else None,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=train_ds,
+        eval_dataset=val_ds,
+        compute_metrics=compute_metrics,
+        callbacks=[EarlyStoppingCallback(early_stopping_patience=2)],
+    )
+
+    t0 = time.time()
+    trainer.train()
+    train_time = time.time() - t0
+
+    val_metrics = trainer.evaluate()
+
+    if is_main_process():
+        trainer.save_model(str(out_dir / "best_model"))
+        tokenizer.save_pretrained(str(out_dir / "best_model"))
+
+        results = {
+            "model": model_key,
+            "hf_id": hf_id,
+            "train_epoch": epoch,
+            "seed": seed,
+            "train_samples": len(train_ds),
+            "val_samples": len(val_ds),
+            "train_time_seconds": round(train_time, 1),
+            "n_gpus": n_gpus,
+            **{k.replace("eval_", ""): v for k, v in val_metrics.items()},
+        }
+
+        with open(out_dir / "eval_results.json", "w") as f:
+            json.dump(results, f, indent=2, ensure_ascii=False)
+
+        log_metrics({
+            "macro_f1": results.get("macro_f1", 0),
+            "accuracy": results.get("accuracy", 0),
+            "f1_approved": results.get("f1_approved", 0),
+            "f1_dismissed": results.get("f1_dismissed", 0),
+            "f1_partial": results.get("f1_partial", 0),
+            "train_time_seconds": train_time,
+        })
+        log_artifact(str(out_dir / "eval_results.json"))
+        end_run()
+
+        print(f"\n{name} done: macro_f1={results.get('macro_f1', 'N/A'):.4f}, "
+              f"acc={results.get('accuracy', 'N/A'):.4f}, time={train_time:.0f}s")
+
+        return results
+
+    end_run()
+    return None
+
+
+def evaluate_cross_epoch(model_key, train_epoch, seed):
+    if not is_main_process():
+        return None
+
+    out_dir = output_dir_for(model_key, train_epoch, seed)
+    model_path = out_dir / "best_model"
+
+    if not model_path.exists():
+        print(f"SKIP cross-eval {run_name(model_key, train_epoch, seed)}: no best_model")
+        return None
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+    model = AutoModelForSequenceClassification.from_pretrained(
+        str(model_path),
+        torch_dtype=torch.float32,
+    )
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    model.eval()
+
+    start_run("temporal-drift-cross-eval", {
+        "model": model_key, "train_epoch": train_epoch, "seed": seed,
+        "experiment": "cross_epoch_eval",
+    }, tags={"experiment_type": "cross_epoch_eval"})
+
+    cross_results = {}
+    for test_epoch in EPOCHS:
+        test_ds = load_split(test_epoch, "test")
+        test_ds = tokenize_dataset(test_ds, tokenizer)
+
+        trainer = Trainer(
+            model=model,
+            compute_metrics=compute_metrics,
+            args=TrainingArguments(
+                output_dir="/tmp/eval_tmp",
+                per_device_eval_batch_size=32,
+                report_to="none",
+                use_cpu=not torch.cuda.is_available(),
+            ),
+        )
+
+        metrics = trainer.evaluate(test_ds)
+
+        all_preds = trainer.predict(test_ds)
+        preds = np.argmax(all_preds.predictions, axis=-1)
+        labels = all_preds.label_ids
+        cm = confusion_matrix(labels, preds, labels=list(range(len(LABELS))))
+        report = classification_report(labels, preds, target_names=LABELS, output_dict=True)
+
+        cross_results[test_epoch] = {
+            "accuracy": metrics["eval_accuracy"],
+            "macro_f1": metrics["eval_macro_f1"],
+            "f1_approved": metrics["eval_f1_approved"],
+            "f1_dismissed": metrics["eval_f1_dismissed"],
+            "f1_partial": metrics["eval_f1_partial"],
+            "confusion_matrix": cm.tolist(),
+            "classification_report": report,
+            "n_samples": len(test_ds),
+        }
+
+        log_metrics({
+            f"cross_{test_epoch}_macro_f1": metrics["eval_macro_f1"],
+            f"cross_{test_epoch}_accuracy": metrics["eval_accuracy"],
+        })
+
+        print(f"  {train_epoch} -> {test_epoch}: "
+              f"macro_f1={metrics['eval_macro_f1']:.4f}, "
+              f"acc={metrics['eval_accuracy']:.4f}")
+
+    result_file = out_dir / "cross_epoch_results.json"
+    full_result = {
+        "model": model_key,
+        "train_epoch": train_epoch,
+        "seed": seed,
+        "cross_eval": cross_results,
+    }
+    with open(result_file, "w") as f:
+        json.dump(full_result, f, indent=2, ensure_ascii=False)
+
+    log_artifact(str(result_file))
+    end_run()
+
+    return full_result
+
+
+def extract_embeddings(model_key, train_epoch, seed, n_samples=1000):
+    if not is_main_process():
+        return
+
+    out_dir = output_dir_for(model_key, train_epoch, seed)
+    model_path = out_dir / "best_model"
+    emb_file = out_dir / "embeddings.npz"
+
+    if emb_file.exists():
+        print(f"SKIP embeddings {run_name(model_key, train_epoch, seed)}: already exists")
+        return
+
+    if not model_path.exists():
+        print(f"SKIP embeddings: no best_model at {model_path}")
+        return
+
+    start_run("temporal-drift-embeddings", {
+        "model": model_key, "train_epoch": train_epoch, "seed": seed,
+        "n_samples": n_samples, "experiment": "embedding_extraction",
+    }, tags={"experiment_type": "embedding_extraction"})
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_path))
+    model = AutoModelForSequenceClassification.from_pretrained(
+        str(model_path),
+        torch_dtype=torch.float32,
+        output_hidden_states=True,
+    )
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    model.eval()
+
+    all_embeddings = {}
+    for epoch in EPOCHS:
+        test_ds = load_split(epoch, "test")
+        if len(test_ds) > n_samples:
+            test_ds = test_ds.shuffle(seed=42).select(range(n_samples))
+        test_ds = tokenize_dataset(test_ds, tokenizer)
+
+        embeddings = []
+        labels_list = []
+        for i in range(0, len(test_ds), 32):
+            batch = test_ds[i:i + 32]
+            inputs = {
+                k: torch.tensor(v).to(device)
+                for k, v in batch.items()
+                if k in ("input_ids", "attention_mask")
+            }
+            with torch.no_grad():
+                outputs = model(**inputs)
+            cls_emb = outputs.hidden_states[-1][:, 0, :].cpu().numpy()
+            embeddings.append(cls_emb)
+            labels_list.extend(batch["label"])
+
+        all_embeddings[f"{epoch}_embeddings"] = np.concatenate(embeddings, axis=0)
+        all_embeddings[f"{epoch}_labels"] = np.array(labels_list)
+        log_metrics({f"emb_{epoch}_n_samples": len(test_ds)})
+
+    np.savez_compressed(str(emb_file), **all_embeddings)
+    log_artifact(str(emb_file))
+    end_run()
+    print(f"  Saved embeddings to {emb_file}")
+
+
+def run_continual(model_key, seed, direction="forward"):
+    if direction == "forward":
+        epoch_order = EPOCHS
+    else:
+        epoch_order = list(reversed(EPOCHS))
+
+    name = f"continual_{direction}_{model_key}_s{seed}"
+    out_dir = RESULTS_DIR / "continual" / name
+
+    if (out_dir / "continual_results.json").exists():
+        print(f"SKIP {name}: already done")
+        return json.loads((out_dir / "continual_results.json").read_text())
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hf_id = MODELS[model_key]
+    cfg = get_training_config(model_key)
+
+    print(f"\n{'='*60}")
+    print(f"Continual learning: {name}")
+    print(f"  Order: {' -> '.join(epoch_order)}")
+    print(f"{'='*60}\n")
+
+    start_run("temporal-drift-continual", {
+        "model": model_key, "hf_id": hf_id, "direction": direction,
+        "seed": seed, "epoch_order": ",".join(epoch_order),
+        "experiment": "continual_learning",
+    }, tags={"experiment_type": "continual_learning"})
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_id)
+    model = AutoModelForSequenceClassification.from_pretrained(
+        hf_id,
+        num_labels=len(LABELS),
+        label2id=LABEL2ID,
+        id2label=ID2LABEL,
+        torch_dtype=torch.float32,
+    )
+
+    results_per_stage = []
+
+    for stage_idx, epoch in enumerate(epoch_order):
+        stage_t0 = time.time()
+        print(f"\n--- Stage {stage_idx + 1}/3: {epoch} ---")
+
+        train_ds = tokenize_dataset(load_split(epoch, "train"), tokenizer)
+        val_ds = tokenize_dataset(load_split(epoch, "validation"), tokenizer)
+
+        n_gpus = torch.cuda.device_count() or 1
+        effective_batch = cfg["per_device_train_batch_size"] * n_gpus * cfg["gradient_accumulation_steps"]
+        total_steps = (len(train_ds) // effective_batch) * 3
+        warmup_steps = int(total_steps * 0.1)
+
+        stage_dir = out_dir / f"stage_{stage_idx}_{epoch}"
+        training_args = TrainingArguments(
+            output_dir=str(stage_dir),
+            num_train_epochs=3,
+            per_device_train_batch_size=cfg["per_device_train_batch_size"],
+            per_device_eval_batch_size=cfg["per_device_eval_batch_size"],
+            gradient_accumulation_steps=cfg["gradient_accumulation_steps"],
+            learning_rate=cfg["learning_rate"],
+            weight_decay=0.01,
+            warmup_steps=warmup_steps,
+            eval_strategy="steps",
+            eval_steps=500,
+            save_strategy="steps",
+            save_steps=500,
+            save_total_limit=1,
+            load_best_model_at_end=True,
+            metric_for_best_model="macro_f1",
+            greater_is_better=True,
+            logging_steps=100,
+            seed=seed,
+            bf16=torch.cuda.is_available(),
+            dataloader_num_workers=4,
+            report_to="none",
+        )
+
+        trainer = Trainer(
+            model=model,
+            args=training_args,
+            train_dataset=train_ds,
+            eval_dataset=val_ds,
+            compute_metrics=compute_metrics,
+            callbacks=[EarlyStoppingCallback(early_stopping_patience=2)],
+        )
+
+        trainer.train()
+        model = trainer.model
+        stage_time = time.time() - stage_t0
+
+        stage_eval = {}
+        for test_epoch in EPOCHS:
+            test_ds = tokenize_dataset(load_split(test_epoch, "test"), tokenizer)
+            metrics = trainer.evaluate(test_ds)
+            stage_eval[test_epoch] = {
+                "accuracy": metrics["eval_accuracy"],
+                "macro_f1": metrics["eval_macro_f1"],
+            }
+            log_metrics({
+                f"stage{stage_idx}_{test_epoch}_macro_f1": metrics["eval_macro_f1"],
+                f"stage{stage_idx}_{test_epoch}_accuracy": metrics["eval_accuracy"],
+            }, step=stage_idx)
+            print(f"    After {epoch}: test on {test_epoch} -> "
+                  f"F1={metrics['eval_macro_f1']:.4f}")
+
+        log_metrics({
+            f"stage{stage_idx}_train_time_s": stage_time,
+        }, step=stage_idx)
+        print(f"  Stage {stage_idx + 1} done in {stage_time:.0f}s ({stage_time/3600:.1f}h)")
+
+        results_per_stage.append({
+            "stage": stage_idx,
+            "trained_on": epoch,
+            "epochs_seen": epoch_order[:stage_idx + 1],
+            "train_time_seconds": round(stage_time, 1),
+            "eval": stage_eval,
+        })
+
+    full_result = {
+        "model": model_key,
+        "direction": direction,
+        "seed": seed,
+        "epoch_order": epoch_order,
+        "stages": results_per_stage,
+    }
+    with open(out_dir / "continual_results.json", "w") as f:
+        json.dump(full_result, f, indent=2, ensure_ascii=False)
+
+    log_artifact(str(out_dir / "continual_results.json"))
+    end_run()
+
+    return full_result
+
+
+def aggregate_results():
+    print("\n\n" + "=" * 80)
+    print("AGGREGATE CROSS-EPOCH RESULTS")
+    print("=" * 80)
+
+    for model_key in MODELS:
+        print(f"\n--- {model_key} ---")
+        matrices = defaultdict(lambda: defaultdict(list))
+
+        for seed in SEEDS:
+            for train_epoch in EPOCHS:
+                result_file = output_dir_for(model_key, train_epoch, seed) / "cross_epoch_results.json"
+                if not result_file.exists():
+                    continue
+                data = json.loads(result_file.read_text())
+                for test_epoch, metrics in data["cross_eval"].items():
+                    matrices[train_epoch][test_epoch].append(metrics["macro_f1"])
+
+        if not matrices:
+            print("  No results yet")
+            continue
+
+        print(f"  {'Train/Test':<15} {'pre_war':>12} {'hybrid_war':>12} {'full_scale':>12}")
+        print(f"  {'-'*51}")
+        for train_epoch in EPOCHS:
+            row = f"  {train_epoch:<15}"
+            for test_epoch in EPOCHS:
+                vals = matrices[train_epoch].get(test_epoch, [])
+                if vals:
+                    mean = np.mean(vals) * 100
+                    std = np.std(vals) * 100
+                    row += f" {mean:>8.1f}±{std:.1f}"
+                else:
+                    row += f" {'---':>12}"
+            print(row)
+
+        fwd_vals = matrices["pre_war"].get("full_scale", [])
+        bwd_vals = matrices["full_scale"].get("pre_war", [])
+        diag_pre = matrices["pre_war"].get("pre_war", [])
+        diag_full = matrices["full_scale"].get("full_scale", [])
+
+        if fwd_vals and diag_pre:
+            fwd_drop = (np.mean(diag_pre) - np.mean(fwd_vals)) * 100
+            print(f"\n  Forward degradation (pre_war diag - pre_war→full_scale): {fwd_drop:.1f} pp")
+        if bwd_vals and diag_full:
+            bwd_drop = (np.mean(diag_full) - np.mean(bwd_vals)) * 100
+            print(f"  Backward degradation (full_scale diag - full_scale→pre_war): {bwd_drop:.1f} pp")
+
+    agg_file = RESULTS_DIR / "aggregate_results.json"
+    all_results = []
+    for model_key in MODELS:
+        for train_epoch in EPOCHS:
+            for seed in SEEDS:
+                rf = output_dir_for(model_key, train_epoch, seed) / "cross_epoch_results.json"
+                if rf.exists():
+                    all_results.append(json.loads(rf.read_text()))
+    with open(agg_file, "w") as f:
+        json.dump(all_results, f, indent=2, ensure_ascii=False)
+    print(f"\nSaved aggregate to {agg_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Temporal drift fine-tuning experiments")
+    parser.add_argument("--model", choices=list(MODELS.keys()),
+                        help="Model to train")
+    parser.add_argument("--epoch", choices=EPOCHS,
+                        help="Training epoch")
+    parser.add_argument("--seed", type=int, default=42,
+                        help="Random seed (default: 42)")
+    parser.add_argument("--all", action="store_true",
+                        help="Run all model×epoch×seed combinations")
+    parser.add_argument("--eval-only", action="store_true",
+                        help="Only run cross-epoch evaluation (skip training)")
+    parser.add_argument("--embeddings", action="store_true",
+                        help="Extract [CLS] embeddings for drift analysis")
+    parser.add_argument("--continual", choices=["forward", "backward"],
+                        help="Run continual learning experiment")
+    parser.add_argument("--aggregate", action="store_true",
+                        help="Aggregate and print all results")
+    parser.add_argument("--max-train-samples", type=int, default=None,
+                        help="Limit training samples (for debugging)")
+    args = parser.parse_args()
+
+    if args.aggregate:
+        aggregate_results()
+        return
+
+    if args.all:
+        for model_key in MODELS:
+            for epoch in EPOCHS:
+                for seed in SEEDS:
+                    train_single(model_key, epoch, seed, args.max_train_samples)
+                    evaluate_cross_epoch(model_key, epoch, seed)
+                    if args.embeddings:
+                        extract_embeddings(model_key, epoch, seed)
+        aggregate_results()
+        return
+
+    if args.continual:
+        if not args.model:
+            parser.error("--continual requires --model")
+        run_continual(args.model, args.seed, args.continual)
+        return
+
+    if not args.model or not args.epoch:
+        parser.error("--model and --epoch required (or use --all)")
+
+    if args.eval_only:
+        evaluate_cross_epoch(args.model, args.epoch, args.seed)
+    elif args.embeddings:
+        extract_embeddings(args.model, args.epoch, args.seed)
+    else:
+        train_single(args.model, args.epoch, args.seed, args.max_train_samples)
+        evaluate_cross_epoch(args.model, args.epoch, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mlops/mlflow_config.json
+++ b/scripts/mlops/mlflow_config.json
@@ -1,0 +1,8 @@
+{
+  "mlflow_tracking_uri": "http://35.84.222.41:5000",
+  "mlflow_tracking_uri_private": "http://172.31.36.11:5000",
+  "artifact_bucket": "secondlayer-mlflow-artifacts",
+  "instance_id": "i-0a428d9dd2f96af1e",
+  "elastic_ip": "35.84.222.41",
+  "region": "us-west-2"
+}

--- a/scripts/mlops/mlflow_logger.py
+++ b/scripts/mlops/mlflow_logger.py
@@ -1,0 +1,115 @@
+"""
+MLflow integration for SageMaker training jobs.
+
+Drop-in logger: import and call at the start/end of any training script.
+
+Usage in train.py:
+    from mlflow_logger import start_run, log_metrics, end_run
+
+    run = start_run("attention-analysis", {"model": "qwen3-32b", "experiment": 1})
+    # ... training ...
+    log_metrics({"accuracy": 0.85, "dar": 0.42})
+    end_run()
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+
+MLFLOW_AVAILABLE = False
+try:
+    import mlflow
+    MLFLOW_AVAILABLE = True
+except ImportError:
+    pass
+
+CONFIG_PATH = Path(__file__).parent / "mlflow_config.json"
+_active_run = None
+
+
+def _load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            return json.load(f)
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI")
+    if tracking_uri:
+        return {"mlflow_tracking_uri": tracking_uri}
+    return None
+
+
+def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> bool:
+    global _active_run
+    if not MLFLOW_AVAILABLE:
+        print("[mlflow_logger] mlflow not installed, logging to local JSON only")
+        return False
+
+    config = _load_config()
+    if not config:
+        print("[mlflow_logger] No MLflow config found, logging to local JSON only")
+        return False
+
+    try:
+        mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
+        mlflow.set_experiment(experiment_name)
+
+        run_tags = {
+            "project": "secondlayer",
+            "launched_from": os.environ.get("SM_TRAINING_JOB_NAME", "local"),
+        }
+        if tags:
+            run_tags.update(tags)
+
+        _active_run = mlflow.start_run(tags=run_tags)
+
+        if params:
+            mlflow.log_params(params)
+
+        sagemaker_job = os.environ.get("SM_TRAINING_JOB_NAME")
+        if sagemaker_job:
+            mlflow.log_param("sagemaker_job_name", sagemaker_job)
+            mlflow.log_param("instance_type", os.environ.get("SM_RESOURCE_CONFIG", "unknown"))
+
+        print(f"[mlflow_logger] Run started: {_active_run.info.run_id}")
+        return True
+    except Exception as e:
+        print(f"[mlflow_logger] Failed to connect to MLflow: {e}")
+        _active_run = None
+        return False
+
+
+def log_metrics(metrics: dict, step: int = None):
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.log_metrics(metrics, step=step)
+        except Exception as e:
+            print(f"[mlflow_logger] Metric logging failed: {e}")
+
+    output_dir = Path(os.environ.get("SM_MODEL_DIR", "/opt/ml/model"))
+    if not output_dir.exists():
+        output_dir = Path(".")
+    metrics_file = output_dir / "mlflow_metrics.jsonl"
+    with open(metrics_file, "a") as f:
+        entry = {"timestamp": time.time(), "metrics": metrics}
+        if step is not None:
+            entry["step"] = step
+        f.write(json.dumps(entry) + "\n")
+
+
+def log_artifact(local_path: str):
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.log_artifact(local_path)
+        except Exception as e:
+            print(f"[mlflow_logger] Artifact logging failed: {e}")
+
+
+def end_run(status: str = "FINISHED"):
+    global _active_run
+    if _active_run and MLFLOW_AVAILABLE:
+        try:
+            mlflow.end_run(status=status)
+            print(f"[mlflow_logger] Run ended: {status}")
+        except Exception as e:
+            print(f"[mlflow_logger] End run failed: {e}")
+    _active_run = None

--- a/scripts/mlops/setup_budgets.py
+++ b/scripts/mlops/setup_budgets.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+Set up AWS Budgets + cost allocation tags for ML workloads.
+
+Creates:
+  - Monthly budget with alerts at $500, $1000, $5000
+  - Cost allocation tags: project, experiment, workload
+  - Applies tags to existing S3 buckets and SageMaker role
+
+Usage:
+  python setup_budgets.py
+  python setup_budgets.py --email alerts@legal.org.ua
+"""
+
+import argparse
+import boto3
+import json
+import sys
+
+ACCOUNT_ID = "272594900302"
+DEFAULT_EMAIL = "mcvovkes@gmail.com"
+BUDGET_NAME = "SecondLayer-ML-Monthly"
+MONTHLY_LIMIT = "5000"
+
+ML_TAGS = [
+    {"Key": "project", "Value": "secondlayer"},
+    {"Key": "workload", "Value": "ml-training"},
+]
+
+S3_BUCKETS = [
+    "secondlayer-ml-data-usw2",
+    "secondlayer-rlhf-exp4",
+]
+
+
+def setup_budgets(email: str):
+    budgets = boto3.client("budgets", region_name="us-east-1")
+
+    try:
+        budgets.describe_budget(AccountId=ACCOUNT_ID, BudgetName=BUDGET_NAME)
+        print(f"  Budget '{BUDGET_NAME}' already exists, updating...")
+        budgets.delete_budget(AccountId=ACCOUNT_ID, BudgetName=BUDGET_NAME)
+    except budgets.exceptions.NotFoundException:
+        pass
+
+    budgets.create_budget(
+        AccountId=ACCOUNT_ID,
+        Budget={
+            "BudgetName": BUDGET_NAME,
+            "BudgetLimit": {"Amount": MONTHLY_LIMIT, "Unit": "USD"},
+            "BudgetType": "COST",
+            "TimeUnit": "MONTHLY",
+            "CostFilters": {
+                "Service": [
+                    "Amazon SageMaker",
+                    "Amazon Elastic Compute Cloud - Compute",
+                    "Amazon Simple Storage Service",
+                ]
+            },
+            "CostTypes": {
+                "IncludeTax": True,
+                "IncludeSubscription": True,
+                "UseBlended": False,
+                "IncludeRefund": False,
+                "IncludeCredit": False,
+                "IncludeSupport": True,
+            },
+        },
+        NotificationsWithSubscribers=[
+            {
+                "Notification": {
+                    "NotificationType": "ACTUAL",
+                    "ComparisonOperator": "GREATER_THAN",
+                    "Threshold": 10.0,
+                    "ThresholdType": "PERCENTAGE",
+                },
+                "Subscribers": [{"SubscriptionType": "EMAIL", "Address": email}],
+            },
+            {
+                "Notification": {
+                    "NotificationType": "ACTUAL",
+                    "ComparisonOperator": "GREATER_THAN",
+                    "Threshold": 20.0,
+                    "ThresholdType": "PERCENTAGE",
+                },
+                "Subscribers": [{"SubscriptionType": "EMAIL", "Address": email}],
+            },
+            {
+                "Notification": {
+                    "NotificationType": "ACTUAL",
+                    "ComparisonOperator": "GREATER_THAN",
+                    "Threshold": 50.0,
+                    "ThresholdType": "PERCENTAGE",
+                },
+                "Subscribers": [{"SubscriptionType": "EMAIL", "Address": email}],
+            },
+            {
+                "Notification": {
+                    "NotificationType": "FORECASTED",
+                    "ComparisonOperator": "GREATER_THAN",
+                    "Threshold": 100.0,
+                    "ThresholdType": "PERCENTAGE",
+                },
+                "Subscribers": [{"SubscriptionType": "EMAIL", "Address": email}],
+            },
+        ],
+    )
+    print(f"  Created budget '{BUDGET_NAME}': ${MONTHLY_LIMIT}/month")
+    print(f"  Alerts at: $500 (10%), $1000 (20%), $2500 (50%), forecast > $5000")
+    print(f"  Notifications to: {email}")
+
+
+def tag_s3_buckets():
+    s3 = boto3.client("s3", region_name="us-west-2")
+    for bucket in S3_BUCKETS:
+        try:
+            existing = s3.get_bucket_tagging(Bucket=bucket).get("TagSet", [])
+        except Exception:
+            existing = []
+
+        existing_keys = {t["Key"] for t in existing}
+        new_tags = existing + [t for t in ML_TAGS if t["Key"] not in existing_keys]
+        s3.put_bucket_tagging(Bucket=bucket, Tagging={"TagSet": new_tags})
+        print(f"  Tagged s3://{bucket}: {[t['Key'] for t in new_tags]}")
+
+
+def tag_sagemaker_jobs():
+    sm = boto3.client("sagemaker", region_name="us-west-2")
+    jobs = sm.list_training_jobs(MaxResults=20, SortBy="CreationTime", SortOrder="Descending")
+    tagged = 0
+    for job in jobs["TrainingJobSummaries"]:
+        try:
+            sm.add_tags(
+                ResourceArn=job["TrainingJobArn"],
+                Tags=ML_TAGS + [{"Key": "experiment", "Value": job["TrainingJobName"].split("-")[0]}],
+            )
+            tagged += 1
+        except Exception as e:
+            print(f"  Warning: couldn't tag {job['TrainingJobName']}: {e}")
+    print(f"  Tagged {tagged} recent SageMaker jobs")
+
+
+def activate_cost_allocation_tags():
+    ce = boto3.client("ce", region_name="us-east-1")
+    try:
+        ce.update_cost_allocation_tags_status(
+            CostAllocationTagsStatus=[
+                {"TagKey": "project", "Status": "Active"},
+                {"TagKey": "experiment", "Status": "Active"},
+                {"TagKey": "workload", "Status": "Active"},
+            ]
+        )
+        print("  Activated cost allocation tags: project, experiment, workload")
+    except Exception as e:
+        print(f"  Cost allocation tags activation (may need manual console step): {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--email", default=DEFAULT_EMAIL)
+    args = parser.parse_args()
+
+    print("Setting up AWS Budgets and cost governance...")
+    setup_budgets(args.email)
+    print("\nTagging existing resources...")
+    tag_s3_buckets()
+    tag_sagemaker_jobs()
+    print("\nActivating cost allocation tags...")
+    activate_cost_allocation_tags()
+    print("\nDone. Budget alerts will start arriving when thresholds are crossed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mlops/setup_mlflow.py
+++ b/scripts/mlops/setup_mlflow.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Deploy a self-hosted MLflow Tracking Server on AWS (t3.small, ~$15/mo).
+
+Creates:
+  - EC2 instance with MLflow + PostgreSQL backend store + S3 artifact store
+  - Security group (port 5000 from VPC only)
+  - S3 bucket for artifacts
+
+Usage:
+  python setup_mlflow.py                # Deploy MLflow server
+  python setup_mlflow.py --teardown     # Remove everything
+"""
+
+import argparse
+import boto3
+import time
+import json
+import sys
+
+REGION = "us-west-2"
+INSTANCE_TYPE = "t3.small"
+MLFLOW_PORT = 5000
+S3_ARTIFACT_BUCKET = "secondlayer-mlflow-artifacts"
+KEY_NAME = "secondlayer-prod"
+STACK_TAG = {"Key": "project", "Value": "secondlayer-mlops"}
+
+ec2 = boto3.client("ec2", region_name=REGION)
+ec2r = boto3.resource("ec2", region_name=REGION)
+s3 = boto3.client("s3", region_name=REGION)
+
+
+def get_default_vpc():
+    vpcs = ec2.describe_vpcs(Filters=[{"Name": "isDefault", "Values": ["true"]}])
+    return vpcs["Vpcs"][0]["VpcId"] if vpcs["Vpcs"] else None
+
+
+def get_latest_ami():
+    images = ec2.describe_images(
+        Owners=["amazon"],
+        Filters=[
+            {"Name": "name", "Values": ["al2023-ami-2023.*-x86_64"]},
+            {"Name": "state", "Values": ["available"]},
+        ],
+    )
+    return sorted(images["Images"], key=lambda x: x["CreationDate"], reverse=True)[0]["ImageId"]
+
+
+def create_s3_bucket():
+    try:
+        s3.create_bucket(
+            Bucket=S3_ARTIFACT_BUCKET,
+            CreateBucketConfiguration={"LocationConstraint": REGION},
+        )
+        print(f"  Created S3 bucket: {S3_ARTIFACT_BUCKET}")
+    except s3.exceptions.BucketAlreadyOwnedByYou:
+        print(f"  S3 bucket already exists: {S3_ARTIFACT_BUCKET}")
+
+
+def create_security_group(vpc_id):
+    existing = ec2.describe_security_groups(
+        Filters=[
+            {"Name": "group-name", "Values": ["mlflow-tracking-server"]},
+            {"Name": "vpc-id", "Values": [vpc_id]},
+        ]
+    )
+    if existing["SecurityGroups"]:
+        sg_id = existing["SecurityGroups"][0]["GroupId"]
+        print(f"  Security group exists: {sg_id}")
+        return sg_id
+
+    sg = ec2.create_security_group(
+        GroupName="mlflow-tracking-server",
+        Description="MLflow Tracking Server - port 5000 VPC only",
+        VpcId=vpc_id,
+    )
+    sg_id = sg["GroupId"]
+
+    vpc_cidr = ec2.describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0]["CidrBlock"]
+    ec2.authorize_security_group_ingress(
+        GroupId=sg_id,
+        IpPermissions=[
+            {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22,
+             "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "SSH"}]},
+            {"IpProtocol": "tcp", "FromPort": MLFLOW_PORT, "ToPort": MLFLOW_PORT,
+             "IpRanges": [{"CidrIp": vpc_cidr, "Description": "MLflow from VPC"}]},
+        ],
+    )
+    ec2.create_tags(Resources=[sg_id], Tags=[STACK_TAG])
+    print(f"  Created security group: {sg_id}")
+    return sg_id
+
+
+USER_DATA = f"""#!/bin/bash
+set -e
+yum update -y
+yum install -y python3-pip postgresql15-server
+
+# Init PostgreSQL
+postgresql-setup --initdb
+systemctl enable postgresql
+systemctl start postgresql
+
+sudo -u postgres psql -c "CREATE USER mlflow WITH PASSWORD 'mlflow_local';"
+sudo -u postgres psql -c "CREATE DATABASE mlflow OWNER mlflow;"
+
+# Install MLflow
+pip3 install mlflow boto3 psycopg2-binary
+
+# Create systemd service
+cat > /etc/systemd/system/mlflow.service << 'SVCEOF'
+[Unit]
+Description=MLflow Tracking Server
+After=postgresql.service
+
+[Service]
+Type=simple
+User=ec2-user
+ExecStart=/usr/local/bin/mlflow server \\
+    --backend-store-uri postgresql://mlflow:mlflow_local@localhost/mlflow \\
+    --default-artifact-root s3://{S3_ARTIFACT_BUCKET}/artifacts \\
+    --host 0.0.0.0 \\
+    --port {MLFLOW_PORT}
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+SVCEOF
+
+systemctl daemon-reload
+systemctl enable mlflow
+systemctl start mlflow
+"""
+
+
+def launch_instance(sg_id, ami_id):
+    existing = ec2.describe_instances(
+        Filters=[
+            {"Name": "tag:project", "Values": ["secondlayer-mlops"]},
+            {"Name": "tag:Name", "Values": ["mlflow-tracking-server"]},
+            {"Name": "instance-state-name", "Values": ["running", "pending"]},
+        ]
+    )
+    for r in existing["Reservations"]:
+        for inst in r["Instances"]:
+            print(f"  MLflow instance already running: {inst['InstanceId']} ({inst.get('PrivateIpAddress', '?')})")
+            return inst["InstanceId"], inst.get("PrivateIpAddress")
+
+    instance = ec2r.create_instances(
+        ImageId=ami_id,
+        InstanceType=INSTANCE_TYPE,
+        KeyName=KEY_NAME,
+        SecurityGroupIds=[sg_id],
+        MinCount=1, MaxCount=1,
+        UserData=USER_DATA,
+        IamInstanceProfile={"Name": "mlflow-tracking-ec2-profile"},
+        TagSpecifications=[{
+            "ResourceType": "instance",
+            "Tags": [
+                STACK_TAG,
+                {"Key": "Name", "Value": "mlflow-tracking-server"},
+            ],
+        }],
+        BlockDeviceMappings=[{
+            "DeviceName": "/dev/xvda",
+            "Ebs": {"VolumeSize": 20, "VolumeType": "gp3"},
+        }],
+    )[0]
+
+    print(f"  Launched instance: {instance.id}, waiting for running state...")
+    instance.wait_until_running()
+    instance.reload()
+    print(f"  Instance running: {instance.private_ip_address}")
+    return instance.id, instance.private_ip_address
+
+
+def deploy():
+    print("Deploying MLflow Tracking Server...")
+    vpc_id = get_default_vpc()
+    if not vpc_id:
+        print("ERROR: No default VPC found")
+        sys.exit(1)
+    print(f"  VPC: {vpc_id}")
+
+    create_s3_bucket()
+    ami_id = get_latest_ami()
+    print(f"  AMI: {ami_id}")
+    sg_id = create_security_group(vpc_id)
+    instance_id, private_ip = launch_instance(sg_id, ami_id)
+
+    config = {
+        "mlflow_tracking_uri": f"http://{private_ip}:{MLFLOW_PORT}",
+        "artifact_bucket": S3_ARTIFACT_BUCKET,
+        "instance_id": instance_id,
+        "region": REGION,
+    }
+
+    config_path = "/home/vovkes/SecondLayer/scripts/mlops/mlflow_config.json"
+    with open(config_path, "w") as f:
+        json.dump(config, f, indent=2)
+    print(f"\n  Config saved: {config_path}")
+    print(f"  MLflow UI: {config['mlflow_tracking_uri']}")
+    print(f"  Artifacts: s3://{S3_ARTIFACT_BUCKET}/artifacts")
+    print(f"\n  Wait ~3 min for MLflow service to start.")
+    return config
+
+
+def teardown():
+    print("Tearing down MLflow infrastructure...")
+    instances = ec2.describe_instances(
+        Filters=[
+            {"Name": "tag:project", "Values": ["secondlayer-mlops"]},
+            {"Name": "instance-state-name", "Values": ["running", "pending", "stopped"]},
+        ]
+    )
+    for r in instances["Reservations"]:
+        for inst in r["Instances"]:
+            ec2.terminate_instances(InstanceIds=[inst["InstanceId"]])
+            print(f"  Terminated: {inst['InstanceId']}")
+
+    sgs = ec2.describe_security_groups(
+        Filters=[{"Name": "tag:project", "Values": ["secondlayer-mlops"]}]
+    )
+    for sg in sgs["SecurityGroups"]:
+        try:
+            ec2.delete_security_group(GroupId=sg["GroupId"])
+            print(f"  Deleted SG: {sg['GroupId']}")
+        except Exception as e:
+            print(f"  SG {sg['GroupId']} delete deferred (instance terminating): {e}")
+
+    print("  Done. S3 bucket preserved (contains artifacts).")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--teardown", action="store_true")
+    args = parser.parse_args()
+    if args.teardown:
+        teardown()
+    else:
+        deploy()

--- a/scripts/mlops/spot_wrapper.py
+++ b/scripts/mlops/spot_wrapper.py
@@ -1,0 +1,58 @@
+"""
+SageMaker Managed Spot Training wrapper.
+
+Wraps existing launch configs to use Spot instances with checkpointing.
+Saves 60-70% on ml.g5.xlarge/g5.12xlarge.
+
+Usage:
+    from spot_wrapper import enable_spot
+
+    job_config = { ... existing CreateTrainingJob params ... }
+    job_config = enable_spot(job_config, checkpoint_s3="s3://bucket/checkpoints/")
+"""
+
+
+def enable_spot(
+    job_config: dict,
+    checkpoint_s3: str,
+    max_wait_seconds: int = None,
+) -> dict:
+    """Add Managed Spot Training to an existing SageMaker job config.
+
+    Args:
+        job_config: Existing CreateTrainingJob params dict
+        checkpoint_s3: S3 URI for spot checkpoint storage
+        max_wait_seconds: Max seconds to wait for spot capacity.
+            Defaults to 2x MaxRuntimeInSeconds.
+    """
+    config = dict(job_config)
+
+    max_runtime = config.get("StoppingCondition", {}).get("MaxRuntimeInSeconds", 7200)
+    if max_wait_seconds is None:
+        max_wait_seconds = max_runtime * 2
+
+    config["EnableManagedSpotTraining"] = True
+    config["StoppingCondition"] = {
+        "MaxRuntimeInSeconds": max_runtime,
+        "MaxWaitTimeInSeconds": max_wait_seconds,
+    }
+    config["CheckpointConfig"] = {
+        "S3Uri": checkpoint_s3,
+    }
+
+    return config
+
+
+def spot_savings_summary(sm_client, region: str, job_name: str) -> dict:
+    """Get spot savings for a completed job."""
+    desc = sm_client.describe_training_job(TrainingJobName=job_name)
+    billable = desc.get("BillableTimeInSeconds", 0)
+    total = desc.get("TrainingTimeInSeconds", 0)
+    savings = 1.0 - (billable / total) if total > 0 else 0.0
+    return {
+        "job_name": job_name,
+        "total_seconds": total,
+        "billable_seconds": billable,
+        "savings_pct": f"{savings:.0%}",
+        "spot_used": desc.get("EnableManagedSpotTraining", False),
+    }


### PR DESCRIPTION
## Summary
- Adds self-hosted MLflow tracking server infrastructure (EC2 t3.small, PostgreSQL + S3 artifacts)
- Drop-in `mlflow_logger.py` with graceful fallback to local JSON when server unreachable
- Integrated MLflow into temporal drift training (per-stage metrics, cross-epoch eval logging)
- Integrated MLflow into DPO training (loss, accuracy, margins, timing)
- Generic `entry_continual.py` for parameterized SageMaker continual learning jobs

## Test plan
- [x] MLflow server alive at 35.84.222.41:5000, receiving metrics from active SageMaker jobs
- [x] Temporal drift continual v2 job logging per-stage F1 metrics to MLflow
- [x] DPO E/456 job logging loss/accuracy/margins to MLflow
- [x] 6 new continual learning jobs launched using generic entry point

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MLflow experiment tracking for SageMaker training with a self-hosted MLflow server and a drop-in logger used by the temporal drift and DPO pipelines. Improves observability of metrics and artifacts, with a safe fallback to local JSON logging if the server is unreachable.

- **New Features**
  - Self-hosted MLflow server automation: EC2 `t3.small` with PostgreSQL backend and S3 artifact store (`scripts/mlops/setup_mlflow.py`), config in `scripts/mlops/mlflow_config.json`.
  - Reusable MLflow logger (`start_run`, `log_metrics`, `log_artifact`, `end_run`) with JSONL fallback (`scripts/*/mlflow_logger.py`).
  - Temporal drift training integrates per-stage metrics, cross-epoch eval logging, and artifact uploads (`train_temporal.py`, `batch_train.py`, `entry_continual.py`).
  - DPO training logs loss/accuracy and saves training history as an artifact (`train_dpo.py`).
  - MLOps utilities: AWS Budgets setup (`setup_budgets.py`) and SageMaker Managed Spot wrapper (`spot_wrapper.py`).

- **Migration**
  - Set `MLFLOW_TRACKING_URI` or place `mlflow_config.json` alongside the training scripts.
  - Ensure the artifact bucket exists and IAM perms allow `s3://secondlayer-mlflow-artifacts`.
  - Open port 5000 access within the VPC for the tracking server.
  - No breaking changes: training continues and logs locally if MLflow is unavailable.

- **Dependencies**
  - Added `mlflow`, `psycopg2-binary`, and `boto3` to training requirements.

<sup>Written for commit 357e0efe4c26bbdecae0cfac4b5a824de078035b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1763?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

