### PR TITLE
feat(benchmark): cross-jurisdiction metadata enrichment pipeline

### DIFF
--- a/scripts/benchmark/audit_metadata_completeness.py
+++ b/scripts/benchmark/audit_metadata_completeness.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""
+Audit metadata completeness across all court decision tables.
+
+Produces a completeness matrix showing which benchmark-relevant fields
+are populated per jurisdiction. Used to decide which jurisdictions
+can join the cross-jurisdiction benchmark.
+
+5 benchmark tasks require:
+  1. court_type classification (CTC)
+  2. decision_type classification
+  3. subject_area classification
+  4. outcome prediction
+  5. cited_provisions extraction
+
+Threshold: jurisdiction needs >= 2 tasks with structured metadata + >50K fulltext.
+
+Usage:
+  python3 scripts/benchmark/audit_metadata_completeness.py [--db-url URL] [--csv output.csv]
+"""
+
+import argparse
+import csv
+import json
+import os
+import sys
+
+import psycopg2
+
+DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:local_dev_password@localhost:5432/secondlayer_local",
+)
+
+JURISDICTIONS = {
+    "ua": {
+        "label": "Ukraine",
+        "language_family": "Slavic",
+        "query": """
+            SELECT
+                (SELECT count(*) FROM edrsr_documents) AS total,
+                (SELECT count(*) FROM edrsr_fulltext WHERE text_length > 500) AS has_fulltext,
+                (SELECT count(*) FROM edrsr_documents WHERE justice_kind IS NOT NULL) AS has_court_type,
+                (SELECT count(*) FROM edrsr_documents WHERE judgment_code IS NOT NULL) AS has_decision_type,
+                (SELECT count(*) FROM edrsr_documents WHERE category_code IS NOT NULL) AS has_subject,
+                0::bigint AS has_outcome,
+                0::bigint AS has_cited_provisions
+        """,
+        "notes": "outcome extracted via regex in lextreme pipeline; category_code = subject proxy",
+    },
+    "pl": {
+        "label": "Poland",
+        "language_family": "Slavic",
+        "table": "pl_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": "keywords",
+            "outcome": None,
+            "cited_provisions": "legal_bases",
+        },
+    },
+    "cz": {
+        "label": "Czech Republic",
+        "language_family": "Slavic",
+        "table": "cz_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": "subject",
+            "outcome": None,
+            "cited_provisions": "cited_provisions",
+        },
+    },
+    "hu": {
+        "label": "Hungary",
+        "language_family": "Uralic",
+        "table": "hu_court_decisions",
+        "columns": {
+            "court_type": "collegium",
+            "decision_type": "decision_type",
+            "subject": "legal_area",
+            "outcome": None,
+            "cited_provisions": "legislation_refs",
+        },
+    },
+    "lt": {
+        "label": "Lithuania",
+        "language_family": "Baltic",
+        "table": "lt_court_decisions",
+        "columns": {
+            "court_type": "instance",
+            "decision_type": "case_type",
+            "subject": "categories",
+            "outcome": "result",
+            "cited_provisions": "eu_norms",
+        },
+    },
+    "lv": {
+        "label": "Latvia",
+        "language_family": "Baltic",
+        "table": "lv_court_decisions",
+        "columns": {
+            "court_type": "case_type",
+            "decision_type": None,
+            "subject": None,
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "ee": {
+        "label": "Estonia",
+        "language_family": "Uralic",
+        "table": "ee_court_decisions",
+        "columns": {
+            "court_type": "case_type",
+            "decision_type": "decision_type",
+            "subject": None,
+            "outcome": "outcome",
+            "cited_provisions": None,
+        },
+    },
+    "dk": {
+        "label": "Denmark",
+        "language_family": "Germanic",
+        "table": "dk_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "case_type",
+            "subject": None,
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "se": {
+        "label": "Sweden",
+        "language_family": "Germanic",
+        "table": "se_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": "subject",
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "fi": {
+        "label": "Finland",
+        "language_family": "Uralic",
+        "table": "fi_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": "subject",
+            "outcome": None,
+            "cited_provisions": "cited_provisions",
+        },
+    },
+    "is": {
+        "label": "Iceland",
+        "language_family": "Germanic",
+        "table": "is_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": "subject",
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "fr": {
+        "label": "France",
+        "language_family": "Romance",
+        "table": "fr_court_decisions",
+        "columns": {
+            "court_type": "jurisdiction",
+            "decision_type": "decision_type",
+            "subject": "themes",
+            "outcome": "solution",
+            "cited_provisions": None,
+        },
+        "notes": "zones JSONB may contain citation data",
+    },
+    "de": {
+        "label": "Germany",
+        "language_family": "Germanic",
+        "table": "de_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": "subject_area",
+            "outcome": "tenor",
+            "cited_provisions": None,
+        },
+        "notes": "tenor is raw text, not a label -- needs classification",
+    },
+    "be": {
+        "label": "Belgium",
+        "language_family": "Romance/Germanic",
+        "table": "be_court_decisions",
+        "columns": {
+            "court_type": "court_name",
+            "decision_type": "decision_type",
+            "subject": None,
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "uk": {
+        "label": "United Kingdom",
+        "language_family": "Germanic",
+        "table": "uk_court_decisions",
+        "columns": {
+            "court_type": "court_code",
+            "decision_type": "decision_type",
+            "subject": "subject",
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "ie": {
+        "label": "Ireland",
+        "language_family": "Germanic",
+        "table": "ie_court_decisions",
+        "columns": {
+            "court_type": "court_type",
+            "decision_type": "decision_type",
+            "subject": None,
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "ch": {
+        "label": "Switzerland",
+        "language_family": "Romance/Germanic",
+        "table": "ch_court_decisions",
+        "columns": {
+            "court_type": "court_code",
+            "decision_type": "decision_type",
+            "subject": None,
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "lu": {
+        "label": "Luxembourg",
+        "language_family": "Romance/Germanic",
+        "table": "lu_court_decisions",
+        "columns": {
+            "court_type": "court",
+            "decision_type": None,
+            "subject": None,
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+    "sg": {
+        "label": "Singapore",
+        "language_family": "Austronesian/Germanic",
+        "table": "sg_court_decisions",
+        "columns": {
+            "court_type": "court_code",
+            "decision_type": "decision_type",
+            "subject": "subject",
+            "outcome": None,
+            "cited_provisions": None,
+        },
+    },
+}
+
+
+def count_field(cur, table, column):
+    if column is None:
+        return 0
+    cur.execute(
+        f"SELECT count(*) FROM {table} WHERE {column} IS NOT NULL AND {column}::text != '' AND {column}::text != '{{}}'"
+    )
+    return cur.fetchone()[0]
+
+
+def count_fulltext(cur, table):
+    cur.execute(
+        f"SELECT count(*) FROM {table} WHERE full_text IS NOT NULL AND length(full_text) > 500"
+    )
+    return cur.fetchone()[0]
+
+
+def count_total(cur, table):
+    cur.execute(f"SELECT count(*) FROM {table}")
+    return cur.fetchone()[0]
+
+
+def audit_jurisdiction(cur, code, config):
+    if "query" in config:
+        cur.execute(config["query"])
+        row = cur.fetchone()
+        return {
+            "code": code,
+            "label": config["label"],
+            "language_family": config["language_family"],
+            "total": row[0],
+            "fulltext": row[1],
+            "court_type": row[2],
+            "decision_type": row[3],
+            "subject": row[4],
+            "outcome": row[5],
+            "cited_provisions": row[6],
+            "notes": config.get("notes", ""),
+        }
+
+    table = config["table"]
+    cols = config["columns"]
+
+    try:
+        total = count_total(cur, table)
+    except psycopg2.errors.UndefinedTable:
+        cur.connection.rollback()
+        return {
+            "code": code,
+            "label": config["label"],
+            "language_family": config["language_family"],
+            "total": 0,
+            "fulltext": 0,
+            "court_type": 0,
+            "decision_type": 0,
+            "subject": 0,
+            "outcome": 0,
+            "cited_provisions": 0,
+            "notes": "TABLE NOT FOUND",
+        }
+
+    fulltext = count_fulltext(cur, table)
+
+    return {
+        "code": code,
+        "label": config["label"],
+        "language_family": config["language_family"],
+        "total": total,
+        "fulltext": fulltext,
+        "court_type": count_field(cur, table, cols["court_type"]),
+        "decision_type": count_field(cur, table, cols["decision_type"]),
+        "subject": count_field(cur, table, cols["subject"]),
+        "outcome": count_field(cur, table, cols["outcome"]),
+        "cited_provisions": count_field(cur, table, cols["cited_provisions"]),
+        "notes": config.get("notes", ""),
+    }
+
+
+def pct(n, total):
+    if total == 0:
+        return "0%"
+    p = n / total * 100
+    if p >= 99.5:
+        return "100%"
+    if p < 0.05:
+        return "0%"
+    return f"{p:.0f}%"
+
+
+def task_count(row):
+    tasks = 0
+    total = row["total"]
+    if total == 0:
+        return 0
+    threshold = 0.05
+    for field in ["court_type", "decision_type", "subject", "outcome", "cited_provisions"]:
+        if row[field] / total >= threshold:
+            tasks += 1
+    return tasks
+
+
+def print_matrix(results):
+    header = f"{'Code':<4} {'Country':<16} {'Family':<12} {'Total':>10} {'Fulltext':>10} {'CourtType':>10} {'DecType':>10} {'Subject':>10} {'Outcome':>10} {'CitedProv':>10} {'Tasks':>5} {'Benchmark':>9}"
+    sep = "-" * len(header)
+    print(sep)
+    print(header)
+    print(sep)
+
+    for r in sorted(results, key=lambda x: (-task_count(x), -x["fulltext"])):
+        tasks = task_count(r)
+        benchmark = "YES" if tasks >= 2 and r["fulltext"] >= 50000 else "no"
+        print(
+            f"{r['code']:<4} {r['label']:<16} {r['language_family']:<12} "
+            f"{r['total']:>10,} {r['fulltext']:>10,} "
+            f"{pct(r['court_type'], r['total']):>10} "
+            f"{pct(r['decision_type'], r['total']):>10} "
+            f"{pct(r['subject'], r['total']):>10} "
+            f"{pct(r['outcome'], r['total']):>10} "
+            f"{pct(r['cited_provisions'], r['total']):>10} "
+            f"{tasks:>5} {benchmark:>9}"
+        )
+        if r.get("notes"):
+            print(f"     ^ {r['notes']}")
+
+    print(sep)
+    qualified = [r for r in results if task_count(r) >= 2 and r["fulltext"] >= 50000]
+    print(f"\nQualified for benchmark (>=2 tasks, >=50K fulltext): {len(qualified)}")
+    for r in qualified:
+        print(f"  {r['code'].upper()} ({r['label']}) -- {task_count(r)} tasks, {r['fulltext']:,} fulltext")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit metadata completeness across court decision tables")
+    parser.add_argument("--db-url", default=DB_URL, help="PostgreSQL connection URL")
+    parser.add_argument("--csv", default=None, help="Output CSV file path")
+    parser.add_argument("--json", default=None, help="Output JSON file path")
+    args = parser.parse_args()
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = True
+    cur = conn.cursor()
+
+    results = []
+    for code, config in JURISDICTIONS.items():
+        print(f"  Auditing {code} ({config['label']})...", end=" ", flush=True)
+        row = audit_jurisdiction(cur, code, config)
+        results.append(row)
+        tasks = task_count(row)
+        print(f"{row['total']:,} total, {row['fulltext']:,} fulltext, {tasks}/5 tasks")
+
+    print("\n")
+    print_matrix(results)
+
+    if args.csv:
+        with open(args.csv, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=[
+                "code", "label", "language_family", "total", "fulltext",
+                "court_type", "decision_type", "subject", "outcome",
+                "cited_provisions", "notes",
+            ])
+            writer.writeheader()
+            writer.writerows(results)
+        print(f"\nCSV written to {args.csv}")
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nJSON written to {args.json}")
+
+    cur.close()
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/enrich_de_metadata.py
+++ b/scripts/benchmark/enrich_de_metadata.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""
+Enrich German court decisions with subject_area and outcome labels.
+
+Strategy:
+  subject_area:
+    1. Court-name-to-subject lookup (covers ~80% -- German courts are specialized)
+    2. Bedrock Haiku fallback for ambiguous courts (Landgericht, OLG, etc.)
+  outcome:
+    1. Regex on tenor column for common German dispositive keywords
+    2. Bedrock Haiku fallback for regex failures
+
+German court hierarchy -> subject area mapping:
+  Federal courts (BGH, BVerwG, BAG, BSG, BFH, BVerfG, BPatG) directly map.
+  State courts (LG, OLG, AG, VG, OVG, ArbG, SG, FG) map via prefix.
+
+Usage:
+  python3 scripts/benchmark/enrich_de_metadata.py [--db-url URL] [--dry-run] [--llm-fallback]
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+
+import psycopg2
+import psycopg2.extras
+
+DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:local_dev_password@localhost:5432/secondlayer_local",
+)
+
+COURT_TO_SUBJECT = {
+    "BGH": "Zivilrecht",
+    "BVerwG": "Verwaltungsrecht",
+    "BAG": "Arbeitsrecht",
+    "BSG": "Sozialrecht",
+    "BFH": "Steuerrecht",
+    "BVerfG": "Verfassungsrecht",
+    "BPatG": "Patentrecht",
+    "OLG": "Zivilrecht",
+    "LG": "Zivilrecht",
+    "AG": "Zivilrecht",
+    "KG": "Zivilrecht",
+    "OVG": "Verwaltungsrecht",
+    "VGH": "Verwaltungsrecht",
+    "VG": "Verwaltungsrecht",
+    "LAG": "Arbeitsrecht",
+    "ArbG": "Arbeitsrecht",
+    "LSG": "Sozialrecht",
+    "SG": "Sozialrecht",
+    "FG": "Steuerrecht",
+    "LVerfG": "Verfassungsrecht",
+    "VerfGH": "Verfassungsrecht",
+    "StGH": "Verfassungsrecht",
+}
+
+COURT_NAME_PATTERNS = [
+    (re.compile(r"\bBundesgerichtshof\b", re.I), "Zivilrecht"),
+    (re.compile(r"\bBundesverwaltungsgericht\b", re.I), "Verwaltungsrecht"),
+    (re.compile(r"\bBundesarbeitsgericht\b", re.I), "Arbeitsrecht"),
+    (re.compile(r"\bBundessozialgericht\b", re.I), "Sozialrecht"),
+    (re.compile(r"\bBundesfinanzhof\b", re.I), "Steuerrecht"),
+    (re.compile(r"\bBundesverfassungsgericht\b", re.I), "Verfassungsrecht"),
+    (re.compile(r"\bBundespatentgericht\b", re.I), "Patentrecht"),
+    (re.compile(r"\bOberlandesgericht\b", re.I), "Zivilrecht"),
+    (re.compile(r"\bLandgericht\b", re.I), "Zivilrecht"),
+    (re.compile(r"\bAmtsgericht\b", re.I), "Zivilrecht"),
+    (re.compile(r"\bKammergericht\b", re.I), "Zivilrecht"),
+    (re.compile(r"\bOberverwaltungsgericht\b", re.I), "Verwaltungsrecht"),
+    (re.compile(r"\bVerwaltungsgericht(?:shof)?\b", re.I), "Verwaltungsrecht"),
+    (re.compile(r"\bLandesarbeitsgericht\b", re.I), "Arbeitsrecht"),
+    (re.compile(r"\bArbeitsgericht\b", re.I), "Arbeitsrecht"),
+    (re.compile(r"\bLandessozialgericht\b", re.I), "Sozialrecht"),
+    (re.compile(r"\bSozialgericht\b", re.I), "Sozialrecht"),
+    (re.compile(r"\bFinanzgericht\b", re.I), "Steuerrecht"),
+    (re.compile(r"\bVerfassungsgericht(?:shof)?\b", re.I), "Verfassungsrecht"),
+    (re.compile(r"\bStaatsgerichtshof\b", re.I), "Verfassungsrecht"),
+]
+
+STRAFRECHT_INDICATORS = re.compile(
+    r"\b(?:Strafsenat|Strafkammer|Strafrecht|Angeklagte[rn]?|Freispruch|Freiheitsstrafe|Geldstrafe|StGB|StPO)\b",
+    re.I,
+)
+
+OUTCOME_GRANTED = re.compile(
+    r"(?:"
+    r"(?:wird|werden)\s+(?:verurteilt|stattgegeben)"
+    r"|(?:der\s+)?(?:Klage|Berufung|Revision)\s+(?:wird\s+)?stattgegeben"
+    r"|(?:die\s+)?Beklagte[rn]?\s+(?:wird|werden)\s+verurteilt"
+    r"|(?:hat|haben)\s+(?:an\s+(?:die|den)\s+Kläger(?:in)?\s+)?zu\s+zahlen"
+    r")",
+    re.IGNORECASE,
+)
+
+OUTCOME_DENIED = re.compile(
+    r"(?:"
+    r"(?:wird|werden)\s+(?:abgewiesen|zurückgewiesen|verworfen)"
+    r"|(?:die\s+)?(?:Klage|Berufung|Revision)\s+wird\s+(?:abgewiesen|zurückgewiesen|verworfen)"
+    r"|(?:wird|werden)\s+als\s+unbegründet\s+(?:abgewiesen|zurückgewiesen)"
+    r"|(?:wird|werden)\s+als\s+unzulässig\s+verworfen"
+    r")",
+    re.IGNORECASE,
+)
+
+OUTCOME_PARTIAL = re.compile(
+    r"(?:"
+    r"teilweise\s+stattgegeben"
+    r"|(?:im\s+[Üü]brigen|im\s+Weiteren)\s+(?:wird\s+(?:die\s+)?(?:Klage|Berufung)\s+)?abgewiesen"
+    r"|(?:wird\s+)?(?:der\s+Klage\s+)?teilweise\s+(?:stattgegeben|abgewiesen)"
+    r")",
+    re.IGNORECASE,
+)
+
+BEDROCK_WORKERS = [
+    {"region": "eu-central-1", "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "eu-west-1",    "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "us-east-1",    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "us-west-2",    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+]
+
+SUBJECT_PROMPT = """Classify the subject area of this German court decision. Return ONLY the category label.
+
+Categories: Zivilrecht, Strafrecht, Verwaltungsrecht, Arbeitsrecht, Sozialrecht, Steuerrecht, Verfassungsrecht, Patentrecht
+
+Text (first 1500 chars):
+{text}
+
+Category:"""
+
+OUTCOME_PROMPT = """Classify the outcome of this German court decision based on the tenor. Return ONLY one label.
+
+Labels:
+- granted (Klage stattgegeben, verurteilt)
+- denied (Klage abgewiesen, zurückgewiesen)
+- partial (teilweise stattgegeben)
+- other (cannot determine)
+
+Tenor:
+{text}
+
+Label:"""
+
+
+def classify_subject_by_court(court_type, court_name):
+    if court_type and court_type in COURT_TO_SUBJECT:
+        return COURT_TO_SUBJECT[court_type]
+    if court_name:
+        for pattern, subject in COURT_NAME_PATTERNS:
+            if pattern.search(court_name):
+                return subject
+    return None
+
+
+def refine_subject_with_text(subject, text):
+    if subject == "Zivilrecht" and text and STRAFRECHT_INDICATORS.search(text[:5000]):
+        return "Strafrecht"
+    return subject
+
+
+def classify_outcome_regex(tenor, full_text):
+    text = tenor or ""
+    if not text and full_text:
+        text = full_text[-3000:]
+    if len(text) < 50:
+        return None
+    if OUTCOME_PARTIAL.search(text):
+        return "partial"
+    if OUTCOME_GRANTED.search(text):
+        return "granted"
+    if OUTCOME_DENIED.search(text):
+        return "denied"
+    return None
+
+
+def classify_llm(text, prompt_template, valid_labels, worker):
+    import boto3
+    client = boto3.client("bedrock-runtime", region_name=worker["region"])
+    prompt = prompt_template.format(text=text)
+
+    try:
+        resp = client.invoke_model(
+            modelId=worker["model"],
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 30,
+                "messages": [{"role": "user", "content": prompt}],
+            }),
+        )
+        body = json.loads(resp["body"].read())
+        answer = body["content"][0]["text"].strip()
+        for label in valid_labels:
+            if label.lower() in answer.lower():
+                return label
+        return None
+    except Exception as e:
+        print(f"  LLM error ({worker['region']}): {e}", flush=True)
+        return None
+
+
+def ensure_columns(conn):
+    cur = conn.cursor()
+    for col in ["enriched_subject_area", "enriched_outcome"]:
+        cur.execute("""
+            SELECT column_name FROM information_schema.columns
+            WHERE table_name = 'de_court_decisions' AND column_name = %s
+        """, (col,))
+        if not cur.fetchone():
+            cur.execute(f"ALTER TABLE de_court_decisions ADD COLUMN {col} TEXT")
+            print(f"Added {col} column to de_court_decisions")
+    conn.commit()
+    cur.close()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Enrich DE court decisions with subject_area and outcome")
+    parser.add_argument("--db-url", default=DB_URL)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--llm-fallback", action="store_true", help="Use Bedrock for ambiguous cases")
+    parser.add_argument("--batch-size", type=int, default=5000)
+    args = parser.parse_args()
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = True
+
+    if not args.dry_run:
+        ensure_columns(conn)
+
+    cur = conn.cursor()
+    cur.execute("SELECT count(*) FROM de_court_decisions")
+    total = cur.fetchone()[0]
+    cur.execute("SELECT count(*) FROM de_court_decisions WHERE full_text IS NOT NULL AND length(full_text) > 500")
+    with_text = cur.fetchone()[0]
+    print(f"DE court decisions: {total:,} total, {with_text:,} with fulltext")
+    cur.close()
+    conn.close()
+
+    conn = psycopg2.connect(args.db_url)
+    cur = conn.cursor(name="de_enrich_cursor")
+    cur.itersize = args.batch_size
+
+    cur.execute("""
+        SELECT id, court_type, court_name, subject_area, tenor, full_text
+        FROM de_court_decisions
+        WHERE enriched_subject_area IS NULL OR enriched_outcome IS NULL
+        ORDER BY id
+    """)
+
+    update_cur = conn.cursor()
+    batch = []
+    stats = {
+        "subject_court_map": 0, "subject_strafrecht_refine": 0, "subject_fail": 0,
+        "outcome_regex": 0, "outcome_fail": 0,
+    }
+    processed = 0
+    llm_subject_ids = []
+    llm_outcome_ids = []
+
+    for row in cur:
+        doc_id, court_type, court_name, existing_subject, tenor, full_text = row
+        processed += 1
+
+        subject = classify_subject_by_court(court_type, court_name)
+        if subject:
+            subject = refine_subject_with_text(subject, full_text)
+            if subject == "Strafrecht" and classify_subject_by_court(court_type, court_name) != "Strafrecht":
+                stats["subject_strafrecht_refine"] += 1
+            stats["subject_court_map"] += 1
+        else:
+            stats["subject_fail"] += 1
+            llm_subject_ids.append(doc_id)
+
+        outcome = classify_outcome_regex(tenor, full_text)
+        if outcome:
+            stats["outcome_regex"] += 1
+        else:
+            stats["outcome_fail"] += 1
+            llm_outcome_ids.append(doc_id)
+
+        batch.append((subject, outcome, doc_id))
+
+        if len(batch) >= 1000 and not args.dry_run:
+            psycopg2.extras.execute_batch(
+                update_cur,
+                """UPDATE de_court_decisions
+                   SET enriched_subject_area = COALESCE(%s, enriched_subject_area),
+                       enriched_outcome = COALESCE(%s, enriched_outcome)
+                   WHERE id = %s""",
+                batch,
+            )
+            conn.commit()
+            batch = []
+
+        if processed % 10000 == 0:
+            print(
+                f"  {processed:,} -- subject: map={stats['subject_court_map']}, fail={stats['subject_fail']} | "
+                f"outcome: regex={stats['outcome_regex']}, fail={stats['outcome_fail']}",
+                flush=True,
+            )
+
+    if batch and not args.dry_run:
+        psycopg2.extras.execute_batch(
+            update_cur,
+            """UPDATE de_court_decisions
+               SET enriched_subject_area = COALESCE(%s, enriched_subject_area),
+                   enriched_outcome = COALESCE(%s, enriched_outcome)
+               WHERE id = %s""",
+            batch,
+        )
+        conn.commit()
+
+    cur.close()
+    update_cur.close()
+    conn.close()
+
+    print(f"\n=== DE Enrichment Summary ===")
+    print(f"Total processed: {processed:,}")
+    print(f"Subject area: mapped={stats['subject_court_map']}, strafrecht_refined={stats['subject_strafrecht_refine']}, need_llm={stats['subject_fail']}")
+    print(f"Outcome: regex={stats['outcome_regex']}, need_llm={stats['outcome_fail']}")
+
+    if args.llm_fallback:
+        print(f"\nLLM fallback: {len(llm_subject_ids)} subject + {len(llm_outcome_ids)} outcome records")
+        print("LLM fallback not yet implemented in batch mode -- use enrich_metadata_llm.py")
+
+    if args.dry_run:
+        print("(dry-run mode -- no changes written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/enrich_hu_outcome.py
+++ b/scripts/benchmark/enrich_hu_outcome.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+Enrich Hungarian court decisions with outcome labels.
+
+Strategy:
+  1. Regex on dispositive section for common Hungarian outcome keywords
+  2. Bedrock Claude Haiku fallback for records where regex fails
+
+Hungarian outcome patterns:
+  - granted:  "helyt ad", "megalapozott", "keresetnek helyt ad"
+  - denied:   "elutasítja", "megalapozatlan", "keresetet elutasítja"
+  - partial:  "részben helyt ad", "részben megalapozott"
+
+Usage:
+  python3 scripts/benchmark/enrich_hu_outcome.py [--db-url URL] [--dry-run] [--llm-fallback]
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+
+import psycopg2
+import psycopg2.extras
+
+DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:local_dev_password@localhost:5432/secondlayer_local",
+)
+
+OUTCOME_GRANTED = re.compile(
+    r"(?:"
+    r"helyt\s+ad(?:ja|ott)?"
+    r"|keres(?:et(?:nek|et|ét)?|etet)\s+(?:a\s+bíróság\s+)?(?:teljes\s+egészében\s+)?helyt\s+ad"
+    r"|megalapozott(?:nak\s+találta)?"
+    r"|kötelezi\s+(?:az?\s+)?alperes"
+    r"|marasztalja"
+    r")",
+    re.IGNORECASE,
+)
+
+OUTCOME_DENIED = re.compile(
+    r"(?:"
+    r"elutasítja"
+    r"|keresetet?\s+elutasít"
+    r"|megalapozatlan"
+    r"|nem\s+alapos"
+    r"|helyt\s+nem\s+ad"
+    r")",
+    re.IGNORECASE,
+)
+
+OUTCOME_PARTIAL = re.compile(
+    r"(?:"
+    r"részben\s+helyt\s+ad"
+    r"|részben\s+megalapozott"
+    r"|részben\s+elutasít"
+    r"|a\s+keresetet\s+részben"
+    r")",
+    re.IGNORECASE,
+)
+
+BEDROCK_WORKERS = [
+    {"region": "eu-central-1", "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "eu-west-1",    "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "us-east-1",    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "us-west-2",    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+]
+
+CLASSIFICATION_PROMPT = """Classify the outcome of this Hungarian court decision. Read the dispositive section and return ONLY one label.
+
+Labels:
+- granted (keresetnek helyt ad, marasztal)
+- denied (keresetet elutasítja)
+- partial (részben helyt ad)
+- other (cannot determine)
+
+Text (last 2000 chars):
+{text}
+
+Label:"""
+
+print_lock = Lock()
+stats = {"regex_granted": 0, "regex_denied": 0, "regex_partial": 0, "regex_fail": 0, "llm_ok": 0, "llm_fail": 0}
+
+
+def log(msg):
+    with print_lock:
+        print(msg, flush=True)
+
+
+def classify_regex(text):
+    if not text or len(text) < 100:
+        return None
+    tail = text[-3000:]
+    if OUTCOME_PARTIAL.search(tail):
+        return "partial"
+    if OUTCOME_GRANTED.search(tail):
+        return "granted"
+    if OUTCOME_DENIED.search(tail):
+        return "denied"
+    return None
+
+
+def classify_llm(text, worker):
+    import boto3
+    client = boto3.client("bedrock-runtime", region_name=worker["region"])
+    prompt = CLASSIFICATION_PROMPT.format(text=text[-2000:])
+
+    try:
+        resp = client.invoke_model(
+            modelId=worker["model"],
+            contentType="application/json",
+            accept="application/json",
+            body=json.dumps({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 20,
+                "messages": [{"role": "user", "content": prompt}],
+            }),
+        )
+        body = json.loads(resp["body"].read())
+        answer = body["content"][0]["text"].strip().lower()
+        for label in ("granted", "denied", "partial", "other"):
+            if label in answer:
+                return label
+        return None
+    except Exception as e:
+        log(f"  LLM error ({worker['region']}): {e}")
+        return None
+
+
+def ensure_outcome_column(conn):
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = 'hu_court_decisions' AND column_name = 'enriched_outcome'
+    """)
+    if not cur.fetchone():
+        cur.execute("ALTER TABLE hu_court_decisions ADD COLUMN enriched_outcome TEXT")
+        conn.commit()
+        log("Added enriched_outcome column to hu_court_decisions")
+    cur.close()
+
+
+def process_batch_regex(db_url, batch_size=5000, dry_run=False):
+    conn = psycopg2.connect(db_url)
+    cur = conn.cursor(name="hu_outcome_cursor")
+    cur.itersize = batch_size
+
+    cur.execute("""
+        SELECT id, full_text FROM hu_court_decisions
+        WHERE full_text IS NOT NULL AND length(full_text) > 500
+          AND enriched_outcome IS NULL
+        ORDER BY id
+    """)
+
+    update_cur = conn.cursor()
+    batch = []
+    total = 0
+    failed_ids = []
+
+    for row in cur:
+        doc_id, text = row
+        outcome = classify_regex(text)
+        total += 1
+
+        if outcome:
+            stats[f"regex_{outcome}"] += 1
+            batch.append((outcome, doc_id))
+        else:
+            stats["regex_fail"] += 1
+            failed_ids.append(doc_id)
+
+        if len(batch) >= 1000 and not dry_run:
+            psycopg2.extras.execute_batch(
+                update_cur,
+                "UPDATE hu_court_decisions SET enriched_outcome = %s WHERE id = %s",
+                batch,
+            )
+            conn.commit()
+            batch = []
+
+        if total % 10000 == 0:
+            log(f"  Processed {total:,} -- granted={stats['regex_granted']}, denied={stats['regex_denied']}, partial={stats['regex_partial']}, fail={stats['regex_fail']}")
+
+    if batch and not dry_run:
+        psycopg2.extras.execute_batch(
+            update_cur,
+            "UPDATE hu_court_decisions SET enriched_outcome = %s WHERE id = %s",
+            batch,
+        )
+        conn.commit()
+
+    cur.close()
+    update_cur.close()
+    conn.close()
+
+    log(f"\nRegex phase complete: {total:,} processed")
+    log(f"  granted={stats['regex_granted']}, denied={stats['regex_denied']}, partial={stats['regex_partial']}")
+    log(f"  regex_fail={stats['regex_fail']} ({stats['regex_fail']/max(total,1)*100:.1f}%)")
+
+    return failed_ids
+
+
+def process_llm_fallback(db_url, failed_ids, dry_run=False):
+    if not failed_ids:
+        return
+
+    log(f"\nLLM fallback for {len(failed_ids):,} records...")
+
+    conn = psycopg2.connect(db_url)
+    cur = conn.cursor()
+    update_cur = conn.cursor()
+    batch = []
+    worker_idx = 0
+
+    for i, doc_id in enumerate(failed_ids):
+        cur.execute("SELECT full_text FROM hu_court_decisions WHERE id = %s", (doc_id,))
+        row = cur.fetchone()
+        if not row or not row[0]:
+            continue
+
+        worker = BEDROCK_WORKERS[worker_idx % len(BEDROCK_WORKERS)]
+        worker_idx += 1
+
+        outcome = classify_llm(row[0], worker)
+        if outcome and outcome != "other":
+            stats["llm_ok"] += 1
+            batch.append((outcome, doc_id))
+        else:
+            stats["llm_fail"] += 1
+
+        if len(batch) >= 100 and not dry_run:
+            psycopg2.extras.execute_batch(
+                update_cur,
+                "UPDATE hu_court_decisions SET enriched_outcome = %s WHERE id = %s",
+                batch,
+            )
+            conn.commit()
+            batch = []
+
+        if (i + 1) % 500 == 0:
+            log(f"  LLM: {i+1}/{len(failed_ids)} -- ok={stats['llm_ok']}, fail={stats['llm_fail']}")
+
+        time.sleep(0.05)
+
+    if batch and not dry_run:
+        psycopg2.extras.execute_batch(
+            update_cur,
+            "UPDATE hu_court_decisions SET enriched_outcome = %s WHERE id = %s",
+            batch,
+        )
+        conn.commit()
+
+    cur.close()
+    update_cur.close()
+    conn.close()
+
+    log(f"\nLLM phase complete: ok={stats['llm_ok']}, fail={stats['llm_fail']}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Enrich HU court decisions with outcome labels")
+    parser.add_argument("--db-url", default=DB_URL)
+    parser.add_argument("--dry-run", action="store_true", help="Don't write to DB")
+    parser.add_argument("--llm-fallback", action="store_true", help="Use Bedrock Haiku for regex failures")
+    args = parser.parse_args()
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = True
+
+    if not args.dry_run:
+        ensure_outcome_column(conn)
+
+    cur = conn.cursor()
+    cur.execute("SELECT count(*) FROM hu_court_decisions")
+    total = cur.fetchone()[0]
+    cur.execute("SELECT count(*) FROM hu_court_decisions WHERE full_text IS NOT NULL AND length(full_text) > 500")
+    with_text = cur.fetchone()[0]
+    cur.execute("SELECT count(*) FROM hu_court_decisions WHERE enriched_outcome IS NOT NULL")
+    already_done = cur.fetchone()[0]
+    cur.close()
+    conn.close()
+
+    log(f"HU court decisions: {total:,} total, {with_text:,} with fulltext, {already_done:,} already enriched")
+
+    if already_done >= with_text:
+        log("All records already enriched. Nothing to do.")
+        return
+
+    failed_ids = process_batch_regex(args.db_url, dry_run=args.dry_run)
+
+    if args.llm_fallback and failed_ids:
+        process_llm_fallback(args.db_url, failed_ids, dry_run=args.dry_run)
+
+    log("\n=== Summary ===")
+    total_classified = stats["regex_granted"] + stats["regex_denied"] + stats["regex_partial"] + stats["llm_ok"]
+    total_processed = total_classified + stats["regex_fail"] - stats["llm_ok"] + stats["llm_fail"]
+    log(f"Total classified: {total_classified:,} / {total_processed:,} ({total_classified/max(total_processed,1)*100:.1f}%)")
+    log(f"  granted={stats['regex_granted'] + stats.get('llm_granted', 0)}")
+    log(f"  denied={stats['regex_denied']}")
+    log(f"  partial={stats['regex_partial']}")
+    if args.dry_run:
+        log("(dry-run mode -- no changes written)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/enrich_metadata_llm.py
+++ b/scripts/benchmark/enrich_metadata_llm.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""
+Multi-jurisdiction LLM metadata enrichment via AWS Bedrock.
+
+Generic pipeline for extracting structured metadata from court decision fulltext
+using Claude Haiku across multiple AWS regions. Supports:
+  - subject_area classification
+  - outcome prediction
+  - cited_provisions extraction
+
+Architecture follows annotate_ner_parallel.py:
+  - Multi-region Bedrock workers for throughput
+  - DB-backed work queue with checkpoint/resume
+  - Cost tracking per jurisdiction per task
+  - Configurable per-jurisdiction: table, text column, target fields, labels, language
+
+Usage:
+  # Enrich German subject_area via LLM
+  python3 scripts/benchmark/enrich_metadata_llm.py --country de --task subject_area
+
+  # Enrich Swedish outcome via LLM
+  python3 scripts/benchmark/enrich_metadata_llm.py --country se --task outcome
+
+  # Enrich UK subject + outcome
+  python3 scripts/benchmark/enrich_metadata_llm.py --country uk --task subject_area outcome
+
+  # Dry run (count records, don't write)
+  python3 scripts/benchmark/enrich_metadata_llm.py --country hu --task outcome --dry-run
+
+  # Limit batch size
+  python3 scripts/benchmark/enrich_metadata_llm.py --country de --task subject_area --limit 5000
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+
+import boto3
+import psycopg2
+import psycopg2.extras
+
+DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:local_dev_password@localhost:5432/secondlayer_local",
+)
+
+WORKERS = [
+    {"region": "eu-central-1", "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "eu-west-1",    "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "eu-west-2",    "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "eu-west-3",    "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "eu-north-1",   "model": "eu.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "us-east-1",    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+    {"region": "us-west-2",    "model": "us.anthropic.claude-haiku-4-5-20251001-v1:0"},
+]
+
+JURISDICTION_CONFIG = {
+    "de": {
+        "table": "de_court_decisions",
+        "language": "German",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "subject_area": {
+                "column": "enriched_subject_area",
+                "categories": ["Zivilrecht", "Strafrecht", "Verwaltungsrecht", "Arbeitsrecht", "Sozialrecht", "Steuerrecht", "Verfassungsrecht", "Patentrecht"],
+                "max_input_chars": 1500,
+            },
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "hu": {
+        "table": "hu_court_decisions",
+        "language": "Hungarian",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "se": {
+        "table": "se_court_decisions",
+        "language": "Swedish",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "subject_area": {
+                "column": "enriched_subject_area",
+                "categories": ["civilrätt", "straffrätt", "förvaltningsrätt", "arbetsrätt", "skatteträtt", "miljörätt", "migrationsrätt", "socialrätt"],
+                "max_input_chars": 1500,
+            },
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "fi": {
+        "table": "fi_court_decisions",
+        "language": "Finnish",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+            "cited_provisions": {
+                "column": "enriched_cited_provisions",
+                "output_type": "json_array",
+                "max_input_chars": 3000,
+            },
+        },
+    },
+    "uk": {
+        "table": "uk_court_decisions",
+        "language": "English",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "subject_area": {
+                "column": "enriched_subject_area",
+                "categories": ["criminal", "civil", "family", "administrative", "commercial", "employment", "immigration", "tax", "intellectual_property", "constitutional"],
+                "max_input_chars": 1500,
+            },
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "lv": {
+        "table": "lv_court_decisions",
+        "language": "Latvian",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "subject_area": {
+                "column": "enriched_subject_area",
+                "categories": ["civillieta", "krimināllieta", "administratīvā_lieta", "darba_lieta"],
+                "max_input_chars": 1500,
+            },
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "pl": {
+        "table": "pl_court_decisions",
+        "language": "Polish",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "cz": {
+        "table": "cz_court_decisions",
+        "language": "Czech",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+    "sg": {
+        "table": "sg_court_decisions",
+        "language": "English",
+        "text_column": "full_text",
+        "id_column": "id",
+        "tasks": {
+            "outcome": {
+                "column": "enriched_outcome",
+                "categories": ["granted", "denied", "partial"],
+                "max_input_chars": 2000,
+                "text_slice": "tail",
+            },
+        },
+    },
+}
+
+PROMPTS = {
+    "subject_area": """Classify the subject area of this {language} court decision. Return ONLY the category label, nothing else.
+
+Categories: {categories}
+
+Text (first {max_chars} chars):
+{text}
+
+Category:""",
+    "outcome": """Classify the outcome of this {language} court decision. Read the dispositive/operative section and return ONLY one label, nothing else.
+
+Labels: {categories}
+
+(granted = claim accepted, plaintiff wins; denied = claim rejected; partial = partly accepted)
+
+Text:
+{text}
+
+Label:""",
+    "cited_provisions": """Extract all legal provisions (law articles, sections, acts) cited in this {language} court decision. Return ONLY a JSON array of strings. If none found, return [].
+
+Text (first {max_chars} chars):
+{text}
+
+Provisions:""",
+}
+
+print_lock = Lock()
+
+
+def log(msg):
+    with print_lock:
+        print(msg, flush=True)
+
+
+def get_text_slice(text, task_config):
+    max_chars = task_config.get("max_input_chars", 2000)
+    if task_config.get("text_slice") == "tail":
+        return text[-max_chars:]
+    return text[:max_chars]
+
+
+def build_prompt(text, task_name, task_config, language):
+    template = PROMPTS[task_name]
+    sliced = get_text_slice(text, task_config)
+    categories = ", ".join(task_config.get("categories", []))
+    return template.format(
+        language=language,
+        categories=categories,
+        max_chars=task_config.get("max_input_chars", 2000),
+        text=sliced,
+    )
+
+
+def parse_classification(response_text, valid_labels):
+    answer = response_text.strip().lower().strip(".")
+    for label in valid_labels:
+        if label.lower() in answer:
+            return label
+    return None
+
+
+def parse_json_array(response_text):
+    text = response_text.strip()
+    if text.startswith("```"):
+        first_nl = text.index("\n") if "\n" in text else len(text)
+        text = text[first_nl + 1:]
+    if text.endswith("```"):
+        text = text[:-3].strip()
+    try:
+        result = json.loads(text)
+        if isinstance(result, list):
+            return result
+    except json.JSONDecodeError:
+        pass
+    return None
+
+
+def ensure_column(conn, table, column, col_type="TEXT"):
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = %s AND column_name = %s
+    """, (table, column))
+    if not cur.fetchone():
+        cur.execute(f"ALTER TABLE {table} ADD COLUMN {column} {col_type}")
+        conn.commit()
+        log(f"  Added column {column} to {table}")
+    cur.close()
+
+
+def worker_loop(worker_id, region, model, work_items, table, id_column, task_name, task_config, language, dry_run):
+    bedrock = boto3.client("bedrock-runtime", region_name=region)
+    conn = psycopg2.connect(DB_URL)
+    conn.autocommit = True
+    cur = conn.cursor()
+
+    column = task_config["column"]
+    output_type = task_config.get("output_type", "classification")
+    valid_labels = [l.lower() for l in task_config.get("categories", [])]
+
+    done = 0
+    errors = 0
+    cost = 0.0
+    t0 = time.time()
+
+    for doc_id, text in work_items:
+        prompt = build_prompt(text, task_name, task_config, language)
+
+        try:
+            body = json.dumps({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 100 if output_type == "json_array" else 30,
+                "temperature": 0,
+                "messages": [{"role": "user", "content": prompt}],
+            })
+
+            resp = bedrock.invoke_model(
+                modelId=model,
+                contentType="application/json",
+                accept="application/json",
+                body=body,
+            )
+
+            result = json.loads(resp["body"].read())
+            resp_text = result["content"][0]["text"]
+            usage = result.get("usage", {})
+            input_tok = usage.get("input_tokens", 0)
+            output_tok = usage.get("output_tokens", 0)
+            c = input_tok * 0.25 / 1e6 + output_tok * 1.25 / 1e6
+            cost += c
+
+            if output_type == "json_array":
+                parsed = parse_json_array(resp_text)
+                value = json.dumps(parsed, ensure_ascii=False) if parsed else None
+            else:
+                value = parse_classification(resp_text, task_config.get("categories", []))
+
+            if value and not dry_run:
+                if output_type == "json_array":
+                    cur.execute(
+                        f"UPDATE {table} SET {column} = %s WHERE {id_column} = %s",
+                        (value, doc_id),
+                    )
+                else:
+                    cur.execute(
+                        f"UPDATE {table} SET {column} = %s WHERE {id_column} = %s",
+                        (value, doc_id),
+                    )
+                done += 1
+            elif value:
+                done += 1
+            else:
+                errors += 1
+
+        except Exception as e:
+            errors += 1
+            if errors <= 5:
+                log(f"  [W{worker_id}] error: {type(e).__name__}: {str(e)[:80]}")
+            time.sleep(1)
+            continue
+
+        if done > 0 and done % 100 == 0:
+            elapsed = time.time() - t0
+            rate = done / elapsed if elapsed > 0 else 0
+            remaining = len(work_items) - done - errors
+            eta = remaining / rate / 60 if rate > 0 else 0
+            log(f"  [W{worker_id}] done={done}/{len(work_items)} err={errors} cost=${cost:.3f} rate={rate:.1f}/s ETA={eta:.0f}min region={region}")
+
+    cur.close()
+    conn.close()
+    return {"worker": worker_id, "region": region, "done": done, "errors": errors, "cost": cost}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Multi-jurisdiction LLM metadata enrichment via Bedrock")
+    parser.add_argument("--country", required=True, choices=list(JURISDICTION_CONFIG.keys()))
+    parser.add_argument("--task", required=True, nargs="+", help="Tasks to run: subject_area, outcome, cited_provisions")
+    parser.add_argument("--db-url", default=DB_URL)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int, default=0, help="Max records to process (0=all)")
+    parser.add_argument("--workers", type=int, default=len(WORKERS), help="Number of parallel workers")
+    args = parser.parse_args()
+
+    global DB_URL
+    DB_URL = args.db_url
+
+    config = JURISDICTION_CONFIG[args.country]
+    table = config["table"]
+    language = config["language"]
+    id_column = config["id_column"]
+    text_column = config["text_column"]
+
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = True
+
+    for task_name in args.task:
+        if task_name not in config["tasks"]:
+            print(f"Task '{task_name}' not configured for {args.country}. Available: {list(config['tasks'].keys())}")
+            sys.exit(1)
+
+        task_config = config["tasks"][task_name]
+        column = task_config["column"]
+
+        if not args.dry_run:
+            col_type = "TEXT[]" if task_config.get("output_type") == "json_array" else "TEXT"
+            ensure_column(conn, table, column, col_type)
+
+        cur = conn.cursor()
+        cur.execute(f"SELECT count(*) FROM {table} WHERE {text_column} IS NOT NULL AND length({text_column}) > 500 AND {column} IS NULL")
+        remaining = cur.fetchone()[0]
+        cur.close()
+
+        limit_clause = f"LIMIT {args.limit}" if args.limit > 0 else ""
+        print(f"\n{'='*60}")
+        print(f"  {args.country.upper()} / {task_name}: {remaining:,} records to enrich")
+        print(f"  Table: {table}, Column: {column}")
+        print(f"  Workers: {min(args.workers, len(WORKERS))}, Limit: {args.limit or 'all'}")
+        print(f"{'='*60}")
+
+        if remaining == 0:
+            print("  Nothing to do.")
+            continue
+
+        cur = conn.cursor()
+        cur.execute(f"""
+            SELECT {id_column}, {text_column}
+            FROM {table}
+            WHERE {text_column} IS NOT NULL AND length({text_column}) > 500
+              AND {column} IS NULL
+            ORDER BY {id_column}
+            {limit_clause}
+        """)
+        rows = cur.fetchall()
+        cur.close()
+
+        n_workers = min(args.workers, len(WORKERS), len(rows))
+        chunk_size = len(rows) // n_workers
+        chunks = []
+        for i in range(n_workers):
+            start = i * chunk_size
+            end = start + chunk_size if i < n_workers - 1 else len(rows)
+            chunks.append(rows[start:end])
+
+        print(f"  Distributing {len(rows):,} records across {n_workers} workers...")
+
+        t0 = time.time()
+        with ThreadPoolExecutor(max_workers=n_workers) as executor:
+            futures = {}
+            for i, chunk in enumerate(chunks):
+                worker = WORKERS[i % len(WORKERS)]
+                f = executor.submit(
+                    worker_loop,
+                    i, worker["region"], worker["model"],
+                    chunk, table, id_column,
+                    task_name, task_config, language, args.dry_run,
+                )
+                futures[f] = i
+
+            total_done = 0
+            total_errors = 0
+            total_cost = 0.0
+            for f in as_completed(futures):
+                result = f.result()
+                total_done += result["done"]
+                total_errors += result["errors"]
+                total_cost += result["cost"]
+                log(f"  Worker {result['worker']} finished: done={result['done']}, errors={result['errors']}, cost=${result['cost']:.3f}")
+
+        elapsed = time.time() - t0
+        print(f"\n  === {args.country.upper()} / {task_name} Summary ===")
+        print(f"  Done: {total_done:,}, Errors: {total_errors:,}, Cost: ${total_cost:.2f}")
+        print(f"  Time: {elapsed:.0f}s, Rate: {total_done/max(elapsed,1):.1f} records/s")
+        if args.dry_run:
+            print("  (dry-run mode)")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/enrich_pl_cz_outcome.py
+++ b/scripts/benchmark/enrich_pl_cz_outcome.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Enrich Polish and Czech court decisions with outcome labels via regex.
+
+Polish outcome patterns (from dispositive section / sentencja):
+  - granted:  "uwzględnia", "zasądza", "zobowiązuje pozwanego"
+  - denied:   "oddala", "nie uwzględnia", "nie zasługuje na uwzględnienie"
+  - partial:  "częściowo uwzględnia", "uwzględnia w części", "w pozostałej części oddala"
+
+Czech outcome patterns (from výrok / výroková část):
+  - granted:  "vyhovuje", "přiznává", "zavazuje žalovaného"
+  - denied:   "zamítá", "nevyhovuje", "zamítá se"
+  - partial:  "částečně vyhovuje", "ve zbytku zamítá", "zčásti vyhovuje"
+
+Usage:
+  python3 scripts/benchmark/enrich_pl_cz_outcome.py [--db-url URL] [--dry-run] [--country pl|cz|both]
+"""
+
+import argparse
+import os
+import re
+
+import psycopg2
+import psycopg2.extras
+
+DB_URL = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:local_dev_password@localhost:5432/secondlayer_local",
+)
+
+PL_OUTCOME_GRANTED = re.compile(
+    r"(?:"
+    r"uwzgl[ęe]dnia\s+(?:pow[oó]dztwo|skarg[ęe]|wniosek|żądanie)"
+    r"|zas[ąa]dza\s+od\s+pozwan"
+    r"|zobowi[ąa]zuje\s+pozwan"
+    r"|orzeka\s+o\s+(?:rozwi[ąa]zaniu|rozwiodzie)"
+    r"|unieważnia"
+    r"|uchyla\s+(?:zaskarżon[ąa]|decyzj[ęe])"
+    r"|zmienia\s+(?:zaskarżon[ąa]|decyzj[ęe])"
+    r"|pow[oó]dztwo\s+(?:jest\s+)?zasadne"
+    r")",
+    re.IGNORECASE,
+)
+
+PL_OUTCOME_DENIED = re.compile(
+    r"(?:"
+    r"oddala\s+(?:pow[oó]dztwo|skarg[ęe]|wniosek|apelacj[ęe]|zażalenie)"
+    r"|nie\s+uwzgl[ęe]dnia"
+    r"|pow[oó]dztwo\s+(?:nie\s+)?(?:zasługuje|podlega)\s+(?:na\s+)?oddaleni"
+    r"|nie\s+zasługuje\s+na\s+uwzgl[ęe]dnienie"
+    r"|utrzymuje\s+w\s+mocy"
+    r"|pow[oó]dztwo\s+(?:jest\s+)?(?:bezzasadne|niezasadne)"
+    r")",
+    re.IGNORECASE,
+)
+
+PL_OUTCOME_PARTIAL = re.compile(
+    r"(?:"
+    r"cz[ęe][śs]ciowo\s+uwzgl[ęe]dnia"
+    r"|uwzgl[ęe]dnia\s+(?:pow[oó]dztwo|skarg[ęe]|wniosek)\s+w\s+cz[ęe][śs]ci"
+    r"|w\s+pozosta[łl](?:ej|ym)\s+cz[ęe][śs]ci\s+oddala"
+    r"|w\s+pozosta[łl](?:ej|ym)\s+zakresie\s+oddala"
+    r"|cz[ęe][śs]ciowo\s+oddala"
+    r")",
+    re.IGNORECASE,
+)
+
+CZ_OUTCOME_GRANTED = re.compile(
+    r"(?:"
+    r"vyhovuje\s+(?:žalob[ěe]|návrhu)"
+    r"|přiznává"
+    r"|zavazuje\s+žalovan"
+    r"|zrušuje\s+(?:napadené|rozhodnutí)"
+    r"|mění\s+(?:rozsudek|rozhodnutí)"
+    r"|žalob[ěe]\s+(?:se\s+)?vyhovuje"
+    r"|žaloba\s+(?:je\s+)?důvodná"
+    r")",
+    re.IGNORECASE,
+)
+
+CZ_OUTCOME_DENIED = re.compile(
+    r"(?:"
+    r"zamítá\s+(?:se|žalobu|návrh|odvolání|dovolání)"
+    r"|žaloba\s+se\s+zamítá"
+    r"|nevyhovuje"
+    r"|žaloba\s+(?:je\s+)?(?:nedůvodná|neopodstatněná)"
+    r"|se\s+zamítá"
+    r"|odmítá\s+(?:se|žalobu|dovolání)"
+    r")",
+    re.IGNORECASE,
+)
+
+CZ_OUTCOME_PARTIAL = re.compile(
+    r"(?:"
+    r"částečně\s+vyhovuje"
+    r"|zčásti\s+vyhovuje"
+    r"|ve\s+zbytku\s+(?:se\s+)?zamítá"
+    r"|v\s+ostatním\s+(?:se\s+)?zamítá"
+    r"|částečně\s+zamítá"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def classify_outcome(text, country):
+    if not text or len(text) < 100:
+        return None
+    tail = text[-4000:]
+
+    if country == "pl":
+        if PL_OUTCOME_PARTIAL.search(tail):
+            return "partial"
+        if PL_OUTCOME_GRANTED.search(tail):
+            return "granted"
+        if PL_OUTCOME_DENIED.search(tail):
+            return "denied"
+    elif country == "cz":
+        if CZ_OUTCOME_PARTIAL.search(tail):
+            return "partial"
+        if CZ_OUTCOME_GRANTED.search(tail):
+            return "granted"
+        if CZ_OUTCOME_DENIED.search(tail):
+            return "denied"
+    return None
+
+
+def ensure_column(conn, table):
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT column_name FROM information_schema.columns
+        WHERE table_name = %s AND column_name = 'enriched_outcome'
+    """, (table,))
+    if not cur.fetchone():
+        cur.execute(f"ALTER TABLE {table} ADD COLUMN enriched_outcome TEXT")
+        conn.commit()
+        print(f"Added enriched_outcome column to {table}")
+    cur.close()
+
+
+def enrich_country(db_url, country, table, dry_run=False, batch_size=5000):
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = True
+
+    if not dry_run:
+        ensure_column(conn, table)
+
+    cur = conn.cursor()
+    cur.execute(f"SELECT count(*) FROM {table}")
+    total = cur.fetchone()[0]
+    cur.execute(f"SELECT count(*) FROM {table} WHERE full_text IS NOT NULL AND length(full_text) > 500")
+    with_text = cur.fetchone()[0]
+    cur.execute(f"SELECT count(*) FROM {table} WHERE enriched_outcome IS NOT NULL")
+    already = cur.fetchone()[0]
+    cur.close()
+
+    print(f"\n{country.upper()} ({table}): {total:,} total, {with_text:,} with fulltext, {already:,} already enriched")
+
+    if already >= with_text:
+        print("  All records already enriched.")
+        return
+
+    conn.close()
+    conn = psycopg2.connect(db_url)
+    cur = conn.cursor(name=f"{country}_outcome_cursor")
+    cur.itersize = batch_size
+
+    cur.execute(f"""
+        SELECT id, full_text FROM {table}
+        WHERE full_text IS NOT NULL AND length(full_text) > 500
+          AND enriched_outcome IS NULL
+        ORDER BY id
+    """)
+
+    update_cur = conn.cursor()
+    batch = []
+    stats = {"granted": 0, "denied": 0, "partial": 0, "fail": 0}
+    processed = 0
+
+    for row in cur:
+        doc_id, text = row
+        processed += 1
+        outcome = classify_outcome(text, country)
+
+        if outcome:
+            stats[outcome] += 1
+            batch.append((outcome, doc_id))
+        else:
+            stats["fail"] += 1
+
+        if len(batch) >= 1000 and not dry_run:
+            psycopg2.extras.execute_batch(
+                update_cur,
+                f"UPDATE {table} SET enriched_outcome = %s WHERE id = %s",
+                batch,
+            )
+            conn.commit()
+            batch = []
+
+        if processed % 10000 == 0:
+            print(f"  {processed:,} -- granted={stats['granted']}, denied={stats['denied']}, partial={stats['partial']}, fail={stats['fail']}", flush=True)
+
+    if batch and not dry_run:
+        psycopg2.extras.execute_batch(
+            update_cur,
+            f"UPDATE {table} SET enriched_outcome = %s WHERE id = %s",
+            batch,
+        )
+        conn.commit()
+
+    cur.close()
+    update_cur.close()
+    conn.close()
+
+    classified = stats["granted"] + stats["denied"] + stats["partial"]
+    print(f"\n  {country.upper()} Summary: {processed:,} processed, {classified:,} classified ({classified/max(processed,1)*100:.1f}%)")
+    print(f"    granted={stats['granted']}, denied={stats['denied']}, partial={stats['partial']}, fail={stats['fail']}")
+    if dry_run:
+        print("    (dry-run mode)")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Enrich PL+CZ court decisions with outcome labels")
+    parser.add_argument("--db-url", default=DB_URL)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--country", choices=["pl", "cz", "both"], default="both")
+    args = parser.parse_args()
+
+    if args.country in ("pl", "both"):
+        enrich_country(args.db_url, "pl", "pl_court_decisions", dry_run=args.dry_run)
+    if args.country in ("cz", "both"):
+        enrich_country(args.db_url, "cz", "cz_court_decisions", dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Metadata completeness audit across all 19 court decision tables (5 benchmark tasks × 19 jurisdictions)
- Regex-based outcome enrichment for HU, DE, PL, CZ (Phase 1, ~$0-15 cost)
- German subject_area via court-name mapping + Strafrecht text detection
- Generic multi-region Bedrock Haiku pipeline for LLM-based enrichment of any jurisdiction/task (Phase 4)
- All enriched fields stored in `enriched_*` columns, original data untouched

## Test plan
- [ ] Run `audit_metadata_completeness.py` on local DB to verify completeness matrix
- [ ] Run `enrich_pl_cz_outcome.py --dry-run` to verify regex coverage
- [ ] Run `enrich_de_metadata.py --dry-run` to verify court-name mapping coverage
- [ ] Run audit on prod to get real numbers for paper §3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-jurisdiction metadata enrichment pipeline to expand the benchmark, including a completeness audit and regex/LLM enrichment for DE, HU, PL, and CZ. Enriched values are written to `enriched_*` columns; original fields are unchanged.

- **New Features**
  - Completeness audit across 19 tables with benchmark eligibility (>=2 tasks, >=50K fulltext).
  - HU: outcome via regex with optional multi-region `AWS Bedrock` Haiku fallback.
  - DE: subject_area via court-name mapping + Strafrecht detection; outcome via tenor regex; auto-adds `enriched_subject_area`/`enriched_outcome`.
  - PL/CZ: outcome via regex to `enriched_outcome`.
  - Generic LLM runner for subject_area/outcome/cited_provisions using multi-region workers (`boto3`, `psycopg2`), with batching and cost tracking.

- **Migration**
  - No manual migrations; scripts create `enriched_*` columns if missing.
  - Examples: `python3 scripts/benchmark/audit_metadata_completeness.py --csv out.csv`, `python3 scripts/benchmark/enrich_pl_cz_outcome.py --country both --dry-run`, `python3 scripts/benchmark/enrich_metadata_llm.py --country de --task subject_area outcome --limit 5000`.

<sup>Written for commit c4a7e7253711df4d5c5ca7fa02ec44dc86639645. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1813?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

