### PR TITLE
fix(ci): fix frontend blue-green deploy service names

### DIFF
--- a/.github/workflows/ci-workstation-prod.yml
+++ b/.github/workflows/ci-workstation-prod.yml
@@ -374,8 +374,11 @@ jobs:
 
           if [ "$FRONTEND_CHANGED" = "true" ]; then
             echo "=== Build & switch frontend ==="
-            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate frontend-prod-${INACTIVE_FE}"
+            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate lexwebapp-prod-${INACTIVE_FE}"
             sleep 5
+
+            echo "=== Update frontend upstream ==="
+            $SSH_CMD "sed -i 's/server lexwebapp-prod-[a-z]*:80/server lexwebapp-prod-${INACTIVE_FE}:80/' ${REMOTE_REPO}/deployment/nginx/includes/prod-upstreams.conf"
             $SSH_CMD "cd ${REMOTE_REPO}/deployment && sed -i 's/^frontend=.*/frontend=${INACTIVE_FE}/' .active-colors && $DC_CMD up -d --force-recreate nginx-prod"
           fi
 

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1276,6 +1276,35 @@ services:
           cpus: '0.1'
           memory: 64M
 
+  lexwebapp-prod-blue:
+    image: lexwebapp-prod:latest
+    container_name: lexwebapp-prod-blue
+    profiles: ["blue"]
+    environment:
+    - NODE_ENV=production
+    - TZ=Europe/Kiev
+    networks:
+    - secondlayer-prod-network
+    restart: unless-stopped
+    healthcheck:
+      test:
+      - CMD
+      - sh
+      - -c
+      - wget --quiet --tries=1 --spider http://127.0.0.1/ || exit 1
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+
   # Minimal monitoring
   prometheus-prod:
     image: prom/prometheus:v2.48.0


### PR DESCRIPTION
## Summary
- Deploy workflow referenced `frontend-prod-*` but compose uses `lexwebapp-prod-*` → `no such service` error
- Added missing `lexwebapp-prod-blue` service definition (mirroring existing green)
- Added `sed` to update `prod-upstreams.conf` before nginx restart so traffic actually switches

## Test plan
- [ ] Merge and verify CI deploys frontend successfully
- [ ] Check nginx upstream points to the new color container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes frontend blue‑green deploy by aligning CI service names with compose and correctly switching nginx upstream. Adds the missing `lexwebapp-prod-blue` service so both colors are available.

- **Bug Fixes**
  - CI now deploys `lexwebapp-prod-${INACTIVE_FE}` instead of `frontend-prod-${INACTIVE_FE}`.
  - Added `lexwebapp-prod-blue` to `docker-compose.prod.yml` (mirrors green).
  - Updates `prod-upstreams.conf` via `sed` before restarting nginx to route traffic to the new color.

<sup>Written for commit 9bc214bc87a37726dd0fcb6c417a21c76db08a52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

