### PR TITLE
fix(security): replace regex HTML stripping with cheerio parser (CodeQL #319-325)

### DIFF
--- a/scripts/hudoc/download-hudoc.ts
+++ b/scripts/hudoc/download-hudoc.ts
@@ -30,6 +30,7 @@
  */
 
 import { writeFileSync, appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, readdirSync, statSync } from 'fs';
+import * as cheerio from 'cheerio';
 import { writeFile, rename, unlink, stat } from 'fs/promises';
 import { join, dirname } from 'path';
 
@@ -208,25 +209,9 @@ function buildFulltextURL(itemId: string): string {
 
 function htmlToText(html: string): string {
   if (!html) return '';
-  // Remove CSS style blocks
-  let text = html.replace(/<style[^>]*>[\s\S]*?<\/style\s*>/gi, '');
-  text = text.replace(/<script[^>]*>[\s\S]*?<\/script\s*>/gi, '');
-  // Convert common block elements to newlines
-  text = text.replace(/<\/(p|div|br|h[1-6]|li|tr|td|th|blockquote|pre)[^>]*>/gi, '\n');
-  text = text.replace(/<br\s*\/?>/gi, '\n');
-  // Remove all remaining tags
-  text = text.replace(/<[^>]+>/g, '');
-  // Decode HTML entities
-  text = text
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(parseInt(n)))
-    .replace(/&#x([0-9a-fA-F]+);/g, (_, n) => String.fromCharCode(parseInt(n, 16)))
-    .replace(/&amp;/g, '&');
-  // Collapse whitespace
+  const $ = cheerio.load(html);
+  $('script, style').remove();
+  let text = $.text();
   text = text.replace(/[ \t]+/g, ' ');
   text = text.replace(/\n{3,}/g, '\n\n');
   text = text.trim();

--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -13,6 +13,7 @@
  */
 
 import axios, { AxiosInstance } from 'axios';
+import * as cheerio from 'cheerio';
 import * as fs from 'fs';
 import * as path from 'path';
 import pg from 'pg';
@@ -202,10 +203,9 @@ function extractArticlesFromEditionHtml(html: string): Array<{ article_number: s
 
     const inlineTitle = match[2]?.trim();
     let body = match[3];
-    body = body.replace(/<script[^>]*>.*?<\/script\s*>/gsi, '');
-    body = body.replace(/<style[^>]*>.*?<\/style\s*>/gsi, '');
-    body = body.replace(/<[^>]+>/g, ' ');
-    body = body.replace(/\s+/g, ' ').replace(/\{[^}]*\}/g, '').trim();
+    const $body = cheerio.load(body);
+    $body('script, style').remove();
+    body = $body.text().replace(/\s+/g, ' ').replace(/\{[^}]*\}/g, '').trim();
     if (body.length < 10) continue;
 
     articles.push({


### PR DESCRIPTION
## Summary

- Replace regex-based HTML tag stripping with `cheerio.load().text()` in two import scripts
- Fixes 7 open CodeQL alerts (#319-325): `js/incomplete-multi-character-sanitization` and `js/bad-tag-filter`
- Affected files: `scripts/hudoc/download-hudoc.ts`, `scripts/rada/import-historical-editions.ts`

## Test plan

- [ ] Verify CodeQL alerts #319-325 close after merge
- [ ] Spot-check HUDOC download output unchanged
- [ ] Spot-check historical edition import output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced regex-based HTML sanitization with `cheerio` parsing in the HUDOC and RADA import scripts to harden text extraction and resolve CodeQL findings. We now remove `script`/`style` nodes and use `cheerio.load(html).text()` for safer, consistent output.

- **Bug Fixes**
  - Resolves CodeQL alerts #319–#325: `js/incomplete-multi-character-sanitization`, `js/bad-tag-filter`.
  - Updated `scripts/hudoc/download-hudoc.ts` and `scripts/rada/import-historical-editions.ts` to parse HTML with `cheerio` and extract plain text.

<sup>Written for commit a12982035d7298dfb5bf721aa56870686dd589f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

