### PR TITLE
fix(rada): parse statute numbered-point articles

### DIFF
--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -287,6 +287,43 @@ function extractArticlesFromEditionHtml(html: string): Array<{ article_number: s
     }
   }
 
+  // Statute fallback: military statutes (Статут внутрішньої служби, Стройовий,
+  // Гарнізонної служби, Дисциплінарний — 548..551) are NOT structured with
+  // "Стаття N" headers. Their articles are continuously-numbered points ("9.",
+  // "10.", ...) grouped under "Розділ" headings; the only "Стаття" tokens are
+  // {amendment notes} in curly braces, which we strip. Extract the numbered
+  // points as articles.
+  if (articles.length < 3) {
+    seen.clear();
+    articles.length = 0;
+    const text = html
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/(p|div|tr|li|h[1-6])>/gi, '\n')
+      .replace(/<[^>]+>/g, ' ')
+      .replace(/&nbsp;/g, ' ').replace(/&mdash;/g, '—').replace(/&laquo;/g, '«').replace(/&raquo;/g, '»').replace(/&amp;/g, '&')
+      .replace(/\{[^}]*\}/g, ' ')          // drop amendment annotations
+      .replace(/[ \t]+/g, ' ');
+    // A point starts at a line boundary: "N. " followed by a capital letter or «.
+    // Body runs until the next such point, a Розділ/Глава heading, or end.
+    const pointRegex = /(?:^|\n)\s*(\d{1,3})\.\s+([А-ЯІЇЄҐ«][\s\S]*?)(?=\n\s*\d{1,3}\.\s+[А-ЯІЇЄҐ«]|\n\s*(?:Розділ|РОЗДІЛ|Глава|ГЛАВА)\s|$)/g;
+    let pm: RegExpExecArray | null;
+    while ((pm = pointRegex.exec(text)) !== null) {
+      const num = pm[1];
+      if (seen.has(num)) continue;
+      const body = pm[2].replace(/\n\s*\n/g, '\n').replace(/[ \t]+/g, ' ').trim();
+      if (body.length < 15) continue;
+      seen.add(num);
+      articles.push({
+        article_number: num,
+        title: undefined,
+        full_text: body,
+        byte_size: Buffer.byteLength(body, 'utf8'),
+      });
+    }
+    // Guard against spurious matches: require a real run of points.
+    if (articles.length < 5) articles.length = 0;
+  }
+
   return articles;
 }
 


### PR DESCRIPTION
## What

Adds a numbered-point fallback to `extractArticlesFromEditionHtml` in `scripts/rada/import-historical-editions.ts`.

## Why

Military statutes (`548-551`) and some other acts (`3894-12`) are **not** structured with `Стаття N` headers. Their articles are continuously-numbered points (`9.`, `10.`, …) grouped under `Розділ` headings; the only `Стаття` tokens are `{amendment notes}` in curly braces (which the parser strips). So the existing parser extracted **0 articles**, and since the loader skips editions with 0 articles, these acts got `total_editions = 0`.

## Fix

When all `Стаття`-based tiers yield `< 3` articles, extract numbered points from the de-tagged, brace-stripped text: line-anchored `N. <Capital>` runs, each captured until the next point or a `Розділ`/`Глава` heading. Guarded by a `>= 5` minimum to avoid spurious matches. **Only triggers when `Стаття` parsing fails**, so the 130+ normal laws/codes already loaded are unaffected (no regression).

## Result (applied to prod)

| Act | Articles | Editions |
|---|---|---|
| 548-14 Статут внутрішньої служби | 401 | 40 |
| 549-14 Стройовий статут | 252 | 12 |
| 550-14 Статут гарнізонної служби | 307 | 27 |
| 551-14 Дисциплінарний статут | 89 | 26 |
| 3894-12 | 9 | 2 |

Latest in-force edition promoted to `is_current`; text verified valid UTF-8. **law/code acts with editions: 135 → 140, 5420 total editions.** This closes the statute tail of the Group B backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes article parsing for Rada statutes that use numbered points instead of “Стаття N”, so these editions are no longer skipped. Adds a guarded fallback in `scripts/rada/import-historical-editions.ts` without affecting normal laws.

- **Bug Fixes**
  - Fallback: if “Стаття”-based parsing returns <3 articles, extract line-start `N.` points from de-tagged, brace-stripped text; stop at next point or `Розділ/Глава`; require ≥5 matches.
  - Covers military statutes `548-14`–`551-14` and `3894-12`; now imports 1,058 articles across 107 editions.
  - Only triggers on failure of the primary path; normal acts unchanged.

<sup>Written for commit 21e455180d6f335bbe7a9e95d05dabe9bc14c4d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

