### PR TITLE
fix(edrsr): stop self-sustaining payload-index storm on serving node

### DIFF
--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -171,33 +171,54 @@ export class EdsrVectorizerService {
   // ── Initialization ───────────────────────────────────────────────────────
 
   /**
-   * Lazy initialization: create the EDRSR collection on first use.
+   * Lazy initialization: ensure the EDRSR collection is usable before first read.
+   *
+   * On a read-only serving node (e.g. `edrsr_serving`, 296M points) the collection
+   * and its payload indexes already exist. The old implementation, on every init,
+   * (a) called `getCollection()` — which scans `points_count` over the whole
+   * collection and takes tens of seconds on a disk-bound serving node, and
+   * (b) re-issued `createPayloadIndex` for all filterable fields. Under load this
+   * became a self-sustaining disk storm: the heavy index (re)builds saturated the
+   * serving node's IOPS → `getCollection()` timed out → `initialized` was never set
+   * → the next search re-ran the whole handshake and re-queued more index builds.
+   * Searches degraded to FTS-only (`vector_available:false`) the entire time.
+   *
+   * Fix: keep the read path cheap. Existence is checked with `getCollections()`
+   * (a name listing, not a points scan). If the collection exists we trust it and
+   * mark init complete — collection/index creation is the vectorization pipeline's
+   * job, not the search path's. The heavy create+verify path runs ONLY when the
+   * collection is genuinely missing. `QDRANT_EDRSR_SKIP_INIT=true` skips even the
+   * existence probe for serving nodes where the collection is known-good.
    */
   private async ensureCollection(): Promise<void> {
     if (this.initialized) return;
 
+    // Serving-node fast path: collection + indexes are known to exist, so skip
+    // every network round-trip and never touch index creation.
+    if (process.env.QDRANT_EDRSR_SKIP_INIT === 'true') {
+      this.initialized = true;
+      logger.info('[EdsrVectorizer] init skipped (QDRANT_EDRSR_SKIP_INIT) — assuming collection + indexes exist', { collection: COLLECTION_NAME });
+      return;
+    }
+
     try {
+      // Cheap existence check — lists collection names, does NOT scan points.
       const collections = await this.qdrant.getCollections();
       const exists = collections.collections.some((c) => c.name === COLLECTION_NAME);
 
       if (exists) {
-        // Verify dimension matches
-        const info = await this.qdrant.getCollection(COLLECTION_NAME);
-        const currentSize = (info.config?.params?.vectors as any)?.size;
-        if (currentSize && currentSize !== EMBEDDING_DIM) {
-          logger.warn(`[EdsrVectorizer] Collection ${COLLECTION_NAME} has dimension ${currentSize}, expected ${EMBEDDING_DIM}. Recreating.`);
-          await this.qdrant.deleteCollection(COLLECTION_NAME);
-          await this._createCollection();
-        } else {
-          logger.info(`[EdsrVectorizer] Collection ${COLLECTION_NAME} exists (${info.points_count} points)`);
-        }
-      } else {
-        await this._createCollection();
+        // Already present — trust it. Do NOT call getCollection() (heavy
+        // points_count scan) or re-create payload indexes on every init; that
+        // work belongs to the vectorization pipeline, not the read path, and
+        // re-issuing it here is what saturated the serving node's disk.
+        this.initialized = true;
+        logger.info(`[EdsrVectorizer] Collection ${COLLECTION_NAME} present — init complete (lazy)`);
+        return;
       }
 
-      // Create payload indexes for filterable fields
+      // Collection genuinely missing — create it and its indexes once.
+      await this._createCollection();
       await this._ensurePayloadIndexes();
-
       this.initialized = true;
     } catch (error) {
       logger.error('[EdsrVectorizer] Failed to initialize collection:', error);


### PR DESCRIPTION
## Problem

Traced from chat `chat-3ebcb0d6` where all `search_court_decisions` (mode=hybrid) returned `vector_available:false` — hybrid silently degraded to FTS-only. Prod logs showed every Qdrant leg failing with `QdrantClientTimeoutError: This operation was aborted` inside `EdsrVectorizerService.ensureCollection() → getCollection()`.

On the `edrsr_serving` node (296M points, r6i.4xlarge, gp3 already maxed at 16000 IOPS / 1000 MB/s) we found the disk pinned at ~120 MB/s (= the random-read IOPS ceiling) and `getCollection` taking 38–60s. The driver was **payload-index (re)building**, not search: `payload_index/` dirs were being written continuously (`court_code`, `adjudication_date`, `judge`).

## Root cause: a self-sustaining loop in the read path

`ensureCollection()` ran on every search until `this.initialized` became true, and did two expensive things each time:
1. `getCollection()` — scans `points_count` over the whole 296M-point collection (tens of seconds when disk-bound).
2. `_ensurePayloadIndexes()` — re-issued `createPayloadIndex` for all 5 filterable fields.

The loop:
1. search → `ensureCollection` → `getCollection` (sometimes succeeds, slowly) → `_ensurePayloadIndexes` queues index builds.
2. Qdrant builds payload indexes over 296M points → saturates gp3 IOPS.
3. Saturated disk → next `getCollection` times out (>20s client timeout) → `initialized` stays false.
4. Next search repeats from step 1, re-queuing more index builds (`update_queue` was at 27).
5. The whole time, the Qdrant leg throws → `vector_available:false`.

## Fix — keep the read path cheap

- Existence checked via `getCollections()` (name listing, no points scan).
- If the collection exists: trust it, mark init done. Never re-create the collection or its payload indexes from the search path — that is the vectorization pipeline's job.
- The create + verify + index path now runs **only** when the collection is genuinely missing (fresh build still works).
- `QDRANT_EDRSR_SKIP_INIT=true` skips even the existence probe for serving nodes.
- Removes the dimension-mismatch auto-delete from the hot path (a transient `getCollection` response could otherwise trigger `deleteCollection()` on the live 296M-point collection).

## Follow-ups (ops, not in this PR)

- Prod env has `QDRANT_EDRSR_MAX_CONCURRENCY=8`, but the code's own comment/default is `2` and says >2 saturates the serving node — should be set back to 2.
- Consider building payload indexes once as an explicit pipeline step, and setting `QDRANT_EDRSR_SKIP_INIT=true` on the serving deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the self-sustaining payload-index rebuild loop by making `EdsrVectorizerService.ensureCollection()` a cheap existence check. Restores the vector leg of hybrid search and prevents disk saturation on serving nodes.

- **Bug Fixes**
  - Use `getCollections()` for a fast existence check instead of `getCollection()` (no points scan).
  - If the collection exists, mark initialized and skip all index (re)creation on the read path.
  - Only create the collection and payload indexes when truly missing; remove dimension-mismatch auto-delete from the hot path.
  - Support `QDRANT_EDRSR_SKIP_INIT=true` to skip even the existence probe on known-good serving nodes.

<sup>Written for commit 85b969716fbfa1b560339a7204772fb3befac395. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

