### PR TITLE
feat(bedrock): cross-region fallback on throttling

### DIFF
--- a/packages/shared/src/utils/bedrock-client.ts
+++ b/packages/shared/src/utils/bedrock-client.ts
@@ -3,8 +3,28 @@ import { logger } from './logger';
 import { ModelSelector } from './model-selector';
 import { requestContext, CostTrackerInterface } from './openai-client';
 
+const FALLBACK_REGIONS = (process.env.BEDROCK_FALLBACK_REGIONS || 'us-east-1,us-west-2').split(',').map(r => r.trim()).filter(Boolean);
+
+function swapRegionPrefix(model: string, targetRegion: string): string {
+  const regionPrefix = targetRegion.startsWith('us-') ? 'us' : targetRegion.startsWith('ap-') ? 'ap' : 'eu';
+  return model.replace(/^(eu|us|ap)\./, `${regionPrefix}.`);
+}
+
+function isThrottlingError(err: any): boolean {
+  const name = err?.name || err?.__type || '';
+  const message = (err?.message || '').toLowerCase();
+  return name === 'ThrottlingException'
+    || name === 'TooManyRequestsException'
+    || name === 'ServiceUnavailableException'
+    || message.includes('throttl')
+    || message.includes('rate exceeded')
+    || message.includes('too many requests')
+    || err?.['$metadata']?.httpStatusCode === 429;
+}
+
 export class BedrockClientManager {
   private client: BedrockRuntimeClient | null = null;
+  private fallbackClients: Array<{ region: string; client: BedrockRuntimeClient }> = [];
   private costTracker: CostTrackerInterface | null = null;
 
   constructor() {
@@ -13,14 +33,22 @@ export class BedrockClientManager {
     const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 
     if (accessKeyId && secretAccessKey) {
-      this.client = new BedrockRuntimeClient({
+      const creds = { accessKeyId, secretAccessKey };
+      this.client = new BedrockRuntimeClient({ region, credentials: creds });
+
+      for (const fbRegion of FALLBACK_REGIONS) {
+        if (fbRegion !== region) {
+          this.fallbackClients.push({
+            region: fbRegion,
+            client: new BedrockRuntimeClient({ region: fbRegion, credentials: creds }),
+          });
+        }
+      }
+
+      logger.info('Bedrock client manager initialized', {
         region,
-        credentials: {
-          accessKeyId,
-          secretAccessKey,
-        },
+        fallbackRegions: this.fallbackClients.map(c => c.region),
       });
-      logger.info('Bedrock client manager initialized', { region });
     } else {
       logger.warn('AWS credentials not configured - Bedrock provider will be unavailable');
     }
@@ -35,6 +63,10 @@ export class BedrockClientManager {
       throw new Error('Bedrock client not configured - missing AWS credentials');
     }
     return this.client;
+  }
+
+  getFallbackClients(): Array<{ region: string; client: BedrockRuntimeClient }> {
+    return this.fallbackClients;
   }
 
   setCostTracker(tracker: CostTrackerInterface) {
@@ -90,6 +122,8 @@ export class BedrockClientManager {
     }
   }
 }
+
+export { isThrottlingError, swapRegionPrefix };
 
 let bedrockManager: BedrockClientManager | null = null;
 

--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -16,7 +16,7 @@ import {
 import { logger } from './logger';
 import { OpenAIClientManager, getOpenAIManager, CostTrackerInterface } from './openai-client';
 import { AnthropicClientManager, getAnthropicManager } from './anthropic-client';
-import { BedrockClientManager, getBedrockManager } from './bedrock-client';
+import { BedrockClientManager, getBedrockManager, isThrottlingError, swapRegionPrefix } from './bedrock-client';
 import { ModelSelector, LLMProvider, BudgetLevel, ModelSelection } from './model-selector';
 
 /** GPT-5 models only support temperature=1 (default) */
@@ -915,7 +915,31 @@ export class LLMClientManager {
     request: UnifiedChatRequest,
     model: string
   ): Promise<UnifiedChatResponse> {
-    const client = this.bedrockManager.getClient();
+    try {
+      return await this.sendBedrockConverse(this.bedrockManager.getClient(), model, request);
+    } catch (err: any) {
+      if (!isThrottlingError(err)) throw err;
+
+      // Cross-region fallback on throttling
+      for (const fb of this.bedrockManager.getFallbackClients()) {
+        const regionModel = swapRegionPrefix(model, fb.region);
+        logger.info(`Bedrock throttled, trying ${fb.region}`, { model: regionModel });
+        try {
+          return await this.sendBedrockConverse(fb.client, regionModel, request);
+        } catch (fbErr: any) {
+          logger.warn(`Bedrock fallback ${fb.region} failed: ${fbErr.message}`);
+          if (!isThrottlingError(fbErr)) throw fbErr;
+        }
+      }
+      throw err;
+    }
+  }
+
+  private async sendBedrockConverse(
+    client: import('@aws-sdk/client-bedrock-runtime').BedrockRuntimeClient,
+    model: string,
+    request: UnifiedChatRequest
+  ): Promise<UnifiedChatResponse> {
     const hasTools = !!(request.tools && request.tools.length > 0);
     const { system, messages } = this.convertToBedrockMessages(request.messages, hasTools);
 
@@ -925,7 +949,6 @@ export class LLMClientManager {
       ...(system.length > 0 ? { system } : {}),
     };
 
-    // Add inference config
     const inferenceConfig: any = {};
     if (request.max_tokens) {
       const modelMaxTokens = model.includes('nova') ? 10000 : request.max_tokens;
@@ -938,7 +961,6 @@ export class LLMClientManager {
       params.inferenceConfig = inferenceConfig;
     }
 
-    // Add tool config
     if (request.tools && request.tools.length > 0 && request.tool_choice !== 'none') {
       params.toolConfig = this.buildBedrockToolConfig(request);
     }
@@ -946,7 +968,6 @@ export class LLMClientManager {
     const command = new ConverseCommand(params);
     const response = await client.send(command);
 
-    // Parse response
     const contentBlocks = response.output?.message?.content || [];
     let textContent = '';
     const toolCalls: ToolCall[] = [];
@@ -968,7 +989,6 @@ export class LLMClientManager {
     const inputTokens = response.usage?.inputTokens || 0;
     const outputTokens = response.usage?.outputTokens || 0;
 
-    // Track cost
     await this.bedrockManager.trackUsage(model, inputTokens, outputTokens);
 
     return {


### PR DESCRIPTION
## Summary
When Bedrock returns ThrottlingException/429, automatically try fallback regions before giving up.

## How it works
```
eu-central-1: eu.anthropic.claude-haiku → ThrottlingException
  ↓ fallback
us-east-1: us.anthropic.claude-haiku → success (or ThrottlingException)
  ↓ fallback  
us-west-2: us.anthropic.claude-haiku → success
```

## Changes
- `BedrockClientManager`: creates fallback clients for `BEDROCK_FALLBACK_REGIONS` (default: us-east-1, us-west-2)
- `executeBedrockChatCompletion`: catches throttling, tries fallback regions with swapped model prefix
- `isThrottlingError()`: detects ThrottlingException, TooManyRequests, 429, ServiceUnavailable
- `swapRegionPrefix()`: adjusts model ID (eu.anthropic.* → us.anthropic.*)

## Context
chat-495c5f6c: cost=0, status=pending — Bedrock call failed before any tool execution. User had sent 20+ requests in a few hours → likely hit per-account rate limit in eu-central-1.

## Config
```
BEDROCK_FALLBACK_REGIONS=us-east-1,us-west-2  # default
```

## Test plan
- [ ] Verify fallback logs appear when primary region throttles
- [ ] Verify model prefix swap (eu.→us.) produces valid model IDs
- [ ] Verify non-throttling errors are NOT retried across regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross-region fallback for Amazon Bedrock when requests are throttled. We retry in fallback regions and auto-adjust model IDs, reducing failures under regional rate limits.

- **New Features**
  - Detects throttling errors (ThrottlingException, TooManyRequests, 429, ServiceUnavailable) and retries in fallback regions.
  - Default fallback order: `us-east-1`, `us-west-2`; model IDs are rewritten (e.g., `eu.anthropic.*` → `us.anthropic.*`).
  - Applies to non-streaming Bedrock chat calls; logs each attempt; non-throttling errors are not retried.

- **Migration**
  - No changes required. Optionally set `BEDROCK_FALLBACK_REGIONS=us-east-1,us-west-2` to override defaults.

<sup>Written for commit 6ebcdcfa525c019a4e999d8b2f9a43e1ab95a15e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

