### PR TITLE
feat(scripts): archive BGE-M3 bulk vectorization pipeline + Go Qdrant uploader

### DIFF
--- a/scripts/edrsr/bge-m3-vectorize/README.md
+++ b/scripts/edrsr/bge-m3-vectorize/README.md
@@ -1,0 +1,56 @@
+# BGE-M3 bulk vectorization pipeline (EDRSR, 100M+ docs)
+
+Scripts used for the June 2026 campaign that built BGE-M3 (1024-dim) embeddings
+for all EDRSR court decisions on Brev 8xH100 (NVIDIA Innovation Lab) and bulk-loaded
+them into Qdrant. Archived here because the Brev instance is temporary.
+
+Tracking: LEXAI-1715 (parent), LEXAI-1718 (ЦПК), LEXAI-1721 (status doc).
+
+## Pipeline (per justice_kind)
+
+1. **Export** — `export_jsonl_fast.py`
+   Parallel PG export into N JSONL shards (id-range sharding via percentile split,
+   threaded fulltext fetch). `--db-url` passed explicitly (use WG tunnel to prod PG).
+2. **Clean** — `clean_edrsr_texts.py` / `clean_parallel.py`
+   Strips court headers (addresses, phones, ЄДРПОУ, emails) up to the
+   УХВАЛА/РІШЕННЯ/ПОСТАНОВА/ВИРОК marker. Saved ~11.3 GB on ЦПК alone.
+3. **Embed** — one of:
+   - `embed_ort_trt.py` — ONNX Runtime + TensorRT FP16, ~10K texts/s/GPU (target)
+   - `embed_stream.py` — PyTorch baseline, ~1.7K texts/s/GPU, upserts straight to Qdrant
+   - `embed_to_disk.py` — embeds to npy + payload JSONL on disk (no Qdrant dependency);
+     write output to `/data`, not the root volume
+   - `embed_tail.py` — re-embeds tail rows lost to npy truncation (see below)
+4. **Upload** — `kas-uploader/` (Go), see below.
+
+## kas-uploader (Go)
+
+Idempotent, streaming, resource-capped bulk uploader for npy + payload JSONL into
+Qdrant via gRPC. Replaces the python `upload_stream*.py` scripts.
+
+- **Deterministic point IDs**: `doc_id*100 + chunk_index` — re-runs overwrite instead
+  of duplicating; resume is safe by construction.
+- Streams npy rows from disk (no full-group RAM load), per-group checkpoint of the
+  contiguous confirmed prefix.
+- Global caps: network token bucket (bytes/s) + AIMD in-flight window.
+- Detects tail-truncated npy files (payload lines without vectors) and defers them
+  to a tail re-embed pass instead of failing.
+
+Measured: **~140K points/s (~1 GB/s)** into a local Qdrant on Brev;
+74,476,529 points (КАС, justice_kind=4) in ~12 min with 0 errors.
+
+```bash
+cd kas-uploader
+go mod tidy   # pulls github.com/qdrant/go-client + golang.org/x/time
+go build -o kas-uploader .
+./kas-uploader -dirs /data/kas-vectorize/export -api-key "$QDRANT_API_KEY" ...
+```
+
+## Campaign results (2026-06-12, prod Qdrant `edrsr_decisions`)
+
+| justice_kind | Corpus | Chunks on prod | Status |
+|---|---|---|---|
+| 1 ЦПК | 38.9M docs | 35,527,796 | done |
+| 2 Кримінальне | 20.6M docs | 14,515,496 | done |
+| 3 ГПК | 7.5M docs | 13,773,100 | done |
+| 4 Адміністративне (КАС) | 22.6M docs | 8,278 (74.5M on Brev-local Qdrant) | transfer to prod pending |
+| 5 КУпАП | 12M docs | 69,391,702 | done |

--- a/scripts/edrsr/bge-m3-vectorize/clean_edrsr_texts.py
+++ b/scripts/edrsr/bge-m3-vectorize/clean_edrsr_texts.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Clean EDRSR court decision texts for embedding.
+Removes court headers (address, phone, email, EDRPOU), collapses whitespace.
+Processes JSONL files in-place.
+"""
+
+import json
+import os
+import re
+import sys
+from multiprocessing import Pool
+from pathlib import Path
+
+HEADER_PATTERNS = [
+    # Court addresses (street, building, city, postal code)
+    re.compile(r'вул\.\s*[А-ЯІЇЄҐа-яіїєґA-Za-z\s\.\,\-]+,?\s*буд\.\s*\d+[а-яА-Я]?(?:\s*,\s*літера\s*[А-Я])?(?:\s*,\s*м\.\s*[А-ЯІЇЄҐа-яіїєґ\s\-]+)?(?:\s*,?\s*\d{5})?', re.UNICODE),
+    # Phone numbers
+    re.compile(r'\(?\d{3}\)?\s*\d{3}[\-\s]?\d{2}[\-\s]?\d{2}'),
+    # Emails
+    re.compile(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'),
+    # EDRPOU codes
+    re.compile(r'(?:ЄДРПОУ|код\s+ЄДРПОУ)\s*:?\s*\d{8}'),
+    # URLs
+    re.compile(r'https?://[^\s]+'),
+    # Postal codes standalone
+    re.compile(r'(?<!\d)\d{5}(?!\d)(?:\s*,\s*м\.\s*[А-ЯІЇЄҐа-яіїєґ\s\-]+)?'),
+]
+
+
+def clean_text(text: str) -> str:
+    lines = text.split('\n')
+    cleaned_lines = []
+    header_zone = True
+
+    for line in lines:
+        stripped = line.strip()
+
+        if header_zone:
+            if not stripped:
+                continue
+            # Detect end of header: line with УХВАЛА/РІШЕННЯ/ПОСТАНОВА/ВИРОК
+            if re.search(r'^\s*(У\s*Х\s*В\s*А\s*Л\s*А|Р\s*І\s*Ш\s*Е\s*Н\s*Н\s*Я|П\s*О\s*С\s*Т\s*А\s*Н\s*О\s*В\s*А|В\s*И\s*Р\s*О\s*К|УХВАЛА|РІШЕННЯ|ПОСТАНОВА|ВИРОК)', stripped, re.IGNORECASE):
+                header_zone = False
+                cleaned_lines.append(stripped)
+                continue
+            # Skip header lines (address, phone, email patterns)
+            is_header = False
+            for pattern in HEADER_PATTERNS:
+                if pattern.search(stripped):
+                    is_header = True
+                    break
+            if is_header:
+                continue
+            # Keep court name and case info even in header zone
+            if len(stripped) < 20 and not re.search(r'(?:суд|справ|№)', stripped, re.IGNORECASE):
+                continue
+            cleaned_lines.append(stripped)
+        else:
+            cleaned_lines.append(stripped)
+
+    result = '\n'.join(cleaned_lines)
+    # Collapse multiple newlines
+    result = re.sub(r'\n{3,}', '\n\n', result)
+    # Collapse multiple spaces
+    result = re.sub(r'[ \t]{3,}', '  ', result)
+    # Remove remaining emails/phones/urls in body
+    for pattern in HEADER_PATTERNS[1:4]:
+        result = pattern.sub('', result)
+
+    return result.strip()
+
+
+def process_file(jsonl_path: str) -> dict:
+    count = 0
+    saved_chars = 0
+
+    # Read all into memory, clean, write back
+    cleaned_lines = []
+    with open(jsonl_path) as fin:
+        for line in fin:
+            doc = json.loads(line)
+            original = doc.get('text', '')
+            cleaned = clean_text(original)
+            saved_chars += len(original) - len(cleaned)
+            doc['text'] = cleaned
+            cleaned_lines.append(json.dumps(doc, ensure_ascii=False))
+            count += 1
+
+    with open(jsonl_path, 'w') as fout:
+        for cl in cleaned_lines:
+            fout.write(cl + '\n')
+
+    del cleaned_lines
+    return {'file': jsonl_path, 'docs': count, 'saved_mb': round(saved_chars / 1024 / 1024, 1)}
+
+
+def main():
+    data_dir = sys.argv[1] if len(sys.argv) > 1 else '/home/nvidia/hpk_export'
+    files = sorted(str(f) for f in Path(data_dir).glob('*.jsonl'))
+    print(f"Cleaning {len(files)} files in {data_dir}...")
+
+    results = []
+    for f in files:
+        r = process_file(f)
+        print(f"  {r['file']}: {r['docs']} docs, saved {r['saved_mb']} MB", flush=True)
+        results.append(r)
+
+    total_docs = sum(r['docs'] for r in results)
+    total_saved = sum(r['saved_mb'] for r in results)
+    for r in results:
+        print(f"  {r['file']}: {r['docs']} docs, saved {r['saved_mb']} MB")
+    print(f"\nTotal: {total_docs} docs, saved {total_saved} MB")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/clean_parallel.py
+++ b/scripts/edrsr/bge-m3-vectorize/clean_parallel.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Parallel cleaning: one process per JSONL shard."""
+import json
+import os
+import re
+import sys
+import time
+from multiprocessing import Pool
+from pathlib import Path
+
+HEADER_PATTERNS = [
+    re.compile(r'вул\.\s*[А-ЯІЇЄҐа-яіїєґA-Za-z\s\.\,\-]+,?\s*буд\.\s*\d+[а-яА-Я]?(?:\s*,\s*літера\s*[А-Я])?(?:\s*,\s*м\.\s*[А-ЯІЇЄҐа-яіїєґ\s\-]+)?(?:\s*,?\s*\d{5})?', re.UNICODE),
+    re.compile(r'\(?\d{3}\)?\s*\d{3}[\-\s]?\d{2}[\-\s]?\d{2}'),
+    re.compile(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'),
+    re.compile(r'(?:ЄДРПОУ|код\s+ЄДРПОУ)\s*:?\s*\d{8}'),
+    re.compile(r'https?://[^\s]+'),
+    re.compile(r'(?<!\d)\d{5}(?!\d)(?:\s*,\s*м\.\s*[А-ЯІЇЄҐа-яіїєґ\s\-]+)?'),
+]
+
+def clean_text(text):
+    lines = text.split('\n')
+    cleaned_lines = []
+    header_zone = True
+    for line in lines:
+        stripped = line.strip()
+        if header_zone:
+            if not stripped:
+                continue
+            if re.search(r'^\s*(У\s*Х\s*В\s*А\s*Л\s*А|Р\s*І\s*Ш\s*Е\s*Н\s*Н\s*Я|П\s*О\s*С\s*Т\s*А\s*Н\s*О\s*В\s*А|В\s*И\s*Р\s*О\s*К|УХВАЛА|РІШЕННЯ|ПОСТАНОВА|ВИРОК)', stripped, re.IGNORECASE):
+                header_zone = False
+                cleaned_lines.append(stripped)
+                continue
+            is_header = False
+            for pattern in HEADER_PATTERNS:
+                if pattern.search(stripped):
+                    is_header = True
+                    break
+            if is_header:
+                continue
+            if len(stripped) < 20 and not re.search(r'(?:суд|справ|№)', stripped, re.IGNORECASE):
+                continue
+            cleaned_lines.append(stripped)
+        else:
+            cleaned_lines.append(stripped)
+    result = '\n'.join(cleaned_lines)
+    result = re.sub(r'\n{3,}', '\n\n', result)
+    result = re.sub(r'[ \t]{3,}', '  ', result)
+    for pattern in HEADER_PATTERNS[1:4]:
+        result = pattern.sub('', result)
+    return result.strip()
+
+def process_file(jsonl_path):
+    t0 = time.time()
+    count = 0
+    saved_chars = 0
+    cleaned_lines = []
+    with open(jsonl_path) as fin:
+        for line in fin:
+            doc = json.loads(line)
+            original = doc.get('text', '')
+            cleaned = clean_text(original)
+            saved_chars += len(original) - len(cleaned)
+            doc['text'] = cleaned
+            cleaned_lines.append(json.dumps(doc, ensure_ascii=False))
+            count += 1
+    with open(jsonl_path, 'w') as fout:
+        for cl in cleaned_lines:
+            fout.write(cl + '\n')
+    elapsed = time.time() - t0
+    saved_mb = round(saved_chars / 1024 / 1024, 1)
+    print(f"  {jsonl_path}: {count} docs, saved {saved_mb} MB, {elapsed:.0f}s", flush=True)
+    return {'file': jsonl_path, 'docs': count, 'saved_mb': saved_mb, 'elapsed': elapsed}
+
+def main():
+    data_dir = sys.argv[1]
+    files = sorted(str(f) for f in Path(data_dir).glob('*.jsonl'))
+    print(f"Cleaning {len(files)} files in parallel...", flush=True)
+    with Pool(len(files)) as pool:
+        results = pool.map(process_file, files)
+    total_docs = sum(r['docs'] for r in results)
+    total_saved = sum(r['saved_mb'] for r in results)
+    print(f"\nTotal: {total_docs} docs, saved {total_saved} MB")
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/embed_ort_trt.py
+++ b/scripts/edrsr/bge-m3-vectorize/embed_ort_trt.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Embed EDRSR docs using ORT+TensorRT FP16 on multi-GPU.
+One process per GPU, each reads its own JSONL shard.
+Runs inside NGC TensorRT container.
+"""
+import argparse
+import json
+import logging
+import os
+import time
+import uuid
+import numpy as np
+from multiprocessing import Process, Value
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [W%(message)s")
+log = logging.getLogger(__name__)
+
+COLLECTION = "edrsr_decisions"
+MAX_CHUNK_CHARS = 2048
+QDRANT_BATCH = 5000
+
+
+def chunk_text(text, max_chars=MAX_CHUNK_CHARS):
+    if len(text) <= max_chars:
+        return [text]
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + max_chars, len(text))
+        if end < len(text):
+            space_idx = text.rfind(" ", start + max_chars // 2, end)
+            if space_idx > 0:
+                end = space_idx
+        chunks.append(text[start:end])
+        start = end
+        if len(text) - start < 100:
+            break
+    return chunks
+
+
+def mean_pooling(hidden_state, attention_mask):
+    mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(np.float32)
+    sum_embeddings = np.sum(hidden_state * mask_expanded, axis=1)
+    sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
+    return sum_embeddings / sum_mask
+
+
+def normalize(embeddings):
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    return embeddings / np.clip(norms, a_min=1e-9, a_max=None)
+
+
+def worker(gpu_id, jsonl_file, justice_kind, qdrant_url, qdrant_api_key,
+           onnx_path, batch_size, progress, total_docs):
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+
+    import onnxruntime as ort
+    from transformers import AutoTokenizer
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import PointStruct
+
+    prefix = f"{gpu_id}] "
+
+    log.info(f"{prefix}Loading tokenizer...")
+    tokenizer = AutoTokenizer.from_pretrained("BAAI/bge-m3", cache_dir="/data/hf_cache")
+
+    log.info(f"{prefix}Creating ORT+TRT session on GPU {gpu_id}...")
+    trt_cache = f"/data/trt_cache_gpu{gpu_id}"
+    os.makedirs(trt_cache, exist_ok=True)
+
+    providers = [
+        ("TensorrtExecutionProvider", {
+            "device_id": 0,
+            "trt_fp16_enable": True,
+            "trt_engine_cache_enable": True,
+            "trt_engine_cache_path": trt_cache,
+        }),
+        ("CUDAExecutionProvider", {"device_id": 0}),
+    ]
+    sess = ort.InferenceSession(onnx_path, providers=providers)
+    active = sess.get_providers()
+    log.info(f"{prefix}Active providers: {active}")
+
+    qdrant = QdrantClient(url=qdrant_url, api_key=qdrant_api_key or None, timeout=300)
+
+    processed = 0
+    total_chunks = 0
+    doc_buffer = []
+    pending_points = []
+    t0 = time.time()
+
+    def embed_and_queue():
+        nonlocal total_chunks
+        if not doc_buffer:
+            return
+
+        all_chunks = []
+        chunk_payloads = []
+        for doc in doc_buffer:
+            text = doc["text"][:15000]
+            chunks = chunk_text(text)
+            for ci, chunk in enumerate(chunks):
+                all_chunks.append(chunk)
+                chunk_payloads.append({
+                    "edrsr_doc_id": doc["doc_id"],
+                    "court_code": doc.get("court_code", 0),
+                    "judge": doc.get("judge", ""),
+                    "cause_num": doc.get("cause_num", ""),
+                    "justice_kind": justice_kind,
+                    "adjudication_date": doc.get("adjudication_date", ""),
+                    "judgment_code": doc.get("judgment_code", 0),
+                    "category_code": doc.get("category_code", 0),
+                    "chunk_index": ci,
+                    "total_chunks": len(chunks),
+                    "text": chunk,
+                    "embedding_model": "bge-m3",
+                })
+
+        encoded = tokenizer(
+            all_chunks, padding=True, truncation=True,
+            max_length=512, return_tensors="np",
+        )
+        input_ids = encoded["input_ids"].astype(np.int64)
+        attention_mask = encoded["attention_mask"].astype(np.int64)
+
+        # Process in sub-batches for ORT
+        all_embeddings = []
+        for i in range(0, len(all_chunks), batch_size):
+            ids_batch = input_ids[i:i + batch_size]
+            mask_batch = attention_mask[i:i + batch_size]
+            outputs = sess.run(None, {
+                "input_ids": ids_batch,
+                "attention_mask": mask_batch,
+            })
+            hidden = outputs[0]
+            pooled = mean_pooling(hidden, mask_batch)
+            normed = normalize(pooled)
+            all_embeddings.append(normed)
+
+        embeddings = np.concatenate(all_embeddings, axis=0)
+
+        for i, (emb, meta) in enumerate(zip(embeddings, chunk_payloads)):
+            pending_points.append(PointStruct(
+                id=str(uuid.uuid4()),
+                vector=emb.tolist(),
+                payload=meta,
+            ))
+
+        total_chunks += len(all_chunks)
+        doc_buffer.clear()
+
+    def flush_qdrant():
+        if not pending_points:
+            return
+        for bs in range(0, len(pending_points), QDRANT_BATCH):
+            batch = pending_points[bs:bs + QDRANT_BATCH]
+            for attempt in range(5):
+                try:
+                    qdrant.upsert(collection_name=COLLECTION, points=batch, wait=False)
+                    break
+                except Exception as e:
+                    if attempt == 4:
+                        log.error(f"{prefix}Qdrant failed after 5 attempts: {e}")
+                    time.sleep(2 ** attempt)
+        pending_points.clear()
+
+    with open(jsonl_file) as f:
+        for line in f:
+            doc = json.loads(line)
+            if not doc.get("text") or len(doc["text"]) < 50:
+                continue
+            doc_buffer.append(doc)
+            processed += 1
+
+            if len(doc_buffer) >= 200:
+                embed_and_queue()
+                with progress.get_lock():
+                    progress.value += 200
+
+                if len(pending_points) >= 20000:
+                    flush_qdrant()
+
+                if processed % 4000 < 200:
+                    g = progress.value
+                    elapsed = time.time() - t0
+                    speed = g / elapsed if elapsed > 0 else 0
+                    eta = (total_docs - g) / speed if speed > 0 else 0
+                    log.info(f"{prefix}local={processed} global={g}/{total_docs} ({100*g/total_docs:.1f}%) "
+                             f"chunks={total_chunks} speed={speed:.0f} docs/s ETA={eta/3600:.1f}h")
+
+    if doc_buffer:
+        embed_and_queue()
+        with progress.get_lock():
+            progress.value += len(doc_buffer)
+    flush_qdrant()
+
+    log.info(f"{prefix}Done: {processed} docs, {total_chunks} chunks")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--justice-kind", type=int, required=True)
+    parser.add_argument("--qdrant-url", required=True)
+    parser.add_argument("--qdrant-api-key", default="")
+    parser.add_argument("--onnx-path", default="/data/bge-m3-onnx/model.onnx")
+    parser.add_argument("--num-gpus", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=64)
+    args = parser.parse_args()
+
+    jsonl_files = sorted(Path(args.data_dir).glob("*.jsonl"))
+    log.info(f"Found {len(jsonl_files)} JSONL files")
+
+    import subprocess
+    result = subprocess.run(
+        ["wc", "-l"] + [str(f) for f in jsonl_files],
+        capture_output=True, text=True,
+    )
+    counts = []
+    for line in result.stdout.strip().split("\n")[:-1]:
+        counts.append(int(line.strip().split()[0]))
+    total_docs = sum(counts)
+    log.info(f"Total docs: {total_docs} (per file: {counts})")
+
+    progress = Value("i", 0)
+    workers = []
+
+    for i, jf in enumerate(jsonl_files[:args.num_gpus]):
+        p = Process(target=worker, args=(
+            i, str(jf), args.justice_kind, args.qdrant_url, args.qdrant_api_key,
+            args.onnx_path, args.batch_size, progress, total_docs,
+        ))
+        p.start()
+        workers.append(p)
+
+    for p in workers:
+        p.join()
+
+    log.info(f"All done! {progress.value} docs")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/embed_stream.py
+++ b/scripts/edrsr/bge-m3-vectorize/embed_stream.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+Stream embed EDRSR: read JSONL from disk, embed on GPU with BGE-M3, push to Qdrant.
+One process per GPU, each reads its own JSONL file.
+
+Usage:
+    HF_HOME=/data/hf_cache TMPDIR=/data/tmp PYTHONPATH=/home/nvidia/.local/lib/python3.12/site-packages \
+    python3 embed_stream.py \
+        --data-dir /data/cpk-vectorize/export \
+        --justice-kind 1 \
+        --qdrant-url http://10.88.0.2:16339 \
+        --qdrant-api-key xxx \
+        --num-gpus 8 \
+        --batch-size 64
+"""
+
+import argparse
+import json
+import logging
+import os
+import time
+import uuid
+from multiprocessing import Process, Value
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [W%(message)s")
+log = logging.getLogger(__name__)
+
+MODEL_ID = "BAAI/bge-m3"
+COLLECTION = "edrsr_decisions"
+MAX_CHUNK_CHARS = 2048
+QDRANT_BATCH = 1000
+
+
+def chunk_text(text, max_chars=MAX_CHUNK_CHARS):
+    if len(text) <= max_chars:
+        return [text]
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + max_chars, len(text))
+        if end < len(text):
+            space_idx = text.rfind(" ", start + max_chars // 2, end)
+            if space_idx > 0:
+                end = space_idx
+        chunks.append(text[start:end])
+        start = end
+        if len(text) - start < 100:
+            break
+    return chunks
+
+
+def worker(gpu_id, jsonl_file, justice_kind, qdrant_url, qdrant_api_key, batch_size, progress, total_docs):
+    import torch
+    from sentence_transformers import SentenceTransformer
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import PointStruct
+
+    prefix = f"{gpu_id}] "
+    device = f"cuda:{gpu_id}"
+
+    log.info(f"{prefix}Loading model on {device}...")
+    model = SentenceTransformer(MODEL_ID, device=device, trust_remote_code=True)
+    log.info(f"{prefix}Model loaded. Processing {jsonl_file}")
+
+    qdrant = QdrantClient(url=qdrant_url, api_key=qdrant_api_key, timeout=300)
+
+    processed = 0
+    total_chunks = 0
+    doc_buffer = []
+    pending_points = []
+    t0 = time.time()
+
+    def embed_and_queue():
+        nonlocal total_chunks
+        if not doc_buffer:
+            return
+
+        all_chunks = []
+        chunk_payloads = []
+        for doc in doc_buffer:
+            text = doc["text"][:15000]
+            chunks = chunk_text(text)
+            for ci, chunk in enumerate(chunks):
+                all_chunks.append(chunk)
+                chunk_payloads.append({
+                    "edrsr_doc_id": doc["doc_id"],
+                    "court_code": doc.get("court_code", 0),
+                    "judge": doc.get("judge", ""),
+                    "cause_num": doc.get("cause_num", ""),
+                    "justice_kind": justice_kind,
+                    "adjudication_date": doc.get("adjudication_date", ""),
+                    "judgment_code": doc.get("judgment_code", 0),
+                    "category_code": doc.get("category_code", 0),
+                    "chunk_index": ci,
+                    "total_chunks": len(chunks),
+                    "text": chunk,
+                })
+
+        embeddings = model.encode(
+            all_chunks, batch_size=batch_size,
+            normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=False,
+        )
+
+        for i, (emb, meta) in enumerate(zip(embeddings, chunk_payloads)):
+            pending_points.append(PointStruct(
+                id=str(uuid.uuid4()),
+                vector=emb.tolist(),
+                payload=meta,
+            ))
+
+        total_chunks += len(all_chunks)
+        doc_buffer.clear()
+
+    def flush_qdrant():
+        if not pending_points:
+            return
+        for bs in range(0, len(pending_points), QDRANT_BATCH):
+            batch = pending_points[bs:bs + QDRANT_BATCH]
+            for attempt in range(5):
+                try:
+                    qdrant.upsert(collection_name=COLLECTION, points=batch, wait=False)
+                    break
+                except Exception as e:
+                    if attempt == 4:
+                        log.error(f"{prefix}Qdrant failed after 5 attempts: {e}")
+                    time.sleep(2 ** attempt)
+        pending_points.clear()
+
+    with open(jsonl_file) as f:
+        for line in f:
+            doc = json.loads(line)
+            if not doc.get("text") or len(doc["text"]) < 50:
+                continue
+            doc_buffer.append(doc)
+            processed += 1
+
+            if len(doc_buffer) >= 200:
+                embed_and_queue()
+                with progress.get_lock():
+                    progress.value += 200
+
+                if len(pending_points) >= 4000:
+                    flush_qdrant()
+
+                if processed % 10000 < 500:
+                    g = progress.value
+                    elapsed = time.time() - t0
+                    speed = g / elapsed if elapsed > 0 else 0
+                    eta = (total_docs - g) / speed if speed > 0 else 0
+                    log.info(f"{prefix}local={processed} global={g}/{total_docs} ({100*g/total_docs:.1f}%) "
+                             f"chunks={total_chunks} speed={speed:.0f} docs/s ETA={eta/3600:.1f}h")
+
+    if doc_buffer:
+        embed_and_queue()
+        with progress.get_lock():
+            progress.value += len(doc_buffer)
+    flush_qdrant()
+
+    log.info(f"{prefix}Done: {processed} docs, {total_chunks} chunks")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--justice-kind", type=int, required=True)
+    parser.add_argument("--qdrant-url", required=True)
+    parser.add_argument("--qdrant-api-key", default="")
+    parser.add_argument("--num-gpus", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=64)
+    args = parser.parse_args()
+
+    jsonl_files = sorted(Path(args.data_dir).glob("*.jsonl"))
+    log.info(f"Found {len(jsonl_files)} JSONL files")
+
+    import subprocess
+    result = subprocess.run(
+        ["wc", "-l"] + [str(f) for f in jsonl_files],
+        capture_output=True, text=True
+    )
+    counts = []
+    for line in result.stdout.strip().split("\n")[:-1]:
+        counts.append(int(line.strip().split()[0]))
+    total_docs = sum(counts)
+    log.info(f"Total docs: {total_docs} (per file: {counts})")
+
+    progress = Value("i", 0)
+    workers = []
+
+    for i, jf in enumerate(jsonl_files[:args.num_gpus]):
+        p = Process(target=worker, args=(
+            i, str(jf), args.justice_kind, args.qdrant_url, args.qdrant_api_key,
+            args.batch_size, progress, total_docs,
+        ))
+        p.start()
+        workers.append(p)
+
+    for p in workers:
+        p.join()
+
+    log.info(f"All done! {progress.value} docs")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/embed_tail.py
+++ b/scripts/edrsr/bge-m3-vectorize/embed_tail.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Embed the truncated tail of a KAS group: chunk texts already exist in the
+payload jsonl beyond the vector count. Reads payloads_gpu0.jsonl[skip:],
+embeds the `text` field with ORT+TRT BGE-M3, writes npy + tail payload to disk.
+No qdrant — fully decoupled from the applying collection."""
+import argparse, json, os, time
+import numpy as np
+
+def mean_pooling(hidden, mask):
+    m = np.expand_dims(mask, -1).astype(np.float32)
+    return np.sum(hidden * m, axis=1) / np.clip(np.sum(m, axis=1), 1e-9, None)
+
+def normalize(e):
+    return e / np.clip(np.linalg.norm(e, axis=1, keepdims=True), 1e-9, None)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--group", type=int, required=True)
+    ap.add_argument("--skip", type=int, required=True)       # rows already embedded
+    ap.add_argument("--count", type=int, default=0)          # max tail lines to process (0=all)
+    ap.add_argument("--gpu", type=int, required=True)
+    ap.add_argument("--src-dir", required=True)              # vsplit{g}
+    ap.add_argument("--out-dir", required=True)              # tail{g}
+    ap.add_argument("--onnx-path", default="/data/bge-m3-ort/model.onnx")
+    ap.add_argument("--batch", type=int, default=64)
+    args = ap.parse_args()
+
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+    import onnxruntime as ort
+    from transformers import AutoTokenizer
+
+    g = args.group
+    os.makedirs(args.out_dir, exist_ok=True)
+    log = lambda m: print(f"{time.strftime('%H:%M:%S')} [tail-g{g}] {m}", flush=True)
+
+    tok = AutoTokenizer.from_pretrained("BAAI/bge-m3", cache_dir="/data/hf_cache")
+    trt_cache = f"/data/trt_cache_gpu{args.gpu}"  # reuse prebuilt engine
+    os.makedirs(trt_cache, exist_ok=True)
+    providers = [
+        ("TensorrtExecutionProvider", {"device_id": 0, "trt_fp16_enable": True,
+            "trt_engine_cache_enable": True, "trt_engine_cache_path": trt_cache}),
+        ("CUDAExecutionProvider", {"device_id": 0}),
+    ]
+    sess = ort.InferenceSession(args.onnx_path, providers=providers)
+    log(f"providers: {sess.get_providers()}")
+
+    src_payload = os.path.join(args.src_dir, "payloads_gpu0.jsonl")
+    out_payload = open(os.path.join(args.out_dir, "payloads_gpu0.jsonl"), "w")
+    emb_buf, all_parts, written, part_no = [], 0, 0, 0
+    texts, metas = [], []
+
+    def flush_embed():
+        nonlocal texts, metas, emb_buf
+        if not texts:
+            return
+        enc = tok(texts, padding=True, truncation=True, max_length=512, return_tensors="np")
+        ids = enc["input_ids"].astype(np.int64); mask = enc["attention_mask"].astype(np.int64)
+        out = sess.run(None, {"input_ids": ids, "attention_mask": mask})
+        emb_buf.append(normalize(mean_pooling(out[0], mask)).astype(np.float32))
+        for m in metas:
+            out_payload.write(json.dumps(m) + "\n")
+        texts, metas = [], []
+
+    def save_part():
+        nonlocal emb_buf, part_no, written
+        if not emb_buf:
+            return
+        merged = np.concatenate(emb_buf, axis=0)
+        np.save(os.path.join(args.out_dir, f"embeddings_gpu0_part{part_no}.npy"), merged)
+        written += merged.shape[0]; part_no += 1; emb_buf = []
+        log(f"saved part{part_no-1}: {merged.shape[0]} (total {written})")
+
+    t0 = time.time()
+    end = args.skip + args.count if args.count else None
+    with open(src_payload) as f:
+        for i, line in enumerate(f):
+            if i < args.skip:
+                continue
+            if end and i >= end:
+                break
+            m = json.loads(line)
+            t = m.get("text", "")
+            if not t:
+                continue
+            texts.append(t); metas.append(m)
+            if len(texts) >= args.batch:
+                flush_embed()
+            if sum(a.shape[0] for a in emb_buf) >= 500000:
+                save_part()
+    flush_embed(); save_part()
+    out_payload.close()
+    log(f"DONE: {written} tail embeddings in {(time.time()-t0)/60:.1f}min")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/embed_to_disk.py
+++ b/scripts/edrsr/bge-m3-vectorize/embed_to_disk.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Phase 1: Embed ГПК docs from JSONL → save vectors+payloads to disk.
+No network dependencies. Pure GPU compute.
+
+Output: /home/nvidia/hpk_vectors/shard_XX.npz (vectors) + shard_XX.jsonl (payloads)
+"""
+
+import argparse
+import json
+import logging
+import os
+import time
+import uuid
+from multiprocessing import Process, Value
+from pathlib import Path
+
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [W%(message)s")
+log = logging.getLogger(__name__)
+
+MODEL_ID = "BAAI/bge-m3"
+JUSTICE_KIND = 3
+MAX_CHUNK_CHARS = 2048
+
+
+def chunk_text(text, max_chars=MAX_CHUNK_CHARS):
+    if len(text) <= max_chars:
+        return [text]
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + max_chars, len(text))
+        if end < len(text):
+            space_idx = text.rfind(" ", start + max_chars // 2, end)
+            if space_idx > 0:
+                end = space_idx
+        chunks.append(text[start:end])
+        start = end
+        if len(text) - start < 100:
+            break
+    return chunks
+
+
+def worker(gpu_id, jsonl_file, output_dir, batch_size, progress, total_docs):
+    import torch
+    from sentence_transformers import SentenceTransformer
+
+    prefix = f"{gpu_id}] "
+    device = f"cuda:{gpu_id}"
+
+    log.info(f"{prefix}Loading model on {device}...")
+    model = SentenceTransformer(MODEL_ID, device=device, trust_remote_code=True)
+    log.info(f"{prefix}Model loaded")
+
+    out_vectors = os.path.join(output_dir, f"shard_{gpu_id:02d}.npy")
+    out_payloads = os.path.join(output_dir, f"shard_{gpu_id:02d}.jsonl")
+
+    all_vectors = []
+    processed = 0
+    total_chunks = 0
+    doc_buffer = []
+    t0 = time.time()
+    flush_count = 0
+
+    def flush_buffer():
+        nonlocal total_chunks, flush_count
+        if not doc_buffer:
+            return
+
+        all_chunks = []
+        chunk_payloads = []
+        for doc in doc_buffer:
+            text = doc["text"][:15000]
+            chunks = chunk_text(text)
+            for ci, chunk in enumerate(chunks):
+                all_chunks.append(chunk)
+                chunk_payloads.append({
+                    "edrsr_doc_id": doc["doc_id"],
+                    "court_code": doc.get("court_code", 0),
+                    "judge": doc.get("judge", ""),
+                    "cause_num": doc.get("cause_num", ""),
+                    "justice_kind": JUSTICE_KIND,
+                    "adjudication_date": doc.get("adjudication_date", ""),
+                    "judgment_code": doc.get("judgment_code", 0),
+                    "category_code": doc.get("category_code", 0),
+                    "chunk_index": ci,
+                    "total_chunks": len(chunks),
+                    "text": chunk,
+                })
+
+        embeddings = model.encode(
+            all_chunks, batch_size=batch_size,
+            normalize_embeddings=True, convert_to_numpy=True, show_progress_bar=False,
+        )
+
+        all_vectors.append(embeddings)
+
+        with open(out_payloads, "a") as f:
+            for p in chunk_payloads:
+                f.write(json.dumps(p, ensure_ascii=False) + "\n")
+
+        total_chunks += len(all_chunks)
+        doc_buffer.clear()
+        flush_count += 1
+
+        # Save vectors periodically (every 50 flushes = 10K docs)
+        if flush_count % 50 == 0:
+            merged = np.concatenate(all_vectors, axis=0)
+            np.save(out_vectors, merged)
+
+    with open(jsonl_file) as f:
+        for line in f:
+            doc = json.loads(line)
+            if not doc.get("text") or len(doc["text"]) < 50:
+                continue
+            doc_buffer.append(doc)
+            processed += 1
+
+            if len(doc_buffer) >= 200:
+                flush_buffer()
+                with progress.get_lock():
+                    progress.value += 200
+
+                if processed % 4000 < 200:
+                    g = progress.value
+                    elapsed = time.time() - t0
+                    speed = g / elapsed if elapsed > 0 else 0
+                    eta = (total_docs - g) / speed if speed > 0 else 0
+                    log.info(f"{prefix}local={processed} global={g}/{total_docs} ({100*g/total_docs:.1f}%) "
+                             f"chunks={total_chunks} speed={speed:.0f} docs/s ETA={eta/3600:.1f}h")
+
+    # Final flush
+    if doc_buffer:
+        flush_buffer()
+        with progress.get_lock():
+            progress.value += len(doc_buffer)
+
+    # Save final vectors
+    merged = np.concatenate(all_vectors, axis=0)
+    np.save(out_vectors, merged)
+    log.info(f"{prefix}Done: {processed} docs, {total_chunks} chunks, vectors shape={merged.shape}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--output-dir", default="/home/nvidia/hpk_vectors")
+    parser.add_argument("--num-gpus", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=64)
+    args = parser.parse_args()
+
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    jsonl_files = sorted(Path(args.data_dir).glob("*.jsonl"))
+    log.info(f"Found {len(jsonl_files)} JSONL files")
+
+    total_docs = 0
+    for f in jsonl_files:
+        with open(f) as fh:
+            total_docs += sum(1 for _ in fh)
+    log.info(f"Total docs: {total_docs}")
+
+    progress = Value("i", 0)
+    workers = []
+    t0 = time.time()
+
+    for i, jf in enumerate(jsonl_files[:args.num_gpus]):
+        p = Process(target=worker, args=(i, str(jf), args.output_dir, args.batch_size, progress, total_docs))
+        p.start()
+        workers.append(p)
+
+    for p in workers:
+        p.join()
+
+    elapsed = time.time() - t0
+    log.info(f"\nEmbedding done! {progress.value} docs in {elapsed:.0f}s ({progress.value/elapsed:.0f} docs/s)")
+    log.info(f"Vectors saved to {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/export_jsonl_fast.py
+++ b/scripts/edrsr/bge-m3-vectorize/export_jsonl_fast.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Fast parallel export of EDRSR docs to JSONL shards.
+Optimized: larger FT batches, threaded fulltext fetch.
+"""
+import argparse
+import json
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from multiprocessing import Process
+from pathlib import Path
+
+import psycopg2
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger("export-fast")
+
+PG_BATCH = 10000
+FT_BATCH = 2000
+FT_THREADS = 2
+
+
+def fetch_fulltext_batch(db_url, sub_ids):
+    conn = psycopg2.connect(db_url, connect_timeout=60)
+    conn.set_session(autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '600s'")
+        cur.execute("""
+            SELECT doc_id, full_text
+            FROM edrsr_fulltext
+            WHERE doc_id = ANY(%s)
+              AND full_text IS NOT NULL AND full_text != ''
+        """, (sub_ids,))
+        result = {row[0]: row[1] for row in cur.fetchall()}
+    conn.close()
+    return result
+
+
+def worker(shard_id, justice_kind, db_url, output_path, doc_id_start, doc_id_end):
+    conn = psycopg2.connect(db_url, connect_timeout=60)
+    conn.set_session(autocommit=True)
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '600s'")
+        cur.execute("SET work_mem = '256MB'")
+
+    exported = 0
+    skipped = 0
+    last_doc_id = doc_id_start - 1
+    t0 = time.time()
+
+    with open(output_path, "w", buffering=8*1024*1024) as f:
+        while True:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT d.doc_id, d.cause_num, d.court_code, d.judge,
+                           d.adjudication_date::text, d.judgment_code, d.category_code
+                    FROM edrsr_documents d
+                    WHERE d.justice_kind = %s AND d.doc_id > %s AND d.doc_id <= %s
+                    ORDER BY d.doc_id ASC
+                    LIMIT %s
+                """, (justice_kind, last_doc_id, doc_id_end, PG_BATCH))
+                meta_rows = cur.fetchall()
+
+            if not meta_rows:
+                break
+
+            doc_ids = [r[0] for r in meta_rows]
+            meta_map = {}
+            for r in meta_rows:
+                meta_map[r[0]] = {
+                    "doc_id": r[0],
+                    "cause_num": r[1] or "",
+                    "court_code": r[2] or 0,
+                    "judge": r[3] or "",
+                    "adjudication_date": r[4] or "",
+                    "judgment_code": r[5] or 0,
+                    "category_code": r[6] or 0,
+                }
+
+            chunks = [doc_ids[i:i + FT_BATCH] for i in range(0, len(doc_ids), FT_BATCH)]
+            with ThreadPoolExecutor(max_workers=FT_THREADS) as executor:
+                futures = {executor.submit(fetch_fulltext_batch, db_url, chunk): chunk for chunk in chunks}
+                for future in as_completed(futures):
+                    try:
+                        ft_map = future.result()
+                        for doc_id, text in ft_map.items():
+                            if doc_id in meta_map:
+                                meta_map[doc_id]["text"] = text
+                    except Exception as e:
+                        log.error(f"[shard {shard_id}] FT fetch error: {e}")
+
+            batch_exported = 0
+            for doc_id in doc_ids:
+                doc = meta_map[doc_id]
+                if "text" not in doc or len(doc["text"]) < 50:
+                    skipped += 1
+                    continue
+                f.write(json.dumps(doc, ensure_ascii=False) + "\n")
+                exported += 1
+                batch_exported += 1
+
+            last_doc_id = doc_ids[-1]
+            elapsed = time.time() - t0
+            rate = exported / elapsed if elapsed > 0 else 0
+            if exported % 50000 < PG_BATCH:
+                log.info(f"[shard {shard_id}] {exported:,} docs | {skipped:,} skipped | {rate:.0f} docs/s")
+
+    conn.close()
+    elapsed = time.time() - t0
+    sz = os.path.getsize(output_path) / 1024 / 1024 / 1024
+    log.info(f"[shard {shard_id}] DONE: {exported:,} docs, {skipped:,} skipped, {sz:.1f} GB in {elapsed/60:.1f} min")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--justice-kind", type=int, required=True)
+    parser.add_argument("--db-url", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--num-shards", type=int, default=8)
+    args = parser.parse_args()
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    log.info(f"Connecting to compute shard boundaries...")
+    conn = psycopg2.connect(args.db_url, connect_timeout=60)
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout = '600s'")
+        cur.execute("SELECT min(doc_id), max(doc_id) FROM edrsr_documents WHERE justice_kind = %s",
+                    (args.justice_kind,))
+        min_id, max_id = cur.fetchone()
+        cur.execute("SELECT count(*) FROM edrsr_documents WHERE justice_kind = %s", (args.justice_kind,))
+        total = cur.fetchone()[0]
+
+        pcts = [i / args.num_shards for i in range(1, args.num_shards)]
+        cur.execute(f"""
+            SELECT unnest(percentile_cont(ARRAY[{','.join(str(p) for p in pcts)}])
+                   WITHIN GROUP (ORDER BY doc_id))::bigint
+            FROM edrsr_documents WHERE justice_kind = %s
+        """, (args.justice_kind,))
+        boundaries = [row[0] for row in cur.fetchall()]
+    conn.close()
+
+    all_bounds = [min_id - 1] + boundaries + [max_id]
+    log.info(f"justice_kind={args.justice_kind}: {total:,} docs, {args.num_shards} shards")
+
+    procs = []
+    for i in range(args.num_shards):
+        start = all_bounds[i]
+        end = all_bounds[i + 1]
+        output_path = str(out_dir / f"docs_{i:02d}.jsonl")
+        log.info(f"  shard {i}: doc_id ({start}, {end}]")
+        p = Process(target=worker, args=(i, args.justice_kind, args.db_url, output_path, start, end))
+        p.start()
+        procs.append(p)
+
+    for p in procs:
+        p.join()
+
+    log.info("All shards done!")
+    total_exported = 0
+    for i in range(args.num_shards):
+        path = out_dir / f"docs_{i:02d}.jsonl"
+        if path.exists() and path.stat().st_size > 0:
+            sz = path.stat().st_size / 1024 / 1024 / 1024
+            with open(path) as ff:
+                cnt = sum(1 for _ in ff)
+            total_exported += cnt
+            log.info(f"  shard {i}: {cnt:,} docs ({sz:.1f} GB)")
+    log.info(f"Total exported: {total_exported:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/kas-uploader/go.mod
+++ b/scripts/edrsr/bge-m3-vectorize/kas-uploader/go.mod
@@ -1,0 +1,3 @@
+module kas-uploader
+
+go 1.22

--- a/scripts/edrsr/bge-m3-vectorize/kas-uploader/main.go
+++ b/scripts/edrsr/bge-m3-vectorize/kas-uploader/main.go
@@ -1,0 +1,586 @@
+// kas-uploader — idempotent, streaming, resource-capped bulk uploader
+// for BGE-M3 embeddings (npy + payload jsonl) into Qdrant via gRPC.
+//
+// Design (replaces python upload_stream*.py):
+//   - Deterministic point IDs: doc_id*100 + chunk_index  → re-runs overwrite,
+//     never duplicate; resume is safe by construction.
+//   - Streams npy rows from disk (no full-group RAM load).
+//   - Per-group checkpoint of the contiguous confirmed batch prefix.
+//   - Global caps: network token bucket (bytes/s) + AIMD in-flight window
+//     (grows on success, halves on errors/timeouts).
+//
+// npy part ordering replicates python exactly:
+//   sorted(glob("embeddings_gpu{N}_part*.npy"), key=int(suffix)) + final "embeddings_gpu{N}.npy" last.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/qdrant/go-client/qdrant"
+	"golang.org/x/time/rate"
+)
+
+// ---------- npy streaming reader ----------
+
+var headerRe = regexp.MustCompile(`'descr':\s*'([^']+)'.*'fortran_order':\s*(\w+).*'shape':\s*\((\d+),\s*(\d+)\)`)
+
+type npyFile struct {
+	path    string
+	rows    int64
+	cols    int64
+	dataOff int64
+}
+
+func parseNpyHeader(path string) (npyFile, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return npyFile{}, err
+	}
+	defer f.Close()
+	magic := make([]byte, 8)
+	if _, err := io.ReadFull(f, magic); err != nil {
+		return npyFile{}, err
+	}
+	if string(magic[:6]) != "\x93NUMPY" {
+		return npyFile{}, fmt.Errorf("%s: not an npy file", path)
+	}
+	major := magic[6]
+	var hlen int64
+	if major == 1 {
+		b := make([]byte, 2)
+		if _, err := io.ReadFull(f, b); err != nil {
+			return npyFile{}, err
+		}
+		hlen = int64(binary.LittleEndian.Uint16(b))
+	} else {
+		b := make([]byte, 4)
+		if _, err := io.ReadFull(f, b); err != nil {
+			return npyFile{}, err
+		}
+		hlen = int64(binary.LittleEndian.Uint32(b))
+	}
+	hdr := make([]byte, hlen)
+	if _, err := io.ReadFull(f, hdr); err != nil {
+		return npyFile{}, err
+	}
+	m := headerRe.FindStringSubmatch(string(hdr))
+	if m == nil {
+		return npyFile{}, fmt.Errorf("%s: cannot parse npy header: %s", path, string(hdr))
+	}
+	if m[1] != "<f4" {
+		return npyFile{}, fmt.Errorf("%s: dtype %s, want <f4", path, m[1])
+	}
+	if m[2] != "False" {
+		return npyFile{}, fmt.Errorf("%s: fortran_order not supported", path)
+	}
+	rows, _ := strconv.ParseInt(m[3], 10, 64)
+	cols, _ := strconv.ParseInt(m[4], 10, 64)
+	off := int64(8)
+	if major == 1 {
+		off += 2 + hlen
+	} else {
+		off += 4 + hlen
+	}
+	return npyFile{path: path, rows: rows, cols: cols, dataOff: off}, nil
+}
+
+// groupFiles returns npy files of a group in exact python order.
+func groupFiles(dir string, gpu int) ([]npyFile, error) {
+	pattern := filepath.Join(dir, fmt.Sprintf("embeddings_gpu%d_part*.npy", gpu))
+	parts, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, err
+	}
+	type pf struct {
+		n    int
+		path string
+	}
+	var pfs []pf
+	for _, p := range parts {
+		base := strings.TrimSuffix(filepath.Base(p), ".npy")
+		idx := strings.LastIndex(base, "part")
+		n, err := strconv.Atoi(base[idx+4:])
+		if err != nil {
+			return nil, fmt.Errorf("bad part suffix in %s", p)
+		}
+		pfs = append(pfs, pf{n, p})
+	}
+	sort.Slice(pfs, func(i, j int) bool { return pfs[i].n < pfs[j].n })
+	var files []npyFile
+	for _, p := range pfs {
+		nf, err := parseNpyHeader(p.path)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, nf)
+	}
+	final := filepath.Join(dir, fmt.Sprintf("embeddings_gpu%d.npy", gpu))
+	if _, err := os.Stat(final); err == nil {
+		nf, err := parseNpyHeader(final)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, nf)
+	}
+	return files, nil
+}
+
+// vectorStream yields rows across the ordered npy files, with seek-resume.
+type vectorStream struct {
+	files   []npyFile
+	fi      int
+	f       *os.File
+	r       *bufio.Reader
+	rowInF  int64
+	rowBuf  []byte
+	cols    int64
+}
+
+func newVectorStream(files []npyFile, skipRows int64) (*vectorStream, error) {
+	vs := &vectorStream{files: files}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no npy files")
+	}
+	vs.cols = files[0].cols
+	for _, f := range files {
+		if f.cols != vs.cols {
+			return nil, fmt.Errorf("inconsistent cols: %s", f.path)
+		}
+	}
+	// seek past whole files
+	for vs.fi < len(files) && skipRows >= files[vs.fi].rows {
+		skipRows -= files[vs.fi].rows
+		vs.fi++
+	}
+	if vs.fi >= len(files) {
+		return vs, nil // fully consumed
+	}
+	if err := vs.openCurrent(skipRows); err != nil {
+		return nil, err
+	}
+	return vs, nil
+}
+
+func (vs *vectorStream) openCurrent(skipRows int64) error {
+	nf := vs.files[vs.fi]
+	f, err := os.Open(nf.path)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Seek(nf.dataOff+skipRows*vs.cols*4, io.SeekStart); err != nil {
+		f.Close()
+		return err
+	}
+	vs.f = f
+	vs.r = bufio.NewReaderSize(f, 4<<20)
+	vs.rowInF = skipRows
+	vs.rowBuf = make([]byte, vs.cols*4)
+	return nil
+}
+
+// next returns the next vector row, or nil when exhausted.
+func (vs *vectorStream) next() ([]float32, error) {
+	for {
+		if vs.f == nil {
+			return nil, nil
+		}
+		if vs.rowInF >= vs.files[vs.fi].rows {
+			vs.f.Close()
+			vs.f = nil
+			vs.fi++
+			if vs.fi >= len(vs.files) {
+				return nil, nil
+			}
+			if err := vs.openCurrent(0); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if _, err := io.ReadFull(vs.r, vs.rowBuf); err != nil {
+			return nil, fmt.Errorf("%s row %d: %w", vs.files[vs.fi].path, vs.rowInF, err)
+		}
+		vs.rowInF++
+		vec := make([]float32, vs.cols)
+		for i := range vec {
+			vec[i] = math.Float32frombits(binary.LittleEndian.Uint32(vs.rowBuf[i*4:]))
+		}
+		return vec, nil
+	}
+}
+
+// ---------- payload → qdrant.Value ----------
+
+func toValue(v any) *qdrant.Value {
+	switch t := v.(type) {
+	case nil:
+		return qdrant.NewValueNull()
+	case string:
+		return qdrant.NewValueString(t)
+	case bool:
+		return qdrant.NewValueBool(t)
+	case float64:
+		if t == math.Trunc(t) && math.Abs(t) < 1e15 {
+			return qdrant.NewValueInt(int64(t))
+		}
+		return qdrant.NewValueDouble(t)
+	case json.Number:
+		if i, err := t.Int64(); err == nil {
+			return qdrant.NewValueInt(i)
+		}
+		f, _ := t.Float64()
+		return qdrant.NewValueDouble(f)
+	default:
+		b, _ := json.Marshal(t)
+		return qdrant.NewValueString(string(b))
+	}
+}
+
+// ---------- batching / AIMD / checkpoint ----------
+
+type batch struct {
+	group   int
+	seq     int64 // batch sequence within group
+	points  []*qdrant.PointStruct
+	bytes   int64
+	lastIdx int64 // payload line index (exclusive) covered by this batch
+}
+
+type checkpointer struct {
+	mu        sync.Mutex
+	path      string
+	confirmed map[int]int64 // group → contiguous confirmed payload-line count
+	pending   map[int]map[int64]int64 // group → seq → lastIdx
+	nextSeq   map[int]int64           // group → next seq expected for frontier
+}
+
+func newCheckpointer(path string) *checkpointer {
+	c := &checkpointer{
+		path:      path,
+		confirmed: map[int]int64{},
+		pending:   map[int]map[int64]int64{},
+		nextSeq:   map[int]int64{},
+	}
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &c.confirmed)
+	}
+	return c
+}
+
+func (c *checkpointer) confirmedLines(group int) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.confirmed[group]
+}
+
+func (c *checkpointer) markDone(group int, seq int64, lastIdx int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.pending[group] == nil {
+		c.pending[group] = map[int64]int64{}
+	}
+	c.pending[group][seq] = lastIdx
+	for {
+		idx, ok := c.pending[group][c.nextSeq[group]]
+		if !ok {
+			break
+		}
+		delete(c.pending[group], c.nextSeq[group])
+		c.confirmed[group] = idx
+		c.nextSeq[group]++
+	}
+}
+
+func (c *checkpointer) save() {
+	c.mu.Lock()
+	b, _ := json.MarshalIndent(c.confirmed, "", " ")
+	c.mu.Unlock()
+	tmp := c.path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0644); err == nil {
+		_ = os.Rename(tmp, c.path)
+	}
+}
+
+// aimd controls the global in-flight window.
+type aimd struct {
+	cur, min, max int64
+}
+
+func (a *aimd) onSuccess() {
+	if atomic.LoadInt64(&a.cur) < a.max {
+		atomic.AddInt64(&a.cur, 1)
+	}
+}
+func (a *aimd) onError() {
+	for {
+		c := atomic.LoadInt64(&a.cur)
+		n := c / 2
+		if n < a.min {
+			n = a.min
+		}
+		if atomic.CompareAndSwapInt64(&a.cur, c, n) {
+			return
+		}
+	}
+}
+
+// ---------- main ----------
+
+func main() {
+	var (
+		dirsFlag   = flag.String("dirs", "", "comma-separated group dirs (each with embeddings_gpu0*.npy + payloads_gpu0.jsonl)")
+		host       = flag.String("host", "10.88.0.6", "qdrant host")
+		port       = flag.Int("port", 6334, "qdrant grpc port")
+		apiKey     = flag.String("api-key", "", "qdrant api key")
+		collection = flag.String("collection", "edrsr_decisions", "collection")
+		batchSize  = flag.Int("batch", 400, "points per upsert")
+		inflight0  = flag.Int64("inflight-start", 8, "initial in-flight window")
+		inflightMx = flag.Int64("inflight-max", 48, "max in-flight window")
+		netMBps    = flag.Float64("net-mbps", 110, "network cap, MB/s (~80% of link)")
+		ckptPath   = flag.String("checkpoint", "kas-upload.ckpt", "checkpoint file")
+		statsEvery = flag.Duration("stats", 15*time.Second, "stats interval")
+		waitUpsert = flag.Bool("wait", false, "wait=true on upserts")
+	)
+	flag.Parse()
+	if *dirsFlag == "" || *apiKey == "" {
+		log.Fatal("need -dirs and -api-key")
+	}
+	dirs := strings.Split(*dirsFlag, ",")
+
+	client, err := qdrant.NewClient(&qdrant.Config{
+		Host: *host, Port: *port, APIKey: *apiKey, UseTLS: false,
+		GrpcOptions: nil,
+	})
+	if err != nil {
+		log.Fatalf("qdrant client: %v", err)
+	}
+	ctx := context.Background()
+	if _, err := client.GetCollectionInfo(ctx, *collection); err != nil {
+		log.Fatalf("collection check: %v", err)
+	}
+
+	ckpt := newCheckpointer(*ckptPath)
+	win := &aimd{cur: *inflight0, min: 2, max: *inflightMx}
+	limiter := rate.NewLimiter(rate.Limit(*netMBps*1024*1024), 8<<20)
+
+	var (
+		sentPoints int64
+		sentBytes  int64
+		errCount   int64
+		inFlight   int64
+	)
+
+	batches := make(chan *batch, 16)
+
+	// upsert workers
+	var wg sync.WaitGroup
+	for w := 0; w < 64; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for b := range batches {
+				// AIMD window gate
+				for atomic.LoadInt64(&inFlight) >= atomic.LoadInt64(&win.cur) {
+					time.Sleep(20 * time.Millisecond)
+				}
+				atomic.AddInt64(&inFlight, 1)
+				_ = limiter.WaitN(ctx, int(b.bytes))
+				var lastErr error
+				for attempt := 0; attempt < 6; attempt++ {
+					cctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+					_, lastErr = client.Upsert(cctx, &qdrant.UpsertPoints{
+						CollectionName: *collection,
+						Wait:           waitUpsert,
+						Points:         b.points,
+					})
+					cancel()
+					if lastErr == nil {
+						break
+					}
+					win.onError()
+					atomic.AddInt64(&errCount, 1)
+					time.Sleep(time.Duration(1<<attempt) * time.Second)
+				}
+				atomic.AddInt64(&inFlight, -1)
+				if lastErr != nil {
+					log.Printf("FATAL group %d seq %d: upsert failed after retries: %v", b.group, b.seq, lastErr)
+					os.Exit(1)
+				}
+				win.onSuccess()
+				atomic.AddInt64(&sentPoints, int64(len(b.points)))
+				atomic.AddInt64(&sentBytes, b.bytes)
+				ckpt.markDone(b.group, b.seq, b.lastIdx)
+			}
+		}()
+	}
+
+	// checkpoint saver + stats
+	stop := make(chan struct{})
+	go func() {
+		t := time.NewTicker(3 * time.Second)
+		s := time.NewTicker(*statsEvery)
+		var lastP, lastB int64
+		lastT := time.Now()
+		for {
+			select {
+			case <-t.C:
+				ckpt.save()
+			case <-s.C:
+				p := atomic.LoadInt64(&sentPoints)
+				bb := atomic.LoadInt64(&sentBytes)
+				dt := time.Since(lastT).Seconds()
+				log.Printf("STATS pts=%d (+%.0f/s) net=%.1fMB/s inflight=%d/%d errs=%d",
+					p, float64(p-lastP)/dt, float64(bb-lastB)/dt/1048576,
+					atomic.LoadInt64(&inFlight), atomic.LoadInt64(&win.cur), atomic.LoadInt64(&errCount))
+				lastP, lastB, lastT = p, bb, time.Now()
+			case <-stop:
+				ckpt.save()
+				return
+			}
+		}
+	}()
+
+	// producers: one per group
+	var pwg sync.WaitGroup
+	for gi, dir := range dirs {
+		pwg.Add(1)
+		go func(group int, dir string) {
+			defer pwg.Done()
+			if err := produceGroup(group, dir, *batchSize, ckpt, batches); err != nil {
+				log.Printf("FATAL group %d (%s): %v", group, dir, err)
+				os.Exit(1)
+			}
+		}(gi, dir)
+	}
+	pwg.Wait()
+	close(batches)
+	wg.Wait()
+	close(stop)
+	ckpt.save()
+	log.Printf("ALL DONE: %d points, %d errors", atomic.LoadInt64(&sentPoints), atomic.LoadInt64(&errCount))
+}
+
+func produceGroup(group int, dir string, batchSize int, ckpt *checkpointer, out chan<- *batch) error {
+	files, err := groupFiles(dir, 0)
+	if err != nil {
+		return err
+	}
+	var totalRows int64
+	for _, f := range files {
+		totalRows += f.rows
+	}
+	skip := ckpt.confirmedLines(group)
+	log.Printf("group %d: %d npy files, %d rows total, resume at line %d", group, len(files), totalRows, skip)
+
+	vs, err := newVectorStream(files, skip)
+	if err != nil {
+		return err
+	}
+	pf, err := os.Open(filepath.Join(dir, "payloads_gpu0.jsonl"))
+	if err != nil {
+		return err
+	}
+	defer pf.Close()
+	sc := bufio.NewScanner(pf)
+	sc.Buffer(make([]byte, 1<<20), 16<<20)
+
+	// skip confirmed payload lines
+	var lineIdx int64
+	for lineIdx < skip && sc.Scan() {
+		lineIdx++
+	}
+
+	// seed frontier so markDone sequencing starts correctly for resumed runs
+	ckpt.mu.Lock()
+	ckpt.nextSeq[group] = 0
+	ckpt.mu.Unlock()
+
+	var (
+		pts      []*qdrant.PointStruct
+		bbytes   int64
+		seq      int64
+	)
+	flush := func() {
+		if len(pts) == 0 {
+			return
+		}
+		out <- &batch{group: group, seq: seq, points: pts, bytes: bbytes, lastIdx: lineIdx}
+		seq++
+		pts = nil
+		bbytes = 0
+	}
+
+	for sc.Scan() {
+		line := sc.Bytes()
+		vec, err := vs.next()
+		if err != nil {
+			return err
+		}
+		if vec == nil {
+			// Embedding job was stopped before flushing its final buffers, so the
+			// payload jsonl has more lines than there are vectors. Verified clean
+			// tail truncation: vector[i] <-> line[i] stay aligned for all i < rows.
+			// Stop here and flush what we have; the missing tail (doc_ids beyond
+			// this point) is re-embedded separately with deterministic IDs, so the
+			// partial last document's remaining chunks slot in without conflict.
+			log.Printf("group %d: tail-truncated cleanly at line %d (rows=%d, trailing payload lines have no vectors — deferred to tail re-embed)",
+				group, lineIdx, totalRows)
+			break
+		}
+		var meta map[string]any
+		dec := json.NewDecoder(strings.NewReader(string(line)))
+		dec.UseNumber()
+		if err := dec.Decode(&meta); err != nil {
+			return fmt.Errorf("line %d: bad json: %w", lineIdx, err)
+		}
+		docIDn, ok := meta["edrsr_doc_id"].(json.Number)
+		if !ok {
+			return fmt.Errorf("line %d: no edrsr_doc_id", lineIdx)
+		}
+		docID, _ := docIDn.Int64()
+		chunkN, _ := meta["chunk_index"].(json.Number)
+		chunkIdx, _ := chunkN.Int64()
+		pointID := uint64(docID)*100 + uint64(chunkIdx)
+
+		payload := make(map[string]*qdrant.Value, len(meta))
+		for k, v := range meta {
+			payload[k] = toValue(v)
+		}
+		pts = append(pts, &qdrant.PointStruct{
+			Id:      qdrant.NewIDNum(pointID),
+			Vectors: qdrant.NewVectors(vec...),
+			Payload: payload,
+		})
+		bbytes += int64(len(line)) + int64(len(vec)*4) + 64
+		lineIdx++
+		if len(pts) >= batchSize {
+			flush()
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return err
+	}
+	flush()
+	// verify alignment: vectors must also be exhausted
+	if v, _ := vs.next(); v != nil {
+		return fmt.Errorf("group %d: payload lines ended but vectors remain — ALIGNMENT ERROR", group)
+	}
+	log.Printf("group %d: produced all %d lines", group, lineIdx)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Archives the EDRSR 100M+ docs BGE-M3 vectorization pipeline scripts from the temporary Brev 8xH100 instance (NVIDIA Innovation Lab, expires ~mid-July) into `scripts/edrsr/bge-m3-vectorize/`
- Adds the idempotent Go gRPC bulk uploader (`kas-uploader/`): deterministic point IDs (`doc_id*100+chunk_index`), npy streaming, AIMD in-flight window, network token bucket; measured ~140K pts/s (~1 GB/s), 74.5M points with 0 errors
- README documents the per-justice_kind pipeline and 2026-06-12 campaign results

Tracking: LEXAI-1715 / LEXAI-1718 / LEXAI-1721

## Notes
- Scripts-only change, no services affected
- No secrets: DB URL and Qdrant API key are passed via CLI flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archives the BGE-M3 bulk vectorization pipeline for EDRSR (100M+ docs) and adds a high-throughput, idempotent Go uploader for Qdrant. This preserves the temporary 8xH100 tooling and enables reproducible, resumable backfills (LEXAI-1715 / LEXAI-1718 / LEXAI-1721).

- **New Features**
  - Pipeline scripts in `scripts/edrsr/bge-m3-vectorize/`: fast PG export (`export_jsonl_fast.py`), header cleaning (`clean_edrsr_texts.py`, `clean_parallel.py`), embedding (`embed_ort_trt.py`, `embed_stream.py`, `embed_to_disk.py`, `embed_tail.py`) using `BAAI/bge-m3`.
  - Go `kas-uploader/`: deterministic IDs `doc_id*100+chunk_index`, npy row streaming with per-group checkpoint, AIMD in-flight window + network token bucket, tail-truncation detection; measured ~140K pts/s (~1 GB/s), 74.5M points with 0 errors.
  - README documents per-justice_kind flow and 2026-06-12 campaign results; scripts-only change, credentials passed via CLI flags.

<sup>Written for commit d7929f0d48b1ab2d559811fe2fa279252b2a35bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

