### PR TITLE
test(chat): A/B model harness + ground-truth citation grounding eval

### DIFF
--- a/scripts/testing/ab-model-quality.ts
+++ b/scripts/testing/ab-model-quality.ts
@@ -1,0 +1,358 @@
+/**
+ * A/B model quality harness for the chat pipeline (Opus vs Sonnet).
+ *
+ * Runs the SAME set of practice_analysis queries through POST /api/chat twice —
+ * once forcing the Opus tier (budget=deep) and once forcing the Sonnet tier
+ * (budget=standard, maxBudget=standard so the classifier can't escalate to deep) —
+ * then has a Bedrock judge do a BLIND, order-randomized pairwise comparison.
+ *
+ * Output: a JSON dump (full answers + costs + response_ids) and a markdown table
+ * with per-query cost, savings %, latency and the judge verdict.
+ *
+ * IMPORTANT
+ * - The real chat orchestration lives in the proprietary @secondlayer/core package,
+ *   which is only wired up in the deployed backend. Local backend ships a NoOp
+ *   ChatService stub, so this must run against a backend that has core (prod).
+ * - Running against prod costs REAL money at the Bedrock layer (~$7 Opus / ~$2.7
+ *   Sonnet per deep practice_analysis query). Use --dry-run first.
+ * - maxBudget semantics are enforced inside proprietary code we can't read here, so
+ *   the harness is SELF-VERIFYING: it records every response_id. After a run, confirm
+ *   which model each variant actually used via the printed `verify` ssh snippet
+ *   (greps the prod "Cost by model" log line per response_id). If the sonnet variant
+ *   still shows Opus, the cap didn't hold and the params need adjusting.
+ *
+ * Auth: Bearer token in AB_TOKEN.
+ *   - Use a SECONDARY_LAYER_KEYS value (no userId) to avoid charging any user;
+ *     cost still comes back in the `complete` SSE event.
+ *   - Or a user JWT to also exercise billing/markup (charged_usd in `cost_summary`).
+ *
+ * Usage:
+ *   AB_BASE_URL=https://legal.org.ua AB_TOKEN=xxxx npx tsx scripts/testing/ab-model-quality.ts --dry-run
+ *   AB_BASE_URL=https://legal.org.ua AB_TOKEN=xxxx npx tsx scripts/testing/ab-model-quality.ts
+ *   ... --queries-file=./my-queries.json   # override the query set (JSON array of strings)
+ *   ... --only=opus|sonnet                 # run a single variant
+ */
+
+// Bedrock SDK is imported lazily inside judge() — it lives in the backend/shared
+// images, not always in host node_modules, and is only needed for grading.
+import { writeFileSync, mkdirSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const BASE_URL = (process.env.AB_BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+const TOKEN = process.env.AB_TOKEN || '';
+const OUT_DIR = process.env.AB_OUT_DIR || join(homedir(), 'ab-model-quality');
+const AWS_REGION = process.env.AWS_REGION || 'eu-central-1';
+const JUDGE_MODEL = process.env.AB_JUDGE_MODEL || 'eu.anthropic.claude-sonnet-4-6';
+const REQUEST_TIMEOUT_MS = 330_000; // > deep wall-clock timeout (300s) + slack
+
+const DRY_RUN = process.argv.includes('--dry-run');
+const ONLY = process.argv.find(a => a.startsWith('--only='))?.split('=')[1] as 'opus' | 'sonnet' | undefined;
+const QUERIES_FILE = process.argv.find(a => a.startsWith('--queries-file='))?.split('=')[1];
+
+// Forced-tier variants. maxBudget caps the ceiling so the practice_analysis
+// classifier (defaultBudget=deep) can't escalate the sonnet arm back to Opus.
+const VARIANTS = [
+  { name: 'opus', body: { budget: 'deep', maxBudget: 'deep', allowDeepEscalation: true } },
+  { name: 'sonnet', body: { budget: 'standard', maxBudget: 'standard', allowDeepEscalation: false } },
+].filter(v => !ONLY || v.name === ONLY);
+
+// Default query set: the real prod query (chat-cb0935df) + typical practice_analysis ones.
+const DEFAULT_QUERIES = [
+  'податкова написала до осіб які мають дррп нерухомість на окупованій території наприклад донецьк після 2014 року у особи є квартира у києві 40 квм в такому разі податкова вказує щодо необхідності впо сумувати податок на площу на нерухомість в києві плюс площа яка на окупованій території, при цьому не має доказів що ця нерухомість існує , можливо вона зруйнована , яка позиція верховного суду з цього питання?',
+  'Яка позиція Верховного Суду щодо стягнення моральної шкоди при незаконному звільненні працівника?',
+  'Як суди застосовують позовну давність у спорах про визнання договору купівлі-продажу нерухомості недійсним?',
+  'Яка судова практика щодо відповідальності поручителя після зміни умов основного зобов’язання без його згоди?',
+];
+
+const QUERIES: string[] = QUERIES_FILE
+  ? JSON.parse(readFileSync(QUERIES_FILE, 'utf8'))
+  : DEFAULT_QUERIES;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface RunResult {
+  variant: string;
+  queryIdx: number;
+  query: string;
+  responseId: string | null;
+  status: 'success' | 'error' | 'timeout' | 'no_answer';
+  answer: string;
+  totalCostUsd: number;
+  chargedUsd: number;
+  toolsUsed: string[];
+  thinkingSteps: number;
+  firstByteMs: number;
+  totalMs: number;
+  errorMessage: string | null;
+}
+
+interface JudgeVerdict {
+  winner: 'opus' | 'sonnet' | 'tie';
+  margin: 'large' | 'moderate' | 'slight' | 'none';
+  opusScore: number;   // 1-5
+  sonnetScore: number; // 1-5
+  opusHallucination: boolean;
+  sonnetHallucination: boolean;
+  reason: string;
+}
+
+const INTERNAL_TOOLS = new Set(['_init', '_classify', '_summarize', 'request_additional_tools']);
+
+// ---------------------------------------------------------------------------
+// Chat call (SSE)
+// ---------------------------------------------------------------------------
+
+async function streamChat(query: string, variant: typeof VARIANTS[number], queryIdx: number): Promise<RunResult> {
+  const startTime = Date.now();
+  const result: RunResult = {
+    variant: variant.name, queryIdx, query,
+    responseId: null, status: 'no_answer', answer: '',
+    totalCostUsd: 0, chargedUsd: 0, toolsUsed: [], thinkingSteps: 0,
+    firstByteMs: 0, totalMs: 0, errorMessage: null,
+  };
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${BASE_URL}/api/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${TOKEN}` },
+      body: JSON.stringify({ query, ...variant.body }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      result.status = 'error';
+      result.errorMessage = `HTTP ${response.status}: ${(await response.text()).slice(0, 300)}`;
+      result.totalMs = Date.now() - startTime;
+      return result;
+    }
+    result.firstByteMs = Date.now() - startTime;
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '', currentEvent = '', currentData = '';
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() || '';
+      for (const line of lines) {
+        if (line.startsWith(':')) continue;
+        if (line.startsWith('event: ')) currentEvent = line.slice(7).trim();
+        else if (line.startsWith('data: ')) currentData = line.slice(6);
+        else if (line === '' && currentEvent && currentData) {
+          try {
+            const data = JSON.parse(currentData);
+            switch (currentEvent) {
+              case 'response_id': result.responseId = data.response_id; break;
+              case 'thinking':
+                result.thinkingSteps++;
+                if (data.tool && !INTERNAL_TOOLS.has(data.tool)) result.toolsUsed.push(data.tool);
+                break;
+              case 'tool_call': {
+                const t = data.name || data.tool;
+                if (t && !INTERNAL_TOOLS.has(t)) result.toolsUsed.push(t);
+                break;
+              }
+              case 'tool_result':
+                if (data.tool && !INTERNAL_TOOLS.has(data.tool)) result.toolsUsed.push(data.tool);
+                break;
+              case 'answer':
+                result.answer = data.text || data.content || result.answer;
+                result.status = 'success';
+                break;
+              case 'complete':
+                result.totalCostUsd = data.total_cost_usd || 0;
+                if (data.answer && !result.answer) result.answer = data.answer;
+                result.status = 'success';
+                break;
+              case 'cost_summary':
+                result.chargedUsd = data.charged_usd || 0;
+                break;
+              case 'error':
+                result.status = 'error';
+                result.errorMessage = data.message || data.error || JSON.stringify(data);
+                break;
+            }
+          } catch { /* skip malformed */ }
+          currentEvent = ''; currentData = '';
+        }
+      }
+    }
+  } catch (err: any) {
+    result.status = err.name === 'AbortError' ? 'timeout' : 'error';
+    result.errorMessage = err.message;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  result.toolsUsed = [...new Set(result.toolsUsed)];
+  result.totalMs = Date.now() - startTime;
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Blind pairwise judge (Bedrock)
+// ---------------------------------------------------------------------------
+
+async function judge(query: string, opus: RunResult, sonnet: RunResult): Promise<JudgeVerdict | null> {
+  if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    console.warn('[judge] no AWS creds — skipping quality grading'); return null;
+  }
+  if (opus.status !== 'success' || sonnet.status !== 'success') return null;
+
+  let BedrockRuntimeClient: any, InvokeModelCommand: any;
+  try {
+    ({ BedrockRuntimeClient, InvokeModelCommand } = await import('@aws-sdk/client-bedrock-runtime'));
+  } catch {
+    console.warn('[judge] @aws-sdk/client-bedrock-runtime not installed — skipping grading'); return null;
+  }
+  const client = new BedrockRuntimeClient({ region: AWS_REGION });
+
+  // Randomize position to remove order bias; map back afterwards.
+  const opusIsA = Math.random() < 0.5;
+  const answerA = opusIsA ? opus.answer : sonnet.answer;
+  const answerB = opusIsA ? sonnet.answer : opus.answer;
+
+  const prompt = `You are a senior Ukrainian lawyer grading two AI answers to the same legal question. Be strict about legal accuracy, correct citation of Supreme Court positions, completeness, and absence of fabricated case numbers or invented norms.
+
+Respond ONLY with JSON:
+{"winner":"A"|"B"|"tie","margin":"large"|"moderate"|"slight"|"none","scoreA":1-5,"scoreB":1-5,"hallucinationA":true|false,"hallucinationB":true|false,"reason":"<2-3 sentences, in Ukrainian>"}
+
+QUESTION:
+${query}
+
+ANSWER A:
+${(answerA || '').slice(0, 6000)}
+
+ANSWER B:
+${(answerB || '').slice(0, 6000)}`;
+
+  try {
+    const resp = await client.send(new InvokeModelCommand({
+      modelId: JUDGE_MODEL,
+      contentType: 'application/json',
+      accept: 'application/json',
+      body: JSON.stringify({
+        anthropic_version: 'bedrock-2023-05-31',
+        max_tokens: 600,
+        temperature: 0,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    }));
+    const content = JSON.parse(new TextDecoder().decode(resp.body)).content?.[0]?.text || '';
+    const m = content.match(/\{[\s\S]*\}/);
+    if (!m) return null;
+    const p = JSON.parse(m[0]);
+    const winner = p.winner === 'tie' ? 'tie' : (p.winner === 'A') === opusIsA ? 'opus' : 'sonnet';
+    return {
+      winner,
+      margin: p.margin ?? 'none',
+      opusScore: opusIsA ? p.scoreA : p.scoreB,
+      sonnetScore: opusIsA ? p.scoreB : p.scoreA,
+      opusHallucination: opusIsA ? !!p.hallucinationA : !!p.hallucinationB,
+      sonnetHallucination: opusIsA ? !!p.hallucinationB : !!p.hallucinationA,
+      reason: p.reason ?? '',
+    };
+  } catch (err: any) {
+    console.warn(`[judge] failed: ${err.message}`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const runId = new Date().toISOString().replace(/[:.]/g, '-');
+  console.log(`\nA/B model quality — Opus vs Sonnet`);
+  console.log(`base=${BASE_URL}  variants=[${VARIANTS.map(v => v.name).join(', ')}]  queries=${QUERIES.length}  runId=${runId}\n`);
+
+  if (DRY_RUN) {
+    console.log('DRY RUN — no requests sent. Plan:');
+    for (const v of VARIANTS) console.log(`  variant ${v.name}: ${JSON.stringify(v.body)}`);
+    QUERIES.forEach((q, i) => console.log(`  q${i}: ${q.slice(0, 90)}${q.length > 90 ? '…' : ''}`));
+    const opusRuns = VARIANTS.find(v => v.name === 'opus') ? QUERIES.length : 0;
+    const sonnetRuns = VARIANTS.find(v => v.name === 'sonnet') ? QUERIES.length : 0;
+    console.log(`\n  est. spend (rough): Opus ${opusRuns}×~$6.8 + Sonnet ${sonnetRuns}×~$2.7 ≈ $${(opusRuns * 6.8 + sonnetRuns * 2.7).toFixed(0)}`);
+    return;
+  }
+
+  if (!TOKEN) { console.error('AB_TOKEN is required.'); process.exit(1); }
+
+  const runs: RunResult[] = [];
+  // Sequential: deep runs are slow & expensive; keep billing/load clean.
+  for (let i = 0; i < QUERIES.length; i++) {
+    for (const v of VARIANTS) {
+      process.stdout.write(`[q${i} ${v.name}] running… `);
+      const r = await streamChat(QUERIES[i], v, i);
+      runs.push(r);
+      console.log(`${r.status}  $${r.totalCostUsd.toFixed(4)}  ${(r.totalMs / 1000).toFixed(1)}s  tools=${r.toolsUsed.length}  id=${r.responseId}`);
+    }
+  }
+
+  // Judge pairwise per query (only when both variants ran).
+  const verdicts: Record<number, JudgeVerdict | null> = {};
+  if (!ONLY) {
+    for (let i = 0; i < QUERIES.length; i++) {
+      const opus = runs.find(r => r.queryIdx === i && r.variant === 'opus');
+      const sonnet = runs.find(r => r.queryIdx === i && r.variant === 'sonnet');
+      if (opus && sonnet) verdicts[i] = await judge(QUERIES[i], opus, sonnet);
+    }
+  }
+
+  // Persist raw output (full answers).
+  mkdirSync(OUT_DIR, { recursive: true });
+  const jsonPath = join(OUT_DIR, `ab-${runId}.json`);
+  writeFileSync(jsonPath, JSON.stringify({ runId, baseUrl: BASE_URL, runs, verdicts }, null, 2));
+
+  // Markdown summary.
+  console.log('\n## A/B summary\n');
+  console.log('| q | opus $ | sonnet $ | savings | opus s | sonnet s | winner | margin | opus/sonnet score | halluc |');
+  console.log('|---|--------|----------|---------|--------|----------|--------|--------|-------------------|--------|');
+  let totOpus = 0, totSonnet = 0;
+  for (let i = 0; i < QUERIES.length; i++) {
+    const o = runs.find(r => r.queryIdx === i && r.variant === 'opus');
+    const s = runs.find(r => r.queryIdx === i && r.variant === 'sonnet');
+    const v = verdicts[i];
+    const oc = o?.totalCostUsd ?? 0, sc = s?.totalCostUsd ?? 0;
+    totOpus += oc; totSonnet += sc;
+    const sav = oc > 0 ? `${(((oc - sc) / oc) * 100).toFixed(0)}%` : '-';
+    const halluc = v ? `${v.opusHallucination ? 'O' : '-'}/${v.sonnetHallucination ? 'S' : '-'}` : '-';
+    console.log(`| q${i} | $${oc.toFixed(3)} | $${sc.toFixed(3)} | ${sav} | ${((o?.totalMs ?? 0) / 1000).toFixed(0)} | ${((s?.totalMs ?? 0) / 1000).toFixed(0)} | ${v?.winner ?? '-'} | ${v?.margin ?? '-'} | ${v ? `${v.opusScore}/${v.sonnetScore}` : '-'} | ${halluc} |`);
+  }
+  const totSav = totOpus > 0 ? `${(((totOpus - totSonnet) / totOpus) * 100).toFixed(0)}%` : '-';
+  console.log(`| **Σ** | **$${totOpus.toFixed(2)}** | **$${totSonnet.toFixed(2)}** | **${totSav}** | | | | | | |`);
+
+  if (!ONLY) {
+    const wins = Object.values(verdicts).filter(Boolean) as JudgeVerdict[];
+    const opusWins = wins.filter(v => v.winner === 'opus').length;
+    const sonnetWins = wins.filter(v => v.winner === 'sonnet').length;
+    const ties = wins.filter(v => v.winner === 'tie').length;
+    console.log(`\nJudge: opus ${opusWins} · sonnet ${sonnetWins} · tie ${ties}  (of ${wins.length} judged)`);
+    for (let i = 0; i < QUERIES.length; i++) if (verdicts[i]?.reason) console.log(`  q${i}: ${verdicts[i]!.reason}`);
+  }
+
+  console.log(`\nraw → ${jsonPath}`);
+
+  // Self-verify which model each arm actually used (maxBudget is enforced in
+  // proprietary code we can't see — confirm from the prod "Cost by model" log).
+  const ids = runs.filter(r => r.responseId).map(r => `${r.variant}:${r.responseId}`);
+  console.log(`\nverify actual model per run (run on prod):`);
+  console.log(`  for id in ${runs.filter(r => r.responseId).map(r => r.responseId).join(' ')}; do echo "== $id =="; docker logs secondlayer-app-prod 2>&1 | grep "$id" | grep "Cost by model"; done`);
+  console.log(`  (variant→id map: ${ids.join('  ')})`);
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/testing/grounding-eval.ts
+++ b/scripts/testing/grounding-eval.ts
@@ -1,0 +1,146 @@
+/**
+ * Ground-truth citation grounding eval for chat answers.
+ *
+ * Replaces the unreliable same-family LLM judge for the one thing that matters in
+ * legal answers: are the cited court cases REAL and ON-TOPIC? Both checks are made
+ * against the EDRSR registry (hard ground truth), not another LLM.
+ *
+ * For each answer it:
+ *   1. Extracts cited case numbers (regex over Ukrainian case-number format).
+ *   2. EXISTS   — does the case number appear in edrsr_documents?
+ *   3. ON-TOPIC — does the case fulltext (edrsr_fulltext) contain the query's
+ *      distinctive topic terms? A real case cited for an unrelated proposition
+ *      ("fabricated relevance") is the failure mode this catches.
+ *
+ * grounding score = (cases that EXIST and are ON-TOPIC) / (cases cited)
+ *
+ * DB access: shells out to psql, feeding SQL via stdin (psql -f -) so no shell
+ * quoting is needed. Default targets prod EDRSR over ssh+docker; override the argv
+ * with env GROUNDING_PSQL (a JSON array) to point at a local EDRSR copy.
+ *
+ * Usage:
+ *   npx tsx scripts/testing/grounding-eval.ts --input=~/ab-model-quality/ab-XXX.json
+ *   ... --topics=./topics.json     # { "0": ["окупов","ОРДЛО","непідконтрольн"], ... }
+ *   ... --on-topic-min=1           # min distinctive terms a case must contain (default 1)
+ */
+
+import { execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+// --- config ---------------------------------------------------------------
+const arg = (k: string) => process.argv.find(a => a.startsWith(`--${k}=`))?.split('=').slice(1).join('=');
+const INPUT = (arg('input') || '').replace(/^~/, homedir());
+const TOPICS_FILE = (arg('topics') || '').replace(/^~/, homedir());
+const ON_TOPIC_MIN = parseInt(arg('on-topic-min') || '1', 10);
+const OUT_DIR = (arg('out') || join(homedir(), 'grounding-eval')).replace(/^~/, homedir());
+const PSQL_ARGV: string[] = process.env.GROUNDING_PSQL
+  ? JSON.parse(process.env.GROUNDING_PSQL)
+  : ['ssh', 'prod', 'docker', 'exec', '-i', 'secondlayer-postgres-prod',
+     'psql', '-U', 'secondlayer', '-d', 'secondlayer_prod', '-t', '-A', '-f', '-'];
+
+// Ukrainian case-number format: 826/11557/18, 640/329/20, 2-97/2011, 755/15457/14-ц
+const CASE_RE = /\b\d{1,4}-?\d{0,5}\/\d{2,6}(?:\/\d{2})?(?:-[а-яіїєґ]+)?\b/gi;
+
+// short stoplist for auto topic-term derivation (function words / boilerplate)
+const STOP = new Set(['яка','який','яке','щодо','після','цьому','такому','разі','коли','якщо','при','для','про','над','під','між','або','осіб','особи','має','мають','наприклад','необхідності','вказує','написала','питання','позиція','верховного','суду']);
+
+// --- helpers --------------------------------------------------------------
+function psql(sql: string): string[] {
+  const out = execFileSync(PSQL_ARGV[0], PSQL_ARGV.slice(1), {
+    input: sql, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+  });
+  return out.split('\n').filter(Boolean);
+}
+const esc = (s: string) => s.replace(/'/g, "''");
+const meta = (r: any) => ({ queryIdx: r.queryIdx, variant: r.variant, label: `q${r.queryIdx ?? '?'}:${r.variant ?? '?'}` });
+
+function deriveTopics(query: string): string[] {
+  const words = (query.toLowerCase().match(/[а-яіїєґ’']{5,}/gi) || [])
+    .map(w => w.replace(/['’]/g, ''))
+    .filter(w => !STOP.has(w));
+  // stem-ish: keep a distinctive 6-char prefix so 'окупованій'/'окупованої' both match 'окупов'
+  const stems = Array.from(new Set(words.map(w => w.slice(0, 6))));
+  return stems.sort((a, b) => b.length - a.length).slice(0, 8);
+}
+
+// --- main -----------------------------------------------------------------
+if (!INPUT) { console.error('--input=<ab-json> required'); process.exit(1); }
+const data = JSON.parse(readFileSync(INPUT, 'utf8'));
+const topicsMap: Record<string, string[]> = TOPICS_FILE ? JSON.parse(readFileSync(TOPICS_FILE, 'utf8')) : {};
+const runs: any[] = data.runs || data;
+
+const results: any[] = [];
+for (const r of runs) {
+  if (r.status && r.status !== 'success') continue;
+  const cases = Array.from(new Set(((r.answer || '').match(CASE_RE) || []) as string[]));
+  if (!cases.length) { results.push({ ...meta(r), cited: 0, note: 'no case numbers cited' }); continue; }
+
+  const provided = topicsMap[String(r.queryIdx)];
+  const topics = (provided && provided.length) ? provided : deriveTopics(r.query || '');
+
+  // one SQL per answer: existence + per-term presence across the cited cases
+  const inList = cases.map(c => `'${esc(c)}'`).join(',');
+  const termCols = topics.map((t, i) => `BOOL_OR(f.full_text ILIKE '%${esc(t)}%') AS t${i}`).join(', ');
+  const sql = `SELECT d.cause_num, COUNT(DISTINCT d.doc_id) AS docs${termCols ? ', ' + termCols : ''}
+    FROM edrsr_documents d LEFT JOIN edrsr_fulltext f USING(doc_id)
+    WHERE d.cause_num IN (${inList}) GROUP BY d.cause_num;`;
+
+  let rows: string[] = [];
+  try { rows = psql(sql); } catch (e: any) { console.error(`psql failed for ${meta(r).label}: ${e.message}`); }
+
+  // psql -t -A default field separator is '|'
+  const found = new Map<string, boolean[]>();
+  for (const line of rows) {
+    const cols = line.split('|');
+    const cause = cols[0];
+    const terms = topics.map((_, i) => (cols[2 + i] || '').trim() === 't');
+    found.set(cause, terms);
+  }
+
+  const perCase = cases.map(c => {
+    const exists = found.has(c);
+    const termHits = exists ? found.get(c)!.filter(Boolean).length : 0;
+    const onTopic = exists && termHits >= ON_TOPIC_MIN;
+    return { case: c, exists, termHits, onTopic };
+  });
+  const grounded = perCase.filter(p => p.onTopic).length;
+  results.push({
+    ...meta(r),
+    cited: cases.length,
+    exist: perCase.filter(p => p.exists).length,
+    onTopic: grounded,
+    existButOffTopic: perCase.filter(p => p.exists && !p.onTopic).length,
+    fabricated: perCase.filter(p => !p.exists).length,
+    groundingScore: +(grounded / cases.length).toFixed(2),
+    topics,
+    perCase,
+  });
+}
+
+// --- report ---------------------------------------------------------------
+mkdirSync(OUT_DIR, { recursive: true });
+const stamp = INPUT.split('/').pop()?.replace(/\.json$/, '') || 'run';
+const outPath = join(OUT_DIR, `grounding-${stamp}.json`);
+writeFileSync(outPath, JSON.stringify(results, null, 2));
+
+console.log('\n## Citation grounding (ground truth: EDRSR registry)\n');
+console.log('| answer | cited | exist | on-topic | exist-but-off-topic | fabricated | score |');
+console.log('|--------|-------|-------|----------|---------------------|------------|-------|');
+for (const r of results) {
+  if (r.cited === 0) { console.log(`| ${r.label} | 0 | - | - | - | - | ${r.note || '-'} |`); continue; }
+  console.log(`| ${r.label} | ${r.cited} | ${r.exist} | ${r.onTopic} | ${r.existButOffTopic} | ${r.fabricated} | ${r.groundingScore} |`);
+}
+const byVar: Record<string, { n: number; s: number; off: number; fab: number }> = {};
+for (const r of results) {
+  if (r.cited === 0) continue;
+  const v = r.variant || 'all';
+  byVar[v] = byVar[v] || { n: 0, s: 0, off: 0, fab: 0 };
+  byVar[v].n++; byVar[v].s += r.groundingScore; byVar[v].off += r.existButOffTopic; byVar[v].fab += r.fabricated;
+}
+console.log('\n### By variant');
+for (const [v, a] of Object.entries(byVar)) {
+  console.log(`- ${v}: mean grounding ${(a.s / a.n).toFixed(2)} · off-topic cites ${a.off} · fabricated ${a.fab} (n=${a.n})`);
+}
+console.log(`\nraw → ${outPath}`);


### PR DESCRIPTION
Tooling behind the practice_analysis budget decision (companion to #1936 / secondlayer-core#37).

## `grounding-eval.ts` — the important one
Replaces the same-family LLM judge for the thing that matters in legal answers: are cited cases **real and on-topic**? Checks each cited case against the **EDRSR registry** (hard ground truth) for EXISTS + ON-TOPIC (query topic terms present in fulltext). `grounding score = real & on-topic / cited`.

Result on the 4-query A/B (post semantic-fix):
| variant | mean grounding | off-topic cites | fabricated |
|---|---|---|---|
| opus | 0.58 | 6 | 3 |
| sonnet | 0.67 | 4 | 1 |

By ground truth **Sonnet grounds slightly better than Opus at ~10% the cost** — contradicting the LLM judge, which was fooled by fluent but off-topic citations. On the flagship occupied-territory query, *both* tiers cited real cases that are 0% about occupied territory.

## `ab-model-quality.ts`
Runs the same queries through `/api/chat` at forced tiers (Opus vs Sonnet), captures cost/latency, blind pairwise judge, self-verifying via `response_id` (actual model confirmed from prod `Cost by model` logs).

Both are scripts/testing tools (not wired into CI). DB access in grounding-eval is via psql stdin — default prod over ssh+docker, override argv with `GROUNDING_PSQL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two testing scripts: an A/B harness to compare Opus vs Sonnet in chat, and a ground-truth citation grounding evaluator against the EDRSR registry. This helps decide the `practice_analysis` budget by measuring cost, latency, and whether cited cases are real and on-topic.

- **New Features**
  - `scripts/testing/ab-model-quality.ts`: Runs the same queries through `/api/chat` with forced tiers (Opus `deep` vs Sonnet `standard`), captures cost/latency, and performs a blind pairwise judge via Bedrock (`@aws-sdk/client-bedrock-runtime`). Self-verifies actual model via `response_id`. Flags: `--dry-run`, `--only`, `--queries-file`.
  - `scripts/testing/grounding-eval.ts`: Extracts cited case numbers, checks existence and topic match in EDRSR fulltext, and computes a grounding score (real & on-topic / cited). Uses `psql` via stdin; default prod over ssh+docker, override with `GROUNDING_PSQL`. Flags: `--input`, `--topics`, `--on-topic-min`.
  - Not wired into CI; intended for manual runs against a backend with `@secondlayer/core`.
  - Early result: Sonnet shows slightly better grounding than Opus at ~10% of the cost.

<sup>Written for commit 9c50b72ff2618dd27086252cbd80a0d1efd41f88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

