### PR TITLE
feat(edrsr): IDF-weighted FTS term selection (CORE-21 P1.5a)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -17,6 +17,7 @@ import { EDRSR_METADATA_SEARCH_ORDER } from '../../services/search-ranking-confi
 import type { SearchResultFilter } from '../../services/search-result-filter.js';
 import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsSearchResponse } from '../../services/edrsr-fts-service.js';
+import { selectFtsTerms } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
 
 const DEFAULT_RRF_K = 60;
@@ -359,7 +360,13 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     limit: number,
     offset: number,
   ): Promise<{ result: EdsrFtsSearchResponse; usedQuery: string; startTokens: number; usedTokens: number; relaxedFromTokens?: number }> {
-    const tokens = String(topicalQuery).trim().split(/\s+/).filter(Boolean);
+    const rawTokens = String(topicalQuery).trim().split(/\s+/).filter(Boolean);
+    // CORE-21 P1.5a: order tokens by IDF (discriminative first) so the probe keeps rare
+    // terms (донецьк/окупован/ДРРП) and relaxation drops the commonest (податок/майно),
+    // instead of the positional tail. Empty idf map → original order (no regression).
+    const idf = this.ftsService ? await this.ftsService.lexemeDf(rawTokens, this.db) : new Map<string, number>();
+    const tokens = selectFtsTerms(rawTokens, idf);
+    const idfRanked = idf.size > 0;
     const startTokens = tokens.length;
     let n = Math.min(startTokens, FULLTEXT_MAX_TOKENS) || 1;
     const cappedFrom = n; // token count at the first (capped) probe
@@ -368,13 +375,14 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     let result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
 
     let steps = 0;
-    // Relax while near-empty (not just hard 0): dropping a trailing AND-term only widens the
-    // match set, so we keep broadening until the probe clears the floor or we hit the bounds.
+    // Relax while near-empty (not just hard 0): dropping the LEAST discriminative AND-term
+    // (the idf-ranked tail) only widens the match set, so we keep broadening until the probe
+    // clears the floor or we hit the bounds.
     while (result.total < FTS_RELAX_MIN_RESULTS && n > FTS_MIN_TOKENS && steps < FTS_MAX_RELAX_STEPS) {
       n -= 1; steps += 1;
       usedQuery = tokens.slice(0, n).join(' ');
       logger.info('[EdsrUnifiedSearch] FTS relax-on-near-empty', {
-        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: usedQuery,
+        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: usedQuery, idf_ranked: idfRanked,
       });
       result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
     }

--- a/mcp_backend/src/migrations/164_edrsr_lexeme_df.sql
+++ b/mcp_backend/src/migrations/164_edrsr_lexeme_df.sql
@@ -1,0 +1,20 @@
+-- Sampled document-frequency of FTS lexemes from edrsr_fulltext, used for
+-- IDF-weighted keyword selection in the unified court search (CORE-21 P1.5a):
+-- keep discriminative terms (e.g. "донецьк", "окупован", "дррп"), drop common
+-- ones ("податок", "майно") when relaxing the all-AND plainto_tsquery.
+--
+-- This migration ONLY creates the (initially empty) table. edrsr_fulltext has
+-- ~296M rows, so the heavy ts_stat populate is OUT OF BAND — see
+-- scripts/edrsr/build-lexeme-df.sql, run off-peak on the local DB-proxy and
+-- exported to prod, then refreshed by the EDRSR cron. The search path is
+-- fallback-safe: an empty/missing table -> current positional behaviour.
+
+CREATE TABLE IF NOT EXISTS edrsr_lexeme_df (
+  lexeme      TEXT PRIMARY KEY,        -- 'simple'-config lexeme == lowercased token
+  df          BIGINT NOT NULL,         -- docs containing the lexeme in the sample
+  sample_docs BIGINT NOT NULL,         -- sample size -> idf = ln(sample_docs / df)
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE edrsr_lexeme_df IS
+  'Sampled FTS lexeme document-frequency for IDF term selection (CORE-21 P1.5a); populated out-of-band by scripts/edrsr/build-lexeme-df.sql, refreshed by the EDRSR cron.';

--- a/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
@@ -1,0 +1,80 @@
+/**
+ * CORE-21 P1.5a — IDF-weighted FTS term selection.
+ * selectFtsTerms (pure ordering) + EdsrFtsService.lexemeDf (df → idf, db-backed).
+ */
+import { selectFtsTerms, EdsrFtsService } from '../edrsr-fts-service';
+
+describe('selectFtsTerms (CORE-21 P1.5a)', () => {
+  // Mimics lexemeDf output: common terms low idf, discriminative terms high.
+  const idf = new Map<string, number>([
+    ['податок', 0.2], ['нерухоме', 1.0], ['майно', 0.3],
+    ['окупована', 4.0], ['територія', 2.0], ['донецьк', 5.0],
+  ]);
+  const reproTokens = ['податок', 'нерухоме', 'майно', 'окупована', 'територія', 'Донецьк'];
+
+  it('orders discriminative (rare) terms first, common last', () => {
+    const out = selectFtsTerms(reproTokens, idf);
+    expect(out.slice(0, 3)).toEqual(['Донецьк', 'окупована', 'територія']);
+    expect(out.slice(-2)).toEqual(['майно', 'податок']); // commonest → relaxation drops these first
+  });
+
+  it('keeps the rare occupation/ДРРП terms across relaxation', () => {
+    // Relaxation pops from the tail; dropping the 3 commonest still leaves the rare ones.
+    const ranked = selectFtsTerms(reproTokens, idf);
+    expect(ranked.slice(0, 3)).toEqual(expect.arrayContaining(['Донецьк', 'окупована']));
+    expect(ranked.indexOf('податок')).toBeGreaterThan(ranked.indexOf('Донецьк'));
+  });
+
+  it('falls back to the original positional order when the idf map is empty', () => {
+    expect(selectFtsTerms(['a', 'b', 'c'], new Map())).toEqual(['a', 'b', 'c']);
+  });
+
+  it('is a stable sort on equal idf (input order preserved)', () => {
+    const flat = new Map([['x', 1], ['y', 1], ['z', 1]]);
+    expect(selectFtsTerms(['x', 'y', 'z'], flat)).toEqual(['x', 'y', 'z']);
+  });
+
+  it('matches tokens case-insensitively but returns original casing', () => {
+    expect(selectFtsTerms(['Донецьк', 'податок'], idf)).toEqual(['Донецьк', 'податок']);
+  });
+});
+
+describe('EdsrFtsService.lexemeDf (CORE-21 P1.5a)', () => {
+  const svc = new EdsrFtsService();
+
+  function dbReturning(rows: any[], probeRows: any[] = []) {
+    return {
+      query: jest.fn().mockImplementation((sql: string) =>
+        Promise.resolve({ rows: /LIMIT 1/.test(sql) ? probeRows : rows })),
+    };
+  }
+
+  it('computes idf for matched lexemes and max idf for absent ones (table populated)', async () => {
+    const db = dbReturning([
+      { lexeme: 'податок', df: 900, sample_docs: 1000 },
+      { lexeme: 'донецьк', df: 10, sample_docs: 1000 },
+    ]);
+    const m = await svc.lexemeDf(['податок', 'донецьк', 'окупована'], db);
+    expect(m.get('податок')!).toBeCloseTo(Math.log(1000 / 900));
+    expect(m.get('донецьк')!).toBeCloseTo(Math.log(1000 / 10));
+    expect(m.get('окупована')!).toBeCloseTo(Math.log(1000)); // absent + populated → max idf
+    expect(m.get('донецьк')!).toBeGreaterThan(m.get('податок')!);
+  });
+
+  it('returns an empty map when the df table is empty (positional fallback)', async () => {
+    const m = await svc.lexemeDf(['податок', 'донецьк'], dbReturning([], []));
+    expect(m.size).toBe(0);
+  });
+
+  it('never throws — returns an empty map on db error', async () => {
+    const db = { query: jest.fn().mockRejectedValue(new Error('relation does not exist')) };
+    const m = await svc.lexemeDf(['x'], db);
+    expect(m.size).toBe(0);
+  });
+
+  it('lowercases tokens before lookup', async () => {
+    const db = dbReturning([{ lexeme: 'донецьк', df: 10, sample_docs: 1000 }]);
+    const m = await svc.lexemeDf(['Донецьк'], db);
+    expect(m.get('донецьк')!).toBeCloseTo(Math.log(1000 / 10));
+  });
+});

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -125,11 +125,66 @@ export interface EdsrIndexProgress {
   percentComplete: number;
 }
 
+/**
+ * IDF-weighted ordering of FTS keyword tokens (CORE-21 P1.5a). Returns the tokens
+ * most-discriminative first so the caller probes the rarest terms and relaxation drops
+ * the commonest. `idfByToken` is keyed by lowercased token (see EdsrFtsService.lexemeDf).
+ *
+ * Zero-risk fallback: an EMPTY idf map (df table unpopulated / lookup failed) preserves
+ * the original token order — i.e. the previous positional behaviour. Stable sort: equal
+ * idf (and the fallback) keep input order via the original index.
+ */
+export function selectFtsTerms(tokens: string[], idfByToken: Map<string, number>): string[] {
+  if (idfByToken.size === 0) return [...tokens];
+  return tokens
+    .map((tok, i) => ({ tok, i, idf: idfByToken.get(tok.toLowerCase()) ?? 0 }))
+    .sort((a, b) => (b.idf - a.idf) || (a.i - b.i))
+    .map(x => x.tok);
+}
+
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
   setEdsrCache(cache: EdsrCacheService): void {
     this.edsrCache = cache;
+  }
+
+  /**
+   * Per-token IDF from the sampled edrsr_lexeme_df table (CORE-21 P1.5a). Returns a
+   * Map<lowercased token, idf>; idf = ln(sample_docs / df) for sampled lexemes, and
+   * ln(sample_docs) (the maximum) for tokens below the sampling floor when the table
+   * IS populated. Returns an EMPTY map when the df table is empty/missing/unreadable —
+   * callers then keep positional ordering (no regression before the table is built).
+   */
+  async lexemeDf(tokens: string[], dbPool: any): Promise<Map<string, number>> {
+    const out = new Map<string, number>();
+    const lexemes = [...new Set(tokens.map(t => t.toLowerCase()).filter(Boolean))];
+    if (lexemes.length === 0) return out;
+    try {
+      const res = await dbPool.query(
+        `SELECT lexeme, df, sample_docs FROM edrsr_lexeme_df WHERE lexeme = ANY($1::text[])`,
+        [lexemes],
+      );
+      // sample_docs identifies whether the table is populated. Any matched row carries
+      // it; otherwise a cheap probe. No value -> empty table -> no signal (positional).
+      let sampleDocs = Number(res.rows[0]?.sample_docs) || 0;
+      if (!sampleDocs) {
+        const probe = await dbPool.query(`SELECT sample_docs FROM edrsr_lexeme_df LIMIT 1`);
+        sampleDocs = Number(probe.rows[0]?.sample_docs) || 0;
+      }
+      if (!sampleDocs) return out;
+      const maxIdf = Math.log(sampleDocs);
+      const dfByLex = new Map<string, number>();
+      for (const r of res.rows) dfByLex.set(r.lexeme, Number(r.df));
+      for (const lex of lexemes) {
+        const df = dfByLex.get(lex);
+        out.set(lex, df && df > 0 ? Math.log(sampleDocs / df) : maxIdf);
+      }
+      return out;
+    } catch (err: any) {
+      logger.warn('[EdsrFtsService] lexemeDf lookup failed; positional FTS fallback', { error: err.message });
+      return new Map();
+    }
   }
 
   /**

--- a/scripts/edrsr/build-lexeme-df.sql
+++ b/scripts/edrsr/build-lexeme-df.sql
@@ -1,0 +1,38 @@
+-- Rebuild edrsr_lexeme_df from a sample of edrsr_fulltext (CORE-21 P1.5a).
+--
+-- HEAVY: ts_stat aggregates every lexeme across the sampled tsvectors. Run
+-- OFF-PEAK on the local DB-proxy, then export the table to prod (local->prod
+-- pattern). Idempotent — safe to re-run; refreshed by the EDRSR cron.
+--
+-- Sample size: 0.3% of ~296M rows ~= 900k docs — enough to rank "податок"
+-- (almost everywhere) below "донецьк" (rare). REPEATABLE makes the count and
+-- the ts_stat see the SAME sample, so sample_docs matches the df corpus.
+-- If ts_stat runs too long, drop the sample to SYSTEM (0.1).
+--
+-- Usage:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/edrsr/build-lexeme-df.sql
+
+SET statement_timeout = '45min';
+
+BEGIN;
+
+TRUNCATE edrsr_lexeme_df;
+
+INSERT INTO edrsr_lexeme_df (lexeme, df, sample_docs, updated_at)
+SELECT
+  s.word,
+  s.ndoc,
+  (SELECT count(*)::bigint
+     FROM edrsr_fulltext TABLESAMPLE SYSTEM (0.3) REPEATABLE (42)),
+  NOW()
+FROM ts_stat(
+  $$SELECT tsv FROM edrsr_fulltext TABLESAMPLE SYSTEM (0.3) REPEATABLE (42)$$
+) AS s(word, ndoc, nentry)
+WHERE s.ndoc >= 3;   -- drop hapax/OCR noise
+
+COMMIT;
+
+ANALYZE edrsr_lexeme_df;
+
+-- Sanity: most common terms should have the largest df.
+-- SELECT lexeme, df FROM edrsr_lexeme_df ORDER BY df DESC LIMIT 10;


### PR DESCRIPTION
Fixes the upstream cause of citation fabrication surfaced by the live P0 gates: the FTS leg throws away the discriminative keywords and collapses to generic ст.266 hits, leaving Qdrant to carry all relevance.

## Problem (confirmed on prod, `chat-b5001317`)
`ftsWithRelaxation` caps to the **first 6** reformulated tokens and relaxes by dropping the **tail**; `plainto_tsquery('simple', …)` ANDs all terms. The LLM puts generic terms first, discriminative ones (донецьк, окупован, ДРРП) later — so relaxation drops exactly the salient terms:

`податок нерухоме майно окупована територія Донецьк` → drop Донецьк → … → **`податок нерухоме майно`** = 90/900 generic. FTS becomes useless; the vector leg surfaces topically-near ст.266 cases that synthesis then mischaracterises.

## Fix — rank tokens by IDF
Keep the rarest (most discriminative) terms in the probe; drop the commonest on relaxation — the inverse of today.

- **migration 164** `edrsr_lexeme_df(lexeme PK, df, sample_docs)` — table only.
- **scripts/edrsr/build-lexeme-df.sql** — off-peak sampled `ts_stat` (0.3% `TABLESAMPLE`, `REPEATABLE`) populate; refreshed by the EDRSR cron; built local → exported to prod.
- **`EdsrFtsService.lexemeDf()`** — batched PK lookup → idf map (`ln(sample/df)`; absent-on-populated-table → max idf). Empty/missing table or error → empty map.
- **`selectFtsTerms()`** — pure, stable idf-desc ordering. **Empty idf map → original positional order**, i.e. byte-for-byte today's behaviour until the df table exists.
- **`ftsWithRelaxation`** — order via `selectFtsTerms`, relax from the idf-ranked tail; logs `idf_ranked`. Constants unchanged (6 / 2 / 3 / 4).

## Safety / rollout
- **Zero-risk fallback**: with no df table, `lexemeDf` returns an empty map and behaviour is identical to current. So the code ships first; the heavy `ts_stat` build runs out of band (local DB-proxy → export to prod), then takes effect automatically.
- Runtime cost: one ~6-element PK lookup per search (~1 ms).

## Tests
`edrsr-fts-term-selection.test.ts` — **9 pass**: ranking on the repro tokens, rare-term retention through relaxation, positional fallback on empty map, stable ties, case-insensitive lookup; `lexemeDf` idf math, absent=max-idf, empty-table, error-safe.

> Pre-existing `core-loader.ts` TS2307s (token-budget-allocator/tool-health-tracker/step-constraints) are core-overlay-only files, resolved at CI build after the overlay — unrelated to this change.

Part of CORE-21 v2 → P1 (CORE-43 → **CORE-45**). Follow-up **CORE-46** (P1.5b: raise vector relevance-gate when FTS still collapses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements IDF‑weighted FTS term selection so searches keep rare, discriminative tokens and relax by dropping generic ones. Addresses CORE-21 P1.5a by preventing FTS collapse to generic ст.266 hits.

- **New Features**
  - Added `selectFtsTerms` to rank tokens by IDF (stable; empty IDF map keeps original order).
  - Added `EdsrFtsService.lexemeDf` to fetch per-token IDF from the DB; absent tokens get max IDF; empty/missing table returns an empty map.
  - Updated unified search to use ranked tokens and relax from the least discriminative; logs `idf_ranked`.
  - Added tests for ranking, fallback, ties, case-insensitive lookup, and IDF math.

- **Migration**
  - Migration 164 creates `edrsr_lexeme_df(lexeme, df, sample_docs)`; table is initially empty.
  - Added `scripts/edrsr/build-lexeme-df.sql` to populate off‑peak; refreshed by the EDRSR cron.
  - Rollout is safe: behavior is unchanged until the table is populated; runtime cost ~ one small lookup per search.

<sup>Written for commit f9daa291d473d127ebbd8740dba953c03a9838f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

