### PR TITLE
fix(scripts): drop hardcoded MLflow password fallback

### DIFF
--- a/scripts/lextreme/sagemaker/launch_cross_jurisdiction.py
+++ b/scripts/lextreme/sagemaker/launch_cross_jurisdiction.py
@@ -132,7 +132,7 @@ def main():
     # 3. Build job config
     print("Step 3: Submitting SageMaker job...")
 
-    mlflow_password = os.environ.get("MLFLOW_TRACKING_PASSWORD", "mNW73dLlYkel1ue7bmQPcIjxeVpSln-k")
+    mlflow_password = os.environ["MLFLOW_TRACKING_PASSWORD"]
 
     job_config = dict(
         TrainingJobName=job_name,


### PR DESCRIPTION
Removes the leaked (and now rotated) MLflow admin password fallback from `launch_cross_jurisdiction.py`. The script now requires `MLFLOW_TRACKING_PASSWORD` in the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the hardcoded MLflow admin password fallback in `scripts/lextreme/sagemaker/launch_cross_jurisdiction.py`. The script now requires the `MLFLOW_TRACKING_PASSWORD` environment variable.

<sup>Written for commit 08e5008b8dcba1010dd7f0494dc07d2782594800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

