### PR TITLE
chore(mlops): retire mlflow.legal.org.ua in favor of mlflow.lex

### DIFF
--- a/scripts/bge-m3-finetune/05_launch_sagemaker.py
+++ b/scripts/bge-m3-finetune/05_launch_sagemaker.py
@@ -155,7 +155,7 @@ def main():
             "MaxRuntimeInSeconds": 50400,  # 14 hours
         },
         Environment={
-            "MLFLOW_TRACKING_URI": "https://mlflow.legal.org.ua",
+            "MLFLOW_TRACKING_URI": "http://35.84.222.41:5000",
             "MLFLOW_TRACKING_USERNAME": mlflow_user,
             "MLFLOW_TRACKING_PASSWORD": mlflow_pass,
         },

--- a/scripts/bge-m3-finetune/sagemaker_entry.py
+++ b/scripts/bge-m3-finetune/sagemaker_entry.py
@@ -32,7 +32,7 @@ def setup_mlflow(stage: int, hp: dict, train_data: str, n_gpus: int):
     try:
         import mlflow
 
-        tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "https://mlflow.legal.org.ua")
+        tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "http://35.84.222.41:5000")
         mlflow.set_tracking_uri(tracking_uri)
         mlflow.set_experiment("bge-m3-finetune")
 

--- a/scripts/citation-graph/16_launch_embed_sagemaker.py
+++ b/scripts/citation-graph/16_launch_embed_sagemaker.py
@@ -180,7 +180,7 @@ def main():
         },
         StoppingCondition={"MaxRuntimeInSeconds": int(args.max_runtime_hours * 3600)},
         Environment={
-            "MLFLOW_TRACKING_URI": "https://mlflow.legal.org.ua",
+            "MLFLOW_TRACKING_URI": "http://35.84.222.41:5000",
             "MLFLOW_TRACKING_USERNAME": mlflow_user,
             "MLFLOW_TRACKING_PASSWORD": mlflow_pass,
         },

--- a/scripts/citation-graph/embed_entry.py
+++ b/scripts/citation-graph/embed_entry.py
@@ -187,7 +187,7 @@ def main():
     print(f"corpus: {len(shard_files)} shards, GPUs: {n_gpu}")
 
     import mlflow
-    mlflow.set_tracking_uri(os.environ.get("MLFLOW_TRACKING_URI", "https://mlflow.legal.org.ua"))
+    mlflow.set_tracking_uri(os.environ.get("MLFLOW_TRACKING_URI", "http://35.84.222.41:5000"))
     mlflow.set_experiment("citation-embedding-eval")
     run = mlflow.start_run(run_name=f"embed-{args.model_slug}")
     mlflow.log_params({

--- a/scripts/mlops/mlflow_config.json
+++ b/scripts/mlops/mlflow_config.json
@@ -1,5 +1,5 @@
 {
-  "mlflow_tracking_uri": "https://mlflow.legal.org.ua",
+  "mlflow_tracking_uri": "http://35.84.222.41:5000",
   "mlflow_tracking_uri_internal": "http://35.84.222.41:5000",
   "mlflow_tracking_uri_private": "http://172.31.36.11:5000",
   "artifact_bucket": "secondlayer-mlflow-artifacts",

--- a/scripts/mlops/nginx/mlflow.conf
+++ b/scripts/mlops/nginx/mlflow.conf
@@ -1,12 +1,12 @@
 server {
     listen 80;
-    server_name mlflow.legal.org.ua;
+    server_name mlflow.lex;
     return 301 https://$host$request_uri;
 }
 
 server {
     listen 443 ssl;
-    server_name mlflow.legal.org.ua;
+    server_name mlflow.lex;
 
     ssl_certificate /etc/nginx/ssl/mlflow.crt;
     ssl_certificate_key /etc/nginx/ssl/mlflow.key;


### PR DESCRIPTION
MLflow UI is now on the internal WG domain `mlflow.lex`; SageMaker jobs log directly to `http://35.84.222.41:5000` (SG-restricted to us-west-2 ranges, real basic-auth enabled). The public Cloudflare record is being removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move MLflow off the public domain to internal `mlflow.lex`, and route SageMaker jobs directly to `http://35.84.222.41:5000` (basic-auth, us-west-2 SG). Updates configs and Nginx to retire `mlflow.legal.org.ua` and remove reliance on public DNS.

- **Migration**
  - Access the UI at `https://mlflow.lex` on the internal network.
  - For jobs/notebooks, set `MLFLOW_TRACKING_URI` to `http://35.84.222.41:5000` and keep `MLFLOW_TRACKING_USERNAME`/`MLFLOW_TRACKING_PASSWORD` configured.

<sup>Written for commit 458412d4c29be65ce28e1b4ef95214f1f5059e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

