### PR TITLE
feat(edrsr): cap fulltext query length + hybrid fallback on zero matches (LEXAI-1755)

### DIFF
--- a/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
@@ -215,6 +215,38 @@ describe('EdsrUnifiedSearchTool', () => {
       expect(parsed.results[0].court_name).toBe('Оболонський');
       expect(parsed.results[0].justice_kind_name).toBe('Цивільне');
     });
+
+    it('truncates an over-long fulltext query to the leading tokens', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      const longQuery = 'один два три чотири пять шість сім вісім девять';
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext', query: longQuery,
+      });
+
+      const passedQuery = mockFtsService.searchFulltext.mock.calls[0][0];
+      expect(passedQuery.split(/\s+/)).toHaveLength(6);
+      expect(passedQuery).toBe('один два три чотири пять шість');
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.query_truncated.from_tokens).toBe(9);
+    });
+
+    it('falls back to hybrid when FTS returns zero matches', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      mockFtsService.searchFulltext = jest.fn(() =>
+        Promise.resolve({ query: 'x', total: 0, results: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext', query: 'безпідставне збагачення',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.mode).toBe('hybrid');
+      expect(parsed.fallback_from).toBe('fulltext');
+      expect(mockVectorizer.semanticSearch).toHaveBeenCalled();
+    });
   });
 
   describe('hybrid mode', () => {

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -22,6 +22,10 @@ import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } fro
 const DEFAULT_RRF_K = 60;
 const DEFAULT_OVERSAMPLE = 3;
 const MAX_OVERSAMPLE = 5;
+// plainto_tsquery ANDs every token, so a long multi-word query (the LLM often emits
+// 7-9 words) matches no single document. Cap the FTS leg to the leading tokens; the
+// full query still drives the hybrid fallback when FTS returns nothing.
+const FULLTEXT_MAX_TOKENS = 6;
 
 const KUPAP_PRESETS: Record<string, { category_codes: number[]; label: string }> = {
   'traffic_dui':        { category_codes: [41090, 5952], label: 'П\'яне водіння (ст. 130 КУпАП)' },
@@ -320,18 +324,38 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
         if (courtResult.rows.length > 0) courtCode = courtResult.rows[0].court_code;
       }
 
+      // Cap the FTS query to its leading tokens — a long all-AND query matches nothing.
+      const originalQuery = String(args.query).trim();
+      const tokens = originalQuery.split(/\s+/).filter(Boolean);
+      let ftsQuery = originalQuery;
+      let truncatedFromTokens: number | undefined;
+      if (tokens.length > FULLTEXT_MAX_TOKENS) {
+        ftsQuery = tokens.slice(0, FULLTEXT_MAX_TOKENS).join(' ');
+        truncatedFromTokens = tokens.length;
+      }
+
       const result = await this.ftsService.searchFulltext(
-        args.query, this.db,
+        ftsQuery, this.db,
         { court_code: courtCode, judge: args.judge, date_from: args.date_from, date_to: args.date_to,
           justice_kind: args.justice_kind, judgment_code: args.judgment_code, category_code: args.category_code } as EdsrFtsFilters,
         args.limit || 20, args.offset || 0,
       );
 
+      // Genuine no-match (not merely relevance-filtered) → fall back to hybrid, whose
+      // semantic leg doesn't require every token to co-occur. Uses the ORIGINAL query.
+      if (result.total === 0 && this.vectorizer) {
+        logger.info('[EdsrUnifiedSearch] fulltext 0 results, falling back to hybrid', {
+          query: originalQuery, ftsQuery, justice_kind: args.justice_kind,
+        });
+        return this.searchHybrid({ ...args, query: originalQuery, _fallback_from: 'fulltext' });
+      }
+
       const enriched = await this.enrichResults(result.results);
-      const output = await this.maybeFilter(enriched, args.query);
+      const output = await this.maybeFilter(enriched, ftsQuery);
 
       return this.wrapResponse({
         mode: 'fulltext', ...result,
+        ...(truncatedFromTokens ? { query_truncated: { from_tokens: truncatedFromTokens, used: ftsQuery } } : {}),
         results: output.filtered,
         ...(output.original_count !== output.filtered_count
           ? { relevance_filter: { from: output.original_count, to: output.filtered_count } }
@@ -393,6 +417,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
     return this.wrapResponse({
       mode: 'hybrid', query, rrf_k: rrfK, oversample,
+      ...(args._fallback_from ? { fallback_from: args._fallback_from } : {}),
       ...(reformulated ? { reformulated: { fts: reformulated.fts, semantic: reformulated.semantic } } : {}),
       legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length },
       total_fused: fused.length, returned: output.filtered.length,


### PR DESCRIPTION
## Problem
`plainto_tsquery` ANDs every token, so the LLM's long (7-9 word) `mode=fulltext` queries matched no single document → 0 results (observed in `chat-a79016ef`: `[ToolHealthTracker] search_court_decisions empty 83%`). Verified the `justice_kind` filter is **not** the cause — the 9-term query returns 0 even without it, while a 3-term query + jk=4 returns 43.

## Fix (`edrsr-unified-search-tool.ts` → `searchFulltext`)
- Cap the FTS leg to the first `FULLTEXT_MAX_TOKENS` (6) tokens; the full query still drives the fallback. Response carries `query_truncated`.
- When FTS genuinely returns `total=0` and a vectorizer is available, fall back to `mode=hybrid` (RRF FTS+semantic) with the **original** query — semantic doesn't require every token to co-occur. Marked via `fallback_from: 'fulltext'`.

## Test
Added: long-query truncation + zero-result hybrid fallback. Suite 18/18 green.

Plane: LEXAI-1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps fulltext query to the first 6 tokens and adds an automatic `hybrid` fallback when fulltext returns 0 results, improving recall for long queries. Addresses LEXAI-1755.

- **New Features**
  - Truncate `fulltext` queries to 6 leading tokens; response includes `query_truncated`.
  - If `fulltext` returns `total=0` and a vectorizer is available, rerun as `hybrid` with the original query; response includes `fallback_from: 'fulltext'`.

<sup>Written for commit ef65d817f2615c39fdf5834baf6a8bbffc23ae7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

