### PR TITLE
fix(ci): use absolute path in stage overlay step

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -215,14 +215,16 @@ jobs:
             chmod 600 "$KEY_FILE"
             scp -i ~/.ssh/stage_key -o StrictHostKeyChecking=accept-new "$KEY_FILE" ${{ env.STAGE_USER }}@${{ env.STAGE_HOST }}:/tmp/core_key
             $SSH_CMD bash -s <<'OVERLAY_EOF'
+              set -euo pipefail
               KEY_FILE=/tmp/core_key
               chmod 600 "$KEY_FILE"
               CORE_TMP=$(mktemp -d)
               trap 'shred -u "$KEY_FILE" 2>/dev/null; rm -rf "$CORE_TMP"' EXIT
               GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
                 git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-              cp -f "$CORE_TMP"/src/services/* $DEPLOY_DIR/mcp_backend/src/services/
-              cp -rf "$CORE_TMP"/src/prompts/* $DEPLOY_DIR/mcp_backend/src/prompts/
+              cp -f "$CORE_TMP"/src/services/* /home/vovkes/SecondLayer/mcp_backend/src/services/
+              cp -rf "$CORE_TMP"/src/prompts/* /home/vovkes/SecondLayer/mcp_backend/src/prompts/
+              cd /home/vovkes/SecondLayer && npm --prefix mcp_backend run build
           OVERLAY_EOF
           fi
 


### PR DESCRIPTION
## Summary

- Fix `$DEPLOY_DIR` not expanding inside single-quoted heredoc in stage deploy overlay step
- Hardcode `/home/vovkes/SecondLayer` path and rebuild backend after proprietary source overlay

## Test plan

- [ ] Merge → sync stage → verify deploy-stage passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the stage deploy overlay by using an absolute path so copy commands don’t break under a single-quoted heredoc. Also rebuilds `mcp_backend` after the overlay to ship compiled code.

- **Bug Fixes**
  - Replace `$DEPLOY_DIR` with `/home/vovkes/SecondLayer` in overlay copy commands.
  - Add `set -euo pipefail` to the remote script.
  - Run `npm --prefix mcp_backend run build` after applying the overlay.

<sup>Written for commit 9ec7f4b22e34e71b38e2c1b16ab15f8232118d7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

