### PR TITLE
feat(shared): add PlannerSlots schema to query-ir (for CORE-50)

### DIFF
--- a/packages/shared/src/query-ir/enums.ts
+++ b/packages/shared/src/query-ir/enums.ts
@@ -13,9 +13,21 @@
  */
 import { z } from 'zod';
 
-/** Procedure code → maps to justice_kind 1..4 (see PROCEDURE_TO_JUSTICE_KIND). */
+/** Procedure code (latin, normalized) → maps to justice_kind 1..4 (see PROCEDURE_TO_JUSTICE_KIND). */
 export const ProcedureCode = z.enum(['cpc', 'crpc', 'gpc', 'cac']);
 export type ProcedureCode = z.infer<typeof ProcedureCode>;
+
+/**
+ * Procedure code in the Ukrainian user-input convention used by the chat
+ * planner slots. Normalized to the latin ProcedureCode before query execution
+ * (mcp_backend mapProcedureCodeToShort). ЦПК→cpc, ГПК→gpc, КАС→cac, КПК→crpc.
+ */
+export const ProcedureCodeUA = z.enum(['ЦПК', 'ГПК', 'КАС', 'КПК']);
+export type ProcedureCodeUA = z.infer<typeof ProcedureCodeUA>;
+
+/** Desired output shape requested by the chat planner (Ukrainian UI labels). */
+export const DesiredOutput = z.enum(['теза', 'чеклист', 'таблиця', 'підбірка', 'порівняння']);
+export type DesiredOutput = z.infer<typeof DesiredOutput>;
 
 /** Court instance level (normalized; aliases resolved before validation). */
 export const CourtLevel = z.enum([

--- a/packages/shared/src/query-ir/parse.ts
+++ b/packages/shared/src/query-ir/parse.ts
@@ -11,7 +11,7 @@
  * for observability of prompt regressions.
  */
 import { z, type ZodType, type ZodIssue } from 'zod';
-import { CourtSearchIR, IntentIR } from './slots';
+import { CourtSearchIR, IntentIR, PlannerSlots } from './slots';
 
 export type ParseResult<T> =
   | { ok: true; value: T }
@@ -48,6 +48,18 @@ export function parseIntentIR(raw: unknown): ParseResult<IntentIR> {
   const obj = typeof raw === 'string' ? extractJsonObject(raw) : raw;
   if (obj === null) return { ok: false, issues: [] };
   return parseWith(IntentIR, obj);
+}
+
+/**
+ * Validate the chat QueryPlanner slot bag (Ukrainian convention). Run this
+ * AFTER the planner's alias-normalization so canonical values reach the
+ * strictObject; unknown slots are dropped (injection guard). Returns ok:false
+ * (never throws) so the planner can keep its normalized slots and just log.
+ */
+export function parsePlannerSlots(raw: unknown): ParseResult<PlannerSlots> {
+  const obj = typeof raw === 'string' ? extractJsonObject(raw) : raw;
+  if (obj === null) return { ok: false, issues: [] };
+  return parseWith(PlannerSlots, obj);
 }
 
 // re-exported for callers that want the literal type name `z` available

--- a/packages/shared/src/query-ir/slots.ts
+++ b/packages/shared/src/query-ir/slots.ts
@@ -15,6 +15,8 @@
 import { z } from 'zod';
 import {
   ProcedureCode,
+  ProcedureCodeUA,
+  DesiredOutput,
   CourtLevel,
   PartyRole,
   JudgmentCode,
@@ -81,6 +83,25 @@ export const ClassifierSlots = z.strictObject({
   registry_tool_hint: z.string().max(64).optional(),
 });
 export type ClassifierSlots = z.infer<typeof ClassifierSlots>;
+
+/**
+ * PlannerSlots — canonical model of the chat QueryPlanner slot bag
+ * (secondlayer-core query-planner.ts). DISTINCT from CourtSearchIR: this uses
+ * the Ukrainian procedure-code convention and carries planner-only fields
+ * (case_category, law_article, desired_output). Validate the planner's slots
+ * AFTER its alias-normalization step (normalizeCourtLevel etc.) — z.strictObject
+ * then drops any unknown slot the LLM invented.
+ */
+export const PlannerSlots = z.strictObject({
+  procedure_code: ProcedureCodeUA.optional(),
+  court_level: CourtLevel.optional(),
+  case_category: z.string().max(200).optional(),
+  law_article: z.string().max(200).optional(),
+  section_focus: z.array(SectionType).max(9).optional(),
+  money_terms: MoneyTerms.optional(),
+  desired_output: DesiredOutput.optional(),
+});
+export type PlannerSlots = z.infer<typeof PlannerSlots>;
 
 /**
  * IntentIR — full output of the planner/intent-classifier.

--- a/packages/shared/tests/query-ir.test.ts
+++ b/packages/shared/tests/query-ir.test.ts
@@ -2,6 +2,7 @@ import {
   buildWhere,
   parseCourtSearchIR,
   parseIntentIR,
+  parsePlannerSlots,
   CourtSearchIR,
   PROCEDURE_TO_JUSTICE_KIND,
 } from '../src/query-ir';
@@ -68,6 +69,43 @@ describe('query-ir / parseIntentIR', () => {
 
   it('rejects an unknown query_type', () => {
     expect(parseIntentIR({ query_type: 'time_travel' }).ok).toBe(false);
+  });
+});
+
+describe('query-ir / parsePlannerSlots', () => {
+  it('accepts Ukrainian-convention planner slots', () => {
+    const r = parsePlannerSlots({
+      procedure_code: 'ЦПК',
+      court_level: 'cassation',
+      case_category: 'споживчий спір',
+      section_focus: ['COURT_REASONING', 'DECISION'],
+      money_terms: { penalty: true },
+      desired_output: 'таблиця',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.procedure_code).toBe('ЦПК');
+      expect(r.value.desired_output).toBe('таблиця');
+    }
+  });
+
+  it('rejects latin procedure_code (planner uses the Ukrainian convention)', () => {
+    expect(parsePlannerSlots({ procedure_code: 'cpc' }).ok).toBe(false);
+  });
+
+  it('DROPS unknown slot keys (injection guard)', () => {
+    expect(parsePlannerSlots({ court_level: 'appeal', registry_tool_hint: 'x' }).ok).toBe(false);
+  });
+
+  it('rejects a non-canonical court_level (alias normalization is the planner job)', () => {
+    // 'велика палата' must be normalized to 'GrandChamber' BEFORE validation
+    expect(parsePlannerSlots({ court_level: 'велика палата' }).ok).toBe(false);
+    expect(parsePlannerSlots({ court_level: 'GrandChamber' }).ok).toBe(true);
+  });
+
+  it('degrades (ok:false, no throw) on garbage', () => {
+    expect(parsePlannerSlots('nope').ok).toBe(false);
+    expect(parsePlannerSlots(null).ok).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Что это

Недостающий канон для CORE-50: слот-бэг чат-планировщика (`secondlayer-core query-planner.ts`) — **другая форма**, чем `CourtSearchIR` (украинская конвенция `procedure_code` + поля только планировщика). Поэтому ему нужна своя схема, прежде чем core сможет валидировать вывод планировщика.

> Base — ветка #1992 (чейн `#1990 → #1992 → этот`). Перетаргетить вверх по мере мёржа.

## Добавлено в `query-ir`

- **`ProcedureCodeUA`** = `z.enum(['ЦПК','ГПК','КАС','КПК'])` — украинский user-input, нормализуется в latin `ProcedureCode` перед запросом.
- **`DesiredOutput`** = `z.enum(['теза','чеклист','таблиця','підбірка','порівняння'])`.
- **`PlannerSlots`** = `z.strictObject({ procedure_code(UA), court_level, case_category, law_article, section_focus, money_terms, desired_output })`.
- **`parsePlannerSlots`** — валидировать **после** alias-нормализации планировщика; strict-drop неизвестных слотов; никогда не бросает (планировщик деградирует + логирует на `ok:false`).

## Почему отдельная схема (не `CourtSearchIR`)

`CourtSearchIR` моделирует EDRSR-фильтры (latin `procedure_code`, `judge`/`court_code`/даты). Слоты планировщика — украинский `procedure_code` + `case_category`/`law_article`/`desired_output`. Прогон core-слотов через `CourtSearchIR.strictObject` отверг бы их целиком. Отсюда `PlannerSlots`.

## Важно про alias-нормализацию

`normalizeCourtLevel` в core делает богатый алиасинг (`велика палата`→`GrandChamber`, `верхов`→`SC`, `касац`→`cassation`). Strict-Zod так не умеет — поэтому `parsePlannerSlots` ставится **после** нормализации (тест это фиксирует: `велика палата` → reject, `GrandChamber` → ok).

## Проверка

`packages/shared`: `tsc --noEmit` EXIT=0, build OK, `jest tests/query-ir.test.ts` → **23/23** (+5 новых).

Refs LEXAI-1771. Потребляется CORE-50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `PlannerSlots` schema and `parsePlannerSlots` to `query-ir` to validate the chat QueryPlanner slot bag (Ukrainian convention). Enables CORE-50 to safely consume planner output and drop unknown slots.

- **New Features**
  - `ProcedureCodeUA` enum (`ЦПК` | `ГПК` | `КАС` | `КПК`) for UA input; normalized to latin `ProcedureCode` before queries.
  - `DesiredOutput` enum (`теза`, `чеклист`, `таблиця`, `підбірка`, `порівняння`).
  - `PlannerSlots` strict object: `procedure_code(UA)`, `court_level`, `case_category`, `law_article`, `section_focus`, `money_terms`, `desired_output`.
  - `parsePlannerSlots`: run after alias normalization; drops unknown keys; never throws (returns `ok:false` on invalid).

<sup>Written for commit 00d3fdbb740aeca6aae715d4854ed0563f9eeec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

