### PR TITLE
fix(benchmark): batch pagination for large table enrichment

### DIFF
--- a/scripts/benchmark/enrich_de_metadata.py
+++ b/scripts/benchmark/enrich_de_metadata.py
@@ -240,22 +240,10 @@ def main():
     cur.close()
     conn.close()
 
-    read_conn = psycopg2.connect(args.db_url)
-    write_conn = psycopg2.connect(args.db_url)
-    write_conn.autocommit = True
+    conn = psycopg2.connect(args.db_url)
+    conn.autocommit = True
+    cur = conn.cursor()
 
-    cur = read_conn.cursor(name="de_enrich_cursor")
-    cur.itersize = args.batch_size
-
-    cur.execute("""
-        SELECT id, court_type, court_name, subject_area, tenor, full_text
-        FROM de_court_decisions
-        WHERE enriched_subject_area IS NULL OR enriched_outcome IS NULL
-        ORDER BY id
-    """)
-
-    update_cur = write_conn.cursor()
-    batch = []
     stats = {
         "subject_court_map": 0, "subject_strafrecht_refine": 0, "subject_fail": 0,
         "outcome_regex": 0, "outcome_fail": 0,
@@ -263,40 +251,55 @@ def main():
     processed = 0
     llm_subject_ids = []
     llm_outcome_ids = []
+    last_id = ""
 
-    for row in cur:
-        doc_id, court_type, court_name, existing_subject, tenor, full_text = row
-        processed += 1
+    while True:
+        cur.execute("""
+            SELECT id, court_type, court_name, subject_area, tenor, full_text
+            FROM de_court_decisions
+            WHERE (enriched_subject_area IS NULL OR enriched_outcome IS NULL)
+              AND id > %s
+            ORDER BY id
+            LIMIT %s
+        """, (last_id, args.batch_size))
+        rows = cur.fetchall()
+        if not rows:
+            break
 
-        subject = classify_subject_by_court(court_type, court_name)
-        if subject:
-            subject = refine_subject_with_text(subject, full_text)
-            if subject == "Strafrecht" and classify_subject_by_court(court_type, court_name) != "Strafrecht":
-                stats["subject_strafrecht_refine"] += 1
-            stats["subject_court_map"] += 1
-        else:
-            stats["subject_fail"] += 1
-            llm_subject_ids.append(doc_id)
+        batch = []
+        for row in rows:
+            doc_id, court_type, court_name, existing_subject, tenor, full_text = row
+            processed += 1
+            last_id = doc_id
 
-        outcome = classify_outcome_regex(tenor, full_text)
-        if outcome:
-            stats["outcome_regex"] += 1
-        else:
-            stats["outcome_fail"] += 1
-            llm_outcome_ids.append(doc_id)
+            subject = classify_subject_by_court(court_type, court_name)
+            if subject:
+                subject = refine_subject_with_text(subject, full_text)
+                if subject == "Strafrecht" and classify_subject_by_court(court_type, court_name) != "Strafrecht":
+                    stats["subject_strafrecht_refine"] += 1
+                stats["subject_court_map"] += 1
+            else:
+                stats["subject_fail"] += 1
+                llm_subject_ids.append(doc_id)
 
-        batch.append((subject, outcome, doc_id))
+            outcome = classify_outcome_regex(tenor, full_text)
+            if outcome:
+                stats["outcome_regex"] += 1
+            else:
+                stats["outcome_fail"] += 1
+                llm_outcome_ids.append(doc_id)
 
-        if len(batch) >= 1000 and not args.dry_run:
+            batch.append((subject, outcome, doc_id))
+
+        if batch and not args.dry_run:
             psycopg2.extras.execute_batch(
-                update_cur,
+                cur,
                 """UPDATE de_court_decisions
                    SET enriched_subject_area = COALESCE(%s, enriched_subject_area),
                        enriched_outcome = COALESCE(%s, enriched_outcome)
                    WHERE id = %s""",
                 batch,
             )
-            batch = []
 
         if processed % 10000 == 0:
             print(
@@ -305,20 +308,8 @@ def main():
                 flush=True,
             )
 
-    if batch and not args.dry_run:
-        psycopg2.extras.execute_batch(
-            update_cur,
-            """UPDATE de_court_decisions
-               SET enriched_subject_area = COALESCE(%s, enriched_subject_area),
-                   enriched_outcome = COALESCE(%s, enriched_outcome)
-               WHERE id = %s""",
-            batch,
-        )
-
     cur.close()
-    update_cur.close()
-    read_conn.close()
-    write_conn.close()
+    conn.close()
 
     print(f"\n=== DE Enrichment Summary ===")
     print(f"Total processed: {processed:,}")

--- a/scripts/benchmark/enrich_pl_cz_outcome.py
+++ b/scripts/benchmark/enrich_pl_cz_outcome.py
@@ -160,58 +160,51 @@ def enrich_country(db_url, country, table, dry_run=False, batch_size=5000):
         return
 
     conn.close()
-    read_conn = psycopg2.connect(db_url)
-    write_conn = psycopg2.connect(db_url)
-    write_conn.autocommit = True
+    conn = psycopg2.connect(db_url)
+    conn.autocommit = True
+    cur = conn.cursor()
 
-    cur = read_conn.cursor(name=f"{country}_outcome_cursor")
-    cur.itersize = batch_size
-
-    cur.execute(f"""
-        SELECT id, full_text FROM {table}
-        WHERE full_text IS NOT NULL AND length(full_text) > 500
-          AND enriched_outcome IS NULL
-        ORDER BY id
-    """)
-
-    update_cur = write_conn.cursor()
-    batch = []
     stats = {"granted": 0, "denied": 0, "partial": 0, "fail": 0}
     processed = 0
+    last_id = ""
 
-    for row in cur:
-        doc_id, text = row
-        processed += 1
-        outcome = classify_outcome(text, country)
+    while True:
+        cur.execute(f"""
+            SELECT id, full_text FROM {table}
+            WHERE full_text IS NOT NULL AND length(full_text) > 500
+              AND enriched_outcome IS NULL
+              AND id > %s
+            ORDER BY id
+            LIMIT %s
+        """, (last_id, batch_size))
+        rows = cur.fetchall()
+        if not rows:
+            break
 
-        if outcome:
-            stats[outcome] += 1
-            batch.append((outcome, doc_id))
-        else:
-            stats["fail"] += 1
+        batch = []
+        for doc_id, text in rows:
+            processed += 1
+            last_id = doc_id
+            outcome = classify_outcome(text, country)
 
-        if len(batch) >= 1000 and not dry_run:
+            if outcome:
+                stats[outcome] += 1
+                batch.append((outcome, doc_id))
+            else:
+                stats["fail"] += 1
+
+        if batch and not dry_run:
             psycopg2.extras.execute_batch(
-                update_cur,
+                cur,
                 f"UPDATE {table} SET enriched_outcome = %s WHERE id = %s",
                 batch,
             )
-            batch = []
 
         if processed % 10000 == 0:
             print(f"  {processed:,} -- granted={stats['granted']}, denied={stats['denied']}, partial={stats['partial']}, fail={stats['fail']}", flush=True)
 
-    if batch and not dry_run:
-        psycopg2.extras.execute_batch(
-            update_cur,
-            f"UPDATE {table} SET enriched_outcome = %s WHERE id = %s",
-            batch,
-        )
-
     cur.close()
-    update_cur.close()
-    read_conn.close()
-    write_conn.close()
+    conn.close()
 
     classified = stats["granted"] + stats["denied"] + stats["partial"]
     print(f"\n  {country.upper()} Summary: {processed:,} processed, {classified:,} classified ({classified/max(processed,1)*100:.1f}%)")


### PR DESCRIPTION
## Summary
- Named cursors on large tables (250K-2.8M rows with fulltext) killed by PgBouncer timeout
- Replace with `id > last_id LIMIT N` pagination -- no long transactions
- DE and PL/CZ scripts fixed; HU already succeeded (79K rows fits in memory)

## Test plan
- [ ] Re-run DE and PL+CZ enrichment on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace named cursors with id-based batch pagination in the DE and PL/CZ enrichment scripts to prevent PgBouncer timeouts on large tables. Pages with id > last_id and writes in small batches to keep transactions short.

- **Bug Fixes**
  - Switch to keyset pagination (id > last_id LIMIT N) to avoid long-lived transactions and PgBouncer kills.
  - Use a single autocommit `psycopg2` connection and per-page `execute_batch` updates; progress logs every 10k.

- **Migration**
  - Re-run DE and PL/CZ enrichment on prod.

<sup>Written for commit 67011dc47d839424cac0fb844a391c75dd684cbd. Summary will update on new commits. <a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1818?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

