### PR TITLE
chore(backend): deploy core P0.enforce (CORE-21)

### DIFF
--- a/mcp_backend/CORE_OVERLAY.md
+++ b/mcp_backend/CORE_OVERLAY.md
@@ -10,6 +10,7 @@ a core-only change triggers a backend build + deploy.
 |------|-------------|-------|
 | 2026-06-23 | `17b1b0a` | CORE-21 P0.1 quote-or-drop (#55) + P0.2 claim↔source verifier (#57): warn-only citation-grounding gates (`ungrounded_quote`, `claim_unsupported`). |
 | 2026-06-23 | `3fd3bed` | CORE-21 P0.3 verify-before-stream (#58): high-stakes query types (practice/institutional/comparative_analysis, due_diligence) verify + repair citations before the answer is streamed — final answer renders at once, not token-by-token. |
+| 2026-06-23 | `810155f` | CORE-21 P0.enforce (#59): flip P0.1/P0.2 warn→enforce — unsupported quotes/holdings on real cited cases are now stripped from the answer (repairUnsupportedCitations), not just flagged. |
 
 > Update this row whenever a core change must reach prod. The overlay always uses
 > core `main` HEAD; keep the recorded commit equal to that HEAD at merge time.

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Rolls **CORE-21 P0.enforce** ([core#59](https://github.com/overthelex/secondlayer-core/pull/59), core `810155f`) to prod via the backend bump (re-clones core HEAD, blue-green).

**P0.enforce — behavioural change:** P0.1 (`ungrounded_quote`) + P0.2 (`claim_unsupported`) go warn-only → **enforce**. Real cited cases with a quote/holding their text doesn't support get the unsupported claim **removed** via `repairUnsupportedCitations`, not just flagged. Conservative + fail-open; supported mentions kept.

Diff: `package.json` 1.0.6→1.0.7 + `CORE_OVERLAY.md` row. 149 core tests green pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys CORE-21 P0.enforce: `ungrounded_quote` and `claim_unsupported` move from warn-only to enforce, removing unsupported quotes/holdings via `repairUnsupportedCitations`. Rolls the latest core to prod with a blue‑green deploy, bumps `mcp_backend` to 1.0.7, and records the rollout in CORE_OVERLAY.md.

<sup>Written for commit 2408b37b47b869f3643c404ab70b914d419c4033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

