### PR TITLE
fix(ci): write prod-backend-vars.conf during deploy

### DIFF
--- a/.github/workflows/ci-workstation-prod.yml
+++ b/.github/workflows/ci-workstation-prod.yml
@@ -381,7 +381,7 @@ jobs:
             $SSH_CMD "sed -i 's/^frontend=.*/frontend=${INACTIVE_FE}/' ${REMOTE_REPO}/deployment/.active-colors"
           fi
 
-          echo "=== Write upstreams and reload nginx ==="
+          echo "=== Write nginx upstream configs ==="
           ACTIVE_FE_NOW=$($SSH_CMD "grep '^frontend=' ${REMOTE_REPO}/deployment/.active-colors | cut -d= -f2")
           $SSH_CMD "cat > ${REMOTE_REPO}/deployment/nginx/includes/prod-upstreams.conf << UPSTREAM_EOF
 # Active upstreams — managed by CI deploy
@@ -397,6 +397,15 @@ upstream prod_frontend {
     keepalive 32;
 }
 UPSTREAM_EOF"
+          $SSH_CMD "cat > ${REMOTE_REPO}/deployment/nginx/includes/prod-backend-vars.conf << VARS_EOF
+# Active backend/frontend hosts — managed by CI deploy
+# DO NOT EDIT MANUALLY
+
+set \\\$prod_backend_host secondlayer-app-prod;
+set \\\$prod_backend http://\\\$prod_backend_host:3000;
+set \\\$prod_frontend_host lexwebapp-prod-${ACTIVE_FE_NOW};
+set \\\$prod_frontend http://\\\$prod_frontend_host:80;
+VARS_EOF"
           $SSH_CMD "cd ${REMOTE_REPO}/deployment && $DC_CMD up -d --force-recreate nginx-prod"
 
       - name: Tag release


### PR DESCRIPTION
## Summary
- Nginx uses `$prod_frontend_host` from `prod-backend-vars.conf` for `proxy_pass`, not the upstream blocks
- Previous fix only updated `prod-upstreams.conf` but `proxy_pass` reads from the vars file
- Now CI writes both files during deploy

## Test plan
- [ ] Next deploy writes both files, nginx resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production deploys by writing `prod-backend-vars.conf` so `nginx` `proxy_pass` points to the correct containers. CI now writes both `prod-upstreams.conf` and `prod-backend-vars.conf` before recreating `nginx-prod`.

- **Bug Fixes**
  - Generate `prod-backend-vars.conf` during deploy to set `$prod_frontend_host` and `$prod_backend_host` correctly.
  - Keep writing `prod-upstreams.conf` and restart `nginx-prod` to apply the configs.

<sup>Written for commit d0e6035556ade01eafa9f96d8450e22a156005d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

