### PR TITLE
refactor(edrsr): repoint search_legal_precedents + countAllResults to prod DB (Phase 2 PR#2)

### DIFF
--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { SectionType } from '../types/index.js';
-import { EdsrLocalAdapter } from '../adapters/edrsr-local-adapter.js';
+import type { EdsrFtsService, EdsrFtsFilters } from '../services/edrsr-fts-service.js';
 import { logger } from '../utils/logger.js';
 import axios from 'axios';
 
@@ -427,12 +427,15 @@ export async function callOpenReyestrTool(toolName: string, args: any): Promise<
 }
 
 /**
- * Count all results by paginating through ZO adapter.
+ * Count results for a query via EDRSR FTS. Returns the FTS total estimate (the service
+ * caps the exact count for speed) plus the first page for right-panel display. Replaces
+ * the old ZakonOnline pagination loop, which routed through a now-deleted dead stub.
  */
 export async function countAllResults(
-  zoAdapter: EdsrLocalAdapter,
+  ftsService: EdsrFtsService,
+  db: any,
   query: string,
-  queryParams?: any
+  filters: EdsrFtsFilters = {}
 ): Promise<{
   total_count: number;
   pages_fetched: number;
@@ -441,83 +444,21 @@ export async function countAllResults(
   first_results: any[];
 }> {
   const startTime = Date.now();
-  const maxApiLimit = 1000;
-  let offset = 0;
-  let totalCount = 0;
-  let pagesFetched = 0;
-  let hasMore = true;
-  let firstResults: any[] = [];
-
-  logger.info('Starting pagination to count all results', { query });
-
-  while (hasMore) {
-    const searchParams = {
-      meta: { search: query },
-      limit: maxApiLimit,
-      offset: offset,
-      ...queryParams,
-    };
-
-    logger.info('Fetching page', {
-      page: pagesFetched + 1,
-      offset,
-      limit: maxApiLimit,
-    });
-
-    try {
-      const response = await zoAdapter.searchCourtDecisions(searchParams);
-      const normalized = await zoAdapter.normalizeResponse(response);
-
-      const resultsInPage = normalized.data.length;
-      // Capture first page results for use in right panel
-      if (pagesFetched === 0 && resultsInPage > 0) {
-        firstResults = normalized.data.slice(0, 50);
-      }
-      totalCount += resultsInPage;
-      pagesFetched++;
-
-      logger.info('Page fetched', {
-        page: pagesFetched,
-        resultsInPage,
-        totalSoFar: totalCount,
-        offset,
-      });
-
-      if (resultsInPage < maxApiLimit) {
-        hasMore = false;
-        logger.info('Last page reached', { totalCount, pagesFetched });
-      } else {
-        offset += maxApiLimit;
-        if (pagesFetched >= 10000) {
-          logger.warn('Reached safety limit of 10,000 pages', { totalCount });
-          hasMore = false;
-        }
-      }
-    } catch (error: any) {
-      logger.error('Error during pagination', {
-        page: pagesFetched + 1,
-        offset,
-        error: error.message,
-      });
-      throw new Error(`Pagination failed at page ${pagesFetched + 1}: ${error.message}`);
-    }
-  }
-
-  const timeTaken = Date.now() - startTime;
-  const costEstimate = pagesFetched * 0.00714;
-
-  logger.info('Pagination completed', {
-    totalCount,
-    pagesFetched,
-    timeTakenMs: timeTaken,
-    costEstimateUsd: costEstimate.toFixed(6),
-  });
+  const resp = await ftsService.searchFulltext(query, db, filters, 50, 0);
+  const firstResults = resp.results.map((r) => ({
+    doc_id: r.doc_id,
+    cause_num: r.cause_num,
+    judge: r.judge,
+    court_code: r.court_code,
+    adjudication_date: r.adjudication_date,
+    url: `https://reyestr.court.gov.ua/Review/${r.doc_id}`,
+  }));
 
   return {
-    total_count: totalCount,
-    pages_fetched: pagesFetched,
-    time_taken_ms: timeTaken,
-    cost_estimate_usd: parseFloat(costEstimate.toFixed(6)),
+    total_count: resp.total,
+    pages_fetched: 1,
+    time_taken_ms: Date.now() - startTime,
+    cost_estimate_usd: 0,
     first_results: firstResults,
   };
 }

--- a/mcp_backend/src/api/tools/legal-advice-tools.ts
+++ b/mcp_backend/src/api/tools/legal-advice-tools.ts
@@ -16,6 +16,7 @@ import type { IEmbeddingPort, ILLMPort } from '../../domain/ports/index.js';
 import { LegalPatternStore } from '../../services/legal-pattern-store.js';
 import { CitationValidator } from '../../services/citation-validator.js';
 import { ShepardizationService, ShepardizationResult } from '../../services/shepardization-service.js';
+import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsResult } from '../../services/edrsr-fts-service.js';
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { CourtDecisionHTMLParser, extractSearchTermsWithAI } from '../../utils/html-parser.js';
@@ -36,9 +37,36 @@ export class LegalAdviceTools extends BaseToolHandler {
     private citationValidator: CitationValidator,
     private shepardizationService?: ShepardizationService,
     private readonly llm?: ILLMPort,
-    private readonly db?: { query: (sql: string, params?: any[]) => Promise<any> }
+    private readonly db?: { query: (sql: string, params?: any[]) => Promise<any> },
+    private readonly ftsService?: EdsrFtsService
   ) {
     super();
+  }
+
+  /** Map EDRSR FTS rows to the case shape this tool's responses expose. */
+  private mapFtsResults(rows: EdsrFtsResult[]): any[] {
+    return rows.map((r) => ({
+      doc_id: r.doc_id,
+      cause_num: r.cause_num,
+      judge: r.judge,
+      court_code: r.court_code,
+      justice_kind: r.justice_kind,
+      adjudication_date: r.adjudication_date,
+      url: `https://reyestr.court.gov.ua/Review/${r.doc_id}`,
+      ...(r.headline ? { headline: r.headline } : {}),
+      ...(r.rank != null ? { rank: r.rank } : {}),
+    }));
+  }
+
+  /** Build EDRSR FTS filters from court_level (SC → cassation) + procedure_code. */
+  private buildEdsrFilters(courtLevel?: string, procedureCode?: string): EdsrFtsFilters {
+    const f: EdsrFtsFilters = {};
+    if (procedureCode) {
+      const jk = mapProcedureCodeToJusticeKind(procedureCode);
+      if (jk !== null) f.justice_kind = jk;
+    }
+    if (courtLevel && courtLevel !== 'all') f.instance_code = 1; // Supreme Court = cassation
+    return f;
   }
 
   getToolDefinitions(): ToolDefinition[] {
@@ -300,18 +328,14 @@ export class LegalAdviceTools extends BaseToolHandler {
     });
 
     if (args.count_all === true) {
-      const countResult = await countAllResults(this.zoAdapter, query);
+      if (!this.ftsService || !this.db) throw new Error('FTS сервіс недоступний');
+      const countResult = await countAllResults(this.ftsService, this.db, query);
       return this.wrapResponse({
         query,
         count_all_mode: true,
         total_count: countResult.total_count,
-        pages_fetched: countResult.pages_fetched,
         time_taken_ms: countResult.time_taken_ms,
-        cost_estimate_usd: countResult.cost_estimate_usd,
-        note: 'Підраховано через пагінацію. Перші результати включені для відображення в правій панелі.',
-        warning: countResult.total_count >= 10000000
-          ? 'Достигнут лимит безопасности в 10,000,000 результатов.'
-          : null,
+        note: 'Оцінка кількості через FTS (точний підрахунок доступний для пошуку за стороною — count_cases_by_party).',
         // Include first page results so the right panel can display decisions
         results: countResult.first_results,
       });
@@ -321,96 +345,39 @@ export class LegalAdviceTools extends BaseToolHandler {
     const caseNumberPattern = /\b(\d{1,4}\/\d{1,6}\/\d{2}(-\w)?)\b/;
     const caseNumberMatch = query.match(caseNumberPattern);
 
-    if (caseNumberMatch) {
+    if (caseNumberMatch && this.ftsService && this.db) {
       const caseNumber = caseNumberMatch[1];
       try {
-        const sourceCase = await this.zoAdapter.getDocumentByCaseNumber(caseNumber);
+        // Load the source case straight from the prod EDRSR DB (replaces dead ZO stub).
+        const srcRes = await this.db.query(
+          `SELECT d.doc_id, d.cause_num, d.judge, d.court_code, d.justice_kind,
+                  d.category_code, d.adjudication_date, f.full_text
+           FROM edrsr_documents d
+           LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+           WHERE d.cause_num = $1
+           ORDER BY d.adjudication_date DESC NULLS LAST
+           LIMIT 1`,
+          [caseNumber],
+        );
+        const sourceCase = srcRes.rows?.[0];
         if (!sourceCase) return await this.performRegularSearch(args);
 
-        let textForAnalysis = '';
-        let textSource = 'metadata';
-
-        if (sourceCase.full_text) {
-          try {
-            if (sourceCase.full_text.includes('<html') || sourceCase.full_text.includes('<!DOCTYPE')) {
-              const parser = new CourtDecisionHTMLParser(sourceCase.full_text);
-              const paragraphs = parser.extractMainText();
-              const sections = parser.identifySections(paragraphs);
-              textForAnalysis = parser.extractKeyContent(sections);
-              textSource = 'parsed_html_key_sections';
-            } else {
-              textForAnalysis = sourceCase.full_text.substring(0, 5000);
-              textSource = 'full_text_truncated';
-            }
-            if (textForAnalysis.length > 5000) textForAnalysis = textForAnalysis.substring(0, 5000);
-          } catch {
-            textForAnalysis = sourceCase.full_text.substring(0, 5000);
-            textSource = 'full_text_truncated_fallback';
-          }
-        } else {
-          const parts = [sourceCase.title, sourceCase.resolution, sourceCase.snippet ? load(sourceCase.snippet).root().text() : undefined].filter(Boolean);
-          textForAnalysis = parts.join('\n');
-          textSource = 'combined_metadata';
-        }
-
+        const textForAnalysis = typeof sourceCase.full_text === 'string'
+          ? sourceCase.full_text.substring(0, 5000)
+          : '';
         if (!textForAnalysis || textForAnalysis.length < 50) return await this.performRegularSearch(args);
 
         const searchTerms = await extractSearchTermsWithAI(textForAnalysis, this.llm);
         const smartQuery = searchTerms.searchQuery || searchTerms.disputeType || '';
+        if (!smartQuery) return await this.performRegularSearch(args);
 
-        const requestedDisplay = args.limit || 10;
-        const userOffset = args.offset || 0;
-        const maxApiLimit = 1000;
-        let similarCasesForDisplay: any[] = [];
-        let totalFound = 0;
-        let offset = userOffset;
-        let pagesFetched = 0;
-        let hasMore = true;
-        const maxPages = 10000;
-
-        while (hasMore && pagesFetched < maxPages) {
-          const similarResponse = await this.zoAdapter.searchCourtDecisions({
-            meta: { search: smartQuery },
-            limit: maxApiLimit,
-            offset,
-          });
-          const normalized = await this.zoAdapter.normalizeResponse(similarResponse);
-          const pageResults = normalized.data.filter((doc: any) => doc.doc_id !== sourceCase.doc_id);
-
-          if (similarCasesForDisplay.length < requestedDisplay) {
-            const remainingSlots = requestedDisplay - similarCasesForDisplay.length;
-            similarCasesForDisplay.push(...pageResults.slice(0, remainingSlots).map((doc: any) => ({
-              cause_num: doc.cause_num,
-              doc_id: doc.doc_id,
-              title: doc.title,
-              resolution: doc.resolution,
-              judge: doc.judge,
-              court_code: doc.court_code,
-              adjudication_date: doc.adjudication_date,
-              url: doc.url,
-              similarity_reason: 'metadata_and_keywords',
-            })));
-          }
-
-          totalFound += pageResults.length;
-          pagesFetched++;
-
-          if (normalized.data.length < maxApiLimit) {
-            hasMore = false;
-          } else if (similarCasesForDisplay.length >= requestedDisplay) {
-            hasMore = false;
-          } else {
-            offset += maxApiLimit;
-          }
-        }
-
-        const reachedLimit = pagesFetched >= maxPages;
-
-        if (similarCasesForDisplay.length > 0) {
-          this.zoAdapter.saveDocumentsToDatabase(similarCasesForDisplay, 1000).catch(err => {
-            logger.error('Failed to save documents to database:', err);
-          });
-        }
+        const requestedDisplay = Math.min(50, Math.max(1, Number(args.limit || 10)));
+        const ftsResp = await this.ftsService.searchFulltext(
+          smartQuery, this.db, {}, Math.max(requestedDisplay * 2, 20), 0,
+        );
+        const similarCasesForDisplay = this.mapFtsResults(
+          ftsResp.results.filter((r) => r.doc_id !== sourceCase.doc_id),
+        ).slice(0, requestedDisplay).map((c) => ({ ...c, similarity_reason: 'fts_keywords' }));
 
         const enrichedSimilar = await this.enrichWithPrecedentStatus(similarCasesForDisplay);
 
@@ -418,17 +385,14 @@ export class LegalAdviceTools extends BaseToolHandler {
           source_case: {
             cause_num: sourceCase.cause_num,
             doc_id: sourceCase.doc_id,
-            title: sourceCase.title,
-            resolution: sourceCase.resolution,
             judge: sourceCase.judge,
             court_code: sourceCase.court_code,
             adjudication_date: sourceCase.adjudication_date,
-            url: sourceCase.url,
+            url: `https://reyestr.court.gov.ua/Review/${sourceCase.doc_id}`,
             category_code: sourceCase.category_code,
             justice_kind: sourceCase.justice_kind,
           },
-          search_method: 'smart_text_search_with_pagination',
-          text_source: textSource,
+          search_method: 'smart_fts_search',
           text_length: textForAnalysis.length,
           extracted_terms: {
             law_articles: searchTerms.lawArticles,
@@ -438,16 +402,11 @@ export class LegalAdviceTools extends BaseToolHandler {
           },
           search_query: smartQuery,
           similar_cases: enrichedSimilar,
-          total_found: totalFound,
-          pages_fetched: pagesFetched,
-          reached_safety_limit: reachedLimit,
+          total_found: ftsResp.total,
           displaying: enrichedSimilar.length,
-          total_available_info: reachedLimit
-            ? `Найдено минимум ${totalFound} прецедентов (показано первых ${enrichedSimilar.length}).`
-            : `Найдено ${totalFound} прецедентов через ${pagesFetched} страниц.`,
         });
       } catch (error: any) {
-        logger.error('Semantic search failed, falling back to regular search', error);
+        logger.error('Smart FTS search failed, falling back to regular search', error);
         return await this.performRegularSearch(args);
       }
     }
@@ -465,119 +424,54 @@ export class LegalAdviceTools extends BaseToolHandler {
     const procedureCode = args.procedure_code ? String(args.procedure_code) : undefined;
     const sectionFocus = Array.isArray(args.section_focus) ? args.section_focus : undefined;
 
+    if (!this.ftsService || !this.db) throw new Error('FTS сервіс недоступний для пошуку прецедентів');
+
     const budget = query.length < 30 ? 'quick' : 'standard';
     const intent = await this.queryPlanner.classifyIntent(query, budget as 'quick' | 'standard');
-    // Optimize query for sph04 AND-mode: long queries with many words return 0 results
+    // Optimize long queries — plainto_tsquery ANDs every token, so a long phrase matches little.
     const searchQuery = query.length > 40
       ? await this.queryPlanner.generateOptimizedSearchQuery(query, intent, budget as 'quick' | 'standard')
       : query;
-    const queryParams = this.queryPlanner.buildQueryParams(intent, searchQuery);
 
-    // Apply court_level and procedure_code filters (from merged search_supreme_court_practice)
-    if (courtLevel && courtLevel !== 'all') {
-      queryParams.where = [
-        ...(queryParams.where || []),
-        ...buildSupremeCourtWhereFilter(courtLevel),
-      ];
-    }
-    if (procedureCode) {
-      const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
-      if (justiceKind !== null) {
-        queryParams.where = [
-          ...(queryParams.where || []),
-          { field: 'justice_kind', operator: '=', value: justiceKind },
-        ];
-      }
-    }
+    const filters = this.buildEdsrFilters(courtLevel, procedureCode);
+    // Over-fetch when filtering by court level to compensate for the GrandChamber post-filter.
+    const fetchLimit = (courtLevel && courtLevel !== 'all') ? Math.max(limit * 3, 30) : limit;
 
-    // Fetch more results when filtering by court level to compensate post-filtering
-    if (courtLevel && courtLevel !== 'all') {
-      queryParams.limit = Math.max(limit * 3, 30);
-    }
-
-    const endpoints = this.queryPlanner.selectEndpoints(intent).filter(e => e === 'court');
-
-    const results: any[] = [];
-    const errors: string[] = [];
-
-    for (const endpoint of endpoints) {
+    const runFts = async (q: string) => {
       try {
-        let response;
-        switch (endpoint) {
-          case 'court':
-            response = await this.zoAdapter.searchCourtDecisions(queryParams);
-            break;
-          default:
-            continue;
-        }
-        const normalized = await this.zoAdapter.normalizeResponse(response);
-        results.push(...normalized.data.slice(offset, offset + limit));
+        const resp = await this.ftsService!.searchFulltext(q, this.db, filters, fetchLimit, offset);
+        return resp.results;
       } catch (error: any) {
-        errors.push(`${endpoint}: ${error.message}`);
+        logger.warn('[search_legal_precedents] FTS leg failed', { error: error.message });
+        return [];
       }
-    }
+    };
 
-    // Fallback: if 0 results, retry with stripped keywords (remove all quotes and Sphinx operators).
-    // Fires even when searchQuery === query (optimizer returned input unchanged) — in that case
-    // we still strip quotes/operators and retry with broader bare-keyword search.
-    if (results.length === 0 && errors.length === 0) {
+    let rows = await runFts(searchQuery);
+
+    // Relax-on-empty: strip operators, then fall back to the 4 most distinctive words.
+    if (rows.length === 0) {
       const stripped = query.replace(/["'|()]/g, ' ').replace(/\s+/g, ' ').trim();
       if (stripped && stripped !== searchQuery) {
-        logger.info('[search_legal_precedents] 0 results with optimized query, retrying with stripped keywords', {
-          optimized: searchQuery,
-          fallback: stripped.substring(0, 100),
-        });
-        const fallbackParams = this.queryPlanner.buildQueryParams(intent, stripped);
-        try {
-          const fallbackResponse = await this.zoAdapter.searchCourtDecisions(fallbackParams);
-          const fallbackNormalized = await this.zoAdapter.normalizeResponse(fallbackResponse);
-          results.push(...fallbackNormalized.data.slice(offset, offset + limit));
-        } catch (error: any) {
-          errors.push(`fallback: ${error.message}`);
-        }
-
-        // Second-level fallback: sph04 AND-mode requires ALL words present in the doc.
-        // A stripped multi-word phrase (8+ words) still returns 0. Retry with only the
-        // 4 longest words (most distinctive nouns), which greatly broadens the match.
-        if (results.length === 0) {
+        rows = await runFts(stripped);
+        if (rows.length === 0) {
           const keyWords = stripped.split(/\s+/).filter(w => w.length >= 6).slice(0, 4).join(' ');
-          if (keyWords && keyWords !== stripped) {
-            logger.info('[search_legal_precedents] 0 results with stripped query, retrying with key words only', {
-              stripped: stripped.substring(0, 100),
-              keyWords,
-            });
-            const shortParams = this.queryPlanner.buildQueryParams(intent, keyWords);
-            try {
-              const shortResponse = await this.zoAdapter.searchCourtDecisions(shortParams);
-              const shortNormalized = await this.zoAdapter.normalizeResponse(shortResponse);
-              results.push(...shortNormalized.data.slice(offset, offset + limit));
-            } catch (error: any) {
-              errors.push(`fallback2: ${error.message}`);
-            }
-          }
+          if (keyWords && keyWords !== stripped) rows = await runFts(keyWords);
         }
       }
     }
 
-    // Post-filter by SC court codes if court_level is specified
-    let filtered = results;
-    if (courtLevel && courtLevel !== 'all') {
-      const scCourtCodePrefix = '99';
-      filtered = results.filter((d: any) => {
-        const code = String(d?.court_code || '');
-        if (!code.startsWith(scCourtCodePrefix)) return false;
-        if (courtLevel === 'GrandChamber') return code === '9901';
-        return true;
-      }).slice(0, limit);
+    let filtered = this.mapFtsResults(rows);
+    // Grand Chamber lives under a single court_code (9901).
+    if (courtLevel === 'GrandChamber') {
+      filtered = filtered.filter((d: any) => String(d?.court_code || '') === '9901');
     }
+    filtered = filtered.slice(0, limit);
 
-    // Add snippets for SC results if section_focus is set
+    // Expose the FTS headline as a snippet when a section focus is requested.
     if (sectionFocus && filtered.length > 0) {
       for (const r of filtered) {
-        const fullText = typeof r.full_text === 'string' ? r.full_text : '';
-        if (fullText) {
-          r.snippets = extractSnippets(fullText, query, 2);
-        }
+        if (r.headline) r.snippets = [r.headline];
       }
     }
 
@@ -586,11 +480,10 @@ export class LegalAdviceTools extends BaseToolHandler {
     return this.wrapResponse({
       results: enriched,
       intent,
-      search_method: 'text_based',
+      search_method: 'fts',
       total: enriched.length,
       ...(courtLevel && courtLevel !== 'all' ? { court_level: courtLevel } : {}),
       ...(procedureCode ? { procedure_code: procedureCode } : {}),
-      ...(errors.length > 0 && { warnings: errors }),
     });
   }
 

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -153,7 +153,8 @@ export function createToolServices(
     coreServices.citationValidator,
     coreServices.shepardizationService,
     llmAdapter,
-    coreServices.db
+    coreServices.db,
+    edsrFtsService
   ));
   toolRegistry.registerHandler(new CourtSessionTools(
     coreServices.zoSessionsAdapter,


### PR DESCRIPTION
Фаза 2, PR #2. `search_legal_precedents` был полностью мёртв (все пути шли в удалённые ZakonOnline-стабы и возвращали пусто). Репойнт на EDRSR FTS; тулза **сохранена** — она даёт precedent-status enrichment + фильтры court_level/procedure поверх `search_court_decisions`.

## Изменения
- **`performRegularSearch`** → `EdsrFtsService.searchFulltext` с `court_level→instance_code` (ВС=кассация) и `procedure_code→justice_kind`. Сохранены: relax-on-empty фолбек (strip → 4 самых длинных слова), пост-фильтр GrandChamber (court_code 9901), headline-сниппеты, Shepardize-enrichment.
- **smart case-number путь**: исходное дело грузится прямо из `edrsr_documents`/`edrsr_fulltext`, AI извлекает термины, похожие дела ищутся через FTS (вместо мёртвого `getDocumentByCaseNumber` + пагинации по стабу). Убраны HTML-парсинг ZO и no-op `saveDocumentsToDatabase`.
- **count_all**: через `EdsrFtsService` (total — FTS-оценка; точные каунты — `count_cases_by_party`). `countAllResults` переписан на `(ftsService, db, query)`, зависимость от `EdsrLocalAdapter` убрана.
- Инжект `EdsrFtsService` в `LegalAdviceTools` (фабрика).

После этого PR единственные оставшиеся вызыватели мёртвых стабов — domain-mismatch тулзы (ECHR / legal-acts / court-sessions) → отдельный retire-PR.

## Заметка
`search-legal-precedents.test.ts` / `get-legal-advice-cpc-gpc.test.ts` — **пре-существующе красные на main** (TS-типизация console + устаревшая арность конструктора), не трогал. `tsc` по исходнику чистый.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repointed `search_legal_precedents` and `countAllResults` from dead ZakonOnline stubs to the production EDRSR FTS service and DB, restoring working search and counts. The tool still adds precedent-status enrichment and court level/procedure filters on top of FTS.

- **Refactors**
  - `performRegularSearch` now uses `EdsrFtsService.searchFulltext`; maps `court_level`→`instance_code` and `procedure_code`→`justice_kind`; keeps relax-on-empty fallback, Grand Chamber post-filter (`court_code` 9901), headline snippets, and Shepardize enrichment.
  - Smart case-number flow now reads the source case from `edrsr_documents`/`edrsr_fulltext`, extracts terms, and finds similar cases via FTS; removed HTML parsing and the no-op save.
  - `countAllResults` now calls FTS for a total estimate and returns the first page; new signature `(ftsService, db, query, filters?)`; removed `EdsrLocalAdapter` dependency.
  - Wired `EdsrFtsService` into `LegalAdviceTools` in the factory.

<sup>Written for commit 4f85bd2d5ea39a8245e97ae1a7870f33053b5f57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

