### PR TITLE
feat(mcp): expose RADA/OpenReyestr gateway tools over MCP transports

### DIFF
--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -154,7 +154,15 @@ export function createMCPSSERoutes(deps: {
     );
 
     mcpServer.setRequestHandler(ListToolsRequestSchema, async () => {
-      return { tools: deps.toolRegistry.getLocalToolDefinitions() };
+      // Expose local backend tools + unified-gateway proxied tools (rada_*, openreyestr_*).
+      // Remote defs are fetched once and cached; executeTool() routes prefixed calls to the
+      // proxy. Falls back to local-only if remote services are unreachable.
+      try {
+        return { tools: await deps.toolRegistry.getAllToolDefinitions() };
+      } catch (err: any) {
+        logger.warn('[MCP] getAllToolDefinitions failed, serving local tools only', { error: err.message });
+        return { tools: deps.toolRegistry.getLocalToolDefinitions() };
+      }
     });
 
     mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {


### PR DESCRIPTION
## Запрос
Включить `rada_*` и `openreyestr_*` инструменты в MCP-подключение Claude Code (OAuth).

## Причина
MCP-транспорты (`/api/v1/mcp`, `/api/v1/sse`) в `tools/list` отдавали только локальные тулы (`getLocalToolDefinitions()`) — 81 шт. Прокси-тулы unified gateway не попадали, хотя на проде `ENABLE_UNIFIED_GATEWAY=true`, env'ы заданы, сервисы подняты, а `executeTool()` уже маршрутизирует `rada_*`/`openreyestr_*` на remote.

## Изменение
`buildMcpServer` → `tools/list` теперь использует `getAllToolDefinitions()` (local + remote, fetch один раз + кэш) с fallback на local-only при недоступности сервисов. Исполнение не меняется — префиксные вызовы уже проксируются.

Добавляет **4 RADA + 27 OpenReyestr** к обоим транспортам (итого ~112).

## Проверка (прод, до деплоя)
- `rada-mcp-app-prod` / `openreyestr-app-prod` — healthy, достижимы из backend-контейнера.
- `GET /api/tools`: RADA → 4, OpenReyestr → 27.
- После деплоя проверю `tools/list` через OAuth-сессию e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `rada_*` and `openreyestr_*` unified-gateway tools over MCP transports (`/api/v1/mcp`, `/api/v1/sse`) so OAuth clients see them in `tools/list`. Expands listings from local-only to include remote proxies.

- **New Features**
  - `tools/list` now uses `getAllToolDefinitions()` (local + remote, cached once).
  - Falls back to `getLocalToolDefinitions()` with a warning if remote services are unreachable.
  - No change to execution; `executeTool()` already routes prefixed calls to the proxy.
  - Adds 4 RADA and 27 OpenReyestr tools (total ~112).

<sup>Written for commit b0b882c9793a42aaf2449c7113e582cb8dc85d67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

