### PR TITLE
fix(backend): prevent crash on unhandled promise rejections

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -1086,6 +1086,10 @@ class HTTPMCPServer {
   }
 }
 
+process.on('unhandledRejection', (reason) => {
+  logger.error('Unhandled promise rejection', { error: reason instanceof Error ? reason.message : String(reason) });
+});
+
 // Start server
 const server = new HTTPMCPServer();
 server.start().catch((error) => {


### PR DESCRIPTION
## Summary
- Adds `process.on('unhandledRejection')` handler to log instead of crash the backend process
- Root cause: Vision OCR credentials file had `600` permissions owned by `node:node`, but the backend process runs as `nodejs` (UID 1001) — EACCES on credential read caused unhandled rejection → process crash → 10 restarts, killing active SSE chat connections mid-stream ("Помилка: network error")
- Permissions already fixed on prod (`chmod 644`); this is the code-level safety net

## Test plan
- [x] Verified backend healthy after permissions fix + restart on prod
- [x] Chat endpoint responds correctly through nginx
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a process-level `process.on('unhandledRejection')` handler to log errors instead of crashing the backend, preventing restarts that cut off SSE chat streams. Acts as a safety net for issues like EACCES on Vision OCR credential reads; production permissions are already fixed.

<sup>Written for commit 78c45667aecfa45d3ab39314f58997b0f64d8941. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

