### PR TITLE
fix(ci): force-recreate nginx-local instead of restart

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -420,7 +420,7 @@ jobs:
 
           [ -n "$START" ] && $DC up -d $START
 
-          $DC restart nginx-local
+          $DC up -d --force-recreate nginx-local
           docker image prune -f || true
 
       - name: Wait for local services to become healthy


### PR DESCRIPTION
## Summary
- Replace `$DC restart nginx-local` with `$DC up -d --force-recreate nginx-local` in CI pipeline
- Fixes bind mount staleness causing nginx health check failures after backend rebuilds

## Test plan
- [x] CI pipeline should pass with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `docker compose up -d --force-recreate` for `nginx-local` in CI instead of `restart` to avoid stale bind mounts after backend rebuilds and stop nginx health check failures.

<sup>Written for commit 579f79ca58ac4a50b3be9d75e939a211e901f504. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1791?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

