### PR TITLE
Simplify pitch deck slides for screen presentation

### DIFF
--- a/docs/pitch-deck.html
+++ b/docs/pitch-deck.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>LEX AI — Legal Intelligence & Due Diligence Platform</title>
+<title>LEX AI -- Legal Intelligence & Due Diligence Platform</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -23,12 +23,14 @@
   .slide {
     width: 1280px;
     height: 720px;
-    padding: 60px 80px;
+    padding: 70px 90px;
     position: relative;
     overflow: hidden;
     page-break-after: always;
     page-break-inside: avoid;
     background: #0c0c1a;
+    display: flex;
+    flex-direction: column;
   }
 
   .slide::before {
@@ -45,7 +47,7 @@
     bottom: 30px;
     right: 50px;
     font-size: 13px;
-    color: rgba(255,255,255,0.25);
+    color: rgba(255,255,255,0.2);
     font-weight: 500;
     letter-spacing: 1px;
   }
@@ -53,67 +55,50 @@
   .logo-bar {
     position: absolute;
     bottom: 30px;
-    left: 80px;
+    left: 90px;
     font-size: 13px;
-    color: rgba(255,255,255,0.3);
+    color: rgba(255,255,255,0.25);
     font-weight: 600;
     letter-spacing: 2px;
     text-transform: uppercase;
   }
 
-  /* ===== SLIDE 1: Cover ===== */
+  h2 {
+    font-size: 46px;
+    font-weight: 700;
+    margin-bottom: 44px;
+    line-height: 1.15;
+    position: relative;
+  }
+
+  h2 span { color: #60a5fa; }
+
+  .big-point {
+    font-size: 22px;
+    color: #cbd5e1;
+    line-height: 1.7;
+    max-width: 900px;
+  }
+
+  .big-point strong { color: #f1f5f9; }
+
+  .pill {
+    display: inline-block;
+    padding: 7px 16px;
+    background: rgba(59,130,246,0.1);
+    border: 1px solid rgba(59,130,246,0.2);
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #93c5fd;
+    margin: 0 6px 8px 0;
+  }
+
+  /* cover */
   .cover {
-    display: flex;
-    flex-direction: column;
     justify-content: center;
     align-items: flex-start;
     background: linear-gradient(135deg, #0c0c1a 0%, #0f172a 50%, #0c0c1a 100%);
-  }
-
-  .cover .badge {
-    display: inline-block;
-    padding: 6px 18px;
-    border: 1px solid rgba(59, 130, 246, 0.4);
-    border-radius: 20px;
-    font-size: 13px;
-    font-weight: 500;
-    color: #60a5fa;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
-    margin-bottom: 30px;
-  }
-
-  .cover h1 {
-    font-size: 64px;
-    font-weight: 800;
-    line-height: 1.1;
-    margin-bottom: 20px;
-    color: #ffffff;
-  }
-
-  .cover h1 span {
-    color: #60a5fa;
-  }
-
-  .cover .subtitle {
-    font-size: 20px;
-    font-weight: 300;
-    color: #94a3b8;
-    line-height: 1.5;
-    max-width: 700px;
-    margin-bottom: 36px;
-  }
-
-  .cover .urls {
-    display: flex;
-    gap: 30px;
-  }
-
-  .cover .url {
-    font-size: 15px;
-    font-weight: 500;
-    color: #60a5fa;
-    letter-spacing: 0.5px;
   }
 
   .cover .glow-orb {
@@ -127,283 +112,141 @@
     background: radial-gradient(circle, rgba(59,130,246,0.15) 0%, rgba(139,92,246,0.08) 40%, transparent 70%);
   }
 
-  /* ===== Common ===== */
-  .slide h2 {
+  /* stat row */
+  .stat-row {
+    display: flex;
+    gap: 48px;
+    margin-top: auto;
+    padding-top: 30px;
+  }
+
+  .stat-item .val {
     font-size: 40px;
-    font-weight: 700;
-    margin-bottom: 40px;
+    font-weight: 800;
+    color: #60a5fa;
     line-height: 1.2;
   }
 
-  .slide h2 span {
-    color: #60a5fa;
-  }
-
-  .feature-pill {
-    display: inline-block;
-    padding: 8px 16px;
-    background: rgba(59,130,246,0.1);
-    border: 1px solid rgba(59,130,246,0.2);
-    border-radius: 8px;
+  .stat-item .lbl {
     font-size: 13px;
-    font-weight: 500;
-    color: #93c5fd;
-    margin: 0 6px 10px 0;
+    color: #64748b;
+    margin-top: 4px;
   }
 
-  .feature-pill.purple {
-    background: rgba(139,92,246,0.1);
-    border: 1px solid rgba(139,92,246,0.2);
-    color: #c4b5fd;
-  }
-
-  /* ===== Problem Grid ===== */
-  .problem-grid {
+  /* grid helpers */
+  .grid-2 {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 24px;
-    margin-top: 10px;
+    gap: 28px;
   }
 
-  .problem-card {
+  .grid-3 {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 24px;
+  }
+
+  .card {
     background: rgba(255,255,255,0.03);
     border: 1px solid rgba(255,255,255,0.06);
     border-radius: 16px;
     padding: 30px;
   }
 
-  .problem-card .icon {
-    font-size: 28px;
-    margin-bottom: 14px;
-  }
-
-  .problem-card h3 {
-    font-size: 18px;
+  .card h3 {
+    font-size: 20px;
     font-weight: 600;
-    margin-bottom: 10px;
     color: #f1f5f9;
+    margin-bottom: 10px;
   }
 
-  .problem-card p {
-    font-size: 14px;
+  .card p {
+    font-size: 15px;
     line-height: 1.6;
     color: #94a3b8;
   }
 
-  /* ===== Solution Cards ===== */
-  .solution-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-    margin-top: 10px;
+  /* pipeline */
+  .pipeline {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    flex: 1;
   }
 
-  .solution-card {
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(59,130,246,0.15);
-    border-radius: 16px;
-    padding: 30px;
-  }
-
-  .solution-card h3 {
-    font-size: 20px;
-    font-weight: 600;
-    margin-bottom: 10px;
-    color: #60a5fa;
-  }
-
-  .solution-card p {
-    font-size: 15px;
-    line-height: 1.7;
-    color: #cbd5e1;
-  }
-
-  /* ===== Data Grid ===== */
-  .data-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-    margin-top: 10px;
-  }
-
-  .data-card {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 16px;
-    padding: 24px;
+  .pipeline .step {
+    flex: 1;
     text-align: center;
-  }
-
-  .data-card .number {
-    font-size: 34px;
-    font-weight: 800;
-    color: #60a5fa;
-    margin-bottom: 4px;
-    line-height: 1.2;
-  }
-
-  .data-card .unit {
-    font-size: 13px;
-    font-weight: 500;
-    color: #60a5fa;
-    margin-bottom: 8px;
-  }
-
-  .data-card .desc {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.5;
-  }
-
-  .data-card.purple .unit { color: #a78bfa; }
-
-  /* ===== Tech ===== */
-  .tech-layout {
-    display: flex;
-    gap: 40px;
-  }
-
-  .tech-left { flex: 1; }
-  .tech-right { flex: 1; }
-
-  .arch-box {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 12px;
-    padding: 18px 22px;
-    margin-bottom: 12px;
-  }
-
-  .arch-box h4 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin-bottom: 4px;
-  }
-
-  .arch-box p {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.5;
-  }
-
-  .tech-stack-list {
-    list-style: none;
-  }
-
-  .tech-stack-list li {
-    padding: 8px 0;
-    border-bottom: 1px solid rgba(255,255,255,0.04);
-    font-size: 13px;
-    color: #cbd5e1;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .tech-stack-list li .dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #3b82f6;
-    flex-shrink: 0;
-  }
-
-  .tech-stack-list li .dot.purple { background: #8b5cf6; }
-
-  /* ===== Market ===== */
-  .market-layout {
-    display: flex;
-    gap: 50px;
-    align-items: flex-start;
-  }
-
-  .market-circles {
-    flex: 0.8;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-  }
-
-  .circle {
-    border-radius: 16px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 20px;
-    width: 100%;
-  }
-
-  .circle-tam {
+    padding: 28px 16px;
+    border-radius: 14px;
     background: rgba(59,130,246,0.06);
     border: 1px solid rgba(59,130,246,0.15);
   }
 
-  .circle-sam {
-    background: rgba(59,130,246,0.10);
-    border: 1px solid rgba(59,130,246,0.25);
+  .pipeline .step h3 {
+    font-size: 18px;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 6px;
   }
 
-  .circle-som {
-    background: rgba(59,130,246,0.18);
-    border: 1px solid rgba(59,130,246,0.35);
+  .pipeline .step p {
+    font-size: 12px;
+    color: #94a3b8;
+    line-height: 1.4;
   }
 
-  .circle .c-label {
-    font-size: 11px;
+  .pipeline .arrow {
+    font-size: 20px;
+    color: #475569;
+    padding: 0 10px;
+    flex-shrink: 0;
+  }
+
+  /* market circles */
+  .market-row {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 36px;
+  }
+
+  .market-box {
+    flex: 1;
+    border-radius: 16px;
+    padding: 28px;
+    text-align: center;
+  }
+
+  .market-box .c-label {
+    font-size: 12px;
     font-weight: 600;
     color: #60a5fa;
     letter-spacing: 1.5px;
     text-transform: uppercase;
   }
 
-  .circle .c-value {
-    font-size: 28px;
+  .market-box .c-value {
+    font-size: 36px;
     font-weight: 800;
     color: #f1f5f9;
+    margin: 4px 0;
   }
 
-  .market-details { flex: 1; }
-
-  .market-item {
-    margin-bottom: 22px;
-  }
-
-  .market-item h4 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #60a5fa;
-    margin-bottom: 6px;
-  }
-
-  .market-item p {
-    font-size: 14px;
-    line-height: 1.6;
+  .market-box .c-desc {
+    font-size: 13px;
     color: #94a3b8;
   }
 
-  .market-item .highlight {
-    color: #f1f5f9;
-    font-weight: 600;
-  }
+  .tam { background: rgba(59,130,246,0.06); border: 1px solid rgba(59,130,246,0.15); }
+  .sam { background: rgba(59,130,246,0.10); border: 1px solid rgba(59,130,246,0.25); }
+  .som { background: rgba(59,130,246,0.18); border: 1px solid rgba(59,130,246,0.35); }
 
-  /* ===== Pricing ===== */
-  .pricing-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-    margin-top: 10px;
-  }
-
+  /* pricing */
   .pricing-card {
     background: rgba(255,255,255,0.02);
     border: 1px solid rgba(255,255,255,0.06);
     border-radius: 16px;
-    padding: 28px;
-    position: relative;
+    padding: 32px;
   }
 
   .pricing-card.featured {
@@ -417,14 +260,13 @@
     color: #94a3b8;
     text-transform: uppercase;
     letter-spacing: 1px;
-    margin-bottom: 10px;
+    margin-bottom: 12px;
   }
 
   .pricing-card .price {
-    font-size: 34px;
+    font-size: 38px;
     font-weight: 800;
     color: #f1f5f9;
-    margin-bottom: 4px;
   }
 
   .pricing-card .price span {
@@ -434,87 +276,20 @@
   }
 
   .pricing-card .desc {
-    font-size: 13px;
-    color: #94a3b8;
-    line-height: 1.5;
-    margin-top: 10px;
-  }
-
-  .unit-econ {
-    display: flex;
-    gap: 36px;
-    margin-top: 24px;
-    padding-top: 18px;
-    border-top: 1px solid rgba(255,255,255,0.06);
-  }
-
-  .unit-econ-item { text-align: center; }
-
-  .unit-econ-item .val {
-    font-size: 26px;
-    font-weight: 800;
-    color: #60a5fa;
-  }
-
-  .unit-econ-item .lbl {
-    font-size: 11px;
-    color: #64748b;
-    margin-top: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  /* ===== Traction ===== */
-  .traction-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-    margin-bottom: 28px;
-  }
-
-  .traction-card {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 16px;
-    padding: 36px;
-    text-align: center;
-  }
-
-  .traction-card .t-val {
-    font-size: 42px;
-    font-weight: 800;
-    color: #f1f5f9;
-    margin-bottom: 8px;
-  }
-
-  .traction-card .t-label {
     font-size: 14px;
     color: #94a3b8;
-    letter-spacing: 0.5px;
+    margin-top: 10px;
+    line-height: 1.5;
   }
 
-  .traction-card .t-detail {
-    font-size: 12px;
-    color: #64748b;
-    margin-top: 8px;
-    line-height: 1.4;
-  }
-
-  /* ===== Team ===== */
-  .team-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 30px;
-    margin-bottom: 30px;
-  }
-
+  /* team */
   .team-card {
     background: rgba(255,255,255,0.02);
     border: 1px solid rgba(255,255,255,0.06);
     border-radius: 16px;
-    padding: 28px;
+    padding: 32px;
     display: flex;
-    gap: 20px;
+    gap: 22px;
     align-items: flex-start;
   }
 
@@ -535,58 +310,63 @@
   .team-avatar.ik { background: linear-gradient(135deg, #06b6d4, #3b82f6); }
 
   .team-info h4 {
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 700;
     color: #f1f5f9;
     margin-bottom: 2px;
   }
 
   .team-info .role {
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 500;
     color: #60a5fa;
     margin-bottom: 10px;
   }
 
   .team-info p {
-    font-size: 13px;
+    font-size: 14px;
     color: #94a3b8;
     line-height: 1.6;
   }
 
-  .why-us {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 18px;
+  /* phase */
+  .phase {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 16px;
+    padding: 36px;
+    position: relative;
   }
 
-  .why-item {
-    background: rgba(59,130,246,0.04);
-    border: 1px solid rgba(59,130,246,0.1);
-    border-radius: 12px;
-    padding: 20px;
-    text-align: center;
+  .phase .num {
+    font-size: 56px;
+    font-weight: 800;
+    color: rgba(59,130,246,0.12);
+    position: absolute;
+    top: 18px;
+    right: 24px;
+    line-height: 1;
   }
 
-  .why-item h4 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin-bottom: 6px;
+  .phase h3 {
+    font-size: 22px;
+    font-weight: 700;
+    color: #60a5fa;
+    margin-bottom: 12px;
   }
 
-  .why-item p {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.5;
+  .phase p {
+    font-size: 15px;
+    color: #cbd5e1;
+    line-height: 1.6;
   }
 
-  /* ===== Contact ===== */
+  /* contact */
   .contact-box {
     background: rgba(255,255,255,0.02);
     border: 1px solid rgba(255,255,255,0.08);
     border-radius: 16px;
-    padding: 28px;
+    padding: 36px;
   }
 
   .contact-box h4 {
@@ -595,11 +375,11 @@
     color: #60a5fa;
     text-transform: uppercase;
     letter-spacing: 1.5px;
-    margin-bottom: 16px;
+    margin-bottom: 18px;
   }
 
   .contact-line {
-    font-size: 14px;
+    font-size: 16px;
     color: #cbd5e1;
     margin-bottom: 8px;
     line-height: 1.5;
@@ -607,9 +387,8 @@
 
   .contact-line strong { color: #f1f5f9; }
 
-  .contact-url {
+  .btn {
     display: inline-block;
-    margin-top: 12px;
     padding: 10px 24px;
     background: linear-gradient(135deg, #3b82f6, #8b5cf6);
     border-radius: 8px;
@@ -617,99 +396,8 @@
     font-weight: 600;
     font-size: 14px;
     text-decoration: none;
-  }
-
-  /* ===== Pipeline ===== */
-  .pipeline-flow {
-    display: flex;
-    align-items: center;
-    gap: 0;
-    margin: 20px 0;
-  }
-
-  .pipeline-step {
-    flex: 1;
-    text-align: center;
-    padding: 24px 16px;
-    border-radius: 12px;
-    position: relative;
-    background: rgba(59,130,246,0.06);
-    border: 1px solid rgba(59,130,246,0.15);
-  }
-
-  .pipeline-step .step-num {
-    font-size: 11px;
-    font-weight: 700;
-    color: #60a5fa;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    margin-bottom: 8px;
-  }
-
-  .pipeline-step .step-title {
-    font-size: 15px;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin-bottom: 6px;
-  }
-
-  .pipeline-step .step-desc {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.4;
-  }
-
-  .pipeline-arrow {
-    font-size: 20px;
-    color: #475569;
-    flex-shrink: 0;
-    padding: 0 8px;
-  }
-
-  /* ===== LLM Phases ===== */
-  .llm-phases {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-    margin-top: 10px;
-  }
-
-  .llm-phase {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 16px;
-    padding: 32px;
-    position: relative;
-  }
-
-  .llm-phase .phase-num {
-    font-size: 48px;
-    font-weight: 800;
-    color: rgba(59,130,246,0.15);
-    position: absolute;
-    top: 16px;
-    right: 20px;
-    line-height: 1;
-  }
-
-  .llm-phase h3 {
-    font-size: 18px;
-    font-weight: 700;
-    color: #60a5fa;
-    margin-bottom: 12px;
-  }
-
-  .llm-phase p {
-    font-size: 14px;
-    color: #cbd5e1;
-    line-height: 1.7;
-  }
-
-  .llm-phase .detail {
-    font-size: 12px;
-    color: #64748b;
-    margin-top: 12px;
-    line-height: 1.5;
+    border: none;
+    cursor: pointer;
   }
 </style>
 </head>
@@ -718,41 +406,37 @@
 <!-- SLIDE 1: Title -->
 <div class="slide cover">
   <div class="glow-orb"></div>
-  <div class="badge">Legal Intelligence & Due Diligence</div>
-  <h1>LEX AI<br><span>Legal Analytics</span><br>As Fast As You Type</h1>
-  <div class="subtitle">
-    We build AI products for legal analytics and due diligence. We train models to gain precision and scale. We collect datasets from open data across countries.
+  <div style="display:inline-block;padding:6px 18px;border:1px solid rgba(59,130,246,0.4);border-radius:20px;font-size:13px;font-weight:500;color:#60a5fa;letter-spacing:1.5px;text-transform:uppercase;margin-bottom:30px;">Legal Intelligence & Due Diligence</div>
+  <h1 style="font-size:68px;font-weight:800;line-height:1.1;margin-bottom:20px;color:#fff;position:relative;">LEX AI</h1>
+  <p style="font-size:24px;font-weight:300;color:#94a3b8;line-height:1.6;max-width:700px;position:relative;">
+    Legal analytics as fast as you type.<br>We train models to gain precision and scale.
+  </p>
+  <div style="margin-top:auto;position:relative;display:flex;align-items:center;gap:30px;">
+    <span style="font-size:15px;font-weight:500;color:#60a5fa;">legal.org.ua</span>
+    <a href="pitch-deck.pdf" download class="btn" style="font-size:13px;padding:8px 20px;box-shadow:0 4px 12px rgba(59,130,246,0.3);" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Download PDF</a>
   </div>
-  <div class="urls">
-    <div class="url">legal.org.ua</div>
-  </div>
-  <a href="pitch-deck.pdf" download style="margin-top:18px;padding:10px 22px;background:linear-gradient(135deg,#3b82f6,#8b5cf6);border:none;border-radius:8px;color:#fff;font-size:13px;font-weight:600;cursor:pointer;box-shadow:0 4px 12px rgba(59,130,246,0.3);transition:opacity .2s;text-decoration:none;display:inline-block;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Download PDF</a>
   <div class="slide-number">01</div>
 </div>
 
 <!-- SLIDE 2: Problem -->
 <div class="slide">
   <h2>The <span>Problem</span></h2>
-  <div class="problem-grid">
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">01</div>
-      <h3>Legal Work is Slow</h3>
-      <p>Lawyers still spend days on manual search across fragmented court databases. Legacy tools offer no AI, no semantic understanding.</p>
+  <div class="grid-2" style="flex:1;">
+    <div class="card">
+      <h3>Legal work is slow</h3>
+      <p>Lawyers spend days on manual search. Legacy tools have no AI, no semantic understanding.</p>
     </div>
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">02</div>
-      <h3>Due Diligence is Fragmented</h3>
-      <p>Checking a counterparty means 10+ separate databases: sanctions, registries, offshore leaks, ownership chains. No one tool connects them all.</p>
+    <div class="card">
+      <h3>Due diligence is fragmented</h3>
+      <p>10+ separate databases to check one counterparty. No single tool connects them.</p>
     </div>
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">03</div>
-      <h3>Many Separate Sources</h3>
-      <p>Court decisions, parliament data, business registries, sanctions lists -- scattered across dozens of systems with no unified interface.</p>
+    <div class="card">
+      <h3>Many separate sources</h3>
+      <p>Courts, parliament, registries, sanctions -- scattered across dozens of systems.</p>
     </div>
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">04</div>
-      <h3>Risks Found Too Late</h3>
-      <p>Important risks are often discovered after the deal closes. Undisclosed owners, sanctions violations, hidden liabilities -- all discoverable, none automatically flagged.</p>
+    <div class="card">
+      <h3>Risks found too late</h3>
+      <p>Hidden owners, sanctions violations, liabilities -- discoverable but never flagged automatically.</p>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -761,30 +445,21 @@
 
 <!-- SLIDE 3: Solution -->
 <div class="slide">
-  <h2>The <span>Solution</span></h2>
-  <div style="display:flex;flex-direction:column;gap:30px;margin-top:10px;">
-    <div style="max-width:900px;">
-      <p style="font-size:22px;color:#cbd5e1;line-height:1.7;margin-bottom:24px;">
-        <strong style="color:#60a5fa;">LEX AI</strong> is a chat pipeline service that handles legal research, case analysis, sanctions screening, ownership checks, and risk assessment -- all in one place.
-      </p>
+  <h2><span>LEX AI</span> Chat Pipeline</h2>
+  <div class="big-point" style="margin-bottom:40px;">
+    One service for legal research, case analysis,<br>sanctions, ownership, and risk checks.<br>
+    At the end of the pipeline -- <strong>one clear picture</strong>.
+  </div>
+  <div class="grid-2" style="max-width:900px;">
+    <div>
+      <div class="pill">Legal Research</div>
+      <div class="pill">Case Analysis</div>
+      <div class="pill">Legislation</div>
     </div>
-    <div class="solution-grid">
-      <div class="solution-card">
-        <h3>Legal Research & Case Analysis</h3>
-        <p>AI reads hundreds of court documents, identifies patterns, finds precedents, and generates defense strategies automatically.</p>
-      </div>
-      <div class="solution-card">
-        <h3>Sanctions & Ownership Checks</h3>
-        <p>Screen counterparties against global sanctions lists, trace beneficial ownership chains, and check offshore connections.</p>
-      </div>
-      <div class="solution-card">
-        <h3>Risk Assessment</h3>
-        <p>Aggregate findings into a single risk profile with risk scores, flagged issues, and recommended action points.</p>
-      </div>
-      <div class="solution-card">
-        <h3>One Clear Picture</h3>
-        <p>At the end of the pipeline, you have a complete view: legal history, compliance status, risk level, and next steps.</p>
-      </div>
+    <div>
+      <div class="pill">Sanctions Screening</div>
+      <div class="pill">Ownership Chains</div>
+      <div class="pill">Risk Assessment</div>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -794,51 +469,26 @@
 <!-- SLIDE 4: How It Works -->
 <div class="slide">
   <h2>How <span>It Works</span></h2>
-  <div style="margin-bottom:20px;">
-    <p style="font-size:18px;color:#cbd5e1;line-height:1.6;">One request checks many sources at once. Typical due diligence takes under 5 minutes.</p>
-  </div>
-  <div class="pipeline-flow">
-    <div class="pipeline-step">
-      <div class="step-num">Step 1</div>
-      <div class="step-title">User Query</div>
-      <div class="step-desc">Natural language request -- a company name, a legal question, a counterparty check</div>
+  <p class="big-point" style="margin-bottom:32px;">One request. Many sources. Under 5 minutes.</p>
+  <div class="pipeline">
+    <div class="step">
+      <h3>Query</h3>
+      <p>Natural language request</p>
     </div>
-    <div class="pipeline-arrow">-></div>
-    <div class="pipeline-step">
-      <div class="step-num">Step 2</div>
-      <div class="step-title">Multi-Source Search</div>
-      <div class="step-desc">AI pipeline queries courts, registries, sanctions, ownership, legislation in parallel</div>
+    <div class="arrow">-></div>
+    <div class="step">
+      <h3>Multi-Source</h3>
+      <p>Courts, registries, sanctions in parallel</p>
     </div>
-    <div class="pipeline-arrow">-></div>
-    <div class="pipeline-step">
-      <div class="step-num">Step 3</div>
-      <div class="step-title">AI Analysis</div>
-      <div class="step-desc">Reads hundreds of documents, extracts key facts, identifies risks and patterns</div>
+    <div class="arrow">-></div>
+    <div class="step">
+      <h3>AI Analysis</h3>
+      <p>Reads hundreds of documents</p>
     </div>
-    <div class="pipeline-arrow">-></div>
-    <div class="pipeline-step">
-      <div class="step-num">Step 4</div>
-      <div class="step-title">Clear Output</div>
-      <div class="step-desc">Risk score, action points, related data, defense strategies -- one unified report</div>
-    </div>
-  </div>
-
-  <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-top:30px;">
-    <div style="background:linear-gradient(135deg,rgba(59,130,246,0.08),rgba(139,92,246,0.06));border:1px solid rgba(59,130,246,0.15);border-radius:16px;padding:28px;">
-      <h4 style="font-size:14px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px;">Due Diligence</h4>
-      <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:8px;">
-        <span style="font-size:28px;font-weight:800;color:#60a5fa;">&lt;5 min</span>
-        <span style="font-size:13px;color:#94a3b8;">full counterparty screening</span>
-      </div>
-      <p style="font-size:12px;color:#94a3b8;line-height:1.5;">Sanctions + ownership + court history + enforcement -- unified risk score for any entity.</p>
-    </div>
-    <div style="background:linear-gradient(135deg,rgba(59,130,246,0.08),rgba(139,92,246,0.06));border:1px solid rgba(59,130,246,0.15);border-radius:16px;padding:28px;">
-      <h4 style="font-size:14px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px;">Legal Case Research</h4>
-      <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:8px;">
-        <span style="font-size:28px;font-weight:800;color:#60a5fa;">Hundreds</span>
-        <span style="font-size:13px;color:#94a3b8;">of documents analyzed quickly</span>
-      </div>
-      <p style="font-size:12px;color:#94a3b8;line-height:1.5;">AI reads court decisions, finds relevant precedents, extracts strategies -- what took a week now takes minutes.</p>
+    <div class="arrow">-></div>
+    <div class="step">
+      <h3>Output</h3>
+      <p>Risk score, action points, report</p>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -848,55 +498,31 @@
 <!-- SLIDE 5: Data Moat -->
 <div class="slide">
   <h2><span>Data</span> Moat</h2>
-  <div style="margin-bottom:24px;">
-    <p style="font-size:18px;color:#cbd5e1;line-height:1.6;">Our advantage is data quality and scale. ML pipelines for model fine-tuning and training.</p>
+  <div class="stat-row" style="margin-top:0;padding-top:0;margin-bottom:36px;">
+    <div class="stat-item">
+      <div class="val">130M+</div>
+      <div class="lbl">Court Decisions</div>
+    </div>
+    <div class="stat-item">
+      <div class="val">22</div>
+      <div class="lbl">Countries</div>
+    </div>
+    <div class="stat-item">
+      <div class="val">4M+</div>
+      <div class="lbl">Sanctions Entities</div>
+    </div>
+    <div class="stat-item">
+      <div class="val">810K+</div>
+      <div class="lbl">Offshore Links</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;">
-    <div class="data-card">
-      <div class="number">130M+</div>
-      <div class="unit">Court Decisions</div>
-      <div class="desc">Across 22 countries</div>
-    </div>
-    <div class="data-card">
-      <div class="number">5M</div>
-      <div class="unit">Full-Text Indexed</div>
-      <div class="desc">Parsed for semantic search</div>
-    </div>
-    <div class="data-card">
-      <div class="number">2M</div>
-      <div class="unit">Vector Embeddings</div>
-      <div class="desc">AI-powered similarity search</div>
-    </div>
-    <div class="data-card">
-      <div class="number">4M+</div>
-      <div class="unit">Sanctions Entities</div>
-      <div class="desc">100+ global lists incl. OFAC, EU, UN</div>
-    </div>
-    <div class="data-card">
-      <div class="number">810K+</div>
-      <div class="unit">Offshore Links</div>
-      <div class="desc">Panama, Paradise, Pandora Papers</div>
-    </div>
-    <div class="data-card">
-      <div class="number">15B+</div>
-      <div class="unit">Breach Records</div>
-      <div class="desc">Dark Web intelligence sources</div>
-    </div>
-    <div class="data-card">
-      <div class="number">41.8M</div>
-      <div class="unit">Registry Records</div>
-      <div class="desc">Enforcement, debtors, bankruptcy</div>
-    </div>
-    <div class="data-card">
-      <div class="number">5M+</div>
-      <div class="unit">Ownership Chains</div>
-      <div class="desc">UK Companies, GLEIF, beneficial owners</div>
-    </div>
-    <div class="data-card">
-      <div class="number">200K+</div>
-      <div class="unit">Legislation</div>
-      <div class="desc">Laws, codes, decrees</div>
-    </div>
+  <p class="big-point">ML pipelines for model fine-tuning and training.<br>Data quality and scale are our advantage.</p>
+  <div style="margin-top:auto;display:flex;gap:8px;flex-wrap:wrap;">
+    <div class="pill">5M Full-Text Indexed</div>
+    <div class="pill">2M Vector Embeddings</div>
+    <div class="pill">15B+ Breach Records</div>
+    <div class="pill">Ownership Chains</div>
+    <div class="pill">200K+ Legislation</div>
   </div>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">05</div>
@@ -905,46 +531,18 @@
 <!-- SLIDE 6: Technology -->
 <div class="slide">
   <h2><span>Technology</span></h2>
-  <div style="display:flex;gap:40px;margin-top:10px;">
-    <div style="flex:1;">
-      <p style="font-size:18px;color:#cbd5e1;line-height:1.7;margin-bottom:28px;">
-        LEX AI uses <strong style="color:#f1f5f9;">AWS, NVIDIA, and GCP cloud grants</strong> to tune open models on the largest legal corpus in the region.
-      </p>
-      <div class="arch-box">
-        <h4>MCP Backend</h4>
-        <p>Court cases, documents, semantic search, AI analysis, billing, consultations. 118 AI tools.</p>
-      </div>
-      <div class="arch-box">
-        <h4>Parliament & Registry Servers</h4>
-        <p>Parliament data, business registries, beneficiaries, debtors, sanctions screening.</p>
-      </div>
-      <div class="arch-box">
-        <h4>Intelligence Pipeline</h4>
-        <p>Parallel queries to 12+ sources. Sanctions, offshore, ownership, threat analysis.</p>
-      </div>
-      <div class="arch-box">
-        <h4>Unified Gateway</h4>
-        <p>Single API aggregating all services. Blue-green production deployment.</p>
-      </div>
-    </div>
-    <div style="flex:0.8;">
-      <h4 style="font-size:13px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px;">Tech Stack</h4>
-      <ul class="tech-stack-list">
-        <li><span class="dot"></span>TypeScript / Node.js 20</li>
-        <li><span class="dot purple"></span>Python / FastAPI</li>
-        <li><span class="dot"></span>PostgreSQL + Qdrant + Redis</li>
-        <li><span class="dot"></span>OpenAI GPT-4o + Embeddings</li>
-        <li><span class="dot"></span>React 19 + Vite + TailwindCSS</li>
-        <li><span class="dot"></span>MCP Protocol (Model Context Protocol)</li>
-        <li><span class="dot"></span>Docker + Blue-Green Deploy + CI/CD</li>
-      </ul>
-      <div style="margin-top:20px;display:flex;gap:8px;flex-wrap:wrap;">
-        <span class="feature-pill">AWS</span>
-        <span class="feature-pill">NVIDIA</span>
-        <span class="feature-pill">GCP</span>
-        <span class="feature-pill">Cloud Grants</span>
-      </div>
-    </div>
+  <p class="big-point" style="margin-bottom:36px;">
+    LEX AI uses <strong>AWS, NVIDIA, and GCP cloud grants</strong><br>to tune open models on the largest legal corpus in the region.
+  </p>
+  <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:auto;">
+    <div class="pill">TypeScript / Node.js</div>
+    <div class="pill">Python / FastAPI</div>
+    <div class="pill">PostgreSQL + Qdrant + Redis</div>
+    <div class="pill">GPT-4o + Embeddings</div>
+    <div class="pill">React 19</div>
+    <div class="pill">MCP Protocol</div>
+    <div class="pill">Docker + CI/CD</div>
+    <div class="pill">118 AI Tools</div>
   </div>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">06</div>
@@ -953,37 +551,22 @@
 <!-- SLIDE 7: LLM Plan -->
 <div class="slide">
   <h2>LLM <span>Training</span> Plan</h2>
-  <div style="margin-bottom:20px;">
-    <p style="font-size:18px;color:#cbd5e1;line-height:1.7;">
-      We are training a legal model for Ukrainian law. Three steps from fine-tuning to high-accuracy production model.
-    </p>
-  </div>
-  <div class="llm-phases">
-    <div class="llm-phase">
-      <div class="phase-num">1</div>
+  <div class="grid-3" style="flex:1;">
+    <div class="phase">
+      <div class="num">1</div>
       <h3>Fine-Tune</h3>
-      <p>Fine-tune on millions of court decisions. Domain-specific embeddings and LoRA adapters. Target: outperform GPT-4o on Ukrainian legal tasks.</p>
-      <div class="detail">Open-weight models (DeepSeek, Qwen) on cloud infrastructure with NVIDIA H100 GPUs.</div>
+      <p>Millions of court decisions. Target: outperform GPT-4o on Ukrainian legal tasks.</p>
     </div>
-    <div class="llm-phase">
-      <div class="phase-num">2</div>
+    <div class="phase">
+      <div class="num">2</div>
       <h3>Scale</h3>
-      <p>Scale to larger corpus and jurisdiction-specific adapters. Continued pre-training on 100M+ decisions across 22 countries.</p>
-      <div class="detail">Multi-jurisdiction coverage. Expand training data beyond Ukraine to CEE and EU courts.</div>
+      <p>Larger corpus, jurisdiction adapters. 100M+ decisions across 22 countries.</p>
     </div>
-    <div class="llm-phase">
-      <div class="phase-num">3</div>
+    <div class="phase">
+      <div class="num">3</div>
       <h3>RLHF</h3>
-      <p>Reinforcement learning from human feedback with practicing lawyers. Target: >95% preference, <0.2% hallucination rate.</p>
-      <div class="detail">Constitutional RLHF -- Ukraine's Constitution as reward signal. LegalTech LLM Constitution as open standard.</div>
+      <p>Feedback from practicing lawyers. >95% preference, &lt;0.2% hallucination.</p>
     </div>
-  </div>
-  <div style="margin-top:24px;display:flex;gap:8px;flex-wrap:wrap;">
-    <span class="feature-pill">Constitutional RLHF</span>
-    <span class="feature-pill">Open-Weight Models</span>
-    <span class="feature-pill">NVIDIA H100</span>
-    <span class="feature-pill">22 Jurisdictions</span>
-    <span class="feature-pill">Calibrated Uncertainty</span>
   </div>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">07</div>
@@ -992,40 +575,24 @@
 <!-- SLIDE 8: Market -->
 <div class="slide">
   <h2>Market <span>Opportunity</span></h2>
-  <div class="market-layout">
-    <div class="market-circles">
-      <div class="circle circle-tam">
-        <span class="c-label">TAM</span>
-        <span class="c-value">$1.2B+</span>
-      </div>
-      <div class="circle circle-sam">
-        <span class="c-label">SAM</span>
-        <span class="c-value">$120M</span>
-      </div>
-      <div class="circle circle-som">
-        <span class="c-label">SOM</span>
-        <span class="c-value">$8M</span>
-      </div>
+  <div class="market-row">
+    <div class="market-box tam">
+      <div class="c-label">TAM</div>
+      <div class="c-value">$1.2B+</div>
+      <div class="c-desc">Legal AI + Due Diligence</div>
     </div>
-    <div class="market-details">
-      <div class="market-item">
-        <h4>TAM -- Legal AI + Due Diligence</h4>
-        <p>Global legal AI market combined with regulatory technology and due diligence. <span class="highlight">$1.2B+</span> and growing fast.</p>
-      </div>
-      <div class="market-item">
-        <h4>SAM -- Ukraine, CEE & Compliance</h4>
-        <p>Legal tech spending in Ukraine/CEE plus KYC/AML compliance market for companies operating in the region.</p>
-      </div>
-      <div class="market-item">
-        <h4>SOM -- Realistic 2-Year Target</h4>
-        <p><span class="highlight">$8M ARR</span> from legal professionals, compliance teams, banks, and law firms doing international due diligence.</p>
-      </div>
-      <div class="market-item">
-        <h4>Few Direct Competitors</h4>
-        <p>Few players combine <span class="highlight">legal AI and global due diligence</span> in one product stack. We do both.</p>
-      </div>
+    <div class="market-box sam">
+      <div class="c-label">SAM</div>
+      <div class="c-value">$120M</div>
+      <div class="c-desc">Ukraine, CEE & Compliance</div>
+    </div>
+    <div class="market-box som">
+      <div class="c-label">SOM</div>
+      <div class="c-value">$8M</div>
+      <div class="c-desc">2-Year Target</div>
     </div>
   </div>
+  <p class="big-point">Few players combine legal AI and global due diligence.<br>We do both in one product stack.</p>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">08</div>
 </div>
@@ -1033,46 +600,22 @@
 <!-- SLIDE 9: Business Model -->
 <div class="slide">
   <h2>Business <span>Model</span></h2>
-  <div style="margin-bottom:16px;">
-    <p style="font-size:18px;color:#cbd5e1;">Subscriptions plus API pricing.</p>
-  </div>
-  <div class="pricing-grid">
+  <p class="big-point" style="margin-bottom:32px;">Subscriptions plus API pricing.</p>
+  <div class="grid-3">
     <div class="pricing-card">
       <h4>LEX Individual</h4>
       <div class="price">$29<span>/mo</span></div>
-      <div class="desc">Solo lawyers. Full access to court search, AI analysis, judge analytics, legislation monitoring.</div>
+      <div class="desc">Solo lawyers. Court search, AI analysis, legislation.</div>
     </div>
     <div class="pricing-card featured">
-      <h4>LEX + Due Diligence Bundle</h4>
+      <h4>LEX + Due Diligence</h4>
       <div class="price">$149+<span>/mo</span></div>
-      <div class="desc">Law firms & corporate legal. Complete legal analytics + due diligence intelligence. Multi-user access.</div>
+      <div class="desc">Law firms. Full analytics + intelligence. Multi-user.</div>
     </div>
     <div class="pricing-card">
       <h4>Enterprise API</h4>
       <div class="price">Custom</div>
-      <div class="desc">Pay-per-query API. On-premise deployment. White-label for banks, fintech, compliance platforms.</div>
-    </div>
-  </div>
-  <div class="unit-econ">
-    <div class="unit-econ-item">
-      <div class="val">$0.02</div>
-      <div class="lbl">Avg Query Cost</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">$0.05</div>
-      <div class="lbl">Avg Query Price</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">60%</div>
-      <div class="lbl">Gross Margin</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">5.9x</div>
-      <div class="lbl">LTV/CAC Ratio</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">2 mo</div>
-      <div class="lbl">Payback Period</div>
+      <div class="desc">Pay-per-query. On-premise. White-label.</div>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -1082,37 +625,18 @@
 <!-- SLIDE 10: Traction -->
 <div class="slide">
   <h2><span>Traction</span></h2>
-  <div style="margin-top:40px;">
-    <div class="traction-grid">
-      <div class="traction-card">
-        <div class="t-val">130M+</div>
-        <div class="t-label">Legal Records Indexed</div>
-        <div class="t-detail">Court decisions across 22 countries</div>
-      </div>
-      <div class="traction-card">
-        <div class="t-val">118</div>
-        <div class="t-label">AI Tools Built</div>
-        <div class="t-detail">Search, analysis, risk, compliance</div>
-      </div>
-      <div class="traction-card">
-        <div class="t-val">Live</div>
-        <div class="t-label">In Production</div>
-        <div class="t-detail">LEX AI is live at legal.org.ua</div>
-      </div>
+  <div class="stat-row" style="margin-top:40px;padding-top:0;margin-bottom:0;gap:80px;">
+    <div class="stat-item">
+      <div class="val" style="font-size:52px;">130M+</div>
+      <div class="lbl" style="font-size:15px;">Legal Records Indexed</div>
     </div>
-  </div>
-  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:20px;">
-    <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:20px;">
-      <div style="font-size:12px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Data Pipeline</div>
-      <p style="font-size:13px;color:#94a3b8;line-height:1.5;">Automated ingestion from open data sources across 22 countries. ML pipelines for model training.</p>
+    <div class="stat-item">
+      <div class="val" style="font-size:52px;">118</div>
+      <div class="lbl" style="font-size:15px;">AI Tools Built</div>
     </div>
-    <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:20px;">
-      <div style="font-size:12px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Research</div>
-      <p style="font-size:13px;color:#94a3b8;line-height:1.5;">6 papers published on arXiv. Active research in legal NLP, temporal drift, and model evaluation.</p>
-    </div>
-    <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:20px;">
-      <div style="font-size:12px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Infrastructure</div>
-      <p style="font-size:13px;color:#94a3b8;line-height:1.5;">AWS + NVIDIA + GCP cloud grants. Training on H100 GPUs. Full CI/CD with blue-green deploys.</p>
+    <div class="stat-item">
+      <div class="val" style="font-size:52px;color:#34d399;">Live</div>
+      <div class="lbl" style="font-size:15px;">In Production</div>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -1122,13 +646,13 @@
 <!-- SLIDE 11: Team -->
 <div class="slide">
   <h2>The <span>Team</span></h2>
-  <div class="team-grid">
+  <div class="grid-2" style="margin-bottom:auto;">
     <div class="team-card">
       <div class="team-avatar vo">VO</div>
       <div class="team-info">
         <h4>Volodymyr Ovcharov</h4>
         <div class="role">AI & Infrastructure</div>
-        <p>15+ years building scalable data platforms. Glushkov Institute of Cybernetics (NAS of Ukraine). AI/ML, LLM training, high-load systems.</p>
+        <p>15+ years in scalable data platforms. Glushkov Institute of Cybernetics, NAS of Ukraine.</p>
       </div>
     </div>
     <div class="team-card">
@@ -1136,22 +660,8 @@
       <div class="team-info">
         <h4>Igor Kyrychenko</h4>
         <div class="role">Legal Domain & Compliance</div>
-        <p>PhD in Law. Deep expertise in Ukrainian and international legal practice. Legal domain modeling, annotation quality, compliance strategy.</p>
+        <p>PhD in Law. Ukrainian and international legal practice. Domain modeling.</p>
       </div>
-    </div>
-  </div>
-  <div class="why-us">
-    <div class="why-item">
-      <h4>AI + Legal Depth</h4>
-      <p>This mix lets us move fast and stay accurate. Domain logic baked into architecture, not bolted on.</p>
-    </div>
-    <div class="why-item">
-      <h4>Data Moat</h4>
-      <p>130M+ legal records across 22 countries. Months to build. Impossible to replicate quickly.</p>
-    </div>
-    <div class="why-item">
-      <h4>Full Stack</h4>
-      <p>Legal analytics + due diligence in one product. Shared infrastructure. Natural cross-sell.</p>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -1159,21 +669,15 @@
 </div>
 
 <!-- SLIDE 12: Ask -->
-<div class="slide" style="display:flex;flex-direction:column;justify-content:center;align-items:center;">
-  <h2 style="text-align:center;margin-bottom:16px;">Looking for <span>Partners, Pilots & Investors</span></h2>
-  <p style="font-size:18px;color:#94a3b8;text-align:center;margin-bottom:36px;">Public beta is live today.</p>
-  <div style="display:flex;gap:40px;justify-content:center;align-items:flex-start;">
-    <div class="contact-box" style="min-width:380px;">
-      <h4>Get in Touch</h4>
-      <div class="contact-line"><strong>Volodymyr Ovcharov</strong></div>
-      <div class="contact-line">volodymyr@legal.org.ua</div>
-      <div class="contact-line" style="margin-bottom:16px;">linkedin.com/in/volodymir-ovcharov</div>
-      <div class="contact-line"><strong>Igor Kyrychenko</strong></div>
-      <div class="contact-line">igor@legal.org.ua</div>
-      <div class="contact-line" style="margin-bottom:16px;">linkedin.com/in/ihor-kyrychenko</div>
-      <div>
-        <a class="contact-url" href="https://legal.org.ua" style="text-decoration:none;">legal.org.ua</a>
-      </div>
+<div class="slide" style="justify-content:center;align-items:center;">
+  <h2 style="text-align:center;margin-bottom:12px;"><span>Partners, Pilots & Investors</span></h2>
+  <p style="font-size:20px;color:#94a3b8;text-align:center;margin-bottom:40px;position:relative;">Public beta is live today.</p>
+  <div class="contact-box" style="min-width:400px;">
+    <h4>Get in Touch</h4>
+    <div class="contact-line"><strong>Volodymyr</strong> -- volodymyr@legal.org.ua</div>
+    <div class="contact-line"><strong>Igor</strong> -- igor@legal.org.ua</div>
+    <div style="margin-top:18px;">
+      <a class="btn" href="https://legal.org.ua" style="text-decoration:none;">legal.org.ua</a>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>

--- a/lexwebapp/public/pitch-deck.html
+++ b/lexwebapp/public/pitch-deck.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>LEX AI — Legal Intelligence & Due Diligence Platform</title>
+<title>LEX AI -- Legal Intelligence & Due Diligence Platform</title>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -23,12 +23,14 @@
   .slide {
     width: 1280px;
     height: 720px;
-    padding: 60px 80px;
+    padding: 70px 90px;
     position: relative;
     overflow: hidden;
     page-break-after: always;
     page-break-inside: avoid;
     background: #0c0c1a;
+    display: flex;
+    flex-direction: column;
   }
 
   .slide::before {
@@ -45,7 +47,7 @@
     bottom: 30px;
     right: 50px;
     font-size: 13px;
-    color: rgba(255,255,255,0.25);
+    color: rgba(255,255,255,0.2);
     font-weight: 500;
     letter-spacing: 1px;
   }
@@ -53,67 +55,50 @@
   .logo-bar {
     position: absolute;
     bottom: 30px;
-    left: 80px;
+    left: 90px;
     font-size: 13px;
-    color: rgba(255,255,255,0.3);
+    color: rgba(255,255,255,0.25);
     font-weight: 600;
     letter-spacing: 2px;
     text-transform: uppercase;
   }
 
-  /* ===== SLIDE 1: Cover ===== */
+  h2 {
+    font-size: 46px;
+    font-weight: 700;
+    margin-bottom: 44px;
+    line-height: 1.15;
+    position: relative;
+  }
+
+  h2 span { color: #60a5fa; }
+
+  .big-point {
+    font-size: 22px;
+    color: #cbd5e1;
+    line-height: 1.7;
+    max-width: 900px;
+  }
+
+  .big-point strong { color: #f1f5f9; }
+
+  .pill {
+    display: inline-block;
+    padding: 7px 16px;
+    background: rgba(59,130,246,0.1);
+    border: 1px solid rgba(59,130,246,0.2);
+    border-radius: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: #93c5fd;
+    margin: 0 6px 8px 0;
+  }
+
+  /* cover */
   .cover {
-    display: flex;
-    flex-direction: column;
     justify-content: center;
     align-items: flex-start;
     background: linear-gradient(135deg, #0c0c1a 0%, #0f172a 50%, #0c0c1a 100%);
-  }
-
-  .cover .badge {
-    display: inline-block;
-    padding: 6px 18px;
-    border: 1px solid rgba(59, 130, 246, 0.4);
-    border-radius: 20px;
-    font-size: 13px;
-    font-weight: 500;
-    color: #60a5fa;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
-    margin-bottom: 30px;
-  }
-
-  .cover h1 {
-    font-size: 64px;
-    font-weight: 800;
-    line-height: 1.1;
-    margin-bottom: 20px;
-    color: #ffffff;
-  }
-
-  .cover h1 span {
-    color: #60a5fa;
-  }
-
-  .cover .subtitle {
-    font-size: 20px;
-    font-weight: 300;
-    color: #94a3b8;
-    line-height: 1.5;
-    max-width: 700px;
-    margin-bottom: 36px;
-  }
-
-  .cover .urls {
-    display: flex;
-    gap: 30px;
-  }
-
-  .cover .url {
-    font-size: 15px;
-    font-weight: 500;
-    color: #60a5fa;
-    letter-spacing: 0.5px;
   }
 
   .cover .glow-orb {
@@ -127,283 +112,141 @@
     background: radial-gradient(circle, rgba(59,130,246,0.15) 0%, rgba(139,92,246,0.08) 40%, transparent 70%);
   }
 
-  /* ===== Common ===== */
-  .slide h2 {
+  /* stat row */
+  .stat-row {
+    display: flex;
+    gap: 48px;
+    margin-top: auto;
+    padding-top: 30px;
+  }
+
+  .stat-item .val {
     font-size: 40px;
-    font-weight: 700;
-    margin-bottom: 40px;
+    font-weight: 800;
+    color: #60a5fa;
     line-height: 1.2;
   }
 
-  .slide h2 span {
-    color: #60a5fa;
-  }
-
-  .feature-pill {
-    display: inline-block;
-    padding: 8px 16px;
-    background: rgba(59,130,246,0.1);
-    border: 1px solid rgba(59,130,246,0.2);
-    border-radius: 8px;
+  .stat-item .lbl {
     font-size: 13px;
-    font-weight: 500;
-    color: #93c5fd;
-    margin: 0 6px 10px 0;
+    color: #64748b;
+    margin-top: 4px;
   }
 
-  .feature-pill.purple {
-    background: rgba(139,92,246,0.1);
-    border: 1px solid rgba(139,92,246,0.2);
-    color: #c4b5fd;
-  }
-
-  /* ===== Problem Grid ===== */
-  .problem-grid {
+  /* grid helpers */
+  .grid-2 {
     display: grid;
     grid-template-columns: 1fr 1fr;
-    gap: 24px;
-    margin-top: 10px;
+    gap: 28px;
   }
 
-  .problem-card {
+  .grid-3 {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 24px;
+  }
+
+  .card {
     background: rgba(255,255,255,0.03);
     border: 1px solid rgba(255,255,255,0.06);
     border-radius: 16px;
     padding: 30px;
   }
 
-  .problem-card .icon {
-    font-size: 28px;
-    margin-bottom: 14px;
-  }
-
-  .problem-card h3 {
-    font-size: 18px;
+  .card h3 {
+    font-size: 20px;
     font-weight: 600;
-    margin-bottom: 10px;
     color: #f1f5f9;
+    margin-bottom: 10px;
   }
 
-  .problem-card p {
-    font-size: 14px;
+  .card p {
+    font-size: 15px;
     line-height: 1.6;
     color: #94a3b8;
   }
 
-  /* ===== Solution Cards ===== */
-  .solution-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 24px;
-    margin-top: 10px;
+  /* pipeline */
+  .pipeline {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    flex: 1;
   }
 
-  .solution-card {
-    background: rgba(255,255,255,0.03);
-    border: 1px solid rgba(59,130,246,0.15);
-    border-radius: 16px;
-    padding: 30px;
-  }
-
-  .solution-card h3 {
-    font-size: 20px;
-    font-weight: 600;
-    margin-bottom: 10px;
-    color: #60a5fa;
-  }
-
-  .solution-card p {
-    font-size: 15px;
-    line-height: 1.7;
-    color: #cbd5e1;
-  }
-
-  /* ===== Data Grid ===== */
-  .data-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-    margin-top: 10px;
-  }
-
-  .data-card {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 16px;
-    padding: 24px;
+  .pipeline .step {
+    flex: 1;
     text-align: center;
-  }
-
-  .data-card .number {
-    font-size: 34px;
-    font-weight: 800;
-    color: #60a5fa;
-    margin-bottom: 4px;
-    line-height: 1.2;
-  }
-
-  .data-card .unit {
-    font-size: 13px;
-    font-weight: 500;
-    color: #60a5fa;
-    margin-bottom: 8px;
-  }
-
-  .data-card .desc {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.5;
-  }
-
-  .data-card.purple .unit { color: #a78bfa; }
-
-  /* ===== Tech ===== */
-  .tech-layout {
-    display: flex;
-    gap: 40px;
-  }
-
-  .tech-left { flex: 1; }
-  .tech-right { flex: 1; }
-
-  .arch-box {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.08);
-    border-radius: 12px;
-    padding: 18px 22px;
-    margin-bottom: 12px;
-  }
-
-  .arch-box h4 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin-bottom: 4px;
-  }
-
-  .arch-box p {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.5;
-  }
-
-  .tech-stack-list {
-    list-style: none;
-  }
-
-  .tech-stack-list li {
-    padding: 8px 0;
-    border-bottom: 1px solid rgba(255,255,255,0.04);
-    font-size: 13px;
-    color: #cbd5e1;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .tech-stack-list li .dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #3b82f6;
-    flex-shrink: 0;
-  }
-
-  .tech-stack-list li .dot.purple { background: #8b5cf6; }
-
-  /* ===== Market ===== */
-  .market-layout {
-    display: flex;
-    gap: 50px;
-    align-items: flex-start;
-  }
-
-  .market-circles {
-    flex: 0.8;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    gap: 16px;
-  }
-
-  .circle {
-    border-radius: 16px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: 20px;
-    width: 100%;
-  }
-
-  .circle-tam {
+    padding: 28px 16px;
+    border-radius: 14px;
     background: rgba(59,130,246,0.06);
     border: 1px solid rgba(59,130,246,0.15);
   }
 
-  .circle-sam {
-    background: rgba(59,130,246,0.10);
-    border: 1px solid rgba(59,130,246,0.25);
+  .pipeline .step h3 {
+    font-size: 18px;
+    font-weight: 700;
+    color: #f1f5f9;
+    margin-bottom: 6px;
   }
 
-  .circle-som {
-    background: rgba(59,130,246,0.18);
-    border: 1px solid rgba(59,130,246,0.35);
+  .pipeline .step p {
+    font-size: 12px;
+    color: #94a3b8;
+    line-height: 1.4;
   }
 
-  .circle .c-label {
-    font-size: 11px;
+  .pipeline .arrow {
+    font-size: 20px;
+    color: #475569;
+    padding: 0 10px;
+    flex-shrink: 0;
+  }
+
+  /* market circles */
+  .market-row {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 36px;
+  }
+
+  .market-box {
+    flex: 1;
+    border-radius: 16px;
+    padding: 28px;
+    text-align: center;
+  }
+
+  .market-box .c-label {
+    font-size: 12px;
     font-weight: 600;
     color: #60a5fa;
     letter-spacing: 1.5px;
     text-transform: uppercase;
   }
 
-  .circle .c-value {
-    font-size: 28px;
+  .market-box .c-value {
+    font-size: 36px;
     font-weight: 800;
     color: #f1f5f9;
+    margin: 4px 0;
   }
 
-  .market-details { flex: 1; }
-
-  .market-item {
-    margin-bottom: 22px;
-  }
-
-  .market-item h4 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #60a5fa;
-    margin-bottom: 6px;
-  }
-
-  .market-item p {
-    font-size: 14px;
-    line-height: 1.6;
+  .market-box .c-desc {
+    font-size: 13px;
     color: #94a3b8;
   }
 
-  .market-item .highlight {
-    color: #f1f5f9;
-    font-weight: 600;
-  }
+  .tam { background: rgba(59,130,246,0.06); border: 1px solid rgba(59,130,246,0.15); }
+  .sam { background: rgba(59,130,246,0.10); border: 1px solid rgba(59,130,246,0.25); }
+  .som { background: rgba(59,130,246,0.18); border: 1px solid rgba(59,130,246,0.35); }
 
-  /* ===== Pricing ===== */
-  .pricing-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 20px;
-    margin-top: 10px;
-  }
-
+  /* pricing */
   .pricing-card {
     background: rgba(255,255,255,0.02);
     border: 1px solid rgba(255,255,255,0.06);
     border-radius: 16px;
-    padding: 28px;
-    position: relative;
+    padding: 32px;
   }
 
   .pricing-card.featured {
@@ -417,14 +260,13 @@
     color: #94a3b8;
     text-transform: uppercase;
     letter-spacing: 1px;
-    margin-bottom: 10px;
+    margin-bottom: 12px;
   }
 
   .pricing-card .price {
-    font-size: 34px;
+    font-size: 38px;
     font-weight: 800;
     color: #f1f5f9;
-    margin-bottom: 4px;
   }
 
   .pricing-card .price span {
@@ -434,87 +276,20 @@
   }
 
   .pricing-card .desc {
-    font-size: 13px;
-    color: #94a3b8;
-    line-height: 1.5;
-    margin-top: 10px;
-  }
-
-  .unit-econ {
-    display: flex;
-    gap: 36px;
-    margin-top: 24px;
-    padding-top: 18px;
-    border-top: 1px solid rgba(255,255,255,0.06);
-  }
-
-  .unit-econ-item { text-align: center; }
-
-  .unit-econ-item .val {
-    font-size: 26px;
-    font-weight: 800;
-    color: #60a5fa;
-  }
-
-  .unit-econ-item .lbl {
-    font-size: 11px;
-    color: #64748b;
-    margin-top: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  /* ===== Traction ===== */
-  .traction-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-    margin-bottom: 28px;
-  }
-
-  .traction-card {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 16px;
-    padding: 36px;
-    text-align: center;
-  }
-
-  .traction-card .t-val {
-    font-size: 42px;
-    font-weight: 800;
-    color: #f1f5f9;
-    margin-bottom: 8px;
-  }
-
-  .traction-card .t-label {
     font-size: 14px;
     color: #94a3b8;
-    letter-spacing: 0.5px;
+    margin-top: 10px;
+    line-height: 1.5;
   }
 
-  .traction-card .t-detail {
-    font-size: 12px;
-    color: #64748b;
-    margin-top: 8px;
-    line-height: 1.4;
-  }
-
-  /* ===== Team ===== */
-  .team-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 30px;
-    margin-bottom: 30px;
-  }
-
+  /* team */
   .team-card {
     background: rgba(255,255,255,0.02);
     border: 1px solid rgba(255,255,255,0.06);
     border-radius: 16px;
-    padding: 28px;
+    padding: 32px;
     display: flex;
-    gap: 20px;
+    gap: 22px;
     align-items: flex-start;
   }
 
@@ -535,58 +310,63 @@
   .team-avatar.ik { background: linear-gradient(135deg, #06b6d4, #3b82f6); }
 
   .team-info h4 {
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 700;
     color: #f1f5f9;
     margin-bottom: 2px;
   }
 
   .team-info .role {
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 500;
     color: #60a5fa;
     margin-bottom: 10px;
   }
 
   .team-info p {
-    font-size: 13px;
+    font-size: 14px;
     color: #94a3b8;
     line-height: 1.6;
   }
 
-  .why-us {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 18px;
+  /* phase */
+  .phase {
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 16px;
+    padding: 36px;
+    position: relative;
   }
 
-  .why-item {
-    background: rgba(59,130,246,0.04);
-    border: 1px solid rgba(59,130,246,0.1);
-    border-radius: 12px;
-    padding: 20px;
-    text-align: center;
+  .phase .num {
+    font-size: 56px;
+    font-weight: 800;
+    color: rgba(59,130,246,0.12);
+    position: absolute;
+    top: 18px;
+    right: 24px;
+    line-height: 1;
   }
 
-  .why-item h4 {
-    font-size: 14px;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin-bottom: 6px;
+  .phase h3 {
+    font-size: 22px;
+    font-weight: 700;
+    color: #60a5fa;
+    margin-bottom: 12px;
   }
 
-  .why-item p {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.5;
+  .phase p {
+    font-size: 15px;
+    color: #cbd5e1;
+    line-height: 1.6;
   }
 
-  /* ===== Contact ===== */
+  /* contact */
   .contact-box {
     background: rgba(255,255,255,0.02);
     border: 1px solid rgba(255,255,255,0.08);
     border-radius: 16px;
-    padding: 28px;
+    padding: 36px;
   }
 
   .contact-box h4 {
@@ -595,11 +375,11 @@
     color: #60a5fa;
     text-transform: uppercase;
     letter-spacing: 1.5px;
-    margin-bottom: 16px;
+    margin-bottom: 18px;
   }
 
   .contact-line {
-    font-size: 14px;
+    font-size: 16px;
     color: #cbd5e1;
     margin-bottom: 8px;
     line-height: 1.5;
@@ -607,9 +387,8 @@
 
   .contact-line strong { color: #f1f5f9; }
 
-  .contact-url {
+  .btn {
     display: inline-block;
-    margin-top: 12px;
     padding: 10px 24px;
     background: linear-gradient(135deg, #3b82f6, #8b5cf6);
     border-radius: 8px;
@@ -617,99 +396,8 @@
     font-weight: 600;
     font-size: 14px;
     text-decoration: none;
-  }
-
-  /* ===== Pipeline ===== */
-  .pipeline-flow {
-    display: flex;
-    align-items: center;
-    gap: 0;
-    margin: 20px 0;
-  }
-
-  .pipeline-step {
-    flex: 1;
-    text-align: center;
-    padding: 24px 16px;
-    border-radius: 12px;
-    position: relative;
-    background: rgba(59,130,246,0.06);
-    border: 1px solid rgba(59,130,246,0.15);
-  }
-
-  .pipeline-step .step-num {
-    font-size: 11px;
-    font-weight: 700;
-    color: #60a5fa;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    margin-bottom: 8px;
-  }
-
-  .pipeline-step .step-title {
-    font-size: 15px;
-    font-weight: 600;
-    color: #f1f5f9;
-    margin-bottom: 6px;
-  }
-
-  .pipeline-step .step-desc {
-    font-size: 12px;
-    color: #94a3b8;
-    line-height: 1.4;
-  }
-
-  .pipeline-arrow {
-    font-size: 20px;
-    color: #475569;
-    flex-shrink: 0;
-    padding: 0 8px;
-  }
-
-  /* ===== LLM Phases ===== */
-  .llm-phases {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-    margin-top: 10px;
-  }
-
-  .llm-phase {
-    background: rgba(255,255,255,0.02);
-    border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 16px;
-    padding: 32px;
-    position: relative;
-  }
-
-  .llm-phase .phase-num {
-    font-size: 48px;
-    font-weight: 800;
-    color: rgba(59,130,246,0.15);
-    position: absolute;
-    top: 16px;
-    right: 20px;
-    line-height: 1;
-  }
-
-  .llm-phase h3 {
-    font-size: 18px;
-    font-weight: 700;
-    color: #60a5fa;
-    margin-bottom: 12px;
-  }
-
-  .llm-phase p {
-    font-size: 14px;
-    color: #cbd5e1;
-    line-height: 1.7;
-  }
-
-  .llm-phase .detail {
-    font-size: 12px;
-    color: #64748b;
-    margin-top: 12px;
-    line-height: 1.5;
+    border: none;
+    cursor: pointer;
   }
 </style>
 </head>
@@ -718,41 +406,37 @@
 <!-- SLIDE 1: Title -->
 <div class="slide cover">
   <div class="glow-orb"></div>
-  <div class="badge">Legal Intelligence & Due Diligence</div>
-  <h1>LEX AI<br><span>Legal Analytics</span><br>As Fast As You Type</h1>
-  <div class="subtitle">
-    We build AI products for legal analytics and due diligence. We train models to gain precision and scale. We collect datasets from open data across countries.
+  <div style="display:inline-block;padding:6px 18px;border:1px solid rgba(59,130,246,0.4);border-radius:20px;font-size:13px;font-weight:500;color:#60a5fa;letter-spacing:1.5px;text-transform:uppercase;margin-bottom:30px;">Legal Intelligence & Due Diligence</div>
+  <h1 style="font-size:68px;font-weight:800;line-height:1.1;margin-bottom:20px;color:#fff;position:relative;">LEX AI</h1>
+  <p style="font-size:24px;font-weight:300;color:#94a3b8;line-height:1.6;max-width:700px;position:relative;">
+    Legal analytics as fast as you type.<br>We train models to gain precision and scale.
+  </p>
+  <div style="margin-top:auto;position:relative;display:flex;align-items:center;gap:30px;">
+    <span style="font-size:15px;font-weight:500;color:#60a5fa;">legal.org.ua</span>
+    <a href="pitch-deck.pdf" download class="btn" style="font-size:13px;padding:8px 20px;box-shadow:0 4px 12px rgba(59,130,246,0.3);" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Download PDF</a>
   </div>
-  <div class="urls">
-    <div class="url">legal.org.ua</div>
-  </div>
-  <a href="pitch-deck.pdf" download style="margin-top:18px;padding:10px 22px;background:linear-gradient(135deg,#3b82f6,#8b5cf6);border:none;border-radius:8px;color:#fff;font-size:13px;font-weight:600;cursor:pointer;box-shadow:0 4px 12px rgba(59,130,246,0.3);transition:opacity .2s;text-decoration:none;display:inline-block;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Download PDF</a>
   <div class="slide-number">01</div>
 </div>
 
 <!-- SLIDE 2: Problem -->
 <div class="slide">
   <h2>The <span>Problem</span></h2>
-  <div class="problem-grid">
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">01</div>
-      <h3>Legal Work is Slow</h3>
-      <p>Lawyers still spend days on manual search across fragmented court databases. Legacy tools offer no AI, no semantic understanding.</p>
+  <div class="grid-2" style="flex:1;">
+    <div class="card">
+      <h3>Legal work is slow</h3>
+      <p>Lawyers spend days on manual search. Legacy tools have no AI, no semantic understanding.</p>
     </div>
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">02</div>
-      <h3>Due Diligence is Fragmented</h3>
-      <p>Checking a counterparty means 10+ separate databases: sanctions, registries, offshore leaks, ownership chains. No one tool connects them all.</p>
+    <div class="card">
+      <h3>Due diligence is fragmented</h3>
+      <p>10+ separate databases to check one counterparty. No single tool connects them.</p>
     </div>
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">03</div>
-      <h3>Many Separate Sources</h3>
-      <p>Court decisions, parliament data, business registries, sanctions lists -- scattered across dozens of systems with no unified interface.</p>
+    <div class="card">
+      <h3>Many separate sources</h3>
+      <p>Courts, parliament, registries, sanctions -- scattered across dozens of systems.</p>
     </div>
-    <div class="problem-card">
-      <div class="icon" style="font-size:24px;font-weight:800;color:#60a5fa;">04</div>
-      <h3>Risks Found Too Late</h3>
-      <p>Important risks are often discovered after the deal closes. Undisclosed owners, sanctions violations, hidden liabilities -- all discoverable, none automatically flagged.</p>
+    <div class="card">
+      <h3>Risks found too late</h3>
+      <p>Hidden owners, sanctions violations, liabilities -- discoverable but never flagged automatically.</p>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -761,30 +445,21 @@
 
 <!-- SLIDE 3: Solution -->
 <div class="slide">
-  <h2>The <span>Solution</span></h2>
-  <div style="display:flex;flex-direction:column;gap:30px;margin-top:10px;">
-    <div style="max-width:900px;">
-      <p style="font-size:22px;color:#cbd5e1;line-height:1.7;margin-bottom:24px;">
-        <strong style="color:#60a5fa;">LEX AI</strong> is a chat pipeline service that handles legal research, case analysis, sanctions screening, ownership checks, and risk assessment -- all in one place.
-      </p>
+  <h2><span>LEX AI</span> Chat Pipeline</h2>
+  <div class="big-point" style="margin-bottom:40px;">
+    One service for legal research, case analysis,<br>sanctions, ownership, and risk checks.<br>
+    At the end of the pipeline -- <strong>one clear picture</strong>.
+  </div>
+  <div class="grid-2" style="max-width:900px;">
+    <div>
+      <div class="pill">Legal Research</div>
+      <div class="pill">Case Analysis</div>
+      <div class="pill">Legislation</div>
     </div>
-    <div class="solution-grid">
-      <div class="solution-card">
-        <h3>Legal Research & Case Analysis</h3>
-        <p>AI reads hundreds of court documents, identifies patterns, finds precedents, and generates defense strategies automatically.</p>
-      </div>
-      <div class="solution-card">
-        <h3>Sanctions & Ownership Checks</h3>
-        <p>Screen counterparties against global sanctions lists, trace beneficial ownership chains, and check offshore connections.</p>
-      </div>
-      <div class="solution-card">
-        <h3>Risk Assessment</h3>
-        <p>Aggregate findings into a single risk profile with risk scores, flagged issues, and recommended action points.</p>
-      </div>
-      <div class="solution-card">
-        <h3>One Clear Picture</h3>
-        <p>At the end of the pipeline, you have a complete view: legal history, compliance status, risk level, and next steps.</p>
-      </div>
+    <div>
+      <div class="pill">Sanctions Screening</div>
+      <div class="pill">Ownership Chains</div>
+      <div class="pill">Risk Assessment</div>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -794,51 +469,26 @@
 <!-- SLIDE 4: How It Works -->
 <div class="slide">
   <h2>How <span>It Works</span></h2>
-  <div style="margin-bottom:20px;">
-    <p style="font-size:18px;color:#cbd5e1;line-height:1.6;">One request checks many sources at once. Typical due diligence takes under 5 minutes.</p>
-  </div>
-  <div class="pipeline-flow">
-    <div class="pipeline-step">
-      <div class="step-num">Step 1</div>
-      <div class="step-title">User Query</div>
-      <div class="step-desc">Natural language request -- a company name, a legal question, a counterparty check</div>
+  <p class="big-point" style="margin-bottom:32px;">One request. Many sources. Under 5 minutes.</p>
+  <div class="pipeline">
+    <div class="step">
+      <h3>Query</h3>
+      <p>Natural language request</p>
     </div>
-    <div class="pipeline-arrow">-></div>
-    <div class="pipeline-step">
-      <div class="step-num">Step 2</div>
-      <div class="step-title">Multi-Source Search</div>
-      <div class="step-desc">AI pipeline queries courts, registries, sanctions, ownership, legislation in parallel</div>
+    <div class="arrow">-></div>
+    <div class="step">
+      <h3>Multi-Source</h3>
+      <p>Courts, registries, sanctions in parallel</p>
     </div>
-    <div class="pipeline-arrow">-></div>
-    <div class="pipeline-step">
-      <div class="step-num">Step 3</div>
-      <div class="step-title">AI Analysis</div>
-      <div class="step-desc">Reads hundreds of documents, extracts key facts, identifies risks and patterns</div>
+    <div class="arrow">-></div>
+    <div class="step">
+      <h3>AI Analysis</h3>
+      <p>Reads hundreds of documents</p>
     </div>
-    <div class="pipeline-arrow">-></div>
-    <div class="pipeline-step">
-      <div class="step-num">Step 4</div>
-      <div class="step-title">Clear Output</div>
-      <div class="step-desc">Risk score, action points, related data, defense strategies -- one unified report</div>
-    </div>
-  </div>
-
-  <div style="display:grid;grid-template-columns:1fr 1fr;gap:24px;margin-top:30px;">
-    <div style="background:linear-gradient(135deg,rgba(59,130,246,0.08),rgba(139,92,246,0.06));border:1px solid rgba(59,130,246,0.15);border-radius:16px;padding:28px;">
-      <h4 style="font-size:14px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px;">Due Diligence</h4>
-      <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:8px;">
-        <span style="font-size:28px;font-weight:800;color:#60a5fa;">&lt;5 min</span>
-        <span style="font-size:13px;color:#94a3b8;">full counterparty screening</span>
-      </div>
-      <p style="font-size:12px;color:#94a3b8;line-height:1.5;">Sanctions + ownership + court history + enforcement -- unified risk score for any entity.</p>
-    </div>
-    <div style="background:linear-gradient(135deg,rgba(59,130,246,0.08),rgba(139,92,246,0.06));border:1px solid rgba(59,130,246,0.15);border-radius:16px;padding:28px;">
-      <h4 style="font-size:14px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px;">Legal Case Research</h4>
-      <div style="display:flex;align-items:baseline;gap:8px;margin-bottom:8px;">
-        <span style="font-size:28px;font-weight:800;color:#60a5fa;">Hundreds</span>
-        <span style="font-size:13px;color:#94a3b8;">of documents analyzed quickly</span>
-      </div>
-      <p style="font-size:12px;color:#94a3b8;line-height:1.5;">AI reads court decisions, finds relevant precedents, extracts strategies -- what took a week now takes minutes.</p>
+    <div class="arrow">-></div>
+    <div class="step">
+      <h3>Output</h3>
+      <p>Risk score, action points, report</p>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -848,55 +498,31 @@
 <!-- SLIDE 5: Data Moat -->
 <div class="slide">
   <h2><span>Data</span> Moat</h2>
-  <div style="margin-bottom:24px;">
-    <p style="font-size:18px;color:#cbd5e1;line-height:1.6;">Our advantage is data quality and scale. ML pipelines for model fine-tuning and training.</p>
+  <div class="stat-row" style="margin-top:0;padding-top:0;margin-bottom:36px;">
+    <div class="stat-item">
+      <div class="val">130M+</div>
+      <div class="lbl">Court Decisions</div>
+    </div>
+    <div class="stat-item">
+      <div class="val">22</div>
+      <div class="lbl">Countries</div>
+    </div>
+    <div class="stat-item">
+      <div class="val">4M+</div>
+      <div class="lbl">Sanctions Entities</div>
+    </div>
+    <div class="stat-item">
+      <div class="val">810K+</div>
+      <div class="lbl">Offshore Links</div>
+    </div>
   </div>
-  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;">
-    <div class="data-card">
-      <div class="number">130M+</div>
-      <div class="unit">Court Decisions</div>
-      <div class="desc">Across 22 countries</div>
-    </div>
-    <div class="data-card">
-      <div class="number">5M</div>
-      <div class="unit">Full-Text Indexed</div>
-      <div class="desc">Parsed for semantic search</div>
-    </div>
-    <div class="data-card">
-      <div class="number">2M</div>
-      <div class="unit">Vector Embeddings</div>
-      <div class="desc">AI-powered similarity search</div>
-    </div>
-    <div class="data-card">
-      <div class="number">4M+</div>
-      <div class="unit">Sanctions Entities</div>
-      <div class="desc">100+ global lists incl. OFAC, EU, UN</div>
-    </div>
-    <div class="data-card">
-      <div class="number">810K+</div>
-      <div class="unit">Offshore Links</div>
-      <div class="desc">Panama, Paradise, Pandora Papers</div>
-    </div>
-    <div class="data-card">
-      <div class="number">15B+</div>
-      <div class="unit">Breach Records</div>
-      <div class="desc">Dark Web intelligence sources</div>
-    </div>
-    <div class="data-card">
-      <div class="number">41.8M</div>
-      <div class="unit">Registry Records</div>
-      <div class="desc">Enforcement, debtors, bankruptcy</div>
-    </div>
-    <div class="data-card">
-      <div class="number">5M+</div>
-      <div class="unit">Ownership Chains</div>
-      <div class="desc">UK Companies, GLEIF, beneficial owners</div>
-    </div>
-    <div class="data-card">
-      <div class="number">200K+</div>
-      <div class="unit">Legislation</div>
-      <div class="desc">Laws, codes, decrees</div>
-    </div>
+  <p class="big-point">ML pipelines for model fine-tuning and training.<br>Data quality and scale are our advantage.</p>
+  <div style="margin-top:auto;display:flex;gap:8px;flex-wrap:wrap;">
+    <div class="pill">5M Full-Text Indexed</div>
+    <div class="pill">2M Vector Embeddings</div>
+    <div class="pill">15B+ Breach Records</div>
+    <div class="pill">Ownership Chains</div>
+    <div class="pill">200K+ Legislation</div>
   </div>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">05</div>
@@ -905,46 +531,18 @@
 <!-- SLIDE 6: Technology -->
 <div class="slide">
   <h2><span>Technology</span></h2>
-  <div style="display:flex;gap:40px;margin-top:10px;">
-    <div style="flex:1;">
-      <p style="font-size:18px;color:#cbd5e1;line-height:1.7;margin-bottom:28px;">
-        LEX AI uses <strong style="color:#f1f5f9;">AWS, NVIDIA, and GCP cloud grants</strong> to tune open models on the largest legal corpus in the region.
-      </p>
-      <div class="arch-box">
-        <h4>MCP Backend</h4>
-        <p>Court cases, documents, semantic search, AI analysis, billing, consultations. 118 AI tools.</p>
-      </div>
-      <div class="arch-box">
-        <h4>Parliament & Registry Servers</h4>
-        <p>Parliament data, business registries, beneficiaries, debtors, sanctions screening.</p>
-      </div>
-      <div class="arch-box">
-        <h4>Intelligence Pipeline</h4>
-        <p>Parallel queries to 12+ sources. Sanctions, offshore, ownership, threat analysis.</p>
-      </div>
-      <div class="arch-box">
-        <h4>Unified Gateway</h4>
-        <p>Single API aggregating all services. Blue-green production deployment.</p>
-      </div>
-    </div>
-    <div style="flex:0.8;">
-      <h4 style="font-size:13px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1.5px;margin-bottom:14px;">Tech Stack</h4>
-      <ul class="tech-stack-list">
-        <li><span class="dot"></span>TypeScript / Node.js 20</li>
-        <li><span class="dot purple"></span>Python / FastAPI</li>
-        <li><span class="dot"></span>PostgreSQL + Qdrant + Redis</li>
-        <li><span class="dot"></span>OpenAI GPT-4o + Embeddings</li>
-        <li><span class="dot"></span>React 19 + Vite + TailwindCSS</li>
-        <li><span class="dot"></span>MCP Protocol (Model Context Protocol)</li>
-        <li><span class="dot"></span>Docker + Blue-Green Deploy + CI/CD</li>
-      </ul>
-      <div style="margin-top:20px;display:flex;gap:8px;flex-wrap:wrap;">
-        <span class="feature-pill">AWS</span>
-        <span class="feature-pill">NVIDIA</span>
-        <span class="feature-pill">GCP</span>
-        <span class="feature-pill">Cloud Grants</span>
-      </div>
-    </div>
+  <p class="big-point" style="margin-bottom:36px;">
+    LEX AI uses <strong>AWS, NVIDIA, and GCP cloud grants</strong><br>to tune open models on the largest legal corpus in the region.
+  </p>
+  <div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:auto;">
+    <div class="pill">TypeScript / Node.js</div>
+    <div class="pill">Python / FastAPI</div>
+    <div class="pill">PostgreSQL + Qdrant + Redis</div>
+    <div class="pill">GPT-4o + Embeddings</div>
+    <div class="pill">React 19</div>
+    <div class="pill">MCP Protocol</div>
+    <div class="pill">Docker + CI/CD</div>
+    <div class="pill">118 AI Tools</div>
   </div>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">06</div>
@@ -953,37 +551,22 @@
 <!-- SLIDE 7: LLM Plan -->
 <div class="slide">
   <h2>LLM <span>Training</span> Plan</h2>
-  <div style="margin-bottom:20px;">
-    <p style="font-size:18px;color:#cbd5e1;line-height:1.7;">
-      We are training a legal model for Ukrainian law. Three steps from fine-tuning to high-accuracy production model.
-    </p>
-  </div>
-  <div class="llm-phases">
-    <div class="llm-phase">
-      <div class="phase-num">1</div>
+  <div class="grid-3" style="flex:1;">
+    <div class="phase">
+      <div class="num">1</div>
       <h3>Fine-Tune</h3>
-      <p>Fine-tune on millions of court decisions. Domain-specific embeddings and LoRA adapters. Target: outperform GPT-4o on Ukrainian legal tasks.</p>
-      <div class="detail">Open-weight models (DeepSeek, Qwen) on cloud infrastructure with NVIDIA H100 GPUs.</div>
+      <p>Millions of court decisions. Target: outperform GPT-4o on Ukrainian legal tasks.</p>
     </div>
-    <div class="llm-phase">
-      <div class="phase-num">2</div>
+    <div class="phase">
+      <div class="num">2</div>
       <h3>Scale</h3>
-      <p>Scale to larger corpus and jurisdiction-specific adapters. Continued pre-training on 100M+ decisions across 22 countries.</p>
-      <div class="detail">Multi-jurisdiction coverage. Expand training data beyond Ukraine to CEE and EU courts.</div>
+      <p>Larger corpus, jurisdiction adapters. 100M+ decisions across 22 countries.</p>
     </div>
-    <div class="llm-phase">
-      <div class="phase-num">3</div>
+    <div class="phase">
+      <div class="num">3</div>
       <h3>RLHF</h3>
-      <p>Reinforcement learning from human feedback with practicing lawyers. Target: >95% preference, <0.2% hallucination rate.</p>
-      <div class="detail">Constitutional RLHF -- Ukraine's Constitution as reward signal. LegalTech LLM Constitution as open standard.</div>
+      <p>Feedback from practicing lawyers. >95% preference, &lt;0.2% hallucination.</p>
     </div>
-  </div>
-  <div style="margin-top:24px;display:flex;gap:8px;flex-wrap:wrap;">
-    <span class="feature-pill">Constitutional RLHF</span>
-    <span class="feature-pill">Open-Weight Models</span>
-    <span class="feature-pill">NVIDIA H100</span>
-    <span class="feature-pill">22 Jurisdictions</span>
-    <span class="feature-pill">Calibrated Uncertainty</span>
   </div>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">07</div>
@@ -992,40 +575,24 @@
 <!-- SLIDE 8: Market -->
 <div class="slide">
   <h2>Market <span>Opportunity</span></h2>
-  <div class="market-layout">
-    <div class="market-circles">
-      <div class="circle circle-tam">
-        <span class="c-label">TAM</span>
-        <span class="c-value">$1.2B+</span>
-      </div>
-      <div class="circle circle-sam">
-        <span class="c-label">SAM</span>
-        <span class="c-value">$120M</span>
-      </div>
-      <div class="circle circle-som">
-        <span class="c-label">SOM</span>
-        <span class="c-value">$8M</span>
-      </div>
+  <div class="market-row">
+    <div class="market-box tam">
+      <div class="c-label">TAM</div>
+      <div class="c-value">$1.2B+</div>
+      <div class="c-desc">Legal AI + Due Diligence</div>
     </div>
-    <div class="market-details">
-      <div class="market-item">
-        <h4>TAM -- Legal AI + Due Diligence</h4>
-        <p>Global legal AI market combined with regulatory technology and due diligence. <span class="highlight">$1.2B+</span> and growing fast.</p>
-      </div>
-      <div class="market-item">
-        <h4>SAM -- Ukraine, CEE & Compliance</h4>
-        <p>Legal tech spending in Ukraine/CEE plus KYC/AML compliance market for companies operating in the region.</p>
-      </div>
-      <div class="market-item">
-        <h4>SOM -- Realistic 2-Year Target</h4>
-        <p><span class="highlight">$8M ARR</span> from legal professionals, compliance teams, banks, and law firms doing international due diligence.</p>
-      </div>
-      <div class="market-item">
-        <h4>Few Direct Competitors</h4>
-        <p>Few players combine <span class="highlight">legal AI and global due diligence</span> in one product stack. We do both.</p>
-      </div>
+    <div class="market-box sam">
+      <div class="c-label">SAM</div>
+      <div class="c-value">$120M</div>
+      <div class="c-desc">Ukraine, CEE & Compliance</div>
+    </div>
+    <div class="market-box som">
+      <div class="c-label">SOM</div>
+      <div class="c-value">$8M</div>
+      <div class="c-desc">2-Year Target</div>
     </div>
   </div>
+  <p class="big-point">Few players combine legal AI and global due diligence.<br>We do both in one product stack.</p>
   <div class="logo-bar">LEX AI</div>
   <div class="slide-number">08</div>
 </div>
@@ -1033,46 +600,22 @@
 <!-- SLIDE 9: Business Model -->
 <div class="slide">
   <h2>Business <span>Model</span></h2>
-  <div style="margin-bottom:16px;">
-    <p style="font-size:18px;color:#cbd5e1;">Subscriptions plus API pricing.</p>
-  </div>
-  <div class="pricing-grid">
+  <p class="big-point" style="margin-bottom:32px;">Subscriptions plus API pricing.</p>
+  <div class="grid-3">
     <div class="pricing-card">
       <h4>LEX Individual</h4>
       <div class="price">$29<span>/mo</span></div>
-      <div class="desc">Solo lawyers. Full access to court search, AI analysis, judge analytics, legislation monitoring.</div>
+      <div class="desc">Solo lawyers. Court search, AI analysis, legislation.</div>
     </div>
     <div class="pricing-card featured">
-      <h4>LEX + Due Diligence Bundle</h4>
+      <h4>LEX + Due Diligence</h4>
       <div class="price">$149+<span>/mo</span></div>
-      <div class="desc">Law firms & corporate legal. Complete legal analytics + due diligence intelligence. Multi-user access.</div>
+      <div class="desc">Law firms. Full analytics + intelligence. Multi-user.</div>
     </div>
     <div class="pricing-card">
       <h4>Enterprise API</h4>
       <div class="price">Custom</div>
-      <div class="desc">Pay-per-query API. On-premise deployment. White-label for banks, fintech, compliance platforms.</div>
-    </div>
-  </div>
-  <div class="unit-econ">
-    <div class="unit-econ-item">
-      <div class="val">$0.02</div>
-      <div class="lbl">Avg Query Cost</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">$0.05</div>
-      <div class="lbl">Avg Query Price</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">60%</div>
-      <div class="lbl">Gross Margin</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">5.9x</div>
-      <div class="lbl">LTV/CAC Ratio</div>
-    </div>
-    <div class="unit-econ-item">
-      <div class="val">2 mo</div>
-      <div class="lbl">Payback Period</div>
+      <div class="desc">Pay-per-query. On-premise. White-label.</div>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -1082,37 +625,18 @@
 <!-- SLIDE 10: Traction -->
 <div class="slide">
   <h2><span>Traction</span></h2>
-  <div style="margin-top:40px;">
-    <div class="traction-grid">
-      <div class="traction-card">
-        <div class="t-val">130M+</div>
-        <div class="t-label">Legal Records Indexed</div>
-        <div class="t-detail">Court decisions across 22 countries</div>
-      </div>
-      <div class="traction-card">
-        <div class="t-val">118</div>
-        <div class="t-label">AI Tools Built</div>
-        <div class="t-detail">Search, analysis, risk, compliance</div>
-      </div>
-      <div class="traction-card">
-        <div class="t-val">Live</div>
-        <div class="t-label">In Production</div>
-        <div class="t-detail">LEX AI is live at legal.org.ua</div>
-      </div>
+  <div class="stat-row" style="margin-top:40px;padding-top:0;margin-bottom:0;gap:80px;">
+    <div class="stat-item">
+      <div class="val" style="font-size:52px;">130M+</div>
+      <div class="lbl" style="font-size:15px;">Legal Records Indexed</div>
     </div>
-  </div>
-  <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:20px;">
-    <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:20px;">
-      <div style="font-size:12px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Data Pipeline</div>
-      <p style="font-size:13px;color:#94a3b8;line-height:1.5;">Automated ingestion from open data sources across 22 countries. ML pipelines for model training.</p>
+    <div class="stat-item">
+      <div class="val" style="font-size:52px;">118</div>
+      <div class="lbl" style="font-size:15px;">AI Tools Built</div>
     </div>
-    <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:20px;">
-      <div style="font-size:12px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Research</div>
-      <p style="font-size:13px;color:#94a3b8;line-height:1.5;">6 papers published on arXiv. Active research in legal NLP, temporal drift, and model evaluation.</p>
-    </div>
-    <div style="background:rgba(255,255,255,0.02);border:1px solid rgba(255,255,255,0.06);border-radius:12px;padding:20px;">
-      <div style="font-size:12px;font-weight:600;color:#60a5fa;text-transform:uppercase;letter-spacing:1px;margin-bottom:10px;">Infrastructure</div>
-      <p style="font-size:13px;color:#94a3b8;line-height:1.5;">AWS + NVIDIA + GCP cloud grants. Training on H100 GPUs. Full CI/CD with blue-green deploys.</p>
+    <div class="stat-item">
+      <div class="val" style="font-size:52px;color:#34d399;">Live</div>
+      <div class="lbl" style="font-size:15px;">In Production</div>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -1122,13 +646,13 @@
 <!-- SLIDE 11: Team -->
 <div class="slide">
   <h2>The <span>Team</span></h2>
-  <div class="team-grid">
+  <div class="grid-2" style="margin-bottom:auto;">
     <div class="team-card">
       <div class="team-avatar vo">VO</div>
       <div class="team-info">
         <h4>Volodymyr Ovcharov</h4>
         <div class="role">AI & Infrastructure</div>
-        <p>15+ years building scalable data platforms. Glushkov Institute of Cybernetics (NAS of Ukraine). AI/ML, LLM training, high-load systems.</p>
+        <p>15+ years in scalable data platforms. Glushkov Institute of Cybernetics, NAS of Ukraine.</p>
       </div>
     </div>
     <div class="team-card">
@@ -1136,22 +660,8 @@
       <div class="team-info">
         <h4>Igor Kyrychenko</h4>
         <div class="role">Legal Domain & Compliance</div>
-        <p>PhD in Law. Deep expertise in Ukrainian and international legal practice. Legal domain modeling, annotation quality, compliance strategy.</p>
+        <p>PhD in Law. Ukrainian and international legal practice. Domain modeling.</p>
       </div>
-    </div>
-  </div>
-  <div class="why-us">
-    <div class="why-item">
-      <h4>AI + Legal Depth</h4>
-      <p>This mix lets us move fast and stay accurate. Domain logic baked into architecture, not bolted on.</p>
-    </div>
-    <div class="why-item">
-      <h4>Data Moat</h4>
-      <p>130M+ legal records across 22 countries. Months to build. Impossible to replicate quickly.</p>
-    </div>
-    <div class="why-item">
-      <h4>Full Stack</h4>
-      <p>Legal analytics + due diligence in one product. Shared infrastructure. Natural cross-sell.</p>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>
@@ -1159,21 +669,15 @@
 </div>
 
 <!-- SLIDE 12: Ask -->
-<div class="slide" style="display:flex;flex-direction:column;justify-content:center;align-items:center;">
-  <h2 style="text-align:center;margin-bottom:16px;">Looking for <span>Partners, Pilots & Investors</span></h2>
-  <p style="font-size:18px;color:#94a3b8;text-align:center;margin-bottom:36px;">Public beta is live today.</p>
-  <div style="display:flex;gap:40px;justify-content:center;align-items:flex-start;">
-    <div class="contact-box" style="min-width:380px;">
-      <h4>Get in Touch</h4>
-      <div class="contact-line"><strong>Volodymyr Ovcharov</strong></div>
-      <div class="contact-line">volodymyr@legal.org.ua</div>
-      <div class="contact-line" style="margin-bottom:16px;">linkedin.com/in/volodymir-ovcharov</div>
-      <div class="contact-line"><strong>Igor Kyrychenko</strong></div>
-      <div class="contact-line">igor@legal.org.ua</div>
-      <div class="contact-line" style="margin-bottom:16px;">linkedin.com/in/ihor-kyrychenko</div>
-      <div>
-        <a class="contact-url" href="https://legal.org.ua" style="text-decoration:none;">legal.org.ua</a>
-      </div>
+<div class="slide" style="justify-content:center;align-items:center;">
+  <h2 style="text-align:center;margin-bottom:12px;"><span>Partners, Pilots & Investors</span></h2>
+  <p style="font-size:20px;color:#94a3b8;text-align:center;margin-bottom:40px;position:relative;">Public beta is live today.</p>
+  <div class="contact-box" style="min-width:400px;">
+    <h4>Get in Touch</h4>
+    <div class="contact-line"><strong>Volodymyr</strong> -- volodymyr@legal.org.ua</div>
+    <div class="contact-line"><strong>Igor</strong> -- igor@legal.org.ua</div>
+    <div style="margin-top:18px;">
+      <a class="btn" href="https://legal.org.ua" style="text-decoration:none;">legal.org.ua</a>
     </div>
   </div>
   <div class="logo-bar">LEX AI</div>


### PR DESCRIPTION
## Summary
- Strip each slide to minimal text for 4-minute live pitch on screen
- Bigger headlines, fewer words, more whitespace per slide
- Move Download PDF button to bottom of title slide
- Remove dense data grids, detailed descriptions, unit economics row

## Test plan
- [ ] Open https://legal.org.ua/pitch-deck.html and verify all 12 slides render cleanly
- [ ] Verify text is readable from distance (presentation mode)
- [ ] Confirm PDF download button works from bottom of slide 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the pitch deck for a 4-minute screen presentation. Bigger headlines, fewer words, and more whitespace to improve readability and pacing.

- **Refactors**
  - Rewrote slides with concise text; larger typography and spacing.
  - Replaced dense data grids with short stats and pill labels; simplified pipeline, market, and pricing views.
  - Streamlined tech stack and training plan into compact cards; trimmed team and traction details.
  - Moved the Download PDF button to the bottom of the title slide; updated docs/pitch-deck.html and lexwebapp/public/pitch-deck.html.

<sup>Written for commit 262d2db1ccdc31fcc286672a3e495e8aac4be0ef. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1808?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

