### PR TITLE
fix(ci): drop host dist bind-mounts from local compose (durable EACCES fix)

### DIFF
--- a/deployment/docker-compose.local.yml
+++ b/deployment/docker-compose.local.yml
@@ -369,8 +369,13 @@ services:
         condition: service_healthy
 
     volumes:
-      - ../mcp_backend/dist:/app/mcp_backend/dist:ro
-      - ../packages/shared/dist:/app/mcp_backend/node_modules/@secondlayer/shared/dist:ro
+      # NOTE: do NOT bind-mount host packages/shared/dist or mcp_backend/dist here.
+      # Dockerfile.mono-backend already compiles fresh dist into the image (and the
+      # local deploy runs `up -d --build`), so mounting host dist only re-introduced
+      # the stale-overwrite the Dockerfile warns about — and, because dist/ is
+      # gitignored, `git clean -ffdx` in CI checkout deletes it while this
+      # restart:unless-stopped container holds the mount, making the Docker daemon
+      # recreate the host dir root-owned and break the next tsc build (EACCES).
       - ../mcp_backend/logs:/app/logs
       - app_local_data:/app/data
       # Vision API credentials for OCR


### PR DESCRIPTION
## Background

Follow-up to the **durable** fix for the `Build shared package` EACCES failures on the self-hosted `local-runner`. PR #2000 added a `chown` band-aid; this removes the root cause.

## Root cause

`deployment/docker-compose.local.yml` bind-mounted host dist into the long-lived (`restart: unless-stopped`) `secondlayer-app-local` container:

```yaml
- ../mcp_backend/dist:/app/mcp_backend/dist:ro
- ../packages/shared/dist:/app/mcp_backend/node_modules/@secondlayer/shared/dist:ro
```

`dist/` is **gitignored**, so `git clean -ffdx` during CI checkout deletes those host dirs. While the container is running and holds the mount, the Docker daemon immediately recreates the host mount-source as **root:root**. The next `Build shared package` step runs `tsc` as the runner user (`vovkes`) and fails:

```
error TS5033: … EACCES: permission denied, mkdir '.../packages/shared/dist/database'
```

The #2000 `chown` step helps but still races a concurrent `docker compose up` that re-clobbers dist during the build's `npm install` window (observed: deploy fails under concurrency, passes on a clean rerun).

## Why removing the mounts is correct

`deployment/Dockerfile.mono-backend` already compiles fresh dist **into the image**:
- builds `packages/shared` dist (line ~39) and `mcp_backend` dist (line ~54)
- copies built dist into the final image (line ~102)
- and explicitly comments: *"No need to copy host dist/ — that caused stale files to overwrite fresh builds."*

The local deploy runs `docker compose up -d --build` (`manage-gateway.sh`), so the image dist is rebuilt on every deploy. The host-dist mounts were therefore both **redundant** (image already has dist) and **harmful** (re-introduced the stale-overwrite the Dockerfile warns about + caused the root race).

## Change

Remove the two host-dist bind-mounts from `docker-compose.local.yml`; the container now uses the image-baked dist. `prod` compose never had these mounts, so production is unaffected.

The `chown` step from #2000 is left in place as a harmless defensive net for any pre-existing root-owned dist.

## Validation

- `docker compose -f deployment/docker-compose.local.yml config` parses cleanly.
- Eliminates the race at its source: no host dist mount → Docker never recreates host dist → tsc always writes as the runner user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes host `dist/` bind-mounts from local Compose to stop intermittent EACCES errors in CI and prevent stale `dist` overwrites. Local deploys now use image-built artifacts; production compose is unchanged.

- **Bug Fixes**
  - Dropped host `dist/` mounts for `mcp_backend` and `@secondlayer/shared` from `deployment/docker-compose.local.yml`.
  - Stops Docker from recreating `dist/` as root after `git clean -ffdx`, which caused `tsc` EACCES in the “Build shared package” step.
  - Uses `Dockerfile.mono-backend` to build and copy fresh `dist/` into the image on `docker compose up -d --build`.

<sup>Written for commit 8a60911c294a2340103dfbfe1bc36deeb3ab6cfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

