### PR TITLE
fix(deploy): use port 80 for frontend/platform health checks

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -570,6 +570,7 @@ jobs:
                 *rada*) port=3001 ;;
                 *openreyestr*) port=3005 ;;
                 *document-service*) port=3002 ;;
+                lexwebapp*|platform*) port=80 ;;
                 secondlayer-app*|*app-prod*) port=3000 ;;
                 *) echo "✓ \$container: no HTTP check needed"; return 0 ;;
               esac


### PR DESCRIPTION
## Summary
- Add `lexwebapp*|platform*) port=80` rule before the `secondlayer-app*|*app-prod*) port=3000` catch-all
- Frontend nginx containers listen on port 80, but `*app-prod*` was matching `lexwebapp-prod-blue` and checking port 3000, causing health check failures and deploy aborts

## Test plan
- [ ] Next prod deploy with frontend changes passes health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes prod deploy health checks by using port 80 for `lexwebapp*` and `platform*` containers, avoiding the `*app-prod*` catch-all on port 3000 that caused false failures and aborted frontend deploys.

<sup>Written for commit 4c372c2d798f8fccaf656a99e466162e2339f188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

