### PR TITLE
fix(ci): recursive copy for core overlay

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -104,7 +104,7 @@ jobs:
           chmod 600 "$KEY_FILE"
           GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
             git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-          cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          cp -rf "$CORE_TMP"/src/services/* mcp_backend/src/services/
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
 
       - name: Build backend

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -178,7 +178,7 @@ jobs:
         run: |
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
-          cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          cp -rf "$CORE_TMP"/src/services/* mcp_backend/src/services/
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
 

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -104,7 +104,7 @@ jobs:
           chmod 600 "$KEY_FILE"
           GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
             git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-          cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          cp -rf "$CORE_TMP"/src/services/* mcp_backend/src/services/
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
 
       - name: Build backend
@@ -222,7 +222,7 @@ jobs:
               trap 'shred -u "$KEY_FILE" 2>/dev/null; rm -rf "$CORE_TMP"' EXIT
               GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
                 git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-              cp -f "$CORE_TMP"/src/services/* /home/vovkes/SecondLayer/mcp_backend/src/services/
+              cp -rf "$CORE_TMP"/src/services/* /home/vovkes/SecondLayer/mcp_backend/src/services/
               cp -rf "$CORE_TMP"/src/prompts/* /home/vovkes/SecondLayer/mcp_backend/src/prompts/
               cd /home/vovkes/SecondLayer && npm --prefix mcp_backend run build
           OVERLAY_EOF


### PR DESCRIPTION
## Summary

`cp -f` → `cp -rf` in all 3 CI workflows for core services overlay.

Core repo now has `src/services/__tests__/` and `src/utils/` directories that `cp -f` skips with error. All occurrences fixed:
- ci-local-deploy.yml (2 places)
- deploy-prod.yml (1 place)
- deploy-stage.yml (2 places)

## Test plan

- [ ] CI local passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CI overlay copy to recursive to include nested directories in `src/services`. Prevents skipped `__tests__` and `utils` content during local, stage, and prod deploys.

- **Bug Fixes**
  - Replace `cp -f` with `cp -rf` in `.github/workflows/ci-local-deploy.yml` (2 spots), `.github/workflows/deploy-stage.yml` (2), and `.github/workflows/deploy-prod.yml` (1).

<sup>Written for commit 00f472dcb75ac7f20703676c426159dcd8a53570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

