### PR TITLE
fix(edrsr): backfill semantic chunk for FTS-only hybrid hits (evidence parity)

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -138,7 +138,7 @@ export function AssistantMessage({
       <div className="flex gap-4 md:gap-5" data-role="assistant">
         {/* Avatar */}
         <div className="flex-shrink-0 mt-0.5">
-          <div className="w-7 h-7 rounded-md overflow-hidden flex items-center justify-center bg-zinc-900 shadow-sm">
+          <div className="w-7 h-7 rounded-md overflow-hidden flex items-center justify-center bg-transparent">
             <LexLogo3D spinning={!!isStreaming} size={28} />
           </div>
         </div>

--- a/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/edrsr-unified-search-tool.test.ts
@@ -50,6 +50,7 @@ describe('EdsrUnifiedSearchTool', () => {
     };
     mockVectorizer = {
       semanticSearch: jest.fn(() => Promise.resolve([])),
+      bestChunkForDocs: jest.fn(() => Promise.resolve(new Map())),
     };
   });
 
@@ -417,6 +418,48 @@ describe('EdsrUnifiedSearchTool', () => {
       const parsed = JSON.parse(result?.content[0].text || '{}');
       expect(parsed.legs.fts_available).toBe(true);
       expect(parsed.legs.vector_available).toBe(false);
+    });
+
+    it('backfills a semantic chunk for FTS-only hits (evidence parity for the filter)', async () => {
+      // FTS leg finds doc 12345 whose only snippet is a boilerplate header; the vector
+      // leg finds a different doc that already carries a real chunk. The FTS-only hit must
+      // get a query-relevant chunk backfilled so the relevance filter judges it fairly.
+      const ftsOnly = {
+        searchFulltext: jest.fn(() => Promise.resolve({
+          query: 'тест', total: 1,
+          results: [{
+            doc_id: 12345, cause_num: '756/1/23', judge: 'Іванов І.І.',
+            court_code: 2605, justice_kind: 1, judgment_code: 3,
+            adjudication_date: '2024-06-15', headline: 'ПОСТАНОВА ІМЕНЕМ УКРАЇНИ',
+            rank: 0.0001,
+          }],
+        })),
+        filterDocIdsByConstraints: jest.fn((ids: number[]) => Promise.resolve(new Set(ids.map(Number)))),
+      };
+      const vectorizer = {
+        semanticSearch: jest.fn(() => Promise.resolve([{
+          id: 'p1', score: 370, text: 'вже має чанк', doc_id: 67890, chunk_index: 4,
+          metadata: { court_code: 2605, justice_kind: 1 },
+        }])),
+        bestChunkForDocs: jest.fn((_q: string, ids: number[]) =>
+          Promise.resolve(new Map(ids.map(id => [id, { text: 'релевантний фрагмент про директора', chunk_index: 2, score: 0.6 }])))),
+      };
+      db = makeDb(() => ({ rows: [] }));
+      tool = new EdsrUnifiedSearchTool(db, ftsOnly as any, vectorizer as any);
+
+      const result = await tool.executeTool('search_court_decisions', { mode: 'hybrid', query: 'тест' });
+      const parsed = JSON.parse(result?.content[0].text || '{}');
+
+      // Only the FTS-only doc is backfilled — the vector hit already had a chunk.
+      expect(vectorizer.bestChunkForDocs).toHaveBeenCalledWith('тест', [12345]);
+      expect(parsed.legs.fts_chunks_backfilled).toBe(1);
+
+      const ftsHit = parsed.results.find((r: any) => r.doc_id === 12345);
+      expect(ftsHit.qdrant_best_chunk_text).toBe('релевантний фрагмент про директора');
+      expect(ftsHit.evidence_chunk_backfilled).toBe(true);
+
+      const vectorHit = parsed.results.find((r: any) => r.doc_id === 67890);
+      expect(vectorHit.evidence_chunk_backfilled).toBeUndefined();
     });
   });
 

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -566,6 +566,12 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
     const top = fused.slice(0, limit);
     const enriched = await this.enrichFusedHits(top);
+    // Evidence parity for the relevance filter: FTS-only hits carry no semantic chunk and
+    // would be judged on an uninformative ts_headline (often the decision's boilerplate
+    // header), so on-topic FTS matches with scattered terms get wrongly dropped. Backfill
+    // each such hit's best query-relevant chunk so both legs feed the filter comparable
+    // evidence. Bounded to the post-slice top set (≤ limit), no-op when nothing needs it.
+    const chunkBackfilled = await this.backfillEvidenceChunks(enriched, semanticQuery);
     const output = await this.maybeFilter(enriched, query);
 
     return this.wrapResponse({
@@ -574,7 +580,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       ...(reformulated ? { reformulated: { fts: reformulated.fts, semantic: reformulated.semantic } } : {}),
       ...(partyName ? { party_filter: { party_name: partyName, party_role: partyRole || 'any' } } : {}),
       ...(instanceCode ? { instance_code: instanceCode } : {}),
-      legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length },
+      legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length, ...(chunkBackfilled > 0 ? { fts_chunks_backfilled: chunkBackfilled } : {}) },
       ...(structuralFilter ? { structural_filter: structuralFilter } : {}),
       total_fused: fused.length, returned: output.filtered.length,
       results: output.filtered,
@@ -793,6 +799,40 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       ...(row.headline ? { headline: row.headline } : {}),
       ...(row.rank != null ? { rank: Number(row.rank) || 0 } : {}),
     }));
+  }
+
+  /**
+   * Give FTS-only hybrid hits a query-relevant semantic chunk so the LLM relevance filter
+   * (search-result-filter) judges every candidate on comparable evidence. Mutates the
+   * enriched hits in place (populates qdrant_best_chunk_text/_index, flags
+   * evidence_chunk_backfilled) and returns how many were backfilled. No-op when the
+   * vectorizer is unavailable or no enriched hit lacks a chunk. Best-effort: a failure
+   * leaves the hits unchanged rather than failing the whole search.
+   */
+  private async backfillEvidenceChunks(enriched: any[], semanticQuery: string): Promise<number> {
+    if (!this.vectorizer || !semanticQuery?.trim()) return 0;
+    const needing = enriched
+      .filter(h => !h.qdrant_best_chunk_text && h.fts_position != null)
+      .map(h => h.doc_id);
+    if (needing.length === 0) return 0;
+    try {
+      const chunks = await this.vectorizer.bestChunkForDocs(semanticQuery, needing);
+      if (chunks.size === 0) return 0;
+      let count = 0;
+      for (const h of enriched) {
+        const c = chunks.get(h.doc_id);
+        if (c) {
+          h.qdrant_best_chunk_text = c.text;
+          h.qdrant_best_chunk_index = c.chunk_index;
+          h.evidence_chunk_backfilled = true;
+          count++;
+        }
+      }
+      return count;
+    } catch (err: any) {
+      logger.warn('[EdsrUnifiedSearch] evidence chunk backfill failed', { error: err.message });
+      return 0;
+    }
   }
 
   private async enrichFusedHits(hits: FusedHit[]): Promise<any[]> {

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -460,6 +460,71 @@ export class EdsrVectorizerService {
     }
   }
 
+  // ── Best chunk per document (evidence backfill) ────────────────────────
+
+  /**
+   * Return the single most query-relevant chunk for each given doc_id.
+   *
+   * Used to backfill an evidence snippet for hybrid hits that came ONLY from the FTS
+   * leg (and therefore have no qdrant_best_chunk_text). Without this, the LLM relevance
+   * filter judges such hits on an uninformative ts_headline — which, when the matched
+   * terms are scattered, collapses to the decision's boilerplate header (court, case
+   * number, judges) and carries zero topical signal, so genuinely on-topic FTS matches
+   * get wrongly dropped. Embeds the query once, then issues one top-1 vector search per
+   * doc_id constrained by the edrsr_doc_id payload index, so every doc gets its own best
+   * chunk regardless of how it ranks globally. Failures per doc are swallowed (best-effort).
+   */
+  async bestChunkForDocs(
+    query: string,
+    docIds: number[],
+  ): Promise<Map<number, { text: string; chunk_index: number; score: number }>> {
+    const out = new Map<number, { text: string; chunk_index: number; score: number }>();
+    const uniqueIds = Array.from(new Set(docIds.filter((id) => Number.isFinite(id) && id > 0)));
+    if (!query?.trim() || uniqueIds.length === 0) return out;
+
+    await this.ensureCollection();
+
+    const result = await this.embeddingClient.generateEmbeddingsBatchWithUsage([query]);
+    this.usageCallback?.(result.totalTokens, EMBEDDING_MODEL, 'edrsr_best_chunk');
+    const queryVector = result.embeddings[0];
+    if (!queryVector) return out;
+
+    // Mirror semanticSearch's scoring params so the backfilled chunk is selected on the
+    // same basis as the vector leg's chunks (in-RAM quantized scoring by default).
+    const searchParams = {
+      hnsw_ef: Number(process.env.QDRANT_EDRSR_HNSW_EF || 128),
+      quantization:
+        process.env.QDRANT_EDRSR_RESCORE === 'true'
+          ? { rescore: true, oversampling: Number(process.env.QDRANT_EDRSR_OVERSAMPLING || 2.0) }
+          : { rescore: false },
+    };
+
+    await Promise.all(uniqueIds.map((docId) => this.searchSemaphore.run(async () => {
+      try {
+        const hits = await this.qdrant.search(COLLECTION_NAME, {
+          vector: queryVector,
+          limit: 1,
+          filter: { must: [{ key: 'edrsr_doc_id', match: { value: docId } }] },
+          with_payload: true,
+          params: searchParams,
+        });
+        const top = hits[0];
+        const text = top?.payload?.text as string | undefined;
+        if (top && text) {
+          out.set(docId, {
+            text,
+            chunk_index: (top.payload?.chunk_index as number) || 0,
+            score: top.score,
+          });
+        }
+      } catch (err: any) {
+        logger.warn('[EdsrVectorizer] bestChunkForDocs failed', { docId, error: err.message });
+      }
+    })));
+
+    return out;
+  }
+
   // ── Core: getVectorizationStats ────────────────────────────────────────
 
   /**


### PR DESCRIPTION
## Problem

In `search_court_decisions` **hybrid** mode, the LLM relevance filter (`SearchResultFilter`) judges each candidate on a short snippet. For **FTS-leg hits** that snippet is `ts_headline`, which — when the matched terms are scattered through a long decision — falls back to the document's **boilerplate header** (ПОСТАНОВА, court, case №, judges). Zero topical signal, so the filter scores them low and drops them.

Vector-leg hits carry an on-topic `qdrant_best_chunk_text`, so the two legs feed the filter **asymmetric evidence**. Genuinely on-topic FTS matches get wrongly cut.

Diagnosed on `chat-708eee48`: the hybrid FTS leg produced 3 candidates that ranked **#1–3 by RRF** yet were all removed by the relevance gate (`relevance_filter: 11→8`) purely because their only evidence was a header snippet.

## Fix

Give every hybrid candidate comparable evidence. After fusion + enrichment, backfill each **FTS-only** hit (within the post-slice top set, ≤ `limit`) with its single most query-relevant chunk:

- New `EdsrVectorizerService.bestChunkForDocs(query, docIds)` — embeds the query once, then issues one **top-1** vector search per `doc_id` constrained by the `edrsr_doc_id` payload index, mirroring `semanticSearch` scoring params. Returns `Map<doc_id, {text, chunk_index, score}>`.
- `searchHybrid` calls it only for hits lacking a chunk; populates `qdrant_best_chunk_text`/`_index` so the existing filter picks it up with no change to `SearchResultFilter`.
- **Best-effort**: per-doc and overall failures are swallowed (search never fails because of backfill).
- **Cost**: a few small vector lookups, only when FTS-only hits are present (no-op for pure-vector results).

## Observability

- `legs.fts_chunks_backfilled` — count per query
- `evidence_chunk_backfilled: true` on each backfilled result

## Tests

- New hybrid test: FTS-only doc gets its chunk backfilled, vector hit untouched, `fts_chunks_backfilled === 1`.
- Full suite green: 35/35 unified-search + 17/17 vectorizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills a semantic evidence chunk for FTS-only hits in `hybrid` court-decision search so the relevance filter judges them fairly and reduces false drops. Also makes the assistant spinner background transparent.

- **Bug Fixes**
  - Added `EdsrVectorizerService.bestChunkForDocs` to fetch the top-1 chunk per `doc_id` via constrained vector search (single embedding).
  - In hybrid search, backfills FTS-only hits within the top fused set and sets `qdrant_best_chunk_text/_index` (best-effort, no-op if none).
  - Exposes `legs.fts_chunks_backfilled` and per-result `evidence_chunk_backfilled`; added a unit test for the backfill path.
  - UI: spinner container uses a transparent background.

<sup>Written for commit fc1fb385798ebe92b933e08cb0eb45fbf960ab31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

