### PR TITLE
ci: pin prod-SSH deploy jobs to prod-runner (fix flaky deploys)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -366,7 +366,11 @@ jobs:
   # ─── Step 3a: Deploy Preview (inactive color) ──────────────────────
   deploy-preview:
     name: Deploy Preview
-    runs-on: [self-hosted, local]
+    # Must run on the prod-reachable runner: this job SSHes to PROD_SERVER_IP.
+    # The `local` label also matches local-runner (cthulhu), which cannot reach
+    # prod's public IP → intermittent `ssh: connect … timed out`. prod-deploy is
+    # a label unique to prod-runner.
+    runs-on: [self-hosted, prod-deploy]
     needs: [detect-changes, pre-deploy-tests]
     if: |
       needs.detect-changes.outputs.has_changes == 'true' &&
@@ -700,7 +704,8 @@ jobs:
   # ─── Step 3b: Promote to Production (requires approval) ───────────
   promote-to-prod:
     name: Promote to Production
-    runs-on: [self-hosted, local]
+    # SSHes to PROD_SERVER_IP — pin to prod-runner (see Deploy Preview note).
+    runs-on: [self-hosted, prod-deploy]
     needs: [detect-changes, deploy-preview]
     if: needs.deploy-preview.result == 'success'
     environment: production
@@ -931,7 +936,8 @@ jobs:
   # ─── Step 3c: Self-heal deploy failures (DISABLED) ─────────────────
   self-heal-deploy:
     name: Self-Heal Deploy Failures
-    runs-on: [self-hosted, local]
+    # SSHes to PROD_SERVER_IP — pin to prod-runner (see Deploy Preview note).
+    runs-on: [self-hosted, prod-deploy]
     needs: [detect-changes, deploy-preview, promote-to-prod]
     if: false  # temporarily disabled — not producing useful fixes
     env:


### PR DESCRIPTION
## Problem

Prod deploys fail intermittently on **Deploy Preview** / **Promote to Production** with:

```
ssh: connect to host *** port 22: Connection timed out   (exit 255)
```

…but a rerun often passes. Root cause is a **runner lottery**, not the network:

- These jobs use `runs-on: [self-hosted, local]`.
- Two runners carry the `local` label:
  - `prod-runner` — **can** SSH to `PROD_SERVER_IP` (prod's public IP) ✅
  - `local-runner` (host cthulhu / 10.88.0.2) — **cannot** reach prod's public IP (only the WG path works) ❌
- GitHub schedules each SSH job on whichever runner is free → ~50/50. Land on prod-runner → success (deploy #871); land on local-runner → SSH timeout (#872, #873 failed repeatedly until a rerun happened to hit prod-runner).

Confirmed not fail2ban (no active bans) and not the dist race (#2000/#2002).

## Fix

1. Added a unique **`prod-deploy`** label to `prod-runner` (runner id 26) via the Actions API — no other runner has it.
2. Repoint the three SSH-to-prod jobs to `runs-on: [self-hosted, prod-deploy]`:
   - Deploy Preview (18 SSH refs)
   - Promote to Production (8)
   - Self-Heal Deploy Failures (9)

Jobs that never SSH stay on `local`: detect-changes, pre-deploy-tests, self-heal-tests, create-release (0 SSH refs).

Result: prod deploys always run on the prod-reachable runner — no more lottery (and prod deploys are now serialized on one runner, which also avoids cross-run races).

## Note

Merging this re-triggers a full deploy of current `main`, which lands the in-flight citation-graph changes (#2003/#2004) that have been stuck behind the lottery — this deploy will run on prod-runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin prod SSH deploy jobs to the `prod-runner` via a unique `prod-deploy` label to stop intermittent SSH timeouts. Deploys now always run on a runner that can reach `PROD_SERVER_IP`.

- **Bug Fixes**
  - Updated `.github/workflows/deploy-prod.yml` to use `runs-on: [self-hosted, prod-deploy]` for Deploy Preview, Promote to Production, and Self-Heal Deploy Failures.
  - Left non-SSH jobs on `local`.
  - Removes the runner lottery and serializes prod deploys.

<sup>Written for commit fcdc5931a60f9bb1715be32097b88fc9cd54f095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

