### PR TITLE
feat(legislation): historical editions support

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -667,18 +667,29 @@ export class RadaLegislationAdapter {
     return chunks;
   }
 
-  async getArticleByNumber(radaId: string, articleNumber: string): Promise<LegislationArticle | null> {
-    // Deterministic pick of the latest version when duplicate rows exist
-    // (see LEXAI-823: multiple is_current rows per article caused random body/title mismatch).
-    const result = await this.db.query(
-      `SELECT la.*
-       FROM legislation_articles la
-       JOIN legislation l ON la.legislation_id = l.id
-       WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.is_current = true
-       ORDER BY la.version_date DESC NULLS LAST, la.id DESC
-       LIMIT 1`,
-      [radaId, articleNumber]
-    );
+  async getArticleByNumber(radaId: string, articleNumber: string, asOfDate?: string): Promise<LegislationArticle | null> {
+    let result;
+    if (asOfDate) {
+      result = await this.db.query(
+        `SELECT la.*
+         FROM legislation_articles la
+         JOIN legislation l ON la.legislation_id = l.id
+         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.version_date <= $3
+         ORDER BY la.version_date DESC
+         LIMIT 1`,
+        [radaId, articleNumber, asOfDate]
+      );
+    } else {
+      result = await this.db.query(
+        `SELECT la.*
+         FROM legislation_articles la
+         JOIN legislation l ON la.legislation_id = l.id
+         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.is_current = true
+         ORDER BY la.version_date DESC NULLS LAST, la.id DESC
+         LIMIT 1`,
+        [radaId, articleNumber]
+      );
+    }
 
     if (result.rows.length === 0) return null;
 
@@ -709,6 +720,120 @@ export class RadaLegislationAdapter {
 
     const result = await this.db.query(sql, params);
     return result.rows;
+  }
+
+  async fetchEditionDates(radaId: string): Promise<string[]> {
+    if (/[^\p{L}\p{N}\-_\/\.]/u.test(radaId) || radaId.includes('..')) {
+      throw new Error(`Invalid legislation ID: ${radaId}`);
+    }
+    const url = `${this.BASE_URL}/laws/show/${radaId}/card4`;
+    logger.info(`Fetching edition dates from ${url}`);
+
+    const response = await this.httpClient.get(url);
+    const html = response.data as string;
+    const edRegex = /\/ed(\d{8})/g;
+    const dates = new Set<string>();
+    let match;
+    while ((match = edRegex.exec(html)) !== null) {
+      dates.add(match[1]);
+    }
+    const sorted = [...dates].sort();
+    logger.info(`Found ${sorted.length} editions for ${radaId}`);
+    return sorted;
+  }
+
+  async fetchEdition(radaId: string, editionDate: string): Promise<{ metadata: LegislationMetadata; articles: LegislationArticle[] }> {
+    if (/[^\p{L}\p{N}\-_\/\.]/u.test(radaId) || radaId.includes('..')) {
+      throw new Error(`Invalid legislation ID: ${radaId}`);
+    }
+    if (!/^\d{8}$/.test(editionDate)) {
+      throw new Error(`Invalid edition date format: ${editionDate}, expected YYYYMMDD`);
+    }
+
+    const url = `${this.BASE_URL}/laws/show/${radaId}/ed${editionDate}/print`;
+    logger.info(`Fetching edition ${editionDate} from ${url}`);
+
+    const callStart = Date.now();
+    try {
+      const response = await this.httpClient.get(url, { timeout: 60000 });
+      const callDuration = (Date.now() - callStart) / 1000;
+      this.externalApiMetrics?.('zakon_rada', 'success', callDuration);
+
+      const html = response.data as string;
+      const $ = cheerio.load(html);
+      const metadata = this.extractMetadata($, radaId, url);
+
+      const versionDate = new Date(
+        parseInt(editionDate.substring(0, 4)),
+        parseInt(editionDate.substring(4, 6)) - 1,
+        parseInt(editionDate.substring(6, 8)),
+      );
+
+      // Edition pages use <pre><b> format
+      let articles = this.extractArticlesPreBold(html);
+
+      // Fallback to rvts9 format if pre/bold found nothing
+      if (articles.length < 3) {
+        articles = this.extractArticles($, radaId);
+      }
+
+      for (const art of articles) {
+        art.version_date = versionDate;
+        art.metadata = { ...art.metadata, edition_date: editionDate, extraction_method: 'edition_endpoint' };
+      }
+
+      logger.info(`Edition ${editionDate} of ${radaId}: ${articles.length} articles`);
+      return { metadata, articles };
+    } catch (error: any) {
+      const callDuration = (Date.now() - callStart) / 1000;
+      this.externalApiMetrics?.('zakon_rada', 'error', callDuration);
+      logger.error(`Failed to fetch edition ${editionDate} of ${radaId}:`, error.message);
+      throw error;
+    }
+  }
+
+  private extractArticlesPreBold(html: string): LegislationArticle[] {
+    const articles: LegislationArticle[] = [];
+    // Edition pages wrap text in <pre> blocks with <b>Стаття N.</b> headers
+    const articleRegex = /<b>Стаття\s+(\d+(?:-\d+)?)\.?<\/b>\s*(.*?)(?=<b>Стаття\s+\d|<\/pre>\s*$|$)/gs;
+
+    const seen = new Set<string>();
+    let match;
+    while ((match = articleRegex.exec(html)) !== null) {
+      const articleNumber = match[1].trim();
+      if (seen.has(articleNumber)) continue;
+      seen.add(articleNumber);
+
+      let body = match[2];
+      // Clean HTML tags but preserve line breaks
+      body = body.replace(/<br\s*\/?>/gi, '\n');
+      body = body.replace(/<b>([^<]*)<\/b>/g, '$1');
+      body = body.replace(/<[^>]+>/g, ' ');
+      body = body.replace(/&nbsp;/g, ' ');
+      body = body.replace(/&mdash;/g, '—');
+      body = body.replace(/&laquo;/g, '«');
+      body = body.replace(/&raquo;/g, '»');
+      body = body.replace(/&amp;/g, '&');
+      body = body.replace(/\{[^}]*\}/g, '');
+      body = body.replace(/[ \t]+/g, ' ');
+      body = body.replace(/\n\s*\n/g, '\n');
+      body = body.trim();
+
+      if (body.length < 5) continue;
+
+      const firstLine = body.split('\n')[0].trim();
+      const title = firstLine.length < 200 ? firstLine : undefined;
+
+      articles.push({
+        article_number: articleNumber,
+        title,
+        full_text: body,
+        byte_size: Buffer.byteLength(body, 'utf8'),
+        metadata: { extraction_method: 'edition_pre_bold' },
+      });
+    }
+
+    return articles;
   }
 
   setExternalApiMetrics(callback: (service: string, status: string, durationSec: number) => void) {

--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -14,6 +14,7 @@ export interface LegislationToolArgs {
   include_html?: boolean;
   include_court_practice?: boolean;
   theme?: 'light' | 'dark';
+  as_of_date?: string;
 }
 
 export class LegislationTools extends BaseToolHandler {
@@ -122,7 +123,7 @@ export class LegislationTools extends BaseToolHandler {
       query: query.substring(0, 50)
     });
 
-    const article = await this.service.getArticle(resolved.radaId, resolved.articleNumber);
+    const article = await this.service.getArticle(resolved.radaId, resolved.articleNumber, args.as_of_date);
     if (!article) {
       return {
         error: `Article ${resolved.articleNumber} not found in legislation ${resolved.radaId}`,
@@ -170,7 +171,7 @@ export class LegislationTools extends BaseToolHandler {
       articles: args.article_numbers.join(', ')
     });
 
-    const articles = await this.service.getMultipleArticles(args.rada_id, args.article_numbers);
+    const articles = await this.service.getMultipleArticles(args.rada_id, args.article_numbers, args.as_of_date);
 
     if (articles.length === 0) {
       return {
@@ -182,6 +183,7 @@ export class LegislationTools extends BaseToolHandler {
     const response: any = {
       rada_id: args.rada_id,
       total_found: articles.length,
+      as_of_date: args.as_of_date || undefined,
       articles: articles.map(a => ({
         article_number: a.article_number,
         title: a.title,
@@ -500,6 +502,10 @@ export class LegislationTools extends BaseToolHandler {
               type: 'string',
               description: 'Номер статті (наприклад, "625", "44", "354-1")',
             },
+            as_of_date: {
+              type: 'string',
+              description: 'Дата для отримання історичної редакції (формат YYYY-MM-DD). Без цього параметру повертається чинна редакція.',
+            },
             include_html: {
               type: 'boolean',
               description: 'Чи включати форматований HTML (за замовчуванням false)',
@@ -528,6 +534,10 @@ export class LegislationTools extends BaseToolHandler {
               type: 'array',
               items: { type: 'string' },
               description: 'Масив номерів статей (наприклад, ["354", "355", "356"])',
+            },
+            as_of_date: {
+              type: 'string',
+              description: 'Дата для отримання історичної редакції (формат YYYY-MM-DD)',
             },
             include_html: {
               type: 'boolean',
@@ -587,6 +597,21 @@ export class LegislationTools extends BaseToolHandler {
             rada_id: {
               type: 'string',
               description: 'ID законодавчого акту',
+            },
+          },
+          required: ['rada_id'],
+        },
+      },
+      {
+        name: 'list_legislation_editions',
+        annotations: { title: 'Редакції закону', readOnlyHint: true, idempotentHint: true },
+        description: 'Перелік всіх доступних історичних редакцій законодавчого акту з датами. Використовуй для вибору дати при запиті get_legislation_section з as_of_date.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            rada_id: {
+              type: 'string',
+              description: 'ID законодавчого акту (наприклад, "435-15" для ЦК)',
             },
           },
           required: ['rada_id'],
@@ -672,6 +697,25 @@ export class LegislationTools extends BaseToolHandler {
     };
   }
 
+  async listLegislationEditions(args: { rada_id: string }): Promise<any> {
+    if (!args.rada_id) throw new Error('rada_id is required');
+    const radaId = normalizeRadaId(args.rada_id);
+    const editions = await this.service.getEditionDates(radaId);
+    const structure = await this.service.getLegislationStructure(radaId);
+    return {
+      rada_id: radaId,
+      title: structure?.title || null,
+      total_editions: editions.length,
+      editions: editions.map(e => ({
+        date: e.edition_date,
+        article_count: e.article_count,
+      })),
+      note: editions.length === 0
+        ? 'Історичні редакції ще не завантажені для цього акту'
+        : undefined,
+    };
+  }
+
   async executeTool(name: string, args: any): Promise<ToolResult | null> {
     switch (name) {
       case 'get_legislation_article': // backward-compat alias
@@ -687,6 +731,8 @@ export class LegislationTools extends BaseToolHandler {
         return this.wrapResponse(await this.getLegislationStructure(args));
       case 'get_legislation_history':
         return this.wrapResponse(await this.getLegislationHistory(args));
+      case 'list_legislation_editions':
+        return this.wrapResponse(await this.listLegislationEditions(args));
       default:
         return null;
     }

--- a/mcp_backend/src/migrations/160_legislation_historical_editions.sql
+++ b/mcp_backend/src/migrations/160_legislation_historical_editions.sql
@@ -1,0 +1,36 @@
+-- Historical legislation editions support
+-- Enables storage and fast temporal lookup of all historical editions of Ukrainian codes
+
+-- 1. Composite index for O(1) temporal lookups: "article X as of date Y"
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_temporal_lookup
+ON legislation_articles (legislation_id, article_number, version_date DESC);
+
+-- 2. Create legislation_editions table (tracks available editions per code)
+CREATE TABLE IF NOT EXISTS legislation_editions (
+  id SERIAL PRIMARY KEY,
+  legislation_id INTEGER NOT NULL REFERENCES legislation(id) ON DELETE CASCADE,
+  edition_date DATE NOT NULL,
+  edition_key VARCHAR(8) NOT NULL, -- YYYYMMDD from zakon.rada.gov.ua URL
+  article_count INTEGER DEFAULT 0,
+  imported_at TIMESTAMPTZ DEFAULT NOW(),
+  metadata JSONB DEFAULT '{}',
+  UNIQUE(legislation_id, edition_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_editions_legislation_date
+ON legislation_editions (legislation_id, edition_date DESC);
+
+-- 3. Track total editions on legislation table
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'legislation' AND column_name = 'total_editions'
+  ) THEN
+    ALTER TABLE legislation ADD COLUMN total_editions INTEGER DEFAULT 0;
+  END IF;
+END $$;
+
+-- 4. Partial index for maintenance queries on historical articles
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_historical
+ON legislation_articles (legislation_id, version_date)
+WHERE is_current = false;

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -476,7 +476,7 @@ export class LegislationService {
     }
   }
 
-  async getArticle(radaId: string, articleNumber: string): Promise<LegislationReference | null> {
+  async getArticle(radaId: string, articleNumber: string, asOfDate?: string): Promise<LegislationReference | null> {
     const kmuPrefix = parseKmuPrefix(radaId);
     if (kmuPrefix) {
       const resolved = await this.resolveKmuRadaId(kmuPrefix.kmuNumber, kmuPrefix.docType);
@@ -486,7 +486,7 @@ export class LegislationService {
     radaId = normalizeRadaId(radaId);
     await this.ensureLegislationExists(radaId);
 
-    const article = await this.adapter.getArticleByNumber(radaId, articleNumber);
+    const article = await this.adapter.getArticleByNumber(radaId, articleNumber, asOfDate);
     if (!article) {
       return null;
     }
@@ -502,7 +502,7 @@ export class LegislationService {
     // header and body must come from the same record (LEXAI-823).
     const actualArticleNumber = article.article_number || articleNumber;
 
-    return {
+    const ref: LegislationReference = {
       rada_id: radaId,
       article_number: actualArticleNumber,
       title: article.title,
@@ -516,20 +516,37 @@ export class LegislationService {
       chapter_number: article.chapter_number,
       chapter_title: article.chapter_title,
     };
+
+    if (asOfDate) {
+      ref.metadata = { ...ref.metadata, is_historical: true, as_of_date: asOfDate };
+    }
+
+    return ref;
   }
 
-  async getMultipleArticles(radaId: string, articleNumbers: string[]): Promise<LegislationReference[]> {
+  async getMultipleArticles(radaId: string, articleNumbers: string[], asOfDate?: string): Promise<LegislationReference[]> {
     await this.ensureLegislationExists(radaId);
 
-    // DISTINCT ON picks the latest version per article when duplicate rows exist (LEXAI-823).
-    const result = await this.db.query(
-      `SELECT DISTINCT ON (la.article_number) la.*, l.rada_id, l.title as npa_title
-       FROM legislation_articles la
-       JOIN legislation l ON la.legislation_id = l.id
-       WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.is_current = true
-       ORDER BY la.article_number, la.version_date DESC NULLS LAST, la.id DESC`,
-      [radaId, articleNumbers]
-    );
+    let result;
+    if (asOfDate) {
+      result = await this.db.query(
+        `SELECT DISTINCT ON (la.article_number) la.*, l.rada_id, l.title as npa_title
+         FROM legislation_articles la
+         JOIN legislation l ON la.legislation_id = l.id
+         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.version_date <= $3
+         ORDER BY la.article_number, la.version_date DESC`,
+        [radaId, articleNumbers, asOfDate]
+      );
+    } else {
+      result = await this.db.query(
+        `SELECT DISTINCT ON (la.article_number) la.*, l.rada_id, l.title as npa_title
+         FROM legislation_articles la
+         JOIN legislation l ON la.legislation_id = l.id
+         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.is_current = true
+         ORDER BY la.article_number, la.version_date DESC NULLS LAST, la.id DESC`,
+        [radaId, articleNumbers]
+      );
+    }
 
     return result.rows.map((row: any) => ({
       rada_id: radaId,
@@ -538,7 +555,7 @@ export class LegislationService {
       full_text: row.full_text,
       full_text_html: row.full_text_html,
       url: `https://zakon.rada.gov.ua/laws/show/${radaId}#n${row.article_number}`,
-      metadata: row.metadata,
+      metadata: asOfDate ? { ...row.metadata, is_historical: true, as_of_date: asOfDate } : row.metadata,
       npa_title: row.npa_title,
       section_number: row.section_number,
       section_title: row.section_title,
@@ -658,6 +675,21 @@ export class LegislationService {
       `SELECT DISTINCT type FROM legislation WHERE type IS NOT NULL ORDER BY type`
     );
     return result.rows.map((row: any) => row.type);
+  }
+
+  async getEditionDates(radaId: string): Promise<Array<{ edition_date: string; article_count: number }>> {
+    const result = await this.db.query(
+      `SELECT le.edition_date, le.article_count
+       FROM legislation_editions le
+       JOIN legislation l ON le.legislation_id = l.id
+       WHERE LOWER(l.rada_id) = LOWER($1)
+       ORDER BY le.edition_date DESC`,
+      [radaId]
+    );
+    return result.rows.map((row: any) => ({
+      edition_date: row.edition_date,
+      article_count: row.article_count,
+    }));
   }
 
   async getAmendmentHistory(radaId: string): Promise<Array<{

--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -1,0 +1,463 @@
+#!/usr/bin/env npx tsx
+/**
+ * Import Historical Legislation Editions
+ *
+ * Downloads all historical editions from zakon.rada.gov.ua/laws/show/{radaId}/ed{YYYYMMDD}
+ * and imports them into PostgreSQL with proper version_date tracking.
+ *
+ * Usage:
+ *   npx tsx scripts/rada/import-historical-editions.ts --code=ЦК
+ *   npx tsx scripts/rada/import-historical-editions.ts --all
+ *   npx tsx scripts/rada/import-historical-editions.ts --resume
+ *   npx tsx scripts/rada/import-historical-editions.ts --code=ЦК --from=20100101 --to=20200101
+ */
+
+import axios, { AxiosInstance } from 'axios';
+import * as fs from 'fs';
+import * as path from 'path';
+import pg from 'pg';
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+const SCRIPTS_DIR = path.resolve(__dirname);
+const PROGRESS_FILE = path.join(SCRIPTS_DIR, 'historical-editions-progress.json');
+const BASE_URL = 'https://zakon.rada.gov.ua';
+const RATE_LIMIT = 2; // requests per second
+const MAX_RETRIES = 3;
+const CHECKPOINT_INTERVAL = 5;
+
+const CODES: Array<{ rada_id: string; short_title: string }> = [
+  { rada_id: '254к/96-ВР', short_title: 'КУ' },
+  { rada_id: '2947-14', short_title: 'СК' },
+  { rada_id: '1129-15', short_title: 'КВК' },
+  { rada_id: '2768-14', short_title: 'ЗК' },
+  { rada_id: '322-08', short_title: 'КЗпП' },
+  { rada_id: '2755-17', short_title: 'ПК' },
+  { rada_id: '436-15', short_title: 'ГК' },
+  { rada_id: '1798-12', short_title: 'ГПК' },
+  { rada_id: '2747-15', short_title: 'КАС' },
+  { rada_id: '2341-14', short_title: 'КК' },
+  { rada_id: '80731-10', short_title: 'КУпАП' },
+  { rada_id: '4651-17', short_title: 'КПК' },
+  { rada_id: '1618-15', short_title: 'ЦПК' },
+  { rada_id: '4495-17', short_title: 'МК' },
+  { rada_id: '435-15', short_title: 'ЦК' },
+  { rada_id: '5403-17', short_title: 'КЦЗ' },
+];
+
+// ─── Token Bucket Rate Limiter ───────────────────────────────────────────────
+
+class TokenBucket {
+  private tokens: number;
+  private waiters: Array<() => void> = [];
+  private interval: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private rate: number, private maxTokens: number) {
+    this.tokens = maxTokens;
+    this.interval = setInterval(() => this.refill(), 1000 / rate);
+  }
+
+  private refill(): void {
+    if (this.tokens < this.maxTokens) {
+      this.tokens++;
+    }
+    if (this.waiters.length > 0 && this.tokens > 0) {
+      this.tokens--;
+      const resolve = this.waiters.shift()!;
+      resolve();
+    }
+  }
+
+  async acquire(): Promise<void> {
+    if (this.tokens > 0) {
+      this.tokens--;
+      return;
+    }
+    return new Promise<void>((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  destroy(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    for (const resolve of this.waiters) resolve();
+    this.waiters = [];
+  }
+}
+
+// ─── HTTP Client ─────────────────────────────────────────────────────────────
+
+function createHttpClient(): AxiosInstance {
+  return axios.create({
+    timeout: 60000,
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+      'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      'Accept-Language': 'uk,en;q=0.9',
+      'Accept-Encoding': 'gzip, deflate',
+    },
+    decompress: true,
+    validateStatus: () => true,
+  });
+}
+
+// ─── Retry ───────────────────────────────────────────────────────────────────
+
+async function withRetry<T>(fn: () => Promise<T>, retries = MAX_RETRIES): Promise<T> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      if (attempt === retries) throw err;
+      const delay = Math.min(1000 * Math.pow(2, attempt), 30000);
+      console.error(`  Attempt ${attempt} failed: ${err.message}, retrying in ${delay}ms...`);
+      await new Promise(r => setTimeout(r, delay));
+    }
+  }
+  throw new Error('Unreachable');
+}
+
+// ─── Progress Tracking ───────────────────────────────────────────────────────
+
+interface CodeProgress {
+  rada_id: string;
+  short_title: string;
+  total_editions: number;
+  completed_editions: string[];
+  failed_editions: string[];
+}
+
+interface OverallProgress {
+  codes: CodeProgress[];
+  started_at: string;
+  last_updated: string;
+}
+
+function loadProgress(): OverallProgress {
+  if (fs.existsSync(PROGRESS_FILE)) {
+    return JSON.parse(fs.readFileSync(PROGRESS_FILE, 'utf-8'));
+  }
+  return { codes: [], started_at: new Date().toISOString(), last_updated: new Date().toISOString() };
+}
+
+function saveProgress(progress: OverallProgress): void {
+  progress.last_updated = new Date().toISOString();
+  fs.writeFileSync(PROGRESS_FILE, JSON.stringify(progress, null, 2));
+}
+
+function getCodeProgress(progress: OverallProgress, radaId: string, shortTitle: string): CodeProgress {
+  let cp = progress.codes.find(c => c.rada_id === radaId);
+  if (!cp) {
+    cp = { rada_id: radaId, short_title: shortTitle, total_editions: 0, completed_editions: [], failed_editions: [] };
+    progress.codes.push(cp);
+  }
+  return cp;
+}
+
+// ─── Article Parser ──────────────────────────────────────────────────────────
+
+function extractArticlesFromEditionHtml(html: string): Array<{ article_number: string; title?: string; full_text: string; byte_size: number }> {
+  const articles: Array<{ article_number: string; title?: string; full_text: string; byte_size: number }> = [];
+  const seen = new Set<string>();
+
+  // Try <pre><b> format first (historical editions)
+  const preBoldRegex = /<b>Стаття\s+(\d+(?:-\d+)?)\.?<\/b>\s*(.*?)(?=<b>Стаття\s+\d|<\/pre>\s*$|$)/gs;
+  let match;
+  while ((match = preBoldRegex.exec(html)) !== null) {
+    const artNum = match[1].trim();
+    if (seen.has(artNum)) continue;
+    seen.add(artNum);
+
+    let body = match[2];
+    body = body.replace(/<br\s*\/?>/gi, '\n');
+    body = body.replace(/<b>([^<]*)<\/b>/g, '$1');
+    body = body.replace(/<[^>]+>/g, ' ');
+    body = body.replace(/&nbsp;/g, ' ').replace(/&mdash;/g, '—').replace(/&laquo;/g, '«').replace(/&raquo;/g, '»').replace(/&amp;/g, '&');
+    body = body.replace(/\{[^}]*\}/g, '');
+    body = body.replace(/[ \t]+/g, ' ').replace(/\n\s*\n/g, '\n').trim();
+    if (body.length < 5) continue;
+
+    const firstLine = body.split('\n')[0].trim();
+    articles.push({
+      article_number: artNum,
+      title: firstLine.length < 200 ? firstLine : undefined,
+      full_text: body,
+      byte_size: Buffer.byteLength(body, 'utf8'),
+    });
+  }
+
+  if (articles.length >= 3) return articles;
+
+  // Fallback: <span class=rvts9> format (current /print pages)
+  seen.clear();
+  articles.length = 0;
+  const rvtsRegex = /<span\s+class=["']?rvts9["']?>\s*Стаття\s+(\d+(?:-\d+)?)\.?\s*([^<]*)<\/span>\s*(.*?)(?=<span\s+class=["']?rvts9["']?>\s*Стаття\s+\d|$)/gs;
+  while ((match = rvtsRegex.exec(html)) !== null) {
+    const artNum = match[1].trim();
+    if (seen.has(artNum)) continue;
+    seen.add(artNum);
+
+    const inlineTitle = match[2]?.trim();
+    let body = match[3];
+    body = body.replace(/<script[^>]*>.*?<\/script>/gs, '');
+    body = body.replace(/<style[^>]*>.*?<\/style>/gs, '');
+    body = body.replace(/<[^>]+>/g, ' ');
+    body = body.replace(/\s+/g, ' ').replace(/\{[^}]*\}/g, '').trim();
+    if (body.length < 10) continue;
+
+    articles.push({
+      article_number: artNum,
+      title: inlineTitle && inlineTitle.length > 2 ? inlineTitle : undefined,
+      full_text: body,
+      byte_size: Buffer.byteLength(body, 'utf8'),
+    });
+  }
+
+  // Last fallback: plain text Стаття N. pattern
+  if (articles.length < 3) {
+    seen.clear();
+    articles.length = 0;
+    const plainRegex = /Стаття\s+(\d+(?:-\d+)?)\.\s*([^\n]{3,200})/g;
+    while ((match = plainRegex.exec(html)) !== null) {
+      const artNum = match[1].trim();
+      if (!seen.has(artNum)) {
+        seen.add(artNum);
+        articles.push({
+          article_number: artNum,
+          title: match[2].trim(),
+          full_text: match[2].trim(),
+          byte_size: Buffer.byteLength(match[2], 'utf8'),
+        });
+      }
+    }
+  }
+
+  return articles;
+}
+
+// ─── Edition Discovery ───────────────────────────────────────────────────────
+
+async function fetchEditionDates(httpClient: AxiosInstance, bucket: TokenBucket, radaId: string): Promise<string[]> {
+  await bucket.acquire();
+  const url = `${BASE_URL}/laws/show/${radaId}/card4`;
+  console.log(`  Fetching edition dates from ${url}`);
+  const response = await withRetry(() => httpClient.get(url));
+  if (response.status !== 200) throw new Error(`HTTP ${response.status} for ${url}`);
+
+  const html = response.data as string;
+  // Match /ed{YYYYMMDD} links — rada_id may appear URL-encoded in HTML
+  const edRegex = /\/ed(\d{8})/g;
+  const dates = new Set<string>();
+  let match;
+  while ((match = edRegex.exec(html)) !== null) dates.add(match[1]);
+
+  return [...dates].sort();
+}
+
+// ─── Import One Edition ──────────────────────────────────────────────────────
+
+async function importEdition(
+  httpClient: AxiosInstance,
+  bucket: TokenBucket,
+  pool: pg.Pool,
+  legislationId: number,
+  radaId: string,
+  editionDate: string,
+): Promise<number> {
+  await bucket.acquire();
+  const url = `${BASE_URL}/laws/show/${radaId}/ed${editionDate}/print`;
+  const response = await withRetry(() => httpClient.get(url));
+  if (response.status !== 200) throw new Error(`HTTP ${response.status} for ${url}`);
+
+  const html = response.data as string;
+  const articles = extractArticlesFromEditionHtml(html);
+  if (articles.length === 0) return 0;
+
+  const versionDate = `${editionDate.substring(0, 4)}-${editionDate.substring(4, 6)}-${editionDate.substring(6, 8)}`;
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    for (const art of articles) {
+      const titleEsc = art.title || null;
+      await client.query(
+        `INSERT INTO legislation_articles (legislation_id, article_number, title, full_text, byte_size, is_current, version_date, metadata)
+         VALUES ($1, $2, $3, $4, $5, false, $6, $7)
+         ON CONFLICT (legislation_id, article_number, version_date) DO NOTHING`,
+        [legislationId, art.article_number, titleEsc, art.full_text, art.byte_size, versionDate,
+         JSON.stringify({ edition_date: editionDate, extraction_method: 'edition_pre_bold' })],
+      );
+    }
+
+    // Record edition in legislation_editions
+    await client.query(
+      `INSERT INTO legislation_editions (legislation_id, edition_date, edition_key, article_count)
+       VALUES ($1, $2, $3, $4)
+       ON CONFLICT (legislation_id, edition_date) DO NOTHING`,
+      [legislationId, versionDate, editionDate, articles.length],
+    );
+
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  return articles.length;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const codeArg = args.find(a => a.startsWith('--code='))?.split('=')[1];
+  const allArg = args.includes('--all');
+  const resumeArg = args.includes('--resume');
+  const fromArg = args.find(a => a.startsWith('--from='))?.split('=')[1];
+  const toArg = args.find(a => a.startsWith('--to='))?.split('=')[1];
+  const dryRun = args.includes('--dry-run');
+
+  if (!codeArg && !allArg && !resumeArg) {
+    console.log('Usage:');
+    console.log('  --code=ЦК              Import one code');
+    console.log('  --all                   Import all 16 codes');
+    console.log('  --resume                Resume from checkpoint');
+    console.log('  --from=YYYYMMDD         Start from this edition date');
+    console.log('  --to=YYYYMMDD           Stop at this edition date');
+    console.log('  --dry-run               Discover editions but do not import');
+    process.exit(0);
+  }
+
+  const dbUrl = process.env.DATABASE_URL || 'postgresql://secondlayer:secondlayer@localhost:5432/secondlayer_prod';
+  const pool = new pg.Pool({ connectionString: dbUrl, max: 3 });
+
+  // Ensure migration tables exist
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS legislation_editions (
+      id SERIAL PRIMARY KEY,
+      legislation_id INTEGER NOT NULL REFERENCES legislation(id) ON DELETE CASCADE,
+      edition_date DATE NOT NULL,
+      edition_key VARCHAR(8) NOT NULL,
+      article_count INTEGER DEFAULT 0,
+      imported_at TIMESTAMPTZ DEFAULT NOW(),
+      metadata JSONB DEFAULT '{}',
+      UNIQUE(legislation_id, edition_date)
+    )
+  `);
+
+  const httpClient = createHttpClient();
+  const bucket = new TokenBucket(RATE_LIMIT, RATE_LIMIT);
+  const progress = loadProgress();
+
+  let codesToProcess: typeof CODES;
+  if (codeArg) {
+    const found = CODES.find(c => c.short_title === codeArg || c.rada_id === codeArg);
+    if (!found) {
+      console.error(`Unknown code: ${codeArg}. Available: ${CODES.map(c => c.short_title).join(', ')}`);
+      process.exit(1);
+    }
+    codesToProcess = [found];
+  } else {
+    codesToProcess = CODES;
+  }
+
+  let totalEditionsImported = 0;
+  let totalArticlesImported = 0;
+
+  for (const code of codesToProcess) {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`Processing: ${code.short_title} (${code.rada_id})`);
+    console.log('='.repeat(60));
+
+    // Get legislation_id from DB
+    const legResult = await pool.query('SELECT id FROM legislation WHERE rada_id = $1', [code.rada_id]);
+    if (legResult.rows.length === 0) {
+      console.error(`  Legislation ${code.rada_id} not found in DB, skipping`);
+      continue;
+    }
+    const legislationId = legResult.rows[0].id;
+
+    // Discover edition dates
+    let editionDates: string[];
+    try {
+      editionDates = await fetchEditionDates(httpClient, bucket, code.rada_id);
+    } catch (err: any) {
+      console.error(`  Failed to fetch edition dates: ${err.message}`);
+      continue;
+    }
+    console.log(`  Found ${editionDates.length} editions`);
+
+    // Apply date filters
+    if (fromArg) editionDates = editionDates.filter(d => d >= fromArg);
+    if (toArg) editionDates = editionDates.filter(d => d <= toArg);
+
+    // Filter already-imported editions
+    const cp = getCodeProgress(progress, code.rada_id, code.short_title);
+    cp.total_editions = editionDates.length;
+
+    const alreadyImported = new Set(cp.completed_editions);
+    // Also check DB for editions imported in previous runs
+    const dbEditions = await pool.query(
+      'SELECT edition_key FROM legislation_editions WHERE legislation_id = $1',
+      [legislationId],
+    );
+    for (const row of dbEditions.rows) alreadyImported.add(row.edition_key);
+
+    const toImport = editionDates.filter(d => !alreadyImported.has(d));
+    console.log(`  To import: ${toImport.length} editions (${alreadyImported.size} already done)`);
+
+    if (dryRun) {
+      console.log(`  [DRY RUN] Would import: ${toImport.join(', ')}`);
+      continue;
+    }
+
+    let editionsDone = 0;
+    for (const edDate of toImport) {
+      try {
+        const artCount = await importEdition(httpClient, bucket, pool, legislationId, code.rada_id, edDate);
+        cp.completed_editions.push(edDate);
+        totalEditionsImported++;
+        totalArticlesImported += artCount;
+        editionsDone++;
+
+        if (editionsDone % CHECKPOINT_INTERVAL === 0) {
+          saveProgress(progress);
+          const pct = ((alreadyImported.size + editionsDone) / editionDates.length * 100).toFixed(1);
+          console.log(`  [${editionsDone}/${toImport.length}] ed${edDate}: ${artCount} articles (${pct}% of ${code.short_title})`);
+        }
+      } catch (err: any) {
+        console.error(`  FAILED ed${edDate}: ${err.message}`);
+        cp.failed_editions.push(edDate);
+      }
+    }
+
+    // Update total_editions on legislation table
+    await pool.query(
+      `UPDATE legislation SET total_editions = (
+        SELECT COUNT(*) FROM legislation_editions WHERE legislation_id = $1
+      ) WHERE id = $1`,
+      [legislationId],
+    );
+
+    saveProgress(progress);
+    console.log(`  Done: ${editionsDone} editions imported for ${code.short_title}`);
+  }
+
+  bucket.destroy();
+  await pool.end();
+
+  console.log(`\n${'='.repeat(60)}`);
+  console.log(`COMPLETE: ${totalEditionsImported} editions, ${totalArticlesImported} articles imported`);
+  console.log('='.repeat(60));
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Store and query all historical editions of 16 Ukrainian codes from zakon.rada.gov.ua
- Each code has dozens to hundreds of editions (ЦК: 182, КК: 242, КПК: 132)
- New `as_of_date` parameter on `get_legislation_section` and `get_legislation_articles` tools
- New `list_legislation_editions` tool to list available edition dates
- Import script with rate limiting, checkpointing, and resume capability

## Test plan
- [x] Migration 160 applied on prod
- [x] Smoke test: Конституція — 9 editions, 1443 articles imported
- [x] Temporal query verified: article 85 returns correct version for different dates
- [ ] Full import running (~4000 editions across 16 codes)
- [ ] Verify temporal queries via API after deploy
- [ ] Check DB size after full import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add historical editions support for Ukrainian legal codes with time-travel lookups via an as_of_date parameter and a tool to list edition dates. Includes a backfill importer and DB indexes for fast temporal queries.

- New Features
  - Added as_of_date to get_legislation_section and get_legislation_articles (YYYY-MM-DD) to return text as of a date.
  - New list_legislation_editions tool listing edition dates with article counts.
  - Service supports temporal reads for single/multiple articles; metadata includes is_historical and as_of_date.
  - Adapter can discover edition dates and fetch specific editions; robust parsers for <pre><b> and rvts9 formats.
  - Import script at scripts/rada/import-historical-editions.ts with rate limiting, retries, checkpoint/resume; writes editions and articles to DB.

- Migration
  - New legislation_editions table with unique (legislation_id, edition_date) and index on (legislation_id, edition_date DESC).
  - Composite index on legislation_articles(legislation_id, article_number, version_date DESC) for temporal lookups.
  - Added total_editions column to legislation.
  - Partial index on historical articles where is_current = false.

<sup>Written for commit a109c69b1786bfe7ad597fc34f7285c0408da777. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

