### PR TITLE
feat(scripts): archive КУпАП dataset-prep + deterministic-ID embed tools (LEXAI-1724)

### DIFF
--- a/scripts/edrsr/bge-m3-vectorize/README.md
+++ b/scripts/edrsr/bge-m3-vectorize/README.md
@@ -54,3 +54,36 @@ go build -o kas-uploader .
 | 3 ГПК | 7.5M docs | 13,773,100 | done |
 | 4 Адміністративне (КАС) | 22.6M docs | 8,278 (74.5M on Brev-local Qdrant) | transfer to prod pending |
 | 5 КУпАП | 12M docs | 69,391,702 | done |
+
+## КУпАП campaign (2026-06-12, LEXAI-1724/1725)
+
+Refined per-year pipeline used for КУпАП (jk=5) and ЦПК (jk=1) re-runs; supersedes
+`clean_parallel.py` for per-year `.jsonl.zst` exports:
+
+1. **Clean + global dedup** — `clean_dedup_yearly.py <src_dir> <out_dir>`
+   Same header-stripping rules as `clean_parallel.py` + global first-occurrence dedup
+   across all year files (by `doc_id`, then by md5 of cleaned text). КУпАП: 11.99M →
+   11.83M docs (156K exact-text dups), ~11 min on 23 cores.
+2. **Quality gate** — `analyze_dataset.py <dataset_dir>`
+   Full-scan stats before embedding: empty/short texts, >15K-char truncation candidates,
+   missing fields, residual header noise, length percentiles, chunk estimate.
+3. **Filter + reshard** — `reshard_filtered.py <src_dir> <out_dir> [codes] [shards]`
+   Filters by `judgment_code` (КУпАП kept {2,5,6} = постанова/ухвала/окрема ухвала)
+   and round-robins into N equal plain-JSONL shards, one per embed worker.
+4. **Embed** — `embed_ort_trt_32w.py` (evolution of `embed_ort_trt.py`):
+   **deterministic point IDs** `uuid5("edrsr/{justice_kind}/{doc_id}/{chunk_index}")`
+   — restarts are idempotent, no random-UUID dup cleanup needed (the lesson that
+   produced `dedup-qdrant-jk.py`).
+
+КУпАП result: 31,271,465 chunks on Brev `qdrant-gpu` :6343, points == chunks 1:1,
+0 failed upserts, HNSW green.
+
+### qdrant-gpu (GPU HNSW indexing) caveats
+
+- NVIDIA driver 580.105.08 segfaults in `libnvidia-eglcore` when qdrant initializes
+  >2 Vulkan devices in one process (newer loader / ICD pinning / capabilities=all do
+  NOT help). Run with `--gpus '"device=0,1"'` + `QDRANT__GPU__PARALLEL_INDEXES=2` max.
+- After a qdrant restart the optimizer stays idle (status `grey`): kick it with
+  `PATCH /collections/<name> {"optimizers_config":{}}`.
+- `indexed_vectors_count` advances only when whole segments finish — long flat
+  periods with both GPUs at 100% are normal.

--- a/scripts/edrsr/bge-m3-vectorize/analyze_dataset.py
+++ b/scripts/edrsr/bge-m3-vectorize/analyze_dataset.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Data-quality analysis of /data/kupap-fulltext-clean before vectorization."""
+import json
+import re
+import subprocess
+import sys
+from multiprocessing import Pool
+from pathlib import Path
+
+if len(sys.argv) != 2:
+    sys.exit('usage: analyze_dataset.py <dataset_dir>')
+SRC = Path(sys.argv[1])
+MAX_CHUNK = 2048
+CAP = 15000
+
+PHONE = re.compile(r'\(?\d{3}\)?\s*\d{3}[\-\s]?\d{2}[\-\s]?\d{2}')
+ADDR = re.compile(r'вул\.\s*\S+.{0,40}буд\.')
+
+
+def ceil_div(a, b):
+    return -(-a // b)
+
+
+def analyze(path_str):
+    p = Path(path_str)
+    dec = subprocess.Popen(['zstd', '-dc', str(p)], stdout=subprocess.PIPE)
+    n = 0
+    empty = 0
+    sub50 = 0
+    sub200 = 0
+    over15k = 0
+    total_chars = 0
+    chunks = 0
+    no_id = 0
+    no_date = 0
+    no_court = 0
+    bad_json = 0
+    noise_head = 0
+    lens = []
+    for line in dec.stdout:
+        try:
+            d = json.loads(line)
+        except Exception:
+            bad_json += 1
+            continue
+        n += 1
+        t = d.get('text') or ''
+        L = len(t)
+        total_chars += L
+        if n % 50 == 0:
+            lens.append(L)
+        if L == 0:
+            empty += 1
+        elif L < 50:
+            sub50 += 1
+        elif L < 200:
+            sub200 += 1
+        if L > CAP:
+            over15k += 1
+        chunks += max(1, ceil_div(min(L, CAP), MAX_CHUNK))
+        if d.get('doc_id') is None:
+            no_id += 1
+        if not d.get('adjudication_date'):
+            no_date += 1
+        if not d.get('court_code'):
+            no_court += 1
+        head = t[:300]
+        if PHONE.search(head) or ADDR.search(head):
+            noise_head += 1
+    dec.stdout.close()
+    dec.wait()
+    return dict(file=p.name, n=n, empty=empty, sub50=sub50, sub200=sub200,
+                over15k=over15k, total_chars=total_chars, chunks=chunks,
+                no_id=no_id, no_date=no_date, no_court=no_court,
+                bad_json=bad_json, noise_head=noise_head, lens=lens)
+
+
+def main():
+    files = sorted(SRC.glob('*.jsonl.zst'))
+    with Pool(len(files)) as pool:
+        results = pool.map(analyze, [str(f) for f in files])
+    tot = lambda k: sum(r[k] for r in results)
+    all_lens = sorted(x for r in results for x in r['lens'])
+    def pct(q):
+        return all_lens[int(q * (len(all_lens) - 1))] if all_lens else 0
+    print(f"{'file':28} {'docs':>9} {'empty':>6} {'<50':>6} {'<200':>7} {'>15k':>7} {'noiseHead':>9} {'noID':>5} {'noDate':>6}")
+    for r in results:
+        print(f"{r['file']:28} {r['n']:>9} {r['empty']:>6} {r['sub50']:>6} {r['sub200']:>7} {r['over15k']:>7} {r['noise_head']:>9} {r['no_id']:>5} {r['no_date']:>6}")
+    print()
+    print(f"TOTAL docs:        {tot('n'):,}")
+    print(f"bad_json:          {tot('bad_json')}")
+    print(f"empty text:        {tot('empty'):,}")
+    print(f"text <50 chars:    {tot('sub50'):,}")
+    print(f"text 50-200 chars: {tot('sub200'):,}")
+    print(f"text >15k chars (truncated at embed): {tot('over15k'):,}")
+    print(f"missing doc_id:    {tot('no_id')}")
+    print(f"missing date:      {tot('no_date')}")
+    print(f"missing court:     {tot('no_court')}")
+    print(f"residual addr/phone in first 300 chars: {tot('noise_head'):,}")
+    print(f"total text:        {tot('total_chars')/1e9:.1f} G chars")
+    print(f"est. chunks (2048 chars, cap 15k): {tot('chunks'):,}")
+    print(f"len percentiles (sampled 1/50): p10={pct(.1)} p50={pct(.5)} p90={pct(.9)} p99={pct(.99)} max={all_lens[-1] if all_lens else 0}")
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/clean_dedup_yearly.py
+++ b/scripts/edrsr/bge-m3-vectorize/clean_dedup_yearly.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""EDRSR per-year dataset prep: header cleaning + global dedup (KUpAP/TsPK campaigns).
+
+Stage 1 (parallel per year-file): decompress jsonl.zst, clean header noise
+(court address/phone/email/EDRPOU), write cleaned tmp jsonl.zst, collect
+(doc_id, md5 of cleaned text) per record.
+
+Driver: chronological first-occurrence dedup by doc_id, then by exact text md5.
+
+Stage 2 (parallel per year-file): drop duplicate records, write final files.
+"""
+import hashlib
+import json
+import os
+import pickle
+import re
+import subprocess
+import sys
+import time
+from multiprocessing import Pool
+from pathlib import Path
+
+if len(sys.argv) != 3:
+    sys.exit('usage: clean_dedup_yearly.py <src_dir> <out_dir>')
+SRC_DIR = Path(sys.argv[1])
+OUT_DIR = Path(sys.argv[2])
+TMP_DIR = OUT_DIR / '.tmp'
+
+HEADER_PATTERNS = [
+    re.compile(r'вул\.\s*[А-ЯІЇЄҐа-яіїєґA-Za-z\s\.\,\-]+,?\s*буд\.\s*\d+[а-яА-Я]?(?:\s*,\s*літера\s*[А-Я])?(?:\s*,\s*м\.\s*[А-ЯІЇЄҐа-яіїєґ\s\-]+)?(?:\s*,?\s*\d{5})?', re.UNICODE),
+    re.compile(r'\(?\d{3}\)?\s*\d{3}[\-\s]?\d{2}[\-\s]?\d{2}'),
+    re.compile(r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}'),
+    re.compile(r'(?:ЄДРПОУ|код\s+ЄДРПОУ)\s*:?\s*\d{8}'),
+    re.compile(r'https?://[^\s]+'),
+    re.compile(r'(?<!\d)\d{5}(?!\d)(?:\s*,\s*м\.\s*[А-ЯІЇЄҐа-яіїєґ\s\-]+)?'),
+]
+
+DOC_START = re.compile(
+    r'^\s*(У\s*Х\s*В\s*А\s*Л\s*А|Р\s*І\s*Ш\s*Е\s*Н\s*Н\s*Я|П\s*О\s*С\s*Т\s*А\s*Н\s*О\s*В\s*А|В\s*И\s*Р\s*О\s*К|УХВАЛА|РІШЕННЯ|ПОСТАНОВА|ВИРОК)',
+    re.IGNORECASE)
+
+
+def clean_text(text):
+    lines = text.split('\n')
+    cleaned_lines = []
+    header_zone = True
+    for line in lines:
+        stripped = line.strip()
+        if header_zone:
+            if not stripped:
+                continue
+            if DOC_START.search(stripped):
+                header_zone = False
+                cleaned_lines.append(stripped)
+                continue
+            is_header = False
+            for pattern in HEADER_PATTERNS:
+                if pattern.search(stripped):
+                    is_header = True
+                    break
+            if is_header:
+                continue
+            if len(stripped) < 20 and not re.search(r'(?:суд|справ|№)', stripped, re.IGNORECASE):
+                continue
+            cleaned_lines.append(stripped)
+        else:
+            cleaned_lines.append(stripped)
+    result = '\n'.join(cleaned_lines)
+    result = re.sub(r'\n{3,}', '\n\n', result)
+    result = re.sub(r'[ \t]{3,}', '  ', result)
+    for pattern in HEADER_PATTERNS[1:4]:
+        result = pattern.sub('', result)
+    return result.strip()
+
+
+def stage1(src_path_str):
+    src_path = Path(src_path_str)
+    tmp_path = TMP_DIR / src_path.name
+    meta_path = TMP_DIR / (src_path.name + '.meta.pkl')
+    t0 = time.time()
+    count = 0
+    saved_chars = 0
+    meta = []  # (doc_id, md5_hexdigest_bytes)
+    dec = subprocess.Popen(['zstd', '-dc', str(src_path)], stdout=subprocess.PIPE)
+    tmp_fh = open(tmp_path, 'wb')
+    enc = subprocess.Popen(['zstd', '-c', '-q', '-T4'], stdin=subprocess.PIPE, stdout=tmp_fh)
+    for line in dec.stdout:
+        doc = json.loads(line)
+        original = doc.get('text') or ''
+        cleaned = clean_text(original)
+        saved_chars += len(original) - len(cleaned)
+        doc['text'] = cleaned
+        out = json.dumps(doc, ensure_ascii=False)
+        enc.stdin.write(out.encode('utf-8'))
+        enc.stdin.write(b'\n')
+        meta.append((doc['doc_id'], hashlib.md5(cleaned.encode('utf-8')).digest()))
+        count += 1
+    dec.stdout.close()
+    enc.stdin.close()
+    if dec.wait() != 0 or enc.wait() != 0:
+        raise RuntimeError(f'zstd failed for {src_path}')
+    tmp_fh.close()
+    with open(meta_path, 'wb') as f:
+        pickle.dump(meta, f, protocol=4)
+    elapsed = time.time() - t0
+    print(f'  [stage1] {src_path.name}: {count} docs, saved {saved_chars/1e6:.0f} MB chars, {elapsed:.0f}s', flush=True)
+    return (src_path.name, count)
+
+
+def stage2(args):
+    name, drop_indexes = args
+    tmp_path = TMP_DIR / name
+    out_path = OUT_DIR / name
+    if not drop_indexes:
+        os.rename(tmp_path, out_path)
+        return (name, 0)
+    drops = set(drop_indexes)
+    dec = subprocess.Popen(['zstd', '-dc', str(tmp_path)], stdout=subprocess.PIPE)
+    out_fh = open(out_path, 'wb')
+    enc = subprocess.Popen(['zstd', '-c', '-q', '-T4'], stdin=subprocess.PIPE, stdout=out_fh)
+    for i, line in enumerate(dec.stdout):
+        if i in drops:
+            continue
+        enc.stdin.write(line)
+    dec.stdout.close()
+    enc.stdin.close()
+    if dec.wait() != 0 or enc.wait() != 0:
+        raise RuntimeError(f'zstd failed for {name}')
+    out_fh.close()
+    os.remove(tmp_path)
+    print(f'  [stage2] {name}: dropped {len(drops)} dups', flush=True)
+    return (name, len(drops))
+
+
+def file_sort_key(p):
+    # chronological order: pre2005 first, then years ascending
+    stem = p.stem.replace('.jsonl', '')
+    year = stem.split('_')[1]
+    return -1 if year == 'pre2005' else int(year)
+
+
+def main():
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    files = sorted(SRC_DIR.glob('*.jsonl.zst'), key=file_sort_key)
+    print(f'Stage 1: cleaning {len(files)} files...', flush=True)
+    t0 = time.time()
+    with Pool(len(files)) as pool:
+        pool.map(stage1, [str(f) for f in files])
+    print(f'Stage 1 done in {time.time()-t0:.0f}s', flush=True)
+
+    print('Building global dedup map...', flush=True)
+    seen_ids = set()
+    seen_md5 = set()
+    drop_by_file = {}
+    total = 0
+    dup_id = 0
+    dup_text = 0
+    for f in files:
+        meta_path = TMP_DIR / (f.name + '.meta.pkl')
+        with open(meta_path, 'rb') as fh:
+            meta = pickle.load(fh)
+        drops = []
+        for i, (doc_id, md5) in enumerate(meta):
+            total += 1
+            if doc_id in seen_ids:
+                dup_id += 1
+                drops.append(i)
+                continue
+            if md5 in seen_md5:
+                dup_text += 1
+                drops.append(i)
+                continue
+            seen_ids.add(doc_id)
+            seen_md5.add(md5)
+        drop_by_file[f.name] = drops
+        if drops:
+            print(f'  {f.name}: {len(drops)} dups', flush=True)
+    print(f'Total: {total} docs, dup doc_id: {dup_id}, dup text: {dup_text}, unique: {total - dup_id - dup_text}', flush=True)
+
+    print('Stage 2: writing final files...', flush=True)
+    t0 = time.time()
+    with Pool(len(files)) as pool:
+        pool.map(stage2, [(f.name, drop_by_file[f.name]) for f in files])
+    print(f'Stage 2 done in {time.time()-t0:.0f}s', flush=True)
+
+    for f in files:
+        meta_path = TMP_DIR / (f.name + '.meta.pkl')
+        if meta_path.exists():
+            os.remove(meta_path)
+    try:
+        TMP_DIR.rmdir()
+    except OSError:
+        pass
+    print('DONE', flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/embed_ort_trt_32w.py
+++ b/scripts/edrsr/bge-m3-vectorize/embed_ort_trt_32w.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Embed EDRSR docs using ORT+TensorRT FP16 on multi-GPU.
+One process per GPU, each reads its own JSONL shard.
+Runs inside NGC TensorRT container.
+"""
+import argparse
+import json
+import logging
+import os
+import time
+import uuid
+import numpy as np
+from multiprocessing import Process, Value
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [W%(message)s")
+log = logging.getLogger(__name__)
+
+COLLECTION = "edrsr_decisions"
+MAX_CHUNK_CHARS = 2048
+QDRANT_BATCH = 400  # 5000 exceeded qdrant 32MB max_request_size -> 400 on every full batch
+
+
+def chunk_text(text, max_chars=MAX_CHUNK_CHARS):
+    if len(text) <= max_chars:
+        return [text]
+    chunks = []
+    start = 0
+    while start < len(text):
+        end = min(start + max_chars, len(text))
+        if end < len(text):
+            space_idx = text.rfind(" ", start + max_chars // 2, end)
+            if space_idx > 0:
+                end = space_idx
+        chunks.append(text[start:end])
+        start = end
+        if len(text) - start < 100:
+            break
+    return chunks
+
+
+def mean_pooling(hidden_state, attention_mask):
+    mask_expanded = np.expand_dims(attention_mask, axis=-1).astype(np.float32)
+    sum_embeddings = np.sum(hidden_state * mask_expanded, axis=1)
+    sum_mask = np.clip(np.sum(mask_expanded, axis=1), a_min=1e-9, a_max=None)
+    return sum_embeddings / sum_mask
+
+
+def normalize(embeddings):
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    return embeddings / np.clip(norms, a_min=1e-9, a_max=None)
+
+
+def worker(gpu_id, jsonl_file, justice_kind, qdrant_url, qdrant_api_key,
+           onnx_path, batch_size, progress, total_docs):
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id % 8)
+
+    import onnxruntime as ort
+    from transformers import AutoTokenizer
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import PointStruct
+
+    prefix = f"{gpu_id}] "
+
+    log.info(f"{prefix}Loading tokenizer...")
+    tokenizer = AutoTokenizer.from_pretrained("BAAI/bge-m3", cache_dir="/data/hf_cache")
+
+    log.info(f"{prefix}Creating ORT+TRT session on GPU {gpu_id}...")
+    trt_cache = f"/data/trt_cache_gpu{gpu_id}"
+    os.makedirs(trt_cache, exist_ok=True)
+
+    providers = [
+        ("TensorrtExecutionProvider", {
+            "device_id": 0,
+            "trt_fp16_enable": True,
+            "trt_engine_cache_enable": True,
+            "trt_engine_cache_path": trt_cache,
+        }),
+        ("CUDAExecutionProvider", {"device_id": 0}),
+    ]
+    sess = ort.InferenceSession(onnx_path, providers=providers)
+    active = sess.get_providers()
+    log.info(f"{prefix}Active providers: {active}")
+
+    qdrant = QdrantClient(url=qdrant_url, api_key=qdrant_api_key or None, timeout=300)
+
+    processed = 0
+    total_chunks = 0
+    doc_buffer = []
+    pending_points = []
+    t0 = time.time()
+
+    def embed_and_queue():
+        nonlocal total_chunks
+        if not doc_buffer:
+            return
+
+        all_chunks = []
+        chunk_payloads = []
+        for doc in doc_buffer:
+            text = doc["text"][:15000]
+            chunks = chunk_text(text)
+            for ci, chunk in enumerate(chunks):
+                all_chunks.append(chunk)
+                chunk_payloads.append({
+                    "edrsr_doc_id": doc["doc_id"],
+                    "court_code": doc.get("court_code", 0),
+                    "judge": doc.get("judge", ""),
+                    "cause_num": doc.get("cause_num", ""),
+                    "justice_kind": justice_kind,
+                    "adjudication_date": doc.get("adjudication_date", ""),
+                    "judgment_code": doc.get("judgment_code", 0),
+                    "category_code": doc.get("category_code", 0),
+                    "chunk_index": ci,
+                    "total_chunks": len(chunks),
+                    "text": chunk,
+                    "embedding_model": "bge-m3",
+                })
+
+        encoded = tokenizer(
+            all_chunks, padding=True, truncation=True,
+            max_length=512, return_tensors="np",
+        )
+        input_ids = encoded["input_ids"].astype(np.int64)
+        attention_mask = encoded["attention_mask"].astype(np.int64)
+
+        # Process in sub-batches for ORT
+        all_embeddings = []
+        for i in range(0, len(all_chunks), batch_size):
+            ids_batch = input_ids[i:i + batch_size]
+            mask_batch = attention_mask[i:i + batch_size]
+            outputs = sess.run(None, {
+                "input_ids": ids_batch,
+                "attention_mask": mask_batch,
+            })
+            hidden = outputs[0]
+            pooled = mean_pooling(hidden, mask_batch)
+            normed = normalize(pooled)
+            all_embeddings.append(normed)
+
+        embeddings = np.concatenate(all_embeddings, axis=0)
+
+        skipped_nonfinite = 0
+        for i, (emb, meta) in enumerate(zip(embeddings, chunk_payloads)):
+            if not np.isfinite(emb).all():
+                skipped_nonfinite += 1
+                with open("/data/kupap-vectorize/quarantine_nonfinite.jsonl", "a") as qf:
+                    qf.write(json.dumps({"doc_id": meta["edrsr_doc_id"], "chunk_index": meta["chunk_index"], "justice_kind": meta["justice_kind"]}) + "\n")
+                continue
+            pending_points.append(PointStruct(
+                id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"edrsr/{meta['justice_kind']}/{meta['edrsr_doc_id']}/{meta['chunk_index']}")),
+                vector=emb.tolist(),
+                payload=meta,
+            ))
+        if skipped_nonfinite:
+            log.warning(f"{prefix}skipped {skipped_nonfinite} non-finite embeddings (quarantined)")
+
+        total_chunks += len(all_chunks)
+        doc_buffer.clear()
+
+    def flush_qdrant():
+        if not pending_points:
+            return
+        for bs in range(0, len(pending_points), QDRANT_BATCH):
+            batch = pending_points[bs:bs + QDRANT_BATCH]
+            for attempt in range(5):
+                try:
+                    qdrant.upsert(collection_name=COLLECTION, points=batch, wait=False)
+                    break
+                except Exception as e:
+                    if attempt == 4:
+                        log.error(f"{prefix}Qdrant failed after 5 attempts: {e}")
+                        try:
+                            with open("/data/kupap-vectorize/failed_upserts.jsonl", "a") as ff:
+                                ids = sorted({p.payload["edrsr_doc_id"] for p in batch})
+                                ff.write(json.dumps({"error": str(e)[:200], "doc_ids": ids}) + "\n")
+                        except Exception:
+                            pass
+                    time.sleep(2 ** attempt)
+        pending_points.clear()
+
+    with open(jsonl_file) as f:
+        for line in f:
+            doc = json.loads(line)
+            if not doc.get("text") or len(doc["text"]) < 50:
+                continue
+            doc_buffer.append(doc)
+            processed += 1
+
+            if len(doc_buffer) >= 200:
+                embed_and_queue()
+                with progress.get_lock():
+                    progress.value += 200
+
+                if len(pending_points) >= 20000:
+                    flush_qdrant()
+
+                if processed % 4000 < 200:
+                    g = progress.value
+                    elapsed = time.time() - t0
+                    speed = g / elapsed if elapsed > 0 else 0
+                    eta = (total_docs - g) / speed if speed > 0 else 0
+                    log.info(f"{prefix}local={processed} global={g}/{total_docs} ({100*g/total_docs:.1f}%) "
+                             f"chunks={total_chunks} speed={speed:.0f} docs/s ETA={eta/3600:.1f}h")
+
+    if doc_buffer:
+        embed_and_queue()
+        with progress.get_lock():
+            progress.value += len(doc_buffer)
+    flush_qdrant()
+
+    log.info(f"{prefix}Done: {processed} docs, {total_chunks} chunks")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", required=True)
+    parser.add_argument("--justice-kind", type=int, required=True)
+    parser.add_argument("--qdrant-url", required=True)
+    parser.add_argument("--qdrant-api-key", default="")
+    parser.add_argument("--onnx-path", default="/data/bge-m3-onnx/model.onnx")
+    parser.add_argument("--num-gpus", type=int, default=8)
+    parser.add_argument("--batch-size", type=int, default=64)
+    args = parser.parse_args()
+
+    jsonl_files = sorted(Path(args.data_dir).glob("*.jsonl"))
+    log.info(f"Found {len(jsonl_files)} JSONL files")
+
+    import subprocess
+    result = subprocess.run(
+        ["wc", "-l"] + [str(f) for f in jsonl_files],
+        capture_output=True, text=True,
+    )
+    counts = []
+    for line in result.stdout.strip().split("\n")[:-1]:
+        counts.append(int(line.strip().split()[0]))
+    total_docs = sum(counts)
+    log.info(f"Total docs: {total_docs} (per file: {counts})")
+
+    progress = Value("i", 0)
+    workers = []
+
+    for i, jf in enumerate(jsonl_files[:args.num_gpus]):
+        p = Process(target=worker, args=(
+            i, str(jf), args.justice_kind, args.qdrant_url, args.qdrant_api_key,
+            args.onnx_path, args.batch_size, progress, total_docs,
+        ))
+        p.start()
+        workers.append(p)
+
+    for p in workers:
+        p.join()
+
+    log.info(f"All done! {progress.value} docs")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/edrsr/bge-m3-vectorize/reshard_filtered.py
+++ b/scripts/edrsr/bge-m3-vectorize/reshard_filtered.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Reshard cleaned KUpAP dataset into N equal plain JSONL shards for embedding.
+
+Filters judgment_code to {2: постанова, 5: ухвала, 6: окрема ухвала}.
+Stage A (parallel per input file): decompress, filter, round-robin lines into
+per-input part files. Stage B (parallel per shard): concatenate parts.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from multiprocessing import Pool
+from pathlib import Path
+
+if len(sys.argv) < 3:
+    sys.exit('usage: reshard_filtered.py <src_dir> <out_dir> [keep_judgment_codes=2,5,6] [num_shards=32]')
+SRC = Path(sys.argv[1])
+OUT = Path(sys.argv[2])
+PARTS = OUT / '.parts'
+KEEP_CODES = set(int(c) for c in (sys.argv[3] if len(sys.argv) > 3 else '2,5,6').split(','))
+NUM_SHARDS = int(sys.argv[4]) if len(sys.argv) > 4 else 32
+
+
+def stage_a(src_str):
+    src = Path(src_str)
+    outs = [open(PARTS / f'{src.name}.part_{i:02d}', 'wb') for i in range(NUM_SHARDS)]
+    dec = subprocess.Popen(['zstd', '-dc', str(src)], stdout=subprocess.PIPE)
+    kept = 0
+    dropped = 0
+    for line in dec.stdout:
+        d = json.loads(line)
+        if d.get('judgment_code') not in KEEP_CODES:
+            dropped += 1
+            continue
+        outs[kept % NUM_SHARDS].write(line)
+        kept += 1
+    dec.stdout.close()
+    if dec.wait() != 0:
+        raise RuntimeError(f'zstd failed: {src}')
+    for f in outs:
+        f.close()
+    print(f'  [A] {src.name}: kept {kept}, dropped {dropped}', flush=True)
+    return kept, dropped
+
+
+def stage_b(shard_idx):
+    out_path = OUT / f'docs_{shard_idx:02d}.jsonl'
+    part_files = sorted(PARTS.glob(f'*.part_{shard_idx:02d}'))
+    n = 0
+    with open(out_path, 'wb') as out:
+        for pf in part_files:
+            with open(pf, 'rb') as f:
+                shutil.copyfileobj(f, out, 1024 * 1024 * 8)
+            os.remove(pf)
+    r = subprocess.run(['wc', '-l', str(out_path)], capture_output=True, text=True)
+    n = int(r.stdout.split()[0])
+    print(f'  [B] docs_{shard_idx:02d}.jsonl: {n} docs, {out_path.stat().st_size/1e9:.2f} GB', flush=True)
+    return n
+
+
+def main():
+    OUT.mkdir(parents=True, exist_ok=True)
+    PARTS.mkdir(exist_ok=True)
+    files = sorted(SRC.glob('*.jsonl.zst'))
+    print(f'Stage A: filtering+splitting {len(files)} files -> {NUM_SHARDS} shards', flush=True)
+    t0 = time.time()
+    with Pool(len(files)) as pool:
+        res = pool.map(stage_a, [str(f) for f in files])
+    kept = sum(r[0] for r in res)
+    dropped = sum(r[1] for r in res)
+    print(f'Stage A done in {time.time()-t0:.0f}s: kept {kept}, dropped {dropped}', flush=True)
+
+    print('Stage B: concatenating parts...', flush=True)
+    t0 = time.time()
+    with Pool(NUM_SHARDS) as pool:
+        counts = pool.map(stage_b, range(NUM_SHARDS))
+    print(f'Stage B done in {time.time()-t0:.0f}s', flush=True)
+    PARTS.rmdir()
+    print(f'Shard totals: min={min(counts)}, max={max(counts)}, sum={sum(counts)}', flush=True)
+    assert sum(counts) == kept, 'shard sum mismatch!'
+    print('DONE', flush=True)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
Archives the dataset-prep pipeline used for the КУпАП (justice_kind=5) BGE-M3 vectorization campaign (2026-06-12) and the in-flight ЦПК re-run, into `scripts/edrsr/bge-m3-vectorize/` alongside the earlier campaign tools (#1917).

- **clean_dedup_yearly.py** - header stripping + global first-occurrence dedup (by doc_id, then by md5 of cleaned text) across per-year .jsonl.zst files. КУпАП: 11.99M → 11.83M docs, 156K exact-text dups removed, ~11 min
- **analyze_dataset.py** - pre-embed quality gate: full-scan stats (empty/short texts, field completeness, residual header noise, length percentiles, chunk estimate)
- **reshard_filtered.py** - judgment_code filter ({2,5,6} for КУпАП) + round-robin into N equal plain-JSONL shards
- **embed_ort_trt_32w.py** - ORT+TensorRT FP16 embedder with **deterministic point IDs** uuid5("edrsr/{jk}/{doc_id}/{chunk_index}") - restarts idempotent, eliminates the random-UUID dup class that required #1916
- **README** - КУпАП campaign results (31.27M chunks, points 1:1, HNSW green) + qdrant-gpu caveats (NVIDIA 580 Vulkan >2-device segfault, optimizer kick after restart)

## Test plan
- [x] Scripts are archived as-used on Brev (battle-tested on 11.8M-doc КУпАП run end-to-end)
- [x] `ast.parse` clean on all four
- [x] Path parametrization via argv verified against original hardcoded behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Archives the per-year dataset-prep and multi-GPU embedding pipeline used for the КУпАП (jk=5) BGE‑M3 campaign, and documents results and GPU caveats. Supports LEXAI‑1724.

- **New Features**
  - `clean_dedup_yearly.py` — header stripping + global first-occurrence dedup across per-year `.jsonl.zst` (by `doc_id`, then md5 of cleaned text).
  - `analyze_dataset.py` — pre-embed full-scan stats (empties/short, field completeness, length percentiles, chunk estimate).
  - `reshard_filtered.py` — filter by `judgment_code` {2,5,6} and round-robin into N equal plain-JSONL shards.
  - `embed_ort_trt_32w.py` — ORT+TensorRT FP16 embedder with deterministic point IDs `uuid5("edrsr/{jk}/{doc_id}/{chunk_index}")`; batched upserts with retries.
  - `README` — КУпАП results (31.27M chunks, 0 failed upserts, HNSW green) and `qdrant-gpu` caveats.

<sup>Written for commit 1ac272c84aef09f037b43baacd0bd2b3b92b72fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

