### PR TITLE
test(chat): practice_analysis defaultBudget is deep

### DIFF
--- a/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
@@ -962,8 +962,11 @@ describe('QueryTypeConfig', () => {
     }
   });
 
-  it('practice_analysis should use standard budget', () => {
-    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('standard');
+  it('practice_analysis should use deep budget', () => {
+    // deep (not standard): practice analysis must load full texts of several key
+    // decisions; standard's 10-call / 8000-char caps exhaust the budget and truncate
+    // full decisions. Mirrors institutional_analysis. See secondlayer-core#34.
+    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('deep');
   });
 
   it('comparative_analysis should use standard budget', () => {


### PR DESCRIPTION
Follow-up to **secondlayer-core#34** (practice_analysis budget `standard` → `deep`).

The pre-deploy backend test `chat-intent-classifier.test.ts` hard-coded `expect(...practice_analysis.defaultBudget).toBe('standard')`. With the overlaid core config now resolving to `deep`, the test failed and blocked the prod deploy (run 27885599171, Pre-Deploy Tests). Updated the assertion to `'deep'`.

This unblocks the deploy that ships the core change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the pre-deploy test to expect `practice_analysis` defaultBudget `'deep'` (was `'standard'`), aligning with the core config change in secondlayer-core#34. This fixes the failing assertion in `chat-intent-classifier.test.ts` and unblocks the deploy.

<sup>Written for commit b1e3762a3c683026e74ce877e3c071f332a5b099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

