### PR TITLE
fix(ci): exclude core test dirs from overlay copy

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -104,7 +104,7 @@ jobs:
           chmod 600 "$KEY_FILE"
           GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
             git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-          cp -rf "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
 
       - name: Build backend

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -178,7 +178,7 @@ jobs:
         run: |
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
-          cp -rf "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
 

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -104,7 +104,7 @@ jobs:
           chmod 600 "$KEY_FILE"
           GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
             git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-          cp -rf "$CORE_TMP"/src/services/* mcp_backend/src/services/
+          find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
 
       - name: Build backend
@@ -222,7 +222,7 @@ jobs:
               trap 'shred -u "$KEY_FILE" 2>/dev/null; rm -rf "$CORE_TMP"' EXIT
               GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
                 git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-              cp -rf "$CORE_TMP"/src/services/* /home/vovkes/SecondLayer/mcp_backend/src/services/
+              find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} /home/vovkes/SecondLayer/mcp_backend/src/services/ \;
               cp -rf "$CORE_TMP"/src/prompts/* /home/vovkes/SecondLayer/mcp_backend/src/prompts/
               cd /home/vovkes/SecondLayer && npm --prefix mcp_backend run build
           OVERLAY_EOF


### PR DESCRIPTION
## Summary

Fix CI failure from #1851: core repo `__tests__/` and `utils/` dirs use `node:test` which Jest doesn't understand ("must contain at least one test").

Changed `cp -rf` to `find -maxdepth 1 -name '*.ts'` — copies only service `.ts` files, skips subdirectories. All 3 workflows updated.

## Test plan

- [ ] CI local build + test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI by copying only top-level .ts service files from `secondlayer-core` into the overlay, excluding test and utils directories that use `node:test` and break Jest.

- **Bug Fixes**
  - Replace recursive copy with: find src/services -maxdepth 1 -name '*.ts' -exec cp -f {} ... in ci-local-deploy, deploy-stage, and deploy-prod workflows.
  - Skips `__tests__/` and `utils/` subdirs while keeping service files in sync.

<sup>Written for commit 326664291a0efc41c5ae2a64a5c56336dbbf7dae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

