### PR TITLE
feat(infra): legal-intern API keys + memory bump

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1544,14 +1544,17 @@ services:
     environment:
       - GRADIO_SERVER_NAME=0.0.0.0
       - GRADIO_SERVER_PORT=7860
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - SECONDLAYER_API_KEY=${SECONDLAYER_API_KEY}
+      - SECONDLAYER_API_URL=http://mono-backend-prod:3000/api
     networks:
       - secondlayer-prod-network
     deploy:
       resources:
         limits:
-          memory: 512M
+          memory: 1G
         reservations:
-          memory: 128M
+          memory: 256M
 
 volumes:
   postgres_prod_data:


### PR DESCRIPTION
## Summary
- Pass `ANTHROPIC_API_KEY`, `SECONDLAYER_API_KEY`, `SECONDLAYER_API_URL` to legal-intern container
- Use internal Docker network URL (`mono-backend-prod:3000`) for SecondLayer API
- Bump memory limit from 512M to 1G (real pipeline needs more memory for LLM client libs)

## Context
LegalIntern now runs the real 9-agent consultation pipeline instead of demo mode. Needs LLM API access and SecondLayer MCP bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable LegalIntern to run the full consultation pipeline in production by wiring required API keys, using the internal SecondLayer URL, and increasing memory to 1G for stability.

- `ANTHROPIC_API_KEY`, `SECONDLAYER_API_KEY`, and `SECONDLAYER_API_URL=http://mono-backend-prod:3000/api` added to the container.
- Memory limit raised from 512M to 1G; reservation from 128M to 256M.

- **Migration**
  - Ensure `ANTHROPIC_API_KEY` and `SECONDLAYER_API_KEY` are set in prod secrets.
  - Verify `mono-backend-prod` is reachable on the `secondlayer-prod-network`.

<sup>Written for commit 40310ed6c0bfb98f9b2ac84a53a25f3a42722b43. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1764?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

