### PR TITLE
fix(ci): remove set -e from stage deploy script

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -230,7 +230,7 @@ jobs:
 
           # Build and deploy Docker services
           $SSH_CMD bash -s -- "$SERVICES" <<'DEPLOY_EOF'
-            set -euo pipefail
+            set -uo pipefail
             SERVICES="$1"
             cd /home/vovkes/SecondLayer/deployment
             DC="docker compose -f docker-compose.stage.yml --env-file .env.stage"


### PR DESCRIPTION
## Summary
- Remove `set -e` from stage deploy SSH script — OpenReyestr migration can fail on first deploy (DB still importing pre-loaded data) which should not abort the entire deploy

## Test plan
- [ ] Merge → sync stage → deploy completes even if openreyestr migrate fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `-e` (errexit) from the stage deploy SSH script so a transient OpenReyestr migration failure during initial DB import doesn’t abort the whole deploy and other services still deploy.
Switches `.github/workflows/deploy-stage.yml` from `set -euo pipefail` to `set -uo pipefail`.

<sup>Written for commit 9af0a5c99a693c19c4b4dbfe3cdf47e5eed17d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

