### PR TITLE
perf(edrsr): cache QueryReformulator (app-side latency)

### DIFF
--- a/mcp_backend/src/services/query-reformulator.ts
+++ b/mcp_backend/src/services/query-reformulator.ts
@@ -20,6 +20,8 @@ const REFORMULATION_PROMPT = `Ти — експерт з українськог�
 {"semantic": "...", "fts": "...", "expanded": "..." або null}`;
 
 const MIN_QUERY_LENGTH = 10;
+const REFORMULATION_CACHE_MAX = 5_000;
+const REFORMULATION_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 
 export interface ReformulatedQueries {
   original: string;
@@ -29,6 +31,10 @@ export interface ReformulatedQueries {
 }
 
 export class QueryReformulator {
+  // In-process TTL cache — legal queries repeat; a hit skips the ~2s LLM round-trip
+  // on the search critical path. Per-process is sufficient (prod runs one backend).
+  private readonly cache = new Map<string, { result: ReformulatedQueries; expires: number }>();
+
   constructor(private readonly llm: ILLMPort) {}
 
   async reformulate(query: string): Promise<ReformulatedQueries> {
@@ -36,6 +42,12 @@ export class QueryReformulator {
 
     if (trimmed.length < MIN_QUERY_LENGTH) {
       return { original: trimmed, semantic: trimmed, fts: trimmed, expanded: null };
+    }
+
+    const cacheKey = trimmed.toLowerCase().replace(/\s+/g, ' ');
+    const cached = this.cache.get(cacheKey);
+    if (cached && cached.expires > Date.now()) {
+      return cached.result;
     }
 
     try {
@@ -75,10 +87,20 @@ export class QueryReformulator {
         fts: result.fts.slice(0, 80),
       });
 
+      this.storeInCache(cacheKey, result);
       return result;
     } catch (err: any) {
       logger.warn('[QueryReformulator] Reformulation failed, using original', { error: err.message });
       return { original: trimmed, semantic: trimmed, fts: trimmed, expanded: null };
     }
+  }
+
+  private storeInCache(key: string, result: ReformulatedQueries): void {
+    // FIFO eviction when full (Map preserves insertion order).
+    if (this.cache.size >= REFORMULATION_CACHE_MAX) {
+      const oldest = this.cache.keys().next().value;
+      if (oldest !== undefined) this.cache.delete(oldest);
+    }
+    this.cache.set(key, { result, expires: Date.now() + REFORMULATION_CACHE_TTL_MS });
   }
 }


### PR DESCRIPTION
After Tier 1 (graph-pin + 256G) qdrant search dropped to 237-900ms, but prod e2e stays ~7s due to the per-query LLM QueryReformulator (~2s, critical path, no cache). Add an in-process TTL cache (normalized query key, 24h, FIFO cap 5000) so repeated legal queries skip the LLM. Transparent, no API/Redis changes. Tracks LEXAI-1743.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an in-process TTL cache to `QueryReformulator` so repeated queries skip the ~2s LLM step, reducing end-to-end search latency. Normalized key, 24h TTL, 5,000-item FIFO cap; no API or Redis changes (LEXAI-1743).

<sup>Written for commit 5995f25e9aa3eaa3ce0011e3da4839014f3a0950. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

