### PR TITLE
fix(citation-graph): FORCE_NOT_NULL on prod COPY to preserve empty strings

### DIFF
--- a/scripts/citation-graph/prod-load-02-copy.sh
+++ b/scripts/citation-graph/prod-load-02-copy.sh
@@ -28,12 +28,16 @@ echo "Source: $INDIR"
 [ -f "$INDIR/MANIFEST.txt" ] && { echo "Expected row counts:"; cat "$INDIR/MANIFEST.txt"; }
 
 echo "-> law_court_citations"
+# FORCE_NOT_NULL: on export, empty-string fields (e.g. law_article='' for
+# supreme_court_ruling / law_by_number rows) become bare CSV fields; on import
+# CSV treats a bare empty field as NULL, which violates the NOT NULL on
+# law_number/law_article. FORCE_NOT_NULL keeps them as '' (matching the source).
 gunzip -c "$INDIR/lcc_final.csv.gz" | $PSQL -c \
-  "COPY law_court_citations (court_case_id, citation_type, law_number, law_article, citation_context, justice_kind, adj_year) FROM STDIN WITH (FORMAT csv)"
+  "COPY law_court_citations (court_case_id, citation_type, law_number, law_article, citation_context, justice_kind, adj_year) FROM STDIN WITH (FORMAT csv, FORCE_NOT_NULL (law_number, law_article, citation_context))"
 
 echo "-> case_citation_edges"
 gunzip -c "$INDIR/cce_final.csv.gz" | $PSQL -c \
-  "COPY case_citation_edges (from_case_id, to_case_number, citation_context, justice_kind, adj_year) FROM STDIN WITH (FORMAT csv)"
+  "COPY case_citation_edges (from_case_id, to_case_number, citation_context, justice_kind, adj_year) FROM STDIN WITH (FORMAT csv, FORCE_NOT_NULL (to_case_number, citation_context))"
 
 echo "=== Loaded row counts (verify against MANIFEST) ==="
 $PSQL -tA -c "SELECT 'law_court_citations', count(*) FROM law_court_citations UNION ALL SELECT 'case_citation_edges', count(*) FROM case_citation_edges"


### PR DESCRIPTION
The export writes empty-string fields (e.g. `law_article=''` for `supreme_court_ruling` / `law_by_number` rows) as bare CSV fields. On `COPY FROM ... FORMAT csv`, a bare empty field is read as **NULL**, which (a) violates `NOT NULL` on `law_number`/`law_article` and (b) silently turns `''` into NULL on nullable columns.

`FORCE_NOT_NULL (law_number, law_article, citation_context)` (and `to_case_number, citation_context` for the edges table) keeps them as `''`, matching the source. Discovered and verified during the full 331M-row prod load. Follow-up to #2003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FORCE_NOT_NULL to the prod COPY step so empty strings in CSV stay as '' instead of becoming NULL. This prevents NOT NULL violations and preserves source data.

- **Bug Fixes**
  - `law_court_citations`: FORCE_NOT_NULL on `law_number`, `law_article`, `citation_context`.
  - `case_citation_edges`: FORCE_NOT_NULL on `to_case_number`, `citation_context`.

<sup>Written for commit 98e44ddd97595699d793462496676cccd102fb80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

