### PR TITLE
refactor(backend): consolidate whitelist defs onto shared query-ir enums

### DIFF
--- a/mcp_backend/src/api/tool-utils.ts
+++ b/mcp_backend/src/api/tool-utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { SectionType } from '../types/index.js';
+import { PROCEDURE_TO_JUSTICE_KIND } from '@secondlayer/shared';
 import type { EdsrFtsService, EdsrFtsFilters } from '../services/edrsr-fts-service.js';
 import { logger } from '../utils/logger.js';
 import axios from 'axios';
@@ -269,13 +270,10 @@ export function buildSupremeCourtHints(_intent?: any): string {
  * justice_kind: 1=цивільне, 2=кримінальне, 3=господарське, 4=адміністративне
  */
 export function mapProcedureCodeToJusticeKind(code: string | null): number | null {
-  const map: Record<string, number> = {
-    cpc: 1,   // цивільне судочинство
-    crpc: 2,  // кримінальне судочинство
-    gpc: 3,   // господарське судочинство
-    cac: 4,   // адміністративне судочинство
-  };
-  return code ? (map[code] ?? null) : null;
+  // Mapping data is single-sourced in @secondlayer/shared (PROCEDURE_TO_JUSTICE_KIND):
+  // cpc→1 (цивільне), crpc→2 (кримінальне), gpc→3 (господарське), cac→4 (адміністративне).
+  if (!code) return null;
+  return (PROCEDURE_TO_JUSTICE_KIND as Record<string, number>)[code] ?? null;
 }
 
 /**

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -14,6 +14,7 @@
  */
 
 import { logger } from '../utils/logger.js';
+import type { PartyRole } from '@secondlayer/shared';
 import type { EdsrCacheService } from './edrsr-cache-service.js';
 import {
   EDRSR_FTS_SEARCH_ORDER,
@@ -21,7 +22,8 @@ import {
   FTS_HEADLINE_MIN_WORDS,
 } from './search-ranking-config.js';
 
-export type PartyRole = 'plaintiff' | 'defendant' | 'any';
+// PartyRole is the canonical whitelist — single source in @secondlayer/shared.
+export type { PartyRole };
 
 export interface EdsrFtsFilters {
   court_code?: number;

--- a/mcp_backend/src/types/index.ts
+++ b/mcp_backend/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { CourtLevel } from '@secondlayer/shared';
+
 export enum SectionType {
   HEADER = 'HEADER',
   FACTS = 'FACTS',
@@ -10,14 +12,13 @@ export enum SectionType {
   AMOUNTS = 'AMOUNTS',
 }
 
+// ProcedureCode here is the Ukrainian user-input convention (legacy); it is
+// normalized to the latin codes (cpc/gpc/cac/crpc) by mapProcedureCodeToShort
+// before query execution. The latin convention is the canonical shared enum.
 export type ProcedureCode = 'ЦПК' | 'ГПК' | 'КАС' | 'КПК';
 
-export type CourtLevel =
-  | 'first_instance'
-  | 'appeal'
-  | 'cassation'
-  | 'SC'
-  | 'GrandChamber';
+// CourtLevel is the canonical whitelist — single source in @secondlayer/shared.
+export type { CourtLevel };
 
 export type DesiredOutput = 'теза' | 'чеклист' | 'таблиця' | 'підбірка' | 'порівняння';
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,6 +4,9 @@ export * as queryIr from './query-ir';
 export { buildWhere } from './query-ir/build-where';
 export type { BuildWhereOptions, BuildWhereResult } from './query-ir/build-where';
 export type { FieldDef, MatchType } from './query-ir/field-def';
+// Whitelist primitives consumers can adopt without the queryIr namespace.
+export type { CourtLevel, PartyRole } from './query-ir/enums';
+export { PROCEDURE_TO_JUSTICE_KIND } from './query-ir/enums';
 export * from './utils/model-selector';
 export * from './utils/openai-client';
 export * from './utils/anthropic-client';


### PR DESCRIPTION
## Что это

Шаг 1 после buildWhere-слоя (#1990): убрать дублированные whitelist-определения в `mcp_backend`, указав их на канонические enum'ы `@secondlayer/shared/query-ir`. Цель — **один источник правды до того, как secondlayer-core начнёт от них зависеть** (CORE-50), иначе плодим расхождение backend ↔ shared ↔ core.

> Base — ветка #1990 (зависит от её top-level экспортов + `buildWhere`). Перетаргетить на `main` после мёржа #1990.

## Изменения

| Что | Было | Стало |
|---|---|---|
| `CourtLevel` | локальный union в `types/index.ts` | ре-экспорт из shared (значения идентичны) |
| `PartyRole` | локальный union в `edrsr-fts-service.ts:24` | ре-экспорт из shared (идентичен) |
| `mapProcedureCodeToJusticeKind` | инлайновая копия map в `tool-utils.ts` | читает shared `PROCEDURE_TO_JUSTICE_KIND` (те же данные, тот же null-fallback) |
| shared `index.ts` | — | top-level экспорт `CourtLevel`/`PartyRole`/`PROCEDURE_TO_JUSTICE_KIND` (без коллизии с `shared/types`) |

## Осознанно отложено (с причиной)

- **`SectionType`** — рантайм `export enum` (`SectionType.DECISION` в 9+ местах: `edrsr-local-adapter`, `procedural-tools`, `tool-utils`, тесты). Замена на Zod-производный union-тип сломала бы рантайм-доступ. Нужен отдельный заход: shared должен отдавать рантайм-значение.
- **`ProcedureCode` (украинский `'ЦПК'|...`)** в `types/index.ts` — расходится с latin shared-enum (`'cpc'|...`); это legacy user-input, нормализуется в latin (`mapProcedureCodeToShort`) перед запросом. Оставлен локально и задокументирован.
- **`QueryType` / `VALID_QUERY_TYPES`** — chat-слой, делается в **CORE-50**.

## Проверка

- `mcp_backend`: `tsc --noEmit` → **0 новых** ошибок (оставшиеся 3 — pre-existing отсутствующие проприетарные стабы core: `token-budget-allocator`/`tool-health-tracker`/`step-constraints`).
- `packages/shared`: build OK, `jest tests/query-ir.test.ts` → 18/18.
- `mapProcedureCodeToJusticeKind`: byte-identical поведение (та же карта `cpc:1/crpc:2/gpc:3/cac:4`, тот же `?? null`).

Refs LEXAI-1771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates backend whitelist types onto canonical enums in `@secondlayer/shared/query-ir` to create a single source of truth ahead of `secondlayer-core` adoption (CORE-50). No behavior changes.

- **Refactors**
  - `CourtLevel` now re-exported from `@secondlayer/shared` (removed local union).
  - `PartyRole` now re-exported from `@secondlayer/shared`.
  - `mapProcedureCodeToJusticeKind` now reads shared `PROCEDURE_TO_JUSTICE_KIND`.
  - `@secondlayer/shared` exposes `CourtLevel`, `PartyRole`, and `PROCEDURE_TO_JUSTICE_KIND` at the top level.

<sup>Written for commit ee2a7494f4d08db2426d7cdae0898004475110be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

