### PR TITLE
feat(chat-search): LLM holding classification for compare_practice_pro_contra

### DIFF
--- a/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
+++ b/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
@@ -1,0 +1,79 @@
+import { ProceduralTools } from '../tools/procedural-tools';
+
+/**
+ * Regression for compare_practice_pro_contra holding classification (LEXAI-1751): the legacy
+ * keyword suffix could put the same decision on both sides with a header-only snippet. The new
+ * path retrieves candidates once and classifies each holding via the LLM into supports / opposes
+ * / not_on_point — a decision can only land on the side the LLM assigns, and not_on_point is dropped.
+ */
+function makeTools(opts: {
+  hits: any[];
+  classifications: any[];
+}): ProceduralTools {
+  const edsrVectorizer: any = {
+    semanticSearch: jest.fn().mockResolvedValue(opts.hits),
+  };
+  const llm: any = {
+    chatCompletion: jest.fn().mockResolvedValue({
+      content: JSON.stringify({ classifications: opts.classifications }),
+    }),
+  };
+  // Required ctor args are unused on this path — stub them.
+  return new ProceduralTools(
+    {} as any, {} as any, {} as any, {} as any, {} as any,
+    llm, undefined, undefined, edsrVectorizer,
+  );
+}
+
+function hit(doc_id: number, court_code: number, text: string) {
+  return {
+    doc_id,
+    score: 0.9,
+    text,
+    metadata: { court_code, adjudication_date: '2025-01-01', cause_num: `c/${doc_id}` },
+  };
+}
+
+async function run(tools: ProceduralTools, args: any) {
+  const res = await (tools as any).comparePracticeProContra(args);
+  return JSON.parse(res.content[0].text);
+}
+
+describe('comparePracticeProContra — LLM holding classification', () => {
+  it('splits pro/contra by LLM stance and drops not_on_point', async () => {
+    const tools = makeTools({
+      hits: [hit(101, 9921, 'frag A'), hit(102, 9921, 'frag B'), hit(103, 1370, 'frag C')],
+      classifications: [
+        { doc_id: 101, stance: 'supports', quote: 'суд погодився', confidence: 0.9 },
+        { doc_id: 102, stance: 'opposes', quote: 'суд відмовив', confidence: 0.8 },
+        { doc_id: 103, stance: 'not_on_point', quote: '', confidence: 0.4 },
+      ],
+    });
+    const out = await run(tools, { procedure_code: 'cac', query: 'теза' });
+
+    expect(out.search_method).toBe('llm_holding_semantic_hnsw');
+    expect(out.pro.map((c: any) => c.doc_id)).toEqual([101]);
+    expect(out.contra.map((c: any) => c.doc_id)).toEqual([102]);
+    expect(out.total_pro).toBe(1);
+    expect(out.total_contra).toBe(1);
+    // A doc never appears on both sides.
+    expect(out.pro.map((c: any) => c.doc_id)).not.toEqual(out.contra.map((c: any) => c.doc_id));
+    // Snippet is the cited quote, not a header.
+    expect(out.pro[0].snippet).toBe('суд погодився');
+    expect(out.insufficient_practice).toBeUndefined();
+  });
+
+  it('flags insufficient_practice when one side is empty', async () => {
+    const tools = makeTools({
+      hits: [hit(201, 9921, 'frag A'), hit(202, 9921, 'frag B')],
+      classifications: [
+        { doc_id: 201, stance: 'supports', quote: 'за', confidence: 0.9 },
+        { doc_id: 202, stance: 'supports', quote: 'теж за', confidence: 0.7 },
+      ],
+    });
+    const out = await run(tools, { procedure_code: 'cac', query: 'теза' });
+    expect(out.total_pro).toBe(2);
+    expect(out.total_contra).toBe(0);
+    expect(out.insufficient_practice).toBe(true);
+  });
+});

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -125,8 +125,9 @@ export class ProceduralTools extends BaseToolHandler {
         description: `Підбірка судової практики "за" і "проти" по правовій тезі
 
 Знаходить дві лінії практики — рішення, що підтверджують тезу, та рішення, що їй суперечать.
+Позиція кожного рішення визначається LLM-класифікацією (за/проти/не по суті), а не збігом ключових слів.
 Використовуйте для аналізу суперечливої практики або підготовки правової позиції.
-Повертає: списки справ pro/contra з цитатами з мотивувальної частини.`,
+Повертає: списки справ pro/contra з цитатою та впевненістю (confidence). Якщо однієї зі сторін немає — повертає insufficient_practice.`,
         inputSchema: {
           type: 'object',
           properties: {
@@ -421,6 +422,71 @@ export class ProceduralTools extends BaseToolHandler {
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
     const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
 
+    // Primary path: retrieve candidates once (no pro/contra keyword suffix) and let the LLM
+    // classify each decision's holding relative to the user's thesis (supports / opposes /
+    // not-on-point) with a cited fragment. The legacy keyword suffix (задовольнити/відмовити)
+    // is non-discriminative and cannot separate opposing holdings — kept only as a fallback
+    // when the LLM or vectorizer is unavailable.
+    if (this.llm) {
+      try {
+        const gathered = await this.gatherProContraCandidates(
+          query, justiceKind, timeRangeParsed, Math.min(12, Math.max(6, limit * 2)),
+        );
+        if (gathered.candidates.length > 0) {
+          const stances = await this.classifyHoldings(query, gathered.candidates);
+          if (stances) {
+            const pro: any[] = [];
+            const contra: any[] = [];
+            for (const c of gathered.candidates) {
+              const v = stances.get(c.doc_id);
+              if (!v) continue;
+              const row = {
+                doc_id: c.doc_id,
+                court_code: c.court_code,
+                date: c.date,
+                case_number: c.case_number,
+                snippet: v.quote || c.fragment,
+                confidence: v.confidence,
+              };
+              if (v.stance === 'supports') pro.push(row);
+              else if (v.stance === 'opposes') contra.push(row);
+              // not_on_point → dropped
+            }
+            const byConf = (a: any, b: any) => (b.confidence || 0) - (a.confidence || 0);
+            pro.sort(byConf);
+            contra.sort(byConf);
+            const proCases = pro.slice(0, limit);
+            const contraCases = contra.slice(0, limit);
+
+            const payload: any = {
+              procedure_code: procedureCode,
+              query,
+              time_range: args.time_range,
+              search_method: `llm_holding_${gathered.method}`,
+              pro: proCases,
+              contra: contraCases,
+              total_pro: proCases.length,
+              total_contra: contraCases.length,
+            };
+            if (proCases.length === 0 || contraCases.length === 0) {
+              payload.insufficient_practice = true;
+              payload.hint = proCases.length === 0 && contraCases.length === 0
+                ? 'Серед знайдених рішень немає таких, що прямо підтверджують або спростовують тезу. Спробуйте переформулювати тезу або скористайтесь find_similar_fact_pattern_cases.'
+                : (proCases.length === 0
+                    ? 'Знайдено лише практику ПРОТИ тези; практики ЗА не виявлено серед кандидатів.'
+                    : 'Знайдено лише практику ЗА тезу; практики ПРОТИ не виявлено серед кандидатів.');
+            }
+            if (timeRangeParsed.warning) payload.warning = timeRangeParsed.warning;
+            return this.wrapResponse(payload);
+          }
+        }
+      } catch (err: any) {
+        logger.warn('[comparePracticeProContra] holding-classification path failed, falling back to keyword FTS', {
+          error: err?.message,
+        });
+      }
+    }
+
     const ftsSearch = async (suffix: string) => {
       if (!this.ftsService || !this.db) return { results: [], instanceLabel: '' };
 
@@ -516,6 +582,141 @@ export class ProceduralTools extends BaseToolHandler {
     if (timeRangeParsed.warning) payload.warning = timeRangeParsed.warning;
 
     return this.wrapResponse(payload);
+  }
+
+  /**
+   * Retrieve distinct candidate decisions for pro/contra classification — semantic search
+   * (preferred: relevant chunk text becomes the fragment) with an FTS fallback. No pro/contra
+   * keyword suffix here; discrimination is done downstream by the LLM.
+   */
+  private async gatherProContraCandidates(
+    query: string,
+    justiceKind: number | null,
+    timeRangeParsed: { date_from?: string; date_to?: string },
+    maxN: number,
+  ): Promise<{ candidates: Array<{ doc_id: number; court_code?: number; date?: string; case_number?: string; fragment: string }>; method: string }> {
+    // Semantic (preferred)
+    if (this.edsrVectorizer) {
+      try {
+        const semFilters: EdrsrSearchFilters = {
+          ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
+          ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
+          ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
+        };
+        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, maxN * 3);
+        const seen = new Set<number>();
+        const out: any[] = [];
+        for (const h of hits) {
+          if (seen.has(h.doc_id)) continue;
+          seen.add(h.doc_id);
+          out.push({
+            doc_id: h.doc_id,
+            court_code: h.metadata.court_code,
+            date: h.metadata.adjudication_date,
+            case_number: h.metadata.cause_num,
+            fragment: (h.text || '').slice(0, 900),
+          });
+          if (out.length >= maxN) break;
+        }
+        if (out.length > 0) return { candidates: out, method: 'semantic_hnsw' };
+      } catch (err: any) {
+        logger.warn('[gatherProContraCandidates] semantic search failed, falling back to FTS', { error: err?.message });
+      }
+    }
+
+    // FTS fallback (headline as fragment)
+    if (this.ftsService && this.db) {
+      const baseFilters: EdsrFtsFilters = {
+        ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
+        ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
+        ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
+      };
+      for (const inst of [
+        { code: 1 }, { code: 2 }, { code: 3 },
+      ] as const) {
+        const resp = await this.ftsService.searchFulltext(
+          trimFtsQuery(query), this.db, { ...baseFilters, instance_code: inst.code }, maxN,
+        );
+        if (resp.results.length > 0) {
+          const seen = new Set<number>();
+          const out: any[] = [];
+          for (const d of resp.results) {
+            if (seen.has(d.doc_id)) continue;
+            seen.add(d.doc_id);
+            out.push({
+              doc_id: d.doc_id,
+              court_code: d.court_code,
+              date: d.adjudication_date,
+              case_number: d.cause_num,
+              fragment: d.headline || '',
+            });
+          }
+          if (out.length > 0) return { candidates: out, method: 'fts' };
+        }
+      }
+    }
+
+    return { candidates: [], method: '' };
+  }
+
+  /**
+   * LLM holding classification: for each candidate decision, classify its holding relative to
+   * the user's thesis as supports / opposes / not_on_point, with a short cited fragment and
+   * confidence. One batched call. Returns null on parse failure so the caller can fall back.
+   */
+  private async classifyHoldings(
+    thesis: string,
+    candidates: Array<{ doc_id: number; case_number?: string; court_code?: number; fragment: string }>,
+  ): Promise<Map<number, { stance: 'supports' | 'opposes' | 'not_on_point'; quote: string; confidence: number }> | null> {
+    if (!this.llm) return null;
+    const items = candidates.map((c, i) => (
+      `#${i} doc_id=${c.doc_id} справа=${c.case_number || '—'}\nФрагмент: ${(c.fragment || '').replace(/\s+/g, ' ').slice(0, 800)}`
+    )).join('\n\n');
+
+    const system =
+      'Ти суддя-аналітик. Тобі дано ТЕЗУ та фрагменти судових рішень. ' +
+      'Для КОЖНОГО рішення визнач його позицію щодо тези: ' +
+      '"supports" — рішення підтверджує тезу; "opposes" — спростовує тезу; ' +
+      '"not_on_point" — фрагмент не дозволяє визначити позицію щодо тези. ' +
+      'Якщо не впевнений — став "not_on_point". Відповідай ВИКЛЮЧНО валідним JSON.';
+    const user =
+      `ТЕЗА: ${thesis}\n\nРІШЕННЯ:\n${items}\n\n` +
+      'Поверни JSON: {"classifications":[{"doc_id":<число>,"stance":"supports|opposes|not_on_point",' +
+      '"quote":"<коротка цитата з фрагмента українською, ≤200 симв.>","confidence":<0..1>}]}';
+
+    const response = await this.llm.chatCompletion(
+      {
+        messages: [
+          { role: 'system', content: system },
+          { role: 'user', content: user },
+        ],
+        temperature: 0.1,
+        response_format: { type: 'json_object' },
+      },
+      'standard',
+    );
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(response.content || '{}');
+    } catch {
+      logger.warn('[classifyHoldings] non-JSON LLM response');
+      return null;
+    }
+    const list = Array.isArray(parsed?.classifications) ? parsed.classifications : [];
+    if (list.length === 0) return null;
+
+    const validDocIds = new Set(candidates.map(c => c.doc_id));
+    const map = new Map<number, { stance: 'supports' | 'opposes' | 'not_on_point'; quote: string; confidence: number }>();
+    for (const item of list) {
+      const docId = Number(item?.doc_id);
+      if (!validDocIds.has(docId)) continue;
+      const stance = item?.stance;
+      if (stance !== 'supports' && stance !== 'opposes' && stance !== 'not_on_point') continue;
+      const confidence = typeof item?.confidence === 'number' ? Math.max(0, Math.min(1, item.confidence)) : 0.5;
+      map.set(docId, { stance, quote: typeof item?.quote === 'string' ? item.quote.slice(0, 300) : '', confidence });
+    }
+    return map.size > 0 ? map : null;
   }
 
   private async findSimilarFactPatternCases(args: any): Promise<ToolResult> {


### PR DESCRIPTION
## Context
Follow-up FU2 (Plane **LEXAI-1751**) to PR #1943. The earlier patch added cross-dedup + honest empty handling, but the **structural** root remained: pro/contra was split by a non-discriminative keyword suffix (`задовольнити` vs `відмовити`) that appears in essentially every decision, so the same doc could rank on both sides with a header-only snippet.

## What changes
Replaces the keyword split with proper holding classification:

1. **`gatherProContraCandidates`** — retrieve distinct candidates **once** (semantic HNSW preferred → relevant chunk text becomes the fragment; FTS fallback → headline). No pro/contra keyword suffix.
2. **`classifyHoldings`** — one batched LLM call (`this.llm.chatCompletion`, `standard` budget, `json_object`) classifies each candidate's holding relative to the user's thesis as **supports / opposes / not_on_point**, with a cited quote and confidence. `not_on_point` is dropped; unknown doc_ids and invalid stances are filtered.
3. **Assembly** — `pro = supports`, `contra = opposes`, sorted by confidence, capped at `limit`. Emits `insufficient_practice` (with a side-specific hint) when a side is empty, instead of fabricating a 1-vs-1 controversy.

The **legacy keyword + dedup path is retained as a fallback** when the LLM/vectorizer is unavailable or classification fails/parses empty — so the tool degrades gracefully.

Tool description updated to state that stance comes from LLM classification (not keyword match) and that results carry `confidence`.

## Cost / latency
+1 LLM pass per tool call (batched, single request, `standard` tier via Bedrock). Candidates capped at 12. Runs inside the existing tool path — watch the 60s tool timeout (semantic retrieval is ~300ms warm; one classification call).

## Tests
- New `pro-contra-holding.test.ts`: stance split drops `not_on_point`, one doc never on both sides, snippet is the cited quote; `insufficient_practice` when a side is empty.
- Type-clean (the 3 pre-existing `core-loader.ts` errors are CORE modules absent in the local split).

## Related
- Companion follow-up FU1 (orchestrator sets `court_level:'SC'` from instance intent) is tracked separately in **CORE-33** (secondlayer-core repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the keyword-based pro/contra split in `compare_practice_pro_contra` with a batched LLM holding classification to stop the same decision appearing on both sides and use real quoted snippets (LEXAI-1751). Results are ranked by confidence and flag `insufficient_practice` when one side is empty, with a graceful legacy fallback.

- **New Features**
  - Retrieve a single candidate set via semantic HNSW (FTS fallback) using a relevant fragment.
  - One batched LLM call classifies holdings as supports/opposes/not_on_point; drop not_on_point.
  - Build pro=supports and contra=opposes; sort by confidence, cap by limit; include quote and confidence.
  - Return `insufficient_practice` with a side-specific hint if one side is empty.
  - Fall back to the legacy keyword+dedup path when the vectorizer/LLM is unavailable or parsing fails; tool help text updated to reflect LLM stance and confidence.

<sup>Written for commit 13b6f3774a1776e2429325d03c370f59e1663ce0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

