### PR TITLE
update(pitch): fix em-dash, add Download PDF button

### DIFF
--- a/lexwebapp/public/pitch-deck.html
+++ b/lexwebapp/public/pitch-deck.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>SecondLayer — Ukrainian Legal LLM</title>
+<title>SecondLayer – Ukrainian Legal LLM</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -615,6 +615,9 @@
   <div class="logo-bar">SECONDLAYER</div>
   <div class="slide-number">09</div>
 </div>
+
+<button onclick="window.print()" style="position:fixed;top:24px;right:24px;z-index:1000;padding:10px 22px;background:linear-gradient(135deg,#3b82f6,#8b5cf6);border:none;border-radius:8px;color:#fff;font-size:14px;font-weight:600;cursor:pointer;box-shadow:0 4px 12px rgba(59,130,246,0.3);transition:opacity .2s;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Download PDF</button>
+<style>@media print { button { display: none !important; } }</style>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace em-dash with en-dash in title
- Add fixed Download PDF button (top-right, uses browser print-to-PDF)
- Button hidden in print output

## Test plan
- [ ] Verify at legal.org.ua/pitch-deck.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the em dash with an en dash in the pitch title and added a fixed "Download PDF" button that uses the browser's print-to-PDF. The button sits top-right during viewing and is hidden in print output.

<sup>Written for commit 87694a3ce59c782c0b6cecfe57458c92496d698b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1776?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

