### PR TITLE
Remove 'Розширена команда' section from team page

### DIFF
--- a/lexwebapp/src/pages/AboutPage/AboutTeamPage.tsx
+++ b/lexwebapp/src/pages/AboutPage/AboutTeamPage.tsx
@@ -197,19 +197,6 @@ export function AboutTeamPage() {
           ))}
         </div>
 
-        <motion.section
-          initial={{ opacity: 0, y: 16 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          className="mt-16 rounded-2xl bg-white border border-claude-border p-8"
-        >
-          <h2 className="text-2xl font-serif text-claude-text font-medium mb-3">
-            {c.wider.title}
-          </h2>
-          <p className="text-base text-claude-subtext font-sans leading-relaxed">
-            {c.wider.body}
-          </p>
-        </motion.section>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removes the "Розширена команда" / "The wider team" section from the /about/team page

## Test plan
- [ ] Verify /about/team page renders without the wider team section
- [ ] Check both UA and EN language versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Розширена команда” (“The wider team”) section from the `/about/team` page to simplify the page in both UA and EN.

<sup>Written for commit 8ccf2782a2c012722801e812fac8bb6df3c84b7f. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1786?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

