### PR TITLE
feat(data): add Polish and Czech court decision pipeline

### DIFF
--- a/mcp_backend/src/migrations/151_pl_cz_court_decisions.sql
+++ b/mcp_backend/src/migrations/151_pl_cz_court_decisions.sql
@@ -1,0 +1,92 @@
+-- Migration 151: Polish and Czech court decisions
+-- Sources:
+--   PL: SAOS API (536K), JuDDGES/pl-court-raw (437K), JuDDGES/pl-nsa (1.8M)
+--   CZ: rozhodnuti.justice.cz API (582K), CzCDC LINDAT (237K), Zenodo Paulik (93K)
+
+-- ============================================================
+-- POLAND
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS pl_court_decisions (
+    id              TEXT PRIMARY KEY,
+    ecli            TEXT UNIQUE,
+    source          TEXT NOT NULL,
+    court_type      TEXT,
+    court_name      TEXT,
+    division        TEXT,
+    case_number     TEXT,
+    decision_type   TEXT,
+    decision_date   DATE,
+    judge           TEXT,
+    judges          JSONB,
+    keywords        TEXT[],
+    legal_bases     TEXT[],
+    referenced_regulations JSONB,
+    parties         TEXT,
+    abstract        TEXT,
+    full_text       TEXT,
+    source_url      TEXT,
+    metadata_json   JSONB,
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pl_court_source ON pl_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_pl_court_type ON pl_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_pl_court_date ON pl_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_pl_court_decision_type ON pl_court_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_pl_court_case_num ON pl_court_decisions(case_number);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_pl_court_fts') THEN
+        CREATE INDEX idx_pl_court_fts ON pl_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- CZECH REPUBLIC
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS cz_court_decisions (
+    id              TEXT PRIMARY KEY,
+    ecli            TEXT UNIQUE,
+    source          TEXT NOT NULL,
+    court_name      TEXT,
+    court_type      TEXT,
+    chamber         TEXT,
+    case_number     TEXT,
+    decision_type   TEXT,
+    decision_date   DATE,
+    publication_date DATE,
+    judge           TEXT,
+    subject         TEXT,
+    keywords        TEXT[],
+    cited_provisions TEXT[],
+    parties         TEXT,
+    abstract        TEXT,
+    full_text       TEXT,
+    source_url      TEXT,
+    metadata_json   JSONB,
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cz_court_source ON cz_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_cz_court_type ON cz_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_cz_court_date ON cz_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_cz_court_decision_type ON cz_court_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_cz_court_case_num ON cz_court_decisions(case_number);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_cz_court_fts') THEN
+        CREATE INDEX idx_cz_court_fts ON cz_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;

--- a/scripts/opendata/download_czech.py
+++ b/scripts/opendata/download_czech.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Download Czech court decisions: justice.cz API + CzCDC + Zenodo."""
+
+import json
+import os
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path("/home/ubuntu/opendata/czech")
+JUSTICE_DIR = BASE_DIR / "justice-api"
+CZDC_DIR = BASE_DIR / "czcdc"
+ZENODO_DIR = BASE_DIR / "zenodo-paulik"
+
+JUSTICE_API = "https://rozhodnuti.justice.cz/api/opendata"
+MAX_WORKERS = 20
+
+
+def download_file(url: str, dest: Path, session: requests.Session = None):
+    """Download a file with resume support."""
+    s = session or requests.Session()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    headers = {}
+    mode = "wb"
+    if dest.exists():
+        existing = dest.stat().st_size
+        headers["Range"] = f"bytes={existing}-"
+        mode = "ab"
+    resp = s.get(url, headers=headers, stream=True, timeout=120)
+    if resp.status_code == 416:
+        return
+    resp.raise_for_status()
+    with open(dest, mode) as f:
+        for chunk in resp.iter_content(chunk_size=1024 * 1024):
+            f.write(chunk)
+
+
+def fetch_json(url: str, session: requests.Session, retries: int = 5):
+    for attempt in range(retries):
+        try:
+            resp = session.get(url, timeout=60)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt)
+            else:
+                raise
+
+
+def download_day(year: int, month: int, day: int, session: requests.Session):
+    """Download all decisions for a given day, handling pagination."""
+    day_dir = JUSTICE_DIR / str(year) / f"{month:02d}" / f"{day:02d}"
+    day_dir.mkdir(parents=True, exist_ok=True)
+
+    page = 0
+    all_items = []
+    while True:
+        url = f"{JUSTICE_API}/{year}/{month}/{day}?page={page}"
+        data = fetch_json(url, session)
+        items = data.get("items", [])
+        all_items.extend(items)
+        if page >= data.get("totalPages", 1) - 1:
+            break
+        page += 1
+
+    out_file = day_dir / "decisions.json"
+    with open(out_file, "w") as f:
+        json.dump(all_items, f, ensure_ascii=False)
+
+    return len(all_items)
+
+
+def download_justice_api():
+    """Download all decisions from rozhodnuti.justice.cz API."""
+    JUSTICE_DIR.mkdir(parents=True, exist_ok=True)
+    checkpoint_file = JUSTICE_DIR / "checkpoint.json"
+
+    completed_days = set()
+    if checkpoint_file.exists():
+        with open(checkpoint_file) as f:
+            cp = json.load(f)
+            completed_days = set(cp.get("completed_days", []))
+            print(f"Resuming, {len(completed_days)} days already done")
+
+    session = requests.Session()
+    session.headers["Accept"] = "application/json"
+
+    years = fetch_json(JUSTICE_API, session)
+    total_decisions = sum(y["pocet"] for y in years)
+    print(f"\njustice.cz API: {total_decisions} decisions across {len(years)} years")
+
+    all_days = []
+    for year_info in years:
+        year = year_info["rok"]
+        months = fetch_json(year_info["odkaz"], session)
+        for month_info in months:
+            month = month_info["mesic"]
+            days = fetch_json(month_info["odkaz"], session)
+            for day_info in days:
+                day_key = day_info["datum"]
+                if day_key not in completed_days:
+                    parts = day_key.split("-")
+                    all_days.append((int(parts[0]), int(parts[1]), int(parts[2]), day_info["pocet"]))
+
+    print(f"Days to download: {len(all_days)} (skipping {len(completed_days)} completed)")
+
+    downloaded = 0
+    t0 = time.time()
+    batch_size = MAX_WORKERS
+
+    for i in range(0, len(all_days), batch_size):
+        batch = all_days[i:i + batch_size]
+
+        with ThreadPoolExecutor(max_workers=batch_size) as pool:
+            futures = {}
+            for (y, m, d, cnt) in batch:
+                fut = pool.submit(download_day, y, m, d, session)
+                futures[fut] = f"{y}-{m:02d}-{d:02d}"
+
+            for future in as_completed(futures):
+                day_key = futures[future]
+                try:
+                    count = future.result()
+                    downloaded += count
+                    completed_days.add(day_key)
+                except Exception as e:
+                    print(f"  FAILED {day_key}: {e}")
+
+        with open(checkpoint_file, "w") as f:
+            json.dump({"completed_days": list(completed_days)}, f)
+
+        elapsed = time.time() - t0
+        rate = downloaded / elapsed if elapsed > 0 else 0
+        pct = downloaded / total_decisions * 100
+        done_days = len(completed_days)
+        total_days_all = done_days + len(all_days) - (i + len(batch))
+        print(f"  Batch {i//batch_size+1} | {downloaded}/{total_decisions} ({pct:.1f}%) | {rate:.0f}/s | days: {done_days}")
+
+    print(f"\njustice.cz download complete: {downloaded} decisions")
+
+
+def download_czcdc():
+    """Download CzCDC 1.0 from LINDAT (6 files: 3 ZIPs + 3 CSVs)."""
+    CZDC_DIR.mkdir(parents=True, exist_ok=True)
+    files = {
+        "ConCo.zip": "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/ac62dab4-5aba-408c-83eb-b3984b526454/content",
+        "SupAdmCo.zip": "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/ce56abe9-9987-4029-86da-ed8aeb3b2c7e/content",
+        "SupCo.zip": "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/e6c91627-b762-4fc4-93c4-ae9cd796904d/content",
+        "ConCo.csv": "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/e5613c2d-87f0-466e-a7e3-823ef2be299b/content",
+        "SupAdmCo.csv": "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/9785df4e-1a7c-4565-92c3-15634f06ab20/content",
+        "SupCo.csv": "https://lindat.mff.cuni.cz/repository/server/api/core/bitstreams/62b012f2-e01b-4488-bf9b-ecfeb205ac2e/content",
+    }
+    session = requests.Session()
+    for fname, url in files.items():
+        dest = CZDC_DIR / fname
+        if dest.exists() and dest.stat().st_size > 10_000:
+            print(f"  {fname} already downloaded ({dest.stat().st_size / 1e6:.1f} MB), skipping")
+            continue
+        print(f"  Downloading {fname}...")
+        download_file(url, dest, session)
+        print(f"  Done: {fname} ({dest.stat().st_size / 1e6:.1f} MB)")
+
+
+def download_zenodo():
+    """Download Paulik Czech Constitutional Court dataset from Zenodo."""
+    ZENODO_DIR.mkdir(parents=True, exist_ok=True)
+    url = "https://zenodo.org/records/11618008/files/ccc_database.zip?download=1"
+    dest = ZENODO_DIR / "ccc_database.zip"
+    if dest.exists() and dest.stat().st_size > 100_000_000:
+        print(f"Zenodo already downloaded: {dest} ({dest.stat().st_size / 1e6:.0f} MB)")
+        return
+    print(f"Downloading Paulik dataset from Zenodo -> {dest}")
+    session = requests.Session()
+    download_file(url, dest, session)
+    print(f"Done: {dest} ({dest.stat().st_size / 1e6:.0f} MB)")
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "czcdc"):
+        download_czcdc()
+    if mode in ("all", "zenodo"):
+        download_zenodo()
+    if mode in ("all", "justice"):
+        download_justice_api()
+
+    print("\n" + "=" * 60)
+    print("All Czech downloads complete!")
+    total_size = sum(f.stat().st_size for f in BASE_DIR.rglob("*") if f.is_file())
+    print(f"Total size: {total_size / (1024**3):.1f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/download_poland.py
+++ b/scripts/opendata/download_poland.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Download Polish court decisions: JuDDGES HuggingFace + SAOS API."""
+
+import json
+import os
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from huggingface_hub import snapshot_download
+
+BASE_DIR = Path("/home/ubuntu/opendata/poland")
+SAOS_DIR = BASE_DIR / "saos-api"
+HF_DIR = BASE_DIR / "huggingface"
+
+SAOS_API = "https://www.saos.org.pl/api/dump/judgments"
+SAOS_PAGE_SIZE = 100
+
+HF_DATASETS = [
+    "JuDDGES/pl-court-raw",
+    "JuDDGES/pl-nsa",
+]
+
+
+def download_huggingface():
+    """Download JuDDGES datasets from HuggingFace."""
+    for repo_id in HF_DATASETS:
+        name = repo_id.split("/")[1]
+        local_dir = HF_DIR / name
+        print(f"\n{'='*60}")
+        print(f"Downloading {repo_id} -> {local_dir}")
+        print(f"{'='*60}")
+        try:
+            snapshot_download(
+                repo_id=repo_id,
+                repo_type="dataset",
+                local_dir=str(local_dir),
+                resume_download=True,
+                max_workers=20,
+            )
+            print(f"Done: {repo_id}")
+        except Exception as e:
+            print(f"ERROR downloading {repo_id}: {e}")
+            raise
+
+
+def download_saos_page(page_num: int, session: requests.Session) -> dict:
+    """Download a single page from SAOS API."""
+    params = {"pageSize": SAOS_PAGE_SIZE, "pageNumber": page_num}
+    for attempt in range(5):
+        try:
+            resp = session.get(SAOS_API, params=params, timeout=60)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                print(f"  Page {page_num} attempt {attempt+1} failed: {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+
+
+def get_saos_total(session: requests.Session) -> int:
+    """Get total judgment count from search endpoint."""
+    resp = session.get(
+        "https://www.saos.org.pl/api/search/judgments",
+        params={"pageSize": 10, "pageNumber": 0},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()["info"]["totalResults"]
+
+
+def download_saos():
+    """Download all judgments from SAOS API with parallel workers."""
+    SAOS_DIR.mkdir(parents=True, exist_ok=True)
+    checkpoint_file = SAOS_DIR / "checkpoint.json"
+
+    start_page = 0
+    if checkpoint_file.exists():
+        with open(checkpoint_file) as f:
+            checkpoint = json.load(f)
+            start_page = checkpoint.get("last_completed_page", -1) + 1
+            print(f"Resuming from page {start_page}")
+
+    session = requests.Session()
+    session.headers["Accept"] = "application/json"
+
+    total_items = get_saos_total(session)
+    total_pages = (total_items + SAOS_PAGE_SIZE - 1) // SAOS_PAGE_SIZE
+    print(f"\nSAOS API: {total_items} judgments, {total_pages} pages")
+
+    batch_size = 20
+    saved = start_page * SAOS_PAGE_SIZE
+    t0 = time.time()
+
+    for batch_start in range(start_page, total_pages, batch_size):
+        batch_end = min(batch_start + batch_size, total_pages)
+        pages_in_batch = list(range(batch_start, batch_end))
+
+        with ThreadPoolExecutor(max_workers=batch_size) as pool:
+            futures = {
+                pool.submit(download_saos_page, p, session): p
+                for p in pages_in_batch
+            }
+            for future in as_completed(futures):
+                page_num = futures[future]
+                try:
+                    data = future.result()
+                    page_file = SAOS_DIR / f"page_{page_num:05d}.json"
+                    with open(page_file, "w") as f:
+                        json.dump(data, f, ensure_ascii=False)
+                    saved += len(data.get("items", []))
+                except Exception as e:
+                    print(f"FAILED page {page_num}: {e}")
+
+        with open(checkpoint_file, "w") as f:
+            json.dump({"last_completed_page": batch_end - 1, "total_pages": total_pages}, f)
+
+        elapsed = time.time() - t0
+        rate = saved / elapsed if elapsed > 0 else 0
+        pct = saved / total_items * 100
+        print(f"  Pages {batch_start}-{batch_end-1} done | {saved}/{total_items} ({pct:.1f}%) | {rate:.0f} items/s")
+
+    print(f"\nSAOS download complete: {saved} judgments in {SAOS_DIR}")
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    HF_DIR.mkdir(parents=True, exist_ok=True)
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "hf"):
+        download_huggingface()
+    if mode in ("all", "saos"):
+        download_saos()
+
+    print("\n" + "="*60)
+    print("All downloads complete!")
+    total_size = sum(f.stat().st_size for f in BASE_DIR.rglob("*") if f.is_file())
+    print(f"Total size: {total_size / (1024**3):.1f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/import_pl_cz_to_db.py
+++ b/scripts/opendata/import_pl_cz_to_db.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Import Polish and Czech court decisions into PostgreSQL (parallel)."""
+
+import json
+import os
+import sys
+import csv
+import zipfile
+import time
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from io import StringIO
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+DB_URL = os.environ.get("DATABASE_URL", "postgresql://secondlayer:secondlayer@localhost:5432/secondlayer_prod")
+MAX_WORKERS = 20
+BATCH_SIZE = 500
+
+PL_BASE = Path("/home/ubuntu/opendata/poland")
+CZ_BASE = Path("/home/ubuntu/opendata/czech")
+
+
+def get_conn():
+    return psycopg2.connect(DB_URL)
+
+
+# ============================================================
+# POLAND: SAOS API JSON files
+# ============================================================
+
+def parse_saos_item(item: dict) -> tuple:
+    saos_id = str(item.get("id", ""))
+    court_cases = item.get("courtCases", [])
+    case_number = court_cases[0]["caseNumber"] if court_cases else None
+    judges_list = item.get("judges", [])
+    judge = judges_list[0]["name"] if judges_list else None
+    source_info = item.get("source", {}) or {}
+
+    return (
+        f"saos-{saos_id}",                                     # id
+        None,                                                    # ecli
+        "saos",                                                  # source
+        item.get("courtType"),                                   # court_type
+        (item.get("division", {}) or {}).get("court", {}).get("name") if item.get("division") else None,
+        (item.get("division", {}) or {}).get("name") if item.get("division") else None,
+        case_number,
+        item.get("judgmentType"),                                # decision_type
+        item.get("judgmentDate"),                                # decision_date
+        judge,
+        json.dumps(judges_list) if judges_list else None,       # judges
+        item.get("keywords") or None,                           # keywords
+        [lb.get("text", lb) if isinstance(lb, dict) else lb for lb in item.get("legalBases", [])] or None,
+        json.dumps(item.get("referencedRegulations")) if item.get("referencedRegulations") else None,
+        None,                                                    # parties
+        item.get("summary"),                                     # abstract
+        item.get("textContent"),                                 # full_text
+        source_info.get("judgmentUrl"),                          # source_url
+        json.dumps({
+            "publicationDate": source_info.get("publicationDate"),
+            "publisher": source_info.get("publisher"),
+            "reviser": source_info.get("reviser"),
+        }),
+    )
+
+
+def import_saos_file(filepath: str) -> int:
+    path = Path(filepath)
+    with open(path) as f:
+        data = json.load(f)
+    items = data.get("items", [])
+    if not items:
+        return 0
+
+    rows = [parse_saos_item(item) for item in items]
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO pl_court_decisions
+                    (id, ecli, source, court_type, court_name, division,
+                     case_number, decision_type, decision_date, judge, judges,
+                     keywords, legal_bases, referenced_regulations,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+        return len(rows)
+    finally:
+        conn.close()
+
+
+def import_poland_saos():
+    saos_dir = PL_BASE / "saos-api"
+    files = sorted(saos_dir.glob("page_*.json"))
+    print(f"\nPL SAOS: {len(files)} files to import")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_saos_file, str(f)): f.name for f in files}
+        done = 0
+        for future in as_completed(futures):
+            fname = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                if done % 100 == 0:
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed
+                    print(f"  SAOS: {done}/{len(files)} files | {imported} rows | {rate:.0f}/s")
+            except Exception as e:
+                print(f"  SAOS FAILED {fname}: {e}")
+
+    print(f"  SAOS complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+# ============================================================
+# POLAND: JuDDGES HuggingFace Parquet
+# ============================================================
+
+def import_hf_parquet_file(filepath: str, source_name: str) -> int:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        print("pyarrow not installed, skipping HF parquet import")
+        return 0
+
+    table = pq.read_table(filepath)
+    df_cols = table.column_names
+    batch_rows = []
+
+    for i in range(table.num_rows):
+        row = {col: table.column(col)[i].as_py() for col in df_cols}
+
+        record_id = f"hf-{source_name}-{i}-{Path(filepath).stem}"
+        text = row.get("text") or row.get("content") or row.get("full_text", "")
+        case_num = row.get("signature") or row.get("case_number") or row.get("caseNumber")
+        court = row.get("court_name") or row.get("courtName") or row.get("court")
+        court_type = row.get("court_type") or row.get("courtType")
+        decision_date = row.get("date") or row.get("judgment_date") or row.get("judgmentDate")
+        decision_type = row.get("type") or row.get("judgment_type") or row.get("judgmentType")
+        judge_name = row.get("chairman") or row.get("judge")
+        ecli = row.get("ecli")
+
+        meta = {k: v for k, v in row.items()
+                if k not in ("text", "content", "full_text", "signature", "case_number",
+                             "court_name", "court_type", "date", "judgment_date", "type",
+                             "judgment_type", "chairman", "judge", "ecli", "caseNumber",
+                             "courtName", "courtType", "judgmentDate", "judgmentType", "court")}
+
+        batch_rows.append((
+            record_id, ecli, f"hf-{source_name}", court_type, court, None,
+            case_num, decision_type,
+            str(decision_date)[:10] if decision_date else None,
+            judge_name, None, None, None, None, None, None,
+            text, None, json.dumps(meta, default=str) if meta else None,
+        ))
+
+        if len(batch_rows) >= BATCH_SIZE:
+            _flush_pl_batch(batch_rows)
+            batch_rows = []
+
+    if batch_rows:
+        _flush_pl_batch(batch_rows)
+    return table.num_rows
+
+
+def _flush_pl_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO pl_court_decisions
+                    (id, ecli, source, court_type, court_name, division,
+                     case_number, decision_type, decision_date, judge, judges,
+                     keywords, legal_bases, referenced_regulations,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def import_poland_hf():
+    for ds_name in ("pl-court-raw", "pl-nsa"):
+        ds_dir = PL_BASE / "huggingface" / ds_name
+        files = sorted(ds_dir.glob("**/*.parquet"))
+        if not files:
+            print(f"  No parquet files in {ds_dir}")
+            continue
+        print(f"\nPL HF {ds_name}: {len(files)} parquet files")
+
+        imported = 0
+        t0 = time.time()
+        with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+            futures = {pool.submit(import_hf_parquet_file, str(f), ds_name): f.name for f in files}
+            done = 0
+            for future in as_completed(futures):
+                fname = futures[future]
+                try:
+                    count = future.result()
+                    imported += count
+                    done += 1
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed if elapsed > 0 else 0
+                    print(f"  HF {ds_name}: {done}/{len(files)} files | {imported} rows | {rate:.0f}/s")
+                except Exception as e:
+                    print(f"  HF FAILED {fname}: {e}")
+
+        print(f"  HF {ds_name} complete: {imported} rows in {time.time()-t0:.0f}s")
+
+
+# ============================================================
+# CZECH: justice.cz API JSON files
+# ============================================================
+
+def import_cz_justice_file(filepath: str) -> int:
+    path = Path(filepath)
+    with open(path) as f:
+        items = json.load(f)
+    if not items:
+        return 0
+
+    rows = []
+    for item in items:
+        ecli = item.get("ecli")
+        record_id = ecli or f"cz-justice-{item.get('jednaciCislo','unknown')}"
+        rows.append((
+            record_id,
+            ecli,
+            "justice.cz",
+            item.get("soud"),
+            None,                                                # court_type
+            None,                                                # chamber
+            item.get("jednaciCislo"),
+            None,                                                # decision_type
+            item.get("datumVydani"),
+            item.get("datumZverejneni"),
+            item.get("autor"),
+            item.get("predmetRizeni"),
+            item.get("klicovaSlova") or None,
+            item.get("zminenaUstanoveni") or None,
+            None, None, None,                                    # parties, abstract, full_text
+            item.get("odkaz"),
+            None,                                                # metadata_json
+        ))
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO cz_court_decisions
+                    (id, ecli, source, court_name, court_type, chamber,
+                     case_number, decision_type, decision_date, publication_date,
+                     judge, subject, keywords, cited_provisions,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+        return len(rows)
+    finally:
+        conn.close()
+
+
+def import_czech_justice():
+    justice_dir = CZ_BASE / "justice-api"
+    files = sorted(justice_dir.rglob("decisions.json"))
+    print(f"\nCZ justice.cz: {len(files)} day files to import")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_cz_justice_file, str(f)): str(f) for f in files}
+        done = 0
+        for future in as_completed(futures):
+            fname = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                if done % 100 == 0:
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed
+                    print(f"  CZ justice: {done}/{len(files)} files | {imported} rows | {rate:.0f}/s")
+            except Exception as e:
+                print(f"  CZ FAILED {fname}: {e}")
+
+    print(f"  CZ justice complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+# ============================================================
+# CZECH: CzCDC from LINDAT (ZIPs with .txt files)
+# ============================================================
+
+def import_czcdc():
+    czcdc_dir = CZ_BASE / "czcdc"
+    zips = sorted(czcdc_dir.glob("*.zip"))
+    if not zips:
+        print("  No CzCDC ZIPs found")
+        return
+
+    court_map = {
+        "ConCo": "Constitutional Court",
+        "SupAdmCo": "Supreme Administrative Court",
+        "SupCo": "Supreme Court",
+    }
+
+    for zf_path in zips:
+        court_key = zf_path.stem
+        court_name = court_map.get(court_key, court_key)
+        print(f"\nCZ CzCDC {court_key}: importing from {zf_path.name}")
+
+        csv_path = czcdc_dir / f"{court_key}.csv"
+        csv_meta = {}
+        if csv_path.exists():
+            for enc in ("utf-8", "windows-1250", "latin-2", "iso-8859-2"):
+                try:
+                    with open(csv_path, encoding=enc, errors="replace") as cf:
+                        reader = csv.DictReader(cf)
+                        for row in reader:
+                            fname = row.get("filename", "")
+                            csv_meta[fname] = row
+                    break
+                except UnicodeDecodeError:
+                    csv_meta = {}
+                    continue
+
+        batch_rows = []
+        imported = 0
+        t0 = time.time()
+
+        with zipfile.ZipFile(zf_path) as zf:
+            txt_files = [n for n in zf.namelist() if n.endswith(".txt")]
+            print(f"  {len(txt_files)} text files")
+
+            for txt_name in txt_files:
+                text = zf.read(txt_name).decode("utf-8", errors="replace")
+                base = Path(txt_name).stem
+                meta = csv_meta.get(base, csv_meta.get(txt_name, {}))
+
+                record_id = f"czcdc-{court_key}-{base}"
+                ecli = meta.get("ecli")
+                case_num = meta.get("docket_number") or meta.get("case_number") or base
+                decision_date = meta.get("decision_date") or meta.get("date")
+
+                batch_rows.append((
+                    record_id, ecli, "czcdc", court_name, court_key, None,
+                    case_num, meta.get("decision_type"), decision_date, None,
+                    meta.get("judge"), meta.get("subject"),
+                    None, None, None, None, text, None,
+                    json.dumps(meta, default=str) if meta else None,
+                ))
+
+                if len(batch_rows) >= BATCH_SIZE:
+                    _flush_cz_batch(batch_rows)
+                    imported += len(batch_rows)
+                    batch_rows = []
+
+        if batch_rows:
+            _flush_cz_batch(batch_rows)
+            imported += len(batch_rows)
+
+        print(f"  CzCDC {court_key} complete: {imported} rows in {time.time()-t0:.0f}s")
+
+
+def _flush_cz_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO cz_court_decisions
+                    (id, ecli, source, court_name, court_type, chamber,
+                     case_number, decision_type, decision_date, publication_date,
+                     judge, subject, keywords, cited_provisions,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def run_migration():
+    """Run the migration SQL on the database."""
+    migration_sql = Path(__file__).parent.parent.parent / "mcp_backend" / "src" / "migrations" / "151_pl_cz_court_decisions.sql"
+    if not migration_sql.exists():
+        migration_sql = Path("/home/ubuntu/151_pl_cz_court_decisions.sql")
+    if not migration_sql.exists():
+        print("Migration file not found, tables must already exist")
+        return
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(migration_sql.read_text())
+        conn.commit()
+        print("Migration 151 applied successfully")
+    finally:
+        conn.close()
+
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "migrate"):
+        run_migration()
+
+    if mode in ("all", "pl", "pl-saos"):
+        import_poland_saos()
+    if mode in ("all", "pl", "pl-hf"):
+        import_poland_hf()
+    if mode in ("all", "cz", "cz-justice"):
+        import_czech_justice()
+    if mode in ("all", "cz", "cz-czcdc"):
+        import_czcdc()
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM pl_court_decisions")
+            pl_count = cur.fetchone()[0]
+            cur.execute("SELECT count(*) FROM cz_court_decisions")
+            cz_count = cur.fetchone()[0]
+        print(f"\n{'='*60}")
+        print(f"Total: PL={pl_count:,}, CZ={cz_count:,}")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Migration 151: `pl_court_decisions` and `cz_court_decisions` tables with FTS indexes
- Download scripts for 5 sources: SAOS API (536K), JuDDGES HuggingFace (2.2M PL), justice.cz API (582K CZ), CzCDC LINDAT (237K CZ), Zenodo Paulik (93K CZ)
- Parallel import script (20 workers) with checkpoint/resume for all sources
- Total: ~3.6M court decisions across Poland and Czech Republic

## Test plan
- [x] Migration applied on prod
- [x] PL SAOS + HF import running on prod (4 parallel screen sessions)
- [x] CZ CzCDC import running on prod
- [x] CZ justice.cz download in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end pipeline to ingest ~3.6M Polish and Czech court decisions into Postgres with new `pl_court_decisions` and `cz_court_decisions` tables and FTS indexes. Includes parallel download/import with checkpoint/resume from SAOS, JuDDGES, justice.cz, CzCDC, and Zenodo.

- **New Features**
  - Migration 151 creates `pl_court_decisions` and `cz_court_decisions` with indexes and FTS.
  - Download scripts for Poland (SAOS API, JuDDGES HF) and Czech (justice.cz API, CzCDC LINDAT, Zenodo).
  - Import script with 20 workers, batching, and resume support.

- **Migration**
  - Apply migration 151.
  - Set `DATABASE_URL`.
  - Run downloads: `scripts/opendata/download_poland.py all` and `scripts/opendata/download_czech.py all`.
  - Import data: `scripts/opendata/import_pl_cz_to_db.py all` (or use mode flags for PL/CZ subsets).

<sup>Written for commit 9adcce5dbffe54a3e0b516d7ed1837ea94a812e5. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1790?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

