### PR TITLE
fix(edrsr): enforce party role via claim-clause regex, not co-occurrence

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -6,7 +6,10 @@
  */
 
 import { describe, it, expect, jest } from '@jest/globals';
-import { EdsrFtsService } from '../edrsr-fts-service';
+import { EdsrFtsService, buildPartyRoleRegex } from '../edrsr-fts-service';
+
+const findRegexParam = (params: any[]): string | undefined =>
+  params.find((p) => typeof p === 'string' && (p.includes('(?:до|проти)') || p.includes('за[[:space:]]+позов')));
 
 const makeDb = () => {
   const calls: { sql: string; params: any[] }[] = [];
@@ -30,6 +33,7 @@ describe('EdsrFtsService.searchFulltext party filters', () => {
     expect(sql).toContain("plainto_tsquery('simple', $1)");
     expect(sql).not.toContain('phraseto_tsquery');
     expect(sql).not.toMatch(/&& to_tsquery/); // no role-noun clause
+    expect(sql).not.toContain('f.full_text ~*'); // no role regex post-filter
     // topical query is the only tsquery param
     expect(db.calls[0].params[0]).toBe('оренда землі');
   });
@@ -56,6 +60,13 @@ describe('EdsrFtsService.searchFulltext party filters', () => {
     expect(sql).toContain('відповідач');
     expect(sql).toContain('відповідача');
     expect(sql).not.toContain('позивач');
+    // claim-clause regex post-filter, anchored on the respondent slot "до …"
+    expect(sql).toContain('f.full_text ~*');
+    const rx = findRegexParam(db.calls[0].params);
+    expect(rx).toBeDefined();
+    expect(rx).toContain('(?:до|проти)');
+    expect(rx).toContain('Нова[[:space:]]+Пошта');
+    expect(rx).toContain('[»"”“]'); // required closing quote discriminates the exact entity
   });
 
   it('adds plaintiff role forms for plaintiff', async () => {
@@ -66,6 +77,9 @@ describe('EdsrFtsService.searchFulltext party filters', () => {
     const sql = db.calls[0].sql;
     expect(sql).toContain('позивач');
     expect(sql).not.toContain('відповідач');
+    const rx = findRegexParam(db.calls[0].params);
+    expect(rx).toBeDefined();
+    expect(rx).toContain('за[[:space:]]+позов'); // anchored on the claimant slot
   });
 
   it('treats party_role "any" as no role constraint', async () => {
@@ -76,6 +90,51 @@ describe('EdsrFtsService.searchFulltext party filters', () => {
     const sql = db.calls[0].sql;
     expect(sql).toContain('phraseto_tsquery');
     expect(sql).not.toMatch(/&& to_tsquery/);
+    expect(sql).not.toContain('f.full_text ~*');
+  });
+});
+
+describe('buildPartyRoleRegex', () => {
+  it('anchors the defendant on the respondent slot and requires a closing quote', () => {
+    const rx = buildPartyRoleRegex('Нова Пошта', 'defendant');
+    expect(rx.startsWith('(?:до|проти)')).toBe(true);
+    expect(rx).toContain('Нова[[:space:]]+Пошта[»"”“]');
+  });
+
+  it('anchors the plaintiff on the claimant slot', () => {
+    const rx = buildPartyRoleRegex('Нова Пошта', 'plaintiff');
+    expect(rx.startsWith('за[[:space:]]+позов')).toBe(true);
+  });
+
+  it('escapes regex metacharacters in user-supplied names', () => {
+    const rx = buildPartyRoleRegex('А.Б (В)', 'defendant');
+    expect(rx).toContain('\\.');
+    expect(rx).toContain('\\(');
+    expect(rx).toContain('\\)');
+  });
+});
+
+describe('EdsrFtsService.filterDocIdsByConstraints', () => {
+  it('adds the claim-clause role regex post-filter on the fused candidates', async () => {
+    const svc = new EdsrFtsService();
+    const db = makeDb();
+    await svc.filterDocIdsByConstraints([1, 2, 3], { party_name: 'Нова Пошта', party_role: 'defendant' }, db);
+
+    const sql = db.calls[0].sql;
+    expect(sql).toContain('f.doc_id = ANY($1)');
+    expect(sql).toContain('phraseto_tsquery');
+    expect(sql).toContain('f.full_text ~*');
+    const rx = findRegexParam(db.calls[0].params);
+    expect(rx).toContain('(?:до|проти)');
+  });
+
+  it('is a pass-through (no query) when no party/instance constraint is given', async () => {
+    const svc = new EdsrFtsService();
+    const db = makeDb();
+    const res = await svc.filterDocIdsByConstraints([1, 2], {}, db);
+
+    expect(db.calls).toHaveLength(0);
+    expect(res.size).toBe(2);
   });
 });
 

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -37,8 +37,10 @@ export interface EdsrFtsFilters {
   // the legal-form prefix (ТОВ / Товариство з обмеженою відповідальністю), which
   // declines and breaks the 'simple' (stemless) config. It is matched as a phrase.
   party_name?: string;
-  // party_role narrows to decisions where the role keyword (відповідач/позивач, with
-  // common case forms) co-occurs with the party name. 'any'/undefined → no role constraint.
+  // party_role narrows to decisions where the party stands in that procedural slot of the
+  // claim clause ("за позовом X до Y про …"), enforced by a claim-clause regex over full_text
+  // (see buildPartyRoleRegex) on top of the tsv role-noun prefilter. NOT mere co-occurrence
+  // of the role word — that wrongly matched courier mentions. 'any'/undefined → no constraint.
   party_role?: PartyRole;
 }
 
@@ -49,6 +51,45 @@ const ROLE_TSQUERY: Record<Exclude<PartyRole, 'any'>, string> = {
   defendant: 'відповідач | відповідача | відповідачу | відповідачем | відповідачі | відповідачів | відповідачам | відповідачами',
   plaintiff: 'позивач | позивача | позивачу | позивачем | позивачі | позивачів | позивачам | позивачами',
 };
+
+// Legal-form prefixes a court may place before a company name in the claim clause
+// ("ТОВ", "ПрАТ", "ПАТ", "ФОП", …). Constant ERE alternation (no user input), so it is
+// safe to embed in the built pattern. Declension suffixes are spelled out because the
+// 'simple' PG config / POSIX regex have no Ukrainian stemmer.
+const LEGAL_FORM_GROUP =
+  '(?:тов|товариств[а-яіїєґ]*[[:space:]]+з[[:space:]]+обмежен[а-яіїєґ]*[[:space:]]+відповідальніст[а-яіїєґ]*' +
+  '|прат|приватн[а-яіїєґ]*[[:space:]]+акціонерн[а-яіїєґ]*[[:space:]]+товариств[а-яіїєґ]*' +
+  '|пат|публічн[а-яіїєґ]*[[:space:]]+акціонерн[а-яіїєґ]*[[:space:]]+товариств[а-яіїєґ]*' +
+  '|пп|приватн[а-яіїєґ]*[[:space:]]+підприємств[а-яіїєґ]*' +
+  '|тдв|ат|дп|кп|фг|фоп)';
+
+/**
+ * Build a POSIX-ERE pattern (for `full_text ~* $param`) that matches the party ONLY when it
+ * stands in the requested procedural slot of the claim clause "за позовом X до Y про …":
+ *   - defendant → the name appears right after "до"/"проти" (the respondent slot)
+ *   - plaintiff → the name appears right after "за позовом" (the claimant slot)
+ *
+ * `party_name` is user input (any company name carried in the user's query), so regex
+ * metacharacters are escaped and internal whitespace is made flexible; the result is passed
+ * as a BOUND PARAMETER, never interpolated into SQL. A REQUIRED closing quote after the name
+ * discriminates the exact legal entity, so «Нова Пошта» is kept while «Нова Пошта Інтернешнл»
+ * (a different company) is rejected.
+ *
+ * This replaces the old bag-of-words role check (party name + the word «відповідач»
+ * co-occurring anywhere in the text), which wrongly matched decisions that merely named the
+ * company as a courier ("надіслано через ТОВ «Нова Пошта»") or where it was the plaintiff.
+ */
+export function buildPartyRoleRegex(partyName: string, role: Exclude<PartyRole, 'any'>): string {
+  const name = partyName
+    .trim()
+    .replace(/[.\\*+?()[\]{}|^$]/g, '\\$&')   // escape ERE metacharacters in user input
+    .replace(/\s+/g, '[[:space:]]+');          // tolerate any whitespace between name tokens
+  // Optional legal form, optional opening quote, the name, then a REQUIRED closing quote.
+  const anchoredName = `${LEGAL_FORM_GROUP}?[[:space:]]*[«"”“]?[[:space:]]*${name}[»"”“]`;
+  return role === 'defendant'
+    ? `(?:до|проти)[[:space:]]+${anchoredName}`
+    : `за[[:space:]]+позов[а-яіїєґ]*[[:space:]]+${anchoredName}`;
+}
 
 export interface EdsrFtsResult {
   doc_id: number;
@@ -146,6 +187,15 @@ export class EdsrFtsService {
     }
 
     conditions.push(`f.tsv @@ (${tsqueryParts.join(' && ')})`);
+
+    // Precise role enforcement: the party must stand in the claim clause's role slot, not
+    // merely co-occur with the role noun anywhere in the text. Applied as a regex post-filter
+    // on full_text — the tsv match above narrows the candidate rows the regex has to scan.
+    if (partyName && filters.party_role && filters.party_role !== 'any') {
+      conditions.push(`f.full_text ~* $${paramIdx}`);
+      params.push(buildPartyRoleRegex(partyName, filters.party_role));
+      paramIdx++;
+    }
 
     // Metadata filters — require JOIN with edrsr_documents
     const hasMetadataFilter = filters.court_code || filters.judge || filters.date_from ||
@@ -335,6 +385,13 @@ export class EdsrFtsService {
     }
 
     const conditions = [`f.tsv @@ (${tsqueryParts.join(' && ')})`];
+    // Claim-clause role post-filter (see buildPartyRoleRegex) — keeps the count honest by
+    // dropping decisions that only mention the party as a courier or in the opposite role.
+    if (partyRole && partyRole !== 'any') {
+      conditions.push(`f.full_text ~* $${p}`);
+      params.push(buildPartyRoleRegex(partyName, partyRole));
+      p++;
+    }
     if (filters.date_from) { conditions.push(`d.adjudication_date >= $${p}`); params.push(filters.date_from); p++; }
     if (filters.date_to) { conditions.push(`d.adjudication_date <= $${p}`); params.push(filters.date_to); p++; }
     if (filters.justice_kind) { conditions.push(`d.justice_kind = $${p}`); params.push(filters.justice_kind); p++; }
@@ -390,8 +447,8 @@ export class EdsrFtsService {
    * requested instance) are dropped instead of polluting the result.
    *
    * Matching mirrors searchFulltext/countByParty exactly (phraseto_tsquery for the name,
-   * enumerated role-noun case forms for the role), so a doc that passes here would also
-   * have passed the FTS leg. With no party/instance constraint it is a pass-through.
+   * role-noun tsv prefilter + claim-clause regex for the role), so a doc that passes here
+   * would also have passed the FTS leg. With no party/instance constraint it is a pass-through.
    */
   async filterDocIdsByConstraints(
     docIds: number[],
@@ -424,6 +481,15 @@ export class EdsrFtsService {
         tsqueryParts.push(`to_tsquery('simple', '${roleTsquery}')`);
       }
       conditions.push(`f.tsv @@ (${tsqueryParts.join(' && ')})`);
+      // Claim-clause role post-filter: re-check the fused (post-RRF) candidates so a
+      // vector-only hit that merely names the party as a courier — or in the opposite role —
+      // is dropped instead of polluting the result. This is the hybrid path that previously
+      // let "через ТОВ «Нова Пошта»" decisions through the defendant filter.
+      if (constraints.party_role && constraints.party_role !== 'any') {
+        conditions.push(`f.full_text ~* $${p}`);
+        params.push(buildPartyRoleRegex(partyName, constraints.party_role));
+        p++;
+      }
     }
 
     if (instanceCode) {


### PR DESCRIPTION
## Проблема

`party_role` фильтр EDRSR матчил **любое** решение, где имя стороны и слово роли (`відповідач`/`позивач`) встречались где угодно в тексте (co-occurrence в `tsv`). Это пропускало:
- дела, где компания — лишь **способ доставки** («надіслано через ТОВ «Нова Пошта»);
- дела, где она на самом деле **позивач**, а не відповідач;
- другое юрлицо («Нова Пошта Інтернешнл», «Нова Пей»).

Аудит чата (`chat-bb4652d6`): из 21 цитированного дела только **9** реально «Нова Пошта = відповідач». А `count_cases_by_party` показывал **16 468** «справ як відповідач» против **~4 187** решений на точном фильтре (завышение ~4–10×).

## Фикс

Новый `buildPartyRoleRegex(partyName, role)` строит POSIX-ERE паттерн **из произвольного имени компании** (имя приходит из запроса пользователя):
- метасимволы экранируются, паттерн передаётся **bound-параметром** (без SQL/regex-инъекций);
- требует, чтобы имя стояло в нужном слоте процессуальной клаузы «за позовом X **до** Y **про** …»: после `до`/`проти` для `defendant`, после `за позовом` для `plaintiff`;
- **обязательная закрывающая кавычка** после имени отделяет точное юрлицо («Нова Пошта» ✓ / «Нова Пошта Інтернешнл» ✗).

Применяется как regex post-filter поверх существующего `tsv`-префильтра (он сужает строки для регекса) в трёх методах: `searchFulltext`, `countByParty`, `filterDocIdsByConstraints` (гибридный post-RRF путь, где и возник баг).

## Валидация (на проде)

- Размеченный набор 21 дело: **9/9** true positives, **0/12** false positives (точность и полнота 100% на наборе).
- Честный счётчик «НП-відповідач» по всем годам: **~4 187 решений / ~1 660 справ** (пик 2021), вместо 16 468.

## Тесты

`edrsr-fts-service.test.ts` расширен: claim-clause regex для defendant/plaintiff, экранирование метасимволов, pass-through `filterDocIdsByConstraints`. Все проходят (12/12 в этом файле, 32/32 в unified-search-tool).

## Оговорки

- Precision-first: ловит стандартную клаузу с кавычками; нестандартные формулировки (несколько співвідповідачів через запятую, имя без кавычек) могут не попасть — это сознательный размен в пользу точности.
- Заметный выигрыш точности; при очень популярной компании регекс гоняется по большему числу строк — при необходимости вынести роль в материализованную колонку отдельной задачей.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces party role in EDRSR by matching the claim clause, not word co‑occurrence. This removes false positives (courier mentions, wrong role, similar names) and fixes inflated `countByParty` numbers.

- **Bug Fixes**
  - Added `buildPartyRoleRegex(partyName, role)` that anchors the name in the claim clause: after `до`/`проти` for defendants, after `за позовом` for plaintiffs; escapes metacharacters; allows legal-form prefixes; requires a closing quote to keep the exact entity.
  - Applied the regex as a `full_text ~* $param` post-filter on top of the existing `tsv` prefilter in `searchFulltext`, `countByParty`, and `filterDocIdsByConstraints`.
  - Tests added for regex construction, role anchoring, escaping, and pass-through logic. Validated: 9/9 true positives, 0/12 false positives; counts now ~4,187 decisions (~1,660 cases) instead of 16,468.

<sup>Written for commit e24aeb53fbe12617bb20bf8c713afa8d15a7899a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

