### PR TITLE
fix(test): add BGE_M3_URL env and BgeM3Client mock to vectorizer test

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
@@ -29,6 +29,13 @@ jest.mock('../../utils/voyage-client.js', () => ({
   })),
 }));
 
+jest.mock('../../utils/bge-m3-client.js', () => ({
+  BgeM3Client: jest.fn().mockImplementation(() => ({
+    embedBatch: jest.fn().mockResolvedValue({ embeddings: [], usage: { total_tokens: 0 } }),
+    embed: jest.fn().mockResolvedValue({ embedding: new Array(1024).fill(0), usage: { total_tokens: 50 } }),
+  })),
+}));
+
 jest.mock('../../utils/logger.js', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
 }));
@@ -40,7 +47,7 @@ describe('EdsrVectorizerService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env = { ...originalEnv, VOYAGEAI_API_KEY: 'test-key', QDRANT_URL: 'http://localhost:6333' };
+    process.env = { ...originalEnv, VOYAGEAI_API_KEY: 'test-key', QDRANT_URL: 'http://localhost:6333', BGE_M3_URL: 'http://localhost:8080' };
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Summary
- Add `BGE_M3_URL` to test env (constructor now requires it)
- Add `BgeM3Client` mock (constructor instantiates it)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix vectorizer service tests by mocking `BgeM3Client` and adding `BGE_M3_URL` to the test env. This matches the updated constructor and avoids real network calls.

<sup>Written for commit cc9edaa58136a13d86c38fd0113a5287f9322047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

