### PR TITLE
fix(research): me5 512-token chunks (XLM-R position limit)

### DIFF
--- a/scripts/citation-graph/16_launch_embed_sagemaker.py
+++ b/scripts/citation-graph/16_launch_embed_sagemaker.py
@@ -45,16 +45,19 @@ MODELS = {
         "model_id": "BAAI/bge-m3",
         "pooling": "cls",
         "doc_prefix": "",
+        "max_len": 1024,    # supports 8192; 1024 = benchmark chunk size
     },
     "me5": {
         "model_id": "intfloat/multilingual-e5-large-instruct",
         "pooling": "mean",
         "doc_prefix": "",   # instruct variant: documents need no prefix
+        "max_len": 512,     # XLM-R position limit (514) - 1024 hits device assert
     },
     "bge-m3-ua": {
         "model_id": "BAAI/bge-m3",   # tokenizer/base arch; weights via --model-s3
         "pooling": "cls",
         "doc_prefix": "",
+        "max_len": 1024,
     },
 }
 
@@ -80,7 +83,8 @@ def main():
     ap.add_argument("--model-s3", help="model.tar.gz S3 URI for finetuned checkpoint")
     ap.add_argument("--instance-type", default="ml.g5.12xlarge")
     ap.add_argument("--batch-size", type=int, default=64)
-    ap.add_argument("--max-len", type=int, default=1024)
+    ap.add_argument("--max-len", type=int, default=None,
+                    help="override model preset chunk size")
     ap.add_argument("--stride", type=int, default=128)
     ap.add_argument("--spot", action="store_true")
     ap.add_argument("--max-runtime-hours", type=float, default=8)
@@ -99,6 +103,7 @@ def main():
         raise SystemExit("bge-m3-ua requires --model-s3 (finetuned model.tar.gz)")
 
     cfg = MODELS[args.model]
+    max_len = args.max_len or cfg["max_len"]
     ts = int(time.time())
     job_name = f"embed-{args.model}-{ts}"
     output_s3 = f"s3://{BUCKET}/citation-eval/embeddings/{args.model}"
@@ -119,7 +124,7 @@ def main():
         "pooling": cfg["pooling"],
         # SageMaker rejects empty hyperparameter values - omit when blank
         **({"doc_prefix": cfg["doc_prefix"]} if cfg["doc_prefix"] else {}),
-        "max_len": str(args.max_len),
+        "max_len": str(max_len),
         "stride": str(args.stride),
         "batch_size": str(args.batch_size),
         "output_s3": output_s3,

--- a/scripts/citation-graph/embed_entry.py
+++ b/scripts/citation-graph/embed_entry.py
@@ -93,6 +93,16 @@ def worker(rank, args, shard_files, progress):
     tok = AutoTokenizer.from_pretrained(model_path)
     model = AutoModel.from_pretrained(model_path, torch_dtype=torch.float16).to(device).eval()
 
+    # guard against exceeding the model's position-embedding table
+    model_max = getattr(model.config, "max_position_embeddings", None)
+    if model_max and model_max < 100_000:
+        # XLM-R style tables reserve 2 positions (pad offset)
+        hard_cap = model_max - 2
+        if args.max_len > hard_cap:
+            print(f"[{rank}] clamp max_len {args.max_len} -> {hard_cap} "
+                  f"(max_position_embeddings={model_max})")
+            args.max_len = hard_cap
+
     bucket, prefix = s3_parts(args.output_s3)
     s3 = boto3.client("s3")
     my_shards = shard_files[rank::torch.cuda.device_count()]


### PR DESCRIPTION
Second launch crash: mE5-large-instruct is XLM-R (514 positions), 1024-token chunks triggered `CUDA error: device-side assert` in position embedding lookup. max_len now lives in the model presets (me5 = 512) and the entry clamps to `max_position_embeddings - 2` as a safety net. BGE-M3 (8192 positions) unaffected. Job relaunched: `embed-me5-1781174946`, S3 prefix verified clean of partial shards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when embedding with mE5 by enforcing model-specific max token lengths and clamping to the model’s position-embedding limit. Launcher now sets per-model `max_len` presets; `me5` uses 512 and `bge-m3` stays at 1024.

- **Bug Fixes**
  - Set per-model `max_len` presets: `BAAI/bge-m3` and `bge-m3-ua` = 1024; `intfloat/multilingual-e5-large-instruct` (mE5) = 512.
  - In the entry script, clamp `max_len` to `max_position_embeddings - 2` to avoid XLM-R (514) device-side asserts.

- **Migration**
  - No action needed. If you need a different chunk size, pass `--max-len` to override (the clamp still applies).

<sup>Written for commit a5021540605f57e7d2e9be3f585dbfe53a32dd28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

