### PR TITLE
fix(deploy): correct OpenReyestr container hostnames

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -579,7 +579,7 @@ services:
       ENABLE_UNIFIED_GATEWAY: "true"
       RADA_MCP_URL: http://rada-mcp-app-prod:3001
       RADA_API_KEY: ${RADA_API_KEY:-}
-      OPENREYESTR_MCP_URL: http://app-openreyestr-prod:3005
+      OPENREYESTR_MCP_URL: http://openreyestr-app-prod:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-}
 
       # SneakyPiper OSINT Proxy
@@ -975,7 +975,7 @@ services:
       ENABLE_UNIFIED_GATEWAY: "true"
       RADA_MCP_URL: http://rada-mcp-app-prod-green:3001
       RADA_API_KEY: ${RADA_API_KEY:-}
-      OPENREYESTR_MCP_URL: http://app-openreyestr-prod-green:3005
+      OPENREYESTR_MCP_URL: http://openreyestr-app-prod-green:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-}
       SNEAKYPIPER_API_URL: ${SNEAKYPIPER_API_URL:-}
       SNEAKYPIPER_API_KEY: ${SNEAKYPIPER_API_KEY:-}
@@ -1513,7 +1513,7 @@ services:
       NODE_ENV: production
       BACKEND_URL: http://app-prod:3000
       BACKEND_API_KEY: ${SECONDARY_LAYER_KEYS:-}
-      OPENREYESTR_URL: http://app-openreyestr-prod:3005
+      OPENREYESTR_URL: http://openreyestr-app-prod:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEYS:-}
       HEALTH_PORT: "3010"
       TZ: Europe/Kiev

--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -540,7 +540,7 @@ services:
       ENABLE_UNIFIED_GATEWAY: "true"
       RADA_MCP_URL: http://rada-mcp-app-stage:3001
       RADA_API_KEY: ${RADA_API_KEY:-}
-      OPENREYESTR_MCP_URL: http://app-openreyestr-stage:3005
+      OPENREYESTR_MCP_URL: http://openreyestr-app-stage:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEY:-}
 
       # Google Cloud Vision API (for OCR in document analysis tools)


### PR DESCRIPTION
## Summary
- `OPENREYESTR_MCP_URL` used Docker Compose service names (`app-openreyestr-prod`) but actual `container_name` is `openreyestr-app-prod` -- Docker DNS resolves container names, not service names when they differ
- This caused 5s timeout on every chat request when fetching OpenReyestr gateway tools, making `search_edrsr_fulltext` and other OpenReyestr tools unavailable via unified gateway
- Fixed in prod/stage/opendata-sync compose files (blue + green)

## Test plan
- [x] Hotfixed on prod via network alias -- `wget http://app-openreyestr-prod-green:3005/health` now resolves
- [ ] CI deploy applies the permanent compose fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected OpenReyestr hostnames in prod and stage `docker-compose` to use the actual `container_name` (e.g., `openreyestr-app-prod`) instead of the service name. This fixes Docker DNS resolution, removes ~5s timeouts, and restores OpenReyestr tools in the unified gateway.

- **Bug Fixes**
  - Updated `OPENREYESTR_MCP_URL` and `OPENREYESTR_URL` to `http://openreyestr-app-*:3005` across prod (blue/green) and stage.
  - Gateway can now load tools like `search_edrsr_fulltext` without timeouts.

<sup>Written for commit 9dae9ffa86039ecf0287876a0c7dd03ea36e8eac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

