### PR TITLE
fix(ci): use correct blue-profile container names for frontend deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -533,7 +533,7 @@ jobs:
               if [ "\$NEW_FRONTEND" = "green" ]; then
                 \$DC --profile green up -d lexwebapp-prod-green
               else
-                \$DC up -d lexwebapp-prod
+                \$DC --profile blue up -d lexwebapp-prod-blue
               fi
             fi
             if [ "${PLATFORM_CHANGED}" = "true" ]; then
@@ -582,7 +582,7 @@ jobs:
               if [ "\$NEW_FRONTEND" = "green" ]; then
                 wait_healthy "lexwebapp-prod-green" 60 || HEALTH_OK=false
               else
-                wait_healthy "lexwebapp-prod" 60 || HEALTH_OK=false
+                wait_healthy "lexwebapp-prod-blue" 60 || HEALTH_OK=false
               fi
             fi
             if [ "${PLATFORM_CHANGED}" = "true" ]; then
@@ -606,8 +606,8 @@ jobs:
                   \$DC --profile green stop lexwebapp-prod-green 2>/dev/null || true
                   \$DC --profile green rm -f lexwebapp-prod-green 2>/dev/null || true
                 else
-                  \$DC stop lexwebapp-prod 2>/dev/null || true
-                  \$DC rm -f lexwebapp-prod 2>/dev/null || true
+                  \$DC --profile blue stop lexwebapp-prod-blue 2>/dev/null || true
+                  \$DC --profile blue rm -f lexwebapp-prod-blue 2>/dev/null || true
                 fi
               fi
               exit 1
@@ -621,10 +621,10 @@ jobs:
               [ "\$BACKEND_COLOR" = "green" ] && PREVIEW_BE_HOST="secondlayer-app-prod-green" || PREVIEW_BE_HOST="secondlayer-app-prod"
             fi
             if [ "${FRONTEND_CHANGED}" = "true" ]; then
-              [ "\$NEW_FRONTEND" = "green" ] && PREVIEW_FE_HOST="lexwebapp-prod-green" || PREVIEW_FE_HOST="lexwebapp-prod"
+              [ "\$NEW_FRONTEND" = "green" ] && PREVIEW_FE_HOST="lexwebapp-prod-green" || PREVIEW_FE_HOST="lexwebapp-prod-blue"
             else
               # No frontend change — preview frontend points to current prod frontend
-              [ "\$FRONTEND_COLOR" = "green" ] && PREVIEW_FE_HOST="lexwebapp-prod-green" || PREVIEW_FE_HOST="lexwebapp-prod"
+              [ "\$FRONTEND_COLOR" = "green" ] && PREVIEW_FE_HOST="lexwebapp-prod-green" || PREVIEW_FE_HOST="lexwebapp-prod-blue"
             fi
 
             printf '# Preview upstreams — managed by deploy script\n# Points to inactive color containers for pre-production preview\n# DO NOT EDIT MANUALLY\n\nupstream preview_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream preview_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$PREVIEW_BE_HOST" "\$PREVIEW_FE_HOST" > nginx/includes/preview-upstreams.conf
@@ -711,11 +711,11 @@ jobs:
               echo "WARNING: .active-colors disagrees with docker state, correcting backend=blue"
             fi
             if docker inspect lexwebapp-prod-green --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
-              if ! docker inspect lexwebapp-prod --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+              if ! docker inspect lexwebapp-prod-blue --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
                 FRONTEND_COLOR="green"
                 echo "WARNING: .active-colors disagrees with docker state, correcting frontend=green"
               fi
-            elif docker inspect lexwebapp-prod --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
+            elif docker inspect lexwebapp-prod-blue --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
               FRONTEND_COLOR="blue"
               echo "WARNING: .active-colors disagrees with docker state, correcting frontend=blue"
             fi
@@ -740,9 +740,9 @@ jobs:
               [ "\$BACKEND_COLOR" = "green" ] && BE_HOST="secondlayer-app-prod-green" || BE_HOST="secondlayer-app-prod"
             fi
             if [ "${FRONTEND_CHANGED}" = "true" ]; then
-              [ "\$NEW_FRONTEND" = "green" ] && FE_HOST="lexwebapp-prod-green" || FE_HOST="lexwebapp-prod"
+              [ "\$NEW_FRONTEND" = "green" ] && FE_HOST="lexwebapp-prod-green" || FE_HOST="lexwebapp-prod-blue"
             else
-              [ "\$FRONTEND_COLOR" = "green" ] && FE_HOST="lexwebapp-prod-green" || FE_HOST="lexwebapp-prod"
+              [ "\$FRONTEND_COLOR" = "green" ] && FE_HOST="lexwebapp-prod-green" || FE_HOST="lexwebapp-prod-blue"
             fi
 
             printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-upstreams.conf
@@ -766,7 +766,7 @@ jobs:
               if docker inspect lexwebapp-prod-green --format '{{.State.Running}}' 2>/dev/null | grep -q true; then
                 FE_HOST="lexwebapp-prod-green"
               else
-                FE_HOST="lexwebapp-prod"
+                FE_HOST="lexwebapp-prod-blue"
               fi
               printf '# Active upstreams — managed by deploy script (blue-green switching)\n# DO NOT EDIT MANUALLY — overwritten during zero-downtime deploy\n\nupstream prod_mcp_backend {\n    server %s:3000;\n    keepalive 128;\n}\n\nupstream prod_frontend {\n    server %s:80;\n    keepalive 32;\n}\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-upstreams.conf
               printf '# Backend hostname variables for dynamic DNS resolution\n# Managed by deploy script (blue-green switching)\n\nset \$prod_backend_host %s;\nset \$prod_backend http://\$prod_backend_host:3000;\nset \$prod_frontend_host %s;\nset \$prod_frontend http://\$prod_frontend_host:80;\n' "\$BE_HOST" "\$FE_HOST" > nginx/includes/prod-backend-vars.conf
@@ -795,8 +795,8 @@ jobs:
                 \$DC --profile green stop lexwebapp-prod-green 2>/dev/null || true
                 \$DC --profile green rm -f lexwebapp-prod-green 2>/dev/null || true
               else
-                \$DC stop lexwebapp-prod 2>/dev/null || true
-                \$DC rm -f lexwebapp-prod 2>/dev/null || true
+                \$DC --profile blue stop lexwebapp-prod-blue 2>/dev/null || true
+                \$DC --profile blue rm -f lexwebapp-prod-blue 2>/dev/null || true
               fi
               FRONTEND_COLOR="\$NEW_FRONTEND"
             fi
@@ -921,7 +921,7 @@ jobs:
 
               echo ""
               echo "=== Last 30 lines from failing containers ==="
-              for svc in app-prod rada-mcp-app-prod app-openreyestr-prod document-service-prod nginx-prod lexwebapp-prod; do
+              for svc in app-prod rada-mcp-app-prod app-openreyestr-prod document-service-prod nginx-prod lexwebapp-prod-blue lexwebapp-prod-green; do
                 echo "--- $svc ---"
                 $SSH_CMD "cd ${REMOTE_REPO}/deployment && docker compose -f docker-compose.prod.yml --env-file .env.prod logs --tail=30 $svc" 2>&1 || true
               done


### PR DESCRIPTION
## Summary
- Frontend blue in compose is `lexwebapp-prod-blue` (profile blue), not `lexwebapp-prod` (default)
- `deploy-prod.yml` was mapping blue → `lexwebapp-prod`, causing nginx to 502 after deploy
- Fixed 15 references across both Phase 1 (preview) and Phase 2 (promote): compose up/stop/rm, health checks, upstream config generation, color detection, fallback logic, diagnostics

## Root cause
Compose defines 3 frontend services: `lexwebapp-prod` (default, no profile), `lexwebapp-prod-green` (profile green), `lexwebapp-prod-blue` (profile blue). The deploy script assumed blue = default, but workstation CI was deploying using the blue profile.

## Test plan
- [ ] Verify on next frontend deploy that upstreams correctly reference `lexwebapp-prod-blue` or `lexwebapp-prod-green`
- [ ] No 502 after nginx recreate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blue-green frontend deploys by using the correct blue-profile container. Blue now maps to `lexwebapp-prod-blue` (with `--profile blue`), preventing nginx 502s after deploy.

- **Bug Fixes**
  - Use `lexwebapp-prod-blue` for compose up/stop/rm and health checks when blue is selected.
  - Fix preview/prod upstream host selection and color detection to target `lexwebapp-prod-blue` instead of `lexwebapp-prod`.
  - Update fallback logic and diagnostics to include `lexwebapp-prod-blue` and `lexwebapp-prod-green`.

<sup>Written for commit d9ac35336c5818f823c65b05cce646419e41e8de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

