### PR TITLE
fix(security): resolve 30 CodeQL code scanning alerts

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -416,7 +416,7 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       const diiaSessionParam = urlParams.get('diia_session');
 
       if (diiaSessionParam) {
-        if (diiaDeeplinkParam) {
+        if (diiaDeeplinkParam && /^https:\/\/diia\.app\//.test(diiaDeeplinkParam)) {
           setDiiaDeeplink(diiaDeeplinkParam);
         }
         setDiiaSessionId(diiaSessionParam);

--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -434,12 +434,10 @@ export class RadaLegislationAdapter {
       const endPos = i + 1 < points.length ? points[i + 1].startPos - 50 : sectionHtml.length;
       const pointHtml = sectionHtml.slice(point.startPos, endPos);
 
-      // Strip HTML tags for plain text
-      const fullText = pointHtml
-        .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '')
-        .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '')
-        .replace(/<em>[\s\S]*?<\/em>/g, '')
-        .replace(/<[^>]+>/g, ' ')
+      // Strip HTML tags for plain text using cheerio parser
+      const $point = cheerio.load(pointHtml, { xml: false });
+      $point('script, style, em').remove();
+      const fullText = $point.text()
         .replace(/\{[^}]*\}/g, '')
         .replace(/\s+/g, ' ')
         .trim();

--- a/mcp_backend/src/middleware/dual-auth.ts
+++ b/mcp_backend/src/middleware/dual-auth.ts
@@ -10,7 +10,7 @@ import { UserService, User } from '../services/user-service.js';
 import { ApiKeyService } from '../services/api-key-service.js';
 import { WebAuthnService } from '../services/webauthn-service.js';
 import { logger } from '../utils/logger.js';
-import { maskSensitive } from '../utils/sanitize-log.js';
+import { maskSensitive, sanitizeId } from '../utils/sanitize-log.js';
 
 const _jwtSecret = process.env.JWT_SECRET;
 if (!_jwtSecret) {
@@ -129,7 +129,7 @@ async function authenticateWithAPIKey(req: AuthenticatedRequest, apiKey: string)
       logger.debug('Phase 2 API key validation result', {
         keyPrefix: maskSensitive(apiKey, 8),
         found: keyInfo !== null,
-        userId: keyInfo?.userId,
+        userId: keyInfo?.userId ? sanitizeId(keyInfo.userId) : undefined,
       });
 
       if (keyInfo) {
@@ -154,9 +154,8 @@ async function authenticateWithAPIKey(req: AuthenticatedRequest, apiKey: string)
         req.authType = 'apikey';
 
         logger.debug('Phase 2 API key authentication successful', {
-          userId: user.id,
-          email: user.email,
-          keyId: keyInfo.id,
+          userId: sanitizeId(user.id),
+          keyId: sanitizeId(keyInfo.id),
           keyName: keyInfo.name,
         });
 
@@ -164,7 +163,7 @@ async function authenticateWithAPIKey(req: AuthenticatedRequest, apiKey: string)
       }
     } catch (error: any) {
       logger.error('Error validating Phase 2 API key', {
-        error: error.message,
+        errorMessage: String(error.message),
         keyPrefix: maskSensitive(apiKey, 8),
       });
       // Continue to check legacy keys
@@ -181,7 +180,6 @@ async function authenticateWithAPIKey(req: AuthenticatedRequest, apiKey: string)
   if (!keyMatch) {
     logger.warn('Invalid API key attempt (not found in Phase 2 or legacy keys)', {
       keyPrefix: maskSensitive(apiKey, 8),
-      validKeysCount: validKeys.length,
     });
     throw new Error('Invalid API key');
   }

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -319,14 +319,14 @@ export function createMCPSSERoutes(deps: {
           const jwtSecret = process.env.JWT_SECRET;
           if (!jwtSecret) throw new Error('JWT_SECRET not configured');
           const decoded = jwt.verify(token, jwtSecret, { algorithms: ['HS256'] }) as any;
-          userId = decoded.userId;
-          logger.debug('[MCP v1/sse] Authenticated with JWT', { userId });
+          userId = String(decoded.userId);
+          logger.debug('[MCP v1/sse] Authenticated with JWT', { userId: sanitizeId(userId) });
         } else {
           // Try OAuth access token first, then API key
           const oauthToken = await deps.oauthService.verifyAccessToken(token);
           if (oauthToken) {
-            userId = oauthToken.userId;
-            logger.debug('[MCP v1/sse] Authenticated with OAuth token', { userId: sanitizeId(userId || ''), clientId: sanitizeId(oauthToken.clientId) });
+            userId = String(oauthToken.userId);
+            logger.debug('[MCP v1/sse] Authenticated with OAuth token', { userId: sanitizeId(userId), clientId: sanitizeId(String(oauthToken.clientId)) });
           } else {
             // API key
             clientKey = token;

--- a/mcp_backend/src/scripts/reindex-user-docs.ts
+++ b/mcp_backend/src/scripts/reindex-user-docs.ts
@@ -104,7 +104,7 @@ async function main() {
     [USER_ID]
   );
 
-  console.log(`Found ${docs.length} documents with text for user ${USER_ID}`);
+  console.log(`Found ${docs.length} documents with text for reindexing`);
   if (DRY_RUN) {
     console.log('DRY_RUN — exiting');
     await pool.end();

--- a/mcp_backend/src/scripts/seed-matter-data.ts
+++ b/mcp_backend/src/scripts/seed-matter-data.ts
@@ -29,7 +29,7 @@ async function seedMatterData() {
       throw new Error(`Test user ${TEST_EMAIL} not found. Run seed-test-account first.`);
     }
     const userId = userResult.rows[0].id;
-    logger.info(`Using test user: ${maskSensitive(TEST_EMAIL, 4)} (${sanitizeId(userId.substring(0, 8))}...)`);
+    logger.info('Using test user', { userId: sanitizeId(userId) });
 
     // Get or create organization
     let orgId: string;
@@ -350,7 +350,7 @@ async function seedMatterData() {
     logger.info(`  Legal holds: 2`);
 
   } catch (error: any) {
-    logger.error('Matter seed failed:', { message: sanitizeId(error.message) });
+    logger.error('Matter seed failed:', { message: String(error.message).substring(0, 100) });
     throw error;
   } finally {
     await db.close();
@@ -396,6 +396,6 @@ const isCleanup = process.argv.includes('--cleanup');
     process.exit(0);
   })
   .catch((error) => {
-    logger.error('Fatal error:', { message: sanitizeId(error.message) });
+    logger.error('Fatal error:', { message: String(error.message).substring(0, 100) });
     process.exit(1);
   });

--- a/mcp_backend/src/scripts/seed-test-account.ts
+++ b/mcp_backend/src/scripts/seed-test-account.ts
@@ -41,7 +41,7 @@ async function cleanupTestAccount() {
     }
 
     const userId = existingUser.rows[0].id;
-    logger.info(`Found test user: ${maskSensitive(TEST_USER.email, 4)} (ID: ${sanitizeId(userId.substring(0, 8))}...)`);
+    logger.info('Found test user', { userId: sanitizeId(userId) });
 
     // Must drop immutability rules to allow FK cascade
     await db.query(`
@@ -120,7 +120,7 @@ async function seedTestAccount() {
 
     if (existingUser.rows.length > 0) {
       userId = existingUser.rows[0].id;
-      logger.info(`Test user already exists: ${maskSensitive(TEST_USER.email, 4)} (ID: ${sanitizeId(userId.substring(0, 8))}...)`);
+      logger.info('Test user already exists', { userId: sanitizeId(userId) });
     } else {
       // Create test user
       const userResult = await db.query(
@@ -131,7 +131,7 @@ async function seedTestAccount() {
       );
 
       userId = userResult.rows[0].id;
-      logger.info(`Created test user: ${maskSensitive(TEST_USER.email, 4)} (ID: ${sanitizeId(userId.substring(0, 8))}...)`);
+      logger.info('Created test user', { userId: sanitizeId(userId) });
     }
 
     // 2. Check if billing record exists
@@ -261,13 +261,13 @@ async function seedTestAccount() {
     );
 
     const billing = finalBilling.rows[0];
-    logger.info('\nTest Account Summary:');
-    logger.info(`   Email: ${maskSensitive(TEST_USER.email, 4)}`);
-    logger.info(`   User ID: ${sanitizeId(userId.substring(0, 8))}...`);
-    logger.info(`   Balance: $${billing.balance_usd} USD`);
-    logger.info(`   Transactions: ${transactions.length}`);
-    logger.info(`   Payment Intents: ${paymentIntents.length}`);
-    logger.info('\nTest account seed completed successfully!');
+    logger.info('Test Account Summary:', {
+      userId: sanitizeId(userId),
+      balanceUsd: billing.balance_usd,
+      transactions: transactions.length,
+      paymentIntents: paymentIntents.length,
+    });
+    logger.info('Test account seed completed successfully!');
   } catch (error: any) {
     logger.error('Error seeding test account:', error);
     throw error;

--- a/mcp_backend/src/scripts/test-email.ts
+++ b/mcp_backend/src/scripts/test-email.ts
@@ -10,11 +10,8 @@ import { maskSensitive } from '../utils/sanitize-log.js';
 async function testEmail(recipientEmail?: string) {
   const recipient = recipientEmail || process.env.TEST_ACCOUNT_EMAIL || 'test@legal.org.ua';
 
-  logger.info('🧪 Testing email service...');
-  logger.info(`📧 Recipient: ${maskSensitive(recipient, 4)}`);
-  logger.info(`📮 SMTP Host: ${process.env.SMTP_HOST || 'not configured'}`);
-  logger.info(`🔌 SMTP Port: ${process.env.SMTP_PORT || 'not configured'}`);
-  logger.info(`👤 SMTP User: ${process.env.SMTP_USER || 'not configured'}`);
+  logger.info('Testing email service...');
+  logger.info('SMTP configured: ' + (process.env.SMTP_HOST ? 'yes' : 'no'));
 
   const emailService = new EmailService();
 
@@ -58,14 +55,7 @@ async function testEmail(recipientEmail?: string) {
     });
     logger.info('✅ Low balance alert sent!');
 
-    logger.info('\n✅ All test emails sent successfully!');
-    logger.info(`\n📬 Check your inbox at: ${maskSensitive(recipient, 4)}`);
-    logger.info('💡 If you don\'t see the emails, check your spam folder.');
-    logger.info('\n📧 Email Configuration:');
-    logger.info(`   From: ${process.env.EMAIL_FROM || 'billing@legal.org.ua'}`);
-    logger.info(`   Host: ${process.env.SMTP_HOST}:${process.env.SMTP_PORT}`);
-    logger.info(`   Secure: ${process.env.SMTP_SECURE || 'false'}`);
-    logger.info(`   User: ${process.env.SMTP_USER}`);
+    logger.info('All test emails sent successfully!');
 
   } catch (error: any) {
     logger.error('\n❌ Email test failed!');

--- a/mcp_backend/src/services/api-key-service.ts
+++ b/mcp_backend/src/services/api-key-service.ts
@@ -63,9 +63,7 @@ export class ApiKeyService {
       );
 
       if (result.rows.length === 0) {
-        logger.debug('[ApiKeyService] API key not found or inactive', {
-          keyPrefix: maskSensitive(apiKey, 8),
-        });
+        logger.debug('[ApiKeyService] API key not found or inactive');
         return null;
       }
 

--- a/mcp_backend/src/services/cost-tracker.ts
+++ b/mcp_backend/src/services/cost-tracker.ts
@@ -52,11 +52,9 @@ export class CostTracker extends BaseCostTracker {
       ]
     );
 
-    const maskedKey = params.clientKey ? maskSensitive(params.clientKey, 8) : 'none';
     logger.debug('Cost tracking record created', {
       requestId: params.requestId,
       userId: sanitizeId(params.userId || ''),
-      clientKeyPrefix: maskedKey,
     });
   }
 

--- a/mcp_backend/src/services/email-service.ts
+++ b/mcp_backend/src/services/email-service.ts
@@ -248,15 +248,13 @@ export class EmailService {
       });
 
       logger.info('Payment success email sent', {
-        email: maskSensitive(params.email, 4),
         amount: params.amount,
         currency: params.currency,
         hasReferralData: !!referralData,
       });
     } catch (error: any) {
       logger.error('Failed to send payment success email', {
-        email: maskSensitive(params.email, 4),
-        error: error.message,
+        errorMessage: String(error.message).substring(0, 100),
       });
     }
   }
@@ -293,14 +291,12 @@ export class EmailService {
       });
 
       logger.info('Admin credit email sent', {
-        email: maskSensitive(params.email, 4),
         amount: params.amount,
         currency: params.currency,
       });
     } catch (error: any) {
       logger.error('Failed to send admin credit email', {
-        email: maskSensitive(params.email, 4),
-        error: error.message,
+        errorMessage: String(error.message).substring(0, 100),
       });
     }
   }
@@ -329,14 +325,12 @@ export class EmailService {
       });
 
       logger.info('Payment failure email sent', {
-        email: maskSensitive(params.email, 4),
         amount: params.amount,
         currency: params.currency,
       });
     } catch (error: any) {
       logger.error('Failed to send payment failure email', {
-        email: maskSensitive(params.email, 4),
-        error: error.message,
+        errorMessage: String(error.message).substring(0, 100),
       });
     }
   }
@@ -374,14 +368,12 @@ export class EmailService {
       });
 
       logger.info('Low balance alert sent', {
-        email: maskSensitive(params.email, 4),
         balance: params.balance,
         currency: params.currency,
       });
     } catch (error: any) {
       logger.error('Failed to send low balance alert', {
-        email: maskSensitive(params.email, 4),
-        error: error.message,
+        errorMessage: String(error.message).substring(0, 100),
       });
     }
   }


### PR DESCRIPTION
## Summary
- **HTML sanitization** (3 alerts): replaced regex-based HTML tag stripping with cheerio parser in `rada-legislation-adapter.ts` — eliminates `js/bad-tag-filter` and `js/incomplete-multi-character-sanitization`
- **Client-side URL redirect** (1 alert): validate `diiaDeeplink` against `https://diia.app/` origin before rendering as `href` in LoginPage
- **Clear-text logging** (26 alerts): remove or sanitize sensitive data (emails, API keys, env vars, error messages) from log statements across 8 files: `dual-auth`, `mcp-sse-routes`, `email-service`, `cost-tracker`, `api-key-service`, `test-email`, `seed-matter-data`, `seed-test-account`, `reindex-user-docs`

## Test plan
- [ ] CI passes (TypeScript build + tests)
- [ ] CodeQL re-scan shows 0 open alerts
- [ ] Login page Diia deeplink still works
- [ ] Payment email notifications still send

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 30 CodeQL security alerts by hardening HTML sanitization, validating login deeplinks, and removing sensitive data from logs. Lowers XSS/open-redirect risk and prevents secret leakage.

- **Bug Fixes**
  - Replace regex-based HTML stripping with `cheerio` parsing in the Rada legislation adapter; removes unsafe tag handling flagged by CodeQL.
  - Validate `diiaDeeplink` against the https://diia.app/ origin before rendering in LoginPage.
  - Remove sensitive data from logs; sanitize IDs and truncate error messages across auth, SSE, email, cost, API key services, and seed scripts (using `sanitizeId`/`maskSensitive`).

<sup>Written for commit 38acd95a3729493e0df06a9be73f972a1dad5b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

