### PR TITLE
feat(chat): shareable read-only links for chats (next to cost panel)

### DIFF
--- a/lexwebapp/src/components/CostSummary.tsx
+++ b/lexwebapp/src/components/CostSummary.tsx
@@ -5,6 +5,7 @@ import type { CostSummary as CostSummaryType } from '../types/models/Message';
 import { getToolLabel } from '../hooks/chat/tool-labels';
 import { useCurrencyRate } from '../hooks/useCurrencyRate';
 import { useMiscT } from '../i18n/misc-i18n';
+import { ShareControl } from './ShareControl';
 
 interface CostSummaryProps {
   data: CostSummaryType;
@@ -32,6 +33,7 @@ export function CostSummary({ data }: CostSummaryProps) {
 
   return (
     <div className="mt-3">
+      <div className="flex items-center gap-3">
       <button
         onClick={() => setExpanded(!expanded)}
         className="flex items-center gap-1.5 text-[12px] text-claude-subtext hover:text-claude-text transition-colors"
@@ -58,6 +60,9 @@ export function CostSummary({ data }: CostSummaryProps) {
           strokeWidth={2}
         />
       </button>
+
+        <ShareControl responseId={data.response_id} />
+      </div>
 
       <AnimatePresence>
         {expanded && (

--- a/lexwebapp/src/components/ShareControl.tsx
+++ b/lexwebapp/src/components/ShareControl.tsx
@@ -1,0 +1,214 @@
+import { useState, useCallback } from 'react';
+import { Share2, Check, Copy, MessageSquare, MessagesSquare, Loader2, AlertCircle } from 'lucide-react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { useChatStore } from '../stores';
+import { api } from '../utils/api-client';
+import { useMiscT } from '../i18n/misc-i18n';
+import type { Message } from '../types/models/Message';
+import type { ShareScope, SharedMessage } from '../utils/api/shares';
+
+interface ShareControlProps {
+  /** response_id of the assistant message this control belongs to (for single-response scope). */
+  responseId?: string;
+}
+
+export function ShareControl({ responseId }: ShareControlProps) {
+  const { t } = useMiscT();
+  const messages = useChatStore((s) => s.messages);
+  const conversationId = useChatStore((s) => s.conversationId);
+
+  const [open, setOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState(false);
+
+  const reset = useCallback(() => {
+    setOpen(false);
+    setShareUrl(null);
+    setCopied(false);
+    setError(false);
+    setCreating(false);
+  }, []);
+
+  const toShared = (m: Message): SharedMessage => ({
+    role: m.role,
+    content: m.content,
+    decisions: m.decisions,
+    citations: m.citations,
+    documents: m.documents,
+  });
+
+  const buildSnapshot = (scope: ShareScope): SharedMessage[] => {
+    const meaningful = (m: Message) =>
+      !!m.content || !!m.decisions?.length || !!m.citations?.length || !!m.documents?.length;
+
+    if (scope === 'conversation') {
+      return messages.filter(meaningful).map(toShared);
+    }
+
+    // Single response: this assistant message + the question that preceded it.
+    let idx = responseId
+      ? messages.findIndex((m) => m.costSummary?.response_id === responseId)
+      : -1;
+    if (idx === -1) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        if (messages[i].role === 'assistant') { idx = i; break; }
+      }
+    }
+    if (idx === -1) return [];
+
+    const out: Message[] = [];
+    const prev = messages[idx - 1];
+    if (prev && prev.role === 'user') out.push(prev);
+    out.push(messages[idx]);
+    return out.map(toShared);
+  };
+
+  const titleFrom = (snap: SharedMessage[]): string => {
+    const firstUser = snap.find((m) => m.role === 'user');
+    const text = firstUser?.content || snap[0]?.content || '';
+    return text.replace(/\s+/g, ' ').trim().slice(0, 80);
+  };
+
+  const handleShare = useCallback(
+    async (scope: ShareScope) => {
+      const snapshotMessages = buildSnapshot(scope);
+      if (snapshotMessages.length === 0) {
+        setError(true);
+        return;
+      }
+      setCreating(true);
+      setError(false);
+      try {
+        const res = await api.shares.create({
+          scope,
+          title: titleFrom(snapshotMessages),
+          snapshot: { messages: snapshotMessages },
+          conversationId,
+        });
+        const url = `${window.location.origin}/shared/${res.data.token}`;
+        setShareUrl(url);
+        try {
+          await navigator.clipboard.writeText(url);
+          setCopied(true);
+        } catch {
+          /* clipboard may be blocked — link is still shown */
+        }
+      } catch {
+        setError(true);
+      } finally {
+        setCreating(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [messages, conversationId, responseId]
+  );
+
+  const copy = useCallback(async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  }, [shareUrl]);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        onClick={() => (open ? reset() : setOpen(true))}
+        className="flex items-center gap-1 text-[12px] text-claude-subtext hover:text-claude-text transition-colors"
+      >
+        <Share2 size={12} strokeWidth={2} />
+        <span>{t('share')}</span>
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <>
+            {/* click-away backdrop */}
+            <div className="fixed inset-0 z-10" onClick={reset} />
+            <motion.div
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={{ duration: 0.15 }}
+              className="absolute left-0 top-full mt-1.5 z-20 w-72 rounded-xl border border-claude-border bg-claude-bg shadow-xl p-1.5"
+            >
+              {!shareUrl ? (
+                <div className="space-y-0.5">
+                  <div className="px-2 py-1.5 text-[11px] font-medium text-claude-subtext uppercase tracking-wide">
+                    {t('shareWhatTitle')}
+                  </div>
+
+                  <button
+                    onClick={() => handleShare('conversation')}
+                    disabled={creating}
+                    className="w-full flex items-start gap-2.5 px-2 py-2 rounded-lg text-left hover:bg-claude-sidebar transition-colors disabled:opacity-50"
+                  >
+                    <MessagesSquare size={15} strokeWidth={2} className="mt-0.5 text-claude-subtext flex-shrink-0" />
+                    <div className="min-w-0">
+                      <div className="text-[13px] text-claude-text">{t('shareWholeConversation')}</div>
+                      <div className="text-[11px] text-claude-subtext">{t('shareWholeConversationHint')}</div>
+                    </div>
+                  </button>
+
+                  <button
+                    onClick={() => handleShare('message')}
+                    disabled={creating}
+                    className="w-full flex items-start gap-2.5 px-2 py-2 rounded-lg text-left hover:bg-claude-sidebar transition-colors disabled:opacity-50"
+                  >
+                    <MessageSquare size={15} strokeWidth={2} className="mt-0.5 text-claude-subtext flex-shrink-0" />
+                    <div className="min-w-0">
+                      <div className="text-[13px] text-claude-text">{t('shareThisResponse')}</div>
+                      <div className="text-[11px] text-claude-subtext">{t('shareThisResponseHint')}</div>
+                    </div>
+                  </button>
+
+                  {creating && (
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-[12px] text-claude-subtext">
+                      <Loader2 size={13} className="animate-spin" strokeWidth={2} />
+                      {t('shareCreating')}
+                    </div>
+                  )}
+                  {error && (
+                    <div className="flex items-center gap-2 px-2 py-1.5 text-[12px] text-red-500">
+                      <AlertCircle size={13} strokeWidth={2} />
+                      {t('shareFailed')}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="p-1.5 space-y-2">
+                  <div className="flex items-center gap-1.5 text-[12px] font-medium text-claude-text">
+                    <Check size={13} strokeWidth={2.5} className="text-emerald-500" />
+                    {t('shareLinkReady')}
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <input
+                      readOnly
+                      value={shareUrl}
+                      onFocus={(e) => e.currentTarget.select()}
+                      className="flex-1 min-w-0 px-2 py-1.5 rounded-md border border-claude-border bg-claude-sidebar text-[12px] font-mono text-claude-text"
+                    />
+                    <button
+                      onClick={copy}
+                      className="flex items-center gap-1 px-2 py-1.5 rounded-md bg-claude-text text-claude-bg text-[12px] hover:opacity-90 transition-opacity flex-shrink-0"
+                    >
+                      {copied ? <Check size={12} strokeWidth={2.5} /> : <Copy size={12} strokeWidth={2} />}
+                      {copied ? t('shareCopied') : t('shareCopyLink')}
+                    </button>
+                  </div>
+                  <div className="text-[11px] text-claude-subtext">{t('shareLinkHint')}</div>
+                </div>
+              )}
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/lexwebapp/src/i18n/misc-i18n.ts
+++ b/lexwebapp/src/i18n/misc-i18n.ts
@@ -2267,6 +2267,123 @@ const miscStrings: Record<string, Record<Locale, string>> = {
     de: 'Endgültig löschen',
     es: 'Eliminar para siempre',
   },
+
+  // ── Chat sharing ──
+  share: {
+    uk: 'Поділитися',
+    en: 'Share',
+    de: 'Teilen',
+    es: 'Compartir',
+  },
+  shareWhatTitle: {
+    uk: 'Чим поділитися?',
+    en: 'What to share?',
+    de: 'Was teilen?',
+    es: '¿Qué compartir?',
+  },
+  shareWholeConversation: {
+    uk: 'Вся розмова',
+    en: 'Whole conversation',
+    de: 'Gesamte Unterhaltung',
+    es: 'Toda la conversación',
+  },
+  shareWholeConversationHint: {
+    uk: 'Поділитися всім діалогом',
+    en: 'Share the entire dialogue',
+    de: 'Den gesamten Dialog teilen',
+    es: 'Compartir todo el diálogo',
+  },
+  shareThisResponse: {
+    uk: 'Лише ця відповідь',
+    en: 'This response only',
+    de: 'Nur diese Antwort',
+    es: 'Solo esta respuesta',
+  },
+  shareThisResponseHint: {
+    uk: 'Поділитися лише цією відповіддю та запитанням',
+    en: 'Share just this answer and its question',
+    de: 'Nur diese Antwort und die Frage teilen',
+    es: 'Compartir solo esta respuesta y su pregunta',
+  },
+  shareCreating: {
+    uk: 'Створення посилання...',
+    en: 'Creating link...',
+    de: 'Link wird erstellt...',
+    es: 'Creando enlace...',
+  },
+  shareLinkReady: {
+    uk: 'Посилання готове',
+    en: 'Link ready',
+    de: 'Link bereit',
+    es: 'Enlace listo',
+  },
+  shareLinkHint: {
+    uk: 'Будь-який користувач платформи зможе відкрити це посилання.',
+    en: 'Any platform user can open this link.',
+    de: 'Jeder Plattformnutzer kann diesen Link öffnen.',
+    es: 'Cualquier usuario de la plataforma puede abrir este enlace.',
+  },
+  shareCopyLink: {
+    uk: 'Копіювати',
+    en: 'Copy',
+    de: 'Kopieren',
+    es: 'Copiar',
+  },
+  shareCopied: {
+    uk: 'Скопійовано',
+    en: 'Copied',
+    de: 'Kopiert',
+    es: 'Copiado',
+  },
+  shareFailed: {
+    uk: 'Не вдалося створити посилання',
+    en: 'Failed to create link',
+    de: 'Link konnte nicht erstellt werden',
+    es: 'No se pudo crear el enlace',
+  },
+  shareOpenInApp: {
+    uk: 'Відкрити',
+    en: 'Open',
+    de: 'Öffnen',
+    es: 'Abrir',
+  },
+  // ── Shared view page ──
+  sharedTitle: {
+    uk: 'Спільна розмова',
+    en: 'Shared conversation',
+    de: 'Geteilte Unterhaltung',
+    es: 'Conversación compartida',
+  },
+  sharedBy: {
+    uk: 'Поділився',
+    en: 'Shared by',
+    de: 'Geteilt von',
+    es: 'Compartido por',
+  },
+  sharedNotFound: {
+    uk: 'Посилання недійсне або скасоване',
+    en: 'This link is invalid or has been revoked',
+    de: 'Dieser Link ist ungültig oder wurde widerrufen',
+    es: 'Este enlace no es válido o ha sido revocado',
+  },
+  sharedReadOnly: {
+    uk: 'Лише для перегляду',
+    en: 'Read-only',
+    de: 'Nur Lesen',
+    es: 'Solo lectura',
+  },
+  sharedBackToChat: {
+    uk: 'До чату',
+    en: 'Back to chat',
+    de: 'Zurück zum Chat',
+    es: 'Volver al chat',
+  },
+  sharedLoading: {
+    uk: 'Завантаження...',
+    en: 'Loading...',
+    de: 'Wird geladen...',
+    es: 'Cargando...',
+  },
 };
 
 export type MiscKey = keyof typeof miscStrings;

--- a/lexwebapp/src/pages/SharedConversationPage/index.tsx
+++ b/lexwebapp/src/pages/SharedConversationPage/index.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Loader2, AlertCircle, Eye, ArrowLeft, ExternalLink } from 'lucide-react';
+import { api } from '../../utils/api-client';
+import { useMiscT } from '../../i18n/misc-i18n';
+import { MarkdownContent } from '../../components/message/MarkdownContent';
+import { LexLogo3D } from '../../components/LexLogo3D';
+import type { Decision } from '../../types/models/Message';
+
+interface SharedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  decisions?: Decision[];
+  citations?: Array<{ text?: string; source?: string }>;
+}
+
+interface ShareRecord {
+  token: string;
+  scope: 'conversation' | 'message';
+  title: string | null;
+  snapshot: { messages: SharedMessage[] };
+  shared_by_name: string | null;
+  created_at: string;
+}
+
+const noop = () => {};
+
+export function SharedConversationPage() {
+  const { token } = useParams<{ token: string }>();
+  const { t } = useMiscT();
+  const [loading, setLoading] = useState(true);
+  const [share, setShare] = useState<ShareRecord | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!token) {
+      setNotFound(true);
+      setLoading(false);
+      return;
+    }
+    api.shares
+      .get(token)
+      .then((res) => {
+        if (cancelled) return;
+        setShare(res.data as ShareRecord);
+      })
+      .catch(() => {
+        if (!cancelled) setNotFound(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-claude-bg">
+        <div className="flex items-center gap-2 text-claude-subtext">
+          <Loader2 size={18} className="animate-spin" strokeWidth={2} />
+          {t('sharedLoading')}
+        </div>
+      </div>
+    );
+  }
+
+  if (notFound || !share) {
+    return (
+      <div className="min-h-screen flex flex-col items-center justify-center gap-4 bg-claude-bg px-4 text-center">
+        <AlertCircle size={32} className="text-claude-subtext" strokeWidth={1.5} />
+        <p className="text-claude-text">{t('sharedNotFound')}</p>
+        <Link to="/chat" className="text-[13px] text-claude-accent hover:underline">
+          {t('sharedBackToChat')}
+        </Link>
+      </div>
+    );
+  }
+
+  const messages = share.snapshot?.messages ?? [];
+
+  return (
+    <div className="min-h-screen bg-claude-bg">
+      {/* Header */}
+      <div className="sticky top-0 z-10 border-b border-claude-border bg-claude-bg/90 backdrop-blur">
+        <div className="max-w-3xl mx-auto px-4 md:px-8 py-3 flex items-center gap-3">
+          <div className="w-7 h-7 rounded-md overflow-hidden flex items-center justify-center bg-zinc-900 flex-shrink-0">
+            <LexLogo3D size={28} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-[14px] font-medium text-claude-text truncate">
+              {share.title || t('sharedTitle')}
+            </div>
+            {share.shared_by_name && (
+              <div className="text-[11px] text-claude-subtext truncate">
+                {t('sharedBy')}: {share.shared_by_name}
+              </div>
+            )}
+          </div>
+          <span className="flex items-center gap-1 text-[11px] text-claude-subtext border border-claude-border rounded-full px-2 py-0.5 flex-shrink-0">
+            <Eye size={11} strokeWidth={2} />
+            {t('sharedReadOnly')}
+          </span>
+          <Link
+            to="/chat"
+            className="flex items-center gap-1 text-[12px] text-claude-subtext hover:text-claude-text transition-colors flex-shrink-0"
+          >
+            <ArrowLeft size={13} strokeWidth={2} />
+            <span className="hidden sm:inline">{t('sharedBackToChat')}</span>
+          </Link>
+        </div>
+      </div>
+
+      {/* Messages */}
+      <div className="max-w-3xl mx-auto px-4 md:px-8 py-6 space-y-6">
+        {messages.map((m, i) =>
+          m.role === 'user' ? (
+            <div key={i} className="flex justify-end">
+              <div className="max-w-[85%] rounded-2xl bg-claude-sidebar px-4 py-2.5 text-[14px] text-claude-text whitespace-pre-wrap">
+                {m.content}
+              </div>
+            </div>
+          ) : (
+            <div key={i} className="space-y-3">
+              <div className="prose-claude">
+                <MarkdownContent content={m.content} openDocByRef={noop} />
+              </div>
+              {m.decisions && m.decisions.length > 0 && (
+                <div className="space-y-1.5">
+                  {m.decisions.map((d, di) => (
+                    <div
+                      key={di}
+                      className="flex items-start gap-2 px-3 py-2 rounded-lg border border-claude-border/60 bg-claude-bg text-[12px]"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="font-medium text-claude-text truncate">{d.number}</div>
+                        <div className="text-claude-subtext truncate">
+                          {[d.court, d.date].filter(Boolean).join(' • ')}
+                        </div>
+                      </div>
+                      {d.externalUrl && (
+                        <a
+                          href={d.externalUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-claude-subtext hover:text-claude-text flex-shrink-0"
+                        >
+                          <ExternalLink size={13} strokeWidth={2} />
+                        </a>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lexwebapp/src/router/guards/AuthGuard.tsx
+++ b/lexwebapp/src/router/guards/AuthGuard.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useState, useRef } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { ROUTES } from '../routes';
 import { api } from '../../utils/api-client';
@@ -16,6 +16,7 @@ import { useOnboardingStore } from '../../stores/onboardingStore';
 
 export const AuthGuard: React.FC = () => {
   const { isAuthenticated, isLoading, user } = useAuth();
+  const location = useLocation();
   const [showOrgModal, setShowOrgModal] = useState(false);
   const [, setOrgChecked] = useState(false);
 
@@ -72,9 +73,14 @@ export const AuthGuard: React.FC = () => {
     );
   }
 
-  // Redirect to login if not authenticated
+  // Redirect to login if not authenticated, preserving the intended
+  // destination so the user lands back on it after signing in.
   if (!isAuthenticated) {
-    return <Navigate to={ROUTES.LOGIN} replace />;
+    const target = `${location.pathname}${location.search}`;
+    const loginUrl = target && target !== '/'
+      ? `${ROUTES.LOGIN}?returnUrl=${encodeURIComponent(target)}`
+      : ROUTES.LOGIN;
+    return <Navigate to={loginUrl} replace />;
   }
 
   // Render child routes + modals

--- a/lexwebapp/src/router/index.tsx
+++ b/lexwebapp/src/router/index.tsx
@@ -88,6 +88,7 @@ const EUComparisonPage = lazyWithRetry(() => import('../pages/EUComparisonPage')
 
 // -- Core app pages --
 const ChatPage = lazyWithRetry(() => import('../pages/ChatPage').then(m => ({ default: m.ChatPage })));
+const SharedConversationPage = lazyWithRetry(() => import('../pages/SharedConversationPage').then(m => ({ default: m.SharedConversationPage })));
 const ProfilePage = lazyWithRetry(() => import('../pages/ProfilePage').then(m => ({ default: m.ProfilePage })));
 const BillingDashboard = lazyWithRetry(() => import('../pages/BillingDashboard').then(m => ({ default: m.BillingDashboard })));
 const BillingOverviewTab = lazyWithRetry(() => import('../components/billing/OverviewTab').then(m => ({ default: m.OverviewTab })));
@@ -335,6 +336,10 @@ export const router = createBrowserRouter([
   {
     element: <AuthGuard />,
     children: [
+      {
+        path: ROUTES.SHARED,
+        element: S(SharedConversationPage),
+      },
       {
         element: <MainLayout />,
         children: [

--- a/lexwebapp/src/router/routes.ts
+++ b/lexwebapp/src/router/routes.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   // Main
   HOME: '/',
   CHAT: '/chat',
+  SHARED: '/shared/:token',
 
   // Referral
   REFERRAL: '/referral',

--- a/lexwebapp/src/utils/api/index.ts
+++ b/lexwebapp/src/utils/api/index.ts
@@ -11,6 +11,7 @@ import { adminApi } from './admin';
 import { documentsApi } from './documents';
 import { teamApi } from './team';
 import { conversationsApi } from './conversations';
+import { sharesApi } from './shares';
 import { decisionsApi, keysApi, gdprApi, toolsApi } from './misc';
 
 export const api = {
@@ -20,6 +21,7 @@ export const api = {
   team: teamApi,
   tools: toolsApi,
   conversations: conversationsApi,
+  shares: sharesApi,
   documents: documentsApi,
   admin: adminApi,
   decisions: decisionsApi,
@@ -34,5 +36,6 @@ export { adminApi } from './admin';
 export { documentsApi } from './documents';
 export { teamApi } from './team';
 export { conversationsApi } from './conversations';
+export { sharesApi } from './shares';
 export { decisionsApi, keysApi, gdprApi, toolsApi } from './misc';
 export { sessionReplayApi } from './session-replay';

--- a/lexwebapp/src/utils/api/shares.ts
+++ b/lexwebapp/src/utils/api/shares.ts
@@ -1,0 +1,31 @@
+import apiClient from './client';
+
+export type ShareScope = 'conversation' | 'message';
+
+export interface SharedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  decisions?: unknown[];
+  citations?: unknown[];
+  documents?: unknown[];
+}
+
+export interface ShareSnapshot {
+  messages: SharedMessage[];
+}
+
+export interface CreateSharePayload {
+  scope: ShareScope;
+  title?: string;
+  snapshot: ShareSnapshot;
+  conversationId?: string | null;
+}
+
+export const sharesApi = {
+  create: (payload: CreateSharePayload) =>
+    apiClient.post<{ token: string }>('/api/shares', payload),
+  get: (token: string) =>
+    apiClient.get(`/api/shares/${token}`),
+  list: () => apiClient.get('/api/shares'),
+  revoke: (token: string) => apiClient.delete(`/api/shares/${token}`),
+};

--- a/mcp_backend/src/factories/__tests__/app-services.test.ts
+++ b/mcp_backend/src/factories/__tests__/app-services.test.ts
@@ -365,7 +365,7 @@ describe('createAppServices', () => {
 
   describe('return shape — all properties present', () => {
     const expectedKeys = [
-      'conversationService', 'evidenceService', 'gdprService', 'auditService',
+      'conversationService', 'shareService', 'evidenceService', 'gdprService', 'auditService',
       'matterService', 'contractService', 'conflictCheckService', 'legalHoldService',
       'timeEntryService', 'matterInvoiceService', 'workflowService',
       'workflowGeneratorService', 'workflowExecutorService', 'chatService',

--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -3,6 +3,7 @@ import { BillingServices } from './billing-services.js';
 import { ToolServices } from './tool-services.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
 import { ConversationService } from '../services/conversation-service.js';
+import { ShareService } from '../services/share-service.js';
 import { ConversationEvidenceService } from '../services/conversation-evidence-service.js';
 import { GdprService } from '../services/gdpr-service.js';
 import { AuditService } from '../services/audit-service.js';
@@ -44,6 +45,7 @@ import { logger } from '../utils/logger.js';
 
 export interface AppServices {
   conversationService: ConversationService;
+  shareService: ShareService;
   evidenceService: ConversationEvidenceService;
   gdprService: GdprService;
   auditService: AuditService;
@@ -92,6 +94,7 @@ export function createAppServices(
 
   // Conversation & GDPR
   const conversationService = new ConversationService(coreServices.db);
+  const shareService = new ShareService(coreServices.db);
   const evidenceService = new ConversationEvidenceService(coreServices.db);
   const gdprService = new GdprService(coreServices.db, tools.minioService, coreServices.embeddingService);
 
@@ -269,6 +272,7 @@ export function createAppServices(
 
   return {
     conversationService,
+    shareService,
     evidenceService,
     gdprService,
     auditService,

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -52,6 +52,7 @@ import { createOAuthRouter } from './routes/oauth-routes.js';
 import { healthCheckRateLimit, webhookRateLimit, globalApiRateLimit, consultationRateLimit, publicSearchRateLimit } from './middleware/rate-limit.js';
 import { createUploadRouter } from './routes/upload-routes.js';
 import { createConversationRouter } from './routes/conversation-routes.js';
+import { createShareRouter } from './routes/share-routes.js';
 import { createEvidenceRoutes } from './routes/evidence-routes.js';
 import { createEdsrRoutes } from './routes/edrsr-routes.js';
 import { createGdprRouter } from './routes/gdpr-routes.js';
@@ -581,6 +582,10 @@ class HTTPMCPServer {
     this.app.use('/api/conversations', requireJWT as any, createConversationRouter(this.app_.conversationService));
     this.app.use('/api/conversations', requireJWT as any, createEvidenceRoutes(this.app_.evidenceService));
     logger.info('Conversation and evidence routes registered at /api/conversations');
+
+    // Share routes - shareable read-only chat links among platform users
+    this.app.use('/api/shares', requireJWT as any, createShareRouter(this.app_.shareService));
+    logger.info('Share routes registered at /api/shares');
 
     // EDRSR direct access routes
     this.app.use('/api/edrsr', requireJWT as any, createEdsrRoutes(this.services.db));

--- a/mcp_backend/src/migrations/163_conversation_shares.sql
+++ b/mcp_backend/src/migrations/163_conversation_shares.sql
@@ -1,0 +1,21 @@
+-- Conversation sharing: shareable read-only links among platform users.
+-- A share stores a point-in-time JSON snapshot of the shared content so it is
+-- decoupled from E2EE (the frontend sends already-decrypted content) and stays
+-- stable even if the source conversation is later edited or deleted.
+
+CREATE TABLE IF NOT EXISTS conversation_shares (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  token TEXT UNIQUE NOT NULL,
+  conversation_id UUID REFERENCES conversations(id) ON DELETE SET NULL,
+  shared_by UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  scope VARCHAR(20) NOT NULL DEFAULT 'conversation'
+    CHECK (scope IN ('conversation', 'message')),
+  title TEXT,
+  snapshot JSONB NOT NULL,
+  view_count INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  revoked_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_shares_token ON conversation_shares(token);
+CREATE INDEX IF NOT EXISTS idx_conversation_shares_shared_by ON conversation_shares(shared_by, created_at DESC);

--- a/mcp_backend/src/routes/share-routes.ts
+++ b/mcp_backend/src/routes/share-routes.ts
@@ -1,0 +1,81 @@
+import { Router, Response } from 'express';
+import { ShareService } from '../services/share-service.js';
+import { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+import { logger } from '../utils/logger.js';
+
+export function createShareRouter(shareService: ShareService): Router {
+  const router = Router();
+
+  // POST / - Create a shareable link from a content snapshot
+  router.post('/', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const { scope, title, snapshot, conversationId } = req.body;
+      if (!snapshot || !Array.isArray(snapshot.messages) || snapshot.messages.length === 0) {
+        return res.status(400).json({ error: 'snapshot.messages required' });
+      }
+
+      const { token } = await shareService.createShare(userId, {
+        scope: scope === 'message' ? 'message' : 'conversation',
+        title,
+        snapshot,
+        conversationId,
+      });
+
+      res.status(201).json({ token });
+    } catch (error: any) {
+      logger.error('[Shares] Create failed', { error: error.message });
+      res.status(400).json({ error: error.message });
+    }
+  }) as any);
+
+  // GET / - List shares created by the current user
+  router.get('/', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const shares = await shareService.listShares(userId);
+      res.json({ shares });
+    } catch (error: any) {
+      logger.error('[Shares] List failed', { error: error.message });
+      res.status(500).json({ error: error.message });
+    }
+  }) as any);
+
+  // GET /:token - View a shared snapshot (any authenticated platform user)
+  router.get('/:token', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const share = await shareService.getShare(req.params.token as string);
+      if (!share) return res.status(404).json({ error: 'Share not found' });
+
+      res.json(share);
+    } catch (error: any) {
+      logger.error('[Shares] Get failed', { error: error.message });
+      res.status(500).json({ error: error.message });
+    }
+  }) as any);
+
+  // DELETE /:token - Revoke a share
+  router.delete('/:token', (async (req: DualAuthRequest, res: Response): Promise<any> => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) return res.status(401).json({ error: 'User not authenticated' });
+
+      const revoked = await shareService.revokeShare(userId, req.params.token as string);
+      if (!revoked) return res.status(404).json({ error: 'Share not found' });
+
+      res.json({ success: true });
+    } catch (error: any) {
+      logger.error('[Shares] Revoke failed', { error: error.message });
+      res.status(500).json({ error: error.message });
+    }
+  }) as any);
+
+  return router;
+}

--- a/mcp_backend/src/services/share-service.ts
+++ b/mcp_backend/src/services/share-service.ts
@@ -1,0 +1,144 @@
+import crypto from 'crypto';
+import type { IDatabase } from '../domain/ports/index.js';
+import { logger } from '../utils/logger.js';
+
+export type ShareScope = 'conversation' | 'message';
+
+/** One message frozen into a share snapshot. */
+export interface SharedMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  decisions?: any[];
+  citations?: any[];
+  documents?: any[];
+}
+
+export interface ShareSnapshot {
+  messages: SharedMessage[];
+}
+
+export interface CreateShareInput {
+  scope: ShareScope;
+  title?: string;
+  snapshot: ShareSnapshot;
+  conversationId?: string | null;
+}
+
+export interface ShareRecord {
+  token: string;
+  scope: ShareScope;
+  title: string | null;
+  snapshot: ShareSnapshot;
+  shared_by_name: string | null;
+  created_at: Date;
+}
+
+export interface ShareSummary {
+  token: string;
+  scope: ShareScope;
+  title: string | null;
+  view_count: number;
+  created_at: Date;
+}
+
+// Guard against storing pathologically large snapshots.
+const MAX_SNAPSHOT_BYTES = 2 * 1024 * 1024; // 2 MB
+const MAX_MESSAGES = 200;
+
+export class ShareService {
+  constructor(private db: IDatabase) {}
+
+  private generateToken(): string {
+    // URL-safe, unguessable (128 bits of entropy).
+    return crypto.randomBytes(16).toString('base64url');
+  }
+
+  async createShare(userId: string, input: CreateShareInput): Promise<{ token: string }> {
+    const scope: ShareScope = input.scope === 'message' ? 'message' : 'conversation';
+
+    const messages = Array.isArray(input.snapshot?.messages) ? input.snapshot.messages : [];
+    if (messages.length === 0) {
+      throw new Error('Nothing to share: snapshot has no messages');
+    }
+    if (messages.length > MAX_MESSAGES) {
+      throw new Error('Too many messages to share');
+    }
+
+    const snapshot: ShareSnapshot = {
+      messages: messages.map((m) => ({
+        role: m.role === 'user' ? 'user' : 'assistant',
+        content: typeof m.content === 'string' ? m.content : '',
+        decisions: Array.isArray(m.decisions) ? m.decisions : undefined,
+        citations: Array.isArray(m.citations) ? m.citations : undefined,
+        documents: Array.isArray(m.documents) ? m.documents : undefined,
+      })),
+    };
+
+    const snapshotJson = JSON.stringify(snapshot);
+    if (Buffer.byteLength(snapshotJson, 'utf8') > MAX_SNAPSHOT_BYTES) {
+      throw new Error('Shared content is too large');
+    }
+
+    const title = (input.title || '').toString().slice(0, 300) || null;
+    const token = this.generateToken();
+
+    await this.db.query(
+      `INSERT INTO conversation_shares (token, conversation_id, shared_by, scope, title, snapshot)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [token, input.conversationId || null, userId, scope, title, snapshotJson]
+    );
+
+    logger.info('[Shares] Created share', { userId, scope, token });
+    return { token };
+  }
+
+  /** Fetch a share by token and increment its view counter. Returns null if missing/revoked. */
+  async getShare(token: string): Promise<ShareRecord | null> {
+    const result = await this.db.query<{
+      token: string;
+      scope: ShareScope;
+      title: string | null;
+      snapshot: ShareSnapshot;
+      shared_by_name: string | null;
+      created_at: Date;
+    }>(
+      `SELECT s.token, s.scope, s.title, s.snapshot, s.created_at, u.name AS shared_by_name
+       FROM conversation_shares s
+       LEFT JOIN users u ON u.id = s.shared_by
+       WHERE s.token = $1 AND s.revoked_at IS NULL`,
+      [token]
+    );
+    const row = result.rows[0];
+    if (!row) return null;
+
+    // Fire-and-forget view count bump.
+    this.db.query(
+      `UPDATE conversation_shares SET view_count = view_count + 1 WHERE token = $1`,
+      [token]
+    ).catch(() => {});
+
+    return row;
+  }
+
+  async listShares(userId: string): Promise<ShareSummary[]> {
+    const result = await this.db.query<ShareSummary>(
+      `SELECT token, scope, title, view_count, created_at
+       FROM conversation_shares
+       WHERE shared_by = $1 AND revoked_at IS NULL
+       ORDER BY created_at DESC
+       LIMIT 200`,
+      [userId]
+    );
+    return result.rows;
+  }
+
+  async revokeShare(userId: string, token: string): Promise<boolean> {
+    const result = await this.db.query(
+      `UPDATE conversation_shares SET revoked_at = NOW()
+       WHERE token = $1 AND shared_by = $2 AND revoked_at IS NULL
+       RETURNING token`,
+      [token, userId]
+    );
+    return result.rows.length > 0;
+  }
+}


### PR DESCRIPTION
## What

Adds a **Share** ("Поділитися") control next to the per-response cost panel at the end of each chat pipeline. The cost details stay; share sits beside them.

When sharing, the user **chooses the scope**:
- **Whole conversation** — the entire dialogue
- **This response only** — the answer plus the question that produced it

A shareable link `/shared/:token` is generated and copied to the clipboard. Any **authenticated platform user** can open it to view a **read-only** snapshot.

## How it works

- A share stores a **point-in-time JSON snapshot** of the (already-decrypted) content. This decouples sharing from E2EE — the frontend sends content it already holds — and keeps the shared view stable even if the source conversation is later edited or deleted.
- New `conversation_shares` table (migration `163`), `ShareService`, and routes under `/api/shares` (create / list / view / revoke), all behind `requireJWT`.
- Server-side guards on snapshot size (2 MB) and message count (200).
- Unguessable 128-bit URL-safe tokens.

## Files

**Backend**
- `migrations/163_conversation_shares.sql`
- `services/share-service.ts`, `routes/share-routes.ts`
- wired through `factories/app-services.ts` + `http-server.ts`

**Frontend**
- `utils/api/shares.ts`
- `components/ShareControl.tsx` (popover: pick scope → link + copy)
- `components/CostSummary.tsx` (share control added beside cost)
- `pages/SharedConversationPage/` (read-only viewer)
- `router/` route registration + `i18n/misc-i18n.ts` (uk/en/de/es)

## Verification

- `tsc --noEmit` passes for both backend (new files clean) and frontend (0 errors).
- Local `eslint` and backend jest are broken in this environment **independently of this change** (eslint: missing `ajv` module; the `app-services` test fails identically on `main` at `llmAdapter.setABTestingService`). CI will run both in a clean env.

## Notes / follow-ups

- The `/shared/:token` page is behind the auth guard ("among our users"). `AuthGuard` currently redirects unauthenticated visitors to `/login` without preserving the return URL, so a logged-out user opening a link lands on `/chat` after login. Preserving the deep link is a small future enhancement, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shareable, read-only chat links via a Share control next to the cost panel. Links open a stable snapshot at /shared/:token and now preserve the deep link through login.

- **New Features**
  - Share control in `CostSummary` with scope picker; link is created and copied.
  - Read-only viewer at `/shared/:token` (auth required); login preserves returnUrl so users land back on the shared link.
  - Backend: `conversation_shares` table, `ShareService`, `/api/shares` (create/list/get/revoke).
  - Point-in-time JSON snapshots (decoupled from E2EE) with 2 MB/200-message limits; 128-bit URL-safe tokens.

- **Migration**
  - Run migration `163_conversation_shares.sql`.
  - No config changes; routes require authentication.

<sup>Written for commit 37026212829ac0f3b49aa40143a7352b6a30ab6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

