### PR TITLE
chore(backend): deploy core citation-grounding gates (CORE-21 P0.1+P0.2)

### DIFF
--- a/mcp_backend/CORE_OVERLAY.md
+++ b/mcp_backend/CORE_OVERLAY.md
@@ -1,0 +1,14 @@
+# Core overlay version
+
+The proprietary chat pipeline (`overthelex/secondlayer-core`) is **not** a pinned
+dependency — `deploy-prod.yml` clones it `--depth 1` at build time and overlays
+`src/services/*.ts` + `src/prompts/*` onto `mcp_backend/`. This file records which
+core commit a deploy is intended to ship, for audit, and bumps the backend path so
+a core-only change triggers a backend build + deploy.
+
+| Date | Core commit | Notes |
+|------|-------------|-------|
+| 2026-06-23 | `17b1b0a` | CORE-21 P0.1 quote-or-drop (#55) + P0.2 claim↔source verifier (#57): warn-only citation-grounding gates (`ungrounded_quote`, `claim_unsupported`). |
+
+> Update this row whenever a core change must reach prod. The overlay always uses
+> core `main` HEAD; keep the recorded commit equal to that HEAD at merge time.

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Ships the merged **secondlayer-core** citation-grounding gates to prod.

### Why a backend bump
`secondlayer-core` is not a pinned dependency — `deploy-prod.yml` clones it `--depth 1` at build time and overlays `src/services/*.ts` + `src/prompts/*` onto `mcp_backend/`. A core-only merge therefore never reaches prod by itself. This bump flips the `mcp_backend/*` paths-filter → backend build re-clones core (now `17b1b0a`) and blue-green deploys.

### What's in the core overlay
- **P0.1** quote-or-drop ([core#55](https://github.com/overthelex/secondlayer-core/pull/55)) — flags a court quote «...» absent from the cited case's text.
- **P0.2** claim↔source verifier ([core#57](https://github.com/overthelex/secondlayer-core/pull/57)) — cheap quick-tier LLM judge for paraphrased holdings with no basis in the source.

Both are **warn-only** (`citation_warning`: `ungrounded_quote` / `claim_unsupported`) — no change to existing answer behaviour, only new advisory events + logs. Enforcement (strip) is a deliberate fast-follow after observing prod false-positive rate.

Repro that motivated this: `chat-b8a0b5fb` cited three real ст.266 КАС ВС cases with fabricated occupied-territory holdings.

Diff: `mcp_backend/package.json` 1.0.4→1.0.5 + `mcp_backend/CORE_OVERLAY.md` (records deployed core commit). No code changes in the monorepo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys `secondlayer-core` citation-grounding gates to production (P0.1 quote‑or‑drop, P0.2 claim↔source verifier) in warn‑only mode. Adds an overlay audit file and bumps `mcp_backend` to trigger a rebuild; aligns with CORE‑21.

- **New Features**
  - Quote‑or‑drop gate emits `citation_warning: ungrounded_quote` when a cited quote isn’t in the source text.
  - Claim↔source verifier emits `citation_warning: claim_unsupported` for paraphrased holdings without source support.

- **Dependencies**
  - Bumps `mcp_backend` version to trigger blue‑green deploy and re‑clone of `secondlayer-core` at build.
  - Adds `mcp_backend/CORE_OVERLAY.md` to record the core overlay version for audit.

<sup>Written for commit f9427d937410b7799425a7354fa2bf566cab17fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

