### PR TITLE
fix(chat): render grounding citation-warnings without NaN% confidence

### DIFF
--- a/lexwebapp/src/components/message/AssistantMessage.tsx
+++ b/lexwebapp/src/components/message/AssistantMessage.tsx
@@ -187,6 +187,33 @@ export function AssistantMessage({
                     </motion.div>
                   );
                 }
+                if (warning.kind === 'grounding') {
+                  const caption: Record<typeof warning.reason, string> = {
+                    low_relevance_case_numbers: 'Можливо, не стосується запиту',
+                    subject_matter_mismatch: 'Інший предмет спору',
+                    ungrounded_quote: 'Цитату не знайдено в тексті',
+                    claim_unsupported: 'Зміст не підтверджено текстом',
+                  };
+                  return (
+                    <motion.div
+                      key={`cw-${idx}`}
+                      initial={{ opacity: 0, y: -4 }}
+                      animate={{ opacity: 1, y: 0 }}
+                      transition={{ duration: 0.25, delay: idx * 0.08 }}
+                      className="flex items-start gap-3 px-3.5 py-3 rounded-lg border bg-amber-50/70 border-amber-200/60"
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="text-[13px] leading-relaxed text-amber-800">
+                          {warning.message}
+                        </p>
+                        <p className="text-[11px] text-amber-700/80 mt-1 font-mono">
+                          {caption[warning.reason]}
+                          {warning.cases.length > 0 ? ` · ${warning.cases.join(', ')}` : ''}
+                        </p>
+                      </div>
+                    </motion.div>
+                  );
+                }
                 return (
                   <motion.div
                     key={`cw-${idx}`}

--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -328,13 +328,21 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
               ? { kind: 'fabricated', fabricated: data.fabricated, message: data.message }
               : data.reason === 'unverified_law_articles'
                 ? { kind: 'unverified_articles', unverified: data.unverified, message: data.message }
-                : {
-                    kind: 'overruled',
-                    case_number: data.case_number,
-                    status: data.status,
-                    confidence: data.confidence,
-                    message: data.message,
-                  };
+                : data.reason === 'low_relevance_case_numbers'
+                  ? { kind: 'grounding', reason: data.reason, cases: data.lowRelevance, message: data.message }
+                  : data.reason === 'subject_matter_mismatch'
+                    ? { kind: 'grounding', reason: data.reason, cases: data.mismatches.map((m) => m.caseNumber), message: data.message }
+                    : data.reason === 'ungrounded_quote'
+                      ? { kind: 'grounding', reason: data.reason, cases: data.ungrounded.map((u) => u.caseNumber), message: data.message }
+                      : data.reason === 'claim_unsupported'
+                        ? { kind: 'grounding', reason: data.reason, cases: data.unsupported.map((u) => u.caseNumber), message: data.message }
+                        : {
+                            kind: 'overruled',
+                            case_number: data.case_number,
+                            status: data.status,
+                            confidence: data.confidence,
+                            message: data.message,
+                          };
           updateMessage(assistantMessageId, {
             citationWarnings: [...existing, normalized],
           });

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -30,6 +30,29 @@ export type CitationWarning =
       reason: 'unverified_law_articles';
       unverified: string[];
       message: string;
+    }
+  // Grounding/relevance gates (chat-answer-verification.ts). These carry NO
+  // confidence/status — the message is self-contained. Do NOT map them to the
+  // `overruled` shape (that produced "Частково змінено · впевненість: NaN%").
+  | {
+      reason: 'low_relevance_case_numbers';
+      lowRelevance: string[];
+      message: string;
+    }
+  | {
+      reason: 'subject_matter_mismatch';
+      mismatches: Array<{ caseNumber: string; claimed: string; actual: string }>;
+      message: string;
+    }
+  | {
+      reason: 'ungrounded_quote';
+      ungrounded: Array<{ caseNumber: string }>;
+      message: string;
+    }
+  | {
+      reason: 'claim_unsupported';
+      unsupported: Array<{ caseNumber: string; reason: string }>;
+      message: string;
     };
 
 import type { Decision, Citation, VaultDocument } from '../../types/models/Message';

--- a/lexwebapp/src/types/models/Message.ts
+++ b/lexwebapp/src/types/models/Message.ts
@@ -3,13 +3,24 @@
  */
 
 /**
- * Per-message warning about one of two distinct problems:
+ * Per-message warning. Several distinct problems share this channel:
  * - `overruled`: shepardization found the cited case was overruled/modified
  *   by a higher court (legacy path, emitted by ShepardizationService).
+ *   Only this kind carries `confidence`/`status`.
  * - `fabricated`: LEXAI-637 — the model cited a case number that never
  *   appeared in any tool result of the current turn. Pulled from prior
  *   messages' context or from training memory.
+ * - `unverified_articles`: cited law articles not confirmed by search/DB.
+ * - `grounding`: relevance/grounding gates in chat-answer-verification.ts —
+ *   real cases cited for the wrong proposition. NO confidence/status; the
+ *   backend message is self-contained. `reason` distinguishes the sub-gate.
  */
+export type GroundingWarningReason =
+  | 'low_relevance_case_numbers'
+  | 'subject_matter_mismatch'
+  | 'ungrounded_quote'
+  | 'claim_unsupported';
+
 export type CitationWarning =
   | {
       kind: 'overruled';
@@ -26,6 +37,12 @@ export type CitationWarning =
   | {
       kind: 'unverified_articles';
       unverified: string[];
+      message: string;
+    }
+  | {
+      kind: 'grounding';
+      reason: GroundingWarningReason;
+      cases: string[];
       message: string;
     };
 


### PR DESCRIPTION
## Problem

Repro: chat-f8dbb84e-0769-4e49-b0ac-5797f3fe26b9 — grounding warnings rendered as **«Частково змінено · впевненість: NaN%»**.

The backend (`mcp_backend/.../chat-answer-verification.ts`) emits **four** grounding/relevance citation-warning kinds, none of which carry `confidence`/`status`:

- `low_relevance_case_numbers`
- `subject_matter_mismatch`
- `ungrounded_quote`
- `claim_unsupported`

The frontend was out of sync: `useAIChatStream` only special-cased `fabricated_case_numbers` and `unverified_law_articles`, so all four new reasons fell through to the `overruled` shape. The renderer then computed `Math.round(warning.confidence * 100)` on an absent field → **`NaN%`**, and mislabeled them **«Частково змінено»** (these cases were never overruled by a higher court).

This is a display-only bug — it does not affect the answer. The substantive root cause (model citing off-topic cases whose full text was never loaded) is tracked separately.

## Fix

- `MCPService.ts` — add the four raw SSE shapes to the `CitationWarning` union.
- `Message.ts` — add a normalized `grounding` kind (`reason` + `cases` + `message`, no confidence).
- `useAIChatStream.ts` — normalize the four reasons explicitly instead of the `overruled` fallback.
- `AssistantMessage.tsx` — render grounding warnings as amber cards with a per-reason caption and the affected case numbers; never a confidence percentage.

## Verification

- `tsc --noEmit` clean
- `npm run build` succeeds
- No existing tests cover these components (ESLint is broken at repo root via a pre-existing `ajv` dependency issue, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misrendered grounding citation warnings that showed “Частково змінено · впевненість: NaN%”. Grounding warnings now display as clear amber notices with reason and affected cases, never a confidence percent.

- **Bug Fixes**
  - Synced frontend with backend by adding four grounding warning kinds to `MCPService` SSE types.
  - Introduced a normalized `grounding` warning shape (`reason`, `cases`, `message`) in the message model.
  - Mapped the four reasons in `useAIChatStream` instead of falling back to `overruled`.
  - Updated `AssistantMessage` to render grounding cards with per-reason captions and case numbers, without confidence/status.

<sup>Written for commit 0ce834776b3351d5f0ce829c7eaabe5d3bbb7b9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

