### PR TITLE
feat(data): Nordic + UK + Ireland court decision pipelines

### DIFF
--- a/mcp_backend/src/migrations/154_nordic_court_decisions.sql
+++ b/mcp_backend/src/migrations/154_nordic_court_decisions.sql
@@ -1,0 +1,167 @@
+-- Migration 154: Nordic court decisions (Denmark, Sweden, Finland, Iceland)
+-- Sources:
+--   DK: alexandrainst/domsdatabasen HF (~4K), domsdatabasen.dk API
+--   SE: swelaw/swelaw HF (~25K), lagen.nu (10K+)
+--   FI: Finlex Open Data API (7 courts, decades), eliask/finlex-data GitHub
+--   IS: haestirettur.is, landsrettur.is, heradsdomstolar.is (scraped, ~3-5K)
+
+-- ============================================================
+-- DENMARK
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS dk_court_decisions (
+    id              TEXT PRIMARY KEY,
+    ecli            TEXT UNIQUE,
+    source          TEXT NOT NULL,
+    court_name      TEXT,
+    court_type      TEXT,
+    case_number     TEXT,
+    case_type       TEXT,
+    decision_date   DATE,
+    judge           TEXT,
+    parties         TEXT,
+    abstract        TEXT,
+    full_text       TEXT,
+    anonymized_text TEXT,
+    source_url      TEXT,
+    metadata_json   JSONB,
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dk_court_source ON dk_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_dk_court_type ON dk_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_dk_court_date ON dk_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_dk_court_case_num ON dk_court_decisions(case_number);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_dk_court_fts') THEN
+        CREATE INDEX idx_dk_court_fts ON dk_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- SWEDEN
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS se_court_decisions (
+    id              TEXT PRIMARY KEY,
+    ecli            TEXT UNIQUE,
+    source          TEXT NOT NULL,
+    court_name      TEXT,
+    court_type      TEXT,
+    case_number     TEXT,
+    decision_type   TEXT,
+    decision_date   DATE,
+    judge           TEXT,
+    subject         TEXT,
+    keywords        TEXT[],
+    parties         TEXT,
+    abstract        TEXT,
+    full_text       TEXT,
+    source_url      TEXT,
+    metadata_json   JSONB,
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_se_court_source ON se_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_se_court_type ON se_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_se_court_date ON se_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_se_court_case_num ON se_court_decisions(case_number);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_se_court_fts') THEN
+        CREATE INDEX idx_se_court_fts ON se_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- FINLAND
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS fi_court_decisions (
+    id              TEXT PRIMARY KEY,
+    ecli            TEXT UNIQUE,
+    source          TEXT NOT NULL,
+    court_name      TEXT,
+    court_type      TEXT,
+    case_number     TEXT,
+    decision_type   TEXT,
+    decision_date   DATE,
+    publication_date DATE,
+    judge           TEXT,
+    subject         TEXT,
+    keywords        TEXT[],
+    cited_provisions TEXT[],
+    parties         TEXT,
+    abstract        TEXT,
+    full_text       TEXT,
+    language        TEXT,
+    source_url      TEXT,
+    metadata_json   JSONB,
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fi_court_source ON fi_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_fi_court_type ON fi_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_fi_court_date ON fi_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_fi_court_case_num ON fi_court_decisions(case_number);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_fi_court_fts') THEN
+        CREATE INDEX idx_fi_court_fts ON fi_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- ICELAND
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS is_court_decisions (
+    id              TEXT PRIMARY KEY,
+    ecli            TEXT UNIQUE,
+    source          TEXT NOT NULL,
+    court_name      TEXT,
+    court_type      TEXT,
+    case_number     TEXT,
+    decision_type   TEXT,
+    decision_date   DATE,
+    judge           TEXT,
+    subject         TEXT,
+    parties         TEXT,
+    abstract        TEXT,
+    full_text       TEXT,
+    source_url      TEXT,
+    metadata_json   JSONB,
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_is_court_source ON is_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_is_court_type ON is_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_is_court_date ON is_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_is_court_case_num ON is_court_decisions(case_number);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_is_court_fts') THEN
+        CREATE INDEX idx_is_court_fts ON is_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;

--- a/mcp_backend/src/migrations/155_uk_ie_court_decisions.sql
+++ b/mcp_backend/src/migrations/155_uk_ie_court_decisions.sql
@@ -1,0 +1,87 @@
+-- Migration 155: UK and Ireland court decisions
+-- Sources:
+--   UK: National Archives Case Law API (~70K), santoshtyss/uk_courts_cases HF (43K), JuDDGES/en-court-raw HF (6K)
+--   IE: courts.ie scraping (~16K)
+
+-- ============================================================
+-- UNITED KINGDOM
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS uk_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    ecli                TEXT UNIQUE,
+    source              TEXT NOT NULL,  -- 'national-archives', 'hf-uk-courts', 'hf-juddges-en'
+    court_name          TEXT,
+    court_code          TEXT,           -- 'uksc', 'ewca/civ', 'ewhc/admin', etc.
+    case_number         TEXT,
+    neutral_citation    TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    judge               TEXT,
+    judges              JSONB,
+    subject             TEXT,
+    keywords            TEXT[],
+    parties             TEXT,
+    abstract            TEXT,
+    full_text           TEXT,
+    source_url          TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_uk_court_source ON uk_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_uk_court_code ON uk_court_decisions(court_code);
+CREATE INDEX IF NOT EXISTS idx_uk_court_date ON uk_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_uk_court_case_num ON uk_court_decisions(case_number);
+CREATE INDEX IF NOT EXISTS idx_uk_court_neutral_cit ON uk_court_decisions(neutral_citation);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_uk_court_fts') THEN
+        CREATE INDEX idx_uk_court_fts ON uk_court_decisions
+            USING GIN (to_tsvector('english',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- IRELAND
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ie_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    ecli                TEXT UNIQUE,
+    source              TEXT NOT NULL,  -- 'courts-ie'
+    court_name          TEXT,
+    court_type          TEXT,           -- 'Supreme Court', 'High Court', 'Court of Appeal'
+    case_number         TEXT,
+    neutral_citation    TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    judge               TEXT,
+    parties             TEXT,
+    abstract            TEXT,
+    full_text           TEXT,
+    source_url          TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ie_court_source ON ie_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_ie_court_type ON ie_court_decisions(court_type);
+CREATE INDEX IF NOT EXISTS idx_ie_court_date ON ie_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_ie_court_case_num ON ie_court_decisions(case_number);
+CREATE INDEX IF NOT EXISTS idx_ie_court_neutral_cit ON ie_court_decisions(neutral_citation);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ie_court_fts') THEN
+        CREATE INDEX idx_ie_court_fts ON ie_court_decisions
+            USING GIN (to_tsvector('english',
+                coalesce(parties, '') || ' ' ||
+                coalesce(abstract, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;

--- a/scripts/opendata/download_denmark.py
+++ b/scripts/opendata/download_denmark.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Download Danish court decisions from HuggingFace datasets.
+
+Sources:
+1. alexandrainst/domsdatabasen - ~3,917 Danish court decisions (~199 MB Parquet)
+2. danish-foundation-models/danish-dynaword - domsdatabasen subset (8,470 rows)
+"""
+
+import json
+import os
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from huggingface_hub import snapshot_download
+
+BASE_DIR = Path("/home/ubuntu/opendata/denmark")
+HF_DIR = BASE_DIR / "huggingface"
+
+HF_DATASETS = {
+    "domsdatabasen": "alexandrainst/domsdatabasen",
+    "danish-dynaword": "danish-foundation-models/danish-dynaword",
+}
+
+
+def download_file(url: str, dest: Path, session: requests.Session = None):
+    """Download a file with resume support and retry logic."""
+    s = session or requests.Session()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    headers = {}
+    mode = "wb"
+    if dest.exists():
+        existing = dest.stat().st_size
+        headers["Range"] = f"bytes={existing}-"
+        mode = "ab"
+    for attempt in range(5):
+        try:
+            resp = s.get(url, headers=headers, stream=True, timeout=120)
+            if resp.status_code == 416:
+                return
+            resp.raise_for_status()
+            with open(dest, mode) as f:
+                for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                    f.write(chunk)
+            return
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                print(f"  Attempt {attempt+1} failed: {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+
+
+def download_huggingface_domsdatabasen():
+    """Download alexandrainst/domsdatabasen from HuggingFace."""
+    repo_id = HF_DATASETS["domsdatabasen"]
+    local_dir = HF_DIR / "domsdatabasen"
+    print(f"\n{'='*60}")
+    print(f"Downloading {repo_id} -> {local_dir}")
+    print(f"Expected: ~3,917 decisions, ~199 MB Parquet")
+    print(f"{'='*60}")
+    t0 = time.time()
+    try:
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            local_dir=str(local_dir),
+            resume_download=True,
+            max_workers=20,
+        )
+        elapsed = time.time() - t0
+        size = sum(f.stat().st_size for f in local_dir.rglob("*") if f.is_file())
+        print(f"Done: {repo_id} ({size / (1024**2):.1f} MB in {elapsed:.1f}s)")
+    except Exception as e:
+        print(f"ERROR downloading {repo_id}: {e}")
+        raise
+
+
+def download_huggingface_dynaword():
+    """Download danish-foundation-models/danish-dynaword from HuggingFace."""
+    repo_id = HF_DATASETS["danish-dynaword"]
+    local_dir = HF_DIR / "danish-dynaword"
+    print(f"\n{'='*60}")
+    print(f"Downloading {repo_id} -> {local_dir}")
+    print(f"Expected: ~8,470 rows (domsdatabasen subset)")
+    print(f"{'='*60}")
+    t0 = time.time()
+    try:
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            local_dir=str(local_dir),
+            resume_download=True,
+            max_workers=20,
+        )
+        elapsed = time.time() - t0
+        size = sum(f.stat().st_size for f in local_dir.rglob("*") if f.is_file())
+        print(f"Done: {repo_id} ({size / (1024**2):.1f} MB in {elapsed:.1f}s)")
+    except Exception as e:
+        print(f"ERROR downloading {repo_id}: {e}")
+        raise
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    HF_DIR.mkdir(parents=True, exist_ok=True)
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "hf"):
+        download_huggingface_domsdatabasen()
+        download_huggingface_dynaword()
+    elif mode == "dynaword":
+        download_huggingface_dynaword()
+
+    print("\n" + "=" * 60)
+    print("All Danish downloads complete!")
+    total_size = sum(f.stat().st_size for f in BASE_DIR.rglob("*") if f.is_file())
+    print(f"Total size: {total_size / (1024**3):.2f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/download_finland.py
+++ b/scripts/opendata/download_finland.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Download Finnish court decisions from multiple sources.
+
+Sources:
+1. Finlex Open Data API (https://opendata.finlex.fi/finlex/avoindata/v1)
+   - judgmentDocumentType values that work: chancellor-of-justice-decision,
+     data-protection-ombudsman-decision
+   - Court decisions (KKO, KHO, etc.) are NOT available via API judgment endpoint
+   - Format: Akoma Ntoso XML, max 10 per page
+
+2. Finlex website scraping (https://www.finlex.fi/fi/oikeuskaytanto/)
+   - KKO precedents: /fi/oikeuskaytanto/korkein-oikeus/ennakkopaatokset/{year}/{number}
+   - KHO yearbook: /fi/oikeuskaytanto/korkein-hallinto-oikeus/vuosikirjat/{year}/{number}
+   - Hovioikeudet: /fi/oikeuskaytanto/hovioikeudet/{year}/{number}
+   - Hallinto-oikeudet: /fi/oikeuskaytanto/hallinto-oikeudet/{year}/{number}
+
+3. eliask/finlex-data GitHub repository (KKO + KHO XML/JSON-LD dump)
+   - https://github.com/eliask/finlex-data
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path("/home/ubuntu/opendata/finland")
+FINLEX_API_DIR = BASE_DIR / "finlex-api"
+FINLEX_WEB_DIR = BASE_DIR / "finlex-web"
+GITHUB_DIR = BASE_DIR / "github-finlex-data"
+
+FINLEX_API = "https://opendata.finlex.fi/finlex/avoindata/v1"
+FINLEX_WEB = "https://www.finlex.fi"
+
+API_JUDGMENT_TYPES = [
+    "chancellor-of-justice-decision",
+    "data-protection-ombudsman-decision",
+]
+
+WEB_COURTS = {
+    "kko-ennakkopaatokset": "/fi/oikeuskaytanto/korkein-oikeus/ennakkopaatokset",
+    "kko-muut": "/fi/oikeuskaytanto/korkein-oikeus/muut-paatokset",
+    "kho-ennakkopaatokset": "/fi/oikeuskaytanto/korkein-hallinto-oikeus/ennakkopaatokset",
+    "kho-muut": "/fi/oikeuskaytanto/korkein-hallinto-oikeus/muut-paatokset",
+    "kho-lyhyet": "/fi/oikeuskaytanto/korkein-hallinto-oikeus/lyhyet-ratkaisuselosteet",
+    "hovioikeudet": "/fi/oikeuskaytanto/hovioikeudet",
+    "hallinto-oikeudet": "/fi/oikeuskaytanto/hallinto-oikeudet",
+}
+
+LOCAL_IPS = [
+    "172.31.29.20",
+    "172.31.21.255",
+    "172.31.31.40",
+    "172.31.22.206",
+    "172.31.28.109",
+    "172.31.21.47",
+]
+
+MAX_WORKERS = 10
+API_PAGE_LIMIT = 10
+USER_AGENT = "SecondLayer-LegalDataCollector/1.0 (legal.org.ua; research)"
+
+
+class MultiIPAdapter(requests.adapters.HTTPAdapter):
+    """Bind outgoing requests to a specific local IP."""
+    def __init__(self, source_address, **kwargs):
+        self.source_address = source_address
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["source_address"] = (self.source_address, 0)
+        super().init_poolmanager(*args, **kwargs)
+
+
+def create_sessions() -> list:
+    """Create one session per local IP for parallel multi-IP requests."""
+    sessions = []
+    for ip in LOCAL_IPS:
+        s = requests.Session()
+        s.headers["User-Agent"] = USER_AGENT
+        adapter = MultiIPAdapter(source_address=ip)
+        s.mount("https://", adapter)
+        s.mount("http://", adapter)
+        sessions.append(s)
+    return sessions
+
+
+def get_session_for_index(sessions: list, idx: int) -> requests.Session:
+    """Round-robin session selection."""
+    return sessions[idx % len(sessions)]
+
+
+def fetch_with_retry(url: str, session: requests.Session, retries: int = 5, accept: str = None) -> requests.Response:
+    """Fetch URL with retry and 429 backoff. Returns response or raises."""
+    for attempt in range(retries):
+        try:
+            headers = {}
+            if accept:
+                headers["Accept"] = accept
+            resp = session.get(url, timeout=60, headers=headers)
+            if resp.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                print(f"  Rate limited (429), waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None and e.response.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                time.sleep(wait)
+                continue
+            if attempt < retries - 1:
+                wait = 2 ** attempt
+                print(f"  Attempt {attempt+1} failed: {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+        except Exception as e:
+            if attempt < retries - 1:
+                wait = 2 ** attempt
+                print(f"  Attempt {attempt+1} failed: {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+    return None
+
+
+# ============================================================
+# Part 1: Finlex Open Data API (chancellor + ombudsman decisions)
+# ============================================================
+
+def download_api_judgment_type(jtype: str, session: requests.Session) -> int:
+    """Download all decisions for a judgment type from Finlex API (XML, max 10/page)."""
+    out_dir = FINLEX_API_DIR / jtype
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    checkpoint_file = out_dir / "checkpoint.json"
+    start_page = 1
+    if checkpoint_file.exists():
+        with open(checkpoint_file) as f:
+            cp = json.load(f)
+            start_page = cp.get("last_completed_page", 0) + 1
+            print(f"  Resuming {jtype} from page {start_page}")
+
+    page = start_page
+    total = 0
+    t0 = time.time()
+
+    while True:
+        url = f"{FINLEX_API}/akn/fi/judgment/{jtype}?page={page}&limit={API_PAGE_LIMIT}"
+        resp = fetch_with_retry(url, session)
+        if resp is None or resp.status_code == 404:
+            break
+
+        xml_content = resp.text
+        if not xml_content or "<Results" not in xml_content:
+            break
+
+        xml_file = out_dir / f"page_{page:05d}.xml"
+        with open(xml_file, "w", encoding="utf-8") as f:
+            f.write(xml_content)
+
+        count_in_page = xml_content.count("<akomaNtoso")
+        total += count_in_page
+
+        with open(checkpoint_file, "w") as f:
+            json.dump({"last_completed_page": page, "type": jtype}, f)
+
+        elapsed = time.time() - t0
+        rate = total / elapsed if elapsed > 0 else 0
+        print(f"    {jtype} page {page}: {total} decisions ({rate:.1f}/s)")
+
+        if count_in_page < API_PAGE_LIMIT:
+            break
+        page += 1
+
+    print(f"  {jtype} complete: {total} decisions")
+    return total
+
+
+def download_finlex_api():
+    """Download decisions from Finlex API (only working judgment types). Uses multi-IP."""
+    FINLEX_API_DIR.mkdir(parents=True, exist_ok=True)
+
+    sessions = create_sessions()
+    print(f"\nFinlex Open Data API: downloading {len(API_JUDGMENT_TYPES)} judgment types")
+    print(f"  Using {len(sessions)} IPs for parallel downloads")
+
+    total = 0
+    for jtype in API_JUDGMENT_TYPES:
+        print(f"\n  Type: {jtype}")
+        count = download_api_judgment_type(jtype, sessions[0])
+        total += count
+
+    print(f"\nFinlex API complete: {total} decisions total")
+
+
+# ============================================================
+# Part 2: Finlex website scraping (KKO, KHO, hovioikeudet, etc.)
+# ============================================================
+
+def discover_decisions_for_court(court: str, base_path: str, session: requests.Session) -> list:
+    """Discover all available decision URLs for a court by scanning year pages."""
+    all_decisions = []
+
+    resp = fetch_with_retry(f"{FINLEX_WEB}{base_path}", session)
+    if resp is None:
+        return []
+
+    years = re.findall(re.escape(base_path) + r'/(\d{4})', resp.text)
+    if not years:
+        years = [str(y) for y in range(2019, 2027)]
+
+    for year in sorted(set(years)):
+        year_url = f"{FINLEX_WEB}{base_path}/{year}"
+        try:
+            resp = fetch_with_retry(year_url, session)
+            if resp is None:
+                continue
+        except Exception:
+            continue
+
+        decisions = re.findall(
+            re.escape(base_path) + r'/' + year + r'/(\d+)',
+            resp.text
+        )
+        unique_nums = sorted(set(decisions), key=int)
+        for num in unique_nums:
+            all_decisions.append((year, num))
+
+        if unique_nums:
+            print(f"    {court}/{year}: {len(unique_nums)} decisions found")
+        time.sleep(0.3)
+
+    return all_decisions
+
+
+def download_web_decision(court: str, base_path: str, year: str, number: str, session: requests.Session) -> bool:
+    """Download a single decision page from finlex.fi."""
+    court_dir = FINLEX_WEB_DIR / court / year
+    court_dir.mkdir(parents=True, exist_ok=True)
+
+    html_path = court_dir / f"{number}.html"
+    if html_path.exists() and html_path.stat().st_size > 500:
+        return True
+
+    url = f"{FINLEX_WEB}{base_path}/{year}/{number}"
+    try:
+        resp = fetch_with_retry(url, session)
+        if resp is None:
+            return False
+        with open(html_path, "w", encoding="utf-8") as f:
+            f.write(resp.text)
+        return True
+    except Exception:
+        return False
+
+
+def download_finlex_web():
+    """Scrape court decisions from finlex.fi website. Uses multi-IP for parallelism."""
+    FINLEX_WEB_DIR.mkdir(parents=True, exist_ok=True)
+
+    sessions = create_sessions()
+    num_workers = len(LOCAL_IPS) * MAX_WORKERS  # 6 IPs × 10 = 60 parallel
+    print(f"\nFinlex website scraping: {len(WEB_COURTS)} courts")
+    print(f"  Using {len(sessions)} IPs, {num_workers} total workers")
+
+    total = 0
+    for court, base_path in WEB_COURTS.items():
+        print(f"\n  Court: {court} ({base_path})")
+
+        checkpoint_file = FINLEX_WEB_DIR / court / "checkpoint.json"
+        completed = set()
+        if checkpoint_file.exists():
+            with open(checkpoint_file) as f:
+                cp = json.load(f)
+                completed = set(tuple(x) for x in cp.get("completed", []))
+                print(f"  Resuming, {len(completed)} already downloaded")
+
+        decisions = discover_decisions_for_court(court, base_path, sessions[0])
+        pending = [(y, n) for (y, n) in decisions if (y, n) not in completed]
+        print(f"  Total: {len(decisions)}, pending: {len(pending)}")
+
+        downloaded = 0
+        t0 = time.time()
+
+        for i in range(0, len(pending), num_workers):
+            batch = pending[i:i + num_workers]
+            with ThreadPoolExecutor(max_workers=num_workers) as pool:
+                futures = {}
+                for idx, (y, n) in enumerate(batch):
+                    s = get_session_for_index(sessions, idx)
+                    futures[pool.submit(download_web_decision, court, base_path, y, n, s)] = (y, n)
+
+                for future in as_completed(futures):
+                    key = futures[future]
+                    try:
+                        if future.result():
+                            downloaded += 1
+                            completed.add(key)
+                    except Exception as e:
+                        print(f"    Failed {key}: {e}")
+
+            (FINLEX_WEB_DIR / court).mkdir(parents=True, exist_ok=True)
+            with open(checkpoint_file, "w") as f:
+                json.dump({"completed": list(completed)}, f)
+
+        elapsed = time.time() - t0
+        rate = downloaded / elapsed if elapsed > 0 else 0
+        print(f"  {court} complete: {downloaded} new decisions ({rate:.1f}/s)")
+        total += downloaded
+
+    print(f"\nFinlex web scraping complete: {total} decisions total")
+
+
+def download_github_repo():
+    """Clone or update eliask/finlex-data GitHub repository."""
+    GITHUB_DIR.parent.mkdir(parents=True, exist_ok=True)
+
+    repo_url = "https://github.com/eliask/finlex-data.git"
+
+    if (GITHUB_DIR / ".git").exists():
+        print(f"\nGitHub repo exists, pulling updates: {GITHUB_DIR}")
+        result = subprocess.run(
+            ["git", "-C", str(GITHUB_DIR), "pull", "--ff-only"],
+            capture_output=True, text=True, timeout=600,
+        )
+        if result.returncode == 0:
+            print(f"  Pull successful")
+        else:
+            print(f"  Pull failed: {result.stderr}")
+            print("  Trying fetch + reset...")
+            subprocess.run(
+                ["git", "-C", str(GITHUB_DIR), "fetch", "origin"],
+                capture_output=True, text=True, timeout=600,
+            )
+    else:
+        print(f"\nCloning eliask/finlex-data (shallow) -> {GITHUB_DIR}")
+        result = subprocess.run(
+            ["git", "clone", "--depth", "1", repo_url, str(GITHUB_DIR)],
+            capture_output=True, text=True, timeout=1800,
+        )
+        if result.returncode == 0:
+            print(f"  Clone successful")
+        else:
+            print(f"  Clone failed: {result.stderr}")
+            raise RuntimeError(f"git clone failed: {result.stderr}")
+
+    # Report size
+    if GITHUB_DIR.exists():
+        size = sum(f.stat().st_size for f in GITHUB_DIR.rglob("*") if f.is_file())
+        print(f"  GitHub repo size: {size / (1024**3):.2f} GB")
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "api"):
+        download_finlex_api()
+    if mode in ("all", "web"):
+        download_finlex_web()
+    if mode in ("all", "github"):
+        download_github_repo()
+
+    print("\n" + "=" * 60)
+    print("All Finnish downloads complete!")
+    total_size = sum(f.stat().st_size for f in BASE_DIR.rglob("*") if f.is_file())
+    print(f"Total size: {total_size / (1024**3):.1f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/download_iceland.py
+++ b/scripts/opendata/download_iceland.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Download Icelandic court decisions from island.is GraphQL API.
+
+Sources:
+- island.is/domar - Unified portal for all Icelandic court decisions
+  Uses GraphQL API for listing and Next.js data routes for full text.
+
+Courts:
+- Haestirettur (Supreme Court)
+- Landsrettur (Court of Appeals)
+- Heradsdomur (District Courts)
+"""
+
+import base64
+import json
+import os
+import re
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+BASE_DIR = Path("/home/ubuntu/opendata/iceland")
+
+COURTS = ["Hæstiréttur", "Landsréttur", "Héraðsdómur"]
+COURT_DIR_NAMES = {
+    "Hæstiréttur": "haestirettur",
+    "Landsréttur": "landsrettur",
+    "Héraðsdómur": "heradsdomur",
+}
+
+GRAPHQL_URL = "https://island.is/api/graphql"
+ISLAND_BASE = "https://island.is"
+ITEMS_PER_PAGE = 10
+
+MAX_WORKERS_PER_IP = 3
+BATCH_DELAY = 1.0
+USER_AGENT = "SecondLayer-LegalDataCollector/1.0 (legal.org.ua; research)"
+
+LOCAL_IPS = [
+    "172.31.29.20",
+    "172.31.21.255",
+    "172.31.31.40",
+    "172.31.22.206",
+    "172.31.28.109",
+    "172.31.21.47",
+]
+
+
+GRAPHQL_QUERY = """
+query GetVerdicts($input: WebVerdictsInput!) {
+  webVerdicts(input: $input) {
+    total
+    items {
+      id
+      title
+      court
+      caseNumber
+      verdictDate
+      keywords
+      presentings
+    }
+  }
+}
+"""
+
+
+def create_multi_ip_sessions() -> list:
+    """Create one session per local IP for parallel multi-IP requests."""
+    sessions = []
+    for ip in LOCAL_IPS:
+        s = requests.Session()
+        s.headers["User-Agent"] = USER_AGENT
+        s.headers["Accept"] = "application/json"
+
+        class BoundAdapter(requests.adapters.HTTPAdapter):
+            def __init__(self, source_addr, **kw):
+                self._source = source_addr
+                super().__init__(**kw)
+
+            def init_poolmanager(self, *a, **kw):
+                kw["source_address"] = (self._source, 0)
+                super().init_poolmanager(*a, **kw)
+
+        adapter = BoundAdapter(ip)
+        s.mount("https://", adapter)
+        s.mount("http://", adapter)
+        sessions.append(s)
+    return sessions
+
+
+def save_checkpoint(checkpoint_file: Path, data: dict):
+    """Save checkpoint atomically."""
+    tmp = checkpoint_file.with_suffix(".tmp")
+    with open(tmp, "w") as f:
+        json.dump(data, f, ensure_ascii=False)
+    tmp.rename(checkpoint_file)
+
+
+def load_checkpoint(checkpoint_file: Path) -> dict:
+    """Load checkpoint if exists."""
+    if checkpoint_file.exists():
+        with open(checkpoint_file) as f:
+            return json.load(f)
+    return {}
+
+
+def get_build_id(session: requests.Session) -> str:
+    """Extract Next.js buildId from island.is/domar page."""
+    for attempt in range(5):
+        try:
+            resp = session.get(f"{ISLAND_BASE}/domar", timeout=30)
+            resp.raise_for_status()
+            html = resp.text
+            # Look for buildId in the page HTML (Next.js embeds it)
+            match = re.search(r'"buildId"\s*:\s*"([^"]+)"', html)
+            if match:
+                return match.group(1)
+            # Alternative pattern in __NEXT_DATA__
+            match = re.search(r'__NEXT_DATA__.*?"buildId"\s*:\s*"([^"]+)"', html, re.DOTALL)
+            if match:
+                return match.group(1)
+            raise ValueError("buildId not found in page HTML")
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                print(f"  Failed to get buildId (attempt {attempt+1}): {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+
+
+def fetch_verdict_list(court: str, page: int, session: requests.Session) -> dict:
+    """Fetch a page of verdicts from the GraphQL API."""
+    payload = {
+        "query": GRAPHQL_QUERY,
+        "variables": {
+            "input": {
+                "court": court,
+                "page": page,
+            }
+        }
+    }
+    for attempt in range(5):
+        try:
+            resp = session.post(
+                GRAPHQL_URL,
+                json=payload,
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            if resp.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                print(f"  Rate limited (429), waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("data", {}).get("webVerdicts", {})
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                print(f"  GraphQL fetch page {page} failed (attempt {attempt+1}): {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                print(f"  GraphQL fetch page {page} FAILED after 5 attempts: {e}")
+                return {}
+    return {}
+
+
+def fetch_verdict_detail(verdict_id: str, build_id: str, session: requests.Session) -> dict:
+    """Fetch full verdict detail via Next.js data route."""
+    url = f"{ISLAND_BASE}/_next/data/{build_id}/domar/{verdict_id}.json"
+    for attempt in range(5):
+        try:
+            resp = session.get(url, timeout=60)
+            if resp.status_code == 404:
+                return None
+            if resp.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                print(f"  Rate limited on detail {verdict_id}, waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                print(f"    FAILED detail for {verdict_id}: {e}")
+                return None
+    return None
+
+
+def extract_detail_data(detail_json: dict) -> dict:
+    """Extract verdict data from the nested Next.js JSON response."""
+    if not detail_json:
+        return {}
+    # Navigate nested pageProps structure
+    page_props = detail_json.get("pageProps", {})
+    # Try multiple nesting levels as structure may vary
+    item = None
+    # Direct pageProps.componentProps.item
+    if "componentProps" in page_props:
+        item = page_props["componentProps"].get("item")
+    # Nested pageProps.pageProps.pageProps.componentProps.item
+    if not item and "pageProps" in page_props:
+        inner = page_props["pageProps"]
+        if isinstance(inner, dict) and "pageProps" in inner:
+            inner2 = inner["pageProps"]
+            if isinstance(inner2, dict) and "componentProps" in inner2:
+                item = inner2["componentProps"].get("item")
+        elif isinstance(inner, dict) and "componentProps" in inner:
+            item = inner["componentProps"].get("item")
+    # Also try top-level props
+    if not item:
+        item = page_props.get("item")
+    return item or page_props
+
+
+def save_verdict(court_dir: Path, verdict_id: str, list_item: dict, detail_data: dict):
+    """Save verdict JSON and PDF (if available) to disk."""
+    # Save combined JSON
+    combined = {
+        "list_item": list_item,
+        "detail": detail_data,
+    }
+    json_path = court_dir / f"{verdict_id}.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(combined, f, ensure_ascii=False, indent=2)
+
+    # Save PDF if pdfString is available (base64 encoded)
+    pdf_string = None
+    if isinstance(detail_data, dict):
+        pdf_string = detail_data.get("pdfString")
+    if pdf_string:
+        try:
+            pdf_bytes = base64.b64decode(pdf_string)
+            pdf_path = court_dir / f"{verdict_id}.pdf"
+            with open(pdf_path, "wb") as f:
+                f.write(pdf_bytes)
+        except Exception as e:
+            print(f"    Warning: failed to decode PDF for {verdict_id}: {e}")
+
+
+def download_court(court: str, build_id: str, sessions: list):
+    """Download all verdicts for a given court."""
+    court_dir_name = COURT_DIR_NAMES[court]
+    court_dir = BASE_DIR / court_dir_name
+    court_dir.mkdir(parents=True, exist_ok=True)
+
+    checkpoint_file = court_dir / "checkpoint.json"
+    checkpoint = load_checkpoint(checkpoint_file)
+    completed_ids = set(checkpoint.get("completed_ids", []))
+
+    num_workers = len(LOCAL_IPS) * MAX_WORKERS_PER_IP  # 6 x 3 = 18
+
+    print(f"\n  Court: {court} ({court_dir_name})")
+    print(f"  Workers: {num_workers}")
+
+    if completed_ids:
+        print(f"  Resuming: {len(completed_ids)} already downloaded")
+
+    # First, enumerate all verdicts via GraphQL pagination
+    print(f"  Fetching verdict list...")
+    all_items = []
+    page = 1
+
+    # Get first page to find total
+    first_result = fetch_verdict_list(court, 1, sessions[0])
+    total = first_result.get("total", 0)
+    items = first_result.get("items", [])
+    all_items.extend(items)
+
+    if total == 0:
+        print(f"  No verdicts found for {court}")
+        return 0
+
+    total_pages = (total + ITEMS_PER_PAGE - 1) // ITEMS_PER_PAGE
+    print(f"  Total: {total} verdicts across {total_pages} pages")
+
+    # Fetch remaining pages
+    for page in range(2, total_pages + 1):
+        session = sessions[(page - 1) % len(sessions)]
+        result = fetch_verdict_list(court, page, session)
+        items = result.get("items", [])
+        if not items:
+            break
+        all_items.extend(items)
+
+        if page % 20 == 0:
+            print(f"    Listed {page}/{total_pages} pages ({len(all_items)} items)")
+        time.sleep(0.3)  # Be polite during listing
+
+    print(f"  Listed {len(all_items)} verdicts total")
+
+    # Filter out already completed
+    to_download = []
+    for item in all_items:
+        verdict_id = item.get("id")
+        if verdict_id and verdict_id not in completed_ids:
+            to_download.append(item)
+
+    print(f"  To download: {len(to_download)} (skipping {len(all_items) - len(to_download)} completed)")
+
+    if not to_download:
+        return 0
+
+    # Download details in parallel batches
+    total_downloaded = 0
+    t0 = time.time()
+
+    for i in range(0, len(to_download), num_workers):
+        batch = to_download[i:i + num_workers]
+
+        with ThreadPoolExecutor(max_workers=num_workers) as pool:
+            futures = {}
+            for idx, item in enumerate(batch):
+                verdict_id = item["id"]
+                s = sessions[idx % len(sessions)]
+                fut = pool.submit(fetch_verdict_detail, verdict_id, build_id, s)
+                futures[fut] = item
+
+            for future in as_completed(futures):
+                item = futures[future]
+                verdict_id = item["id"]
+                try:
+                    detail_json = future.result()
+                    if detail_json is not None:
+                        detail_data = extract_detail_data(detail_json)
+                        save_verdict(court_dir, verdict_id, item, detail_data)
+                        completed_ids.add(verdict_id)
+                        total_downloaded += 1
+                    else:
+                        # Still mark as completed if 404 (verdict doesn't exist)
+                        completed_ids.add(verdict_id)
+                except Exception as e:
+                    print(f"    ERROR {verdict_id}: {e}")
+
+        # Save checkpoint after each batch
+        save_checkpoint(checkpoint_file, {"completed_ids": list(completed_ids)})
+
+        # Polite delay between batches
+        time.sleep(BATCH_DELAY)
+
+        # Progress report
+        elapsed = time.time() - t0
+        rate = total_downloaded / elapsed if elapsed > 0 else 0
+        print(f"    Progress: {i + len(batch)}/{len(to_download)} | downloaded: {total_downloaded} | {rate:.1f}/s")
+
+    elapsed = time.time() - t0
+    print(f"  {court} complete: {total_downloaded} verdicts in {elapsed:.0f}s")
+    return total_downloaded
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    sessions = create_multi_ip_sessions()
+
+    # Get buildId (needed for detail fetches)
+    print(f"{'='*60}")
+    print(f"Downloading Icelandic court decisions from island.is")
+    print(f"{'='*60}")
+    print(f"\nFetching Next.js buildId from island.is/domar...")
+    build_id = get_build_id(sessions[0])
+    print(f"  buildId: {build_id}")
+
+    total_downloaded = 0
+
+    courts_to_download = COURTS
+    if mode == "supreme":
+        courts_to_download = ["Hæstiréttur"]
+    elif mode == "appeals":
+        courts_to_download = ["Landsréttur"]
+    elif mode == "district":
+        courts_to_download = ["Héraðsdómur"]
+    elif mode != "all":
+        # Allow passing court dir name directly
+        name_to_court = {v: k for k, v in COURT_DIR_NAMES.items()}
+        if mode in name_to_court:
+            courts_to_download = [name_to_court[mode]]
+        else:
+            print(f"Unknown mode: {mode}")
+            print(f"Valid modes: all, supreme, appeals, district, haestirettur, landsrettur, heradsdomur")
+            sys.exit(1)
+
+    for court in courts_to_download:
+        downloaded = download_court(court, build_id, sessions)
+        total_downloaded += downloaded
+
+    print(f"\n{'='*60}")
+    print(f"All Icelandic downloads complete! Total: {total_downloaded} verdicts")
+    if BASE_DIR.exists():
+        total_size = sum(f.stat().st_size for f in BASE_DIR.rglob("*") if f.is_file())
+        print(f"Total size: {total_size / (1024**3):.2f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/download_ireland.py
+++ b/scripts/opendata/download_ireland.py
@@ -1,0 +1,485 @@
+#!/usr/bin/env python3
+"""Download Irish court decisions from courts.ie (HTML scraping).
+
+Source: https://www2.courts.ie/Judgments
+- Paginated HTML listing sorted by delivery date (descending)
+- Individual judgments as HTML pages or PDF files
+- Coverage: Supreme Court 2001+, High Court 2004+, Court of Appeal 2014+
+- Estimated ~16K judgments total
+
+No API available -- requires HTML scraping.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.parse import urljoin, urlparse
+
+BASE_DIR = Path("/home/ubuntu/opendata/ireland")
+LISTING_URL = "https://www2.courts.ie/Judgments?sort=desc:DateOfDelivery&page={page}"
+BASE_URL = "https://www2.courts.ie"
+
+MAX_WORKERS_PER_IP = 5
+BATCH_DELAY = 1.5
+USER_AGENT = "SecondLayer-Legal-Research/1.0 (academic research)"
+
+LOCAL_IPS = [
+    "172.31.29.20",
+    "172.31.21.255",
+    "172.31.31.40",
+    "172.31.22.206",
+    "172.31.28.109",
+    "172.31.21.47",
+]
+
+# Court type mapping from URL patterns
+COURT_TYPES = {
+    "supreme": "supreme-court",
+    "court-of-appeal": "court-of-appeal",
+    "high": "high-court",
+    "circuit": "circuit-court",
+    "district": "district-court",
+    "special": "special-court",
+}
+
+
+def create_multi_ip_sessions() -> list:
+    """Create one session per local IP for parallel multi-IP requests."""
+    sessions = []
+    for ip in LOCAL_IPS:
+        s = requests.Session()
+        s.headers["User-Agent"] = USER_AGENT
+        s.headers["Accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        s.headers["Accept-Language"] = "en-IE,en;q=0.9"
+
+        class BoundAdapter(requests.adapters.HTTPAdapter):
+            def __init__(self, source_addr, **kw):
+                self._source = source_addr
+                super().__init__(**kw)
+
+            def init_poolmanager(self, *a, **kw):
+                kw["source_address"] = (self._source, 0)
+                super().init_poolmanager(*a, **kw)
+
+        adapter = BoundAdapter(ip)
+        s.mount("https://", adapter)
+        s.mount("http://", adapter)
+        sessions.append(s)
+    return sessions
+
+
+def save_checkpoint(checkpoint_file: Path, data: dict):
+    """Save checkpoint atomically."""
+    tmp = checkpoint_file.with_suffix(".tmp")
+    with open(tmp, "w") as f:
+        json.dump(data, f, ensure_ascii=False)
+    tmp.rename(checkpoint_file)
+
+
+def load_checkpoint(checkpoint_file: Path) -> dict:
+    """Load checkpoint if exists."""
+    if checkpoint_file.exists():
+        with open(checkpoint_file) as f:
+            return json.load(f)
+    return {}
+
+
+def classify_court_type(url: str) -> str:
+    """Classify the court type from a judgment URL path."""
+    url_lower = url.lower()
+    if "supreme" in url_lower:
+        return "supreme-court"
+    elif "court-of-appeal" in url_lower or "courtofappeal" in url_lower:
+        return "court-of-appeal"
+    elif "high" in url_lower:
+        return "high-court"
+    elif "circuit" in url_lower:
+        return "circuit-court"
+    elif "district" in url_lower:
+        return "district-court"
+    else:
+        return "other"
+
+
+def extract_case_id(url: str) -> str:
+    """Extract a unique case ID from a judgment URL."""
+    parsed = urlparse(url)
+    path = parsed.path.rstrip("/")
+    # Use last path segment as base ID
+    segments = [s for s in path.split("/") if s]
+    if segments:
+        case_id = segments[-1]
+    else:
+        case_id = url.replace("/", "_").replace(":", "")
+    # Clean up for filesystem
+    case_id = re.sub(r'[^\w\-.]', '_', case_id)
+    return case_id
+
+
+def fetch_listing_page(page_num: int, session: requests.Session) -> str | None:
+    """Fetch a listing page from courts.ie."""
+    url = LISTING_URL.format(page=page_num)
+    for attempt in range(5):
+        try:
+            resp = session.get(url, timeout=30)
+            if resp.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                print(f"  Rate limited (429) on listing page {page_num}, waiting {wait}s...")
+                time.sleep(wait)
+                continue
+            if resp.status_code >= 500:
+                wait = min(2 ** (attempt + 1), 60)
+                print(f"  Server error {resp.status_code} on listing page {page_num}, retry in {wait}s...")
+                time.sleep(wait)
+                continue
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.text
+        except requests.exceptions.RequestException as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                print(f"  FAILED listing page {page_num}: {e}")
+                return None
+    return None
+
+
+def extract_judgment_links(html: str) -> list[dict]:
+    """Extract judgment links from a listing page HTML.
+
+    Returns list of dicts with keys: url, title, court, date
+    """
+    judgments = []
+
+    # Pattern 1: Look for judgment links in typical courts.ie HTML structure
+    # Links usually follow pattern: /Judgments/... or /view/...
+    link_pattern = re.compile(
+        r'<a[^>]+href=["\'](/[Jj]udg[^"\']*?)["\'][^>]*>(.*?)</a>',
+        re.DOTALL
+    )
+
+    for match in link_pattern.finditer(html):
+        href = match.group(1)
+        link_text = re.sub(r'<[^>]+>', '', match.group(2)).strip()
+        if href and link_text and len(link_text) > 3:
+            full_url = urljoin(BASE_URL, href)
+            judgments.append({
+                "url": full_url,
+                "title": link_text,
+            })
+
+    # Pattern 2: Alternative link format with /view/ prefix
+    view_pattern = re.compile(
+        r'<a[^>]+href=["\'](/view/[^"\']+)["\'][^>]*>(.*?)</a>',
+        re.DOTALL
+    )
+    seen_urls = {j["url"] for j in judgments}
+    for match in view_pattern.finditer(html):
+        href = match.group(1)
+        link_text = re.sub(r'<[^>]+>', '', match.group(2)).strip()
+        full_url = urljoin(BASE_URL, href)
+        if full_url not in seen_urls and link_text and len(link_text) > 3:
+            judgments.append({
+                "url": full_url,
+                "title": link_text,
+            })
+            seen_urls.add(full_url)
+
+    # Pattern 3: Generic link pattern matching judgment-like URLs
+    generic_pattern = re.compile(
+        r'href=["\']([^"\']*(?:judgment|decision|ruling|case)[^"\']*)["\']',
+        re.IGNORECASE
+    )
+    for match in generic_pattern.finditer(html):
+        href = match.group(1)
+        if href.startswith("/"):
+            full_url = urljoin(BASE_URL, href)
+        elif href.startswith("http"):
+            full_url = href
+        else:
+            continue
+        if full_url not in seen_urls:
+            judgments.append({
+                "url": full_url,
+                "title": "",
+            })
+            seen_urls.add(full_url)
+
+    return judgments
+
+
+def fetch_judgment(url: str, session: requests.Session) -> dict | None:
+    """Fetch an individual judgment page. Returns dict with html and/or pdf_url."""
+    for attempt in range(5):
+        try:
+            resp = session.get(url, timeout=60)
+            if resp.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                time.sleep(wait)
+                continue
+            if resp.status_code >= 500:
+                wait = min(2 ** (attempt + 1), 60)
+                time.sleep(wait)
+                continue
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+
+            content_type = resp.headers.get("Content-Type", "")
+            result = {"url": url}
+
+            if "application/pdf" in content_type:
+                result["pdf_content"] = resp.content
+                result["is_pdf"] = True
+            else:
+                result["html_content"] = resp.text
+                result["is_pdf"] = False
+                # Check for PDF links within the HTML page
+                pdf_links = re.findall(
+                    r'href=["\']([^"\']+\.pdf[^"\']*)["\']',
+                    resp.text,
+                    re.IGNORECASE
+                )
+                if pdf_links:
+                    result["pdf_links"] = [
+                        urljoin(url, link) for link in pdf_links
+                    ]
+
+            return result
+        except requests.exceptions.RequestException as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                print(f"    FAILED {url}: {e}")
+                return None
+    return None
+
+
+def fetch_pdf(url: str, session: requests.Session) -> bytes | None:
+    """Download a PDF file."""
+    for attempt in range(5):
+        try:
+            resp = session.get(url, timeout=90)
+            if resp.status_code == 429:
+                wait = min(2 ** (attempt + 2), 120)
+                time.sleep(wait)
+                continue
+            if resp.status_code >= 500:
+                wait = min(2 ** (attempt + 1), 60)
+                time.sleep(wait)
+                continue
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.content
+        except requests.exceptions.RequestException as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                return None
+    return None
+
+
+def save_judgment(court_dir: Path, case_id: str, data: dict):
+    """Save judgment HTML and/or PDF to disk."""
+    if data.get("is_pdf") and data.get("pdf_content"):
+        pdf_path = court_dir / f"{case_id}.pdf"
+        with open(pdf_path, "wb") as f:
+            f.write(data["pdf_content"])
+    elif data.get("html_content"):
+        html_path = court_dir / f"{case_id}.html"
+        with open(html_path, "w", encoding="utf-8") as f:
+            f.write(data["html_content"])
+
+
+def discover_all_judgments(sessions: list) -> list[dict]:
+    """Paginate through all listing pages to discover judgment URLs."""
+    print("\n  Discovering judgments via listing pages...")
+    all_judgments = []
+    seen_urls = set()
+    page = 0
+    empty_pages = 0
+    max_empty = 3  # Stop after 3 consecutive empty pages
+
+    while empty_pages < max_empty:
+        session = sessions[page % len(sessions)]
+        html = fetch_listing_page(page, session)
+
+        if html is None:
+            empty_pages += 1
+            page += 1
+            continue
+
+        links = extract_judgment_links(html)
+        new_count = 0
+        for item in links:
+            if item["url"] not in seen_urls:
+                seen_urls.add(item["url"])
+                all_judgments.append(item)
+                new_count += 1
+
+        if new_count == 0:
+            empty_pages += 1
+        else:
+            empty_pages = 0
+
+        if page % 50 == 0:
+            print(f"    Page {page}: {len(all_judgments)} total judgments discovered")
+
+        page += 1
+        time.sleep(0.5)  # Polite delay during discovery
+
+    print(f"  Discovery complete: {len(all_judgments)} judgments across {page} pages")
+    return all_judgments
+
+
+def download_all(sessions: list):
+    """Main download workflow."""
+    courts_ie_dir = BASE_DIR / "courts-ie"
+    courts_ie_dir.mkdir(parents=True, exist_ok=True)
+
+    checkpoint_file = BASE_DIR / "checkpoint.json"
+    checkpoint = load_checkpoint(checkpoint_file)
+    completed_urls = set(checkpoint.get("completed_urls", []))
+    discovered_judgments = checkpoint.get("discovered_judgments", None)
+
+    num_workers = len(LOCAL_IPS) * MAX_WORKERS_PER_IP  # 6 x 5 = 30
+
+    print(f"\n  Output directory: {courts_ie_dir}")
+    print(f"  Workers: {num_workers}")
+
+    if completed_urls:
+        print(f"  Resuming: {len(completed_urls)} already downloaded")
+
+    # Discovery phase (or load from checkpoint)
+    if discovered_judgments is None:
+        all_judgments = discover_all_judgments(sessions)
+        # Save discovery to checkpoint
+        save_checkpoint(checkpoint_file, {
+            "completed_urls": list(completed_urls),
+            "discovered_judgments": all_judgments,
+        })
+    else:
+        all_judgments = discovered_judgments
+        print(f"  Loaded {len(all_judgments)} judgments from checkpoint")
+
+    # Filter out completed
+    to_download = [j for j in all_judgments if j["url"] not in completed_urls]
+    print(f"  To download: {len(to_download)} (skipping {len(all_judgments) - len(to_download)} completed)")
+
+    if not to_download:
+        print("  Nothing to download!")
+        return 0
+
+    # Download phase
+    total_downloaded = 0
+    total_pdfs = 0
+    t0 = time.time()
+
+    for i in range(0, len(to_download), num_workers):
+        batch = to_download[i:i + num_workers]
+
+        with ThreadPoolExecutor(max_workers=num_workers) as pool:
+            futures = {}
+            for idx, item in enumerate(batch):
+                s = sessions[idx % len(sessions)]
+                fut = pool.submit(fetch_judgment, item["url"], s)
+                futures[fut] = item
+
+            for future in as_completed(futures):
+                item = futures[future]
+                url = item["url"]
+                try:
+                    result = future.result()
+                    if result is not None:
+                        court_type = classify_court_type(url)
+                        court_dir = courts_ie_dir / court_type
+                        court_dir.mkdir(parents=True, exist_ok=True)
+
+                        case_id = extract_case_id(url)
+                        save_judgment(court_dir, case_id, result)
+                        total_downloaded += 1
+
+                        # Download linked PDFs if any
+                        if result.get("pdf_links"):
+                            pdf_session = sessions[total_pdfs % len(sessions)]
+                            for pdf_url in result["pdf_links"][:1]:  # Only first PDF
+                                pdf_content = fetch_pdf(pdf_url, pdf_session)
+                                if pdf_content:
+                                    pdf_path = court_dir / f"{case_id}.pdf"
+                                    with open(pdf_path, "wb") as f:
+                                        f.write(pdf_content)
+                                    total_pdfs += 1
+
+                    completed_urls.add(url)
+                except Exception as e:
+                    print(f"    ERROR {url}: {e}")
+                    completed_urls.add(url)  # Don't retry broken URLs forever
+
+        # Save checkpoint after each batch
+        save_checkpoint(checkpoint_file, {
+            "completed_urls": list(completed_urls),
+            "discovered_judgments": all_judgments,
+        })
+
+        # Polite delay between batches
+        time.sleep(BATCH_DELAY)
+
+        # Progress report
+        elapsed = time.time() - t0
+        rate = total_downloaded / elapsed if elapsed > 0 else 0
+        done_count = i + len(batch)
+        print(f"    Progress: {done_count}/{len(to_download)} | "
+              f"downloaded: {total_downloaded} | pdfs: {total_pdfs} | "
+              f"{rate:.1f}/s | elapsed: {elapsed:.0f}s")
+
+    elapsed = time.time() - t0
+    print(f"\n  Download complete: {total_downloaded} judgments + {total_pdfs} PDFs in {elapsed:.0f}s")
+    return total_downloaded
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode not in ("all",):
+        print(f"Unknown mode: {mode}")
+        print("Valid modes: all")
+        sys.exit(1)
+
+    sessions = create_multi_ip_sessions()
+
+    print(f"{'='*60}")
+    print(f"Downloading Irish court decisions from courts.ie")
+    print(f"{'='*60}")
+    print(f"  Mode: {mode}")
+    print(f"  IPs: {len(LOCAL_IPS)}")
+    print(f"  Workers per IP: {MAX_WORKERS_PER_IP}")
+    print(f"  Total parallelism: {len(LOCAL_IPS) * MAX_WORKERS_PER_IP}")
+
+    total_downloaded = download_all(sessions)
+
+    print(f"\n{'='*60}")
+    print(f"Ireland download complete! Total: {total_downloaded} judgments")
+    if BASE_DIR.exists():
+        total_files = sum(1 for f in BASE_DIR.rglob("*") if f.is_file() and f.name != "checkpoint.json")
+        total_size = sum(
+            f.stat().st_size for f in BASE_DIR.rglob("*")
+            if f.is_file() and f.name != "checkpoint.json"
+        )
+        print(f"Total files: {total_files}")
+        print(f"Total size: {total_size / (1024**3):.2f} GB")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/download_sweden.py
+++ b/scripts/opendata/download_sweden.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Download Swedish court decisions from HuggingFace and lagen.nu.
+
+Sources:
+1. swelaw/swelaw - ~3 GB Parquet, CC0 license, ~25K court cases among other docs
+2. lagen.nu - 10,000+ court decisions (Supreme Court, Supreme Administrative Court, etc.)
+   Uses /dataset/dv endpoint which provides year-based index pages.
+   Volunteer-run site, be polite with request rates.
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import requests
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from huggingface_hub import snapshot_download
+from urllib.parse import urljoin
+
+BASE_DIR = Path("/home/ubuntu/opendata/sweden")
+HF_DIR = BASE_DIR / "huggingface"
+LAGEN_DIR = BASE_DIR / "lagen-nu"
+
+LAGEN_BASE = "https://lagen.nu"
+
+# Court codes from /dataset/dv with their available year ranges
+LAGEN_COURTS = {
+    "nja": (1981, 2021),   # Hogsta domstolen (Supreme Court)
+    "hfd": (2011, 2023),   # Hogsta forvaltningsdomstolen (Supreme Administrative Court)
+    "ad": (1993, 2023),    # Arbetsdomstolen (Labour Court)
+    "md": (2004, 2016),    # Marknadsdomstolen (Market Court)
+    "mig": (2006, 2023),   # Migrationsoverdomstolen (Migration Court of Appeal)
+    "mod": (1999, 2023),   # Miljooverdomstolen (Environmental Court of Appeal)
+    "pmod": (2016, 2023),  # Patent och marknadsoverdomstolen
+    "ra": (1993, 2010),    # Regeringsratten (old admin supreme)
+    "rh": (1993, 2022),    # Hovratt (Courts of Appeal)
+    "rk": (2008, 2022),    # Kammarratt (Administrative Courts of Appeal)
+}
+
+MAX_LAGEN_WORKERS = 5
+LAGEN_BATCH_DELAY = 0.5
+
+LOCAL_IPS = [
+    "172.31.29.20",
+    "172.31.21.255",
+    "172.31.31.40",
+    "172.31.22.206",
+    "172.31.28.109",
+    "172.31.21.47",
+]
+
+
+def download_file(url: str, dest: Path, session: requests.Session = None):
+    """Download a file with resume support."""
+    s = session or requests.Session()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    headers = {}
+    mode = "wb"
+    if dest.exists():
+        existing = dest.stat().st_size
+        headers["Range"] = f"bytes={existing}-"
+        mode = "ab"
+    for attempt in range(5):
+        try:
+            resp = s.get(url, headers=headers, stream=True, timeout=120)
+            if resp.status_code == 416:
+                return
+            resp.raise_for_status()
+            with open(dest, mode) as f:
+                for chunk in resp.iter_content(chunk_size=1024 * 1024):
+                    f.write(chunk)
+            return
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                print(f"  Attempt {attempt+1} failed: {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+
+
+def fetch_with_retry(url: str, session: requests.Session, retries: int = 5, timeout: int = 60):
+    """Fetch URL with exponential backoff retry."""
+    for attempt in range(retries):
+        try:
+            resp = session.get(url, timeout=timeout)
+            resp.raise_for_status()
+            return resp
+        except Exception as e:
+            if attempt < retries - 1:
+                wait = 2 ** attempt
+                print(f"  Fetch {url} attempt {attempt+1} failed: {e}, retrying in {wait}s")
+                time.sleep(wait)
+            else:
+                raise
+
+
+def download_huggingface():
+    """Download swelaw/swelaw dataset from HuggingFace."""
+    repo_id = "swelaw/swelaw"
+    local_dir = HF_DIR / "swelaw"
+    print(f"\n{'='*60}")
+    print(f"Downloading {repo_id} -> {local_dir}")
+    print(f"Expected: ~3 GB Parquet, ~25K court cases + other docs")
+    print(f"{'='*60}")
+    t0 = time.time()
+    try:
+        snapshot_download(
+            repo_id=repo_id,
+            repo_type="dataset",
+            local_dir=str(local_dir),
+            resume_download=True,
+            max_workers=20,
+        )
+        elapsed = time.time() - t0
+        size = sum(f.stat().st_size for f in local_dir.rglob("*") if f.is_file())
+        print(f"Done: {repo_id} ({size / (1024**3):.2f} GB in {elapsed:.1f}s)")
+    except Exception as e:
+        print(f"ERROR downloading {repo_id}: {e}")
+        raise
+
+
+def get_court_decisions_index(court: str, year: int, session: requests.Session) -> list:
+    """Fetch the index of available decisions for a given court+year from lagen.nu /dataset/dv."""
+    decisions = []
+    url = f"{LAGEN_BASE}/dataset/dv?{court}={year}"
+    try:
+        resp = fetch_with_retry(url, session, timeout=30)
+        html = resp.text
+        # Extract all decision links: href="https://lagen.nu/dom/{court}/{identifier}"
+        pattern = r'href="https://lagen\.nu/dom/([^"]+)"'
+        matches = re.findall(pattern, html)
+        seen = set()
+        for match in matches:
+            # match is like "nja/2022s1003" or "hfd/2023ref15"
+            if match not in seen:
+                seen.add(match)
+                decisions.append(match)
+    except Exception as e:
+        print(f"  Failed to get index for {court}/{year}: {e}")
+
+    return decisions
+
+
+def download_decision(decision_path: str, session: requests.Session) -> bool:
+    """Download a single court decision HTML.
+
+    decision_path is like "nja/2022s1003" (court/identifier).
+    """
+    parts = decision_path.split("/", 1)
+    if len(parts) != 2:
+        return False
+    court, case_id = parts
+
+    court_dir = LAGEN_DIR / court
+    court_dir.mkdir(parents=True, exist_ok=True)
+    safe_id = case_id.replace("/", "_")
+    dest = court_dir / f"{safe_id}.html"
+
+    if dest.exists() and dest.stat().st_size > 100:
+        return True
+
+    url = f"{LAGEN_BASE}/dom/{decision_path}"
+    for attempt in range(5):
+        try:
+            resp = session.get(url, timeout=60)
+            if resp.status_code == 404:
+                return False
+            resp.raise_for_status()
+            with open(dest, "w", encoding="utf-8") as f:
+                f.write(resp.text)
+            return True
+        except Exception as e:
+            if attempt < 4:
+                wait = 2 ** attempt
+                time.sleep(wait)
+            else:
+                print(f"    FAILED {decision_path}: {e}")
+                return False
+    return False
+
+
+def create_multi_ip_sessions() -> list:
+    """Create one session per local IP for parallel multi-IP requests."""
+    sessions = []
+    for ip in LOCAL_IPS:
+        s = requests.Session()
+        s.headers["User-Agent"] = "SecondLayer-Legal-Research/1.0 (academic research; mcvovkes@gmail.com)"
+
+        class BoundAdapter(requests.adapters.HTTPAdapter):
+            def __init__(self, source_addr, **kw):
+                self._source = source_addr
+                super().__init__(**kw)
+
+            def init_poolmanager(self, *a, **kw):
+                kw["source_address"] = (self._source, 0)
+                super().init_poolmanager(*a, **kw)
+
+        adapter = BoundAdapter(ip)
+        s.mount("https://", adapter)
+        s.mount("http://", adapter)
+        sessions.append(s)
+    return sessions
+
+
+def download_lagen():
+    """Download court decisions from lagen.nu. Uses multi-IP for higher throughput."""
+    LAGEN_DIR.mkdir(parents=True, exist_ok=True)
+    checkpoint_file = LAGEN_DIR / "checkpoint.json"
+
+    completed = set()
+    if checkpoint_file.exists():
+        with open(checkpoint_file) as f:
+            cp = json.load(f)
+            completed = set(cp.get("completed", []))
+            print(f"Resuming, {len(completed)} decisions already downloaded")
+
+    sessions = create_multi_ip_sessions()
+    num_workers = len(LOCAL_IPS) * MAX_LAGEN_WORKERS  # 6 x 5 = 30
+
+    print(f"\n{'='*60}")
+    print(f"Downloading court decisions from lagen.nu")
+    print(f"Courts: {', '.join(LAGEN_COURTS.keys())}")
+    print(f"Multi-IP mode: {len(sessions)} IPs x {MAX_LAGEN_WORKERS} workers = {num_workers} parallel")
+    print(f"{'='*60}")
+
+    total_downloaded = 0
+    total_skipped = 0
+    t0 = time.time()
+
+    for court, (start_year, end_year) in LAGEN_COURTS.items():
+        print(f"\n  Court: {court} ({start_year}-{end_year})")
+
+        # Gather all decision paths for this court across all years
+        all_decisions = []
+        for year in range(start_year, end_year + 1):
+            time.sleep(LAGEN_BATCH_DELAY)
+            decisions = get_court_decisions_index(court, year, sessions[0])
+            if decisions:
+                print(f"    {year}: {len(decisions)} decisions found")
+            all_decisions.extend(decisions)
+
+        # Filter out already completed
+        to_download = []
+        for decision_path in all_decisions:
+            if decision_path not in completed:
+                to_download.append(decision_path)
+            else:
+                total_skipped += 1
+
+        print(f"  Total for {court}: {len(all_decisions)} found, {len(to_download)} to download, {total_skipped} already done")
+
+        if not to_download:
+            continue
+
+        # Download in batches
+        for i in range(0, len(to_download), num_workers):
+            batch = to_download[i:i + num_workers]
+
+            with ThreadPoolExecutor(max_workers=num_workers) as pool:
+                futures = {}
+                for idx, decision_path in enumerate(batch):
+                    s = sessions[idx % len(sessions)]
+                    fut = pool.submit(download_decision, decision_path, s)
+                    futures[fut] = decision_path
+
+                for future in as_completed(futures):
+                    decision_path = futures[future]
+                    try:
+                        success = future.result()
+                        if success:
+                            completed.add(decision_path)
+                            total_downloaded += 1
+                    except Exception as e:
+                        print(f"    ERROR {decision_path}: {e}")
+
+            # Save checkpoint after each batch
+            with open(checkpoint_file, "w") as f:
+                json.dump({"completed": list(completed)}, f)
+
+            # Polite delay between batches
+            time.sleep(LAGEN_BATCH_DELAY)
+
+            # Progress report
+            elapsed = time.time() - t0
+            rate = total_downloaded / elapsed if elapsed > 0 else 0
+            print(f"    Progress: {i + len(batch)}/{len(to_download)} | total downloaded: {total_downloaded} | {rate:.1f}/s")
+
+    elapsed = time.time() - t0
+    print(f"\nlagen.nu download complete: {total_downloaded} decisions in {elapsed:.0f}s")
+
+
+def main():
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+    HF_DIR.mkdir(parents=True, exist_ok=True)
+
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "hf"):
+        download_huggingface()
+    if mode in ("all", "lagen"):
+        download_lagen()
+
+    print("\n" + "=" * 60)
+    print("All Swedish downloads complete!")
+    total_size = sum(f.stat().st_size for f in BASE_DIR.rglob("*") if f.is_file())
+    print(f"Total size: {total_size / (1024**3):.2f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/download_uk.py
+++ b/scripts/opendata/download_uk.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Download UK court decisions from National Archives Case Law API + HuggingFace datasets."""
+
+import os
+import sys
+import json
+import time
+import itertools
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+from urllib.parse import urljoin
+
+import requests
+
+BASE_DIR = Path(os.environ.get("OUT_DIR", "/home/ubuntu/opendata/uk"))
+API_DIR = BASE_DIR / "national-archives"
+HF_DIR = BASE_DIR / "huggingface"
+CHECKPOINT = BASE_DIR / "checkpoint.json"
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
+    "Accept": "application/xml, text/xml, */*",
+}
+
+LOCAL_IPS = [
+    "172.31.29.20",
+    "172.31.21.255",
+    "172.31.31.40",
+    "172.31.22.206",
+    "172.31.28.109",
+    "172.31.21.47",
+]
+
+COURTS = {
+    "uksc": "UK Supreme Court",
+    "ukpc": "Privy Council",
+    "ewca/civ": "Court of Appeal (Civil)",
+    "ewca/crim": "Court of Appeal (Criminal)",
+    "ewhc/admin": "Administrative Court",
+    "ewhc/ch": "Chancery Division",
+    "ewhc/kb": "King's Bench Division",
+    "ewhc/comm": "Commercial Court",
+    "ewhc/fam": "Family Division",
+    "ewhc/tcc": "Technology & Construction",
+    "ewfc": "Family Court",
+    "ukftt/grc": "General Regulatory Chamber",
+    "ukftt/tc": "Tax Chamber",
+    "ukut/aac": "Upper Tribunal AAC",
+    "ukut/iac": "Upper Tribunal IAC",
+    "ewcop": "Court of Protection",
+    "ewhc/pat": "Patents Court",
+    "eat": "Employment Appeal Tribunal",
+    "ewhc/scco": "Senior Costs Office",
+    "ukut/lc": "Upper Tribunal Lands",
+    "ukut/tcc": "Upper Tribunal Tax",
+    "ewhc/ipec": "IP Enterprise Court",
+}
+
+BASE_URL = "https://caselaw.nationalarchives.gov.uk"
+ATOM_NS = "http://www.w3.org/2005/Atom"
+
+
+# ============================================================
+# Multi-IP session pool
+# ============================================================
+
+class SourceAddressAdapter(requests.adapters.HTTPAdapter):
+    def __init__(self, source_address, **kwargs):
+        self._source_address = source_address
+        super().__init__(**kwargs)
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["source_address"] = (self._source_address, 0)
+        super().init_poolmanager(*args, **kwargs)
+
+
+def get_session_for_ip(ip):
+    s = requests.Session()
+    s.headers.update(HEADERS)
+    adapter = SourceAddressAdapter(source_address=ip)
+    s.mount("https://", adapter)
+    s.mount("http://", adapter)
+    return s
+
+
+SESSIONS = {ip: get_session_for_ip(ip) for ip in LOCAL_IPS}
+_ip_cycle = itertools.cycle(LOCAL_IPS)
+
+
+def get_next_session():
+    ip = next(_ip_cycle)
+    return SESSIONS[ip], ip
+
+
+# ============================================================
+# Checkpoint management
+# ============================================================
+
+def load_checkpoint():
+    if CHECKPOINT.exists():
+        return json.loads(CHECKPOINT.read_text())
+    return {
+        "courts_done": [],
+        "court_pages": {},      # court_code -> last completed page
+        "downloaded_uris": {},  # court_code -> list of completed URIs
+    }
+
+
+def save_checkpoint(cp):
+    CHECKPOINT.write_text(json.dumps(cp, ensure_ascii=False, indent=2))
+
+
+# ============================================================
+# National Archives API
+# ============================================================
+
+def parse_atom_feed(xml_text):
+    """Parse Atom XML feed, return (entries, next_url)."""
+    entries = []
+    next_url = None
+
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        print(f"    XML parse error: {e}", flush=True)
+        return entries, next_url
+
+    for entry in root.findall(f"{{{ATOM_NS}}}entry"):
+        title_el = entry.find(f"{{{ATOM_NS}}}title")
+        updated_el = entry.find(f"{{{ATOM_NS}}}updated")
+        link_el = entry.find(f"{{{ATOM_NS}}}link[@rel='alternate']")
+        if link_el is None:
+            link_el = entry.find(f"{{{ATOM_NS}}}link")
+        id_el = entry.find(f"{{{ATOM_NS}}}id")
+
+        uri = None
+        if link_el is not None:
+            href = link_el.get("href", "")
+            # URI is the path portion after the base URL
+            if href.startswith(BASE_URL):
+                uri = href[len(BASE_URL):]
+            elif href.startswith("/"):
+                uri = href
+            else:
+                uri = href
+
+        entries.append({
+            "title": title_el.text if title_el is not None else "",
+            "updated": updated_el.text if updated_el is not None else "",
+            "uri": uri,
+            "id": id_el.text if id_el is not None else "",
+        })
+
+    # Find next page link
+    for link in root.findall(f"{{{ATOM_NS}}}link"):
+        if link.get("rel") == "next":
+            next_url = link.get("href", "")
+            break
+
+    return entries, next_url
+
+
+def fetch_atom_page(url, session, max_retries=5):
+    """Fetch a single Atom feed page with retries and backoff."""
+    for attempt in range(max_retries):
+        try:
+            r = session.get(url, timeout=60)
+            if r.status_code == 200:
+                return r.text
+            elif r.status_code == 429:
+                retry_after = int(r.headers.get("Retry-After", 60))
+                print(f"    429 rate limited, waiting {retry_after}s", flush=True)
+                time.sleep(retry_after)
+            elif r.status_code >= 500:
+                time.sleep((attempt + 1) * 5)
+            else:
+                print(f"    HTTP {r.status_code} for {url}", flush=True)
+                time.sleep((attempt + 1) * 3)
+        except requests.exceptions.RequestException as e:
+            time.sleep((attempt + 1) * 5)
+
+    return None
+
+
+def download_judgment_xml(uri, court_dir, session, max_retries=5):
+    """Download a single judgment XML by its URI."""
+    # Build safe filename from URI
+    safe_name = uri.strip("/").replace("/", "_") + ".xml"
+    out_path = court_dir / safe_name
+
+    if out_path.exists() and out_path.stat().st_size > 100:
+        return uri, True, 0  # already exists
+
+    data_url = f"{BASE_URL}{uri}/data.xml"
+
+    for attempt in range(max_retries):
+        try:
+            r = session.get(data_url, timeout=60)
+            if r.status_code == 200 and len(r.content) > 100:
+                out_path.write_bytes(r.content)
+                return uri, True, len(r.content)
+            elif r.status_code == 429:
+                retry_after = int(r.headers.get("Retry-After", 60))
+                time.sleep(retry_after)
+            elif r.status_code == 404:
+                return uri, False, 0
+            else:
+                time.sleep((attempt + 1) * 3)
+        except requests.exceptions.RequestException:
+            time.sleep((attempt + 1) * 5)
+
+    return uri, False, 0
+
+
+def run_court(court_code, court_name, cp):
+    """Download all judgments for a single court."""
+    safe_court = court_code.replace("/", "_")
+    court_dir = API_DIR / safe_court
+    court_dir.mkdir(parents=True, exist_ok=True)
+    metadata_file = court_dir / "metadata.jsonl"
+
+    # Resume from last page
+    start_page = cp.get("court_pages", {}).get(court_code, 0) + 1
+    done_uris = set(cp.get("downloaded_uris", {}).get(court_code, []))
+
+    print(f"\n  [{court_code}] {court_name}", flush=True)
+    print(f"    Resuming from page {start_page}, {len(done_uris)} already downloaded", flush=True)
+
+    # Phase 1: Collect all URIs from Atom feed
+    all_entries = []
+    page = start_page
+    url = f"{BASE_URL}/atom.xml?court={court_code}&page={page}&per_page=50"
+
+    session, ip = get_next_session()
+
+    while url:
+        xml_text = fetch_atom_page(url, session)
+        if xml_text is None:
+            print(f"    Failed to fetch page {page}, stopping pagination", flush=True)
+            break
+
+        entries, next_url = parse_atom_feed(xml_text)
+        if not entries:
+            break
+
+        all_entries.extend(entries)
+
+        # Update checkpoint for page
+        if "court_pages" not in cp:
+            cp["court_pages"] = {}
+        cp["court_pages"][court_code] = page
+
+        if page % 10 == 0:
+            save_checkpoint(cp)
+            print(f"    Page {page}: {len(all_entries)} entries so far", flush=True)
+
+        page += 1
+        url = next_url
+
+        # Small delay between pagination requests
+        time.sleep(0.3)
+
+    print(f"    Found {len(all_entries)} total entries in feed", flush=True)
+
+    # Phase 2: Download XMLs in parallel (5 workers per IP, 6 IPs = 30 total)
+    to_download = [e for e in all_entries if e["uri"] and e["uri"] not in done_uris]
+    print(f"    Downloading {len(to_download)} new judgments ({len(done_uris)} skipped)", flush=True)
+
+    if not to_download:
+        return len(done_uris)
+
+    success = 0
+    fail = 0
+    total_bytes = 0
+    start_time = time.time()
+
+    # Create worker pool with IP rotation
+    workers_per_ip = 5
+    total_workers = len(LOCAL_IPS) * workers_per_ip
+
+    # Assign entries to IPs round-robin
+    ip_assignments = {}
+    for i, entry in enumerate(to_download):
+        ip = LOCAL_IPS[i % len(LOCAL_IPS)]
+        if ip not in ip_assignments:
+            ip_assignments[ip] = []
+        ip_assignments[ip].append(entry)
+
+    def download_with_ip(entry, ip):
+        session = SESSIONS[ip]
+        return download_judgment_xml(entry["uri"], court_dir, session)
+
+    with ThreadPoolExecutor(max_workers=total_workers) as pool:
+        futures = {}
+        for ip, entries in ip_assignments.items():
+            for entry in entries:
+                fut = pool.submit(download_with_ip, entry, ip)
+                futures[fut] = entry
+
+        metadata_entries = []
+        for i, fut in enumerate(as_completed(futures)):
+            uri, ok, size = fut.result()
+            entry = futures[fut]
+
+            if ok:
+                success += 1
+                total_bytes += size
+                if "downloaded_uris" not in cp:
+                    cp["downloaded_uris"] = {}
+                if court_code not in cp["downloaded_uris"]:
+                    cp["downloaded_uris"][court_code] = []
+                cp["downloaded_uris"][court_code].append(uri)
+
+                metadata_entries.append({
+                    "uri": uri,
+                    "title": entry["title"],
+                    "date": entry["updated"],
+                    "court": court_code,
+                })
+            else:
+                fail += 1
+
+            if (i + 1) % 100 == 0:
+                elapsed = time.time() - start_time
+                rate = (success + fail) / elapsed if elapsed > 0 else 0
+                print(
+                    f"    [{i+1}/{len(to_download)}] "
+                    f"{success} ok, {fail} fail, "
+                    f"{rate:.1f} req/s, {total_bytes/1024/1024:.1f} MB",
+                    flush=True,
+                )
+                save_checkpoint(cp)
+
+        # Write metadata
+        if metadata_entries:
+            with open(metadata_file, "a", encoding="utf-8") as f:
+                for m in metadata_entries:
+                    f.write(json.dumps(m, ensure_ascii=False) + "\n")
+
+    save_checkpoint(cp)
+    elapsed = time.time() - start_time
+    print(
+        f"    Done: {success} ok, {fail} fail, "
+        f"{total_bytes/1024/1024:.1f} MB in {elapsed:.0f}s",
+        flush=True,
+    )
+
+    return success + len(done_uris)
+
+
+def run_national_archives():
+    """Download all courts from National Archives API."""
+    API_DIR.mkdir(parents=True, exist_ok=True)
+    cp = load_checkpoint()
+
+    print("=" * 60, flush=True)
+    print("National Archives Case Law API", flush=True)
+    print(f"Courts: {len(COURTS)}", flush=True)
+    print("=" * 60, flush=True)
+
+    total_all = 0
+    done_courts = set(cp.get("courts_done", []))
+
+    for court_code, court_name in COURTS.items():
+        if court_code in done_courts:
+            print(f"\n  [{court_code}] SKIPPED (already complete)", flush=True)
+            continue
+
+        count = run_court(court_code, court_name, cp)
+        total_all += count
+
+        # Mark court as done
+        if "courts_done" not in cp:
+            cp["courts_done"] = []
+        cp["courts_done"].append(court_code)
+        save_checkpoint(cp)
+
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"National Archives TOTAL: {total_all:,} judgments", flush=True)
+    print("=" * 60, flush=True)
+
+    return total_all
+
+
+# ============================================================
+# HuggingFace datasets
+# ============================================================
+
+def run_hf_uk_courts():
+    """Download santoshtyss/uk_courts_cases (43K cases, 983 MB)."""
+    out_dir = HF_DIR / "uk_courts_cases"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print("\n=== HuggingFace: santoshtyss/uk_courts_cases (43K cases) ===", flush=True)
+
+    from huggingface_hub import snapshot_download
+    path = snapshot_download(
+        "santoshtyss/uk_courts_cases",
+        repo_type="dataset",
+        local_dir=str(out_dir),
+        max_workers=20,
+    )
+    print(f"  Downloaded to: {path}", flush=True)
+
+    # Count records
+    try:
+        import pyarrow.parquet as pq
+        total = 0
+        for f in sorted(Path(path).rglob("*.parquet")):
+            pf = pq.ParquetFile(f)
+            total += pf.metadata.num_rows
+        print(f"  uk_courts_cases total: {total:,} cases", flush=True)
+        return total
+    except Exception as e:
+        print(f"  Could not count records: {e}", flush=True)
+        return 0
+
+
+def run_hf_juddges():
+    """Download JuDDGES/en-court-raw (6K cases, 85.7 MB)."""
+    out_dir = HF_DIR / "juddges_en"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print("\n=== HuggingFace: JuDDGES/en-court-raw (6K cases) ===", flush=True)
+
+    from huggingface_hub import snapshot_download
+    path = snapshot_download(
+        "JuDDGES/en-court-raw",
+        repo_type="dataset",
+        local_dir=str(out_dir),
+        max_workers=20,
+    )
+    print(f"  Downloaded to: {path}", flush=True)
+
+    # Count records
+    try:
+        import pyarrow.parquet as pq
+        total = 0
+        for f in sorted(Path(path).rglob("*.parquet")):
+            pf = pq.ParquetFile(f)
+            total += pf.metadata.num_rows
+        print(f"  JuDDGES/en-court-raw total: {total:,} cases", flush=True)
+        return total
+    except Exception as e:
+        print(f"  Could not count records: {e}", flush=True)
+        return 0
+
+
+def run_huggingface():
+    """Download all HuggingFace datasets."""
+    HF_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("=" * 60, flush=True)
+    print("HuggingFace UK Court Datasets", flush=True)
+    print("=" * 60, flush=True)
+
+    total = 0
+    total += run_hf_uk_courts()
+    total += run_hf_juddges()
+
+    print(f"\nHuggingFace TOTAL: {total:,} cases", flush=True)
+    return total
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python download_uk.py <mode>", flush=True)
+        print("  Modes: all, api, hf", flush=True)
+        sys.exit(1)
+
+    mode = sys.argv[1].lower()
+    BASE_DIR.mkdir(parents=True, exist_ok=True)
+
+    start_time = time.time()
+    print(f"UK Court Decisions Download - {datetime.now().isoformat()}", flush=True)
+    print(f"Mode: {mode}", flush=True)
+    print(f"Output: {BASE_DIR}", flush=True)
+    print(f"IPs: {len(LOCAL_IPS)}", flush=True)
+    print("", flush=True)
+
+    total = 0
+
+    if mode in ("all", "api"):
+        total += run_national_archives()
+
+    if mode in ("all", "hf"):
+        total += run_huggingface()
+
+    elapsed = time.time() - start_time
+    print(f"\n{'=' * 60}", flush=True)
+    print(f"COMPLETE: {total:,} total documents in {elapsed/60:.1f} min", flush=True)
+    print("=" * 60, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/import_nordic_to_db.py
+++ b/scripts/opendata/import_nordic_to_db.py
@@ -1,0 +1,948 @@
+#!/usr/bin/env python3
+"""Import Nordic court decisions (DK, SE, FI, IS) into PostgreSQL (parallel)."""
+
+import json
+import os
+import sys
+import re
+import time
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+DB_URL = os.environ.get("DATABASE_URL", "postgresql://secondlayer:secondlayer@localhost:5432/secondlayer_prod")
+MAX_WORKERS = 20
+BATCH_SIZE = 500
+
+DK_BASE = Path("/home/ubuntu/opendata/denmark")
+SE_BASE = Path("/home/ubuntu/opendata/sweden")
+FI_BASE = Path("/home/ubuntu/opendata/finland")
+IS_BASE = Path("/home/ubuntu/opendata/iceland")
+
+CHECKPOINT_DIR = Path("/home/ubuntu/opendata/.checkpoints")
+CHECKPOINT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def get_conn():
+    return psycopg2.connect(DB_URL)
+
+
+def load_checkpoint(name: str) -> set:
+    cp_file = CHECKPOINT_DIR / f"nordic_{name}.json"
+    if cp_file.exists():
+        return set(json.loads(cp_file.read_text()))
+    return set()
+
+
+def save_checkpoint(name: str, done: set):
+    cp_file = CHECKPOINT_DIR / f"nordic_{name}.json"
+    cp_file.write_text(json.dumps(list(done)))
+
+
+def strip_html(html_text: str) -> str:
+    """Strip HTML tags and return plain text."""
+    if not html_text:
+        return ""
+    text = re.sub(r'<script[^>]*>.*?</script>', '', html_text, flags=re.DOTALL)
+    text = re.sub(r'<style[^>]*>.*?</style>', '', text, flags=re.DOTALL)
+    text = re.sub(r'<[^>]+>', ' ', text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
+# ============================================================
+# DENMARK: HuggingFace domsdatabasen (Parquet)
+# ============================================================
+
+def import_dk_hf_file(filepath: str) -> int:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        print("pyarrow not installed, skipping HF parquet import")
+        return 0
+
+    table = pq.read_table(filepath)
+    df_cols = table.column_names
+    batch_rows = []
+    count = 0
+
+    for i in range(table.num_rows):
+        row = {col: table.column(col)[i].as_py() for col in df_cols}
+
+        record_id = f"hf-domsdatabasen-{i}-{Path(filepath).stem}"
+        court = row.get("court") or row.get("court_name")
+        case_type = row.get("case_type") or row.get("type")
+        text = row.get("text") or row.get("content") or row.get("full_text", "")
+        anonymized = row.get("anonymized_text")
+        case_number = row.get("case_number") or row.get("case_id")
+        decision_date = row.get("date") or row.get("decision_date")
+        ecli = row.get("ecli")
+        abstract = row.get("abstract") or row.get("summary")
+
+        meta = {k: v for k, v in row.items()
+                if k not in ("court", "court_name", "case_type", "type", "text",
+                             "content", "full_text", "anonymized_text", "case_number",
+                             "case_id", "date", "decision_date", "ecli", "abstract", "summary")}
+
+        batch_rows.append((
+            record_id,
+            ecli,
+            "hf-domsdatabasen",
+            court,                                          # court_name
+            None,                                           # court_type
+            case_number,
+            case_type,
+            str(decision_date)[:10] if decision_date else None,
+            None,                                           # judge
+            None,                                           # parties
+            abstract,
+            text,                                           # full_text
+            anonymized,                                     # anonymized_text
+            None,                                           # source_url
+            json.dumps(meta, default=str) if meta else None,
+        ))
+
+        if len(batch_rows) >= BATCH_SIZE:
+            _flush_dk_batch(batch_rows)
+            count += len(batch_rows)
+            batch_rows = []
+
+    if batch_rows:
+        _flush_dk_batch(batch_rows)
+        count += len(batch_rows)
+
+    return count
+
+
+def _flush_dk_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO dk_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     case_type, decision_date, judge, parties, abstract,
+                     full_text, anonymized_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def import_denmark_hf():
+    ds_dir = DK_BASE / "huggingface" / "domsdatabasen"
+    files = sorted(ds_dir.glob("**/*.parquet"))
+    if not files:
+        print(f"  No parquet files in {ds_dir}")
+        return 0
+    print(f"\nDK HF domsdatabasen: {len(files)} parquet files")
+
+    checkpoint = load_checkpoint("dk_hf")
+    files_to_do = [f for f in files if f.name not in checkpoint]
+    print(f"  Skipping {len(files) - len(files_to_do)} already imported files")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_dk_hf_file, str(f)): f for f in files_to_do}
+        done = 0
+        for future in as_completed(futures):
+            fpath = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                checkpoint.add(fpath.name)
+                if done % 10 == 0:
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed if elapsed > 0 else 0
+                    print(f"  DK HF: {done}/{len(files_to_do)} files | {imported} rows | {rate:.0f}/s")
+                    save_checkpoint("dk_hf", checkpoint)
+            except Exception as e:
+                print(f"  DK HF FAILED {fpath.name}: {e}")
+
+    save_checkpoint("dk_hf", checkpoint)
+    print(f"  DK HF complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+# ============================================================
+# SWEDEN: HuggingFace swelaw (Parquet)
+# ============================================================
+
+def import_se_hf_file(filepath: str) -> int:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        print("pyarrow not installed, skipping HF parquet import")
+        return 0
+
+    table = pq.read_table(filepath)
+    df_cols = table.column_names
+    batch_rows = []
+    count = 0
+
+    for i in range(table.num_rows):
+        row = {col: table.column(col)[i].as_py() for col in df_cols}
+
+        # Filter to court cases only (look for document type indicators)
+        doc_type = row.get("type") or row.get("document_type") or row.get("category", "")
+        # Skip non-court documents (legislation, regulations, etc.)
+        if doc_type and any(skip in str(doc_type).lower() for skip in ("lag", "forordning", "regulation", "statute")):
+            continue
+
+        record_id = f"hf-swelaw-{i}-{Path(filepath).stem}"
+        text = row.get("text") or row.get("content") or row.get("full_text", "")
+        title = row.get("title") or row.get("subject")
+        decision_date = row.get("date") or row.get("decision_date")
+        court = row.get("court") or row.get("court_name")
+        case_number = row.get("case_number") or row.get("number")
+        ecli = row.get("ecli")
+        keywords = row.get("keywords")
+
+        meta = {k: v for k, v in row.items()
+                if k not in ("text", "content", "full_text", "title", "subject",
+                             "date", "decision_date", "court", "court_name",
+                             "case_number", "number", "ecli", "keywords",
+                             "type", "document_type", "category")}
+
+        batch_rows.append((
+            record_id,
+            ecli,
+            "hf-swelaw",
+            court,                                          # court_name
+            None,                                           # court_type
+            case_number,
+            None,                                           # decision_type
+            str(decision_date)[:10] if decision_date else None,
+            None,                                           # judge
+            title,                                          # subject
+            keywords,
+            None,                                           # parties
+            None,                                           # abstract
+            text,                                           # full_text
+            None,                                           # source_url
+            json.dumps(meta, default=str) if meta else None,
+        ))
+
+        if len(batch_rows) >= BATCH_SIZE:
+            _flush_se_batch(batch_rows)
+            count += len(batch_rows)
+            batch_rows = []
+
+    if batch_rows:
+        _flush_se_batch(batch_rows)
+        count += len(batch_rows)
+
+    return count
+
+
+def import_se_lagen_file(filepath: str, court: str) -> int:
+    """Import a single lagen.nu HTML file."""
+    path = Path(filepath)
+    try:
+        html = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return 0
+
+    text = strip_html(html)
+    if not text:
+        return 0
+
+    record_id = f"lagen-nu-{court}-{path.stem}"
+
+    row = (
+        record_id,
+        None,                                               # ecli
+        "lagen-nu",
+        court,                                              # court_name
+        None,                                               # court_type
+        None,                                               # case_number
+        None,                                               # decision_type
+        None,                                               # decision_date
+        None,                                               # judge
+        None,                                               # subject
+        None,                                               # keywords
+        None,                                               # parties
+        None,                                               # abstract
+        text,                                               # full_text
+        None,                                               # source_url
+        None,                                               # metadata_json
+    )
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO se_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, judge, subject, keywords,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, [row], page_size=BATCH_SIZE)
+        conn.commit()
+        return 1
+    finally:
+        conn.close()
+
+
+def _flush_se_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO se_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, judge, subject, keywords,
+                     parties, abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def import_sweden_hf():
+    ds_dir = SE_BASE / "huggingface" / "swelaw"
+    files = sorted(ds_dir.glob("**/*.parquet"))
+    if not files:
+        print(f"  No parquet files in {ds_dir}")
+        return 0
+    print(f"\nSE HF swelaw: {len(files)} parquet files")
+
+    checkpoint = load_checkpoint("se_hf")
+    files_to_do = [f for f in files if f.name not in checkpoint]
+    print(f"  Skipping {len(files) - len(files_to_do)} already imported files")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_se_hf_file, str(f)): f for f in files_to_do}
+        done = 0
+        for future in as_completed(futures):
+            fpath = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                checkpoint.add(fpath.name)
+                if done % 10 == 0:
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed if elapsed > 0 else 0
+                    print(f"  SE HF: {done}/{len(files_to_do)} files | {imported} rows | {rate:.0f}/s")
+                    save_checkpoint("se_hf", checkpoint)
+            except Exception as e:
+                print(f"  SE HF FAILED {fpath.name}: {e}")
+
+    save_checkpoint("se_hf", checkpoint)
+    print(f"  SE HF complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+def import_sweden_lagen():
+    lagen_dir = SE_BASE / "lagen-nu"
+    if not lagen_dir.exists():
+        print(f"  lagen.nu directory not found: {lagen_dir}")
+        return 0
+
+    courts = [d for d in lagen_dir.iterdir() if d.is_dir()]
+    if not courts:
+        print("  No court directories in lagen-nu")
+        return 0
+
+    checkpoint = load_checkpoint("se_lagen")
+    total_imported = 0
+    t0 = time.time()
+
+    for court_dir in sorted(courts):
+        court_name = court_dir.name
+        files = sorted(court_dir.glob("**/*.html"))
+        files_to_do = [f for f in files if f"{court_name}/{f.name}" not in checkpoint]
+        if not files_to_do:
+            continue
+        print(f"\nSE lagen.nu {court_name}: {len(files_to_do)} HTML files")
+
+        imported = 0
+        with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+            futures = {pool.submit(import_se_lagen_file, str(f), court_name): f for f in files_to_do}
+            done = 0
+            for future in as_completed(futures):
+                fpath = futures[future]
+                try:
+                    count = future.result()
+                    imported += count
+                    done += 1
+                    checkpoint.add(f"{court_name}/{fpath.name}")
+                    if done % 200 == 0:
+                        elapsed = time.time() - t0
+                        rate = total_imported + imported
+                        print(f"  lagen.nu {court_name}: {done}/{len(files_to_do)} | {imported} rows")
+                        save_checkpoint("se_lagen", checkpoint)
+                except Exception as e:
+                    print(f"  lagen.nu FAILED {fpath.name}: {e}")
+
+        total_imported += imported
+        save_checkpoint("se_lagen", checkpoint)
+
+    print(f"  SE lagen.nu complete: {total_imported} rows in {time.time()-t0:.0f}s")
+    return total_imported
+
+
+# ============================================================
+# FINLAND: Finlex API XML
+# ============================================================
+
+def parse_finlex_xml(filepath: str) -> dict:
+    """Parse Akoma Ntoso XML from Finlex API."""
+    import xml.etree.ElementTree as ET
+
+    path = Path(filepath)
+    try:
+        tree = ET.parse(path)
+        root = tree.getroot()
+    except Exception:
+        # Fallback: read as text
+        text = path.read_text(encoding="utf-8", errors="replace")
+        return {"full_text": strip_html(text), "raw_xml": True}
+
+    # Handle namespaces
+    ns = {"akn": "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"}
+
+    result = {}
+
+    # Try to extract judgment body text
+    body = root.find(".//{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}judgmentBody")
+    if body is None:
+        body = root.find(".//judgmentBody")
+    if body is None:
+        body = root.find(".//{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}body")
+    if body is None:
+        body = root
+
+    text_parts = []
+    for elem in body.iter():
+        if elem.text:
+            text_parts.append(elem.text.strip())
+        if elem.tail:
+            text_parts.append(elem.tail.strip())
+    result["full_text"] = " ".join(t for t in text_parts if t)
+
+    # Extract metadata
+    meta = root.find(".//{http://docs.oasis-open.org/legaldocml/ns/akn/3.0}meta")
+    if meta is None:
+        meta = root.find(".//meta")
+
+    if meta is not None:
+        # Try to get ECLI
+        for frbr in meta.iter():
+            if "FRBRuri" in frbr.tag or "FRBRExpression" in frbr.tag:
+                uri = frbr.get("value") or frbr.get("href", "")
+                if "ECLI" in uri:
+                    result["ecli"] = uri
+
+    return result
+
+
+def import_fi_api_file(filepath: str, court: str) -> int:
+    """Import a single Finlex API XML file."""
+    path = Path(filepath)
+    parsed = parse_finlex_xml(filepath)
+    text = parsed.get("full_text", "")
+    if not text:
+        return 0
+
+    record_id = f"finlex-{court}-{path.stem}"
+
+    # Try to load accompanying metadata
+    meta_file = path.with_suffix(".json")
+    meta = {}
+    if meta_file.exists():
+        try:
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+
+    # Also check metadata.jsonl in the same directory
+    if not meta:
+        jsonl_file = path.parent / "metadata.jsonl"
+        if jsonl_file.exists():
+            try:
+                for line in jsonl_file.read_text(encoding="utf-8").splitlines():
+                    item = json.loads(line)
+                    if item.get("filename") == path.name or item.get("id") == path.stem:
+                        meta = item
+                        break
+            except Exception:
+                pass
+
+    ecli = parsed.get("ecli") or meta.get("ecli")
+    decision_date = meta.get("decision_date") or meta.get("date")
+    case_number = meta.get("case_number") or meta.get("diaarinumero")
+    court_name = meta.get("court_name") or meta.get("court") or court
+    subject = meta.get("subject") or meta.get("asia")
+    keywords = meta.get("keywords") or meta.get("asiasanat")
+    cited = meta.get("cited_provisions") or meta.get("lainkohdat")
+    language = meta.get("language") or meta.get("kieli") or "fi"
+    judge = meta.get("judge") or meta.get("esittelija")
+    publication_date = meta.get("publication_date")
+
+    row = (
+        record_id,
+        ecli,
+        "finlex-api",
+        court_name,
+        None,                                               # court_type
+        case_number,
+        None,                                               # decision_type
+        str(decision_date)[:10] if decision_date else None,
+        publication_date,
+        judge,
+        subject,
+        keywords if isinstance(keywords, str) else json.dumps(keywords) if keywords else None,
+        cited if isinstance(cited, str) else json.dumps(cited) if cited else None,
+        None,                                               # parties
+        None,                                               # abstract
+        text,
+        language,
+        None,                                               # source_url
+        json.dumps(meta, default=str) if meta else None,
+    )
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO fi_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, publication_date, judge,
+                     subject, keywords, cited_provisions, parties, abstract,
+                     full_text, language, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, [row], page_size=BATCH_SIZE)
+        conn.commit()
+        return 1
+    finally:
+        conn.close()
+
+
+def _flush_fi_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO fi_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, publication_date, judge,
+                     subject, keywords, cited_provisions, parties, abstract,
+                     full_text, language, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def import_finland_api():
+    api_dir = FI_BASE / "finlex-api"
+    if not api_dir.exists():
+        print(f"  Finlex API directory not found: {api_dir}")
+        return 0
+
+    courts = [d for d in api_dir.iterdir() if d.is_dir()]
+    if not courts:
+        print("  No court directories in finlex-api")
+        return 0
+
+    checkpoint = load_checkpoint("fi_api")
+    total_imported = 0
+    t0 = time.time()
+
+    for court_dir in sorted(courts):
+        court_name = court_dir.name
+        files = sorted(court_dir.glob("**/*.xml"))
+        files_to_do = [f for f in files if f"{court_name}/{f.name}" not in checkpoint]
+        if not files_to_do:
+            continue
+        print(f"\nFI Finlex API {court_name}: {len(files_to_do)} XML files")
+
+        imported = 0
+        with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+            futures = {pool.submit(import_fi_api_file, str(f), court_name): f for f in files_to_do}
+            done = 0
+            for future in as_completed(futures):
+                fpath = futures[future]
+                try:
+                    count = future.result()
+                    imported += count
+                    done += 1
+                    checkpoint.add(f"{court_name}/{fpath.name}")
+                    if done % 100 == 0:
+                        elapsed = time.time() - t0
+                        print(f"  Finlex {court_name}: {done}/{len(files_to_do)} | {imported} rows")
+                        save_checkpoint("fi_api", checkpoint)
+                except Exception as e:
+                    print(f"  Finlex FAILED {fpath.name}: {e}")
+
+        total_imported += imported
+        save_checkpoint("fi_api", checkpoint)
+
+    print(f"  FI Finlex API complete: {total_imported} rows in {time.time()-t0:.0f}s")
+    return total_imported
+
+
+def import_fi_github_file(filepath: str) -> int:
+    """Import a single finlex-data GitHub XML file."""
+    import xml.etree.ElementTree as ET
+
+    path = Path(filepath)
+    try:
+        tree = ET.parse(path)
+        root = tree.getroot()
+    except Exception:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        text = strip_html(text)
+        if not text:
+            return 0
+        record_id = f"finlex-github-{path.stem}"
+        row = (record_id, None, "finlex-github", None, None, None,
+               None, None, None, None, None, None, None, None, None,
+               text, "fi", None, None)
+        conn = get_conn()
+        try:
+            with conn.cursor() as cur:
+                execute_values(cur, """
+                    INSERT INTO fi_court_decisions
+                        (id, ecli, source, court_name, court_type, case_number,
+                         decision_type, decision_date, publication_date, judge,
+                         subject, keywords, cited_provisions, parties, abstract,
+                         full_text, language, source_url, metadata_json)
+                    VALUES %s
+                    ON CONFLICT (id) DO NOTHING
+                """, [row], page_size=BATCH_SIZE)
+            conn.commit()
+            return 1
+        finally:
+            conn.close()
+
+    # Extract text from XML
+    text_parts = []
+    for elem in root.iter():
+        if elem.text:
+            text_parts.append(elem.text.strip())
+        if elem.tail:
+            text_parts.append(elem.tail.strip())
+    text = " ".join(t for t in text_parts if t)
+    if not text:
+        return 0
+
+    record_id = f"finlex-github-{path.stem}"
+
+    row = (
+        record_id,
+        None,                                               # ecli
+        "finlex-github",
+        None,                                               # court_name
+        None,                                               # court_type
+        None,                                               # case_number
+        None,                                               # decision_type
+        None,                                               # decision_date
+        None,                                               # publication_date
+        None,                                               # judge
+        None,                                               # subject
+        None,                                               # keywords
+        None,                                               # cited_provisions
+        None,                                               # parties
+        None,                                               # abstract
+        text,
+        "fi",                                               # language
+        None,                                               # source_url
+        None,                                               # metadata_json
+    )
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO fi_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, publication_date, judge,
+                     subject, keywords, cited_provisions, parties, abstract,
+                     full_text, language, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, [row], page_size=BATCH_SIZE)
+        conn.commit()
+        return 1
+    finally:
+        conn.close()
+
+
+def import_finland_github():
+    github_dir = FI_BASE / "github-finlex-data"
+    if not github_dir.exists():
+        print(f"  GitHub finlex-data directory not found: {github_dir}")
+        return 0
+
+    files = sorted(github_dir.rglob("*.xml"))
+    if not files:
+        print("  No XML files in github-finlex-data")
+        return 0
+
+    checkpoint = load_checkpoint("fi_github")
+    files_to_do = [f for f in files if f.name not in checkpoint]
+    print(f"\nFI GitHub finlex-data: {len(files_to_do)} XML files (skipping {len(files) - len(files_to_do)})")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_fi_github_file, str(f)): f for f in files_to_do}
+        done = 0
+        for future in as_completed(futures):
+            fpath = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                checkpoint.add(fpath.name)
+                if done % 200 == 0:
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed if elapsed > 0 else 0
+                    print(f"  FI GitHub: {done}/{len(files_to_do)} | {imported} rows | {rate:.0f}/s")
+                    save_checkpoint("fi_github", checkpoint)
+            except Exception as e:
+                print(f"  FI GitHub FAILED {fpath.name}: {e}")
+
+    save_checkpoint("fi_github", checkpoint)
+    print(f"  FI GitHub complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+# ============================================================
+# ICELAND: haestirettur (Supreme Court)
+# ============================================================
+
+def import_is_html_file(filepath: str, source: str, court_name: str) -> int:
+    """Import a single Icelandic court HTML file."""
+    path = Path(filepath)
+    try:
+        html = path.read_text(encoding="utf-8", errors="replace")
+    except Exception:
+        return 0
+
+    text = strip_html(html)
+    if not text:
+        return 0
+
+    # Derive court from parent dirs for heradsdomstolar
+    if source == "heradsdomstolar":
+        # path: .../heradsdomstolar/{court}/{year}/file.html
+        parts = path.parts
+        try:
+            idx = parts.index("heradsdomstolar")
+            court_name = parts[idx + 1] if idx + 1 < len(parts) - 1 else court_name
+        except (ValueError, IndexError):
+            pass
+
+    record_id = f"{source}-{path.stem}"
+
+    row = (
+        record_id,
+        None,                                               # ecli
+        source,
+        court_name,
+        None,                                               # court_type
+        None,                                               # case_number
+        None,                                               # decision_type
+        None,                                               # decision_date
+        None,                                               # judge
+        None,                                               # subject
+        None,                                               # parties
+        None,                                               # abstract
+        text,                                               # full_text
+        None,                                               # source_url
+        None,                                               # metadata_json
+    )
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO is_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, judge, subject, parties,
+                     abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, [row], page_size=BATCH_SIZE)
+        conn.commit()
+        return 1
+    finally:
+        conn.close()
+
+
+def _flush_is_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO is_court_decisions
+                    (id, ecli, source, court_name, court_type, case_number,
+                     decision_type, decision_date, judge, subject, parties,
+                     abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _import_iceland_court(source: str, court_name: str, base_dir: Path):
+    """Generic importer for Icelandic court HTML files."""
+    if not base_dir.exists():
+        print(f"  {source} directory not found: {base_dir}")
+        return 0
+
+    files = sorted(base_dir.rglob("*.html"))
+    if not files:
+        print(f"  No HTML files in {base_dir}")
+        return 0
+
+    checkpoint = load_checkpoint(f"is_{source}")
+    files_to_do = [f for f in files if f.name not in checkpoint]
+    print(f"\nIS {source}: {len(files_to_do)} HTML files (skipping {len(files) - len(files_to_do)})")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_is_html_file, str(f), source, court_name): f for f in files_to_do}
+        done = 0
+        for future in as_completed(futures):
+            fpath = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                checkpoint.add(fpath.name)
+                if done % 200 == 0:
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed if elapsed > 0 else 0
+                    print(f"  IS {source}: {done}/{len(files_to_do)} | {imported} rows | {rate:.0f}/s")
+                    save_checkpoint(f"is_{source}", checkpoint)
+            except Exception as e:
+                print(f"  IS {source} FAILED {fpath.name}: {e}")
+
+    save_checkpoint(f"is_{source}", checkpoint)
+    print(f"  IS {source} complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+def import_iceland_haestirettur():
+    return _import_iceland_court(
+        "haestirettur",
+        "Hæstiréttur Íslands",
+        IS_BASE / "haestirettur"
+    )
+
+
+def import_iceland_landsrettur():
+    return _import_iceland_court(
+        "landsrettur",
+        "Landsréttur",
+        IS_BASE / "landsrettur"
+    )
+
+
+def import_iceland_heradsdomstolar():
+    return _import_iceland_court(
+        "heradsdomstolar",
+        "Héraðsdómstólar",
+        IS_BASE / "heradsdomstolar"
+    )
+
+
+# ============================================================
+# Migration
+# ============================================================
+
+def run_migration():
+    """Run the migration SQL on the database."""
+    migration_sql = Path(__file__).parent.parent.parent / "mcp_backend" / "src" / "migrations" / "154_nordic_court_decisions.sql"
+    if not migration_sql.exists():
+        migration_sql = Path("/home/ubuntu/154_nordic_court_decisions.sql")
+    if not migration_sql.exists():
+        print("Migration file 154_nordic_court_decisions.sql not found, tables must already exist")
+        return
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(migration_sql.read_text())
+        conn.commit()
+        print("Migration 154 applied successfully")
+    finally:
+        conn.close()
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "migrate"):
+        run_migration()
+
+    if mode in ("all", "dk"):
+        import_denmark_hf()
+
+    if mode in ("all", "se", "se-hf"):
+        import_sweden_hf()
+    if mode in ("all", "se", "se-lagen"):
+        import_sweden_lagen()
+
+    if mode in ("all", "fi", "fi-api"):
+        import_finland_api()
+    if mode in ("all", "fi", "fi-github"):
+        import_finland_github()
+
+    if mode in ("all", "is", "is-haestirettur"):
+        import_iceland_haestirettur()
+    if mode in ("all", "is", "is-landsrettur"):
+        import_iceland_landsrettur()
+    if mode in ("all", "is", "is-heradsdomstolar"):
+        import_iceland_heradsdomstolar()
+
+    # Final summary
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            counts = {}
+            for table in ("dk_court_decisions", "se_court_decisions",
+                          "fi_court_decisions", "is_court_decisions"):
+                try:
+                    cur.execute(f"SELECT count(*) FROM {table}")
+                    counts[table] = cur.fetchone()[0]
+                except Exception:
+                    conn.rollback()
+                    counts[table] = "N/A"
+        print(f"\n{'='*60}")
+        print("Nordic court decisions summary:")
+        for table, count in counts.items():
+            label = table.replace("_court_decisions", "").upper()
+            print(f"  {label}: {count:,}" if isinstance(count, int) else f"  {label}: {count}")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Migration 154: `dk_court_decisions`, `se_court_decisions`, `fi_court_decisions`, `is_court_decisions` tables
- Migration 155: `uk_court_decisions`, `ie_court_decisions` tables
- Download scripts with multi-IP (6 public IPs) parallelism for DK, SE, FI, IS, UK, IE
- Import script for Nordic countries (PostgreSQL, 20 workers, batch 500)

### Data sources & volumes

| Country | Source | Est. decisions |
|---------|--------|---------------|
| Denmark | HF alexandrainst/domsdatabasen + danish-dynaword | ~12K |
| Sweden | HF swelaw/swelaw + lagen.nu (10 courts, 1981–2023) | ~46K |
| Finland | Finlex API + finlex.fi web + GitHub dump | ~10K+ |
| Iceland | island.is GraphQL API (cron retry) | ~5K |
| UK | National Archives API + 2 HF datasets | ~119K |
| Ireland | courts.ie scraping | ~16K |

**Total estimated: ~200K court decisions across 6 jurisdictions**

## Test plan

- [x] All Python scripts pass syntax validation
- [x] DK download complete (9.9 GB)
- [x] SE download complete (HF 2.8 GB + lagen.nu 21.5K decisions)
- [x] FI download complete (6.6 GB)
- [x] UK + IE downloads running on prod (multi-IP, 30 threads)
- [x] IS cron retry configured (hourly, island.is currently down)
- [ ] Run migrations on local DB
- [ ] Run import script after all downloads complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end pipelines and database schema for court decisions across Denmark, Sweden, Finland, Iceland, the UK, and Ireland. Enables parallel, multi-IP downloads and a parallel import path, targeting ~200k decisions.

- **New Features**
  - New tables with FTS indexes: `dk_court_decisions`, `se_court_decisions`, `fi_court_decisions`, `is_court_decisions`, `uk_court_decisions`, `ie_court_decisions` (Nordics use locale FTS; UK/IE use English).
  - Download scripts with multi-IP parallelism and retry/resume for DK, SE, FI, IS, UK, IE:
    - DK: HF `alexandrainst/domsdatabasen`, `danish-foundation-models/danish-dynaword`
    - SE: HF `swelaw/swelaw`, `lagen.nu`
    - FI: Finlex API, finlex.fi, GitHub `eliask/finlex-data`
    - IS: island.is GraphQL
    - UK: National Archives API, HF `santoshtyss/uk_courts_cases`, `JuDDGES/en-court-raw`
    - IE: courts.ie scraper
  - Parallel PostgreSQL import for Nordics (`import_nordic_to_db.py`) with 20 workers and batch size 500, plus checkpointing.

- **Migration**
  - Run migrations 154 and 155 to create new tables and FTS indexes.
  - Set `DATABASE_URL`, then run `import_nordic_to_db.py` after downloads complete.
  - If using rate-limit mitigation, configure available outbound IPs to match the scripts’ multi-IP setup.
  - Optional: schedule periodic retries for Iceland if island.is availability is intermittent.

<sup>Written for commit 221ef9100633af3994d24982f22e39b547b71ffd. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1798?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

