### PR TITLE
feat(mlops): MLflow HTTPS, login page, auth, IP allowlist

### DIFF
--- a/scripts/mlops/nginx/login.html
+++ b/scripts/mlops/nginx/login.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MLflow - SecondLayer</title>
+<style>
+  *{margin:0;padding:0;box-sizing:border-box}
+  body{
+    min-height:100vh;display:flex;align-items:center;justify-content:center;
+    font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+    background:#0f172a;color:#e2e8f0;
+  }
+  .card{
+    width:100%;max-width:400px;padding:48px 40px;
+    background:#1e293b;border-radius:16px;
+    box-shadow:0 25px 50px -12px rgba(0,0,0,0.5);
+  }
+  .logo{
+    display:flex;align-items:center;gap:12px;
+    margin-bottom:32px;justify-content:center;
+  }
+  .logo svg{width:36px;height:36px}
+  .logo span{font-size:22px;font-weight:600;letter-spacing:-0.5px}
+  .logo .accent{color:#38bdf8}
+  .subtitle{
+    text-align:center;font-size:14px;color:#94a3b8;
+    margin-bottom:28px;
+  }
+  label{
+    display:block;font-size:13px;font-weight:500;
+    color:#94a3b8;margin-bottom:6px;
+  }
+  input{
+    width:100%;padding:12px 14px;
+    background:#0f172a;border:1px solid #334155;border-radius:8px;
+    color:#e2e8f0;font-size:15px;
+    transition:border-color .2s;outline:none;
+    margin-bottom:18px;
+  }
+  input:focus{border-color:#38bdf8}
+  input::placeholder{color:#475569}
+  button{
+    width:100%;padding:12px;margin-top:4px;
+    background:#2563eb;border:none;border-radius:8px;
+    color:#fff;font-size:15px;font-weight:600;
+    cursor:pointer;transition:background .2s;
+  }
+  button:hover{background:#1d4ed8}
+  button:active{background:#1e40af}
+  button:disabled{opacity:0.6;cursor:not-allowed}
+  .error{
+    background:#7f1d1d;border:1px solid #991b1b;
+    border-radius:8px;padding:10px 14px;
+    font-size:13px;color:#fca5a5;
+    margin-bottom:18px;display:none;
+  }
+  .error.show{display:block}
+  .footer{
+    text-align:center;margin-top:24px;
+    font-size:12px;color:#475569;
+  }
+  .spinner{
+    display:inline-block;width:16px;height:16px;
+    border:2px solid #fff4;border-top-color:#fff;
+    border-radius:50%;animation:spin .6s linear infinite;
+    vertical-align:middle;margin-right:6px;
+  }
+  @keyframes spin{to{transform:rotate(360deg)}}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="logo">
+    <svg viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect width="36" height="36" rx="8" fill="#1e3a5f"/>
+      <path d="M10 26V10h4v12h8v4H10z" fill="#38bdf8"/>
+      <path d="M18 10h4l4 8-4 8h-4l4-8-4-8z" fill="#60a5fa"/>
+    </svg>
+    <span>ML<span class="accent">flow</span></span>
+  </div>
+  <div class="subtitle">SecondLayer Experiment Tracking</div>
+  <div class="error" id="error">Incorrect username or password</div>
+  <form id="form" autocomplete="on">
+    <label for="user">Username</label>
+    <input id="user" name="username" type="text" placeholder="admin" autocomplete="username" required autofocus>
+    <label for="pass">Password</label>
+    <input id="pass" name="password" type="password" placeholder="********" autocomplete="current-password" required>
+    <button type="submit" id="btn">Sign in</button>
+  </form>
+  <div class="footer">legal.org.ua</div>
+</div>
+<script>
+const form=document.getElementById('form'),
+      err=document.getElementById('error'),
+      btn=document.getElementById('btn');
+
+form.addEventListener('submit',async e=>{
+  e.preventDefault();
+  err.classList.remove('show');
+  const u=document.getElementById('user').value,
+        p=document.getElementById('pass').value;
+  if(!u||!p)return;
+
+  btn.disabled=true;
+  btn.innerHTML='<span class="spinner"></span>Signing in...';
+
+  const token=btoa(u+':'+p);
+  document.cookie='mlflow_auth='+token+';path=/;secure;samesite=strict;max-age=86400';
+
+  try{
+    const r=await fetch('/__auth_check',{credentials:'same-origin'});
+    if(r.ok){
+      window.location.href='/';
+    }else{
+      document.cookie='mlflow_auth=;path=/;max-age=0';
+      err.classList.add('show');
+      btn.disabled=false;
+      btn.textContent='Sign in';
+    }
+  }catch(_){
+    document.cookie='mlflow_auth=;path=/;max-age=0';
+    err.classList.add('show');
+    btn.disabled=false;
+    btn.textContent='Sign in';
+  }
+});
+</script>
+</body>
+</html>

--- a/scripts/mlops/nginx/mlflow.conf
+++ b/scripts/mlops/nginx/mlflow.conf
@@ -1,0 +1,52 @@
+server {
+    listen 80;
+    server_name mlflow.legal.org.ua;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name mlflow.legal.org.ua;
+
+    ssl_certificate /etc/nginx/ssl/mlflow.crt;
+    ssl_certificate_key /etc/nginx/ssl/mlflow.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    location = /login {
+        alias /var/www/mlflow/login.html;
+        default_type text/html;
+    }
+
+    location = /__auth_check {
+        proxy_pass http://127.0.0.1:5000/api/2.0/mlflow/registered-models/search;
+        proxy_method GET;
+        proxy_set_header Authorization "Basic $cookie_mlflow_auth";
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        proxy_hide_header WWW-Authenticate;
+    }
+
+    location / {
+        if ($cookie_mlflow_auth = "") {
+            return 302 /login;
+        }
+
+        proxy_pass http://127.0.0.1:5000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Authorization "Basic $cookie_mlflow_auth";
+        proxy_hide_header WWW-Authenticate;
+        proxy_read_timeout 300s;
+        proxy_connect_timeout 75s;
+
+        proxy_intercept_errors on;
+        error_page 401 = @relogin;
+    }
+
+    location @relogin {
+        add_header Set-Cookie "mlflow_auth=; Path=/; Max-Age=0" always;
+        return 302 /login;
+    }
+}


### PR DESCRIPTION
## Summary
- Custom login page for `https://mlflow.legal.org.ua` (replaces browser Basic Auth popup)
- Nginx reverse proxy config with cookie-based auth (Cloudflare Origin CA, Full Strict SSL)
- Completes LEXAI-1094 TODOs: Auth (#1), HTTPS/TLS (#2), IP allowlist (#5)

## Infrastructure applied (not in code)
- MLflow basic auth enabled (`--app-name basic-auth`, admin + sagemaker users)
- Cloudflare DNS: `mlflow.legal.org.ua` → 35.84.222.41 (proxied)
- Cloudflare Origin CA cert (valid to 2041)
- SG `sg-0b5ec07e219590892`: `0.0.0.0/0` removed from port 5000, restricted to VPC + known IPs + 7 SageMaker NAT CIDRs
- MLflow experiment permissions granted for pre-auth experiments
- Run progress metrics backfilled (elapsed_hours, progress_pct, current_stage, eta)

## Test plan
- [x] `https://mlflow.legal.org.ua/` redirects to `/login`
- [x] Login with valid credentials → MLflow UI
- [x] Login with invalid credentials → error message
- [x] All 3 experiments visible with runs and metrics
- [x] Port 5000 not accessible from `0.0.0.0/0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds HTTPS reverse proxy and a custom login page for mlflow.legal.org.ua. Replaces the browser Basic Auth with cookie-based login and completes LEXAI-1094: Auth (#1), HTTPS/TLS (#2), IP allowlist (#5).

- New Features
  - Added `scripts/mlops/nginx/mlflow.conf` reverse proxy: force HTTPS, terminate TLS (Cloudflare Origin CA), serve `/login` and `/__auth_check`, forward `Authorization: Basic $cookie_mlflow_auth` to MLflow, and on 401 clear the cookie and redirect to `/login`.
  - Added `scripts/mlops/nginx/login.html` login page that sets a secure `mlflow_auth` cookie (1 day, SameSite=Strict) and verifies access before redirecting to the MLflow UI.

- Migration
  - Copy `mlflow.conf` to `/etc/nginx/conf.d/` and `login.html` to `/var/www/mlflow/`, then reload `nginx`.
  - Run MLflow with basic-auth enabled and valid users; upstream at `127.0.0.1:5000`.
  - Use Cloudflare Full (Strict) with the Origin CA cert on the host; keep port 5000 restricted per the IP allowlist.

<sup>Written for commit 9051bf6052e568e8a75a937107d2629371b5d09b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1768?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

