### PR TITLE
feat(opendata): add EDRSR court decisions to scheduled sync pipeline

### DIFF
--- a/mcp_backend/src/migrations/161_edrsr_import_source.sql
+++ b/mcp_backend/src/migrations/161_edrsr_import_source.sql
@@ -1,0 +1,28 @@
+-- Add EDRSR current year as csv_zip source in import catalog
+INSERT INTO import_source_catalog (name, title, source_type, source_url, source_config, target_table, upsert_sql, default_threads_per_ip, rate_limit_ms)
+VALUES (
+  'edrsr_current_year',
+  'ЄДРСР — Судові рішення (поточний рік)',
+  'csv_zip',
+  'https://data.gov.ua/dataset/16ab7f06-7414-405f-8354-0a492475272d/resource/b1a4ac1c-b17a-4988-8e6d-dedae8b2dd63/download/edrsr_data_2026.zip',
+  '{
+    "csv_file": "documents.csv",
+    "delimiter": "\t",
+    "skip_header": true,
+    "unique_column": "doc_id",
+    "columns": ["doc_id", "court_code", "judgment_code", "justice_kind", "category_code", "cause_num", "adjudication_date", "receipt_date", "judge", "doc_url", "status", "date_publ"],
+    "year_urls": {
+      "2024": "https://data.gov.ua/dataset/1a6b5c08-0879-4387-8878-ac0027494274/resource/d3427d17-3fe4-4675-9a09-5274cd3476dc/download/edrsr_data_2024.zip",
+      "2025": "https://data.gov.ua/dataset/2a95ae17-ed46-42ae-ad66-dd9b7a727bb7/resource/9f19ad2b-000f-4176-b283-95e399ad8e5e/download/edrsr_data_2025.zip",
+      "2026": "https://data.gov.ua/dataset/16ab7f06-7414-405f-8354-0a492475272d/resource/b1a4ac1c-b17a-4988-8e6d-dedae8b2dd63/download/edrsr_data_2026.zip"
+    }
+  }'::jsonb,
+  'edrsr_documents',
+  NULL,
+  1,
+  0
+)
+ON CONFLICT (name) DO UPDATE SET
+  title = EXCLUDED.title,
+  source_url = EXCLUDED.source_url,
+  source_config = EXCLUDED.source_config;

--- a/mcp_backend/src/services/import-task-service.ts
+++ b/mcp_backend/src/services/import-task-service.ts
@@ -9,6 +9,9 @@
 import https from 'https';
 import http from 'http';
 import { URL } from 'url';
+import fs from 'fs';
+import path from 'path';
+import AdmZip from 'adm-zip';
 import { Database } from '../database/database.js';
 import { logger } from '../utils/logger.js';
 
@@ -231,6 +234,8 @@ export class ImportTaskService {
         await this.runJsonArrayImport(taskId, source, ips, signal);
       } else if (source.source_type === 'file_download') {
         await this.runFileDownloadImport(taskId, source, signal);
+      } else if (source.source_type === 'csv_zip') {
+        await this.runCsvZipImport(taskId, source, signal);
       } else {
         throw new Error(`Unknown source_type: ${source.source_type}`);
       }
@@ -492,6 +497,211 @@ export class ImportTaskService {
       mem.pagesDone = 1;
       mem.lastError = 'file_download type requires running sync-all-registries. Use start_import for api_paginated or json_array sources.';
     }
+  }
+
+  // ---- CSV ZIP (EDRSR-style: download ZIP → extract TSV → bulk insert via NOT EXISTS) ----
+
+  private async runCsvZipImport(taskId: number, source: SourceCatalog, signal: AbortSignal): Promise<void> {
+    const config = source.source_config || {};
+    const csvFile = (config.csv_file as string) || 'documents.csv';
+    const delimiter = (config.delimiter as string) || '\t';
+    const columns = (config.columns as string[]) || [];
+    const uniqueColumn = (config.unique_column as string) || 'doc_id';
+    const skipHeader = config.skip_header !== false;
+
+    if (!columns.length || !source.target_table) {
+      throw new Error('csv_zip requires source_config.columns and target_table');
+    }
+
+    // Resolve URL: use year_urls map if available (current year by default)
+    const yearUrls = config.year_urls as Record<string, string> | undefined;
+    const currentYear = String(new Date().getFullYear());
+    const downloadUrl = yearUrls?.[currentYear] || source.source_url;
+
+    const tmpDir = `/tmp/import_csvzip_${taskId}`;
+    const zipPath = path.join(tmpDir, 'data.zip');
+
+    try {
+      fs.mkdirSync(tmpDir, { recursive: true });
+
+      // Step 1: Download ZIP
+      logger.info(`[ImportTask ${taskId}] Downloading ZIP from ${downloadUrl} (year ${currentYear})`);
+      await this.downloadFile(downloadUrl, zipPath, signal);
+      if (signal.aborted) return;
+
+      const zipSize = fs.statSync(zipPath).size;
+      logger.info(`[ImportTask ${taskId}] Downloaded ${(zipSize / 1024 / 1024).toFixed(1)} MB`);
+
+      // Step 2: Extract target CSV from ZIP
+      const zip = new AdmZip(zipPath);
+      const entry = zip.getEntry(csvFile) || zip.getEntries().find(e => e.entryName.endsWith('.csv'));
+      if (!entry) throw new Error(`${csvFile} not found in ZIP`);
+
+      const csvPath = path.join(tmpDir, 'data.csv');
+      fs.writeFileSync(csvPath, zip.readFile(entry)!);
+      // Free ZIP memory early
+      fs.unlinkSync(zipPath);
+
+      // Step 3: Count lines
+      const totalLines = await this.countFileLines(csvPath) - (skipHeader ? 1 : 0);
+      logger.info(`[ImportTask ${taskId}] CSV records: ${totalLines}`);
+      await this.db.query('UPDATE import_tasks SET total_items = $2, total_pages = $3 WHERE id = $1',
+        [taskId, totalLines, Math.ceil(totalLines / 5000)]);
+
+      // Step 4: Parse and batch insert
+      const mem = taskProgress.get(taskId);
+      const fileContent = fs.readFileSync(csvPath, 'utf-8');
+      const lines = fileContent.split('\n');
+      const startIdx = skipHeader ? 1 : 0;
+
+      const BATCH_SIZE = 5000;
+      let imported = 0;
+      let failed = 0;
+      let skipped = 0;
+      let batchNum = 0;
+
+      for (let i = startIdx; i < lines.length; i += BATCH_SIZE) {
+        if (signal.aborted) break;
+
+        const batch = lines.slice(i, i + BATCH_SIZE).filter(line => line.trim());
+        if (!batch.length) continue;
+        batchNum++;
+
+        const rows: any[][] = [];
+        for (const line of batch) {
+          const cleaned = line.replace(/"/g, '');
+          const parts = cleaned.split(delimiter);
+          if (parts.length < columns.length) continue;
+          rows.push(parts.slice(0, columns.length));
+        }
+
+        if (!rows.length) continue;
+
+        try {
+          const result = await this.insertCsvBatchNotExists(source.target_table, columns, uniqueColumn, rows);
+          imported += result.inserted;
+          skipped += result.skipped;
+        } catch (err: any) {
+          failed += rows.length;
+          logger.error(`[ImportTask ${taskId}] Batch ${batchNum} failed: ${err.message}`);
+        }
+
+        if (mem) {
+          mem.recordsImported = imported;
+          mem.recordsFailed = failed;
+          mem.pagesDone = batchNum;
+          mem.currentPage = batchNum;
+        }
+
+        if (batchNum % 20 === 0) {
+          await this.db.query(
+            `UPDATE import_tasks SET pages_done = $2, records_imported = $3, records_failed = $4, last_activity_at = NOW(), updated_at = NOW() WHERE id = $1`,
+            [taskId, batchNum, imported, failed],
+          ).catch(() => {});
+          logger.info(`[ImportTask ${taskId}] Progress: ${imported} inserted, ${skipped} existing, ${failed} failed (batch ${batchNum})`);
+        }
+      }
+
+      if (mem) {
+        mem.recordsImported = imported;
+        mem.recordsFailed = failed;
+        mem.pagesDone = batchNum;
+        mem.lastError = skipped > 0 ? `${skipped} already existed` : null;
+      }
+
+      logger.info(`[ImportTask ${taskId}] Done: ${imported} new, ${skipped} existing, ${failed} failed`);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  private async insertCsvBatchNotExists(
+    table: string, columns: string[], uniqueColumn: string, rows: any[][],
+  ): Promise<{ inserted: number; skipped: number }> {
+    const colList = columns.join(', ');
+
+    // Use transaction with temp table (required for partitioned tables — no parent-level unique index)
+    const inserted = await this.db.transaction(async (client) => {
+      const tmpTable = `_tmp_csvzip_${Date.now()}`;
+      await client.query(`CREATE TEMP TABLE ${tmpTable} (LIKE ${table} INCLUDING DEFAULTS) ON COMMIT DROP`);
+
+      const params: any[] = [];
+      const valueClauses: string[] = [];
+      for (const row of rows) {
+        const placeholders = row.map((_, ci) => `$${params.length + ci + 1}`).join(',');
+        valueClauses.push(`(${placeholders})`);
+        for (const val of row) {
+          params.push(val === '' ? null : val);
+        }
+      }
+
+      await client.query(`INSERT INTO ${tmpTable} (${colList}) VALUES ${valueClauses.join(',')}`, params);
+
+      const result = await client.query(
+        `INSERT INTO ${table} (${colList})
+         SELECT ${colList} FROM ${tmpTable} t
+         WHERE NOT EXISTS (SELECT 1 FROM ${table} d WHERE d.${uniqueColumn} = t.${uniqueColumn})`
+      );
+      return result.rowCount || 0;
+    });
+
+    return { inserted, skipped: rows.length - inserted };
+  }
+
+  private downloadFile(url: string, dest: string, signal: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const doRequest = (reqUrl: string, redirectCount = 0) => {
+        if (redirectCount > 5) { reject(new Error('Too many redirects')); return; }
+        const reqParsed = new URL(reqUrl);
+        const reqProto = reqParsed.protocol === 'https:' ? https : http;
+
+        const req = reqProto.get(reqUrl, { timeout: 600_000 }, (res) => {
+          if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+            doRequest(res.headers.location, redirectCount + 1);
+            return;
+          }
+          if (res.statusCode !== 200) {
+            reject(new Error(`HTTP ${res.statusCode} downloading ${reqUrl}`));
+            return;
+          }
+          const file = fs.createWriteStream(dest);
+          res.pipe(file);
+          file.on('finish', () => { file.close(); resolve(); });
+          file.on('error', reject);
+        });
+
+        req.on('error', reject);
+        req.on('timeout', () => { req.destroy(); reject(new Error('Download timeout')); });
+
+        const onAbort = () => { req.destroy(); reject(new Error('Aborted')); };
+        signal.addEventListener('abort', onAbort, { once: true });
+        req.on('close', () => signal.removeEventListener('abort', onAbort));
+      };
+
+      doRequest(url);
+    });
+  }
+
+  private countFileLines(filePath: string): Promise<number> {
+    return new Promise((resolve) => {
+      let count = 0;
+      const stream = fs.createReadStream(filePath, { encoding: 'utf-8' });
+      let remaining = '';
+      stream.on('data', (chunk: string) => {
+        remaining += chunk;
+        let idx = remaining.indexOf('\n');
+        while (idx !== -1) {
+          count++;
+          remaining = remaining.substring(idx + 1);
+          idx = remaining.indexOf('\n');
+        }
+      });
+      stream.on('end', () => {
+        if (remaining.length > 0) count++;
+        resolve(count);
+      });
+      stream.on('error', () => resolve(0));
+    });
   }
 
   // ========================= HTTP Fetcher =========================

--- a/opendata-sync/src/config.ts
+++ b/opendata-sync/src/config.ts
@@ -91,6 +91,14 @@ const backendDailySources: DataSourceSchedule[] = [
 
 const backendWeeklySources: DataSourceSchedule[] = [
   {
+    name: 'edrsr_current_year',
+    title: 'ЄДРСР — Судові рішення (поточний рік)',
+    cron: '0 1 * * 0', // Sunday 01:00
+    target: 'backend',
+    sourceName: 'edrsr_current_year',
+    enabled: true,
+  },
+  {
     name: 'nipo_trademarks',
     title: 'УІПВ — Торгові марки',
     cron: '0 2 * * 0', // Sunday 02:00


### PR DESCRIPTION
## Summary
- Adds EDRSR (Ukrainian court decisions registry) as a weekly source in `opendata-sync` service (Sunday 01:00)
- Implements new `csv_zip` source type in `import-task-service` — downloads ZIP from data.gov.ua, extracts TSV via AdmZip, bulk inserts via temp table + NOT EXISTS (required for partitioned `edrsr_documents` table)
- Migration 161 registers `edrsr_current_year` in `import_source_catalog` with year-based URL map (2024/2025/2026)

## Activation
After merge and deploy:
1. Run migration 161 on prod
2. Rebuild `opendata-sync-prod` and `app-prod` containers

## Test plan
- [ ] Verify `opendata-sync` builds cleanly (`cd opendata-sync && npx tsc --noEmit`)
- [ ] Verify `mcp_backend` builds without new errors
- [ ] Run migration 161 on prod DB
- [ ] Test manually: `POST /api/tools/start_import` with `source_name: edrsr_current_year`
- [ ] Verify new records appear in `edrsr_documents` for current year
- [ ] Confirm opendata-sync schedules the source on next restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds automated weekly sync of EDRSR (Ukrainian court decisions) by introducing a `csv_zip` importer and registering `edrsr_current_year` in the pipeline.

- **New Features**
  - New `csv_zip` source in `import-task-service`: downloads ZIP from data.gov.ua, extracts TSV/CSV via `adm-zip`, and bulk inserts using a temp table + NOT EXISTS into `edrsr_documents`.
  - Registers `edrsr_current_year` with a year-based URL map (2024–2026) and schedules it for Sunday 01:00 in `opendata-sync`.

- **Migration**
  - Run migration 161 in prod.
  - Redeploy `opendata-sync` and `mcp_backend`.
  - Optional: trigger `POST /api/tools/start_import` with `source_name: edrsr_current_year`.

<sup>Written for commit dd9b004a1d0c3cdee820ebe9294eef006b166c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

