### PR TITLE
fix(edrsr): default Qdrant collection to edrsr_serving + log target at init (LEXAI-1754)

### DIFF
--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -18,7 +18,10 @@ import { v4 as uuidv4 } from 'uuid';
 
 const EMBEDDING_DIM = 1024;
 const EMBEDDING_MODEL = 'bge-m3';
-const COLLECTION_NAME = process.env.QDRANT_EDRSR_COLLECTION || 'edrsr_decisions';
+// Default to the live unified collection. The old `edrsr_decisions` collection
+// was deleted at the edrsr_serving cutover (2026-06-21); defaulting to it would
+// make semantic search silently return nothing if the env var is ever missing.
+const COLLECTION_NAME = process.env.QDRANT_EDRSR_COLLECTION || 'edrsr_serving';
 const EMBED_BATCH_SIZE = 64; // TEI supports larger batches than VoyageAI
 const QDRANT_UPSERT_BATCH = 100; // Qdrant upsert sub-batch
 const DEFAULT_CONCURRENCY = 5;
@@ -132,6 +135,7 @@ export class EdsrVectorizerService {
     });
 
     this.concurrency = concurrency;
+    logger.info('[EdsrVectorizer] initialized', { collection: COLLECTION_NAME, qdrantUrl });
   }
 
   setUsageCallback(cb: EmbeddingUsageCallback | undefined): void {
@@ -141,7 +145,7 @@ export class EdsrVectorizerService {
   // ── Initialization ───────────────────────────────────────────────────────
 
   /**
-   * Lazy initialization: create the edrsr_decisions collection on first use.
+   * Lazy initialization: create the EDRSR collection on first use.
    */
   private async ensureCollection(): Promise<void> {
     if (this.initialized) return;


### PR DESCRIPTION
## Problem
`EdsrVectorizerService` defaulted `COLLECTION_NAME` to `edrsr_decisions` — the collection deleted at the `edrsr_serving` cutover (2026-06-21). Prod sets `QDRANT_EDRSR_COLLECTION=edrsr_serving` explicitly, but a missing/typo'd env var (new env, local run) would point semantic search at a non-existent collection and **silently return nothing**.

## Fix
- Default to `edrsr_serving` (the live unified collection, 296.56M points).
- Log the resolved collection + Qdrant URL at init, so a misconfiguration surfaces in logs instead of masquerading as "no results".

Plane: LEXAI-1754 (split out of CORE-34)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the EDRSR Qdrant collection to `edrsr_serving` and log the resolved collection and URL at service init. Prevents silent empty results when `QDRANT_EDRSR_COLLECTION` is missing or wrong (LEXAI-1754).

- **Bug Fixes**
  - Change default from `edrsr_decisions` (deleted) to `edrsr_serving`.
  - Log `{ collection, qdrantUrl }` on service init to surface misconfigurations.

<sup>Written for commit 3f04a3d6f4de83dd124e0c37f1cbecf3891c7040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

