### PR TITLE
fix(research): bump transformers to clear Dependabot ReDoS/Trainer alerts

### DIFF
--- a/scripts/citation-graph/16_launch_embed_sagemaker.py
+++ b/scripts/citation-graph/16_launch_embed_sagemaker.py
@@ -35,7 +35,9 @@ from spot_wrapper import enable_spot
 REGION = "us-west-2"
 ROLE = "arn:aws:iam::272594900302:role/SageMakerDPOExecutionRole"
 BUCKET = "secondlayer-ml-data-usw2"
-IMAGE_URI = "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.5.1-gpu-py311-cu124-ubuntu22.04-sagemaker"
+# torch>=2.6 base: lifts the transformers>=4.50 torch.load(.bin) restriction
+# (CVE-2025-32434), so we can run a patched transformers (ReDoS/Trainer fixes).
+IMAGE_URI = "763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.8.0-gpu-py312-cu129-ubuntu22.04-sagemaker"
 
 VARIANTS = {
     # corpus variant -> (local dir name, s3 prefix suffix)

--- a/scripts/citation-graph/requirements_embed.txt
+++ b/scripts/citation-graph/requirements_embed.txt
@@ -1,6 +1,7 @@
-# <4.50: newer versions block torch.load of .bin weights on torch<2.6
-# (CVE-2025-32434), and BAAI/bge-m3 ships pytorch_model.bin only
-transformers>=4.44,<4.50
+# torch>=2.6 base image (pytorch-training 2.8.0) lifts the torch.load(.bin)
+# restriction added in transformers>=4.50 (CVE-2025-32434), so bge-m3's
+# pytorch_model.bin loads fine. >=4.53 clears the ReDoS/Trainer advisories.
+transformers>=4.53,<5
 mlflow>=2.10
 pyarrow>=15
 sentencepiece


### PR DESCRIPTION
## What

Resolves all **11 open Dependabot alerts** (#218–#228), every one against `transformers` in `scripts/citation-graph/requirements_embed.txt`.

## Why the pin existed

The file pinned `transformers>=4.44,<4.50` deliberately: transformers ≥4.50 refuses to `torch.load` `.bin` weights on `torch<2.6` (CVE-2025-32434), and `BAAI/bge-m3` ships only `pytorch_model.bin`. The SageMaker base image was `pytorch-training:2.5.1` (torch 2.5.1).

## Change

- Base image → `pytorch-training:2.8.0-gpu-py312-cu129-ubuntu22.04-sagemaker` (torch 2.8 ≥ 2.6), which lifts the `.bin` load restriction.
- `transformers>=4.53,<5` — pulls in the ReDoS fixes (#218–#227) and the `Trainer` RCE fix (#228).

## Risk

The embed job (`embed_entry.py`) is **inference-only**: `AutoModel.from_pretrained` + a manual forward pass under `torch.set_grad_enabled(False)`. It never uses `Trainer`, and the `AutoModel`/`AutoTokenizer`/`torch_dtype` APIs are stable across 4.53 + torch 2.8. No code changes were required beyond the image/pin.

⚠️ Validation: the SageMaker embedding/finetune jobs should be re-run once to confirm bge-m3 (incl. the S3-loaded `bge-m3-ua` weights) loads and embeds correctly on the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade SageMaker image to PyTorch 2.8 and bump `transformers` to `>=4.53,<5` to resolve 11 Dependabot alerts for the citation-graph embed job. Unblocks loading `BAAI/bge-m3` `.bin` weights (moved off `torch<2.6`); no code changes needed for the inference-only flow.

- **Dependencies**
  - Base image → `763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:2.8.0-gpu-py312-cu129-ubuntu22.04-sagemaker` (`torch` 2.8).
  - `transformers` → `>=4.53,<5` (pulls security fixes).

- **Migration**
  - Re-run the SageMaker embedding/finetune jobs once to confirm `bge-m3` (incl. S3 `bge-m3-ua`) loads and embeds correctly.

<sup>Written for commit dfd5ea789714429d3686b7b1daa2c39b0ebaf6d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

