### PR TITLE
feat(edrsr): semantic search for all 5 codices (unified collection)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -405,7 +405,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
   // ── Semantic search (Qdrant vectors) ─────────────────────────────
 
-  private static readonly VECTORIZED_JUSTICE_KINDS = new Set([3, 5]); // ГПК, КупАП
+  private static readonly VECTORIZED_JUSTICE_KINDS = new Set([1, 2, 3, 4, 5]); // ЦПК, КПК, ГПК, КАС, КУпАП (unified edrsr_serving 296.56M)
 
   private async searchSemantic(args: any): Promise<ToolResult> {
     if (!args.query) return this.wrapError('query є обов\'язковим для режиму semantic');


### PR DESCRIPTION
edrsr_serving now has all jk 1-5 (296.56M). Expand VECTORIZED_JUSTICE_KINDS {3,5}→{1,2,3,4,5} so mode=semantic uses vectors for every codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable semantic search for all five codices in the unified `edrsr_serving` collection. `search_court_decisions` mode=semantic now uses Qdrant vectors for every codex, removing FTS fallback.

- **New Features**
  - Expanded `VECTORIZED_JUSTICE_KINDS` from {3,5} to {1,2,3,4,5} (ЦПК, КПК, ГПК, КАС, КУпАП).

<sup>Written for commit 29d348cc44148415bcc96a608f362f58b430b277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

