### PR TITLE
feat(ml): judge-guided DPO pipeline for temporal bias experiment

### DIFF
--- a/scripts/lextreme/dpo-judge/build_dpo_pairs.py
+++ b/scripts/lextreme/dpo-judge/build_dpo_pairs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Build DPO training pairs from judge annotations.
+
+Reads judge_annotations.jsonl and response_pairs.jsonl, pairs them,
+and outputs DPO-format JSONL (prompt, chosen, rejected) filtered by
+judge confidence.
+"""
+
+import json
+import argparse
+from pathlib import Path
+from collections import Counter
+
+DATA_DIR = Path(__file__).parent
+PAIRS_PATH = DATA_DIR / "response_pairs.jsonl"
+ANNOTATIONS_PATH = DATA_DIR / "judge_annotations.jsonl"
+OUTPUT_PATH = DATA_DIR / "dpo_train.jsonl"
+STATS_PATH = DATA_DIR / "dpo_stats.json"
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--min-confidence", choices=["high", "medium", "low"], default="medium",
+                        help="Minimum judge confidence to include")
+    args = parser.parse_args()
+
+    confidence_order = {"high": 3, "medium": 2, "low": 1}
+    min_conf = confidence_order[args.min_confidence]
+
+    pairs_by_id = {}
+    with open(PAIRS_PATH) as f:
+        for line in f:
+            d = json.loads(line)
+            pairs_by_id[d["metadata"]["doc_id"]] = d
+
+    annotations = []
+    with open(ANNOTATIONS_PATH) as f:
+        for line in f:
+            annotations.append(json.loads(line))
+
+    stats = Counter()
+    dpo_pairs = []
+
+    for ann in annotations:
+        doc_id = ann["doc_id"]
+        pair = pairs_by_id.get(doc_id)
+        if pair is None:
+            stats["missing_pair"] += 1
+            continue
+
+        agg = ann["aggregation"]
+        conf = confidence_order.get(agg["confidence"], 0)
+
+        if conf < min_conf:
+            stats["low_confidence"] += 1
+            continue
+
+        if agg["majority_preferred"] == "tie":
+            stats["tie"] += 1
+            continue
+
+        if agg["majority_preferred"] == "A":
+            chosen = pair["response_a"]
+            rejected = pair["response_b"]
+        else:
+            chosen = pair["response_b"]
+            rejected = pair["response_a"]
+
+        dpo_pairs.append({
+            "prompt": pair["prompt"],
+            "chosen": chosen,
+            "rejected": rejected,
+            "metadata": {
+                "doc_id": doc_id,
+                "epoch": ann["epoch"],
+                "label": ann["label"],
+                "adjudication_date": ann.get("adjudication_date", ""),
+                "confidence": agg["confidence"],
+                "agreement": agg["agreement"],
+                "score_a": ann["score_a_weighted"],
+                "score_b": ann["score_b_weighted"],
+                "preferred": agg["majority_preferred"],
+            },
+        })
+        stats["included"] += 1
+        stats[f"epoch_{ann['epoch']}"] += 1
+        stats[f"preferred_{agg['majority_preferred']}"] += 1
+
+    with open(OUTPUT_PATH, "w") as f:
+        for p in dpo_pairs:
+            f.write(json.dumps(p, ensure_ascii=False) + "\n")
+
+    summary = {
+        "total_annotations": len(annotations),
+        "total_dpo_pairs": len(dpo_pairs),
+        "min_confidence": args.min_confidence,
+        "breakdown": dict(stats),
+        "epoch_distribution": {
+            e: stats.get(f"epoch_{e}", 0)
+            for e in ["pre_war", "hybrid_war", "full_scale"]
+        },
+        "preference_distribution": {
+            "A": stats.get("preferred_A", 0),
+            "B": stats.get("preferred_B", 0),
+        },
+    }
+
+    with open(STATS_PATH, "w") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)
+
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+    print(f"\nOutput: {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lextreme/dpo-judge/generate_responses.py
+++ b/scripts/lextreme/dpo-judge/generate_responses.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Generate response pairs for judge-guided DPO experiment.
+
+For each sampled EDRSR case, generates two legal analyses:
+  - Model A: CPT Qwen 2.5 (domain-adapted)
+  - Model B: GPT-4o-mini (general-purpose baseline)
+
+Uses AWS Bedrock for GPT-4o-mini and a local/remote endpoint for CPT Qwen.
+Outputs JSONL with prompt, response_a, response_b, and metadata.
+"""
+
+import json
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent
+INPUT_PATH = DATA_DIR / "sampled_cases.jsonl"
+OUTPUT_PATH = DATA_DIR / "response_pairs.jsonl"
+
+PROMPT_TEMPLATE = """Ви -- досвідчений юрист-аналітик. Проаналізуйте наведені обставини справи та надайте юридичний висновок.
+
+Завдання:
+1. Визначте застосовні правові норми (конкретні статті кодексів та законів).
+2. Оцініть, чи підтверджуються позовні вимоги встановленими фактами.
+3. Спрогнозуйте рішення суду: задоволено / відмовлено / частково задоволено.
+4. Обґрунтуйте свій висновок з посиланням на норми та факти справи.
+
+Обставини справи:
+{facts}"""
+
+SYSTEM_PROMPT = "Ви -- досвідчений юрист-аналітик з глибоким знанням українського законодавства."
+
+
+def build_prompt(case: dict) -> str:
+    return PROMPT_TEMPLATE.format(facts=case["text"])
+
+
+async def generate_bedrock(client, prompt: str, model_id: str, temperature: float = 0.3) -> str:
+    """Generate response via AWS Bedrock."""
+    import boto3
+
+    body = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "messages": [
+            {"role": "user", "content": prompt}
+        ],
+        "system": SYSTEM_PROMPT,
+        "max_tokens": 1024,
+        "temperature": temperature,
+    }
+
+    if "gpt" in model_id or "openai" in model_id:
+        body = {
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": 1024,
+            "temperature": temperature,
+        }
+
+    response = client.invoke_model(
+        modelId=model_id,
+        body=json.dumps(body),
+    )
+    result = json.loads(response["body"].read())
+
+    if "content" in result:
+        return result["content"][0]["text"]
+    elif "choices" in result:
+        return result["choices"][0]["message"]["content"]
+    else:
+        raise ValueError(f"Unexpected response format: {list(result.keys())}")
+
+
+async def generate_local(session, prompt: str, endpoint: str, temperature: float = 0.3) -> str:
+    """Generate response via local/remote vLLM or compatible endpoint."""
+    import aiohttp
+
+    payload = {
+        "model": "cpt-qwen",
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": 1024,
+        "temperature": temperature,
+    }
+
+    async with session.post(f"{endpoint}/v1/chat/completions", json=payload) as resp:
+        result = await resp.json()
+        return result["choices"][0]["message"]["content"]
+
+
+async def process_case(
+    case: dict,
+    bedrock_client,
+    session,
+    cpt_endpoint: str,
+    bedrock_model: str,
+    semaphore: asyncio.Semaphore,
+) -> dict | None:
+    prompt = build_prompt(case)
+
+    async with semaphore:
+        try:
+            response_b = await asyncio.to_thread(
+                generate_bedrock, bedrock_client, prompt, bedrock_model
+            )
+        except Exception as e:
+            logger.error(f"Bedrock error for {case.get('doc_id', '?')}: {e}")
+            return None
+
+        try:
+            response_a = await generate_local(session, prompt, cpt_endpoint)
+        except Exception as e:
+            logger.error(f"CPT endpoint error for {case.get('doc_id', '?')}: {e}")
+            return None
+
+    return {
+        "prompt": prompt,
+        "response_a": response_a,
+        "response_b": response_b,
+        "metadata": {
+            "doc_id": case.get("doc_id", ""),
+            "epoch": case["epoch"],
+            "label": case["label"],
+            "adjudication_date": case.get("adjudication_date", ""),
+            "text_len": case["text_len"],
+            "model_a": "cpt-qwen-2.5",
+            "model_b": bedrock_model,
+            "generated_at": datetime.utcnow().isoformat(),
+        },
+    }
+
+
+async def main_async(args):
+    import aiohttp
+    import boto3
+
+    cases = []
+    with open(INPUT_PATH) as f:
+        for line in f:
+            cases.append(json.loads(line))
+    logger.info(f"Loaded {len(cases)} cases")
+
+    if args.limit:
+        cases = cases[: args.limit]
+        logger.info(f"Limited to {len(cases)} cases")
+
+    already_done = set()
+    if OUTPUT_PATH.exists():
+        with open(OUTPUT_PATH) as f:
+            for line in f:
+                d = json.loads(line)
+                already_done.add(d["metadata"]["doc_id"])
+        logger.info(f"Resuming: {len(already_done)} already done")
+        cases = [c for c in cases if c.get("doc_id", "") not in already_done]
+        logger.info(f"Remaining: {len(cases)} cases")
+
+    bedrock_client = boto3.client("bedrock-runtime", region_name=args.region)
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    done = 0
+    errors = 0
+
+    async with aiohttp.ClientSession() as session:
+        with open(OUTPUT_PATH, "a") as out:
+            for batch_start in range(0, len(cases), args.batch_size):
+                batch = cases[batch_start : batch_start + args.batch_size]
+                tasks = [
+                    process_case(c, bedrock_client, session, args.cpt_endpoint, args.bedrock_model, semaphore)
+                    for c in batch
+                ]
+                results = await asyncio.gather(*tasks)
+
+                for r in results:
+                    if r is not None:
+                        out.write(json.dumps(r, ensure_ascii=False) + "\n")
+                        done += 1
+                    else:
+                        errors += 1
+
+                out.flush()
+                logger.info(f"Progress: {done + len(already_done)}/{len(cases) + len(already_done)} done, {errors} errors")
+
+    logger.info(f"Finished: {done} new, {errors} errors, {len(already_done)} resumed")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate response pairs for DPO judge experiment")
+    parser.add_argument("--cpt-endpoint", type=str, default="http://localhost:8000",
+                        help="CPT Qwen vLLM endpoint URL")
+    parser.add_argument("--bedrock-model", type=str, default="us.amazon.nova-pro-v1:0",
+                        help="Bedrock model ID for Model B")
+    parser.add_argument("--region", type=str, default="us-east-1")
+    parser.add_argument("--concurrency", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=20)
+    parser.add_argument("--limit", type=int, default=None, help="Limit number of cases (for testing)")
+    args = parser.parse_args()
+
+    asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lextreme/dpo-judge/judge_responses.py
+++ b/scripts/lextreme/dpo-judge/judge_responses.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+Judge response pairs using multi-LLM panel.
+
+Three judges (GPT-4o via Bedrock, Claude Sonnet via Bedrock, Qwen-72B via Bedrock)
+independently score each response pair on a 4-criterion legal rubric.
+Majority vote determines the preferred response.
+
+Outputs JSONL with judge scores, preference, confidence, and metadata.
+"""
+
+import json
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+from datetime import datetime
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+DATA_DIR = Path(__file__).parent
+INPUT_PATH = DATA_DIR / "response_pairs.jsonl"
+OUTPUT_PATH = DATA_DIR / "judge_annotations.jsonl"
+
+JUDGE_PROMPT = """You are an expert legal evaluation judge. You will evaluate two legal analyses of a Ukrainian court case. The case has a known ground-truth outcome.
+
+## Case Facts
+{facts}
+
+## Ground Truth Outcome
+{label}
+
+## Case Date
+{date}
+
+## Response A (Model: {model_a})
+{response_a}
+
+## Response B (Model: {model_b})
+{response_b}
+
+## Evaluation Criteria (score each 1-5):
+
+1. PREDICTION CORRECTNESS (weight: 40%)
+   Did the response correctly predict the court's decision?
+   5 = correct prediction with nuanced confidence assessment
+   3 = partially correct (e.g., predicted "partial" when answer was "approved")
+   1 = completely wrong prediction
+
+2. LEGAL REASONING (weight: 30%)
+   Is the legal argumentation logically sound? Are the cited norms applicable?
+   5 = flawless legal logic, correctly identifies all relevant statutes
+   3 = generally sound but misses key norms or contains logical gaps
+   1 = fundamentally flawed reasoning or fabricated legal norms
+
+3. FACTUAL GROUNDING (weight: 20%)
+   Does the analysis reference actual facts from the case?
+   5 = every claim tied to specific case facts
+   3 = some claims grounded, some generic
+   1 = ignores case facts, produces generic legal boilerplate
+
+4. TEMPORAL AWARENESS (weight: 10%)
+   Does the analysis apply the correct edition of the law for the case date?
+   5 = explicitly acknowledges the temporal context and cites correct law version
+   3 = uses generally applicable norms without temporal specificity
+   1 = cites laws not yet enacted or already repealed at the case date
+
+You MUST output valid JSON and nothing else:
+{{"response_a": {{"prediction": N, "reasoning": N, "grounding": N, "temporal": N}}, "response_b": {{"prediction": N, "reasoning": N, "grounding": N, "temporal": N}}, "preferred": "A" or "B", "confidence": "high" or "medium" or "low", "explanation": "brief justification in 1-2 sentences"}}"""
+
+JUDGES = {
+    "claude_sonnet": {
+        "model_id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        "provider": "anthropic",
+    },
+    "nova_pro": {
+        "model_id": "us.amazon.nova-pro-v1:0",
+        "provider": "amazon",
+    },
+    "llama4_maverick": {
+        "model_id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+        "provider": "meta",
+    },
+}
+
+
+def build_judge_prompt(pair: dict) -> str:
+    facts = pair["prompt"].split("Обставини справи:\n", 1)[-1]
+    return JUDGE_PROMPT.format(
+        facts=facts,
+        label=pair["metadata"]["label"],
+        date=pair["metadata"].get("adjudication_date", "unknown"),
+        model_a=pair["metadata"]["model_a"],
+        model_b=pair["metadata"]["model_b"],
+        response_a=pair["response_a"],
+        response_b=pair["response_b"],
+    )
+
+
+def invoke_bedrock(client, model_id: str, provider: str, prompt: str) -> dict:
+    if provider == "anthropic":
+        body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "messages": [{"role": "user", "content": prompt}],
+            "system": "You are an expert legal evaluation judge. Output only valid JSON.",
+            "max_tokens": 512,
+            "temperature": 0.1,
+        }
+    else:
+        body = {
+            "messages": [
+                {"role": "system", "content": "You are an expert legal evaluation judge. Output only valid JSON."},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": 512,
+            "temperature": 0.1,
+        }
+
+    response = client.invoke_model(modelId=model_id, body=json.dumps(body))
+    result = json.loads(response["body"].read())
+
+    if "content" in result:
+        text = result["content"][0]["text"]
+    elif "choices" in result:
+        text = result["choices"][0]["message"]["content"]
+    elif "output" in result and "message" in result["output"]:
+        text = result["output"]["message"]["content"][0]["text"]
+    else:
+        raise ValueError(f"Unexpected response format: {list(result.keys())}")
+
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+
+    return json.loads(text)
+
+
+def compute_weighted_score(scores: dict) -> float:
+    return (
+        scores["prediction"] * 0.4
+        + scores["reasoning"] * 0.3
+        + scores["grounding"] * 0.2
+        + scores["temporal"] * 0.1
+    )
+
+
+def aggregate_judges(judge_results: dict) -> dict:
+    preferences = [r["preferred"] for r in judge_results.values() if r is not None]
+    a_count = preferences.count("A")
+    b_count = preferences.count("B")
+
+    if a_count > b_count:
+        majority = "A"
+    elif b_count > a_count:
+        majority = "B"
+    else:
+        majority = "tie"
+
+    agreement = max(a_count, b_count)
+
+    if agreement == len(preferences):
+        confidence = "high"
+    elif agreement > len(preferences) / 2:
+        confidence = "medium"
+    else:
+        confidence = "low"
+
+    return {
+        "majority_preferred": majority,
+        "agreement": agreement,
+        "total_judges": len(preferences),
+        "confidence": confidence,
+    }
+
+
+async def judge_pair(pair: dict, bedrock_client, semaphore: asyncio.Semaphore) -> dict | None:
+    prompt = build_judge_prompt(pair)
+    judge_results = {}
+
+    for judge_name, judge_config in JUDGES.items():
+        async with semaphore:
+            try:
+                result = await asyncio.to_thread(
+                    invoke_bedrock,
+                    bedrock_client,
+                    judge_config["model_id"],
+                    judge_config["provider"],
+                    prompt,
+                )
+                judge_results[judge_name] = result
+            except Exception as e:
+                logger.error(f"Judge {judge_name} error for {pair['metadata']['doc_id']}: {e}")
+                judge_results[judge_name] = None
+
+    valid_results = {k: v for k, v in judge_results.items() if v is not None}
+    if len(valid_results) < 2:
+        logger.warning(f"Too few valid judges for {pair['metadata']['doc_id']}, skipping")
+        return None
+
+    aggregation = aggregate_judges(valid_results)
+
+    score_a_per_judge = {}
+    score_b_per_judge = {}
+    for jname, jresult in valid_results.items():
+        score_a_per_judge[jname] = compute_weighted_score(jresult["response_a"])
+        score_b_per_judge[jname] = compute_weighted_score(jresult["response_b"])
+
+    return {
+        "doc_id": pair["metadata"]["doc_id"],
+        "epoch": pair["metadata"]["epoch"],
+        "label": pair["metadata"]["label"],
+        "adjudication_date": pair["metadata"].get("adjudication_date", ""),
+        "text_len": pair["metadata"]["text_len"],
+        "judge_scores": judge_results,
+        "score_a_weighted": sum(score_a_per_judge.values()) / len(score_a_per_judge),
+        "score_b_weighted": sum(score_b_per_judge.values()) / len(score_b_per_judge),
+        "aggregation": aggregation,
+        "judged_at": datetime.utcnow().isoformat(),
+    }
+
+
+async def main_async(args):
+    import boto3
+
+    pairs = []
+    with open(INPUT_PATH) as f:
+        for line in f:
+            pairs.append(json.loads(line))
+    logger.info(f"Loaded {len(pairs)} response pairs")
+
+    if args.limit:
+        pairs = pairs[: args.limit]
+
+    already_done = set()
+    if OUTPUT_PATH.exists():
+        with open(OUTPUT_PATH) as f:
+            for line in f:
+                d = json.loads(line)
+                already_done.add(d["doc_id"])
+        logger.info(f"Resuming: {len(already_done)} already judged")
+        pairs = [p for p in pairs if p["metadata"]["doc_id"] not in already_done]
+
+    bedrock_client = boto3.client("bedrock-runtime", region_name=args.region)
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    done = 0
+    errors = 0
+
+    with open(OUTPUT_PATH, "a") as out:
+        for batch_start in range(0, len(pairs), args.batch_size):
+            batch = pairs[batch_start : batch_start + args.batch_size]
+            tasks = [judge_pair(p, bedrock_client, semaphore) for p in batch]
+            results = await asyncio.gather(*tasks)
+
+            for r in results:
+                if r is not None:
+                    out.write(json.dumps(r, ensure_ascii=False) + "\n")
+                    done += 1
+                else:
+                    errors += 1
+
+            out.flush()
+            logger.info(f"Progress: {done + len(already_done)}/{len(pairs) + len(already_done)} judged, {errors} errors")
+
+    logger.info(f"Done: {done} new, {errors} errors")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Judge response pairs with multi-LLM panel")
+    parser.add_argument("--region", type=str, default="us-east-1")
+    parser.add_argument("--concurrency", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=10)
+    parser.add_argument("--limit", type=int, default=None)
+    args = parser.parse_args()
+
+    asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lextreme/dpo-judge/sampling_stats.json
+++ b/scripts/lextreme/dpo-judge/sampling_stats.json
@@ -1,0 +1,21 @@
+{
+  "total": 3006,
+  "per_epoch": {
+    "pre_war": 1002,
+    "hybrid_war": 1002,
+    "full_scale": 1002
+  },
+  "per_label": {
+    "approved": 1002,
+    "dismissed": 1002,
+    "partial": 1002
+  },
+  "text_len": {
+    "min": 2000,
+    "max": 12000,
+    "median": 6472
+  },
+  "seed": 42,
+  "min_text_len": 2000,
+  "max_text_len": 12000
+}

--- a/scripts/lextreme/sample_dpo_cases.py
+++ b/scripts/lextreme/sample_dpo_cases.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+Stratified sampling of EDRSR cases for judge-guided DPO experiment.
+
+Samples 1000 cases per epoch (3000 total), balanced by label,
+filtered by text length (2K-12K chars) for optimal LLM context usage.
+
+Uses the full dataset (output-full/) which includes metadata:
+doc_id, adjudication_date, jurisdiction.
+"""
+
+import json
+import random
+import argparse
+from pathlib import Path
+from collections import defaultdict
+
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+LABELS = ["approved", "dismissed", "partial"]
+DATA_DIR = Path(__file__).parent / "output-full"
+OUTPUT_DIR = Path(__file__).parent / "dpo-judge"
+
+MIN_TEXT_LEN = 2000
+MAX_TEXT_LEN = 12000
+SAMPLES_PER_LABEL_PER_EPOCH = 334  # ~1000 per epoch, ~3000 total
+
+
+def load_epoch(epoch: str) -> list[dict]:
+    path = DATA_DIR / epoch / "train.jsonl"
+    cases = []
+    with open(path) as f:
+        for line in f:
+            d = json.loads(line)
+            text_len = len(d["text"])
+            if MIN_TEXT_LEN <= text_len <= MAX_TEXT_LEN:
+                d["epoch"] = epoch
+                d["text_len"] = text_len
+                cases.append(d)
+    return cases
+
+
+def stratified_sample(cases: list[dict], per_label: int, seed: int) -> list[dict]:
+    rng = random.Random(seed)
+    by_label = defaultdict(list)
+    for c in cases:
+        by_label[c["label"]].append(c)
+
+    sampled = []
+    for label in LABELS:
+        pool = by_label[label]
+        n = min(per_label, len(pool))
+        sampled.extend(rng.sample(pool, n))
+        print(f"    {label}: {n}/{len(pool)} sampled")
+
+    rng.shuffle(sampled)
+    return sampled
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sample EDRSR cases for DPO judge experiment")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--per-label", type=int, default=SAMPLES_PER_LABEL_PER_EPOCH)
+    parser.add_argument("--min-len", type=int, default=MIN_TEXT_LEN)
+    parser.add_argument("--max-len", type=int, default=MAX_TEXT_LEN)
+    args = parser.parse_args()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    all_sampled = []
+
+    for epoch in EPOCHS:
+        print(f"\n{epoch}:")
+        cases = load_epoch(epoch)
+        print(f"  {len(cases)} cases in range [{args.min_len}, {args.max_len}] chars")
+
+        sampled = stratified_sample(cases, args.per_label, args.seed)
+        all_sampled.extend(sampled)
+        print(f"  → {len(sampled)} sampled")
+
+    output_path = OUTPUT_DIR / "sampled_cases.jsonl"
+    with open(output_path, "w") as f:
+        for case in all_sampled:
+            f.write(json.dumps(case, ensure_ascii=False) + "\n")
+
+    stats = {
+        "total": len(all_sampled),
+        "per_epoch": {e: sum(1 for c in all_sampled if c["epoch"] == e) for e in EPOCHS},
+        "per_label": {l: sum(1 for c in all_sampled if c["label"] == l) for l in LABELS},
+        "text_len": {
+            "min": min(c["text_len"] for c in all_sampled),
+            "max": max(c["text_len"] for c in all_sampled),
+            "median": sorted(c["text_len"] for c in all_sampled)[len(all_sampled) // 2],
+        },
+        "seed": args.seed,
+        "min_text_len": args.min_len,
+        "max_text_len": args.max_len,
+    }
+
+    stats_path = OUTPUT_DIR / "sampling_stats.json"
+    with open(stats_path, "w") as f:
+        json.dump(stats, f, indent=2, ensure_ascii=False)
+
+    print(f"\n{'='*50}")
+    print(f"Total sampled: {len(all_sampled)}")
+    print(f"Output: {output_path}")
+    print(f"Stats:  {stats_path}")
+    print(json.dumps(stats, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- 3-stage pipeline for TACL temporal judge bias paper
- Stratified sampling: 3006 EDRSR cases (1002/epoch, balanced labels, 2K-12K chars)
- Response generation: CPT Qwen 2.5 vs GPT-4o-mini via Bedrock
- 3-judge panel (Claude Sonnet / Nova Pro / Llama4 Maverick) with legal rubric
- Confidence-filtered DPO pair builder with epoch metadata

## Test plan
- [x] Sampling script runs successfully (3006 cases output)
- [ ] Response generation (blocked on CPT Qwen training)
- [ ] Judge pipeline (after responses generated)
- [ ] DPO pair builder (after judging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 3-stage, judge-guided DPO pipeline to study temporal bias in legal reasoning on EDRSR cases. It samples cases, generates paired analyses, runs a 3-judge evaluation, and exports confidence-filtered DPO pairs.

- **New Features**
  - Stratified sampling (`sample_dpo_cases.py`): 3006 cases (1002/epoch), balanced labels, 2k–12k chars; writes sampled_cases.jsonl and sampling_stats.json.
  - Response generation (`generate_responses.py`): Model A via CPT Qwen endpoint, Model B via AWS Bedrock (configurable; default `us.amazon.nova-pro-v1:0`); concurrent and resumable; outputs response_pairs.jsonl.
  - Judging (`judge_responses.py`): 3-judge panel (Claude Sonnet, Nova Pro, Llama4 Maverick) with 4-criterion rubric; aggregates majority preference, weighted scores, and confidence; outputs judge_annotations.jsonl.
  - DPO export (`build_dpo_pairs.py`): filters by min confidence (high/medium/low), drops ties, preserves epoch/label metadata; writes dpo_train.jsonl and dpo_stats.json.

- **Dependencies**
  - `boto3` with AWS Bedrock access and region configured.
  - A CPT Qwen endpoint exposing OpenAI-compatible `/v1/chat/completions` (e.g., `vLLM`).
  - `aiohttp` for local/remote endpoint calls.

<sup>Written for commit e77482476e5bf2a19278901ebd7384b7d980e9c2. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1784?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

