### PR TITLE
chore(backend): ship V3 curated chat toolset (CORE-53)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## What
Bumps `mcp_backend` to 1.0.9 to trigger a backend rebuild + prod deploy.

## Why
Ships the V3 curated chat toolset from `secondlayer-core` PR #65 (merged). `FIXED_V2_TOOLS` is now the curated **14-tool EDRSR + Ukrainian legislation** set (6 legislation + 8 court/practice), dropping the deprecated `search_legal_precedents`. CI clones `secondlayer-core@main` (`--depth 1`) and overlays the real `chat-service.ts` at build time, so a backend rebuild ships it — no monorepo source change. Any `mcp_backend/*` change marks backend as changed in detect-changes → triggers the deploy.

Part of V3 roadmap CORE-51, phase P1 (CORE-53).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship the V3 curated chat toolset to production by triggering a backend rebuild/deploy. Delivers the 14-tool EDRSR + Ukrainian legislation set and removes the deprecated `search_legal_precedents` (CORE-53).

- **Dependencies**
  - Bump `mcp_backend` to `1.0.9` to trigger deploy.
  - CI clones `secondlayer-core@main` and overlays the production `chat-service.ts`; `FIXED_V2_TOOLS` now points to the curated set.
  - No monorepo source changes.

<sup>Written for commit fead7f0522769938dfcdd8f56da175d61f00edb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

