### PR TITLE
fix(deploy): add HTTP readiness check before blue-green switch

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -551,7 +551,7 @@ jobs:
                 local status
                 status=\$(docker inspect --format='{{.State.Health.Status}}' "\$container" 2>/dev/null || echo "not_found")
                 case "\$status" in
-                  healthy) echo "✓ \$container: healthy (\${elapsed}s)"; return 0 ;;
+                  healthy) echo "✓ \$container: docker healthy (\${elapsed}s)"; break ;;
                   unhealthy)
                     echo "✗ \$container: unhealthy after \${elapsed}s"
                     docker logs --tail=20 "\$container" 2>&1
@@ -559,8 +559,31 @@ jobs:
                   *) sleep 5; elapsed=\$((elapsed + 5)) ;;
                 esac
               done
-              echo "✗ \$container: timed out (\${max_wait}s)"
-              docker logs --tail=20 "\$container" 2>&1
+              if [ \$elapsed -ge \$max_wait ]; then
+                echo "✗ \$container: timed out (\${max_wait}s)"
+                docker logs --tail=20 "\$container" 2>&1
+                return 1
+              fi
+              # Application-level HTTP readiness check
+              local port=""
+              case "\$container" in
+                *app-prod*|secondlayer-app*) port=3000 ;;
+                *rada*) port=3001 ;;
+                *openreyestr*) port=3005 ;;
+                *document-service*) port=3002 ;;
+                *) echo "✓ \$container: no HTTP check needed"; return 0 ;;
+              esac
+              echo "Verifying HTTP readiness on port \$port..."
+              local http_wait=0
+              while [ \$http_wait -lt 60 ]; do
+                if docker exec "\$container" wget -q -O /dev/null --timeout=5 "http://127.0.0.1:\${port}/health" 2>/dev/null; then
+                  echo "✓ \$container: HTTP ready on :\$port (\${http_wait}s after docker healthy)"
+                  return 0
+                fi
+                sleep 3; http_wait=\$((http_wait + 3))
+              done
+              echo "✗ \$container: docker healthy but HTTP not responding on :\$port after 60s"
+              docker logs --tail=30 "\$container" 2>&1
               return 1
             }
 
@@ -733,6 +756,28 @@ jobs:
 
             echo "Promoting: Backend \$BACKEND_COLOR → \$NEW_BACKEND, Frontend \$FRONTEND_COLOR → \$NEW_FRONTEND"
 
+            # --- 0. Verify new containers are still healthy before switching traffic ---
+            if [ "\$ANY_BACKEND" = "true" ]; then
+              if [ "\$NEW_BACKEND" = "green" ]; then
+                BE_CONTAINER="secondlayer-app-prod-green"
+              else
+                BE_CONTAINER="secondlayer-app-prod"
+              fi
+              echo "Pre-switch health check: \$BE_CONTAINER"
+              for i in 1 2 3 4 5 6; do
+                if docker exec "\$BE_CONTAINER" wget -q -O /dev/null --timeout=5 "http://127.0.0.1:3000/health" 2>/dev/null; then
+                  echo "✓ \$BE_CONTAINER: HTTP ready"
+                  break
+                fi
+                if [ \$i -eq 6 ]; then
+                  echo "::error::\$BE_CONTAINER is not responding on :3000 — aborting promotion"
+                  exit 1
+                fi
+                echo "  Waiting... (\$i/6)"
+                sleep 10
+              done
+            fi
+
             # --- 1. Switch prod upstreams to new color ---
             if [ "\$ANY_BACKEND" = "true" ]; then
               [ "\$NEW_BACKEND" = "green" ] && BE_HOST="secondlayer-app-prod-green" || BE_HOST="secondlayer-app-prod"
@@ -811,15 +856,19 @@ jobs:
             if [ "\$BACKEND_COLOR" = "green" ]; then
               BE_CONTAINER="secondlayer-app-prod-green"
               OR_CONTAINER="openreyestr-app-prod-green"
+              RADA_CONTAINER="rada-mcp-app-prod-green"
             else
               BE_CONTAINER="secondlayer-app-prod"
               OR_CONTAINER="openreyestr-app-prod"
+              RADA_CONTAINER="rada-mcp-app-prod"
             fi
-            echo "Adding canonical DNS aliases (app-prod, app-openreyestr-prod) to \$BE_CONTAINER, \$OR_CONTAINER"
+            echo "Adding canonical DNS aliases (app-prod, app-openreyestr-prod, rada-mcp-app-prod) to \$BE_CONTAINER, \$OR_CONTAINER, \$RADA_CONTAINER"
             docker network disconnect "\$NETWORK" "\$BE_CONTAINER" 2>/dev/null || true
             docker network connect --alias app-prod "\$NETWORK" "\$BE_CONTAINER" || true
             docker network disconnect "\$NETWORK" "\$OR_CONTAINER" 2>/dev/null || true
             docker network connect --alias app-openreyestr-prod "\$NETWORK" "\$OR_CONTAINER" || true
+            docker network disconnect "\$NETWORK" "\$RADA_CONTAINER" 2>/dev/null || true
+            docker network connect --alias rada-mcp-app-prod "\$NETWORK" "\$RADA_CONTAINER" || true
 
             # Restart monitoring if needed
             if [ "${MONITORING_CHANGED}" = "true" ]; then


### PR DESCRIPTION
## Summary
- `wait_healthy()` now does an **application-level HTTP check** after Docker reports healthy - waits up to 60s for the HTTP endpoint to respond
- `promote-to-prod` verifies the new backend responds on :3000 **before** writing upstream config and recreating nginx
- Prevents the scenario where nginx switches to a container that passed Docker healthcheck but hasn't started its HTTP server yet

## Root cause
Docker HEALTHCHECK reported "healthy" before Express finished initialization. Nginx was recreated pointing to the new container, causing "network error" for users during the ~10-20s gap.

## Test plan
- [ ] Next deploy should show "HTTP ready on :3000" in logs after "docker healthy"
- [ ] No network errors during blue-green transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds app-level HTTP readiness checks to the deploy pipeline and verifies the backend before switching Nginx during blue‑green. Prevents traffic from moving to a container whose server isn’t listening yet.

- **Bug Fixes**
  - `wait_healthy()` now confirms `/health` responds inside the container on known ports (3000, 3001, 3002, 3005), waiting up to 60s after Docker reports healthy.
  - `promote-to-prod` verifies the new backend responds on :3000 before writing upstream config and recreating Nginx; aborts if not ready.
  - Adds canonical DNS alias wiring for `rada-mcp-app-prod` in both colors to keep routing consistent.

<sup>Written for commit 5865ce00d5c7a377a1cc9936aa6999154e7d7e52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

