### PR TITLE
fix(benchmark): audit includes enriched columns

### DIFF
--- a/scripts/benchmark/audit_metadata_completeness.py
+++ b/scripts/benchmark/audit_metadata_completeness.py
@@ -56,7 +56,7 @@ JURISDICTIONS = {
             "court_type": "court_type",
             "decision_type": "decision_type",
             "subject": "keywords",
-            "outcome": None,
+            "outcome": ["enriched_outcome"],
             "cited_provisions": "legal_bases",
         },
     },
@@ -68,7 +68,7 @@ JURISDICTIONS = {
             "court_type": "court_type",
             "decision_type": "decision_type",
             "subject": "subject",
-            "outcome": None,
+            "outcome": ["enriched_outcome"],
             "cited_provisions": "cited_provisions",
         },
     },
@@ -80,7 +80,7 @@ JURISDICTIONS = {
             "court_type": "collegium",
             "decision_type": "decision_type",
             "subject": "legal_area",
-            "outcome": None,
+            "outcome": ["enriched_outcome"],
             "cited_provisions": "legislation_refs",
         },
     },
@@ -188,11 +188,10 @@ JURISDICTIONS = {
         "columns": {
             "court_type": "court_type",
             "decision_type": "decision_type",
-            "subject": "subject_area",
-            "outcome": "tenor",
+            "subject": ["subject_area", "enriched_subject_area"],
+            "outcome": ["enriched_outcome"],
             "cited_provisions": None,
         },
-        "notes": "tenor is raw text, not a label -- needs classification",
     },
     "be": {
         "label": "Belgium",
@@ -269,9 +268,26 @@ JURISDICTIONS = {
 }
 
 
+def column_exists(cur, table, column):
+    cur.execute("""
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = %s AND column_name = %s
+    """, (table, column))
+    return cur.fetchone() is not None
+
+
 def count_field(cur, table, column):
     if column is None:
         return 0
+    if isinstance(column, (list, tuple)):
+        parts = []
+        for c in column:
+            if column_exists(cur, table, c):
+                parts.append(f"({c} IS NOT NULL AND {c}::text != '' AND {c}::text != '{{}}')")
+        if not parts:
+            return 0
+        cur.execute(f"SELECT count(*) FROM {table} WHERE {' OR '.join(parts)}")
+        return cur.fetchone()[0]
     cur.execute(
         f"SELECT count(*) FROM {table} WHERE {column} IS NOT NULL AND {column}::text != '' AND {column}::text != '{{}}'"
     )


### PR DESCRIPTION
## Summary
- Audit now checks both original and `enriched_*` columns via OR
- Updated HU/DE/PL/CZ column mappings to include enriched fields
- DE `tenor` (raw text) replaced with `enriched_outcome` (classified label)

## Test plan
- [ ] Re-run audit on prod to see updated numbers post-enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the metadata completeness audit to count values in either original columns or their `enriched_*` counterparts. Updates HU/PL/CZ/DE mappings and aligns DE outcome/subject with classified labels to avoid undercounting.

- **Bug Fixes**
  - `count_field` accepts a list of columns and uses OR logic; ignores missing columns safely.
  - Mapping updates: HU/PL/CZ set `outcome` to `enriched_outcome`; DE sets `outcome` to `enriched_outcome` and `subject` to `subject_area` or `enriched_subject_area`.

- **Migration**
  - Re-run the benchmark audit to refresh completeness metrics.

<sup>Written for commit 5c4f6b54dcf5f2fa4d93ee26109d8cb24cf8b3f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1819?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

