### PR TITLE
fix(edrsr): serving-node guard — pass QDRANT_EDRSR_SKIP_INIT to prod backend

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -544,6 +544,11 @@ services:
       QDRANT_EDRSR_RESCORE: ${QDRANT_EDRSR_RESCORE:-}
       QDRANT_EDRSR_OVERSAMPLING: ${QDRANT_EDRSR_OVERSAMPLING:-}
       QDRANT_EDRSR_SCORE_THRESHOLD: ${QDRANT_EDRSR_SCORE_THRESHOLD:-}
+      # Serving-node guard: when true, the read path assumes the edrsr_serving
+      # collection + payload indexes already exist and never (re)creates them.
+      # Re-issuing createPayloadIndex on a pre-built serving node triggers full
+      # segment rebuilds that saturate its IO and time out searches.
+      QDRANT_EDRSR_SKIP_INIT: ${QDRANT_EDRSR_SKIP_INIT:-}
       BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
@@ -742,6 +747,11 @@ services:
       QDRANT_EDRSR_RESCORE: ${QDRANT_EDRSR_RESCORE:-}
       QDRANT_EDRSR_OVERSAMPLING: ${QDRANT_EDRSR_OVERSAMPLING:-}
       QDRANT_EDRSR_SCORE_THRESHOLD: ${QDRANT_EDRSR_SCORE_THRESHOLD:-}
+      # Serving-node guard: when true, the read path assumes the edrsr_serving
+      # collection + payload indexes already exist and never (re)creates them.
+      # Re-issuing createPayloadIndex on a pre-built serving node triggers full
+      # segment rebuilds that saturate its IO and time out searches.
+      QDRANT_EDRSR_SKIP_INIT: ${QDRANT_EDRSR_SKIP_INIT:-}
       BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
@@ -969,6 +979,11 @@ services:
       QDRANT_EDRSR_RESCORE: ${QDRANT_EDRSR_RESCORE:-}
       QDRANT_EDRSR_OVERSAMPLING: ${QDRANT_EDRSR_OVERSAMPLING:-}
       QDRANT_EDRSR_SCORE_THRESHOLD: ${QDRANT_EDRSR_SCORE_THRESHOLD:-}
+      # Serving-node guard: when true, the read path assumes the edrsr_serving
+      # collection + payload indexes already exist and never (re)creates them.
+      # Re-issuing createPayloadIndex on a pre-built serving node triggers full
+      # segment rebuilds that saturate its IO and time out searches.
+      QDRANT_EDRSR_SKIP_INIT: ${QDRANT_EDRSR_SKIP_INIT:-}
       BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod
@@ -1236,6 +1251,11 @@ services:
       QDRANT_EDRSR_RESCORE: ${QDRANT_EDRSR_RESCORE:-}
       QDRANT_EDRSR_OVERSAMPLING: ${QDRANT_EDRSR_OVERSAMPLING:-}
       QDRANT_EDRSR_SCORE_THRESHOLD: ${QDRANT_EDRSR_SCORE_THRESHOLD:-}
+      # Serving-node guard: when true, the read path assumes the edrsr_serving
+      # collection + payload indexes already exist and never (re)creates them.
+      # Re-issuing createPayloadIndex on a pre-built serving node triggers full
+      # segment rebuilds that saturate its IO and time out searches.
+      QDRANT_EDRSR_SKIP_INIT: ${QDRANT_EDRSR_SKIP_INIT:-}
       BGE_M3_URL: ${BGE_M3_URL:-}
       REDIS_URL: redis://:${REDIS_PASSWORD}@redis-prod:6379
       REDIS_HOST: redis-prod


### PR DESCRIPTION
## Problem

The `qdrant-readonly` EC2 (r6i.4xlarge, hosts the pre-built `edrsr_serving` collection, 296M points / 2.1 TB) was IO-saturated: `~856 MB/s` reads + `~700 MB/s` writes at 4-5% CPU, with searches failing as `Operation 'fill query context' timed out after 60s` and `GET /collections/edrsr_serving` taking 107s.

### Root cause
On every prod backend (re)start, `EdsrVectorizerService.ensureCollection()` could hit the *collection-missing* branch (TOCTOU while qdrant is still loading the 2.1 TB collection) and run `_ensurePayloadIndexes()` → **5× `PUT /collections/edrsr_serving/index`**. On a pre-built serving node each call triggers a **full segment rebuild** (`temp_segments/segment_builder_*` rewriting `matrix.dat` + payload), which on the EBS-bandwidth-capped node (~750 MB/s) runs for hours and starves all queries.

Observed in logs: 5 PUT /index per prod deploy (00:06, 01:36, 02:40), source `172.31.29.20` (prod EC2).

The guard from #1967 exists on the read path, but the env switch it relies on — `QDRANT_EDRSR_SKIP_INIT` (already supported in `edrsr-vectorizer-service.ts:198`) — was **not wired through docker-compose**, so it could not be enabled in prod.

## Fix
Pass `QDRANT_EDRSR_SKIP_INIT` through to `app-prod`, `app-prod-green`, `document-service-prod`, `document-service-prod-green`. With `QDRANT_EDRSR_SKIP_INIT=true` in prod env, the read path assumes the collection + indexes exist and never (re)creates them.

## Deploy note
Set `QDRANT_EDRSR_SKIP_INIT=true` in `.env.prod` on the prod host **before** the next Brev→EC2 EDRSR cutover, so backend restarts can never re-trigger the index storm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes `QDRANT_EDRSR_SKIP_INIT` through prod `docker-compose` for `app-prod`, `app-prod-green`, `document-service-prod`, and `document-service-prod-green` so the EDRSR read path skips collection/index initialization on the pre-built serving node. Prevents accidental `PUT /collections/edrsr_serving/index` calls that trigger full segment rebuilds and IO saturation.

- **Migration**
  - Set `QDRANT_EDRSR_SKIP_INIT=true` in `.env.prod` before the next deploy/cutover.

<sup>Written for commit b346bb059c0f477893cf1b441a7b68954c33d815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

