### PR TITLE
chore: trigger core overlay for sectionizer spaced markers fix

### DIFF
--- a/mcp_backend/src/services/semantic-sectionizer.ts
+++ b/mcp_backend/src/services/semantic-sectionizer.ts
@@ -10,3 +10,4 @@ export class SemanticSectionizer {
     return [];
   }
 }
+// spaced markers fix


### PR DESCRIPTION
Trigger CI for secondlayer-core#17 — normalize spaced court markers in sectionizer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Triggers the overlay build to include the `secondlayer-core` fix that normalizes spaced court markers in the sectionizer. No functional changes; the edit only forces CI to run.

<sup>Written for commit 53802eebf41006254edba9ade2e3e57121f03cd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

