### PR TITLE
chore: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,69 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest on `main` | Yes |
+| older releases | No |
+
+Only the latest production deployment is actively maintained with security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in SecondLayer, please report it responsibly.
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, please use one of the following channels:
+
+1. **GitHub Security Advisories** (preferred): [Report a vulnerability](https://github.com/overthelex/secondlayer/security/advisories/new)
+2. **Email**: security@legal.org.ua
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected components (backend, frontend, MCP servers, infrastructure)
+- Potential impact assessment
+- Any suggested fixes (optional)
+
+### Response timeline
+
+- **Acknowledgement**: within 48 hours
+- **Initial assessment**: within 5 business days
+- **Fix for critical issues**: as soon as possible, typically within 7 days
+- **Fix for non-critical issues**: within 30 days
+
+### What to expect
+
+- We will acknowledge receipt of your report promptly
+- We will keep you informed about the progress of the fix
+- We will credit you in the fix announcement (unless you prefer to remain anonymous)
+
+## Scope
+
+The following are in scope for security reports:
+
+- **legal.org.ua** and its subdomains
+- Backend MCP servers (mcp_backend, mcp_rada, mcp_openreyestr)
+- Frontend web application (lexwebapp)
+- Authentication and authorization flows (OAuth, OIDC, Diia, WebAuthn)
+- Payment processing (Monobank integration)
+- API endpoints and tool execution
+- Data storage and encryption (Vault, E2EE consultations)
+
+The following are out of scope:
+
+- Third-party services and APIs we consume (EDRSR, Rada API, data.gov.ua)
+- Issues requiring physical access to infrastructure
+- Social engineering attacks
+- Denial of service attacks
+
+## Security Practices
+
+- All user-facing authentication supports multi-factor (WebAuthn, Diia)
+- Consultations use end-to-end encryption
+- API access requires Bearer token or authenticated session
+- Production deployments use blue-green strategy with health checks
+- Dependencies are monitored via Dependabot


### PR DESCRIPTION
## Summary
- Adds `SECURITY.md` with vulnerability reporting instructions, response timelines, and scope definition
- Enables the GitHub Security Policy tab at `/security/policy`

## Test plan
- [ ] Verify https://github.com/overthelex/secondlayer/security/policy renders the policy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SECURITY.md with clear vulnerability reporting steps, response timelines, and in/out-of-scope definitions. This also enables the GitHub Security Policy tab and documents supported versions and key security practices.

<sup>Written for commit acf4b2ff756f8e2162218e1b9afc3a3afe1239fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

