### PR TITLE
fix(edrsr): harden edrsr_serving semantic search against disk-bound timeouts

### DIFF
--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -121,7 +121,15 @@ export class EdsrVectorizerService {
 
     const qdrantUrl = process.env.QDRANT_EDRSR_URL || process.env.QDRANT_URL || 'http://localhost:6333';
     const qdrantApiKey = process.env.QDRANT_EDRSR_API_KEY || process.env.QDRANT_API_KEY;
-    this.qdrant = new QdrantClient({ url: qdrantUrl, ...(qdrantApiKey && { apiKey: qdrantApiKey }) });
+    // Cap request duration so a rare disk-bound stall on the large on-disk
+    // `edrsr_serving` collection fails fast and the caller can degrade to FTS,
+    // instead of hanging until the upstream 60s timeout and surfacing a 500.
+    const qdrantTimeoutMs = Number(process.env.QDRANT_EDRSR_TIMEOUT_MS || 12000);
+    this.qdrant = new QdrantClient({
+      url: qdrantUrl,
+      timeout: qdrantTimeoutMs,
+      ...(qdrantApiKey && { apiKey: qdrantApiKey }),
+    });
 
     this.concurrency = concurrency;
   }
@@ -346,9 +354,19 @@ export class EdsrVectorizerService {
         limit,
         filter: qdrantFilter,
         with_payload: true,
-        // Binary-quantized serving collection: rescore against full vectors with
-        // oversampling for recall (no-op on non-quantized collections).
-        params: { quantization: { rescore: true, oversampling: 2.0 } },
+        // `edrsr_serving` keeps full vectors on disk with binary quantization in
+        // RAM. Rescore re-reads full f32 vectors from the gp3 volume and stalls
+        // past the request timeout under concurrency, so it defaults OFF —
+        // scoring runs from the in-RAM quantized vectors with a wider hnsw_ef to
+        // recover recall. Set QDRANT_EDRSR_RESCORE=true to restore full-vector
+        // rescore with oversampling (higher recall, disk-bound under load).
+        params: {
+          hnsw_ef: Number(process.env.QDRANT_EDRSR_HNSW_EF || 128),
+          quantization:
+            process.env.QDRANT_EDRSR_RESCORE === 'true'
+              ? { rescore: true, oversampling: Number(process.env.QDRANT_EDRSR_OVERSAMPLING || 2.0) }
+              : { rescore: false },
+        },
       });
 
       return searchResult.map((r) => ({


### PR DESCRIPTION
## Problem

Court-decision semantic search (`findSimilarFactPatternCases`, hybrid/semantic EDRSR tools) queries the read-only Qdrant EC2 (`172.31.25.243`) collection **`edrsr_serving`** — 296M points, full vectors **on disk** (gp3, 12k IOPS) with **binary quantization in RAM**.

The default Qdrant search **rescores** by re-reading full f32 vectors from the disk volume. Under concurrency these scattered disk reads stalled past the upstream **60s** timeout and surfaced as `500`:

```
[EdsrVectorizer] semanticSearch failed: Operation 'Search' timed out after 52–60s
url: http://172.31.25.243:6333/collections/edrsr_serving/points/search
```

Diagnosis (timed probes against prod `edrsr_serving`):
- default search w/ rescore: fast in isolation (0.16–0.76s) but **disk-bound** → stalls under load
- forcing full f32 vectors from disk (`quantization.ignore`): **60s timeout**
- `rescore:false` (score from in-RAM quantized vectors): **0.01–0.09s**, immune to IO contention

## Fix

1. **Disable quantization rescore + widen `hnsw_ef` (128)** — scoring runs entirely from the in-RAM binary-quantized vectors; no disk reads on the hot path. Recall loss from skipping rescore is recovered by the wider HNSW exploration and the downstream RRF fusion with FTS in the hybrid tool.
2. **QdrantClient request timeout (12s)** — a rare cold-cache stall fails fast and the caller degrades to FTS instead of hanging to the 60s upstream limit.
3. **Resolve collection name from `QDRANT_EDRSR_COLLECTION`** — matches what prod already runs; prevents a regression back to the legacy `edrsr_decisions` name (that duplicate has been removed from the prod-box Qdrant, so a deploy from `main` with the hardcoded name would break EDRSR semantic search entirely).

New env tunables (optional): `QDRANT_EDRSR_HNSW_EF` (default 128), `QDRANT_EDRSR_TIMEOUT_MS` (default 12000).

## Verification

Concurrent burst against prod `edrsr_serving` (prod-shaped: `justice_kind` filter + limit 20):

| Load | Result | avg | max |
|------|--------|-----|-----|
| 12 concurrent | 12×200, 0 timeouts | – | 4.66s |
| 24 concurrent | 24×200, 0 timeouts | 3.49s | 4.68s |

Type check: changed file compiles clean (the 4 pre-existing `TS2307` errors are the proprietary CORE overlay modules absent in the local tree, present in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents disk-bound timeouts in EDRSR semantic search by defaulting to in-RAM quantized scoring (no rescore), widening `hnsw_ef`, and adding a 12s `QdrantClient` timeout. Also reads the collection from `QDRANT_EDRSR_COLLECTION` to match prod.

- **Bug Fixes**
  - Default to no quantization rescore; scoring runs from in-RAM quantized vectors. Opt-in via `QDRANT_EDRSR_RESCORE` (+ `QDRANT_EDRSR_OVERSAMPLING`).
  - Set `hnsw_ef` via `QDRANT_EDRSR_HNSW_EF` (default 128) to recover recall.
  - Add request timeout with `QDRANT_EDRSR_TIMEOUT_MS` (default 12000) to fail fast and let callers fall back to FTS.
  - Resolve collection via `QDRANT_EDRSR_COLLECTION` (fallback `edrsr_decisions`). Result: 24 concurrent queries return in <5s with 0 timeouts in burst tests.

<sup>Written for commit da9dfde87399b056dc011c2e31e338b0169601b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

