### PR TITLE
test(chat): practice_analysis uses standard budget (Sonnet), not deep

### DIFF
--- a/mcp_backend/src/prompts/query-type-config.ts
+++ b/mcp_backend/src/prompts/query-type-config.ts
@@ -11,7 +11,7 @@ export interface QueryTypeConfigEntry {
 
 export const QUERY_TYPE_CONFIG: Record<string, QueryTypeConfigEntry> = {
   case_lookup: { defaultBudget: 'standard', requiresGrounding: true, description: '', maxToolCalls: 5, thinkingPrefix: 'Шукаю справу', preferredScenarios: ['case_search'] },
-  practice_analysis: { defaultBudget: 'deep', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Аналізую практику', preferredScenarios: ['practice_search'] },
+  practice_analysis: { defaultBudget: 'standard', requiresGrounding: true, description: '', maxToolCalls: 10, thinkingPrefix: 'Аналізую практику', preferredScenarios: ['practice_search'] },
   legislation_lookup: { defaultBudget: 'quick', requiresGrounding: true, description: '', maxToolCalls: 3, thinkingPrefix: 'Шукаю законодавство', preferredScenarios: ['legislation_search'] },
   legal_consultation: { defaultBudget: 'standard', requiresGrounding: true, description: '', maxToolCalls: 8, thinkingPrefix: 'Надаю консультацію', preferredScenarios: ['consultation'] },
   registry_lookup: { defaultBudget: 'quick', requiresGrounding: true, description: '', maxToolCalls: 3, thinkingPrefix: 'Шукаю в реєстрі', preferredScenarios: ['registry_search'] },

--- a/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/chat-intent-classifier.test.ts
@@ -962,11 +962,12 @@ describe('QueryTypeConfig', () => {
     }
   });
 
-  it('practice_analysis should use deep budget', () => {
-    // deep (not standard): practice analysis must load full texts of several key
-    // decisions; standard's 10-call / 8000-char caps exhaust the budget and truncate
-    // full decisions. Mirrors institutional_analysis. See secondlayer-core#34.
-    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('deep');
+  it('practice_analysis should use standard budget', () => {
+    // standard (Sonnet), not deep (Opus): A/B on prod (2026-06-21, LEXAI) showed deep
+    // costs ~10x more on practice_analysis with no measurable quality gain — both tiers
+    // cite real-but-sometimes-irrelevant cases, so the bottleneck is citation grounding,
+    // not model tier. deep is reserved for institutional_analysis + explicit budget:'deep'.
+    expect(QUERY_TYPE_CONFIG.practice_analysis.defaultBudget).toBe('standard');
   });
 
   it('comparative_analysis should use standard budget', () => {


### PR DESCRIPTION
Companion to **secondlayer-core#37**.

Aligns the `query-type-config` stub and the `chat-intent-classifier` test with core (`practice_analysis.defaultBudget === 'standard'`) and with the A/B finding (2026-06-21): deep/Opus costs ~10x more on practice_analysis with **no measurable grounding quality gain** (both tiers cite real-but-sometimes-irrelevant cases — bottleneck is citation grounding, not model tier).

Reverts the `toBe('deep')` assertion from #1931. Without this, the overlay step in CI/deploy (which copies core's `standard` config over the stub) would fail the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch `practice_analysis` to the `standard` budget (Sonnet) and update tests to match. Aligns with `secondlayer-core#37` and A/B results; cuts cost (~10x vs deep) with no measured quality loss.

- **Bug Fixes**
  - Set `QUERY_TYPE_CONFIG.practice_analysis.defaultBudget` to `standard`.
  - Updated `chat-intent-classifier` test expectation to `standard` to match the core overlay and prevent CI failures.

<sup>Written for commit 785d883325166815b42c9232998a878883b5afa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

