### PR TITLE
fix(search): support pre-2017 VSU case number format

### DIFF
--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -172,23 +172,14 @@ export function generateCaseNumberVariations(caseNumber: string): string[] {
   const variations = new Set<string>();
   variations.add(caseNumber);
 
+  // Standard format: 123/456/22-ц
   const match = caseNumber.match(/^(\d+\/\d+\/)(\d{2,4})(-[а-яіїєґА-ЯІЇЄҐ])?$/);
   if (match) {
     const prefix = match[1];
     const year = match[2];
     const suffix = match[3] || '';
 
-    let shortYear = year;
-    let longYear = year;
-
-    if (year.length === 2) {
-      shortYear = year;
-      const yearNum = parseInt(year, 10);
-      longYear = yearNum < 50 ? `20${year}` : `19${year}`;
-    } else if (year.length === 4) {
-      longYear = year;
-      shortYear = year.slice(-2);
-    }
+    const [shortYear, longYear] = expandYear(year);
 
     variations.add(`${prefix}${shortYear}${suffix}`);
     variations.add(`${prefix}${longYear}${suffix}`);
@@ -199,7 +190,29 @@ export function generateCaseNumberVariations(caseNumber: string): string[] {
     }
   }
 
+  // Pre-2017 VSU format: 5-15кс12 → also try 5-15/12, 5-15/2012
+  const vsuMatch = caseNumber.match(/^(\d+-\d+)[а-яіїєґА-ЯІЇЄҐ]+(\d{2,4})$/);
+  if (vsuMatch) {
+    const numPart = vsuMatch[1];
+    const year = vsuMatch[2];
+    const [shortYear, longYear] = expandYear(year);
+
+    variations.add(`${numPart}/${shortYear}`);
+    variations.add(`${numPart}/${longYear}`);
+  }
+
   return Array.from(variations);
+}
+
+function expandYear(year: string): [string, string] {
+  if (year.length === 2) {
+    const yearNum = parseInt(year, 10);
+    return [year, yearNum < 50 ? `20${year}` : `19${year}`];
+  }
+  if (year.length === 4) {
+    return [year.slice(-2), year];
+  }
+  return [year, year];
 }
 
 /**


### PR DESCRIPTION
## Summary
- `generateCaseNumberVariations` now handles old VSU (Верховний Суд України) case numbers like `5-15кс12`
- Generates slash-based variations (`5-15/12`, `5-15/2012`) that EDRSR actually stores
- Extracted `expandYear` helper to reduce duplication

## Context
User searched for `5-15кс12` — the system found 0 results because EDRSR stores the same case as `5-15/12`. The regex only matched the modern `число/число/рік` format.

## Test plan
- [x] Verified `5-15кс12` → `['5-15кс12', '5-15/12', '5-15/2012']`
- [x] Verified standard format `123/456/22-ц` still works correctly
- [x] Verified `5-15/12` does NOT falsely match VSU pattern
- [x] TypeScript build passes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes search for old VSU case numbers by generating EDRSR-compatible variations. Queries like 5-15кс12 now match cases stored as 5-15/12 and 5-15/2012.

- **Bug Fixes**
  - Parse pre-2017 VSU format (e.g., 5-15кс12) in `generateCaseNumberVariations`.
  - Generate slash-based 2-digit and 4-digit year variants; modern `123/456/22-ц` behavior unchanged.

- **Refactors**
  - Extracted `expandYear(year)` to centralize 2-digit/4-digit year expansion.

<sup>Written for commit d1e6b37b533977b34f5b7fcf7a5cb9a3c6ed34b4. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1803?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

