### PR TITLE
feat(citation-graph): local-compute full rebuild scripts + deferred-load flags

### DIFF
--- a/scripts/citation-graph/RUNBOOK-full-rebuild.md
+++ b/scripts/citation-graph/RUNBOOK-full-rebuild.md
@@ -1,0 +1,121 @@
+# Full EDRSR citation rebuild — local-compute → prod-export runbook
+
+Rebuild `law_court_citations` (+ `case_citation_edges`) from the **whole**
+EDRSR corpus (~120-140M decisions, 2007-2026) cleanly, then publish to prod.
+
+**Why local compute:** cthulhu (16 cores, NVMe, 123 GB RAM, full `edrsr_fulltext`
+partitions) extracts ~3× faster than prod at equal workers and carries no live
+traffic. Benchmarked sweet spot **W=14 ≈ 10,582 rows/s** → ~3.4-4 h load.
+Prod only does a pre-deduped bulk COPY + index build (no extraction load).
+
+**Why deferred-index:** writing into UNLOGGED, index-free staging then
+dedup+index once was ~25% faster end-to-end than inline unique-index +
+`ON CONFLICT` (bench: 758 s vs 881 s on 2M; the inline path also degrades as the
+table grows, deferred stays flat).
+
+```
+LOCAL (cthulhu)                          PROD
+01 prep.sql   -> lcc_bulk/cce_bulk        01 prep.sql  -> TRUNCATE + drop indexes
+02 run.sh     -> extract --all (3.4-4h)   02 copy.sh   -> COPY gz CSV in
+03 finalize   -> dedup+index+enrich       03 finalize  -> build indexes + enrich
+04 export.sh  -> gz CSV ─────────────────▶ (transfer S3/scp)
+```
+
+---
+
+## Pre-flight (local)
+
+```bash
+# on cthulhu:  ssh -J workstation local.lex
+cd ~/SecondLayer/scripts/citation-graph
+git pull            # ensure these scripts are present
+
+# CRITICAL: the local extract-citations.py MUST have the deferred flags.
+# main-branch does NOT yet; the local copy was patched. Verify:
+python3 extract-citations.py --help | grep -- --bulk-load   # must print a line
+#   (run.sh also guards this and aborts if missing)
+
+# Disk check — staging raw (~150 GB) + dedup (~100 GB) + indexes on top of the
+# existing 502M stale baseline (~111 GB). Need ~400 GB headroom.
+df -h /var/lib/docker   # or wherever the local PG volume lives
+```
+
+The stale 502M `law_court_citations` and its `mv_citations_by_year` are **left
+untouched** by this whole local flow — it builds into separate `*_bulk`/`*_final`
+tables. Decide its fate only after prod is validated (see Cleanup).
+
+## 1-3. Run on local (inside tmux)
+
+```bash
+tmux new -s citerebuild
+cd ~/SecondLayer/scripts/citation-graph
+ENV=~/SecondLayer/deployment/.env.local
+PU=$(grep ^POSTGRES_USER= $ENV|cut -d= -f2-); PD=$(grep ^POSTGRES_DB= $ENV|cut -d= -f2-)
+PSQL="docker exec -i secondlayer-postgres-local psql -U $PU -d $PD"
+
+$PSQL -f - < local-rebuild-01-prep.sql                       # instant
+./local-rebuild-02-run.sh 2>&1 | tee local-rebuild-run.log   # ~3.4-4 h
+$PSQL -f - < local-rebuild-03-finalize.sql                   # ~30-60 min
+```
+
+Checkpoint after finalize: confirm `lcc dedup` is in the expected range and
+`codex_article` is NOT phantom-inflated (the old stale table had 396M codex from
+the range-explosion bug; the fixed parser should yield far fewer). Confirm
+`decisions_with_statute_citation` is ~100M+ (old stale covered only ~35M).
+
+## 4. Export local → prod
+
+```bash
+# pick ONE transfer mode. S3 default (both hosts reach eu-central-1):
+OUTDIR=/data/citation-export TRANSFER=s3 \
+  S3_URI=s3://<bucket>/citerebuild ./local-rebuild-04-export.sh
+# direct copy alternative (needs a route reachable FROM cthulhu):
+#   TRANSFER=scp PROD_SSH=ubuntu@<prod> PROD_DIR=/tmp/citation-export ./local-rebuild-04-export.sh
+```
+
+> local → prod / S3 is the sanctioned direction. NEVER pull prod/AWS → local
+> (paid egress).
+
+## 1-3. Load on prod (inside tmux)
+
+```bash
+ssh prod
+cd ~/SecondLayer/scripts/citation-graph
+aws s3 cp --recursive s3://<bucket>/citerebuild /tmp/citation-export   # if S3
+
+psql "$DATABASE_URL" -f prod-load-01-prep.sql        # TRUNCATE + drop indexes
+INDIR=/tmp/citation-export ./prod-load-02-copy.sh    # COPY (~30-60 min)
+psql "$DATABASE_URL" -f prod-load-03-finalize.sql    # indexes + enrich (hours)
+```
+
+Verify loaded counts match `MANIFEST.txt`. The unique-index build in finalize
+**re-validates** dedup — a uniqueness violation there means the export was not
+clean; stop and investigate rather than forcing it.
+
+After nginx/back-end smoke check on a couple of `get_citation_graph` /
+legislation-citation queries, the rebuild is live.
+
+## Cleanup (only after prod validated)
+
+- Local stale 502M baseline: `TRUNCATE law_court_citations` (NOT `DROP` — keeps
+  the OID and the dependent `mv_citations_by_year`), or leave as-is until the
+  next ingestion cycle. Drop `lcc_bulk`/`cce_bulk`/`lcc_final`/`cce_final` to
+  reclaim local disk.
+- Prod: once happy, `DROP TABLE law_court_citations_backup_prerebuild;`.
+
+## Known caveats / risks
+
+- **OFFSET pagination**: the extractor paginates each year partition with
+  `OFFSET/LIMIT`; tail chunks on the large recent-year partitions (~10-15M rows)
+  re-scan from the top. Mitigated by the larger `--chunk-size 100000` (fewer
+  re-scans) and the partition fitting in page cache. If a big year crawls,
+  keyset pagination (`WHERE doc_id > last ORDER BY doc_id`) is the real fix — a
+  follow-up change to `extract-citations.py`, out of scope here.
+- **Resumability**: `02-run.sh` is all-or-nothing across years. If it dies
+  mid-corpus, the cleanest restart is to re-`01-prep` (truncates staging) and
+  rerun. For a partial restart, run single `--year` invocations for the missing
+  years into the same `lcc_bulk`/`cce_bulk` (append-only, dedup happens in
+  finalize regardless).
+- **Flags not in main**: `--bulk-load`/`--no-enrich` live only in the local/prod
+  copies. To make `git pull` self-sufficient on any box, land them in main (small
+  PR) — otherwise keep the patched local copy.

--- a/scripts/citation-graph/extract-citations.py
+++ b/scripts/citation-graph/extract-citations.py
@@ -248,6 +248,11 @@ _JUSTICE_KIND_FILTER = None
 _USE_PARTITIONS = None
 _TARGET_TABLE = "law_court_citations"
 _CASE_TABLE = "case_citation_edges"
+# Bulk-load mode: plain INSERT, no ON CONFLICT (target table must have NO unique
+# index during load). Dedup + unique index are built once afterwards (deferred index).
+_BULK_LOAD = False
+# Skip the per-year justice_kind enrich UPDATE (defer it to a single end-of-run pass).
+_NO_ENRICH = False
 
 # case_reference is routed to the separate decision->case edge table, not the statute table
 _STATUTE_TYPES = {"law_article", "codex_article", "constitution", "law_by_number", "supreme_court_ruling"}
@@ -337,7 +342,7 @@ def write_statute(rows: list[tuple], adj_year: int):
         cur,
         f"""INSERT INTO {_TARGET_TABLE}
            (court_case_id, citation_type, law_number, law_article, citation_context, justice_kind, adj_year)
-           VALUES %s ON CONFLICT DO NOTHING""",
+           VALUES %s {'' if _BULK_LOAD else 'ON CONFLICT DO NOTHING'}""",
         # r = (doc_id, citation_type, law_ref, article_ref, raw_match, justice_kind)
         [(r[0], r[1], r[2], r[3], r[4][:500], r[5], adj_year) for r in rows],
         page_size=5000,
@@ -356,7 +361,7 @@ def write_cases(rows: list[tuple], adj_year: int):
         cur,
         f"""INSERT INTO {_CASE_TABLE}
            (from_case_id, to_case_number, citation_context, justice_kind, adj_year)
-           VALUES %s ON CONFLICT DO NOTHING""",
+           VALUES %s {'' if _BULK_LOAD else 'ON CONFLICT DO NOTHING'}""",
         # r = (doc_id, to_case_number, raw_match, justice_kind)
         [(r[0], r[1], r[2][:500], r[3], adj_year) for r in rows],
         page_size=5000,
@@ -432,7 +437,7 @@ def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000
                 rate = stats.rows_processed / elapsed if elapsed > 0 else 0
                 print(f"    [{i+1}/{len(chunks)}] {stats.rows_processed:,} rows, {stats.citations_found:,} citations, {rate:,.0f} rows/sec")
 
-    if not dry_run:
+    if not dry_run and not _NO_ENRICH:
         enrich_justice_kind(year)
 
     stats.elapsed_sec = time.time() - t0
@@ -451,15 +456,19 @@ def main():
     parser.add_argument("--target-table", type=str, default="law_court_citations", help="Statute-citation destination table (use a staging table for pilots)")
     parser.add_argument("--case-table", type=str, default="case_citation_edges", help="decision->case edge destination table")
     parser.add_argument("--limit", type=int, default=None, help="Cap rows processed per year (for piloting)")
+    parser.add_argument("--bulk-load", action="store_true", help="Plain INSERT, no ON CONFLICT (deferred index: target tables must have NO unique index; dedup+index built afterwards)")
+    parser.add_argument("--no-enrich", action="store_true", help="Skip per-year justice_kind enrich UPDATE (defer to a single end-of-run pass)")
     args = parser.parse_args()
 
     if not args.year and not args.all:
         parser.error("Specify --year YYYY or --all")
 
-    global _JUSTICE_KIND_FILTER, _TARGET_TABLE, _CASE_TABLE
+    global _JUSTICE_KIND_FILTER, _TARGET_TABLE, _CASE_TABLE, _BULK_LOAD, _NO_ENRICH
     _JUSTICE_KIND_FILTER = args.justice_kind
     _TARGET_TABLE = args.target_table
     _CASE_TABLE = args.case_table
+    _BULK_LOAD = args.bulk_load
+    _NO_ENRICH = args.no_enrich
 
     years = list(range(args.years_from, args.years_to + 1)) if args.all else [args.year]
 

--- a/scripts/citation-graph/local-rebuild-01-prep.sql
+++ b/scripts/citation-graph/local-rebuild-01-prep.sql
@@ -1,0 +1,54 @@
+-- =====================================================================
+-- local-rebuild-01-prep.sql   (runs ON local / cthulhu)
+-- Stage-1 of the full EDRSR citation rebuild on the 16-core local box.
+--
+-- Strategy: DEFERRED-INDEX BULK LOAD. The extractor streams raw citations
+-- into UNLOGGED, INDEX-FREE staging tables (fastest possible insert path,
+-- benchmarked ~25% faster end-to-end than inline unique-index + ON CONFLICT).
+-- Dedup + indexing happen afterwards in local-rebuild-03-finalize.sql.
+--
+-- This script is NON-DESTRUCTIVE to the existing 502M-row law_court_citations
+-- baseline: it only (re)creates the lcc_bulk / cce_bulk staging tables. The
+-- stale baseline and its mv_citations_by_year stay untouched until the rebuild
+-- is validated and exported to prod.
+--
+-- Run ONCE before launching the extractor:
+--   docker exec -i secondlayer-postgres-local \
+--     psql -U "$PU" -d "$PD" -f - < local-rebuild-01-prep.sql
+-- (or pipe via the wrapper in local-rebuild-02-run.sh, which sources .env.local)
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Raw statute-citation sink. No PK, no unique index, no ON CONFLICT during
+-- load -> every INSERT is a pure heap append. UNLOGGED skips WAL (this data
+-- is reproducible from edrsr_fulltext, so crash-durability is unnecessary).
+DROP TABLE IF EXISTS lcc_bulk;
+CREATE UNLOGGED TABLE lcc_bulk (
+  court_case_id    bigint,
+  citation_type    text,
+  law_number       text,
+  law_article      text,
+  citation_context text,
+  justice_kind     smallint,
+  adj_year         smallint
+);
+
+-- Raw decision->case-number edge sink (proto decision<->decision graph;
+-- case numbers resolved to doc_ids in a later phase, off the critical path).
+DROP TABLE IF EXISTS cce_bulk;
+CREATE UNLOGGED TABLE cce_bulk (
+  from_case_id     bigint,
+  to_case_number   text,
+  citation_context text,
+  justice_kind     smallint,
+  adj_year         smallint
+);
+
+COMMIT;
+
+-- Sanity:
+--   \d+ lcc_bulk
+--   SELECT count(*) FROM law_court_citations;  -- 502M stale baseline, untouched

--- a/scripts/citation-graph/local-rebuild-02-run.sh
+++ b/scripts/citation-graph/local-rebuild-02-run.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# =====================================================================
+# local-rebuild-02-run.sh   (runs ON local / cthulhu, inside tmux/screen)
+# Stage-2: launch the parallel extractor over ALL years into the staging
+# tables created by local-rebuild-01-prep.sql.
+#
+# Benchmarked sweet spot on this box (16 cores, NVMe, 123 GB RAM):
+#   W=14 -> ~10,582 rows/s   (W=8 ~8,188; W=16 oversubscribed, load 26)
+# Full corpus (~120-140M decisions) => ~3.4-4 h of load wall-clock.
+#
+# DEFERRED pattern: --bulk-load (skip ON CONFLICT, append-only) +
+#                   --no-enrich (skip per-year justice_kind UPDATE).
+# Dedup + justice_kind enrichment are done once, after load, in finalize.
+#
+# ALWAYS run under tmux/screen — this is a multi-hour job:
+#   tmux new -s citerebuild
+#   ./local-rebuild-02-run.sh 2>&1 | tee local-rebuild-run.log
+# =====================================================================
+set -euo pipefail
+
+WORKERS="${WORKERS:-14}"
+CHUNK="${CHUNK:-100000}"      # bigger chunks than the 50K bench -> fewer OFFSET
+                             # re-scans on the large recent-year partitions.
+YEARS_FROM="${YEARS_FROM:-2007}"
+YEARS_TO="${YEARS_TO:-2026}"
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+
+# --- DB connection from deployment/.env.local -----------------------
+ENV_FILE="$REPO_ROOT/deployment/.env.local"
+PU=$(grep "^POSTGRES_USER=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+PW=$(grep "^POSTGRES_PASSWORD=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+PD=$(grep "^POSTGRES_DB=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+export DATABASE_URL="host=localhost port=5432 dbname=$PD user=$PU password=$PW"
+
+# --- guard: the local extractor MUST carry the deferred-load flags ---
+# (main-branch extract-citations.py does NOT have them yet; the local copy
+#  was patched. Abort loudly rather than silently doing an inline load.)
+if ! python3 extract-citations.py --help 2>&1 | grep -q -- '--bulk-load'; then
+  echo "FATAL: extract-citations.py here has no --bulk-load flag." >&2
+  echo "       This box needs the deferred-load patched copy (flags:" >&2
+  echo "       --bulk-load, --no-enrich). Restore it before running." >&2
+  exit 1
+fi
+
+echo "=== Full citation rebuild (local, deferred bulk-load) ==="
+echo "Years   : $YEARS_FROM-$YEARS_TO"
+echo "Workers : $WORKERS   Chunk: $CHUNK"
+echo "Sink    : lcc_bulk (statutes) + cce_bulk (case edges)"
+echo "Start   : $(date -u +%FT%TZ)"
+echo
+
+nice -n 10 python3 extract-citations.py \
+  --all --years-from "$YEARS_FROM" --years-to "$YEARS_TO" \
+  --workers "$WORKERS" --chunk-size "$CHUNK" \
+  --bulk-load --no-enrich \
+  --target-table lcc_bulk --case-table cce_bulk
+
+echo
+echo "=== Load done: $(date -u +%FT%TZ) ==="
+PSQL="docker exec secondlayer-postgres-local psql -U $PU -d $PD -tA"
+echo "lcc_bulk raw rows: $($PSQL -c 'SELECT count(*) FROM lcc_bulk;')"
+echo "cce_bulk raw rows: $($PSQL -c 'SELECT count(*) FROM cce_bulk;')"
+echo "Next: psql -f local-rebuild-03-finalize.sql"

--- a/scripts/citation-graph/local-rebuild-03-finalize.sql
+++ b/scripts/citation-graph/local-rebuild-03-finalize.sql
@@ -1,0 +1,91 @@
+-- =====================================================================
+-- local-rebuild-03-finalize.sql   (runs ON local / cthulhu)
+-- Stage-3: turn the raw UNLOGGED staging heaps (lcc_bulk / cce_bulk) into
+-- clean, deduped, indexed, enriched tables ready to export to prod.
+--
+-- Steps: dedup (DISTINCT ON the unique key) -> build indexes on the smaller
+-- deduped table -> enrich justice_kind from edrsr_documents (source of truth;
+-- edrsr_fulltext.justice_kind is only ~2% populated).
+--
+-- Benchmark reference: 16M raw -> 10.4M dedup + indexes in 14s. The full
+-- corpus (~1B raw) is a large DISTINCT ON sort; budget ~30-60 min. Give the
+-- session room: run with a generous work_mem (set below, session-scoped).
+--
+-- Run:
+--   docker exec -i secondlayer-postgres-local \
+--     psql -U "$PU" -d "$PD" -f - < local-rebuild-03-finalize.sql
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+
+-- Big sort/hash for the one-shot dedup. Session-scoped, reverted on disconnect.
+SET work_mem = '2GB';
+SET maintenance_work_mem = '4GB';
+
+-- 1. Statute citations: dedup on the canonical key. DISTINCT ON keeps the
+--    first row per (court_case_id, citation_type, law_number, law_article).
+DROP TABLE IF EXISTS lcc_final;
+CREATE UNLOGGED TABLE lcc_final AS
+  SELECT DISTINCT ON (court_case_id, citation_type, law_number, law_article)
+         court_case_id, citation_type, law_number, law_article,
+         citation_context, justice_kind, adj_year
+  FROM lcc_bulk
+  ORDER BY court_case_id, citation_type, law_number, law_article;
+
+CREATE UNIQUE INDEX uq_lcc_final
+  ON lcc_final (court_case_id, citation_type, law_number, law_article);
+CREATE INDEX idx_lcc_final_adj_year ON lcc_final (adj_year);
+
+-- 2. Case-number edges: dedup on (from_case_id, to_case_number).
+DROP TABLE IF EXISTS cce_final;
+CREATE UNLOGGED TABLE cce_final AS
+  SELECT DISTINCT ON (from_case_id, to_case_number)
+         from_case_id, to_case_number, citation_context, justice_kind, adj_year
+  FROM cce_bulk
+  ORDER BY from_case_id, to_case_number;
+
+CREATE UNIQUE INDEX uq_cce_final ON cce_final (from_case_id, to_case_number);
+CREATE INDEX idx_cce_final_adj_year ON cce_final (adj_year);
+
+-- 3. Enrich justice_kind from edrsr_documents IF that table exists locally.
+--    Guarded so this script also works on a box without the documents table
+--    (in which case enrichment is deferred to the prod side after load).
+DO $$
+BEGIN
+  IF to_regclass('public.edrsr_documents') IS NOT NULL THEN
+    UPDATE lcc_final t
+       SET justice_kind = d.justice_kind
+      FROM edrsr_documents d
+     WHERE t.court_case_id = d.doc_id
+       AND t.justice_kind IS NULL
+       AND d.justice_kind IS NOT NULL;
+    RAISE NOTICE 'lcc_final justice_kind enriched';
+
+    UPDATE cce_final t
+       SET justice_kind = d.justice_kind
+      FROM edrsr_documents d
+     WHERE t.from_case_id = d.doc_id
+       AND t.justice_kind IS NULL
+       AND d.justice_kind IS NOT NULL;
+    RAISE NOTICE 'cce_final justice_kind enriched';
+  ELSE
+    RAISE NOTICE 'edrsr_documents not present locally - enrich on prod after load';
+  END IF;
+END $$;
+
+ANALYZE lcc_final;
+ANALYZE cce_final;
+
+-- Report: raw vs deduped + type breakdown (sanity-check the phantom-codex fix).
+SELECT 'lcc raw'   AS t, count(*) FROM lcc_bulk
+UNION ALL SELECT 'lcc dedup', count(*) FROM lcc_final
+UNION ALL SELECT 'cce raw',   count(*) FROM cce_bulk
+UNION ALL SELECT 'cce dedup', count(*) FROM cce_final;
+
+SELECT citation_type, count(*) AS n,
+       count(DISTINCT court_case_id) AS decisions
+FROM lcc_final GROUP BY citation_type ORDER BY n DESC;
+
+-- distinct decisions covered (compare against ~120-140M corpus; old stale
+-- table only covered ~35M):
+SELECT count(DISTINCT court_case_id) AS decisions_with_statute_citation FROM lcc_final;

--- a/scripts/citation-graph/local-rebuild-04-export.sh
+++ b/scripts/citation-graph/local-rebuild-04-export.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# =====================================================================
+# local-rebuild-04-export.sh   (runs ON local / cthulhu)
+# Stage-4: dump the clean lcc_final / cce_final tables to gzipped CSV and
+# ship them to prod. local -> prod is the SANCTIONED data direction
+# (never prod/AWS -> local; egress is paid). Two transfer modes below;
+# pick one with TRANSFER=s3 (default) or TRANSFER=scp.
+#
+# CSV (not text) so embedded delimiters/newlines in citation_context are
+# safely quoted. Column order matches the prod load (id/created_at omitted,
+# filled by DEFAULT on COPY FROM).
+#
+# Run:
+#   OUTDIR=/data/citation-export TRANSFER=s3 S3_URI=s3://<bucket>/citerebuild \
+#     ./local-rebuild-04-export.sh
+# =====================================================================
+set -euo pipefail
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ENV_FILE="$REPO_ROOT/deployment/.env.local"
+PU=$(grep "^POSTGRES_USER=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+PD=$(grep "^POSTGRES_DB=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+
+OUTDIR="${OUTDIR:-/data/citation-export}"
+TRANSFER="${TRANSFER:-s3}"
+mkdir -p "$OUTDIR"
+PSQL="docker exec -i secondlayer-postgres-local psql -U $PU -d $PD"
+
+echo "=== Exporting clean citation tables -> $OUTDIR ==="
+
+# Stream COPY straight through gzip. The column list is the contract with the
+# prod loader (prod-load-02-copy-index.sh expects exactly these orders).
+$PSQL -c "\copy (SELECT court_case_id, citation_type, law_number, law_article, citation_context, justice_kind, adj_year FROM lcc_final) TO STDOUT WITH (FORMAT csv)" \
+  | gzip -1 > "$OUTDIR/lcc_final.csv.gz"
+echo "  lcc_final.csv.gz : $(du -h "$OUTDIR/lcc_final.csv.gz" | cut -f1)"
+
+$PSQL -c "\copy (SELECT from_case_id, to_case_number, citation_context, justice_kind, adj_year FROM cce_final) TO STDOUT WITH (FORMAT csv)" \
+  | gzip -1 > "$OUTDIR/cce_final.csv.gz"
+echo "  cce_final.csv.gz : $(du -h "$OUTDIR/cce_final.csv.gz" | cut -f1)"
+
+# Row-count manifest so the prod side can verify a complete transfer/load.
+$PSQL -tA -c "SELECT 'lcc_final', count(*) FROM lcc_final UNION ALL SELECT 'cce_final', count(*) FROM cce_final" \
+  > "$OUTDIR/MANIFEST.txt"
+cat "$OUTDIR/MANIFEST.txt"
+
+echo "=== Transfer ($TRANSFER) ==="
+case "$TRANSFER" in
+  s3)
+    : "${S3_URI:?set S3_URI=s3://bucket/prefix}"
+    # local -> S3 (eu-central-1). aws creds from the box's environment/role.
+    aws s3 cp "$OUTDIR/lcc_final.csv.gz" "$S3_URI/lcc_final.csv.gz"
+    aws s3 cp "$OUTDIR/cce_final.csv.gz" "$S3_URI/cce_final.csv.gz"
+    aws s3 cp "$OUTDIR/MANIFEST.txt"     "$S3_URI/MANIFEST.txt"
+    echo "Uploaded to $S3_URI . On prod: aws s3 cp --recursive $S3_URI ./"
+    ;;
+  scp)
+    : "${PROD_SSH:?set PROD_SSH=user@prod-host (a route reachable FROM this box)}"
+    : "${PROD_DIR:=/tmp/citation-export}"
+    ssh "$PROD_SSH" "mkdir -p $PROD_DIR"
+    scp "$OUTDIR/lcc_final.csv.gz" "$OUTDIR/cce_final.csv.gz" "$OUTDIR/MANIFEST.txt" "$PROD_SSH:$PROD_DIR/"
+    echo "Copied to $PROD_SSH:$PROD_DIR"
+    ;;
+  none)
+    echo "Files staged in $OUTDIR; transfer manually."
+    ;;
+  *) echo "Unknown TRANSFER=$TRANSFER (use s3|scp|none)"; exit 1 ;;
+esac

--- a/scripts/citation-graph/prod-load-01-prep.sql
+++ b/scripts/citation-graph/prod-load-01-prep.sql
@@ -1,0 +1,68 @@
+-- =====================================================================
+-- prod-load-01-prep.sql   (runs ON prod)
+-- Prepare prod tables to receive the pre-deduped local export via COPY.
+--
+-- Because the incoming data is ALREADY deduped on local, prod does a pure
+-- append-only COPY with NO indexes maintained during load (drop them all,
+-- including the unique index — there are no conflicts to arbitrate). All
+-- indexes are (re)built afterwards in prod-load-03-finalize.sql.
+--
+-- DESTRUCTIVE: TRUNCATEs law_court_citations + case_citation_edges. A guarded
+-- backup of the current law_court_citations is taken first (rollback path).
+--
+-- Run ONCE, immediately before the COPY:
+--   psql "$DATABASE_URL" -f prod-load-01-prep.sql
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- 1. Guarded safety backup (skip if one already exists from a prior attempt).
+DO $$
+BEGIN
+  IF to_regclass('public.law_court_citations_backup_prerebuild') IS NULL THEN
+    EXECUTE 'CREATE TABLE law_court_citations_backup_prerebuild AS TABLE law_court_citations';
+    RAISE NOTICE 'Backup created: law_court_citations_backup_prerebuild (% rows)',
+      (SELECT count(*) FROM law_court_citations_backup_prerebuild);
+  ELSE
+    RAISE NOTICE 'Backup already exists - skipping';
+  END IF;
+END $$;
+
+-- 2. Columns the refined pipeline carries (no-op if prep-full-rebuild already ran).
+ALTER TABLE law_court_citations ADD COLUMN IF NOT EXISTS justice_kind smallint;
+ALTER TABLE law_court_citations ADD COLUMN IF NOT EXISTS adj_year     smallint;
+
+-- 3. case_citation_edges target (create if first run).
+CREATE TABLE IF NOT EXISTS case_citation_edges (
+  id               bigserial PRIMARY KEY,
+  from_case_id     bigint   NOT NULL,
+  to_case_number   text     NOT NULL,
+  citation_context text     DEFAULT '',
+  justice_kind     smallint,
+  adj_year         smallint,
+  created_at       timestamptz DEFAULT now()
+);
+
+-- 4. Clear both targets. Backup of law_court_citations retained above.
+TRUNCATE law_court_citations RESTART IDENTITY;
+TRUNCATE case_citation_edges  RESTART IDENTITY;
+
+-- 5. Drop EVERY secondary/unique index for the load. Data is pre-deduped, so
+--    the unique index is not needed as a conflict arbiter during COPY; it is
+--    rebuilt (and re-validates uniqueness) in finalize. Keeping any btree
+--    maintained across a ~600M-row COPY is the dominant avoidable cost.
+DROP INDEX IF EXISTS uq_lcc_dedup;
+DROP INDEX IF EXISTS idx_lcc_adj_year;
+DROP INDEX IF EXISTS idx_lcc_article;
+DROP INDEX IF EXISTS idx_lcc_law;
+DROP INDEX IF EXISTS idx_lcc_type;
+DROP INDEX IF EXISTS idx_lcc_case;
+DROP INDEX IF EXISTS uq_cce_dedup;
+DROP INDEX IF EXISTS idx_cce_adj_year;
+
+COMMIT;
+
+-- After this: COPY the data in (prod-load-02-copy-index.sh), then build
+-- indexes + enrich (prod-load-03-finalize.sql).

--- a/scripts/citation-graph/prod-load-02-copy.sh
+++ b/scripts/citation-graph/prod-load-02-copy.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# =====================================================================
+# prod-load-02-copy.sh   (runs ON prod)
+# Stream the gzipped CSV export into the prepared (TRUNCATEd, index-free)
+# prod tables. Run AFTER prod-load-01-prep.sql, BEFORE prod-load-03-finalize.sql.
+#
+# Fetch the files first (S3 example):
+#   aws s3 cp --recursive s3://<bucket>/citerebuild /tmp/citation-export
+#
+# Run:
+#   INDIR=/tmp/citation-export ./prod-load-02-copy.sh
+# =====================================================================
+set -euo pipefail
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+ENV_FILE="$REPO_ROOT/deployment/.env.prod"
+PU=$(grep "^POSTGRES_USER=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+PD=$(grep "^POSTGRES_DB=" "$ENV_FILE" | head -1 | cut -d= -f2-)
+INDIR="${INDIR:-/tmp/citation-export}"
+
+# prod postgres container name (adjust if the compose service differs).
+PGC="${PGC:-secondlayer-postgres-prod}"
+PSQL="docker exec -i $PGC psql -U $PU -d $PD"
+
+echo "=== COPY into prod (index-free heap append) ==="
+echo "Source: $INDIR"
+[ -f "$INDIR/MANIFEST.txt" ] && { echo "Expected row counts:"; cat "$INDIR/MANIFEST.txt"; }
+
+echo "-> law_court_citations"
+gunzip -c "$INDIR/lcc_final.csv.gz" | $PSQL -c \
+  "COPY law_court_citations (court_case_id, citation_type, law_number, law_article, citation_context, justice_kind, adj_year) FROM STDIN WITH (FORMAT csv)"
+
+echo "-> case_citation_edges"
+gunzip -c "$INDIR/cce_final.csv.gz" | $PSQL -c \
+  "COPY case_citation_edges (from_case_id, to_case_number, citation_context, justice_kind, adj_year) FROM STDIN WITH (FORMAT csv)"
+
+echo "=== Loaded row counts (verify against MANIFEST) ==="
+$PSQL -tA -c "SELECT 'law_court_citations', count(*) FROM law_court_citations UNION ALL SELECT 'case_citation_edges', count(*) FROM case_citation_edges"
+echo "Next: psql -f prod-load-03-finalize.sql"

--- a/scripts/citation-graph/prod-load-03-finalize.sql
+++ b/scripts/citation-graph/prod-load-03-finalize.sql
@@ -1,0 +1,64 @@
+-- =====================================================================
+-- prod-load-03-finalize.sql   (runs ON prod, AFTER the COPY)
+-- Rebuild indexes on the freshly loaded prod tables and backfill any
+-- justice_kind values still NULL (belt-and-suspenders: local already
+-- enriched if it had edrsr_documents; this fills the rest from prod's
+-- authoritative edrsr_documents).
+--
+-- CREATE INDEX CONCURRENTLY keeps the (now live) tables readable and cannot
+-- run inside a txn block -> NO BEGIN/COMMIT here. Each btree on a ~600M-row
+-- table takes tens of minutes; the three secondary ones are independent and
+-- may be launched in parallel psql sessions to cut wall-clock.
+--
+-- Run:
+--   psql "$DATABASE_URL" -f prod-load-03-finalize.sql
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+
+-- 1. Unique index = dedup guarantee + court_case_id lookups. Built CONCURRENTLY.
+--    (Data is pre-deduped on local; if this fails with a uniqueness violation
+--    the export was not clean -> investigate before proceeding.)
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_lcc_dedup
+  ON law_court_citations (court_case_id, citation_type, law_number, law_article);
+
+-- 2. adj_year index first - the enrich UPDATE below filters on it.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_adj_year
+  ON law_court_citations (adj_year);
+
+-- 3. Backfill justice_kind from the authoritative documents table (fills only
+--    rows still NULL). Heavy on ~600M rows but one-shot; run in screen/tmux.
+UPDATE law_court_citations t
+   SET justice_kind = d.justice_kind
+  FROM edrsr_documents d
+ WHERE t.court_case_id = d.doc_id
+   AND t.justice_kind IS NULL
+   AND d.justice_kind IS NOT NULL;
+
+-- 4. Secondary query indexes (independent; parallelizable across sessions).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_article ON law_court_citations (law_article);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_law     ON law_court_citations (law_number);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_lcc_type    ON law_court_citations (citation_type);
+
+-- 5. case_citation_edges indexes + enrich.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_cce_dedup
+  ON case_citation_edges (from_case_id, to_case_number);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cce_adj_year
+  ON case_citation_edges (adj_year);
+
+UPDATE case_citation_edges t
+   SET justice_kind = d.justice_kind
+  FROM edrsr_documents d
+ WHERE t.from_case_id = d.doc_id
+   AND t.justice_kind IS NULL
+   AND d.justice_kind IS NOT NULL;
+
+-- 6. Refresh planner stats.
+ANALYZE law_court_citations;
+ANALYZE case_citation_edges;
+
+-- Sanity:
+--   SELECT citation_type, count(*) FROM law_court_citations GROUP BY 1 ORDER BY 2 DESC;
+--   SELECT count(DISTINCT court_case_id) FROM law_court_citations;  -- coverage
+--   -- when satisfied, drop the rollback backup:
+--   -- DROP TABLE law_court_citations_backup_prerebuild;


### PR DESCRIPTION
## What

Scripts + runbook to rebuild `law_court_citations` (+ `case_citation_edges`) from the **whole** EDRSR corpus (~120-140M decisions, 2007-2026) as a **local-compute → prod-export** pipeline, plus the two extractor flags that make the deferred-index load possible.

## Why local compute
cthulhu (16c, NVMe, 123GB RAM, full `edrsr_fulltext`) extracts ~3× faster than prod at equal workers and carries no live traffic. Benchmarked sweet spot **W=14 ≈ 10,582 rows/s** → ~3.4-4h load. Prod only does a pre-deduped bulk COPY + index build.

## Why deferred-index
UNLOGGED, index-free staging → dedup+index once is ~25% faster end-to-end than inline unique-index + `ON CONFLICT` (758s vs 881s on 2M), and stays flat as the table grows (inline degrades 2,871→2,276 rows/s from 600K→2M).

## Changes
- **`extract-citations.py`**: `--bulk-load` (plain INSERT, no `ON CONFLICT`) + `--no-enrich` (defer per-year `justice_kind` UPDATE). Identical to the copy used in the local/prod benchmarks; lands them in main so any box is self-sufficient on `git pull`.
- **`local-rebuild-0{1..4}`**: prep staging → `extract --all` → dedup+index+enrich → gz CSV export (S3/scp). **Non-destructive** to the stale 502M baseline + its `mv_citations_by_year`.
- **`prod-load-0{1..3}`**: backup + TRUNCATE + drop-all-indexes → COPY → `CONCURRENTLY` index build (uq re-validates dedup) + `justice_kind` backfill.
- **`RUNBOOK-full-rebuild.md`**: end-to-end order, checkpoints, ETAs, caveats.

## Caveats (in runbook)
- OFFSET pagination re-scans tail chunks on big recent-year partitions — mitigated by `--chunk-size 100000`; real fix (keyset) is a follow-up.
- `02-run.sh` is all-or-nothing across years; partial restart = re-prep or per-year reruns into the same staging (dedup in finalize regardless).

Scripts-only; no runtime/service code touched. Follow-up to #1995.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local-compute → prod-export pipeline to rebuild `law_court_citations` and `case_citation_edges` with deferred index loading. This speeds up the full EDRSR run and keeps prod work to COPY + index build.

- New Features
  - `extract-citations.py`: adds `--bulk-load` (plain INSERT, no `ON CONFLICT`) and `--no-enrich` (defer `justice_kind` updates).
  - Local scripts: `local-rebuild-01-prep.sql`, `-02-run.sh`, `-03-finalize.sql`, `-04-export.sh` for UNLOGGED staging, parallel extract, dedup/index/enrich, and gz CSV export.
  - Prod scripts: `prod-load-01-prep.sql`, `-02-copy.sh`, `-03-finalize.sql` for backup, TRUNCATE/drop indexes, COPY, `CONCURRENTLY` rebuild indexes, and `justice_kind` backfill.
  - Performance: ~25% faster end-to-end vs inline upserts; local compute runs ~3× faster than prod at W=14.

- Migration
  - Follow `RUNBOOK-full-rebuild.md` to run local extract → export → prod load.
  - Verify MANIFEST row counts on prod; the unique index build re-validates dedup.
  - Local baseline remains untouched; after validation, drop `law_court_citations_backup_prerebuild` on prod if no longer needed.

<sup>Written for commit c920eba2f9f0c47445c66ce5ad07a0acae3f8cc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

