### PR TITLE
test(legislation): align ensureLegislationExists test with batch ANY($1) lookup

### DIFF
--- a/mcp_backend/src/services/__tests__/legislation-service.test.ts
+++ b/mcp_backend/src/services/__tests__/legislation-service.test.ts
@@ -255,9 +255,11 @@ describe('LegislationService', () => {
 
       await service.ensureLegislationExists('254k/96-vr');
 
+      // Lookup is a case-insensitive batch query (LOWER(rada_id) = ANY($1)); the
+      // Latin '254k/96-vr' input must reach the DB normalized to Cyrillic, lowercased.
       expect(mockDb.query).toHaveBeenCalledWith(
-        expect.stringContaining('LOWER(rada_id) = LOWER'),
-        ['254к/96-вр']
+        expect.stringContaining('LOWER(rada_id) = ANY'),
+        [['254к/96-вр']]
       );
     });
 


### PR DESCRIPTION
## Problem

Local CI on `main` has been failing with **1 failed test / 961** in `Unit test backend`, blocking the deploy pipeline:

```
● LegislationService › ensureLegislationExists › should normalize rada_id before lookup

    - Expected
    + Received
    - StringContaining "LOWER(rada_id) = LOWER",
    + "SELECT id, rada_id, total_articles FROM legislation WHERE LOWER(rada_id) = ANY($1)",
      Array [
    +   Array [
          "254к/96-вр",
    +   ],
      ],
```

## Cause

`ensureLegislationExists` was changed (КУпАП two-document split support) to do a case-insensitive **batch** lookup:

```js
const radaIds = expandKupapRadaIds(radaId).map((id) => id.toLowerCase());
await this.db.query(
  'SELECT id, rada_id, total_articles FROM legislation WHERE LOWER(rada_id) = ANY($1)',
  [radaIds]
);
```

The unit test still asserted the old single-value shape (`LOWER(rada_id) = LOWER` + flat `['254к/96-вр']`). The production behavior is correct — only the test was stale.

## Fix

Update the assertion to the new query shape (`LOWER(rada_id) = ANY`) and nested array param (`[['254к/96-вр']]`). The test's intent is unchanged: the Latin `254k/96-vr` input must reach the DB normalized to Cyrillic and lowercased (`254к/96-вр`).

## Verification

- ✅ `legislation-service.test.ts`: **36/36 pass** (was 35 pass / 1 fail)
- Built `@secondlayer/shared` + ran the suite against the current `main` implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align ensureLegislationExists unit test with the batch ANY($1) lookup to fix the failing test on main and unblock CI. The test now asserts "LOWER(rada_id) = ANY" with a nested array param and still verifies normalization to Cyrillic lowercase ("254к/96-вр").

<sup>Written for commit 3cc3ce87d4411e7ca768116d44ef36d95505305c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

