### PR TITLE
fix(research): finetune stage-2 resume via model channel

### DIFF
--- a/scripts/bge-m3-finetune/05_launch_sagemaker.py
+++ b/scripts/bge-m3-finetune/05_launch_sagemaker.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Launch BGE-M3 fine-tuning on SageMaker.
+
+Uploads training data + scripts to S3, launches training job.
+
+Usage:
+    # Stage 1 (contrastive, ~2h on g5.2xlarge):
+    python 05_launch_sagemaker.py --stage 1 --train-data stage1_citation_pairs.jsonl
+
+    # Stage 2 (supervised + distillation, ~1h on g5.2xlarge):
+    python 05_launch_sagemaker.py --stage 2 --train-data stage2_supervised.jsonl \
+        --resume-from s3://secondlayer-ml-data-usw2/bge-m3-finetune/stage1/
+
+    # With spot instances (60-70% cheaper):
+    python 05_launch_sagemaker.py --stage 1 --train-data stage1_citation_pairs.jsonl --spot
+"""
+
+import argparse
+import boto3
+import os
+import sys
+import tarfile
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "mlops"))
+from spot_wrapper import enable_spot
+
+REGION = "us-west-2"
+ROLE = "arn:aws:iam::272594900302:role/SageMakerDPOExecutionRole"
+BUCKET = "secondlayer-ml-data-usw2"
+IMAGE_URI = "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.5.1-gpu-py311-cu124-ubuntu22.04-sagemaker"
+
+STAGE_HYPERPARAMS = {
+    1: {
+        "stage": "1",
+        "learning_rate": "5e-5",
+        "num_train_epochs": "1",
+        "per_device_train_batch_size": "2",
+        "warmup_ratio": "0.1",
+        "query_max_len": "256",
+        "passage_max_len": "512",
+        "unified_finetuning": "False",
+        "use_self_distill": "False",
+    },
+    2: {
+        "stage": "2",
+        "learning_rate": "1e-5",
+        "num_train_epochs": "3",
+        "per_device_train_batch_size": "2",
+        "warmup_ratio": "0.05",
+        "query_max_len": "256",
+        "passage_max_len": "512",
+        "unified_finetuning": "True",
+        "use_self_distill": "True",
+        "self_distill_start_step": "500",
+    },
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Launch BGE-M3 fine-tuning on SageMaker")
+    parser.add_argument("--stage", type=int, required=True, choices=[1, 2])
+    parser.add_argument("--train-data", required=True, help="Local path to training JSONL")
+    parser.add_argument("--resume-from", help="S3 URI of Stage 1 model output (for Stage 2)")
+    parser.add_argument("--instance-type", default="ml.g5.2xlarge")
+    parser.add_argument("--spot", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    timestamp = int(time.time())
+    job_name = f"bge-m3-ft-stage{args.stage}-{timestamp}"
+    s3_prefix = f"bge-m3-finetune/stage{args.stage}/{job_name}"
+
+    s3 = boto3.client("s3", region_name=REGION)
+    sm = boto3.client("sagemaker", region_name=REGION)
+
+    # Upload training data
+    print(f"Uploading training data to S3...")
+    data_key = f"{s3_prefix}/train_data/train.jsonl"
+    s3.upload_file(args.train_data, BUCKET, data_key)
+    print(f"  s3://{BUCKET}/{data_key}")
+
+    # Package source code
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    tar_path = f"/tmp/bge-m3-ft-source-{timestamp}.tar.gz"
+
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.add(os.path.join(script_dir, "sagemaker_entry.py"), arcname="sagemaker_entry.py")
+        tar.add(os.path.join(script_dir, "train_wrapper.py"), arcname="train_wrapper.py")
+        tar.add(os.path.join(script_dir, "requirements.txt"), arcname="requirements.txt")
+
+    code_key = f"{s3_prefix}/sourcedir.tar.gz"
+    s3.upload_file(tar_path, BUCKET, code_key)
+    print(f"  s3://{BUCKET}/{code_key}")
+    os.remove(tar_path)
+
+    # Build job config
+    hyperparams = {
+        **STAGE_HYPERPARAMS[args.stage],
+        "sagemaker_program": "sagemaker_entry.py",
+        "sagemaker_submit_directory": f"s3://{BUCKET}/{code_key}",
+        "sagemaker_region": REGION,
+    }
+
+    input_channels = [
+        {
+            "ChannelName": "training",
+            "DataSource": {
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": f"s3://{BUCKET}/{s3_prefix}/train_data/",
+                    "S3DataDistributionType": "FullyReplicated",
+                }
+            },
+        },
+    ]
+
+    if args.resume_from:
+        # delivered as model.tar.gz; sagemaker_entry extracts it
+        input_channels.append({
+            "ChannelName": "model",
+            "DataSource": {
+                "S3DataSource": {
+                    "S3DataType": "S3Prefix",
+                    "S3Uri": args.resume_from,
+                    "S3DataDistributionType": "FullyReplicated",
+                }
+            },
+        })
+
+    # MLflow credentials from env
+    mlflow_user = os.environ.get("MLFLOW_TRACKING_USERNAME", "sagemaker")
+    mlflow_pass = os.environ.get("MLFLOW_TRACKING_PASSWORD", "")
+    if not mlflow_pass:
+        print("WARNING: MLFLOW_TRACKING_PASSWORD not set, MLflow logging will fail")
+
+    job_config = dict(
+        TrainingJobName=job_name,
+        RoleArn=ROLE,
+        AlgorithmSpecification={
+            "TrainingImage": IMAGE_URI,
+            "TrainingInputMode": "File",
+        },
+        HyperParameters=hyperparams,
+        InputDataConfig=input_channels,
+        OutputDataConfig={
+            "S3OutputPath": f"s3://{BUCKET}/bge-m3-finetune/output/",
+        },
+        ResourceConfig={
+            "InstanceType": args.instance_type,
+            "InstanceCount": 1,
+            "VolumeSizeInGB": 200,
+        },
+        StoppingCondition={
+            "MaxRuntimeInSeconds": 50400,  # 14 hours
+        },
+        Environment={
+            "MLFLOW_TRACKING_URI": "https://mlflow.legal.org.ua",
+            "MLFLOW_TRACKING_USERNAME": mlflow_user,
+            "MLFLOW_TRACKING_PASSWORD": mlflow_pass,
+        },
+        Tags=[
+            {"Key": "project", "Value": "secondlayer"},
+            {"Key": "experiment", "Value": f"bge-m3-finetune-stage{args.stage}"},
+            {"Key": "workload", "Value": "ml-training"},
+        ],
+    )
+
+    if args.spot:
+        job_config = enable_spot(
+            job_config,
+            checkpoint_s3=f"s3://{BUCKET}/bge-m3-finetune/checkpoints/{job_name}/",
+        )
+        print("Spot training enabled (~60-70% savings)")
+
+    if args.dry_run:
+        print(f"\nDRY RUN — job config:")
+        import json
+        print(json.dumps(job_config, indent=2, default=str))
+        return
+
+    response = sm.create_training_job(**job_config)
+    print(f"\nJob launched: {job_name}")
+    print(f"Instance: {args.instance_type}")
+    print(f"Monitor:")
+    print(f"  aws sagemaker describe-training-job --training-job-name {job_name} --region {REGION} --query TrainingJobStatus")
+    print(f"  aws sagemaker describe-training-job --training-job-name {job_name} --region {REGION} --query 'SecondaryStatusTransitions[-1]'")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bge-m3-finetune/sagemaker_entry.py
+++ b/scripts/bge-m3-finetune/sagemaker_entry.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""SageMaker entry point for BGE-M3 fine-tuning.
+
+Runs inside the SageMaker training container. Reads hyperparameters from
+SM_HP_* env vars, installs FlagEmbedding, and launches training.
+Logs params/metrics/artifacts to MLflow.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def install_deps():
+    subprocess.check_call([
+        sys.executable, "-m", "pip", "install", "-q",
+        "transformers>=4.42,<4.44",
+        "FlagEmbedding==1.2.11",
+        "peft",
+        "sentencepiece",
+        "datasets",
+        "mlflow>=2.10",
+    ])
+
+
+def setup_mlflow(stage: int, hp: dict, train_data: str, n_gpus: int):
+    """Start MLflow run and log hyperparameters."""
+    try:
+        import mlflow
+
+        tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "https://mlflow.legal.org.ua")
+        mlflow.set_tracking_uri(tracking_uri)
+        mlflow.set_experiment("bge-m3-finetune")
+
+        job_name = os.environ.get("SM_TRAINING_JOB_NAME", "local")
+        instance_type = "unknown"
+        rc = os.environ.get("SM_RESOURCE_CONFIG", "")
+        if rc:
+            try:
+                instance_type = json.loads(rc).get("current_instance_type", "unknown")
+            except Exception:
+                pass
+
+        run = mlflow.start_run(
+            run_name=f"stage{stage}-{job_name}",
+            tags={
+                "project": "secondlayer",
+                "task": "bge-m3-finetune",
+                "stage": str(stage),
+                "launched_from": job_name,
+                "hardware": f"{n_gpus}xA10G",
+            },
+        )
+
+        train_size = 0
+        try:
+            with open(train_data) as f:
+                for _ in f:
+                    train_size += 1
+        except Exception:
+            pass
+
+        mlflow.log_params({
+            "stage": stage,
+            "base_model": hp.get("resume_from", "BAAI/bge-m3") if hp.get("resume_from") else "BAAI/bge-m3",
+            "learning_rate": hp.get("learning_rate", "1e-5"),
+            "num_train_epochs": hp.get("num_train_epochs", "3"),
+            "per_device_train_batch_size": hp.get("per_device_train_batch_size", "2"),
+            "warmup_ratio": hp.get("warmup_ratio", "0.05"),
+            "query_max_len": hp.get("query_max_len", "512"),
+            "passage_max_len": hp.get("passage_max_len", "2048"),
+            "unified_finetuning": hp.get("unified_finetuning", "False"),
+            "use_self_distill": hp.get("use_self_distill", "False"),
+            "n_gpus": n_gpus,
+            "instance_type": instance_type,
+            "train_pairs": train_size,
+        })
+
+        print(f"[mlflow] Run started: {run.info.run_id}")
+        print(f"[mlflow] Experiment: bge-m3-finetune")
+        return True
+    except Exception as e:
+        print(f"[mlflow] Failed to start: {e}")
+        return False
+
+
+def parse_training_logs(log_line: str) -> dict:
+    """Extract loss/lr/step from FlagEmbedding training output."""
+    metrics = {}
+    # Pattern: {'loss': 0.1234, 'grad_norm': ..., 'learning_rate': ..., 'epoch': ...}
+    loss_match = re.search(r"'loss':\s*([\d.]+)", log_line)
+    lr_match = re.search(r"'learning_rate':\s*([\d.e-]+)", log_line)
+    epoch_match = re.search(r"'epoch':\s*([\d.]+)", log_line)
+    step_match = re.search(r"(\d+)/\d+", log_line)
+
+    if loss_match:
+        metrics["loss"] = float(loss_match.group(1))
+    if lr_match:
+        metrics["learning_rate"] = float(lr_match.group(1))
+    if epoch_match:
+        metrics["epoch"] = float(epoch_match.group(1))
+
+    step = None
+    if step_match:
+        step = int(step_match.group(1))
+
+    return metrics, step
+
+
+def stream_and_log(cmd: list[str]) -> int:
+    """Run training command, stream stdout, and log metrics to MLflow."""
+    mlflow_ok = False
+    try:
+        import mlflow
+        mlflow_ok = mlflow.active_run() is not None
+    except ImportError:
+        pass
+
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    for line in process.stdout:
+        print(line, end="", flush=True)
+
+        if mlflow_ok and ("loss" in line or "'loss'" in line):
+            metrics, step = parse_training_logs(line)
+            if metrics:
+                try:
+                    mlflow.log_metrics(metrics, step=step)
+                except Exception:
+                    pass
+
+    process.wait()
+    return process.returncode
+
+
+def main():
+    install_deps()
+
+    # SageMaker paths
+    train_dir = os.environ.get("SM_CHANNEL_TRAINING", "/opt/ml/input/data/training")
+    model_dir = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+    n_gpus = int(os.environ.get("SM_NUM_GPUS", "1"))
+
+    # Read hyperparameters
+    hp = {}
+    hp_file = "/opt/ml/input/config/hyperparameters.json"
+    if os.path.exists(hp_file):
+        with open(hp_file) as f:
+            hp = json.load(f)
+    else:
+        for k, v in os.environ.items():
+            if k.startswith("SM_HP_"):
+                hp[k[6:].lower()] = v
+
+    stage = int(hp.get("stage", "2"))
+    resume_from = hp.get("resume_from", "")
+    base_model = resume_from if resume_from else "BAAI/bge-m3"
+
+    # Stage-1 checkpoint arrives via the 'model' channel as model.tar.gz -
+    # extract it and use the local dir (from_pretrained can't read s3:// URIs)
+    model_channel = os.environ.get("SM_CHANNEL_MODEL")
+    if model_channel:
+        import tarfile
+        tars = [f for f in os.listdir(model_channel) if f.endswith(".tar.gz")]
+        if tars:
+            dest = "/tmp/stage1_model"
+            os.makedirs(dest, exist_ok=True)
+            with tarfile.open(os.path.join(model_channel, tars[0])) as t:
+                t.extractall(dest)
+            if not os.path.exists(os.path.join(dest, "config.json")):
+                subs = [d for d in os.listdir(dest)
+                        if os.path.exists(os.path.join(dest, d, "config.json"))]
+                if subs:
+                    dest = os.path.join(dest, subs[0])
+            base_model = dest
+        else:
+            base_model = model_channel
+        print(f"Using checkpoint from model channel: {base_model}")
+
+    # FlagEmbedding 1.2.11 expects --train_data to be a directory containing JSONL files
+    train_data = train_dir
+
+    print(f"Stage: {stage}")
+    print(f"Base model: {base_model}")
+    print(f"Train data: {train_data}")
+    print(f"GPUs: {n_gpus}")
+
+    # MLflow
+    t0 = time.time()
+    mlflow_ok = setup_mlflow(stage, hp, train_data, n_gpus)
+
+    # Build FlagEmbedding command
+    # Use train_wrapper.py which inits gloo dist before importing FlagEmbedding.
+    # This satisfies dist.get_rank() without DDP wrapper, so gradient checkpointing works.
+    wrapper_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "train_wrapper.py")
+
+    cmd = [
+        sys.executable, wrapper_path,
+        "--model_name_or_path", base_model,
+        "--train_data", train_data,
+        "--output_dir", model_dir,
+        "--overwrite_output_dir",
+        "--learning_rate", hp.get("learning_rate", "1e-5"),
+        "--num_train_epochs", hp.get("num_train_epochs", "3"),
+        "--per_device_train_batch_size", hp.get("per_device_train_batch_size", "2"),
+        "--warmup_ratio", hp.get("warmup_ratio", "0.05"),
+        "--query_max_len", hp.get("query_max_len", "512"),
+        "--passage_max_len", hp.get("passage_max_len", "2048"),
+        "--temperature", "0.02",
+        "--logging_steps", "50",
+        "--save_steps", "1000",
+        "--save_total_limit", "2",
+        "--fp16",
+        "--dataloader_drop_last", "True",
+        "--gradient_checkpointing",
+        "--same_task_within_batch", "True",
+        "--do_train",
+    ]
+
+    if hp.get("unified_finetuning", "False").lower() == "true":
+        cmd.extend([
+            "--unified_finetuning", "True",
+            "--use_self_distill", "True",
+            "--self_distill_start_step", hp.get("self_distill_start_step", "500"),
+        ])
+
+    print(f"\nCommand: {' '.join(cmd)}")
+
+    returncode = stream_and_log(cmd)
+
+    elapsed = time.time() - t0
+
+    if mlflow_ok:
+        try:
+            import mlflow
+            mlflow.log_metrics({"training_time_s": elapsed})
+            # Log model config as artifact
+            config_path = os.path.join(model_dir, "config.json")
+            if os.path.exists(config_path):
+                mlflow.log_artifact(config_path)
+            mlflow.end_run(status="FINISHED" if returncode == 0 else "FAILED")
+            print(f"[mlflow] Run ended: {'FINISHED' if returncode == 0 else 'FAILED'}")
+        except Exception as e:
+            print(f"[mlflow] End run failed: {e}")
+
+    if returncode != 0:
+        sys.exit(returncode)
+
+    print(f"\nTraining complete in {elapsed:.0f}s. Model saved to {model_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`--resume-from` previously fed an `s3://` URI into `from_pretrained` (would crash at model load). The stage-1 `model.tar.gz` now arrives as a SageMaker model channel and gets extracted locally in the entry - same pattern as embed_entry. Stage 2 launched with this path: `bge-m3-ft-stage2-1781203604`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Stage 2 fine-tune resume by loading the Stage 1 checkpoint via a SageMaker `model` channel instead of passing an `s3://` URI to `from_pretrained`, preventing crashes and allowing Stage 2 to run.

- **Bug Fixes**
  - `05_launch_sagemaker.py` uploads code/data to S3, attaches Stage 1 artifact as the `model` input channel, and sets stage-specific hyperparams (spot supported).
  - `sagemaker_entry.py` extracts `model.tar.gz` from the `model` channel to a local path and uses it as the base model; streams training logs and logs metrics to `mlflow`.
  - Uses `FlagEmbedding` 1.2.11 with `transformers` (>=4.42,<4.44); trains from the `training` channel directory.

<sup>Written for commit 07d9d97729fd54e682eaccf3808b4fc9ecec0168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

