### PR TITLE
fix(test): rename setTokenUsageCallback → setUsageCallback in vectorizer test

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
@@ -59,16 +59,16 @@ describe('EdsrVectorizerService', () => {
     });
   });
 
-  describe('setTokenUsageCallback', () => {
+  describe('setUsageCallback', () => {
     it('should accept callback', () => {
       const service = new EdsrVectorizerService();
       const cb = jest.fn();
-      expect(() => service.setTokenUsageCallback(cb)).not.toThrow();
+      expect(() => service.setUsageCallback(cb)).not.toThrow();
     });
 
     it('should accept undefined to clear callback', () => {
       const service = new EdsrVectorizerService();
-      expect(() => service.setTokenUsageCallback(undefined)).not.toThrow();
+      expect(() => service.setUsageCallback(undefined)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix stale method name in `edrsr-vectorizer-service.test.ts`: `setTokenUsageCallback` was renamed to `setUsageCallback` but the test wasn't updated

## Test plan
- [x] TS compilation passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update vectorizer service tests to use the renamed method `setUsageCallback` instead of `setTokenUsageCallback`, keeping tests in sync with the service API. Prevents compilation/test failures due to the stale method name.

<sup>Written for commit 3d980e68fe44f71e693014d167b7a2e428d7e532. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

