### PR TITLE
docs(claude): correct ModelSelector tier defaults (Bedrock-first)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Tool registry: `mcp_backend/src/api/tool-registry.ts` maps tool names to handler
 Key exports used across all services:
 - `getOpenAIManager` / `getAnthropicManager` - LLM client singletons
 - `LLMManager` - Unified interface for OpenAI/Anthropic with fallback
-- `ModelSelector` - Budget-aware model selection (quick → gpt-4o-mini, standard → gpt-4o-mini, deep → gpt-4o)
+- `ModelSelector` - Budget-aware, multi-provider model selection. Provider order via `LLM_PROVIDER_STRATEGY` (prod = `bedrock-first`). Prod tiers (Bedrock, eu-central-1): quick → Claude Haiku 4.5, standard → Claude Sonnet 4.6, deep → Claude Opus 4.6; throttle fallback → Amazon Nova (micro/pro). OpenAI fallback tiers: quick → gpt-5-nano, standard → gpt-5-mini, deep → gpt-5.1
 - `logger` - Winston-based structured logging
 - `BaseDatabase` - PostgreSQL connection pool management
 - `CostTracker` / `CostCalculator` - Per-request API cost tracking


### PR DESCRIPTION
The `ModelSelector` description in CLAUDE.md listed stale OpenAI defaults (`quick`/`standard` → gpt-4o-mini, `deep` → gpt-4o).

Reality on prod (`secondlayer-app-prod-green` env):
- `LLM_PROVIDER_STRATEGY=bedrock-first`
- Bedrock (eu-central-1): quick → Claude Haiku 4.5, standard → Sonnet 4.6, deep → Opus 4.6
- Bedrock throttle fallback → Amazon Nova (micro/pro)
- OpenAI fallback tiers: quick → gpt-5-nano, standard → gpt-5-mini, deep → gpt-5.1

`gpt-4o-mini` is no longer used anywhere. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected `ModelSelector` docs to reflect `LLM_PROVIDER_STRATEGY=bedrock-first` in prod, replacing stale OpenAI defaults. Tiers now resolve to Bedrock (eu-central-1): quick → Claude Haiku 4.5, standard → Claude Sonnet 4.6, deep → Claude Opus 4.6; throttle fallback → Amazon Nova (micro/pro); OpenAI fallback: quick → `gpt-5-nano`, standard → `gpt-5-mini`, deep → `gpt-5.1`.

<sup>Written for commit 13b0882993dc1653d78b79ebede352a1dd036e90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

