### PR TITLE
fix(ci): fix deploy job core overlay copy

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -354,7 +354,7 @@ jobs:
             chmod 600 "$KEY_FILE"
             GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
               git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
-            cp -f "$CORE_TMP"/src/services/* mcp_backend/src/services/
+            find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
             cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
             npm --prefix mcp_backend install && npm --prefix mcp_backend run build
           fi


### PR DESCRIPTION
Fixes the second overlay step (deploy job line 357) — same cp -f issue as #1852.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the deploy job’s core overlay copy to reliably copy only service .ts files and avoid directory-related cp -f errors. Mirrors the build step by using a find-based copy for `secondlayer-core/src/services` into `mcp_backend/src/services`.

<sup>Written for commit 728d87c0c542f4e41a1ef0b35005292a4f35cdec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

