### PR TITLE
fix(research): pin transformers<4.50 for .bin checkpoints on torch 2.5.1

### DIFF
--- a/scripts/citation-graph/requirements_embed.txt
+++ b/scripts/citation-graph/requirements_embed.txt
@@ -1,4 +1,6 @@
-transformers>=4.44
+# <4.50: newer versions block torch.load of .bin weights on torch<2.6
+# (CVE-2025-32434), and BAAI/bge-m3 ships pytorch_model.bin only
+transformers>=4.44,<4.50
 mlflow>=2.10
 pyarrow>=15
 sentencepiece


### PR DESCRIPTION
Third launch-crash of the embed entry: transformers>=4.50 refuses `torch.load` for .bin weights on torch<2.6 (CVE-2025-32434). DLC image has torch 2.5.1, BAAI/bge-m3 has no safetensors. Pinned `transformers>=4.44,<4.50`. Relaunched as `embed-bge-m3-1781186938`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned `transformers` to `>=4.44,<4.50` to restore loading of `.bin` checkpoints on `torch 2.5.1`, fixing embed job crashes with `BAAI/bge-m3`.

- **Bug Fixes**
  - Workaround for `transformers>=4.50` blocking `torch.load` on `torch<2.6` (CVE-2025-32434); our DLC uses `torch 2.5.1`.
  - `BAAI/bge-m3` ships only `pytorch_model.bin` (no `safetensors`), so embeddings load and run again.

<sup>Written for commit beac56aaf7b8c7a0eaff32dc5dda57262250bf19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

