### PR TITLE
feat(data): add court decision migrations for HU, Baltics, Western Europe

### DIFF
--- a/mcp_backend/src/migrations/152_hu_court_decisions.sql
+++ b/mcp_backend/src/migrations/152_hu_court_decisions.sql
@@ -1,0 +1,47 @@
+-- Migration 152: Hungarian court decisions
+-- Sources:
+--   Ordinary courts: eakta.birosag.hu (~225K+ anonymized decisions, DOCX full text)
+--   Constitutional Court: HUNCOURT OSF (15K, 1990-2021) + alkotmanybirosag.hu API (2022+)
+
+CREATE TABLE IF NOT EXISTS hu_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    egyedi_azonosito    TEXT UNIQUE,
+    source              TEXT NOT NULL,
+    court_name          TEXT,
+    collegium           TEXT,
+    legal_area          TEXT,
+    case_number         TEXT,
+    decision_type       TEXT,
+    decision_year       INT,
+    decision_date       DATE,
+    judge               TEXT,
+    subject             TEXT,
+    summary             TEXT,
+    legislation_refs    TEXT[],
+    related_cases       JSONB,
+    full_text           TEXT,
+    source_url          TEXT,
+    download_url        TEXT,
+    index_id            TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_hu_court_source ON hu_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_hu_court_name ON hu_court_decisions(court_name);
+CREATE INDEX IF NOT EXISTS idx_hu_court_collegium ON hu_court_decisions(collegium);
+CREATE INDEX IF NOT EXISTS idx_hu_court_date ON hu_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_hu_court_year ON hu_court_decisions(decision_year);
+CREATE INDEX IF NOT EXISTS idx_hu_court_type ON hu_court_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_hu_court_case_num ON hu_court_decisions(case_number);
+CREATE INDEX IF NOT EXISTS idx_hu_court_egyedi ON hu_court_decisions(egyedi_azonosito);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_hu_court_fts') THEN
+        CREATE INDEX idx_hu_court_fts ON hu_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(summary, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;

--- a/mcp_backend/src/migrations/153_baltic_court_decisions.sql
+++ b/mcp_backend/src/migrations/153_baltic_court_decisions.sql
@@ -1,0 +1,120 @@
+-- Migration 153: Baltic states court decisions
+-- Sources:
+--   LT: LITEKO CSV bulk (liteko.teismai.lt, ~51K decisions, CC BY 4.0)
+--   LV: manas.tiesas.lv (~127K PDF decisions)
+--   EE: avaandmed.rik.ee (497K metadata XML + ECLI sitemaps)
+
+-- ============================================================
+-- LITHUANIA
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS lt_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    dokumento_id        TEXT UNIQUE,
+    source              TEXT NOT NULL,
+    court_name          TEXT,
+    case_number         TEXT,
+    instance            TEXT,
+    case_type           TEXT,
+    result              TEXT,
+    decision_date       DATE,
+    received_date       DATE,
+    judge               TEXT,
+    panel               TEXT,
+    parties             TEXT,
+    categories          TEXT[],
+    eu_norms            TEXT[],
+    duration_days       INT,
+    full_text           TEXT,
+    source_url          TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lt_court_source ON lt_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_lt_court_name ON lt_court_decisions(court_name);
+CREATE INDEX IF NOT EXISTS idx_lt_court_case_num ON lt_court_decisions(case_number);
+CREATE INDEX IF NOT EXISTS idx_lt_court_date ON lt_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_lt_court_type ON lt_court_decisions(case_type);
+CREATE INDEX IF NOT EXISTS idx_lt_court_instance ON lt_court_decisions(instance);
+CREATE INDEX IF NOT EXISTS idx_lt_court_dokid ON lt_court_decisions(dokumento_id);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_lt_court_fts') THEN
+        CREATE INDEX idx_lt_court_fts ON lt_court_decisions
+            USING GIN (to_tsvector('simple',
+                coalesce(parties, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- LATVIA
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS lv_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    source              TEXT NOT NULL,
+    court_name          TEXT,
+    case_number         TEXT,
+    instance            TEXT,
+    case_type           TEXT,
+    decision_date       DATE,
+    full_text           TEXT,
+    source_url          TEXT,
+    pdf_id              INT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_lv_court_source ON lv_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_lv_court_name ON lv_court_decisions(court_name);
+CREATE INDEX IF NOT EXISTS idx_lv_court_case_num ON lv_court_decisions(case_number);
+CREATE INDEX IF NOT EXISTS idx_lv_court_date ON lv_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_lv_court_type ON lv_court_decisions(case_type);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_lv_court_fts') THEN
+        CREATE INDEX idx_lv_court_fts ON lv_court_decisions
+            USING GIN (to_tsvector('simple', coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- ESTONIA
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ee_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    ecli                TEXT UNIQUE,
+    source              TEXT NOT NULL,
+    court_name          TEXT,
+    case_number         TEXT,
+    case_type           TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    judge               TEXT,
+    outcome             TEXT,
+    full_text           TEXT,
+    source_url          TEXT,
+    pdf_url             TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ee_court_source ON ee_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_ee_court_name ON ee_court_decisions(court_name);
+CREATE INDEX IF NOT EXISTS idx_ee_court_case_num ON ee_court_decisions(case_number);
+CREATE INDEX IF NOT EXISTS idx_ee_court_date ON ee_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_ee_court_type ON ee_court_decisions(case_type);
+CREATE INDEX IF NOT EXISTS idx_ee_court_ecli ON ee_court_decisions(ecli);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_ee_court_fts') THEN
+        CREATE INDEX idx_ee_court_fts ON ee_court_decisions
+            USING GIN (to_tsvector('simple', coalesce(full_text, '')));
+    END IF;
+END $$;

--- a/mcp_backend/src/migrations/154_western_europe_court_decisions.sql
+++ b/mcp_backend/src/migrations/154_western_europe_court_decisions.sql
@@ -1,0 +1,120 @@
+-- Migration 154: France, Germany, Belgium court decisions
+-- Sources:
+--   FR: HF antoinejeannot/jurisprudence (1.13M, Cour de cassation + appel + tribunaux)
+--   DE: HF openlegaldata/court-decisions-germany (250K) + Zenodo federal courts
+--   BE: OpenJustice.be API (~227K) + Constitutional Court (~5.5K)
+
+-- ============================================================
+-- FRANCE
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS fr_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    ecli                TEXT UNIQUE,
+    source              TEXT NOT NULL,
+    jurisdiction        TEXT,
+    court_name          TEXT,
+    chamber             TEXT,
+    case_number         TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    solution            TEXT,
+    themes              TEXT[],
+    summary             TEXT,
+    full_text           TEXT,
+    zones               JSONB,
+    source_url          TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fr_court_source ON fr_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_fr_court_jurisdiction ON fr_court_decisions(jurisdiction);
+CREATE INDEX IF NOT EXISTS idx_fr_court_date ON fr_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_fr_court_type ON fr_court_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_fr_court_ecli ON fr_court_decisions(ecli);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_fr_court_fts') THEN
+        CREATE INDEX idx_fr_court_fts ON fr_court_decisions
+            USING GIN (to_tsvector('french',
+                coalesce(summary, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- GERMANY
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS de_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    ecli                TEXT,
+    source              TEXT NOT NULL,
+    court_name          TEXT,
+    court_type          TEXT,
+    court_level         TEXT,
+    case_number         TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    subject_area        TEXT,
+    full_text           TEXT,
+    tenor               TEXT,
+    tatbestand          TEXT,
+    reasoning           TEXT,
+    source_url          TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_de_court_source ON de_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_de_court_name ON de_court_decisions(court_name);
+CREATE INDEX IF NOT EXISTS idx_de_court_date ON de_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_de_court_type ON de_court_decisions(decision_type);
+CREATE INDEX IF NOT EXISTS idx_de_court_ecli ON de_court_decisions(ecli);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_de_court_fts') THEN
+        CREATE INDEX idx_de_court_fts ON de_court_decisions
+            USING GIN (to_tsvector('german',
+                coalesce(full_text, '')));
+    END IF;
+END $$;
+
+-- ============================================================
+-- BELGIUM
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS be_court_decisions (
+    id                  TEXT PRIMARY KEY,
+    ecli                TEXT UNIQUE,
+    source              TEXT NOT NULL,
+    court_name          TEXT,
+    language            TEXT,
+    case_number         TEXT,
+    decision_type       TEXT,
+    decision_date       DATE,
+    summary             TEXT,
+    full_text           TEXT,
+    source_url          TEXT,
+    metadata_json       JSONB,
+    imported_at         TIMESTAMPTZ DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_be_court_source ON be_court_decisions(source);
+CREATE INDEX IF NOT EXISTS idx_be_court_name ON be_court_decisions(court_name);
+CREATE INDEX IF NOT EXISTS idx_be_court_date ON be_court_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_be_court_lang ON be_court_decisions(language);
+CREATE INDEX IF NOT EXISTS idx_be_court_ecli ON be_court_decisions(ecli);
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_be_court_fts') THEN
+        CREATE INDEX idx_be_court_fts ON be_court_decisions
+            USING GIN (to_tsvector('french',
+                coalesce(summary, '') || ' ' ||
+                coalesce(full_text, '')));
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Adds 3 untracked migration files for 7 countries: Hungary, Lithuania, Latvia, Estonia, France, Germany, Belgium
- Tables already exist on prod (created manually) but aren't in `schema_migrations` — this PR tracks them properly
- Combined with already-merged Nordic + UK/IE migrations (#1798), this brings the total to **17 countries** with court decision tables

## Countries covered (after deploy)

| Migration | Countries | Est. decisions |
|-----------|-----------|----------------|
| 152_hu | 🇭🇺 Hungary | ~225K |
| 153_baltic | 🇱🇹 Lithuania, 🇱🇻 Latvia, 🇪🇪 Estonia | ~675K |
| 154_western_europe | 🇫🇷 France, 🇩🇪 Germany, 🇧🇪 Belgium | ~1.6M |

## Test plan
- [x] All migrations use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` — idempotent
- [x] Migration runner tracks by filename, no numbering conflicts with existing 153_ab_testing or 154_nordic
- [ ] CI deploys and migration runner records them in `schema_migrations`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add three migrations to track existing court decision tables for Hungary, the Baltics, and Western Europe. These bring prod tables under `schema_migrations` with idempotent creates and search indexes.

- **Migration**
  - Adds `152_hu_court_decisions.sql`, `153_baltic_court_decisions.sql`, `154_western_europe_court_decisions.sql` covering HU, LT/LV/EE, and FR/DE/BE.
  - Uses CREATE TABLE/INDEX IF NOT EXISTS and creates GIN FTS indexes (locale-aware where applicable).
  - Migration runner tracks by filename; safe alongside existing `153_ab_testing` and `154_nordic`.

<sup>Written for commit 815e799e3ca7ea827d872ae8a16c11ef95f75f9b. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1799?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

