### PR TITLE
feat(infra): A/B testing infrastructure for model routing

### DIFF
--- a/mcp_backend/src/api/tools/ab-testing-tools.ts
+++ b/mcp_backend/src/api/tools/ab-testing-tools.ts
@@ -1,0 +1,212 @@
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { ABTestingService } from '../../services/ab-testing-service.js';
+import { logger } from '../../utils/logger.js';
+
+export class ABTestingTools extends BaseToolHandler {
+  constructor(private abService: ABTestingService) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'ab_create_experiment',
+        annotations: { title: 'Створити A/B експеримент' },
+        description: `Створити новий A/B експеримент для порівняння моделей, промптів або фіч.
+
+Приклад для порівняння моделей Bedrock:
+{
+  "name": "sonnet-4.5-vs-4.6",
+  "experiment_type": "model",
+  "target_budget": "standard",
+  "traffic_pct": 50,
+  "config": {
+    "variants": [
+      { "name": "control", "model": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0", "weight": 50 },
+      { "name": "treatment", "model": "eu.anthropic.claude-sonnet-4-6", "weight": 50 }
+    ]
+  }
+}
+
+Статуси: draft → running → paused/completed. Тільки running експерименти впливають на трафік.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Унікальна назва експерименту' },
+            description: { type: 'string', description: 'Опис експерименту' },
+            experiment_type: {
+              type: 'string',
+              enum: ['model', 'prompt', 'feature'],
+              description: 'Тип: model (заміна моделі), prompt (зміна промпту), feature (фіча-флаг)',
+            },
+            config: {
+              type: 'object',
+              description: 'Конфігурація з масивом variants: [{ name, model?, weight }]',
+              properties: {
+                variants: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      name: { type: 'string' },
+                      model: { type: 'string' },
+                      weight: { type: 'number' },
+                    },
+                    required: ['name', 'weight'],
+                  },
+                },
+              },
+              required: ['variants'],
+            },
+            target_budget: {
+              type: 'string',
+              enum: ['quick', 'standard', 'deep'],
+              description: 'Який budget tier перехоплювати (null = всі)',
+            },
+            traffic_pct: {
+              type: 'number',
+              description: 'Відсоток користувачів, що потрапляють в експеримент (0-100, за замовчуванням 100)',
+            },
+          },
+          required: ['name', 'config'],
+        },
+      },
+      {
+        name: 'ab_list_experiments',
+        annotations: { title: 'Список A/B експериментів', readOnlyHint: true },
+        description: 'Отримати список A/B експериментів з опціональним фільтром за статусом.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            status: {
+              type: 'string',
+              enum: ['draft', 'running', 'paused', 'completed'],
+              description: 'Фільтр за статусом',
+            },
+          },
+        },
+      },
+      {
+        name: 'ab_update_status',
+        annotations: { title: 'Оновити статус A/B експерименту' },
+        description: `Змінити статус експерименту: running (запустити), paused (призупинити), completed (завершити).
+Тільки running експерименти впливають на розподіл трафіку.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            experiment_id: { type: 'string', description: 'ID експерименту' },
+            status: {
+              type: 'string',
+              enum: ['running', 'paused', 'completed'],
+              description: 'Новий статус',
+            },
+          },
+          required: ['experiment_id', 'status'],
+        },
+      },
+      {
+        name: 'ab_get_results',
+        annotations: { title: 'Результати A/B експерименту', readOnlyHint: true },
+        description: `Агреговані результати по варіантах: кількість юзерів, подій, середня вартість, latency, токени, помилки.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            experiment_id: { type: 'string', description: 'ID експерименту' },
+          },
+          required: ['experiment_id'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    try {
+      switch (name) {
+        case 'ab_create_experiment':
+          return await this.handleCreate(args);
+        case 'ab_list_experiments':
+          return await this.handleList(args);
+        case 'ab_update_status':
+          return await this.handleUpdateStatus(args);
+        case 'ab_get_results':
+          return await this.handleResults(args);
+        default:
+          return null;
+      }
+    } catch (err: any) {
+      logger.error(`ABTestingTools.${name} failed`, { error: err.message });
+      return { content: [{ type: 'text', text: `Помилка: ${err.message}` }], isError: true };
+    }
+  }
+
+  private async handleCreate(args: any): Promise<ToolResult> {
+    if (!args.config?.variants || args.config.variants.length < 2) {
+      return this.wrapError('Потрібно мінімум 2 варіанти');
+    }
+
+    const experiment = await this.abService.createExperiment({
+      name: args.name,
+      description: args.description,
+      experiment_type: args.experiment_type,
+      config: args.config,
+      target_budget: args.target_budget,
+      traffic_pct: args.traffic_pct,
+    });
+
+    return this.wrapResponse({
+      ok: true,
+      experiment,
+      message: `Експеримент "${experiment.name}" створено (id: ${experiment.id}, статус: draft). Використайте ab_update_status для запуску.`,
+    });
+  }
+
+  private async handleList(args: any): Promise<ToolResult> {
+    const experiments = await this.abService.listExperiments(args.status);
+    return this.wrapResponse({
+      experiments: experiments.map(e => ({
+        id: e.id,
+        name: e.name,
+        status: e.status,
+        experiment_type: e.experiment_type,
+        target_budget: e.target_budget,
+        traffic_pct: e.traffic_pct,
+        variants: e.config.variants.map(v => `${v.name}(${v.weight}%)${v.model ? ` → ${v.model}` : ''}`),
+        created_at: e.created_at,
+        started_at: e.started_at,
+        ended_at: e.ended_at,
+      })),
+      count: experiments.length,
+    });
+  }
+
+  private async handleUpdateStatus(args: any): Promise<ToolResult> {
+    const experiment = await this.abService.updateExperimentStatus(args.experiment_id, args.status);
+    if (!experiment) {
+      return this.wrapError(`Експеримент ${args.experiment_id} не знайдено`);
+    }
+    return this.wrapResponse({
+      ok: true,
+      experiment: { id: experiment.id, name: experiment.name, status: experiment.status },
+      message: `Статус "${experiment.name}" змінено на ${experiment.status}`,
+    });
+  }
+
+  private async handleResults(args: any): Promise<ToolResult> {
+    const experiment = await this.abService.getExperiment(args.experiment_id);
+    if (!experiment) {
+      return this.wrapError(`Експеримент ${args.experiment_id} не знайдено`);
+    }
+
+    const results = await this.abService.getExperimentResults(args.experiment_id);
+
+    return this.wrapResponse({
+      experiment: { id: experiment.id, name: experiment.name, status: experiment.status },
+      results,
+      summary: results.length === 0
+        ? 'Ще немає подій для цього експерименту.'
+        : results.map(r =>
+            `${r.variant_name}: ${r.user_count} юзерів, ${r.event_count} подій, avg cost $${r.avg_cost_usd?.toFixed(4) ?? 'N/A'}, avg latency ${r.avg_latency_ms?.toFixed(0) ?? 'N/A'}ms`
+          ).join('\n'),
+    });
+  }
+}

--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -29,6 +29,7 @@ import { AttorneyPayoutService } from '../services/attorney-payout-service.js';
 import { ConsultationE2eeService } from '../services/consultation-e2ee-service.js';
 import { OAuthService } from '../services/oauth-service.js';
 import { LegislationMonitoringService } from '../services/legislation-monitoring-service.js';
+import { ABTestingService } from '../services/ab-testing-service.js';
 import { MCPSSEServer } from '../api/mcp-sse-server.js';
 import { BannerService } from '../services/banner-service.js';
 import { UserService } from '../services/user-service.js';
@@ -71,6 +72,7 @@ export interface AppServices {
   mcpSSEServer: MCPSSEServer;
   llmAdapter: LLMAdapter;
   legislationMonitoringService: LegislationMonitoringService;
+  abTestingService: ABTestingService;
 }
 
 export function createAppServices(
@@ -79,6 +81,11 @@ export function createAppServices(
   tools: ToolServices,
   llmAdapter: LLMAdapter
 ): AppServices {
+  // A/B testing service
+  const abTestingService = new ABTestingService(coreServices.db);
+  llmAdapter.setABTestingService(abTestingService);
+  logger.info('A/B testing service initialized');
+
   // OAuth 2.0 service for ChatGPT integration
   const oauthService = new OAuthService(coreServices.db);
   logger.info('OAuth 2.0 service initialized');
@@ -290,5 +297,6 @@ export function createAppServices(
     mcpSSEServer,
     llmAdapter,
     legislationMonitoringService,
+    abTestingService,
   };
 }

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -42,6 +42,8 @@ import { WorkflowMemoryPushService } from '../services/workflow-memory-push-serv
 import { OsintProxyAdapter } from '../adapters/osint-proxy-adapter.js';
 import { OsintProxyTools } from '../api/tools/osint-proxy-tools.js';
 import { IndiaCourtTools } from '../api/tools/india-court-tools.js';
+import { ABTestingTools } from '../api/tools/ab-testing-tools.js';
+import { ABTestingService } from '../services/ab-testing-service.js';
 import { logger } from '../utils/logger.js';
 import path from 'path';
 
@@ -180,6 +182,10 @@ export function createToolServices(
   const wmPushService = new WorkflowMemoryPushService(coreServices.db, pushSummarize);
   wmTools.setPushService(wmPushService);
   toolRegistry.registerHandler(wmTools);
+
+  // A/B testing tools
+  const abTestingService = new ABTestingService(coreServices.db);
+  toolRegistry.registerHandler(new ABTestingTools(abTestingService));
 
   logger.info('Core tool handlers registered with ToolRegistry');
 

--- a/mcp_backend/src/infrastructure/adapters/llm-adapter.ts
+++ b/mcp_backend/src/infrastructure/adapters/llm-adapter.ts
@@ -1,10 +1,4 @@
-/**
- * Adapter that wraps the shared-package LLMClientManager behind ILLMPort.
- *
- * The shared package cannot depend on mcp_backend's domain ports, so we
- * adapt it here instead of adding `implements` directly to the class.
- */
-
+import { AsyncLocalStorage } from 'async_hooks';
 import { LLMClientManager } from '@secondlayer/shared';
 import type {
   ILLMPort,
@@ -15,16 +9,63 @@ import type {
   BudgetLevel,
   LLMProvider,
 } from '../../domain/ports/index.js';
+import type { ABTestingService } from '../../services/ab-testing-service.js';
+import { logger } from '../../utils/logger.js';
+
+const abUserContext = new AsyncLocalStorage<{ userId: string }>();
+
+export function runWithABUser<T>(userId: string, fn: () => T): T {
+  return abUserContext.run({ userId }, fn);
+}
 
 export class LLMAdapter implements ILLMPort {
+  private abTestingService?: ABTestingService;
+
   constructor(private readonly manager: LLMClientManager) {}
+
+  setABTestingService(service: ABTestingService): void {
+    this.abTestingService = service;
+    logger.info('A/B testing service wired to LLM adapter');
+  }
 
   async chatCompletion(
     request: LLMRequest,
     budget?: BudgetLevel,
     preferredProvider?: LLMProvider,
   ): Promise<LLMResponse> {
-    // Structurally compatible — no mapping needed
+    const userId = abUserContext.getStore()?.userId;
+    if (this.abTestingService && userId && budget) {
+      try {
+        const override = await this.abTestingService.resolveModelForUser(userId, budget);
+        if (override) {
+          const callStart = Date.now();
+          const result = await this.manager.chatCompletionWithModel(
+            request as any,
+            override.model,
+            'bedrock',
+          );
+          const latencyMs = Date.now() - callStart;
+          this.abTestingService.trackEvent({
+            experimentId: override.experimentId,
+            userId,
+            variantName: override.variant,
+            eventType: 'llm_call',
+            eventData: {
+              model: override.model,
+              budget,
+              tokens: (result as any).usage?.total_tokens,
+              cost_usd: (result as any).usage
+                ? estimateCost(override.model, (result as any).usage.prompt_tokens, (result as any).usage.completion_tokens)
+                : undefined,
+              latency_ms: latencyMs,
+            },
+          });
+          return result as LLMResponse;
+        }
+      } catch (err: any) {
+        logger.warn('A/B model override failed, falling back to default', { error: err.message });
+      }
+    }
     return this.manager.chatCompletion(request as any, budget, preferredProvider);
   }
 
@@ -49,4 +90,16 @@ export class LLMAdapter implements ILLMPort {
   setCostTracker(tracker: ICostTracker): void {
     this.manager.setCostTracker(tracker as any);
   }
+}
+
+function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
+  const rates: Record<string, [number, number]> = {
+    'claude-haiku': [0.25 / 1e6, 1.25 / 1e6],
+    'claude-sonnet-4-5': [3 / 1e6, 15 / 1e6],
+    'claude-sonnet-4-6': [3 / 1e6, 15 / 1e6],
+    'claude-opus': [15 / 1e6, 75 / 1e6],
+  };
+  const key = Object.keys(rates).find(k => model.includes(k)) ?? 'claude-sonnet-4-6';
+  const [inRate, outRate] = rates[key];
+  return inputTokens * inRate + outputTokens * outRate;
 }

--- a/mcp_backend/src/migrations/153_ab_testing.sql
+++ b/mcp_backend/src/migrations/153_ab_testing.sql
@@ -1,0 +1,66 @@
+-- Migration 153: A/B testing infrastructure
+
+CREATE TABLE IF NOT EXISTS ab_experiments (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL UNIQUE,
+    description     TEXT,
+    experiment_type TEXT NOT NULL DEFAULT 'model',
+    status          TEXT NOT NULL DEFAULT 'draft',
+    config          JSONB NOT NULL DEFAULT '{}',
+    target_budget   TEXT,
+    traffic_pct     INT NOT NULL DEFAULT 100,
+    created_by      TEXT,
+    created_at      TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW(),
+    started_at      TIMESTAMPTZ,
+    ended_at        TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS ab_assignments (
+    id              BIGSERIAL PRIMARY KEY,
+    experiment_id   TEXT NOT NULL REFERENCES ab_experiments(id),
+    user_id         TEXT NOT NULL,
+    variant_name    TEXT NOT NULL,
+    assigned_at     TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(experiment_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS ab_events (
+    id              BIGSERIAL PRIMARY KEY,
+    experiment_id   TEXT NOT NULL REFERENCES ab_experiments(id),
+    user_id         TEXT NOT NULL,
+    variant_name    TEXT NOT NULL,
+    event_type      TEXT NOT NULL,
+    event_data      JSONB DEFAULT '{}',
+    created_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+DO $$ BEGIN
+    CREATE INDEX idx_ab_assignments_user ON ab_assignments(user_id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE INDEX idx_ab_assignments_experiment ON ab_assignments(experiment_id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE INDEX idx_ab_events_experiment ON ab_events(experiment_id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE INDEX idx_ab_events_user ON ab_events(user_id);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE INDEX idx_ab_events_created ON ab_events(created_at);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+    CREATE INDEX idx_ab_experiments_status ON ab_experiments(status);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -13,6 +13,7 @@ import { CostTracker } from '../services/cost-tracker.js';
 import { Database } from '../database/database.js';
 import { v4 as uuidv4 } from 'uuid';
 import { requestContext } from '../utils/openai-client.js';
+import { runWithABUser } from '../infrastructure/adapters/llm-adapter.js';
 
 export function createChatInlineRoutes(deps: {
   chatService: ChatService;
@@ -184,25 +185,24 @@ export function createChatInlineRoutes(deps: {
         internetEnabled: internetEnabled !== false,
       };
       try {
-        for await (const event of deps.chatService.chat(chatRequest)) {
-          if (abortController.signal.aborted) break;
+        await runWithABUser(userId || '', async () => {
+          for await (const event of deps.chatService.chat(chatRequest)) {
+            if (abortController.signal.aborted) break;
 
-          if (event.type === 'complete') {
-            chatCompleted = true;
-            chatTotalCostUsd = event.data?.total_cost_usd || 0;
-            event.data.response_id = requestId;
-            // Include auto-created conversationId so the client can track it
-            if (chatRequest.conversationId && chatRequest.conversationId !== conversationId) {
-              event.data.conversationId = chatRequest.conversationId;
+            if (event.type === 'complete') {
+              chatCompleted = true;
+              chatTotalCostUsd = event.data?.total_cost_usd || 0;
+              event.data.response_id = requestId;
+              if (chatRequest.conversationId && chatRequest.conversationId !== conversationId) {
+                event.data.conversationId = chatRequest.conversationId;
+              }
             }
+
+            res.write(`event: ${event.type}\n`);
+            res.write(`data: ${JSON.stringify(event.data)}\n\n`);
           }
+        });
 
-          res.write(`event: ${event.type}\n`);
-          res.write(`data: ${JSON.stringify(event.data)}\n\n`);
-        }
-
-        // If aborted (timeout) and no answer was sent, emit an error event
-        // so the frontend knows to reset streaming state
         if (abortController.signal.aborted && !chatCompleted && !res.writableEnded) {
           logger.warn('[ChatService] Sending timeout error to client', { requestId });
           res.write(`event: error\n`);

--- a/mcp_backend/src/services/ab-testing-service.ts
+++ b/mcp_backend/src/services/ab-testing-service.ts
@@ -1,0 +1,277 @@
+import crypto from 'crypto';
+import { logger } from '../utils/logger.js';
+
+type BudgetLevel = 'quick' | 'standard' | 'deep';
+
+export interface ABVariant {
+  name: string;
+  model?: string;
+  weight: number;
+  [key: string]: any;
+}
+
+export interface ABExperimentConfig {
+  variants: ABVariant[];
+}
+
+export interface ABExperiment {
+  id: string;
+  name: string;
+  description: string | null;
+  experiment_type: string;
+  status: string;
+  config: ABExperimentConfig;
+  target_budget: BudgetLevel | null;
+  traffic_pct: number;
+  created_by: string | null;
+  created_at: Date;
+  updated_at: Date;
+  started_at: Date | null;
+  ended_at: Date | null;
+}
+
+export interface ABVariantResult {
+  variant_name: string;
+  user_count: number;
+  event_count: number;
+  avg_cost_usd: number | null;
+  total_cost_usd: number | null;
+  avg_latency_ms: number | null;
+  avg_tokens: number | null;
+  error_count: number;
+}
+
+export interface ABModelOverride {
+  model: string;
+  experimentId: string;
+  variant: string;
+}
+
+interface DB {
+  query: (sql: string, params?: any[]) => Promise<any>;
+}
+
+export class ABTestingService {
+  private experimentCache = new Map<string, { exp: ABExperiment; ts: number }>();
+  private assignmentCache = new Map<string, { variant: string; ts: number }>();
+  private activeByBudgetCache: { experiments: ABExperiment[]; ts: number } | null = null;
+  private readonly CACHE_TTL_MS = 60_000;
+
+  constructor(private db: DB) {}
+
+  async createExperiment(params: {
+    name: string;
+    description?: string;
+    experiment_type?: string;
+    config: ABExperimentConfig;
+    target_budget?: BudgetLevel;
+    traffic_pct?: number;
+    created_by?: string;
+  }): Promise<ABExperiment> {
+    const id = `ab_${Date.now()}_${crypto.randomBytes(4).toString('hex')}`;
+    const res = await this.db.query(
+      `INSERT INTO ab_experiments (id, name, description, experiment_type, config, target_budget, traffic_pct, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING *`,
+      [
+        id,
+        params.name,
+        params.description ?? null,
+        params.experiment_type ?? 'model',
+        JSON.stringify(params.config),
+        params.target_budget ?? null,
+        params.traffic_pct ?? 100,
+        params.created_by ?? null,
+      ],
+    );
+    this.invalidateCache();
+    return this.rowToExperiment(res.rows[0]);
+  }
+
+  async getExperiment(id: string): Promise<ABExperiment | null> {
+    const cached = this.experimentCache.get(id);
+    if (cached && Date.now() - cached.ts < this.CACHE_TTL_MS) return cached.exp;
+
+    const res = await this.db.query('SELECT * FROM ab_experiments WHERE id = $1', [id]);
+    if (res.rows.length === 0) return null;
+    const exp = this.rowToExperiment(res.rows[0]);
+    this.experimentCache.set(id, { exp, ts: Date.now() });
+    return exp;
+  }
+
+  async listExperiments(status?: string): Promise<ABExperiment[]> {
+    const sql = status
+      ? 'SELECT * FROM ab_experiments WHERE status = $1 ORDER BY created_at DESC'
+      : 'SELECT * FROM ab_experiments ORDER BY created_at DESC';
+    const res = await this.db.query(sql, status ? [status] : []);
+    return res.rows.map((r: any) => this.rowToExperiment(r));
+  }
+
+  async updateExperimentStatus(id: string, status: 'running' | 'paused' | 'completed'): Promise<ABExperiment | null> {
+    const timeField = status === 'running' ? 'started_at' : status === 'completed' ? 'ended_at' : null;
+    const sql = timeField
+      ? `UPDATE ab_experiments SET status = $2, ${timeField} = NOW(), updated_at = NOW() WHERE id = $1 RETURNING *`
+      : `UPDATE ab_experiments SET status = $2, updated_at = NOW() WHERE id = $1 RETURNING *`;
+    const res = await this.db.query(sql, [id, status]);
+    this.invalidateCache();
+    if (res.rows.length === 0) return null;
+    return this.rowToExperiment(res.rows[0]);
+  }
+
+  async getOrAssignVariant(experimentId: string, userId: string): Promise<string | null> {
+    const cacheKey = `${experimentId}:${userId}`;
+    const cached = this.assignmentCache.get(cacheKey);
+    if (cached && Date.now() - cached.ts < this.CACHE_TTL_MS) return cached.variant;
+
+    const existing = await this.db.query(
+      'SELECT variant_name FROM ab_assignments WHERE experiment_id = $1 AND user_id = $2',
+      [experimentId, userId],
+    );
+    if (existing.rows.length > 0) {
+      const v = existing.rows[0].variant_name;
+      this.assignmentCache.set(cacheKey, { variant: v, ts: Date.now() });
+      return v;
+    }
+
+    const experiment = await this.getExperiment(experimentId);
+    if (!experiment || experiment.status !== 'running') return null;
+
+    const variant = this.pickVariant(experiment.config.variants, experimentId, userId);
+
+    await this.db.query(
+      `INSERT INTO ab_assignments (experiment_id, user_id, variant_name)
+       VALUES ($1, $2, $3) ON CONFLICT (experiment_id, user_id) DO NOTHING`,
+      [experimentId, userId, variant],
+    );
+
+    this.assignmentCache.set(cacheKey, { variant, ts: Date.now() });
+    return variant;
+  }
+
+  async resolveModelForUser(userId: string, budget: BudgetLevel): Promise<ABModelOverride | null> {
+    const experiments = await this.getActiveExperimentsForBudget(budget);
+    if (experiments.length === 0) return null;
+
+    const experiment = experiments[0];
+
+    if (!this.isUserEnrolled(experiment, userId)) return null;
+
+    const variant = await this.getOrAssignVariant(experiment.id, userId);
+    if (!variant) return null;
+
+    const variantConfig = experiment.config.variants.find(v => v.name === variant);
+    if (!variantConfig?.model) return null;
+
+    return {
+      model: variantConfig.model,
+      experimentId: experiment.id,
+      variant,
+    };
+  }
+
+  async trackEvent(params: {
+    experimentId: string;
+    userId: string;
+    variantName: string;
+    eventType: string;
+    eventData?: Record<string, any>;
+  }): Promise<void> {
+    await this.db.query(
+      `INSERT INTO ab_events (experiment_id, user_id, variant_name, event_type, event_data)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [params.experimentId, params.userId, params.variantName, params.eventType, JSON.stringify(params.eventData ?? {})],
+    ).catch(err => {
+      logger.warn('Failed to track A/B event', { error: err.message, experimentId: params.experimentId });
+    });
+  }
+
+  async getExperimentResults(experimentId: string): Promise<ABVariantResult[]> {
+    const res = await this.db.query(
+      `SELECT
+         e.variant_name,
+         COUNT(DISTINCT e.user_id) AS user_count,
+         COUNT(*) AS event_count,
+         AVG((e.event_data->>'cost_usd')::numeric) AS avg_cost_usd,
+         SUM((e.event_data->>'cost_usd')::numeric) AS total_cost_usd,
+         AVG((e.event_data->>'latency_ms')::numeric) AS avg_latency_ms,
+         AVG((e.event_data->>'tokens')::numeric) AS avg_tokens,
+         COUNT(*) FILTER (WHERE e.event_type = 'error') AS error_count
+       FROM ab_events e
+       WHERE e.experiment_id = $1
+       GROUP BY e.variant_name
+       ORDER BY e.variant_name`,
+      [experimentId],
+    );
+
+    return res.rows.map((r: Record<string, any>) => ({
+      variant_name: r.variant_name,
+      user_count: Number(r.user_count),
+      event_count: Number(r.event_count),
+      avg_cost_usd: r.avg_cost_usd !== null ? Number(r.avg_cost_usd) : null,
+      total_cost_usd: r.total_cost_usd !== null ? Number(r.total_cost_usd) : null,
+      avg_latency_ms: r.avg_latency_ms !== null ? Number(r.avg_latency_ms) : null,
+      avg_tokens: r.avg_tokens !== null ? Number(r.avg_tokens) : null,
+      error_count: Number(r.error_count),
+    }));
+  }
+
+  private async getActiveExperimentsForBudget(budget: BudgetLevel): Promise<ABExperiment[]> {
+    if (this.activeByBudgetCache && Date.now() - this.activeByBudgetCache.ts < this.CACHE_TTL_MS) {
+      return this.activeByBudgetCache.experiments.filter(
+        e => e.target_budget === null || e.target_budget === budget,
+      );
+    }
+
+    const res = await this.db.query(
+      `SELECT * FROM ab_experiments WHERE status = 'running' AND experiment_type = 'model' ORDER BY created_at DESC`,
+    );
+    const experiments = res.rows.map((r: any) => this.rowToExperiment(r));
+    this.activeByBudgetCache = { experiments, ts: Date.now() };
+
+    return experiments.filter((e: ABExperiment) => e.target_budget === null || e.target_budget === budget);
+  }
+
+  private pickVariant(variants: ABVariant[], experimentId: string, userId: string): string {
+    const hash = crypto.createHash('sha256').update(experimentId + userId).digest();
+    const bucket = hash.readUInt32BE(0) % 10000;
+
+    const totalWeight = variants.reduce((s, v) => s + v.weight, 0);
+    let cumulative = 0;
+    for (const v of variants) {
+      cumulative += (v.weight / totalWeight) * 10000;
+      if (bucket < cumulative) return v.name;
+    }
+    return variants[variants.length - 1].name;
+  }
+
+  private isUserEnrolled(experiment: ABExperiment, userId: string): boolean {
+    if (experiment.traffic_pct >= 100) return true;
+    const hash = crypto.createHash('sha256').update('enroll:' + experiment.id + userId).digest();
+    const bucket = hash.readUInt32BE(0) % 100;
+    return bucket < experiment.traffic_pct;
+  }
+
+  private invalidateCache(): void {
+    this.experimentCache.clear();
+    this.assignmentCache.clear();
+    this.activeByBudgetCache = null;
+  }
+
+  private rowToExperiment(row: any): ABExperiment {
+    return {
+      id: row.id,
+      name: row.name,
+      description: row.description,
+      experiment_type: row.experiment_type,
+      status: row.status,
+      config: typeof row.config === 'string' ? JSON.parse(row.config) : row.config,
+      target_budget: row.target_budget,
+      traffic_pct: row.traffic_pct,
+      created_by: row.created_by,
+      created_at: row.created_at,
+      updated_at: row.updated_at,
+      started_at: row.started_at,
+      ended_at: row.ended_at,
+    };
+  }
+}

--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -132,6 +132,15 @@ export class LLMClientManager {
     this.externalApiMetrics = callback;
   }
 
+  async chatCompletionWithModel(
+    request: UnifiedChatRequest,
+    model: string,
+    provider: LLMProvider,
+  ): Promise<UnifiedChatResponse> {
+    const selection: ModelSelection = { provider, model, budget: 'standard' };
+    return this.executeChatCompletion(request, selection);
+  }
+
   async chatCompletion(
     request: UnifiedChatRequest,
     budget: BudgetLevel = 'standard',


### PR DESCRIPTION
## Summary
- Add A/B testing infrastructure for production model routing experiments on legal.org.ua
- Migration 153: `ab_experiments`, `ab_assignments`, `ab_events` tables with indexes
- `ABTestingService`: deterministic sticky assignment (SHA-256 hash), traffic enrollment control, model override resolution, event tracking with cost/latency/tokens, aggregated results per variant
- 4 MCP tools: `ab_create_experiment`, `ab_list_experiments`, `ab_update_status`, `ab_get_results`
- `LLMAdapter` intercepts Bedrock LLM calls and routes to experiment variant model via `AsyncLocalStorage` (thread-safe)
- `LLMClientManager.chatCompletionWithModel()` added to shared package for direct model override bypassing `ModelSelector`
- In-memory cache (60s TTL) for experiments and assignments to avoid DB hits on hot path

## First experiment
Bedrock Sonnet 4.5 vs 4.6 for standard-tier queries — compare cost, latency, token usage.

## Test plan
- [ ] Run migration on local DB
- [ ] Create experiment via `ab_create_experiment` tool
- [ ] Start experiment, verify LLM calls are routed to variant model
- [ ] Check `ab_get_results` returns per-variant aggregates
- [ ] Verify fallback to default model when no experiment is active

Plane: LEXAI-1108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds A/B testing for production model routing so we can compare Bedrock model variants with sticky user assignment, traffic control, and built‑in metrics. Addresses Linear LEXAI-1108.

- New Features
  - Migration 153: `ab_experiments`, `ab_assignments`, `ab_events` with indexes.
  - `ABTestingService`: SHA‑256 sticky assignment, traffic %, model override, event tracking, 60s caches.
  - `LLMAdapter`: routes to variant model using `AsyncLocalStorage` user context; tracks latency/tokens/cost; fallback safe.
  - `runWithABUser` wraps chat streaming to bind user ID for routing.
  - 4 MCP tools: `ab_create_experiment`, `ab_list_experiments`, `ab_update_status`, `ab_get_results`.
  - Shared `@secondlayer/shared` update: `LLMClientManager.chatCompletionWithModel()` for direct model selection.

- Migration
  - Run migration 153.
  - Create an experiment and set status to running.
  - Verify variant routing in prod logs and `ab_get_results`.
  - Stop or complete the experiment to restore default routing.

<sup>Written for commit 751707c23337d41fd4513e1fed342675cb15ad63. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1795?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

