### PR TITLE
test(edrsr): align vectorizer test mock with edrsr_serving default

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
@@ -6,7 +6,7 @@
  * and error paths.
  */
 
-const mockGetCollections = jest.fn().mockResolvedValue({ collections: [{ name: 'edrsr_decisions' }] });
+const mockGetCollections = jest.fn().mockResolvedValue({ collections: [{ name: 'edrsr_serving' }] });
 const mockGetCollection = jest.fn().mockResolvedValue({ points_count: 5000 });
 const mockCollectionExists = jest.fn().mockResolvedValue(true);
 
@@ -83,7 +83,7 @@ describe('EdsrVectorizerService', () => {
     it('should return stats when collection exists', async () => {
       const service = new EdsrVectorizerService();
       mockGetCollections.mockResolvedValueOnce({
-        collections: [{ name: 'edrsr_decisions' }],
+        collections: [{ name: 'edrsr_serving' }],
       });
       mockGetCollection.mockResolvedValueOnce({ points_count: 5000 });
 


### PR DESCRIPTION
Follow-up to LEXAI-1754 (#1948). The default Qdrant collection changed `edrsr_decisions`→`edrsr_serving`, but `edrsr-vectorizer-service.test.ts` still mocked `getCollections` with the old name, breaking the `getVectorizationStats › collection exists` assertion in CI (run 27903256112).

Updated the two mock collection names. Test green locally (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the vectorizer test mock with the new default Qdrant collection `edrsr_serving` (per Linear LEXAI-1754) to fix the getVectorizationStats "collection exists" failure in CI. Replaces `edrsr_decisions` with `edrsr_serving` in `edrsr-vectorizer-service.test.ts`.

<sup>Written for commit 0f07accbeb4c8d8c897135caf02181c35be80323. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

