### PR TITLE
feat(sft-serve): citation-grounded serving + validator (LEXAI-1737)

### DIFF
--- a/scripts/sft-serve/citation_validator.py
+++ b/scripts/sft-serve/citation_validator.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Deterministic citation guardrail for the legal chat generator (LEXAI-1737).
+
+The SFT+DPO model has high citation coverage and low hedge, but still fabricates
+~15% out-of-context [doc:ID] citations. Fabrication is dangerous in a legal product
+and is best handled NOT by training but post-hoc: every [doc:ID] the model emits is
+checked against the doc_ids that were actually in the retrieved context; anything
+outside the context is stripped. Citations that survive are guaranteed grounded.
+
+Handles both single `[doc:123]` and grouped `[doc:123, doc:456]` forms; in a group,
+only the invalid ids are dropped and valid ones kept.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# one [doc:...] bracket; the inner text may hold several comma-separated ids
+_BRACKET = re.compile(r"\[doc:\s*([^\]]+?)\s*\]")
+_ID = re.compile(r"\d+")
+
+
+@dataclass
+class ValidationResult:
+    answer: str                       # answer with out-of-context citations stripped
+    kept: list[str] = field(default_factory=list)        # grounded doc_ids that survived
+    stripped: list[str] = field(default_factory=list)     # fabricated/out-of-context, removed
+    n_citations: int = 0              # total citations the model emitted
+
+    @property
+    def fabrication_rate(self) -> float:
+        return len(self.stripped) / self.n_citations if self.n_citations else 0.0
+
+
+def validate_citations(answer: str, context_doc_ids) -> ValidationResult:
+    """Strip every [doc:ID] not present in context_doc_ids. Returns the cleaned answer."""
+    valid = {str(x) for x in context_doc_ids}
+    res = ValidationResult(answer=answer)
+
+    def repl(m: re.Match) -> str:
+        ids = _ID.findall(m.group(1))
+        res.n_citations += len(ids)
+        kept = []
+        for i in ids:
+            if i in valid:
+                kept.append(i)
+                res.kept.append(i)
+            else:
+                res.stripped.append(i)
+        if not kept:
+            return ""  # whole citation was fabricated -> drop the bracket
+        return "[" + ", ".join("doc:" + i for i in kept) + "]"
+
+    cleaned = _BRACKET.sub(repl, answer)
+    # tidy doubled spaces / space-before-punctuation left by removed brackets
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    cleaned = re.sub(r"\s+([,.;:)])", r"\1", cleaned)
+    res.answer = cleaned.strip()
+    return res
+
+
+if __name__ == "__main__":
+    ctx = {"100", "200", "300"}  # doc_ids actually retrieved
+    tests = [
+        "Суд визнав скаргу неподаною [doc:100], повернув її [doc:999].",
+        "Підстави викладені у [doc:100, doc:888, doc:200].",
+        "Жодного посилання немає.",
+        "Усе вигадано [doc:777] і [doc:888].",
+    ]
+    for t in tests:
+        r = validate_citations(t, ctx)
+        print("IN :", t)
+        print("OUT:", r.answer)
+        print("    kept=%s stripped=%s fab_rate=%.0f%%" % (r.kept, r.stripped, 100 * r.fabrication_rate))
+        print("-" * 60)

--- a/scripts/sft-serve/requirements.txt
+++ b/scripts/sft-serve/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110
+uvicorn>=0.29
+pydantic>=2.0
+transformers>=4.57
+torch>=2.4

--- a/scripts/sft-serve/serve.py
+++ b/scripts/sft-serve/serve.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Serving endpoint for the citation-grounded legal generator (LEXAI-1737).
+
+Loads the final model (SFT-v2 + DPO de-hedge + cg-DPO, merged) and wraps generation
+with the deterministic citation validator: every [doc:ID] the model emits that is NOT
+in the retrieved context is stripped before returning. Grounded citations only.
+
+POST /generate {query, context: [{doc_id, text}], max_new_tokens?}
+  -> {answer, kept_citations, stripped_citations, fabrication_rate}
+
+Production note: swap HF generate for vLLM (OpenAI-compatible server) for throughput;
+the prompt format and the validator are unchanged. Run: uvicorn serve:app --port 8088
+"""
+import os
+
+import torch
+from fastapi import FastAPI
+from pydantic import BaseModel
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from citation_validator import validate_citations
+
+MODEL_PATH = os.environ.get("MODEL_PATH", "/data/cpt-pipeline/17_final_v2")
+SYSTEM_PROMPT = (
+    "Ти — український юридичний асистент. Відповідай ВИКЛЮЧНО на основі наданих "
+    "витягів із судових рішень ЄДРСР. Кожне фактичне твердження підкріплюй "
+    "посиланням у форматі [doc:ID], де ID — це edrsr_doc_id відповідного джерела. "
+    "Пиши українською."
+)
+
+app = FastAPI(title="lex-generator")
+_tok = None
+_model = None
+
+
+class Source(BaseModel):
+    doc_id: str
+    text: str
+
+
+class GenRequest(BaseModel):
+    query: str
+    context: list[Source]
+    max_new_tokens: int = 512
+
+
+def _load():
+    global _tok, _model
+    if _model is not None:
+        return
+    _tok = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True, extra_special_tokens={})
+    if _tok.pad_token is None:
+        _tok.pad_token = _tok.eos_token
+    _model = AutoModelForCausalLM.from_pretrained(
+        MODEL_PATH, torch_dtype=torch.bfloat16, device_map="auto",
+        attn_implementation="sdpa", trust_remote_code=True,
+    )
+    _model.eval()
+
+
+def _build_user(req: GenRequest) -> str:
+    ctx = "\n\n".join(f"[doc:{s.doc_id}] {s.text}" for s in req.context)
+    return (f"Питання: {req.query}\n\nДжерела (витяги з рішень ЄДРСР):\n{ctx}\n\n"
+            "Дай обґрунтовану відповідь українською з посиланнями [doc:ID].")
+
+
+@app.on_event("startup")
+def _startup():
+    _load()
+
+
+@app.get("/health")
+def health():
+    return {"ok": _model is not None, "model": MODEL_PATH}
+
+
+@app.post("/generate")
+def generate(req: GenRequest):
+    _load()
+    msgs = [{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": _build_user(req)}]
+    ids = _tok.apply_chat_template(msgs, add_generation_prompt=True, return_tensors="pt",
+                                   truncation=True, max_length=3500).to(_model.device)
+    with torch.no_grad():
+        out = _model.generate(ids, max_new_tokens=req.max_new_tokens, do_sample=False,
+                              pad_token_id=_tok.pad_token_id)
+    raw = _tok.decode(out[0, ids.shape[1]:], skip_special_tokens=True)
+    # GUARDRAIL: keep only citations that are in the retrieved context
+    v = validate_citations(raw, {s.doc_id for s in req.context})
+    return {
+        "answer": v.answer,
+        "kept_citations": v.kept,
+        "stripped_citations": v.stripped,    # fabricated/out-of-context, removed
+        "fabrication_rate": round(v.fabrication_rate, 3),
+    }

--- a/scripts/sft-serve/serve_smoke.py
+++ b/scripts/sft-serve/serve_smoke.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""End-to-end serving smoke (no FastAPI): load final model, generate on a held-out
+example, apply the citation validator, and report what got stripped."""
+import json
+import os
+import sys
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from citation_validator import validate_citations
+
+MODEL_PATH = os.environ.get("MODEL_PATH", "/data/cpt-pipeline/17_final_v2")
+SYSTEM_PROMPT = (
+    "Ти — український юридичний асистент. Відповідай ВИКЛЮЧНО на основі наданих "
+    "витягів із судових рішень ЄДРСР. Кожне фактичне твердження підкріплюй "
+    "посиланням у форматі [doc:ID], де ID — це edrsr_doc_id відповідного джерела. Пиши українською."
+)
+
+tok = AutoTokenizer.from_pretrained(MODEL_PATH, trust_remote_code=True, extra_special_tokens={})
+if tok.pad_token is None:
+    tok.pad_token = tok.eos_token
+model = AutoModelForCausalLM.from_pretrained(
+    MODEL_PATH, torch_dtype=torch.bfloat16, device_map="auto",
+    attn_implementation="sdpa", trust_remote_code=True)
+model.eval()
+
+# take a couple held-out examples (with ground-truth context ids)
+recs = [json.loads(l) for l in open("/data/sft-distill/run_100k/retrieved.jsonl")][50:50 + int(sys.argv[1] if len(sys.argv) > 1 else 2)]
+for rec in recs:
+    rows = list(rec["relevant"]) + list(rec["distractors"])
+    ctx = "\n\n".join("[doc:%s] %s" % (r["doc_id"], r["text"][:280]) for r in rows)
+    ctx_ids = {str(r["doc_id"]) for r in rows}
+    user = ("Питання: %s\n\nДжерела (витяги з рішень ЄДРСР):\n%s\n\nДай обґрунтовану відповідь з посиланнями [doc:ID]." % (rec["query"], ctx))
+    ids = tok.apply_chat_template([{"role": "system", "content": SYSTEM_PROMPT}, {"role": "user", "content": user}],
+                                  add_generation_prompt=True, return_tensors="pt", truncation=True, max_length=3500).to(model.device)
+    with torch.no_grad():
+        out = model.generate(ids, max_new_tokens=400, do_sample=False, pad_token_id=tok.pad_token_id)
+    raw = tok.decode(out[0, ids.shape[1]:], skip_special_tokens=True)
+    v = validate_citations(raw, ctx_ids)
+    print("=" * 70)
+    print("Q:", rec["query"][:90])
+    print("--- RAW (model) ---\n", raw[:500])
+    print("--- VALIDATED (served) ---\n", v.answer[:500])
+    print("kept=%s stripped(fabricated)=%s fab_rate=%.0f%%" % (v.kept, v.stripped, 100 * v.fabrication_rate))


### PR DESCRIPTION
Deploy candidate = SFT-v2 + DPO de-hedge + cg-DPO (17_final_v2). citation_validator.py strips every [doc:ID] not in the retrieved context at serving time -> 0% fabricated citations. serve.py = FastAPI /generate wrapping generation with the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds citation-grounded serving for the legal chat model by stripping any [doc:ID] not in the retrieved context. Addresses LEXAI-1737 and ensures only grounded citations are returned.

- **New Features**
  - Deterministic citation validator that removes out-of-context [doc:ID]; supports grouped brackets; returns kept/stripped lists and a fabrication_rate.
  - FastAPI service that loads the merged SFT‑v2 + DPO de‑hedge + cg‑DPO model from `MODEL_PATH`; `POST /generate` accepts `query` and `context[{doc_id, text}]`, validates citations, and returns `answer`, `kept_citations`, `stripped_citations`, `fabrication_rate`; includes `/health`.
  - `serve_smoke.py` for an end-to-end smoke test without FastAPI.

- **Dependencies**
  - Add `fastapi`, `uvicorn`, `pydantic`, `transformers`, `torch`.

<sup>Written for commit 8860eefacdfd77824778c1c6af01e473b1a2aabc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

