### PR TITLE
fix(legislation): get_legislation_history 11 MB → 3 KB via grouped summary

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -670,6 +670,9 @@ export class LegislationTools extends BaseToolHandler {
 - Знайти які постанови/закони вносили зміни до акту
 - Проаналізувати еволюцію правового регулювання
 
+Без article_number повертає загальну статистику змін (згруповано по статтях).
+З article_number повертає повну історію конкретної статті.
+
 💰 Вартість: $0.00 (тільки PostgreSQL запит)`,
         inputSchema: {
           type: 'object',
@@ -678,6 +681,10 @@ export class LegislationTools extends BaseToolHandler {
               type: 'string',
               description: 'ID законодавчого акту на zakon.rada.gov.ua (наприклад, "1388-98-п" для Постанови КМУ №1388, "435-15" для ЦК)',
             },
+            article_number: {
+              type: 'string',
+              description: 'Номер статті для детальної історії (наприклад, "266"). Без цього параметра повертає загальну статистику змін.',
+            },
           },
           required: ['rada_id'],
         },
@@ -685,7 +692,7 @@ export class LegislationTools extends BaseToolHandler {
     ];
   }
 
-  async getLegislationHistory(args: { rada_id: string }): Promise<any> {
+  async getLegislationHistory(args: { rada_id: string; article_number?: string }): Promise<any> {
     if (!args.rada_id) {
       throw new Error('rada_id is required');
     }
@@ -708,15 +715,32 @@ export class LegislationTools extends BaseToolHandler {
       }
     }
 
-    logger.info('[MCP Tool] get_legislation_history started', { rada_id: radaId });
+    const articleFilter = args.article_number?.trim() || null;
+    logger.info('[MCP Tool] get_legislation_history started', { rada_id: radaId, article_number: articleFilter });
 
-    // Get amendment history (non-current article versions)
-    const history = await this.service.getAmendmentHistory(radaId);
-
-    // Also get current legislation metadata
     const structure = await this.service.getLegislationStructure(radaId);
 
-    if (!structure && history.length === 0) {
+    if (articleFilter) {
+      // Detailed history for a specific article
+      const history = await this.service.getAmendmentHistory(radaId);
+      const filtered = history.filter(h => h.article_number === articleFilter);
+      return {
+        rada_id: radaId,
+        title: structure?.title || null,
+        article_number: articleFilter,
+        url: `https://zakon.rada.gov.ua/laws/show/${radaId}`,
+        total_versions: filtered.length,
+        versions: filtered,
+        note: filtered.length === 0
+          ? `Попередні редакції статті ${articleFilter} не знайдені в базі`
+          : undefined,
+      };
+    }
+
+    // Summary mode: grouped stats instead of 70K raw rows
+    const summary = await this.service.getAmendmentSummary(radaId);
+
+    if (!structure && summary.length === 0) {
       return {
         rada_id: radaId,
         error: `Законодавчий акт ${radaId} не знайдено в базі даних`,
@@ -725,18 +749,20 @@ export class LegislationTools extends BaseToolHandler {
       };
     }
 
+    const totalAmendments = summary.reduce((s, r) => s + r.version_count, 0);
+
     return {
       rada_id: radaId,
       title: structure?.title || null,
       type: structure?.type || null,
       total_current_articles: structure?.total_articles || null,
       url: `https://zakon.rada.gov.ua/laws/show/${radaId}`,
-      amendment_history: history,
-      total_amendments: history.length,
-      amended_articles: [...new Set(history.map(h => h.article_number))],
-      note: history.length === 0
-        ? 'Історія змін порожня — можливо акт ще не був змінений або попередні редакції не збережено в базі. Перевірте актуальний текст на zakon.rada.gov.ua'
-        : undefined,
+      total_amendments: totalAmendments,
+      total_amended_articles: summary.length,
+      most_amended_articles: summary.slice(0, 30),
+      note: summary.length === 0
+        ? 'Історія змін порожня — можливо акт ще не був змінений або попередні редакції не збережено в базі'
+        : 'Для детальної історії конкретної статті вкажіть article_number',
     };
   }
 

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -718,6 +718,32 @@ export class LegislationService {
     }));
   }
 
+  async getAmendmentSummary(radaId: string): Promise<Array<{
+    article_number: string;
+    version_count: number;
+    earliest_version: string | null;
+    latest_version: string | null;
+  }>> {
+    const result = await this.db.query(
+      `SELECT la.article_number,
+              COUNT(*)::int as version_count,
+              MIN(la.metadata->>'version_date') as earliest_version,
+              MAX(la.metadata->>'version_date') as latest_version
+       FROM legislation_articles la
+       JOIN legislation l ON la.legislation_id = l.id
+       WHERE LOWER(l.rada_id) = LOWER($1) AND la.is_current = false
+       GROUP BY la.article_number
+       ORDER BY COUNT(*) DESC`,
+      [radaId]
+    );
+    return result.rows.map((row: any) => ({
+      article_number: row.article_number,
+      version_count: row.version_count,
+      earliest_version: row.earliest_version,
+      latest_version: row.latest_version,
+    }));
+  }
+
   async searchLegislation(query: string, radaId?: string, limit: number = 10): Promise<LegislationSearchResult[]> {
     if (radaId) {
       await this.ensureLegislationExists(radaId);


### PR DESCRIPTION
## Summary
- `get_legislation_history` for ПКУ (2755-17) returned **70K raw rows = 11 MB** — context bomb
- Now returns grouped summary: top 30 most-amended articles with version counts + date ranges (~3 KB)
- New optional `article_number` param: get full version history for one article only
- Discovered via chat-a19212d8 analysis — tool call #21 returned 11 MB

## Before/After
```
Before: get_legislation_history({rada_id: "2755-17"})
→ 70K rows, 11 MB, all amendment versions for all 359 articles

After (no filter): get_legislation_history({rada_id: "2755-17"})
→ 30 rows, ~3 KB, most-amended articles with stats

After (with filter): get_legislation_history({rada_id: "2755-17", article_number: "266"})
→ Full version history for article 266 only
```

## Test plan
- [ ] Call get_legislation_history for ПКУ without article_number — verify ~3 KB response
- [ ] Call with article_number: "266" — verify full history returned
- [ ] Call for law with no amendments — verify proper note message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce `get_legislation_history` payloads by returning a grouped summary by default and add an `article_number` option for per-article detail. For ПКУ (2755-17), responses drop from ~11 MB to ~3 KB.

- **New Features**
  - Default summary mode: returns top 30 most-amended articles with version counts and earliest/latest dates.
  - Optional `article_number`: returns full version history for that one article.
  - Adds `getAmendmentSummary` query in the service.

- **Migration**
  - The default response no longer includes raw `amendment_history`. Use `most_amended_articles`, `total_amendments`, and `total_amended_articles`.
  - To fetch full versions, pass `article_number` (e.g., `"266"`) to receive detailed history for that article only.

<sup>Written for commit 1abd53171744437c8a9b752d1301f9dc111c9995. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

