### PR TITLE
fix(deploy): backend log observability — BACKEND_LOG_LEVEL + disable dead file transport

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -651,7 +651,8 @@ services:
       TURN_SHARED_SECRET: ${TURN_SHARED_SECRET:-}
       STUN_SERVER_URL: ${STUN_SERVER_URL:-stun:stun.l.google.com:19302}
 
-      LOG_LEVEL: ${LOG_LEVEL:-info}
+      LOG_LEVEL: ${BACKEND_LOG_LEVEL:-info}
+      LOG_TO_FILE: "false"
       TZ: Europe/Kiev
     ports:
     - "127.0.0.1:3007:3000"
@@ -1026,7 +1027,8 @@ services:
       TURN_SERVER_URL: ${TURN_SERVER_URL:-}
       TURN_SHARED_SECRET: ${TURN_SHARED_SECRET:-}
       STUN_SERVER_URL: ${STUN_SERVER_URL:-stun:stun.l.google.com:19302}
-      LOG_LEVEL: ${LOG_LEVEL:-info}
+      LOG_LEVEL: ${BACKEND_LOG_LEVEL:-info}
+      LOG_TO_FILE: "false"
       TZ: Europe/Kiev
     depends_on:
       pgbouncer-prod:


### PR DESCRIPTION
## Problem (Plane LEXAI-1722)

Global `LOG_LEVEL=warn` in `deployment/.env.prod` silences all pipeline info-logs (TokenBudgetAllocator, allow-set, tool health, PipelineMetrics). The core#31 bug (article verification inert in prod) was invisible in logs because of this. Additionally, the in-container winston file transport writes root-owned files frozen since Jun 1 — dead weight that misleads debugging.

## Fix

Backend services (`app-prod`, `app-prod-green`) in `docker-compose.prod.yml`:
- `LOG_LEVEL: ${BACKEND_LOG_LEVEL:-info}` — backend defaults to info independently of the global `LOG_LEVEL=warn` (which stays for other services). Override via `BACKEND_LOG_LEVEL` in `.env.prod` if needed.
- `LOG_TO_FILE: "false"` — docker json-file logging (already capped 50m × 10) is the source of truth; kills the broken file transport.

## Verification plan

After deploy: send a test chat query, confirm allow-set / PipelineMetrics info-records appear in `docker logs secondlayer-app-prod*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve backend log observability in production by decoupling the backend log level from the global setting and disabling the broken file transport. Addresses LEXAI-1722 where pipeline info logs were hidden under a global `LOG_LEVEL=warn`.

- **Bug Fixes**
  - Backend services (`app-prod`, `app-prod-green`) now use `LOG_LEVEL: ${BACKEND_LOG_LEVEL:-info}` so they default to info and can be overridden via `.env.prod`.
  - Disabled in-container file logging with `LOG_TO_FILE: "false"`; rely on Docker json-file logs (already size-capped).

<sup>Written for commit 6fd9a708b357e38361e6760da3c32748ff1ef1e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

