### PR TITLE
fix(session-replay): enable page scrolling

### DIFF
--- a/lexwebapp/src/pages/AdminSessionReplayPage.tsx
+++ b/lexwebapp/src/pages/AdminSessionReplayPage.tsx
@@ -164,7 +164,7 @@ export function AdminSessionReplayPage() {
   // Replay view
   if (selectedSession) {
     return (
-      <div className="min-h-screen bg-gray-950 text-gray-100 p-4">
+      <div className="h-full overflow-y-auto bg-gray-950 text-gray-100 p-4">
         {/* Header */}
         <div className="flex items-center gap-4 mb-4">
           <button
@@ -279,7 +279,7 @@ export function AdminSessionReplayPage() {
 
   // Session list view
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100 p-4">
+    <div className="h-full overflow-y-auto bg-gray-950 text-gray-100 p-4">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-xl font-semibold">Запис сесій користувачів</h1>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- MainLayout wraps content in `h-screen overflow-hidden`
- Session replay page used `min-h-screen` which overflowed but was clipped
- Changed to `h-full overflow-y-auto` so the page scrolls within the layout container

## Test plan
- [ ] Session list and replay views scroll properly on /admin/session-replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scrolling on the Session Replay page inside `MainLayout`. Replaces `min-h-screen` with `h-full overflow-y-auto` on both the list and replay views so content scrolls instead of being clipped.

<sup>Written for commit eb94c806b7952f640fe58ff46c7da217be3d9bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

