### PR TITLE
refactor(infra): rename LegalIntern to LMAF

### DIFF
--- a/deployment/Dockerfile.lmaf
+++ b/deployment/Dockerfile.lmaf
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends git && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV TZ=Europe/Kiev
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN git clone https://github.com/overthelex/secondlayer-agents.git /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 7860
+
+ENV GRADIO_SERVER_NAME=0.0.0.0
+ENV GRADIO_SERVER_PORT=7860
+
+CMD ["python", "app.py"]

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1529,12 +1529,12 @@ services:
         reservations:
           memory: 64M
 
-  legal-intern-prod:
+  lmaf-prod:
     build:
       context: ..
-      dockerfile: deployment/Dockerfile.legal-intern
-    image: legal-intern-prod:latest
-    container_name: legal-intern-prod
+      dockerfile: deployment/Dockerfile.lmaf
+    image: lmaf-prod:latest
+    container_name: lmaf-prod
     restart: unless-stopped
     logging:
       driver: json-file

--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -659,7 +659,7 @@ server {
     }
 }
 
-# agents.legal.org.ua — LegalIntern multi-agent consultation demo
+# agents.legal.org.ua — LMAF (Legal Multi-Agent Framework)
 server {
     listen 80;
     server_name agents.legal.org.ua;
@@ -680,7 +680,7 @@ server {
     include /etc/nginx/includes/ssl-common.conf;
 
     location / {
-        proxy_pass http://legal-intern-prod:7860;
+        proxy_pass http://lmaf-prod:7860;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- Rename Docker service from `legal-intern-prod` to `lmaf-prod`
- Rename `Dockerfile.legal-intern` to `Dockerfile.lmaf`
- Update nginx upstream to `lmaf-prod:7860`

## Test plan
- [ ] Verify `docker compose config` parses correctly
- [ ] Deploy and verify `agents.legal.org.ua` responds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the LegalIntern service to LMAF across infra. Updated Dockerfile, Compose service, and nginx upstream to `lmaf-prod` with no behavior changes.

- **Refactors**
  - Added `deployment/Dockerfile.lmaf`; replaced `Dockerfile.legal-intern` usage.
  - Renamed Compose service to `lmaf-prod` and updated image/container names.
  - Pointed nginx for `agents.legal.org.ua` to `lmaf-prod:7860`.

- **Migration**
  - Deploy the renamed service: `docker compose -f deployment/docker-compose.prod.yml up -d --build lmaf-prod`.
  - Confirm `agents.legal.org.ua` responds via port 7860.

<sup>Written for commit 3d5395136a38df8851d1d5819ddd64e11e2d8731. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1766?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

