### PR TITLE
fix(security): resolve CodeQL code scanning alerts

### DIFF
--- a/mcp_backend/src/services/referral-service.ts
+++ b/mcp_backend/src/services/referral-service.ts
@@ -14,10 +14,13 @@ const REFERRAL_CODE_LENGTH = 8;
 
 function generateReferralCode(): string {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789';
-  const bytes = randomBytes(REFERRAL_CODE_LENGTH);
+  const maxValid = Math.floor(256 / chars.length) * chars.length;
   let code = '';
-  for (let i = 0; i < REFERRAL_CODE_LENGTH; i++) {
-    code += chars[bytes[i] % chars.length];
+  while (code.length < REFERRAL_CODE_LENGTH) {
+    const byte = randomBytes(1)[0];
+    if (byte < maxValid) {
+      code += chars[byte % chars.length];
+    }
   }
   return code;
 }

--- a/scripts/hudoc/download-hudoc.ts
+++ b/scripts/hudoc/download-hudoc.ts
@@ -209,9 +209,8 @@ function buildFulltextURL(itemId: string): string {
 function htmlToText(html: string): string {
   if (!html) return '';
   // Remove CSS style blocks
-  let text = html.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
-  // Remove script blocks
-  text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+  let text = html.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
+  text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
   // Convert common block elements to newlines
   text = text.replace(/<\/(p|div|br|h[1-6]|li|tr|td|th|blockquote|pre)[^>]*>/gi, '\n');
   text = text.replace(/<br\s*\/?>/gi, '\n');
@@ -220,13 +219,13 @@ function htmlToText(html: string): string {
   // Decode HTML entities
   text = text
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)));
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)))
+    .replace(/&amp;/g, '&');
   // Collapse whitespace
   text = text.replace(/[ \t]+/g, ' ');
   text = text.replace(/\n{3,}/g, '\n\n');

--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -202,8 +202,8 @@ function extractArticlesFromEditionHtml(html: string): Array<{ article_number: s
 
     const inlineTitle = match[2]?.trim();
     let body = match[3];
-    body = body.replace(/<script[^>]*>.*?<\/script>/gs, '');
-    body = body.replace(/<style[^>]*>.*?<\/style>/gs, '');
+    body = body.replace(/<script[^>]*>.*?<\/script\s*>/gsi, '');
+    body = body.replace(/<style[^>]*>.*?<\/style\s*>/gsi, '');
     body = body.replace(/<[^>]+>/g, ' ');
     body = body.replace(/\s+/g, ' ').replace(/\{[^}]*\}/g, '').trim();
     if (body.length < 10) continue;

--- a/scripts/record-demo-video.ts
+++ b/scripts/record-demo-video.ts
@@ -19,9 +19,6 @@ import { execSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
 
-// Allow self-signed certs for local dev
-process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
-
 const BASE_URL = process.env.TEST_BASE_URL || 'https://localhost';
 const TEST_EMAIL = process.env.TEST_EMAIL || 'testuser@secondlayer.com';
 const TEST_PASSWORD = process.env.TEST_PASSWORD || 'testuser123';


### PR DESCRIPTION
## Summary
- **referral-service**: fix biased crypto random (modulo on `randomBytes`) → rejection sampling for uniform distribution
- **download-hudoc**: fix `</script>` regex to handle `</script >` (space before `>`), move `&amp;` decode to last to prevent double-unescaping chain
- **import-historical-editions**: add `i` flag to script/style tag removal (was missing case-insensitive matching)
- **record-demo-video**: remove global `NODE_TLS_REJECT_UNAUTHORIZED=0` (redundant — Playwright context already has `ignoreHTTPSErrors: true`)
- **26 alerts dismissed** as false positives (masked logging via `sanitizeId`/`maskSensitive`, safe React text rendering, deterministic regexes)

Resolves all 31 open CodeQL code scanning alerts → 0 remaining.

## Test plan
- [ ] `npm run build` passes for mcp_backend
- [ ] CodeQL re-scan shows 0 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all open CodeQL security alerts by removing RNG bias, hardening HTML scrubbing, and dropping a risky TLS override. After merge, CodeQL should report 0 alerts across the repo.

- **Bug Fixes**
  - referral-service: replace modulo on `randomBytes` with rejection sampling for uniform referral codes.
  - download-hudoc: make script/style regex handle spaces before `>`; decode `&amp;` last to prevent double unescaping.
  - import-historical-editions: add case-insensitive, space-tolerant script/style removal.
  - record-demo-video: remove global `NODE_TLS_REJECT_UNAUTHORIZED=0` (Playwright already ignores HTTPS errors).
  - Dismissed 26 CodeQL alerts as false positives (masked logging, safe React text rendering, deterministic regexes).

<sup>Written for commit 7a2750a8b3b8567d3aab1b0cf92a9700a6589ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

