### PR TITLE
fix(security): resolve remaining 9 CodeQL alerts

### DIFF
--- a/lexwebapp/src/pages/LoginPage/index.tsx
+++ b/lexwebapp/src/pages/LoginPage/index.tsx
@@ -416,8 +416,13 @@ export function LoginPage({ onLoginSuccess }: LoginPageProps) {
       const diiaSessionParam = urlParams.get('diia_session');
 
       if (diiaSessionParam) {
-        if (diiaDeeplinkParam && /^https:\/\/diia\.app\//.test(diiaDeeplinkParam)) {
-          setDiiaDeeplink(diiaDeeplinkParam);
+        if (diiaDeeplinkParam) {
+          try {
+            const parsed = new URL(diiaDeeplinkParam);
+            if (parsed.origin === 'https://diia.app') {
+              setDiiaDeeplink(parsed.href);
+            }
+          } catch { /* invalid URL, ignore */ }
         }
         setDiiaSessionId(diiaSessionParam);
         window.history.replaceState({}, '', window.location.pathname);

--- a/mcp_backend/src/middleware/dual-auth.ts
+++ b/mcp_backend/src/middleware/dual-auth.ts
@@ -163,8 +163,7 @@ async function authenticateWithAPIKey(req: AuthenticatedRequest, apiKey: string)
       }
     } catch (error: any) {
       logger.error('Error validating Phase 2 API key', {
-        errorMessage: String(error.message),
-        keyPrefix: maskSensitive(apiKey, 8),
+        errorMessage: String(error.message).substring(0, 100),
       });
       // Continue to check legacy keys
     }

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -326,7 +326,7 @@ export function createMCPSSERoutes(deps: {
           const oauthToken = await deps.oauthService.verifyAccessToken(token);
           if (oauthToken) {
             userId = String(oauthToken.userId);
-            logger.debug('[MCP v1/sse] Authenticated with OAuth token', { userId: sanitizeId(userId), clientId: sanitizeId(String(oauthToken.clientId)) });
+            logger.debug('[MCP v1/sse] Authenticated with OAuth token');
           } else {
             // API key
             clientKey = token;
@@ -380,6 +380,8 @@ export function createMCPSSERoutes(deps: {
         });
       }
 
+      const safeUserId = sanitizeId(userId || 'anonymous');
+
       // Create MCP Server instance for this connection
       const mcpServer = new Server(
         {
@@ -410,7 +412,7 @@ export function createMCPSSERoutes(deps: {
         try {
           logger.info('[MCP v1/sse] Tool call', {
             tool: toolName,
-            userId: sanitizeId(userId || 'anonymous'),
+            userId: safeUserId,
           });
 
           // Phase 2 Billing: Check credits BEFORE execution
@@ -422,7 +424,7 @@ export function createMCPSSERoutes(deps: {
 
               if (!balance.hasCredits) {
                 logger.warn('[MCP v1/sse] Insufficient credits', {
-                  userId: sanitizeId(userId),
+                  userId: safeUserId,
                   tool: toolName,
                   creditsRequired,
                 });
@@ -490,10 +492,9 @@ export function createMCPSSERoutes(deps: {
 
               if (deduction.success) {
                 logger.info('[MCP v1/sse] Credits deducted', {
-                  userId: sanitizeId(userId),
+                  userId: safeUserId,
                   tool: toolName,
                   creditsDeducted: creditsRequired,
-                  newBalance: deduction.newBalance,
                 });
               }
             }

--- a/mcp_backend/src/scripts/seed-matter-data.ts
+++ b/mcp_backend/src/scripts/seed-matter-data.ts
@@ -350,7 +350,7 @@ async function seedMatterData() {
     logger.info(`  Legal holds: 2`);
 
   } catch (error: any) {
-    logger.error('Matter seed failed:', { message: String(error.message).substring(0, 100) });
+    logger.error('Matter seed failed');
     throw error;
   } finally {
     await db.close();
@@ -396,6 +396,6 @@ const isCleanup = process.argv.includes('--cleanup');
     process.exit(0);
   })
   .catch((error) => {
-    logger.error('Fatal error:', { message: String(error.message).substring(0, 100) });
+    logger.error('Fatal error');
     process.exit(1);
   });

--- a/mcp_backend/src/services/cost-tracker.ts
+++ b/mcp_backend/src/services/cost-tracker.ts
@@ -54,7 +54,6 @@ export class CostTracker extends BaseCostTracker {
 
     logger.debug('Cost tracking record created', {
       requestId: params.requestId,
-      userId: sanitizeId(params.userId || ''),
     });
   }
 


### PR DESCRIPTION
## Summary
- **URL redirect** (#308): replace regex with `URL()` constructor + origin check to fully break CodeQL taint chain for Diia deeplink
- **mcp-sse-routes** (#287, #288, #289, #312): introduce `safeUserId` computed once after auth, used in all subsequent logs — breaks taint from `oauthToken`
- **dual-auth** (#315): remove `apiKey` param from error log
- **cost-tracker** (#301): remove tainted `userId` from debug log
- **seed-matter-data** (#313, #314): remove `error.message` from logs (tainted via `process.env` in throw path)

## Test plan
- [ ] CI passes
- [ ] CodeQL re-scan shows 0 open alerts
- [ ] Diia login deeplink still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the remaining 9 CodeQL security alerts by hardening URL validation and removing tainted data from logs. Improves deeplink safety and breaks taint flows across auth, SSE, seeding, and cost tracking.

- **Bug Fixes**
  - Deeplink redirect: use `URL()` with origin check for `https://diia.app` and ignore invalid URLs.
  - SSE routes: compute `safeUserId` once after auth; stop logging raw `userId`, `newBalance`, and OAuth debug context.
  - Dual auth: remove API key from logs; cap `errorMessage` to 100 chars.
  - Cost tracker: remove `userId` from debug logs.
  - Seed script: stop logging `error.message`; log generic errors instead.

<sup>Written for commit 25ca0156a3c39e4ab21a6b31a8a26dac7460b645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

