### PR TITLE
feat: query-ir slot-IR + whitelist + buildWhere (registry & EDRSR adopt it)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -12,6 +12,7 @@
  */
 
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { buildWhere, type FieldDef } from '@secondlayer/shared';
 import { logger } from '../../utils/logger.js';
 import { EDRSR_METADATA_SEARCH_ORDER } from '../../services/search-ranking-config.js';
 import type { SearchResultFilter } from '../../services/search-result-filter.js';
@@ -269,10 +270,6 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       if (!args.justice_kind) args.justice_kind = 5;
     }
 
-    const conditions: string[] = [];
-    const params: any[] = [];
-    let paramIdx = 1;
-
     let resolvedCourtCodes: number[] | null = null;
     if (args.court_name && !args.court_code) {
       const courtResult = await this.db.query(
@@ -286,24 +283,33 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       }
     }
 
-    if (args.cause_num) { conditions.push(`d.cause_num = $${paramIdx}`); params.push(args.cause_num); paramIdx++; }
-    if (args.judge) { conditions.push(`LOWER(d.judge) LIKE LOWER($${paramIdx})`); params.push(`%${args.judge}%`); paramIdx++; }
-    if (args.court_code) { conditions.push(`d.court_code = $${paramIdx}`); params.push(args.court_code); paramIdx++; }
-    else if (resolvedCourtCodes?.length) { conditions.push(`d.court_code = ANY($${paramIdx})`); params.push(resolvedCourtCodes); paramIdx++; }
-    if (args.justice_kind) { conditions.push(`d.justice_kind = $${paramIdx}`); params.push(args.justice_kind); paramIdx++; }
-    if (args.judgment_code) { conditions.push(`d.judgment_code = $${paramIdx}`); params.push(args.judgment_code); paramIdx++; }
-    if (args._military_category_codes?.length) { conditions.push(`d.category_code = ANY($${paramIdx})`); params.push(args._military_category_codes); paramIdx++; }
-    else if (args._kupap_category_codes?.length) { conditions.push(`d.category_code = ANY($${paramIdx})`); params.push(args._kupap_category_codes); paramIdx++; }
-    else if (args.category_code) { conditions.push(`d.category_code = $${paramIdx}`); params.push(args.category_code); paramIdx++; }
-    if (args.date_from) { conditions.push(`d.adjudication_date >= $${paramIdx}`); params.push(args.date_from); paramIdx++; }
-    if (args.date_to) { conditions.push(`d.adjudication_date <= $${paramIdx}`); params.push(args.date_to); paramIdx++; }
-    if (args.instance_code) { conditions.push(`c.instance_code = $${paramIdx}`); params.push(args.instance_code); paramIdx++; }
+    // Whitelisted slot → SQL mapping, assembled by the shared safe builder.
+    // Field order preserved for param-index parity; scalar-vs-array branches
+    // (court_code, category) and military→kupap→category precedence mirror the
+    // previous inline logic exactly. judge uses ILIKE (idx_edrsr_docs_judge is a
+    // plain b-tree, unusable under a leading-wildcard LIKE either way, so ILIKE
+    // is result-identical to the former LOWER(judge) LIKE LOWER()).
+    const fields: FieldDef[] = [];
+    const filters: Record<string, any> = {};
+    const add = (def: FieldDef, value: any) => { fields.push(def); filters[def.name] = value; };
 
-    if (conditions.length === 0) {
+    if (args.cause_num) add({ name: 'cause_num', match: 'exact', columns: ['d.cause_num'] }, args.cause_num);
+    if (args.judge) add({ name: 'judge', match: 'ilike', columns: ['d.judge'] }, args.judge);
+    if (args.court_code) add({ name: 'court_code', match: 'exact', columns: ['d.court_code'] }, args.court_code);
+    else if (resolvedCourtCodes?.length) add({ name: 'court_codes', match: 'eq_any', columns: ['d.court_code'] }, resolvedCourtCodes);
+    if (args.justice_kind) add({ name: 'justice_kind', match: 'exact', columns: ['d.justice_kind'] }, args.justice_kind);
+    if (args.judgment_code) add({ name: 'judgment_code', match: 'exact', columns: ['d.judgment_code'] }, args.judgment_code);
+    if (args._military_category_codes?.length) add({ name: 'military_category', match: 'eq_any', columns: ['d.category_code'] }, args._military_category_codes);
+    else if (args._kupap_category_codes?.length) add({ name: 'kupap_category', match: 'eq_any', columns: ['d.category_code'] }, args._kupap_category_codes);
+    else if (args.category_code) add({ name: 'category_code', match: 'exact', columns: ['d.category_code'] }, args.category_code);
+    if (args.date_from) add({ name: 'date_from', match: 'gte', columns: ['d.adjudication_date'] }, args.date_from);
+    if (args.date_to) add({ name: 'date_to', match: 'lte', columns: ['d.adjudication_date'] }, args.date_to);
+    if (args.instance_code) add({ name: 'instance_code', match: 'exact', columns: ['c.instance_code'] }, args.instance_code);
+
+    const { whereClause, values: params, nextParamIndex: paramIdx } = buildWhere(fields, filters);
+    if (!whereClause) {
       return this.wrapError('Потрібен хоча б один параметр пошуку');
     }
-
-    const whereClause = conditions.join(' AND ');
     const needsCourtJoin = args.instance_code || args.court_name;
     const includeFulltext = args.include_fulltext === true;
 

--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -9,26 +9,10 @@
  * state-registry-tools.ts, spending-tools.ts (partial).
  */
 
-export type MatchType =
-  | 'ilike'         // col ILIKE $N  (%val%)
-  | 'exact'         // col = $N
-  | 'ilike_multi'   // (col1 ILIKE $N OR col2 ILIKE $N ...)  (%val%)
-  | 'exact_multi'   // (col1 = $N OR col2 = $N ...)
-  | 'gte'           // col >= $N
-  | 'lte'           // col <= $N
-  | 'array_contains' // $N = ANY(col)
-  | 'ilike_cast'    // col::text ILIKE $N  (%val%)
-  | 'fts'           // to_tsvector('english', col) @@ plainto_tsquery('english', $N)
-  | 'fts_simple';   // to_tsvector('simple', col) @@ plainto_tsquery('simple', $N)
-
-export interface FieldDef {
-  name: string;
-  description: string;
-  match: MatchType;
-  columns: string[];
-  type?: 'string' | 'number' | 'boolean';
-  transform?: 'uppercase';
-}
+// MatchType / FieldDef are the canonical query-builder primitives, now owned by
+// @secondlayer/shared/query-ir so registry AND EDRSR share one definition.
+import type { MatchType, FieldDef } from '@secondlayer/shared';
+export type { MatchType, FieldDef };
 
 export interface RegistryDef {
   title: string;

--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -7,6 +7,7 @@
 
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { REGISTRY_CATALOG, RegistryDef, FieldDef } from './registry-catalog.js';
+import { buildWhere } from '@secondlayer/shared';
 import { logger } from '../../utils/logger.js';
 
 const REGISTRY_KEYS = Object.keys(REGISTRY_CATALOG);
@@ -115,85 +116,10 @@ ${registryDescriptions}
     fields: FieldDef[],
     filters: Record<string, any>
   ): { whereClause: string | null; values: any[]; paramIndex: number } {
-    const conditions: string[] = [];
-    const values: any[] = [];
-    let pi = 1;
-
-    for (const field of fields) {
-      let val = filters[field.name];
-      if (val === undefined || val === null || val === '') continue;
-
-      if (field.type === 'number') val = Number(val);
-      if (field.transform === 'uppercase' && typeof val === 'string') val = val.toUpperCase();
-
-      switch (field.match) {
-        case 'ilike':
-          conditions.push(`${field.columns[0]} ILIKE $${pi}`);
-          values.push(`%${val}%`);
-          pi++;
-          break;
-
-        case 'exact':
-          conditions.push(`${field.columns[0]} = $${pi}`);
-          values.push(val);
-          pi++;
-          break;
-
-        case 'ilike_multi':
-          conditions.push(`(${field.columns.map(c => `${c} ILIKE $${pi}`).join(' OR ')})`);
-          values.push(`%${val}%`);
-          pi++;
-          break;
-
-        case 'exact_multi':
-          conditions.push(`(${field.columns.map(c => `${c} = $${pi}`).join(' OR ')})`);
-          values.push(val);
-          pi++;
-          break;
-
-        case 'gte':
-          conditions.push(`${field.columns[0]} >= $${pi}`);
-          values.push(val);
-          pi++;
-          break;
-
-        case 'lte':
-          conditions.push(`${field.columns[0]} <= $${pi}`);
-          values.push(val);
-          pi++;
-          break;
-
-        case 'array_contains':
-          conditions.push(`$${pi} = ANY(${field.columns[0]})`);
-          values.push(val);
-          pi++;
-          break;
-
-        case 'ilike_cast':
-          conditions.push(`${field.columns[0]}::text ILIKE $${pi}`);
-          values.push(`%${val}%`);
-          pi++;
-          break;
-
-        case 'fts':
-          conditions.push(`to_tsvector('english', ${field.columns[0]}) @@ plainto_tsquery('english', $${pi})`);
-          values.push(val);
-          pi++;
-          break;
-
-        case 'fts_simple':
-          conditions.push(`to_tsvector('simple', ${field.columns[0]}) @@ plainto_tsquery('simple', $${pi})`);
-          values.push(val);
-          pi++;
-          break;
-      }
-    }
-
-    return {
-      whereClause: conditions.length > 0 ? conditions.join(' AND ') : null,
-      values,
-      paramIndex: pi,
-    };
+    // Delegates to the shared query-builder (single source of WHERE-building
+    // logic for registry + EDRSR). `paramIndex` = next free $N for LIMIT.
+    const { whereClause, values, nextParamIndex } = buildWhere(fields, filters);
+    return { whereClause, values, paramIndex: nextParamIndex };
   }
 
   private describeRegistry(key: string, def: RegistryDef): string {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -30,7 +30,8 @@
     "openai": "^6.27.0",
     "pg": "^8.20.0",
     "uuid": "^14.0.0",
-    "winston": "^3.11.0"
+    "winston": "^3.11.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,9 @@
 export { createLogger, logger, type Logger } from './utils/logger';
 export * as queryIr from './query-ir';
+// Query-builder primitives re-exported at top level (no name collision with ./types).
+export { buildWhere } from './query-ir/build-where';
+export type { BuildWhereOptions, BuildWhereResult } from './query-ir/build-where';
+export type { FieldDef, MatchType } from './query-ir/field-def';
 export * from './utils/model-selector';
 export * from './utils/openai-client';
 export * from './utils/anthropic-client';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,5 @@
 export { createLogger, logger, type Logger } from './utils/logger';
+export * as queryIr from './query-ir';
 export * from './utils/model-selector';
 export * from './utils/openai-client';
 export * from './utils/anthropic-client';

--- a/packages/shared/src/query-ir/build-where.ts
+++ b/packages/shared/src/query-ir/build-where.ts
@@ -1,0 +1,118 @@
+/**
+ * query-ir/build-where.ts — the single safe WHERE-clause builder.
+ *
+ * Generalizes the registry-search buildWhereClause so registry AND EDRSR
+ * share one implementation. Guarantees:
+ *   - field whitelist: only declared FieldDef[] are processed; any extra key
+ *     in `filters` is ignored (combine with a z.strictObject IR upstream).
+ *   - parameterization: every value goes through a $N placeholder, never
+ *     string-interpolated into SQL.
+ *
+ * Special slots that aren't a simple column match (e.g. EDRSR party_role
+ * regex anchoring, FTS tsquery composition) stay in the caller and compose
+ * via the `startParamIndex` / `nextParamIndex` cursor.
+ */
+import type { FieldDef } from './field-def';
+
+export interface BuildWhereOptions {
+  /** First $N index to use (default 1). Lets callers prepend other conditions. */
+  startParamIndex?: number;
+}
+
+export interface BuildWhereResult {
+  /** Conditions joined with AND, or null when nothing matched. */
+  whereClause: string | null;
+  values: any[];
+  /** Next free $N index (for LIMIT/OFFSET or further conditions). */
+  nextParamIndex: number;
+}
+
+/**
+ * Build a parameterized WHERE fragment from whitelisted fields + raw filters.
+ * Faithful port of registry-search-tool.buildWhereClause, made pure + composable.
+ */
+export function buildWhere(
+  fields: FieldDef[],
+  filters: Record<string, any>,
+  opts: BuildWhereOptions = {}
+): BuildWhereResult {
+  const conditions: string[] = [];
+  const values: any[] = [];
+  let pi = opts.startParamIndex ?? 1;
+
+  for (const field of fields) {
+    let val = filters[field.name];
+    if (val === undefined || val === null || val === '') continue;
+
+    if (field.type === 'number') val = Number(val);
+    if (field.transform === 'uppercase' && typeof val === 'string') val = val.toUpperCase();
+
+    switch (field.match) {
+      case 'ilike':
+        conditions.push(`${field.columns[0]} ILIKE $${pi}`);
+        values.push(`%${val}%`);
+        pi++;
+        break;
+
+      case 'exact':
+        conditions.push(`${field.columns[0]} = $${pi}`);
+        values.push(val);
+        pi++;
+        break;
+
+      case 'ilike_multi':
+        conditions.push(`(${field.columns.map(c => `${c} ILIKE $${pi}`).join(' OR ')})`);
+        values.push(`%${val}%`);
+        pi++;
+        break;
+
+      case 'exact_multi':
+        conditions.push(`(${field.columns.map(c => `${c} = $${pi}`).join(' OR ')})`);
+        values.push(val);
+        pi++;
+        break;
+
+      case 'gte':
+        conditions.push(`${field.columns[0]} >= $${pi}`);
+        values.push(val);
+        pi++;
+        break;
+
+      case 'lte':
+        conditions.push(`${field.columns[0]} <= $${pi}`);
+        values.push(val);
+        pi++;
+        break;
+
+      case 'array_contains':
+        conditions.push(`$${pi} = ANY(${field.columns[0]})`);
+        values.push(val);
+        pi++;
+        break;
+
+      case 'ilike_cast':
+        conditions.push(`${field.columns[0]}::text ILIKE $${pi}`);
+        values.push(`%${val}%`);
+        pi++;
+        break;
+
+      case 'fts':
+        conditions.push(`to_tsvector('english', ${field.columns[0]}) @@ plainto_tsquery('english', $${pi})`);
+        values.push(val);
+        pi++;
+        break;
+
+      case 'fts_simple':
+        conditions.push(`to_tsvector('simple', ${field.columns[0]}) @@ plainto_tsquery('simple', $${pi})`);
+        values.push(val);
+        pi++;
+        break;
+    }
+  }
+
+  return {
+    whereClause: conditions.length > 0 ? conditions.join(' AND ') : null,
+    values,
+    nextParamIndex: pi,
+  };
+}

--- a/packages/shared/src/query-ir/build-where.ts
+++ b/packages/shared/src/query-ir/build-where.ts
@@ -90,6 +90,12 @@ export function buildWhere(
         pi++;
         break;
 
+      case 'eq_any':
+        conditions.push(`${field.columns[0]} = ANY($${pi})`);
+        values.push(val);
+        pi++;
+        break;
+
       case 'ilike_cast':
         conditions.push(`${field.columns[0]}::text ILIKE $${pi}`);
         values.push(`%${val}%`);

--- a/packages/shared/src/query-ir/enums.ts
+++ b/packages/shared/src/query-ir/enums.ts
@@ -1,0 +1,88 @@
+/**
+ * query-ir/enums.ts — canonical whitelists for safe query generation.
+ *
+ * Single source of truth for every constrained value a query slot may take.
+ * Declared as Zod enums so the SAME definition enforces constraints at runtime
+ * (validating LLM/user output) and at compile time (via z.infer).
+ *
+ * Migrate the scattered duplicates here and re-export, then delete the originals:
+ *   - mcp_backend/src/types/index.ts            (CourtLevel, ProcedureCode union)
+ *   - mcp_backend/src/api/tool-utils.ts         (mapProcedureCodeToJusticeKind)
+ *   - mcp_backend/src/services/edrsr-fts-service.ts (PartyRole)
+ *   - secondlayer-core chat-system-prompt.ts    (VALID_QUERY_TYPES Set)
+ */
+import { z } from 'zod';
+
+/** Procedure code → maps to justice_kind 1..4 (see PROCEDURE_TO_JUSTICE_KIND). */
+export const ProcedureCode = z.enum(['cpc', 'crpc', 'gpc', 'cac']);
+export type ProcedureCode = z.infer<typeof ProcedureCode>;
+
+/** Court instance level (normalized; aliases resolved before validation). */
+export const CourtLevel = z.enum([
+  'first_instance',
+  'appeal',
+  'cassation',
+  'SC',
+  'GrandChamber',
+]);
+export type CourtLevel = z.infer<typeof CourtLevel>;
+
+/** Party role for FTS party-name anchoring. */
+export const PartyRole = z.enum(['plaintiff', 'defendant', 'any']);
+export type PartyRole = z.infer<typeof PartyRole>;
+
+/** EDRSR judgment_code whitelist: 1=Вирок 2=Постанова 3=Рішення 5=Ухвала
+ *  6=Окрема ухвала 7=Додаткове рішення 10=Окрема думка. */
+export const JudgmentCode = z.enum(['1', '2', '3', '5', '6', '7', '10']);
+export type JudgmentCode = z.infer<typeof JudgmentCode>;
+
+/** justice_kind: 1=цивільне 2=кримінальне 3=господарське 4=адмін 5=адмін-правопорушення. */
+export const JusticeKind = z.union([
+  z.literal(1),
+  z.literal(2),
+  z.literal(3),
+  z.literal(4),
+  z.literal(5),
+]);
+export type JusticeKind = z.infer<typeof JusticeKind>;
+
+/** Document section markers (mirror of SectionType in semantic-sectionizer). */
+export const SectionType = z.enum([
+  'HEADER',
+  'FACTS',
+  'CLAIMS',
+  'PROCEDURAL_HISTORY',
+  'LAW_REFERENCES',
+  'MOTIVES',
+  'COURT_REASONING',
+  'DECISION',
+  'AMOUNTS',
+]);
+export type SectionType = z.infer<typeof SectionType>;
+
+/** Chat query type (replaces VALID_QUERY_TYPES Set in secondlayer-core). */
+export const QueryType = z.enum([
+  'case_lookup',
+  'practice_analysis',
+  'legislation_lookup',
+  'legal_consultation',
+  'registry_lookup',
+  'parliament_query',
+  'document_query',
+  'calculation',
+  'document_drafting',
+  'comparative_analysis',
+  'due_diligence',
+  'institutional_analysis',
+  'osint_investigation',
+  'unsupported',
+]);
+export type QueryType = z.infer<typeof QueryType>;
+
+/** Procedure code → justice_kind. Replaces mapProcedureCodeToJusticeKind. */
+export const PROCEDURE_TO_JUSTICE_KIND: Record<ProcedureCode, JusticeKind> = {
+  cpc: 1,
+  crpc: 2,
+  gpc: 3,
+  cac: 4,
+};

--- a/packages/shared/src/query-ir/field-def.ts
+++ b/packages/shared/src/query-ir/field-def.ts
@@ -1,0 +1,31 @@
+/**
+ * query-ir/field-def.ts — declarative field → SQL match mapping.
+ *
+ * Canonical home for MatchType / FieldDef (moved out of mcp_backend
+ * registry-catalog.ts so registry AND EDRSR share ONE definition).
+ * A FieldDef whitelists a slot: only declared fields ever reach SQL, and
+ * each maps to a fixed parameterized condition shape — no interpolation.
+ */
+
+export type MatchType =
+  | 'ilike'          // col ILIKE $N  (%val%)
+  | 'exact'          // col = $N
+  | 'ilike_multi'    // (col1 ILIKE $N OR col2 ILIKE $N ...)  (%val%)
+  | 'exact_multi'    // (col1 = $N OR col2 = $N ...)
+  | 'gte'            // col >= $N
+  | 'lte'            // col <= $N
+  | 'array_contains' // $N = ANY(col)
+  | 'ilike_cast'     // col::text ILIKE $N  (%val%)
+  | 'fts'            // to_tsvector('english', col) @@ plainto_tsquery('english', $N)
+  | 'fts_simple';    // to_tsvector('simple', col) @@ plainto_tsquery('simple', $N)
+
+export interface FieldDef {
+  name: string;
+  /** Human/LLM-facing description of the filter (optional for non-catalog uses). */
+  description?: string;
+  match: MatchType;
+  /** Fully-qualified column name(s), e.g. 'name' or 'd.judge'. */
+  columns: string[];
+  type?: 'string' | 'number' | 'boolean';
+  transform?: 'uppercase';
+}

--- a/packages/shared/src/query-ir/field-def.ts
+++ b/packages/shared/src/query-ir/field-def.ts
@@ -14,7 +14,8 @@ export type MatchType =
   | 'exact_multi'    // (col1 = $N OR col2 = $N ...)
   | 'gte'            // col >= $N
   | 'lte'            // col <= $N
-  | 'array_contains' // $N = ANY(col)
+  | 'array_contains' // $N = ANY(col)         — col is an array column, val is scalar
+  | 'eq_any'         // col = ANY($N)          — col is scalar, val is an array of allowed values
   | 'ilike_cast'     // col::text ILIKE $N  (%val%)
   | 'fts'            // to_tsvector('english', col) @@ plainto_tsquery('english', $N)
   | 'fts_simple';    // to_tsvector('simple', col) @@ plainto_tsquery('simple', $N)

--- a/packages/shared/src/query-ir/index.ts
+++ b/packages/shared/src/query-ir/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @secondlayer/shared/query-ir — safe query generation layer.
+ *
+ * slot-IR (Zod) + whitelist + (downstream) query-builder. The deterministic,
+ * DB-free pattern that replaces SHACL-style validation for input queries.
+ *
+ * Pipeline:
+ *   LLM (reformulate/plan) → JSON
+ *     → parseCourtSearchIR / parseIntentIR   [Zod .strictObject, enum whitelist]
+ *     → CourtSearchIR / IntentIR             [canonical slot-IR]
+ *     → resolvePresets() (backend)           [preset → category_code[]]
+ *     → buildWhere(FieldDef[], ir) (backend) [parameterized $N, no interpolation]
+ *     → SQL / tsquery / Qdrant filter
+ *
+ * See Plane LEXAI-1771 (this module + builder) and CORE-50 (wire into core).
+ */
+export * from './enums';
+export * from './slots';
+export * from './parse';

--- a/packages/shared/src/query-ir/index.ts
+++ b/packages/shared/src/query-ir/index.ts
@@ -17,3 +17,5 @@
 export * from './enums';
 export * from './slots';
 export * from './parse';
+export * from './field-def';
+export * from './build-where';

--- a/packages/shared/src/query-ir/parse.ts
+++ b/packages/shared/src/query-ir/parse.ts
@@ -1,0 +1,54 @@
+/**
+ * query-ir/parse.ts — single validation entry point for LLM/user output.
+ *
+ * Replaces the scattered manual validation:
+ *   - mcp_backend query-reformulator.ts:75-87 (regex + typeof + fallback)
+ *   - secondlayer-core query-planner.ts sanitizeIntent()/normalizeCourtLevel()
+ *   - secondlayer-core chat-intent-classifier.ts typeof checks
+ *
+ * Contract: NEVER throws. Callers degrade gracefully on { ok: false } (e.g.
+ * fall back to plain FTS/semantic search or general_search) and log issues
+ * for observability of prompt regressions.
+ */
+import { z, type ZodType, type ZodIssue } from 'zod';
+import { CourtSearchIR, IntentIR } from './slots';
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; issues: ZodIssue[] };
+
+/** Pull the first JSON object out of an LLM string response. */
+export function extractJsonObject(raw: string): unknown | null {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[0]);
+  } catch {
+    return null;
+  }
+}
+
+/** Generic strict-parse wrapper. */
+export function parseWith<T>(schema: ZodType<T>, raw: unknown): ParseResult<T> {
+  const r = schema.safeParse(raw);
+  return r.success
+    ? { ok: true, value: r.data }
+    : { ok: false, issues: r.error.issues };
+}
+
+/** Validate a court/EDRSR search IR (object OR raw LLM string). */
+export function parseCourtSearchIR(raw: unknown): ParseResult<CourtSearchIR> {
+  const obj = typeof raw === 'string' ? extractJsonObject(raw) : raw;
+  if (obj === null) return { ok: false, issues: [] };
+  return parseWith(CourtSearchIR, obj);
+}
+
+/** Validate full planner/classifier intent IR (object OR raw LLM string). */
+export function parseIntentIR(raw: unknown): ParseResult<IntentIR> {
+  const obj = typeof raw === 'string' ? extractJsonObject(raw) : raw;
+  if (obj === null) return { ok: false, issues: [] };
+  return parseWith(IntentIR, obj);
+}
+
+// re-exported for callers that want the literal type name `z` available
+export { z };

--- a/packages/shared/src/query-ir/slots.ts
+++ b/packages/shared/src/query-ir/slots.ts
@@ -1,0 +1,97 @@
+/**
+ * query-ir/slots.ts — canonical slot-IR for safe query generation.
+ *
+ * The single intermediate representation that sits between the LLM
+ * (reformulator / planner / intent-classifier) and the query-builder.
+ * Every value is constrained by the whitelists in ./enums; z.strictObject
+ * DROPS any field the LLM invents — this is the injection guard that lets us
+ * trust the IR downstream without re-checking each field.
+ *
+ * Downstream consumers (keep slot names stable):
+ *   - mcp_backend buildWhere(FieldDef[], ir)         → SQL / tsquery
+ *   - secondlayer-core filterTools(domains, slots)   → reads edrpou,
+ *       case_number, registry_tool_hint to inject tools
+ */
+import { z } from 'zod';
+import {
+  ProcedureCode,
+  CourtLevel,
+  PartyRole,
+  JudgmentCode,
+  JusticeKind,
+  SectionType,
+  QueryType,
+} from './enums';
+
+/** YYYY-MM-DD (kept as a regex to stay zod-v4-API-agnostic). */
+const IsoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD');
+
+/** Monetary claim flags (mirror of money_terms in the planner). */
+export const MoneyTerms = z.strictObject({
+  penalty: z.boolean().optional(),
+  inflation: z.boolean().optional(),
+  three_percent: z.boolean().optional(),
+  legal_fees: z.boolean().optional(),
+});
+export type MoneyTerms = z.infer<typeof MoneyTerms>;
+
+/**
+ * CourtSearchIR — canonical EDRSR/court search slots.
+ * Unifies EdsrFtsFilters (mcp_backend) + planner slots into one schema.
+ */
+export const CourtSearchIR = z.strictObject({
+  // free-text query variants (produced by the reformulator)
+  query_semantic: z.string().min(3).max(2000).optional(),
+  query_fts: z.string().min(2).max(2000).optional(),
+
+  // structured filters (all whitelisted)
+  procedure_code: ProcedureCode.optional(),
+  court_level: CourtLevel.optional(),
+  justice_kind: JusticeKind.optional(),
+  judgment_code: JudgmentCode.optional(),
+  category_code: z.number().int().positive().optional(),
+  court_code: z.number().int().positive().optional(),
+  instance_code: z.number().int().positive().optional(),
+
+  judge: z.string().max(200).optional(),
+  date_from: IsoDate.optional(),
+  date_to: IsoDate.optional(),
+
+  party_name: z.string().max(200).optional(),
+  party_role: PartyRole.optional(),
+
+  section_focus: z.array(SectionType).max(9).optional(),
+  money_terms: MoneyTerms.optional(),
+
+  // preset resolves to a hardcoded category_code[] in the backend preset
+  // registry (KUPAP_PRESETS / MILITARY_PRESETS) AFTER validation.
+  preset: z.string().max(64).optional(),
+});
+export type CourtSearchIR = z.infer<typeof CourtSearchIR>;
+
+/**
+ * ClassifierSlots — entity slots the chat layer extracts and filterTools()
+ * consumes. Kept separate from CourtSearchIR because these drive tool
+ * selection, not the SQL WHERE clause. Slot NAMES must not change.
+ */
+export const ClassifierSlots = z.strictObject({
+  edrpou: z.string().regex(/^\d{8,10}$/).optional(),
+  case_number: z.string().max(64).optional(),
+  law_reference: z.string().max(200).optional(),
+  registry_tool_hint: z.string().max(64).optional(),
+});
+export type ClassifierSlots = z.infer<typeof ClassifierSlots>;
+
+/**
+ * IntentIR — full output of the planner/intent-classifier.
+ * Wraps the query type + domains + both slot bags.
+ */
+export const IntentIR = z.strictObject({
+  query_type: QueryType,
+  confidence: z.number().min(0).max(1).default(0.7),
+  domains: z.array(z.string()).default(['court']),
+  keywords: z.string().optional(),
+  search: CourtSearchIR.optional(),
+  slots: ClassifierSlots.optional(),
+});
+export type IntentIR = z.infer<typeof IntentIR>;

--- a/packages/shared/tests/query-ir.test.ts
+++ b/packages/shared/tests/query-ir.test.ts
@@ -1,0 +1,146 @@
+import {
+  buildWhere,
+  parseCourtSearchIR,
+  parseIntentIR,
+  CourtSearchIR,
+  PROCEDURE_TO_JUSTICE_KIND,
+} from '../src/query-ir';
+import type { FieldDef } from '../src/query-ir';
+
+describe('query-ir / parseCourtSearchIR', () => {
+  it('accepts a valid IR and returns typed value', () => {
+    const r = parseCourtSearchIR({
+      query_fts: 'оренда землі',
+      procedure_code: 'gpc',
+      justice_kind: 3,
+      court_level: 'cassation',
+      party_role: 'plaintiff',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.procedure_code).toBe('gpc');
+      expect(r.value.justice_kind).toBe(3);
+    }
+  });
+
+  it('DROPS unknown fields (injection guard via z.strictObject)', () => {
+    const r = parseCourtSearchIR({
+      query_fts: 'тест',
+      ['; DROP TABLE decisions;--']: 1,
+      arbitrary_filter: 'x',
+    });
+    // strictObject => unknown keys make it fail, never silently pass through
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects enum values outside the whitelist', () => {
+    const r = parseCourtSearchIR({ court_level: 'supreme_galactic_court' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects malformed dates', () => {
+    const r = parseCourtSearchIR({ date_from: '06/01/2026' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('extracts JSON object from a raw LLM string', () => {
+    const r = parseCourtSearchIR('here you go:\n{"query_fts":"борг","justice_kind":1}\nhope it helps');
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.justice_kind).toBe(1);
+  });
+
+  it('degrades (ok:false, no throw) on garbage input', () => {
+    expect(parseCourtSearchIR('not json at all').ok).toBe(false);
+    expect(parseCourtSearchIR(42).ok).toBe(false);
+    expect(parseCourtSearchIR(null).ok).toBe(false);
+  });
+});
+
+describe('query-ir / parseIntentIR', () => {
+  it('validates query_type against the whitelist and keeps stable slot names', () => {
+    const r = parseIntentIR({
+      query_type: 'registry_lookup',
+      slots: { edrpou: '12345678' },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value.slots?.edrpou).toBe('12345678');
+  });
+
+  it('rejects an unknown query_type', () => {
+    expect(parseIntentIR({ query_type: 'time_travel' }).ok).toBe(false);
+  });
+});
+
+describe('query-ir / PROCEDURE_TO_JUSTICE_KIND', () => {
+  it('maps procedure codes to justice kinds', () => {
+    expect(PROCEDURE_TO_JUSTICE_KIND.cpc).toBe(1);
+    expect(PROCEDURE_TO_JUSTICE_KIND.crpc).toBe(2);
+    expect(PROCEDURE_TO_JUSTICE_KIND.gpc).toBe(3);
+    expect(PROCEDURE_TO_JUSTICE_KIND.cac).toBe(4);
+  });
+});
+
+describe('query-ir / buildWhere', () => {
+  const FIELDS: FieldDef[] = [
+    { name: 'name', match: 'ilike', columns: ['name'] },
+    { name: 'edrpou', match: 'exact', columns: ['edrpou'] },
+    { name: 'justice_kind', match: 'exact', columns: ['d.justice_kind'], type: 'number' },
+    { name: 'code', match: 'exact', columns: ['code'], transform: 'uppercase' },
+    { name: 'tags', match: 'array_contains', columns: ['tags'] },
+    { name: 'date_from', match: 'gte', columns: ['d.adjudication_date'] },
+    { name: 'owner', match: 'ilike_multi', columns: ['owner_a', 'owner_b'] },
+  ];
+
+  it('builds parameterized conditions joined by AND', () => {
+    const r = buildWhere(FIELDS, { name: 'Іван', edrpou: '12345678' });
+    expect(r.whereClause).toBe('name ILIKE $1 AND edrpou = $2');
+    expect(r.values).toEqual(['%Іван%', '12345678']);
+    expect(r.nextParamIndex).toBe(3);
+  });
+
+  it('ignores fields not present in the whitelist', () => {
+    const r = buildWhere(FIELDS, { name: 'x', injected_col: 'DROP', '1=1': true });
+    expect(r.whereClause).toBe('name ILIKE $1');
+    expect(r.values).toEqual(['%x%']);
+  });
+
+  it('coerces numbers and uppercases when declared', () => {
+    const r = buildWhere(FIELDS, { justice_kind: '3', code: 'abc' });
+    expect(r.whereClause).toBe('d.justice_kind = $1 AND code = $2');
+    expect(r.values).toEqual([3, 'ABC']);
+  });
+
+  it('skips null / undefined / empty-string values', () => {
+    const r = buildWhere(FIELDS, { name: '', edrpou: null, justice_kind: undefined });
+    expect(r.whereClause).toBeNull();
+    expect(r.values).toEqual([]);
+    expect(r.nextParamIndex).toBe(1);
+  });
+
+  it('renders array_contains, gte and ilike_multi correctly', () => {
+    const r = buildWhere(FIELDS, { tags: 'urgent', date_from: '2026-01-01', owner: 'ТОВ' });
+    expect(r.whereClause).toBe(
+      '$1 = ANY(tags) AND d.adjudication_date >= $2 AND (owner_a ILIKE $3 OR owner_b ILIKE $3)'
+    );
+    expect(r.values).toEqual(['urgent', '2026-01-01', '%ТОВ%']);
+  });
+
+  it('honors startParamIndex for composition with prior conditions', () => {
+    const r = buildWhere(FIELDS, { name: 'x', edrpou: '12345678' }, { startParamIndex: 5 });
+    expect(r.whereClause).toBe('name ILIKE $5 AND edrpou = $6');
+    expect(r.nextParamIndex).toBe(7);
+  });
+
+  it('end-to-end: validated IR feeds the builder', () => {
+    const parsed = parseCourtSearchIR({ judge: 'Петренко', justice_kind: 2 });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    const edrsrFields: FieldDef[] = [
+      { name: 'judge', match: 'ilike', columns: ['d.judge'] },
+      { name: 'justice_kind', match: 'exact', columns: ['d.justice_kind'], type: 'number' },
+    ];
+    const r = buildWhere(edrsrFields, parsed.value as Record<string, any>);
+    expect(r.whereClause).toBe('d.judge ILIKE $1 AND d.justice_kind = $2');
+    expect(r.values).toEqual(['%Петренко%', 2]);
+  });
+});

--- a/packages/shared/tests/query-ir.test.ts
+++ b/packages/shared/tests/query-ir.test.ts
@@ -125,6 +125,41 @@ describe('query-ir / buildWhere', () => {
     expect(r.values).toEqual(['urgent', '2026-01-01', '%ТОВ%']);
   });
 
+  it('renders eq_any (col = ANY($N)) for array-valued slots', () => {
+    const fields: FieldDef[] = [
+      { name: 'category_codes', match: 'eq_any', columns: ['d.category_code'] },
+    ];
+    const r = buildWhere(fields, { category_codes: [40851, 5459] });
+    expect(r.whereClause).toBe('d.category_code = ANY($1)');
+    expect(r.values).toEqual([[40851, 5459]]);
+  });
+
+  it('matches the EDRSR structured WHERE shape and param order', () => {
+    // mirrors edrsr-unified-search-tool.searchStructured field order
+    const fields: FieldDef[] = [
+      { name: 'judge', match: 'ilike', columns: ['d.judge'] },
+      { name: 'court_codes', match: 'eq_any', columns: ['d.court_code'] },
+      { name: 'justice_kind', match: 'exact', columns: ['d.justice_kind'] },
+      { name: 'military_category', match: 'eq_any', columns: ['d.category_code'] },
+      { name: 'date_from', match: 'gte', columns: ['d.adjudication_date'] },
+      { name: 'instance_code', match: 'exact', columns: ['c.instance_code'] },
+    ];
+    const r = buildWhere(fields, {
+      judge: 'Коваль',
+      court_codes: [991, 992],
+      justice_kind: 2,
+      military_category: [40851, 5459],
+      date_from: '2026-01-01',
+      instance_code: 1,
+    });
+    expect(r.whereClause).toBe(
+      'd.judge ILIKE $1 AND d.court_code = ANY($2) AND d.justice_kind = $3 AND ' +
+      'd.category_code = ANY($4) AND d.adjudication_date >= $5 AND c.instance_code = $6'
+    );
+    expect(r.values).toEqual(['%Коваль%', [991, 992], 2, [40851, 5459], '2026-01-01', 1]);
+    expect(r.nextParamIndex).toBe(7); // next free $N → LIMIT
+  });
+
   it('honors startParamIndex for composition with prior conditions', () => {
     const r = buildWhere(FIELDS, { name: 'x', edrpou: '12345678' }, { startParamIndex: 5 });
     expect(r.whereClause).toBe('name ILIKE $5 AND edrpou = $6');


### PR DESCRIPTION
## Что это

Слой **«безопасная генерация запросов»** в `packages/shared/src/query-ir/`: **slot-IR (Zod) + whitelist + единый query-builder** — детерминированный DB-free паттерн, функционально заменяющий SHACL-валидацию входных запросов. И registry, и EDRSR теперь строят WHERE через один `buildWhere`.

Закрывает большую часть **LEXAI-1771**; точка подключения в core — **CORE-50** (blocked by этим PR).

## Состав

**`query-ir/`**
| Файл | Содержимое |
|---|---|
| `enums.ts` | whitelists как Zod-enum: `ProcedureCode`, `CourtLevel`, `PartyRole`, `JudgmentCode`, `JusticeKind`, `SectionType`, `QueryType` + `PROCEDURE_TO_JUSTICE_KIND` |
| `slots.ts` | канонический slot-IR через `z.strictObject`: `CourtSearchIR`, `ClassifierSlots`, `IntentIR`, `MoneyTerms` |
| `parse.ts` | `parseCourtSearchIR` / `parseIntentIR` — единая точка валидации, **никогда не бросает** |
| `field-def.ts` | `MatchType` (11 типов, вкл. `eq_any`) + `FieldDef` — канонический дом |
| `build-where.ts` | `buildWhere(fields, filters, {startParamIndex})` — единый безопасный сборщик WHERE |
| `tests/query-ir.test.ts` | 18 тестов |

**Adoption (удаление дублей сборки WHERE)**
- `registry-search-tool.buildWhereClause` → делегирует на shared `buildWhere`.
- `edrsr-unified-search-tool.searchStructured` → инлайновая сборка заменена на `buildWhere`; добавлен `eq_any` (`col = ANY($N)`) для resolved-court_code и military/kupap category-массивов. Порядок полей, индексы и значения параметров **byte-identical** прежним → count/data SQL и LIMIT/OFFSET без изменений.
- `registry-catalog` ре-экспортит `FieldDef`/`MatchType` из shared. `zod ^4.4.3` в deps shared.

## Решения / гарантии

- **`z.strictObject`** — injection-guard: выдуманные LLM поля отбрасываются (тест: `'; DROP TABLE…'` ключ → `ok:false`).
- **Field-whitelist в builder**: обрабатываются только объявленные `FieldDef`; лишние ключи `filters` игнорируются; всё через `$N`, нулевая интерполяция.
- **`startParamIndex`** — композиция с уже добавленными условиями (FTS / party-role в EDRSR-fulltext).
- **EDRSR parity**: единственная дельта — `judge` теперь `ILIKE` вместо `LOWER(judge) LIKE LOWER()`. `idx_edrsr_docs_judge` — обычный b-tree, неюзабельный под ведущим `%` в любом случае → результат идентичен, регрессии плана нет.
- Даты регэкспом (не `z.string().date()`); слот-имена сохранены под core `filterTools()`.

## Проверка

- `packages/shared`: `tsc --noEmit` EXIT=0; `jest tests/query-ir.test.ts` → **18/18 passed**. (Несвязанный pre-existing fail сьюта `base-http-server.test.ts` — Jest/ESM parse-ошибка, веткой не затронут.)
- `mcp_backend`: правки registry + EDRSR дают **0 новых** ошибок типов (оставшиеся 3 — pre-existing отсутствующие проприетарные стабы core: `token-budget-allocator`/`tool-health-tracker`/`step-constraints`, инжектятся в CI).

## Follow-up (вне PR)

- Подключение `parseCourtSearchIR`/`parseIntentIR` в core (**CORE-50**).
- `resolvePresets()` — вынести KUPAP/MILITARY → `category_code[]` в отдельный модуль.
- Миграция оставшихся дублей whitelist из `types/index.ts` / `tool-utils.ts`.
- (Опц.) EDRSR FTS-ветка party-role regex через `startParamIndex`-композицию.

🤖 Generated with [Claude Code](https://claude.com/claude-code)