### PR TITLE
feat(scripts): Qdrant dedup tooling for edrsr_decisions

### DIFF
--- a/scripts/edrsr/dedup-qdrant-jk.py
+++ b/scripts/edrsr/dedup-qdrant-jk.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""
+Deduplicate Qdrant edrsr_decisions collection by (edrsr_doc_id, chunk_index).
+
+Keeps exactly one point per (edrsr_doc_id, chunk_index) pair, deletes the rest.
+Uses standard UUID-offset scroll (reliable on large partitions) with streaming
+deletes. Checkpoint file enables resume after interruption.
+
+Usage:
+    python3 dedup-qdrant-jk.py --justice-kind 3          # dedup jk=3 (smaller, run first)
+    python3 dedup-qdrant-jk.py --justice-kind 1          # dedup jk=1
+    python3 dedup-qdrant-jk.py --justice-kind 3 --dry-run  # scan only, no deletes
+    python3 dedup-qdrant-jk.py --justice-kind 3 --resume   # resume from checkpoint
+    python3 dedup-qdrant-jk.py --justice-kind 3 --verify-only  # post-dedup verification
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("dedup-qdrant")
+
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://bigbox.lex:6333")
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY", "3cCOLVQESro11stD9LvVQm4TnWDm9DqUxKjfYBXy")
+COLLECTION = "edrsr_decisions"
+
+SCROLL_BATCH = 10_000
+DELETE_BATCH = 500
+DELETE_CONCURRENCY = 4
+CHECKPOINT_EVERY = 500_000  # save checkpoint every N points scanned
+VERIFY_SAMPLE = 200
+
+
+def qdrant_request(method: str, path: str, body: dict | None = None, timeout: int = 120) -> dict:
+    url = f"{QDRANT_URL}/collections/{COLLECTION}{path}"
+    data = json.dumps(body).encode() if body else None
+    req = Request(url, data=data, method=method)
+    req.add_header("api-key", QDRANT_API_KEY)
+    if data:
+        req.add_header("Content-Type", "application/json")
+    with urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read())
+
+
+def create_snapshot() -> str:
+    log.info("Creating collection snapshot (safety backup)...")
+    t0 = time.time()
+    url = f"{QDRANT_URL}/collections/{COLLECTION}/snapshots?wait=true"
+    req = Request(url, data=b"", method="POST")
+    req.add_header("api-key", QDRANT_API_KEY)
+    with urlopen(req, timeout=1800) as resp:
+        result = json.loads(resp.read())
+    snap = result["result"]["name"]
+    elapsed = time.time() - t0
+    log.info(f"Snapshot created: {snap} ({elapsed:.0f}s)")
+    return snap
+
+
+def count_points(justice_kind: int, exact: bool = False) -> int:
+    result = qdrant_request("POST", "/points/count", {
+        "filter": {"must": [{"key": "justice_kind", "match": {"value": justice_kind}}]},
+        "exact": exact,
+    })
+    return result["result"]["count"]
+
+
+def scroll_batch(justice_kind: int, offset: str | None) -> tuple[list[dict], str | None]:
+    body = {
+        "filter": {"must": [{"key": "justice_kind", "match": {"value": justice_kind}}]},
+        "limit": SCROLL_BATCH,
+        "with_payload": ["edrsr_doc_id", "chunk_index"],
+        "with_vector": False,
+    }
+    if offset:
+        body["offset"] = offset
+
+    result = qdrant_request("POST", "/points/scroll", body)
+    points = result["result"]["points"]
+    next_offset = result["result"].get("next_page_offset")
+    return points, next_offset
+
+
+def delete_points(point_ids: list[str]) -> int:
+    if not point_ids:
+        return 0
+    for attempt in range(3):
+        try:
+            qdrant_request("POST", "/points/delete?wait=false", {"points": point_ids}, timeout=60)
+            return len(point_ids)
+        except (HTTPError, URLError, TimeoutError) as e:
+            if attempt < 2:
+                log.warning(f"Delete retry {attempt+1}: {e}")
+                time.sleep(2 ** attempt)
+            else:
+                log.error(f"Delete failed after 3 attempts: {e}, skipping {len(point_ids)} points")
+                return 0
+    return 0
+
+
+class DedupState:
+    def __init__(self, justice_kind: int, checkpoint_file: str):
+        self.justice_kind = justice_kind
+        self.checkpoint_file = checkpoint_file
+        self.last_offset: str | None = None
+        self.scanned = 0
+        self.duplicates_found = 0
+        self.deleted = 0
+        self.pending_deletes: list[str] = []
+        self.snapshot_name: str | None = None
+        self.started_at = time.strftime("%Y-%m-%dT%H:%M:%S")
+        self.lock = Lock()
+
+    def save(self):
+        data = {
+            "justice_kind": self.justice_kind,
+            "last_offset": self.last_offset,
+            "scanned": self.scanned,
+            "duplicates_found": self.duplicates_found,
+            "deleted": self.deleted,
+            "pending_deletes": self.pending_deletes,
+            "snapshot_name": self.snapshot_name,
+            "started_at": self.started_at,
+            "updated_at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+        tmp = self.checkpoint_file + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, self.checkpoint_file)
+
+    @classmethod
+    def load(cls, checkpoint_file: str) -> "DedupState":
+        with open(checkpoint_file) as f:
+            data = json.load(f)
+        state = cls(data["justice_kind"], checkpoint_file)
+        state.last_offset = data.get("last_offset")
+        state.scanned = data.get("scanned", 0)
+        state.duplicates_found = data.get("duplicates_found", 0)
+        state.deleted = data.get("deleted", 0)
+        state.pending_deletes = data.get("pending_deletes", [])
+        state.snapshot_name = data.get("snapshot_name")
+        state.started_at = data.get("started_at", "")
+        return state
+
+
+def flush_deletes(state: DedupState, executor: ThreadPoolExecutor, dry_run: bool):
+    """Delete accumulated duplicate point IDs in parallel batches."""
+    if not state.pending_deletes:
+        return
+
+    if dry_run:
+        state.deleted += len(state.pending_deletes)
+        state.pending_deletes = []
+        return
+
+    batches = []
+    for i in range(0, len(state.pending_deletes), DELETE_BATCH):
+        batches.append(state.pending_deletes[i:i + DELETE_BATCH])
+
+    futures = []
+    for batch in batches:
+        futures.append(executor.submit(delete_points, batch))
+
+    total_del = 0
+    for f in as_completed(futures):
+        total_del += f.result()
+
+    with state.lock:
+        state.deleted += total_del
+        state.pending_deletes = []
+
+
+def run_dedup(justice_kind: int, dry_run: bool, resume: bool, skip_snapshot: bool, checkpoint_file: str):
+    if resume and os.path.exists(checkpoint_file):
+        state = DedupState.load(checkpoint_file)
+        log.info(f"Resuming from checkpoint: scanned={state.scanned}, deleted={state.deleted}, offset={state.last_offset}")
+    else:
+        state = DedupState(justice_kind, checkpoint_file)
+
+    total = count_points(justice_kind)
+    log.info(f"=== Dedup justice_kind={justice_kind}: {total:,} points ===")
+
+    # Phase 0: snapshot
+    if not skip_snapshot and not state.snapshot_name and not dry_run:
+        state.snapshot_name = create_snapshot()
+        state.save()
+    elif state.snapshot_name:
+        log.info(f"Using existing snapshot: {state.snapshot_name}")
+
+    # Phase 1+2: scan and delete
+    # seen maps (edrsr_doc_id, chunk_index) -> first point UUID
+    seen: dict[tuple[int, int], str] = {}
+    offset = state.last_offset
+    last_log = time.time()
+    t0 = time.time()
+    batch_num = 0
+
+    executor = ThreadPoolExecutor(max_workers=DELETE_CONCURRENCY)
+
+    try:
+        while True:
+            points, next_offset = scroll_batch(justice_kind, offset)
+            if not points:
+                break
+
+            for p in points:
+                pid = p["id"]
+                payload = p["payload"]
+                doc_id = payload.get("edrsr_doc_id")
+                chunk_idx = payload.get("chunk_index")
+
+                if doc_id is None or chunk_idx is None:
+                    continue
+
+                key = (doc_id, chunk_idx)
+                if key in seen:
+                    state.pending_deletes.append(pid)
+                    state.duplicates_found += 1
+                else:
+                    seen[key] = pid
+
+            state.scanned += len(points)
+            offset = next_offset
+            state.last_offset = offset
+            batch_num += 1
+
+            # Flush deletes when buffer is large enough
+            if len(state.pending_deletes) >= DELETE_BATCH * DELETE_CONCURRENCY:
+                flush_deletes(state, executor, dry_run)
+
+            # Periodic logging and checkpoint
+            if time.time() - last_log > 10:
+                elapsed = time.time() - t0
+                rate = state.scanned / elapsed if elapsed > 0 else 0
+                eta = (total - state.scanned) / rate if rate > 0 else 0
+                pct = state.scanned / total * 100 if total > 0 else 0
+                mem_mb = len(seen) * 80 / 1_000_000  # rough estimate
+                log.info(
+                    f"  {state.scanned:>12,}/{total:,} ({pct:.1f}%) | "
+                    f"dups: {state.duplicates_found:,} | deleted: {state.deleted:,} | "
+                    f"rate: {rate:,.0f}/s | ETA: {eta/60:.1f}m | "
+                    f"seen_keys: {len(seen):,} (~{mem_mb:.0f} MB)"
+                )
+                last_log = time.time()
+
+            if state.scanned % CHECKPOINT_EVERY < SCROLL_BATCH:
+                state.save()
+
+            if not next_offset:
+                break
+
+        # Final flush
+        flush_deletes(state, executor, dry_run)
+        state.save()
+
+    finally:
+        executor.shutdown(wait=True)
+
+    elapsed = time.time() - t0
+    log.info(f"=== Done: scanned {state.scanned:,}, dups found {state.duplicates_found:,}, "
+             f"deleted {state.deleted:,} in {elapsed/60:.1f}m ===")
+    log.info(f"Unique (doc_id, chunk_index) pairs: {len(seen):,}")
+
+    # Phase 3: quick verify
+    new_total = count_points(justice_kind)
+    expected = len(seen)
+    log.info(f"Post-dedup count: {new_total:,} (expected ~{expected:,})")
+    if abs(new_total - expected) > expected * 0.01:
+        log.warning(f"Count mismatch! Diff: {new_total - expected:,}")
+    else:
+        log.info("Count looks correct (within 1%)")
+
+    return state
+
+
+def run_verify(justice_kind: int):
+    """Post-dedup verification: sample random docs and check chunk consistency."""
+    total = count_points(justice_kind)
+    log.info(f"=== Verify justice_kind={justice_kind}: {total:,} points ===")
+
+    doc_checks = {}
+    for prefix in [None, "2", "4", "6", "8", "a", "c", "e"]:
+        body = {
+            "filter": {"must": [
+                {"key": "justice_kind", "match": {"value": justice_kind}},
+                {"key": "chunk_index", "match": {"value": 0}},
+            ]},
+            "limit": 30,
+            "with_payload": ["edrsr_doc_id", "total_chunks"],
+            "with_vector": False,
+        }
+        if prefix:
+            body["offset"] = f"{prefix}0000000-0000-0000-0000-000000000000"
+        result = qdrant_request("POST", "/points/scroll", body)
+        for p in result["result"]["points"]:
+            doc_id = p["payload"].get("edrsr_doc_id")
+            tc = p["payload"].get("total_chunks", 0)
+            if doc_id and doc_id not in doc_checks:
+                doc_checks[doc_id] = tc
+
+    log.info(f"Verifying {len(doc_checks)} documents...")
+    ok = 0
+    bad = 0
+
+    for doc_id, expected_chunks in doc_checks.items():
+        result = qdrant_request("POST", "/points/count", {
+            "filter": {"must": [{"key": "edrsr_doc_id", "match": {"value": doc_id}}]},
+            "exact": True,
+        })
+        actual = result["result"]["count"]
+        if actual == expected_chunks:
+            ok += 1
+        else:
+            bad += 1
+            if bad <= 10:
+                log.warning(f"  doc_id={doc_id}: expected={expected_chunks}, actual={actual}")
+
+    log.info(f"Verification: {ok}/{ok+bad} OK, {bad} mismatched")
+    if bad > 0:
+        log.warning(f"{bad} documents still have incorrect chunk counts")
+    else:
+        log.info("All sampled documents have correct chunk counts")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Dedup Qdrant edrsr_decisions by (edrsr_doc_id, chunk_index)")
+    parser.add_argument("--justice-kind", type=int, required=True, choices=[1, 2, 3, 5])
+    parser.add_argument("--dry-run", action="store_true", help="Scan and report, no deletes")
+    parser.add_argument("--resume", action="store_true", help="Resume from checkpoint")
+    parser.add_argument("--skip-snapshot", action="store_true", help="Skip pre-flight snapshot")
+    parser.add_argument("--verify-only", action="store_true", help="Only run verification")
+    parser.add_argument("--checkpoint-file", type=str, default=None)
+    args = parser.parse_args()
+
+    if args.checkpoint_file is None:
+        args.checkpoint_file = f"/tmp/dedup-jk{args.justice_kind}-checkpoint.json"
+
+    if args.verify_only:
+        run_verify(args.justice_kind)
+        return
+
+    state = run_dedup(
+        justice_kind=args.justice_kind,
+        dry_run=args.dry_run,
+        resume=args.resume,
+        skip_snapshot=args.skip_snapshot,
+        checkpoint_file=args.checkpoint_file,
+    )
+
+    if not args.dry_run:
+        log.info("Running post-dedup verification...")
+        run_verify(args.justice_kind)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/dedup-qdrant/main.go
+++ b/scripts/edrsr/dedup-qdrant/main.go
@@ -1,0 +1,392 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	scrollBatch = 10_000
+	deleteBatch = 500
+)
+
+var (
+	qdrantURL = "http://localhost:6333"
+	apiKey    = "3cCOLVQESro11stD9LvVQm4TnWDm9DqUxKjfYBXy"
+	collection = "edrsr_decisions"
+)
+
+// Partition boundaries for parallel scroll (split UUID hex space into N equal parts)
+var partitions8 = [][2]string{
+	{"", "20000000-0000-0000-0000-000000000000"},
+	{"20000000-0000-0000-0000-000000000000", "40000000-0000-0000-0000-000000000000"},
+	{"40000000-0000-0000-0000-000000000000", "60000000-0000-0000-0000-000000000000"},
+	{"60000000-0000-0000-0000-000000000000", "80000000-0000-0000-0000-000000000000"},
+	{"80000000-0000-0000-0000-000000000000", "a0000000-0000-0000-0000-000000000000"},
+	{"a0000000-0000-0000-0000-000000000000", "c0000000-0000-0000-0000-000000000000"},
+	{"c0000000-0000-0000-0000-000000000000", "e0000000-0000-0000-0000-000000000000"},
+	{"e0000000-0000-0000-0000-000000000000", ""},
+}
+
+// ShardedMap — concurrent map sharded by doc_id for low contention
+type ShardedMap struct {
+	shards [256]shard
+}
+
+type shard struct {
+	mu sync.Mutex
+	m  map[uint64]struct{}
+}
+
+func NewShardedMap() *ShardedMap {
+	sm := &ShardedMap{}
+	for i := range sm.shards {
+		sm.shards[i].m = make(map[uint64]struct{}, 1<<16)
+	}
+	return sm
+}
+
+func encodeKey(docID int64, chunkIdx int) uint64 {
+	return uint64(docID)<<16 | uint64(chunkIdx)
+}
+
+// TryInsert returns true if key was new (inserted), false if already existed
+func (sm *ShardedMap) TryInsert(docID int64, chunkIdx int) bool {
+	key := encodeKey(docID, chunkIdx)
+	s := &sm.shards[byte(docID)]
+	s.mu.Lock()
+	_, exists := s.m[key]
+	if !exists {
+		s.m[key] = struct{}{}
+	}
+	s.mu.Unlock()
+	return !exists
+}
+
+func (sm *ShardedMap) Len() int {
+	total := 0
+	for i := range sm.shards {
+		sm.shards[i].mu.Lock()
+		total += len(sm.shards[i].m)
+		sm.shards[i].mu.Unlock()
+	}
+	return total
+}
+
+// Qdrant API types
+type ScrollRequest struct {
+	Filter     map[string]interface{} `json:"filter"`
+	Limit      int                    `json:"limit"`
+	WithPayload []string             `json:"with_payload"`
+	WithVector  bool                 `json:"with_vector"`
+	Offset     string                `json:"offset,omitempty"`
+}
+
+type ScrollResponse struct {
+	Result struct {
+		Points         []Point `json:"points"`
+		NextPageOffset *string `json:"next_page_offset"`
+	} `json:"result"`
+}
+
+type Point struct {
+	ID      string                 `json:"id"`
+	Payload map[string]interface{} `json:"payload"`
+}
+
+type CountResponse struct {
+	Result struct {
+		Count int64 `json:"count"`
+	} `json:"result"`
+}
+
+var httpClient = &http.Client{Timeout: 120 * time.Second}
+
+func qdrantPost(path string, body interface{}) ([]byte, error) {
+	data, _ := json.Marshal(body)
+	url := fmt.Sprintf("%s/collections/%s%s", qdrantURL, collection, path)
+	req, _ := http.NewRequest("POST", url, bytes.NewReader(data))
+	req.Header.Set("api-key", apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respData, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(respData[:min(200, len(respData))]))
+	}
+	return respData, nil
+}
+
+func countPoints(justiceKind int) int64 {
+	body := map[string]interface{}{
+		"filter": map[string]interface{}{
+			"must": []interface{}{
+				map[string]interface{}{"key": "justice_kind", "match": map[string]interface{}{"value": justiceKind}},
+			},
+		},
+		"exact": false,
+	}
+	data, err := qdrantPost("/points/count", body)
+	if err != nil {
+		log.Fatalf("count failed: %v", err)
+	}
+	var resp CountResponse
+	json.Unmarshal(data, &resp)
+	return resp.Result.Count
+}
+
+func deletePoints(ids []string) error {
+	body := map[string]interface{}{"points": ids}
+	_, err := qdrantPost("/points/delete?wait=false", body)
+	return err
+}
+
+// scrollWorker scrolls a partition of the UUID space
+func scrollWorker(id int, justiceKind int, startOffset, endOffset string, seen *ShardedMap, stats *Stats, deleteCh chan<- []string) {
+	offset := startOffset
+	filter := map[string]interface{}{
+		"must": []interface{}{
+			map[string]interface{}{"key": "justice_kind", "match": map[string]interface{}{"value": justiceKind}},
+		},
+	}
+
+	var localDups []string
+
+	for {
+		req := ScrollRequest{
+			Filter:      filter,
+			Limit:       scrollBatch,
+			WithPayload: []string{"edrsr_doc_id", "chunk_index"},
+			WithVector:  false,
+		}
+		if offset != "" {
+			req.Offset = offset
+		}
+
+		data, err := qdrantPost("/points/scroll", req)
+		if err != nil {
+			log.Printf("[W%d] scroll error: %v, retrying in 2s", id, err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		var resp ScrollResponse
+		json.Unmarshal(data, &resp)
+
+		points := resp.Result.Points
+		if len(points) == 0 {
+			break
+		}
+
+		// Check if we've crossed into the next partition
+		if endOffset != "" && points[0].ID >= endOffset {
+			break
+		}
+
+		for _, p := range points {
+			if endOffset != "" && p.ID >= endOffset {
+				break
+			}
+
+			docIDf, ok1 := p.Payload["edrsr_doc_id"].(float64)
+			chunkf, ok2 := p.Payload["chunk_index"].(float64)
+			if !ok1 || !ok2 {
+				continue
+			}
+
+			if !seen.TryInsert(int64(docIDf), int(chunkf)) {
+				localDups = append(localDups, p.ID)
+			}
+		}
+
+		atomic.AddInt64(&stats.scanned, int64(len(points)))
+
+		// Flush local dups to delete channel
+		if len(localDups) >= deleteBatch {
+			batch := make([]string, len(localDups))
+			copy(batch, localDups)
+			atomic.AddInt64(&stats.dupsFound, int64(len(batch)))
+			deleteCh <- batch
+			localDups = localDups[:0]
+		}
+
+		if resp.Result.NextPageOffset == nil {
+			break
+		}
+		offset = *resp.Result.NextPageOffset
+
+		if endOffset != "" && offset >= endOffset {
+			break
+		}
+	}
+
+	// Flush remaining
+	if len(localDups) > 0 {
+		atomic.AddInt64(&stats.dupsFound, int64(len(localDups)))
+		deleteCh <- localDups
+	}
+}
+
+type Stats struct {
+	scanned  int64
+	dupsFound int64
+	deleted  int64
+	start    time.Time
+}
+
+func deleteWorker(id int, ch <-chan []string, stats *Stats, wg *sync.WaitGroup, dryRun bool) {
+	defer wg.Done()
+	for batch := range ch {
+		if dryRun {
+			atomic.AddInt64(&stats.deleted, int64(len(batch)))
+			continue
+		}
+		// Split into sub-batches of deleteBatch
+		for i := 0; i < len(batch); i += deleteBatch {
+			end := i + deleteBatch
+			if end > len(batch) {
+				end = len(batch)
+			}
+			sub := batch[i:end]
+			for attempt := 0; attempt < 3; attempt++ {
+				err := deletePoints(sub)
+				if err == nil {
+					atomic.AddInt64(&stats.deleted, int64(len(sub)))
+					break
+				}
+				log.Printf("[D%d] delete error (attempt %d): %v", id, attempt+1, err)
+				time.Sleep(time.Duration(1<<attempt) * time.Second)
+				if attempt == 2 {
+					log.Printf("[D%d] giving up on %d points", id, len(sub))
+				}
+			}
+		}
+	}
+}
+
+func progressLogger(stats *Stats, total int64, seen *ShardedMap, done <-chan struct{}) {
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			s := atomic.LoadInt64(&stats.scanned)
+			d := atomic.LoadInt64(&stats.dupsFound)
+			del := atomic.LoadInt64(&stats.deleted)
+			elapsed := time.Since(stats.start).Seconds()
+			rate := float64(s) / elapsed
+			eta := float64(total-s) / rate
+			pct := float64(s) / float64(total) * 100
+			seenN := seen.Len()
+			log.Printf("%12d/%d (%.1f%%) | dups: %d | deleted: %d | rate: %.0f/s | ETA: %.1fm | seen: %d",
+				s, total, pct, d, del, rate, eta/60, seenN)
+		}
+	}
+}
+
+func main() {
+	justiceKind := flag.Int("jk", 0, "justice_kind to dedup (required)")
+	workers := flag.Int("workers", 8, "number of scroll workers")
+	deleteWorkers := flag.Int("dworkers", 4, "number of delete workers")
+	dryRun := flag.Bool("dry-run", false, "scan only, no deletes")
+	url := flag.String("url", "http://localhost:6333", "Qdrant URL")
+	flag.Parse()
+
+	if *justiceKind == 0 {
+		log.Fatal("--jk required (1, 2, 3, or 5)")
+	}
+	qdrantURL = *url
+
+	total := countPoints(*justiceKind)
+	log.Printf("=== Dedup justice_kind=%d: %d points, %d scroll workers, %d delete workers ===",
+		*justiceKind, total, *workers, *deleteWorkers)
+	if *dryRun {
+		log.Println("DRY RUN — no deletes")
+	}
+
+	seen := NewShardedMap()
+	stats := &Stats{start: time.Now()}
+
+	// Build partition boundaries based on worker count
+	partitions := buildPartitions(*workers)
+
+	// Delete channel and workers
+	deleteCh := make(chan []string, *workers*4)
+	var delWg sync.WaitGroup
+	for i := 0; i < *deleteWorkers; i++ {
+		delWg.Add(1)
+		go deleteWorker(i, deleteCh, stats, &delWg, *dryRun)
+	}
+
+	// Progress logger
+	progressDone := make(chan struct{})
+	go progressLogger(stats, total, seen, progressDone)
+
+	// Scroll workers
+	var scrollWg sync.WaitGroup
+	for i, p := range partitions {
+		scrollWg.Add(1)
+		go func(id int, start, end string) {
+			defer scrollWg.Done()
+			scrollWorker(id, *justiceKind, start, end, seen, stats, deleteCh)
+			log.Printf("[W%d] done", id)
+		}(i, p[0], p[1])
+	}
+
+	scrollWg.Wait()
+	close(deleteCh)
+	delWg.Wait()
+	close(progressDone)
+
+	elapsed := time.Since(stats.start)
+	log.Printf("=== Done: scanned %d, dups %d, deleted %d in %.1fm ===",
+		stats.scanned, stats.dupsFound, stats.deleted, elapsed.Minutes())
+	log.Printf("Unique keys: %d", seen.Len())
+
+	// Verify
+	newTotal := countPoints(*justiceKind)
+	log.Printf("Post-dedup count: %d (expected ~%d)", newTotal, seen.Len())
+	diff := newTotal - int64(seen.Len())
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > int64(seen.Len())/100 {
+		log.Printf("WARNING: count mismatch, diff=%d", newTotal-int64(seen.Len()))
+	} else {
+		log.Println("Count OK (within 1%)")
+	}
+}
+
+func buildPartitions(n int) [][2]string {
+	if n == 8 {
+		return partitions8
+	}
+	// Generate N equal partitions of hex UUID space
+	parts := make([][2]string, n)
+	step := 0x100 / n
+	for i := 0; i < n; i++ {
+		start := ""
+		end := ""
+		if i > 0 {
+			start = fmt.Sprintf("%02x000000-0000-0000-0000-000000000000", i*step)
+		}
+		if i < n-1 {
+			end = fmt.Sprintf("%02x000000-0000-0000-0000-000000000000", (i+1)*step)
+		}
+		parts[i] = [2]string{start, end}
+	}
+	return parts
+}


### PR DESCRIPTION
## Summary
- Go parallel dedup tool (4 scroll workers, sharded concurrent map, async deletes)
- Python fallback with checkpoint/resume support
- Deduplicates by (edrsr_doc_id, chunk_index) — keeps first seen, deletes rest
- Used to clean jk=1 (ЦПК) and jk=3 (ГПК) duplicates from vectorization restarts

## Context
Vectorization scripts used random UUIDs without checkpoint — restarts created 2-3x duplicates.
- jk=3: 4.6M dups deleted (13.8M → ~9.1M)
- jk=1: in progress, ~27M dups expected (54M → ~22M)

## Test plan
- [x] Dry-run on jk=3 verified dup detection
- [x] Full run on jk=3 completed (69 min, 4.6M deleted)
- [x] jk=1 running on bigbox now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Go and Python tools to deduplicate the Qdrant `edrsr_decisions` collection by (edrsr_doc_id, chunk_index), removing duplicates from vectorization restarts. For jk=3, 4.6M points were deleted (13.8M → ~9.1M in ~69 min); jk=1 cleanup is in progress (~27M expected).

- **New Features**
  - Go tool: parallel scroll workers, sharded concurrent map, async batched deletes with retries.
  - Python tool: UUID-offset scroll with checkpoint/resume, dry-run and verify-only modes, optional pre-snapshot.
  - Dedup rule: keep the first point per (edrsr_doc_id, chunk_index); delete the rest.
  - Usage: Go flags `--jk`, `--workers`, `--dworkers`, `--dry-run`, `--url`; Python flags `--justice-kind`, `--dry-run`, `--resume`, `--verify-only`, `--skip-snapshot`.

<sup>Written for commit 63bbb7bd372c1ecfdbadfdd19682ade87e6b90af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

