### PR TITLE
fix(legislation): resolve КУпАП across both RADA documents (LEXAI-1770)

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -3,6 +3,20 @@ import * as cheerio from 'cheerio';
 import { logger } from '../utils/logger';
 import type { IDatabase } from '../domain/ports/index.js';
 
+/**
+ * КУпАП (Кодекс України про адміністративні правопорушення) is split in RADA
+ * into two documents: 80731-10 (статті 1–212-21) and 80732-10 (статті 213–330).
+ * Article numbers don't overlap, so a КУпАП article lookup must search BOTH
+ * rada_ids (LEXAI-1770). Defined locally to avoid a circular import with
+ * legislation-service.ts (which imports this adapter).
+ */
+const KUPAP_RADA_IDS = ['80731-10', '80732-10'];
+
+function expandKupapRadaIds(radaId: string): string[] {
+  const lower = String(radaId || '').toLowerCase();
+  return KUPAP_RADA_IDS.some((id) => id === lower) ? [...KUPAP_RADA_IDS] : [radaId];
+}
+
 export interface LegislationMetadata {
   rada_id: string;
   type: 'code' | 'law' | 'regulation';
@@ -33,6 +47,8 @@ export interface LegislationArticle {
   version_date?: Date;
   byte_size: number;
   metadata?: any;
+  /** rada_id of the legislation row this article belongs to (set on direct lookups). */
+  rada_id?: string;
 }
 
 export interface ArticleChunk {
@@ -821,26 +837,29 @@ export class RadaLegislationAdapter {
   }
 
   async getArticleByNumber(radaId: string, articleNumber: string, asOfDate?: string): Promise<LegislationArticle | null> {
+    // КУпАП spans two RADA documents (80731-10 / 80732-10); search both halves.
+    // Article numbers don't overlap between them, so the match stays unambiguous.
+    const radaIds = expandKupapRadaIds(radaId).map((id) => id.toLowerCase());
     let result;
     if (asOfDate) {
       result = await this.db.query(
-        `SELECT la.*
+        `SELECT la.*, l.rada_id
          FROM legislation_articles la
          JOIN legislation l ON la.legislation_id = l.id
-         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.version_date <= $3
+         WHERE LOWER(l.rada_id) = ANY($1) AND la.article_number = $2 AND la.version_date <= $3
          ORDER BY la.version_date DESC
          LIMIT 1`,
-        [radaId, articleNumber, asOfDate]
+        [radaIds, articleNumber, asOfDate]
       );
     } else {
       result = await this.db.query(
-        `SELECT la.*
+        `SELECT la.*, l.rada_id
          FROM legislation_articles la
          JOIN legislation l ON la.legislation_id = l.id
-         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.is_current = true
+         WHERE LOWER(l.rada_id) = ANY($1) AND la.article_number = $2 AND la.is_current = true
          ORDER BY la.version_date DESC NULLS LAST, la.id DESC
          LIMIT 1`,
-        [radaId, articleNumber]
+        [radaIds, articleNumber]
       );
     }
 
@@ -864,8 +883,9 @@ export class RadaLegislationAdapter {
     const params: any[] = [query, `%${query}%`];
 
     if (radaId) {
-      sql += ` AND LOWER(l.rada_id) = LOWER($3)`;
-      params.push(radaId);
+      // КУпАП spans 80731-10 + 80732-10 — filter across both halves.
+      sql += ` AND LOWER(l.rada_id) = ANY($3)`;
+      params.push(expandKupapRadaIds(radaId).map((id) => id.toLowerCase()));
     }
 
     sql += ` ORDER BY ts_rank(to_tsvector('simple', la.full_text), plainto_tsquery('simple', $1)) DESC LIMIT $${params.length + 1}`;

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -31,6 +31,29 @@ export interface LegislationSearchResult {
 }
 
 /**
+ * КУпАП (Кодекс України про адміністративні правопорушення) is split in RADA
+ * into TWO documents:
+ *   - 80731-10 → статті 1–212-21  (loaded as legislation.id=653)
+ *   - 80732-10 → статті 213–330   (loaded as legislation.id=22)
+ * The alias maps resolve КУпАП to 80731-10, so a citation to ст. 213+ would
+ * silently miss its DB row (this caused ~18.7K unresolved statute citations,
+ * LEXAI-1770). Article numbers do NOT overlap between the two halves, so
+ * searching BOTH rada_ids is safe and unambiguous.
+ *
+ * Given either КУпАП half, returns both rada_ids; otherwise returns [radaId].
+ * Used to widen article lookups to `LOWER(rada_id) = ANY(...)`.
+ */
+export const KUPAP_RADA_IDS = ['80731-10', '80732-10'] as const;
+
+export function expandKupapRadaIds(radaId: string): string[] {
+  const lower = String(radaId || '').toLowerCase();
+  if (KUPAP_RADA_IDS.some((id) => id.toLowerCase() === lower)) {
+    return [...KUPAP_RADA_IDS];
+  }
+  return [radaId];
+}
+
+/**
  * Парсит ссылку на законодательство из текста, используя regexp.
  * Для сложных случаев следует использовать parseLegislationReferenceWithAI.
  */
@@ -54,6 +77,8 @@ export function parseLegislationReference(text: string): { radaId: string; artic
     'КК': '2341-14',
     'КУ': '254к/96-вр',
     'КОНСТИТУЦІЯ': '254к/96-вр',
+    // КУпАП resolves to the first half here; article lookups widen to both
+    // halves (80731-10 + 80732-10) via expandKupapRadaIds (LEXAI-1770).
     'КУПАП': '80731-10',
     'КУпАП': '80731-10',
   };
@@ -441,10 +466,13 @@ export class LegislationService {
     }
 
     radaId = normalizeRadaId(radaId);
+    // КУпАП is split across two RADA documents (80731-10 / 80732-10). Accept either
+    // half as "present" so a ст. 213+ lookup doesn't trigger a needless refetch.
+    const radaIds = expandKupapRadaIds(radaId).map((id) => id.toLowerCase());
     // Case-insensitive lookup — RADA API may return different casing (e.g. 254к/96-ВР vs 254к/96-вр)
     const result = await this.db.query(
-      'SELECT id, rada_id, total_articles FROM legislation WHERE LOWER(rada_id) = LOWER($1)',
-      [radaId]
+      'SELECT id, rada_id, total_articles FROM legislation WHERE LOWER(rada_id) = ANY($1)',
+      [radaIds]
     );
     if (result.rows.length > 0) {
       const row = result.rows[0];
@@ -495,10 +523,14 @@ export class LegislationService {
       return null;
     }
 
+    // For КУпАП the matched article may live in the 80732-10 half even when the
+    // caller passed 80731-10 — use the record's own rada_id for title/URL.
+    const matchedRadaId = article.rada_id || radaId;
+
     // Fetch NPA title from legislation table
     const legResult = await this.db.query(
       `SELECT title FROM legislation WHERE LOWER(rada_id) = LOWER($1) LIMIT 1`,
-      [radaId]
+      [matchedRadaId]
     );
     const npaTitle = legResult.rows[0]?.title || undefined;
 
@@ -507,12 +539,12 @@ export class LegislationService {
     const actualArticleNumber = article.article_number || articleNumber;
 
     const ref: LegislationReference = {
-      rada_id: radaId,
+      rada_id: matchedRadaId,
       article_number: actualArticleNumber,
       title: article.title,
       full_text: article.full_text,
       full_text_html: article.full_text_html,
-      url: `https://zakon.rada.gov.ua/laws/show/${radaId}#n${actualArticleNumber}`,
+      url: `https://zakon.rada.gov.ua/laws/show/${matchedRadaId}#n${actualArticleNumber}`,
       metadata: article.metadata,
       npa_title: npaTitle,
       section_number: article.section_number,
@@ -531,34 +563,40 @@ export class LegislationService {
   async getMultipleArticles(radaId: string, articleNumbers: string[], asOfDate?: string): Promise<LegislationReference[]> {
     await this.ensureLegislationExists(radaId);
 
+    // КУпАП spans two RADA documents (80731-10 / 80732-10); widen the lookup to
+    // both halves. Article numbers don't overlap, so this stays unambiguous.
+    const radaIds = expandKupapRadaIds(radaId).map((id) => id.toLowerCase());
+
     let result;
     if (asOfDate) {
       result = await this.db.query(
         `SELECT DISTINCT ON (la.article_number) la.*, l.rada_id, l.title as npa_title
          FROM legislation_articles la
          JOIN legislation l ON la.legislation_id = l.id
-         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.version_date <= $3
+         WHERE LOWER(l.rada_id) = ANY($1) AND la.article_number = ANY($2) AND la.version_date <= $3
          ORDER BY la.article_number, la.version_date DESC`,
-        [radaId, articleNumbers, asOfDate]
+        [radaIds, articleNumbers, asOfDate]
       );
     } else {
       result = await this.db.query(
         `SELECT DISTINCT ON (la.article_number) la.*, l.rada_id, l.title as npa_title
          FROM legislation_articles la
          JOIN legislation l ON la.legislation_id = l.id
-         WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = ANY($2) AND la.is_current = true
+         WHERE LOWER(l.rada_id) = ANY($1) AND la.article_number = ANY($2) AND la.is_current = true
          ORDER BY la.article_number, la.version_date DESC NULLS LAST, la.id DESC`,
-        [radaId, articleNumbers]
+        [radaIds, articleNumbers]
       );
     }
 
     return result.rows.map((row: any) => ({
-      rada_id: radaId,
+      // Use the matched record's own rada_id, not the input — for КУпАП the
+      // article may live in the 80732-10 half even when the caller passed 80731-10.
+      rada_id: row.rada_id || radaId,
       article_number: row.article_number,
       title: row.title,
       full_text: row.full_text,
       full_text_html: row.full_text_html,
-      url: `https://zakon.rada.gov.ua/laws/show/${radaId}#n${row.article_number}`,
+      url: `https://zakon.rada.gov.ua/laws/show/${row.rada_id || radaId}#n${row.article_number}`,
       metadata: asOfDate ? { ...row.metadata, is_historical: true, as_of_date: asOfDate } : row.metadata,
       npa_title: row.npa_title,
       section_number: row.section_number,


### PR DESCRIPTION
## Problem

КУпАП (Кодекс України про адміністративні правопорушення) is split in RADA into **two** documents:
- `80731-10` → статті 1–212-21 (loaded as `legislation.id=653`)
- `80732-10` → статті 213–330 (loaded as `legislation.id=22`)

The legislation alias maps resolved КУпАП to `80731-10` **only**, so the article-lookup SQL (`LOWER(rada_id) = LOWER($1)`) never matched articles in the second half. Every citation to ст. 213+ КУпАП silently returned no DB row — ~18.7K unresolved statute citations.

## Fix

Add `expandKupapRadaIds(radaId)` — given either КУпАП half it returns both rada_ids, otherwise `[radaId]` — and widen the article lookups to `LOWER(rada_id) = ANY(...)`:

- `RadaLegislationAdapter.getArticleByNumber` (single article; the path used by `LegislationService.getArticle`)
- `RadaLegislationAdapter.searchArticles` (optional rada_id filter)
- `LegislationService.getMultipleArticles` (`get_legislation_articles` tool)
- `LegislationService.ensureLegislationExists` (so a ст. 213+ lookup doesn't trigger a needless refetch)

Article numbers don't overlap between the two halves, so searching both is safe and unambiguous. `getArticleByNumber` now also selects `l.rada_id` so the single-article title/URL point at the correct half (`80732-10` for ст. 213+) instead of always `80731-10`. The alias maps keep `80731-10` as the canonical id; expansion happens purely at the DB-query layer, leaving all other code aliases intact.

## Scope / safety

- No DB writes; no migration; `legislation_citation_links` untouched.
- Touched files typecheck clean (`npx tsc --noEmit`). Pre-existing unrelated errors remain for `core-loader.ts` (references to proprietary core-overlay services `token-budget-allocator` / `tool-health-tracker` / `step-constraints` that only exist in `secondlayer-core`) — not introduced here.

A companion fix in `secondlayer-core` (`incremental-allow-set.ts`) makes the hallucination/allow-set guard treat either КУпАП half as searched, so ст. 213+ citations aren't falsely flagged as fabricated; it is delivered separately via the core repo's bundle flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix КУпАП lookups by searching both RADA documents (`80731-10` and `80732-10`) so citations to ст. 213–330 resolve correctly. Addresses Linear LEXAI-1770 and clears ~18.7K unresolved statute citations.

- **Bug Fixes**
  - Added `expandKupapRadaIds()` to map either half of КУпАП to both IDs.
  - Updated queries to use `LOWER(l.rada_id) = ANY(...)` in:
    - `RadaLegislationAdapter.getArticleByNumber` and `searchArticles`
    - `LegislationService.ensureLegislationExists` and `getMultipleArticles`
  - `getArticleByNumber` now returns `l.rada_id`; titles/URLs use the matched half (e.g., `80732-10` for ст. 213+).
  - Alias stays canonical to `80731-10`; expansion is only at the DB layer. No schema changes or migrations.

<sup>Written for commit ccf74a02f2982efc60e2bbde2a4647b2aadee1cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/1998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

