### PR TITLE
fix(search): cap legislation text 2KB + empty FTS hint

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -25,6 +25,14 @@ interface SearchDedup {
   ts: number;
 }
 
+const MAX_ARTICLE_TEXT_CHARS = 2000;
+
+function capText(text: string | undefined | null): string {
+  if (!text) return '';
+  if (text.length <= MAX_ARTICLE_TEXT_CHARS) return text;
+  return text.slice(0, MAX_ARTICLE_TEXT_CHARS) + '… [обрізано]';
+}
+
 export class LegislationTools extends BaseToolHandler {
   private service: LegislationService;
   private renderer: LegislationRenderer;
@@ -82,7 +90,7 @@ export class LegislationTools extends BaseToolHandler {
           articles: relevantArticles.map(a => ({
             article_number: a.article_number,
             title: a.title,
-            full_text: a.full_text,
+            full_text: capText(a.full_text),
             url: a.url,
             metadata: a.metadata,
           })),
@@ -145,7 +153,7 @@ export class LegislationTools extends BaseToolHandler {
       rada_id: article.rada_id,
       article_number: article.article_number,
       title: article.title,
-      full_text: article.full_text,
+      full_text: capText(article.full_text),
       url: article.url,
       metadata: article.metadata,
       npa_title: article.npa_title,
@@ -197,7 +205,7 @@ export class LegislationTools extends BaseToolHandler {
       articles: articles.map(a => ({
         article_number: a.article_number,
         title: a.title,
-        full_text: a.full_text,
+        full_text: capText(a.full_text),
         url: a.url,
         npa_title: a.npa_title,
         section_number: a.section_number,
@@ -313,7 +321,7 @@ export class LegislationTools extends BaseToolHandler {
               rada_id: article.rada_id,
               article_number: article.article_number,
               title: article.title,
-              full_text: article.full_text,
+              full_text: capText(article.full_text),
               url: article.url,
               npa_title: article.npa_title,
               section_number: article.section_number,
@@ -358,7 +366,7 @@ export class LegislationTools extends BaseToolHandler {
             rada_id: resolvedRadaId,
             article_number: a.article_number,
             title: a.title,
-            full_text: a.full_text || '',
+            full_text: capText(a.full_text),
             url: `https://zakon.rada.gov.ua/laws/show/${resolvedRadaId}#n${a.article_number}`,
           })),
         };
@@ -387,7 +395,7 @@ export class LegislationTools extends BaseToolHandler {
         rada_id: a.rada_id,
         article_number: a.article_number,
         title: a.title,
-        full_text: a.full_text || '',
+        full_text: capText(a.full_text),
         url: a.url,
         npa_title: a.npa_title,
         section_number: a.section_number,
@@ -511,7 +519,7 @@ export class LegislationTools extends BaseToolHandler {
               rada_id: pattern.rada_id,
               article_number: articleNumber,
               title: article.title,
-              full_text: article.full_text,
+              full_text: capText(article.full_text),
               url: article.url,
             });
           }

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -530,6 +530,9 @@ export class ProceduralTools extends BaseToolHandler {
       results,
     };
     if (timeRangeParsed.warning) payload.time_range_warning = timeRangeParsed.warning;
+    if (results.length === 0) {
+      payload.hint = 'Результатів не знайдено. Повторний виклик з іншим формулюванням навряд чи дасть результат — FTS шукає точний збіг усіх слів. Спробуйте search_edrsr_fulltext з коротшим запитом (2-3 слова) або compare_practice_pro_contra.';
+    }
 
     return this.wrapResponse(payload);
   }


### PR DESCRIPTION
## Summary
From chat-a1ba260b analysis (1.4 MB total tool results, $2.45 charged):

1. **`search_legislation` full_text cap**: articles like ПКУ transitional provisions can be 50+ KB each. With 15 results = 232 KB in one tool call. Now capped at 2000 chars per article with `… [обрізано]` suffix.

2. **`find_similar_fact_pattern_cases` empty hint**: LLM called this tool 12 times rephrasing the same query, getting empty results each time. Now returns a hint on empty results suggesting `search_edrsr_fulltext` or `compare_practice_pro_contra` instead.

## Impact estimate
- search_legislation: 232 KB → ~30 KB max (15 articles × 2 KB)
- find_similar_fact_pattern_cases: 12 empty calls → likely 3-4 (LLM reads hint and switches tool)

## Test plan
- [ ] search_legislation for ПКУ without rada_id — verify articles capped at 2000 chars
- [ ] find_similar_fact_pattern_cases with obscure query — verify hint in empty response
- [ ] Verify full article text still available via get_legislation_article (not capped there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps legislation article text to 2,000 chars to reduce response size and avoid context bloat. Adds a hint when FTS finds no similar cases to prevent pointless retries.

- **Bug Fixes**
  - Truncate `full_text` in `search_legislation` (and related outputs) to 2,000 chars with "… [обрізано]" suffix; worst-case response drops from ~232 KB to ~30 KB (15 results).
  - When `find_similar_fact_pattern_cases` returns no matches, include a hint suggesting `search_edrsr_fulltext` (short 2–3 word query) or `compare_practice_pro_contra`.

<sup>Written for commit f862b56db2e19efc51a5c0e16b3b6f2b610d0f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

