### PR TITLE
feat(sft): citation-faithfulness eval suite + DPO de-hedge tooling (LEXAI-1735/1736)

### DIFF
--- a/scripts/sft-train/build_dpo_dehedge.py
+++ b/scripts/sft-train/build_dpo_dehedge.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Build DPO preference pairs to remove the compulsive 'джерел недостатньо' hedge (LEXAI-1735).
+
+rejected = the original hedged teacher answer (from sft-distill teacher.jsonl).
+chosen   = a de-hedged rewrite (Haiku): same substance + ALL [doc:ID] citations,
+           but answering directly, no insufficiency preamble.
+
+Only NORMAL (non-refusal) answers whose text hedges are used. Output conversational
+DPO format: {prompt:[sys,user], chosen:[asst], rejected:[asst]} -> train/eval.jsonl.
+Resumable. Runs on Brev (Bedrock Haiku 4.5).
+"""
+import argparse, json, os, re, threading, time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import boto3
+
+REWRITE_MODEL = os.environ.get("REWRITE_MODEL", "eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+SYSTEM_PROMPT = (
+    "Ти — український юридичний асистент. Відповідай ВИКЛЮЧНО на основі наданих витягів "
+    "із судових рішень ЄДРСР. Кожне фактичне твердження підкріплюй посиланням [doc:ID]. "
+    "Якщо у наданих джерелах немає достатньої підстави — прямо напиши про це. Пиши українською."
+)
+REWRITE_SYS = (
+    "Перепиши юридичну відповідь так, щоб вона відповідала ПРЯМО ПО СУТІ, впевнено, "
+    "без вступних фраз про недостатність/відсутність джерел. ЗБЕРЕЖИ всю суть і ВСІ "
+    "посилання [doc:ID] без змін. Не додавай нічого нового. Поверни лише переписану відповідь."
+)
+HEDGE = re.compile(r"недостатньо|відсутн|на жаль|не можу надати|жодне з.*джерел", re.I)
+
+_lock = threading.Lock()
+_bd = None
+def bd():
+    global _bd
+    with _lock:
+        if _bd is None:
+            _bd = boto3.client("bedrock-runtime", region_name="eu-central-1")
+        return _bd
+
+def invoke(system, user, max_tokens=1500, retries=6):
+    body = {"anthropic_version": "bedrock-2023-05-31", "max_tokens": max_tokens,
+            "temperature": 0.3, "system": system,
+            "messages": [{"role": "user", "content": [{"type": "text", "text": user}]}]}
+    delay = 2.0
+    for a in range(retries):
+        try:
+            r = bd().invoke_model(modelId=REWRITE_MODEL, body=json.dumps(body))
+            return "".join(b.get("text", "") for b in json.loads(r["body"].read())["content"]).strip()
+        except Exception as e:
+            if a == retries - 1:
+                raise
+            time.sleep(delay); delay = min(delay * 2, 30)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--teacher", default="/data/sft-distill/run_30k/teacher.jsonl")
+    p.add_argument("--out-dir", default="/data/cpt-pipeline/13_dpo_dehedge")
+    p.add_argument("--limit", type=int, default=4000)
+    p.add_argument("--workers", type=int, default=24)
+    p.add_argument("--eval-frac", type=float, default=0.03)
+    args = p.parse_args()
+    os.makedirs(args.out_dir, exist_ok=True)
+    pairs_path = os.path.join(args.out_dir, "pairs.jsonl")
+
+    done = set()
+    if os.path.exists(pairs_path):
+        for l in open(pairs_path):
+            try: done.add(json.loads(l)["id"])
+            except Exception: pass
+
+    rows = []
+    for l in open(args.teacher):
+        r = json.loads(l)
+        if r.get("is_refusal") or r["id"] in done:
+            continue
+        ans = r.get("answer", "")
+        # only hedged normal answers that DO carry citations (so chosen keeps them)
+        if HEDGE.search(ans[:300]) and "[doc:" in ans:
+            rows.append(r)
+        if len(rows) >= args.limit:
+            break
+    print(f"hedged-with-citation candidates: {len(rows)} (workers={args.workers})", flush=True)
+
+    fh = open(pairs_path, "a")
+    wlock = threading.Lock()
+
+    def work(r):
+        chosen = invoke(REWRITE_SYS, r["answer"], max_tokens=1600)
+        if len(chosen) < 40 or "[doc:" not in chosen:
+            return  # rewrite failed to keep citations -> skip
+        user = (f"Питання: {r['query']}\n\nДжерела (витяги з рішень ЄДРСР):\n{r['context']}\n\n"
+                "Дай обґрунтовану відповідь українською з посиланнями [doc:ID].")
+        rec = {"id": r["id"],
+               "prompt": [{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": user}],
+               "chosen": [{"role": "assistant", "content": chosen}],
+               "rejected": [{"role": "assistant", "content": r["answer"]}]}
+        with wlock:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n"); fh.flush()
+
+    n = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futs = [ex.submit(work, r) for r in rows]
+        for f in as_completed(futs):
+            n += 1
+            try: f.result()
+            except Exception as e:
+                if n % 50 == 0: print("err:", str(e)[:80], flush=True)
+            if n % 100 == 0:
+                print(f"{n}/{len(rows)}", flush=True)
+    fh.close()
+
+    # split train/eval
+    allp = [json.loads(l) for l in open(pairs_path)]
+    import random
+    random.Random(42).shuffle(allp)
+    ne = max(1, int(len(allp) * args.eval_frac))
+    with open(os.path.join(args.out_dir, "eval.jsonl"), "w") as f:
+        for r in allp[:ne]: f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    with open(os.path.join(args.out_dir, "train.jsonl"), "w") as f:
+        for r in allp[ne:]: f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    print(f"DONE: {len(allp)} pairs -> train {len(allp)-ne}, eval {ne}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sft-train/eval_dp.sh
+++ b/scripts/sft-train/eval_dp.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Data-parallel citation-faithfulness eval on 8 GPUs: each GPU runs a full copy of
+# the 14B over 1/8 of the examples. Runs base then SFT, merges shard counts.
+set -u
+cd /data/sft-train
+export HF_HOME=/data/hf_cache
+B=/data/cpt-pipeline/09_checkpoints/qwen25-14b/checkpoint-3000/checkpoint-3000/final
+A=/data/cpt-pipeline/12_sft_output_14b/final
+D=/data/sft-distill/run_100k/retrieved.jsonl
+N=${N:-240}
+NG=${NG:-8}
+
+run_dp () {  # $1=label  $2=adapter-args
+  local label="$1"; shift
+  rm -f shard_${label}_*.json
+  for g in $(seq 0 $((NG-1))); do
+    CUDA_VISIBLE_DEVICES=$g python3 eval_sft.py --base-model "$B" "$@" \
+        --eval-data "$D" --n "$N" --label "$label" \
+        --shard-idx "$g" --shard-count "$NG" \
+        --output "shard_${label}_${g}.json" &
+  done
+  wait
+  python3 merge_eval.py "shard_${label}_*.json" "eval_${label}.json"
+}
+
+echo "=== BASE (8-GPU data-parallel) ==="
+run_dp base
+echo "=== SFT (8-GPU data-parallel) ==="
+run_dp sft --adapter "$A"
+echo "=== DONE ==="

--- a/scripts/sft-train/eval_dpo_compare.sh
+++ b/scripts/sft-train/eval_dpo_compare.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Compare SFT (merged) vs SFT+DPO-dehedge on 8 GPUs: citation-faithfulness + hedge rate.
+# The point: did DPO remove the compulsive 'джерел недостатньо' hedge without losing citations?
+set -u
+cd /data/sft-train
+export HF_HOME=/data/hf_cache
+SFTM=/data/cpt-pipeline/12_sft_merged
+DPO=/data/cpt-pipeline/13_dpo_dehedge_output/final
+D=/data/sft-distill/run_100k/retrieved.jsonl
+N=${N:-240}; NG=${NG:-8}
+
+run_dp () {  # $1=label  rest=extra args (e.g. --adapter ...)
+  local label="$1"; shift
+  rm -f shard_${label}_*.json
+  for g in $(seq 0 $((NG-1))); do
+    CUDA_VISIBLE_DEVICES=$g python3 eval_sft.py --base-model "$SFTM" "$@" \
+        --eval-data "$D" --n "$N" --label "$label" \
+        --shard-idx "$g" --shard-count "$NG" --output "shard_${label}_${g}.json" &
+  done
+  wait
+  python3 merge_eval.py "shard_${label}_*.json" "eval_${label}.json"
+}
+
+echo "=== SFT (merged, no DPO) ==="
+run_dp sftm
+echo "=== SFT + DPO de-hedge ==="
+run_dp dpo --adapter "$DPO"
+echo "=== DONE compare ==="

--- a/scripts/sft-train/eval_sft.py
+++ b/scripts/sft-train/eval_sft.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Citation-faithfulness eval for SFT-v1 (LEXAI-1736).
+
+Generates answers with the model (base, or base+LoRA) on held-out (query, context)
+examples and measures whether it cites the RELEVANT sources and ignores the RAFT
+distractors. Run twice (base vs SFT) on the same eval set to measure the SFT lift.
+
+Eval data = a slice of scripts/sft-distill `retrieved.jsonl` (has ground-truth
+relevant/distractor doc_ids per example). Use a run NOT in SFT training (e.g. run_100k)
+for an honest held-out measure.
+
+Usage:
+  python3 eval_sft.py --base-model <ckpt> --eval-data <retrieved.jsonl> --n 200 \
+      [--adapter <lora_dir>] --label base   --output base.json
+"""
+import argparse
+import json
+import random
+import re
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+SYSTEM_PROMPT = (
+    "Ти — український юридичний асистент. Відповідай ВИКЛЮЧНО на основі наданих "
+    "витягів із судових рішень ЄДРСР. Кожне фактичне твердження підкріплюй "
+    "посиланням у форматі [doc:ID], де ID — це edrsr_doc_id відповідного джерела. "
+    "Якщо у наданих джерелах немає достатньої підстави для відповіді — прямо "
+    "напиши, що наданих джерел недостатньо, і не вигадуй. Пиши українською."
+)
+# Softer prompt: drop the hedging instruction, push to answer with citations.
+SOFT_SYSTEM_PROMPT = (
+    "Ти — український юридичний асистент. Відповідай по суті на основі наданих "
+    "витягів із судових рішень ЄДРСР, активно використовуючи релевантні джерела. "
+    "Кожне твердження підкріплюй посиланням [doc:ID] на відповідне джерело. "
+    "Пиши українською."
+)
+# match doc IDs incl. comma-grouped form [doc:A, doc:B, doc:C] that SFT models emit
+CITE = re.compile(r"doc:\s*([0-9]+)")
+REFUSAL_HINT = re.compile(r"недостатньо|відсутн|не можу надати|немає підстав", re.I)
+HEDGE_HINT = re.compile(r"недостатньо|на жаль|відсутн|не можу надати", re.I)
+
+
+def build_prompt(rec):
+    """Same context layout as the distillation teacher saw."""
+    if rec.get("is_refusal"):
+        ctx_rows = list(rec["distractors"])
+    else:
+        ctx_rows = list(rec["relevant"]) + list(rec["distractors"])
+    random.Random(rec["id"]).shuffle(ctx_rows)
+    ctx = "\n\n".join(f"[doc:{r['doc_id']}] {r['text']}" for r in ctx_rows)
+    user = (
+        f"Питання: {rec['query']}\n\n"
+        f"Джерела (витяги з рішень ЄДРСР):\n{ctx}\n\n"
+        "Дай обґрунтовану відповідь українською з посиланнями [doc:ID]."
+    )
+    return user
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-model", required=True)
+    ap.add_argument("--adapter", default=None)
+    ap.add_argument("--eval-data", required=True)
+    ap.add_argument("--n", type=int, default=200, help="TOTAL examples (sharded across processes)")
+    ap.add_argument("--max-new-tokens", type=int, default=512)
+    ap.add_argument("--label", default="model")
+    ap.add_argument("--shard-idx", type=int, default=0)
+    ap.add_argument("--shard-count", type=int, default=1)
+    ap.add_argument("--soft-prompt", action="store_true", help="use the softer (less hedging) system prompt")
+    ap.add_argument("--output", required=True)
+    args = ap.parse_args()
+    sys_prompt = SOFT_SYSTEM_PROMPT if args.soft_prompt else SYSTEM_PROMPT
+
+    tokenizer = AutoTokenizer.from_pretrained(args.base_model, trust_remote_code=True,
+                                              extra_special_tokens={})
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    print(f"[{args.label}] loading base {args.base_model}")
+    model = AutoModelForCausalLM.from_pretrained(
+        args.base_model, torch_dtype=torch.bfloat16, device_map="auto",
+        attn_implementation="sdpa", trust_remote_code=True,
+    )
+    if args.adapter:
+        print(f"[{args.label}] loading adapter {args.adapter}")
+        model = PeftModel.from_pretrained(model, args.adapter)
+    model.eval()
+
+    recs = []
+    with open(args.eval_data) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                recs.append(json.loads(line))
+            if len(recs) >= args.n:
+                break
+    # data-parallel: this process handles every shard_count-th example
+    recs = recs[args.shard_idx::args.shard_count]
+    print(f"[{args.label} shard {args.shard_idx}/{args.shard_count}] {len(recs)} examples", flush=True)
+
+    tot_cit = rel_cit = dis_cit = oth_cit = 0
+    answered = with_cite = 0
+    ref_total = ref_correct = 0
+    norm_total = 0
+    norm_hedge = 0  # normal answers that open with a 'sources insufficient' hedge
+
+    for i, rec in enumerate(recs):
+        user = build_prompt(rec)
+        msgs = [{"role": "system", "content": sys_prompt}, {"role": "user", "content": user}]
+        inputs = tokenizer.apply_chat_template(
+            msgs, add_generation_prompt=True, return_tensors="pt", truncation=True, max_length=3500,
+        ).to(model.device)
+        with torch.no_grad():
+            out = model.generate(inputs, max_new_tokens=args.max_new_tokens, do_sample=False,
+                                 pad_token_id=tokenizer.pad_token_id)
+        ans = tokenizer.decode(out[0, inputs.shape[1]:], skip_special_tokens=True)
+
+        rel = {str(d["doc_id"]) for d in rec.get("relevant", [])}
+        dis = {str(d["doc_id"]) for d in rec.get("distractors", [])}
+        cites = set(CITE.findall(ans))
+
+        if rec.get("is_refusal"):
+            ref_total += 1
+            # correct refusal: signals insufficiency AND doesn't fabricate relevant cites
+            if REFUSAL_HINT.search(ans) and not cites:
+                ref_correct += 1
+        else:
+            norm_total += 1
+            answered += 1
+            if HEDGE_HINT.search(ans[:200]):
+                norm_hedge += 1
+            if cites:
+                with_cite += 1
+            for c in cites:
+                tot_cit += 1
+                if c in rel:
+                    rel_cit += 1
+                elif c in dis:
+                    dis_cit += 1
+                else:
+                    oth_cit += 1
+        if (i + 1) % 25 == 0:
+            print(f"[{args.label}] {i+1}/{len(recs)}")
+
+    # raw counts (mergeable across shards); percentages are convenience for single-shard
+    res = {
+        "label": args.label, "adapter": args.adapter,
+        "shard": [args.shard_idx, args.shard_count], "n": len(recs),
+        "counts": {
+            "tot_cit": tot_cit, "rel_cit": rel_cit, "dis_cit": dis_cit, "oth_cit": oth_cit,
+            "norm_total": norm_total, "with_cite": with_cite, "norm_hedge": norm_hedge,
+            "ref_total": ref_total, "ref_correct": ref_correct,
+        },
+        "pct_relevant": round(100 * rel_cit / tot_cit, 2) if tot_cit else None,
+        "pct_distractor": round(100 * dis_cit / tot_cit, 2) if tot_cit else None,
+        "pct_out_of_context": round(100 * oth_cit / tot_cit, 2) if tot_cit else None,
+    }
+    with open(args.output, "w") as f:
+        json.dump(res, f, ensure_ascii=False, indent=2)
+    print(json.dumps(res, ensure_ascii=False), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/sft-train/eval_soft.sh
+++ b/scripts/sft-train/eval_soft.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Re-eval SFT with the SOFTER system prompt (8-GPU data-parallel) to test whether
+# over-hedging is prompt-driven. Compare eval_sft_soft.json vs eval_sft.json.
+set -u
+cd /data/sft-train
+export HF_HOME=/data/hf_cache
+B=/data/cpt-pipeline/09_checkpoints/qwen25-14b/checkpoint-3000/checkpoint-3000/final
+A=/data/cpt-pipeline/12_sft_output_14b/final
+D=/data/sft-distill/run_100k/retrieved.jsonl
+N=${N:-240}; NG=${NG:-8}
+
+rm -f shard_sftsoft_*.json
+for g in $(seq 0 $((NG-1))); do
+  CUDA_VISIBLE_DEVICES=$g python3 eval_sft.py --base-model "$B" --adapter "$A" \
+      --eval-data "$D" --n "$N" --label sftsoft --soft-prompt \
+      --shard-idx "$g" --shard-count "$NG" --output "shard_sftsoft_${g}.json" &
+done
+wait
+python3 merge_eval.py "shard_sftsoft_*.json" "eval_sft_soft.json"
+echo "=== DONE soft ==="

--- a/scripts/sft-train/gen_inspect.py
+++ b/scripts/sft-train/gen_inspect.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Print full SFT generations on held-out examples to manually assess citation behavior."""
+import json, re, random, sys
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+B = "/data/cpt-pipeline/09_checkpoints/qwen25-14b/checkpoint-3000/checkpoint-3000/final"
+A = "/data/cpt-pipeline/12_sft_output_14b/final"
+SYS = ("Ти — український юридичний асистент. Відповідай ВИКЛЮЧНО на основі наданих витягів із "
+       "судових рішень ЄДРСР. Кожне фактичне твердження підкріплюй посиланням у форматі [doc:ID], "
+       "де ID — це edrsr_doc_id відповідного джерела. Якщо у наданих джерелах немає достатньої "
+       "підстави для відповіді — прямо напиши, що наданих джерел недостатньо, і не вигадуй. Пиши українською.")
+CITE = re.compile(r"doc:\s*([0-9]+)")
+OFFSET = int(sys.argv[1]) if len(sys.argv) > 1 else 100
+K = int(sys.argv[2]) if len(sys.argv) > 2 else 10
+
+tok = AutoTokenizer.from_pretrained(B, trust_remote_code=True, extra_special_tokens={})
+if tok.pad_token is None:
+    tok.pad_token = tok.eos_token
+m = AutoModelForCausalLM.from_pretrained(B, torch_dtype=torch.bfloat16, device_map="auto", trust_remote_code=True)
+m = PeftModel.from_pretrained(m, A); m.eval()
+
+recs = [json.loads(l) for l in open("/data/sft-distill/run_100k/retrieved.jsonl")][OFFSET:OFFSET + K]
+for rec in recs:
+    if rec.get("is_refusal"):
+        rows = list(rec["distractors"])
+    else:
+        rows = list(rec["relevant"]) + list(rec["distractors"])
+    random.Random(rec["id"]).shuffle(rows)
+    ctx = "\n\n".join("[doc:%s] %s" % (r["doc_id"], r["text"][:280]) for r in rows)
+    user = ("Питання: %s\n\nДжерела:\n%s\n\nДай обґрунтовану відповідь з посиланнями [doc:ID]." %
+            (rec["query"], ctx))
+    ids = tok.apply_chat_template([{"role": "system", "content": SYS}, {"role": "user", "content": user}],
+                                  add_generation_prompt=True, return_tensors="pt",
+                                  truncation=True, max_length=3500).to(m.device)
+    out = m.generate(ids, max_new_tokens=512, do_sample=False, pad_token_id=tok.pad_token_id)
+    ans = tok.decode(out[0, ids.shape[1]:], skip_special_tokens=True)
+    rel = {str(d["doc_id"]) for d in rec.get("relevant", [])}
+    dis = {str(d["doc_id"]) for d in rec.get("distractors", [])}
+    cited = CITE.findall(ans)
+    tag = lambda c: "REL" if c in rel else ("DIS" if c in dis else "OOC")
+    print("\n" + "=" * 70)
+    print("REFUSAL-CASE" if rec.get("is_refusal") else "NORMAL", "| Q:", rec["query"][:110])
+    print("cited:", [(c, tag(c)) for c in cited], "| has_cite:", bool(cited))
+    print("ANSWER:\n" + ans[:900])

--- a/scripts/sft-train/merge_eval.py
+++ b/scripts/sft-train/merge_eval.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Merge data-parallel eval shard JSONs (sum raw counts -> final faithfulness %)."""
+import glob
+import json
+import sys
+
+pattern, out = sys.argv[1], sys.argv[2]
+agg = {"tot_cit": 0, "rel_cit": 0, "dis_cit": 0, "oth_cit": 0,
+       "norm_total": 0, "with_cite": 0, "norm_hedge": 0, "ref_total": 0, "ref_correct": 0}
+label = None
+for p in sorted(glob.glob(pattern)):
+    d = json.load(open(p))
+    label = d.get("label")
+    for k in agg:
+        agg[k] += d["counts"][k]
+
+t = agg["tot_cit"] or 1
+res = {
+    "label": label,
+    "normal_examples": agg["norm_total"], "refusal_examples": agg["ref_total"],
+    "total_citations": agg["tot_cit"],
+    "pct_relevant": round(100 * agg["rel_cit"] / t, 2),
+    "pct_distractor": round(100 * agg["dis_cit"] / t, 2),
+    "pct_out_of_context": round(100 * agg["oth_cit"] / t, 2),
+    "pct_normal_with_citation": round(100 * agg["with_cite"] / max(1, agg["norm_total"]), 2),
+    "pct_normal_hedged": round(100 * agg["norm_hedge"] / max(1, agg["norm_total"]), 2),
+    "refusal_correct_pct": round(100 * agg["ref_correct"] / max(1, agg["ref_total"]), 2),
+    "avg_citations_per_answer": round(agg["tot_cit"] / max(1, agg["norm_total"]), 2),
+}
+json.dump(res, open(out, "w"), ensure_ascii=False, indent=2)
+print(json.dumps(res, ensure_ascii=False, indent=2))

--- a/scripts/sft-train/merge_sft.py
+++ b/scripts/sft-train/merge_sft.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Merge the SFT-v1 LoRA adapter into the CPT base -> a standalone model for DPO/serving."""
+import sys
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+BASE = "/data/cpt-pipeline/09_checkpoints/qwen25-14b/checkpoint-3000/checkpoint-3000/final"
+ADAPTER = "/data/cpt-pipeline/12_sft_output_14b/final"
+OUT = sys.argv[1] if len(sys.argv) > 1 else "/data/cpt-pipeline/12_sft_merged"
+
+tok = AutoTokenizer.from_pretrained(BASE, trust_remote_code=True, extra_special_tokens={})
+if tok.pad_token is None:
+    tok.pad_token = tok.eos_token
+print("loading base...", flush=True)
+m = AutoModelForCausalLM.from_pretrained(BASE, torch_dtype=torch.bfloat16, device_map="cuda:0",
+                                         trust_remote_code=True)
+print("applying + merging adapter...", flush=True)
+m = PeftModel.from_pretrained(m, ADAPTER)
+m = m.merge_and_unload()
+print("saving merged ->", OUT, flush=True)
+m.save_pretrained(OUT, safe_serialization=True)
+tok.save_pretrained(OUT)
+print("DONE merge ->", OUT, flush=True)


### PR DESCRIPTION
8-GPU data-parallel citation-faithfulness eval (eval_sft/merge_eval/eval_dp/eval_soft/eval_dpo_compare/gen_inspect) and DPO de-hedge tooling (build_dpo_dehedge: chosen=Haiku de-hedged rewrite / rejected=hedged teacher answer; merge_sft: merge LoRA into base).

Results: SFT-v1 cites relevantly (70%) but over-hedges; DPO cut hedge 3x (18.6->5.7%) and raised citation coverage +15pp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an 8‑GPU citation‑faithfulness eval suite and DPO de‑hedge tooling to reduce the “джерел недостатньо” hedge without losing citations. Addresses LEXAI-1735/1736: DPO cut hedge 3× (18.6%→5.7%) and improved citation coverage by +15pp; SFT‑v1 cites relevantly ~70%.

- **New Features**
  - eval: `eval_sft.py` (citation relevance/distractor/OOC, refusal correctness, hedge rate; base or LoRA; sharded); `merge_eval.py` (merge shard counts); `eval_dp.sh` (base vs SFT, 8‑GPU); `eval_soft.sh` (soft prompt check); `eval_dpo_compare.sh` (SFT merged vs SFT+DPO).
  - DPO de‑hedge: `build_dpo_dehedge.py` builds preference pairs (chosen=de‑hedged rewrite preserving [doc:ID], rejected=hedged teacher); resumable; splits train/eval.
  - Model tooling: `merge_sft.py` merges SFT LoRA into base for serving/DPO; `gen_inspect.py` prints full generations for manual review.

<sup>Written for commit bad872fff0ec6f568a70655569069a7ea4ca9b42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

