### PR TITLE
feat(search): enable semantic search for ГПК (justice_kind=3)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -94,8 +94,8 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 4 режими пошуку:
 • **structured** — за метаданими: номер справи, суддя, суд, дата, категорія, військові пресети. Найшвидший, коли відомі точні параметри.
 • **fulltext** — повнотекстовий пошук (PostgreSQL tsvector) з підсвіченими фрагментами. Для пошуку за ключовими словами та юридичними термінами.
-• **hybrid** — FTS + семантичний пошук (Qdrant Voyage-3.5) з мерджем через Reciprocal Rank Fusion. Найкращий recall, коли запит містить і семантику, і точні токени. Семантична нога працює для КупАП (justice_kind=5).
-• **semantic** — чистий семантичний пошук по векторній базі Qdrant. Доступний для КУпАП (justice_kind=5), для решти — fallback на fulltext.
+• **hybrid** — FTS + семантичний пошук (Qdrant BGE-M3) з мерджем через Reciprocal Rank Fusion. Найкращий recall, коли запит містить і семантику, і точні токени. Семантична нога працює для ГПК (3) та КупАП (5).
+• **semantic** — чистий семантичний пошук по векторній базі Qdrant. Доступний для ГПК (justice_kind=3) та КУпАП (justice_kind=5), для решти — fallback на fulltext.
 
 Фільтри (спільні для всіх режимів): court_code/court_name, judge, justice_kind, judgment_code, category_code, date_from/date_to.
 Пресети: military_preset (військові справи), kupap_preset (адмінправопорушення — traffic_dui, traffic_accident, domestic_violence, hooliganism тощо).
@@ -405,7 +405,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
   // ── Semantic search (Qdrant vectors) ─────────────────────────────
 
-  private static readonly VECTORIZED_JUSTICE_KINDS = new Set([5]); // КупАП
+  private static readonly VECTORIZED_JUSTICE_KINDS = new Set([3, 5]); // ГПК, КупАП
 
   private async searchSemantic(args: any): Promise<ToolResult> {
     if (!args.query) return this.wrapError('query є обов\'язковим для режиму semantic');


### PR DESCRIPTION
## Summary
- Add justice_kind=3 (ГПК) to VECTORIZED_JUSTICE_KINDS
- 2.2M ГПК court decisions (2022-2026) vectorized with BAAI/bge-m3 on 8xH100 Brev
- ~8.7M chunks, 1024-dim vectors in prod Qdrant

## Test plan
- [ ] Verify `search_court_decisions` mode=semantic justice_kind=3 returns vector results
- [ ] Verify mode=hybrid justice_kind=3 shows both FTS and Qdrant legs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable semantic and hybrid search for ГПК cases (`justice_kind=3`) using BGE-M3 embeddings in Qdrant. This covers ~2.2M decisions (2022–2026, ~8.7M chunks) and improves recall for ГПК queries.

- **New Features**
  - Added `justice_kind=3` to `VECTORIZED_JUSTICE_KINDS`, enabling semantic and hybrid search for ГПК.
  - Updated mode descriptions to reflect BGE-M3 and availability for ГПК (3) and КУпАП (5).

<sup>Written for commit 8f7fb8f2a2118cef16fb26e718436812d69d0457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

