### PR TITLE
feat(metrics): wire V3 chat grounding + thrashing telemetry (CORE-55)

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -1,0 +1,396 @@
+{
+  "schemaVersion": 38,
+  "title": "SecondLayer - Chat Quality (V3)",
+  "uid": "chat-quality-v3",
+  "tags": [
+    "secondlayer",
+    "chat",
+    "v3",
+    "grounding"
+  ],
+  "timezone": "browser",
+  "editable": true,
+  "version": 1,
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "refresh": "1m",
+  "panels": [
+    {
+      "type": "row",
+      "title": "V3 Chat Quality (CORE-55)",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "stat",
+      "title": "Grounding score (avg, 1h)",
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "green",
+                "value": 85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_grounding_score_sum[1h]))/sum(rate(chat_grounding_score_count[1h]))",
+          "refId": "A"
+        }
+      ],
+      "id": 2
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Grounding score percentiles",
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(chat_grounding_score_bucket[1h])) by (le))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(chat_grounding_score_bucket[1h])) by (le))",
+          "refId": "B",
+          "legendFormat": "p95"
+        }
+      ],
+      "id": 3
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Grounding violations / min by signal",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_grounding_signals_total[5m])) by (signal_type) * 60",
+          "refId": "A",
+          "legendFormat": "{{signal_type}}"
+        }
+      ],
+      "id": 4
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Chat requests / min by query_type",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_grounding_score_count[5m])) by (query_type) * 60",
+          "refId": "A",
+          "legendFormat": "{{query_type}}"
+        }
+      ],
+      "id": 5
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Agentic iterations (p50/p95)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(chat_agentic_iterations_bucket[1h])) by (le))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(chat_agentic_iterations_bucket[1h])) by (le))",
+          "refId": "B",
+          "legendFormat": "p95"
+        }
+      ],
+      "id": 6
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Tool calls / request (p50/p95)",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(chat_tool_calls_per_request_bucket[1h])) by (le))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(chat_tool_calls_per_request_bucket[1h])) by (le))",
+          "refId": "B",
+          "legendFormat": "p95"
+        }
+      ],
+      "id": 7
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Tool repeat-max p95 (thrashing)",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "A",
+          "legendFormat": "p95"
+        }
+      ],
+      "id": 8
+    }
+  ]
+}

--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -200,6 +200,18 @@ export function createAppServices(
     metricsService.chatToolGroupRequests.inc({ groups });
   });
 
+  // V3 chat telemetry (CORE-55): grounding quality + tool-thrashing per request.
+  chatService.setChatTelemetryCallback((t) => {
+    const qt = t.queryType || 'unknown';
+    metricsService.chatGroundingScore.observe({ query_type: qt }, t.groundingScore);
+    metricsService.chatAgenticIterations.observe({ query_type: qt }, t.iterations);
+    metricsService.chatToolCallsPerRequest.observe({ query_type: qt }, t.toolCalls);
+    metricsService.chatToolRepeatMax.observe({ query_type: qt }, t.toolRepeatMax);
+    for (const [k, v] of Object.entries(t.signals)) {
+      if (v > 0) metricsService.chatGroundingSignals.inc({ signal_type: k }, v);
+    }
+  });
+
   logger.info('Prometheus metrics service initialized');
 
   // Upload recovery service (uses BullMQ for re-enqueuing)

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -26,6 +26,22 @@ export interface ChatPlanResult {
   planSessionId: string;
 }
 
+/** V3 telemetry (CORE-55) — one record per chat request, wired to Prometheus. */
+export interface ChatTelemetry {
+  queryType: string;
+  groundingScore: number;
+  signals: {
+    fabricatedCases: number;
+    fabricatedArticles: number;
+    lowRelevance: number;
+    subjectMismatch: number;
+    ungroundedQuotes: number;
+  };
+  iterations: number;
+  toolCalls: number;
+  toolRepeatMax: number;
+}
+
 export class ChatService {
   constructor(...args: any[]) {}
 
@@ -43,4 +59,6 @@ export class ChatService {
   }
 
   setToolGroupMetricsCallback(callback: (groups: any) => void): void {}
+
+  setChatTelemetryCallback(callback: (t: ChatTelemetry) => void): void {}
 }

--- a/mcp_backend/src/services/metrics-service.ts
+++ b/mcp_backend/src/services/metrics-service.ts
@@ -50,6 +50,12 @@ export class MetricsService {
 
   // Chat tool grouping metrics
   readonly chatToolGroupRequests: Counter;
+  // V3 chat telemetry (CORE-55)
+  readonly chatGroundingScore: Histogram;
+  readonly chatGroundingSignals: Counter;
+  readonly chatAgenticIterations: Histogram;
+  readonly chatToolCallsPerRequest: Histogram;
+  readonly chatToolRepeatMax: Histogram;
 
   constructor() {
     this.registry = new Registry();
@@ -202,6 +208,42 @@ export class MetricsService {
       name: 'chat_tool_group_requests_total',
       help: 'LLM requests for additional tool groups via meta-tool',
       labelNames: ['groups'] as const,
+      registers: [this.registry],
+    });
+
+    // V3 chat telemetry (CORE-55) — grounding quality + tool-thrashing per request.
+    this.chatGroundingScore = new Histogram({
+      name: 'chat_grounding_score',
+      help: 'Per-request composite grounding score (0-100; lower = more fabricated/ungrounded citations)',
+      labelNames: ['query_type'] as const,
+      buckets: [0, 25, 50, 70, 85, 95, 100],
+      registers: [this.registry],
+    });
+    this.chatGroundingSignals = new Counter({
+      name: 'chat_grounding_signals_total',
+      help: 'Count of grounding violations by signal type (fabricated_cases, fabricated_articles, low_relevance, subject_mismatch, ungrounded_quotes)',
+      labelNames: ['signal_type'] as const,
+      registers: [this.registry],
+    });
+    this.chatAgenticIterations = new Histogram({
+      name: 'chat_agentic_iterations',
+      help: 'Agentic-loop iterations per chat request (high = thrashing)',
+      labelNames: ['query_type'] as const,
+      buckets: [1, 2, 3, 5, 8, 12, 16, 25],
+      registers: [this.registry],
+    });
+    this.chatToolCallsPerRequest = new Histogram({
+      name: 'chat_tool_calls_per_request',
+      help: 'Total tool calls executed per chat request',
+      labelNames: ['query_type'] as const,
+      buckets: [0, 1, 2, 3, 5, 8, 12, 20],
+      registers: [this.registry],
+    });
+    this.chatToolRepeatMax = new Histogram({
+      name: 'chat_tool_repeat_max',
+      help: 'Max calls to a single tool in one request (repeats with varying params = thrashing)',
+      labelNames: ['query_type'] as const,
+      buckets: [1, 2, 3, 4, 6, 8, 12],
       registers: [this.registry],
     });
 


### PR DESCRIPTION
## What
Backend wiring for V3 chat telemetry. Core emit landed in `secondlayer-core#66` (merged); this exposes it via Prometheus + a Grafana dashboard.

## Changes
- **metrics-service.ts** — 5 new metrics:
  - `chat_grounding_score` (Histogram, `query_type`)
  - `chat_grounding_signals_total` (Counter, `signal_type`: fabricated_cases/articles, low_relevance, subject_mismatch, ungrounded_quotes)
  - `chat_agentic_iterations`, `chat_tool_calls_per_request`, `chat_tool_repeat_max` (Histograms, `query_type`)
- **app-services.ts** — `chatService.setChatTelemetryCallback(...)` → the metrics above.
- **chat-service.ts** (stub) — `ChatTelemetry` type + `setChatTelemetryCallback` (real impl pulled from core overlay at build).
- **deployment/grafana/dashboards/07-chat-quality.json** — "Chat Quality (V3)" dashboard: grounding-score percentiles, violations by signal, iterations / tool-calls / repeat-max.

## Why
Make V3 measurable: are answers well-grounded? is the model thrashing tools? These were computed inline but never aggregated.

## Validation
- Backend `tsc`: only the 3 pre-existing core-overlay `TS2307` (core-loader) — none in changed files.
- Grafana JSON validated.

Telemetry only — no behavior change. V3 roadmap CORE-51, phase P3 (CORE-55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires V3 chat telemetry to Prometheus and adds a “Chat Quality (V3)” Grafana dashboard. Meets CORE-55 by making grounding quality and tool thrashing measurable; no behavior change.

- **New Features**
  - Added Prometheus metrics: chat_grounding_score (histogram, by query_type), chat_grounding_signals_total (counter, by signal_type), chat_agentic_iterations (histogram, by query_type), chat_tool_calls_per_request (histogram, by query_type), chat_tool_repeat_max (histogram, by query_type).
  - Hooked `chatService.setChatTelemetryCallback(...)` to record these metrics; introduced `ChatTelemetry` type in chat service.
  - New Grafana dashboard (07-chat-quality.json): grounding score percentiles, violations by signal, agentic iterations, tool calls per request, and tool repeat-max.

<sup>Written for commit 62ba58f4f5c6fe092f8f483bb6a265ca29bbf5ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

