### PR TITLE
ci: verify core overlay copied key files; stop swallowing clone errors (LEXAI-1757)

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -104,8 +104,12 @@ jobs:
           chmod 600 "$KEY_FILE"
           GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
             git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+          test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+            || { echo "::error::core clone incomplete — key files missing in $CORE_TMP"; exit 1; }
           find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          test -s mcp_backend/src/services/chat-execution-loop.ts && test -s mcp_backend/src/prompts/chat-system-prompt.ts \
+            || { echo "::error::core overlay failed — key files missing after copy"; exit 1; }
 
       - name: Build backend
         if: needs.detect-changes.outputs.backend == 'true'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -178,9 +178,13 @@ jobs:
         run: |
           CORE_TMP=$(mktemp -d)
           gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
+          test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+            || { echo "::error::core clone incomplete — key files missing in $CORE_TMP"; exit 1; }
           find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
           rm -rf "$CORE_TMP"
+          test -s mcp_backend/src/services/chat-execution-loop.ts && test -s mcp_backend/src/prompts/chat-system-prompt.ts \
+            || { echo "::error::core overlay failed — key files missing after copy"; exit 1; }
 
       - name: Build & test backend
         if: needs.detect-changes.outputs.backend == 'true'
@@ -464,11 +468,15 @@ jobs:
           if [ "$BACKEND_CHANGED" = "true" ]; then
             # Overlay proprietary source from private repo before building
             CORE_TMP=$(mktemp -d)
-            gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1 2>/dev/null
+            gh repo clone overthelex/secondlayer-core "$CORE_TMP" -- --depth 1
+            test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+              || { echo "::error::core clone incomplete — key files missing in $CORE_TMP"; exit 1; }
             SCP_CMD="scp -i $PROD_SSH_KEY_PATH -o StrictHostKeyChecking=no"
             $SCP_CMD -r "$CORE_TMP"/src/services/* "${PROD_USER}@${PROD_SERVER}:${REMOTE_REPO}/mcp_backend/src/services/"
             $SCP_CMD -r "$CORE_TMP"/src/prompts/* "${PROD_USER}@${PROD_SERVER}:${REMOTE_REPO}/mcp_backend/src/prompts/"
             rm -rf "$CORE_TMP"
+            $SSH_CMD "test -s ${REMOTE_REPO}/mcp_backend/src/services/chat-execution-loop.ts && test -s ${REMOTE_REPO}/mcp_backend/src/prompts/chat-system-prompt.ts" \
+              || { echo "::error::core overlay missing on prod after scp"; exit 1; }
 
             $SSH_CMD "cd ${REMOTE_REPO} && npm --prefix mcp_backend install && npm --prefix mcp_backend run build"
           fi

--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -104,8 +104,12 @@ jobs:
           chmod 600 "$KEY_FILE"
           GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
             git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+          test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+            || { echo "::error::core clone incomplete — key files missing in $CORE_TMP"; exit 1; }
           find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
           cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          test -s mcp_backend/src/services/chat-execution-loop.ts && test -s mcp_backend/src/prompts/chat-system-prompt.ts \
+            || { echo "::error::core overlay failed — key files missing after copy"; exit 1; }
 
       - name: Build backend
         if: env.BACKEND_CHANGED == 'true'
@@ -222,8 +226,13 @@ jobs:
               trap 'shred -u "$KEY_FILE" 2>/dev/null; rm -rf "$CORE_TMP"' EXIT
               GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
                 git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+              test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+                || { echo "core clone incomplete — key files missing"; exit 1; }
               find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} /home/vovkes/SecondLayer/mcp_backend/src/services/ \;
               cp -rf "$CORE_TMP"/src/prompts/* /home/vovkes/SecondLayer/mcp_backend/src/prompts/
+              test -s /home/vovkes/SecondLayer/mcp_backend/src/services/chat-execution-loop.ts \
+                && test -s /home/vovkes/SecondLayer/mcp_backend/src/prompts/chat-system-prompt.ts \
+                || { echo "core overlay failed — key files missing after copy"; exit 1; }
               cd /home/vovkes/SecondLayer && npm --prefix mcp_backend run build
           OVERLAY_EOF
           fi


### PR DESCRIPTION
## Problem
The deploy overlays proprietary `secondlayer-core` into `mcp_backend/src/{services,prompts}`. `deploy-prod`'s remote-overlay cloned with stderr discarded (`2>/dev/null`), and **no step verified the overlay actually delivered files**. A transient clone/scp miss failed silently — run 27905061817 died on `TS6053: chat-execution-loop.ts not found`, caught only by `tsc` (prod was safe: blue-green health check blocked the switch).

## Fix
Across all overlay blocks (deploy-prod runner + remote, ci-local-deploy, deploy-stage runner + remote):
- drop `2>/dev/null` on the prod clone;
- assert key files (`chat-execution-loop.ts`, `chat-system-prompt.ts`) exist **in the clone before copy** and **at the destination after copy/scp** — fail fast with a clear `::error::` if missing.

## Test
All three workflows validated as YAML. Guards are additive (no behavior change on the happy path); they convert silent partial overlays into loud, early failures.

Plane: LEXAI-1757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on incomplete `secondlayer-core` overlays and stop hiding clone errors in prod deploys. Addresses LEXAI-1757 by verifying key files before and after copy/scp.

- **Bug Fixes**
  - Removed stderr redirection from prod `gh repo clone`.
  - Assert `chat-execution-loop.ts` and `chat-system-prompt.ts` exist in the clone before copying.
  - Verify the same files after overlay: local/stage copies and on the prod remote after scp.
  - Applied to `deploy-prod`, `deploy-stage`, and `ci-local-deploy`; no change on the happy path.

<sup>Written for commit 78968182d928871781e3bccc54dc7f14caaf56f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

