### PR TITLE
fix(chat-search): ground AI legislation refs, dedupe pro/contra, court-level fact-pattern filter

### DIFF
--- a/mcp_backend/src/api/__tests__/legislation-grounding.test.ts
+++ b/mcp_backend/src/api/__tests__/legislation-grounding.test.ts
@@ -1,0 +1,43 @@
+import { articleGroundingRatio } from '../legislation-tools';
+
+/**
+ * Regression for the search_legislation grounding guard (LEXAI): the AI classifier can
+ * confidently resolve a plausible-but-wrong article. The grounding ratio must be LOW for an
+ * off-topic article (so the handler supplements with semantic search) and HIGH for the
+ * genuinely relevant one.
+ */
+describe('articleGroundingRatio', () => {
+  // Real-world miss from chat-c758e2a4: query about ВПО/occupied-territory property-tax
+  // пільги was resolved to ст. 265 "склад податку на майно" (wrong) instead of ст. 266.
+  const query =
+    'податок на нерухоме майно окупована територія звільнення від оподаткування пільга ВПО';
+
+  const article265 =
+    'Склад податку на майно 265.1. Податок на майно складається з: податку на нерухоме майно, ' +
+    'відмінне від земельної ділянки; транспортного податку; плати за землю.';
+
+  const article266 =
+    'Податок на нерухоме майно, відмінне від земельної ділянки. Пільги із сплати податку. ' +
+    'Звільнення від оподаткування об’єктів на тимчасово окупованій території. База оподаткування ' +
+    'зменшується для внутрішньо переміщених осіб (ВПО).';
+
+  it('flags an off-topic article as poorly grounded', () => {
+    const ratio = articleGroundingRatio(query, article265);
+    expect(ratio).toBeLessThan(0.5);
+  });
+
+  it('rates the on-topic article as well grounded', () => {
+    const ratio = articleGroundingRatio(query, article266);
+    expect(ratio).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it('does not flag when the query has no distinctive terms', () => {
+    expect(articleGroundingRatio('ст 5', 'будь-який текст')).toBe(1);
+  });
+
+  it('tolerates Ukrainian inflection via prefix matching', () => {
+    // query "оподаткування" vs article "оподаткуванню" — same stem, different ending.
+    expect(articleGroundingRatio('оподаткування пільга', 'правила оподаткуванню та пільгам'))
+      .toBeGreaterThanOrEqual(0.5);
+  });
+});

--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -33,6 +33,39 @@ function capText(text: string | undefined | null): string {
   return text.slice(0, MAX_ARTICLE_TEXT_CHARS) + '… [обрізано]';
 }
 
+/** Confidence at/above which an AI-resolved article is trusted without semantic supplementation. */
+const AI_REF_TRUSTED_CONFIDENCE = 0.9;
+/** Min share of distinctive query terms that must appear in the resolved article for it to be "grounded". */
+const ARTICLE_GROUNDING_MIN_RATIO = 0.5;
+const GROUNDING_TOKEN_MIN_LEN = 5;
+/** Compare on a prefix to tolerate Ukrainian inflection (відмінки/числа). */
+const GROUNDING_PREFIX_LEN = 6;
+
+/**
+ * Heuristic grounding check: does the resolved article's text actually cover the query's
+ * distinctive terms? Guards against the AI classifier confidently returning a plausible but
+ * off-topic article number (e.g. ст. 265 "склад податку" for a query about ВПО/occupied-territory
+ * пільги that lives in ст. 266 / підрозділ 10 розд. XX). Returns the share [0..1] of distinctive
+ * query tokens found in the article; callers treat a low share as "supplement with semantic search".
+ */
+export function articleGroundingRatio(query: string, articleText: string): number {
+  const normalize = (s: string) =>
+    (s || '').toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ');
+  const queryTokens = [
+    ...new Set(
+      normalize(query)
+        .split(' ')
+        .filter(t => t.length >= GROUNDING_TOKEN_MIN_LEN)
+    ),
+  ];
+  if (queryTokens.length === 0) return 1; // nothing distinctive to check — don't flag
+  const haystack = normalize(articleText);
+  const matched = queryTokens.filter(t =>
+    haystack.includes(t.slice(0, Math.min(t.length, GROUNDING_PREFIX_LEN)))
+  ).length;
+  return matched / queryTokens.length;
+}
+
 export class LegislationTools extends BaseToolHandler {
   private service: LegislationService;
   private renderer: LegislationRenderer;
@@ -307,6 +340,33 @@ export class LegislationTools extends BaseToolHandler {
           };
         }
 
+        const resolvedArticle = {
+          rada_id: article.rada_id,
+          article_number: article.article_number,
+          title: article.title,
+          full_text: capText(article.full_text),
+          url: article.url,
+          npa_title: article.npa_title,
+          section_number: article.section_number,
+          section_title: article.section_title,
+          chapter_number: article.chapter_number,
+          chapter_title: article.chapter_title,
+        };
+
+        // Grounding guard: the AI classifier can confidently return a plausible-but-wrong
+        // article number (no retrieval/grounding on its side). If the resolved article does
+        // not actually cover the query's distinctive terms — or confidence is below the
+        // trusted bar — supplement with semantic search scoped to the same rada_id so the
+        // genuinely relevant article (e.g. ст. 266 vs ст. 265, or підрозділ 10 розд. XX
+        // transitional points) still surfaces instead of a single wrong answer.
+        const grounding = articleGroundingRatio(
+          args.query,
+          `${article.title || ''} ${article.full_text || ''}`
+        );
+        const trusted =
+          (directRef.confidence ?? 0) >= AI_REF_TRUSTED_CONFIDENCE &&
+          grounding >= ARTICLE_GROUNDING_MIN_RATIO;
+
         const response: any = {
           query: args.query,
           resolved_reference: {
@@ -314,23 +374,58 @@ export class LegislationTools extends BaseToolHandler {
             article_number: directRef.articleNumber,
             source: directRef.source,
             confidence: directRef.confidence,
+            grounding_ratio: Number(grounding.toFixed(2)),
           },
           total_found: 1,
-          articles: [
-            {
-              rada_id: article.rada_id,
-              article_number: article.article_number,
-              title: article.title,
-              full_text: capText(article.full_text),
-              url: article.url,
-              npa_title: article.npa_title,
-              section_number: article.section_number,
-              section_title: article.section_title,
-              chapter_number: article.chapter_number,
-              chapter_title: article.chapter_title,
-            },
-          ],
+          articles: [resolvedArticle],
         };
+
+        if (!trusted) {
+          try {
+            const supplemental = await this.service.findRelevantArticles(
+              args.query,
+              resolvedRadaId,
+              limit
+            );
+            const seen = new Set<string>([
+              `${resolvedArticle.rada_id}:${resolvedArticle.article_number}`,
+            ]);
+            for (const a of supplemental) {
+              const key = `${a.rada_id}:${a.article_number}`;
+              if (seen.has(key)) continue;
+              seen.add(key);
+              response.articles.push({
+                rada_id: a.rada_id,
+                article_number: a.article_number,
+                title: a.title,
+                full_text: capText(a.full_text),
+                url: a.url,
+                npa_title: a.npa_title,
+                section_number: a.section_number,
+                section_title: a.section_title,
+                chapter_number: a.chapter_number,
+                chapter_title: a.chapter_title,
+              });
+            }
+            response.total_found = response.articles.length;
+            if (response.articles.length > 1) {
+              response.resolved_reference.supplemented = true;
+              response.note =
+                'AI-визначена стаття могла не повністю відповідати запиту — додано релевантні статті за семантичним пошуком. Перевірте, яка стаття відповідає питанню.';
+            }
+            logger.info('[MCP Tool] search_legislation supplemented low-grounding AI reference', {
+              rada_id: resolvedRadaId,
+              ai_article: directRef.articleNumber,
+              confidence: directRef.confidence,
+              grounding_ratio: Number(grounding.toFixed(2)),
+              supplemental_count: response.articles.length - 1,
+            });
+          } catch (err: any) {
+            logger.warn('[MCP Tool] search_legislation supplemental search failed', {
+              error: err?.message,
+            });
+          }
+        }
 
         if (args.include_html) {
           response.html = this.renderer.renderArticleHTML(article, {

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -158,6 +158,11 @@ export class ProceduralTools extends BaseToolHandler {
           properties: {
             procedure_code: { type: 'string', enum: ['cpc', 'gpc', 'cac', 'crpc'], description: 'Вид судочинства: cpc (цивільне), gpc (господарське), cac (адміністративне), crpc (кримінальне)' },
             facts_text: { type: 'string', description: 'Опис фактичних обставин справи (довільний текст)' },
+            court_level: {
+              type: 'string',
+              enum: ['SC', 'GrandChamber'],
+              description: 'Обмежити пошук інстанцією: SC — лише Верховний Суд (касаційні суди, код суду 99*), GrandChamber — лише Велика Палата ВС (9901). Використовуйте, коли питання саме про позицію Верховного Суду. За замовчуванням — усі інстанції.',
+            },
             time_range: {
               oneOf: [
                 { type: 'string' },
@@ -425,14 +430,18 @@ export class ProceduralTools extends BaseToolHandler {
         ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
       };
 
+      const bareQuery = trimFtsQuery(query, 3);
       for (const inst of [
         { code: 1, label: 'Верховний Суд' },
         { code: 2, label: 'апеляційні суди' },
         { code: 3, label: 'суди першої інстанції' },
       ] as const) {
         const resp = await this.ftsService.searchFulltext(
-          `${trimFtsQuery(query, 3)} ${suffix}`, this.db,
+          `${bareQuery} ${suffix}`, this.db,
           { ...baseFilters, instance_code: inst.code }, limit,
+          0,
+          // Snippet highlights the topic, not the "задовольнити/відмовити" discriminator suffix.
+          bareQuery,
         );
         if (resp.results.length > 0) {
           return { results: resp.results, instanceLabel: inst.label };
@@ -446,6 +455,26 @@ export class ProceduralTools extends BaseToolHandler {
       ftsSearch('відмовити у задоволенні позову'),
     ]);
 
+    // The pro/contra discriminator (keyword suffix) is non-discriminative: SC decisions
+    // routinely contain both "задовольнити" and "відмовити", so the same document can rank
+    // on both sides. Cross-dedupe by doc_id, keeping each document on the side where it
+    // ranks higher, so one decision can never appear as both pro and contra.
+    const proByDoc = new Map<number, any>();
+    for (const d of proResult.results) if (!proByDoc.has(d.doc_id)) proByDoc.set(d.doc_id, d);
+    const contraByDoc = new Map<number, any>();
+    for (const d of contraResult.results) if (!contraByDoc.has(d.doc_id)) contraByDoc.set(d.doc_id, d);
+
+    for (const [docId, proDoc] of [...proByDoc.entries()]) {
+      const contraDoc = contraByDoc.get(docId);
+      if (!contraDoc) continue;
+      // Same doc on both sides → keep on the higher-ranked side only.
+      if ((contraDoc.rank || 0) >= (proDoc.rank || 0)) {
+        proByDoc.delete(docId);
+      } else {
+        contraByDoc.delete(docId);
+      }
+    }
+
     const mapFtsCase = (d: any) => ({
       doc_id: d.doc_id,
       court_code: d.court_code,
@@ -454,17 +483,36 @@ export class ProceduralTools extends BaseToolHandler {
       snippet: d.headline,
     });
 
+    const proCases = [...proByDoc.values()].slice(0, limit).map(mapFtsCase);
+    const contraCases = [...contraByDoc.values()].slice(0, limit).map(mapFtsCase);
+    const distinctDocs = new Set<number>([
+      ...proCases.map(c => c.doc_id),
+      ...contraCases.map(c => c.doc_id),
+    ]);
+
     const payload: any = {
       procedure_code: procedureCode,
       query,
       time_range: args.time_range,
-      court_level_pro: proResult.instanceLabel || undefined,
-      court_level_contra: contraResult.instanceLabel || undefined,
-      pro: proResult.results.slice(0, limit).map(mapFtsCase),
-      contra: contraResult.results.slice(0, limit).map(mapFtsCase),
-      total_pro: proResult.results.length,
-      total_contra: contraResult.results.length,
+      court_level_pro: proCases.length > 0 ? (proResult.instanceLabel || undefined) : undefined,
+      court_level_contra: contraCases.length > 0 ? (contraResult.instanceLabel || undefined) : undefined,
+      pro: proCases,
+      contra: contraCases,
+      total_pro: proCases.length,
+      total_contra: contraCases.length,
     };
+
+    // Honest signalling instead of fabricating a 1-vs-1 controversy out of a single
+    // boilerplate-matched decision. The keyword discriminator cannot reliably separate
+    // opposing holdings; when too little distinct practice is found, say so.
+    if (distinctDocs.size <= 1) {
+      payload.insufficient_practice = true;
+      payload.hint =
+        'Недостатньо різної практики для протиставлення позицій «за/проти» за цим запитом. ' +
+        'Розбиття за ключовими словами не є надійним для класифікації позицій суду — ' +
+        'перевірте знайдені рішення вручну або скористайтесь find_similar_fact_pattern_cases ' +
+        'чи search_edrsr_fulltext із вужчим запитом.';
+    }
     if (timeRangeParsed.warning) payload.warning = timeRangeParsed.warning;
 
     return this.wrapResponse(payload);
@@ -482,6 +530,19 @@ export class ProceduralTools extends BaseToolHandler {
       );
     }
     if (!factsText) throw new Error('facts_text parameter is required');
+
+    // Optional instance filter: SC = Supreme Court (cassation courts, court_code 99*),
+    // GrandChamber = Велика Палата (9901). Lets the orchestrator answer "what does the
+    // Supreme Court say" instead of being crowded out by long first-instance texts that
+    // dominate pure cosine ranking.
+    const courtLevelFilter: 'SC' | 'GrandChamber' | undefined =
+      args.court_level === 'SC' || args.court_level === 'GrandChamber' ? args.court_level : undefined;
+    const matchesCourtLevel = (courtCode: any): boolean => {
+      if (!courtLevelFilter) return true;
+      const code = String(courtCode ?? '');
+      if (!code.startsWith('99')) return false;
+      return courtLevelFilter === 'GrandChamber' ? code === '9901' : true;
+    };
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
     const extracted = await extractSearchTermsWithAI(factsText, this.llm);
@@ -509,11 +570,15 @@ export class ProceduralTools extends BaseToolHandler {
           ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
         };
         // Over-fetch chunks, then dedupe to distinct cases (a case may match on
-        // several chunks; we want the top distinct decisions).
-        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, limit * 4);
+        // several chunks; we want the top distinct decisions). When restricting to a
+        // court level (SC is a minority of the corpus), over-fetch much wider so enough
+        // 99* decisions survive the post-filter.
+        const overfetch = courtLevelFilter ? Math.max(limit * 20, 200) : limit * 4;
+        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, overfetch);
         const seen = new Set<number>();
         for (const h of hits) {
           if (seen.has(h.doc_id)) continue;
+          if (!matchesCourtLevel(h.metadata.court_code)) continue;
           seen.add(h.doc_id);
           results.push({
             doc_id: h.doc_id,
@@ -540,17 +605,25 @@ export class ProceduralTools extends BaseToolHandler {
         ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
       };
 
-      for (const inst of [
-        { code: 1, label: 'Верховний Суд' },
-        { code: 2, label: 'апеляційні суди' },
-        { code: 3, label: 'суди першої інстанції' },
-      ] as const) {
+      // When the caller asked for Supreme Court only, restrict the FTS fallback to
+      // instance_code=1 (Верховний Суд) rather than walking down to first instance.
+      const instances = courtLevelFilter
+        ? ([{ code: 1, label: 'Верховний Суд' }] as const)
+        : ([
+            { code: 1, label: 'Верховний Суд' },
+            { code: 2, label: 'апеляційні суди' },
+            { code: 3, label: 'суди першої інстанції' },
+          ] as const);
+      for (const inst of instances) {
         const resp = await this.ftsService.searchFulltext(
           trimFtsQuery(query), this.db, { ...baseFilters, instance_code: inst.code }, limit,
         );
         if (resp.results.length > 0) {
           courtLevel = inst.label;
-          results = resp.results.slice(0, limit).map((d) => ({
+          results = resp.results
+            .filter((d) => matchesCourtLevel(d.court_code))
+            .slice(0, limit)
+            .map((d) => ({
             doc_id: d.doc_id,
             court_code: d.court_code,
             date: d.adjudication_date,
@@ -566,7 +639,8 @@ export class ProceduralTools extends BaseToolHandler {
     const payload: any = {
       procedure_code: procedureCode,
       time_range: args.time_range,
-      court_level: courtLevel || undefined,
+      court_level: courtLevel || (courtLevelFilter === 'GrandChamber' ? 'Велика Палата ВС' : courtLevelFilter === 'SC' ? 'Верховний Суд' : undefined),
+      court_level_filter: courtLevelFilter || undefined,
       search_method: searchMethod || undefined,
       extracted_search_terms: extractedTerms,
       search_query: query,
@@ -574,7 +648,9 @@ export class ProceduralTools extends BaseToolHandler {
     };
     if (timeRangeParsed.warning) payload.time_range_warning = timeRangeParsed.warning;
     if (results.length === 0) {
-      payload.hint = 'Результатів не знайдено. Спробуйте переформулювати фабулу ширше або скористайтесь search_edrsr_fulltext з коротшим запитом (2-3 слова) чи compare_practice_pro_contra.';
+      payload.hint = courtLevelFilter
+        ? `Практику ${courtLevelFilter === 'GrandChamber' ? 'Великої Палати ВС' : 'Верховного Суду'} за цією фабулою не знайдено. Спробуйте без court_level (усі інстанції), ширшу фабулу, або search_supreme_court_practice / search_edrsr_fulltext.`
+        : 'Результатів не знайдено. Спробуйте переформулювати фабулу ширше або скористайтесь search_edrsr_fulltext з коротшим запитом (2-3 слова) чи compare_practice_pro_contra.';
     }
 
     return this.wrapResponse(payload);

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -79,6 +79,7 @@ export class EdsrFtsService {
     filters: EdsrFtsFilters = {},
     limit: number = 20,
     offset: number = 0,
+    headlineQuery?: string,
   ): Promise<EdsrFtsSearchResponse> {
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const safeOffset = Math.max(offset, 0);
@@ -151,6 +152,17 @@ export class EdsrFtsService {
       paramIdx++;
     }
 
+    // Optional separate query for snippet highlighting. Callers that append discriminator
+    // terms to the FTS match (e.g. compare_practice_pro_contra adds "відмовити у задоволенні")
+    // can pass the bare user query here so ts_headline centres the snippet on the topic,
+    // not on the boilerplate suffix (which produced header-only snippets — see LEXAI fix).
+    let headlineParamIdx = 1;
+    if (headlineQuery && headlineQuery !== query) {
+      headlineParamIdx = paramIdx;
+      params.push(headlineQuery);
+      paramIdx++;
+    }
+
     const whereClause = conditions.join(' AND ');
 
     // Build FROM clause — only join edrsr_documents when metadata filters are used
@@ -160,7 +172,7 @@ export class EdsrFtsService {
 
     const buildSelectFields = (withHeadline: boolean) => {
       const headlineExpr = withHeadline
-        ? `safe_ts_headline('simple'::regconfig, f.full_text, plainto_tsquery('simple', $1),
+        ? `safe_ts_headline('simple'::regconfig, f.full_text, plainto_tsquery('simple', $${headlineParamIdx}),
            'MaxWords=${FTS_HEADLINE_MAX_WORDS}, MinWords=${FTS_HEADLINE_MIN_WORDS}, StartSel=**, StopSel=**') AS headline`
         : `NULL AS headline`;
 


### PR DESCRIPTION
## Context
Diagnosed from chat run `chat-c758e2a4` (ВПО property-tax-on-occupied-territory question). Three subsystems underperformed; this fixes the two that live in `mcp_backend`/LEXAI plus the index-side of the third. The chat-orchestration part (forcing `court_level` from instance intent) lives in `secondlayer-core` and is a separate change.

## Fixes

### 1. `search_legislation` — grounding guard (`legislation-tools.ts`)
The AI article resolver has no retrieval grounding and confidently returned wrong articles: **ст. 265** ("склад податку") for a query about ВПО/occupied-territory пільги (should be **266**), and **ст. 38** (МПЗ) for a query about **підрозділ 10 розд. XX** transitional provisions. Now, when the resolved article is below the trusted confidence bar **or** its text doesn't cover the query's distinctive terms (`articleGroundingRatio`), we supplement with semantic search scoped to the same `rada_id` instead of returning a single wrong answer. Never drops the AI article — only adds relevant ones.

### 2. `compare_practice_pro_contra` — dedupe + honest empty (`procedural-tools.ts`, `edrsr-fts-service.ts`)
The pro/contra split is a non-discriminative keyword suffix (`задовольнити` vs `відмовити`) — SC decisions contain both, so the **same** decision ranked on both sides with a **header-only** snippet. Now:
- cross-dedupe by `doc_id` (keep the higher-ranked side) so one doc can't be both pro and contra;
- snippet highlights the **bare** user query, not the discriminator suffix, via a new optional `headlineQuery` param on `EdsrFtsService.searchFulltext` (default-off, no impact on other callers);
- emit `insufficient_practice` + hint when too little distinct practice exists, instead of fabricating a 1-vs-1 controversy.

### 3. `find_similar_fact_pattern_cases` — court-level filter (`procedural-tools.ts`)
Pure-cosine ranking is dominated by long first-instance texts, so "what does the **Supreme Court** say" never surfaced ВС practice. Added optional `court_level` (`SC` / `GrandChamber`) → over-fetch + post-filter to `court_code` `99*` (`9901` for Grand Chamber), and restrict the FTS fallback to instance 1. The Qdrant index already contains abundant SC merits practice on this topic (verified on prod).

## Tests
- New `legislation-grounding.test.ts` (4 cases) for the grounding heuristic.
- `legislation-service` + `legislation-reference` suites: 45/45 pass.
- Type-clean (the 3 pre-existing `core-loader.ts` errors are CORE modules absent in the local repo split, unrelated to this change).

## Follow-ups (separate, not in this PR)
- CORE: orchestrator should set `court_level: 'SC'` when the user explicitly asks for the Supreme Court position, and consider force-opening top-N fact-pattern candidates by score.
- Larger: replace the keyword pro/contra discriminator with LLM holding classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves legal search accuracy by grounding legislation references, deduping pro/contra results, and adding a Supreme Court filter to fact‑pattern search. Results are more reliable, and users can target Supreme Court or Grand Chamber practice when needed.

- **Bug Fixes**
  - Legislation search now supplements low-confidence or off-topic resolved articles with same-law semantic results instead of returning a single wrong citation.
  - Pro/contra: cross-dedupe by `doc_id` (keep higher-ranked side) and emit `insufficient_practice` when there aren’t enough distinct cases.

- **New Features**
  - `find_similar_fact_pattern_cases`: optional `court_level` (`SC` or `GrandChamber`) with over-fetch + post-filtering; FTS fallback restricted to instance 1 when set.
  - `EdsrFtsService.searchFulltext`: optional `headlineQuery` to center snippets on the user’s topic rather than discriminator keywords.

<sup>Written for commit 097cf900858a530037166714ee97708c179f5009. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

