### PR TITLE
feat(deploy): forward chat-latency tunables to backend containers (CORE-32/35/36)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -564,6 +564,12 @@ services:
       BEDROCK_FALLBACK_MODEL_QUICK: ${BEDROCK_FALLBACK_MODEL_QUICK:-eu.amazon.nova-micro-v1:0}
       BEDROCK_FALLBACK_MODEL_STANDARD: ${BEDROCK_FALLBACK_MODEL_STANDARD:-eu.amazon.nova-pro-v1:0}
       BEDROCK_FALLBACK_MODEL_DEEP: ${BEDROCK_FALLBACK_MODEL_DEEP:-eu.amazon.nova-pro-v1:0}
+      # Chat-latency tunables (CORE-32 region pinning / CORE-35 hedged streaming / CORE-36 parallel-seed).
+      # Empty default = feature off (no behavior change); enable by setting the value in .env.prod.
+      BEDROCK_QUICK_REGION: ${BEDROCK_QUICK_REGION:-}
+      BEDROCK_FALLBACK_REGIONS: ${BEDROCK_FALLBACK_REGIONS:-}
+      BEDROCK_HEDGE_MS: ${BEDROCK_HEDGE_MS:-}
+      CHAT_PARALLEL_SEED_MIN: ${CHAT_PARALLEL_SEED_MIN:-}
       VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
       VOYAGEAI_API_KEY_2: ${VOYAGEAI_API_KEY_2:-}
       VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}
@@ -981,6 +987,12 @@ services:
       BEDROCK_FALLBACK_MODEL_QUICK: ${BEDROCK_FALLBACK_MODEL_QUICK:-eu.amazon.nova-micro-v1:0}
       BEDROCK_FALLBACK_MODEL_STANDARD: ${BEDROCK_FALLBACK_MODEL_STANDARD:-eu.amazon.nova-pro-v1:0}
       BEDROCK_FALLBACK_MODEL_DEEP: ${BEDROCK_FALLBACK_MODEL_DEEP:-eu.amazon.nova-pro-v1:0}
+      # Chat-latency tunables (CORE-32 region pinning / CORE-35 hedged streaming / CORE-36 parallel-seed).
+      # Empty default = feature off (no behavior change); enable by setting the value in .env.prod.
+      BEDROCK_QUICK_REGION: ${BEDROCK_QUICK_REGION:-}
+      BEDROCK_FALLBACK_REGIONS: ${BEDROCK_FALLBACK_REGIONS:-}
+      BEDROCK_HEDGE_MS: ${BEDROCK_HEDGE_MS:-}
+      CHAT_PARALLEL_SEED_MIN: ${CHAT_PARALLEL_SEED_MIN:-}
       VOYAGEAI_API_KEY: ${VOYAGEAI_API_KEY:-}
       VOYAGEAI_API_KEY_2: ${VOYAGEAI_API_KEY_2:-}
       VOYAGEAI_EMBEDDING_MODEL: ${VOYAGEAI_EMBEDDING_MODEL:-voyage-multilingual-2}


### PR DESCRIPTION
## Why
The chat-latency suite — bedrock **region pinning** (#1944, CORE-32), **hedged streaming** (#1946, CORE-35), and **parallel-seed** (#42, CORE-36) — is merged and live in the prod image but **dormant**: the controlling env vars were never forwarded through `docker-compose.prod.yml`, so enabling any of them currently requires a code change. Verified on prod that `BEDROCK_QUICK_REGION`, `BEDROCK_HEDGE_MS`, `BEDROCK_FALLBACK_REGIONS`, and `CHAT_PARALLEL_SEED_MIN` are all unset.

## What
Forward the four tunables to both backend service blocks (`app-prod`, `app-prod-green`) with empty defaults:
```yaml
BEDROCK_QUICK_REGION: ${BEDROCK_QUICK_REGION:-}
BEDROCK_FALLBACK_REGIONS: ${BEDROCK_FALLBACK_REGIONS:-}
BEDROCK_HEDGE_MS: ${BEDROCK_HEDGE_MS:-}
CHAT_PARALLEL_SEED_MIN: ${CHAT_PARALLEL_SEED_MIN:-}
```
Same propagation pattern as LEXAI-1758 (QDRANT_EDRSR tunables). Empty `${VAR:-}` defaults mean **no behavior change** until a value is set in `.env.prod`. Scoped to the backend blocks only (document-service doesn't run chat).

## Enablement plan (staged, after merge)
1. **CORE-32 (this step):** set `BEDROCK_QUICK_REGION=us-east-1` in prod `.env.prod` → quick-tier (intent/plan/replan/summarization) Haiku calls route to us-east-1, isolating them from the Sonnet/Opus quota on eu-central-1. Model prefix is auto-swapped `eu.`→`us.`. Reversible by clearing the var.
2. **CORE-35:** set `BEDROCK_HEDGE_MS` once region pinning is validated; measure p95.
3. **CORE-36:** run grounding-eval A/B, then set `CHAT_PARALLEL_SEED_MIN=2` only if grounding holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose chat-latency env vars in `docker-compose.prod.yml` so region pinning (CORE-32), hedged streaming (CORE-35), and parallel seeding (CORE-36) can be enabled via `.env.prod`. No behavior change; all vars default to empty.

- **Migration**
  - Forwarded to `app-prod` and `app-prod-green`: `BEDROCK_QUICK_REGION`, `BEDROCK_FALLBACK_REGIONS`, `BEDROCK_HEDGE_MS`, `CHAT_PARALLEL_SEED_MIN`.
  - To enable CORE-32: set `BEDROCK_QUICK_REGION=us-east-1` in `.env.prod`; clear to disable.

<sup>Written for commit b5badadddf991f4893b51ab66bbeaeec13b59f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

