### PR TITLE
chore(osint): disable SneakyPiper osint_* tools in chat (upstream down)

### DIFF
--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -222,13 +222,27 @@ export function createToolServices(
   logger.info('Upload, MinIO, and Vault services initialized');
 
   // OSINT proxy (SneakyPiper integration)
+  //
+  // TEMPORARILY DISABLED 2026-06-23: the upstream SneakyPiper self-hosted yente /
+  // OpenSanctions host (178.150.37.129, reachable over the wg-panoptic mesh at
+  // 10.77.0.1:8200) is down, and the INTERPOL relay is failing. Every osint_* call
+  // therefore returned an empty result set, which for a sanctions/PEP check is a
+  // dangerous false-negative ("nothing found" reads as "not sanctioned"). We keep the
+  // adapter and tools in the codebase (nothing deleted) but skip registration so they
+  // do not reach the chat. Re-enable once the host is restored: either revert this
+  // guard or set OSINT_PROXY_ENABLED=true.
   const osintAdapter = new OsintProxyAdapter(
     process.env.SNEAKYPIPER_API_URL || '',
     process.env.SNEAKYPIPER_API_KEY || ''
   );
-  if (osintAdapter.isConfigured()) {
+  const osintProxyEnabled = process.env.OSINT_PROXY_ENABLED === 'true';
+  if (osintProxyEnabled && osintAdapter.isConfigured()) {
     toolRegistry.registerHandler(new OsintProxyTools(osintAdapter));
     logger.info('OSINT proxy tools registered (SneakyPiper)');
+  } else if (osintAdapter.isConfigured()) {
+    logger.warn(
+      'OSINT proxy tools NOT registered: disabled via kill-switch (set OSINT_PROXY_ENABLED=true to re-enable once SneakyPiper upstream is restored)'
+    );
   }
 
   return {


### PR DESCRIPTION
## Why
The upstream **SneakyPiper** self-hosted **yente / OpenSanctions** host (`178.150.37.129`, reachable over the `wg-panoptic` mesh at `10.77.0.1:8200`) is **down**, and the INTERPOL relay is failing. Verified on the prod backend host `18.194.114.116`:

```
ERROR app.adapters.opensanctions: OpenSanctions match failed:
WARNING app.adapters.interpol_worldbank: World Bank debarment search failed:
WARNING app.adapters.interpol_worldbank: INTERPOL search failed:
```
- `curl 10.77.0.1:8200/healthz` → 000, `ping` 100% loss, WG peer shows `0 B received`.

Every `osint_*` call (`osint_search_sanctions`, `_interpol`, `_worldbank_debarment`, `_cve`, ...) returned `{results:[], total:0}`. For a sanctions/PEP check this is a **dangerous false-negative** — "nothing found" reads as "not sanctioned".

## What
Gate `OsintProxyTools` registration behind a new env kill-switch **`OSINT_PROXY_ENABLED`** (default **off**). When off, the tools are not registered and therefore do not reach the chat (filterTools drops unregistered names) or the direct API.

**Nothing is deleted** — the adapter (`OsintProxyAdapter`) and tools (`OsintProxyTools`) stay in the codebase.

## Re-enable (once 178.150.37.129 / yente is restored)
Either revert this guard, or set `OSINT_PROXY_ENABLED=true` in the prod backend env.

## Scope
- One file: `mcp_backend/src/factories/tool-services.ts`
- Typecheck clean (`tsc --noEmit`)
- Tools still working upstream (ip/domain reputation, corporate registry) are unaffected — they are part of the same proxy and will simply not be exposed while the switch is off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled `osint_*` chat tools by gating `OsintProxyTools` registration behind `OSINT_PROXY_ENABLED` (default off). This avoids false negatives while the SneakyPiper/OpenSanctions upstream is down.

- **Migration**
  - Re-enable by setting `OSINT_PROXY_ENABLED=true` once the upstream is restored (registration also requires a configured `OsintProxyAdapter`).

<sup>Written for commit c7556e8a1c9aa4f28bf4ad7a3b18cf367f04df14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

