### PR TITLE
fix(security): harden cadvisor, sanitize JWT from nginx logs

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1402,7 +1402,11 @@ services:
   cadvisor-prod:
     image: gcr.io/cadvisor/cadvisor:v0.55.1
     container_name: cadvisor-prod
-    privileged: true
+    privileged: false
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - no-new-privileges:true
     devices:
       - /dev/kmsg
     environment:

--- a/deployment/nginx/includes/preview-server-common.conf
+++ b/deployment/nginx/includes/preview-server-common.conf
@@ -13,7 +13,7 @@ add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsaf
 add_header X-Preview "true" always;
 
 # Logging
-access_log /var/log/nginx/preview.legal.org.ua-access.log;
+access_log /var/log/nginx/preview.legal.org.ua-access.log sanitized;
 error_log /var/log/nginx/preview.legal.org.ua-error.log;
 
 # Settings

--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -27,7 +27,7 @@ if ($request_uri ~ ^(.+)/$) {
 include /etc/nginx/includes/security-headers.conf;
 
 # Logging
-access_log /var/log/nginx/legal.org.ua-access.log;
+access_log /var/log/nginx/legal.org.ua-access.log sanitized;
 error_log /var/log/nginx/legal.org.ua-error.log;
 
 # Settings

--- a/deployment/nginx/prod.legal.org.ua.conf
+++ b/deployment/nginx/prod.legal.org.ua.conf
@@ -4,6 +4,15 @@
 # Hide nginx version in error pages and Server header
 server_tokens off;
 
+# Sanitize JWT tokens from access logs
+map $request_uri $sanitized_uri {
+    "~^(?<prefix>.*)token=[^&]+(?<suffix>.*)$"  "${prefix}token=[REDACTED]${suffix}";
+    default                                      $request_uri;
+}
+log_format sanitized '$remote_addr - $remote_user [$time_local] "$request_method $sanitized_uri $server_protocol" '
+                     '$status $body_bytes_sent "$http_referer" '
+                     '"$http_user_agent" "$http_x_forwarded_for"';
+
 # Rate limiting zones (must be in http context, before server blocks)
 # Use X-Forwarded-For from Cloudflare/ALB as real client IP
 limit_req_zone $binary_remote_addr zone=api_limit:10m rate=60r/s;


### PR DESCRIPTION
## Summary
- Remove `privileged: true` from cadvisor-prod, replace with `cap_add: SYS_PTRACE` + `no-new-privileges`
- Add `sanitized` log_format to nginx that redacts `?token=` query parameters, preventing JWT tokens from being written to access logs
- Applied to both prod and preview server configs

## Already applied on prod (not in this PR)
- **fail2ban**: fixed duplicate `[DEFAULT]` section in `jail.local`, service restarted and running
- **.env permissions**: `chmod 600` on all 6 `.env` files
- **claude-promo-notifier**: service + directory removed (had hardcoded Telegram bot token)
- **UFW PG 5438**: restricted from `Anywhere` to `10.88.0.0/24` (WG subnet only)

## Test plan
- [ ] Verify cadvisor-prod starts without privileged mode after deploy
- [ ] Verify nginx logs redact `token=` params: `grep "REDACTED" /var/log/nginx/legal.org.ua-access.log`
- [ ] Verify no JWT tokens appear in new log entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened `cadvisor-prod` by removing privileged mode, adding `SYS_PTRACE`, and enabling `no-new-privileges`. Sanitized `nginx` access logs to redact `?token=` JWTs via a new `sanitized` log_format, applied to both prod and preview servers.

<sup>Written for commit 47cdc48fa3cf3ad0101f61505b3f491496461418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

