### PR TITLE
fix(ci): correct openreyestr compose service name

### DIFF
--- a/.github/workflows/ci-workstation-prod.yml
+++ b/.github/workflows/ci-workstation-prod.yml
@@ -358,7 +358,7 @@ jobs:
 
           if [ "$BACKEND_CHANGED" = "true" ] || [ "$RADA_CHANGED" = "true" ] || [ "$OPENREYESTR_CHANGED" = "true" ]; then
             echo "=== Rebuild and restart active backend ==="
-            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate app-prod rada-mcp-app-prod openreyestr-app-prod"
+            $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate app-prod rada-mcp-app-prod app-openreyestr-prod"
 
             echo "=== Wait for health ==="
             for i in $(seq 1 30); do


### PR DESCRIPTION
## Summary
- Compose service is `app-openreyestr-prod`, not `openreyestr-app-prod`

## Test plan
- [ ] CI deploy should pass without "no such service" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI deploy by using the correct Docker Compose service name for OpenReyestr. Replaces `openreyestr-app-prod` with `app-openreyestr-prod` to stop the "no such service" error during prod workstation deploys.

<sup>Written for commit 6366297fe77de65f9687581c2350c18010787567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

