### PR TITLE
fix(data): correct IN-SC jurisdiction stats trigger and seed

### DIFF
--- a/mcp_backend/src/migrations/158_fix_india_sc_stats.sql
+++ b/mcp_backend/src/migrations/158_fix_india_sc_stats.sql
@@ -1,0 +1,51 @@
+-- Migration 158: Fix IN-SC jurisdiction stats
+-- Problem: indian_sc_judgments (38K metadata) and indian_court_fulltext source='sc' (149K fulltext)
+-- are completely disjoint (zero CNR overlap). The fulltext trigger only tracked fulltext_decisions
+-- but each fulltext entry is a distinct decision, so total_decisions was undercounted.
+-- Fix: update trigger to also track total_decisions for SC, then re-seed from actual data.
+
+-- ============================================================
+-- UPDATED TRIGGER: indian_court_fulltext → jurisdiction_fulltext_stats
+-- For SC: each fulltext entry is a distinct decision (no overlap with indian_sc_judgments),
+-- so we increment both total_decisions and fulltext_decisions.
+-- For HC: indian_hc_judgments already tracks total_decisions, so only fulltext_decisions.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION trg_jurisdiction_stats_india_fulltext()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_code TEXT;
+    v_src TEXT;
+BEGIN
+    v_src := CASE WHEN TG_OP = 'DELETE' THEN OLD.source ELSE NEW.source END;
+    v_code := CASE WHEN v_src = 'sc' THEN 'IN-SC' WHEN v_src = 'hc' THEN 'IN-HC' END;
+
+    IF v_code IS NULL THEN RETURN NULL; END IF;
+
+    IF TG_OP = 'INSERT' THEN
+        UPDATE jurisdiction_fulltext_stats SET
+            total_decisions    = total_decisions    + CASE WHEN v_code = 'IN-SC' THEN 1 ELSE 0 END,
+            fulltext_decisions = fulltext_decisions + 1,
+            updated_at = NOW()
+        WHERE jurisdiction_code = v_code;
+    ELSIF TG_OP = 'DELETE' THEN
+        UPDATE jurisdiction_fulltext_stats SET
+            total_decisions    = total_decisions    - CASE WHEN v_code = 'IN-SC' THEN 1 ELSE 0 END,
+            fulltext_decisions = fulltext_decisions - 1,
+            updated_at = NOW()
+        WHERE jurisdiction_code = v_code;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================================
+-- RE-SEED IN-SC: total = metadata + fulltext (disjoint sets)
+-- ============================================================
+
+UPDATE jurisdiction_fulltext_stats SET
+    total_decisions = (SELECT COUNT(*) FROM indian_sc_judgments)
+                    + COALESCE((SELECT COUNT(*) FROM indian_court_fulltext WHERE source = 'sc'), 0),
+    fulltext_decisions = COALESCE((SELECT COUNT(*) FROM indian_court_fulltext WHERE source = 'sc'), 0),
+    updated_at = NOW()
+WHERE jurisdiction_code = 'IN-SC';


### PR DESCRIPTION
## Summary
- `indian_sc_judgments` (38K metadata) and `indian_court_fulltext source='sc'` (149K fulltext) are completely disjoint (zero CNR overlap)
- The fulltext trigger only tracked `fulltext_decisions` but not `total_decisions`, causing 389% fulltext ratio
- Fix: trigger now increments both counters for IN-SC; re-seed sets total = 187,153, fulltext = 148,884 (79.6%)

## Test plan
- [x] Already applied on prod, verified correct stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IN-SC jurisdiction stats by updating the fulltext trigger to also count total decisions and re-seeding accurate counts. Prevents inflated ratios caused by disjoint Supreme Court datasets.

- **Bug Fixes**
  - Update `trg_jurisdiction_stats_india_fulltext`: for `IN-SC`, increment/decrement both `total_decisions` and `fulltext_decisions`; for `IN-HC`, only `fulltext_decisions`.
  - Re-seed IN-SC stats from source tables: total = 187,153; fulltext = 148,884 (79.6%).
  - Reason: `indian_sc_judgments` and `indian_court_fulltext` with `source='sc'` are disjoint; prior logic undercounted totals and produced a 389% fulltext ratio.

<sup>Written for commit 4e6e7233fffb76af9e1deddc195b8580ea17d7b2. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1805?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

