### PR TITLE
fix(benchmark): pass db_url as param in LLM enrichment

### DIFF
--- a/scripts/benchmark/enrich_metadata_llm.py
+++ b/scripts/benchmark/enrich_metadata_llm.py
@@ -303,9 +303,9 @@ def ensure_column(conn, table, column, col_type="TEXT"):
     cur.close()
 
 
-def worker_loop(worker_id, region, model, work_items, table, id_column, task_name, task_config, language, dry_run):
+def worker_loop(worker_id, region, model, work_items, table, id_column, task_name, task_config, language, dry_run, db_url):
     bedrock = boto3.client("bedrock-runtime", region_name=region)
-    conn = psycopg2.connect(DB_URL)
+    conn = psycopg2.connect(db_url)
     conn.autocommit = True
     cur = conn.cursor()
 
@@ -396,8 +396,7 @@ def main():
     parser.add_argument("--workers", type=int, default=len(WORKERS), help="Number of parallel workers")
     args = parser.parse_args()
 
-    global DB_URL
-    DB_URL = args.db_url
+    db_url = args.db_url
 
     config = JURISDICTION_CONFIG[args.country]
     table = config["table"]
@@ -467,7 +466,7 @@ def main():
                     worker_loop,
                     i, worker["region"], worker["model"],
                     chunk, table, id_column,
-                    task_name, task_config, language, args.dry_run,
+                    task_name, task_config, language, args.dry_run, db_url,
                 )
                 futures[f] = i
 


### PR DESCRIPTION
## Summary
- `global DB_URL` after `default=DB_URL` causes SyntaxError
- Pass `db_url` as local var and parameter to `worker_loop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the LLM enrichment benchmark by removing the global DB URL. Passes `db_url` from CLI into `worker_loop` to avoid a Python 3.10+ SyntaxError and make the DB connection explicit.

- **Bug Fixes**
  - Replaced global `DB_URL` with local `db_url`; passed into `worker_loop` and used in `psycopg2.connect`.
  - Eliminates SyntaxError from `global DB_URL` usage and clarifies DB config in multi-worker runs.

<sup>Written for commit f83463dda38352f7ca2084421aeb53b6784144d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1820?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

