### PR TITLE
feat(edrsr): _eval_baseline A/B flag + retrieval eval harness (CORE-21 P1.eval)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -360,12 +360,15 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     filters: EdsrFtsFilters,
     limit: number,
     offset: number,
+    noIdf: boolean = false,
   ): Promise<{ result: EdsrFtsSearchResponse; usedQuery: string; startTokens: number; usedTokens: number; relaxedFromTokens?: number }> {
     const rawTokens = String(topicalQuery).trim().split(/\s+/).filter(Boolean);
     // CORE-21 P1.5a: order tokens by IDF (discriminative first) so the probe keeps rare
     // terms (донецьк/окупован/ДРРП) and relaxation drops the commonest (податок/майно),
     // instead of the positional tail. Empty idf map → original order (no regression).
-    const idf = this.ftsService ? await this.ftsService.lexemeDf(rawTokens, this.db) : new Map<string, number>();
+    // noIdf is the A/B baseline arm (P1.eval) — bypass the df lookup to reproduce the old
+    // positional behaviour for a controlled before/after.
+    const idf = (this.ftsService && !noIdf) ? await this.ftsService.lexemeDf(rawTokens, this.db) : new Map<string, number>();
     const tokens = selectFtsTerms(rawTokens, idf);
     const idfRanked = idf.size > 0;
     const startTokens = tokens.length;
@@ -507,8 +510,12 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     // Same term-budget relaxation as fulltext mode — the hybrid FTS leg previously passed
     // the full reformulated query uncapped, so one rare term collapsed it to 0 (the
     // semantic leg masked it, but lost the precise FTS hits). Cap + relax here too.
+    // P1.eval A/B baseline arm: bypass IDF term selection (P1.5a) and the strict relevance
+    // gate (P1.5b) to reproduce the pre-improvement retrieval for a controlled before/after.
+    // Debug-only; never set on normal traffic.
+    const evalBaseline = args._eval_baseline === true;
     const ftsPromise = this
-      .ftsWithRelaxation(ftsQuery, filters, candidateLimit, 0)
+      .ftsWithRelaxation(ftsQuery, filters, candidateLimit, 0, evalBaseline)
       .then(r => r.result)
       .catch((err: any) => { logger.warn('[EdsrUnifiedSearch] FTS leg failed', { error: err.message }); return null; });
 
@@ -586,7 +593,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     // mis-cited as on-point practice. Raise the relevance-gate bar to 8-10 in that case so
     // only directly-relevant hits survive. (Even IDF-ranked FTS — P1.5a — can return 0 on an
     // ultra-specific all-AND query; this is the paired safeguard.)
-    const ftsCollapsed = (ftsResponse?.total ?? 0) < FTS_RELAX_MIN_RESULTS;
+    const ftsCollapsed = (ftsResponse?.total ?? 0) < FTS_RELAX_MIN_RESULTS && !evalBaseline;
     if (ftsCollapsed) {
       logger.info('[EdsrUnifiedSearch] FTS collapsed — strict relevance gate', {
         fts_total: ftsResponse?.total ?? 0, min_score: STRICT_MIN_SCORE, candidates: enriched.length,
@@ -600,7 +607,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       ...(reformulated ? { reformulated: { fts: reformulated.fts, semantic: reformulated.semantic } } : {}),
       ...(partyName ? { party_filter: { party_name: partyName, party_role: partyRole || 'any' } } : {}),
       ...(instanceCode ? { instance_code: instanceCode } : {}),
-      legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length, ...(chunkBackfilled > 0 ? { fts_chunks_backfilled: chunkBackfilled } : {}), ...(ftsCollapsed ? { fts_collapsed: true, strict_relevance_gate: true } : {}) },
+      legs: { fts_available: !!ftsResponse, vector_available: !!vectorResults, fts_candidates: ftsResults.length, vector_candidates: vectorHits.length, ...(chunkBackfilled > 0 ? { fts_chunks_backfilled: chunkBackfilled } : {}), ...(ftsCollapsed ? { fts_collapsed: true, strict_relevance_gate: true } : {}), ...(evalBaseline ? { eval_baseline: true } : {}) },
       ...(structuralFilter ? { structural_filter: structuralFilter } : {}),
       total_fused: fused.length, returned: output.filtered.length,
       results: output.filtered,

--- a/scripts/edrsr/fts-ab-eval.mjs
+++ b/scripts/edrsr/fts-ab-eval.mjs
@@ -1,0 +1,103 @@
+// CORE-21 P1.eval — N-query A/B for FTS IDF selection (P1.5a) + strict relevance gate (P1.5b).
+//
+// For each curated query, calls search_court_decisions (hybrid) twice — treatment (current)
+// and baseline (_eval_baseline: bypasses IDF + strict gate) — then an INDEPENDENT Bedrock judge
+// scores each returned case's topical relevance from its own snippet. Reports precision@10
+// (fraction scored >= 7) per arm + deltas.
+//
+// Run inside the backend container (has localhost API + Bedrock creds):
+//   docker exec -e EVAL_JWT="$JWT" <backend> node /tmp/fts-ab-eval.mjs
+//
+import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
+
+const API = process.env.EVAL_API || 'http://localhost:3000';
+const JWT = process.env.EVAL_JWT;
+const MODEL = process.env.BEDROCK_MODEL_QUICK || 'eu.anthropic.claude-haiku-4-5-20251001-v1:0';
+const REGION = process.env.AWS_REGION || process.env.BEDROCK_REGION || 'eu-central-1';
+const RELEVANT = 7; // judge score >= this counts as on-topic
+
+if (!JWT) { console.error('EVAL_JWT env required'); process.exit(1); }
+const bedrock = new BedrockRuntimeClient({ region: REGION });
+
+const QUERIES = [
+  { q: 'податок на нерухоме майно сумування площі квартири на окупованій території Донецьк ДРРП', jk: 4 },
+  { q: 'оскарження податкового повідомлення-рішення з ПДВ безтоварні операції', jk: 4 },
+  { q: 'поновлення на роботі після незаконного звільнення працівника', jk: 1 },
+  { q: 'стягнення аліментів на утримання неповнолітньої дитини у твердій грошовій сумі', jk: 1 },
+  { q: 'визнання права власності на спадкове майно за заповітом', jk: 1 },
+  { q: 'розірвання шлюбу та поділ спільного майна подружжя', jk: 1 },
+  { q: 'відшкодування шкоди завданої внаслідок ДТП страхове відшкодування', jk: 1 },
+  { q: 'самовільне залишення військової частини військовослужбовцем під час воєнного стану', jk: 2 },
+  { q: 'керування транспортним засобом у стані алкогольного сп’яніння позбавлення права', jk: 5 },
+  { q: 'дрібне хуліганство адміністративний арешт', jk: 5 },
+  { q: 'банкрутство фізичної особи відновлення платоспроможності боржника', jk: 3 },
+  { q: 'визнання протиправним рішення про відмову у державній реєстрації права на нерухомість', jk: 4 },
+  { q: 'невиплата заробітної плати стягнення середнього заробітку за час затримки', jk: 1 },
+  { q: 'оскарження дій державного виконавця у виконавчому провадженні', jk: 4 },
+  { q: 'визнання недійсним договору купівлі-продажу нерухомого майна', jk: 1 },
+];
+
+async function search(query, jk, baseline) {
+  const body = { mode: 'hybrid', query, limit: 10, ...(jk ? { justice_kind: jk } : {}), ...(baseline ? { _eval_baseline: true } : {}) };
+  const r = await fetch(`${API}/api/tools/search_court_decisions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${JWT}` },
+    body: JSON.stringify(body),
+  });
+  const j = await r.json();
+  const textBlock = Array.isArray(j?.content) ? j.content.find(c => c.type === 'text')?.text : null;
+  const parsed = textBlock ? JSON.parse(textBlock) : j;
+  return { results: parsed.results || [], legs: parsed.legs || {} };
+}
+
+function snippet(r) {
+  return (r.qdrant_best_chunk_text || r.fts_headline || r.headline || '').replace(/\s+/g, ' ').slice(0, 280);
+}
+
+async function judge(query, results) {
+  if (!results.length) return { scored: {}, precision: null, n: 0 };
+  const items = results.map(r => ({ doc_id: r.doc_id, cause_num: r.cause_num, court: r.court_name, snippet: snippet(r) }));
+  const prompt =
+    `Запит користувача: "${query}"\n\n` +
+    `Нижче — судові рішення (номер, суд, фрагмент тексту). Для КОЖНОГО оціни, наскільки воно ПРЯМО ` +
+    `відповідає на правове питання запиту, за шкалою 0-10:\n` +
+    `- 8-10: прямо про те саме питання/статтю/обставини\n- 5-7: та сама галузь, але інше питання\n- 0-4: не стосується\n` +
+    `Суди СТРОГО за фрагментом тексту, не за номером. Поверни ЛИШЕ JSON-масив: [{"doc_id":N,"score":M}]\n\n` +
+    JSON.stringify(items);
+  const payload = { anthropic_version: 'bedrock-2023-05-31', max_tokens: 1024, temperature: 0, messages: [{ role: 'user', content: prompt }] };
+  try {
+    const resp = await bedrock.send(new InvokeModelCommand({ modelId: MODEL, contentType: 'application/json', body: JSON.stringify(payload) }));
+    const out = JSON.parse(new TextDecoder().decode(resp.body));
+    const text = out.content?.[0]?.text || '';
+    const arr = JSON.parse((text.match(/\[[\s\S]*\]/) || ['[]'])[0]);
+    const scored = {};
+    for (const s of arr) if (typeof s.doc_id !== 'undefined' && typeof s.score === 'number') scored[s.doc_id] = s.score;
+    const vals = results.map(r => scored[r.doc_id] ?? 0);
+    const rel = vals.filter(v => v >= RELEVANT).length;
+    return { scored, precision: rel / results.length, n: results.length, relevant: rel, avg: vals.reduce((a, b) => a + b, 0) / vals.length };
+  } catch (e) {
+    return { scored: {}, precision: null, n: results.length, error: e.message };
+  }
+}
+
+const rows = [];
+let bN = 0, tN = 0, bSum = 0, tSum = 0, collapseN = 0, strictN = 0;
+for (const { q, jk } of QUERIES) {
+  const [base, treat] = await Promise.all([search(q, jk, true), search(q, jk, false)]);
+  const [bj, tj] = await Promise.all([judge(q, base.results), judge(q, treat.results)]);
+  if (treat.legs.fts_collapsed) collapseN++;
+  if (treat.legs.strict_relevance_gate) strictN++;
+  if (bj.precision != null) { bN++; bSum += bj.precision; }
+  if (tj.precision != null) { tN++; tSum += tj.precision; }
+  rows.push({ q: q.slice(0, 42), jk,
+    base_n: base.results.length, base_p: bj.precision, base_avg: bj.avg,
+    treat_n: treat.results.length, treat_p: tj.precision, treat_avg: tj.avg,
+    collapsed: !!treat.legs.fts_collapsed, eval_ok: !!base.legs.eval_baseline });
+  const pct = x => x == null ? ' n/a' : (x * 100).toFixed(0).padStart(3) + '%';
+  console.log(`${pct(bj.precision)} → ${pct(tj.precision)}  [${base.results.length}/${treat.results.length}]  ${treat.legs.fts_collapsed ? 'COLLAPSE' : '        '}  ${q.slice(0, 50)}`);
+}
+
+console.log('\n=== A/B summary (precision@10, judge score >= 7) ===');
+console.log(`queries: ${QUERIES.length}  |  baseline mean: ${(bSum / bN * 100).toFixed(1)}%  treatment mean: ${(tSum / tN * 100).toFixed(1)}%  |  delta: ${((tSum / tN - bSum / bN) * 100).toFixed(1)} pp`);
+console.log(`FTS-collapse rate: ${collapseN}/${QUERIES.length}  |  strict-gate fired: ${strictN}/${QUERIES.length}  |  eval_baseline flag honored: ${rows.every(r => r.eval_ok)}`);
+console.log('\nJSON:', JSON.stringify({ rows, baseline_mean: bSum / bN, treatment_mean: tSum / tN }, null, 0));


### PR DESCRIPTION
Tooling to measure the **P1.5a (IDF) + P1.5b (strict gate)** retrieval improvements with a controlled before/after, instead of noisy single full-chat repros.

- **`_eval_baseline`** — debug-only per-request flag on hybrid `search_court_decisions`. Bypasses IDF term selection (→ positional) and the strict relevance gate (→ default minScore), reproducing pre-improvement retrieval. Defaults off; surfaced in `legs.eval_baseline`; zero impact on normal traffic.
- **`scripts/edrsr/fts-ab-eval.mjs`** — 15 curated diverse UA legal queries (tax/occupation repro + criminal/civil/labor/admin/family/procedural). Per query, calls the search API twice (baseline vs treatment), then an **independent Bedrock judge** scores each returned case's topical relevance **from its own snippet** (not the gate prompt, not metadata). Reports precision@10 per arm + delta, FTS-collapse / strict-gate rates. Runs in the backend container.

Result = a defensible number for the retrieval change, isolating it from stochastic chat synthesis. Edited tool file type-clean.

Part of CORE-21 v2 → P1 (CORE-43). Measures #1978 (P1.5a) + #1980 (P1.5b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a debug-only `_eval_baseline` A/B switch and a backend eval harness to measure P1.5a (IDF term ranking) and P1.5b (strict relevance gate) with clear before/after precision@10. Supports CORE-21 P1.eval by isolating retrieval changes from chat variability.

- **New Features**
  - Hybrid `search_court_decisions`: `_eval_baseline` skips IDF term selection and the strict relevance gate to reproduce pre-change retrieval; default off; exposed in `legs.eval_baseline`.
  - `scripts/edrsr/fts-ab-eval.mjs`: runs 15 curated queries, calls the API twice (baseline vs treatment), uses a Bedrock judge to score snippets, and reports precision@10 per arm plus collapse/gate stats. Requires `EVAL_JWT`; uses `@aws-sdk/client-bedrock-runtime`.

<sup>Written for commit e08f05cfbc72dcfe84ecaa0aadc1443ff51c4cf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

