### PR TITLE
feat(edrsr): migrate vectorizer from Voyage AI to BGE-M3

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -278,6 +278,7 @@ services:
       VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
       VOYAGEAI_API_KEY_2: ${VOYAGEAI_API_KEY_2:-}
       VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}
+      BGE_M3_URL: ${BGE_M3_URL:-}
 
       # LLM Provider Strategy
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-bedrock-first}

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -537,6 +537,7 @@ services:
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
       QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
+      BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -720,6 +721,7 @@ services:
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
       QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
+      BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -939,6 +941,7 @@ services:
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
       QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
+      BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379
@@ -1191,6 +1194,7 @@ services:
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
       QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
       QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
+      BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
       REDIS_PORT: 6379

--- a/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-hybrid-tools.ts
@@ -1,5 +1,5 @@
 /**
- * EDRSR Hybrid Search — dense vectors (Qdrant/Voyage-3) + sparse FTS (tsvector) via RRF.
+ * EDRSR Hybrid Search — dense vectors (Qdrant/BGE-M3) + sparse FTS (tsvector) via RRF.
  *
  * 1 tool:
  * - edrsr_hybrid_search — паралельний виклик FTS + семантичного пошуку в Qdrant,
@@ -56,7 +56,7 @@ export class EdsrHybridTools extends BaseToolHandler {
       {
         name: 'edrsr_hybrid_search',
         annotations: { title: 'Гібридний пошук ЄДРСР', readOnlyHint: true, openWorldHint: true },
-        description: `Гібридний пошук судових рішень ЄДРСР: семантика (Qdrant, ~88M векторів, Voyage-3-large 1024-dim)
+        description: `Гібридний пошук судових рішень ЄДРСР: семантика (Qdrant, ~118M векторів, BGE-M3 1024-dim)
 + лексика (PG tsvector FTS) з мерджем через Reciprocal Rank Fusion.
 
 Коли використовувати:

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -161,13 +161,13 @@ export function createToolServices(
   let edsrVectorizer: EdsrVectorizerService | undefined;
   try {
     edsrVectorizer = new EdsrVectorizerService();
-    edsrVectorizer.setTokenUsageCallback((tokens, model, task) => {
+    edsrVectorizer.setUsageCallback((tokens, model, task) => {
       costTracker.recordVoyageCall({ model, totalTokens: tokens, task }).catch((err) => {
-        logger.warn('Failed to record Voyage cost', { error: err.message });
+        logger.warn('Failed to record embedding cost', { error: err.message });
       });
     });
   } catch (err: any) {
-    logger.warn('EdsrVectorizerService not available (VOYAGEAI_API_KEY missing?)', { error: err.message });
+    logger.warn('EdsrVectorizerService not available (BGE_M3_URL missing?)', { error: err.message });
   }
   const edsrUnifiedSearch = new EdsrUnifiedSearchTool(coreServices.db, edsrFtsService, edsrVectorizer);
   edsrUnifiedSearch.setResultFilter(new SearchResultFilter(llmAdapter));

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -2,15 +2,14 @@
  * EdsrVectorizerService — On-demand vectorization of EDRSR court decisions.
  *
  * When a search returns EDRSR doc_ids, this service checks if they have vectors
- * in Qdrant. If not, it fetches fulltext from PG, chunks, embeds with VoyageAI
+ * in Qdrant. If not, it fetches fulltext from PG, chunks, embeds with BGE-M3
  * in parallel batches, and stores in a dedicated `edrsr_decisions` Qdrant collection.
  *
- * Uses voyage-3.5 (1024-dim) via voyage-client.ts directly (not EmbeddingService)
- * to avoid coupling with the `legal_sections` collection.
+ * Uses BGE-M3 (1024-dim) via self-hosted HuggingFace TEI endpoint.
  */
 
 import { QdrantClient } from '@qdrant/js-client-rest';
-import { VoyageAIClient, VoyageBatchResult } from '../utils/voyage-client.js';
+import { BgeM3Client, EmbeddingBatchResult } from '../utils/bge-m3-client.js';
 import { logger } from '../utils/logger.js';
 import { Semaphore } from '../utils/semaphore.js';
 import { v4 as uuidv4 } from 'uuid';
@@ -18,9 +17,9 @@ import { v4 as uuidv4 } from 'uuid';
 // ── Constants ────────────────────────────────────────────────────────────────
 
 const EMBEDDING_DIM = 1024;
-const VOYAGE_MODEL = process.env.VOYAGEAI_EMBEDDING_MODEL || 'voyage-3.5';
+const EMBEDDING_MODEL = 'bge-m3';
 const COLLECTION_NAME = 'edrsr_decisions';
-const EMBED_BATCH_SIZE = 50; // VoyageAI batch size
+const EMBED_BATCH_SIZE = 64; // TEI supports larger batches than VoyageAI
 const QDRANT_UPSERT_BATCH = 100; // Qdrant upsert sub-batch
 const DEFAULT_CONCURRENCY = 5;
 const MAX_CHUNK_CHARS = 2048;
@@ -66,7 +65,7 @@ export interface EdrsrVectorizationStats {
   collection_exists: boolean;
 }
 
-export type VoyageTokensCallback = (tokens: number, model: string, task: string) => void;
+export type EmbeddingUsageCallback = (tokens: number, model: string, task: string) => void;
 
 // ── Chunking ─────────────────────────────────────────────────────────────────
 
@@ -107,18 +106,18 @@ function chunkText(text: string, maxChars = MAX_CHUNK_CHARS, overlapWords = CHUN
 // ── Service ──────────────────────────────────────────────────────────────────
 
 export class EdsrVectorizerService {
-  private voyageClient: VoyageAIClient;
+  private embeddingClient: BgeM3Client;
   private qdrant: QdrantClient;
   private initialized = false;
-  private tokenUsageCallback?: VoyageTokensCallback;
+  private usageCallback?: EmbeddingUsageCallback;
   private concurrency: number;
 
   constructor(concurrency: number = DEFAULT_CONCURRENCY) {
-    const apiKey = process.env.VOYAGEAI_API_KEY;
-    if (!apiKey) {
-      throw new Error('VOYAGEAI_API_KEY is required for EdsrVectorizerService');
+    const bgeUrl = process.env.BGE_M3_URL;
+    if (!bgeUrl) {
+      throw new Error('BGE_M3_URL is required for EdsrVectorizerService');
     }
-    this.voyageClient = new VoyageAIClient(apiKey, process.env.VOYAGEAI_API_KEY_2 || '');
+    this.embeddingClient = new BgeM3Client(bgeUrl);
 
     const qdrantUrl = process.env.QDRANT_EDRSR_URL || process.env.QDRANT_URL || 'http://localhost:6333';
     const qdrantApiKey = process.env.QDRANT_EDRSR_API_KEY || process.env.QDRANT_API_KEY;
@@ -127,9 +126,8 @@ export class EdsrVectorizerService {
     this.concurrency = concurrency;
   }
 
-  /** Register a callback to receive VoyageAI token usage (for cost tracking). */
-  setTokenUsageCallback(cb: VoyageTokensCallback | undefined): void {
-    this.tokenUsageCallback = cb;
+  setUsageCallback(cb: EmbeddingUsageCallback | undefined): void {
+    this.usageCallback = cb;
   }
 
   // ── Initialization ───────────────────────────────────────────────────────
@@ -314,8 +312,8 @@ export class EdsrVectorizerService {
     await this.ensureCollection();
 
     // Embed query
-    const result = await this.voyageClient.generateEmbeddingsBatchWithUsage([query], VOYAGE_MODEL);
-    this.tokenUsageCallback?.(result.totalTokens, result.model, 'edrsr_semantic_search');
+    const result = await this.embeddingClient.generateEmbeddingsBatchWithUsage([query]);
+    this.usageCallback?.(result.totalTokens, EMBEDDING_MODEL, 'edrsr_semantic_search');
     const queryVector = result.embeddings[0];
 
     // Build Qdrant filter
@@ -536,12 +534,12 @@ export class EdsrVectorizerService {
 
     for (let i = 0; i < texts.length; i += EMBED_BATCH_SIZE) {
       const batch = texts.slice(i, i + EMBED_BATCH_SIZE);
-      const batchResult: VoyageBatchResult = await this.voyageClient.generateEmbeddingsBatchWithUsage(batch, VOYAGE_MODEL);
+      const batchResult: EmbeddingBatchResult = await this.embeddingClient.generateEmbeddingsBatchWithUsage(batch);
       allEmbeddings.push(...batchResult.embeddings);
       totalTokens += batchResult.totalTokens;
     }
 
-    this.tokenUsageCallback?.(totalTokens, VOYAGE_MODEL, 'edrsr_vectorize');
+    this.usageCallback?.(totalTokens, EMBEDDING_MODEL, 'edrsr_vectorize');
 
     // 3. Build Qdrant points
     const points = allChunks.map((chunk, idx) => {
@@ -565,6 +563,7 @@ export class EdsrVectorizerService {
           chunk_index: chunk.chunkIndex,
           total_chunks: chunk.totalChunks,
           text: chunk.text,
+          embedding_model: EMBEDDING_MODEL,
         },
       };
     });

--- a/mcp_backend/src/utils/bge-m3-client.ts
+++ b/mcp_backend/src/utils/bge-m3-client.ts
@@ -1,0 +1,99 @@
+/**
+ * BGE-M3 embedding client for HuggingFace Text Embeddings Inference (TEI).
+ * Uses the OpenAI-compatible /v1/embeddings endpoint.
+ * Drop-in replacement for VoyageAIClient in the EDRSR vectorizer.
+ */
+
+import { logger } from './logger.js';
+
+const MAX_RETRIES = 3;
+const BATCH_SIZE = 64;
+
+interface TEIEmbeddingResponse {
+  object: string;
+  data: Array<{ object: string; embedding: number[]; index: number }>;
+  model: string;
+  usage: { prompt_tokens: number; total_tokens: number };
+}
+
+export interface EmbeddingBatchResult {
+  embeddings: number[][];
+  totalTokens: number;
+  model: string;
+}
+
+export class BgeM3Client {
+  private baseUrl: string;
+  private model = 'BAAI/bge-m3';
+
+  constructor(baseUrl: string) {
+    if (!baseUrl) {
+      throw new Error('BGE_M3_URL is required for BgeM3Client');
+    }
+    this.baseUrl = baseUrl.replace(/\/+$/, '');
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    const result = await this.generateEmbeddingsBatch([text]);
+    return result[0];
+  }
+
+  async generateEmbeddingsBatch(texts: string[]): Promise<number[][]> {
+    const result = await this.generateEmbeddingsBatchWithUsage(texts);
+    return result.embeddings;
+  }
+
+  async generateEmbeddingsBatchWithUsage(texts: string[]): Promise<EmbeddingBatchResult> {
+    const allEmbeddings: number[][] = [];
+    let totalTokens = 0;
+
+    for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+      const batch = texts.slice(i, i + BATCH_SIZE);
+      const { embeddings, tokens } = await this._embedBatchWithRetry(batch);
+      allEmbeddings.push(...embeddings);
+      totalTokens += tokens;
+    }
+
+    return { embeddings: allEmbeddings, totalTokens, model: this.model };
+  }
+
+  private async _embedBatchWithRetry(texts: string[]): Promise<{ embeddings: number[][]; tokens: number }> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        return await this._embedBatch(texts);
+      } catch (err: any) {
+        lastError = err;
+        if (err.status === 429 || err.status === 503) {
+          const delay = Math.pow(2, attempt) * 1000;
+          logger.warn(`[BgeM3Client] ${err.status} on attempt ${attempt + 1}, retrying in ${delay}ms`);
+          await new Promise((r) => setTimeout(r, delay));
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    throw lastError ?? new Error('BgeM3Client: max retries exceeded');
+  }
+
+  private async _embedBatch(texts: string[]): Promise<{ embeddings: number[][]; tokens: number }> {
+    const response = await fetch(`${this.baseUrl}/v1/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: texts, model: this.model }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      const err: any = new Error(`BGE-M3 TEI error ${response.status}: ${body}`);
+      err.status = response.status;
+      throw err;
+    }
+
+    const data = (await response.json()) as TEIEmbeddingResponse;
+    const embeddings = data.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);
+    return { embeddings, tokens: data.usage?.total_tokens ?? 0 };
+  }
+}


### PR DESCRIPTION
## Summary
- Switch EDRSR vectorizer from Voyage AI 3.5 API to self-hosted BGE-M3 via HuggingFace TEI
- Resolve mixed embedding space problem (Voyage + BGE-M3 vectors in same Qdrant collection)
- Add `embedding_model` field to Qdrant payload for future provenance tracking
- Add `BGE_M3_URL` env var to prod and local docker-compose

## Changes
- **New**: `mcp_backend/src/utils/bge-m3-client.ts` - HTTP client for TEI endpoint (drop-in replacement for VoyageAIClient)
- **Modified**: `edrsr-vectorizer-service.ts` - Voyage → BGE-M3 client, `embedding_model: "bge-m3"` in payload
- **Modified**: `tool-services.ts` - factory guard `BGE_M3_URL` instead of `VOYAGEAI_API_KEY`
- **Modified**: `edrsr-hybrid-tools.ts` - updated descriptions to BGE-M3
- **Modified**: `docker-compose.prod.yml` / `docker-compose.local.yml` - added `BGE_M3_URL` env var

## Prerequisites
- Deploy TEI container on workstation before merging: `docker run -d --name tei-bge-m3 -p 8080:80 ghcr.io/huggingface/text-embeddings-inference:cpu-1.5 --model-id BAAI/bge-m3`
- Set `BGE_M3_URL=http://10.88.0.4:8080` in `.env.prod`

## Test plan
- [ ] TEI vector parity test (cosine > 0.999 vs SentenceTransformer)
- [ ] `search_court_decisions` mode=semantic, justice_kind=3 returns results
- [ ] On-demand vectorized doc has `embedding_model: "bge-m3"` in Qdrant payload
- [ ] Smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate the EDRSR vectorizer from Voyage AI to self-hosted BGE‑M3 via Hugging Face TEI to unify embeddings and fix the mixed-space issue in Qdrant. Adds provenance to stored vectors and a new `BGE_M3_URL` config.

- **New Features**
  - Replaced Voyage client with `BgeM3Client` (TEI `/v1/embeddings`) and switched to BGE‑M3 (1024‑dim).
  - Write `embedding_model: "bge-m3"` in Qdrant payloads to avoid mixed embedding spaces.
  - Added `BGE_M3_URL` to `docker-compose` and updated factory guard/usage callback; tool descriptions now reference BGE‑M3.

- **Migration**
  - Deploy Hugging Face TEI for `BAAI/bge-m3` and ensure it’s reachable.
  - Set `BGE_M3_URL` in environment (e.g., `.env.prod`) before deploy.

<sup>Written for commit fb2aa8275d8fef7ca19e3f0f6f0a18ee4c6ab59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

