### PR TITLE
feat(research): EVAL-500K data prep for citation-grounded embedding eval (PAPER-48)

### DIFF
--- a/docs/proposals/citation-grounded-embedding-eval-design.md
+++ b/docs/proposals/citation-grounded-embedding-eval-design.md
@@ -1,0 +1,150 @@
+# Experimental Design: Citation-Grounded Evaluation of Dense Retrieval for Ukrainian Legal Search
+
+Working title: *"Citations as Ground Truth: Large-Scale Evaluation of Dense Retrievers
+on a Low-Resource Legal Corpus without Human Annotation"*
+
+Target venue: NLLP @ EMNLP 2026 (deadline 2026-08-11), extended version → ECIR / IPM.
+Compute: NVIDIA Brev `legalex` (8×H100, expires ~2026-07-19), commercial APIs for eval subset only.
+
+## 1. Research Questions
+
+- **RQ1 (main, methodological):** Can citation-graph-derived relevance replace human
+  annotation for *ranking* embedding models on legal retrieval? Validation: does the
+  model ranking produced by citation-based eval agree (Kendall's τ) with the ranking
+  on human-annotated UA-Legal-Bench / statute-retrieval benchmark?
+- **RQ2 (domain adaptation vs scale):** Does a small domain-finetuned embedder
+  (BGE-M3-UA, two-stage citation+supervised finetune) outperform large general-purpose
+  commercial embedders (Voyage 3.5, OpenAI text-embedding-3-large) on Ukrainian legal text?
+- **RQ3 (temporal robustness, ablation):** Is the model ranking stable across decision
+  years (2010–2025)? Does retrieval degrade on older cases (terminology drift, new codes,
+  martial-law-era law)? Ties into the temporal-drift line of the dissertation.
+- **RQ4 (efficiency frontier):** $/1M docs indexed, query latency, index size, GPU-hours —
+  which model is Pareto-optimal for production?
+
+## 2. Corpus and Sampling
+
+Source: EDRSR court decisions in local PostgreSQL (local = data proxy) + Qdrant.
+
+Two scales:
+
+| Set | Size | Embedded by | Purpose |
+|-----|------|------------|---------|
+| **EVAL-500K** | 500K decisions, stratified by jurisdiction (civil / criminal / commercial / administrative) × year (2010–2025) | ALL models incl. commercial APIs | model comparison (RQ1–RQ4) |
+| **FULL** | entire corpus | top-2 open models only (winner + runner-up) | scale validation + production index side effect |
+
+Stratification keeps per-cell counts proportional to corpus but with a floor
+(min 2K per jurisdiction×year cell) so temporal ablation has power.
+
+**Text preprocessing (critical):** strip all citation strings (case numbers, "справа №",
+article references like "ст. 625 ЦК") from document text *before* embedding.
+Otherwise dense models trivially match citation tokens and the eval measures lexical
+citation overlap, not semantic retrieval. Keep a no-strip variant as an ablation to
+quantify the leak. Reuse extraction regexes from `extract-citations-fast.py`.
+
+## 3. Ground Truth from the Citation Graph
+
+Existing asset: 2.39M co-citation edges (`cocitation_edges_raw.csv`).
+
+Relevance signals, graded:
+
+| Grade | Signal |
+|-------|--------|
+| 3 | direct citation (query case cites candidate case, or vice versa) |
+| 2 | strong co-citation: share ≥3 cited articles/precedents (weighted by inverse article frequency — discount ubiquitous articles like ст. 129 Конституції) |
+| 1 | weak co-citation: share 1–2 cited articles after IDF weighting |
+| 0 | everything else |
+
+- **Query set:** 3,000 query decisions sampled from EVAL-500K, stratified as above;
+  each must have ≥5 graded-relevant candidates inside EVAL-500K.
+- **IDF weighting is mandatory:** the citation graph is power-law (confirmed in
+  degree-centrality analysis); unweighted co-citation makes everything relevant to
+  everything through hub articles.
+- **Candidate pool:** full EVAL-500K (not re-ranking a BM25 shortlist) — this is the
+  honest setting and is what 8×H100 + Qdrant buys us.
+
+## 4. Models
+
+Open (run on Brev, fp16/bf16):
+
+1. **BGE-M3** (BAAI, 568M) — base multilingual
+2. **BGE-M3-UA** — our two-stage finetune (stage1: 500K citation pairs, stage2: 65K supervised); retrain final checkpoint on H100 if needed
+3. **multilingual-e5-large-instruct** (560M)
+4. **Qwen3-Embedding-8B** (or gte-Qwen2-7B-instruct) — large open embedder, MTEB-multilingual SOTA class
+5. *(optional, if time)* our CPT-Qwen 1.5B converted to embedder via LLM2Vec — connects CPT line to retrieval
+
+Commercial (EVAL-500K only, via API):
+
+6. **Voyage 3.5** (already partially indexed in prod Qdrant — reuse where chunking matches)
+7. **OpenAI text-embedding-3-large**
+8. *(optional)* Cohere embed-multilingual-v4
+
+Sparse baselines (CPU, reuse `08_bm25_baseline.R` / `09_bm25_casetext.R`):
+
+9. **BM25** (Ukrainian-stemmed)
+10. *(optional)* BM25 + dense hybrid (RRF) for the production recommendation
+
+**Chunking fixed across all models:** 1024 tokens, 128 overlap, doc vector = mean of
+chunk vectors. One ablation on the winner: mean-pool vs first-chunk vs max-sim (late
+interaction style scoring at query time).
+
+## 5. Metrics and Statistics
+
+- Retrieval: nDCG@{10,100} (graded), Recall@{10,100}, MRR@10.
+- RQ1: Kendall's τ between model rankings (citation-eval vs UA-Legal-Bench);
+  per-query Pearson r of nDCG scores; report agreement at top-1 ("does it pick the
+  same winner").
+- Significance: paired bootstrap over queries (10K resamples), Bonferroni over model pairs.
+- RQ3: nDCG@10 per year-bucket (2010–14, 2015–19, 2020–21, 2022–25), per-model slopes.
+- RQ4: GPU-hours and $ per model (Brev $22.75/hr ÷ 8 GPUs), API $ actuals, p50/p95
+  query latency against Qdrant, index RAM/disk.
+
+## 6. Compute Plan (Brev 8×H100)
+
+EVAL-500K ≈ 500K docs × ~3 chunks avg ≈ 1.5M chunks per model.
+
+- 560M-class models: ~2–4K chunks/s on 8 GPUs → **~10–20 min per model**. Trivial.
+- Qwen3-8B embedder: ~10× slower → **~2–3 h**.
+- FULL corpus (assume ~15M decisions ≈ 45M chunks): winner model ~4–6 h (560M class)
+  or ~1.5–2 days (8B class) — feasible either way before Brev expiry.
+- BGE-M3-UA retraining on H100: stage1+stage2 ≈ hours (xr-large was 65 min on H100).
+
+Job hygiene (per established practice): **smoke test on 1K docs first** to calibrate
+throughput and catch schema issues; atomic jobs = 1 model × 1 corpus slice; checkpoint
+every N batches with resume; embeddings written as parquet shards to local NVMe,
+synced over wg-sync to local, bulk-loaded to Qdrant named vectors
+(`edrsr_eval_{model}` collections); progress logged to MLflow (10.88.0.4:5000).
+
+API cost (EVAL-500K ≈ 1.5B tokens): OpenAI-3-large ~$195, Voyage-3.5 ~$90 (minus
+already-indexed overlap), Cohere ~$180. Total commercial ≲ $500.
+
+## 7. Timeline (today = 2026-06-11)
+
+| Week | Work |
+|------|------|
+| Jun 11–17 | EVAL-500K sampling + citation stripping + graded qrels build; smoke runs on Brev; freeze model list |
+| Jun 18–24 | Embed EVAL-500K with all open models; API runs; BGE-M3-UA final train |
+| Jun 25–Jul 1 | Retrieval runs + metrics; RQ1 validation vs UA-Legal-Bench; RQ3 temporal slices |
+| Jul 2–8 | FULL-corpus run with top-2 (production index side effect); RQ4 efficiency numbers |
+| Jul 9–19 | Buffer before Brev expiry; figures (R + tikzDevice); ablations (no-strip leak, pooling) |
+| Jul 20–Aug 8 | Writing, internal fact-check pass, NLLP submission Aug 11 |
+
+## 8. Deliverables
+
+1. NLLP paper (citation-grounded eval methodology + UA legal retrieval study).
+2. HF dataset under `overthelex`: query set + graded qrels + doc IDs
+   ("UA-Legal-Retrieval-Cite", complements UA-Legal-Bench).
+3. Production EDRSR embedding index with the winning model (replaces/validates
+   current Voyage setup) — direct product value.
+4. Reusable eval harness in `scripts/citation-graph/` (extends exp1).
+
+## 9. Risks
+
+- **Citation leakage** despite stripping (paraphrased references, party names shared
+  across related cases). Mitigation: no-strip ablation quantifies it; manual audit of
+  50 query–candidate pairs.
+- **Co-citation ≠ semantic relevance** for boilerplate-heavy procedural decisions.
+  Mitigation: IDF weighting; exclude decision types dominated by templates
+  (court orders / судові накази) from the query set.
+- **RQ1 validation fails** (τ low): that is itself a publishable negative result —
+  "citation-based eval does NOT substitute human annotation" — but reframe needed.
+- **Brev expiry**: front-load all GPU work; commercial API runs are Brev-independent.

--- a/scripts/citation-graph/12_sample_eval500k.py
+++ b/scripts/citation-graph/12_sample_eval500k.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+EVAL-500K: stratified sample of EDRSR decisions for the citation-grounded
+embedding benchmark.
+
+Stratification: justice_kind (1-4) x adjudication year (2010-2025).
+Filters: substantive judgment codes (Вирок/Постанова/Рішення), full text
+present and >= --min-chars. Allocation proportional to cell population with
+a per-cell floor so temporal slices keep statistical power.
+
+Two passes per year (checkpointed, resumable):
+  1. cell counts (metadata only)
+  2. random oversample via setseed()+random(), then text-length verification
+     against edrsr_fulltext_p_{year}, trim to exact allocation
+
+Usage:
+  source mcp_backend/.env equivalents or set DATABASE_URL, then:
+  python3 12_sample_eval500k.py --counts-only          # pass 1 + allocation preview
+  python3 12_sample_eval500k.py                        # full run -> output/eval500k/
+  python3 12_sample_eval500k.py --target 2000 --floor 20 --years 2020 2021   # smoke
+  python3 12_sample_eval500k.py --export-text          # jsonl shards, citations stripped
+"""
+
+import argparse
+import csv
+import json
+import logging
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval500k_common import (
+    DB_DSN, DEFAULT_JUDGMENT_CODES, JUSTICE_KINDS, YEAR_MIN, YEAR_MAX,
+    strip_citations,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger("sample")
+
+OUTPUT_DIR = Path(__file__).parent / "output" / "eval500k"
+
+OVERSAMPLE = 1.4          # headroom for docs failing the text-length check
+SEED = 0.42               # setseed() for reproducible SQL random()
+
+
+def get_conn():
+    return psycopg2.connect(DB_DSN)
+
+
+# ── Pass 1: cell counts ─────────────────────────────────────────────────────
+
+def count_cells(conn, years, kinds, judgment_codes):
+    counts = {}
+    with conn.cursor() as cur:
+        for year in years:
+            cur.execute(
+                """
+                SELECT justice_kind, COUNT(*)
+                FROM edrsr_documents
+                WHERE adjudication_date >= make_date(%s, 1, 1)
+                  AND adjudication_date <  make_date(%s, 1, 1)
+                  AND justice_kind = ANY(%s)
+                  AND judgment_code = ANY(%s)
+                GROUP BY justice_kind
+                """,
+                (year, year + 1, list(kinds), list(judgment_codes)),
+            )
+            for kind, n in cur.fetchall():
+                counts[(year, kind)] = n
+            log.info("counts %d: %s", year,
+                     {JUSTICE_KINDS[k]: counts.get((year, k), 0) for k in kinds})
+    return counts
+
+
+def allocate(counts, target, floor):
+    """Proportional allocation with floor, capped at cell population."""
+    total = sum(counts.values())
+    alloc = {}
+    for cell, n in counts.items():
+        alloc[cell] = min(n, max(floor, round(target * n / total)))
+    # trim overshoot from the largest cells (floor inflates the total)
+    overshoot = sum(alloc.values()) - target
+    for cell in sorted(alloc, key=alloc.get, reverse=True):
+        if overshoot <= 0:
+            break
+        reducible = alloc[cell] - max(floor, 1)
+        cut = min(reducible, overshoot)
+        alloc[cell] -= cut
+        overshoot -= cut
+    return alloc
+
+
+# ── Pass 2: per-year sampling + text verification ───────────────────────────
+
+def sample_year(conn, year, kinds, judgment_codes, year_alloc, counts, min_chars):
+    """Oversample the year partition once, verify text length, trim per cell."""
+    max_frac = max(
+        (OVERSAMPLE * year_alloc.get((year, k), 0) / counts[(year, k)])
+        for k in kinds if counts.get((year, k))
+    )
+    max_frac = min(1.0, max_frac)
+    log.info("year %d: scan with random() < %.5f", year, max_frac)
+
+    candidates = defaultdict(list)
+    with conn.cursor("sample_%d" % year) as cur:  # server-side cursor
+        cur.itersize = 50_000
+        cur.execute(
+            """
+            SELECT doc_id, justice_kind, judgment_code, court_code, cause_num,
+                   EXTRACT(YEAR FROM adjudication_date)::int AS adj_year
+            FROM edrsr_documents
+            WHERE adjudication_date >= make_date(%s, 1, 1)
+              AND adjudication_date <  make_date(%s, 1, 1)
+              AND justice_kind = ANY(%s)
+              AND judgment_code = ANY(%s)
+              AND random() < %s
+            """,
+            (year, year + 1, list(kinds), list(judgment_codes), max_frac),
+        )
+        for row in cur:
+            candidates[row[1]].append(row)
+
+    # verify text length in batches, keep first `alloc` passing docs per cell
+    kept = []
+    with conn.cursor() as cur:
+        for kind in kinds:
+            need = year_alloc.get((year, kind), 0)
+            rows = candidates.get(kind, [])
+            taken = 0
+            for i in range(0, len(rows), 5000):
+                if taken >= need:
+                    break
+                batch = rows[i:i + 5000]
+                cur.execute(
+                    f"""
+                    SELECT doc_id, length(full_text)
+                    FROM edrsr_fulltext_p_{year}
+                    WHERE doc_id = ANY(%s) AND length(full_text) >= %s
+                    """,
+                    ([r[0] for r in batch], min_chars),
+                )
+                ok = dict(cur.fetchall())
+                for r in batch:
+                    if taken >= need:
+                        break
+                    if r[0] in ok:
+                        kept.append(r + (ok[r[0]],))
+                        taken += 1
+            if taken < need:
+                log.warning("year %d kind %s: only %d/%d after text filter "
+                            "(raise OVERSAMPLE or lower --min-chars)",
+                            year, JUSTICE_KINDS[kind], taken, need)
+    return kept
+
+
+# ── Text export ──────────────────────────────────────────────────────────────
+
+def export_text(conn, sample_rows, out_dir, shard_size, no_strip):
+    """Write jsonl shards {doc_id, adj_year, justice_kind, text} with citations stripped."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    by_year = defaultdict(list)
+    for r in sample_rows:
+        by_year[r["adj_year"]].append(r)
+
+    written = 0
+    with conn.cursor() as cur:
+        for year in sorted(by_year):
+            rows = by_year[year]
+            meta = {r["doc_id"]: r for r in rows}
+            ids = list(meta)
+            shard_idx, buf = 0, []
+
+            def flush():
+                nonlocal shard_idx, buf
+                if not buf:
+                    return
+                path = out_dir / f"texts-{year}-{shard_idx:04d}.jsonl"
+                with open(path, "w", encoding="utf-8") as f:
+                    f.writelines(buf)
+                shard_idx += 1
+                buf = []
+
+            for i in range(0, len(ids), 2000):
+                cur.execute(
+                    f"SELECT doc_id, full_text FROM edrsr_fulltext_p_{year} WHERE doc_id = ANY(%s)",
+                    (ids[i:i + 2000],),
+                )
+                for doc_id, text in cur.fetchall():
+                    m = meta[doc_id]
+                    out = text if no_strip else strip_citations(text)
+                    buf.append(json.dumps(
+                        {"doc_id": doc_id, "adj_year": m["adj_year"],
+                         "justice_kind": m["justice_kind"], "text": out},
+                        ensure_ascii=False) + "\n")
+                    written += 1
+                    if len(buf) >= shard_size:
+                        flush()
+            flush()
+            log.info("export year %d done (%d docs total)", year, written)
+    log.info("exported %d docs to %s (%d shards)", written, out_dir, shard_idx)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--target", type=int, default=500_000)
+    ap.add_argument("--floor", type=int, default=2_000, help="min docs per (year, kind) cell")
+    ap.add_argument("--min-chars", type=int, default=1_000)
+    ap.add_argument("--years", type=int, nargs="*", default=list(range(YEAR_MIN, YEAR_MAX + 1)))
+    ap.add_argument("--judgment-codes", type=int, nargs="*", default=list(DEFAULT_JUDGMENT_CODES))
+    ap.add_argument("--counts-only", action="store_true")
+    ap.add_argument("--export-text", action="store_true")
+    ap.add_argument("--no-strip", action="store_true", help="export raw text (leak ablation)")
+    ap.add_argument("--shard-size", type=int, default=10_000)
+    args = ap.parse_args()
+
+    kinds = sorted(JUSTICE_KINDS)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    sample_path = OUTPUT_DIR / "sample.csv"
+
+    conn = get_conn()
+    conn.set_session(readonly=True)
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '120min'")
+        cur.execute("SELECT setseed(%s)", (SEED,))
+
+    # text export over an existing sample
+    if args.export_text and sample_path.exists():
+        years = set(args.years)
+        with open(sample_path) as f:
+            rows = [{**r, "doc_id": int(r["doc_id"]), "adj_year": int(r["adj_year"]),
+                     "justice_kind": int(r["justice_kind"])} for r in csv.DictReader(f)
+                    if int(r["adj_year"]) in years]
+        suffix = "raw" if args.no_strip else "stripped"
+        export_text(conn, rows, OUTPUT_DIR / f"texts_{suffix}", args.shard_size, args.no_strip)
+        return
+
+    # pass 1
+    counts_path = OUTPUT_DIR / "cell_counts.json"
+    counts = None
+    if counts_path.exists():
+        cached = {tuple(map(int, k.split(","))): v
+                  for k, v in json.load(open(counts_path)).items()}
+        if set(args.years) <= {y for y, _ in cached}:
+            counts = {c: n for c, n in cached.items() if c[0] in args.years}
+            log.info("loaded cached cell counts (%d cells)", len(counts))
+        else:
+            log.info("cached counts do not cover requested years, recounting")
+    if counts is None:
+        counts = count_cells(conn, args.years, kinds, args.judgment_codes)
+        json.dump({f"{y},{k}": n for (y, k), n in counts.items()}, open(counts_path, "w"))
+
+    alloc = allocate(counts, args.target, args.floor)
+    log.info("population %s docs, allocated %s",
+             f"{sum(counts.values()):,}", f"{sum(alloc.values()):,}")
+    if args.counts_only:
+        for (y, k) in sorted(alloc):
+            print(f"{y} {JUSTICE_KINDS[k]:>15}: pop={counts[(y, k)]:>9,} alloc={alloc[(y, k)]:>7,}")
+        return
+
+    # pass 2, checkpointed per year
+    fieldnames = ["doc_id", "justice_kind", "judgment_code", "court_code",
+                  "cause_num", "adj_year", "text_len"]
+    all_rows = []
+    for year in args.years:
+        ckpt = OUTPUT_DIR / f"year_{year}.csv"
+        if ckpt.exists():
+            log.info("year %d: checkpoint exists, skipping", year)
+            with open(ckpt) as f:
+                all_rows.extend(list(csv.DictReader(f)))
+            continue
+        kept = sample_year(conn, year, kinds, args.judgment_codes, alloc, counts, args.min_chars)
+        with open(ckpt, "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(fieldnames)
+            for r in kept:
+                w.writerow([r[0], r[1], r[2], r[3], r[4], r[5], r[6]])
+        with open(ckpt) as f:
+            all_rows.extend(list(csv.DictReader(f)))
+        log.info("year %d: kept %d docs", year, len(kept))
+
+    with open(sample_path, "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(all_rows)
+
+    manifest = {
+        "target": args.target, "floor": args.floor, "min_chars": args.min_chars,
+        "years": args.years, "judgment_codes": args.judgment_codes,
+        "seed": SEED, "oversample": OVERSAMPLE,
+        "population": sum(counts.values()), "sampled": len(all_rows),
+        "cells": {f"{y},{k}": {"population": counts[(y, k)], "allocated": alloc[(y, k)]}
+                  for (y, k) in sorted(alloc)},
+    }
+    json.dump(manifest, open(OUTPUT_DIR / "manifest.json", "w"), indent=2)
+    log.info("DONE: %d docs -> %s", len(all_rows), sample_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/13_build_qrels.py
+++ b/scripts/citation-graph/13_build_qrels.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Graded qrels from the citation graph for the EVAL-500K benchmark.
+
+Relevance grades (query q, candidate d, both inside EVAL-500K):
+  excluded  same cause_num as q (same case across instances - trivial near-dup)
+  3         direct reference: q's case_reference set contains d.cause_num
+            (or vice versa)
+  2         strong co-citation: >= 3 shared IDF-informative article tokens
+  1         weak co-citation: 1-2 shared informative tokens
+  0         everything else (implicit)
+
+"Informative" article tokens: document frequency within the sample in
+[--min-df, --hub-frac * N]. Hub articles (ст. 129 Конституції etc.) carry no
+relevance signal; df=1 tokens cannot create pairs.
+
+Inputs:  output/eval500k/sample.csv  (from 12_sample_eval500k.py)
+Outputs: output/eval500k/qrels.txt        TREC format: qid 0 doc_id grade
+         output/eval500k/queries.csv      selected query docs + strata
+         output/eval500k/excluded.txt     same-case pairs (qid doc_id)
+         output/eval500k/qrels_stats.json
+
+Usage:
+  python3 13_build_qrels.py
+  python3 13_build_qrels.py --num-queries 100 --min-relevant 3   # smoke
+"""
+
+import argparse
+import csv
+import json
+import logging
+import os
+import random
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import psycopg2
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from eval500k_common import (
+    ARTICLE_CITATION_TYPES, DB_DSN, JUSTICE_KINDS, article_token, norm_cause_num,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger("qrels")
+
+OUTPUT_DIR = Path(__file__).parent / "output" / "eval500k"
+SEED = 42
+
+MAX_CANDIDATES_PER_QUERY = 1000
+
+
+def load_sample(path):
+    with open(path) as f:
+        rows = list(csv.DictReader(f))
+    docs = {int(r["doc_id"]): r for r in rows}
+    log.info("sample: %d docs", len(docs))
+    return docs
+
+
+def fetch_citations(doc_ids):
+    """Per-doc article tokens and referenced case numbers."""
+    doc_articles = defaultdict(set)
+    doc_caserefs = defaultdict(set)
+    conn = psycopg2.connect(DB_DSN)
+    conn.set_session(readonly=True)
+    ids = list(doc_ids)
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '60min'")
+        for i in range(0, len(ids), 10_000):
+            cur.execute(
+                """
+                SELECT court_case_id, citation_type, law_number, law_article
+                FROM law_court_citations
+                WHERE court_case_id = ANY(%s)
+                  AND citation_type = ANY(%s)
+                """,
+                (ids[i:i + 10_000], list(ARTICLE_CITATION_TYPES) + ["case_reference"]),
+            )
+            for doc_id, ctype, law_number, law_article in cur.fetchall():
+                if ctype == "case_reference":
+                    cn = norm_cause_num(law_number)
+                    if cn:
+                        doc_caserefs[doc_id].add(cn)
+                else:
+                    doc_articles[doc_id].add(article_token(law_number, law_article))
+            if (i // 10_000) % 10 == 0:
+                log.info("citations: %d/%d docs fetched", min(i + 10_000, len(ids)), len(ids))
+    conn.close()
+    log.info("citations: %d docs with articles, %d with case refs",
+             len(doc_articles), len(doc_caserefs))
+    return doc_articles, doc_caserefs
+
+
+def informative_tokens(doc_articles, n_docs, min_df, hub_frac):
+    df = Counter(t for toks in doc_articles.values() for t in toks)
+    hub_cap = int(hub_frac * n_docs)
+    keep = {t for t, c in df.items() if min_df <= c <= hub_cap}
+    hubs = sorted(((t, c) for t, c in df.items() if c > hub_cap), key=lambda x: -x[1])
+    log.info("tokens: %d total, %d informative (df in [%d, %d]); top hubs dropped: %s",
+             len(df), len(keep), min_df, hub_cap,
+             [f"{t} (df={c})" for t, c in hubs[:5]])
+    return keep, {t: df[t] for t in keep}, hubs
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sample", default=str(OUTPUT_DIR / "sample.csv"))
+    ap.add_argument("--num-queries", type=int, default=3_000)
+    ap.add_argument("--min-relevant", type=int, default=5)
+    ap.add_argument("--min-df", type=int, default=2)
+    ap.add_argument("--hub-frac", type=float, default=0.0005,
+                    help="drop tokens cited by more than this fraction of the sample")
+    ap.add_argument("--strong-shared", type=int, default=3,
+                    help="shared informative tokens for grade 2")
+    ap.add_argument("--grade1-min", type=int, default=1,
+                    help="min shared informative tokens for grade 1")
+    args = ap.parse_args()
+
+    rng = random.Random(SEED)
+    docs = load_sample(args.sample)
+    doc_articles, doc_caserefs = fetch_citations(docs.keys())
+
+    keep, df, hubs = informative_tokens(doc_articles, len(docs), args.min_df, args.hub_frac)
+    doc_tokens = {d: toks & keep for d, toks in doc_articles.items()}
+    doc_tokens = {d: t for d, t in doc_tokens.items() if t}
+
+    # inverted indexes inside the sample
+    token_index = defaultdict(list)
+    for d, toks in doc_tokens.items():
+        for t in toks:
+            token_index[t].append(d)
+    cause_index = defaultdict(list)   # normalized cause_num -> doc_ids
+    for d, meta in docs.items():
+        cn = norm_cause_num(meta["cause_num"])
+        if cn:
+            cause_index[cn].append(d)
+
+    def relevant_for(q):
+        """(grade>=1 candidates dict, same-case exclusions set) for query q."""
+        same_case = set(cause_index.get(norm_cause_num(docs[q]["cause_num"]), [])) - {q}
+        shared = Counter()
+        for t in doc_tokens.get(q, ()):
+            for d in token_index[t]:
+                if d != q:
+                    shared[d] += 1
+        grades = {}
+        for d, n in shared.items():
+            if d in same_case or n < args.grade1_min:
+                continue
+            grades[d] = 2 if n >= args.strong_shared else 1
+        # direct references override co-citation grade
+        q_cn = norm_cause_num(docs[q]["cause_num"])
+        for cn in doc_caserefs.get(q, ()):
+            for d in cause_index.get(cn, []):
+                if d != q and d not in same_case:
+                    grades[d] = 3
+        for d, refs in (() if not q_cn else
+                        ((d, doc_caserefs.get(d, ())) for d in list(grades))):
+            if q_cn in refs:
+                grades[d] = 3
+        return grades, same_case
+
+    # query selection: stratified over (year, kind) among eligible docs
+    eligible = defaultdict(list)
+    for d in doc_tokens:
+        meta = docs[d]
+        eligible[(meta["adj_year"], meta["justice_kind"])].append(d)
+    for cell in eligible:
+        rng.shuffle(eligible[cell])
+
+    total_eligible = sum(len(v) for v in eligible.values())
+    queries, qrels, excluded = [], {}, {}
+    checked = 0
+    for cell, pool in sorted(eligible.items()):
+        quota = max(1, round(args.num_queries * len(pool) / total_eligible))
+        taken = 0
+        for q in pool:
+            if taken >= quota or len(queries) >= args.num_queries:
+                break
+            grades, same_case = relevant_for(q)
+            checked += 1
+            if len(grades) < args.min_relevant:
+                continue
+            if len(grades) > MAX_CANDIDATES_PER_QUERY:
+                top = sorted(grades.items(), key=lambda kv: -kv[1])[:MAX_CANDIDATES_PER_QUERY]
+                log.warning("query %s: %d relevant truncated to %d",
+                            q, len(grades), MAX_CANDIDATES_PER_QUERY)
+                grades = dict(top)
+            queries.append(q)
+            qrels[q] = grades
+            excluded[q] = same_case
+            taken += 1
+    log.info("queries: %d selected (checked %d candidates)", len(queries), checked)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_DIR / "qrels.txt", "w") as f:
+        for q in queries:
+            for d, g in sorted(qrels[q].items(), key=lambda kv: -kv[1]):
+                f.write(f"{q} 0 {d} {g}\n")
+    with open(OUTPUT_DIR / "excluded.txt", "w") as f:
+        for q in queries:
+            for d in sorted(excluded[q]):
+                f.write(f"{q} {d}\n")
+    with open(OUTPUT_DIR / "queries.csv", "w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["doc_id", "adj_year", "justice_kind", "judgment_code",
+                    "n_relevant", "n_grade3", "n_grade2", "n_grade1", "n_excluded"])
+        for q in queries:
+            g = Counter(qrels[q].values())
+            meta = docs[q]
+            w.writerow([q, meta["adj_year"], meta["justice_kind"], meta["judgment_code"],
+                        len(qrels[q]), g[3], g[2], g[1], len(excluded[q])])
+
+    grade_totals = Counter(g for v in qrels.values() for g in v.values())
+    stats = {
+        "num_queries": len(queries),
+        "params": {"min_relevant": args.min_relevant, "min_df": args.min_df,
+                   "hub_frac": args.hub_frac, "strong_shared": args.strong_shared,
+                   "grade1_min": args.grade1_min,
+                   "max_candidates": MAX_CANDIDATES_PER_QUERY, "seed": SEED},
+        "sample_docs": len(docs),
+        "docs_with_informative_tokens": len(doc_tokens),
+        "informative_tokens": len(keep),
+        "dropped_hubs": [{"token": t, "df": c} for t, c in hubs[:50]],
+        "grade_totals": {str(k): v for k, v in sorted(grade_totals.items(), reverse=True)},
+        "avg_relevant_per_query": round(sum(len(v) for v in qrels.values()) / max(1, len(queries)), 1),
+        "excluded_same_case_pairs": sum(len(v) for v in excluded.values()),
+    }
+    json.dump(stats, open(OUTPUT_DIR / "qrels_stats.json", "w"), indent=2, ensure_ascii=False)
+    log.info("DONE: %s", json.dumps(stats["grade_totals"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/14_build_relevant_pool.py
+++ b/scripts/citation-graph/14_build_relevant_pool.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Pooled retrieval corpus for the EVAL-500K benchmark (BEIR-style), to cut
+embedding time on Brev.
+
+Pool = queries ∪ all graded candidates ∪ same-case exclusions (must be
+embedded so they can be filtered out of rankings at eval time) + stratified
+distractors from the rest of EVAL-500K, proportional to (year, kind) cells,
+up to --target docs total.
+
+Model ranking (RQ1) is unaffected by pool size; absolute metric values are
+reported as pooled-corpus numbers in the paper.
+
+Inputs:  output/eval500k/{sample.csv, qrels.txt, excluded.txt}
+         output/eval500k/texts_stripped/   (from 12_sample_eval500k.py --export-text)
+Outputs: output/eval500k/pool.csv
+         output/eval500k/pool_manifest.json
+         output/eval500k/texts_pool/       (filtered jsonl shards)
+
+Usage:
+  python3 14_build_relevant_pool.py                 # default target 100K
+  python3 14_build_relevant_pool.py --target 150000
+"""
+
+import argparse
+import csv
+import json
+import logging
+import random
+from collections import defaultdict
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger("pool")
+
+OUTPUT_DIR = Path(__file__).parent / "output" / "eval500k"
+SEED = 42
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--target", type=int, default=100_000)
+    ap.add_argument("--texts-dir", default=str(OUTPUT_DIR / "texts_stripped"))
+    ap.add_argument("--out-texts-dir", default=str(OUTPUT_DIR / "texts_pool"))
+    ap.add_argument("--skip-texts", action="store_true", help="only build pool.csv")
+    args = ap.parse_args()
+
+    rng = random.Random(SEED)
+
+    core = set()
+    with open(OUTPUT_DIR / "qrels.txt") as f:
+        for line in f:
+            q, _, d, _ = line.split()
+            core.add(int(q))
+            core.add(int(d))
+    with open(OUTPUT_DIR / "excluded.txt") as f:
+        for line in f:
+            _, d = line.split()
+            core.add(int(d))
+    log.info("core (queries + graded + same-case): %d docs", len(core))
+
+    with open(OUTPUT_DIR / "sample.csv") as f:
+        sample = list(csv.DictReader(f))
+    by_id = {int(r["doc_id"]): r for r in sample}
+    missing = core - set(by_id)
+    if missing:
+        raise SystemExit(f"{len(missing)} core docs not in sample.csv - qrels/sample mismatch")
+
+    n_distractors = max(0, args.target - len(core))
+    cells = defaultdict(list)
+    for r in sample:
+        d = int(r["doc_id"])
+        if d not in core:
+            cells[(r["adj_year"], r["justice_kind"])].append(d)
+    total_rest = sum(len(v) for v in cells.values())
+    distractors = set()
+    for cell, pool in sorted(cells.items()):
+        take = min(len(pool), round(n_distractors * len(pool) / total_rest))
+        distractors.update(rng.sample(pool, take))
+    log.info("distractors: %d (stratified over %d cells)", len(distractors), len(cells))
+
+    pool = core | distractors
+    fieldnames = list(sample[0].keys()) + ["in_core"]
+    with open(OUTPUT_DIR / "pool.csv", "w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+        for d in sorted(pool):
+            w.writerow({**by_id[d], "in_core": int(d in core)})
+
+    comp = defaultdict(int)
+    for d in pool:
+        comp[by_id[d]["adj_year"]] += 1
+    json.dump({
+        "target": args.target, "seed": SEED,
+        "pool_size": len(pool), "core": len(core), "distractors": len(distractors),
+        "by_year": dict(sorted(comp.items())),
+    }, open(OUTPUT_DIR / "pool_manifest.json", "w"), indent=2)
+    log.info("pool.csv: %d docs (%.1fx reduction vs %d)",
+             len(pool), len(sample) / len(pool), len(sample))
+
+    if args.skip_texts:
+        return
+
+    out_dir = Path(args.out_texts_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    kept = 0
+    for shard in sorted(Path(args.texts_dir).glob("texts-*.jsonl")):
+        out_lines = []
+        with open(shard, encoding="utf-8") as f:
+            for line in f:
+                # avoid full json parse: doc_id is the first key
+                doc_id = int(line[line.index(":") + 1: line.index(",")])
+                if doc_id in pool:
+                    out_lines.append(line)
+        if out_lines:
+            with open(out_dir / shard.name, "w", encoding="utf-8") as f:
+                f.writelines(out_lines)
+            kept += len(out_lines)
+    if kept != len(pool):
+        log.warning("texts: %d written != pool %d", kept, len(pool))
+    else:
+        log.info("texts: %d docs -> %s", kept, out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/eval500k_common.py
+++ b/scripts/citation-graph/eval500k_common.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""
+Shared helpers for the EVAL-500K citation-grounded retrieval benchmark.
+
+Used by:
+  12_sample_eval500k.py  - stratified corpus sampling + citation-stripped text export
+  13_build_qrels.py      - graded qrels from the citation graph
+
+Citation regexes mirror extract-citations-fast.py (the same patterns that
+populated law_court_citations), so stripping removes exactly what the
+ground-truth graph was built from.
+"""
+
+import os
+import re
+
+DB_DSN = os.environ.get(
+    "DATABASE_URL",
+    "postgresql://secondlayer:local_db_password@localhost:5432/secondlayer_local",
+)
+
+JUSTICE_KINDS = {1: "civil", 2: "criminal", 3: "commercial", 4: "administrative"}
+
+# Substantive decisions only: Вирок (1), Постанова (2), Рішення (3).
+# Судові накази (4) and ухвали (5) are template-dominated; 6/7/10 are marginal.
+DEFAULT_JUDGMENT_CODES = (1, 2, 3)
+
+YEAR_MIN, YEAR_MAX = 2010, 2025
+
+# ── Citation patterns (same as extract-citations-fast.py) ───────────────────
+
+STRIP_PATTERNS = [
+    re.compile(
+        r'(?:(?:ч(?:астин[аи]|\.)\s*\d+\s+)?'
+        r'(?:стат(?:т[іея]|ей)|ст\.)\s*'
+        r'([\d,\s\-та]+))\s+'
+        r'(ЦК|КК|ГК|ГПК|КПК|КАС|ЦПК|КЗпП|СК|ЗК|ПК|МК|БК|ВК|ЛК|ЖК|КУпАП|КАСУ)'
+        r'(?:\s+України)?',
+        re.IGNORECASE | re.UNICODE,
+    ),
+    re.compile(
+        r'(?:стат(?:т[іея]|ей)|ст\.)\s*'
+        r'([\d,\s\-та]+)'
+        r'\s+(?:Закону\s+України|ЗУ|Закону)\s+'
+        r'(?:[«"]([^»"]+)[»"]|(?:від|№)\s*(\d[\d.\-/]+))',
+        re.IGNORECASE | re.UNICODE,
+    ),
+    re.compile(
+        r'(?:стат(?:т[іея]|ей)|ст\.)\s*'
+        r'([\d,\s\-та]+)\s+'
+        r'Конституці[їі]\s+України',
+        re.IGNORECASE | re.UNICODE,
+    ),
+    re.compile(r'(?:справ[аи]\s*)?№\s*(\d{1,4}/\d+/\d{2,4})', re.IGNORECASE),
+    re.compile(
+        r'Закон(?:у|ом)?\s+України\s+'
+        r'(?:від\s+(\d{2}\.\d{2}\.\d{4})\s+)?'
+        r'№\s*([\d\-]+(?:\-[IVX]+)?)',
+        re.IGNORECASE | re.UNICODE,
+    ),
+    re.compile(
+        r'(?:постанов[аиі]|ухвал[аиі])\s+'
+        r'(?:Пленуму\s+)?'
+        r'(?:Верховного\s+Суду|ВС|Великої\s+Палати\s+ВС)',
+        re.IGNORECASE | re.UNICODE,
+    ),
+]
+
+_WS = re.compile(r'[ \t]{2,}')
+
+
+def strip_citations(text: str) -> str:
+    """Remove citation strings so dense models cannot match citation tokens.
+
+    Replaces each citation span with a single space (keeps sentence flow),
+    then collapses runs of whitespace.
+    """
+    for pat in STRIP_PATTERNS:
+        text = pat.sub(' ', text)
+    return _WS.sub(' ', text)
+
+
+# ── Article tokens for co-citation ──────────────────────────────────────────
+
+ARTICLE_CITATION_TYPES = ('codex_article', 'law_article', 'constitution', 'law_by_number')
+
+_NORM = re.compile(r'\s+')
+
+
+def article_token(law_number: str, law_article: str) -> str:
+    """Canonical token for an (act, article) pair, e.g. 'цивільний кодекс україни::625'."""
+    ln = _NORM.sub(' ', (law_number or '').strip().lower())
+    la = _NORM.sub(' ', (law_article or '').strip().lower())
+    return f"{ln}::{la}"
+
+
+def norm_cause_num(cause: str) -> str:
+    return _NORM.sub('', (cause or '').strip().lower())


### PR DESCRIPTION
## Summary

Experimental design + data prep scripts for the NLLP 2026 paper **"Citations as Ground Truth"**: large-scale evaluation of dense retrievers on EDRSR using citation-graph-derived qrels instead of human annotation (Plane PAPER-48).

- `docs/proposals/citation-grounded-embedding-eval-design.md` - full experimental design (RQ1-RQ4, model list, metrics, Brev compute plan, timeline to the Aug 11 deadline)
- `scripts/citation-graph/eval500k_common.py` - shared citation-strip regexes (mirror of extract-citations-fast.py so stripping removes exactly what the ground-truth graph was built from) + token canonicalization
- `scripts/citation-graph/12_sample_eval500k.py` - stratified sampler: justice_kind (1-4) x year (2010-2025), substantive judgment codes only, text-length verification, setseed-reproducible, per-year checkpoints with resume, jsonl export with citation stripping (`--no-strip` for the leak ablation)
- `scripts/citation-graph/13_build_qrels.py` - graded qrels: grade 3 = direct case reference via cause_num, grade 2/1 = shared IDF-informative articles; hub filtering, same-case exclusion, TREC output, CLI-tunable thresholds
- `scripts/citation-graph/14_build_relevant_pool.py` - BEIR-style pooled corpus (44K core + stratified distractors = 100K docs), cuts Brev embedding compute 5x

## Results of the 2026-06-11 run (artifacts not committed, in `scripts/citation-graph/output/eval500k/`)

- 499,997-doc stratified sample, all 64 cells filled
- 3,000 queries, avg 76.5 relevant/query (379 g3 / 35,194 g2 / 193,907 g1), 486 same-case pairs excluded; two looser qrels configs kept for sensitivity analysis
- 100,003-doc pool (2.7 GB stripped texts), ready for embedding runs on Brev

## Test plan

- [x] Smoke: 2K-doc sample (2020-2021) + qrels end-to-end
- [x] Full run: 500K sample in ~7 min, qrels in ~80 s, pool + text filtering verified doc-for-doc
- [x] Citation stripping spot-checked (case numbers / article refs removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the EVAL-500K data prep pipeline for citation-grounded embedding evaluation, enabling reproducible sampling, graded qrels from the citation graph, and a 100K pooled corpus to cut embedding compute. Supports PAPER-48.

- **New Features**
  - `docs/proposals/citation-grounded-embedding-eval-design.md`: study design, models, metrics, and compute plan.
  - `scripts/citation-graph/eval500k_common.py`: shared citation-strip patterns (mirrors `extract-citations-fast.py`) and token/cause-num canonicalization.
  - `scripts/citation-graph/12_sample_eval500k.py`: stratified 500K sampler (justice_kind × year), substantive judgment filter, min-length check, deterministic seed, per-year checkpoints, JSONL export with citation stripping (`--no-strip` ablation).
  - `scripts/citation-graph/13_build_qrels.py`: graded qrels from the citation graph (g3 direct refs; g2/g1 shared IDF-weighted articles), hub filtering, same-case exclusion, TREC output with tunable thresholds.
  - `scripts/citation-graph/14_build_relevant_pool.py`: BEIR-style 100K pool (queries + graded + same-case + stratified distractors) and filtered text shards; ~5× lower embedding compute.

<sup>Written for commit b0d9da562aac928c261cae094c503ab92f5ff2b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

