### PR TITLE
feat(grafana): Bedrock costs dashboard via PostgreSQL

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -160,7 +160,7 @@ services:
       interval: 30s
       timeout: 5s
       retries: 10
-      start_period: 600s
+      start_period: 1800s
     restart: unless-stopped
     networks:
     - secondlayer-prod-network
@@ -1410,6 +1410,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
       - GF_USERS_ALLOW_SIGN_UP=false
       - PROMETHEUS_HOST=prometheus-prod
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-}
     volumes:
       - grafana_prod_data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning:ro

--- a/deployment/grafana/dashboards/04-api-costs.json
+++ b/deployment/grafana/dashboards/04-api-costs.json
@@ -3,10 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -26,321 +23,374 @@
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "id": 1,
       "panels": [],
-      "title": "Cost Summary",
+      "title": "Bedrock Inference Costs",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
+          "color": { "mode": "thresholds" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 1 },
-              { "color": "red", "value": 5 }
+              { "color": "yellow", "value": 5 },
+              { "color": "red", "value": 20 }
             ]
           },
           "unit": "currencyUSD"
-        },
-        "overrides": []
+        }
       },
-      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
       "id": 2,
       "options": {
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "sum(rate(cost_tracking_total_usd[1h])) * 3600",
-          "legendFormat": "Cost/Hour",
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT COALESCE(SUM(total_cost_usd), 0) as cost FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '24 hours'",
+          "format": "table",
           "refId": "A"
         }
       ],
-      "title": "Cost / Hour",
+      "title": "Cost / 24h",
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
+          "color": { "mode": "thresholds" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 20 },
+              { "color": "yellow", "value": 30 },
               { "color": "red", "value": 100 }
             ]
           },
           "unit": "currencyUSD"
-        },
-        "overrides": []
+        }
       },
-      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
       "id": 3,
       "options": {
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "sum(rate(cost_tracking_total_usd[1h])) * 86400",
-          "legendFormat": "Cost/Day",
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT COALESCE(SUM(total_cost_usd), 0) as cost FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '7 days'",
+          "format": "table",
           "refId": "A"
         }
       ],
-      "title": "Cost / Day (Extrapolated)",
+      "title": "Cost / 7d",
       "type": "stat"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
+          "color": { "mode": "thresholds" },
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 500 },
-              { "color": "red", "value": 2000 }
+              { "color": "yellow", "value": 100 },
+              { "color": "red", "value": 500 }
             ]
           },
           "unit": "currencyUSD"
-        },
-        "overrides": []
+        }
       },
-      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 1 },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
       "id": 4,
       "options": {
         "colorMode": "background",
-        "graphMode": "area",
+        "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "sum(rate(cost_tracking_total_usd[1h])) * 2592000",
-          "legendFormat": "Cost/Month",
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT COALESCE(SUM(total_cost_usd), 0) as cost FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '30 days'",
+          "format": "table",
           "refId": "A"
         }
       ],
-      "title": "Cost / Month (Extrapolated)",
+      "title": "Cost / 30d",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "blue", "value": null }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT COUNT(*) as calls FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '24 hours' AND total_cost_usd > 0",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Paid Calls / 24h",
       "type": "stat"
     },
     {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
-      "id": 5,
+      "id": 10,
       "panels": [],
-      "title": "Cost Trends",
+      "title": "Daily Cost Trend",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
+          "color": { "mode": "palette-classic" },
           "custom": {
             "axisBorderShow": false,
             "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "USD/s",
+            "axisLabel": "USD",
             "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 20,
+            "drawStyle": "bars",
+            "fillOpacity": 80,
             "gradientMode": "scheme",
-            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
+            "lineWidth": 1,
             "pointSize": 5,
-            "scaleDistribution": { "type": "linear" },
             "showPoints": "never",
-            "spanNulls": false,
-            "stacking": { "group": "A", "mode": "none" },
-            "thresholdsStyle": { "mode": "off" }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              { "color": "green", "value": null }
-            ]
+            "stacking": { "group": "A", "mode": "normal" }
           },
           "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
-      "id": 6,
-      "options": {
-        "legend": {
-          "calcs": ["mean", "max", "sum"],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
         }
       },
-      "pluginVersion": "10.0.0",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "id": 11,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "sum(rate(cost_tracking_total_usd[5m])) by (tool_name)",
-          "legendFormat": "{{tool_name}}",
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT date_trunc('day', created_at) as time, tool_name, SUM(total_cost_usd) as cost FROM cost_tracking WHERE created_at >= NOW() - INTERVAL '30 days' AND total_cost_usd > 0 GROUP BY 1, 2 ORDER BY 1",
+          "format": "time_series",
           "refId": "A"
         }
       ],
-      "title": "Cost Trend by Tool",
+      "title": "Daily Cost by Tool",
       "type": "timeseries"
     },
     {
       "collapsed": false,
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
-      "id": 7,
+      "id": 20,
       "panels": [],
-      "title": "Top Expensive Tools",
+      "title": "Model Breakdown (Bedrock)",
       "type": "row"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "Prometheus"
-      },
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisLabel": "USD",
+            "axisPlacement": "auto",
+            "drawStyle": "bars",
+            "fillOpacity": 80,
+            "gradientMode": "scheme",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
           },
-          "mappings": [],
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 15 },
+      "id": 21,
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT date_trunc('day', ct.created_at) as time, call->>'model' as model, SUM((call->>'cost')::numeric) as cost FROM cost_tracking ct, jsonb_array_elements(ct.openai_calls) as call WHERE ct.created_at >= NOW() - INTERVAL '30 days' AND ct.openai_calls IS NOT NULL AND ct.openai_calls != 'null'::jsonb AND call->>'model' LIKE 'eu.anthropic.%' GROUP BY 1, 2 ORDER BY 1",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "title": "Daily Cost by Bedrock Model",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "id": 30,
+      "panels": [],
+      "title": "Top Tools & Token Usage",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "currencyUSD",
           "thresholds": {
             "mode": "absolute",
             "steps": [
               { "color": "green", "value": null },
-              { "color": "yellow", "value": 0.5 },
-              { "color": "red", "value": 2 }
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
             ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
+          }
+        }
       },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 15 },
-      "id": 8,
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "id": 31,
       "options": {
         "displayMode": "gradient",
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "auto",
         "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": ["lastNotNull"],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "valueMode": "color"
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
       },
-      "pluginVersion": "10.0.0",
       "targets": [
         {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "Prometheus"
-          },
-          "expr": "topk(10, sum by (tool_name) (cost_tracking_total_usd))",
-          "legendFormat": "{{tool_name}}",
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT tool_name as metric, SUM(total_cost_usd) as value FROM cost_tracking WHERE created_at >= $__timeFrom() AND created_at <= $__timeTo() AND total_cost_usd > 0 GROUP BY tool_name ORDER BY value DESC LIMIT 10",
+          "format": "table",
           "refId": "A"
         }
       ],
-      "title": "Top 10 Expensive Tools",
+      "title": "Top 10 Tools by Cost",
       "type": "bargauge"
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "id": 32,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT call->>'model' as metric, SUM(COALESCE((call->>'prompt_tokens')::int, 0) + COALESCE((call->>'completion_tokens')::int, 0)) as value FROM cost_tracking ct, jsonb_array_elements(ct.openai_calls) as call WHERE ct.created_at >= $__timeFrom() AND ct.created_at <= $__timeTo() AND ct.openai_calls IS NOT NULL AND ct.openai_calls != 'null'::jsonb GROUP BY 1 ORDER BY value DESC LIMIT 10",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Token Usage by Model",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "id": 40,
+      "panels": [],
+      "title": "Hourly Cost (Zoom In)",
+      "type": "row"
+    },
+    {
+      "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisLabel": "USD",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "scheme",
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "currencyUSD"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 33 },
+      "id": 41,
+      "options": {
+        "legend": { "calcs": ["sum", "mean"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "postgres", "uid": "PostgreSQL" },
+          "rawSql": "SELECT date_trunc('hour', created_at) as time, SUM(total_cost_usd) as total FROM cost_tracking WHERE created_at >= $__timeFrom() AND created_at <= $__timeTo() AND total_cost_usd > 0 GROUP BY 1 ORDER BY 1",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "title": "Hourly Cost",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",
   "schemaVersion": 38,
-  "tags": ["secondlayer", "costs", "billing"],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-24h",
-    "to": "now"
-  },
+  "tags": ["secondlayer", "costs", "bedrock", "billing"],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
   "title": "SecondLayer - API Costs",
   "uid": "api-costs",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/deployment/grafana/provisioning/datasources/prometheus.yml
+++ b/deployment/grafana/provisioning/datasources/prometheus.yml
@@ -10,3 +10,21 @@ datasources:
     editable: false
     jsonData:
       timeInterval: 10s
+
+  - name: PostgreSQL
+    uid: PostgreSQL
+    type: postgres
+    access: proxy
+    url: pgbouncer-prod:5432
+    user: secondlayer
+    secureJsonData:
+      password: $POSTGRES_PASSWORD
+    jsonData:
+      database: secondlayer_prod
+      sslmode: disable
+      maxOpenConns: 2
+      maxIdleConns: 2
+      connMaxLifetime: 14400
+      postgresVersion: 1500
+      timescaledb: false
+    editable: false


### PR DESCRIPTION
## Summary
Old Prometheus-based dashboard was broken (counters reset on deploy, always showed 0).

Rewrote to query `cost_tracking` table directly via PostgreSQL datasource:
- **Cost cards**: actual 24h / 7d / 30d costs + paid call count
- **Daily cost by tool**: stacked bar chart (30d)
- **Daily cost by Bedrock model**: `eu.anthropic.claude-*` breakdown from `openai_calls` JSONB
- **Top 10 tools**: bar gauge (time-range aware)
- **Token usage by model**: from JSONB call details
- **Hourly cost**: line chart for zoom-in

Also adds PostgreSQL datasource provisioning + `POSTGRES_PASSWORD` env to Grafana container.

## Test plan
- [ ] After deploy, recreate grafana: `docker compose ... up -d --force-recreate grafana-prod`
- [ ] Open https://grafana.legal.org.ua/d/api-costs - panels show real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the API costs dashboard to query PostgreSQL instead of Prometheus, fixing counter resets and showing accurate Bedrock inference costs. Adds a provisioned PostgreSQL datasource and small Grafana container tweaks to enable it.

- New Features
  - Cost cards for 24h, 7d, 30d, plus paid call count
  - Daily stacked bars by tool (30d) and by Bedrock model from JSONB
  - Top 10 tools by cost (time-range aware)
  - Token usage by model from JSONB
  - Hourly cost trend (zoom-in)

- Migration
  - Provisioned PostgreSQL datasource in Grafana (via `pgbouncer-prod`); set `POSTGRES_PASSWORD` in the Grafana env
  - After deploy, recreate the Grafana service to load the datasource
  - Increased Grafana healthcheck start_period to 1800s

<sup>Written for commit 3d8c0b180583828cacbb16ac6438cf1767933869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

