### PR TITLE
fix(data): wrap IN-SC reseed in conditional for envs without India tables

### DIFF
--- a/mcp_backend/src/migrations/158_fix_india_sc_stats.sql
+++ b/mcp_backend/src/migrations/158_fix_india_sc_stats.sql
@@ -43,9 +43,13 @@ $$ LANGUAGE plpgsql;
 -- RE-SEED IN-SC: total = metadata + fulltext (disjoint sets)
 -- ============================================================
 
-UPDATE jurisdiction_fulltext_stats SET
-    total_decisions = (SELECT COUNT(*) FROM indian_sc_judgments)
-                    + COALESCE((SELECT COUNT(*) FROM indian_court_fulltext WHERE source = 'sc'), 0),
-    fulltext_decisions = COALESCE((SELECT COUNT(*) FROM indian_court_fulltext WHERE source = 'sc'), 0),
-    updated_at = NOW()
-WHERE jurisdiction_code = 'IN-SC';
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'indian_sc_judgments' AND table_schema = 'public') THEN
+        UPDATE jurisdiction_fulltext_stats SET
+            total_decisions = (SELECT COUNT(*) FROM indian_sc_judgments)
+                            + COALESCE((SELECT COUNT(*) FROM indian_court_fulltext WHERE source = 'sc'), 0),
+            fulltext_decisions = COALESCE((SELECT COUNT(*) FROM indian_court_fulltext WHERE source = 'sc'), 0),
+            updated_at = NOW()
+        WHERE jurisdiction_code = 'IN-SC';
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary
- Migration 158 failed on local CI because `indian_sc_judgments` table doesn't exist in the local environment
- Wrapped the reseed UPDATE in `DO $$ IF EXISTS ... END $$` to match the pattern used in migrations 156/157

## Test plan
- [ ] CI passes on local (no India tables)
- [x] Already verified on prod (has India tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)