### PR TITLE
fix(chat-search): embed full fact pattern directly in find_similar_fact_pattern_cases (LEXAI-1752)

### DIFF
--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -746,17 +746,20 @@ export class ProceduralTools extends BaseToolHandler {
     };
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
-    const extracted = await extractSearchTermsWithAI(factsText, this.llm);
-    const extractedTerms = Array.isArray(extracted?.keywords) ? extracted.keywords : [];
-    const query = typeof extracted?.searchQuery === 'string' && extracted.searchQuery.trim().length > 0
-      ? extracted.searchQuery.trim()
-      : (extractedTerms.length > 0 ? extractedTerms.join(' ') : factsText.slice(0, 180));
-
     const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
 
     let results: any[] = [];
     let courtLevel = '';
     let searchMethod = '';
+    // Term extraction is deferred to the FTS fallback (below). The semantic path
+    // embeds the full fact pattern directly, so we no longer block on an upfront
+    // keyword-extraction LLM call that — when it returned no keywords — collapsed
+    // the query to a truncated literal and zeroed out the results.
+    let extractedTerms: string[] = [];
+    let ftsQuery = '';
+    // BGE-M3 is the ideal consumer of natural-language facts; pass the fact pattern
+    // straight through (capped — the model truncates long input anyway).
+    const semanticQuery = factsText.slice(0, 4000);
 
     // Primary path: HNSW semantic search over the unified edrsr_serving collection
     // (BGE-M3 vectors, 296M chunks). Semantic similarity is the natural fit for
@@ -775,7 +778,7 @@ export class ProceduralTools extends BaseToolHandler {
         // court level (SC is a minority of the corpus), over-fetch much wider so enough
         // 99* decisions survive the post-filter.
         const overfetch = courtLevelFilter ? Math.max(limit * 20, 200) : limit * 4;
-        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, overfetch);
+        const hits = await this.edsrVectorizer.semanticSearch(semanticQuery, semFilters, overfetch);
         const seen = new Set<number>();
         for (const h of hits) {
           if (seen.has(h.doc_id)) continue;
@@ -800,6 +803,13 @@ export class ProceduralTools extends BaseToolHandler {
     // Fallback: multi-instance FTS (when the vectorizer is unavailable or returns
     // nothing — e.g. very rare terminology not well represented in embeddings).
     if (results.length === 0 && this.ftsService && this.db) {
+      // FTS is lexical, so here (and only here) we extract keywords from the facts.
+      const extracted = await extractSearchTermsWithAI(factsText, this.llm);
+      extractedTerms = Array.isArray(extracted?.keywords) ? extracted.keywords : [];
+      ftsQuery = typeof extracted?.searchQuery === 'string' && extracted.searchQuery.trim().length > 0
+        ? extracted.searchQuery.trim()
+        : (extractedTerms.length > 0 ? extractedTerms.join(' ') : factsText.slice(0, 180));
+
       const baseFilters: EdsrFtsFilters = {
         ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
         ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
@@ -817,7 +827,7 @@ export class ProceduralTools extends BaseToolHandler {
           ] as const);
       for (const inst of instances) {
         const resp = await this.ftsService.searchFulltext(
-          trimFtsQuery(query), this.db, { ...baseFilters, instance_code: inst.code }, limit,
+          trimFtsQuery(ftsQuery), this.db, { ...baseFilters, instance_code: inst.code }, limit,
         );
         if (resp.results.length > 0) {
           courtLevel = inst.label;
@@ -844,7 +854,7 @@ export class ProceduralTools extends BaseToolHandler {
       court_level_filter: courtLevelFilter || undefined,
       search_method: searchMethod || undefined,
       extracted_search_terms: extractedTerms,
-      search_query: query,
+      search_query: searchMethod === 'fts' ? ftsQuery : factsText.slice(0, 200),
       results,
     };
     if (timeRangeParsed.warning) payload.time_range_warning = timeRangeParsed.warning;


### PR DESCRIPTION
## Problem
`find_similar_fact_pattern_cases` ran its semantic HNSW leg with the AI-extracted **keyword query** instead of the fact pattern itself. When `extractSearchTermsWithAI` returned no keywords, the query collapsed to a 180-char truncated literal and the search returned **0 results** (observed in chat `chat-9a74cdbc-cf23-4291-9a52-6ad32b4f880b`).

## Fix
- Embed the full `facts_text` directly via BGE-M3 (its natural input) for the semantic leg — HNSW over `edrsr_serving` (296M chunks).
- Defer keyword extraction to the FTS fallback, where lexical terms are actually needed. Removes the upfront LLM extraction call from the common path.
- `search_query` in the payload now reflects what was actually used per method.

## Test
Typecheck clean. Logic-only change; no dedicated test exists for this handler.

Plane: LEXAI-1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes semantic case search by embedding the full fact pattern in the HNSW path and deferring keyword extraction to the FTS fallback. Addresses Linear LEXAI-1752 and restores results when keyword extraction returns nothing.

- **Bug Fixes**
  - Embed full `facts_text` for semantic search (BGE-M3; capped at 4k chars).
  - Run keyword extraction only in the FTS fallback; remove the upfront extraction call.
  - Set response `search_query` to the actual query used (FTS: extracted/trimmed; semantic: 200-char facts preview).
  - Improves recall and reduces latency by dropping an extra LLM call.

<sup>Written for commit 73f824fc6b95ab65c79a82d450d8d7ce59fe0d76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

