### PR TITLE
fix(legislation): preserve amendment annotations in parsed article text

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -154,13 +154,34 @@ export class RadaLegislationAdapter {
       // Load the article HTML into cheerio for text extraction
       const $article = cheerio.load(`<div>${articleHtml}</div>`);
 
+      // Extract amendment annotations from <em> blocks before removing them.
+      // Rada marks amended parts as: <em>{Частина N статті M в редакції Закону № X від DD.MM.YYYY}</em>
+      // These are critical legal metadata — preserve them as plain-text notes in full_text.
+      const amendmentNotes: string[] = [];
+      $article('em').each((_i, el) => {
+        const emText = $article(el).text()
+          .replace(/\s+/g, ' ')
+          .trim();
+        // Only keep notes that look like amendment markers (contain "редакції" or "доповнено" or "виключено")
+        if (/редакції|доповнено|виключено|втратила|набрала/i.test(emText) && emText.length > 5) {
+          // Strip surrounding {} but keep the content
+          const cleaned = emText.replace(/^\{|\}$/g, '').trim();
+          if (cleaned) amendmentNotes.push(`[${cleaned}]`);
+        }
+      });
+
       // Extract clean text (remove HTML tags, scripts, styles)
       $article('script, style, em').remove();
-      const fullText = $article.text()
+      const bodyText = $article.text()
         .trim()
         .replace(/\s+/g, ' ')
-        .replace(/\{[^}]+\}/g, '') // Remove {...} comments
+        .replace(/\{[^}]+\}/g, '') // Remove remaining {...} inline markers
         .trim();
+
+      // Append amendment notes after the article body so LLMs can see them
+      const fullText = amendmentNotes.length > 0
+        ? `${bodyText} ${amendmentNotes.join(' ')}`
+        : bodyText;
 
       if (fullText.length < 10) continue;
 
@@ -208,6 +229,7 @@ export class RadaLegislationAdapter {
           subsection_title: subsectionTitle,
           paragraph_number: structure.paragraphNumber,
           paragraph_title: structure.paragraphTitle,
+          amendment_notes: amendmentNotes.length > 0 ? amendmentNotes : undefined,
         },
       });
     }
@@ -436,11 +458,22 @@ export class RadaLegislationAdapter {
 
       // Strip HTML tags for plain text using cheerio parser
       const $point = cheerio.load(pointHtml, { xml: false });
+      const pointAmendmentNotes: string[] = [];
+      $point('em').each((_i, el) => {
+        const emText = $point(el).text().replace(/\s+/g, ' ').trim();
+        if (/редакції|доповнено|виключено|втратила|набрала/i.test(emText) && emText.length > 5) {
+          const cleaned = emText.replace(/^\{|\}$/g, '').trim();
+          if (cleaned) pointAmendmentNotes.push(`[${cleaned}]`);
+        }
+      });
       $point('script, style, em').remove();
-      const fullText = $point.text()
+      const pointBodyText = $point.text()
         .replace(/\{[^}]*\}/g, '')
         .replace(/\s+/g, ' ')
         .trim();
+      const fullText = pointAmendmentNotes.length > 0
+        ? `${pointBodyText} ${pointAmendmentNotes.join(' ')}`
+        : pointBodyText;
 
       if (fullText.length < 10) continue;
 

--- a/mcp_backend/src/migrations/162_refresh_legislation_cache.sql
+++ b/mcp_backend/src/migrations/162_refresh_legislation_cache.sql
@@ -1,0 +1,21 @@
+-- Migration 162: Invalidate ALL legislation article caches so they get re-fetched
+-- with corrected parser that preserves amendment annotations.
+--
+-- The parser was stripping <em>{...}</em> amendment notes (e.g. "Частина четверта
+-- статті 310 в редакції Закону № 4173-IX від 19.12.2024") from full_text.
+-- This affected ALL legislation, not just КАС.
+
+DO $$
+DECLARE
+  deleted_count INTEGER;
+  updated_count INTEGER;
+BEGIN
+  DELETE FROM legislation_articles;
+  GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+  UPDATE legislation SET total_articles = 0, updated_at = NOW();
+  GET DIAGNOSTICS updated_count = ROW_COUNT;
+
+  RAISE NOTICE 'Cleared % stale articles across % laws. Re-fetch on next access.', deleted_count, updated_count;
+END;
+$$;


### PR DESCRIPTION
## Summary
- The Rada HTML parser was stripping `<em>{...}</em>` blocks containing amendment metadata (e.g. "Частина четверта статті 310 в редакції Закону № 4173-IX від 19.12.2024"), causing the LLM to incorrectly report articles as unchanged
- Amendment notes are now extracted before `<em>` removal and appended as `[annotation]` to `full_text` — both for regular articles and transitional provisions
- Migration 162 invalidates **all** cached legislation articles to trigger re-fetch with the corrected parser

## Test plan
- [ ] Verify КАС Article 310 now contains `[Частина четверта статті 310 в редакції Закону № 4173-IX від 19.12.2024]` in `full_text` after re-fetch
- [ ] Verify other amended articles (e.g. ЦК, КК) also preserve their amendment annotations
- [ ] Smoke test legislation retrieval to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves amendment annotations by extracting Rada `<em>{...}</em>` notes and appending them to article text, so amended articles are no longer reported as unchanged. Also triggers a cache refresh to re-fetch all legislation with the corrected parser.

- **Bug Fixes**
  - Extract amendment notes from `<em>` before removal, clean braces, keep real markers, and append as `[note]` to `full_text` for articles and transitional provisions.
  - Store notes in metadata as `amendment_notes`.

- **Migration**
  - Migration 162 deletes `legislation_articles` and resets `legislation.total_articles` to force re-fetch.

<sup>Written for commit c662855a39f6cde8a170dc97da515f64fc7ea016. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

