### PR TITLE
fix(migration): remove CONCURRENTLY from CREATE INDEX in migration 160

### DIFF
--- a/mcp_backend/src/migrations/160_legislation_historical_editions.sql
+++ b/mcp_backend/src/migrations/160_legislation_historical_editions.sql
@@ -2,7 +2,7 @@
 -- Enables storage and fast temporal lookup of all historical editions of Ukrainian codes
 
 -- 1. Composite index for O(1) temporal lookups: "article X as of date Y"
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_temporal_lookup
+CREATE INDEX IF NOT EXISTS idx_articles_temporal_lookup
 ON legislation_articles (legislation_id, article_number, version_date DESC);
 
 -- 2. Create legislation_editions table (tracks available editions per code)
@@ -31,6 +31,6 @@ DO $$ BEGIN
 END $$;
 
 -- 4. Partial index for maintenance queries on historical articles
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_articles_historical
+CREATE INDEX IF NOT EXISTS idx_articles_historical
 ON legislation_articles (legislation_id, version_date)
 WHERE is_current = false;


### PR DESCRIPTION
## Summary
- Remove `CONCURRENTLY` from two `CREATE INDEX` statements in migration 160
- `CREATE INDEX CONCURRENTLY` cannot run inside a transaction block, causing CI failure

## Test plan
- [x] CI should pass (migrate-local no longer errors on transaction block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed CONCURRENTLY from two CREATE INDEX statements in migration 160 so the migration can run inside a transaction block and stop failing CI. Updates `idx_articles_temporal_lookup` and `idx_articles_historical` to use standard CREATE INDEX, fixing the “cannot run inside a transaction block” error in migrate-local.

<sup>Written for commit bc696651e6535380941b98081e75a8f0b7e94e58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

