### PR TITLE
fix(ci): move EDRSR cron sync to workstation runner

### DIFF
--- a/.github/workflows/cron-edrsr-sync.yml
+++ b/.github/workflows/cron-edrsr-sync.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   sync-edrsr:
     name: Sync EDRSR ${{ inputs.year || 'current year' }}
-    runs-on: [self-hosted, local]
+    runs-on: [self-hosted, workstation]
     timeout-minutes: 30
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Switch `cron-edrsr-sync.yml` runner from `local` to `workstation` (AWS EC2)
- Fixed WG tunnel: removed stale peer, assigned `10.88.0.4/32` to workstation's actual key, updated SSH config to use WG IP

## Test plan
- [x] WG tunnel workstation → prod: ping OK (3ms)
- [x] SSH `workstation → prod` via WG: works
- [x] All required tools present on workstation (wget, unzip, rsync, psql)
- [ ] Wait for next cron run (04:00 Kyiv) or trigger manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the EDRSR cron sync GitHub Action from `local` to `workstation` self-hosted runner to use the EC2 workstation with a stable WireGuard tunnel to prod and required tooling.

<sup>Written for commit 1a9732d9257b7b462b1287cabc2285f113943fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

