### PR TITLE
fix(legislation): resolve cited-law gaps - slash rada_ids, missing laws, is_current

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -70,8 +70,11 @@ export class RadaLegislationAdapter {
     if (/[^\p{L}\p{N}\-_\/\.]/u.test(radaId) || radaId.includes('..')) {
       throw new Error(`Invalid legislation ID: ${radaId}`);
     }
-    // Use /print endpoint for full text with all articles
-    const url = `${this.BASE_URL}/laws/show/${encodeURIComponent(radaId)}/print`;
+    // Use /print endpoint for full text with all articles.
+    // RADA IDs may contain a literal slash (e.g. "213/95-вр"); encode each
+    // path segment but keep the "/" separators literal (encoded "%2F" 404s).
+    const encodedId = radaId.split('/').map((seg) => encodeURIComponent(seg)).join('/');
+    const url = `${this.BASE_URL}/laws/show/${encodedId}/print`;
     logger.info(`Fetching legislation from ${url}`);
 
     const callStart = Date.now();

--- a/mcp_backend/src/migrations/165_fix_legislation_is_current_flag.sql
+++ b/mcp_backend/src/migrations/165_fix_legislation_is_current_flag.sql
@@ -1,0 +1,53 @@
+-- LEXAI-1770: Fix legislation codes that have articles but ZERO is_current=true.
+--
+-- Root cause: codes imported ONLY via scripts/rada/import-historical-editions.ts
+-- insert every edition with is_current=false (hardcoded). The "current redaction"
+-- is normally flagged by RadaLegislationAdapter.saveLegislationToDatabase
+-- (is_current=true), but these codes never went through that path, so 0 rows are
+-- current. This breaks citation resolution AND LegislationService /
+-- get_legislation_section (all of which filter WHERE is_current = true).
+--
+-- Known affected (prod, 2026-06): 647, 648, 650, 660, 661, 662
+-- (Кримінально-виконавчий, Кодекс цив. захисту, ГПК, Конституція, ЦПК, Митний).
+--
+-- Corrective rule (generic, self-healing): for every legislation_id that has
+-- articles but no current ones, pick the CURRENT REDACTION = the latest edition
+-- whose version_date <= today (ignores future-dated / not-yet-effective editions,
+-- e.g. ЦПК 2028-01-01), and flag exactly that edition's articles is_current=true.
+-- Idempotent: re-running is a no-op because affected codes will then have >0 current.
+
+DO $$
+DECLARE
+  affected_count INTEGER;
+BEGIN
+  -- Codes with articles but zero current articles.
+  WITH broken AS (
+    SELECT legislation_id
+    FROM legislation_articles
+    GROUP BY legislation_id
+    HAVING COUNT(*) > 0
+       AND COUNT(*) FILTER (WHERE is_current) = 0
+  ),
+  -- Current redaction per broken code = latest edition effective on/before today.
+  -- Fall back to the overall latest edition if every edition is future-dated.
+  chosen AS (
+    SELECT DISTINCT ON (la.legislation_id)
+           la.legislation_id,
+           la.version_date
+    FROM legislation_articles la
+    JOIN broken b ON b.legislation_id = la.legislation_id
+    ORDER BY la.legislation_id,
+             (la.version_date::date <= CURRENT_DATE) DESC,  -- prefer effective editions
+             la.version_date DESC                            -- then newest
+  )
+  UPDATE legislation_articles la
+  SET is_current = true,
+      updated_at = NOW()
+  FROM chosen c
+  WHERE la.legislation_id = c.legislation_id
+    AND la.version_date   = c.version_date
+    AND la.is_current = false;
+
+  GET DIAGNOSTICS affected_count = ROW_COUNT;
+  RAISE NOTICE 'LEXAI-1770: flagged % articles as is_current across previously-broken codes', affected_count;
+END $$;

--- a/scripts/rada/import-historical-editions.ts
+++ b/scripts/rada/import-historical-editions.ts
@@ -414,6 +414,52 @@ async function importEdition(
   return articles.length;
 }
 
+// ─── Reconcile current redaction ─────────────────────────────────────────────
+// After importing editions for a code, flag exactly the current redaction
+// (latest edition effective on/before today; future-dated editions are ignored)
+// as is_current=true and demote all others. Keeps is_current-filtered consumers
+// (citation resolution, LegislationService, get_legislation_section) working.
+// Idempotent: safe to re-run.
+async function reconcileCurrentEdition(pool: pg.Pool, legislationId: number): Promise<void> {
+  const chosen = await pool.query(
+    `SELECT version_date
+       FROM legislation_articles
+      WHERE legislation_id = $1
+      ORDER BY (version_date::date <= CURRENT_DATE) DESC, version_date DESC
+      LIMIT 1`,
+    [legislationId],
+  );
+  if (chosen.rows.length === 0) return;
+  const currentVersion: Date = chosen.rows[0].version_date;
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    // Demote any rows wrongly flagged on other editions.
+    await client.query(
+      `UPDATE legislation_articles
+          SET is_current = false
+        WHERE legislation_id = $1 AND is_current = true AND version_date <> $2`,
+      [legislationId, currentVersion],
+    );
+    // Promote the chosen current redaction.
+    const res = await client.query(
+      `UPDATE legislation_articles
+          SET is_current = true, updated_at = NOW()
+        WHERE legislation_id = $1 AND version_date = $2 AND is_current = false`,
+      [legislationId, currentVersion],
+    );
+    await client.query('COMMIT');
+    const d = new Date(currentVersion).toISOString().slice(0, 10);
+    console.log(`  Flagged current redaction ${d}: ${res.rowCount} articles is_current=true`);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function main() {
@@ -590,6 +636,12 @@ async function main() {
       ) WHERE id = $1`,
       [legislationId],
     );
+
+    // Flag the current redaction so is_current-filtered consumers
+    // (citation resolution, LegislationService, get_legislation_section) work.
+    // This importer inserts every edition with is_current=false; without this
+    // step a code imported ONLY here would have zero current articles (LEXAI-1770).
+    await reconcileCurrentEdition(pool, legislationId);
 
     saveProgress(progress);
     console.log(`  Done: ${editionsDone} editions imported for ${code.short_title}`);

--- a/scripts/rada/import-missing-cited-laws.ts
+++ b/scripts/rada/import-missing-cited-laws.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env npx tsx
+/**
+ * Import MISSING cited laws (LEXAI-1770)
+ *
+ * Imports a curated worklist of Ukrainian laws that are CITED by court
+ * decisions (law_court_citations) but MISSING from public.legislation, so the
+ * citations can resolve. Many are OLD / repealed laws, imported anyway for
+ * historical resolution.
+ *
+ * Uses RadaLegislationAdapter (fetch text from zakon.rada.gov.ua print
+ * endpoint -> sectionize into articles -> upsert into public.legislation +
+ * legislation_articles). 100% ADDITIVE: ON CONFLICT (rada_id) DO UPDATE and
+ * ON CONFLICT (legislation_id, article_number, version_date) DO UPDATE.
+ *
+ * Usage:
+ *   DATABASE_URL=... npx tsx scripts/rada/import-missing-cited-laws.ts [--only=2343-12,697-12] [--delay=4000] [--dry-run]
+ *
+ * Rate limit: sequential with --delay ms between docs (default 4000ms) to
+ * respect zakon.rada.gov.ua throttling. Checkpoints to import-missing-progress.json.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import pg from 'pg';
+import { RadaLegislationAdapter } from '../../mcp_backend/src/adapters/rada-legislation-adapter';
+import type { IDatabase, IQueryResult, ITransactionClient } from '../../mcp_backend/src/domain/ports/database';
+
+const PROGRESS_FILE = path.join(__dirname, 'import-missing-progress.json');
+
+// ─── Worklist: cited-name -> rada_id (verified on zakon.rada.gov.ua) ──────────
+// cites = citation volume in law_court_citations (for prioritisation/logging)
+interface WorkItem { rada_id: string; cited_name: string; cites: number; note?: string; }
+
+const WORKLIST: WorkItem[] = [
+  { rada_id: '5464-10',   cited_name: 'Житловий кодекс України', cites: 5502, note: 'Housing Code УРСР (active)' },
+  { rada_id: '2343-12',   cited_name: 'Про відновлення платоспроможності боржника або визнання його банкрутом', cites: 4734, note: 'old bankruptcy law (repealed 2019)' },
+  { rada_id: '1251-12',   cited_name: 'Про систему оподаткування', cites: 746, note: 'repealed 2011' },
+  { rada_id: '697-12',    cited_name: 'Про власність', cites: 734, note: 'repealed 2007' },
+  { rada_id: '606-14',    cited_name: 'Про виконавче провадження', cites: 706, note: 'old, repealed 2017' },
+  { rada_id: '213/95-вр', cited_name: 'Водний кодекс України', cites: 690, note: 'active' },
+  { rada_id: '755-15',    cited_name: 'Про державну реєстрацію юридичних осіб та фізичних осіб - підприємців', cites: 1140, note: 'covers all spelling variants; active (renamed)' },
+  { rada_id: '509-12',    cited_name: 'Про державну податкову службу в Україні', cites: 692, note: 'covers вариант без В Україні; repealed 2012' },
+  { rada_id: '2181-14',   cited_name: 'Про порядок погашення зобовязань платників податків перед бюджетами та державними цільовими фондами', cites: 618, note: 'covers №2181- + variants; repealed 2011' },
+  { rada_id: '1788-12',   cited_name: 'Про пенсійне забезпечення', cites: 260, note: 'active' },
+  { rada_id: '168/97-вр', cited_name: 'Про податок на додану вартість', cites: 210, note: 'repealed 2011' },
+  { rada_id: '334/94-вр', cited_name: 'Про оподаткування прибутку підприємств', cites: 194, note: 'repealed 2013' },
+  { rada_id: '280/97-вр', cited_name: 'Про місцеве самоврядування в Україні', cites: 258, note: 'covers скороч. variant; active' },
+  { rada_id: '1105-14',   cited_name: 'Про загальнообовязкове державне соціальне страхування від нещасного випадку на виробництві та професійного захворювання, які спричинили втрату працездатності', cites: 178, note: 'active (now generic social insurance law)' },
+  { rada_id: '2633-15',   cited_name: 'Про теплопостачання', cites: 176, note: 'active' },
+  { rada_id: '108/95-вр', cited_name: 'Про оплату праці', cites: 160, note: 'active' },
+  { rada_id: '265/95-вр', cited_name: 'Про застосування реєстраторів розрахункових операцій у сфері торгівлі, громадського харчування та послуг', cites: 156, note: 'active' },
+  { rada_id: '889-15',    cited_name: 'Про податок з доходів фізичних осіб', cites: 144, note: 'repealed 2011' },
+  { rada_id: '2482-12',   cited_name: 'Про приватизацію державного житлового фонду', cites: 144, note: 'active' },
+  { rada_id: '1058-15',   cited_name: 'Про загальнообовязкове державне пенсійне страхування', cites: 214, note: 'covers №1058-; active' },
+  { rada_id: '575/97-вр', cited_name: 'Про електроенергетику', cites: 136, note: 'repealed 2019' },
+  { rada_id: '1875-15',   cited_name: 'Про житлово-комунальні послуги', cites: 132, note: 'old, repealed 2019' },
+  { rada_id: '875-12',    cited_name: 'Про основи соціальної захищеності осіб з інвалідністю в Україні', cites: 112, note: 'active' },
+  { rada_id: '2344-14',   cited_name: 'Про автомобільний транспорт', cites: 100, note: 'active' },
+];
+
+// ─── Minimal IDatabase wrapper over a pg.Pool ─────────────────────────────────
+class PgPoolDatabase implements IDatabase {
+  constructor(private pool: pg.Pool) {}
+
+  async query<T = any>(text: string, params?: unknown[]): Promise<IQueryResult<T>> {
+    const r = await this.pool.query(text, params as any[]);
+    return { rows: r.rows as T[], rowCount: r.rowCount ?? 0 } as IQueryResult<T>;
+  }
+
+  async transaction<T>(callback: (client: ITransactionClient) => Promise<T>): Promise<T> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      const txClient: ITransactionClient = {
+        query: async (text: string, p?: unknown[]) => {
+          const r = await client.query(text, p as any[]);
+          return { rows: r.rows, rowCount: r.rowCount ?? 0 } as any;
+        },
+      } as ITransactionClient;
+      const result = await callback(txClient);
+      await client.query('COMMIT');
+      return result;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  async connect(): Promise<void> { /* pool auto-connects */ }
+  async close(): Promise<void> { await this.pool.end(); }
+  // Optional members some IDatabase impls expose; not used by the adapter.
+  getPool(): pg.Pool { return this.pool; }
+}
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+function loadProgress(): { done: string[]; failed: Record<string, string> } {
+  if (fs.existsSync(PROGRESS_FILE)) return JSON.parse(fs.readFileSync(PROGRESS_FILE, 'utf-8'));
+  return { done: [], failed: {} };
+}
+function saveProgress(p: { done: string[]; failed: Record<string, string> }) {
+  fs.writeFileSync(PROGRESS_FILE, JSON.stringify(p, null, 2));
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const only = args.find((a) => a.startsWith('--only='))?.split('=')[1]?.split(',').map((s) => s.trim());
+  const delay = parseInt(args.find((a) => a.startsWith('--delay='))?.split('=')[1] || '4000', 10);
+  const dryRun = args.includes('--dry-run');
+
+  let work = WORKLIST.filter((w) => !w.note?.includes('do not use'));
+  if (only) work = work.filter((w) => only.includes(w.rada_id));
+
+  const dbUrl = process.env.DATABASE_URL;
+  if (!dbUrl) { console.error('DATABASE_URL required'); process.exit(1); }
+
+  const pool = new pg.Pool({ connectionString: dbUrl, max: 4 });
+  const db = new PgPoolDatabase(pool);
+  const adapter = new RadaLegislationAdapter(db);
+
+  const before = await pool.query('SELECT count(*)::int c FROM legislation');
+  console.log(`Legislation rows before: ${before.rows[0].c}`);
+  console.log(`Worklist: ${work.length} laws, delay ${delay}ms, dryRun=${dryRun}\n`);
+
+  const progress = loadProgress();
+  let imported = 0, failed = 0, skipped = 0;
+
+  for (const item of work) {
+    if (progress.done.includes(item.rada_id)) { console.log(`SKIP (done) ${item.rada_id}`); skipped++; continue; }
+
+    // Skip if already present by rada_id (additive: never re-fetch existing)
+    const exists = await pool.query('SELECT id FROM legislation WHERE rada_id = $1', [item.rada_id]);
+    if (exists.rows.length > 0) {
+      console.log(`SKIP (exists) ${item.rada_id} (legislation id ${exists.rows[0].id})`);
+      progress.done.push(item.rada_id); saveProgress(progress); skipped++; continue;
+    }
+
+    try {
+      console.log(`FETCH ${item.rada_id} — ${item.cited_name.slice(0, 50)} (${item.cites} cites)`);
+      const { metadata, articles } = await adapter.fetchLegislation(item.rada_id);
+      console.log(`  parsed: "${metadata.title.slice(0, 60)}" — ${articles.length} articles`);
+
+      if (articles.length === 0) {
+        console.warn(`  WARN: 0 articles for ${item.rada_id}, skipping save`);
+        progress.failed[item.rada_id] = '0 articles parsed';
+        saveProgress(progress); failed++;
+        await sleep(delay); continue;
+      }
+
+      if (!dryRun) {
+        const { legislationId } = await adapter.saveLegislationToDatabase(metadata, articles);
+        console.log(`  SAVED legislation id=${legislationId}, ${articles.length} articles`);
+        progress.done.push(item.rada_id); saveProgress(progress);
+      } else {
+        console.log(`  DRY-RUN: would save ${articles.length} articles`);
+      }
+      imported++;
+    } catch (err: any) {
+      console.error(`  FAIL ${item.rada_id}: ${err.message}`);
+      progress.failed[item.rada_id] = err.message; saveProgress(progress); failed++;
+    }
+
+    await sleep(delay);
+  }
+
+  const after = await pool.query('SELECT count(*)::int c FROM legislation');
+  console.log(`\nDone. imported=${imported} skipped=${skipped} failed=${failed}`);
+  console.log(`Legislation rows after: ${after.rows[0].c}`);
+  await pool.end();
+}
+
+main().catch((e) => { console.error('Fatal:', e); process.exit(1); });


### PR DESCRIPTION
## Summary
Fixes the legislation side of decision→legislation-article citation resolution (LEXAI-1770). Court decisions cite ~504K statute references via `law_court_citations`, but many failed to resolve to a real legislation article. Three root causes addressed:

1. **Slash-form RADA IDs 404'd.** `RadaLegislationAdapter.fetchLegislation` used `encodeURIComponent` on the whole `radaId`, encoding the literal `/` in IDs like `213/95-вр` → `%2F` → 404. This made the Water Code and ~7 other major laws permanently un-fetchable. Now each path segment is encoded individually, `/` kept literal.

2. **Laws cited but missing from the registry.** New `scripts/rada/import-missing-cited-laws.ts` — curated worklist of laws referenced by decisions but absent from `legislation` (Житловий кодекс, old bankruptcy law 2343-12, Водний кодекс, Про місцеве самоврядування, …), checkpoint/resume, rate-limit-safe. **19 laws imported to prod** (`legislation` 585→604, +4,862 articles), unlocking ~15.5K citations.

3. **`is_current` never set for 6 codes.** `import-historical-editions.ts` inserts every edition with `is_current=false`; codes imported only via that path (Митний/ЦПК/ГПК/Кримінально-виконавчий/Цив.захисту/Конституція) ended up with **zero current articles**, breaking `is_current`-filtered consumers (citation resolution, `LegislationService`, `get_legislation_section`). Fixed two ways:
   - `reconcileCurrentEdition()` flags the current redaction per code after import (prevents recurrence).
   - **Migration `165_fix_legislation_is_current_flag.sql`** — idempotent, self-healing backfill that promotes the latest edition (≤ today) to `is_current=true` for any code with articles but zero current (~1,883 rows flip).

## Testing
- `tsc --noEmit`: adapter + scripts clean.
- Slash-encoding verified against RADA (`213/95-вр`: encoded `%2F` → 404, literal `/` → 200).
- Missing-law import already executed additively on prod (0 failures, 19 laws).
- Migration validated read-only (per-code flip counts; chosen current editions spot-checked — Constitution correctly → 2019-02-21).

## Notes / out of scope
- The ГПК malformed-`article_number` extraction fix + the ~120K phantom-row backfill ride with the separate citation-extraction-pipeline work (not in this PR).
- 5 laws (755-15, 1058-15, 1105-14, 2482-12, 875-12) are already present under renamed titles → need a resolver name→rada_id alias map (follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes decision→legislation citation resolution (LEXAI-1770) by correctly fetching slash-form RADA IDs, importing cited-but-missing laws, and guaranteeing a current edition per code. Unlocks ~15.5k citations and restores current-article filters.

- **Bug Fixes**
  - Encode RADA ID path segments so “/” stays literal (e.g., `213/95-вр`), preventing RADA /print 404s.
  - Ensure `is_current` is set: reconcile current redaction after historical imports and add an idempotent SQL backfill that promotes the latest effective edition and demotes others.

- **New Features**
  - Add `scripts/rada/import-missing-cited-laws.ts` to import cited-but-missing laws; 19 laws (+4,862 articles) imported to prod.

<sup>Written for commit 895acb64ad0a04d0a9ff7361e4c36aa8264d6929. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

