### PR TITLE
fix(edrsr): correct response shape + robustness in fts-ab-eval harness

### DIFF
--- a/scripts/edrsr/fts-ab-eval.mjs
+++ b/scripts/edrsr/fts-ab-eval.mjs
@@ -39,15 +39,26 @@ const QUERIES = [
 
 async function search(query, jk, baseline) {
   const body = { mode: 'hybrid', query, limit: 10, ...(jk ? { justice_kind: jk } : {}), ...(baseline ? { _eval_baseline: true } : {}) };
-  const r = await fetch(`${API}/api/tools/search_court_decisions`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${JWT}` },
-    body: JSON.stringify(body),
-  });
-  const j = await r.json();
-  const textBlock = Array.isArray(j?.content) ? j.content.find(c => c.type === 'text')?.text : null;
-  const parsed = textBlock ? JSON.parse(textBlock) : j;
-  return { results: parsed.results || [], legs: parsed.legs || {} };
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 90_000);
+  try {
+    const r = await fetch(`${API}/api/tools/search_court_decisions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${JWT}` },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+    const j = await r.json();
+    // HTTP wraps the tool result: { success, tool, result: { content: [{type:'text', text}] } }
+    const content = j?.result?.content ?? j?.content;
+    const textBlock = Array.isArray(content) ? content.find(c => c.type === 'text')?.text : null;
+    const parsed = textBlock ? JSON.parse(textBlock) : (j?.result ?? j);
+    return { results: parsed.results || [], legs: parsed.legs || {} };
+  } catch (e) {
+    return { results: [], legs: {}, error: e.name === 'AbortError' ? 'timeout' : e.message };
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 function snippet(r) {
@@ -82,22 +93,29 @@ async function judge(query, results) {
 
 const rows = [];
 let bN = 0, tN = 0, bSum = 0, tSum = 0, collapseN = 0, strictN = 0;
+const pct = x => x == null ? ' n/a' : (x * 100).toFixed(0).padStart(3) + '%';
 for (const { q, jk } of QUERIES) {
-  const [base, treat] = await Promise.all([search(q, jk, true), search(q, jk, false)]);
-  const [bj, tj] = await Promise.all([judge(q, base.results), judge(q, treat.results)]);
-  if (treat.legs.fts_collapsed) collapseN++;
-  if (treat.legs.strict_relevance_gate) strictN++;
-  if (bj.precision != null) { bN++; bSum += bj.precision; }
-  if (tj.precision != null) { tN++; tSum += tj.precision; }
-  rows.push({ q: q.slice(0, 42), jk,
-    base_n: base.results.length, base_p: bj.precision, base_avg: bj.avg,
-    treat_n: treat.results.length, treat_p: tj.precision, treat_avg: tj.avg,
-    collapsed: !!treat.legs.fts_collapsed, eval_ok: !!base.legs.eval_baseline });
-  const pct = x => x == null ? ' n/a' : (x * 100).toFixed(0).padStart(3) + '%';
-  console.log(`${pct(bj.precision)} → ${pct(tj.precision)}  [${base.results.length}/${treat.results.length}]  ${treat.legs.fts_collapsed ? 'COLLAPSE' : '        '}  ${q.slice(0, 50)}`);
+  try {
+    const [base, treat] = await Promise.all([search(q, jk, true), search(q, jk, false)]);
+    const [bj, tj] = await Promise.all([judge(q, base.results), judge(q, treat.results)]);
+    if (treat.legs.fts_collapsed) collapseN++;
+    if (treat.legs.strict_relevance_gate) strictN++;
+    if (bj.precision != null) { bN++; bSum += bj.precision; }
+    if (tj.precision != null) { tN++; tSum += tj.precision; }
+    rows.push({ q: q.slice(0, 42), jk,
+      base_n: base.results.length, base_p: bj.precision, base_avg: bj.avg,
+      treat_n: treat.results.length, treat_p: tj.precision, treat_avg: tj.avg,
+      collapsed: !!treat.legs.fts_collapsed, eval_ok: !!base.legs.eval_baseline,
+      err: base.error || treat.error || null });
+    console.log(`${pct(bj.precision)} → ${pct(tj.precision)}  [${base.results.length}/${treat.results.length}]  ${treat.legs.fts_collapsed ? 'COLLAPSE' : '        '}  ${base.error || treat.error ? '(' + (base.error || treat.error) + ') ' : ''}${q.slice(0, 48)}`);
+  } catch (e) {
+    console.log(` ERR  ${q.slice(0, 48)} :: ${e.message}`);
+    rows.push({ q: q.slice(0, 42), jk, err: e.message });
+  }
 }
 
+const bMean = bN ? bSum / bN : null, tMean = tN ? tSum / tN : null;
 console.log('\n=== A/B summary (precision@10, judge score >= 7) ===');
-console.log(`queries: ${QUERIES.length}  |  baseline mean: ${(bSum / bN * 100).toFixed(1)}%  treatment mean: ${(tSum / tN * 100).toFixed(1)}%  |  delta: ${((tSum / tN - bSum / bN) * 100).toFixed(1)} pp`);
-console.log(`FTS-collapse rate: ${collapseN}/${QUERIES.length}  |  strict-gate fired: ${strictN}/${QUERIES.length}  |  eval_baseline flag honored: ${rows.every(r => r.eval_ok)}`);
+console.log(`queries: ${QUERIES.length}  scored arms: base ${bN}, treat ${tN}  |  baseline mean: ${pct(bMean)}  treatment mean: ${pct(tMean)}  |  delta: ${bMean != null && tMean != null ? ((tMean - bMean) * 100).toFixed(1) + ' pp' : 'n/a'}`);
+console.log(`FTS-collapse rate: ${collapseN}/${QUERIES.length}  |  strict-gate fired: ${strictN}/${QUERIES.length}  |  eval_baseline honored: ${rows.filter(r => r.eval_ok).length}/${rows.length}`);
 console.log('\nJSON:', JSON.stringify({ rows, baseline_mean: bSum / bN, treatment_mean: tSum / tN }, null, 0));


### PR DESCRIPTION
Follow-up to #1982. The A/B eval harness parsed `j.content`, but the HTTP `/api/tools/:tool` endpoint wraps the tool result under **`j.result.content`** — so on the first run every arm returned 0 results (`[0/0]`). Plus hardening against the env churn seen during the prod run.

- Parse `j.result?.content ?? j.content`.
- Per-search `AbortController` (90s) — a slow/hung search yields `timeout`, not an indefinite hang.
- Per-query `try/catch` — one failure no longer aborts the whole run.
- Null-safe summary (no `NaN` when an arm has zero scored queries).

Validated on prod after the fix: 15-query run completed — baseline **57.0%** vs treatment **56.0%** precision@10 (−1.1 pp, within noise; gains concentrate on the FTS-collapse case). Script-only change (not built/tested by CI).

Part of CORE-21 v2 → P1.eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the FTS A/B eval harness to read the HTTP tool response (`j.result.content`), restoring real results instead of [0/0] and correct precision metrics. Adds resilience (timeouts and per-query error handling) to meet CORE-21 P1.eval reliability needs.

- **Bug Fixes**
  - Parse `j.result?.content ?? j.content`; fallback keeps local runs working.
  - Add per-search `AbortController` (90s) to return `timeout` instead of hanging.
  - Wrap each query in `try/catch` so one failure doesn’t stop the run.
  - Null-safe summary and clearer logs (scored-arm counts, `eval_baseline` check, error notes).

<sup>Written for commit 92cb5559999ec6e6d4ff43318d4c48a78466a563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

