### PR TITLE
fix(ci): clean stale dist dirs before build in deploy step

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -356,12 +356,15 @@ jobs:
               git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
             find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
             cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+            rm -rf mcp_backend/dist
             npm --prefix mcp_backend install && npm --prefix mcp_backend run build
           fi
           if [ "$RADA_CHANGED" = "true" ]; then
+            rm -rf mcp_rada/dist
             npm --prefix mcp_rada install && npm --prefix mcp_rada run build
           fi
           if [ "$OPENREYESTR_CHANGED" = "true" ]; then
+            rm -rf mcp_openreyestr/dist
             npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build
           fi
 


### PR DESCRIPTION
## Summary
- Add `rm -rf dist` before `npm run build` for backend/rada/openreyestr in the Deploy to Local step
- Fixes EACCES errors when Docker leaves `dist/` owned by root

## Test plan
- [ ] Merge and verify local CI deploy step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clean dist directories before builds in the CI local deploy workflow to prevent EACCES errors from root-owned artifacts. Removes `mcp_backend/dist`, `mcp_rada/dist`, and `mcp_openreyestr/dist` before running `npm run build`.

<sup>Written for commit 9df31753a93a5c1f4863cdd05ef15df7597f3977. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

