### PR TITLE
fix(edrsr): push justice_kind into Qdrant filter (typed) on hybrid leg

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -508,8 +508,22 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       ? EdsrUnifiedSearchTool.VECTORIZED_JUSTICE_KINDS.has(justiceKind)
       : true; // no justice_kind filter → search the whole unified collection (all codices vectorized)
 
+    // The vector leg gets only the filters Qdrant can enforce via payload indices
+    // (court_code/justice_kind/judge/date) — with justice_kind coerced to a number so the
+    // integer index matches. Pushing justice_kind into the Qdrant filter pre-constrains the
+    // candidates by codex instead of returning cross-codex hits that the post-fusion pass
+    // would otherwise drop. party_name/party_role/instance_code stay FTS-only and are
+    // re-checked post-fusion below.
+    const vectorFilters: EdrsrSearchFilters = {
+      court_code: args.court_code,
+      justice_kind: justiceKind,
+      judge: args.judge,
+      date_from: args.date_from,
+      date_to: args.date_to,
+    };
+
     const vectorPromise = (this.vectorizer && hasVectors)
-      ? this.vectorizer.semanticSearch(semanticQuery, filters as unknown as EdrsrSearchFilters, candidateLimit)
+      ? this.vectorizer.semanticSearch(semanticQuery, vectorFilters, candidateLimit)
           .catch((err: any) => { logger.warn('[EdsrUnifiedSearch] Qdrant leg failed', { error: err.message }); return null; })
       : Promise.resolve(null);
 

--- a/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
@@ -166,4 +166,38 @@ describe('EdsrVectorizerService', () => {
       expect('score_threshold' in searchArgs()).toBe(false);
     });
   });
+
+  describe('semanticSearch filter coercion', () => {
+    const filterMust = () => (((mockSearch.mock.calls.at(-1)![1] as any).filter?.must) ?? []) as any[];
+
+    it('coerces a string justice_kind into an integer Qdrant match (index is integer)', async () => {
+      const service = new EdsrVectorizerService();
+      // hybrid callers may forward the raw tool-call arg, which arrives as a string
+      await service.semanticSearch('тест', { justice_kind: '4' as unknown as number });
+      const jk = filterMust().find((c) => c.key === 'justice_kind');
+      expect(jk).toBeDefined();
+      expect(jk.match.value).toBe(4);
+    });
+
+    it('coerces a string court_code into an integer Qdrant match', async () => {
+      const service = new EdsrVectorizerService();
+      await service.semanticSearch('тест', { court_code: '9931' as unknown as number });
+      const cc = filterMust().find((c) => c.key === 'court_code');
+      expect(cc).toBeDefined();
+      expect(cc.match.value).toBe(9931);
+    });
+
+    it('keeps a numeric justice_kind unchanged', async () => {
+      const service = new EdsrVectorizerService();
+      await service.semanticSearch('тест', { justice_kind: 1 });
+      const jk = filterMust().find((c) => c.key === 'justice_kind');
+      expect(jk.match.value).toBe(1);
+    });
+
+    it('adds no justice_kind clause when no filter is supplied', async () => {
+      const service = new EdsrVectorizerService();
+      await service.semanticSearch('тест');
+      expect(filterMust().find((c) => c.key === 'justice_kind')).toBeUndefined();
+    });
+  });
 });

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -390,12 +390,16 @@ export class EdsrVectorizerService {
     // Build Qdrant filter
     const must: any[] = [];
 
+    // court_code / justice_kind payload indices are integers. Tool-call args (and HTTP
+    // JSON) often arrive as strings ("4"); a string `value` is treated by Qdrant as a
+    // keyword and silently matches nothing, so the vector leg returns 0 candidates even
+    // though the code exists. Coerce to Number so the integer index actually matches.
     if (filters?.court_code) {
-      must.push({ key: 'court_code', match: { value: filters.court_code } });
+      must.push({ key: 'court_code', match: { value: Number(filters.court_code) } });
     }
 
     if (filters?.justice_kind) {
-      must.push({ key: 'justice_kind', match: { value: filters.justice_kind } });
+      must.push({ key: 'justice_kind', match: { value: Number(filters.justice_kind) } });
     }
 
     if (filters?.judge) {


### PR DESCRIPTION
## Problem

The Qdrant payload indices for `justice_kind` and `court_code` on the serving collection are **integers**. The hybrid search path forwarded the raw tool-call arg to the vector leg, and tool-call/HTTP JSON frequently delivers these as **strings** (`"4"`). Qdrant treats a string `match.value` as a keyword, which never matches an integer index — so the vector leg **silently returned 0 candidates** whenever a codex/court was specified, leaving FTS to carry the entire hybrid result.

Observed across recent chats: hybrid legs with a `justice_kind`/`court_level` came back with `qdrant=0` while the FTS leg returned full sets. Per-leg metadata (`legs.vector_candidates`) confirmed the vector leg fired but contributed nothing to the fused result.

`searchSemantic` already coerced to `Number` (line was fine); `searchHybrid` did not — it cast the FTS `filters` object (with the raw `args.justice_kind`) to `EdrsrSearchFilters`.

## Fix

- **`EdsrVectorizerService.semanticSearch`** — coerce `court_code`/`justice_kind` to `Number` when building the Qdrant `must` filter. Fixes every caller defensively.
- **`searchHybrid`** — build a dedicated `EdrsrSearchFilters` for the vector leg with the numeric `justiceKind` (mirrors `searchSemantic`) instead of casting the FTS filters. `party_name`/`party_role`/`instance_code` stay FTS-only and are still re-checked in the post-fusion structural pass (#1968).

Pushing `justice_kind` into the Qdrant filter **pre-constrains** the vector candidates by codex, so relevant in-codex hits survive RRF instead of being returned cross-codex and dropped by the structural post-filter.

## Tests

Adds coverage in `edrsr-vectorizer-service.test.ts`:
- string `justice_kind` (`"4"`) → integer `4` in the Qdrant match
- string `court_code` (`"9931"`) → integer `9931`
- numeric `justice_kind` unchanged
- no-filter → no `justice_kind` clause

`npm test` for the two affected suites: vectorizer 17/17, unified-search 34/34.

Note: the 3 pre-existing `tsc` errors in `factories/core-loader.ts` reference proprietary modules absent from the public repo (CI overlays them) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-candidate vector results in hybrid search by coercing `court_code`/`justice_kind` to numbers and pushing `justice_kind` into the Qdrant filter. This restores vector candidates and improves hybrid relevance (in-codex hits survive RRF).

- **Bug Fixes**
  - Coerce `court_code` and `justice_kind` to Number in `EdsrVectorizerService.semanticSearch` so Qdrant’s integer payload indices match.
  - In `EdsrUnifiedSearchTool.searchHybrid`, pass a dedicated vector `EdrsrSearchFilters` with numeric `justiceKind` and only Qdrant-enforced fields; keep `party_name`/`party_role`/`instance_code` as FTS-only post-fusion checks.

<sup>Written for commit 105cc2e6f6df2c9e3c2d9654887e786663b9e790. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

