### PR TITLE
feat(query-ir): validate search_court_decisions tool args at boundary (CORE-54)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {

--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -12,7 +12,7 @@
  */
 
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
-import { buildWhere, type FieldDef } from '@secondlayer/shared';
+import { buildWhere, parseEdsrSearchArgs, type FieldDef } from '@secondlayer/shared';
 import { logger } from '../../utils/logger.js';
 import { EDRSR_METADATA_SEARCH_ORDER } from '../../services/search-ranking-config.js';
 import type { SearchResultFilter } from '../../services/search-result-filter.js';
@@ -232,6 +232,21 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
 
   async executeTool(name: string, args: any): Promise<ToolResult | null> {
     if (name !== 'search_court_decisions') return null;
+
+    // Safe-input boundary (LEXAI-1771 / CORE-54): validate raw model-produced
+    // arguments against the canonical Zod schema before any handler logic.
+    // Unknown (injected) fields are stripped; invalid enum/date/range values are
+    // rejected with a clean, model-actionable message instead of silently
+    // producing wrong filters. SQL stays parameterized downstream via buildWhere.
+    const parsed = parseEdsrSearchArgs(args);
+    if (!parsed.ok) {
+      const detail = parsed.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ');
+      logger.warn('[search_court_decisions] invalid arguments rejected', { detail });
+      return this.wrapError(`Невалідні параметри пошуку: ${detail || 'перевір mode та фільтри'}`);
+    }
+    args = parsed.value;
 
     // court_level is the cross-tool convention (search_legal_precedents,
     // find_similar_fact_pattern_cases): SC / GrandChamber → cassation instance. Map it onto

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,6 +7,9 @@ export type { FieldDef, MatchType } from './query-ir/field-def';
 // Whitelist primitives consumers can adopt without the queryIr namespace.
 export type { CourtLevel, PartyRole } from './query-ir/enums';
 export { PROCEDURE_TO_JUSTICE_KIND } from './query-ir/enums';
+// Tool-call argument validators (V3 chat tool-execution boundary).
+export { parseEdsrSearchArgs } from './query-ir/tool-args';
+export type { EdsrSearchArgs } from './query-ir/tool-args';
 export * from './utils/model-selector';
 export * from './utils/openai-client';
 export * from './utils/anthropic-client';

--- a/packages/shared/src/query-ir/index.ts
+++ b/packages/shared/src/query-ir/index.ts
@@ -19,3 +19,4 @@ export * from './slots';
 export * from './parse';
 export * from './field-def';
 export * from './build-where';
+export * from './tool-args';

--- a/packages/shared/src/query-ir/tool-args.ts
+++ b/packages/shared/src/query-ir/tool-args.ts
@@ -1,0 +1,84 @@
+/**
+ * query-ir/tool-args.ts — canonical Zod schemas for LLM tool-call arguments.
+ *
+ * The V3 chat pipeline lets the model self-select tools and emit their
+ * arguments directly (there is no classifier/planner slot layer in V3). These
+ * schemas validate those raw model-produced arguments at the tool-execution
+ * boundary: enum/date/range violations and unknown (injected/unsupported)
+ * fields are rejected with a clean error the model can act on — so the model
+ * never believes an unsupported filter was applied. The SQL layer is already
+ * parameterized via buildWhere(); this is the upstream defense-in-depth +
+ * correctness guard.
+ *
+ * Numerics are coerced (model occasionally emits "2" for 2) so well-formed but
+ * loosely-typed calls are not needlessly rejected; booleans are NOT coerced
+ * (z.coerce.boolean("false") === true is a footgun).
+ */
+import { z } from 'zod';
+import { PartyRole } from './enums';
+
+const ISO_DATE = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD');
+
+/** Valid EDRSR judgment-form codes (Вирок/Постанова/Рішення/Ухвала/…). */
+const JUDGMENT_CODES = [1, 2, 3, 5, 6, 7, 10] as const;
+
+const MILITARY_PRESETS = [
+  'awol', 'desertion', 'insubordination', 'disobedience', 'draft_evasion',
+  'self_harm', 'negligence', 'abuse_of_power', 'looting', 'all_military',
+] as const;
+
+const KUPAP_PRESETS = [
+  'traffic_dui', 'traffic_accident', 'domestic_violence', 'hooliganism',
+  'drugs_alcohol', 'admin_oversight', 'child_neglect', 'petty_theft',
+  'border_crossing', 'quarantine', 'tax_violations', 'no_license', 'all_kupap',
+] as const;
+
+/**
+ * Arguments for the `search_court_decisions` (EDRSR unified search) tool.
+ * `.strict()` → unknown keys fail validation (injection guard + prevents the
+ * model from silently relying on unsupported filters); invalid enum/date/range
+ * values fail too, so the caller can surface a clean error to the model.
+ */
+export const EdsrSearchArgs = z.object({
+  mode: z.enum(['structured', 'fulltext', 'hybrid', 'semantic']),
+  query: z.string().max(2000).optional(),
+  party_name: z.string().max(200).optional(),
+  party_role: PartyRole.optional(),
+  cause_num: z.string().max(64).optional(),
+  judge: z.string().max(200).optional(),
+  court_code: z.coerce.number().int().positive().optional(),
+  court_name: z.string().max(200).optional(),
+  justice_kind: z.coerce.number().int().min(1).max(5).optional(),
+  judgment_code: z.coerce
+    .number()
+    .int()
+    .refine((v) => (JUDGMENT_CODES as readonly number[]).includes(v), {
+      message: 'invalid judgment_code (allowed: 1,2,3,5,6,7,10)',
+    })
+    .optional(),
+  category_code: z.coerce.number().int().positive().optional(),
+  date_from: ISO_DATE.optional(),
+  date_to: ISO_DATE.optional(),
+  instance_code: z.coerce.number().int().min(1).max(3).optional(),
+  court_level: z.enum(['all', 'SC', 'GrandChamber']).optional(),
+  military_preset: z.enum(MILITARY_PRESETS).optional(),
+  kupap_preset: z.enum(KUPAP_PRESETS).optional(),
+  include_fulltext: z.boolean().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  offset: z.coerce.number().int().min(0).optional(),
+  oversample: z.coerce.number().int().min(1).max(5).optional(),
+  rrf_k: z.coerce.number().int().positive().optional(),
+}).strict();
+export type EdsrSearchArgs = z.infer<typeof EdsrSearchArgs>;
+
+import type { ParseResult } from './parse';
+import { parseWith } from './parse';
+
+/**
+ * Validate raw `search_court_decisions` arguments. Never throws — returns
+ * { ok:false, issues } on invalid enum/date/range so the handler can reject
+ * with a clean, model-actionable message. Unknown fields are stripped.
+ */
+export function parseEdsrSearchArgs(raw: unknown): ParseResult<EdsrSearchArgs> {
+  return parseWith(EdsrSearchArgs, raw);
+}

--- a/packages/shared/tests/query-ir.test.ts
+++ b/packages/shared/tests/query-ir.test.ts
@@ -3,6 +3,7 @@ import {
   parseCourtSearchIR,
   parseIntentIR,
   parsePlannerSlots,
+  parseEdsrSearchArgs,
   CourtSearchIR,
   PROCEDURE_TO_JUSTICE_KIND,
 } from '../src/query-ir';
@@ -215,5 +216,63 @@ describe('query-ir / buildWhere', () => {
     const r = buildWhere(edrsrFields, parsed.value as Record<string, any>);
     expect(r.whereClause).toBe('d.judge ILIKE $1 AND d.justice_kind = $2');
     expect(r.values).toEqual(['%Петренко%', 2]);
+  });
+});
+
+describe('query-ir / parseEdsrSearchArgs (tool-call boundary)', () => {
+  it('accepts a valid structured search and keeps known fields', () => {
+    const r = parseEdsrSearchArgs({
+      mode: 'structured',
+      judge: 'Петренко',
+      justice_kind: 2,
+      judgment_code: 1,
+      date_from: '2023-01-01',
+      party_role: 'defendant',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.mode).toBe('structured');
+      expect(r.value.justice_kind).toBe(2);
+      expect(r.value.party_role).toBe('defendant');
+    }
+  });
+
+  it('rejects unknown (injected/unsupported) fields via .strict()', () => {
+    const r = parseEdsrSearchArgs({ mode: 'fulltext', query: 'оренда', sql: 'DROP TABLE x', region: 'Kyiv' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('coerces stringified numerics ("2" -> 2)', () => {
+    const r = parseEdsrSearchArgs({ mode: 'structured', justice_kind: '2', limit: '50' });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.value.justice_kind).toBe(2);
+      expect(r.value.limit).toBe(50);
+    }
+  });
+
+  it('rejects out-of-range justice_kind', () => {
+    const r = parseEdsrSearchArgs({ mode: 'structured', justice_kind: 99 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects invalid judgment_code', () => {
+    const r = parseEdsrSearchArgs({ mode: 'structured', judgment_code: 4 });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a malformed date', () => {
+    const r = parseEdsrSearchArgs({ mode: 'structured', date_from: 'вчора' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an unknown mode', () => {
+    const r = parseEdsrSearchArgs({ mode: 'magic' });
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects an invalid party_role enum', () => {
+    const r = parseEdsrSearchArgs({ mode: 'hybrid', query: 'x', party_role: 'judge' });
+    expect(r.ok).toBe(false);
   });
 });


### PR DESCRIPTION
## What
Adds a canonical Zod schema `EdsrSearchArgs` to `@secondlayer/shared/query-ir` and validates raw model-produced arguments at the `search_court_decisions` (EDRSR unified search) handler entry.

## Why (CORE-54 / P2 of the V3 roadmap CORE-51)
The V3 chat pipeline lets the model self-select tools and emit their arguments directly — there is **no classifier/planner slot layer in V3**, so the right safe-input surface is the **tool-call argument boundary** (not slot validation).

The LEXAI-1771 layer already protects the SQL boundary (EDRSR/registry build WHERE via `buildWhere` with a FieldDef whitelist + `$N` params). This PR adds the upstream guard:
- **`.strict()`** — unknown/unsupported fields are rejected, so the model never relies on a filter that would be silently ignored.
- Invalid **enum/date/range** values (`mode`, `party_role`, `justice_kind` 1–5, `judgment_code`, `court_level`, military/kupap presets, `YYYY-MM-DD` dates) fail with a clean, model-actionable error.
- Numerics are **coerced** (`"2"` → `2`) so well-formed loosely-typed calls still pass.

## Changes
- `packages/shared/src/query-ir/tool-args.ts` (new) — `EdsrSearchArgs` schema + `parseEdsrSearchArgs`.
- `packages/shared/src/query-ir/index.ts`, `packages/shared/src/index.ts` — exports.
- `mcp_backend/src/api/tools/edrsr-unified-search-tool.ts` — validate at `executeTool` entry; on failure return a clean `wrapError`.
- `packages/shared/tests/query-ir.test.ts` — +8 cases (31 pass).

## Validation
- `packages/shared` builds clean; `query-ir` suite: **31 passed**.
- Backend standalone `tsc` shows only pre-existing core-overlay `TS2307` (token-budget-allocator / tool-health-tracker / step-constraints in core-loader.ts) — resolved in CI by the core overlay; none relate to this change.

Closes the active-pipeline part of CORE-54. SQL-injection safety was already delivered by LEXAI-1771 / #1990.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict argument validation for `search_court_decisions` using a new Zod schema to block unsupported fields and bad values at the tool boundary. Delivers CORE-54 by adding an upstream guard for V3’s self-selected tools.

- **New Features**
  - Added `EdsrSearchArgs` schema and `parseEdsrSearchArgs` in `@secondlayer/shared/query-ir`; exported from `@secondlayer/shared`.
  - Validates args in `mcp_backend` before handler logic; returns a clear error on failure.
  - Unknown fields are rejected; enums/dates/ranges validated; numerics are coerced.
  - Added tests for parser coverage (+8 cases).

<sup>Written for commit ce76b491f41118561c1400c6c3c83ba18ba48348. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

