### PR TITLE
fix(benchmark): audit SE enriched columns

### DIFF
--- a/scripts/benchmark/audit_metadata_completeness.py
+++ b/scripts/benchmark/audit_metadata_completeness.py
@@ -139,8 +139,8 @@ JURISDICTIONS = {
         "columns": {
             "court_type": "court_type",
             "decision_type": "decision_type",
-            "subject": "subject",
-            "outcome": None,
+            "subject": ["subject", "enriched_subject_area"],
+            "outcome": ["enriched_outcome"],
             "cited_provisions": None,
         },
     },


### PR DESCRIPTION
## Summary
- Add enriched_subject_area and enriched_outcome to SE audit mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SE enriched columns to the metadata completeness audit to include enriched subject and outcome fields. The audit now checks subject via ["subject", "enriched_subject_area"] and outcome via ["enriched_outcome"].

<sup>Written for commit 502e5c0d830a0a6edbb012c9fdd2383747fd544e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1821?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

