### PR TITLE
feat(citations): parallel-write EDRSR extraction + full-rebuild prep SQL

### DIFF
--- a/scripts/citation-graph/extract-citations.py
+++ b/scripts/citation-graph/extract-citations.py
@@ -127,22 +127,81 @@ class PartitionStats:
 
 # ── Extraction ───────────────────────────────────────────────
 
+# Max width of a "real" article-range expansion. Ukrainian codes have at most
+# a few hundred base articles, so a legitimate "ст. 5-9" spans a handful of numbers.
+# Anything wider is almost certainly a flattened-superscript list misread as a range
+# (e.g. "ст. 1115, 1117, 1119 - 11111" where 1115 == article 111⁵ == "111-5").
+MAX_RANGE_SPAN = 20
+
+
 def parse_article_numbers(raw: str) -> list[str]:
-    """Parse '3, 5, 7-9 та 12' into ['3', '5', '7', '8', '9', '12']."""
+    """Parse an article enumeration into a list of canonical article numbers.
+
+    Handles three shapes:
+      - plain lists: '3, 5 та 12'            -> ['3', '5', '12']
+      - true ranges: '7-9'                   -> ['7', '8', '9']
+      - dashed/superscript articles: '129-1' -> ['129-1']   (NOT a range)
+        and their OCR-flattened form '1291'  -> ['129-1']
+
+    Procedural codes (ГПК/ЦПК/КАС) heavily use superscript article numbers
+    (стаття 111⁵). In source text the superscript is flattened to a trailing
+    digit ('1115'). The previous implementation (a) treated every '-' as a
+    numeric range — so '1119 - 11111' exploded into ~10k phantom articles, and
+    (b) lost genuine dashed articles like '129-1' (range(129,2) is empty).
+    """
     articles = []
-    raw = raw.replace("та", ",").replace("і", ",").replace("й", ",")
+    # Normalise list separators ("та"/"і"/"й" = "and"). Use word boundaries so we
+    # don't strip the Cyrillic letters out of unrelated tokens.
+    raw = re.sub(r"\s+(?:та|і|й)\s+", ",", raw)
     for part in raw.split(","):
-        part = part.strip()
+        part = part.strip().strip(".")
+        if not part:
+            continue
         if "-" in part:
-            try:
-                a, b = part.split("-", 1)
-                for n in range(int(a.strip()), int(b.strip()) + 1):
-                    articles.append(str(n))
-            except ValueError:
+            a, b = (s.strip() for s in part.split("-", 1))
+            if a.isdigit() and b.isdigit():
+                ai, bi = int(a), int(b)
+                span = bi - ai
+                # Genuine narrow ascending range -> expand.
+                if 0 < span <= MAX_RANGE_SPAN:
+                    articles.extend(str(n) for n in range(ai, bi + 1))
+                # Dashed article number written with an explicit hyphen
+                # (e.g. "129-1"): keep canonical form, do NOT expand.
+                elif span <= 0 or len(b) <= 2:
+                    articles.append(f"{a}-{b}")
+                # Anything else (wide "range" like 1119-11111) is a flattened
+                # superscript list mis-joined by a stray hyphen: keep only the
+                # endpoints in canonical dashed form, drop the phantom middle.
+                else:
+                    articles.append(normalize_flattened(a))
+                    articles.append(normalize_flattened(b))
+            else:
                 articles.append(part)
         elif part.isdigit():
-            articles.append(part)
+            articles.append(normalize_flattened(part))
     return articles
+
+
+def normalize_flattened(num: str) -> str:
+    """Map an OCR-flattened superscript article number to canonical 'base-index'.
+
+    Ukrainian procedural codes number inserted articles with a superscript:
+    стаття 111⁵ (article 111, insert 5). When the superscript collapses into the
+    base it becomes '1115'. Heuristic: a 4-5 digit token whose leading 1-3 digits
+    form a plausible base article and trailing 1-2 digits a plausible insert index
+    is rewritten as 'base-index'. Plain 1-3 digit articles pass through unchanged.
+
+    NOTE: this is a best-effort heuristic for the regex capture path. The
+    authoritative disambiguation against the legislation_articles registry happens
+    in the backfill SQL; here we only avoid emitting raw 4-5 digit garbage.
+    """
+    if len(num) <= 3 or not num.isdigit():
+        return num
+    # Prefer a 2-digit insert index for 5-digit tokens, 1-digit for 4-digit tokens.
+    if len(num) == 5:
+        return f"{num[:3]}-{num[3:]}"
+    # 4 digits: split as 3+1 (e.g. 1115 -> 111-5). Callers reconcile against registry.
+    return f"{num[:3]}-{num[3:]}"
 
 MAX_TEXT_LEN = 10_000
 
@@ -187,6 +246,11 @@ def extract_citations_from_text(doc_id: int, text: str) -> list[Citation]:
 
 _JUSTICE_KIND_FILTER = None
 _USE_PARTITIONS = None
+_TARGET_TABLE = "law_court_citations"
+_CASE_TABLE = "case_citation_edges"
+
+# case_reference is routed to the separate decision->case edge table, not the statute table
+_STATUTE_TYPES = {"law_article", "codex_article", "constitution", "law_by_number", "supreme_court_ruling"}
 
 def _check_partitions():
     global _USE_PARTITIONS
@@ -204,81 +268,124 @@ def _check_partitions():
     return _USE_PARTITIONS
 
 def process_chunk(args: tuple) -> dict:
-    """Process a chunk of rows from a partition. Runs in a separate process."""
-    year, offset, chunk_size = args
+    """Process a chunk of rows from a partition. Runs in a separate process.
+    Each worker writes its own results on its own connection (parallel writes,
+    no IPC of citation tuples back to the main process)."""
+    year, offset, chunk_size, dry_run = args
     conn = get_conn()
     cur = conn.cursor(name=f"cite_{year}_{offset}")
 
+    # Partitions carry justice_kind per row, so filter/select directly off the partition (no join needed).
     if _check_partitions():
         table = f"edrsr_fulltext_p_{year}"
-        year_filter = ""
-    else:
-        table = "edrsr_fulltext"
-        year_filter = f"AND f.adj_year = {year} "
-
-    if _JUSTICE_KIND_FILTER is not None:
+        where = "WHERE justice_kind = %s " if _JUSTICE_KIND_FILTER is not None else ""
+        params = ([_JUSTICE_KIND_FILTER] if _JUSTICE_KIND_FILTER is not None else []) + [offset, chunk_size]
         cur.execute(
-            f"SELECT f.doc_id, f.full_text FROM {table} f "
-            f"JOIN edrsr_documents d ON f.doc_id = d.doc_id "
-            f"WHERE d.justice_kind = %s {year_filter}"
-            f"OFFSET %s LIMIT %s",
-            (_JUSTICE_KIND_FILTER, offset, chunk_size),
+            f"SELECT doc_id, full_text, justice_kind FROM {table} {where}OFFSET %s LIMIT %s",
+            tuple(params),
         )
     else:
+        where = "AND justice_kind = %s " if _JUSTICE_KIND_FILTER is not None else ""
+        params = [year] + ([_JUSTICE_KIND_FILTER] if _JUSTICE_KIND_FILTER is not None else []) + [offset, chunk_size]
         cur.execute(
-            f"SELECT doc_id, full_text FROM {table} WHERE adj_year = %s OFFSET %s LIMIT %s",
-            (year, offset, chunk_size),
+            f"SELECT doc_id, full_text, justice_kind FROM edrsr_fulltext WHERE adj_year = %s {where}OFFSET %s LIMIT %s",
+            tuple(params),
         )
 
-    all_citations = []
+    statute_data = []   # (doc_id, citation_type, law_ref, article_ref, raw_match, justice_kind)
+    case_data = []      # (doc_id, to_case_number, raw_match, justice_kind)
     rows = 0
     type_counts = Counter()
 
-    for doc_id, text in cur:
+    for doc_id, text, jk in cur:
         rows += 1
         if not text:
             continue
         try:
-            cites = extract_citations_from_text(doc_id, text)
-            all_citations.extend(cites)
-            for c in cites:
+            for c in extract_citations_from_text(doc_id, text):
                 type_counts[c.citation_type] += 1
+                if c.citation_type == "case_reference":
+                    case_data.append((c.doc_id, c.law_ref, c.raw_match, jk))
+                else:
+                    statute_data.append((c.doc_id, c.citation_type, c.law_ref, c.article_ref, c.raw_match, jk))
         except Exception:
             pass
 
     cur.close()
     conn.close()
 
+    # Write directly from this worker (parallel writes across workers, disjoint doc_ids per chunk)
+    if not dry_run:
+        write_statute(statute_data, adj_year=year)
+        write_cases(case_data, adj_year=year)
+
     return {
         "year": year,
         "offset": offset,
         "rows": rows,
-        "citations": len(all_citations),
+        "citations": len(statute_data) + len(case_data),
         "type_counts": dict(type_counts),
-        "data": [(c.doc_id, c.citation_type, c.law_ref, c.article_ref, c.raw_match) for c in all_citations],
     }
 
-def write_citations(results: list[tuple], justice_kind: int = None, adj_year: int = None):
-    """Bulk-insert citation results."""
-    if not results:
+def write_statute(rows: list[tuple], adj_year: int):
+    """Bulk-insert statute citations. Idempotent via ON CONFLICT DO NOTHING (dedup)."""
+    if not rows:
         return
     conn = get_conn()
     cur = conn.cursor()
     execute_values(
         cur,
-        """INSERT INTO law_court_citations
+        f"""INSERT INTO {_TARGET_TABLE}
            (court_case_id, citation_type, law_number, law_article, citation_context, justice_kind, adj_year)
-           VALUES %s""",
-        [(r[0], r[1], r[2], r[3], r[4][:500], justice_kind, adj_year) for r in results],
+           VALUES %s ON CONFLICT DO NOTHING""",
+        # r = (doc_id, citation_type, law_ref, article_ref, raw_match, justice_kind)
+        [(r[0], r[1], r[2], r[3], r[4][:500], r[5], adj_year) for r in rows],
         page_size=5000,
     )
     conn.commit()
     cur.close()
     conn.close()
 
+def write_cases(rows: list[tuple], adj_year: int):
+    """Bulk-insert decision->case reference edges. Idempotent via ON CONFLICT DO NOTHING (dedup)."""
+    if not rows:
+        return
+    conn = get_conn()
+    cur = conn.cursor()
+    execute_values(
+        cur,
+        f"""INSERT INTO {_CASE_TABLE}
+           (from_case_id, to_case_number, citation_context, justice_kind, adj_year)
+           VALUES %s ON CONFLICT DO NOTHING""",
+        # r = (doc_id, to_case_number, raw_match, justice_kind)
+        [(r[0], r[1], r[2][:500], r[3], adj_year) for r in rows],
+        page_size=5000,
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+
+def enrich_justice_kind(year: int):
+    """Backfill justice_kind from edrsr_documents (the source of truth; edrsr_fulltext.justice_kind
+    is only ~2% populated). Set-based UPDATE per year, decoupled from chunked pagination."""
+    conn = get_conn()
+    cur = conn.cursor()
+    for tbl, col in ((_TARGET_TABLE, "court_case_id"), (_CASE_TABLE, "from_case_id")):
+        cur.execute(
+            f"UPDATE {tbl} t SET justice_kind = d.justice_kind "
+            f"FROM edrsr_documents d "
+            f"WHERE t.{col} = d.doc_id AND t.adj_year = %s "
+            f"AND t.justice_kind IS NULL AND d.justice_kind IS NOT NULL",
+            (year,),
+        )
+        print(f"    enriched justice_kind on {tbl}: {cur.rowcount:,} rows")
+    conn.commit()
+    cur.close()
+    conn.close()
+
 # ── Main ─────────────────────────────────────────────────────
 
-def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000) -> PartitionStats:
+def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000, limit: int = None) -> PartitionStats:
     stats = PartitionStats(year=year)
     t0 = time.time()
 
@@ -286,18 +393,15 @@ def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000
     cur = conn.cursor()
     if _check_partitions():
         table = f"edrsr_fulltext_p_{year}"
-        year_filter = ""
+        if _JUSTICE_KIND_FILTER is not None:
+            cur.execute(f"SELECT COUNT(*) FROM {table} WHERE justice_kind = %s", (_JUSTICE_KIND_FILTER,))
+        else:
+            cur.execute(f"SELECT COUNT(*) FROM {table}")
     else:
-        table = "edrsr_fulltext"
-        year_filter = f"AND f.adj_year = {year} "
-
-    if _JUSTICE_KIND_FILTER is not None:
-        cur.execute(
-            f"SELECT COUNT(*) FROM {table} f JOIN edrsr_documents d ON f.doc_id = d.doc_id WHERE d.justice_kind = %s {year_filter}",
-            (_JUSTICE_KIND_FILTER,),
-        )
-    else:
-        cur.execute(f"SELECT COUNT(*) FROM {table} WHERE adj_year = %s", (year,))
+        if _JUSTICE_KIND_FILTER is not None:
+            cur.execute("SELECT COUNT(*) FROM edrsr_fulltext WHERE adj_year = %s AND justice_kind = %s", (year, _JUSTICE_KIND_FILTER))
+        else:
+            cur.execute("SELECT COUNT(*) FROM edrsr_fulltext WHERE adj_year = %s", (year,))
     total = cur.fetchone()[0]
     cur.close()
     conn.close()
@@ -306,7 +410,11 @@ def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000
         print(f"  Year {year}: 0 rows, skipping")
         return stats
 
-    chunks = [(year, offset, chunk_size) for offset in range(0, total, chunk_size)]
+    if limit is not None and total > limit:
+        print(f"  Year {year}: capping {total:,} -> {limit:,} rows (--limit)")
+        total = limit
+
+    chunks = [(year, offset, chunk_size, dry_run) for offset in range(0, total, chunk_size)]
     print(f"  Year {year}: {total:,} rows, {len(chunks)} chunks, {workers} workers")
 
     with ProcessPoolExecutor(max_workers=workers) as pool:
@@ -319,13 +427,13 @@ def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000
             for k, v in result["type_counts"].items():
                 stats.by_type[k] += v
 
-            if not dry_run and result["data"]:
-                write_citations(result["data"], justice_kind=_JUSTICE_KIND_FILTER, adj_year=year)
-
             if (i + 1) % 10 == 0 or i == len(futures) - 1:
                 elapsed = time.time() - t0
                 rate = stats.rows_processed / elapsed if elapsed > 0 else 0
                 print(f"    [{i+1}/{len(chunks)}] {stats.rows_processed:,} rows, {stats.citations_found:,} citations, {rate:,.0f} rows/sec")
+
+    if not dry_run:
+        enrich_justice_kind(year)
 
     stats.elapsed_sec = time.time() - t0
     return stats
@@ -340,13 +448,18 @@ def main():
     parser.add_argument("--years-from", type=int, default=2007, help="Start year for --all")
     parser.add_argument("--years-to", type=int, default=2026, help="End year for --all")
     parser.add_argument("--justice-kind", type=int, default=None, help="Filter by justice_kind (e.g. 5 for КУпАП)")
+    parser.add_argument("--target-table", type=str, default="law_court_citations", help="Statute-citation destination table (use a staging table for pilots)")
+    parser.add_argument("--case-table", type=str, default="case_citation_edges", help="decision->case edge destination table")
+    parser.add_argument("--limit", type=int, default=None, help="Cap rows processed per year (for piloting)")
     args = parser.parse_args()
 
     if not args.year and not args.all:
         parser.error("Specify --year YYYY or --all")
 
-    global _JUSTICE_KIND_FILTER
+    global _JUSTICE_KIND_FILTER, _TARGET_TABLE, _CASE_TABLE
     _JUSTICE_KIND_FILTER = args.justice_kind
+    _TARGET_TABLE = args.target_table
+    _CASE_TABLE = args.case_table
 
     years = list(range(args.years_from, args.years_to + 1)) if args.all else [args.year]
 
@@ -354,13 +467,14 @@ def main():
     print(f"=== Citation Extraction Pipeline ===")
     print(f"Years: {years[0]}–{years[-1]} ({len(years)} years){jk_label}")
     print(f"Workers: {args.workers}, Chunk: {args.chunk_size:,}")
+    print(f"Statute table: {_TARGET_TABLE} | case-edge table: {_CASE_TABLE}" + (f" | limit/year: {args.limit:,}" if args.limit else ""))
     print(f"Dry run: {args.dry_run}\n")
 
     all_stats = []
     t_total = time.time()
 
     for year in years:
-        stats = process_year(year, args.workers, args.dry_run, args.chunk_size)
+        stats = process_year(year, args.workers, args.dry_run, args.chunk_size, args.limit)
         all_stats.append(stats)
         print(f"  → Year {year}: {stats.citations_found:,} citations in {stats.elapsed_sec:.1f}s")
         print(f"    Types: {dict(stats.by_type)}\n")

--- a/scripts/citation-graph/postrun-rebuild-indexes.sql
+++ b/scripts/citation-graph/postrun-rebuild-indexes.sql
@@ -1,0 +1,30 @@
+-- =====================================================================
+-- postrun-rebuild-indexes.sql
+-- Rebuild the secondary QUERY indexes on law_court_citations AFTER the full
+-- extraction run completes (they were dropped by prep-full-rebuild-tables.sql
+-- to keep the ~700M-row load fast).
+--
+-- Run ONCE, after extract-citations.py --all has finished:
+--   psql "$DATABASE_URL" -f postrun-rebuild-indexes.sql
+--
+-- Uses CREATE INDEX CONCURRENTLY so the (now live again) table stays readable
+-- and is not write-locked. CONCURRENTLY cannot run inside a transaction block,
+-- so there is NO BEGIN/COMMIT here. Idempotent via IF NOT EXISTS.
+--
+-- Building a btree on a few-hundred-million-row table takes a while
+-- (tens of minutes each; they are independent and could be launched in
+-- parallel psql sessions if you want to shorten wall-clock).
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_article ON law_court_citations (law_article);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_law     ON law_court_citations (law_number);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_type    ON law_court_citations (citation_type);
+
+-- Refresh planner stats after the bulk load + index build.
+ANALYZE law_court_citations;
+ANALYZE case_citation_edges;
+
+-- Note: idx_lcc_case (btree on court_case_id) is intentionally NOT recreated -
+-- the uq_lcc_dedup unique index leads with court_case_id and serves those lookups.

--- a/scripts/citation-graph/prep-full-rebuild-tables.sql
+++ b/scripts/citation-graph/prep-full-rebuild-tables.sql
@@ -1,0 +1,88 @@
+-- =====================================================================
+-- prep-full-rebuild-tables.sql
+-- Prepare PROD tables for the full EDRSR citation extraction run.
+--
+-- Strategy: TRUNCATE + full rebuild. All DDL below runs on EMPTY tables,
+-- so it is effectively instant (< 1 min incl. the safety backup).
+--
+-- Safe to re-run: idempotent (IF NOT EXISTS / IF EXISTS / guarded backup).
+-- DESTRUCTIVE: it TRUNCATEs law_court_citations. The backup table created
+-- in step 1 is your rollback path.
+--
+-- Run ONCE, immediately before launching the extractor:
+--   psql "$DATABASE_URL" -f prep-full-rebuild-tables.sql
+--   nice -n 10 python3 extract-citations.py --all --workers 8
+--
+-- AFTER the extractor finishes, run postrun-rebuild-indexes.sql to rebuild
+-- the secondary query indexes that step 4 drops for load speed.
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- 1. Safety backup of the current table (snapshot). Guarded so a re-run
+--    never clobbers an existing backup.
+DO $$
+BEGIN
+  IF to_regclass('public.law_court_citations_backup_prerebuild') IS NULL THEN
+    EXECUTE 'CREATE TABLE law_court_citations_backup_prerebuild AS TABLE law_court_citations';
+    RAISE NOTICE 'Backup created: law_court_citations_backup_prerebuild (% rows)',
+      (SELECT count(*) FROM law_court_citations_backup_prerebuild);
+  ELSE
+    RAISE NOTICE 'Backup law_court_citations_backup_prerebuild already exists - skipping';
+  END IF;
+END $$;
+
+-- 2. New columns the refined pipeline writes (nullable, no default ->
+--    metadata-only, instant). justice_kind is backfilled per-year by the
+--    extractor's enrich step; adj_year is set on insert.
+ALTER TABLE law_court_citations ADD COLUMN IF NOT EXISTS justice_kind smallint;
+ALTER TABLE law_court_citations ADD COLUMN IF NOT EXISTS adj_year     smallint;
+
+-- 3. Clear the old batch (~384K real + ~120K ГПК phantom rows). Backup retained.
+TRUNCATE law_court_citations RESTART IDENTITY;
+
+-- 4. Drop secondary QUERY indexes for the duration of the load. Maintaining
+--    these on every one of ~700M inserts is pure overhead during a rebuild;
+--    they are recreated post-run. idx_lcc_case is dropped permanently - it is
+--    redundant with the new unique index's leading column (court_case_id).
+DROP INDEX IF EXISTS idx_lcc_article;
+DROP INDEX IF EXISTS idx_lcc_law;
+DROP INDEX IF EXISTS idx_lcc_type;
+DROP INDEX IF EXISTS idx_lcc_case;
+
+-- 5. Unique index = dedup + the conflict arbiter for `ON CONFLICT DO NOTHING`.
+--    Built on the empty table = instant. Kept during the load (required).
+--    Its leading column also serves court_case_id lookups (replaces idx_lcc_case).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_lcc_dedup
+  ON law_court_citations (court_case_id, citation_type, law_number, law_article);
+
+-- 6. adj_year index = needed for the per-year enrich UPDATE (justice_kind
+--    backfill filters on adj_year). Without it each year's enrich would
+--    seq-scan the whole growing table. Kept during the load.
+CREATE INDEX IF NOT EXISTS idx_lcc_adj_year ON law_court_citations (adj_year);
+
+-- 7. case_citation_edges: decision -> referenced case-number raw edges
+--    (proto decision<->decision graph; case numbers are resolved to doc_ids
+--    in a later step). to_case_number stays text until resolution.
+CREATE TABLE IF NOT EXISTS case_citation_edges (
+  id               bigserial PRIMARY KEY,
+  from_case_id     bigint   NOT NULL,
+  to_case_number   text     NOT NULL,
+  citation_context text     DEFAULT '',
+  justice_kind     smallint,
+  adj_year         smallint,
+  created_at       timestamptz DEFAULT now()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cce_dedup
+  ON case_citation_edges (from_case_id, to_case_number);
+CREATE INDEX IF NOT EXISTS idx_cce_adj_year ON case_citation_edges (adj_year);
+
+COMMIT;
+
+-- Sanity check (run manually after):
+--   \d law_court_citations
+--   \d case_citation_edges
+--   SELECT count(*) FROM law_court_citations_backup_prerebuild;  -- old rows preserved
+--   SELECT count(*) FROM law_court_citations;                    -- expect 0 before run


### PR DESCRIPTION
## Summary
Refines the EDRSR legislation-citation extraction pipeline for a full-corpus rebuild (scaling `law_court_citations` beyond its current 0.03% coverage) and adds the prod table-prep SQL. Validated + benchmarked on prod. Ref **LEXAI-1770**.

## Changes
**`scripts/citation-graph/extract-citations.py`**
- **Parallel writes**: each worker writes its own statute/case results on its own connection and returns only stats — removes the serial main-process writer + the IPC pickling of millions of tuples. **+47% @ 8 workers**, restored positive scaling.
- `--target-table` / `--case-table` / `--limit` flags for safe piloting into staging tables.
- `case_reference` routed to a separate decision→case edge table (proto decision↔decision graph).
- Dedup via unique index + `ON CONFLICT DO NOTHING` (idempotent re-runs, 0 dup tuples).
- Per-row `justice_kind` backfilled from `edrsr_documents` (edrsr_fulltext.justice_kind only ~2.2% populated) via per-year set-based UPDATE.
- Phantom article-range fix (`MAX_RANGE_SPAN` + `normalize_flattened`) — kills `range(1119,11111)` explosions.

**`scripts/citation-graph/prep-full-rebuild-tables.sql`** (run before) — idempotent: backup → ADD justice_kind/adj_year → TRUNCATE → drop secondary indexes for load speed → unique + adj_year indexes → create `case_citation_edges`.

**`scripts/citation-graph/postrun-rebuild-indexes.sql`** (run after) — `CREATE INDEX CONCURRENTLY` rebuild of query indexes + `ANALYZE`.

## Benchmark (prod, 8-core box, year 2024, 600K rows)
| workers | rows/sec |
|---|---|
| 6 | 2,456 |
| **8** | **2,871** (sweet-spot, lowest load) |
| 12 | 2,764 |
| 18 | 2,819 (load ~9.7, no gain) |

Full-corpus ETA **~10h @ 8 workers**. Projection: ~700-850M statute rows + ~200M case-edge rows.

## Not included / follow-up
- The full rebuild itself is NOT run yet (run order: prep.sql → `extract-citations.py --all --workers 8` in tmux → postrun.sql).
- Resolving `case_citation_edges` case-numbers → doc_ids to materialize the decision↔decision graph (feeds the Neo4j ETL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up and hardens the EDRSR citation extractor for a full-corpus rebuild by parallelizing writes and fixing article-range parsing. Preps `law_court_citations` and adds `case_citation_edges`; +47% throughput at 8 workers on prod (~2.9k rows/sec). Ref LEXAI-1770.

- **New Features**
  - Parallel DB writes per worker; removes main-process writer and IPC, restoring scaling.
  - New flags: `--target-table`, `--case-table`, `--limit` for safe pilots.
  - Routes `case_reference` into `case_citation_edges` (decision → case edge table).
  - Idempotent inserts via unique index + `ON CONFLICT DO NOTHING`.
  - Per-year `justice_kind` backfill from `edrsr_documents`.
  - Fixes phantom article ranges with `MAX_RANGE_SPAN` and `normalize_flattened`.

- **Migration**
  - Run `scripts/citation-graph/prep-full-rebuild-tables.sql` to back up, truncate, add columns, drop query indexes, add unique/`adj_year` indexes, and create `case_citation_edges`.
  - Run extractor: `python3 scripts/citation-graph/extract-citations.py --all --workers 8 [--target-table ...] [--case-table ...] [--limit ...]`.
  - After completion, run `scripts/citation-graph/postrun-rebuild-indexes.sql` to rebuild indexes concurrently and `ANALYZE`.

<sup>Written for commit 763e63e687c596b9b8219ece2ec79062bd81386b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

