### PR TITLE
fix(infra): fix broken charts on admin infrastructure page

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1372,7 +1372,7 @@ services:
     image: oliver006/redis_exporter:v1.56.0
     container_name: redis-exporter-prod
     environment:
-      REDIS_ADDR: "redis://redis-prod:6379"
+      REDIS_ADDR: "redis://:${REDIS_PASSWORD}@redis-prod:6379"
     networks:
       - secondlayer-prod-network
     restart: unless-stopped

--- a/mcp_backend/src/routes/admin/admin-metrics.ts
+++ b/mcp_backend/src/routes/admin/admin-metrics.ts
@@ -405,17 +405,17 @@ export function createAdminMetricsRoutes(
         queueDepth,
         concurrencyActive, concurrencyMax,
       ] = await Promise.all([
-        prometheus.queryRange('upload_jobs_completed_total', start, end, step),
-        prometheus.queryRange('upload_jobs_failed_total', start, end, step),
-        prometheus.queryRange('upload_jobs_active', start, end, step),
-        prometheus.queryRange('upload_jobs_waiting', start, end, step),
-        prometheus.queryRange('upload_jobs_delayed', start, end, step),
+        prometheus.queryRange('bullmq_jobs{status="completed"}', start, end, step),
+        prometheus.queryRange('bullmq_jobs{status="failed"}', start, end, step),
+        prometheus.queryRange('bullmq_jobs{status="active"}', start, end, step),
+        prometheus.queryRange('bullmq_jobs{status="waiting"}', start, end, step),
+        prometheus.queryRange('bullmq_jobs{status="delayed"}', start, end, step),
         prometheus.queryRange('histogram_quantile(0.50, rate(upload_processing_duration_seconds_bucket[5m]))', start, end, step),
         prometheus.queryRange('histogram_quantile(0.95, rate(upload_processing_duration_seconds_bucket[5m]))', start, end, step),
         prometheus.queryRange('histogram_quantile(0.99, rate(upload_processing_duration_seconds_bucket[5m]))', start, end, step),
         prometheus.queryRange('upload_queue_depth', start, end, step),
-        prometheus.queryRange('upload_concurrent_processing', start, end, step),
-        prometheus.queryRange('upload_max_concurrent_processing', start, end, step),
+        prometheus.queryRange('upload_processing_active', start, end, step),
+        prometheus.queryRange('cpu_adaptive_concurrency', start, end, step),
       ]);
 
       const completedVals = jobsCompleted[0]?.values || [];


### PR DESCRIPTION
## Summary
- Fix Upload Pipeline section: Prometheus queries used wrong metric names (`upload_jobs_*` → `bullmq_jobs{status=...}`, `upload_concurrent_processing` → `upload_processing_active`, `upload_max_concurrent_processing` → `cpu_adaptive_concurrency`)
- Fix Redis charts in Infrastructure section: redis-exporter lacked `REDIS_PASSWORD` so all Redis metrics were empty (`redis_up=0`)

## Post-deploy
Restart redis-exporter on prod: `docker compose -f docker-compose.prod.yml --env-file .env.prod up -d redis-exporter`

## Test plan
- [ ] Verify Upload Pipeline section shows BullMQ job counts, queue depth, concurrency
- [ ] Verify Redis Memory, Redis Commands Rate, Redis Clients charts populate after exporter restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Upload Pipeline and Redis charts on the admin Infrastructure page. Uses the correct Prometheus metrics and passes Redis auth to `redis_exporter` so charts populate again.

- **Bug Fixes**
  - Upload Pipeline: query `bullmq_jobs{status="completed|failed|active|waiting|delayed"}`; fix concurrency to `upload_processing_active` and `cpu_adaptive_concurrency`.
  - Redis: set `REDIS_ADDR` to `redis://:${REDIS_PASSWORD}@redis-prod:6379` for `redis_exporter` to restore metrics.

- **Migration**
  - After deploy, restart the exporter: `docker compose -f docker-compose.prod.yml --env-file .env.prod up -d redis-exporter`

<sup>Written for commit 55136613813df5762b8fb01d47d33571aa138b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

