### PR TITLE
fix(edrsr): find_similar_fact_pattern_cases uses HNSW semantic search

### DIFF
--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -16,6 +16,7 @@ import { EdsrLocalAdapter } from '../../adapters/edrsr-local-adapter.js';
 import type { IEmbeddingPort, ILLMPort } from '../../domain/ports/index.js';
 import { LegalPatternStore } from '../../services/legal-pattern-store.js';
 import { EdsrFtsService, EdsrFtsFilters } from '../../services/edrsr-fts-service.js';
+import { EdsrVectorizerService, EdrsrSearchFilters } from '../../services/edrsr-vectorizer-service.js';
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { extractSearchTermsWithAI } from '../../utils/html-parser.js';
@@ -78,6 +79,7 @@ export class ProceduralTools extends BaseToolHandler {
     private readonly llm?: ILLMPort,
     private readonly ftsService?: EdsrFtsService,
     private readonly db?: any,
+    private readonly edsrVectorizer?: EdsrVectorizerService,
   ) {
     super();
   }
@@ -147,9 +149,10 @@ export class ProceduralTools extends BaseToolHandler {
         annotations: { title: 'Схожі за фактами справи', readOnlyHint: true },
         description: `Пошук судових справ зі схожими фактичними обставинами
 
-Витягує ключові терміни з опису фактів та шукає справи з аналогічними обставинами.
-Використовуйте для пошуку релевантної практики, коли є опис ситуації клієнта.
-Повертає: список справ з релевантністю та ключовими фрагментами.`,
+Семантичний (векторний) пошук по реєстру судових рішень: знаходить справи з аналогічною
+фабулою за змістом, а не лише за точним збігом слів. Використовуйте для пошуку релевантної
+практики, коли є опис ситуації клієнта.
+Повертає: список справ з релевантністю (score) та ключовими фрагментами.`,
         inputSchema: {
           type: 'object',
           properties: {
@@ -491,8 +494,46 @@ export class ProceduralTools extends BaseToolHandler {
 
     let results: any[] = [];
     let courtLevel = '';
+    let searchMethod = '';
 
-    if (this.ftsService && this.db) {
+    // Primary path: HNSW semantic search over the unified edrsr_serving collection
+    // (BGE-M3 vectors, 296M chunks). Semantic similarity is the natural fit for
+    // "find cases with a similar fact pattern", and HNSW is fast (~300ms warm) —
+    // unlike the multi-instance FTS loop below, which scans the full-text index 3×
+    // and routinely blew the 60s tool timeout on practice_analysis queries.
+    if (this.edsrVectorizer) {
+      try {
+        const semFilters: EdrsrSearchFilters = {
+          ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
+          ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
+          ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
+        };
+        // Over-fetch chunks, then dedupe to distinct cases (a case may match on
+        // several chunks; we want the top distinct decisions).
+        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, limit * 4);
+        const seen = new Set<number>();
+        for (const h of hits) {
+          if (seen.has(h.doc_id)) continue;
+          seen.add(h.doc_id);
+          results.push({
+            doc_id: h.doc_id,
+            court_code: h.metadata.court_code,
+            date: h.metadata.adjudication_date,
+            case_number: h.metadata.cause_num,
+            snippet: (h.text || '').slice(0, 600) + ((h.text || '').length > 600 ? '…' : ''),
+            score: typeof h.score === 'number' ? Number(h.score.toFixed(4)) : undefined,
+          });
+          if (results.length >= limit) break;
+        }
+        if (results.length > 0) searchMethod = 'semantic_hnsw';
+      } catch (err: any) {
+        logger.warn('[findSimilarFactPatternCases] semantic HNSW search failed, falling back to FTS', { error: err.message });
+      }
+    }
+
+    // Fallback: multi-instance FTS (when the vectorizer is unavailable or returns
+    // nothing — e.g. very rare terminology not well represented in embeddings).
+    if (results.length === 0 && this.ftsService && this.db) {
       const baseFilters: EdsrFtsFilters = {
         ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
         ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
@@ -516,6 +557,7 @@ export class ProceduralTools extends BaseToolHandler {
             case_number: d.cause_num,
             snippet: d.headline,
           }));
+          searchMethod = 'fts';
           break;
         }
       }
@@ -525,13 +567,14 @@ export class ProceduralTools extends BaseToolHandler {
       procedure_code: procedureCode,
       time_range: args.time_range,
       court_level: courtLevel || undefined,
+      search_method: searchMethod || undefined,
       extracted_search_terms: extractedTerms,
       search_query: query,
       results,
     };
     if (timeRangeParsed.warning) payload.time_range_warning = timeRangeParsed.warning;
     if (results.length === 0) {
-      payload.hint = 'Результатів не знайдено. Повторний виклик з іншим формулюванням навряд чи дасть результат — FTS шукає точний збіг усіх слів. Спробуйте search_edrsr_fulltext з коротшим запитом (2-3 слова) або compare_practice_pro_contra.';
+      payload.hint = 'Результатів не знайдено. Спробуйте переформулювати фабулу ширше або скористайтесь search_edrsr_fulltext з коротшим запитом (2-3 слова) чи compare_practice_pro_contra.';
     }
 
     return this.wrapResponse(payload);

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -117,6 +117,20 @@ export function createToolServices(
     coreServices.patternStore,
     coreServices.db
   ));
+  // EDRSR vectorizer (BGE-M3 + qdrant edrsr_serving HNSW) — shared by ProceduralTools
+  // (find_similar_fact_pattern_cases) and EdsrUnifiedSearchTool below.
+  let edsrVectorizer: EdsrVectorizerService | undefined;
+  try {
+    edsrVectorizer = new EdsrVectorizerService();
+    edsrVectorizer.setUsageCallback((tokens, model, task) => {
+      costTracker.recordVoyageCall({ model, totalTokens: tokens, task }).catch((err) => {
+        logger.warn('Failed to record embedding cost', { error: err.message });
+      });
+    });
+  } catch (err: any) {
+    logger.warn('EdsrVectorizerService not available (BGE_M3_URL missing?)', { error: err.message });
+  }
+
   toolRegistry.registerHandler(new ProceduralTools(
     coreServices.zoAdapter,
     coreServices.zoPracticeAdapter,
@@ -126,6 +140,7 @@ export function createToolServices(
     llmAdapter,
     edsrFtsService,
     coreServices.db,
+    edsrVectorizer,
   ));
   toolRegistry.registerHandler(new LegalAdviceTools(
     coreServices.queryPlanner,
@@ -158,17 +173,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new DecisionLayerTools(llmAdapter));
 
   // EDRSR unified search (structured + FTS + hybrid + semantic in one tool)
-  let edsrVectorizer: EdsrVectorizerService | undefined;
-  try {
-    edsrVectorizer = new EdsrVectorizerService();
-    edsrVectorizer.setUsageCallback((tokens, model, task) => {
-      costTracker.recordVoyageCall({ model, totalTokens: tokens, task }).catch((err) => {
-        logger.warn('Failed to record embedding cost', { error: err.message });
-      });
-    });
-  } catch (err: any) {
-    logger.warn('EdsrVectorizerService not available (BGE_M3_URL missing?)', { error: err.message });
-  }
+  // Reuses the edsrVectorizer instance created above.
   const edsrUnifiedSearch = new EdsrUnifiedSearchTool(coreServices.db, edsrFtsService, edsrVectorizer);
   edsrUnifiedSearch.setResultFilter(new SearchResultFilter(llmAdapter));
   edsrUnifiedSearch.setQueryReformulator(new QueryReformulator(llmAdapter));


### PR DESCRIPTION
## Проблема
`find_similar_fact_pattern_cases` выполнял 3-проходный FTS-цикл (по одному `searchFulltext` на инстанцию) по полнотекстовому индексу ЕДРСР + AI-извлечение терминов. На запросах `practice_analysis` это регулярно превышало 60-секундный лимит инструмента ChatService — чат терял результаты поиска по фабуле.

Обнаружено в `chat-e69ec75e-33a8-4fee-8ecb-bd78c865fbd7` (20:07:03): `Tool "find_similar_fact_pattern_cases" перевищив ліміт часу 60с` (retry).

## Фикс
Основной путь переведён на **семантический HNSW-поиск** по унифицированной коллекции `edrsr_serving` (BGE-M3, 296M чанков, ~300мс в тёплом кеше) через общий `EdsrVectorizerService`. Семантическое сходство — естественный инструмент для «найти дела со схожей фабулой»; возвращает scored + дедуплицированный по делам список. **FTS остаётся фолбэком**, если вектор-сервис недоступен или ничего не вернул. Описание инструмента обновлено.

## Изменения
- `mcp_backend/src/api/tools/procedural-tools.ts` — HNSW-first + FTS fallback, новый параметр конструктора `edsrVectorizer`, обновлён `description`, поле `search_method` в ответе.
- `mcp_backend/src/factories/tool-services.ts` — создание `EdsrVectorizerService` поднято выше регистрации `ProceduralTools`, общий инстанс с `EdsrUnifiedSearchTool` (без дубля клиента/cost-callback).

## Вне скоупа (отдельно)
Таймауты Shepardization-батча (4 дела в том же запросе) — цитатный граф, требует поднять лимит / распараллелить / кешировать.

Plane: LEXAI-1745

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches find_similar_fact_pattern_cases to HNSW semantic search over the unified EDRSR collection to eliminate 60s timeouts and return better fact-pattern matches. Keeps FTS as a fallback. Addresses LEXAI-1745.

- **Bug Fixes**
  - Primary path uses `EdsrVectorizerService` (BGE‑M3, HNSW) with over-fetch + dedupe by case; ~300ms warm.
  - FTS runs only as a fallback when the vectorizer is unavailable or returns no hits.
  - Adds `search_method` to the response and updates the tool description and hints.
  - Reuses a single `EdsrVectorizerService` instance across tools; creation moved earlier and hooks into cost tracking.

<sup>Written for commit dd30359fb6df5921769dafc81773ed7b12d733c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

