### PR TITLE
fix(mcp): OAuth protected-resource metadata for /api/v1/sse transport

### DIFF
--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -300,6 +300,14 @@ export function createMCPSSERoutes(deps: {
       const authHeader = req.headers.authorization;
       if (!authHeader || !authHeader.startsWith('Bearer ')) {
         logger.warn('[MCP v1/sse] Missing or invalid Authorization header');
+        // Point OAuth clients at the protected-resource metadata for THIS transport
+        // (resource = public /api/v1/sse), so the SDK's resource check passes. Without this
+        // header the SDK falls back to the root metadata (resource = /sse) and rejects.
+        const baseUrl = getBaseUrl(req);
+        res.setHeader(
+          'WWW-Authenticate',
+          `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource/api/v1/sse"`
+        );
         return res.status(401).json({
           error: 'Unauthorized',
           message: 'Authorization header with Bearer token is required',
@@ -645,6 +653,23 @@ export function createMCPSSERoutes(deps: {
       bearer_methods_supported: ['header'],
     });
   });
+
+  // RFC 9728 metadata for the standard MCP SSE transport (GET/POST /v1/sse).
+  // Publicly this transport is reached at /api/v1/sse (nginx rewrites /api/v1/sse -> /v1/sse),
+  // so the advertised `resource` MUST be the public /api/v1/sse URL to match the client's
+  // configured server URL — otherwise the SDK rejects with "resource does not match expected".
+  // Clients (e.g. Claude Code) probe the path-aware well-known for both /api/v1/sse and /v1/sse.
+  const v1SseResourceMetadata = (req: Request, res: Response) => {
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      resource: `${baseUrl}/api/v1/sse`,
+      authorization_servers: [baseUrl],
+      scopes_supported: ['mcp'],
+      bearer_methods_supported: ['header'],
+    });
+  };
+  router.get('/.well-known/oauth-protected-resource/api/v1/sse', v1SseResourceMetadata);
+  router.get('/.well-known/oauth-protected-resource/v1/sse', v1SseResourceMetadata);
 
   // Redirect /register to /oauth/register (MCP client compatibility)
   router.post('/register', (req: Request, res: Response) => {


### PR DESCRIPTION
## Проблема

OAuth не подключается к стандартному MCP SSE-транспорту (`/api/v1/sse`) из Claude Code:

- `GET /v1/sse` (публично `/api/v1/sse`) возвращал «голый» 401 **без** заголовка `WWW-Authenticate`.
- SDK откатывался на корневые метаданные `/.well-known/oauth-protected-resource`, где объявлен `resource: /sse` (ChatGPT-keepalive эндпоинт).
- Проверка ресурса в SDK отклоняла подключение: `Protected resource .../sse does not match expected .../api/v1/sse`.
- Конфиг с `url=/sse` выдавал токен, но затем **зависал**: `GET /sse` — это keepalive-канал, а не полноценный MCP SSE-транспорт → connection timeout.

Метаданные и реальный транспорт были рассинхронизированы.

## Исправление

В `mcp_backend/src/routes/mcp-sse-routes.ts`:

1. `GET /v1/sse` при 401 теперь отдаёт `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/api/v1/sse"`.
2. Добавлены path-aware роуты метаданных `/.well-known/oauth-protected-resource/api/v1/sse` и `/v1/sse`, объявляющие `resource` = публичный `/api/v1/sse` (с учётом nginx-rewrite `^/api(/v1/sse.*)$ → $1`).

После деплоя клиентский `.mcp.json` с OAuth:
```json
{ "mcpServers": { "secondlayer": { "type": "sse", "url": "https://mcp.legal.org.ua/api/v1/sse" } } }
```
проходит handshake без ручного Bearer-токена.

## Проверка

- Изолированная правка одного файла; `tsc` по `mcp-sse-routes.ts` — без ошибок (предсуществующие ошибки `core-loader.ts` относятся к проприетарным CORE-21 сервисам, подмешиваемым в CI, и не связаны с этим PR).
- Полную сборку с проприетарным кодом выполнит CI.

После merge + деплоя проверю e2e подключение OAuth из Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth handshake for the standard MCP SSE transport by advertising path-aware protected-resource metadata and a proper `WWW-Authenticate` on 401. OAuth clients (e.g., Claude Code) can now connect to `/api/v1/sse` without manual tokens.

- **Bug Fixes**
  - On `GET /v1/sse` 401, send `WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/api/v1/sse"`.
  - Serve path-aware OAuth metadata for the transport, advertising `resource` = public `/api/v1/sse` to avoid SDK fallback to `/sse` keepalive.

<sup>Written for commit 862ca9e47fc4d9d921cbf378f26dcb2de1040f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

