### PR TITLE
feat(infra): add grafana.legal.org.ua nginx proxy

### DIFF
--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -659,6 +659,54 @@ server {
     }
 }
 
+# grafana.legal.org.ua — Grafana monitoring dashboards
+server {
+    listen 80;
+    listen [::]:80;
+    server_name grafana.legal.org.ua;
+
+    set_real_ip_from 172.31.0.0/16;
+    real_ip_header X-Forwarded-For;
+
+    if ($http_x_forwarded_proto = "") {
+        return 301 https://$host$request_uri;
+    }
+
+    location / {
+        proxy_pass http://grafana-prod:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name grafana.legal.org.ua;
+
+    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
+
+    include /etc/nginx/includes/ssl-common.conf;
+
+    location / {
+        proxy_pass http://grafana-prod:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+
 # agents.legal.org.ua — LMAF (Legal Multi-Agent Framework)
 server {
     listen 80;


### PR DESCRIPTION
## Summary
- Added HTTP+HTTPS server blocks for grafana.legal.org.ua in nginx prod config
- Proxies to grafana-prod:3000 with WebSocket upgrade support
- Already deployed and verified on prod

## Test plan
- [x] Grafana accessible at https://grafana.legal.org.ua/login (200)
- [x] Uptime Kuma monitor re-added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `nginx` reverse proxy for grafana.legal.org.ua to expose Grafana over HTTPS with WebSocket support. Grafana is now reachable at https://grafana.legal.org.ua/login and monitored by Uptime Kuma.

- **New Features**
  - Added HTTP and HTTPS server blocks proxying to `grafana-prod:3000`.
  - Enabled WebSocket upgrades and preserved client IP headers.
  - Configured TLS with existing Let’s Encrypt certs and HTTP→HTTPS redirect.

<sup>Written for commit 5670755c61ef8cdcff8a36825f00c311eb37b671. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1772?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

