### PR TITLE
fix(data): Singapore import keepalive + pre-filter

### DIFF
--- a/mcp_backend/src/migrations/159_singapore_court_decisions.sql
+++ b/mcp_backend/src/migrations/159_singapore_court_decisions.sql
@@ -50,18 +50,18 @@ END $$;
 CREATE OR REPLACE FUNCTION sg_court_decisions_stats_trigger() RETURNS trigger AS $$
 BEGIN
     IF TG_OP = 'INSERT' AND NEW.full_text IS NOT NULL AND length(NEW.full_text) > 100 THEN
-        INSERT INTO jurisdiction_fulltext_stats (jurisdiction, total_decisions, with_fulltext, last_updated)
-        VALUES ('SG', 1, 1, NOW())
-        ON CONFLICT (jurisdiction) DO UPDATE SET
+        INSERT INTO jurisdiction_fulltext_stats (jurisdiction_code, jurisdiction_name, total_decisions, fulltext_decisions, updated_at)
+        VALUES ('SG', 'Singapore', 1, 1, NOW())
+        ON CONFLICT (jurisdiction_code) DO UPDATE SET
             total_decisions = jurisdiction_fulltext_stats.total_decisions + 1,
-            with_fulltext = jurisdiction_fulltext_stats.with_fulltext + 1,
-            last_updated = NOW();
+            fulltext_decisions = jurisdiction_fulltext_stats.fulltext_decisions + 1,
+            updated_at = NOW();
     ELSIF TG_OP = 'INSERT' THEN
-        INSERT INTO jurisdiction_fulltext_stats (jurisdiction, total_decisions, with_fulltext, last_updated)
-        VALUES ('SG', 1, 0, NOW())
-        ON CONFLICT (jurisdiction) DO UPDATE SET
+        INSERT INTO jurisdiction_fulltext_stats (jurisdiction_code, jurisdiction_name, total_decisions, fulltext_decisions, updated_at)
+        VALUES ('SG', 'Singapore', 1, 0, NOW())
+        ON CONFLICT (jurisdiction_code) DO UPDATE SET
             total_decisions = jurisdiction_fulltext_stats.total_decisions + 1,
-            last_updated = NOW();
+            updated_at = NOW();
     END IF;
     RETURN NEW;
 END;

--- a/scripts/opendata/singapore/import_to_db.py
+++ b/scripts/opendata/singapore/import_to_db.py
@@ -262,7 +262,7 @@ def main():
     cp_meta = load_checkpoint_metadata(html_dir.parent)
     log.info(f"Checkpoint metadata: {len(cp_meta)} entries")
 
-    conn = psycopg2.connect(DB_URL)
+    conn = psycopg2.connect(DB_URL, keepalives=1, keepalives_idle=30, keepalives_interval=10, keepalives_count=5)
     cur = conn.cursor()
 
     cur.execute("SELECT neutral_citation FROM sg_court_decisions WHERE source = 'elitigation'")
@@ -275,16 +275,24 @@ def main():
 
     file_paths = [str(f) for f in files]
 
+    # Pre-filter: only parse files not already in DB to avoid long idle connection
+    pending_paths = []
+    for f in files:
+        raw_cit = f.stem
+        neutral = format_neutral_citation(raw_cit)
+        if neutral not in existing:
+            pending_paths.append(str(f))
+        else:
+            total_skipped += 1
+    file_paths = pending_paths
+    log.info(f"Skipped {total_skipped} already in DB, parsing {len(file_paths)} new files...")
+
     log.info(f"Parsing HTML files with {args.workers} workers...")
     with ProcessPoolExecutor(max_workers=args.workers) as pool:
         batch = []
         for i, record in enumerate(pool.map(process_file, file_paths, chunksize=50)):
             if record is None:
                 total_failed += 1
-                continue
-
-            if record["neutral_citation"] in existing:
-                total_skipped += 1
                 continue
 
             # Merge in checkpoint metadata for fields the HTML parser missed
@@ -304,7 +312,7 @@ def main():
                 inserted = insert_batch(cur, batch)
                 conn.commit()
                 total_imported += inserted
-                log.info(f"  [{i+1}/{len(files)}] Imported {total_imported:,}, skipped {total_skipped:,}, failed {total_failed:,}")
+                log.info(f"  [{i+1}/{len(file_paths)}] Imported {total_imported:,}, skipped {total_skipped:,}, failed {total_failed:,}")
                 batch = []
 
         if batch:


### PR DESCRIPTION
## Summary
- Add TCP keepalive to psycopg2 connection — prevents idle disconnect during long multiprocess parsing
- Pre-filter files already in DB before spawning workers — avoids parsing 10K files when only 4K are new
- Fix `jurisdiction_fulltext_stats` trigger column names (`jurisdiction_code`, `fulltext_decisions`, `updated_at`)

## Context
During prod import of 10,690 Singapore court decisions, the second batch failed because the PG connection was idle for ~2 min while 8 workers parsed HTML. Fix already deployed to prod, 10,690/10,690 imported successfully.

## Test plan
- [x] Verified on prod: 10,690 decisions imported, 578 MB text, 0 failures
- [x] Re-run with pre-filter: skipped 6,636 already in DB, imported 4,054 new in 50 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents idle PostgreSQL disconnects during the Singapore import by enabling TCP keepalive on the `psycopg2` connection, and speeds up imports by skipping files already in the DB. Also fixes the stats trigger to use the correct columns.

- **Bug Fixes**
  - Enabled TCP keepalive on `psycopg2` (idle 30s, interval 10s, count 5) to keep connections alive during long multiprocess parsing.
  - Corrected `jurisdiction_fulltext_stats` trigger to use `jurisdiction_code`, `jurisdiction_name`, `fulltext_decisions`, and `updated_at` with conflict on `jurisdiction_code`.

- **Performance**
  - Pre-filtered files by neutral citation before spawning workers to avoid parsing documents already stored.

<sup>Written for commit 0934ab2d3d5a8497084fce88a74e671196962b3e. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1815?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

