### PR TITLE
update(pitch): replace SWC with AWS/Google/NVIDIA badges

### DIFF
--- a/lexwebapp/public/pitch-deck.html
+++ b/lexwebapp/public/pitch-deck.html
@@ -158,7 +158,7 @@
   <div style="display:flex;gap:24px;align-items:center;">
     <div style="font-size:15px;font-weight:500;color:#60a5fa;">legal.org.ua</div>
     <div style="font-size:13px;color:#475569;">|</div>
-    <div style="font-size:13px;color:#94a3b8;">SWC Regional Finalist 2026</div>
+    <div style="font-size:13px;color:#94a3b8;">AWS Activate  |  Google for Startups  |  NVIDIA Inception</div>
   </div>
   <div class="slide-number">01</div>
 </div>
@@ -515,8 +515,8 @@
       <div style="font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;">AI Tools in Production</div>
     </div>
     <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:22px;text-align:center;">
-      <div style="font-size:30px;font-weight:800;color:#f1f5f9;margin-bottom:4px;">SWC</div>
-      <div style="font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;">Regional Finalist 2026</div>
+      <div style="font-size:30px;font-weight:800;color:#f1f5f9;margin-bottom:4px;">3</div>
+      <div style="font-size:11px;color:#64748b;text-transform:uppercase;letter-spacing:0.5px;">Startup Programs (AWS, GCP, NVIDIA)</div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- Replace SWC Regional Finalist with AWS Activate, Google for Startups, NVIDIA Inception on cover
- Update traction card accordingly

## Test plan
- [ ] Verify at legal.org.ua/pitch-deck.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the SWC badge with AWS Activate, Google for Startups, and NVIDIA Inception on the pitch deck cover, and updated the traction card to show three startup programs (AWS, GCP, NVIDIA). Copy-only changes in pitch-deck.html to the cover line and traction card.

<sup>Written for commit 5bd57f29fc5e03927d44abbfdeedc09e9398c45b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1775?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

