### PR TITLE
feat(ui): unverified law article citation warnings

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -166,7 +166,8 @@ export function AssistantMessage({
           {citationWarnings && citationWarnings.length > 0 && (
             <div className="space-y-1.5 mt-4">
               {citationWarnings.map((warning, idx) => {
-                if (warning.kind === 'fabricated') {
+                if (warning.kind === 'fabricated' || warning.kind === 'unverified_articles') {
+                  const items = warning.kind === 'fabricated' ? warning.fabricated : warning.unverified;
                   return (
                     <motion.div
                       key={`cw-${idx}`}
@@ -180,7 +181,7 @@ export function AssistantMessage({
                           {warning.message}
                         </p>
                         <p className="text-[11px] text-amber-700/80 mt-1 font-mono">
-                          Не підтверджено пошуком: {warning.fabricated.join(', ')}
+                          Не підтверджено пошуком: {items.join(', ')}
                         </p>
                       </div>
                     </motion.div>

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -326,13 +326,15 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
           const normalized: import('../../types/models/Message').CitationWarning =
             data.reason === 'fabricated_case_numbers'
               ? { kind: 'fabricated', fabricated: data.fabricated, message: data.message }
-              : {
-                  kind: 'overruled',
-                  case_number: data.case_number,
-                  status: data.status,
-                  confidence: data.confidence,
-                  message: data.message,
-                };
+              : data.reason === 'unverified_law_articles'
+                ? { kind: 'unverified_articles', unverified: data.unverified, message: data.message }
+                : {
+                    kind: 'overruled',
+                    case_number: data.case_number,
+                    status: data.status,
+                    confidence: data.confidence,
+                    message: data.message,
+                  };
           updateMessage(assistantMessageId, {
             citationWarnings: [...existing, normalized],
           });

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -25,6 +25,11 @@ export type CitationWarning =
       reason: 'fabricated_case_numbers';
       fabricated: string[];
       message: string;
+    }
+  | {
+      reason: 'unverified_law_articles';
+      unverified: string[];
+      message: string;
     };
 
 import type { Decision, Citation, VaultDocument } from '../../types/models/Message';

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -22,6 +22,11 @@ export type CitationWarning =
       kind: 'fabricated';
       fabricated: string[];
       message: string;
+    }
+  | {
+      kind: 'unverified_articles';
+      unverified: string[];
+      message: string;
     };
 
 export interface CostSummary {


### PR DESCRIPTION
## Summary
- New `CitationWarning` variant: `kind: 'unverified_articles'` with `unverified: string[]`
- SSE normalization maps `reason: 'unverified_law_articles'` → new variant
- Renders same amber warning as fabricated case numbers (reuses existing component)
- Companion to secondlayer-core#19

## Test plan
- [ ] Trigger a chat with legislation — verify no warnings for valid articles
- [ ] Verify amber warning renders when backend flags unverified articles
- [ ] TypeScript builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show amber warnings for unverified law article citations flagged by the backend, reusing the existing fabricated-citation UI. Adds a new `CitationWarning` variant and SSE normalization to support the `secondlayer-core` hallucination guard.

- **New Features**
  - Add `unverified_articles` to `Message.CitationWarning` and extend `MCPService` to accept `reason: 'unverified_law_articles'`.
  - Normalize SSE `reason: 'unverified_law_articles'` to the new variant in `useAIChatStream`.
  - Update `AssistantMessage` to render the same amber warning for unverified articles, listing the unverified items.

<sup>Written for commit 10c76067db0fa1f16227a2fc5568e264c774c4bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

