### PR TITLE
update(pitch): enlarge partner logos and add LEX logo

### DIFF
--- a/docs/pitch-deck.html
+++ b/docs/pitch-deck.html
@@ -462,6 +462,10 @@
 <div class="slide cover">
   <div class="left-accent"></div>
   <div class="accent-line"></div>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" style="position:absolute;top:40px;right:52px;width:56px;height:56px;">
+    <path d="M6 4h6v20h-4V8H6a2 2 0 0 1 0-4z" fill="#232F3C"/>
+    <path d="M14 8h12l-6 8 6 8H14l6-8-6-8z" fill="#587999"/>
+  </svg>
   <h1 style="font-family:'Crimson Pro',serif;font-size:72px;font-weight:700;color:#18181B;line-height:1.05;margin-bottom:20px;position:relative;">LEX AI</h1>
   <p style="font-size:24px;color:#71717A;line-height:1.6;max-width:640px;margin-bottom:0;position:relative;">
     Legal analytics as fast as you type.<br>
@@ -472,9 +476,9 @@
   </div>
   <div style="position:absolute;bottom:28px;left:90px;display:flex;align-items:center;gap:36px;">
     <span style="font-size:11px;font-weight:600;color:#A1A1AA;letter-spacing:1.5px;text-transform:uppercase;">Backed by</span>
-    <img src="partner-nvidia-inception.jpg" alt="NVIDIA Inception Program" style="height:32px;object-fit:contain;opacity:0.75;">
-    <img src="partner-aws-startups.jpg" alt="AWS Startups" style="height:28px;object-fit:contain;opacity:0.75;">
-    <img src="partner-google-cloud.jpg" alt="Google Cloud for Startups" style="height:28px;object-fit:contain;opacity:0.75;">
+    <img src="partner-nvidia-inception.jpg" alt="NVIDIA Inception Program" style="height:64px;object-fit:contain;opacity:0.75;">
+    <img src="partner-aws-startups.jpg" alt="AWS Startups" style="height:56px;object-fit:contain;opacity:0.75;">
+    <img src="partner-google-cloud.jpg" alt="Google Cloud for Startups" style="height:56px;object-fit:contain;opacity:0.75;">
   </div>
   <div class="slide-number">01</div>
 </div>

--- a/lexwebapp/public/pitch-deck.html
+++ b/lexwebapp/public/pitch-deck.html
@@ -462,6 +462,10 @@
 <div class="slide cover">
   <div class="left-accent"></div>
   <div class="accent-line"></div>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" style="position:absolute;top:40px;right:52px;width:56px;height:56px;">
+    <path d="M6 4h6v20h-4V8H6a2 2 0 0 1 0-4z" fill="#232F3C"/>
+    <path d="M14 8h12l-6 8 6 8H14l6-8-6-8z" fill="#587999"/>
+  </svg>
   <h1 style="font-family:'Crimson Pro',serif;font-size:72px;font-weight:700;color:#18181B;line-height:1.05;margin-bottom:20px;position:relative;">LEX AI</h1>
   <p style="font-size:24px;color:#71717A;line-height:1.6;max-width:640px;margin-bottom:0;position:relative;">
     Legal analytics as fast as you type.<br>
@@ -472,9 +476,9 @@
   </div>
   <div style="position:absolute;bottom:28px;left:90px;display:flex;align-items:center;gap:36px;">
     <span style="font-size:11px;font-weight:600;color:#A1A1AA;letter-spacing:1.5px;text-transform:uppercase;">Backed by</span>
-    <img src="partner-nvidia-inception.jpg" alt="NVIDIA Inception Program" style="height:32px;object-fit:contain;opacity:0.75;">
-    <img src="partner-aws-startups.jpg" alt="AWS Startups" style="height:28px;object-fit:contain;opacity:0.75;">
-    <img src="partner-google-cloud.jpg" alt="Google Cloud for Startups" style="height:28px;object-fit:contain;opacity:0.75;">
+    <img src="partner-nvidia-inception.jpg" alt="NVIDIA Inception Program" style="height:64px;object-fit:contain;opacity:0.75;">
+    <img src="partner-aws-startups.jpg" alt="AWS Startups" style="height:56px;object-fit:contain;opacity:0.75;">
+    <img src="partner-google-cloud.jpg" alt="Google Cloud for Startups" style="height:56px;object-fit:contain;opacity:0.75;">
   </div>
   <div class="slide-number">01</div>
 </div>


### PR DESCRIPTION
## Summary
- Doubled partner logo sizes (NVIDIA 32→64px, AWS/Google 28→56px)
- Added LEX SVG logo to top-right corner of the title slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enlarged partner logos on the title slide for better visibility and added the LEX SVG logo to the top-right. NVIDIA increased from 32→64px; AWS/Google from 28→56px, applied in both pitch deck HTML files.

<sup>Written for commit 2917837dfc91e7938af22bffd81c7a32ccbe973d. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1816?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

