### PR TITLE
feat(citation-graph): enable Neo4j backend for chat (CORE-56)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -570,6 +570,12 @@ services:
       BEDROCK_FALLBACK_MODEL_QUICK: ${BEDROCK_FALLBACK_MODEL_QUICK:-eu.amazon.nova-micro-v1:0}
       BEDROCK_FALLBACK_MODEL_STANDARD: ${BEDROCK_FALLBACK_MODEL_STANDARD:-eu.amazon.nova-pro-v1:0}
       BEDROCK_FALLBACK_MODEL_DEEP: ${BEDROCK_FALLBACK_MODEL_DEEP:-eu.amazon.nova-pro-v1:0}
+      # Citation graph backend (CORE-56): neo4j = CitationGraphService (Neo4j on qdrant.lex).
+      CITATION_BACKEND: ${CITATION_BACKEND:-postgres}
+      NEO4J_URI: ${NEO4J_URI:-bolt://localhost:7687}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-}
+      NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
       # Chat-latency tunables (CORE-32 region pinning / CORE-35 hedged streaming / CORE-36 parallel-seed).
       # Empty default = feature off (no behavior change); enable by setting the value in .env.prod.
       BEDROCK_QUICK_REGION: ${BEDROCK_QUICK_REGION:-}
@@ -776,6 +782,12 @@ services:
       BEDROCK_FALLBACK_MODEL_QUICK: ${BEDROCK_FALLBACK_MODEL_QUICK:-eu.amazon.nova-micro-v1:0}
       BEDROCK_FALLBACK_MODEL_STANDARD: ${BEDROCK_FALLBACK_MODEL_STANDARD:-eu.amazon.nova-pro-v1:0}
       BEDROCK_FALLBACK_MODEL_DEEP: ${BEDROCK_FALLBACK_MODEL_DEEP:-eu.amazon.nova-pro-v1:0}
+      # Citation graph backend (CORE-56): neo4j = CitationGraphService (Neo4j on qdrant.lex).
+      CITATION_BACKEND: ${CITATION_BACKEND:-postgres}
+      NEO4J_URI: ${NEO4J_URI:-bolt://localhost:7687}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-}
+      NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
       ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN:-}
       ZAKONONLINE_API_TOKEN2: ${ZAKONONLINE_API_TOKEN2:-}
       VISION_CREDENTIALS_PATH: /app/credentials/vision-credentials.json
@@ -1005,6 +1017,12 @@ services:
       BEDROCK_FALLBACK_MODEL_QUICK: ${BEDROCK_FALLBACK_MODEL_QUICK:-eu.amazon.nova-micro-v1:0}
       BEDROCK_FALLBACK_MODEL_STANDARD: ${BEDROCK_FALLBACK_MODEL_STANDARD:-eu.amazon.nova-pro-v1:0}
       BEDROCK_FALLBACK_MODEL_DEEP: ${BEDROCK_FALLBACK_MODEL_DEEP:-eu.amazon.nova-pro-v1:0}
+      # Citation graph backend (CORE-56): neo4j = CitationGraphService (Neo4j on qdrant.lex).
+      CITATION_BACKEND: ${CITATION_BACKEND:-postgres}
+      NEO4J_URI: ${NEO4J_URI:-bolt://localhost:7687}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-}
+      NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
       # Chat-latency tunables (CORE-32 region pinning / CORE-35 hedged streaming / CORE-36 parallel-seed).
       # Empty default = feature off (no behavior change); enable by setting the value in .env.prod.
       BEDROCK_QUICK_REGION: ${BEDROCK_QUICK_REGION:-}
@@ -1280,6 +1298,12 @@ services:
       BEDROCK_FALLBACK_MODEL_QUICK: ${BEDROCK_FALLBACK_MODEL_QUICK:-eu.amazon.nova-micro-v1:0}
       BEDROCK_FALLBACK_MODEL_STANDARD: ${BEDROCK_FALLBACK_MODEL_STANDARD:-eu.amazon.nova-pro-v1:0}
       BEDROCK_FALLBACK_MODEL_DEEP: ${BEDROCK_FALLBACK_MODEL_DEEP:-eu.amazon.nova-pro-v1:0}
+      # Citation graph backend (CORE-56): neo4j = CitationGraphService (Neo4j on qdrant.lex).
+      CITATION_BACKEND: ${CITATION_BACKEND:-postgres}
+      NEO4J_URI: ${NEO4J_URI:-bolt://localhost:7687}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-}
+      NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
       ZAKONONLINE_API_TOKEN: ${ZAKONONLINE_API_TOKEN:-}
       ZAKONONLINE_API_TOKEN2: ${ZAKONONLINE_API_TOKEN2:-}
       VISION_CREDENTIALS_PATH: /app/credentials/vision-credentials.json

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Enables `get_citation_graph` (Neo4j) in V3 chat.

- **compose**: pass `CITATION_BACKEND` + `NEO4J_URI/USER/PASSWORD/DATABASE` to backend services (defaults keep `postgres`; prod `.env.prod` sets `neo4j`).
- **bump 1.0.10**: rebuild backend → pulls core@main with `get_citation_graph` in `FIXED_V2_TOOLS` (core#67).

Prod backend already reaches Neo4j on qdrant.lex (`172.31.25.243:7687`, 391M CITES_ARTICLE edges, verified). `CITATION_BACKEND=neo4j` + creds set in `.env.prod` (server secret, not in git). CORE-56 / epic CORE-51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Neo4j-backed citation graph in V3 chat by wiring `CITATION_BACKEND` and `NEO4J_*` env vars through the prod compose file. Bumps `secondlayer-mcp` to 1.0.10 to pull `secondlayer-core@main` where `get_citation_graph` is included in `FIXED_V2_TOOLS`. Addresses CORE-56 (epic CORE-51).

- **Migration**
  - To use Neo4j, set `CITATION_BACKEND=neo4j` and provide `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `NEO4J_DATABASE`. Defaults keep Postgres.

<sup>Written for commit 1718d87a7f3190c6a1de4d9881bb333de38ded9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

