### PR TITLE
fix(docker): eliminate slow chown -R with COPY --chown

### DIFF
--- a/deployment/Dockerfile.mono-backend
+++ b/deployment/Dockerfile.mono-backend
@@ -90,22 +90,21 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 \
     PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
-COPY --from=builder /app/mcp_backend/package.json ./package.json
-COPY --from=builder /app/mcp_backend/package-lock.json* ./
-COPY --from=builder /app/mcp_backend/node_modules ./node_modules
-COPY --from=builder /app/mcp_backend/dist ./dist
-COPY --from=builder /app/mcp_backend/scripts ./scripts
-COPY --from=builder /app/mcp_backend/assets ./assets
-COPY --from=builder /app/mcp_backend/src/migrations ./src/migrations
-
 RUN apk add --no-cache su-exec && \
-    mkdir -p /app/data /app/data/uploads /app/data/uploads/multer-tmp && \
     addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001 && \
-    chown -R nodejs:nodejs /app
+    mkdir -p /app/data /app/data/uploads /app/data/uploads/multer-tmp && \
+    chown -R nodejs:nodejs /app/data
 
-COPY deployment/scripts/backend-entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/package.json ./package.json
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/package-lock.json* ./
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/node_modules ./node_modules
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/dist ./dist
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/scripts ./scripts
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/assets ./assets
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_backend/src/migrations ./src/migrations
+
+COPY --chmod=755 deployment/scripts/backend-entrypoint.sh /usr/local/bin/entrypoint.sh
 
 EXPOSE 3000
 

--- a/deployment/Dockerfile.mono-openreyestr
+++ b/deployment/Dockerfile.mono-openreyestr
@@ -55,17 +55,15 @@ RUN apk add --no-cache tzdata
 ENV TZ=Europe/Kiev
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-COPY --from=builder /app/mcp_openreyestr/package.json ./package.json
-COPY --from=builder /app/mcp_openreyestr/package-lock.json* ./
-COPY --from=builder /app/mcp_openreyestr/node_modules ./node_modules
-COPY --from=builder /app/mcp_openreyestr/dist ./dist
-COPY --from=builder /app/mcp_openreyestr/src/migrations ./src/migrations
-COPY --from=builder /app/mcp_openreyestr/src/migrations/*.sql ./dist/migrations/
-
-# Create non-root user
 RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nodejs -u 1001 && \
-    chown -R nodejs:nodejs /app
+    adduser -S nodejs -u 1001
+
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_openreyestr/package.json ./package.json
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_openreyestr/package-lock.json* ./
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_openreyestr/node_modules ./node_modules
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_openreyestr/dist ./dist
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_openreyestr/src/migrations ./src/migrations
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_openreyestr/src/migrations/*.sql ./dist/migrations/
 
 USER nodejs
 

--- a/deployment/Dockerfile.mono-rada
+++ b/deployment/Dockerfile.mono-rada
@@ -55,16 +55,15 @@ RUN apk add --no-cache tzdata
 ENV TZ=Europe/Kiev
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-COPY --from=builder /app/mcp_rada/package.json ./package.json
-COPY --from=builder /app/mcp_rada/package-lock.json* ./
-COPY --from=builder /app/mcp_rada/node_modules ./node_modules
-COPY --from=builder /app/mcp_rada/dist ./dist
-COPY --from=builder /app/mcp_rada/scripts ./scripts
-COPY --from=builder /app/mcp_rada/src/migrations ./src/migrations
-
 RUN addgroup -g 1001 -S nodejs && \
-    adduser -S nodejs -u 1001 && \
-    chown -R nodejs:nodejs /app
+    adduser -S nodejs -u 1001
+
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_rada/package.json ./package.json
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_rada/package-lock.json* ./
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_rada/node_modules ./node_modules
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_rada/dist ./dist
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_rada/scripts ./scripts
+COPY --from=builder --chown=nodejs:nodejs /app/mcp_rada/src/migrations ./src/migrations
 
 USER nodejs
 


### PR DESCRIPTION
## Summary
- Replace `chown -R nodejs:nodejs /app` with `COPY --chown=nodejs:nodejs` in all 3 backend Dockerfiles
- Move user/group creation before COPY instructions so `--chown` can reference the user
- Backend: `chown -R` only on empty `/app/data` dir (for runtime uploads), not entire `/app`

## Why
`chown -R /app` recursively walks every file in node_modules + dist after copy, causing CI/CD builds to hang for minutes on this step. `COPY --chown` sets ownership during the copy layer itself with zero overhead.

## Affected files
- `deployment/Dockerfile.mono-backend`
- `deployment/Dockerfile.mono-rada`
- `deployment/Dockerfile.mono-openreyestr`

## Test plan
- [ ] CI/CD build passes for all 3 services
- [ ] Containers start and health checks pass
- [ ] Files inside containers owned by nodejs:nodejs (verify with `docker exec <c> ls -la /app/mcp_backend/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up backend Docker builds by switching from recursive chown to COPY --chown, removing the long post-copy ownership step.

- **Refactors**
  - Create node user/group before COPY and use --chown=nodejs:nodejs on all COPY --from=builder layers.
  - Only chown /app/data (runtime uploads), not the entire /app.
  - Set entrypoint permissions with COPY --chmod=755.

<sup>Written for commit 38438aebcb6166a1714a58807c380d483ce2babb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

