### PR TITLE
feat(containers): add 7d and 30d time ranges

### DIFF
--- a/lexwebapp/src/pages/AdminContainersPage.tsx
+++ b/lexwebapp/src/pages/AdminContainersPage.tsx
@@ -26,7 +26,7 @@ import { getErrorMessage } from '../utils/errors';
 
 // ── Types ──────────────────────────────────────────────
 
-type TimeRange = '1h' | '6h' | '24h';
+type TimeRange = '1h' | '6h' | '24h' | '7d' | '30d';
 
 interface ContainerSnapshot {
   name: string;
@@ -244,7 +244,7 @@ export function AdminContainersPage() {
           <h2 className="text-xl font-semibold text-claude-text">Контейнери</h2>
           <div className="flex items-center gap-2">
             {/* Time range */}
-            {(['1h', '6h', '24h'] as TimeRange[]).map((r) => (
+            {(['1h', '6h', '24h', '7d', '30d'] as TimeRange[]).map((r) => (
               <button
                 key={r}
                 onClick={() => setRange(r)}

--- a/mcp_backend/src/routes/admin/admin-metrics.ts
+++ b/mcp_backend/src/routes/admin/admin-metrics.ts
@@ -14,9 +14,9 @@ import { logger } from '../../utils/logger.js';
  * Helper: parse range param and compute start/end/step
  */
 function parseRange(range: string) {
-  const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400 };
+  const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400, '7d': 604800, '30d': 2592000 };
   const seconds = rangeSeconds[range] || 3600;
-  const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : '5m';
+  const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : seconds <= 86400 ? '5m' : seconds <= 604800 ? '30m' : '2h';
   const end = Math.floor(Date.now() / 1000);
   const start = end - seconds;
   return { start, end, step };
@@ -45,9 +45,9 @@ export function createAdminMetricsRoutes(
   router.get('/metrics/traffic', async (req: Request, res: Response) => {
     try {
       const range = (req.query.range as string) || '1h';
-      const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400 };
+      const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400, '7d': 604800, '30d': 2592000 };
       const seconds = rangeSeconds[range] || 3600;
-      const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : '5m';
+      const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : seconds <= 86400 ? '5m' : seconds <= 604800 ? '30m' : '2h';
       const end = Math.floor(Date.now() / 1000);
       const start = end - seconds;
 
@@ -76,9 +76,9 @@ export function createAdminMetricsRoutes(
   router.get('/metrics/latency', async (req: Request, res: Response) => {
     try {
       const range = (req.query.range as string) || '1h';
-      const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400 };
+      const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400, '7d': 604800, '30d': 2592000 };
       const seconds = rangeSeconds[range] || 3600;
-      const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : '5m';
+      const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : seconds <= 86400 ? '5m' : seconds <= 604800 ? '30m' : '2h';
       const end = Math.floor(Date.now() / 1000);
       const start = end - seconds;
 
@@ -169,9 +169,9 @@ export function createAdminMetricsRoutes(
   router.get('/metrics/containers', async (req: Request, res: Response) => {
     try {
       const range = (req.query.range as string) || '1h';
-      const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400 };
+      const rangeSeconds: Record<string, number> = { '1h': 3600, '6h': 21600, '24h': 86400, '7d': 604800, '30d': 2592000 };
       const seconds = rangeSeconds[range] || 3600;
-      const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : '5m';
+      const step = seconds <= 3600 ? '30s' : seconds <= 21600 ? '2m' : seconds <= 86400 ? '5m' : seconds <= 604800 ? '30m' : '2h';
       const end = Math.floor(Date.now() / 1000);
       const start = end - seconds;
 


### PR DESCRIPTION
## Summary
- Added 7d and 30d time ranges to container metrics page
- Backend: step sizes 30m (7d) and 2h (30d) to keep response manageable
- Prometheus retention is 30d - covers all ranges

## Test plan
- [ ] Click 7d/30d buttons on /admin/containers - graphs render
- [ ] Existing 1h/6h/24h still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds 7d and 30d time ranges for admin container metrics with coarser sampling to keep responses fast. Backend metrics endpoints now accept these ranges; 30d Prometheus retention covers them.

- **New Features**
  - Frontend: Added 7d and 30d buttons to the Admin Containers page.
  - Backend: Added support for 7d (30m step) and 30d (2h step) across traffic, latency, and containers endpoints.
  - Existing 1h/6h/24h ranges are unchanged.

<sup>Written for commit 92acb064396cc136365ffb956d3a1a1385fe4fcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

