### PR TITLE
fix(benchmark): separate read/write connections for named cursors

### DIFF
--- a/scripts/benchmark/enrich_de_metadata.py
+++ b/scripts/benchmark/enrich_de_metadata.py
@@ -240,8 +240,11 @@ def main():
     cur.close()
     conn.close()
 
-    conn = psycopg2.connect(args.db_url)
-    cur = conn.cursor(name="de_enrich_cursor")
+    read_conn = psycopg2.connect(args.db_url)
+    write_conn = psycopg2.connect(args.db_url)
+    write_conn.autocommit = True
+
+    cur = read_conn.cursor(name="de_enrich_cursor")
     cur.itersize = args.batch_size
 
     cur.execute("""
@@ -251,7 +254,7 @@ def main():
         ORDER BY id
     """)
 
-    update_cur = conn.cursor()
+    update_cur = write_conn.cursor()
     batch = []
     stats = {
         "subject_court_map": 0, "subject_strafrecht_refine": 0, "subject_fail": 0,
@@ -293,7 +296,6 @@ def main():
                    WHERE id = %s""",
                 batch,
             )
-            conn.commit()
             batch = []
 
         if processed % 10000 == 0:
@@ -312,11 +314,11 @@ def main():
                WHERE id = %s""",
             batch,
         )
-        conn.commit()
 
     cur.close()
     update_cur.close()
-    conn.close()
+    read_conn.close()
+    write_conn.close()
 
     print(f"\n=== DE Enrichment Summary ===")
     print(f"Total processed: {processed:,}")

--- a/scripts/benchmark/enrich_hu_outcome.py
+++ b/scripts/benchmark/enrich_hu_outcome.py
@@ -147,8 +147,11 @@ def ensure_outcome_column(conn):
 
 
 def process_batch_regex(db_url, batch_size=5000, dry_run=False):
-    conn = psycopg2.connect(db_url)
-    cur = conn.cursor(name="hu_outcome_cursor")
+    read_conn = psycopg2.connect(db_url)
+    write_conn = psycopg2.connect(db_url)
+    write_conn.autocommit = True
+
+    cur = read_conn.cursor(name="hu_outcome_cursor")
     cur.itersize = batch_size
 
     cur.execute("""
@@ -158,7 +161,7 @@ def process_batch_regex(db_url, batch_size=5000, dry_run=False):
         ORDER BY id
     """)
 
-    update_cur = conn.cursor()
+    update_cur = write_conn.cursor()
     batch = []
     total = 0
     failed_ids = []
@@ -181,7 +184,6 @@ def process_batch_regex(db_url, batch_size=5000, dry_run=False):
                 "UPDATE hu_court_decisions SET enriched_outcome = %s WHERE id = %s",
                 batch,
             )
-            conn.commit()
             batch = []
 
         if total % 10000 == 0:
@@ -193,11 +195,11 @@ def process_batch_regex(db_url, batch_size=5000, dry_run=False):
             "UPDATE hu_court_decisions SET enriched_outcome = %s WHERE id = %s",
             batch,
         )
-        conn.commit()
 
     cur.close()
     update_cur.close()
-    conn.close()
+    read_conn.close()
+    write_conn.close()
 
     log(f"\nRegex phase complete: {total:,} processed")
     log(f"  granted={stats['regex_granted']}, denied={stats['regex_denied']}, partial={stats['regex_partial']}")

--- a/scripts/benchmark/enrich_pl_cz_outcome.py
+++ b/scripts/benchmark/enrich_pl_cz_outcome.py
@@ -160,8 +160,11 @@ def enrich_country(db_url, country, table, dry_run=False, batch_size=5000):
         return
 
     conn.close()
-    conn = psycopg2.connect(db_url)
-    cur = conn.cursor(name=f"{country}_outcome_cursor")
+    read_conn = psycopg2.connect(db_url)
+    write_conn = psycopg2.connect(db_url)
+    write_conn.autocommit = True
+
+    cur = read_conn.cursor(name=f"{country}_outcome_cursor")
     cur.itersize = batch_size
 
     cur.execute(f"""
@@ -171,7 +174,7 @@ def enrich_country(db_url, country, table, dry_run=False, batch_size=5000):
         ORDER BY id
     """)
 
-    update_cur = conn.cursor()
+    update_cur = write_conn.cursor()
     batch = []
     stats = {"granted": 0, "denied": 0, "partial": 0, "fail": 0}
     processed = 0
@@ -193,7 +196,6 @@ def enrich_country(db_url, country, table, dry_run=False, batch_size=5000):
                 f"UPDATE {table} SET enriched_outcome = %s WHERE id = %s",
                 batch,
             )
-            conn.commit()
             batch = []
 
         if processed % 10000 == 0:
@@ -205,11 +207,11 @@ def enrich_country(db_url, country, table, dry_run=False, batch_size=5000):
             f"UPDATE {table} SET enriched_outcome = %s WHERE id = %s",
             batch,
         )
-        conn.commit()
 
     cur.close()
     update_cur.close()
-    conn.close()
+    read_conn.close()
+    write_conn.close()
 
     classified = stats["granted"] + stats["denied"] + stats["partial"]
     print(f"\n  {country.upper()} Summary: {processed:,} processed, {classified:,} classified ({classified/max(processed,1)*100:.1f}%)")


### PR DESCRIPTION
## Summary
- Named cursors require an open transaction -- `conn.commit()` invalidates them
- Split into `read_conn` (holds cursor in transaction) and `write_conn` (autocommit for UPDATEs)
- Applied to all 3 enrichment scripts: HU, DE, PL+CZ

## Test plan
- [ ] Re-run all 3 enrichment scripts on prod via SSM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix named cursor invalidation in benchmark enrichment scripts by using separate read/write connections. Keeps the named cursor in an open transaction and moves updates to an autocommit connection to prevent cursor errors.

- **Bug Fixes**
  - Use `read_conn` to hold the named cursor transaction and `write_conn` (autocommit) for updates.
  - Remove `commit()` calls that invalidated the cursor on the read connection.
  - Applied to HU, DE, and PL+CZ enrichment scripts using `psycopg2` named cursors.

<sup>Written for commit d631fffb22a7c11f157cded466cffcb1a1f4b255. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1817?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

