### PR TITLE
fix(edrsr): chat uses HNSW for all codices (description + no-jk semantic)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -94,8 +94,8 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 4 режими пошуку:
 • **structured** — за метаданими: номер справи, суддя, суд, дата, категорія, військові пресети. Найшвидший, коли відомі точні параметри.
 • **fulltext** — повнотекстовий пошук (PostgreSQL tsvector) з підсвіченими фрагментами. Для пошуку за ключовими словами та юридичними термінами.
-• **hybrid** — FTS + семантичний пошук (Qdrant BGE-M3) з мерджем через Reciprocal Rank Fusion. Найкращий recall, коли запит містить і семантику, і точні токени. Семантична нога працює для ГПК (3) та КупАП (5).
-• **semantic** — чистий семантичний пошук по векторній базі Qdrant. Доступний для ГПК (justice_kind=3) та КУпАП (justice_kind=5), для решти — fallback на fulltext.
+• **hybrid** — FTS + семантичний пошук (Qdrant BGE-M3) з мерджем через Reciprocal Rank Fusion. Найкращий recall, коли запит містить і семантику, і точні токени. Семантична нога працює для ВСІХ видів судочинства (justice_kind 1-5).
+• **semantic** — чистий семантичний пошук по векторній базі Qdrant (296M чанків, увесь ЄДРСР). Працює для ВСІХ видів судочинства (justice_kind 1-5); justice_kind не обов'язковий (без нього шукає по всіх кодексах). Найкраще для концептуальних/розмовних запитів.
 
 Фільтри (спільні для всіх режимів): court_code/court_name, judge, justice_kind, judgment_code, category_code, date_from/date_to.
 Пресети: military_preset (військові справи), kupap_preset (адмінправопорушення — traffic_dui, traffic_accident, domestic_violence, hooliganism тощо).
@@ -373,7 +373,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     const justiceKind = args.justice_kind ? Number(args.justice_kind) : undefined;
     const hasVectors = justiceKind
       ? EdsrUnifiedSearchTool.VECTORIZED_JUSTICE_KINDS.has(justiceKind)
-      : false;
+      : true; // no justice_kind filter → search the whole unified collection (all codices vectorized)
 
     const vectorPromise = (this.vectorizer && hasVectors)
       ? this.vectorizer.semanticSearch(semanticQuery, filters as unknown as EdrsrSearchFilters, candidateLimit)
@@ -413,7 +413,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     const justiceKind = args.justice_kind ? Number(args.justice_kind) : undefined;
     const hasVectors = justiceKind
       ? EdsrUnifiedSearchTool.VECTORIZED_JUSTICE_KINDS.has(justiceKind)
-      : false;
+      : true; // no justice_kind filter → search the whole unified collection (all codices vectorized)
 
     if (!this.vectorizer || !hasVectors) {
       logger.info('[EdsrUnifiedSearch] Semantic fallback to FTS', { justice_kind: justiceKind, vectorizer: !!this.vectorizer });
@@ -422,9 +422,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
         try {
           const parsed = JSON.parse(result.content[0].text);
           parsed.mode = 'semantic (fallback to fulltext)';
-          parsed._notice = justiceKind
-            ? `Семантичний пошук для justice_kind=${justiceKind} ще недоступний. Результати через FTS. Доступні: КУпАП (5).`
-            : 'Вкажіть justice_kind для семантичного пошуку. Доступні: КУпАП (justice_kind=5).';
+          parsed._notice = 'Семантичний пошук тимчасово недоступний (векторний сервіс), результати через FTS.';
           result.content[0].text = JSON.stringify(parsed, null, 2);
         } catch { /* keep original */ }
       }


### PR DESCRIPTION
After PR #1927 expanded VECTORIZED_JUSTICE_KINDS to {1..5}, the tool DESCRIPTION still told the chat LLM semantic/hybrid only work for ГПК(3)+КУпАП(5) → chat avoided the vector path for civil/criminal/admin → HNSW unused for most chat queries. Fix: update description (all jk 1-5, 296M) + allow semantic without justice_kind (search whole collection) + refresh stale fallback notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat use HNSW semantic/hybrid for all justice kinds (1–5), including when justice_kind is omitted. Updates the tool description and fallback message so chat takes the vector path by default.

- **Bug Fixes**
  - Updated mode descriptions: hybrid/semantic now support all justice_kinds 1–5; semantic notes 296M chunks and optional justice_kind (searches all codices when missing).
  - Enabled collection-wide semantic search when justice_kind is not provided (treats vectors as available).
  - Replaced stale fallback text with a generic “vector service unavailable” notice.

<sup>Written for commit f9afd457bc6074f980bfe207f6639e9f3572c9a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

