### PR TITLE
fix(research): embed_entry spawn-context SemLock crash

### DIFF
--- a/scripts/citation-graph/embed_entry.py
+++ b/scripts/citation-graph/embed_entry.py
@@ -190,9 +190,9 @@ def main():
         "output_s3": args.output_s3,
     })
 
-    progress = mp.Array("l", [0, 0, 0])  # docs, chunks, shards
-    t0 = time.time()
     ctx = mp.get_context("spawn")
+    progress = ctx.Array("l", [0, 0, 0])  # docs, chunks, shards
+    t0 = time.time()
     procs = [ctx.Process(target=worker, args=(r, args, shard_files, progress))
              for r in range(n_gpu)]
     for p in procs:


### PR DESCRIPTION
One-liner: `mp.Array` must come from the same `spawn` context as the worker processes - the default fork-context SemLock crashed the first SageMaker run (`embed-me5-1781172464`) with `RuntimeError: A SemLock created in a fork context...`. Jobs relaunched with the fixed entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix crash in `scripts/citation-graph/embed_entry.py` by creating the progress shared array from the same `spawn` context as worker processes. Prevents the SemLock fork/spawn mismatch that broke the first SageMaker run.

- **Bug Fixes**
  - Create `progress` via `ctx.Array` from `mp.get_context("spawn")` so the SemLock matches the worker context, resolving the "A SemLock created in a fork context..." RuntimeError.

<sup>Written for commit b4ecec4fb882402afbb8d60546c9711e788c2515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

