### PR TITLE
fix(deploy): correct port matching order for health checks

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -567,10 +567,10 @@ jobs:
               # Application-level HTTP readiness check
               local port=""
               case "\$container" in
-                *app-prod*|secondlayer-app*) port=3000 ;;
                 *rada*) port=3001 ;;
                 *openreyestr*) port=3005 ;;
                 *document-service*) port=3002 ;;
+                secondlayer-app*|*app-prod*) port=3000 ;;
                 *) echo "✓ \$container: no HTTP check needed"; return 0 ;;
               esac
               echo "Verifying HTTP readiness on port \$port..."


### PR DESCRIPTION
## Summary
- `*app-prod*` glob was matching `rada-mcp-app-prod` and `openreyestr-app-prod` before specific patterns
- Reordered case branches: specific services first (`*rada*` → 3001, `*openreyestr*` → 3005), generic last
- This caused the previous deploy to fail with "HTTP not responding on :3000" for rada (3001) and openreyestr (3005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix health check port matching in the prod deploy workflow. Match `*rada*` (3001) and `*openreyestr*` (3005) before generic `secondlayer-app*`/`*app-prod*` (3000) to prevent failed readiness checks on the wrong port.

<sup>Written for commit 4d4b820e53de60deb06f54ccda8b210ec0f47b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

