### PR TITLE
Add GitHub and HuggingFace links to team page

### DIFF
--- a/lexwebapp/src/pages/AboutPage/AboutTeamPage.tsx
+++ b/lexwebapp/src/pages/AboutPage/AboutTeamPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
-import { ArrowLeft, Linkedin, Mail, Phone } from 'lucide-react';
+import { ArrowLeft, Linkedin, Mail, Phone, Github } from 'lucide-react';
 import { useDocumentMeta } from '../../hooks/useDocumentMeta';
 import { useHreflang } from '../../hooks/useHreflang';
 import { useLocaleStore } from '../../stores/localeStore';
@@ -18,6 +18,8 @@ interface Founder {
   linkedin: string;
   email: string;
   phone?: string;
+  github?: string;
+  huggingface?: string;
 }
 
 interface TeamCopy {
@@ -56,6 +58,8 @@ const en: TeamCopy = {
         'MSc Computational Science, Igor Sikorsky Kyiv Polytechnic Institute (KPI). PhD candidate (Computer Science, specialty 122), V.M. Glushkov Institute of Cybernetics, National Academy of Sciences of Ukraine. Dissertation: 5/6 chapters completed.',
       linkedin: 'https://linkedin.com/in/volodymir-ovcharov',
       email: 'volodymyr@legal.org.ua',
+      github: 'https://github.com/overthelex',
+      huggingface: 'https://huggingface.co/overthelex',
     },
     {
       slug: 'igor',
@@ -105,6 +109,8 @@ const uk: TeamCopy = {
         'Магістр прикладної математики, КПІ ім. Ігоря Сікорського. Аспірант (компʼютерні науки, спеціальність 122), Інститут кібернетики ім. В.М. Глушкова НАН України. Дисертація: 5/6 розділів завершено.',
       linkedin: 'https://linkedin.com/in/volodymir-ovcharov',
       email: 'volodymyr@legal.org.ua',
+      github: 'https://github.com/overthelex',
+      huggingface: 'https://huggingface.co/overthelex',
     },
     {
       slug: 'igor',
@@ -282,6 +288,28 @@ function FounderCard({
               <Mail size={14} />
               {f.email}
             </a>
+            {f.github && (
+              <a
+                href={f.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-claude-subtext hover:text-claude-accent transition-colors"
+              >
+                <Github size={14} />
+                GitHub
+              </a>
+            )}
+            {f.huggingface && (
+              <a
+                href={f.huggingface}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-claude-subtext hover:text-claude-accent transition-colors"
+              >
+                <span className="text-xs font-bold">🤗</span>
+                HuggingFace
+              </a>
+            )}
             {f.phone && (
               <a
                 href={`tel:${f.phone.replace(/\s+/g, '')}`}


### PR DESCRIPTION
## Summary
- Adds GitHub and HuggingFace profile links to Volodymyr Ovcharov on /about/team
- New optional fields `github?` and `huggingface?` in Founder interface

## Test plan
- [ ] Verify links render on /about/team for Ovcharov (both UA/EN)
- [ ] Verify Igor's card unchanged (no github/hf fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub and HuggingFace links to Volodymyr Ovcharov’s card on /about/team (EN and UA). Adds optional `github` and `huggingface` fields to the `Founder` interface and conditionally renders them with a `lucide-react` GitHub icon and a HuggingFace label; other cards remain unchanged.

<sup>Written for commit 84fd5a48a461cc2ccf04a292367f55e5d5f49213. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1788?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

