### PR TITLE
feat(data): add CZ fulltext fetcher and Paulik importer

### DIFF
--- a/scripts/opendata/fetch_cz_fulltexts.py
+++ b/scripts/opendata/fetch_cz_fulltexts.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Fetch full texts for Czech justice.cz decisions from finaldoc API."""
+
+import json
+import os
+import time
+import requests
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import psycopg2
+
+DB_URL = os.environ.get("DATABASE_URL", "postgresql://secondlayer:secondlayer@localhost:5432/secondlayer_prod")
+MAX_WORKERS = 20
+BATCH_SIZE = 200
+
+
+def extract_text(doc: dict) -> str:
+    parts = []
+    for section in ("header", "verdict", "justification", "information"):
+        paragraphs = doc.get(section, [])
+        if not paragraphs:
+            continue
+        for para in paragraphs:
+            texts = para.get("texts", [])
+            line = "".join(t.get("text", "") for t in texts)
+            if line.strip():
+                parts.append(line.strip())
+
+    verdict_text = doc.get("verdictText", "")
+    justification_text = doc.get("justificationText", "")
+
+    structured = "\n\n".join(parts)
+    plain = f"{verdict_text}\n\n{justification_text}".strip()
+
+    result = structured if len(structured) > len(plain) else plain
+    return result.replace("\x00", "")
+
+
+def fetch_one(row: tuple, session: requests.Session) -> tuple:
+    record_id, url = row
+    for attempt in range(3):
+        try:
+            resp = session.get(url, timeout=30)
+            resp.raise_for_status()
+            doc = resp.json()
+            text = extract_text(doc)
+            return (record_id, text, None)
+        except Exception as e:
+            if attempt < 2:
+                time.sleep(1)
+            else:
+                return (record_id, None, str(e))
+
+
+def main():
+    conn = psycopg2.connect(DB_URL)
+    cur = conn.cursor()
+
+    cur.execute("""
+        SELECT count(*) FROM cz_court_decisions
+        WHERE source = 'justice.cz' AND full_text IS NULL AND source_url IS NOT NULL
+    """)
+    total = cur.fetchone()[0]
+    print(f"Records to fetch: {total}")
+
+    processed = 0
+    updated = 0
+    failed = 0
+    t0 = time.time()
+
+    while True:
+        cur.execute("""
+            SELECT id, source_url FROM cz_court_decisions
+            WHERE source = 'justice.cz' AND full_text IS NULL AND source_url IS NOT NULL
+            LIMIT %s
+        """, (BATCH_SIZE * MAX_WORKERS,))
+        rows = cur.fetchall()
+        if not rows:
+            break
+
+        session = requests.Session()
+        session.headers["Accept"] = "application/json"
+
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+            futures = {pool.submit(fetch_one, row, session): row[0] for row in rows}
+
+            batch_updates = []
+            for future in as_completed(futures):
+                record_id, text, error = future.result()
+                processed += 1
+                if text:
+                    batch_updates.append((text, record_id))
+                else:
+                    failed += 1
+
+            if batch_updates:
+                cur2 = conn.cursor()
+                for text, rid in batch_updates:
+                    cur2.execute(
+                        "UPDATE cz_court_decisions SET full_text = %s, updated_at = NOW() WHERE id = %s",
+                        (text, rid)
+                    )
+                    updated += 1
+                conn.commit()
+                cur2.close()
+
+        elapsed = time.time() - t0
+        rate = processed / elapsed if elapsed > 0 else 0
+        pct = processed / total * 100 if total > 0 else 0
+        print(f"  {processed}/{total} ({pct:.1f}%) | updated: {updated} | failed: {failed} | {rate:.0f}/s")
+
+    conn.close()
+    print(f"\nDone: {updated} updated, {failed} failed in {time.time()-t0:.0f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/import_cz_paulik.py
+++ b/scripts/opendata/import_cz_paulik.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Import Paulik Czech Constitutional Court dataset from Zenodo ZIP into DB."""
+
+import csv
+import io
+import json
+import os
+import sys
+import time
+import zipfile
+
+csv.field_size_limit(sys.maxsize)
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+DB_URL = os.environ.get("DATABASE_URL")
+ZIP_PATH = "/home/ubuntu/opendata/czech/zenodo-paulik/ccc_database.zip"
+BATCH_SIZE = 500
+
+
+def main():
+    zf = zipfile.ZipFile(ZIP_PATH)
+
+    print("Loading texts...")
+    texts = {}
+    with zf.open("ccc_database/csv/ccc_texts.csv") as f:
+        reader = csv.DictReader(io.TextIOWrapper(f, encoding="utf-8", errors="replace"))
+        for row in reader:
+            texts[row["doc_id"]] = row.get("text", "").replace("\x00", "")
+    print(f"  Loaded {len(texts)} texts")
+
+    print("Loading metadata...")
+    with zf.open("ccc_database/csv/ccc_metadata.csv") as f:
+        reader = csv.DictReader(io.TextIOWrapper(f, encoding="utf-8", errors="replace"))
+        meta_rows = list(reader)
+    print(f"  Loaded {len(meta_rows)} metadata rows")
+
+    conn = psycopg2.connect(DB_URL)
+    cur = conn.cursor()
+
+    cur.execute("SELECT count(*) FROM cz_court_decisions WHERE source = 'paulik-zenodo'")
+    existing = cur.fetchone()[0]
+    print(f"  Already imported: {existing}")
+
+    if existing >= len(meta_rows):
+        print("  All already imported, skipping")
+        return
+
+    batch = []
+    imported = 0
+    skipped = 0
+    t0 = time.time()
+
+    for row in meta_rows:
+        doc_id = row["doc_id"]
+        ecli = doc_id if doc_id.startswith("ECLI:") else None
+        record_id = f"paulik-{doc_id}"
+        text = texts.get(doc_id, "")
+
+        na = lambda v: None if v == "NA" or not v else v
+
+        batch.append((
+            record_id,
+            ecli,
+            "paulik-zenodo",
+            "Constitutional Court",
+            "ConCo",
+            None,
+            na(row.get("case_id")),
+            na(row.get("type_decision")),
+            na(row.get("date_decision")),
+            na(row.get("date_publication")),
+            na(row.get("judge_rapporteur_name")),
+            na(row.get("subject_proceedings")),
+            None,
+            None,
+            na(row.get("applicant")),
+            None,
+            text if text else None,
+            na(row.get("url_address")),
+            json.dumps({
+                k: v for k, v in row.items()
+                if k not in ("doc_id", "case_id", "date_decision", "date_publication",
+                             "judge_rapporteur_name", "subject_proceedings", "applicant",
+                             "url_address", "type_decision")
+                and v and v != "NA"
+            }) or None,
+        ))
+
+        if len(batch) >= BATCH_SIZE:
+            execute_values(cur, """
+                INSERT INTO cz_court_decisions
+                    (id, ecli, source, court_name, court_type, chamber,
+                     case_number, decision_type, decision_date, publication_date,
+                     judge, subject, keywords, cited_provisions,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, batch, page_size=BATCH_SIZE)
+            conn.commit()
+            imported += len(batch)
+            batch = []
+            elapsed = time.time() - t0
+            print(f"  {imported}/{len(meta_rows)} ({100*imported/len(meta_rows):.1f}%) | {imported/elapsed:.0f}/s")
+
+    if batch:
+        execute_values(cur, """
+            INSERT INTO cz_court_decisions
+                (id, ecli, source, court_name, court_type, chamber,
+                 case_number, decision_type, decision_date, publication_date,
+                 judge, subject, keywords, cited_provisions,
+                 parties, abstract, full_text, source_url, metadata_json)
+            VALUES %s
+            ON CONFLICT (id) DO NOTHING
+        """, batch, page_size=BATCH_SIZE)
+        conn.commit()
+        imported += len(batch)
+
+    conn.close()
+    print(f"\nDone: {imported} imported in {time.time()-t0:.0f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `fetch_cz_fulltexts.py` — 20-thread fetcher for justice.cz finaldoc API, fills full_text for 539K CZ lower court decisions
- `import_cz_paulik.py` — imports Paulik/Zenodo Constitutional Court dataset (93,826 decisions with full texts, 1993-2023)
- CZ total now 871,155 decisions with 99.99% full texts

## Test plan
- [x] Both scripts ran successfully on prod
- [x] CZ justice.cz fulltexts: 539,210/539,225 fetched
- [x] Paulik: 93,826/93,826 imported

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two data scripts to fetch CZ lower court full texts from the justice.cz finaldoc API and import the Paulik Constitutional Court dataset. This raises coverage to 871,155 CZ decisions with near-complete full texts.

- **New Features**
  - `scripts/opendata/fetch_cz_fulltexts.py`: 20-thread fetcher for justice.cz; extracts structured text; batch-updates `cz_court_decisions.full_text`; fetched 539,210/539,225 records.
  - `scripts/opendata/import_cz_paulik.py`: Imports Paulik/Zenodo dataset (1993–2023) from ZIP; maps fields and inserts into `cz_court_decisions` with `ON CONFLICT DO NOTHING`; imported 93,826 records with texts and `metadata_json`.
  - Result: 871,155 CZ decisions total with 99.99% full texts.

<sup>Written for commit b12a336152e669516ea518f0f371161733857e8c. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1792?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

