### PR TITLE
fix(search): compare_practice_pro_contra returns empty due to FTS over-restriction

### DIFF
--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -428,7 +428,7 @@ export class ProceduralTools extends BaseToolHandler {
         { code: 3, label: 'суди першої інстанції' },
       ] as const) {
         const resp = await this.ftsService.searchFulltext(
-          `${trimFtsQuery(query)} ${suffix}`, this.db,
+          `${trimFtsQuery(query, 3)} ${suffix}`, this.db,
           { ...baseFilters, instance_code: inst.code }, limit,
         );
         if (resp.results.length > 0) {


### PR DESCRIPTION
## Summary
- `compare_practice_pro_contra` appends pro/contra suffixes ("задовольнити позов" / "відмовити у задоволенні позову") to a `trimFtsQuery(query)` with default maxWords=6
- `plainto_tsquery` ANDs all terms, so 6 + 2-3 suffix words = 8-9 AND terms — too restrictive, consistently returning 0 results
- Discovered via chat-57a69891: query about property tax on occupied territory got `{"pro": [], "contra": [], "total_pro": 0, "total_contra": 0}`
- Fix: trim main query to 3 words, keeping total AND terms at 5-6

## Test plan
- [ ] Run `compare_practice_pro_contra` with a multi-word legal query — should return non-empty pro/contra results
- [ ] Verify short queries (1-2 words) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed `compare_practice_pro_contra` returning empty results by trimming the main FTS query to 3 words before appending the pro/contra suffix. This reduces `plainto_tsquery` AND terms and avoids over-restriction, restoring relevant results.

<sup>Written for commit 9c5a50fd951ddc7e1411716467859b617e6ad950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

