### PR TITLE
feat(mlops): add MLflow auth, HTTPS, and IP allowlist

### DIFF
--- a/scripts/lextreme/sagemaker/dpo-code/mlflow_logger.py
+++ b/scripts/lextreme/sagemaker/dpo-code/mlflow_logger.py
@@ -38,6 +38,16 @@ def _load_config():
     return None
 
 
+def _setup_auth(config: dict):
+    if not config.get("auth_enabled"):
+        return
+    if not os.environ.get("MLFLOW_TRACKING_USERNAME"):
+        username = config.get("auth_username", "sagemaker")
+        os.environ["MLFLOW_TRACKING_USERNAME"] = username
+    if not os.environ.get("MLFLOW_TRACKING_PASSWORD"):
+        print("[mlflow_logger] WARNING: MLFLOW_TRACKING_PASSWORD not set, auth may fail")
+
+
 def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> bool:
     global _active_run
     if not MLFLOW_AVAILABLE:
@@ -50,12 +60,14 @@ def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> b
         return False
 
     try:
+        _setup_auth(config)
         mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
         mlflow.set_experiment(experiment_name)
 
         run_tags = {
             "project": "secondlayer",
             "launched_from": os.environ.get("SM_TRAINING_JOB_NAME", "local"),
+            "hardware": os.environ.get("MLFLOW_HARDWARE_TAG", "a10g"),
         }
         if tags:
             run_tags.update(tags)

--- a/scripts/lextreme/sagemaker/td-code/mlflow_logger.py
+++ b/scripts/lextreme/sagemaker/td-code/mlflow_logger.py
@@ -38,6 +38,16 @@ def _load_config():
     return None
 
 
+def _setup_auth(config: dict):
+    if not config.get("auth_enabled"):
+        return
+    if not os.environ.get("MLFLOW_TRACKING_USERNAME"):
+        username = config.get("auth_username", "sagemaker")
+        os.environ["MLFLOW_TRACKING_USERNAME"] = username
+    if not os.environ.get("MLFLOW_TRACKING_PASSWORD"):
+        print("[mlflow_logger] WARNING: MLFLOW_TRACKING_PASSWORD not set, auth may fail")
+
+
 def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> bool:
     global _active_run
     if not MLFLOW_AVAILABLE:
@@ -50,12 +60,14 @@ def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> b
         return False
 
     try:
+        _setup_auth(config)
         mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
         mlflow.set_experiment(experiment_name)
 
         run_tags = {
             "project": "secondlayer",
             "launched_from": os.environ.get("SM_TRAINING_JOB_NAME", "local"),
+            "hardware": os.environ.get("MLFLOW_HARDWARE_TAG", "a10g"),
         }
         if tags:
             run_tags.update(tags)

--- a/scripts/mlops/mlflow_config.json
+++ b/scripts/mlops/mlflow_config.json
@@ -1,8 +1,11 @@
 {
-  "mlflow_tracking_uri": "http://35.84.222.41:5000",
+  "mlflow_tracking_uri": "https://mlflow.legal.org.ua",
+  "mlflow_tracking_uri_internal": "http://35.84.222.41:5000",
   "mlflow_tracking_uri_private": "http://172.31.36.11:5000",
   "artifact_bucket": "secondlayer-mlflow-artifacts",
   "instance_id": "i-0a428d9dd2f96af1e",
   "elastic_ip": "35.84.222.41",
-  "region": "us-west-2"
+  "region": "us-west-2",
+  "auth_enabled": true,
+  "auth_username": "sagemaker"
 }

--- a/scripts/mlops/mlflow_logger.py
+++ b/scripts/mlops/mlflow_logger.py
@@ -38,6 +38,16 @@ def _load_config():
     return None
 
 
+def _setup_auth(config: dict):
+    if not config.get("auth_enabled"):
+        return
+    if not os.environ.get("MLFLOW_TRACKING_USERNAME"):
+        username = config.get("auth_username", "sagemaker")
+        os.environ["MLFLOW_TRACKING_USERNAME"] = username
+    if not os.environ.get("MLFLOW_TRACKING_PASSWORD"):
+        print("[mlflow_logger] WARNING: MLFLOW_TRACKING_PASSWORD not set, auth may fail")
+
+
 def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> bool:
     global _active_run
     if not MLFLOW_AVAILABLE:
@@ -50,12 +60,14 @@ def start_run(experiment_name: str, params: dict = None, tags: dict = None) -> b
         return False
 
     try:
+        _setup_auth(config)
         mlflow.set_tracking_uri(config["mlflow_tracking_uri"])
         mlflow.set_experiment(experiment_name)
 
         run_tags = {
             "project": "secondlayer",
             "launched_from": os.environ.get("SM_TRAINING_JOB_NAME", "local"),
+            "hardware": os.environ.get("MLFLOW_HARDWARE_TAG", "a10g"),
         }
         if tags:
             run_tags.update(tags)

--- a/scripts/mlops/setup_mlflow.py
+++ b/scripts/mlops/setup_mlflow.py
@@ -71,19 +71,28 @@ def create_security_group(vpc_id):
 
     sg = ec2.create_security_group(
         GroupName="mlflow-tracking-server",
-        Description="MLflow Tracking Server - port 5000 VPC only",
+        Description="MLflow Tracking Server - port 5000 with auth + IP allowlist",
         VpcId=vpc_id,
     )
     sg_id = sg["GroupId"]
 
     vpc_cidr = ec2.describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0]["CidrBlock"]
+    sagemaker_cidrs = [
+        {"CidrIp": "44.224.0.0/11", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+        {"CidrIp": "34.208.0.0/12", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+        {"CidrIp": "35.80.0.0/12", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+        {"CidrIp": "35.160.0.0/13", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+        {"CidrIp": "52.32.0.0/13", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+        {"CidrIp": "54.184.0.0/13", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+        {"CidrIp": "100.20.0.0/14", "Description": "AWS us-west-2 EC2 (SageMaker NAT)"},
+    ]
     ec2.authorize_security_group_ingress(
         GroupId=sg_id,
         IpPermissions=[
             {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22,
              "IpRanges": [{"CidrIp": "0.0.0.0/0", "Description": "SSH"}]},
             {"IpProtocol": "tcp", "FromPort": MLFLOW_PORT, "ToPort": MLFLOW_PORT,
-             "IpRanges": [{"CidrIp": vpc_cidr, "Description": "MLflow from VPC"}]},
+             "IpRanges": [{"CidrIp": vpc_cidr, "Description": "MLflow from VPC"}] + sagemaker_cidrs},
         ],
     )
     ec2.create_tags(Resources=[sg_id], Tags=[STACK_TAG])
@@ -104,11 +113,26 @@ systemctl start postgresql
 sudo -u postgres psql -c "CREATE USER mlflow WITH PASSWORD 'mlflow_local';"
 sudo -u postgres psql -c "CREATE DATABASE mlflow OWNER mlflow;"
 
-# Install MLflow
-pip3 install mlflow boto3 psycopg2-binary
+# Install MLflow with auth support
+pip3 install mlflow boto3 psycopg2-binary flask-wtf
 
-# Create systemd service
-cat > /etc/systemd/system/mlflow.service << 'SVCEOF'
+# Generate secrets
+ADMIN_PASS=$(python3 -c "import secrets; print(secrets.token_urlsafe(24))")
+FLASK_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+
+# Create auth config
+cat > /home/ec2-user/basic_auth.ini << AUTHEOF
+[mlflow]
+default_permission = READ
+database_uri = sqlite:////home/ec2-user/basic_auth.db
+admin_username = admin
+admin_password = $ADMIN_PASS
+authorization_function = mlflow.server.auth:authenticate_request_basic_auth
+AUTHEOF
+chown ec2-user:ec2-user /home/ec2-user/basic_auth.ini
+
+# Create systemd service with basic auth
+cat > /etc/systemd/system/mlflow.service << SVCEOF
 [Unit]
 Description=MLflow Tracking Server
 After=postgresql.service
@@ -116,11 +140,15 @@ After=postgresql.service
 [Service]
 Type=simple
 User=ec2-user
-ExecStart=/usr/local/bin/mlflow server \\
-    --backend-store-uri postgresql://mlflow:mlflow_local@localhost/mlflow \\
-    --default-artifact-root s3://{S3_ARTIFACT_BUCKET}/artifacts \\
-    --host 0.0.0.0 \\
-    --port {MLFLOW_PORT}
+WorkingDirectory=/home/ec2-user
+Environment=MLFLOW_AUTH_CONFIG_PATH=/home/ec2-user/basic_auth.ini
+Environment=MLFLOW_FLASK_SERVER_SECRET_KEY=$FLASK_KEY
+ExecStart=/usr/local/bin/mlflow server \\\\
+    --backend-store-uri postgresql://mlflow:mlflow_local@localhost/mlflow \\\\
+    --default-artifact-root s3://{S3_ARTIFACT_BUCKET}/artifacts \\\\
+    --host 0.0.0.0 \\\\
+    --port {MLFLOW_PORT} \\\\
+    --app-name basic-auth
 Restart=always
 RestartSec=5
 
@@ -131,6 +159,10 @@ SVCEOF
 systemctl daemon-reload
 systemctl enable mlflow
 systemctl start mlflow
+
+echo "MLflow admin password: $ADMIN_PASS" > /home/ec2-user/mlflow_credentials.txt
+chown ec2-user:ec2-user /home/ec2-user/mlflow_credentials.txt
+chmod 600 /home/ec2-user/mlflow_credentials.txt
 """
 
 


### PR DESCRIPTION
## Summary
- Enable basic auth on MLflow server (`--app-name basic-auth`) with admin + sagemaker users
- Set up `https://mlflow.legal.org.ua` via Cloudflare Origin CA cert + nginx reverse proxy
- Restrict SG port 5000: removed `0.0.0.0/0`, added VPC CIDR + known IPs + 7 SageMaker NAT CIDRs
- Update all 3 `mlflow_logger.py` copies with `_setup_auth()` (reads `MLFLOW_TRACKING_USERNAME`/`MLFLOW_TRACKING_PASSWORD` env vars)
- Update `setup_mlflow.py` deployment script with auth + restricted SG
- Config now points to HTTPS URL

## Infrastructure changes (already applied)
- MLflow EC2: basic auth enabled, nginx with TLS on port 443
- Cloudflare: A record `mlflow.legal.org.ua` → 35.84.222.41 (proxied), Origin CA cert (valid to 2041)
- SG `sg-0b5ec07e219590892`: port 5000 restricted, ports 80/443 open for Cloudflare

## Test plan
- [x] `https://mlflow.legal.org.ua/` returns 401 without auth
- [x] `https://mlflow.legal.org.ua/` returns 200 with admin credentials
- [x] SageMaker user can create experiments via API
- [ ] Verify next SageMaker training job logs metrics successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure the MLflow tracking server with basic auth, HTTPS at https://mlflow.legal.org.ua, and an IP allowlist. Clients now use the HTTPS endpoint and support auth via env vars.

- **New Features**
  - Enabled MLflow basic auth on the server (`--app-name basic-auth`) with generated admin creds; service runs with `MLFLOW_AUTH_CONFIG_PATH` and `MLFLOW_FLASK_SERVER_SECRET_KEY`.
  - Added HTTPS via Cloudflare Origin CA and nginx; updated config to `https://mlflow.legal.org.ua` (kept internal/private URIs for EC2/VPC).
  - Restricted SG port 5000 to VPC CIDR and us-west-2 SageMaker NAT CIDRs; ports 80/443 open for Cloudflare.
  - Updated all `mlflow_logger.py` to `_setup_auth()` using `MLFLOW_TRACKING_USERNAME`/`MLFLOW_TRACKING_PASSWORD` (default username `sagemaker`) and added a `hardware` tag via `MLFLOW_HARDWARE_TAG`.
  - `setup_mlflow.py`: installs `mlflow`, `flask-wtf`, writes basic-auth config, and configures systemd.

- **Migration**
  - Point clients to `https://mlflow.legal.org.ua`.
  - Set `MLFLOW_TRACKING_USERNAME` and `MLFLOW_TRACKING_PASSWORD` in training jobs (e.g., SageMaker).
  - If access is blocked, run from VPC/SageMaker or request your IP/CIDR be added to the allowlist.

<sup>Written for commit b40f3568da6f465d9fc40d5f16e3772cc49c89f9. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1767?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

