### PR TITLE
fix(legislation): cap score>0.6 results at 15 to prevent maxToolCalls exhaustion

### DIFF
--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -1094,8 +1094,8 @@ export class LegislationService {
         }
       }
 
-      // Return all rows above MIN_SCORE threshold, not limited by caller's limit
-      const result = { rows: allRows };
+      // Return all rows above MIN_SCORE threshold, capped at 15 to avoid maxToolCalls exhaustion
+      const result = { rows: allRows.slice(0, 15) };
 
       return result.rows.map((row: any) => ({
         rada_id: row.rada_id,


### PR DESCRIPTION
## Summary
- Score > 0.6 threshold returned too many results → LLM called get_court_decision for each → exhausted maxToolCalls=12 → timeout
- Cap at 15 results keeps пп. 38.6 (score 0.713) and 69.14 (0.68) while preventing budget exhaustion

## Test plan
- [ ] No timeout on tax/occupation query
- [ ] пп. 38.6 and 69.14 still found via vector search

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap legislation search results with score > 0.6 to 15 to prevent exhausting the `maxToolCalls` budget and avoid timeouts. Keeps high-scoring items while reducing `get_court_decision` calls on tax/occupation queries.

<sup>Written for commit 1889fceb6719603f0fa4e40c9f6b0533955f4159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

