### PR TITLE
feat(data): add dedup, HF export, and repo split scripts for PL/CZ court decisions

### DIFF
--- a/scripts/opendata/dedup_and_quality.py
+++ b/scripts/opendata/dedup_and_quality.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Deduplication and quality analysis for PL and CZ court decisions — optimized."""
+
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import psycopg2
+
+DB_URL = os.environ.get("DATABASE_URL")
+
+
+def q(sql: str, label: str = ""):
+    """Run query, print result immediately."""
+    conn = psycopg2.connect(DB_URL)
+    cur = conn.cursor()
+    t0 = time.time()
+    cur.execute(sql)
+    rows = cur.fetchall()
+    cols = [d[0] for d in cur.description]
+    conn.close()
+    elapsed = time.time() - t0
+    if label:
+        print(f"\n--- {label} ({elapsed:.1f}s) ---", flush=True)
+    widths = [max(len(str(c)), *(len(str(r[i])) for r in rows)) for i, c in enumerate(cols)] if rows else []
+    if rows:
+        print("  " + " | ".join(str(c).ljust(w) for c, w in zip(cols, widths)), flush=True)
+        print("  " + "-+-".join("-" * w for w in widths), flush=True)
+        for r in rows:
+            print("  " + " | ".join(str(v).ljust(w) for v, w in zip(r, widths)), flush=True)
+    return rows
+
+
+def main():
+    print("=" * 70, flush=True)
+    print("POLAND", flush=True)
+    print("=" * 70, flush=True)
+
+    q("""
+        SELECT source, count(*) AS total,
+               count(full_text) AS with_text,
+               count(case_number) AS with_case_num,
+               count(decision_date) AS with_date,
+               count(court_type) AS with_court_type,
+               count(judge) AS with_judge
+        FROM pl_court_decisions GROUP BY source ORDER BY total DESC
+    """, "PL: records per source")
+
+    q("""
+        SELECT source,
+               count(*) FILTER (WHERE full_text IS NULL OR full_text = '') AS no_text,
+               count(*) FILTER (WHERE length(full_text) < 100) AS tiny,
+               count(*) FILTER (WHERE length(full_text) BETWEEN 100 AND 5000) AS short_med,
+               count(*) FILTER (WHERE length(full_text) > 5000) AS long
+        FROM pl_court_decisions GROUP BY source ORDER BY count(*) DESC
+    """, "PL: text quality buckets")
+
+    q("""
+        SELECT count(*) AS dupe_groups, sum(cnt) AS total_rows_in_dupes
+        FROM (
+            SELECT case_number, decision_date, count(*) AS cnt
+            FROM pl_court_decisions
+            WHERE case_number IS NOT NULL AND decision_date IS NOT NULL
+            GROUP BY case_number, decision_date HAVING count(*) > 1
+        ) d
+    """, "PL: duplicate groups (case_number + date)")
+
+    q("""
+        SELECT a.source AS src_a, b.source AS src_b, count(*) AS overlap
+        FROM pl_court_decisions a
+        JOIN pl_court_decisions b
+            ON a.case_number = b.case_number AND a.decision_date = b.decision_date AND a.id < b.id
+        WHERE a.case_number IS NOT NULL AND a.decision_date IS NOT NULL AND a.source != b.source
+        GROUP BY a.source, b.source ORDER BY overlap DESC
+    """, "PL: cross-source overlap (case+date)")
+
+    q("""
+        SELECT case_number, decision_date::text, array_agg(source), array_agg(length(coalesce(full_text,'')))
+        FROM pl_court_decisions
+        WHERE case_number IS NOT NULL AND decision_date IS NOT NULL
+        GROUP BY case_number, decision_date HAVING count(*) > 1
+        LIMIT 10
+    """, "PL: sample duplicate groups")
+
+    pl_unique = q("""
+        SELECT count(DISTINCT (case_number, decision_date)) AS unique_keys
+        FROM pl_court_decisions WHERE case_number IS NOT NULL AND decision_date IS NOT NULL
+    """, "PL: unique (case+date) count")
+
+    pl_no_key = q("SELECT count(*) FROM pl_court_decisions WHERE case_number IS NULL OR decision_date IS NULL",
+                  "PL: records without dedup key")
+
+    pl_total = q("SELECT count(*) FROM pl_court_decisions", "PL: total")
+
+    print("\n" + "=" * 70, flush=True)
+    print("CZECH REPUBLIC", flush=True)
+    print("=" * 70, flush=True)
+
+    q("""
+        SELECT source, count(*) AS total,
+               count(full_text) AS with_text,
+               count(ecli) AS with_ecli,
+               count(case_number) AS with_case_num,
+               count(decision_date) AS with_date,
+               count(judge) AS with_judge
+        FROM cz_court_decisions GROUP BY source ORDER BY total DESC
+    """, "CZ: records per source")
+
+    q("""
+        SELECT source,
+               count(*) FILTER (WHERE full_text IS NULL OR full_text = '') AS no_text,
+               count(*) FILTER (WHERE length(full_text) < 100) AS tiny,
+               count(*) FILTER (WHERE length(full_text) BETWEEN 100 AND 5000) AS short_med,
+               count(*) FILTER (WHERE length(full_text) > 5000) AS long
+        FROM cz_court_decisions GROUP BY source ORDER BY count(*) DESC
+    """, "CZ: text quality buckets")
+
+    q("""
+        SELECT count(*) AS dupe_groups, sum(cnt) AS total_rows_in_dupes
+        FROM (
+            SELECT ecli, count(*) AS cnt FROM cz_court_decisions
+            WHERE ecli IS NOT NULL GROUP BY ecli HAVING count(*) > 1
+        ) d
+    """, "CZ: duplicate ECLI groups")
+
+    q("""
+        SELECT a.source AS src_a, b.source AS src_b, count(*) AS overlap
+        FROM cz_court_decisions a
+        JOIN cz_court_decisions b ON a.ecli = b.ecli AND a.id < b.id
+        WHERE a.ecli IS NOT NULL AND a.source != b.source
+        GROUP BY a.source, b.source ORDER BY overlap DESC
+    """, "CZ: cross-source ECLI overlap")
+
+    q("""
+        SELECT ecli, array_agg(source), array_agg(length(coalesce(full_text,'')))
+        FROM cz_court_decisions WHERE ecli IS NOT NULL
+        GROUP BY ecli HAVING count(*) > 1 LIMIT 10
+    """, "CZ: sample ECLI duplicates")
+
+    cz_unique = q("SELECT count(DISTINCT ecli) FROM cz_court_decisions WHERE ecli IS NOT NULL",
+                  "CZ: unique ECLI count")
+    cz_no_ecli = q("SELECT count(*) FROM cz_court_decisions WHERE ecli IS NULL",
+                   "CZ: records without ECLI")
+    cz_total = q("SELECT count(*) FROM cz_court_decisions", "CZ: total")
+
+    print("\n" + "=" * 70, flush=True)
+    print("DEDUP SUMMARY", flush=True)
+    print("=" * 70, flush=True)
+
+    pl_t = pl_total[0][0]
+    pl_u = pl_unique[0][0]
+    pl_n = pl_no_key[0][0]
+    print(f"  PL: {pl_t:,} total -> {pl_u:,} unique (case+date) + {pl_n:,} without key", flush=True)
+    print(f"  PL after dedup: ~{pl_u + pl_n:,} (removing ~{pl_t - pl_u - pl_n:,} dupes)", flush=True)
+
+    cz_t = cz_total[0][0]
+    cz_u = cz_unique[0][0]
+    cz_n = cz_no_ecli[0][0]
+    print(f"  CZ: {cz_t:,} total -> {cz_u:,} unique ECLI + {cz_n:,} without ECLI", flush=True)
+    print(f"  CZ after dedup: ~{cz_u + cz_n:,} (removing ~{cz_t - cz_u - cz_n:,} dupes)", flush=True)
+
+    print(f"\n  COMBINED after dedup: ~{pl_u + pl_n + cz_u + cz_n:,}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/publish_hf_datasets.py
+++ b/scripts/opendata/publish_hf_datasets.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Export PL+CZ court decisions to Parquet and publish on HuggingFace."""
+
+import os
+import sys
+import time
+import json
+from pathlib import Path
+
+import psycopg2
+import pyarrow as pa
+import pyarrow.parquet as pq
+from huggingface_hub import HfApi, create_repo
+
+DB_URL = os.environ.get("DATABASE_URL")
+OUT_DIR = Path("/home/ubuntu/opendata/hf-export")
+SHARD_ROWS = 50_000
+REPO_ID = "overthelex/european-court-decisions"
+
+PL_SCHEMA = pa.schema([
+    ("id", pa.large_string()),
+    ("ecli", pa.large_string()),
+    ("source", pa.large_string()),
+    ("court_type", pa.large_string()),
+    ("court_name", pa.large_string()),
+    ("division", pa.large_string()),
+    ("case_number", pa.large_string()),
+    ("decision_type", pa.large_string()),
+    ("decision_date", pa.large_string()),
+    ("judge", pa.large_string()),
+    ("keywords", pa.list_(pa.string())),
+    ("legal_bases", pa.list_(pa.string())),
+    ("parties", pa.large_string()),
+    ("abstract", pa.large_string()),
+    ("source_url", pa.large_string()),
+    ("full_text", pa.large_string()),
+])
+
+CZ_SCHEMA = pa.schema([
+    ("id", pa.large_string()),
+    ("ecli", pa.large_string()),
+    ("source", pa.large_string()),
+    ("court_name", pa.large_string()),
+    ("court_type", pa.large_string()),
+    ("case_number", pa.large_string()),
+    ("decision_type", pa.large_string()),
+    ("decision_date", pa.large_string()),
+    ("publication_date", pa.large_string()),
+    ("judge", pa.large_string()),
+    ("subject", pa.large_string()),
+    ("keywords", pa.list_(pa.string())),
+    ("cited_provisions", pa.list_(pa.string())),
+    ("parties", pa.large_string()),
+    ("source_url", pa.large_string()),
+    ("full_text", pa.large_string()),
+])
+
+PL_COLS = [f.name for f in PL_SCHEMA]
+CZ_COLS = [f.name for f in CZ_SCHEMA]
+
+
+def export_config(table: str, columns: list, schema: pa.Schema, config_dir: Path, where: str = "TRUE"):
+    config_dir.mkdir(parents=True, exist_ok=True)
+    conn = psycopg2.connect(DB_URL)
+    cur = conn.cursor("export_cursor")
+    cur.itersize = SHARD_ROWS
+
+    col_sql = ", ".join(columns)
+    cur.execute(f"SELECT {col_sql} FROM {table} WHERE {where} ORDER BY id")
+
+    shard_idx = 0
+    total_rows = 0
+    batch = []
+
+    for row in cur:
+        converted = []
+        for i, col in enumerate(columns):
+            v = row[i]
+            if isinstance(v, list):
+                converted.append(v if v else None)
+            elif isinstance(v, dict):
+                converted.append(json.dumps(v, ensure_ascii=False) if v else None)
+            elif v is not None:
+                converted.append(str(v))
+            else:
+                converted.append(None)
+        batch.append(converted)
+
+        if len(batch) >= SHARD_ROWS:
+            _write_shard(batch, columns, schema, config_dir, shard_idx)
+            total_rows += len(batch)
+            shard_idx += 1
+            print(f"  shard {shard_idx}: {total_rows:,} rows", flush=True)
+            batch = []
+
+    if batch:
+        _write_shard(batch, columns, schema, config_dir, shard_idx)
+        total_rows += len(batch)
+        shard_idx += 1
+
+    conn.close()
+    print(f"  Done: {total_rows:,} rows, {shard_idx} shards", flush=True)
+    return total_rows, shard_idx
+
+
+def _write_shard(batch, columns, schema, config_dir, shard_idx):
+    arrays = {}
+    for i, col in enumerate(columns):
+        vals = [row[i] for row in batch]
+        field_type = schema.field(col).type
+        if isinstance(field_type, pa.ListType):
+            arrays[col] = pa.array(vals, type=pa.list_(pa.string()))
+        else:
+            arrays[col] = pa.array(vals, type=pa.large_string())
+
+    table = pa.table(arrays, schema=schema)
+    path = config_dir / f"train-{shard_idx:05d}.parquet"
+    pq.write_table(
+        table, path,
+        compression="zstd",
+        compression_level=3,
+        write_page_index=True,
+        row_group_size=min(len(batch), 10_000),
+    )
+
+
+README = """---
+license: cc-by-nc-sa-4.0
+language:
+- pl
+- cs
+pretty_name: "European Court Decisions: Polish & Czech"
+tags:
+- legal
+- court-decisions
+- polish
+- czech
+- civil-law
+- judgments
+- caselaw
+- legal-nlp
+size_categories:
+- 1M<n<10M
+task_categories:
+- text-generation
+- text-classification
+- summarization
+- feature-extraction
+annotations_creators:
+- no-annotation
+language_creators:
+- found
+multilinguality:
+- multilingual
+source_datasets:
+- original
+configs:
+- config_name: pl
+  data_files:
+  - split: train
+    path: "data/pl/train-*.parquet"
+  default: true
+- config_name: cz-justice
+  data_files:
+  - split: train
+    path: "data/cz-justice/train-*.parquet"
+- config_name: cz-czcdc
+  data_files:
+  - split: train
+    path: "data/cz-czcdc/train-*.parquet"
+---
+
+# European Court Decisions: Polish & Czech
+
+The largest open dataset of Polish and Czech court decisions: **3,701,200 decisions** with full texts across all court levels.
+
+## Dataset at a Glance
+
+| Config | Country | Records | Courts | License |
+|--------|---------|---------|--------|---------|
+| `pl` | Poland | 2,830,029 | Common + Administrative + Supreme + Constitutional Tribunal + KIO | CC BY 4.0 |
+| `cz-justice` | Czech Republic | 539,622 | District, regional, high courts (2020-2026) | CC BY 4.0 |
+| `cz-czcdc` | Czech Republic | 331,549 | Supreme + Supreme Administrative + Constitutional (1993-2023) | CC BY-NC-SA 4.0 |
+
+## What Makes This Dataset Unique
+
+### vs LEXTREME ([joelniklaus/lextreme](https://hf.co/datasets/joelniklaus/lextreme))
+LEXTREME contains **zero** Polish or Czech court decisions. It is a benchmark for legal NLU tasks, not a corpus.
+
+### vs Multi_Legal_Pile ([joelniklaus/Multi_Legal_Pile](https://hf.co/datasets/joelniklaus/Multi_Legal_Pile))
+Multi_Legal_Pile contains 296,652 Czech caselaw documents (from CzCDC apex courts only) and **zero** Polish caselaw. This dataset adds 574K more Czech decisions (lower courts 2020-2026) and the entire Polish corpus of 2.83M decisions.
+
+### vs JuDDGES ([JuDDGES/pl-court-raw](https://hf.co/datasets/JuDDGES/pl-court-raw) + [JuDDGES/pl-nsa](https://hf.co/datasets/JuDDGES/pl-nsa))
+JuDDGES provides 437K Polish common court + 1.8M administrative court decisions. This dataset adds 493K decisions from the SAOS API (Supreme Court, Constitutional Tribunal, National Appeal Chamber) that are **absent from all existing HuggingFace datasets**. It also adds the entire Czech corpus.
+
+| | This Dataset | Best on HF | Advantage |
+|---|---|---|---|
+| **Poland** | 2,830,029 | ~2,237,450 (JuDDGES) | +593K (+26%) |
+| **Czech Republic** | 871,171 | 296,652 (Multi_Legal_Pile) | +574K (+194%) |
+| **Total** | **3,701,200** | ~2,534,102 | **+1,167K (+46%)** |
+
+## Loading the Data
+
+```python
+from datasets import load_dataset
+
+# Load Polish court decisions
+pl = load_dataset("overthelex/european-court-decisions", "pl", split="train", streaming=True)
+
+# Load Czech lower courts (CC BY 4.0)
+cz_justice = load_dataset("overthelex/european-court-decisions", "cz-justice", split="train")
+
+# Load Czech apex courts (CC BY-NC-SA 4.0)
+cz_czcdc = load_dataset("overthelex/european-court-decisions", "cz-czcdc", split="train")
+
+for row in pl.take(3):
+    print(row["court_type"], row["case_number"], len(row["full_text"]))
+```
+
+## Sources
+
+### Poland (`pl` config)
+
+| Source | Records | Court Types | Period | License |
+|--------|---------|-------------|--------|---------|
+| [SAOS API](https://www.saos.org.pl/api/) | 492,731 | Supreme Court, Constitutional Tribunal, National Appeal Chamber, Common Courts | 2000-2026 | Public domain |
+| [JuDDGES/pl-court-raw](https://hf.co/datasets/JuDDGES/pl-court-raw) | 437,446 | Common courts (district, regional, appellate) | 2002-2025 | CC BY 4.0 |
+| [JuDDGES/pl-nsa](https://hf.co/datasets/JuDDGES/pl-nsa) | 1,899,852 | Administrative courts (WSA + NSA) | 2004-2025 | CC BY 4.0 |
+
+### Czech Republic
+
+**`cz-justice` config** (CC BY 4.0):
+
+| Source | Records | Court Types | Period |
+|--------|---------|-------------|--------|
+| [rozhodnuti.justice.cz](https://rozhodnuti.justice.cz/api/opendata) | 539,622 | District, regional, high courts | 2020-2026 |
+
+**`cz-czcdc` config** (CC BY-NC-SA 4.0):
+
+| Source | Records | Court Types | Period |
+|--------|---------|-------------|--------|
+| [CzCDC 1.0](https://lindat.mff.cuni.cz/repository/xmlui/handle/11372/LRT-3052) | 237,723 | Supreme, Supreme Administrative, Constitutional | 1993-2018 |
+| [Paulik/Zenodo](https://zenodo.org/records/11618008) | 93,826 | Constitutional Court | 1993-2023 |
+
+## Schema
+
+### Polish decisions (`pl`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique record identifier |
+| `ecli` | string | European Case Law Identifier |
+| `source` | string | `saos`, `hf-pl-court-raw`, `hf-pl-nsa` |
+| `court_type` | string | COMMON, SUPREME, CONSTITUTIONAL_TRIBUNAL, NATIONAL_APPEAL_CHAMBER |
+| `court_name` | string | Court name |
+| `case_number` | string | Docket / case number |
+| `decision_type` | string | SENTENCE, RESOLUTION, DECISION, REGULATION, REASONS |
+| `decision_date` | string | YYYY-MM-DD |
+| `judge` | string | Presiding judge |
+| `keywords` | list[string] | Legal keywords |
+| `legal_bases` | list[string] | Legal bases cited |
+| `full_text` | string | Full decision text |
+
+### Czech decisions (`cz-justice`, `cz-czcdc`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique record identifier |
+| `ecli` | string | ECLI:CZ:... identifier |
+| `source` | string | `justice.cz`, `czcdc`, `paulik-zenodo` |
+| `court_name` | string | Court name |
+| `case_number` | string | Docket / case number |
+| `decision_type` | string | Type of decision |
+| `decision_date` | string | YYYY-MM-DD |
+| `judge` | string | Judge / rapporteur |
+| `subject` | string | Subject matter |
+| `keywords` | list[string] | Keywords |
+| `cited_provisions` | list[string] | Cited legal provisions |
+| `full_text` | string | Full decision text |
+
+## Data Quality
+
+Data was deduplicated and cleaned before publication:
+- **PL**: 12,213 SAOS internal duplicates removed (kept longest text), 27,473 empty texts removed, 153 micro-texts (<100 chars) removed
+- **CZ**: 0 duplicates detected (sources cover non-overlapping court levels)
+- **CZ**: CzCDC and Paulik cover different time periods for Constitutional Court (no ECLI overlap)
+
+## Licensing
+
+The dataset combines sources with different licenses:
+- **`pl` config**: All sources are CC BY 4.0 or public domain. **Safe for commercial use.**
+- **`cz-justice` config**: CC BY 4.0. **Safe for commercial use.**
+- **`cz-czcdc` config**: Includes CzCDC (CC BY-NC-SA 4.0). **Non-commercial use only.**
+
+The top-level license is set to CC BY-NC-SA 4.0 to reflect the most restrictive component.
+
+## Personal and Sensitive Information
+
+Court decisions are public documents. Polish decisions from SAOS contain judge names. Czech decisions from justice.cz are anonymized by the Ministry of Justice. CzCDC decisions contain original text as published by the courts.
+
+## Citation
+
+```bibtex
+@misc{ovcharov2026europeancourt,
+  title={European Court Decisions: 3.7M Polish and Czech Court Decisions},
+  author={Ovcharov, Volodymyr},
+  year={2026},
+  publisher={HuggingFace},
+  url={https://huggingface.co/datasets/overthelex/european-court-decisions}
+}
+```
+"""
+
+
+def main():
+    os.environ["HF_XET_HIGH_PERFORMANCE"] = "1"
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "export"):
+        print("=== Exporting PL ===", flush=True)
+        export_config("pl_court_decisions", PL_COLS, PL_SCHEMA,
+                       OUT_DIR / "data" / "pl")
+
+        print("\n=== Exporting CZ justice.cz ===", flush=True)
+        export_config("cz_court_decisions", CZ_COLS, CZ_SCHEMA,
+                       OUT_DIR / "data" / "cz-justice",
+                       "source = 'justice.cz'")
+
+        print("\n=== Exporting CZ CzCDC + Paulik ===", flush=True)
+        export_config("cz_court_decisions", CZ_COLS, CZ_SCHEMA,
+                       OUT_DIR / "data" / "cz-czcdc",
+                       "source IN ('czcdc', 'paulik-zenodo')")
+
+        readme_path = OUT_DIR / "README.md"
+        readme_path.write_text(README)
+        print(f"\nREADME written to {readme_path}", flush=True)
+
+    if mode in ("all", "publish"):
+        api = HfApi()
+        create_repo(REPO_ID, repo_type="dataset", exist_ok=True)
+        print(f"\nRepo {REPO_ID} ready", flush=True)
+
+        print("Uploading...", flush=True)
+        api.upload_large_folder(
+            folder_path=str(OUT_DIR),
+            repo_id=REPO_ID,
+            repo_type="dataset",
+            num_workers=8,
+        )
+        print(f"\nPublished: https://huggingface.co/datasets/{REPO_ID}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/split_hf_repos.py
+++ b/scripts/opendata/split_hf_repos.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Split european-court-decisions into pl-court-decisions and cz-court-decisions repos."""
+
+import os
+import time
+from huggingface_hub import HfApi, hf_hub_download
+
+api = HfApi()
+SRC = "overthelex/european-court-decisions"
+
+PL_REPO = "overthelex/pl-court-decisions"
+CZ_REPO = "overthelex/cz-court-decisions"
+
+PL_README = """---
+license: cc-by-4.0
+language:
+- pl
+pretty_name: "Polish Court Decisions"
+tags:
+- legal
+- court-decisions
+- polish
+- civil-law
+- judgments
+- caselaw
+- legal-nlp
+size_categories:
+- 1M<n<10M
+task_categories:
+- text-generation
+- text-classification
+- summarization
+- feature-extraction
+annotations_creators:
+- no-annotation
+language_creators:
+- found
+source_datasets:
+- original
+configs:
+- config_name: default
+  data_files:
+  - split: train
+    path: "data/train-*.parquet"
+---
+
+# Polish Court Decisions
+
+The largest open dataset of Polish court decisions: **2,830,029 decisions** with full texts across all court levels.
+
+## What Makes This Dataset Unique
+
+| Source | This dataset | Best on HF (JuDDGES) | Difference |
+|--------|-------------|----------------------|------------|
+| Common courts | 437,446 | 437,450 (pl-court-raw) | same source |
+| Administrative courts | 1,899,852 | ~1,800,000 (pl-nsa) | same source |
+| Supreme Court + Constitutional Tribunal + KIO | 492,731 | **0** | **+493K unique** |
+| **Total** | **2,830,029** | ~2,237,450 | **+593K (+26%)** |
+
+### Key differentiator: SAOS API data
+
+The 493K decisions from the [SAOS API](https://www.saos.org.pl/api/) include Supreme Court, Constitutional Tribunal, and National Appeal Chamber rulings that are **absent from all existing HuggingFace datasets**, including JuDDGES, Multi_Legal_Pile, and LEXTREME.
+
+## Comparison with LEXTREME and Multi_Legal_Pile
+
+- **LEXTREME** ([joelniklaus/lextreme](https://hf.co/datasets/joelniklaus/lextreme)): Contains **zero** Polish court decisions. Polish data in LEXTREME is limited to MultiEURLEX topic classification.
+- **Multi_Legal_Pile** ([joelniklaus/Multi_Legal_Pile](https://hf.co/datasets/joelniklaus/Multi_Legal_Pile)): Contains **zero** Polish caselaw. Only Polish legislation (89K docs from MARCELL).
+- **JuDDGES**: pl-court-raw (437K common courts) + pl-nsa (~1.8M admin courts). Does not include Supreme Court, Constitutional Tribunal, or KIO decisions.
+
+## Loading the Data
+
+```python
+from datasets import load_dataset
+
+ds = load_dataset("overthelex/pl-court-decisions", split="train", streaming=True)
+
+for row in ds.take(3):
+    print(row["court_type"], row["case_number"], len(row["full_text"] or ""))
+```
+
+## Sources
+
+| Source | Records | Court Types | Period | License |
+|--------|---------|-------------|--------|---------|
+| [SAOS API](https://www.saos.org.pl/api/) | 492,731 | Supreme Court, Constitutional Tribunal, National Appeal Chamber, Common Courts | 2000-2026 | Public domain (Polish Copyright Act Art. 4) |
+| [JuDDGES/pl-court-raw](https://hf.co/datasets/JuDDGES/pl-court-raw) | 437,446 | Common courts (district, regional, appellate) | 2002-2025 | CC BY 4.0 |
+| [JuDDGES/pl-nsa](https://hf.co/datasets/JuDDGES/pl-nsa) | 1,899,852 | Administrative courts (WSA + NSA) | 2004-2025 | CC BY 4.0 |
+
+## Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique record identifier |
+| `ecli` | string | European Case Law Identifier |
+| `source` | string | `saos`, `hf-pl-court-raw`, `hf-pl-nsa` |
+| `court_type` | string | COMMON, SUPREME, CONSTITUTIONAL_TRIBUNAL, NATIONAL_APPEAL_CHAMBER |
+| `court_name` | string | Court name |
+| `case_number` | string | Docket / case number |
+| `decision_type` | string | SENTENCE, RESOLUTION, DECISION, REGULATION, REASONS |
+| `decision_date` | string | YYYY-MM-DD |
+| `judge` | string | Presiding judge |
+| `keywords` | list[string] | Legal keywords |
+| `legal_bases` | list[string] | Legal bases cited |
+| `full_text` | string | Full decision text |
+
+## Data Quality
+
+- 12,213 SAOS internal duplicates removed (kept longest text)
+- 27,473 empty texts removed
+- 153 micro-texts (<100 chars) removed
+
+## Citation
+
+```bibtex
+@misc{ovcharov2026plcourt,
+  title={Polish Court Decisions: 2.83M decisions from SAOS, common, and administrative courts},
+  author={Ovcharov, Volodymyr},
+  year={2026},
+  publisher={HuggingFace},
+  url={https://huggingface.co/datasets/overthelex/pl-court-decisions}
+}
+```
+"""
+
+CZ_README = """---
+license: cc-by-nc-sa-4.0
+language:
+- cs
+pretty_name: "Czech Court Decisions"
+tags:
+- legal
+- court-decisions
+- czech
+- civil-law
+- judgments
+- caselaw
+- legal-nlp
+size_categories:
+- 100K<n<1M
+task_categories:
+- text-generation
+- text-classification
+- summarization
+- feature-extraction
+annotations_creators:
+- no-annotation
+language_creators:
+- found
+source_datasets:
+- original
+configs:
+- config_name: justice
+  data_files:
+  - split: train
+    path: "data/justice/train-*.parquet"
+  default: true
+- config_name: czcdc
+  data_files:
+  - split: train
+    path: "data/czcdc/train-*.parquet"
+---
+
+# Czech Court Decisions
+
+The largest open dataset of Czech court decisions: **871,171 decisions** with full texts across all court levels.
+
+## What Makes This Dataset Unique
+
+| Source | This dataset | Best on HF (Multi_Legal_Pile) | Difference |
+|--------|-------------|-------------------------------|------------|
+| Lower courts (district, regional, high) | 539,622 | **0** | **+540K unique** |
+| Supreme Court | 111,977 | 111,977 (CzCDC in MLP) | same |
+| Supreme Administrative Court | 52,660 | 52,660 (CzCDC in MLP) | same |
+| Constitutional Court | 166,912 | 73,086 (CzCDC in MLP) | **+94K** |
+| **Total** | **871,171** | 296,652 | **+574K (+194%)** |
+
+### Key differentiator: rozhodnuti.justice.cz
+
+The 540K lower court decisions from the [Czech Ministry of Justice API](https://rozhodnuti.justice.cz/api/opendata) are **absent from all existing HuggingFace datasets**.
+
+## Configs and Licensing
+
+| Config | Records | Courts | License |
+|--------|---------|--------|---------|
+| `justice` (default) | 539,622 | District, regional, high courts (2020-2026) | **CC BY 4.0** (commercial OK) |
+| `czcdc` | 331,549 | Supreme + Supreme Administrative + Constitutional (1993-2023) | **CC BY-NC-SA 4.0** (non-commercial) |
+
+## Loading the Data
+
+```python
+from datasets import load_dataset
+
+# Lower courts (CC BY 4.0 -- commercial OK)
+justice = load_dataset("overthelex/cz-court-decisions", "justice", split="train")
+
+# Apex courts (CC BY-NC-SA 4.0)
+czcdc = load_dataset("overthelex/cz-court-decisions", "czcdc", split="train")
+```
+
+## Sources
+
+**`justice` config** (CC BY 4.0):
+
+| Source | Records | Court Types | Period |
+|--------|---------|-------------|--------|
+| [rozhodnuti.justice.cz](https://rozhodnuti.justice.cz/api/opendata) | 539,622 | District, regional, high courts | 2020-2026 |
+
+**`czcdc` config** (CC BY-NC-SA 4.0):
+
+| Source | Records | Court Types | Period |
+|--------|---------|-------------|--------|
+| [CzCDC 1.0](https://lindat.mff.cuni.cz/repository/xmlui/handle/11372/LRT-3052) | 237,723 | Supreme, Supreme Administrative, Constitutional | 1993-2018 |
+| [Paulik/Zenodo](https://zenodo.org/records/11618008) | 93,826 | Constitutional Court | 1993-2023 |
+
+## Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique record identifier |
+| `ecli` | string | ECLI:CZ:... identifier |
+| `source` | string | `justice.cz`, `czcdc`, `paulik-zenodo` |
+| `court_name` | string | Court name |
+| `case_number` | string | Docket / case number |
+| `decision_type` | string | Type of decision |
+| `decision_date` | string | YYYY-MM-DD |
+| `judge` | string | Judge / rapporteur |
+| `subject` | string | Subject matter |
+| `keywords` | list[string] | Keywords |
+| `cited_provisions` | list[string] | Cited legal provisions |
+| `full_text` | string | Full decision text |
+
+## Data Quality
+
+- 0 duplicates (sources cover non-overlapping court levels)
+- CzCDC and Paulik cover different time periods for Constitutional Court
+
+## Citation
+
+```bibtex
+@misc{ovcharov2026czcourt,
+  title={Czech Court Decisions: 871K decisions across all court levels},
+  author={Ovcharov, Volodymyr},
+  year={2026},
+  publisher={HuggingFace},
+  url={https://huggingface.co/datasets/overthelex/cz-court-decisions}
+}
+```
+"""
+
+
+def copy_files(src_prefix: str, dst_repo: str, dst_prefix: str):
+    """Copy parquet files from source repo to destination repo."""
+    files = list(api.list_repo_tree(SRC, repo_type="dataset", path_in_repo=src_prefix, recursive=True))
+    parquets = [f for f in files if hasattr(f, 'rfilename') and f.rfilename.endswith('.parquet')]
+    print(f"  Copying {len(parquets)} files from {src_prefix} -> {dst_repo}:{dst_prefix}", flush=True)
+
+    for i, f in enumerate(parquets):
+        src_path = f.rfilename
+        fname = src_path.split('/')[-1]
+        dst_path = f"{dst_prefix}/{fname}"
+
+        local = hf_hub_download(SRC, src_path, repo_type="dataset")
+        api.upload_file(
+            path_or_fileobj=local,
+            path_in_repo=dst_path,
+            repo_id=dst_repo,
+            repo_type="dataset",
+        )
+        print(f"  [{i+1}/{len(parquets)}] {dst_path}", flush=True)
+
+
+def main():
+    # PL repo
+    print("=== PL ===", flush=True)
+    api.upload_file(
+        path_or_fileobj=PL_README.encode(),
+        path_in_repo="README.md",
+        repo_id=PL_REPO,
+        repo_type="dataset",
+    )
+    copy_files("data/pl", PL_REPO, "data")
+
+    # CZ repo
+    print("\n=== CZ ===", flush=True)
+    api.upload_file(
+        path_or_fileobj=CZ_README.encode(),
+        path_in_repo="README.md",
+        repo_id=CZ_REPO,
+        repo_type="dataset",
+    )
+    copy_files("data/cz-justice", CZ_REPO, "data/justice")
+    copy_files("data/cz-czcdc", CZ_REPO, "data/czcdc")
+
+    print("\n=== Done ===", flush=True)
+    print(f"PL: https://huggingface.co/datasets/{PL_REPO}", flush=True)
+    print(f"CZ: https://huggingface.co/datasets/{CZ_REPO}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- `dedup_and_quality.py` — deduplication and quality analysis for PL/CZ court decision tables
- `publish_hf_datasets.py` — server-side cursor export to Parquet (zstd, 50K-row shards) and HuggingFace upload
- `split_hf_repos.py` — splits combined european-court-decisions into separate pl-court-decisions and cz-court-decisions repos

Published datasets:
- [overthelex/pl-court-decisions](https://huggingface.co/datasets/overthelex/pl-court-decisions) — 2.83M decisions, CC BY 4.0
- [overthelex/cz-court-decisions](https://huggingface.co/datasets/overthelex/cz-court-decisions) — 871K decisions (justice + czcdc configs)

## Test plan
- [x] Scripts ran successfully on prod
- [x] Both HF repos accessible and indexed
- [x] Old combined repo deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three scripts to dedupe PL/CZ court decisions, export to Parquet, publish to HuggingFace, and split the combined dataset into country-specific repos. Publishes `overthelex/pl-court-decisions` (2.83M) and `overthelex/cz-court-decisions` (871K).

- **New Features**
  - `scripts/opendata/dedup_and_quality.py` — dedup + quality stats for PL (case_number+date) and CZ (ECLI), with overlap diagnostics.
  - `scripts/opendata/publish_hf_datasets.py` — server-side cursor export to Parquet (zstd, 50K-row shards) and upload to `overthelex/european-court-decisions` (`pl`, `cz-justice`, `cz-czcdc` configs).
  - `scripts/opendata/split_hf_repos.py` — copies shards and READMEs into `overthelex/pl-court-decisions` and `overthelex/cz-court-decisions`.

- **Migration**
  - Requires `DATABASE_URL` and HF credentials; install `psycopg2`, `pyarrow`, `huggingface_hub`.
  - Run `publish_hf_datasets.py all` to export/publish, then `split_hf_repos.py` to create country repos.

<sup>Written for commit 2b6dcd98a9c8153530412837c0457fa57366217b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1793?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

