### PR TITLE
feat(infra): legal-intern Bedrock credentials

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1544,7 +1544,9 @@ services:
     environment:
       - GRADIO_SERVER_NAME=0.0.0.0
       - GRADIO_SERVER_PORT=7860
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AWS_REGION=${AWS_REGION:-eu-central-1}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - SECONDLAYER_API_KEY=${SECONDLAYER_API_KEY}
       - SECONDLAYER_API_URL=http://mono-backend-prod:3000/api
     networks:


### PR DESCRIPTION
## Summary
- Replace `ANTHROPIC_API_KEY` with `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` for legal-intern container
- All LLM calls go through AWS Bedrock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the legal-intern service to use AWS Bedrock for all LLM calls instead of the Anthropic API. Replaces `ANTHROPIC_API_KEY` with `AWS_REGION` (defaults to eu-central-1), `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` in `docker-compose.prod.yml`.

- **Migration**
  - Set `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and optionally `AWS_REGION` in production secrets for the legal-intern container.
  - Remove `ANTHROPIC_API_KEY` from the environment.
  - Ensure the IAM user/role has Bedrock InvokeModel permissions and access to required models.

<sup>Written for commit 57480b5aa513a705768963de8022a71fab49d6af. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1765?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

