### PR TITLE
fix(session-replay): cast cost to Number before .toFixed()

### DIFF
--- a/lexwebapp/src/pages/AdminSessionReplayPage.tsx
+++ b/lexwebapp/src/pages/AdminSessionReplayPage.tsx
@@ -255,8 +255,8 @@ export function AdminSessionReplayPage() {
                         )}
                         <div className="flex items-center gap-2 mt-1">
                           <span className="text-gray-500">{formatTime(log.created_at)}</span>
-                          {log.total_cost_usd > 0 && (
-                            <span className="text-yellow-500">${log.total_cost_usd.toFixed(4)}</span>
+                          {Number(log.total_cost_usd) > 0 && (
+                            <span className="text-yellow-500">${Number(log.total_cost_usd).toFixed(4)}</span>
                           )}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- `total_cost_usd` from PostgreSQL NUMERIC column arrives as string via node-postgres
- Calling `.toFixed()` on a string throws TypeError, crashing the replay page
- Wrap with `Number()` before comparison and formatting

## Test plan
- [ ] Open session replay for Вікторія (alisssa8@gmail.com) — no crash, cost values display

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash on the session replay page by casting `total_cost_usd` to `Number` before comparisons and `.toFixed()`. PostgreSQL `NUMERIC` values arrive as strings via `node-postgres`, which caused a TypeError.

<sup>Written for commit 4621eb2f45705957c433d7b33fef150fab1c52a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

