### PR TITLE
update(pitch): add moat pills to cover slide

### DIFF
--- a/lexwebapp/public/pitch-deck.html
+++ b/lexwebapp/public/pitch-deck.html
@@ -155,6 +155,20 @@
   <div class="subtitle">
     We trained a 14B-parameter LLM on 115M Ukrainian court decisions. Now we sell inference via API -- so any legal tech product can have expert-level legal reasoning without training their own model.
   </div>
+  <div style="display:flex;gap:14px;flex-wrap:wrap;margin-bottom:28px;">
+    <div style="display:flex;align-items:center;gap:8px;padding:8px 16px;background:rgba(59,130,246,0.08);border:1px solid rgba(59,130,246,0.2);border-radius:8px;">
+      <div style="font-size:13px;font-weight:600;color:#93c5fd;">115M court decisions</div>
+      <div style="font-size:11px;color:#64748b;">cleaned & tokenized</div>
+    </div>
+    <div style="display:flex;align-items:center;gap:8px;padding:8px 16px;background:rgba(139,92,246,0.08);border:1px solid rgba(139,92,246,0.2);border-radius:8px;">
+      <div style="font-size:13px;font-weight:600;color:#c4b5fd;">8xH100 GPU</div>
+      <div style="font-size:11px;color:#64748b;">+ MLflow pipeline</div>
+    </div>
+    <div style="display:flex;align-items:center;gap:8px;padding:8px 16px;background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.2);border-radius:8px;">
+      <div style="font-size:13px;font-weight:600;color:#86efac;">First in Ukraine</div>
+      <div style="font-size:11px;color:#64748b;">a 500B model costs $10M+ to replicate</div>
+    </div>
+  </div>
   <div style="display:flex;gap:24px;align-items:center;">
     <div style="font-size:15px;font-weight:500;color:#60a5fa;">legal.org.ua</div>
     <div style="font-size:13px;color:#475569;">|</div>


### PR DESCRIPTION
## Summary
- Add three moat badges on cover: 115M court decisions, 8xH100 GPU + MLflow, First in Ukraine ($10M+ to replicate at 500B scale)

## Test plan
- [ ] Verify at legal.org.ua/pitch-deck.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three moat pills to the pitch deck cover to highlight our key advantages. They show: "115M court decisions" (cleaned & tokenized), "8xH100 GPU + MLflow pipeline", and "First in Ukraine" ("a 500B model costs $10M+ to replicate").

<sup>Written for commit 975348d3474cd5edc76de776dd63fd574f009594. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1778?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

