### PR TITLE
fix(rada): drop sentinel edition dates (year 3000) from historical editions

### DIFF
--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -295,7 +295,13 @@ async function fetchEditionDates(httpClient: AxiosInstance, bucket: TokenBucket,
     if (dates.size > 0) console.log(`  (fallback) parsed ${dates.size} edition dates from card4 history table`);
   }
 
-  return [...dates].sort();
+  // Drop implausible / sentinel dates: Rada uses year 3000 (ed3000XXXX) for
+  // editions with no fixed effective date; real editions fall within 1900-2099.
+  const plausible = [...dates].filter((k) => {
+    const y = Number(k.slice(0, 4));
+    return y >= 1900 && y <= 2099;
+  });
+  return plausible.sort();
 }
 
 // ─── Import One Edition ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Проблема
`list_legislation_editions` показував редакції з датами `3000-01-01` / `2999-12-31`. Це не артефакт парсингу — Rada використовує ключ `ed3000XXXX` як заглушку для редакцій без визначеної дати набуття чинності.

## Фікс
- `fetchEditionDates` тепер відкидає ключі з неправдоподібним роком (поза 1900–2099), тож sentinel-роки 3000 не імпортуються (реальні майбутні редакції 2027/2028 лишаються).
- Дані на проді почищено: видалено 12 sentinel-редакцій + 4297 версій статей, перераховано `total_editions` для 7 кодексів. Підсумок: 2187 редакцій, 928 041 версія.

Пов'язано: #1934, #1939, LEXAI-638.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop Rada’s year-3000 sentinel edition dates from import so historical editions no longer show 3000-01-01 / 2999-12-31. Matches LEXAI-638 to exclude placeholder editions while keeping real future ones.

- **Bug Fixes**
  - Filter `fetchEditionDates` to plausible years (1900–2099) to drop Rada’s `ed3000XXXX` placeholders.
  - Real future editions (e.g., 2027/2028) are preserved.
  - Prod cleanup: removed 12 sentinel editions and 4,297 article versions; recalculated totals for 7 codes (now 2,187 editions, 928,041 versions).

<sup>Written for commit 6518c8a403dda6f737be8fe8714db1c2e7e3b88d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

