### PR TITLE
chore(backend): deploy core P0.3 verify-before-stream (CORE-21)

### DIFF
--- a/mcp_backend/CORE_OVERLAY.md
+++ b/mcp_backend/CORE_OVERLAY.md
@@ -9,6 +9,7 @@ a core-only change triggers a backend build + deploy.
 | Date | Core commit | Notes |
 |------|-------------|-------|
 | 2026-06-23 | `17b1b0a` | CORE-21 P0.1 quote-or-drop (#55) + P0.2 claim↔source verifier (#57): warn-only citation-grounding gates (`ungrounded_quote`, `claim_unsupported`). |
+| 2026-06-23 | `3fd3bed` | CORE-21 P0.3 verify-before-stream (#58): high-stakes query types (practice/institutional/comparative_analysis, due_diligence) verify + repair citations before the answer is streamed — final answer renders at once, not token-by-token. |
 
 > Update this row whenever a core change must reach prod. The overlay always uses
 > core `main` HEAD; keep the recorded commit equal to that HEAD at merge time.

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Rolls **CORE-21 P0.3** ([core#58](https://github.com/overthelex/secondlayer-core/pull/58), core `3fd3bed`) to prod.

Backend bump flips the `mcp_backend/*` paths-filter → backend build re-clones core HEAD and blue-green deploys. (Core isn't a pinned dep; the overlay always uses core `main` HEAD.)

**P0.3 — user-visible streaming change:** for high-stakes query types (`practice_analysis`, `institutional_analysis`, `comparative_analysis`, `due_diligence`) the final answer is verified + citation-repaired **before** it streams, so it renders at once instead of token-by-token. Tool/thinking progress still streams. This closes the window where a fabricated citation was briefly shown before P0.1/P0.2/CORE-39 stripped it.

Diff: `mcp_backend/package.json` 1.0.5→1.0.6 + `CORE_OVERLAY.md` row. No monorepo code changes. 144 core tests green pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys CORE-21 P0.3 (verify-before-stream) to production via the `mcp_backend` overlay. High-stakes queries now show a verified, citation-repaired final answer all at once; tool/thinking progress still streams.

- **New Features**
  - For `practice_analysis`, `institutional_analysis`, `comparative_analysis`, and `due_diligence`, we verify and repair citations before streaming so the final answer renders in one piece (meets CORE-21 P0.3).

- **Dependencies**
  - Bump `secondlayer-mcp` to `1.0.6` to trigger deploy.
  - Update `mcp_backend/CORE_OVERLAY.md` to record the deployed core change.

<sup>Written for commit 8add6e259330e1d4ece43e6f94bb3d3b034aa405. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

