### PR TITLE
fix(ci): write upstreams file directly instead of sed

### DIFF
--- a/.github/workflows/ci-workstation-prod.yml
+++ b/.github/workflows/ci-workstation-prod.yml
@@ -377,10 +377,27 @@ jobs:
             $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --build --force-recreate lexwebapp-prod-${INACTIVE_FE}"
             sleep 5
 
-            echo "=== Update frontend upstream ==="
-            $SSH_CMD "sed -i 's/server lexwebapp-prod-[a-z]*:80/server lexwebapp-prod-${INACTIVE_FE}:80/' ${REMOTE_REPO}/deployment/nginx/includes/prod-upstreams.conf"
-            $SSH_CMD "cd ${REMOTE_REPO}/deployment && sed -i 's/^frontend=.*/frontend=${INACTIVE_FE}/' .active-colors && $DC_CMD up -d --force-recreate nginx-prod"
+            echo "=== Update frontend upstream and switch ==="
+            $SSH_CMD "sed -i 's/^frontend=.*/frontend=${INACTIVE_FE}/' ${REMOTE_REPO}/deployment/.active-colors"
           fi
+
+          echo "=== Write upstreams and reload nginx ==="
+          ACTIVE_FE_NOW=$($SSH_CMD "grep '^frontend=' ${REMOTE_REPO}/deployment/.active-colors | cut -d= -f2")
+          $SSH_CMD "cat > ${REMOTE_REPO}/deployment/nginx/includes/prod-upstreams.conf << UPSTREAM_EOF
+# Active upstreams — managed by CI deploy
+# DO NOT EDIT MANUALLY
+
+upstream prod_mcp_backend {
+    server secondlayer-app-prod:3000;
+    keepalive 128;
+}
+
+upstream prod_frontend {
+    server lexwebapp-prod-${ACTIVE_FE_NOW}:80;
+    keepalive 32;
+}
+UPSTREAM_EOF"
+          $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --force-recreate nginx-prod"
 
       - name: Tag release
         run: |


### PR DESCRIPTION
## Summary
- Previous sed-based upstream update was unreliable (matched wrong patterns, used compose service names instead of container names)
- Nginx crashed with "host not found" because upstream pointed to `lexwebapp-prod:80` and `app-prod:3000` (non-existent DNS names)
- Now writes the complete upstreams file using `.active-colors` state after all deploys complete
- Backend upstream always points to `secondlayer-app-prod:3000` (container name, not service name)

## Test plan
- [ ] Next frontend-only deploy should write correct upstreams and nginx stays healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace fragile sed-based upstream updates with writing the full Nginx upstreams file from `.active-colors` to fix DNS resolution and keep Nginx healthy. Backend now targets container names directly and Nginx is reloaded after changes.

- **Bug Fixes**
  - Generate `nginx/includes/prod-upstreams.conf` from `.active-colors` after deploy.
  - Backend upstream set to `secondlayer-app-prod:3000`.
  - Frontend upstream set to `lexwebapp-prod-${ACTIVE_FE}:80`; update `.active-colors` to switch.
  - Force-recreate `nginx-prod` to apply changes.

<sup>Written for commit 2b708afed98024b25d9d1f189efd903fb8611183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

