### PR TITLE
fix(search): cascade court instance filter SC→AC→FC instead of SC-only

### DIFF
--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -295,6 +295,34 @@ export function buildSupremeCourtWhereFilter(courtLevel: string): any[] {
   return [];
 }
 
+/** Court instance cascade order: SC → appellate → first instance */
+const INSTANCE_CASCADE = [
+  { level: 'SC', code: 1, label: 'Верховний Суд' },
+  { level: 'AC', code: 2, label: 'апеляційні суди' },
+  { level: 'FC', code: 3, label: 'суди першої інстанції' },
+] as const;
+
+/**
+ * Cascading court search: try SC first, if empty — appellate, if empty — first instance.
+ * Returns results + which instance level actually matched.
+ */
+export async function searchWithInstanceCascade(
+  searchFn: (whereFilters: any[]) => Promise<{ data: any[] }>,
+  baseWhereFilters: any[],
+): Promise<{ data: any[]; instanceLevel: string; instanceLabel: string }> {
+  for (const inst of INSTANCE_CASCADE) {
+    const filters = [
+      ...baseWhereFilters,
+      { field: 'instance_code', operator: '=', value: inst.code },
+    ];
+    const result = await searchFn(filters);
+    if (result.data.length > 0) {
+      return { data: result.data, instanceLevel: inst.level, instanceLabel: inst.label };
+    }
+  }
+  return { data: [], instanceLevel: 'none', instanceLabel: '' };
+}
+
 /**
  * Pick section types for answer based on intent classification.
  */

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -28,6 +28,7 @@ import {
   extractSnippets,
   buildSupremeCourtHints,
   buildSupremeCourtWhereFilter,
+  searchWithInstanceCascade,
   mapProcedureCodeToJusticeKind,
   extractCaseNumberFromText,
   safeParseJsonFromToolResult,
@@ -388,31 +389,37 @@ export class ProceduralTools extends BaseToolHandler {
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
 
-    // Build where-filters for SC instance and justice_kind
-    const whereFilters: any[] = [
-      ...buildSupremeCourtWhereFilter('SC'),
-    ];
+    const baseWhereFilters: any[] = [];
     const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
     if (justiceKind !== null) {
-      whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
+      baseWhereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
     }
 
-    const mk = (q: string) => ({
-      meta: { search: q },
-      where: whereFilters.length > 0 ? whereFilters : undefined,
-      limit,
-      offset: 0,
+    const timeParams = {
       ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
       ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
-    });
+    };
 
-    const [proResp, contraResp] = await Promise.all([
-      this.zoAdapter.searchCourtDecisions(mk(`${query} задовольн`)),
-      this.zoAdapter.searchCourtDecisions(mk(`${query} відмов`)),
+    const cascadeSearch = async (suffix: string) => {
+      return searchWithInstanceCascade(
+        async (filters) => {
+          const resp = await this.zoAdapter.searchCourtDecisions({
+            meta: { search: `${query} ${suffix}` },
+            where: filters.length > 0 ? filters : undefined,
+            limit,
+            offset: 0,
+            ...timeParams,
+          });
+          return this.zoAdapter.normalizeResponse(resp);
+        },
+        baseWhereFilters,
+      );
+    };
+
+    const [proResult, contraResult] = await Promise.all([
+      cascadeSearch('задовольн'),
+      cascadeSearch('відмов'),
     ]);
-
-    const proNorm = await this.zoAdapter.normalizeResponse(proResp);
-    const contraNorm = await this.zoAdapter.normalizeResponse(contraResp);
 
     const mapCase = (d: any) => {
       const courtName = extractCourtFromTitle(d?.title);
@@ -433,10 +440,12 @@ export class ProceduralTools extends BaseToolHandler {
       procedure_code: procedureCode,
       query,
       time_range: args.time_range,
-      pro: proNorm.data.slice(0, limit).map(mapCase),
-      contra: contraNorm.data.slice(0, limit).map(mapCase),
-      total_pro: proNorm.data.length,
-      total_contra: contraNorm.data.length,
+      court_level_pro: proResult.instanceLabel || undefined,
+      court_level_contra: contraResult.instanceLabel || undefined,
+      pro: proResult.data.slice(0, limit).map(mapCase),
+      contra: contraResult.data.slice(0, limit).map(mapCase),
+      total_pro: proResult.data.length,
+      total_contra: contraResult.data.length,
     };
     if (timeRangeParsed.warning) payload.warning = timeRangeParsed.warning;
 
@@ -463,28 +472,32 @@ export class ProceduralTools extends BaseToolHandler {
       ? extracted.searchQuery.trim()
       : (extractedTerms.length > 0 ? extractedTerms.join(' ') : factsText.slice(0, 180));
 
-    // Build where-filters for SC instance and justice_kind
-    const whereFilters: any[] = [
-      ...buildSupremeCourtWhereFilter('SC'),
-    ];
+    const baseWhereFilters: any[] = [];
     const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
     if (justiceKind !== null) {
-      whereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
+      baseWhereFilters.push({ field: 'justice_kind', operator: '=', value: justiceKind });
     }
 
-    const searchParams: any = {
-      meta: { search: query },
-      where: whereFilters.length > 0 ? whereFilters : undefined,
-      limit,
-      offset: 0,
+    const timeParams = {
       ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
       ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
     };
 
-    const resp = await this.zoAdapter.searchCourtDecisions(searchParams);
-    const norm = await this.zoAdapter.normalizeResponse(resp);
+    const cascadeResult = await searchWithInstanceCascade(
+      async (filters) => {
+        const resp = await this.zoAdapter.searchCourtDecisions({
+          meta: { search: query },
+          where: filters.length > 0 ? filters : undefined,
+          limit,
+          offset: 0,
+          ...timeParams,
+        });
+        return this.zoAdapter.normalizeResponse(resp);
+      },
+      baseWhereFilters,
+    );
 
-    const results = norm.data.slice(0, limit).map((d: any) => {
+    const results = cascadeResult.data.slice(0, limit).map((d: any) => {
       const fullText = typeof d?.full_text === 'string' ? d.full_text : '';
       const courtName = extractCourtFromTitle(d?.title);
       return {
@@ -501,6 +514,7 @@ export class ProceduralTools extends BaseToolHandler {
     const payload: any = {
       procedure_code: procedureCode,
       time_range: args.time_range,
+      court_level: cascadeResult.instanceLabel || undefined,
       extracted_search_terms: extractedTerms,
       search_query: query,
       results,


### PR DESCRIPTION
## Summary
- `find_similar_fact_pattern_cases` and `compare_practice_pro_contra` were hardcoded to search only Supreme Court decisions (`instance_code=1`), returning 0 results when no SC practice existed
- Added `searchWithInstanceCascade()` utility: SC → appellate → first instance
- Response includes `court_level` field so the LLM knows which court level was found

## Test plan
- [ ] Verify lower-court results returned when SC practice is absent
- [ ] Verify SC results still returned first when they exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes procedural case search by cascading court instance from Supreme Court to appellate to first instance, so results still appear when no SC decisions exist. Responses now include which court level matched.

- **Bug Fixes**
  - Added `searchWithInstanceCascade()` to try SC → AC → FC and return matched level.
  - Switched `find_similar_fact_pattern_cases` and `compare_practice_pro_contra` to the cascade; keeps time range and `justice_kind` filters; SC still preferred.
  - Payloads now include `court_level` (similar cases) and `court_level_pro`/`court_level_contra` (pro/con), with totals based on the matched level.

<sup>Written for commit aad6325d30f0acb5fd9aa8b352114229c3110fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

