### PR TITLE
ci: reset dist ownership before shared build on self-hosted runner

### DIFF
--- a/.github/workflows/ci-local-deploy.yml
+++ b/.github/workflows/ci-local-deploy.yml
@@ -87,6 +87,13 @@ jobs:
         with:
           node-version: 20
 
+      # Self-hosted runner: deployment/docker-compose.local.yml bind-mounts
+      # packages/shared/dist and mcp_backend/dist into containers. When those host
+      # dirs are absent, the Docker daemon (root) creates them root-owned, which
+      # then blocks the next tsc build under the runner user (EACCES). Reset first.
+      - name: Reset dist ownership (self-hosted runner)
+        run: sudo chown -R "$(id -u):$(id -g)" packages/shared/dist mcp_backend/dist 2>/dev/null || true
+
       - name: Build shared package
         run: cd packages/shared && npm install --legacy-peer-deps && npm run build
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -170,6 +170,13 @@ jobs:
         with:
           node-version: 20
 
+      # Self-hosted runner: deployment/docker-compose.local.yml bind-mounts
+      # packages/shared/dist and mcp_backend/dist into containers. When those host
+      # dirs are absent, the Docker daemon (root) creates them root-owned, which
+      # then blocks the next tsc build under the runner user (EACCES). Reset first.
+      - name: Reset dist ownership (self-hosted runner)
+        run: sudo chown -R "$(id -u):$(id -g)" packages/shared/dist mcp_backend/dist 2>/dev/null || true
+
       - name: Build shared package
         run: cd packages/shared && npm install --legacy-peer-deps && npm run build
 


### PR DESCRIPTION
## Problem

Every deploy to prod has been failing at the **Build shared package** step on the self-hosted `local-runner` with:

```
error TS5033: Could not write file '.../packages/shared/dist/database/base-database.d.ts':
EACCES: permission denied, mkdir '.../packages/shared/dist/database'.
```

### Root cause

`deployment/docker-compose.local.yml` bind-mounts the host dist dirs into containers:

```yaml
- ../mcp_backend/dist:/app/mcp_backend/dist:ro
- ../packages/shared/dist:/app/mcp_backend/node_modules/@secondlayer/shared/dist:ro
```

When those host dirs don't exist at `docker compose up` time, the Docker daemon (running as **root**) creates them **root-owned** on the host. The next pipeline run's `Build shared package` step runs `tsc` as the runner user (`vovkes`) and can't write into the root-owned `dist` → EACCES → the whole deploy aborts before reaching any build/test. A one-off `chown` doesn't stick because the next `compose up` recreates the dir as root again.

This blocked deploy-prod runs #866 and #868, and is independent of the code in those commits.

## Fix

Add a pre-build step in **both** workflows (`deploy-prod.yml` Pre-Deploy Tests and `ci-local-deploy.yml`) that resets ownership of the two dist dirs to the runner user right before `Build shared package`:

```yaml
- name: Reset dist ownership (self-hosted runner)
  run: sudo chown -R "$(id -u):$(id -g)" packages/shared/dist mcp_backend/dist 2>/dev/null || true
```

- Uses passwordless sudo already available on the self-hosted runner.
- `2>/dev/null || true` makes it a harmless no-op anywhere the dirs don't exist or sudo isn't present.
- Self-heals on every run, so the failure can't recur.

## Notes / scope

- This is purely the **dist permission** blocker. The latest `main` (b2d6022) also has a **separate** `Unit test backend` failure (local CI #1082, `revokeAccess`/`evaluateAccessGate`) that is unrelated to this change and will still need addressing by the relevant author.
- `ci-local-deploy.yml` only triggers on push to `main`, so this PR's checks (CodeQL/cubic) run on GitHub-hosted runners and aren't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix self-hosted deploy failures by resetting dist directory ownership before building the shared package. Adds a pre-build step in `deploy-prod.yml` and `ci-local-deploy.yml` so `tsc` can write to `packages/shared/dist` and `mcp_backend/dist`.

- **Bug Fixes**
  - Resets dist ownership on the self-hosted runner before the shared build.
  - Prevents EACCES from root-owned bind-mounted dist dirs.
  - Safe no-op on GitHub-hosted runners or when dirs are missing; runs each time to self-heal.

<sup>Written for commit 717b091b3f35207061753eaa016473676dbdbce0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

