### PR TITLE
fix(rada): discover editions from card4 history table when /ed links absent (КУпАП)

### DIFF
--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -280,6 +280,21 @@ async function fetchEditionDates(httpClient: AxiosInstance, bucket: TokenBucket,
   let match;
   while ((match = edRegex.exec(html)) !== null) dates.add(match[1]);
 
+  // Fallback: some codices (e.g. КУпАП 80731-10) list editions in the card4
+  // history table with empty \"Текст редакції\" cells, so there are no /ed
+  // links. Each edition row has <span class=\"dat1\">DD.MM.YYYY</span> and the
+  // event cell text contains \"Редакція\". Parse those dates and build ed-keys
+  // (the text exists at /ed{YYYYMMDD}/print even without a card4 hyperlink).
+  if (dates.size === 0) {
+    const rowRegex = /<span class=\"dat1\">(\d{2})\.(\d{2})\.(\d{4})<\/span>([\s\S]*?)(?=<span class=\"dat1\">|<\/tbody>|$)/g;
+    let row;
+    while ((row = rowRegex.exec(html)) !== null) {
+      const [, dd, mm, yyyy, rest] = row;
+      if (/редакц/i.test(rest)) dates.add(`${yyyy}${mm}${dd}`);
+    }
+    if (dates.size > 0) console.log(`  (fallback) parsed ${dates.size} edition dates from card4 history table`);
+  }
+
   return [...dates].sort();
 }
 


### PR DESCRIPTION
## Проблема
КУпАП (`80731-10`) при імпорті історичних редакцій дав **0 редакцій**: його card4 перелічує редакції у таблиці історії з порожніми клітинками «Текст редакції», тож `/ed{8}`-гіперпосилань немає. Самі сторінки редакцій існують (`/ed{YYYYMMDD}/print`).

## Фікс
Fallback у `fetchEditionDates`: якщо `/ed`-посилань 0 — парсимо дати редакцій із таблиці історії (рядки `dat1`, клітинка події містить «Редакція»), будуємо ed-ключі.

## Результат
**303 редакції КУпАП** (1996…2017; `80731-10` заморожений на 07.05.2017). Інші 15 кодексів не зачіпаються. Пов'язано: PR #1934, LEXAI-638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix edition discovery for codices where card4 has no `/ed` links by parsing the history table instead. Restores 303 editions for КУпАП (80731-10, 1996–2017). Linked to LEXAI-638.

- **Bug Fixes**
  - In `fetchEditionDates`, when no `/ed` links are found, parse `<span class="dat1">DD.MM.YYYY</span>` rows whose event cell contains “Редакція” and build `ed{YYYYMMDD}` keys (pages exist at `/ed{YYYYMMDD}/print`).

<sup>Written for commit 576f18961eeab4e2884db55c187be1d9154dda35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

