### PR TITLE
fix(allow-set): include cross-referenced articles from retrieved law text

### DIFF
--- a/mcp_backend/src/factories/core-loader.ts
+++ b/mcp_backend/src/factories/core-loader.ts
@@ -1,5 +1,5 @@
 // Proprietary implementation: @secondlayer/core (private repo)
-// Core overlay: CORE-24/25/26/27/28 — budget limits, step constraints, health gating, allow-set cleanup
+// Core overlay: CORE-24/25/26/27/28/29 — budget limits, step constraints, health gating, allow-set cross-refs
 
 /**
  * Core service loader.


### PR DESCRIPTION
## Summary
- Triggers rebuild to pick up CORE-29 overlay from secondlayer-core
- **CORE-29:** When a retrieved law article's text contains cross-references to other articles (e.g. Article 258 ЦК referencing "ст. 362 ЦК"), those references are now added to the allow-set
- Prevents false positive "Не підтверджено пошуком" warnings when the answer quotes verbatim law text

## Context
Chat `chat-b73d2e21` showed "Не підтверджено пошуком: ст. 362 ЦК, ст. 681 ЦК, ст. 728 ЦК, ст. 925 ЦК, ст. 1293 ЦК" — all of which are legitimate cross-references inside Article 258 ЦК text, not hallucinations.

## Test plan
- [x] 17/17 allow-set unit tests pass (including new cross-ref test)
- [ ] CI passes
- [ ] Verify warning no longer appears for legislation queries with cross-references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates CORE-29 overlay from `secondlayer-core` to include cross-referenced articles from retrieved law text in the allow-set. This prevents false “Не підтверджено пошуком” warnings when answers quote law passages that reference other articles.

<sup>Written for commit e18b7179e8c020108aa849b5a8975cae2dcfc73d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

