### PR TITLE
fix(backend): parse HUDOC HTML with cheerio to clear CodeQL alerts

### DIFF
--- a/mcp_backend/src/services/echr-hudoc-sync-service.ts
+++ b/mcp_backend/src/services/echr-hudoc-sync-service.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { load } from 'cheerio';
 import { Database } from '../database/database.js';
 import { logger } from '../utils/logger.js';
 
@@ -139,22 +140,19 @@ async function fetchHtml(url: string): Promise<string> {
 
 function htmlToText(html: string): string {
   if (!html) return '';
-  let text = html;
-  text = text.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
-  text = text.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, '');
-  text = text.replace(/<br\s*\/?>/gi, '\n');
-  text = text.replace(/<\/p>/gi, '\n\n');
-  text = text.replace(/<\/div>/gi, '\n');
-  text = text.replace(/<\/tr>/gi, '\n');
-  text = text.replace(/<\/li>/gi, '\n');
-  text = text.replace(/<[^>]+>/g, '');
-  text = text.replace(/&nbsp;/gi, ' ');
-  text = text.replace(/&amp;/gi, '&');
-  text = text.replace(/&lt;/gi, '<');
-  text = text.replace(/&gt;/gi, '>');
-  text = text.replace(/&quot;/gi, '"');
-  text = text.replace(/&#39;/gi, "'");
-  text = text.replace(/&[a-zA-Z0-9#]+;/g, '');
+  // Parse with a real HTML parser rather than regex: regex-based tag
+  // stripping/entity-unescaping is unreliable (misses `</script >`, can
+  // re-introduce `<script`, double-unescapes `&`) — flagged by CodeQL.
+  const $ = load(html);
+  // Drop non-content elements outright so their contents never leak into text.
+  $('script, style, noscript, template, head').remove();
+  // Preserve the line breaks the block-level structure implied.
+  $('br').replaceWith('\n');
+  $('p').append('\n\n');
+  $('div, tr, li').append('\n');
+  // .text() strips remaining tags and decodes HTML entities natively.
+  let text = $.root().text();
+  text = text.replace(/\u00a0/g, ' ');  // nbsp -> regular space
   text = text.replace(/[ \t]+/g, ' ');
   text = text.replace(/\n{3,}/g, '\n\n');
   text = text.trim();


### PR DESCRIPTION
## What

Resolves all **5 open CodeQL code-scanning alerts** (#326–#330), all in `mcp_backend/src/services/echr-hudoc-sync-service.ts` → `htmlToText()`.

| Alert | Rule | Issue |
|---|---|---|
| #330 | `js/bad-tag-filter` | `/<\/script>/` doesn't match `</script >` |
| #327–#329 | `js/incomplete-multi-character-sanitization` | stripped output may still contain `<script` / `<style` |
| #326 | `js/double-escaping` | the `&amp;`→`&` unescape chain can double-unescape `&` |

## Fix

Replace the regex-based tag stripping + manual entity-unescaping with a real HTML parse via `cheerio` (already a dependency, used across the codebase):

- `remove()` `script, style, noscript, template, head` so their contents never leak into text
- map block-level elements (`br`, `p`, `div`, `tr`, `li`) to line breaks to preserve structure
- `.text()` strips remaining tags and decodes HTML entities natively (no hand-rolled `&amp;`/`&lt;`/… chain)

## Verification

- `tsc --noEmit`: no errors in the edited file.
- Functional check: `<script >evil()</script >after` → `after` (the spaced end-tag the old regex missed is now stripped); `Case&nbsp;A&amp;B &lt;ECHR&gt;` → `Case A&B <ECHR>` (entities decode correctly, structure preserved).

This function feeds the ECHR HUDOC plain-text indexing pipeline; output shape (plain text with paragraph breaks) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace regex-based HTML stripping in the HUDOC sync with `cheerio` parsing to produce safe, reliable plain text. Clears 5 CodeQL alerts while preserving the output format.

- **Bug Fixes**
  - Remove `script`, `style`, `noscript`, `template`, `head` before extraction.
  - Map `br`, `p`, `div`, `tr`, `li` to line breaks to keep structure.
  - Use `.text()` to strip tags and decode entities; convert `nbsp` and normalize whitespace.
  - Resolves CodeQL rules: `js/bad-tag-filter`, `js/incomplete-multi-character-sanitization` (x3), `js/double-escaping`.

<sup>Written for commit 5334746bd29609c1367c0bf76f031056005b3ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

