### PR TITLE
feat(citation-graph): CitationGraphService (Neo4j) behind CITATION_BACKEND flag

### DIFF
--- a/mcp_backend/.env.example
+++ b/mcp_backend/.env.example
@@ -89,6 +89,16 @@ REDIS_PORT=6379
 QDRANT_URL=http://localhost:6333
 
 # =============================================================================
+# Citation Graph (Neo4j) — LEXAI-1770
+# =============================================================================
+# Backend for get_citation_graph: postgres (@secondlayer/core) | neo4j (CitationGraphService)
+CITATION_BACKEND=postgres
+NEO4J_URI=bolt://localhost:7687
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=
+NEO4J_DATABASE=neo4j
+
+# =============================================================================
 # MinIO Object Storage
 # =============================================================================
 MINIO_ACCESS_KEY=minioadmin

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -88,6 +88,7 @@
     "mammoth": "^1.11.0",
     "minio": "^8.0.6",
     "multer": "^2.1.0",
+    "neo4j-driver": "^5.28.3",
     "node-cron": "^4.2.1",
     "nodemailer": "^9.0.1",
     "openai": "^6.27.0",

--- a/mcp_backend/src/api/tools/legal-advice-tools.ts
+++ b/mcp_backend/src/api/tools/legal-advice-tools.ts
@@ -15,6 +15,7 @@ import { SemanticSectionizer } from '../../services/semantic-sectionizer.js';
 import type { IEmbeddingPort, ILLMPort } from '../../domain/ports/index.js';
 import { LegalPatternStore } from '../../services/legal-pattern-store.js';
 import { CitationValidator } from '../../services/citation-validator.js';
+import type { CitationGraphService } from '../../services/citation-graph-service.js';
 import { ShepardizationService, ShepardizationResult } from '../../services/shepardization-service.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsResult } from '../../services/edrsr-fts-service.js';
 import { SectionType } from '../../types/index.js';
@@ -38,9 +39,35 @@ export class LegalAdviceTools extends BaseToolHandler {
     private shepardizationService?: ShepardizationService,
     private readonly llm?: ILLMPort,
     private readonly db?: { query: (sql: string, params?: any[]) => Promise<any> },
-    private readonly ftsService?: EdsrFtsService
+    private readonly ftsService?: EdsrFtsService,
+    private readonly citationGraphService?: CitationGraphService
   ) {
     super();
+  }
+
+  /**
+   * Resolve any case identifier (UUID, numeric doc_id, case_number) to the EDRSR
+   * doc_id (bigint as string) used as the Decision key in the Neo4j citation graph.
+   * Chain: UUID → documents.zakononline_id; case_number → edrsr_documents.doc_id; numeric → as-is.
+   */
+  private async resolveToEdrsrDocId(input: string): Promise<string | null> {
+    if (!this.db) return null;
+    if (/^\d+$/.test(input)) return input;
+
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (uuidRegex.test(input)) {
+      const doc = await this.db.query(
+        `SELECT zakononline_id::text AS doc_id FROM documents WHERE id = $1 AND deleted_at IS NULL LIMIT 1`,
+        [input]
+      );
+      return doc.rows[0]?.doc_id ?? null;
+    }
+
+    const edrsr = await this.db.query(
+      `SELECT doc_id::text AS doc_id FROM edrsr_documents WHERE cause_num = $1 ORDER BY adjudication_date DESC NULLS LAST LIMIT 1`,
+      [input]
+    );
+    return edrsr.rows[0]?.doc_id ?? null;
   }
 
   /** Map EDRSR FTS rows to the case shape this tool's responses expose. */
@@ -281,6 +308,31 @@ export class LegalAdviceTools extends BaseToolHandler {
 
   private async getCitationGraph(args: any): Promise<ToolResult> {
     const input = String(args.case_id).trim();
+    const depth = args.depth || 2;
+
+    // CITATION_BACKEND=neo4j → serve the decision→article graph from Neo4j.
+    if (this.citationGraphService?.isEnabled()) {
+      const docId = await this.resolveToEdrsrDocId(input);
+      if (!docId) {
+        return this.wrapResponse({
+          error: `Не вдалося конвертувати "${input}" у doc_id ЄДРСР для графа цитувань.`,
+          provided_value: input,
+          backend: 'neo4j',
+        });
+      }
+      try {
+        const graph = await this.citationGraphService.getCitationGraph(docId, depth);
+        return this.wrapResponse({ graph, backend: 'neo4j' });
+      } catch (error: any) {
+        logger.error('[LegalAdviceTools] Neo4j citation graph failed', { input, docId, error: error?.message });
+        return this.wrapResponse({
+          error: 'Граф цитувань (Neo4j) тимчасово недоступний.',
+          detail: error?.message,
+          provided_value: input,
+          backend: 'neo4j',
+        });
+      }
+    }
 
     if (!this.db) {
       // No DB — only UUID passthrough works

--- a/mcp_backend/src/factories/core-services.ts
+++ b/mcp_backend/src/factories/core-services.ts
@@ -8,6 +8,7 @@ import { LegalPatternStore } from '../services/legal-pattern-store.js';
 import { CitationValidator } from '../services/citation-validator.js';
 import { HallucinationGuard } from '../services/hallucination-guard.js';
 import { ShepardizationService } from '../services/shepardization-service.js';
+import { CitationGraphService } from '../services/citation-graph-service.js';
 import { MCPQueryAPI } from '../api/mcp-query-api.js';
 import { LegislationTools } from '../api/legislation-tools.js';
 import { LegislationService } from '../services/legislation-service.js';
@@ -31,6 +32,7 @@ export interface BackendCoreServices {
   patternStore: LegalPatternStore;
   shepardizationService: ShepardizationService;
   citationValidator: CitationValidator;
+  citationGraphService: CitationGraphService;
   hallucinationGuard: HallucinationGuard;
   legislationTools: LegislationTools;
   reyestrDownloadService: ReyestrDownloadService;
@@ -54,6 +56,7 @@ export function createBackendCoreServices(): BackendCoreServices {
   const patternStore = new LegalPatternStore(db, embeddingService);
   const shepardizationService = new ShepardizationService(zoAdapter, db);
   const citationValidator = new CitationValidator(db, shepardizationService);
+  const citationGraphService = new CitationGraphService();
   const hallucinationGuard = new HallucinationGuard(db, shepardizationService);
   const legislationService = new LegislationService(db, embeddingService, undefined, llmAdapter);
   const legislationTools = new LegislationTools(legislationService, undefined, patternStore);
@@ -86,6 +89,7 @@ export function createBackendCoreServices(): BackendCoreServices {
     patternStore,
     shepardizationService,
     citationValidator,
+    citationGraphService,
     hallucinationGuard,
     legislationTools,
     reyestrDownloadService,

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -154,7 +154,8 @@ export function createToolServices(
     coreServices.shepardizationService,
     llmAdapter,
     coreServices.db,
-    edsrFtsService
+    edsrFtsService,
+    coreServices.citationGraphService
   ));
   toolRegistry.registerHandler(new CourtSessionTools(
     coreServices.zoSessionsAdapter,

--- a/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
+++ b/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for CitationGraphService (Neo4j-backed citation graph).
+ * neo4j-driver is fully mocked — no live Neo4j required.
+ */
+
+const mockRun = jest.fn();
+const mockSessionClose = jest.fn().mockResolvedValue(undefined);
+const mockSession = jest.fn(() => ({ run: mockRun, close: mockSessionClose }));
+const mockDriverClose = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('neo4j-driver', () => {
+  const int = (n: number) => ({ __int: n, toNumber: () => n });
+  return {
+    __esModule: true,
+    default: {
+      driver: () => ({ session: mockSession, close: mockDriverClose }),
+      auth: { basic: (u: string, p: string) => ({ scheme: 'basic', principal: u, credentials: p }) },
+      session: { READ: 'READ' },
+      int,
+      isInt: (v: any) => !!v && typeof v === 'object' && '__int' in v,
+    },
+  };
+});
+
+import { CitationGraphService } from '../citation-graph-service.js';
+
+function rec(obj: Record<string, any>) {
+  return { get: (k: string) => obj[k] };
+}
+const neoInt = (n: number) => ({ __int: n, toNumber: () => n });
+
+describe('CitationGraphService', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...ORIGINAL_ENV, CITATION_BACKEND: 'neo4j', NEO4J_URI: 'bolt://test:7687', NEO4J_PASSWORD: 'x' };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('isEnabled', () => {
+    it('is true when CITATION_BACKEND=neo4j', () => {
+      expect(new CitationGraphService().isEnabled()).toBe(true);
+    });
+
+    it('is false by default (postgres)', () => {
+      process.env = { ...ORIGINAL_ENV };
+      delete process.env.CITATION_BACKEND;
+      expect(new CitationGraphService().isEnabled()).toBe(false);
+    });
+
+    it('is false for explicit postgres', () => {
+      process.env = { ...ORIGINAL_ENV, CITATION_BACKEND: 'postgres' };
+      expect(new CitationGraphService().isEnabled()).toBe(false);
+    });
+  });
+
+  describe('getDecisionCitations', () => {
+    it('maps Decision->Article records and closes the session', async () => {
+      mockRun.mockResolvedValueOnce({
+        records: [
+          rec({ law: 'ЦПК України', article: '175', ct: 'codex_article', ctx: 'ст. 175 ЦПК' }),
+          rec({ law: 'КК України', article: '185', ct: 'codex_article', ctx: 'ст. 185 КК' }),
+        ],
+      });
+
+      const svc = new CitationGraphService();
+      const out = await svc.getDecisionCitations('86560781');
+
+      expect(out).toEqual([
+        { law: 'ЦПК України', article: '175', citationType: 'codex_article', context: 'ст. 175 ЦПК' },
+        { law: 'КК України', article: '185', citationType: 'codex_article', context: 'ст. 185 КК' },
+      ]);
+      // doc_id is coerced to string for the Decision key lookup
+      expect(mockRun.mock.calls[0][1]).toMatchObject({ docId: '86560781' });
+      expect(mockSessionClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('getArticleStats', () => {
+    it('parses neo4j Integer properties to JS numbers', async () => {
+      mockRun.mockResolvedValueOnce({
+        records: [rec({ law: 'КУпАП', article: '130', tc: neoInt(2965804), ud: neoInt(1500000) })],
+      });
+
+      const stats = await new CitationGraphService().getArticleStats('КУпАП', '130');
+      expect(stats).toEqual({ law: 'КУпАП', article: '130', totalCitations: 2965804, uniqueDecisions: 1500000 });
+    });
+
+    it('returns null when the article is absent', async () => {
+      mockRun.mockResolvedValueOnce({ records: [] });
+      expect(await new CitationGraphService().getArticleStats('X', '1')).toBeNull();
+    });
+  });
+
+  describe('getArticleCitedBy', () => {
+    it('returns decisions and total count from two queries', async () => {
+      mockRun
+        .mockResolvedValueOnce({ records: [rec({ docId: '111' }), rec({ docId: '222' })] })
+        .mockResolvedValueOnce({ records: [rec({ c: neoInt(42) })] });
+
+      const out = await new CitationGraphService().getArticleCitedBy('ЦПК України', '178');
+      expect(out).toEqual({ count: 42, decisions: ['111', '222'] });
+      expect(mockRun).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('healthCheck', () => {
+    it('returns ok with node-label counts', async () => {
+      mockRun.mockResolvedValueOnce({
+        records: [
+          rec({ label: 'Decision', c: neoInt(33138541) }),
+          rec({ label: 'Article', c: neoInt(3133367) }),
+          rec({ label: null, c: neoInt(0) }),
+        ],
+      });
+
+      const h = await new CitationGraphService().healthCheck();
+      expect(h.ok).toBe(true);
+      expect(h.enabled).toBe(true);
+      expect(h.counts).toEqual({ Decision: 33138541, Article: 3133367 });
+    });
+
+    it('returns ok=false with error on driver failure', async () => {
+      mockRun.mockRejectedValueOnce(new Error('connection refused'));
+      const h = await new CitationGraphService().healthCheck();
+      expect(h.ok).toBe(false);
+      expect(h.error).toContain('connection refused');
+    });
+  });
+
+  describe('getCitationGraph', () => {
+    it('builds decision/article/law nodes and edges at depth 1', async () => {
+      mockRun.mockResolvedValueOnce({
+        records: [rec({ law: 'ЦПК України', article: '175', ct: 'codex_article', ctx: null })],
+      });
+
+      const g = await new CitationGraphService().getCitationGraph('500', 1);
+      expect(g.root).toEqual({ docId: '500' });
+      expect(g.nodes).toEqual(
+        expect.arrayContaining([
+          { id: 'decision:500', type: 'decision', label: '500' },
+          { id: 'article:ЦПК України|175', type: 'article', label: 'ЦПК України ст.175' },
+          { id: 'law:ЦПК України', type: 'law', label: 'ЦПК України' },
+        ])
+      );
+      expect(g.edges).toEqual(
+        expect.arrayContaining([
+          { from: 'decision:500', to: 'article:ЦПК України|175', type: 'CITES_ARTICLE' },
+          { from: 'article:ЦПК України|175', to: 'law:ЦПК України', type: 'OF_LAW' },
+        ])
+      );
+    });
+  });
+
+  describe('close', () => {
+    it('closes the driver if initialized', async () => {
+      const svc = new CitationGraphService();
+      mockRun.mockResolvedValueOnce({ records: [] });
+      await svc.getDecisionCitations('1'); // triggers driver init
+      await svc.close();
+      expect(mockDriverClose).toHaveBeenCalled();
+    });
+  });
+});

--- a/mcp_backend/src/services/citation-graph-service.ts
+++ b/mcp_backend/src/services/citation-graph-service.ts
@@ -1,0 +1,270 @@
+/**
+ * CitationGraphService
+ *
+ * Neo4j-backed citation graph for EDRSR court decisions.
+ *
+ * Graph model (loaded via neo4j-admin import, see LEXAI-1770):
+ *   (:Decision {doc_id})-[:CITES_ARTICLE {citation_type, citation_context}]->(:Article)
+ *   (:Article {art_id, law_number, law_article, total_citations, unique_decisions})-[:OF_LAW]->(:Law {law_number})
+ *   (:Article)-[:COCITED {weight}]->(:Article)
+ *
+ * Gated behind the CITATION_BACKEND feature flag (postgres | neo4j). When set to
+ * `neo4j`, isEnabled() returns true and the driver connects to NEO4J_URI. The
+ * Postgres path (CitationValidator / @secondlayer/core) remains the default.
+ *
+ * Thin graph: only ids + edge metadata live here; fulltext/vectors stay in
+ * Postgres/Qdrant and are joined back by doc_id.
+ */
+
+import neo4j, { type Driver } from 'neo4j-driver';
+import { logger } from '../utils/logger.js';
+
+export interface ArticleCitation {
+  law: string;
+  article: string;
+  citationType?: string | null;
+  context?: string | null;
+}
+
+export interface CocitedArticle {
+  law: string;
+  article: string;
+  weight: number;
+}
+
+export interface CitedArticleStat {
+  law: string;
+  article: string;
+  totalCitations: number;
+  uniqueDecisions: number;
+}
+
+export interface CitationGraphNode {
+  id: string;
+  type: 'decision' | 'article' | 'law';
+  label: string;
+}
+
+export interface CitationGraphEdge {
+  from: string;
+  to: string;
+  type: 'CITES_ARTICLE' | 'OF_LAW' | 'COCITED';
+  weight?: number;
+}
+
+export interface CitationGraphResult {
+  root: { docId: string };
+  nodes: CitationGraphNode[];
+  edges: CitationGraphEdge[];
+  truncated: boolean;
+}
+
+export interface CitationGraphHealth {
+  ok: boolean;
+  enabled: boolean;
+  uri: string;
+  error?: string;
+  counts?: Record<string, number>;
+}
+
+/** Convert a neo4j Integer | bigint | number to a JS number safely. */
+function toNum(v: any): number {
+  if (v == null) return 0;
+  if (typeof v === 'number') return v;
+  if (typeof v === 'bigint') return Number(v);
+  if (neo4j.isInt(v)) return (v as any).toNumber();
+  const n = Number(v);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+export class CitationGraphService {
+  private driver: Driver | null = null;
+  private readonly uri: string;
+  private readonly user: string;
+  private readonly password: string;
+  private readonly database: string;
+  private readonly enabled: boolean;
+
+  constructor() {
+    this.uri = process.env.NEO4J_URI || 'bolt://localhost:7687';
+    this.user = process.env.NEO4J_USER || 'neo4j';
+    this.password = process.env.NEO4J_PASSWORD || '';
+    this.database = process.env.NEO4J_DATABASE || 'neo4j';
+    this.enabled = (process.env.CITATION_BACKEND || 'postgres').toLowerCase() === 'neo4j';
+  }
+
+  /** True when CITATION_BACKEND=neo4j. Callers fall back to the Postgres path otherwise. */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  private getDriver(): Driver {
+    if (!this.driver) {
+      this.driver = neo4j.driver(
+        this.uri,
+        neo4j.auth.basic(this.user, this.password),
+        {
+          maxConnectionPoolSize: 20,
+          connectionAcquisitionTimeout: 15_000,
+          maxTransactionRetryTime: 10_000,
+        }
+      );
+      logger.info('[CitationGraphService] Neo4j driver initialized', { uri: this.uri, database: this.database });
+    }
+    return this.driver;
+  }
+
+  private async run<T>(cypher: string, params: Record<string, any>, map: (record: any) => T): Promise<T[]> {
+    const session = this.getDriver().session({ database: this.database, defaultAccessMode: neo4j.session.READ });
+    try {
+      const result = await session.run(cypher, params);
+      return result.records.map(map);
+    } finally {
+      await session.close();
+    }
+  }
+
+  /** Connectivity + node-label counts. Cheap (uses count-store). */
+  async healthCheck(): Promise<CitationGraphHealth> {
+    const base = { enabled: this.enabled, uri: this.uri };
+    try {
+      const rows = await this.run(
+        'MATCH (n) RETURN labels(n)[0] AS label, count(*) AS c',
+        {},
+        (r) => ({ label: r.get('label') as string | null, c: toNum(r.get('c')) })
+      );
+      const counts: Record<string, number> = {};
+      for (const row of rows) if (row.label) counts[row.label] = row.c;
+      return { ...base, ok: true, counts };
+    } catch (error: any) {
+      logger.error('[CitationGraphService] healthCheck failed', { error: error?.message });
+      return { ...base, ok: false, error: error?.message };
+    }
+  }
+
+  /** Articles cited by a given decision (Decision -> Article). */
+  async getDecisionCitations(docId: string | number, limit = 200): Promise<ArticleCitation[]> {
+    return this.run(
+      `MATCH (d:Decision {doc_id: $docId})-[c:CITES_ARTICLE]->(a:Article)
+       RETURN a.law_number AS law, a.law_article AS article,
+              c.citation_type AS ct, c.citation_context AS ctx
+       LIMIT $limit`,
+      { docId: String(docId), limit: neo4j.int(limit) },
+      (r) => ({
+        law: r.get('law'),
+        article: r.get('article'),
+        citationType: r.get('ct'),
+        context: r.get('ctx'),
+      })
+    );
+  }
+
+  /** Decisions that cite a given article (Article <- Decision), plus total count. */
+  async getArticleCitedBy(
+    law: string,
+    article: string,
+    limit = 100
+  ): Promise<{ count: number; decisions: string[] }> {
+    const [decisions, countRows] = await Promise.all([
+      this.run(
+        `MATCH (a:Article {law_number: $law, law_article: $article})<-[:CITES_ARTICLE]-(d:Decision)
+         RETURN d.doc_id AS docId LIMIT $limit`,
+        { law, article, limit: neo4j.int(limit) },
+        (r) => r.get('docId') as string
+      ),
+      this.run(
+        `MATCH (a:Article {law_number: $law, law_article: $article})<-[c:CITES_ARTICLE]-()
+         RETURN count(c) AS c`,
+        { law, article },
+        (r) => toNum(r.get('c'))
+      ),
+    ]);
+    return { count: countRows[0] ?? 0, decisions };
+  }
+
+  /** Precomputed citation stats for an article (from the Article node). */
+  async getArticleStats(law: string, article: string): Promise<CitedArticleStat | null> {
+    const rows = await this.run(
+      `MATCH (a:Article {law_number: $law, law_article: $article})
+       RETURN a.law_number AS law, a.law_article AS article,
+              a.total_citations AS tc, a.unique_decisions AS ud
+       LIMIT 1`,
+      { law, article },
+      (r) => ({
+        law: r.get('law'),
+        article: r.get('article'),
+        totalCitations: toNum(r.get('tc')),
+        uniqueDecisions: toNum(r.get('ud')),
+      })
+    );
+    return rows[0] ?? null;
+  }
+
+  /** Articles co-cited alongside a given article, by descending weight. */
+  async getCocitedArticles(law: string, article: string, limit = 20): Promise<CocitedArticle[]> {
+    return this.run(
+      `MATCH (a:Article {law_number: $law, law_article: $article})-[co:COCITED]-(b:Article)
+       RETURN b.law_number AS law, b.law_article AS article, co.weight AS weight
+       ORDER BY co.weight DESC
+       LIMIT $limit`,
+      { law, article, limit: neo4j.int(limit) },
+      (r) => ({ law: r.get('law'), article: r.get('article'), weight: toNum(r.get('weight')) })
+    );
+  }
+
+  /**
+   * Build a bounded citation-graph neighborhood around a decision for visualization.
+   * depth 1: decision -> cited articles (+ their laws).
+   * depth >=2: also include the most co-cited articles for each cited article.
+   */
+  async getCitationGraph(docId: string | number, depth = 1, articleLimit = 50): Promise<CitationGraphResult> {
+    const id = String(docId);
+    const nodes = new Map<string, CitationGraphNode>();
+    const edges: CitationGraphEdge[] = [];
+
+    const decisionKey = `decision:${id}`;
+    nodes.set(decisionKey, { id: decisionKey, type: 'decision', label: id });
+
+    const cited = await this.getDecisionCitations(id, articleLimit);
+    for (const a of cited) {
+      const artKey = `article:${a.law}|${a.article}`;
+      const lawKey = `law:${a.law}`;
+      if (!nodes.has(artKey)) {
+        nodes.set(artKey, { id: artKey, type: 'article', label: `${a.law} ст.${a.article}` });
+      }
+      if (!nodes.has(lawKey)) {
+        nodes.set(lawKey, { id: lawKey, type: 'law', label: a.law });
+      }
+      edges.push({ from: decisionKey, to: artKey, type: 'CITES_ARTICLE' });
+      edges.push({ from: artKey, to: lawKey, type: 'OF_LAW' });
+    }
+
+    if (depth >= 2) {
+      for (const a of cited.slice(0, 15)) {
+        const artKey = `article:${a.law}|${a.article}`;
+        const cocited = await this.getCocitedArticles(a.law, a.article, 5);
+        for (const c of cocited) {
+          const ck = `article:${c.law}|${c.article}`;
+          if (!nodes.has(ck)) {
+            nodes.set(ck, { id: ck, type: 'article', label: `${c.law} ст.${c.article}` });
+          }
+          edges.push({ from: artKey, to: ck, type: 'COCITED', weight: c.weight });
+        }
+      }
+    }
+
+    return {
+      root: { docId: id },
+      nodes: Array.from(nodes.values()),
+      edges,
+      truncated: cited.length >= articleLimit,
+    };
+  }
+
+  async close(): Promise<void> {
+    if (this.driver) {
+      await this.driver.close();
+      this.driver = null;
+    }
+  }
+}

--- a/mcp_backend/src/services/config-service.ts
+++ b/mcp_backend/src/services/config-service.ts
@@ -87,6 +87,10 @@ const CONFIG_REGISTRY: ConfigEntry[] = [
   { key: 'POSTGRES_HOST', category: 'database', description: 'PostgreSQL host', is_secret: false, value_type: 'string', default_value: 'localhost' },
   { key: 'POSTGRES_PORT', category: 'database', description: 'PostgreSQL port', is_secret: false, value_type: 'number', default_value: '5432' },
   { key: 'POSTGRES_DB', category: 'database', description: 'PostgreSQL database name', is_secret: false, value_type: 'string', default_value: 'secondlayer' },
+  { key: 'CITATION_BACKEND', category: 'database', description: 'Citation graph backend (postgres = @secondlayer/core, neo4j = CitationGraphService). Requires restart.', is_secret: false, value_type: 'select', default_value: 'postgres', options: ['postgres', 'neo4j'] },
+  { key: 'NEO4J_URI', category: 'database', description: 'Neo4j Bolt URI for citation graph', is_secret: false, value_type: 'string', default_value: 'bolt://localhost:7687' },
+  { key: 'NEO4J_USER', category: 'database', description: 'Neo4j username for citation graph', is_secret: false, value_type: 'string', default_value: 'neo4j' },
+  { key: 'NEO4J_DATABASE', category: 'database', description: 'Neo4j database name for citation graph', is_secret: false, value_type: 'string', default_value: 'neo4j' },
 
   // Redis
   { key: 'REDIS_HOST', category: 'redis', description: 'Redis host', is_secret: false, value_type: 'string', default_value: 'localhost' },
@@ -123,6 +127,7 @@ const CONFIG_REGISTRY: ConfigEntry[] = [
   { key: 'ZAKONONLINE_API_TOKEN', category: 'external_apis', description: 'ZakonOnline API token', is_secret: true, value_type: 'string', default_value: '' },
   { key: 'JWT_SECRET', category: 'auth', description: 'JWT signing secret', is_secret: true, value_type: 'string', default_value: '' },
   { key: 'POSTGRES_PASSWORD', category: 'database', description: 'PostgreSQL password', is_secret: true, value_type: 'string', default_value: '' },
+  { key: 'NEO4J_PASSWORD', category: 'database', description: 'Neo4j password for citation graph', is_secret: true, value_type: 'string', default_value: '' },
   { key: 'SECONDARY_LAYER_KEYS', category: 'auth', description: 'API authentication keys', is_secret: true, value_type: 'string', default_value: '' },
   { key: 'MINIO_ACCESS_KEY', category: 'storage', description: 'MinIO access key', is_secret: true, value_type: 'string', default_value: '' },
   { key: 'MINIO_SECRET_KEY', category: 'storage', description: 'MinIO secret key', is_secret: true, value_type: 'string', default_value: '' },


### PR DESCRIPTION
## Summary
Adds a **Neo4j-backed `CitationGraphService`** for the EDRSR citation graph, gated by a new **`CITATION_BACKEND`** feature flag (`postgres` | `neo4j`). Default stays `postgres` (`@secondlayer/core`); setting `neo4j` routes `get_citation_graph` to the new service. Part of the LEXAI-1770 pilot (full graph already loaded to Neo4j on qdrant.lex: 33.1M Decision / 3.13M Article / 1.56M Law / 391.9M CITES_ARTICLE).

## Graph model
```
(:Decision {doc_id})-[:CITES_ARTICLE {citation_type, citation_context}]->(:Article)
(:Article {art_id, law_number, law_article, total_citations, unique_decisions})-[:OF_LAW]->(:Law {law_number})
(:Article)-[:COCITED {weight}]->(:Article)
```

## Changes
- **`citation-graph-service.ts`** (new): lazy Bolt driver, READ sessions, safe `Integer→number` coercion. Methods: `getDecisionCitations`, `getArticleCitedBy`, `getArticleStats`, `getCocitedArticles`, `getCitationGraph` (bounded neighborhood), `healthCheck`, `isEnabled`, `close`.
- **`config-service.ts`**: registers `CITATION_BACKEND`, `NEO4J_URI`, `NEO4J_USER`, `NEO4J_DATABASE` (+ secret `NEO4J_PASSWORD`).
- **`core-services.ts`**: instantiates the service and exposes it on `BackendCoreServices`.
- **`legal-advice-tools.ts` / `tool-services.ts`**: inject the service; when the flag is on, `get_citation_graph` resolves any identifier to an EDRSR `doc_id` and serves the decision→article graph from Neo4j, with a graceful fallback message on error. Postgres path untouched when flag is off.
- **`.env.example`**: documents the new vars.

## Testing
- **Unit:** 11 cases, `neo4j-driver` fully mocked — `npx jest src/services/__tests__/citation-graph-service.test.ts` ✅
- **Live e2e** against the loaded graph (via SSH tunnel): `healthCheck` counts correct; `КК ст.185` → 3,308,876 citations / 1,114,641 decisions; co-citation + neighborhood graph return sensible results.
- **Types:** `tsc --noEmit` introduces no new errors (only the 3 pre-existing `@secondlayer/core` overlay module-resolution errors remain, unrelated to this PR).

## Rollout
Flag defaults to `postgres` — no behavior change until `CITATION_BACKEND=neo4j` + `NEO4J_*` are set. Requires restart (read at construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Neo4j-backed citation graph behind a `CITATION_BACKEND` flag and routes `get_citation_graph` to it when enabled, with no default behavior change. Supports LEXAI-1770 by enabling decision→article, co-citation, and neighborhood graph queries.

- **New Features**
  - Introduces `CitationGraphService` (Neo4j) with health check and read-only sessions.
  - Routes `get_citation_graph` to Neo4j when `CITATION_BACKEND=neo4j`; resolves UUID/doc_id/case number to EDRSR `doc_id` and falls back with a clear message on errors.
  - Provides decision→article, article cited-by + stats, co-citation, and a bounded neighborhood graph.
  - Adds config/env for `CITATION_BACKEND`, `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `NEO4J_DATABASE`; updates `.env.example` and config registry; wires service into factories; includes unit tests with mocked `neo4j-driver`.

- **Migration**
  - Set `CITATION_BACKEND=neo4j`.
  - Configure `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `NEO4J_DATABASE`.
  - Restart the backend.

<sup>Written for commit 72f28fb0817a017c5bef55cf8d27b8e0ff264b8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

