### PR TITLE
fix: ECHR sync implicit any types for Docker build

### DIFF
--- a/mcp_backend/src/services/echr-hudoc-sync-service.ts
+++ b/mcp_backend/src/services/echr-hudoc-sync-service.ts
@@ -307,7 +307,7 @@ export class EchrHudocSyncService {
        GROUP BY c.respondent, l.completed_at, l.status
        ORDER BY c.respondent`
     );
-    return res.rows.map(r => ({
+    return res.rows.map((r: any) => ({
       country: r.country,
       lastSyncAt: r.last_sync_at,
       lastStatus: r.last_status,
@@ -504,7 +504,7 @@ export class EchrHudocSyncService {
        WHERE item_id = ANY($1) AND (full_text IS NULL OR full_text = '')`,
       [itemIds]
     );
-    return res.rows.map(r => r.item_id);
+    return res.rows.map((r: any) => r.item_id);
   }
 
   private async downloadTextsInBatches(itemIds: string[]): Promise<{ downloaded: number; errors: number }> {


### PR DESCRIPTION
## Summary
- Fixes Docker build failure from #1887 — two `noImplicitAny` errors in `echr-hudoc-sync-service.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Docker build failure by adding explicit `any` annotations to two `map` callbacks in `mcp_backend/src/services/echr-hudoc-sync-service.ts` to satisfy `noImplicitAny`. No runtime changes; TypeScript now compiles under the strict Docker tsconfig.

<sup>Written for commit 18d27972d23d4fc84995c90b5ab0da50493e0ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

