### PR TITLE
fix(lexwebapp): move noscript crawler fallback out of <head> into <body>

### DIFF
--- a/lexwebapp/index.html
+++ b/lexwebapp/index.html
@@ -99,6 +99,38 @@
     }
     </script>
 
+
+    <!-- Google Ads: loaded dynamically after analytics consent (GDPR) -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      // Set consent defaults BEFORE any gtag config
+      gtag('consent', 'default', {
+        analytics_storage: 'denied',
+        ad_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+      });
+      window.__loadGtag = function() {
+        if (window.__gtagLoaded) return;
+        window.__gtagLoaded = true;
+        gtag('consent', 'update', {
+          analytics_storage: 'granted',
+          ad_storage: 'granted',
+          ad_user_data: 'granted',
+          ad_personalization: 'granted',
+        });
+        var s = document.createElement('script');
+        s.async = true;
+        s.src = 'https://www.googletagmanager.com/gtag/js?id=AW-18033840618';
+        document.head.appendChild(s);
+        gtag('js', new Date());
+        gtag('config', 'AW-18033840618');
+      };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
     <!-- Noscript fallback for crawlers -->
     <noscript>
       <div style="max-width:720px;margin:40px auto;font-family:system-ui,sans-serif;color:#e4e4e7;background:#0a0a0b;padding:40px">
@@ -170,38 +202,6 @@
         <p>Start free — 50 credits on registration. <a href="https://legal.org.ua">Sign up</a></p>
       </div>
     </noscript>
-
-    <!-- Google Ads: loaded dynamically after analytics consent (GDPR) -->
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      // Set consent defaults BEFORE any gtag config
-      gtag('consent', 'default', {
-        analytics_storage: 'denied',
-        ad_storage: 'denied',
-        ad_user_data: 'denied',
-        ad_personalization: 'denied',
-      });
-      window.__loadGtag = function() {
-        if (window.__gtagLoaded) return;
-        window.__gtagLoaded = true;
-        gtag('consent', 'update', {
-          analytics_storage: 'granted',
-          ad_storage: 'granted',
-          ad_user_data: 'granted',
-          ad_personalization: 'granted',
-        });
-        var s = document.createElement('script');
-        s.async = true;
-        s.src = 'https://www.googletagmanager.com/gtag/js?id=AW-18033840618';
-        document.head.appendChild(s);
-        gtag('js', new Date());
-        gtag('config', 'AW-18033840618');
-      };
-    </script>
-  </head>
-  <body>
-    <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
     <script>
       if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Problem

The Vite production build of `lexwebapp` emits:

```
Unable to parse HTML; parse5 error code disallowed-content-in-noscript-in-head
 at /app/lexwebapp/index.html:104:7
```

A `<noscript>` placed in `<head>` may only contain `<link>`, `<style>`, and `<meta>`. The crawler-fallback block held a `<div>` with headings/lists/links, which parse5 rejects. The build still completed, but the fallback markup was malformed.

## Fix

Moved the entire `<noscript>` block verbatim from `<head>` into `<body>`, right after `<div id="root">`. Content is unchanged. A body-level `<noscript>` accepts flow content, so the warning is gone and crawlers still receive the fallback markup.

Single file changed: `lexwebapp/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the crawler `<noscript>` fallback from `<head>` to `<body>` to comply with HTML rules and remove the Vite parse5 error. Content is unchanged; the build is clean and crawlers still see the fallback.

<sup>Written for commit 6d35b3cf51ad86518eccdec0824d772cb159a20a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

