### PR TITLE
perf(bedrock): tier-based region pinning to isolate quick-tier quota

### DIFF
--- a/packages/shared/src/utils/bedrock-client.ts
+++ b/packages/shared/src/utils/bedrock-client.ts
@@ -5,6 +5,13 @@ import { requestContext, CostTrackerInterface } from './openai-client';
 
 const FALLBACK_REGIONS = (process.env.BEDROCK_FALLBACK_REGIONS || 'us-east-1,us-west-2').split(',').map(r => r.trim()).filter(Boolean);
 
+// Tier-based region pinning (opt-in). When set, "quick"-tier calls (intent
+// classification, plan generation, replan, context summarization, etc.) are
+// routed to a separate region than the standard/deep main loop. This isolates
+// the many small Haiku calls from the heavy Sonnet/Opus quota on the primary
+// region, removing the reactive-throttle penalty under load. Unset → no change.
+const QUICK_REGION = (process.env.BEDROCK_QUICK_REGION || '').trim() || null;
+
 function swapRegionPrefix(model: string, targetRegion: string): string {
   const regionPrefix = targetRegion.startsWith('us-') ? 'us' : targetRegion.startsWith('ap-') ? 'ap' : 'eu';
   return model.replace(/^(eu|us|ap)\./, `${regionPrefix}.`);
@@ -24,11 +31,12 @@ function isThrottlingError(err: any): boolean {
 
 export class BedrockClientManager {
   private client: BedrockRuntimeClient | null = null;
+  private primaryRegion: string = process.env.AWS_REGION || 'eu-central-1';
   private fallbackClients: Array<{ region: string; client: BedrockRuntimeClient }> = [];
   private costTracker: CostTrackerInterface | null = null;
 
   constructor() {
-    const region = process.env.AWS_REGION || 'eu-central-1';
+    const region = this.primaryRegion;
     const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
     const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
 
@@ -36,7 +44,10 @@ export class BedrockClientManager {
       const creds = { accessKeyId, secretAccessKey };
       this.client = new BedrockRuntimeClient({ region, credentials: creds });
 
-      for (const fbRegion of FALLBACK_REGIONS) {
+      // Ensure the quick-tier region also has a client even if it's not in the
+      // throttle fallback list, so tier pinning has something to route to.
+      const regions = new Set([...FALLBACK_REGIONS, ...(QUICK_REGION ? [QUICK_REGION] : [])]);
+      for (const fbRegion of regions) {
         if (fbRegion !== region) {
           this.fallbackClients.push({
             region: fbRegion,
@@ -48,6 +59,7 @@ export class BedrockClientManager {
       logger.info('Bedrock client manager initialized', {
         region,
         fallbackRegions: this.fallbackClients.map(c => c.region),
+        quickRegion: QUICK_REGION,
       });
     } else {
       logger.warn('AWS credentials not configured - Bedrock provider will be unavailable');
@@ -67,6 +79,30 @@ export class BedrockClientManager {
 
   getFallbackClients(): Array<{ region: string; client: BedrockRuntimeClient }> {
     return this.fallbackClients;
+  }
+
+  /** All region clients (primary first, then fallbacks). */
+  private allClients(): Array<{ region: string; client: BedrockRuntimeClient }> {
+    return [{ region: this.primaryRegion, client: this.getClient() }, ...this.fallbackClients];
+  }
+
+  /**
+   * Pick the region client for a given resource tier. "quick"-tier calls route
+   * to BEDROCK_QUICK_REGION when configured (and a client exists for it);
+   * everything else stays on the primary region. Falls back to primary if the
+   * configured quick region has no client.
+   */
+  getClientForTier(tier: string): { region: string; client: BedrockRuntimeClient } {
+    if (tier === 'quick' && QUICK_REGION && QUICK_REGION !== this.primaryRegion) {
+      const pinned = this.fallbackClients.find(c => c.region === QUICK_REGION);
+      if (pinned) return pinned;
+    }
+    return { region: this.primaryRegion, client: this.getClient() };
+  }
+
+  /** Failover targets for throttling, excluding the region already tried. */
+  getFailoverClients(excludeRegion: string): Array<{ region: string; client: BedrockRuntimeClient }> {
+    return this.allClients().filter(c => c.region !== excludeRegion);
   }
 
   setCostTracker(tracker: CostTrackerInterface) {

--- a/packages/shared/src/utils/llm-client-manager.ts
+++ b/packages/shared/src/utils/llm-client-manager.ts
@@ -207,7 +207,7 @@ export class LLMClientManager {
     selection: ModelSelection
   ): Promise<UnifiedChatResponse> {
     if (selection.provider === 'bedrock') {
-      return await this.executeBedrockChatCompletion(request, selection.model);
+      return await this.executeBedrockChatCompletion(request, selection.model, selection.budget);
     }
     if (selection.provider === 'anthropic') {
       return await this.executeAnthropicChatCompletion(request, selection.model);
@@ -437,7 +437,7 @@ export class LLMClientManager {
     const streamStart = Date.now();
     try {
       if (selection.provider === 'bedrock') {
-        yield* this.executeBedrockStreamCompletion(request, selection.model, signal);
+        yield* this.executeBedrockStreamCompletion(request, selection.model, signal, budget);
       } else if (selection.provider === 'anthropic') {
         yield* this.executeAnthropicStreamCompletion(request, selection.model, signal);
       } else {
@@ -455,7 +455,7 @@ export class LLMClientManager {
           logger.info(`Stream bedrock fallback: ${selection.model} → ${bedrockFallback.model}`);
           const fbStart = Date.now();
           try {
-            yield* this.executeBedrockStreamCompletion(request, bedrockFallback.model, signal);
+            yield* this.executeBedrockStreamCompletion(request, bedrockFallback.model, signal, budget);
             this.externalApiMetrics?.('bedrock-fallback', 'success', (Date.now() - fbStart) / 1000);
             return;
           } catch (fbError: any) {
@@ -473,7 +473,7 @@ export class LLMClientManager {
         const fbStart = Date.now();
         try {
           if (fallbackSelection.provider === 'bedrock') {
-            yield* this.executeBedrockStreamCompletion(request, fallbackSelection.model, signal);
+            yield* this.executeBedrockStreamCompletion(request, fallbackSelection.model, signal, fallbackSelection.budget);
           } else if (fallbackSelection.provider === 'anthropic') {
             yield* this.executeAnthropicStreamCompletion(request, fallbackSelection.model, signal);
           } else {
@@ -913,15 +913,20 @@ export class LLMClientManager {
 
   private async executeBedrockChatCompletion(
     request: UnifiedChatRequest,
-    model: string
+    model: string,
+    budget: BudgetLevel = 'standard'
   ): Promise<UnifiedChatResponse> {
+    // Tier-based region pinning: quick-tier calls may route to a separate
+    // region (BEDROCK_QUICK_REGION) to isolate quota from the main loop.
+    const pin = this.bedrockManager.getClientForTier(budget);
+    const pinnedModel = swapRegionPrefix(model, pin.region);
     try {
-      return await this.sendBedrockConverse(this.bedrockManager.getClient(), model, request);
+      return await this.sendBedrockConverse(pin.client, pinnedModel, request);
     } catch (err: any) {
       if (!isThrottlingError(err)) throw err;
 
-      // Cross-region fallback on throttling
-      for (const fb of this.bedrockManager.getFallbackClients()) {
+      // Cross-region fallback on throttling (excluding the region already tried)
+      for (const fb of this.bedrockManager.getFailoverClients(pin.region)) {
         const regionModel = swapRegionPrefix(model, fb.region);
         logger.info(`Bedrock throttled, trying ${fb.region}`, { model: regionModel });
         try {
@@ -1008,9 +1013,15 @@ export class LLMClientManager {
   private async *executeBedrockStreamCompletion(
     request: UnifiedChatRequest,
     model: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    budget: BudgetLevel = 'standard'
   ): AsyncGenerator<UnifiedStreamChunk> {
-    const client = this.bedrockManager.getClient();
+    // Tier-based region pinning (see executeBedrockChatCompletion). The stream
+    // path keeps the existing model/provider fallback in chatCompletionStream;
+    // here we only choose the region client + matching model prefix.
+    const pin = this.bedrockManager.getClientForTier(budget);
+    const client = pin.client;
+    model = swapRegionPrefix(model, pin.region);
     const hasTools = !!(request.tools && request.tools.length > 0);
     const { system, messages } = this.convertToBedrockMessages(request.messages, hasTools);
 


### PR DESCRIPTION
## What

Opt-in **tier-based Bedrock region pinning**. When `BEDROCK_QUICK_REGION` is set, quick-tier LLM calls route to that region while standard/deep stay on `AWS_REGION`.

## Why

In the chat pipeline, many small quick-tier calls (intent classification, plan generation, replan, context summarization, name variations) contend for the **same per-region Bedrock TPM/RPM quota** as the heavy Sonnet/Opus main loop. Under load this trips the reactive cross-region fallback, which only fires **after** a `ThrottlingException` — so we pay a failed round-trip + backoff before recovering.

Pinning the quick tier to its own region gives **quota isolation at zero added token cost and zero hedging risk** (this is plain routing, not duplicated requests).

This is step 1 of a broader plan (tier pinning → proactive `global.` profile / least-loaded routing → hedged synthesis streaming for tail latency).

## How

- `BedrockClientManager`:
  - `getClientForTier(tier)` — quick → `BEDROCK_QUICK_REGION` (if a client exists), else primary.
  - `getFailoverClients(excludeRegion)` — throttle failover now skips the region already tried and includes the primary.
  - Constructor ensures a client is created for the quick region even when it isn't in `BEDROCK_FALLBACK_REGIONS`.
- `llm-client-manager`: thread the resource `budget` into the Bedrock chat + stream paths; pin the region client and swap the model's regional prefix accordingly.

## Safety / rollout

- **Default behavior unchanged**: with `BEDROCK_QUICK_REGION` unset, `getClientForTier` resolves to the primary region and the prefix swap is a no-op.
- No public method signatures changed → no downstream changes needed in `mcp_backend`.
- `packages/shared` builds clean (`tsc`).

### New env var
| Var | Default | Effect |
|-----|---------|--------|
| `BEDROCK_QUICK_REGION` | unset | When set (e.g. `us-east-1`), quick-tier calls pin to this region for quota isolation. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in tier-based Bedrock region pinning to isolate quick-tier traffic. Quick-tier calls route to `BEDROCK_QUICK_REGION` while standard/deep stay on `AWS_REGION`, reducing throttling and retries.

- **New Features**
  - New env var `BEDROCK_QUICK_REGION`. When set, quick-tier calls pin to this region; unset keeps current behavior.
  - `BedrockClientManager`: `getClientForTier(tier)` selects quick/primary region; ensures a client exists for the quick region; `getFailoverClients(excludeRegion)` skips the region already tried.
  - `llm-client-manager`: threads `budget` into Bedrock chat/stream, pins the region client, and swaps the model’s regional prefix; throttle fallback now avoids repeating the same region.

- **Migration**
  - Optional: set `BEDROCK_QUICK_REGION` (e.g., `us-east-1`) to enable quota isolation. No code changes required.

<sup>Written for commit da3ff27e2cae0e6cd8329e631f25aab16e073156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

