### PR TITLE
fix(ci): symlink nginx certs to prevent SSL crash on deploy

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -365,10 +365,12 @@ jobs:
             npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build
           fi
 
-      - name: Link env files from main repo
+      - name: Link env files and certs from main repo
         run: |
           ln -sf /home/vovkes/SecondLayer/deployment/.env.local deployment/.env.local
           ln -sf /home/vovkes/SecondLayer/deployment/.env.prod deployment/.env.prod 2>/dev/null || true
+          rm -rf deployment/nginx/certs
+          ln -sf /home/vovkes/SecondLayer/deployment/nginx/certs deployment/nginx/certs
 
       - name: Safety check — prod containers untouched
         run: |


### PR DESCRIPTION
## Summary
- CI checkout creates empty `deployment/nginx/certs/` dir (certs are gitignored)
- When `docker compose up --force-recreate nginx-local` runs, the bind mount points to the empty checkout dir
- Nginx crashes with `cannot load certificate` error
- Fix: symlink certs dir from main repo, same pattern already used for `.env.local`

## Test plan
- [ ] CI deploy step passes without SSL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Symlink `deployment/nginx/certs` from the main repo in CI and remove the empty checkout dir to prevent `nginx` SSL failures on deploy. This mirrors the existing `.env.local` symlink pattern and fixes `cannot load certificate` errors when running `docker compose up --force-recreate nginx-local`.

<sup>Written for commit 9674e7f47ba8ab9f84a9e272ceeb81f401609200. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1796?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

