### PR TITLE
fix(session-replay): import rrweb-player CSS statically

### DIFF
--- a/lexwebapp/src/pages/AdminSessionReplayPage.tsx
+++ b/lexwebapp/src/pages/AdminSessionReplayPage.tsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Play, Clock, User, Monitor, Database, ChevronLeft, ChevronRight, RefreshCw } from 'lucide-react';
 import { sessionReplayApi } from '../utils/api/session-replay';
+import 'rrweb-player/dist/style.css';
 
 interface SessionRecord {
   id: string;
@@ -110,29 +111,28 @@ export function AdminSessionReplayPage() {
       }
     }
 
-    // Dynamic import to avoid SSR issues
     import('rrweb-player').then((mod) => {
       const RRWebPlayer = mod.default || mod;
-
-      // Import CSS
-      import('rrweb-player/dist/style.css').catch(() => {});
-
       if (!replayerContainerRef.current) return;
 
-      const player = new RRWebPlayer({
-        target: replayerContainerRef.current,
-        props: {
-          events: replayEvents,
-          width: 1024,
-          height: 600,
-          autoPlay: false,
-          showController: true,
-          speedOption: [1, 2, 4, 8],
-          // Mouse cursor is shown by default in rrweb-player
-        },
-      });
-
-      replayerRef.current = player;
+      try {
+        const player = new RRWebPlayer({
+          target: replayerContainerRef.current,
+          props: {
+            events: replayEvents,
+            width: 1024,
+            height: 600,
+            autoPlay: false,
+            showController: true,
+            speedOption: [1, 2, 4, 8],
+          },
+        });
+        replayerRef.current = player;
+      } catch (err) {
+        console.error('[SessionReplay] Player init failed', err);
+      }
+    }).catch((err) => {
+      console.error('[SessionReplay] Failed to load rrweb-player', err);
     });
 
     return () => {


### PR DESCRIPTION
## Summary
- rrweb-player CSS was loaded via dynamic `import()` which silently failed in Vite production builds
- The player rendered without styles — replay iframe and controls invisible (only a thin blue bar visible)
- Changed to static `import 'rrweb-player/dist/style.css'` so Vite creates a proper CSS chunk (`AdminSessionReplayPage-*.css`) loaded alongside the lazy JS chunk
- Added error handling to player initialization to prevent silent failures

## Test plan
- [ ] Open /admin/session-replay on prod after deploy
- [ ] Click on a session to replay — player should show controls + replay content
- [ ] Verify both small and large sessions render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invisible session replay UI by importing `rrweb-player` CSS statically so production builds load styles. Adds error handling to prevent silent player initialization failures.

- **Bug Fixes**
  - Use static `import 'rrweb-player/dist/style.css'` so Vite emits and loads the CSS chunk with the lazy page; fixes missing controls and iframe in prod.
  - Add try/catch around `rrweb-player` initialization and a catch on the dynamic module import to log load/init errors.

<sup>Written for commit 5a838f78f1925f9c618c18b5b82bc9ac2aeb1e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

