### PR TITLE
fix(chat): transparent background for streaming spinner icon

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -138,7 +138,7 @@ export function AssistantMessage({
       <div className="flex gap-4 md:gap-5" data-role="assistant">
         {/* Avatar */}
         <div className="flex-shrink-0 mt-0.5">
-          <div className="w-7 h-7 rounded-md overflow-hidden flex items-center justify-center bg-zinc-900 shadow-sm">
+          <div className="w-7 h-7 rounded-md overflow-hidden flex items-center justify-center bg-transparent">
             <LexLogo3D spinning={!!isStreaming} size={28} />
           </div>
         </div>


### PR DESCRIPTION
## What

The rotating assistant logo shown while a response is streaming sat on a black (`bg-zinc-900`) rounded square with a shadow. Changed it to `bg-transparent` and removed the shadow so the spinner blends into the chat background.

## Change

`lexwebapp/src/components/message/AssistantMessage.tsx` — avatar container class `bg-zinc-900 shadow-sm` → `bg-transparent`.

## Verification

`npm run build` in `lexwebapp` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the streaming assistant spinner background transparent and removed the shadow so it blends into the chat background.

Changed the avatar container in lexwebapp/src/components/message/AssistantMessage.tsx from bg-zinc-900 shadow-sm to bg-transparent.

<sup>Written for commit c1784f64657d1d11902a7a94d2297fef4f845fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

