### PR TITLE
fix(ci): use correct compose service names for backend deploy

### DIFF
--- a/.github/workflows/ci-workstation-prod.yml
+++ b/.github/workflows/ci-workstation-prod.yml
@@ -357,19 +357,19 @@ jobs:
           DC_CMD="docker compose -f docker-compose.prod.yml --env-file .env.prod"
 
           if [ "$BACKEND_CHANGED" = "true" ] || [ "$RADA_CHANGED" = "true" ] || [ "$OPENREYESTR_CHANGED" = "true" ]; then
-            echo "=== Start inactive backend color ==="
-            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate secondlayer-app-prod-${INACTIVE_BE}"
+            echo "=== Rebuild and restart active backend ==="
+            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate app-prod rada-mcp-app-prod openreyestr-app-prod"
 
             echo "=== Wait for health ==="
             for i in $(seq 1 30); do
-              HEALTH=$($SSH_CMD "docker inspect --format='{{.State.Health.Status}}' secondlayer-app-prod-${INACTIVE_BE} 2>/dev/null" || echo "starting")
+              HEALTH=$($SSH_CMD "docker inspect --format='{{.State.Health.Status}}' secondlayer-app-prod 2>/dev/null" || echo "starting")
               echo "  Health check $i: $HEALTH"
               [ "$HEALTH" = "healthy" ] && break
               sleep 2
             done
 
-            echo "=== Switch backend traffic ==="
-            $SSH_CMD "cd ${REMOTE_REPO}/deployment && sed -i 's/^backend=.*/backend=${INACTIVE_BE}/' .active-colors && $DC_CMD up -d --force-recreate nginx-prod"
+            echo "=== Force-recreate nginx ==="
+            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --force-recreate nginx-prod"
           fi
 
           if [ "$FRONTEND_CHANGED" = "true" ]; then


### PR DESCRIPTION
## Summary
- Previous PR (#1870) triggered all-services deploy because compose file changed
- Backend deploy used container names (`secondlayer-app-prod-green`) instead of compose service names (`app-prod-green`)
- Blue-green for backend is not fully set up (no blue variant services exist), so deploy directly to active services with `--build --force-recreate`

## Test plan
- [ ] CI should pass: detect → build → deploy all services successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the prod CI backend deploy by using Docker Compose service names and deploying directly to active services. Unblocks backend releases while blue‑green is not in place.

- **Bug Fixes**
  - Use compose services `app-prod`, `rada-mcp-app-prod`, `openreyestr-app-prod` with `--build --force-recreate`.
  - Drop inactive color rollout; wait for `secondlayer-app-prod` health and then force-recreate `nginx-prod`.
  - Remove container-name targets like `secondlayer-app-prod-green` that caused failed/no-op deploys.

<sup>Written for commit fa8ca52f5e38464362dd0968878e1a842f4d324e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

