### PR TITLE
chore(rada): add Group A laws to historical-editions loader

### DIFF
--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -46,6 +46,16 @@ const CODES: Array<{ rada_id: string; short_title: string }> = [
   { rada_id: '4495-17', short_title: 'МК' },
   { rada_id: '435-15', short_title: 'ЦК' },
   { rada_id: '5403-17', short_title: 'КЦЗ' },
+  // Group A: substantive laws that already have current article text loaded
+  // (total_articles > 0) but no historical editions yet.
+  { rada_id: '1058-15', short_title: 'ПЕНС-ЗДПС' },     // Про загальнообов'язкове державне пенсійне страхування
+  { rada_id: '389-19', short_title: 'ВОЄННИЙ-СТАН' },   // Про правовий режим воєнного стану
+  { rada_id: '1576-12', short_title: 'ГОСП-ТОВ' },      // Про господарські товариства
+  { rada_id: '2262-12', short_title: 'ПЕНС-ВІЙСЬК' },   // Про пенсійне забезпечення осіб, звільнених з військової служби
+  { rada_id: '2275-19', short_title: 'ТОВ-ТДВ' },       // Про товариства з обмеженою та додатковою відповідальністю
+  { rada_id: '2778-17', short_title: 'КУЛЬТУРА' },      // Про культуру
+  { rada_id: '1023-12', short_title: 'ЗПС' },           // Про захист прав споживачів
+  { rada_id: '2011-12', short_title: 'ЗАХ-ВІЙСЬК' },    // Про соціальний і правовий захист військовослужбовців
 ];
 
 // ─── Token Bucket Rate Limiter ───────────────────────────────────────────────


### PR DESCRIPTION
## What

Extends the hardcoded `CODES` list in `scripts/rada/import-historical-editions.ts` with **8 substantive laws** (Group A) that already had current article text in prod but **no historical editions** loaded.

## Why

Audit of prod found historical editions were loaded for only 16 of 585 acts (Конституція + основні кодекси). 241 laws/codes had none. Group A = the subset whose article text was already present, so editions could be backfilled immediately.

## Result (already imported to prod)

Ran the loader against prod (external scrape from zakon.rada.gov.ua → prod DB). **478 editions / 29,123 historical articles** imported. Acts with editions on prod: **16 → 24**.

| rada_id | акт | editions |
|---|---|---|
| 1058-15 | Про загальнообов'язкове державне пенсійне страхування | 114 |
| 2011-12 | Про соц. і правовий захист військовослужбовців | 108 |
| 2262-12 | Про пенсійне забезпечення військових | 89 |
| 1576-12 | Про господарські товариства | 46 |
| 1023-12 | Про захист прав споживачів | 43 |
| 389-19 | Про правовий режим воєнного стану | 33 |
| 2778-17 | Про культуру | 31 |
| 2275-19 | Про ТОВ та ТДВ | 14 |

This PR just persists the `CODES` additions so future `--all`/`--resume` runs include these acts. No runtime/service code touched.

## Verification
`mcp__secondlayer__list_legislation_editions {rada_id:'2778-17'}` now returns 31 editions (2010–2024).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds eight Group A laws to the `CODES` list in `scripts/rada/import-historical-editions.ts` so the historical-editions loader includes them on future `--all`/`--resume` runs. This preserves the prod backfill (478 editions / 29,123 historical articles) and raises covered acts with editions from 16 to 24.

<sup>Written for commit fe30c079b1320ba5bf1b4fc1772da15bfdd1428e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

