### PR TITLE
feat(edrsr): cap concurrent Qdrant searches with a semaphore (LEXAI-1758)

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
@@ -40,7 +40,28 @@ jest.mock('../../utils/logger.js', () => ({
   logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
 }));
 
-import { EdsrVectorizerService } from '../edrsr-vectorizer-service';
+import { EdsrVectorizerService, AsyncSemaphore } from '../edrsr-vectorizer-service';
+
+describe('AsyncSemaphore', () => {
+  it('caps concurrent runs at max (LEXAI-1758)', async () => {
+    const sem = new AsyncSemaphore(2);
+    let active = 0, peak = 0;
+    const task = () => sem.run(async () => {
+      active++; peak = Math.max(peak, active);
+      await new Promise((r) => setTimeout(r, 15));
+      active--;
+    });
+    await Promise.all(Array.from({ length: 6 }, task));
+    expect(peak).toBe(2);
+    expect(active).toBe(0);
+  });
+
+  it('runs all tasks and returns their results in order', async () => {
+    const sem = new AsyncSemaphore(2);
+    const results = await Promise.all([1, 2, 3, 4].map((n) => sem.run(async () => n * 10)));
+    expect(results).toEqual([10, 20, 30, 40]);
+  });
+});
 
 describe('EdsrVectorizerService', () => {
   const originalEnv = process.env;

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -25,6 +25,30 @@ const COLLECTION_NAME = process.env.QDRANT_EDRSR_COLLECTION || 'edrsr_serving';
 const EMBED_BATCH_SIZE = 64; // TEI supports larger batches than VoyageAI
 const QDRANT_UPSERT_BATCH = 100; // Qdrant upsert sub-batch
 const DEFAULT_CONCURRENCY = 5;
+// Cap concurrent Qdrant searches against edrsr_serving (LEXAI-1758). Each search
+// fans across ~293 on-disk-graph segments; more than ~2 in flight saturates the
+// serving node's cores and blows the request timeout (aborts → hybrid loses its
+// vector leg). Tunable via env.
+const QDRANT_SEARCH_CONCURRENCY = Math.max(1, Number(process.env.QDRANT_EDRSR_MAX_CONCURRENCY || 2));
+
+/** Minimal async semaphore — bounds in-flight work to `max` concurrent runs. */
+export class AsyncSemaphore {
+  private active = 0;
+  private readonly queue: Array<() => void> = [];
+  constructor(private readonly max: number) {}
+  async run<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.active >= this.max) {
+      await new Promise<void>((resolve) => this.queue.push(resolve));
+    }
+    this.active++;
+    try {
+      return await fn();
+    } finally {
+      this.active--;
+      this.queue.shift()?.();
+    }
+  }
+}
 const MAX_CHUNK_CHARS = 2048;
 const CHUNK_OVERLAP_WORDS = 50;
 
@@ -113,6 +137,8 @@ export class EdsrVectorizerService {
   private qdrant: QdrantClient;
   private initialized = false;
   private usageCallback?: EmbeddingUsageCallback;
+  // Shared across all callers (singleton service) → global cap on concurrent searches.
+  private readonly searchSemaphore = new AsyncSemaphore(QDRANT_SEARCH_CONCURRENCY);
   private concurrency: number;
 
   constructor(concurrency: number = DEFAULT_CONCURRENCY) {
@@ -353,7 +379,8 @@ export class EdsrVectorizerService {
     const qdrantFilter = must.length > 0 ? { must } : undefined;
 
     try {
-      const searchResult = await this.qdrant.search(COLLECTION_NAME, {
+      // Bound concurrent Qdrant searches — see QDRANT_SEARCH_CONCURRENCY (LEXAI-1758).
+      const searchResult = await this.searchSemaphore.run(() => this.qdrant.search(COLLECTION_NAME, {
         vector: queryVector,
         limit,
         filter: qdrantFilter,
@@ -371,7 +398,7 @@ export class EdsrVectorizerService {
               ? { rescore: true, oversampling: Number(process.env.QDRANT_EDRSR_OVERSAMPLING || 2.0) }
               : { rescore: false },
         },
-      });
+      }));
 
       return searchResult.map((r) => ({
         id: r.id as string,


### PR DESCRIPTION
## Problem
Semantic searches on `edrsr_serving` abort under concurrency. The chat fires `search_court_decisions` (hybrid) vector legs in parallel; with ~293 on-disk-graph segments each query fans across all of them, so 3 concurrent reach 13–17s and blow the 12s timeout — hybrid then loses its vector leg and returns 0 (`chat-bbdcdd47` steps 5/6). Measured on `qdrant.lex`: single ~5s, 3 concurrent 13–17s; graph already resident in RAM, so it's concurrency + 293-segment fan-out, not cold disk.

## Fix (P1 mitigations)
- **Concurrency cap (main):** global `AsyncSemaphore` in `EdsrVectorizerService` (singleton → shared across hybrid, `find_similar`, all callers) bounding concurrent Qdrant searches to `QDRANT_EDRSR_MAX_CONCURRENCY` (default **2**).
- **Timeout bump:** `QDRANT_EDRSR_TIMEOUT_MS` set to **20000** in prod `.env.prod` (applies on this deploy).

Root-cause segment merge (293 → ~16) tracked separately in LEXAI-1759.

## Test
`AsyncSemaphore` unit tests (caps at max, preserves results) + full suite 9/9. Typecheck clean.

Plane: LEXAI-1758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps concurrent Qdrant searches for `edrsr_serving` with a global semaphore to stop hybrid search timeouts under load. Improves reliability of semantic search per LEXAI-1758.

- **Bug Fixes**
  - Limit in-flight Qdrant searches via a global `AsyncSemaphore` in EdsrVectorizerService; tune with `QDRANT_EDRSR_MAX_CONCURRENCY` (default 2).
  - Increase `QDRANT_EDRSR_TIMEOUT_MS` to `20000` in production to avoid aborts when requests run in parallel.

<sup>Written for commit 8d452447c11d77ca9282aad09bbcfa42c42dd8eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

