### PR TITLE
feat(infra): stage branch-based deploy workflow

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -2,14 +2,13 @@
 # Pipeline: Deploy to Stage (GCP)
 # - Builds and tests changed services
 # - Deploys to GCP stage VM (stage.legal.org.ua) via SSH
-# - Triggered on PR to main (for pre-merge validation) or manually
+# - Triggered on push/merge to stage branch or manually
 ##############################################################################
 name: 'Deploy to Stage'
 
 on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+  push:
+    branches: [stage]
   workflow_dispatch:
     inputs:
       services:
@@ -19,12 +18,12 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 concurrency:
-  group: deploy-stage-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: deploy-stage
+  cancel-in-progress: false
 
 env:
   STAGE_HOST: 34.159.151.177
@@ -189,7 +188,24 @@ jobs:
           SSH_CMD="ssh -i ~/.ssh/stage_key -o StrictHostKeyChecking=accept-new ${{ env.STAGE_USER }}@${{ env.STAGE_HOST }}"
 
           # Sync code to stage
-          $SSH_CMD "cd ${{ env.DEPLOY_DIR }} && git fetch origin && git checkout ${GITHUB_SHA} --force"
+          $SSH_CMD "cd ${{ env.DEPLOY_DIR }} && git fetch origin stage && git checkout ${GITHUB_SHA} --force"
+
+          # Build TypeScript on stage VM (Dockerfiles require pre-built dist/)
+          $SSH_CMD bash -s -- "$SERVICES" <<'BUILD_EOF'
+            set -euo pipefail
+            SERVICES="$1"
+            cd /home/vovkes/SecondLayer
+            npm --prefix packages/shared install --legacy-peer-deps && npm --prefix packages/shared run build
+            if echo "$SERVICES" | grep -q "backend"; then
+              npm --prefix mcp_backend install && npm --prefix mcp_backend run build
+            fi
+            if echo "$SERVICES" | grep -q "rada"; then
+              npm --prefix mcp_rada install && npm --prefix mcp_rada run build
+            fi
+            if echo "$SERVICES" | grep -q "openreyestr"; then
+              npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build
+            fi
+          BUILD_EOF
 
           # Overlay proprietary source if backend is being deployed
           if echo "$SERVICES" | grep -q "backend"; then
@@ -306,42 +322,12 @@ jobs:
 
           if [ "$FAILED" = "true" ]; then exit 1; fi
 
-      - name: Comment PR with stage URL
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const body = [
-              '## Stage Deployment',
-              '',
-              '| | |',
-              '|---|---|',
-              `| **URL** | https://stage.legal.org.ua |`,
-              `| **Commit** | \`${context.sha.substring(0, 7)}\` |`,
-              `| **Services** | ${{ steps.services.outputs.list }} |`,
-              '',
-              '> Deploy completed — test before merging.',
-            ].join('\n');
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const existing = comments.find(c => c.body.includes('## Stage Deployment'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body,
-              });
-            }
+      - name: Tag successful stage deploy
+        run: |
+          TAG="stage-$(date +%Y%m%d-%H%M%S)"
+          git tag "$TAG" "${{ github.sha }}"
+          git push origin "$TAG"
+          git tag -l "stage-*" --sort=-creatordate | tail -n +11 | while read -r old_tag; do
+            git push origin ":refs/tags/$old_tag" 2>/dev/null || true
+            git tag -d "$old_tag" 2>/dev/null || true
+          done

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -801,8 +801,11 @@ services:
         max-file: "5"
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - ./nginx/stage.legal.org.ua.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/cf-origin-cert.pem:/etc/nginx/certs/cf-origin-cert.pem:ro
+      - ./nginx/cf-origin-key.pem:/etc/nginx/certs/cf-origin-key.pem:ro
       - nginx_stage_logs:/var/log/nginx
     depends_on:
       app-stage:

--- a/deployment/nginx/stage.legal.org.ua.conf
+++ b/deployment/nginx/stage.legal.org.ua.conf
@@ -20,6 +20,18 @@ server {
     listen 80;
     listen [::]:80;
     server_name stage.legal.org.ua;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name stage.legal.org.ua;
+
+    ssl_certificate /etc/nginx/certs/cf-origin-cert.pem;
+    ssl_certificate_key /etc/nginx/certs/cf-origin-key.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
 
     client_max_body_size 100M;
 
@@ -95,16 +107,6 @@ server {
     # Webhook endpoints
     location /webhooks/ {
         proxy_pass http://stage_mcp_backend;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-    }
-
-    # MinIO S3 proxy
-    location /s3/ {
-        proxy_pass http://minio-stage:9000/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary

- Switch stage CI/CD from PR-triggered to branch-based: push/merge to `stage` branch deploys to stage.legal.org.ua
- Add TypeScript build step on stage VM before Docker build (Dockerfiles need pre-built dist/)
- Fix nginx: add HTTPS with Cloudflare Origin Certificate, remove MinIO proxy dependency
- Tag successful deploys with `stage-YYYYMMDD-HHMMSS`

## Workflow

```
feature branch → PR to stage → merge → deploy to stage.legal.org.ua
                 PR to main  → merge → deploy to prod (legal.org.ua)
```

## Test plan

- [ ] Merge this PR to main, then sync stage branch
- [ ] Create a test PR to stage and merge — verify deploy triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches stage deploys to a branch-based workflow. Pushing or merging to `stage` deploys to https://stage.legal.org.ua with HTTPS, pre-builds TypeScript on the VM, and tags successful releases.

- **New Features**
  - Deploy triggers on push to `stage` (manual dispatch still available).
  - Pre-builds TypeScript on the stage VM before Docker builds for `packages/shared`, `mcp_backend`, `mcp_rada`, `mcp_openreyestr`.
  - Enables HTTPS: opens port 443, mounts Cloudflare Origin cert/key, and redirects HTTP→HTTPS.
  - Removes MinIO S3 proxy from nginx.
  - Tags deploys as `stage-YYYYMMDD-HHMMSS` and prunes older tags to keep the latest 10.
  - Sets a single concurrency group without canceling in-progress runs; grants `contents: write` to push tags.

- **Migration**
  - Place `deployment/nginx/cf-origin-cert.pem` and `deployment/nginx/cf-origin-key.pem` on the VM for HTTPS.
  - Use the `stage` branch for staging: merge/push to `stage` to deploy; `main` continues to deploy production.

<sup>Written for commit 87b7b61ebc3a94abab8c0c587f1007b03d981799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

