### PR TITLE
feat(edrsr): enable semantic search on unified serving collection

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-semantic-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-semantic-tools.ts
@@ -222,23 +222,26 @@ export class EdsrSemanticTools extends BaseToolHandler {
   private async searchSemantic(args: any): Promise<ToolResult> {
     if (!args.query) return this.wrapError('query є обов\'язковим параметром');
 
-    // TEMP: Redirect to FTS while Qdrant DB is being populated
-    logger.info('[EdsrSemanticTools] Semantic search temporarily redirected to FTS (Qdrant populating)');
-    const ftsResult = await this.searchFulltext({
-      ...args,
-      limit: args.limit || 10,
-    });
-
-    // Add notice about redirect
-    if (ftsResult.content?.[0]?.text) {
-      try {
-        const parsed = JSON.parse(ftsResult.content[0].text);
-        parsed._notice = 'Семантичний пошук тимчасово недоступний (база Qdrant наповнюється). Результати отримано через FTS.';
-        ftsResult.content[0].text = JSON.stringify(parsed);
-      } catch { /* keep original */ }
+    try {
+      const results = await this.vectorizer.semanticSearch(
+        args.query,
+        {
+          court_code: args.court_code,
+          justice_kind: args.justice_kind,
+          judge: args.judge,
+          date_from: args.date_from,
+          date_to: args.date_to,
+        },
+        args.limit || 10,
+      );
+      // Flatten metadata to top level so enrichResults can resolve court/justice/judgment names
+      const flat = results.map((r) => ({ ...r, ...r.metadata }));
+      const enriched = await this.enrichResults(flat);
+      return this.wrapResponse({ query: args.query, total: enriched.length, results: enriched });
+    } catch (err: any) {
+      logger.error('[EdsrSemanticTools] searchSemantic failed', { error: err?.message });
+      return this.wrapError(`Семантичний пошук не вдався: ${err?.message || err}`);
     }
-
-    return ftsResult;
   }
 
   private async vectorizeResults(args: any): Promise<ToolResult> {


### PR DESCRIPTION
The unified edrsr_serving collection (296.56M, BGE-M3, on_disk+binary, all payload indexes) is live on the dedicated qdrant EC2. Remove the TEMP FTS-redirect in searchSemantic and route through EdsrVectorizerService again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables semantic search for EDRSR by routing `searchSemantic` to the unified `edrsr_serving` collection in Qdrant and removing the temporary FTS redirect. Users now get vector-based results with proper enrichment.

- **New Features**
  - Calls `EdsrVectorizerService.semanticSearch` with filters (`court_code`, `justice_kind`, `judge`, `date_from`, `date_to`) and `limit` defaulting to 10.
  - Flattens result metadata before enrichment to resolve court/justice/judgment names.
  - Adds error logging and a user-facing failure message.

<sup>Written for commit 17066c5451987f40469ff8e5bd16282126070ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

