### PR TITLE
chore(ui): remove OSINT card from welcome screen

### DIFF
--- a/lexwebapp/src/components/EmptyState.tsx
+++ b/lexwebapp/src/components/EmptyState.tsx
@@ -55,20 +55,6 @@ const PROMPT_POOL: SamplePrompt[] = [
   { category: 'Глибокий аналіз', text: 'Набувальна давність (ст. 344 ЦК): земельне та містобудівне законодавство, практика ВС, КС та аналіз патернів' },
   { category: 'Глибокий аналіз', text: 'Компанія «Газпром»: санкції РНБО, пов\'язані юрособи в Україні, судові справи, виконавчі провадження та закупівлі' },
   { category: 'Глибокий аналіз', text: 'Відповідальність директора ТОВ: ст. 89 ГК, ст. 1166 ЦК, практика ВС, банкрутні справи та дані з реєстрів' },
-
-  // ── OSINT (міжнародні бази, кіберрозвідка) ──
-  { category: 'OSINT', text: 'Перевірка санкцій OFAC/EU/UN для Huawei Technologies' },
-  { category: 'OSINT', text: 'Перевір IP 185.220.101.1 на шкідливу активність' },
-  { category: 'OSINT', text: 'Витоки облікових даних для домену @jpmorgan.com' },
-  { category: 'OSINT', text: 'Червоні повідомлення ІНТЕРПОЛУ за шахрайство' },
-  { category: 'OSINT', text: 'Репутація домену suspicious-site.com через VirusTotal' },
-  { category: 'OSINT', text: 'Жертви ransomware у фінансовому секторі' },
-  { category: 'OSINT', text: 'Дебармент Світового банку для консалтингових фірм' },
-  { category: 'OSINT', text: 'Офшорні зв\'язки через ICIJ для shell-компаній' },
-  { category: 'OSINT', text: 'Згадки у медіа та тональність для компанії Wirecard' },
-  { category: 'OSINT', text: 'CVE вразливості Cisco критичного рівня' },
-  { category: 'OSINT', text: 'Витоки API-ключів у GitHub для acme-corp.com' },
-  { category: 'OSINT', text: 'Публікації на darknet-форумах про витоки даних' },
 ];
 
 /**
@@ -78,7 +64,6 @@ const PROMPT_POOL: SamplePrompt[] = [
 const DISPLAY_SLOTS: string[] = [
   'Швидкий пошук',
   'Дослідження',
-  'OSINT',
   'Глибокий аналіз',
 ];
 


### PR DESCRIPTION
Removes the **OSINT** suggestion card (e.g. "Витоки облікових даних для домену @jpmorgan.com") from the chat empty-state welcome screen.

OSINT `osint_*` tools are disabled while the SneakyPiper upstream is down (#1964), so these prompts produced broken/empty results. Welcome screen now shows three categories: **Швидкий пошук / Дослідження / Глибокий аналіз**.

- One file: `lexwebapp/src/components/EmptyState.tsx` (removed OSINT display slot + its prompt pool)
- `npm run build` passes

Re-add alongside re-enabling osint tools once `178.150.37.129` / yente is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the OSINT suggestion card and its prompt pool from the chat empty-state because OSINT tools are temporarily disabled (#1964). This avoids broken/empty results and keeps only three categories on the welcome screen: Швидкий пошук, Дослідження, Глибокий аналіз.

<sup>Written for commit 5b352dda98ca8c60cf72feb3afb567949c00302a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

