### PR TITLE
feat(research): SageMaker embedding jobs for citation-grounded eval (PAPER-48)

### DIFF
--- a/scripts/citation-graph/16_launch_embed_sagemaker.py
+++ b/scripts/citation-graph/16_launch_embed_sagemaker.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""
+Launch one atomic embedding job (1 job = 1 model) on SageMaker for the
+citation-grounded eval pool (PAPER-48). Hybrid plan: 560M-class models run
+here, Qwen3-Embedding-8B stays on Brev.
+
+Prereqs:
+  export MLFLOW_TRACKING_USERNAME=sagemaker MLFLOW_TRACKING_PASSWORD=...
+  python3 16_launch_embed_sagemaker.py --upload-corpus        # once, 2.7 GB
+
+Jobs (quota: 1 on-demand + 1 spot per instance type -> J1/J2 in parallel):
+  J1: python3 16_launch_embed_sagemaker.py --model bge-m3 --spot
+  J2: python3 16_launch_embed_sagemaker.py --model me5
+  J3: finetune via ../bge-m3-finetune/05_launch_sagemaker.py (g5.2xlarge, other quota)
+  J4: python3 16_launch_embed_sagemaker.py --model bge-m3-ua \
+        --model-s3 s3://secondlayer-ml-data-usw2/bge-m3-finetune/output/<job>/output/model.tar.gz
+
+Monitor via MLflow (experiment 'citation-embedding-eval'), not log parsing.
+Embeddings land in s3://secondlayer-ml-data-usw2/citation-eval/embeddings/<slug>/
+as one parquet per corpus shard (spot-safe resume via existing-key skip).
+"""
+
+import argparse
+import os
+import sys
+import tarfile
+import time
+from pathlib import Path
+
+import boto3
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "mlops"))
+from spot_wrapper import enable_spot
+
+REGION = "us-west-2"
+ROLE = "arn:aws:iam::272594900302:role/SageMakerDPOExecutionRole"
+BUCKET = "secondlayer-ml-data-usw2"
+IMAGE_URI = "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.5.1-gpu-py311-cu124-ubuntu22.04-sagemaker"
+
+CORPUS_LOCAL = Path(__file__).parent / "output" / "eval500k" / "texts_pool"
+CORPUS_S3_PREFIX = "citation-eval/texts_pool"
+
+MODELS = {
+    "bge-m3": {
+        "model_id": "BAAI/bge-m3",
+        "pooling": "cls",
+        "doc_prefix": "",
+    },
+    "me5": {
+        "model_id": "intfloat/multilingual-e5-large-instruct",
+        "pooling": "mean",
+        "doc_prefix": "",   # instruct variant: documents need no prefix
+    },
+    "bge-m3-ua": {
+        "model_id": "BAAI/bge-m3",   # tokenizer/base arch; weights via --model-s3
+        "pooling": "cls",
+        "doc_prefix": "",
+    },
+}
+
+
+def upload_corpus(s3):
+    shards = sorted(CORPUS_LOCAL.glob("*.jsonl"))
+    if not shards:
+        raise SystemExit(f"no shards in {CORPUS_LOCAL} - run 14_build_relevant_pool.py first")
+    existing = set()
+    for page in s3.get_paginator("list_objects_v2").paginate(
+            Bucket=BUCKET, Prefix=CORPUS_S3_PREFIX + "/"):
+        existing.update(o["Key"] for o in page.get("Contents", []))
+    todo = [p for p in shards if f"{CORPUS_S3_PREFIX}/{p.name}" not in existing]
+    print(f"uploading {len(todo)}/{len(shards)} shards to s3://{BUCKET}/{CORPUS_S3_PREFIX}/")
+    for i, p in enumerate(todo, 1):
+        s3.upload_file(str(p), BUCKET, f"{CORPUS_S3_PREFIX}/{p.name}")
+        print(f"  [{i}/{len(todo)}] {p.name}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--model", choices=sorted(MODELS))
+    ap.add_argument("--model-s3", help="model.tar.gz S3 URI for finetuned checkpoint")
+    ap.add_argument("--instance-type", default="ml.g5.12xlarge")
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--max-len", type=int, default=1024)
+    ap.add_argument("--stride", type=int, default=128)
+    ap.add_argument("--spot", action="store_true")
+    ap.add_argument("--max-runtime-hours", type=float, default=8)
+    ap.add_argument("--upload-corpus", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    s3 = boto3.client("s3", region_name=REGION)
+    if args.upload_corpus:
+        upload_corpus(s3)
+        if not args.model:
+            return
+    if not args.model:
+        raise SystemExit("--model required (or --upload-corpus alone)")
+    if args.model == "bge-m3-ua" and not args.model_s3:
+        raise SystemExit("bge-m3-ua requires --model-s3 (finetuned model.tar.gz)")
+
+    cfg = MODELS[args.model]
+    ts = int(time.time())
+    job_name = f"embed-{args.model}-{ts}"
+    output_s3 = f"s3://{BUCKET}/citation-eval/embeddings/{args.model}"
+
+    script_dir = Path(__file__).parent
+    code_key = f"citation-eval/code/{job_name}/sourcedir.tar.gz"
+    if not args.dry_run:
+        tar_path = f"/tmp/embed-source-{ts}.tar.gz"
+        with tarfile.open(tar_path, "w:gz") as tar:
+            tar.add(script_dir / "embed_entry.py", arcname="embed_entry.py")
+            tar.add(script_dir / "requirements_embed.txt", arcname="requirements.txt")
+        s3.upload_file(tar_path, BUCKET, code_key)
+        os.remove(tar_path)
+
+    hyperparams = {
+        "model_id": cfg["model_id"],
+        "model_slug": args.model,
+        "pooling": cfg["pooling"],
+        # SageMaker rejects empty hyperparameter values - omit when blank
+        **({"doc_prefix": cfg["doc_prefix"]} if cfg["doc_prefix"] else {}),
+        "max_len": str(args.max_len),
+        "stride": str(args.stride),
+        "batch_size": str(args.batch_size),
+        "output_s3": output_s3,
+        "sagemaker_program": "embed_entry.py",
+        "sagemaker_submit_directory": f"s3://{BUCKET}/{code_key}",
+        "sagemaker_region": REGION,
+    }
+
+    channels = [{
+        "ChannelName": "corpus",
+        "DataSource": {"S3DataSource": {
+            "S3DataType": "S3Prefix",
+            "S3Uri": f"s3://{BUCKET}/{CORPUS_S3_PREFIX}/",
+            "S3DataDistributionType": "FullyReplicated",
+        }},
+    }]
+    if args.model_s3:
+        channels.append({
+            "ChannelName": "model",
+            "DataSource": {"S3DataSource": {
+                "S3DataType": "S3Prefix",
+                "S3Uri": args.model_s3,
+                "S3DataDistributionType": "FullyReplicated",
+            }},
+        })
+
+    mlflow_user = os.environ.get("MLFLOW_TRACKING_USERNAME", "sagemaker")
+    mlflow_pass = os.environ.get("MLFLOW_TRACKING_PASSWORD", "")
+    if not mlflow_pass:
+        print("WARNING: MLFLOW_TRACKING_PASSWORD not set, MLflow logging will fail")
+
+    job_config = dict(
+        TrainingJobName=job_name,
+        RoleArn=ROLE,
+        AlgorithmSpecification={"TrainingImage": IMAGE_URI, "TrainingInputMode": "File"},
+        HyperParameters=hyperparams,
+        InputDataConfig=channels,
+        OutputDataConfig={"S3OutputPath": f"s3://{BUCKET}/citation-eval/job-output/"},
+        ResourceConfig={
+            "InstanceType": args.instance_type,
+            "InstanceCount": 1,
+            "VolumeSizeInGB": 100,
+        },
+        StoppingCondition={"MaxRuntimeInSeconds": int(args.max_runtime_hours * 3600)},
+        Environment={
+            "MLFLOW_TRACKING_URI": "https://mlflow.legal.org.ua",
+            "MLFLOW_TRACKING_USERNAME": mlflow_user,
+            "MLFLOW_TRACKING_PASSWORD": mlflow_pass,
+        },
+        Tags=[
+            {"Key": "project", "Value": "secondlayer"},
+            {"Key": "experiment", "Value": "citation-embedding-eval"},
+            {"Key": "workload", "Value": "ml-embedding"},
+        ],
+    )
+
+    if args.spot:
+        job_config = enable_spot(
+            job_config,
+            checkpoint_s3=f"s3://{BUCKET}/citation-eval/checkpoints/{job_name}/",
+        )
+        print("Spot enabled (resume = skip existing parquet keys)")
+
+    if args.dry_run:
+        import json
+        print(json.dumps(job_config, indent=2, default=str))
+        return
+
+    boto3.client("sagemaker", region_name=REGION).create_training_job(**job_config)
+    print(f"\nLaunched: {job_name} on {args.instance_type}")
+    print(f"Embeddings -> {output_s3}/")
+    print(f"MLflow: experiment 'citation-embedding-eval', run 'embed-{args.model}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/embed_entry.py
+++ b/scripts/citation-graph/embed_entry.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+SageMaker entry: embed the EVAL pool corpus with one HF encoder model.
+
+One job = one model (atomic). Reads jsonl shards from the 'corpus' channel,
+chunks each doc (max_len tokens with stride overlap), embeds on every visible
+GPU (one worker process per GPU, shards split round-robin), mean-pools chunk
+vectors into a doc vector, writes one parquet per input shard directly to S3.
+
+Spot-safe: a shard whose parquet already exists in S3 is skipped, so a
+restarted job resumes where it stopped.
+
+MLflow: experiment 'citation-embedding-eval', params + throughput metrics
+logged from the master process every 60s and at completion.
+"""
+
+import argparse
+import json
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+
+import boto3
+
+CORPUS_DIR = Path(os.environ.get("SM_CHANNEL_CORPUS", "/opt/ml/input/data/corpus"))
+WORK_DIR = Path("/tmp/embed_out")
+
+
+def resolve_model_dir():
+    """Channel 'model' may hold an unextracted model.tar.gz - extract once."""
+    chan = os.environ.get("SM_CHANNEL_MODEL")
+    if not chan:
+        return None
+    import tarfile
+    chan = Path(chan)
+    tars = list(chan.glob("*.tar.gz"))
+    if tars:
+        dest = Path("/tmp/finetuned_model")
+        if not dest.exists():
+            dest.mkdir(parents=True)
+            with tarfile.open(tars[0]) as t:
+                t.extractall(dest)
+        # checkpoint may be nested one level down
+        if not (dest / "config.json").exists():
+            sub = [p for p in dest.iterdir() if (p / "config.json").exists()]
+            if sub:
+                dest = sub[0]
+        return str(dest)
+    return str(chan)
+
+
+MODEL_DIR = resolve_model_dir()
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_id", required=True)
+    ap.add_argument("--model_slug", required=True, help="short name for paths/MLflow")
+    ap.add_argument("--pooling", choices=["cls", "mean"], default="cls")
+    ap.add_argument("--max_len", type=int, default=1024)
+    ap.add_argument("--stride", type=int, default=128, help="token overlap between chunks")
+    ap.add_argument("--batch_size", type=int, default=64)
+    ap.add_argument("--doc_prefix", default="", help="e.g. 'passage: ' for non-instruct e5")
+    ap.add_argument("--output_s3", required=True, help="s3://bucket/prefix for parquet shards")
+    # injected by SageMaker, ignored
+    ap.add_argument("--sagemaker_program", default=None)
+    ap.add_argument("--sagemaker_submit_directory", default=None)
+    ap.add_argument("--sagemaker_region", default=None)
+    args, _ = ap.parse_known_args()
+    return args
+
+
+def s3_parts(uri):
+    rest = uri[len("s3://"):]
+    bucket, _, prefix = rest.partition("/")
+    return bucket, prefix.rstrip("/")
+
+
+def shard_done_key(prefix, shard_name):
+    return f"{prefix}/{shard_name.replace('.jsonl', '.parquet')}"
+
+
+def worker(rank, args, shard_files, progress):
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    import torch
+    from transformers import AutoModel, AutoTokenizer
+
+    torch.set_grad_enabled(False)
+    device = f"cuda:{rank}"
+    model_path = MODEL_DIR if MODEL_DIR else args.model_id
+    tok = AutoTokenizer.from_pretrained(model_path)
+    model = AutoModel.from_pretrained(model_path, torch_dtype=torch.float16).to(device).eval()
+
+    bucket, prefix = s3_parts(args.output_s3)
+    s3 = boto3.client("s3")
+    my_shards = shard_files[rank::torch.cuda.device_count()]
+
+    for shard in my_shards:
+        out_key = shard_done_key(prefix, shard.name)
+        try:
+            s3.head_object(Bucket=bucket, Key=out_key)
+            print(f"[{rank}] skip {shard.name} (exists)")
+            continue
+        except s3.exceptions.ClientError:
+            pass
+
+        doc_ids, vectors, chunk_counts = [], [], []
+        pending = []  # (doc_idx, input_ids, attention_mask) per chunk
+
+        def embed_pending():
+            embs = []
+            for i in range(0, len(pending), args.batch_size):
+                batch = pending[i:i + args.batch_size]
+                maxlen = max(len(b[1]) for b in batch)
+                ids = torch.full((len(batch), maxlen), tok.pad_token_id, dtype=torch.long)
+                mask = torch.zeros((len(batch), maxlen), dtype=torch.long)
+                for j, (_, bi, bm) in enumerate(batch):
+                    ids[j, :len(bi)] = torch.tensor(bi)
+                    mask[j, :len(bm)] = torch.tensor(bm)
+                out = model(input_ids=ids.to(device), attention_mask=mask.to(device))
+                h = out.last_hidden_state
+                if args.pooling == "cls":
+                    e = h[:, 0]
+                else:
+                    m = mask.to(device).unsqueeze(-1)
+                    e = (h * m).sum(1) / m.sum(1).clamp(min=1)
+                e = torch.nn.functional.normalize(e, dim=-1)
+                embs.append(e.float().cpu())
+            return torch.cat(embs) if embs else torch.empty(0)
+
+        docs = []
+        with open(shard, encoding="utf-8") as f:
+            for line in f:
+                d = json.loads(line)
+                docs.append((d["doc_id"], d["text"]))
+
+        for doc_idx, (doc_id, text) in enumerate(docs):
+            enc = tok(args.doc_prefix + text, max_length=args.max_len,
+                      truncation=True, stride=args.stride,
+                      return_overflowing_tokens=True, padding=False)
+            for ids_, mask_ in zip(enc["input_ids"], enc["attention_mask"]):
+                pending.append((doc_idx, ids_, mask_))
+
+        chunk_embs = embed_pending()
+        owners = torch.tensor([p[0] for p in pending])
+        for doc_idx, (doc_id, _) in enumerate(docs):
+            sel = chunk_embs[owners == doc_idx]
+            if not len(sel):
+                continue
+            v = torch.nn.functional.normalize(sel.mean(0), dim=-1)
+            doc_ids.append(doc_id)
+            vectors.append(v.numpy())
+            chunk_counts.append(len(sel))
+
+        WORK_DIR.mkdir(parents=True, exist_ok=True)
+        local = WORK_DIR / f"{rank}.parquet"
+        pq.write_table(pa.table({
+            "doc_id": pa.array(doc_ids, pa.int64()),
+            "vector": pa.array([v.tolist() for v in vectors], pa.list_(pa.float32())),
+            "n_chunks": pa.array(chunk_counts, pa.int32()),
+        }), local)
+        s3.upload_file(str(local), bucket, out_key)
+        with progress.get_lock():
+            progress[0] += len(doc_ids)
+            progress[1] += sum(chunk_counts)
+            progress[2] += 1
+        print(f"[{rank}] {shard.name}: {len(doc_ids)} docs, {sum(chunk_counts)} chunks")
+
+
+def main():
+    args = parse_args()
+    import torch
+    n_gpu = torch.cuda.device_count()
+    shard_files = sorted(CORPUS_DIR.glob("*.jsonl"))
+    print(f"corpus: {len(shard_files)} shards, GPUs: {n_gpu}")
+
+    import mlflow
+    mlflow.set_tracking_uri(os.environ.get("MLFLOW_TRACKING_URI", "https://mlflow.legal.org.ua"))
+    mlflow.set_experiment("citation-embedding-eval")
+    run = mlflow.start_run(run_name=f"embed-{args.model_slug}")
+    mlflow.log_params({
+        "model_id": args.model_id, "model_slug": args.model_slug,
+        "pooling": args.pooling, "max_len": args.max_len, "stride": args.stride,
+        "batch_size": args.batch_size, "doc_prefix": args.doc_prefix or "(none)",
+        "n_shards": len(shard_files), "n_gpus": n_gpu,
+        "finetuned_checkpoint": bool(MODEL_DIR),
+        "instance_type": os.environ.get("SM_CURRENT_INSTANCE_TYPE", "?"),
+        "output_s3": args.output_s3,
+    })
+
+    progress = mp.Array("l", [0, 0, 0])  # docs, chunks, shards
+    t0 = time.time()
+    ctx = mp.get_context("spawn")
+    procs = [ctx.Process(target=worker, args=(r, args, shard_files, progress))
+             for r in range(n_gpu)]
+    for p in procs:
+        p.start()
+
+    while any(p.is_alive() for p in procs):
+        time.sleep(60)
+        el = time.time() - t0
+        docs, chunks, shards = progress[0], progress[1], progress[2]
+        mlflow.log_metrics({
+            "docs_done": docs, "chunks_done": chunks, "shards_done": shards,
+            "docs_per_sec": round(docs / el, 2), "chunks_per_sec": round(chunks / el, 2),
+        }, step=int(el))
+        print(f"[master] {el:.0f}s: {shards}/{len(shard_files)} shards, "
+              f"{docs} docs, {docs / el:.1f} docs/s")
+
+    failed = [p.exitcode for p in procs if p.exitcode]
+    el = time.time() - t0
+    mlflow.log_metrics({
+        "total_docs": progress[0], "total_chunks": progress[1],
+        "wall_seconds": round(el), "final_docs_per_sec": round(progress[0] / el, 2),
+    })
+    mlflow.end_run("FAILED" if failed else "FINISHED")
+    if failed:
+        raise SystemExit(f"worker(s) failed: {failed}")
+    # token success marker for the model artifact path
+    Path("/opt/ml/model/DONE").write_text(json.dumps({
+        "docs": progress[0], "chunks": progress[1], "seconds": round(el)}))
+    print(f"DONE: {progress[0]} docs, {progress[1]} chunks in {el:.0f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/requirements_embed.txt
+++ b/scripts/citation-graph/requirements_embed.txt
@@ -1,0 +1,5 @@
+transformers>=4.44
+mlflow>=2.10
+pyarrow>=15
+sentencepiece
+protobuf


### PR DESCRIPTION
## Summary

Hybrid compute plan for PAPER-48: all 560M-class embedding work moves to SageMaker (ml.g5.12xlarge, us-west-2), leaving only Qwen3-Embedding-8B (~1.5 h) for the next Brev window.

- `scripts/citation-graph/embed_entry.py` - atomic SageMaker entry (1 job = 1 model): per-GPU worker processes, 1024-token chunks with 128 stride, mean-pooled doc vectors, parquet-per-shard straight to S3 with existing-key skip (spot-safe resume), MLflow throughput metrics every 60 s (experiment `citation-embedding-eval`)
- `scripts/citation-graph/16_launch_embed_sagemaker.py` - launcher with presets (bge-m3 / me5 / bge-m3-ua via finetuned model.tar.gz channel), `--upload-corpus`, `--spot`, `--dry-run`; reuses role/bucket/DLC/spot_wrapper conventions from `bge-m3-finetune/05_launch_sagemaker.py`
- `scripts/citation-graph/requirements_embed.txt`

## Job plan (g5 quota: 1 on-demand + 1 spot per type)

| Job | What | Instance | Est. |
|---|---|---|---|
| J1 | embed BAAI/bge-m3 | g5.12xlarge spot | ~40-60 min |
| J2 | embed mE5-large-instruct | g5.12xlarge on-demand | ~40-60 min |
| J3 | BGE-M3-UA finetune (existing 05_launch_sagemaker.py) | g5.2xlarge | ~3 h |
| J4 | embed bge-m3-ua (after J3) | g5.12xlarge spot | ~40-60 min |

## Test plan

- [x] py_compile both scripts
- [x] `--dry-run` job config validated (channels, spot block, hyperparams, MLflow env)
- [ ] First real job validates end-to-end on SageMaker (J1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves 560M-class embedding jobs for the citation-grounded eval (PAPER-48) to SageMaker with an atomic per-model runner and a simple launcher. Spot-safe resume and MLflow metrics are built in; only the 8B job stays on Brev.

- **New Features**
  - `scripts/citation-graph/embed_entry.py`: SageMaker entrypoint that shards docs, chunks to 1024 tokens with 128 stride, runs one worker per GPU, pools chunk vectors to doc vectors, and writes one parquet per shard directly to S3; skips existing outputs for spot-safe resume; logs throughput to MLflow (`citation-embedding-eval`) every 60s; supports finetuned checkpoints via the `model` channel.
  - `scripts/citation-graph/16_launch_embed_sagemaker.py`: Launcher with presets for `bge-m3`, `me5`, and `bge-m3-ua` (via `--model-s3`); includes `--upload-corpus`, `--spot`, and `--dry-run`; sets MLflow env, reuses existing role/DLC conventions, and writes embeddings to `s3://.../citation-eval/embeddings/<slug>/`.
  - `scripts/citation-graph/requirements_embed.txt`: Adds `transformers`, `mlflow`, `pyarrow`, `sentencepiece`, and `protobuf`.

<sup>Written for commit 827167065d268431b9e5e13b40b3447d1ddd9447. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

