### PR TITLE
feat(edrsr): strict relevance gate when FTS collapses (CORE-21 P1.5b)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -15,6 +15,7 @@ import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handle
 import { logger } from '../../utils/logger.js';
 import { EDRSR_METADATA_SEARCH_ORDER } from '../../services/search-ranking-config.js';
 import type { SearchResultFilter } from '../../services/search-result-filter.js';
+import { STRICT_MIN_SCORE } from '../../services/search-result-filter.js';
 import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsSearchResponse } from '../../services/edrsr-fts-service.js';
 import { selectFtsTerms } from '../../services/edrsr-fts-service.js';
@@ -580,7 +581,18 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     // each such hit's best query-relevant chunk so both legs feed the filter comparable
     // evidence. Bounded to the post-slice top set (≤ limit), no-op when nothing needs it.
     const chunkBackfilled = await this.backfillEvidenceChunks(enriched, semanticQuery);
-    const output = await this.maybeFilter(enriched, query);
+    // CORE-21 P1.5b: when the FTS leg collapsed, the fused set is effectively vector-only,
+    // and semantic search floods "partially relevant" (5-7) same-codex cases that get
+    // mis-cited as on-point practice. Raise the relevance-gate bar to 8-10 in that case so
+    // only directly-relevant hits survive. (Even IDF-ranked FTS — P1.5a — can return 0 on an
+    // ultra-specific all-AND query; this is the paired safeguard.)
+    const ftsCollapsed = (ftsResponse?.total ?? 0) < FTS_RELAX_MIN_RESULTS;
+    if (ftsCollapsed) {
+      logger.info('[EdsrUnifiedSearch] FTS collapsed — strict relevance gate', {
+        fts_total: ftsResponse?.total ?? 0, min_score: STRICT_MIN_SCORE, candidates: enriched.length,
+      });
+    }
+    const output = await this.maybeFilter(enriched, query, ftsCollapsed ? { minScore: STRICT_MIN_SCORE } : undefined);
 
     return this.wrapResponse({
       mode: 'hybrid', query, rrf_k: rrfK, oversample,
@@ -588,7 +600,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       ...(reformulated ? { reformulated: { fts: reformulated.fts, semantic: reformulated.semantic } } : {}),
       ...(partyName ? { party_filter: { party_name: partyName, party_role: partyRole || 'any' } } : {}),
       ...(instanceCode ? { instance_code: instanceCode } : {}),
-      legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length, ...(chunkBackfilled > 0 ? { fts_chunks_backfilled: chunkBackfilled } : {}) },
+      legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length, ...(chunkBackfilled > 0 ? { fts_chunks_backfilled: chunkBackfilled } : {}), ...(ftsCollapsed ? { fts_collapsed: true, strict_relevance_gate: true } : {}) },
       ...(structuralFilter ? { structural_filter: structuralFilter } : {}),
       total_fused: fused.length, returned: output.filtered.length,
       results: output.filtered,
@@ -716,11 +728,12 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
   private async maybeFilter(
     results: any[],
     query: string,
+    options?: { minScore?: number },
   ): Promise<{ filtered: any[]; original_count: number; filtered_count: number }> {
     if (!this.resultFilter) {
       return { filtered: results, original_count: results.length, filtered_count: results.length };
     }
-    return this.resultFilter.filterResults(results, query);
+    return this.resultFilter.filterResults(results, query, options);
   }
 
   // ── RRF fusion ──────────────────────────────────────────────────

--- a/mcp_backend/src/services/__tests__/search-result-filter-strict.test.ts
+++ b/mcp_backend/src/services/__tests__/search-result-filter-strict.test.ts
@@ -1,0 +1,58 @@
+/**
+ * CORE-21 P1.5b — strict relevance threshold for FTS-collapsed (vector-only) fusion.
+ * Verifies the parameterized keep-threshold in SearchResultFilter.
+ */
+import { SearchResultFilter, STRICT_MIN_SCORE } from '../search-result-filter';
+
+function mkResults(n: number) {
+  return Array.from({ length: n }, (_, i) => ({ doc_id: i + 1, cause_num: `${i + 1}/2/24`, court_name: 'КАС ВС' }));
+}
+
+function llmReturning(scores: Record<number, number>, capture?: { prompt?: string }) {
+  return {
+    chatCompletion: jest.fn().mockImplementation((req: any) => {
+      if (capture) capture.prompt = req.messages.find((m: any) => m.role === 'system')?.content;
+      const arr = Object.entries(scores).map(([d, s]) => ({ doc_id: Number(d), score: s }));
+      return Promise.resolve({ content: JSON.stringify(arr) });
+    }),
+  } as any;
+}
+
+describe('SearchResultFilter strict threshold (CORE-21 P1.5b)', () => {
+  const results = mkResults(9); // >= MIN_RESULTS_TO_FILTER (8)
+  const scores: Record<number, number> = { 1: 9, 2: 8, 3: 6, 4: 6, 5: 5, 6: 4, 7: 3, 8: 6, 9: 7 };
+
+  it('default keeps score >= 5 (partially relevant survive)', async () => {
+    const out = await new SearchResultFilter(llmReturning(scores)).filterResults(results, 'q');
+    expect(out.filtered.map(r => r.doc_id).sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 8, 9]);
+  });
+
+  it('strict (minScore 7) drops the 5-6 flood, keeps only 7-10', async () => {
+    const out = await new SearchResultFilter(llmReturning(scores))
+      .filterResults(results, 'q', { minScore: STRICT_MIN_SCORE });
+    expect(out.filtered.map(r => r.doc_id).sort((a, b) => a - b)).toEqual([1, 2, 9]);
+  });
+
+  it('threads the threshold into the ranking prompt', async () => {
+    const cap: { prompt?: string } = {};
+    await new SearchResultFilter(llmReturning(scores, cap))
+      .filterResults(results, 'q', { minScore: STRICT_MIN_SCORE });
+    expect(cap.prompt).toContain('>= 7');
+  });
+
+  it('uses the default >= 5 in the prompt when no option is passed', async () => {
+    const cap: { prompt?: string } = {};
+    await new SearchResultFilter(llmReturning(scores, cap)).filterResults(results, 'q');
+    expect(cap.prompt).toContain('>= 5');
+  });
+
+  it('still skips filtering below the 8-result floor even when strict', async () => {
+    const out = await new SearchResultFilter(llmReturning(scores))
+      .filterResults(mkResults(5), 'q', { minScore: STRICT_MIN_SCORE });
+    expect(out.filtered.length).toBe(5);
+  });
+
+  it('STRICT_MIN_SCORE is 7', () => {
+    expect(STRICT_MIN_SCORE).toBe(7);
+  });
+});

--- a/mcp_backend/src/services/search-result-filter.ts
+++ b/mcp_backend/src/services/search-result-filter.ts
@@ -2,7 +2,8 @@ import { logger } from '../utils/logger.js';
 import { withLLMRetry } from '../utils/llm-retry.js';
 import type { ILLMPort } from '../domain/ports/index.js';
 
-const FILTER_PROMPT = `Ти — юридичний асистент з ранжування. Тобі надано пошуковий запит користувача та список судових рішень (метадані).
+function filterPrompt(minScore: number): string {
+  return `Ти — юридичний асистент з ранжування. Тобі надано пошуковий запит користувача та список судових рішень (метадані).
 Оціни релевантність кожного рішення до запиту за шкалою 0-10.
 
 КРИТЕРІЇ:
@@ -11,10 +12,18 @@ const FILTER_PROMPT = `Ти — юридичний асистент з ранж�
 - 0-4: нерелевантне (інша тема, інша галузь права)
 
 Поверни ТІЛЬКИ JSON масив об'єктів: [{"doc_id": 12345, "score": 8}, ...]
-Порядок — за спаданням score. Включи ТІЛЬКИ рішення зі score >= 5.`;
+Порядок — за спаданням score. Включи ТІЛЬКИ рішення зі score >= ${minScore}.`;
+}
 
 const MIN_RESULTS_TO_FILTER = 8;
 const MIN_SCORE = 5;
+/**
+ * Stricter keep-threshold for when the FTS leg collapsed and the fused set is effectively
+ * vector-only (CORE-21 P1.5b). Without a precise FTS anchor, semantic search surfaces
+ * "partially relevant" (5-7) same-codex cases that get mis-cited as on-point practice;
+ * requiring 8-10 ("прямо стосується") drops that flood.
+ */
+export const STRICT_MIN_SCORE = 7;
 
 export class SearchResultFilter {
   constructor(private readonly llm: ILLMPort) {}
@@ -22,9 +31,10 @@ export class SearchResultFilter {
   async filterResults(
     results: any[],
     query: string,
-    options?: { maxResults?: number },
+    options?: { maxResults?: number; minScore?: number },
   ): Promise<{ filtered: any[]; original_count: number; filtered_count: number }> {
     const originalCount = results.length;
+    const minScore = options?.minScore ?? MIN_SCORE;
 
     if (results.length < MIN_RESULTS_TO_FILTER || !query?.trim()) {
       return { filtered: results, original_count: originalCount, filtered_count: originalCount };
@@ -48,7 +58,7 @@ export class SearchResultFilter {
         () => this.llm.chatCompletion(
           {
             messages: [
-              { role: 'system', content: FILTER_PROMPT },
+              { role: 'system', content: filterPrompt(minScore) },
               {
                 role: 'user',
                 content: `Запит: "${query}"\n\nРезультати (${summaries.length}):\n${JSON.stringify(summaries, null, 0)}`,
@@ -71,7 +81,7 @@ export class SearchResultFilter {
           const parsed = JSON.parse(objMatch[0]);
           const arr = parsed.results || parsed.decisions || parsed.items || Object.values(parsed).find(Array.isArray);
           if (Array.isArray(arr)) {
-            return this.applyScores(results, arr, query, options?.maxResults);
+            return this.applyScores(results, arr, query, options?.maxResults, minScore);
           }
         }
         logger.warn('[SearchResultFilter] Could not parse LLM response, returning unfiltered');
@@ -79,7 +89,7 @@ export class SearchResultFilter {
       }
 
       const scored: Array<{ doc_id: number; score: number }> = JSON.parse(jsonMatch[0]);
-      return this.applyScores(results, scored, query, options?.maxResults);
+      return this.applyScores(results, scored, query, options?.maxResults, minScore);
     } catch (err: any) {
       logger.warn('[SearchResultFilter] Filtering failed, returning unfiltered', { error: err.message });
       return { filtered: results, original_count: originalCount, filtered_count: originalCount };
@@ -91,6 +101,7 @@ export class SearchResultFilter {
     scored: Array<{ doc_id: number; score: number }>,
     query: string,
     maxResults?: number,
+    minScore: number = MIN_SCORE,
   ): { filtered: any[]; original_count: number; filtered_count: number } {
     const scoreMap = new Map<number, number>();
     for (const s of scored) {
@@ -102,7 +113,7 @@ export class SearchResultFilter {
     const filtered = results
       .filter(r => {
         const score = scoreMap.get(r.doc_id);
-        return score !== undefined && score >= MIN_SCORE;
+        return score !== undefined && score >= minScore;
       })
       .sort((a, b) => (scoreMap.get(b.doc_id) || 0) - (scoreMap.get(a.doc_id) || 0));
 


### PR DESCRIPTION
Paired safeguard to **P1.5a** (#1978). Even with IDF-ranked terms, an ultra-specific all-AND `plainto_tsquery` can return **0** (confirmed on prod `chat-be7051c7`: FTS leg = 0/0 on «сумування…окупована…територія»). The fused set is then effectively **vector-only**, and semantic search floods *partially relevant* (5-7) same-codex ст.266 cases that get mis-cited as on-point Supreme Court practice — the fabrication mechanism.

## Fix
When the FTS leg collapsed (`ftsResponse.total < FTS_RELAX_MIN_RESULTS`), raise the relevance-gate keep-threshold from **≥5** to **≥7** (8-10 = «прямо стосується») so only directly-relevant hits survive.

- **SearchResultFilter** — parameterized keep-threshold (`options.minScore`, default 5; exported `STRICT_MIN_SCORE=7`). The ranking prompt now interpolates the threshold so the LLM applies it. Default behaviour byte-for-byte unchanged.
- **edrsr-unified-search-tool** (hybrid path) — compute `ftsCollapsed`, pass strict `minScore` to `maybeFilter`/`filterResults`; log it; surface `legs.fts_collapsed` / `strict_relevance_gate`. Scoped to **hybrid only** (fulltext/semantic untouched).

## Why this is the right lever
The 8-result gate floor and the LLM judge already exist; this only tightens the cutoff in the one scenario where there's no FTS precision to anchor relevance. No new model calls, no new infra. Reuses the FTS-collapse signal from P1.5a.

## Tests
`search-result-filter-strict.test.ts` — **6 pass**: default keeps ≥5, strict keeps only ≥7 (drops the 5-6 flood), prompt reflects the threshold in both modes, 8-result floor still respected.

> Pre-existing `core-loader.ts` TS2307s are core-overlay-only files (resolved at CI build) — unrelated.

Part of CORE-21 v2 → P1 (CORE-43 → **CORE-46**). Builds on P1.5a (#1978).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a strict relevance gate for hybrid search when FTS returns too few results, raising the keep threshold from ≥5 to ≥7 so only directly relevant cases remain. Addresses CORE-21 P1.5b by preventing vector-only floods of partial matches.

- **New Features**
  - `SearchResultFilter`: parameterized `minScore` (default 5); exported `STRICT_MIN_SCORE=7`; threshold is interpolated into the ranking prompt.
  - Hybrid `edrsr-unified-search-tool`: detect FTS collapse (`ftsResponse.total < FTS_RELAX_MIN_RESULTS`), apply strict `minScore`, log, and expose `legs.fts_collapsed` and `strict_relevance_gate`.
  - Scope: hybrid path only; default behavior unchanged when FTS does not collapse.
  - Tests: verify default ≥5 vs strict ≥7, prompt includes the threshold, and filtering still skips below the 8-result floor.

<sup>Written for commit f889532b64eb3a8a508a736dcff3958ce2ec7d55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

