### PR TITLE
chore(backend): bump version to 1.0.4 (trigger deploy, exercise LEXAI-1757 overlay guards)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Trivial release marker to trigger a fresh backend deploy — the first run of the hardened core-overlay verification added in LEXAI-1757. CORE-37 was activated via an earlier (manual) deploy that predated those guards, so this confirms the normal PR→deploy path with the new fail-fast checks.

No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `secondlayer-mcp` to 1.0.4 to trigger a backend deploy and validate the new core-overlay verification guards from LEXAI-1757 on the normal PR→deploy path. No functional changes.

<sup>Written for commit 577e2dce9652911866c6686d6e0d1e14764f715f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

