### PR TITLE
chore(core): trigger rebuild with core#33 overlay (CORE-21 execute loop split)

### DIFF
--- a/mcp_backend/src/factories/core-loader.ts
+++ b/mcp_backend/src/factories/core-loader.ts
@@ -1,5 +1,5 @@
 // Proprietary implementation: @secondlayer/core (private repo)
-// Core overlay: CORE-21 graph pipeline (core#32) — REPLAN node, fast path, plan-service decomposition, metrics fix
+// Core overlay: CORE-21 complete (core#33) — execute loop split into nodes, chat-service 935 lines
 
 /**
  * Core service loader.


### PR DESCRIPTION
Rebuild backend with overlay from overthelex/secondlayer-core#33: execute loop split into node modules, chat-service.ts 1813→935 lines. No behavior changes intended.

Plane: CORE-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger rebuild to consume `@secondlayer/core` overlay core#33 for CORE-21, which splits the chat execute loop into node modules. No behavior changes expected; this just syncs our backend with the latest core overlay.

<sup>Written for commit 91ea1d342d68aa36492b542246f5125fc8ee1488. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

