### PR TITLE
fix(edrsr): enforce instance_code/party filters in semantic search mode

### DIFF
--- a/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
@@ -565,4 +565,47 @@ describe('EdsrUnifiedSearchTool', () => {
       expect(parsed.mode).toContain('semantic');
     });
   });
+
+  describe('semantic structural enforcement', () => {
+    const vectorHit = (doc_id: number, score: number) => ({
+      doc_id, score, text: 'фрагмент', chunk_index: 0,
+      metadata: { court_code: 2605, cause_num: `${doc_id}/23`, justice_kind: 4, judgment_code: 3 },
+    });
+
+    it('drops lower-instance vector hits when court_level=SC (instance_code=1)', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      // Qdrant cannot filter by instance; it returns an SC doc (111) and a lower-instance one (222).
+      mockVectorizer.semanticSearch = jest.fn(() => Promise.resolve([vectorHit(222, 0.9), vectorHit(111, 0.4)]));
+      // Only the cassation doc satisfies instance_code=1.
+      mockFtsService.filterDocIdsByConstraints = jest.fn((ids: number[]) =>
+        Promise.resolve(new Set(ids.filter(id => id === 111))));
+
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'semantic', query: 'тест', justice_kind: 4, court_level: 'SC',
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      const ids = parsed.results.map((r: any) => r.doc_id);
+      expect(ids).toContain(111);
+      expect(ids).not.toContain(222);
+      expect(parsed.instance_code).toBe(1);
+      expect(parsed.structural_filter.dropped).toBe(1);
+      expect(mockFtsService.filterDocIdsByConstraints).toHaveBeenCalled();
+    });
+
+    it('does not run structural enforcement without party/instance filters', async () => {
+      db = makeDb(() => ({ rows: [] }));
+      mockVectorizer.semanticSearch = jest.fn(() => Promise.resolve([vectorHit(444, 0.7)]));
+      tool = new EdsrUnifiedSearchTool(db, mockFtsService, mockVectorizer);
+
+      const result = await tool.executeTool('search_court_decisions', {
+        mode: 'semantic', query: 'тест', justice_kind: 4,
+      });
+
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+      expect(parsed.structural_filter).toBeUndefined();
+      expect(mockFtsService.filterDocIdsByConstraints).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -615,7 +615,39 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
         const existing = deduped.get(r.doc_id);
         if (!existing || r.score > existing.score) deduped.set(r.doc_id, r);
       }
-      const topResults = Array.from(deduped.values()).sort((a, b) => b.score - a.score).slice(0, limit);
+      let ranked = Array.from(deduped.values()).sort((a, b) => b.score - a.score);
+
+      // Structural enforcement. The Qdrant leg cannot filter by instance_code / party_name /
+      // party_role (court_level=SC/GrandChamber maps onto instance_code=1 upstream), so pure
+      // semantic hits arrive unconstrained. Without this, a court_level=SC query leaked
+      // lower-instance courts (окружні/апеляційні) and off-party cases into the result —
+      // mirrors the post-fusion pass in searchHybrid. Re-check candidates against
+      // edrsr_fulltext/edrsr_courts and drop the ones that don't satisfy the constraints.
+      const partyName = typeof args.party_name === 'string' ? args.party_name.trim() || undefined : undefined;
+      const partyRole = args.party_role as EdsrFtsFilters['party_role'] | undefined;
+      const instanceCode = args.instance_code ? Number(args.instance_code) : undefined;
+      let structuralFilter: { dropped: number; party_role_relaxed?: boolean } | undefined;
+      if ((partyName || instanceCode) && ranked.length > 0 && this.ftsService) {
+        const docIds = ranked.map(r => r.doc_id);
+        let allowed = await this.ftsService.filterDocIdsByConstraints(
+          docIds, { party_name: partyName, party_role: partyRole, instance_code: instanceCode }, this.db,
+        );
+        // Role may not co-occur as a keyword even when the party IS a party — mirror
+        // hybrid/fulltext: if the role wipes everything, keep name + instance, drop the role.
+        let roleRelaxed = false;
+        if (allowed.size === 0 && partyName && partyRole && partyRole !== 'any') {
+          roleRelaxed = true;
+          allowed = await this.ftsService.filterDocIdsByConstraints(
+            docIds, { party_name: partyName, instance_code: instanceCode }, this.db,
+          );
+        }
+        const before = ranked.length;
+        ranked = ranked.filter(r => allowed.has(r.doc_id));
+        if (before !== ranked.length || roleRelaxed) {
+          structuralFilter = { dropped: before - ranked.length, ...(roleRelaxed ? { party_role_relaxed: true } : {}) };
+        }
+      }
+      const topResults = ranked.slice(0, limit);
 
       const enriched = await this.enrichResults(topResults.map(r => ({
         doc_id: r.doc_id, cause_num: r.metadata.cause_num, judge: r.metadata.judge,
@@ -636,6 +668,9 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       return this.wrapResponse({
         mode: 'semantic', query: args.query,
         ...(reformulated ? { reformulated: { semantic: reformulated.semantic } } : {}),
+        ...(instanceCode ? { instance_code: instanceCode } : {}),
+        ...(partyName ? { party_filter: { party_name: partyName, party_role: partyRole || 'any' } } : {}),
+        ...(structuralFilter ? { structural_filter: structuralFilter } : {}),
         total: deduped.size, returned: output.filtered.length,
         results: output.filtered,
         ...(output.original_count !== output.filtered_count


### PR DESCRIPTION
## Problem

`mode=semantic` in `search_court_decisions` skipped the post-fusion structural enforcement that `mode=hybrid` applies. The Qdrant leg cannot filter by `instance_code` / `party_name` / `party_role`, so pure-semantic results arrived **unconstrained**. A `court_level=SC` query (mapped upstream to `instance_code=1`) leaked lower-instance courts and off-party cases.

### Observed (chat-001815fe)

A tax question (property tax on real estate in occupied territory) issued a semantic call with `court_level=SC` + `justice_kind=4`. The result included:
- first-instance окружні and апеляційні courts (despite SC-only filter);
- topically-adjacent **ПДВ (VAT)** cases (`320/8793/24`, `160/24453/24`) that were then mis-cited in the answer as Supreme Court **property-tax** practice — with fabricated holdings.

The hybrid calls in the same chat were unaffected (they enforce `instance_code`). Only the semantic leg leaked.

## Fix

Mirror `searchHybrid`'s structural pass in `searchSemantic`: after dedup/ranking, re-check candidates via `EdsrFtsService.filterDocIdsByConstraints` (`instance_code` + `party_name`/`party_role`, with the same role-relaxation fallback) and drop non-matching hits. Surface `instance_code`, `party_filter`, `structural_filter` in the response for transparency.

The FTS leg already honors `instance_code` (edrsr-fts-service.ts:243), so the FTS-fallback path was already correct — no change needed there.

## Tests

Adds a `semantic structural enforcement` block:
- drops a lower-instance vector hit when `court_level=SC` (`instance_code=1`), asserts `structural_filter.dropped`;
- no enforcement runs without party/instance filters.

`npx jest src/api/__tests__/edrsr-unified-search-tool.test.ts` → **34 passed**. Backend `tsc` clean (verified with core overlay).

## Follow-up (separate, not in this PR)

The grounding failure — model fabricating property-tax holdings for the VAT cases the search surfaced — is a `secondlayer-core` anti-fabrication concern, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes semantic search leaking lower-instance and off-party results by enforcing `instance_code` and party filters after ranking, matching hybrid behavior. Improves precision for `search_court_decisions` when `mode=semantic`.

- **Bug Fixes**
  - Apply post-ranking structural checks in `searchSemantic` via `EdsrFtsService.filterDocIdsByConstraints` with role-relaxation fallback; drop non-matching hits and align with `searchHybrid`.
  - Expose `instance_code`, `party_filter`, and `structural_filter` in the response; add tests for SC-only filtering and the no-filter pass-through.

<sup>Written for commit 30552853631b5f8d6e9e894b14c5d7686477f99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

