### PR TITLE
chore(backend): ship core chat editions/history tools (CORE-52)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## What
Bumps `mcp_backend` to 1.0.8 to trigger a backend rebuild + prod deploy.

## Why
The chat fix lives entirely in `secondlayer-core` (PR overthelex/secondlayer-core#64, merged): `FIXED_V2_TOOLS` now exposes `list_legislation_editions`, `get_legislation_history`, `get_legislation_structure`. CI clones `secondlayer-core@main` (`--depth 1`, unpinned) and overlays the real `chat-service.ts` at build time, so a backend rebuild is all that's needed to ship it — no monorepo source change.

Any change under `mcp_backend/*` marks the backend as changed in `detect-changes`, so this version bump is the deploy trigger.

## Effect
Fixes chat denying that legislation editions exist (repro: chat-826518e1, "дай всі редакції ЦК"). Part of V3 roadmap CORE-51, phase P0 (CORE-52).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `mcp_backend` to 1.0.8 to trigger a backend rebuild and deploy core chat tools for legislation editions, history, and structure. Enables `list_legislation_editions`, `get_legislation_history`, and `get_legislation_structure`, fixing chats that claimed editions don't exist (CORE-52).

<sup>Written for commit 1bb3b67b3d945b289c96463b199c153b47dfb640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

