### PR TITLE
fix(allow-set): verify law articles via DB lookup before warning

### DIFF
--- a/mcp_backend/src/factories/core-loader.ts
+++ b/mcp_backend/src/factories/core-loader.ts
@@ -1,5 +1,5 @@
 // Proprietary implementation: @secondlayer/core (private repo)
-// Core overlay: CORE-24/25/26/27/28/29 — budget limits, step constraints, health gating, allow-set cross-refs
+// Core overlay: CORE-24/25/26/27/28/29/30 — budget limits, step constraints, health gating, article verification
 
 /**
  * Core service loader.


### PR DESCRIPTION
## Summary
Triggers rebuild to pick up CORE-29 + CORE-30 from secondlayer-core:
- **CORE-29:** Cross-referenced articles from retrieved law text added to allow-set
- **CORE-30:** Before warning about unverified articles, look them up in the legislation DB via `get_legislation_articles`. Only truly non-existent articles trigger a warning.

## Context
Two chats showed false positive warnings:
- `chat-b73d2e21` — Article 258 ЦК cross-references (ст. 362, 681, 728, 925, 1293) flagged as unverified (fixed by CORE-29)
- `chat-3c15e47b` — LLM-cited valid articles (ст. 4.1.3 ПКУ, ст. 56 ПКУ) not in search results but real (fixed by CORE-30)

## Test plan
- [x] 19/19 allow-set unit tests pass
- [ ] CI passes
- [ ] Verify warning no longer appears for valid article references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify law articles via the legislation DB before warning and include cross‑referenced articles from retrieved law text in the allow‑set. This removes false "unverified article" warnings.

- **Bug Fixes**
  - Check article existence with `get_legislation_articles` before warning; only warn when not found in the DB.
  - Add cross‑referenced articles from retrieved law text to the allow‑set.

<sup>Written for commit 3ce269d089a7e6e2196270ff3ec0355f02212a66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

