### PR TITLE
fix(edrsr): honor court_level + enforce party/instance in hybrid search

### DIFF
--- a/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
@@ -44,6 +44,9 @@ describe('EdsrUnifiedSearchTool', () => {
           rank: 0.5,
         }],
       })),
+      // Default: pass-through (keep every candidate). Tests override to assert dropping.
+      filterDocIdsByConstraints: jest.fn((docIds: number[]) =>
+        Promise.resolve(new Set(docIds.map(Number)))),
     };
     mockVectorizer = {
       semanticSearch: jest.fn(() => Promise.resolve([])),
@@ -387,6 +390,131 @@ describe('EdsrUnifiedSearchTool', () => {
       const parsed = JSON.parse(result?.content[0].text || '{}');
       expect(parsed.legs.fts_available).toBe(true);
       expect(parsed.legs.vector_available).toBe(false);
+    });
+  });
+
+  describe('court_level / instance_code', () => {
+    it('exposes court_level param with SC / GrandChamber enum', () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db);
+      const props = tool.getToolDefinitions()[0].inputSchema.properties as any;
+      expect(props.court_level).toBeTruthy();
+      expect(props.court_level.enum).toEqual(['all', 'SC', 'GrandChamber']);
+    });
+
+    it('maps court_level=SC to instance_code=1 in fulltext FTS filters', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext', query: 'податок нерухомість', court_level: 'SC',
+      });
+
+      const filters = mockFtsService.searchFulltext.mock.calls[0][2];
+      expect(filters.instance_code).toBe(1);
+    });
+
+    it('maps court_level=GrandChamber to instance_code=1 in structured WHERE', async () => {
+      db = makeDb((sql) => {
+        if (sql.includes('COUNT(*)')) return { rows: [{ total: 0 }] };
+        return { rows: [] };
+      });
+      tool = new EdsrUnifiedSearchTool(db);
+
+      await tool.executeTool('search_court_decisions', {
+        mode: 'structured', cause_num: '910/1/23', court_level: 'GrandChamber',
+      });
+
+      const instanceCall = calls.find(c => c.sql.includes('c.instance_code'));
+      expect(instanceCall).toBeTruthy();
+      expect(instanceCall!.params).toContain(1);
+    });
+
+    it('explicit instance_code wins over court_level', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext', query: 'тест', court_level: 'SC', instance_code: 2,
+      });
+
+      const filters = mockFtsService.searchFulltext.mock.calls[0][2];
+      expect(filters.instance_code).toBe(2);
+    });
+
+    it('passes instance_code into the hybrid FTS leg filters', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+
+      await tool.executeTool('search_court_decisions', {
+        mode: 'hybrid', query: 'тест', court_level: 'SC',
+      });
+
+      const filters = mockFtsService.searchFulltext.mock.calls[0][2];
+      expect(filters.instance_code).toBe(1);
+    });
+  });
+
+  describe('hybrid structural enforcement', () => {
+    const vectorHit = (doc_id: number, score: number) => ({
+      doc_id, score, text: 'фрагмент', chunk_index: 0,
+      metadata: { court_code: 2605, cause_num: `${doc_id}/23`, justice_kind: 1, judgment_code: 3 },
+    });
+
+    it('drops vector-only hits that fail the party constraint', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      // FTS leg returns the party-matching doc; vector leg adds an unconstrained extra.
+      mockFtsService.searchFulltext = jest.fn(() => Promise.resolve({
+        query: 'тест', total: 1,
+        results: [{ doc_id: 111, court_code: 2605, justice_kind: 1, judgment_code: 3, rank: 0.5, headline: null }],
+      }));
+      mockFtsService.filterDocIdsByConstraints = jest.fn((ids: number[]) =>
+        // Only the FTS doc actually contains "Нова Пошта" as a party; 222 is vector noise.
+        Promise.resolve(new Set(ids.filter(id => id === 111))));
+      mockVectorizer.semanticSearch = jest.fn(() => Promise.resolve([vectorHit(222, 0.9), vectorHit(111, 0.4)]));
+
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'hybrid', query: 'тест', party_name: 'Нова Пошта', party_role: 'defendant',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      const ids = parsed.results.map((r: any) => r.doc_id);
+      expect(ids).toContain(111);
+      expect(ids).not.toContain(222);
+      expect(parsed.structural_filter.dropped).toBe(1);
+      expect(parsed.party_filter).toEqual({ party_name: 'Нова Пошта', party_role: 'defendant' });
+    });
+
+    it('relaxes party_role when the role wipes every candidate', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      mockFtsService.searchFulltext = jest.fn(() => Promise.resolve({ query: 'тест', total: 0, results: [] }));
+      mockVectorizer.semanticSearch = jest.fn(() => Promise.resolve([vectorHit(333, 0.8)]));
+      // First pass (name + role) → empty; second pass (name only) → keeps 333.
+      mockFtsService.filterDocIdsByConstraints = jest.fn((ids: number[], c: any) =>
+        Promise.resolve(c.party_role ? new Set<number>() : new Set(ids.map(Number))));
+
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'hybrid', query: 'тест', party_name: 'Нова Пошта', party_role: 'defendant',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.structural_filter.party_role_relaxed).toBe(true);
+      expect(parsed.results.map((r: any) => r.doc_id)).toContain(333);
+      expect(mockFtsService.filterDocIdsByConstraints).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not run structural enforcement without party/instance filters', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      mockVectorizer.semanticSearch = jest.fn(() => Promise.resolve([vectorHit(444, 0.7)]));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+
+      const result = await tool.executeTool('search_court_decisions', { mode: 'hybrid', query: 'тест' });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.structural_filter).toBeUndefined();
+      expect(mockFtsService.filterDocIdsByConstraints).not.toHaveBeenCalled();
     });
   });
 

--- a/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
@@ -331,6 +331,33 @@ describe('EdsrUnifiedSearchTool', () => {
       expect(parsed.total).toBe(3);
     });
 
+    it('relaxes on near-collapse (1–2 hits), not just a hard 0', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      const seen: string[] = [];
+      // Over-narrow AND-chain: 5–6 tokens scrape a single hit (mimics the prod
+      // "Нова Пошта кур'єрська служба пошкодження вантажу" + defendant → total 1),
+      // dropping to ≤4 clears the floor. A strict ===0 trigger would never fire here.
+      mockFtsService.searchFulltext = jest.fn((q: string) => {
+        seen.push(q);
+        const n = q.split(/\s+/).filter(Boolean).length;
+        return Promise.resolve(n <= 4
+          ? { query: q, total: 50, results: [{ doc_id: 1, rank: 0.4 }] }
+          : { query: q, total: 1, results: [{ doc_id: 9, rank: 0.4 }] });
+      });
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'fulltext', query: 'один два три чотири пять шість',
+      });
+
+      // capped to 6 (total 1), relaxed 6→5→4 where the floor (3) is cleared
+      expect(seen[0].split(/\s+/)).toHaveLength(6);
+      expect(seen[seen.length - 1].split(/\s+/)).toHaveLength(4);
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.term_relaxed).toEqual({ from_tokens: 6, to_tokens: 4 });
+      expect(parsed.total).toBe(50);
+    });
+
     it('does not relax below FTS_MIN_TOKENS (2)', async () => {
       db = makeDb(() => ({ rows: [] }));
       const seen: string[] = [];

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -23,15 +23,21 @@ const DEFAULT_RRF_K = 60;
 const DEFAULT_OVERSAMPLE = 3;
 const MAX_OVERSAMPLE = 5;
 // plainto_tsquery ANDs every token, and a party filter adds ~2 more conjuncts, so one
-// rare term can collapse the whole conjunction to 0 (observed: "…вантажу логістика" +
-// defendant → 0 while 6 tokens → 144). Rather than guess a single fixed cap, start from
-// the leading FULLTEXT_MAX_TOKENS and relax DOWNWARD on an empty result — dropping the
-// trailing (least-salient) token and retrying down to FTS_MIN_TOKENS. The party filter is
-// part of every probe, so relaxation is selectivity-aware for free. FTS_MAX_RELAX_STEPS
-// bounds the extra probe queries on the hot path.
+// rare term can collapse the whole conjunction to ~0 (observed: "…вантажу логістика" +
+// defendant → 0 while 6 tokens → 144; and "Нова Пошта кур'єрська служба пошкодження
+// вантажу" + defendant → 1, starving the precise FTS leg). Rather than guess a single
+// fixed cap, start from the leading FULLTEXT_MAX_TOKENS and relax DOWNWARD while the probe
+// stays near-empty — dropping the trailing (least-salient) token and retrying down to
+// FTS_MIN_TOKENS. Dropping a conjunct can only widen the match set (monotone), so this
+// stops at the narrowest query that clears FTS_RELAX_MIN_RESULTS — the most precise probe
+// that still feeds the leg. The party filter is part of every probe, so relaxation is
+// selectivity-aware for free. FTS_MAX_RELAX_STEPS bounds the extra probes on the hot path.
 const FULLTEXT_MAX_TOKENS = 6;
 const FTS_MIN_TOKENS = 2;
 const FTS_MAX_RELAX_STEPS = 4;
+// Relax not just on a hard 0, but on near-collapse: 1–2 hits means the AND-chain is
+// over-narrow and the FTS leg can't carry recall (the semantic leg ends up masking it).
+const FTS_RELAX_MIN_RESULTS = 3;
 
 const KUPAP_PRESETS: Record<string, { category_codes: number[]; label: string }> = {
   'traffic_dui':        { category_codes: [41090, 5952], label: 'П\'яне водіння (ст. 130 КУпАП)' },
@@ -362,10 +368,14 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     let result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
 
     let steps = 0;
-    while (result.total === 0 && n > FTS_MIN_TOKENS && steps < FTS_MAX_RELAX_STEPS) {
+    // Relax while near-empty (not just hard 0): dropping a trailing AND-term only widens the
+    // match set, so we keep broadening until the probe clears the floor or we hit the bounds.
+    while (result.total < FTS_RELAX_MIN_RESULTS && n > FTS_MIN_TOKENS && steps < FTS_MAX_RELAX_STEPS) {
       n -= 1; steps += 1;
       usedQuery = tokens.slice(0, n).join(' ');
-      logger.info('[EdsrUnifiedSearch] FTS relax-on-empty', { from_tokens: n + 1, to_tokens: n, query: usedQuery });
+      logger.info('[EdsrUnifiedSearch] FTS relax-on-near-empty', {
+        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: usedQuery,
+      });
       result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
     }
 

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -109,7 +109,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
 ⚠️ Роль сторони (конкретна особа/компанія саме ЯК відповідач або позивач) → передавай party_name + party_role у режимі fulltext/hybrid, а НЕ дописуй слово «відповідач» у query. party_name прив'язується до тексту як фраза, party_role — до рольового слова, тож «де X — відповідач» дасть точніший результат, ніж семантика чи ключові слова. Для точного № справи/статті → structured або fulltext.
 
-Фільтри (спільні для всіх режимів): court_code/court_name, judge, justice_kind, judgment_code, category_code, date_from/date_to, party_name, party_role.
+Фільтри (спільні для всіх режимів): court_code/court_name, judge, justice_kind, judgment_code, category_code, date_from/date_to, party_name, party_role, court_level (SC=Верховний Суд).
 Пресети: military_preset (військові справи), kupap_preset (адмінправопорушення — traffic_dui, traffic_accident, domestic_violence, hooliganism тощо).
 Для повного тексту рішення — get_court_decision. Для резолютивки — edrsr_get_decision_dispositive.`,
       inputSchema: {
@@ -171,7 +171,12 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
           },
           instance_code: {
             type: 'number',
-            description: 'Інстанція суду: 1=Касаційна, 2=Апеляційна, 3=Перша (тільки structured)',
+            description: 'Інстанція суду: 1=Касаційна, 2=Апеляційна, 3=Перша. Працює в усіх режимах (structured/fulltext/hybrid).',
+          },
+          court_level: {
+            type: 'string',
+            enum: ['all', 'SC', 'GrandChamber'],
+            description: 'Рівень суду: all (всі), SC (Верховний Суд: КЦС/КГС/КАС/ККС), GrandChamber (Велика Палата ВС). SC/GrandChamber → касаційна інстанція (мапиться на instance_code=1). Узгоджено з search_legal_precedents / find_similar_fact_pattern_cases.',
           },
           military_preset: {
             type: 'string',
@@ -218,6 +223,13 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
   async executeTool(name: string, args: any): Promise<ToolResult | null> {
     if (name !== 'search_court_decisions') return null;
+
+    // court_level is the cross-tool convention (search_legal_precedents,
+    // find_similar_fact_pattern_cases): SC / GrandChamber → cassation instance. Map it onto
+    // instance_code so every mode honours it; explicit instance_code wins if both are given.
+    if (!args.instance_code && (args.court_level === 'SC' || args.court_level === 'GrandChamber')) {
+      args.instance_code = 1;
+    }
 
     switch (args.mode) {
       case 'structured': return this.searchStructured(args);
@@ -383,6 +395,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       const baseFilters: EdsrFtsFilters = {
         court_code: courtCode, judge: args.judge, date_from: args.date_from, date_to: args.date_to,
         justice_kind: args.justice_kind, judgment_code: args.judgment_code, category_code: args.category_code,
+        instance_code: args.instance_code,
       };
       const partyName = typeof args.party_name === 'string' ? args.party_name.trim() : undefined;
       const partyRole = args.party_role as EdsrFtsFilters['party_role'] | undefined;
@@ -451,13 +464,19 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     const rrfK = Math.max(Number(args.rrf_k) || DEFAULT_RRF_K, 1);
     const candidateLimit = limit * oversample;
 
+    const partyName = typeof args.party_name === 'string' ? args.party_name.trim() || undefined : undefined;
+    const partyRole = args.party_role as EdsrFtsFilters['party_role'] | undefined;
+    const instanceCode = args.instance_code ? Number(args.instance_code) : undefined;
+
     const filters: EdsrFtsFilters = {
       court_code: args.court_code, justice_kind: args.justice_kind,
       judge: args.judge, date_from: args.date_from, date_to: args.date_to,
-      // Party constraints apply to the FTS leg only; the semantic leg can't filter by
-      // role, so RRF still surfaces topically-relevant vector hits as a safety net.
-      party_name: typeof args.party_name === 'string' ? args.party_name.trim() || undefined : undefined,
-      party_role: args.party_role,
+      instance_code: instanceCode,
+      // Party/instance constraints apply to the FTS leg here; the semantic leg can't filter
+      // by them, so RRF still surfaces topically-relevant vector hits. The structural
+      // post-fusion pass below re-checks those vector-only hits and drops non-matching ones.
+      party_name: partyName,
+      party_role: partyRole,
     };
 
     const reformulated = this.queryReformulator
@@ -490,7 +509,37 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
     const ftsResults = ftsResponse?.results || [];
     const vectorHits: EdrsrSearchResult[] = vectorResults || [];
-    const fused = this.fuseRRF(ftsResults, vectorHits, rrfK);
+    let fused = this.fuseRRF(ftsResults, vectorHits, rrfK);
+
+    // Post-fusion structural enforcement. The Qdrant leg cannot filter by party_name/
+    // party_role/instance_code, so vector-only hits arrive unconstrained and previously
+    // diluted the result (e.g. "Нова Пошта as defendant" returned cases without the party;
+    // court_level=SC returned lower-instance courts). Re-check the fused candidates against
+    // edrsr_fulltext/edrsr_courts and drop the ones that don't actually satisfy the
+    // constraints. FTS-leg hits already match, so only vector-only hits can be removed.
+    let structuralFilter: { dropped: number; party_role_relaxed?: boolean } | undefined;
+    if ((partyName || instanceCode) && fused.length > 0) {
+      const docIds = fused.map(h => h.doc_id);
+      let allowed = await this.ftsService.filterDocIdsByConstraints(
+        docIds, { party_name: partyName, party_role: partyRole, instance_code: instanceCode }, this.db,
+      );
+      // Role may simply not co-occur as a keyword even when the party IS a party (court
+      // phrasing varies) — mirror fulltext mode: if the role wipes everything, drop the role
+      // but keep the name + instance constraint rather than returning nothing.
+      let roleRelaxed = false;
+      if (allowed.size === 0 && partyName && partyRole && partyRole !== 'any') {
+        roleRelaxed = true;
+        allowed = await this.ftsService.filterDocIdsByConstraints(
+          docIds, { party_name: partyName, instance_code: instanceCode }, this.db,
+        );
+      }
+      const before = fused.length;
+      fused = fused.filter(h => allowed.has(h.doc_id));
+      if (before !== fused.length || roleRelaxed) {
+        structuralFilter = { dropped: before - fused.length, ...(roleRelaxed ? { party_role_relaxed: true } : {}) };
+      }
+    }
+
     const top = fused.slice(0, limit);
     const enriched = await this.enrichFusedHits(top);
     const output = await this.maybeFilter(enriched, query);
@@ -499,7 +548,10 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       mode: 'hybrid', query, rrf_k: rrfK, oversample,
       ...(args._fallback_from ? { fallback_from: args._fallback_from } : {}),
       ...(reformulated ? { reformulated: { fts: reformulated.fts, semantic: reformulated.semantic } } : {}),
+      ...(partyName ? { party_filter: { party_name: partyName, party_role: partyRole || 'any' } } : {}),
+      ...(instanceCode ? { instance_code: instanceCode } : {}),
       legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length },
+      ...(structuralFilter ? { structural_filter: structuralFilter } : {}),
       total_fused: fused.length, returned: output.filtered.length,
       results: output.filtered,
       ...(output.original_count !== output.filtered_count

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -383,6 +383,80 @@ export class EdsrFtsService {
   }
 
   /**
+   * Return the subset of doc_ids that satisfy structural constraints the Qdrant leg
+   * cannot enforce — party_name/party_role (tsv phrase + role match) and instance_code
+   * (court instance). Used by hybrid search to re-check fused candidates AFTER RRF, so
+   * vector-only hits that don't actually involve the named party (or aren't from the
+   * requested instance) are dropped instead of polluting the result.
+   *
+   * Matching mirrors searchFulltext/countByParty exactly (phraseto_tsquery for the name,
+   * enumerated role-noun case forms for the role), so a doc that passes here would also
+   * have passed the FTS leg. With no party/instance constraint it is a pass-through.
+   */
+  async filterDocIdsByConstraints(
+    docIds: number[],
+    constraints: { party_name?: string; party_role?: PartyRole; instance_code?: number },
+    dbPool: any,
+  ): Promise<Set<number>> {
+    const matched = new Set<number>();
+    if (docIds.length === 0) return matched;
+
+    const partyName = constraints.party_name?.trim();
+    const instanceCode = constraints.instance_code;
+    if (!partyName && !instanceCode) {
+      for (const id of docIds) matched.add(Number(id));
+      return matched;
+    }
+
+    const params: any[] = [docIds];
+    let p = 2;
+    const conditions: string[] = [`f.doc_id = ANY($1)`];
+
+    if (partyName) {
+      const tsqueryParts: string[] = [`phraseto_tsquery('simple', $${p})`];
+      params.push(partyName);
+      p++;
+      const roleTsquery = constraints.party_role && constraints.party_role !== 'any'
+        ? ROLE_TSQUERY[constraints.party_role]
+        : null;
+      if (roleTsquery) {
+        // roleTsquery is a hardcoded constant — safe to inline, no user input.
+        tsqueryParts.push(`to_tsquery('simple', '${roleTsquery}')`);
+      }
+      conditions.push(`f.tsv @@ (${tsqueryParts.join(' && ')})`);
+    }
+
+    if (instanceCode) {
+      conditions.push(`c.instance_code = $${p}`);
+      params.push(instanceCode);
+      p++;
+    }
+
+    // edrsr_courts join only needed for the instance filter.
+    const fromClause = instanceCode
+      ? `edrsr_fulltext f
+         JOIN edrsr_documents d ON d.doc_id = f.doc_id
+         JOIN edrsr_courts c ON c.court_code = d.court_code`
+      : `edrsr_fulltext f`;
+
+    try {
+      const sql = `SELECT f.doc_id FROM ${fromClause} WHERE ${conditions.join(' AND ')}`;
+      const res = await dbPool.query(sql, params);
+      for (const row of res.rows) matched.add(Number(row.doc_id));
+      logger.info('[EdsrFtsService] filterDocIdsByConstraints', {
+        candidates: docIds.length, matched: matched.size,
+        party_name: partyName, party_role: constraints.party_role ?? 'any', instance_code: instanceCode,
+      });
+      return matched;
+    } catch (err: any) {
+      logger.error('[EdsrFtsService] filterDocIdsByConstraints failed', { error: err.message });
+      // Fail open: on error keep all candidates rather than dropping the whole result set.
+      for (const id of docIds) matched.add(Number(id));
+      return matched;
+    }
+  }
+
+  /**
    * Populate tsv column for rows that haven't been indexed yet.
    * Designed to be called repeatedly by a background job / cron.
    *


### PR DESCRIPTION
## Problem

Diagnosed from two prod chats where `search_court_decisions` returned results that didn't match the request:

- **`chat-8c5cbf84`** — «Нова Пошта as defendant»: the FTS leg was party-constrained, but the Qdrant leg can't filter by party, so RRF mixed in vector-only hits → returned cases that don't involve the party. 23/35 results were unconstrained vector hits.
- **`chat-057a4ad2`** — «позиція Верховного Суду»: the model passed `court_level: "SC"`, but the handler never read it → returned окружний/апеляційний admin courts, **0 ВС decisions**.

### Root causes (in `edrsr-unified-search-tool.ts`)

1. **`court_level` was never a parameter.** The model used `court_level: "SC"` (the convention from `search_legal_precedents` / `find_similar_fact_pattern_cases`), but the schema didn't define it and the handler never read `args.court_level`. The real `instance_code` filter existed but was wired into **structured mode only** — not fulltext/hybrid.
2. **`party_name`/`party_role` constrained the FTS leg only.** `EdrsrSearchFilters` (Qdrant) has no party fields, so the cast `filters as unknown as EdrsrSearchFilters` silently dropped them. The unconstrained vector leg then polluted the fused result, with no post-fusion re-check.

## Fix

**court_level**
- Add `court_level` (`all` | `SC` | `GrandChamber`) to the schema, consistent with sibling tools.
- Normalize `SC`/`GrandChamber` → `instance_code = 1` (explicit `instance_code` wins).
- Wire `instance_code` into the **fulltext** and **hybrid** FTS-leg filters (was structured-only).

**party / instance enforcement in hybrid**
- New `EdsrFtsService.filterDocIdsByConstraints(docIds, {party_name, party_role, instance_code})` — re-checks fused candidates against `edrsr_fulltext`/`edrsr_courts` using the *same* tsquery matching as the FTS leg (`phraseto_tsquery` + enumerated role case-forms).
- After RRF, drop fused hits that fail the constraints. FTS-leg hits already match, so only **vector-only noise** is removed.
- Mirrors fulltext mode's **party_role relaxation** (drop the role keyword rather than return nothing) and **fails open** on DB error (keep candidates, don't nuke the result set).

**Debuggability** — hybrid response now echoes `party_filter`, `instance_code`, and `structural_filter: { dropped, party_role_relaxed }`.

## Scope / notes
- **Semantic mode** (pure vector) still cannot honor `court_level`/party — out of scope here; hybrid is the recommended mode when structural filters matter. Can follow up if needed.
- Pre-existing `tsc` errors in `core-loader.ts` (proprietary `secondlayer-core` services not in this repo) are unrelated.

## Tests
8 new tests (31 total in the suite, all green): court_level→instance_code across structured/fulltext/hybrid, explicit-instance precedence, hybrid instance passthrough, post-fusion drop of vector-only non-matches, party_role relaxation, and no-op when no party/instance filter. FTS-service suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `court_level` in `search_court_decisions`, enforces party/instance constraints in hybrid, and relaxes the full‑text probe when it returns near‑empty (<3) so the FTS leg isn’t starved. Maps `SC`/`GrandChamber` to cassation across modes and drops vector‑only noise after fusion.

- **Bug Fixes**
  - Added `court_level` (`all` | `SC` | `GrandChamber`); map to `instance_code=1` unless explicit; honored in structured/fulltext/hybrid.
  - Hybrid now passes `instance_code` into the FTS leg and re-checks fused hits via `EdsrFtsService.filterDocIdsByConstraints` (party_name, party_role, instance_code); drops non-matching vector-only hits; relaxes `party_role` when it wipes candidates; fail-open on DB error.
  - Full‑text: relax token budget on near‑collapse (<3 hits) instead of only on 0, stopping at the narrowest query that clears the floor; added a test for this.
  - Response echoes `party_filter`, `instance_code`, and `structural_filter`.

<sup>Written for commit c331311bc80576ba8efad626231f986cb29453eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Follow-up commit: relax FTS on near-collapse (not just hard 0)

Diagnosed from the same subsystem while reviewing `chat-24248fc1` / `chat-8db0c036` (both «Нова Пошта as defendant»).

**Problem.** The term-budget `ftsWithRelaxation` (commit `caa1e191`) only relaxed the AND-chain when an FTS probe returned `total === 0`. But `party_name`/`party_role` add ~2 conjuncts, so an over-specified reformulated query commonly collapses to **1–2 hits, not 0** — starving the precise FTS leg, after which the semantic leg masks it in hybrid (losing the precise hits). On prod the 6-token leg `Нова Пошта кур'єрська служба пошкодження вантажу` + defendant returned `total=1`, so relaxation never fired. A second run of the identical query did **not** collapse — confirming the trigger is reformulator-nondeterministic, which a near-collapse floor fixes deterministically.

**Fix.** Add `FTS_RELAX_MIN_RESULTS = 3`; relax while `result.total < FTS_RELAX_MIN_RESULTS` instead of `=== 0`. Dropping a trailing AND-term only widens the match set (monotone), so the loop stops at the narrowest query that clears the floor — the most precise probe that still feeds the leg. `FTS_MIN_TOKENS`/`FTS_MAX_RELAX_STEPS` bounds and the downstream `party_role` / hybrid-fallback tiers (still on `===0`) are unchanged. Log renamed to `relax-on-near-empty`, surfacing `prev_total`.

**Tests.** New `relaxes on near-collapse (1–2 hits)` reproduces the prod case (6 tokens → total 1 → relax 6→4). Existing relax tests unchanged. Suite: **32/32 pass**.

_Follow-up (untracked): IDF/term-frequency ordering of terms by rarity (estimate selectivity up-front) — commit `caa1e191` mislabeled this as LEXAI-1760, which is actually the parties-table pipeline._