### PR TITLE
feat(chat): label search_court_decisions + FTS/Qdrant query breakdown

### DIFF
--- a/lexwebapp/src/components/CostSummary.tsx
+++ b/lexwebapp/src/components/CostSummary.tsx
@@ -89,6 +89,44 @@ export function CostSummary({ data }: CostSummaryProps) {
                 </div>
               )}
 
+              {/* Search-leg breakdown (FTS vs Qdrant) */}
+              {data.search_stats &&
+                (data.search_stats.fts > 0 ||
+                  data.search_stats.qdrant > 0 ||
+                  (data.search_stats.structured ?? 0) > 0) && (
+                <div className="pt-0.5">
+                  <span className="font-medium text-claude-text">{t('searchBreakdown')}</span>
+                  <table className="mt-1 w-full max-w-[280px] text-[11px]">
+                    <thead>
+                      <tr className="text-claude-subtext/70">
+                        <th className="text-left font-normal pb-0.5">{t('searchKind')}</th>
+                        <th className="text-right font-normal pb-0.5">{t('searchCount')}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.search_stats.fts > 0 && (
+                        <tr className="border-t border-claude-border/30">
+                          <td className="py-0.5">{t('searchFts')}</td>
+                          <td className="py-0.5 text-right tabular-nums">{data.search_stats.fts}</td>
+                        </tr>
+                      )}
+                      {data.search_stats.qdrant > 0 && (
+                        <tr className="border-t border-claude-border/30">
+                          <td className="py-0.5">{t('searchQdrant')}</td>
+                          <td className="py-0.5 text-right tabular-nums">{data.search_stats.qdrant}</td>
+                        </tr>
+                      )}
+                      {(data.search_stats.structured ?? 0) > 0 && (
+                        <tr className="border-t border-claude-border/30">
+                          <td className="py-0.5">{t('searchStructured')}</td>
+                          <td className="py-0.5 text-right tabular-nums">{data.search_stats.structured}</td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
               {/* Cost breakdown */}
               <div className="flex items-center gap-3 flex-wrap">
                 {Number(data.total_cost_usd) > 0 && (

--- a/lexwebapp/src/hooks/chat/tool-labels.ts
+++ b/lexwebapp/src/hooks/chat/tool-labels.ts
@@ -4,6 +4,8 @@
  */
 
 export const TOOL_LABELS: Record<string, string> = {
+  search_court_decisions: 'Пошук судових рішень',
+  search_court_cases: 'Пошук судових справ',
   search_legal_precedents: 'Пошук прецедентів',
   get_court_decision: 'Отримання рішення',
   get_case_documents_chain: 'Ланцюг документів',

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -367,6 +367,7 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
               total_cost_usd: data.total_cost_usd || 0,
               charged_usd: data.charged_usd || 0,
               response_id: data.response_id || responseIdRef.current || undefined,
+              search_stats: data.search_stats ?? costSummaryRef.current?.search_stats,
             };
             updateMessage(assistantMessageId, {
               costSummary: costSummaryRef.current as CostSummary,

--- a/lexwebapp/src/i18n/misc-i18n.ts
+++ b/lexwebapp/src/i18n/misc-i18n.ts
@@ -2087,6 +2087,42 @@ const miscStrings: Record<string, Record<Locale, string>> = {
     de: 'Anfrage-ID kopieren',
     es: 'Copiar ID de solicitud',
   },
+  searchBreakdown: {
+    uk: 'Пошукові запити:',
+    en: 'Search queries:',
+    de: 'Suchanfragen:',
+    es: 'Consultas de búsqueda:',
+  },
+  searchKind: {
+    uk: 'Тип пошуку',
+    en: 'Search type',
+    de: 'Suchtyp',
+    es: 'Tipo de búsqueda',
+  },
+  searchCount: {
+    uk: 'Запитів',
+    en: 'Queries',
+    de: 'Anfragen',
+    es: 'Consultas',
+  },
+  searchFts: {
+    uk: 'Повнотекстовий (FTS)',
+    en: 'Full-text (FTS)',
+    de: 'Volltext (FTS)',
+    es: 'Texto completo (FTS)',
+  },
+  searchQdrant: {
+    uk: 'Семантичний (Qdrant)',
+    en: 'Semantic (Qdrant)',
+    de: 'Semantisch (Qdrant)',
+    es: 'Semántico (Qdrant)',
+  },
+  searchStructured: {
+    uk: 'За реквізитами',
+    en: 'Structured',
+    de: 'Strukturiert',
+    es: 'Estructurado',
+  },
 
   // ── Confirm Modal ──
   confirm: {

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -49,7 +49,7 @@ export interface ChatStreamCallbacks {
   onAnswer?: (data: { text: string; provider: string; model: string; norms?: Array<{ text: string; source: string }> }) => void;
   onEvidenceUpdate?: (data: EvidenceEnvelope) => void;
   onCitationWarning?: (data: CitationWarning) => void;
-  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string; conversationId?: string }) => void;
+  onComplete?: (data: { iterations: number; elapsed_ms: number; tools_used?: string[]; total_cost_usd?: number; charged_usd?: number; response_id?: string; conversationId?: string; search_stats?: { fts: number; qdrant: number; structured?: number } }) => void;
   onCostSummary?: (data: { total_cost_usd: number; charged_usd: number; balance_usd: number | null }) => void;
   onBudgetEscalated?: (data: { reason: string; estimatedCost: { minUsd: number; maxUsd: number }; requiresConfirmation?: boolean }) => void;
   onError?: (data: { message?: string; code?: string; current_balance_usd?: number }) => void;

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -29,12 +29,25 @@ export type CitationWarning =
       message: string;
     };
 
+/**
+ * Breakdown of search-leg usage for a single chat turn.
+ * - `fts`: PostgreSQL full-text queries (fulltext + hybrid modes)
+ * - `qdrant`: vector/semantic queries (semantic + hybrid modes)
+ * - `structured`: metadata-only (structured mode), neither FTS nor Qdrant
+ */
+export interface SearchStats {
+  fts: number;
+  qdrant: number;
+  structured?: number;
+}
+
 export interface CostSummary {
   tools_used: string[];
   total_cost_usd: number;
   charged_usd?: number;
   balance_usd?: number | null;
   response_id?: string;
+  search_stats?: SearchStats;
   /** @deprecated use charged_usd */
   credits_deducted?: number;
   /** @deprecated use balance_usd */

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -170,6 +170,20 @@ export function createChatInlineRoutes(deps: {
 
       let chatCompleted = false;
       let chatTotalCostUsd = 0;
+      // Aggregate search-leg usage across the turn so the UI can show how many
+      // queries hit FTS (PostgreSQL full-text) vs Qdrant (vector/semantic).
+      // Derived from each tool call's `mode` param on `thinking` events.
+      const searchStats = { fts: 0, qdrant: 0, structured: 0 };
+      const tallySearch = (tool?: string, mode?: string) => {
+        if (tool === 'search_court_decisions' || tool === 'search_court_cases') {
+          if (mode === 'fulltext') searchStats.fts += 1;
+          else if (mode === 'semantic') searchStats.qdrant += 1;
+          else if (mode === 'hybrid') { searchStats.fts += 1; searchStats.qdrant += 1; }
+          else if (mode === 'structured') searchStats.structured += 1;
+        } else if (tool === 'semantic_search') {
+          searchStats.qdrant += 1;
+        }
+      };
       const chatRequest = {
         query,
         history,
@@ -191,10 +205,17 @@ export function createChatInlineRoutes(deps: {
           for await (const event of deps.chatService.chat(chatRequest)) {
             if (abortController.signal.aborted) break;
 
+            if (event.type === 'thinking') {
+              tallySearch(event.data?.tool, event.data?.params?.mode);
+            }
+
             if (event.type === 'complete') {
               chatCompleted = true;
               chatTotalCostUsd = event.data?.total_cost_usd || 0;
               event.data.response_id = requestId;
+              if (searchStats.fts || searchStats.qdrant || searchStats.structured) {
+                event.data.search_stats = searchStats;
+              }
               if (chatRequest.conversationId && chatRequest.conversationId !== conversationId) {
                 event.data.conversationId = chatRequest.conversationId;
               }
@@ -229,11 +250,13 @@ export function createChatInlineRoutes(deps: {
           const chargedUsd = trackingRow.rows[0]?.total_cost_usd
             ? parseFloat(trackingRow.rows[0].total_cost_usd)
             : chatTotalCostUsd;
+          const hasSearchStats = searchStats.fts || searchStats.qdrant || searchStats.structured;
           const costSummaryFull = {
             total_cost_usd: chatTotalCostUsd,
             charged_usd: chargedUsd,
             balance_usd: summary?.balance_usd ?? 0,
             response_id: requestId,
+            ...(hasSearchStats ? { search_stats: searchStats } : {}),
           };
           res.write(`event: cost_summary\n`);
           res.write(`data: ${JSON.stringify({
@@ -241,10 +264,13 @@ export function createChatInlineRoutes(deps: {
             markup_percentage: trackingRow.rows[0]?.markup_percentage ?? 0,
           })}\n\n`);
 
-          // Persist charged_usd back to conversation_messages so reload shows correct cost
+          // Persist charged_usd + search_stats back to conversation_messages so reload
+          // shows correct cost and the FTS/Qdrant breakdown. Merge into the existing
+          // cost_summary JSONB so already-saved fields (e.g. tools_used) are preserved.
           if (conversationId) {
             deps.db.query(
-              `UPDATE conversation_messages SET cost_summary = $1
+              `UPDATE conversation_messages
+               SET cost_summary = COALESCE(cost_summary, '{}'::jsonb) || $1::jsonb
                WHERE id = (
                  SELECT id FROM conversation_messages
                  WHERE conversation_id = $2 AND role = 'assistant'


### PR DESCRIPTION
## Что и зачем

На панели стоимости/инструментов в чате `search_court_decisions` показывался «сырым» именем (нет записи в `TOOL_LABELS`). Плюс по запросу: добавить раскрывающуюся вместе с инструментами табличку с числом FTS- и Qdrant-запросов.

## Изменения

**Display fix**
- `tool-labels.ts`: добавлены `search_court_decisions` → «Пошук судових рішень» и legacy `search_court_cases`.

**FTS vs Qdrant breakdown** (раньше этих данных на фронте не было — `complete` отдавал только дедуп-список `tools_used`)
- Backend `chat-inline-routes.ts`: агрегирую режимы из `params.mode` по `thinking`-событиям (`fulltext`→FTS, `semantic`→Qdrant, `hybrid`→оба, `structured`→за реквізитами; `semantic_search`→Qdrant). Кладу `search_stats` в `complete`-событие и в `cost_summary`. UPDATE переделан на JSONB-merge (`COALESCE(cost_summary,'{}') || $1`), чтобы не затирать `tools_used` — побочно чинит давнюю перезапись.
- Frontend: тип `SearchStats` + поле `search_stats` (`Message.ts`), проброс через `MCPService`/`useAIChatStream`, таблица в `CostSummary.tsx` (внутри того же разворачивающегося блока), i18n uk/en/de/es.

Таблица показывается только при наличии поисковых запросов и переживает перезагрузку чата (хранится в `cost_summary`). Появляется для **новых** запросов; старые чаты `search_stats` не имеют.

## Проверка
- Frontend `tsc --noEmit`: 0 ошибок.
- Backend: только 3 пред-существующие ошибки `core-loader.ts` (приватный `@secondlayer/core`); затронутые файлы чистые (сверено через `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a proper label for `search_court_decisions` and shows a per-turn FTS/Qdrant/structured breakdown in the chat cost summary. Counts are computed on the backend and saved to `cost_summary` so they persist after reload.

- **New Features**
  - Backend tallies search modes from tool call `mode` (fulltext, semantic, hybrid, structured, plus `semantic_search`), emits `search_stats` on `complete`, and persists it in `cost_summary`.
  - UI renders a compact table in `CostSummary` when data exists; `MCPService`/`useAIChatStream` plumb `search_stats`; i18n added (uk/en/de/es). New chats only.

- **Bug Fixes**
  - Update `cost_summary` via JSONB merge to preserve `tools_used` while adding `search_stats`.
  - Add labels for `search_court_decisions` and legacy `search_court_cases`.

<sup>Written for commit af14b2302a429f44cefb35518e253b9dc08af843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

