### PR TITLE
feat(data): import 210K court decisions + fulltext check and dedup

### DIFF
--- a/scripts/opendata/check_and_dedup_nordic.py
+++ b/scripts/opendata/check_and_dedup_nordic.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+"""
+Check fulltext coverage and deduplicate Nordic court decisions (DK, SE, FI).
+
+Usage:
+    python check_and_dedup_nordic.py all      # Run both check and dedup for all countries
+    python check_and_dedup_nordic.py dk       # Check + dedup Denmark only
+    python check_and_dedup_nordic.py se       # Check + dedup Sweden only
+    python check_and_dedup_nordic.py fi       # Check + dedup Finland only
+    python check_and_dedup_nordic.py check    # Check fulltext coverage only (all countries)
+    python check_and_dedup_nordic.py dedup    # Dedup only (all countries)
+"""
+
+import hashlib
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from glob import glob
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MIN_FULLTEXT_LENGTH = 500
+NUM_WORKERS = 20
+
+PATHS = {
+    "dk": {
+        "parquet": "/home/ubuntu/opendata/denmark/huggingface/domsdatabasen/",
+    },
+    "se": {
+        "parquet": "/home/ubuntu/opendata/sweden/huggingface/swelaw/",
+        "html": "/home/ubuntu/opendata/sweden/lagen-nu/",
+    },
+    "fi": {
+        "xml_api": "/home/ubuntu/opendata/finland/finlex-api/",
+        "html_web": "/home/ubuntu/opendata/finland/finlex-web/",
+        "github": "/home/ubuntu/opendata/finland/github-finlex-data/",
+    },
+    "uk": {
+        "xml_api": "/home/ubuntu/opendata/uk/national-archives/",
+        "parquet_hf1": "/home/ubuntu/opendata/uk/huggingface/uk_courts_cases/",
+        "parquet_hf2": "/home/ubuntu/opendata/uk/huggingface/en-court-raw/",
+    },
+}
+
+DEDUP_REPORT_DIR = {
+    "dk": "/home/ubuntu/opendata/denmark/",
+    "se": "/home/ubuntu/opendata/sweden/",
+    "fi": "/home/ubuntu/opendata/finland/",
+    "uk": "/home/ubuntu/opendata/uk/",
+}
+
+# ---------------------------------------------------------------------------
+# Text extraction helpers
+# ---------------------------------------------------------------------------
+
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def strip_html(html_content: str) -> str:
+    """Strip HTML tags using regex."""
+    return HTML_TAG_RE.sub("", html_content)
+
+
+def extract_xml_text(xml_content: str) -> str:
+    """Extract text content from XML body elements."""
+    # Remove XML declarations and processing instructions
+    text = re.sub(r"<\?[^?]+\?>", "", xml_content)
+    # Remove CDATA markers
+    text = re.sub(r"<!\[CDATA\[", "", text)
+    text = re.sub(r"\]\]>", "", text)
+    # Strip all tags
+    text = HTML_TAG_RE.sub(" ", text)
+    return text.strip()
+
+
+def normalize_text(text: str) -> str:
+    """Normalize text for dedup hashing: strip whitespace, lowercase."""
+    return re.sub(r"\s+", "", text.lower())
+
+
+def compute_hash(text: str) -> str:
+    """SHA256 of normalized text."""
+    normalized = normalize_text(text)
+    return hashlib.sha256(normalized.encode("utf-8", errors="replace")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Parquet processing
+# ---------------------------------------------------------------------------
+
+TEXT_COLUMNS = ["text", "content", "full_text", "fulltext", "body"]
+
+
+def find_text_column(schema):
+    """Find the text column in a Parquet schema."""
+    col_names = [f.name for f in schema]
+    for candidate in TEXT_COLUMNS:
+        if candidate in col_names:
+            return candidate
+    # Fallback: first string-like column with a relevant name
+    for name in col_names:
+        if any(kw in name.lower() for kw in ["text", "content", "body"]):
+            return name
+    return None
+
+
+def process_parquet_file_check(filepath: str) -> dict:
+    """Check a single Parquet file for fulltext coverage."""
+    import pyarrow.parquet as pq
+
+    try:
+        table = pq.read_table(filepath)
+    except Exception as e:
+        return {"file": filepath, "error": str(e), "total": 0, "with_text": 0, "without_text": 0, "lengths": []}
+
+    text_col = find_text_column(table.schema)
+    if text_col is None:
+        num_rows = table.num_rows
+        return {
+            "file": filepath,
+            "total": num_rows,
+            "with_text": 0,
+            "without_text": num_rows,
+            "lengths": [],
+            "text_col": None,
+        }
+
+    col_data = table.column(text_col).to_pylist()
+    with_text = 0
+    without_text = 0
+    lengths = []
+    missing_samples = []
+
+    for i, val in enumerate(col_data):
+        if val and len(str(val)) >= MIN_FULLTEXT_LENGTH:
+            with_text += 1
+            lengths.append(len(str(val)))
+        else:
+            without_text += 1
+            if len(missing_samples) < 5:
+                missing_samples.append(f"{filepath}:row_{i}")
+
+    return {
+        "file": filepath,
+        "total": len(col_data),
+        "with_text": with_text,
+        "without_text": without_text,
+        "lengths": lengths,
+        "text_col": text_col,
+        "missing_samples": missing_samples,
+    }
+
+
+def process_parquet_file_dedup(filepath: str) -> list:
+    """Hash each row in a Parquet file for dedup."""
+    import pyarrow.parquet as pq
+
+    try:
+        table = pq.read_table(filepath)
+    except Exception:
+        return []
+
+    text_col = find_text_column(table.schema)
+    if text_col is None:
+        return []
+
+    col_data = table.column(text_col).to_pylist()
+    results = []
+    for i, val in enumerate(col_data):
+        if val and len(str(val)) >= MIN_FULLTEXT_LENGTH:
+            h = compute_hash(str(val))
+            results.append((h, f"{filepath}:row_{i}"))
+    return results
+
+
+# ---------------------------------------------------------------------------
+# File-based processing (HTML / XML)
+# ---------------------------------------------------------------------------
+
+def process_html_file_check(filepath: str) -> dict:
+    """Check a single HTML file for fulltext."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except Exception as e:
+        return {"file": filepath, "error": str(e), "text_len": 0, "has_fulltext": False}
+
+    text = strip_html(content).strip()
+    return {
+        "file": filepath,
+        "text_len": len(text),
+        "has_fulltext": len(text) >= MIN_FULLTEXT_LENGTH,
+    }
+
+
+def process_html_file_dedup(filepath: str) -> Optional[tuple]:
+    """Hash HTML file text content for dedup."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except Exception:
+        return None
+
+    text = strip_html(content).strip()
+    if len(text) < MIN_FULLTEXT_LENGTH:
+        return None
+    return (compute_hash(text), filepath)
+
+
+def process_xml_file_check(filepath: str) -> dict:
+    """Check a single XML file for fulltext."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except Exception as e:
+        return {"file": filepath, "error": str(e), "text_len": 0, "has_fulltext": False}
+
+    text = extract_xml_text(content)
+    return {
+        "file": filepath,
+        "text_len": len(text),
+        "has_fulltext": len(text) >= MIN_FULLTEXT_LENGTH,
+    }
+
+
+def process_xml_file_dedup(filepath: str) -> Optional[tuple]:
+    """Hash XML file text content for dedup."""
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except Exception:
+        return None
+
+    text = extract_xml_text(content)
+    if len(text) < MIN_FULLTEXT_LENGTH:
+        return None
+    return (compute_hash(text), filepath)
+
+
+def process_github_file_check(filepath: str) -> dict:
+    """Check a GitHub data file (XML or JSON)."""
+    ext = Path(filepath).suffix.lower()
+    if ext == ".json":
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+            # Try common keys for text content
+            text = ""
+            for key in ["text", "content", "body", "full_text"]:
+                if key in data and data[key]:
+                    text = str(data[key])
+                    break
+            if not text and isinstance(data, dict):
+                # Concatenate all string values
+                text = " ".join(str(v) for v in data.values() if isinstance(v, str))
+            return {"file": filepath, "text_len": len(text), "has_fulltext": len(text) >= MIN_FULLTEXT_LENGTH}
+        except Exception as e:
+            return {"file": filepath, "error": str(e), "text_len": 0, "has_fulltext": False}
+    elif ext == ".xml":
+        return process_xml_file_check(filepath)
+    else:
+        return {"file": filepath, "text_len": 0, "has_fulltext": False}
+
+
+def process_github_file_dedup(filepath: str) -> Optional[tuple]:
+    """Hash a GitHub data file for dedup."""
+    ext = Path(filepath).suffix.lower()
+    if ext == ".json":
+        try:
+            with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+                data = json.load(f)
+            text = ""
+            for key in ["text", "content", "body", "full_text"]:
+                if key in data and data[key]:
+                    text = str(data[key])
+                    break
+            if not text and isinstance(data, dict):
+                text = " ".join(str(v) for v in data.values() if isinstance(v, str))
+            if len(text) < MIN_FULLTEXT_LENGTH:
+                return None
+            return (compute_hash(text), filepath)
+        except Exception:
+            return None
+    elif ext == ".xml":
+        return process_xml_file_dedup(filepath)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Check fulltext coverage
+# ---------------------------------------------------------------------------
+
+def check_parquet_source(label: str, base_path: str) -> dict:
+    """Check Parquet-based source."""
+    if not os.path.exists(base_path):
+        print(f"  [{label}] Path not found: {base_path}")
+        return {"source": label, "path": base_path, "exists": False}
+
+    parquet_files = glob(os.path.join(base_path, "**/*.parquet"), recursive=True)
+    if not parquet_files:
+        print(f"  [{label}] No Parquet files found in {base_path}")
+        return {"source": label, "path": base_path, "exists": True, "total_files": 0}
+
+    print(f"  [{label}] Processing {len(parquet_files)} Parquet files...")
+
+    total = 0
+    with_text = 0
+    without_text = 0
+    all_lengths = []
+    missing_samples = []
+
+    with ProcessPoolExecutor(max_workers=NUM_WORKERS) as executor:
+        futures = {executor.submit(process_parquet_file_check, f): f for f in parquet_files}
+        for future in as_completed(futures):
+            result = future.result()
+            if "error" in result:
+                print(f"    Warning: {result['file']}: {result['error']}")
+                continue
+            total += result["total"]
+            with_text += result["with_text"]
+            without_text += result["without_text"]
+            all_lengths.extend(result["lengths"])
+            if "missing_samples" in result:
+                missing_samples.extend(result["missing_samples"])
+
+    avg_len = sum(all_lengths) / len(all_lengths) if all_lengths else 0
+
+    report = {
+        "source": label,
+        "path": base_path,
+        "exists": True,
+        "total_files": len(parquet_files),
+        "total_rows": total,
+        "with_fulltext": with_text,
+        "without_fulltext": without_text,
+        "avg_text_length": int(avg_len),
+        "missing_samples": missing_samples[:5],
+    }
+
+    print(f"    Total rows: {total}")
+    print(f"    With fulltext (>={MIN_FULLTEXT_LENGTH} chars): {with_text}")
+    print(f"    Without fulltext: {without_text}")
+    print(f"    Average text length: {int(avg_len)}")
+    if missing_samples:
+        print(f"    Missing fulltext samples: {missing_samples[:5]}")
+
+    return report
+
+
+def check_file_source(label: str, base_path: str, pattern: str, processor) -> dict:
+    """Check file-based source (HTML/XML)."""
+    if not os.path.exists(base_path):
+        print(f"  [{label}] Path not found: {base_path}")
+        return {"source": label, "path": base_path, "exists": False}
+
+    files = glob(os.path.join(base_path, pattern), recursive=True)
+    if not files:
+        print(f"  [{label}] No files matching {pattern} in {base_path}")
+        return {"source": label, "path": base_path, "exists": True, "total_files": 0}
+
+    print(f"  [{label}] Processing {len(files)} files...")
+
+    with_text = 0
+    without_text = 0
+    all_lengths = []
+    missing_samples = []
+
+    with ProcessPoolExecutor(max_workers=NUM_WORKERS) as executor:
+        futures = {executor.submit(processor, f): f for f in files}
+        done_count = 0
+        for future in as_completed(futures):
+            done_count += 1
+            if done_count % 10000 == 0:
+                print(f"    Progress: {done_count}/{len(files)}")
+            result = future.result()
+            if "error" in result:
+                continue
+            if result["has_fulltext"]:
+                with_text += 1
+                all_lengths.append(result["text_len"])
+            else:
+                without_text += 1
+                if len(missing_samples) < 5:
+                    missing_samples.append(result["file"])
+
+    total = with_text + without_text
+    avg_len = sum(all_lengths) / len(all_lengths) if all_lengths else 0
+
+    report = {
+        "source": label,
+        "path": base_path,
+        "exists": True,
+        "total_files": total,
+        "with_fulltext": with_text,
+        "without_fulltext": without_text,
+        "avg_text_length": int(avg_len),
+        "missing_samples": missing_samples[:5],
+    }
+
+    print(f"    Total files: {total}")
+    print(f"    With fulltext (>={MIN_FULLTEXT_LENGTH} chars): {with_text}")
+    print(f"    Without fulltext: {without_text}")
+    print(f"    Average text length: {int(avg_len)}")
+    if missing_samples:
+        print(f"    Missing fulltext samples: {missing_samples[:5]}")
+
+    return report
+
+
+def check_country(country: str) -> list:
+    """Run fulltext check for a country."""
+    print(f"\n{'='*60}")
+    print(f"  FULLTEXT CHECK: {country.upper()}")
+    print(f"{'='*60}")
+
+    reports = []
+
+    if country == "dk":
+        reports.append(check_parquet_source("DK Domsdatabasen (Parquet)", PATHS["dk"]["parquet"]))
+
+    elif country == "se":
+        reports.append(check_parquet_source("SE SweLaw (Parquet)", PATHS["se"]["parquet"]))
+        reports.append(check_file_source(
+            "SE lagen.nu (HTML)", PATHS["se"]["html"], "**/*.html", process_html_file_check
+        ))
+
+    elif country == "fi":
+        reports.append(check_file_source(
+            "FI Finlex API (XML)", PATHS["fi"]["xml_api"], "**/*.xml", process_xml_file_check
+        ))
+        reports.append(check_file_source(
+            "FI Finlex Web (HTML)", PATHS["fi"]["html_web"], "**/*.html", process_html_file_check
+        ))
+        # GitHub data can be XML or JSON
+        github_path = PATHS["fi"]["github"]
+        if os.path.exists(github_path):
+            github_files = (
+                glob(os.path.join(github_path, "**/*.xml"), recursive=True)
+                + glob(os.path.join(github_path, "**/*.json"), recursive=True)
+            )
+            if github_files:
+                reports.append(check_file_source(
+                    "FI GitHub finlex-data (XML/JSON)", github_path, "**/*.[xj]*", process_github_file_check
+                ))
+            else:
+                print(f"  [FI GitHub] No XML/JSON files in {github_path}")
+                reports.append({"source": "FI GitHub finlex-data", "path": github_path, "exists": True, "total_files": 0})
+        else:
+            print(f"  [FI GitHub] Path not found: {github_path}")
+            reports.append({"source": "FI GitHub finlex-data", "path": github_path, "exists": False})
+
+    elif country == "uk":
+        reports.append(check_file_source(
+            "UK National Archives (XML)", PATHS["uk"]["xml_api"], "**/*.xml", process_xml_file_check
+        ))
+        hf1 = PATHS["uk"]["parquet_hf1"]
+        if os.path.exists(hf1) and glob(os.path.join(hf1, "**/*.parquet"), recursive=True):
+            reports.append(check_parquet_source("UK HF uk_courts_cases (Parquet)", hf1))
+        hf2 = PATHS["uk"]["parquet_hf2"]
+        if os.path.exists(hf2) and glob(os.path.join(hf2, "**/*.parquet"), recursive=True):
+            reports.append(check_parquet_source("UK HF JuDDGES en-court-raw (Parquet)", hf2))
+
+    return reports
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+def dedup_parquet_source(label: str, base_path: str) -> dict:
+    """Dedup a Parquet-based source."""
+    if not os.path.exists(base_path):
+        return {"source": label, "exists": False}
+
+    parquet_files = glob(os.path.join(base_path, "**/*.parquet"), recursive=True)
+    if not parquet_files:
+        return {"source": label, "exists": True, "total_files": 0}
+
+    print(f"  [{label}] Hashing rows from {len(parquet_files)} Parquet files...")
+
+    hash_to_locations = defaultdict(list)
+
+    with ProcessPoolExecutor(max_workers=NUM_WORKERS) as executor:
+        futures = {executor.submit(process_parquet_file_dedup, f): f for f in parquet_files}
+        for future in as_completed(futures):
+            results = future.result()
+            for h, loc in results:
+                hash_to_locations[h].append(loc)
+
+    total = sum(len(v) for v in hash_to_locations.values())
+    unique = len(hash_to_locations)
+    duplicate_groups = {h: locs for h, locs in hash_to_locations.items() if len(locs) > 1}
+    duplicate_count = sum(len(locs) - 1 for locs in duplicate_groups.values())
+
+    print(f"    Total hashed rows: {total}")
+    print(f"    Unique texts: {unique}")
+    print(f"    Duplicate rows: {duplicate_count}")
+    print(f"    Duplicate groups: {len(duplicate_groups)}")
+
+    return {
+        "source": label,
+        "total_files": total,
+        "unique_texts": unique,
+        "duplicate_count": duplicate_count,
+        "duplicate_groups": [
+            {"hash": h, "count": len(locs), "files": locs[:10]}
+            for h, locs in list(duplicate_groups.items())[:100]
+        ],
+    }
+
+
+def dedup_file_source(label: str, base_path: str, pattern: str, processor) -> dict:
+    """Dedup a file-based source."""
+    if not os.path.exists(base_path):
+        return {"source": label, "exists": False}
+
+    files = glob(os.path.join(base_path, pattern), recursive=True)
+    if not files:
+        return {"source": label, "exists": True, "total_files": 0}
+
+    print(f"  [{label}] Hashing {len(files)} files...")
+
+    hash_to_locations = defaultdict(list)
+
+    with ProcessPoolExecutor(max_workers=NUM_WORKERS) as executor:
+        futures = {executor.submit(processor, f): f for f in files}
+        done_count = 0
+        for future in as_completed(futures):
+            done_count += 1
+            if done_count % 10000 == 0:
+                print(f"    Progress: {done_count}/{len(files)}")
+            result = future.result()
+            if result is not None:
+                h, loc = result
+                hash_to_locations[h].append(loc)
+
+    total = sum(len(v) for v in hash_to_locations.values())
+    unique = len(hash_to_locations)
+    duplicate_groups = {h: locs for h, locs in hash_to_locations.items() if len(locs) > 1}
+    duplicate_count = sum(len(locs) - 1 for locs in duplicate_groups.values())
+
+    print(f"    Total hashed files: {total}")
+    print(f"    Unique texts: {unique}")
+    print(f"    Duplicate files: {duplicate_count}")
+    print(f"    Duplicate groups: {len(duplicate_groups)}")
+
+    return {
+        "source": label,
+        "total_files": total,
+        "unique_texts": unique,
+        "duplicate_count": duplicate_count,
+        "duplicate_groups": [
+            {"hash": h, "count": len(locs), "files": locs[:10]}
+            for h, locs in list(duplicate_groups.items())[:100]
+        ],
+    }
+
+
+def dedup_country(country: str) -> dict:
+    """Run dedup for a country."""
+    print(f"\n{'='*60}")
+    print(f"  DEDUPLICATION: {country.upper()}")
+    print(f"{'='*60}")
+
+    sources = []
+
+    if country == "dk":
+        sources.append(dedup_parquet_source("DK Domsdatabasen (Parquet)", PATHS["dk"]["parquet"]))
+
+    elif country == "se":
+        sources.append(dedup_parquet_source("SE SweLaw (Parquet)", PATHS["se"]["parquet"]))
+        sources.append(dedup_file_source(
+            "SE lagen.nu (HTML)", PATHS["se"]["html"], "**/*.html", process_html_file_dedup
+        ))
+
+    elif country == "fi":
+        sources.append(dedup_file_source(
+            "FI Finlex API (XML)", PATHS["fi"]["xml_api"], "**/*.xml", process_xml_file_dedup
+        ))
+        sources.append(dedup_file_source(
+            "FI Finlex Web (HTML)", PATHS["fi"]["html_web"], "**/*.html", process_html_file_dedup
+        ))
+        github_path = PATHS["fi"]["github"]
+        if os.path.exists(github_path):
+            github_files = (
+                glob(os.path.join(github_path, "**/*.xml"), recursive=True)
+                + glob(os.path.join(github_path, "**/*.json"), recursive=True)
+            )
+            if github_files:
+                sources.append(dedup_file_source(
+                    "FI GitHub finlex-data (XML/JSON)", github_path, "**/*.[xj]*", process_github_file_dedup
+                ))
+
+    elif country == "uk":
+        sources.append(dedup_file_source(
+            "UK National Archives (XML)", PATHS["uk"]["xml_api"], "**/*.xml", process_xml_file_dedup
+        ))
+        hf1 = PATHS["uk"]["parquet_hf1"]
+        if os.path.exists(hf1) and glob(os.path.join(hf1, "**/*.parquet"), recursive=True):
+            sources.append(dedup_parquet_source("UK HF uk_courts_cases (Parquet)", hf1))
+        hf2 = PATHS["uk"]["parquet_hf2"]
+        if os.path.exists(hf2) and glob(os.path.join(hf2, "**/*.parquet"), recursive=True):
+            sources.append(dedup_parquet_source("UK HF JuDDGES en-court-raw (Parquet)", hf2))
+
+    # Aggregate report
+    total_files = sum(s.get("total_files", 0) for s in sources)
+    unique_texts = sum(s.get("unique_texts", 0) for s in sources)
+    duplicate_count = sum(s.get("duplicate_count", 0) for s in sources)
+    all_groups = []
+    for s in sources:
+        all_groups.extend(s.get("duplicate_groups", []))
+
+    report = {
+        "country": country.upper(),
+        "total_files": total_files,
+        "unique_texts": unique_texts,
+        "duplicate_count": duplicate_count,
+        "sources": sources,
+        "duplicate_groups": all_groups,
+    }
+
+    # Write report
+    report_dir = DEDUP_REPORT_DIR.get(country)
+    if report_dir:
+        os.makedirs(report_dir, exist_ok=True)
+        report_path = os.path.join(report_dir, "dedup_report.json")
+        with open(report_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        print(f"\n  Report written to: {report_path}")
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Summary table
+# ---------------------------------------------------------------------------
+
+def print_summary(check_results: dict, dedup_results: dict):
+    """Print final summary table."""
+    print(f"\n{'='*80}")
+    print(f"  SUMMARY")
+    print(f"{'='*80}")
+
+    header = f"{'Country':<6} {'Source':<35} {'Total':<10} {'With FT':<10} {'No FT':<10} {'Avg Len':<10} {'Dupes':<8}"
+    print(header)
+    print("-" * 80)
+
+    for country in ["dk", "se", "fi"]:
+        checks = check_results.get(country, [])
+        dedup = dedup_results.get(country, {})
+        dedup_sources = {s["source"]: s for s in dedup.get("sources", [])} if dedup else {}
+
+        for cr in checks:
+            if not cr.get("exists", False):
+                continue
+            source = cr.get("source", "?")
+            total = cr.get("total_rows", cr.get("total_files", 0))
+            with_ft = cr.get("with_fulltext", 0)
+            without_ft = cr.get("without_fulltext", 0)
+            avg_len = cr.get("avg_text_length", 0)
+            dupes = dedup_sources.get(source, {}).get("duplicate_count", 0)
+            print(f"{country.upper():<6} {source[:35]:<35} {total:<10} {with_ft:<10} {without_ft:<10} {avg_len:<10} {dupes:<8}")
+
+    print("-" * 80)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    mode = sys.argv[1].lower()
+
+    countries = []
+    run_check = True
+    run_dedup = True
+
+    all_countries = ["dk", "se", "fi", "uk"]
+
+    if mode == "all":
+        countries = all_countries
+    elif mode in all_countries:
+        countries = [mode]
+    elif mode == "check":
+        countries = all_countries
+        run_dedup = False
+    elif mode == "dedup":
+        countries = all_countries
+        run_check = False
+    else:
+        print(f"Unknown mode: {mode}")
+        print(__doc__)
+        sys.exit(1)
+
+    check_results = {}
+    dedup_results = {}
+
+    for country in countries:
+        if run_check:
+            check_results[country] = check_country(country)
+        if run_dedup:
+            dedup_results[country] = dedup_country(country)
+
+    print_summary(check_results, dedup_results)
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/import_nordic_to_db.py
+++ b/scripts/opendata/import_nordic_to_db.py
@@ -29,6 +29,33 @@ def get_conn():
     return psycopg2.connect(DB_URL)
 
 
+def clean_str(s):
+    """Remove null bytes that PostgreSQL rejects."""
+    if s is None:
+        return None
+    if isinstance(s, str):
+        return s.replace("\x00", "")
+    return s
+
+
+def clean_json(obj):
+    """Recursively remove null bytes from JSON-serializable object."""
+    if obj is None:
+        return None
+    s = json.dumps(obj, default=str)
+    return s.replace("\\u0000", "").replace("\x00", "")
+
+
+def clean_date(val):
+    """Validate and clean a date value. Returns YYYY-MM-DD string or None."""
+    if val is None:
+        return None
+    s = str(val)[:10]
+    if len(s) < 8 or not s[:4].isdigit():
+        return None
+    return s
+
+
 def load_checkpoint(name: str) -> set:
     cp_file = CHECKPOINT_DIR / f"nordic_{name}.json"
     if cp_file.exists():
@@ -88,20 +115,20 @@ def import_dk_hf_file(filepath: str) -> int:
 
         batch_rows.append((
             record_id,
-            ecli,
+            clean_str(ecli),
             "hf-domsdatabasen",
-            court,                                          # court_name
-            None,                                           # court_type
-            case_number,
-            case_type,
-            str(decision_date)[:10] if decision_date else None,
-            None,                                           # judge
-            None,                                           # parties
-            abstract,
-            text,                                           # full_text
-            anonymized,                                     # anonymized_text
-            None,                                           # source_url
-            json.dumps(meta, default=str) if meta else None,
+            clean_str(court),
+            None,
+            clean_str(case_number),
+            clean_str(case_type),
+            clean_date(decision_date),
+            None,
+            None,
+            clean_str(abstract),
+            clean_str(text),
+            clean_str(anonymized),
+            None,
+            clean_json(meta) if meta else None,
         ))
 
         if len(batch_rows) >= BATCH_SIZE:
@@ -218,7 +245,7 @@ def import_se_hf_file(filepath: str) -> int:
             None,                                           # court_type
             case_number,
             None,                                           # decision_type
-            str(decision_date)[:10] if decision_date else None,
+            clean_date(decision_date),
             None,                                           # judge
             title,                                          # subject
             keywords,
@@ -226,7 +253,7 @@ def import_se_hf_file(filepath: str) -> int:
             None,                                           # abstract
             text,                                           # full_text
             None,                                           # source_url
-            json.dumps(meta, default=str) if meta else None,
+            clean_json(meta) if meta else None,
         ))
 
         if len(batch_rows) >= BATCH_SIZE:

--- a/scripts/opendata/import_uk_to_db.py
+++ b/scripts/opendata/import_uk_to_db.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Import UK court decisions into PostgreSQL (parallel)."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from xml.etree import ElementTree as ET
+
+import psycopg2
+from psycopg2.extras import execute_values
+
+DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:1xfXUY8y7DM8Sm1w6T2cmBnNsnzfgnNJ2Ajl1Zl11xc@172.18.0.13:5432/secondlayer_prod",
+)
+MAX_WORKERS = 20
+BATCH_SIZE = 500
+
+UK_TNA_BASE = Path("/home/ubuntu/opendata/uk/national-archives")
+UK_HF_BASE = Path("/home/ubuntu/opendata/uk/huggingface/uk_courts_cases")
+
+AKN_NS = "http://docs.oasis-open.org/legaldocml/ns/akn/3.0"
+NS = {"akn": AKN_NS}
+
+
+def get_conn():
+    return psycopg2.connect(DB_URL)
+
+
+# ============================================================
+# UK: National Archives Akoma Ntoso XML
+# ============================================================
+
+def _extract_text(elem):
+    """Recursively extract all text content from an element."""
+    parts = []
+    if elem.text:
+        parts.append(elem.text)
+    for child in elem:
+        parts.append(_extract_text(child))
+        if child.tail:
+            parts.append(child.tail)
+    return " ".join(parts)
+
+
+def parse_tna_xml(filepath: str) -> tuple | None:
+    """Parse a single Akoma Ntoso XML file into a row tuple."""
+    try:
+        tree = ET.parse(filepath)
+    except ET.ParseError:
+        return None
+
+    root = tree.getroot()
+
+    # FRBRWork identifiers
+    frbr_work = root.find(f".//{{{AKN_NS}}}FRBRWork")
+    frbr_uri = ""
+    neutral_citation = None
+    decision_date = None
+    court_name = None
+
+    if frbr_work is not None:
+        uri_el = frbr_work.find(f"{{{AKN_NS}}}FRBRuri")
+        if uri_el is not None:
+            frbr_uri = uri_el.get("value", "")
+
+        # Neutral citation from FRBRalias with name="cite"
+        for alias in frbr_work.findall(f"{{{AKN_NS}}}FRBRalias"):
+            if alias.get("name") == "cite":
+                neutral_citation = alias.get("value")
+                break
+
+        # Decision date from FRBRdate with name="judgment"
+        for date_el in frbr_work.findall(f"{{{AKN_NS}}}FRBRdate"):
+            if date_el.get("name") == "judgment":
+                decision_date = date_el.get("date")
+                break
+
+        # Court name from FRBRauthor
+        author_el = frbr_work.find(f"{{{AKN_NS}}}FRBRauthor")
+        if author_el is not None:
+            court_name = author_el.get("href", "").lstrip("#")
+
+    # Fallback court name from header or docTitle
+    if not court_name:
+        header = root.find(f".//{{{AKN_NS}}}header")
+        if header is not None:
+            p_el = header.find(f"{{{AKN_NS}}}p")
+            if p_el is not None and p_el.text:
+                court_name = p_el.text.strip()
+        if not court_name:
+            doc_title = root.find(f".//{{{AKN_NS}}}docTitle")
+            if doc_title is not None and doc_title.text:
+                court_name = doc_title.text.strip()
+
+    # Record id from URI
+    record_id = f"tna-{frbr_uri.lstrip('/')}" if frbr_uri else f"tna-{Path(filepath).stem}"
+
+    # Court code from parent directory name
+    court_code = Path(filepath).parent.name.replace("_", "/")
+
+    # Judge(s) from judge elements
+    judges = []
+    for judge_el in root.findall(f".//{{{AKN_NS}}}judge"):
+        judge_text = (judge_el.text or "").strip()
+        if judge_text:
+            judges.append(judge_text)
+    judge = judges[0] if judges else None
+
+    # Parties from party elements
+    parties = []
+    for party_el in root.findall(f".//{{{AKN_NS}}}party"):
+        party_text = (party_el.text or "").strip()
+        if party_text:
+            parties.append(party_text)
+
+    # Full text from body
+    body = root.find(f".//{{{AKN_NS}}}body")
+    if body is None:
+        body = root.find(f".//{{{AKN_NS}}}judgmentBody")
+    full_text = _extract_text(body).strip() if body is not None else None
+
+    # Source URL
+    source_url = f"https://caselaw.nationalarchives.gov.uk{frbr_uri}" if frbr_uri else None
+
+    return (
+        record_id,                                              # id
+        None,                                                   # ecli
+        "tna",                                                  # source
+        court_name,                                             # court_name
+        court_code,                                             # court_code
+        None,                                                   # case_number
+        neutral_citation,                                       # neutral_citation
+        None,                                                   # decision_type
+        decision_date,                                          # decision_date
+        judge,                                                  # judge
+        json.dumps(judges) if judges else None,                 # judges
+        None,                                                   # subject
+        None,                                                   # keywords
+        json.dumps(parties) if parties else None,               # parties
+        None,                                                   # abstract
+        full_text,                                              # full_text
+        source_url,                                             # source_url
+        None,                                                   # metadata_json
+    )
+
+
+def import_tna_batch(filepaths: list[str]) -> int:
+    """Parse and insert a batch of TNA XML files."""
+    rows = []
+    for fp in filepaths:
+        row = parse_tna_xml(fp)
+        if row is not None:
+            rows.append(row)
+
+    if not rows:
+        return 0
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO uk_court_decisions
+                    (id, ecli, source, court_name, court_code,
+                     case_number, neutral_citation, decision_type, decision_date,
+                     judge, judges, subject, keywords, parties,
+                     abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+        return len(rows)
+    finally:
+        conn.close()
+
+
+def import_uk_tna():
+    """Import National Archives Akoma Ntoso XML files."""
+    if not UK_TNA_BASE.exists():
+        print(f"TNA directory not found: {UK_TNA_BASE}")
+        return 0
+
+    files = sorted(UK_TNA_BASE.rglob("*.xml"))
+    print(f"\nUK TNA: {len(files)} XML files to import")
+    if not files:
+        return 0
+
+    # Chunk files into batches for workers
+    batches = [
+        [str(f) for f in files[i : i + BATCH_SIZE]]
+        for i in range(0, len(files), BATCH_SIZE)
+    ]
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_tna_batch, batch): idx for idx, batch in enumerate(batches)}
+        done = 0
+        for future in as_completed(futures):
+            batch_idx = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                if done % 10 == 0 or done == len(batches):
+                    elapsed = time.time() - t0
+                    rate = imported / elapsed if elapsed > 0 else 0
+                    print(f"  TNA: {done}/{len(batches)} batches | {imported} rows | {rate:.0f}/s")
+            except Exception as e:
+                print(f"  TNA FAILED batch {batch_idx}: {e}")
+
+    print(f"  TNA complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+# ============================================================
+# UK: HuggingFace Parquet
+# ============================================================
+
+def import_uk_hf_file(filepath: str) -> int:
+    """Import a single HuggingFace parquet file."""
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        print("pyarrow not installed, skipping HF parquet import")
+        return 0
+
+    table = pq.read_table(filepath)
+    df_cols = table.column_names
+    batch_rows = []
+    total = 0
+
+    for i in range(table.num_rows):
+        row = {col: table.column(col)[i].as_py() for col in df_cols}
+
+        record_id = f"hf-uk-courts-{i}-{Path(filepath).stem}"
+        full_text = row.get("text") or row.get("content") or row.get("full_text", "")
+        case_number = row.get("case_number") or row.get("caseNumber") or row.get("signature")
+        court_name = row.get("court_name") or row.get("courtName") or row.get("court")
+        court_code = row.get("court_code") or row.get("courtCode")
+        neutral_citation = row.get("neutral_citation") or row.get("citation")
+        decision_date = row.get("date") or row.get("decision_date") or row.get("judgment_date")
+        decision_type = row.get("type") or row.get("decision_type") or row.get("judgment_type")
+        judge_name = row.get("judge") or row.get("chairman")
+        ecli = row.get("ecli")
+        subject = row.get("subject")
+        keywords = row.get("keywords")
+        parties = row.get("parties")
+        abstract = row.get("abstract") or row.get("summary")
+        source_url = row.get("source_url") or row.get("url")
+
+        meta = {
+            k: v for k, v in row.items()
+            if k not in (
+                "text", "content", "full_text", "case_number", "caseNumber", "signature",
+                "court_name", "courtName", "court", "court_code", "courtCode",
+                "neutral_citation", "citation", "date", "decision_date", "judgment_date",
+                "type", "decision_type", "judgment_type", "judge", "chairman",
+                "ecli", "subject", "keywords", "parties", "abstract", "summary",
+                "source_url", "url",
+            )
+        }
+
+        batch_rows.append((
+            record_id,
+            ecli,
+            "hf-uk-courts",
+            court_name,
+            court_code,
+            case_number,
+            neutral_citation,
+            decision_type,
+            str(decision_date)[:10] if decision_date else None,
+            judge_name,
+            None,                                                   # judges
+            subject,
+            json.dumps(keywords) if keywords and not isinstance(keywords, str) else keywords,
+            json.dumps(parties) if parties and not isinstance(parties, str) else parties,
+            abstract,
+            full_text,
+            source_url,
+            json.dumps(meta, default=str) if meta else None,
+        ))
+
+        if len(batch_rows) >= BATCH_SIZE:
+            _flush_uk_batch(batch_rows)
+            total += len(batch_rows)
+            batch_rows = []
+
+    if batch_rows:
+        _flush_uk_batch(batch_rows)
+        total += len(batch_rows)
+
+    return total
+
+
+def _flush_uk_batch(rows):
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            execute_values(cur, """
+                INSERT INTO uk_court_decisions
+                    (id, ecli, source, court_name, court_code,
+                     case_number, neutral_citation, decision_type, decision_date,
+                     judge, judges, subject, keywords, parties,
+                     abstract, full_text, source_url, metadata_json)
+                VALUES %s
+                ON CONFLICT (id) DO NOTHING
+            """, rows, page_size=BATCH_SIZE)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def import_uk_hf():
+    """Import HuggingFace Parquet files for UK courts."""
+    if not UK_HF_BASE.exists():
+        print(f"HF directory not found: {UK_HF_BASE}")
+        return 0
+
+    files = sorted(UK_HF_BASE.glob("**/*.parquet"))
+    if not files:
+        print(f"  No parquet files in {UK_HF_BASE}")
+        return 0
+
+    print(f"\nUK HF: {len(files)} parquet files")
+
+    imported = 0
+    t0 = time.time()
+    with ProcessPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        futures = {pool.submit(import_uk_hf_file, str(f)): f.name for f in files}
+        done = 0
+        for future in as_completed(futures):
+            fname = futures[future]
+            try:
+                count = future.result()
+                imported += count
+                done += 1
+                elapsed = time.time() - t0
+                rate = imported / elapsed if elapsed > 0 else 0
+                print(f"  HF: {done}/{len(files)} files | {imported} rows | {rate:.0f}/s")
+            except Exception as e:
+                print(f"  HF FAILED {fname}: {e}")
+
+    print(f"  HF complete: {imported} rows in {time.time()-t0:.0f}s")
+    return imported
+
+
+# ============================================================
+# Main
+# ============================================================
+
+def main():
+    mode = sys.argv[1] if len(sys.argv) > 1 else "all"
+
+    if mode in ("all", "tna"):
+        import_uk_tna()
+    if mode in ("all", "hf"):
+        import_uk_hf()
+
+    conn = get_conn()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT count(*) FROM uk_court_decisions")
+            uk_count = cur.fetchone()[0]
+        print(f"\n{'='*60}")
+        print(f"Total UK court decisions: {uk_count:,}")
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Import scripts for 4 jurisdictions into PostgreSQL on prod. Fulltext coverage check + SHA256 dedup.

DK: 3,917 | SE: 79,876 | FI: 73,040 | UK: 53,469 = 210,302 total rows.

Null byte sanitization and invalid date validation for Parquet import. 4,549 duplicates identified (0.02%), 96% fulltext coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Import 210,302 court decisions into PostgreSQL and add tooling to check fulltext coverage and deduplicate across DK, SE, FI, and UK. Includes a UK importer and data cleaning to prevent insert errors.

- **New Features**
  - UK importer `scripts/opendata/import_uk_to_db.py` for TNA Akoma Ntoso XML and HuggingFace Parquet; parallel batches into `uk_court_decisions`.
  - Fulltext coverage + SHA-256 dedup `scripts/opendata/check_and_dedup_nordic.py` for DK/SE/FI/UK; writes `dedup_report.json`.
  - Parquet import sanitizes null bytes, cleans JSON, and normalizes dates to `YYYY-MM-DD`.
  - Imported: DK 3,917; SE 79,876; FI 73,040; UK 53,469 (210,302 total). 96% fulltext. 4,549 duplicates flagged.

<sup>Written for commit f4fb667d2a39caf0593054582ccb1f9d1eff7b79. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1800?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

