### PR TITLE
feat(edrsr): configurable EDRSR collection + binary-quant rescore (cutover to unified serving)

### DIFF
--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -18,7 +18,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 const EMBEDDING_DIM = 1024;
 const EMBEDDING_MODEL = 'bge-m3';
-const COLLECTION_NAME = 'edrsr_decisions';
+const COLLECTION_NAME = process.env.QDRANT_EDRSR_COLLECTION || 'edrsr_decisions';
 const EMBED_BATCH_SIZE = 64; // TEI supports larger batches than VoyageAI
 const QDRANT_UPSERT_BATCH = 100; // Qdrant upsert sub-batch
 const DEFAULT_CONCURRENCY = 5;
@@ -346,6 +346,9 @@ export class EdsrVectorizerService {
         limit,
         filter: qdrantFilter,
         with_payload: true,
+        // Binary-quantized serving collection: rescore against full vectors with
+        // oversampling for recall (no-op on non-quantized collections).
+        params: { quantization: { rescore: true, oversampling: 2.0 } },
       });
 
       return searchResult.map((r) => ({


### PR DESCRIPTION
Cutover prep for the unified EDRSR serving collection (`edrsr_serving`, 296.56M, on_disk + binary quant, all payload indexes) on the dedicated qdrant EC2.

## Changes
- `QDRANT_EDRSR_COLLECTION` env override for the EDRSR Qdrant collection name (default `edrsr_decisions`). Prod sets it to `edrsr_serving`.
- Add `rescore: true, oversampling: 2.0` search params for binary-quant recall (no-op on non-quantized collections).

## Deploy
After merge: update prod `.env.prod` (QDRANT_EDRSR_URL → EC2 qdrant, QDRANT_EDRSR_COLLECTION=edrsr_serving) → CI/CD recreates backend. Rollback = revert env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut over EDRSR to the unified serving collection by making the Qdrant collection configurable and enabling binary-quant rescore. This improves recall on quantized indexes and lets prod point to `edrsr_serving` on the dedicated Qdrant EC2.

- **New Features**
  - Make EDRSR Qdrant collection name configurable via `QDRANT_EDRSR_COLLECTION` (default `edrsr_decisions`).
  - Add search params `quantization: { rescore: true, oversampling: 2.0 }` (no-op on non-quantized collections).

- **Migration**
  - Update prod env: set `QDRANT_EDRSR_URL` to the EC2 Qdrant and `QDRANT_EDRSR_COLLECTION=edrsr_serving`.
  - Redeploy via CI/CD. Roll back by reverting these env vars.

<sup>Written for commit bc85c41bcbdb4b1165c4c416640209f45ef5992f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

