### PR TITLE
feat(infra): add GCP stage environment with CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -1,0 +1,347 @@
+##############################################################################
+# Pipeline: Deploy to Stage (GCP)
+# - Builds and tests changed services
+# - Deploys to GCP stage VM (stage.legal.org.ua) via SSH
+# - Triggered on PR to main (for pre-merge validation) or manually
+##############################################################################
+name: 'Deploy to Stage'
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      services:
+        description: 'Services to deploy (comma-separated: backend,rada,openreyestr,frontend). Leave empty to auto-detect.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: deploy-stage-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  STAGE_HOST: 34.159.151.177
+  STAGE_USER: vovkes
+  DEPLOY_DIR: /home/vovkes/SecondLayer
+
+jobs:
+  # ─── Step 1: Detect what changed ─────────────────────────────────────
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      shared: ${{ steps.changes.outputs.shared }}
+      backend: ${{ steps.changes.outputs.backend }}
+      rada: ${{ steps.changes.outputs.rada }}
+      openreyestr: ${{ steps.changes.outputs.openreyestr }}
+      frontend: ${{ steps.changes.outputs.frontend }}
+      deployment: ${{ steps.changes.outputs.deployment }}
+      any_backend: ${{ steps.changes.outputs.any_backend }}
+      services_to_build: ${{ steps.changes.outputs.services_to_build }}
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        uses: ./.github/actions/detect-changes
+
+      - name: Check if any services need deploy
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.services }}" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Manual deploy requested: ${{ inputs.services }}"
+          else
+            SERVICES='${{ steps.changes.outputs.services_to_build }}'
+            if [ "$SERVICES" = '[]' ]; then
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "No services changed — skipping"
+            else
+              echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+  # ─── Step 2: Build & test ────────────────────────────────────────────
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    env:
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build shared package
+        run: cd packages/shared && npm install --legacy-peer-deps && npm run build
+
+      - name: Overlay proprietary source
+        if: env.BACKEND_CHANGED == 'true'
+        env:
+          CORE_REPO_SSH_KEY: ${{ secrets.CORE_REPO_SSH_KEY }}
+        run: |
+          CORE_TMP=$(mktemp -d)
+          KEY_FILE=$(mktemp)
+          trap 'shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"; rm -rf "$CORE_TMP"' EXIT
+          printf '%s\n' "$CORE_REPO_SSH_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
+            git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+          cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+
+      - name: Build backend
+        if: env.BACKEND_CHANGED == 'true'
+        run: cd mcp_backend && npm install && npm run build
+
+      - name: Unit test backend
+        if: env.BACKEND_CHANGED == 'true'
+        run: |
+          cd mcp_backend && npx jest --no-cache --forceExit \
+            src/controllers/__tests__/ \
+            src/middleware/__tests__/ \
+            src/adapters/__tests__/ \
+            src/services/__tests__/
+
+      - name: Build RADA
+        if: env.RADA_CHANGED == 'true'
+        run: cd mcp_rada && npm install && npm run build
+
+      - name: Build OpenReyestr
+        if: env.OPENREYESTR_CHANGED == 'true'
+        run: cd mcp_openreyestr && npm install && npm run build
+
+      - name: Install frontend deps
+        if: env.FRONTEND_CHANGED == 'true'
+        run: cd lexwebapp && npm install --legacy-peer-deps
+
+      - name: Build frontend
+        if: env.FRONTEND_CHANGED == 'true'
+        run: cd lexwebapp && npm run build
+        env:
+          VITE_API_URL: https://stage.legal.org.ua
+          NODE_OPTIONS: --max-old-space-size=8192
+
+  # ─── Step 3: Deploy to stage VM ──────────────────────────────────────
+  deploy-stage:
+    name: Deploy to Stage
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-and-test]
+    if: |
+      always() &&
+      needs.build-and-test.result == 'success'
+    env:
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+      SHARED_CHANGED: ${{ needs.detect-changes.outputs.shared }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH
+        env:
+          STAGE_SSH_KEY: ${{ secrets.STAGE_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$STAGE_SSH_KEY" > ~/.ssh/stage_key
+          chmod 600 ~/.ssh/stage_key
+          ssh-keyscan -H ${{ env.STAGE_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Resolve services to deploy
+        id: services
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.services }}" ]; then
+            echo "list=${{ inputs.services }}" >> "$GITHUB_OUTPUT"
+          else
+            SERVICES=""
+            [ "$BACKEND_CHANGED" = "true" ] && SERVICES="backend"
+            [ "$RADA_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}rada"
+            [ "$OPENREYESTR_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}openreyestr"
+            [ "$FRONTEND_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}frontend"
+            [ "$SHARED_CHANGED" = "true" ] && [ -z "$SERVICES" ] && SERVICES="backend,rada,openreyestr,frontend"
+            echo "list=${SERVICES:-backend,frontend}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy via SSH
+        env:
+          SERVICES: ${{ steps.services.outputs.list }}
+          CORE_REPO_SSH_KEY: ${{ secrets.CORE_REPO_SSH_KEY }}
+        run: |
+          SSH_CMD="ssh -i ~/.ssh/stage_key -o StrictHostKeyChecking=accept-new ${{ env.STAGE_USER }}@${{ env.STAGE_HOST }}"
+
+          # Sync code to stage
+          $SSH_CMD "cd ${{ env.DEPLOY_DIR }} && git fetch origin && git checkout ${GITHUB_SHA} --force"
+
+          # Overlay proprietary source if backend is being deployed
+          if echo "$SERVICES" | grep -q "backend"; then
+            KEY_FILE=$(mktemp)
+            trap 'shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"' EXIT
+            printf '%s\n' "$CORE_REPO_SSH_KEY" > "$KEY_FILE"
+            chmod 600 "$KEY_FILE"
+            scp -i ~/.ssh/stage_key -o StrictHostKeyChecking=accept-new "$KEY_FILE" ${{ env.STAGE_USER }}@${{ env.STAGE_HOST }}:/tmp/core_key
+            $SSH_CMD bash -s <<'OVERLAY_EOF'
+              KEY_FILE=/tmp/core_key
+              chmod 600 "$KEY_FILE"
+              CORE_TMP=$(mktemp -d)
+              trap 'shred -u "$KEY_FILE" 2>/dev/null; rm -rf "$CORE_TMP"' EXIT
+              GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
+                git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+              cp -f "$CORE_TMP"/src/services/* $DEPLOY_DIR/mcp_backend/src/services/
+              cp -rf "$CORE_TMP"/src/prompts/* $DEPLOY_DIR/mcp_backend/src/prompts/
+          OVERLAY_EOF
+          fi
+
+          # Build and deploy Docker services
+          $SSH_CMD bash -s -- "$SERVICES" <<'DEPLOY_EOF'
+            set -euo pipefail
+            SERVICES="$1"
+            cd /home/vovkes/SecondLayer/deployment
+            DC="docker compose -f docker-compose.stage.yml --env-file .env.stage"
+
+            STOP="" BUILD="" START=""
+
+            if echo "$SERVICES" | grep -q "backend"; then
+              STOP="$STOP app-stage document-service-stage"
+              BUILD="$BUILD app-stage document-service-stage migrate-stage"
+              START="$START app-stage document-service-stage"
+            fi
+            if echo "$SERVICES" | grep -q "rada"; then
+              STOP="$STOP rada-mcp-app-stage"
+              BUILD="$BUILD rada-mcp-app-stage rada-db-init-stage rada-migrate-stage"
+              START="$START rada-mcp-app-stage"
+            fi
+            if echo "$SERVICES" | grep -q "openreyestr"; then
+              STOP="$STOP app-openreyestr-stage"
+              BUILD="$BUILD app-openreyestr-stage migrate-openreyestr-stage"
+              START="$START app-openreyestr-stage"
+            fi
+            if echo "$SERVICES" | grep -q "frontend"; then
+              STOP="$STOP lexwebapp-stage"
+              BUILD="$BUILD lexwebapp-stage"
+              START="$START lexwebapp-stage"
+            fi
+
+            [ -n "$STOP" ] && $DC stop $STOP 2>/dev/null || true
+            [ -n "$STOP" ] && $DC rm -f $STOP 2>/dev/null || true
+            [ -n "$BUILD" ] && $DC build --no-cache $BUILD
+
+            # Run migrations
+            if echo "$SERVICES" | grep -q "backend"; then
+              timeout 120 $DC up --abort-on-container-exit migrate-stage || true
+            fi
+            if echo "$SERVICES" | grep -q "rada"; then
+              timeout 120 $DC up --abort-on-container-exit rada-db-init-stage || true
+              timeout 120 $DC up --abort-on-container-exit rada-migrate-stage || true
+            fi
+            if echo "$SERVICES" | grep -q "openreyestr"; then
+              timeout 120 $DC up --abort-on-container-exit migrate-openreyestr-stage || true
+            fi
+
+            [ -n "$START" ] && $DC up -d $START
+
+            # Always recreate nginx after any deploy
+            $DC up -d --force-recreate nginx-stage
+
+            docker image prune -f || true
+          DEPLOY_EOF
+
+      - name: Health check
+        run: |
+          SSH_CMD="ssh -i ~/.ssh/stage_key -o StrictHostKeyChecking=accept-new ${{ env.STAGE_USER }}@${{ env.STAGE_HOST }}"
+
+          FAILED=false
+
+          wait_healthy() {
+            local name=$1 container=$2 max_wait=${3:-120}
+            local elapsed=0
+            echo "Waiting for $name ($container)..."
+            while [ $elapsed -lt $max_wait ]; do
+              status=$($SSH_CMD "docker inspect --format='{{.State.Health.Status}}' $container 2>/dev/null || echo not_found")
+              case "$status" in
+                healthy) echo "✓ $name: healthy (${elapsed}s)"; return 0 ;;
+                unhealthy) echo "✗ $name: unhealthy"; FAILED=true; return 1 ;;
+                *) sleep 10; elapsed=$((elapsed + 10)) ;;
+              esac
+            done
+            echo "✗ $name: timed out"
+            FAILED=true
+          }
+
+          if [ "${{ env.BACKEND_CHANGED }}" = "true" ]; then
+            wait_healthy "Backend" "secondlayer-app-stage" 180
+            wait_healthy "Document Service" "document-service-stage" 120
+          fi
+          [ "${{ env.RADA_CHANGED }}" = "true" ] && wait_healthy "RADA" "rada-mcp-app-stage" 120
+          [ "${{ env.OPENREYESTR_CHANGED }}" = "true" ] && wait_healthy "OpenReyestr" "openreyestr-app-stage" 120
+          [ "${{ env.FRONTEND_CHANGED }}" = "true" ] && wait_healthy "Frontend" "lexwebapp-stage" 60
+
+          # Verify stage is reachable via HTTPS
+          for i in 1 2 3 4 5; do
+            curl -sf --max-time 10 "https://stage.legal.org.ua/health" > /dev/null 2>&1 && {
+              echo "✓ stage.legal.org.ua reachable"
+              break
+            }
+            echo "Attempt $i: stage not reachable yet, retrying..."
+            sleep 10
+          done
+
+          if [ "$FAILED" = "true" ]; then exit 1; fi
+
+      - name: Comment PR with stage URL
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '## Stage Deployment',
+              '',
+              '| | |',
+              '|---|---|',
+              `| **URL** | https://stage.legal.org.ua |`,
+              `| **Commit** | \`${context.sha.substring(0, 7)}\` |`,
+              `| **Services** | ${{ steps.services.outputs.list }} |`,
+              '',
+              '> Deploy completed — test before merging.',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const existing = comments.find(c => c.body.includes('## Stage Deployment'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -4,12 +4,12 @@ services:
     container_name: secondlayer-postgres-stage
     command: >-
       postgres
-      -c max_connections=500
-      -c shared_buffers=8GB
-      -c effective_cache_size=40GB
-      -c work_mem=128MB
-      -c maintenance_work_mem=2GB
-      -c wal_buffers=64MB
+      -c max_connections=200
+      -c shared_buffers=512MB
+      -c effective_cache_size=1536MB
+      -c work_mem=16MB
+      -c maintenance_work_mem=256MB
+      -c wal_buffers=16MB
       -c idle_in_transaction_session_timeout=60000
       -c statement_timeout=300000
       -c lock_timeout=30000
@@ -36,9 +36,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 12G
+          memory: 1G
         reservations:
-          memory: 8G
+          memory: 512M
 
   # PgBouncer connection pooler for PostgreSQL
   pgbouncer-stage:
@@ -102,14 +102,14 @@ services:
   postgres-openreyestr-stage:
     image: mcvovkes/openreyestr-db:latest
     container_name: openreyestr-postgres-stage
-    shm_size: '4g'
+    shm_size: '256m'
     command: >-
       postgres
-      -c max_connections=200
-      -c shared_buffers=2GB
-      -c effective_cache_size=6GB
-      -c work_mem=128MB
-      -c maintenance_work_mem=1GB
+      -c max_connections=100
+      -c shared_buffers=256MB
+      -c effective_cache_size=768MB
+      -c work_mem=16MB
+      -c maintenance_work_mem=128MB
       -c idle_in_transaction_session_timeout=60000
       -c statement_timeout=300000
       -c lock_timeout=30000
@@ -134,11 +134,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
-          memory: 16G
+          cpus: '1'
+          memory: 1G
         reservations:
-          cpus: '0.5'
-          memory: 4G
+          cpus: '0.25'
+          memory: 512M
 
   qdrant-stage:
     image: qdrant/qdrant:latest
@@ -163,9 +163,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 8G
+          memory: 1G
         reservations:
-          memory: 4G
+          memory: 512M
   redis-stage:
     image: redis:7-alpine
     container_name: secondlayer-redis-stage
@@ -173,7 +173,7 @@ services:
     - "127.0.0.1:6381:6379"
     volumes:
     - redis_stage_data:/data
-    command: redis-server --appendonly yes --maxmemory 8192mb --maxmemory-policy noeviction
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
     healthcheck:
       test:
       - CMD
@@ -191,9 +191,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 9G
+          memory: 768M
         reservations:
-          memory: 4G
+          memory: 256M
   migrate-stage:
     build:
       context: ..
@@ -493,7 +493,7 @@ services:
         max-file: "10"
     command:
     - node
-    - --max-old-space-size=8192
+    - --max-old-space-size=2048
     - dist/http-server.js
     environment:
       NODE_ENV: staging
@@ -624,10 +624,10 @@ services:
       resources:
         limits:
           cpus: '2'
-          memory: 10G
+          memory: 2G
         reservations:
           cpus: '0.5'
-          memory: 4G
+          memory: 1G
   # Document Analysis Service (OCR, PDF parsing)
   document-service-stage:
     build:
@@ -635,7 +635,7 @@ services:
       dockerfile: deployment/Dockerfile.document-service
     image: document-service:latest
     container_name: document-service-stage
-    command: ["node", "--max-old-space-size=5120", "--expose-gc", "dist/document-service.js"]
+    command: ["node", "--max-old-space-size=1024", "--expose-gc", "dist/document-service.js"]
     logging:
       driver: json-file
       options:
@@ -736,11 +736,11 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
-          memory: 6G
+          cpus: '1'
+          memory: 1536M
         reservations:
-          cpus: '0.5'
-          memory: 1G
+          cpus: '0.25'
+          memory: 512M
 
   lexwebapp-stage:
     build:
@@ -801,12 +801,8 @@ services:
         max-file: "5"
     ports:
       - "80:80"
-      - "443:443"
     volumes:
       - ./nginx/stage.legal.org.ua.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./nginx/includes:/etc/nginx/includes:ro
-      - /etc/letsencrypt:/etc/letsencrypt:ro
-      - /var/www/html:/var/www/html:ro
       - nginx_stage_logs:/var/log/nginx
     depends_on:
       app-stage:

--- a/deployment/nginx/stage.legal.org.ua.conf
+++ b/deployment/nginx/stage.legal.org.ua.conf
@@ -1,8 +1,6 @@
-# Main Nginx Configuration for stage.legal.org.ua
-# Runs as a Docker container (nginx-stage) in docker-compose.stage.yml
-# Upstreams use Docker service names (internal ports, not mapped ports)
+# Nginx for stage.legal.org.ua (GCP VM)
+# TLS terminates at Cloudflare — nginx listens on HTTP only
 
-# Upstreams (Docker service names)
 upstream stage_mcp_backend {
     server app-stage:3000;
     keepalive 128;
@@ -13,174 +11,116 @@ upstream stage_frontend {
     keepalive 32;
 }
 
-# HTTP - redirect to HTTPS
-server {
-    listen 80;
-    listen [::]:80;
-    server_name stage.legal.org.ua legal.org.ua mcp.legal.org.ua stage.mcp.legal.org.ua grafana.legal.org.ua sso.legal.org.ua nextcloud.legal.org.ua;
-
-    location /.well-known/acme-challenge/ {
-        root /var/www/html;
-    }
-
-    location / {
-        return 301 https://$host$request_uri;
-    }
-}
-
-# HTTPS - Main server (stage.legal.org.ua)
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name stage.legal.org.ua;
-
-    ssl_certificate /etc/letsencrypt/live/stage.legal.org.ua/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/stage.legal.org.ua/privkey.pem;
-
-    include /etc/nginx/includes/ssl-common.conf;
-    include /etc/nginx/includes/server-common.conf;
-}
-
-# HTTPS - legal.org.ua
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name legal.org.ua;
-
-    ssl_certificate /etc/letsencrypt/live/legal.org.ua/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/legal.org.ua/privkey.pem;
-
-    include /etc/nginx/includes/ssl-common.conf;
-    include /etc/nginx/includes/server-common.conf;
-}
-
-# HTTPS - mcp.legal.org.ua / stage.mcp.legal.org.ua
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name mcp.legal.org.ua stage.mcp.legal.org.ua;
-
-    ssl_certificate /etc/letsencrypt/live/mcp.legal.org.ua/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/mcp.legal.org.ua/privkey.pem;
-
-    include /etc/nginx/includes/ssl-common.conf;
-    include /etc/nginx/includes/server-common.conf;
-}
-
-# HTTPS - grafana.legal.org.ua (monitoring dashboard)
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name grafana.legal.org.ua;
-
-    ssl_certificate /etc/letsencrypt/live/grafana.legal.org.ua/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/grafana.legal.org.ua/privkey.pem;
-
-    include /etc/nginx/includes/ssl-common.conf;
-
-    # Security Headers
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-
-    # Logging
-    access_log /var/log/nginx/grafana.legal.org.ua-access.log;
-    error_log /var/log/nginx/grafana.legal.org.ua-error.log;
-
-    location / {
-        proxy_pass http://grafana-prod:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-    }
-}
-
-# HTTPS - sso.legal.org.ua (Authentik SSO)
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name sso.legal.org.ua;
-
-    ssl_certificate /etc/letsencrypt/live/sso.legal.org.ua/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/sso.legal.org.ua/privkey.pem;
-
-    include /etc/nginx/includes/ssl-common.conf;
-
-    # Security Headers
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-
-    # Logging
-    access_log /var/log/nginx/sso.legal.org.ua-access.log;
-    error_log /var/log/nginx/sso.legal.org.ua-error.log;
-
-    location / {
-        proxy_pass http://authentik-server-stage:9000;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-
-        # Authentik may send large headers (tokens, cookies)
-        proxy_buffer_size 16k;
-        proxy_buffers 4 16k;
-        proxy_busy_buffers_size 32k;
-    }
-}
-
-# HTTPS - nextcloud.legal.org.ua (Nextcloud file storage)
-server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    http2 on;
-    server_name nextcloud.legal.org.ua;
-
-    ssl_certificate /etc/letsencrypt/live/nextcloud.legal.org.ua/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/nextcloud.legal.org.ua/privkey.pem;
-
-    include /etc/nginx/includes/ssl-common.conf;
-
-    # Security Headers
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-
-    # Logging
-    access_log /var/log/nginx/nextcloud.legal.org.ua-access.log;
-    error_log /var/log/nginx/nextcloud.legal.org.ua-error.log;
-
-    # Nextcloud needs large uploads
-    client_max_body_size 512M;
-
-    location / {
-        proxy_pass http://nextcloud-stage:80;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_buffering off;
-        proxy_request_buffering off;
-    }
-}
-
-# WebSocket upgrade map
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name stage.legal.org.ua;
+
+    client_max_body_size 100M;
+
+    # Trust Cloudflare proxy headers
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 131.0.72.0/22;
+    real_ip_header CF-Connecting-IP;
+
+    # Security headers
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Health endpoint (direct, no proxy)
+    location = /health {
+        proxy_pass http://stage_mcp_backend/health;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+    }
+
+    # API endpoints
+    location /api/ {
+        proxy_pass http://stage_mcp_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+    }
+
+    # SSE streaming endpoints
+    location ~ ^/api/tools/.*/stream$ {
+        proxy_pass http://stage_mcp_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 600s;
+        chunked_transfer_encoding off;
+    }
+
+    # Auth callbacks
+    location /auth/ {
+        proxy_pass http://stage_mcp_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    # Webhook endpoints
+    location /webhooks/ {
+        proxy_pass http://stage_mcp_backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    # MinIO S3 proxy
+    location /s3/ {
+        proxy_pass http://minio-stage:9000/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+
+    # Frontend (default)
+    location / {
+        proxy_pass http://stage_frontend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
 }


### PR DESCRIPTION
## Summary

- Add `deploy-stage.yml` GitHub Actions workflow — triggers on PRs to main, builds/tests on GitHub-hosted runners, deploys to GCP stage VM via SSH
- Simplify nginx config for stage — HTTP-only (Cloudflare terminates TLS), Cloudflare real IP trust
- Tune docker-compose.stage.yml memory limits for e2-standard-2 (8 GB RAM)

## Infrastructure created

| Resource | Details |
|----------|---------|
| GCP Project | `secondlayer-stage` (445452671181) |
| VM | `stage-vm`, e2-standard-2, europe-west3-a |
| Static IP | `34.159.151.177` |
| DNS | `stage.legal.org.ua` → Cloudflare proxy → VM |
| Auto-schedule | Start 08:00 Mon–Fri, Stop 22:00 daily (Kyiv TZ) |
| GitHub Secret | `STAGE_SSH_KEY` |

## Test plan

- [ ] PR triggers deploy-stage workflow (this PR itself)
- [ ] Manual workflow_dispatch deploys to stage VM
- [ ] Health check passes after deploy
- [ ] stage.legal.org.ua reachable via browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GCP stage environment and a CI/CD pipeline that builds, tests, and deploys to a stage VM on PRs to main. Simplifies `nginx` for Cloudflare and tunes stage `docker-compose` resources for an 8 GB RAM VM.

- New Features
  - GitHub Actions workflow `deploy-stage.yml`: triggers on PRs to `main` and `workflow_dispatch`, auto-detects changed services, builds/tests, deploys via SSH, runs health checks, and comments the PR with the stage URL.
  - Stage infra: GCP VM `stage-vm` (e2-standard-2, `europe-west3-a`), DNS `stage.legal.org.ua` through Cloudflare, static IP, and auto start/stop schedule.
  - Uses secrets `STAGE_SSH_KEY` (SSH to VM) and `CORE_REPO_SSH_KEY` (overlay proprietary backend code).

- Refactors
  - `deployment/nginx/stage.legal.org.ua.conf`: HTTP-only behind Cloudflare, trusts real IPs, sets security headers, supports WebSocket/SSE, and routes API/auth/webhooks/MinIO and frontend.
  - `deployment/docker-compose.stage.yml`: right-sizes Postgres/OpenReyestr/Qdrant/Redis resources, lowers Node `--max-old-space-size`, and adjusts CPU/memory limits for the e2-standard-2 host.
  - Removes TLS mounts/443 from the `nginx` container since TLS terminates at Cloudflare.

<sup>Written for commit b6e49838e2b096c0823421ba1ea12a6155849196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

