### PR TITLE
chore: trigger core overlay for maxToolCalls 16/30

### DIFF
--- a/mcp_backend/src/services/chat-constants.ts
+++ b/mcp_backend/src/services/chat-constants.ts
@@ -3,7 +3,7 @@
 // Includes transitional provisions search rule
 
 export const CHAT_CONSTANTS = {
-  MAX_TOOL_CALLS: 12,
+  MAX_TOOL_CALLS: 16,
   MAX_CONTEXT_CHARS: 100000,
   MAX_RESULT_CHARS: 50000,
   DEFAULT_BUDGET: 'standard' as const,


### PR DESCRIPTION
Trigger CI to pull latest secondlayer-core with maxToolCalls: standard 12→16, deep 20→30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased `MAX_TOOL_CALLS` from 12 to 16 for standard chats to align with the latest `secondlayer-core` overlay. This allows more tool calls per session; the deep budget (30) is handled in core with no app changes here.

<sup>Written for commit 1be4c821b1062cfe135aa0cda9ae7b81bf5f05a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

