### PR TITLE
feat(citation-graph): enrich get_court_decision with Neo4j citation summary

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -16,6 +16,7 @@ import type { EdsrFtsService } from '../../services/edrsr-fts-service.js';
 import { SemanticSectionizer } from '../../services/semantic-sectionizer.js';
 import type { IEmbeddingPort } from '../../domain/ports/index.js';
 import { LegalPatternStore } from '../../services/legal-pattern-store.js';
+import type { CitationGraphService } from '../../services/citation-graph-service.js';
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
@@ -29,7 +30,8 @@ export class CourtDecisionTools extends BaseToolHandler {
     private embeddingService: IEmbeddingPort,
     private patternStore: LegalPatternStore,
     private db?: any,
-    private ftsService?: EdsrFtsService
+    private ftsService?: EdsrFtsService,
+    private citationGraphService?: CitationGraphService
   ) {
     super();
   }
@@ -50,6 +52,11 @@ export class CourtDecisionTools extends BaseToolHandler {
             case_number: { type: 'string' },
             depth: { type: 'number', default: 2 },
             reasoning_budget: { type: 'string', enum: ['quick', 'standard', 'deep'], default: 'standard' },
+            include_citations: {
+              type: 'boolean',
+              default: true,
+              description: 'Додати зведення цитованих статей з графа цитувань (Neo4j). Активне лише коли CITATION_BACKEND=neo4j; інакше ігнорується.',
+            },
           },
           required: [],
         },
@@ -395,6 +402,31 @@ export class CourtDecisionTools extends BaseToolHandler {
       full_text: fullText || undefined,
       full_text_length: fullText.length,
     };
+
+    // Best-effort citation-graph enrichment (Neo4j). Gated by CITATION_BACKEND=neo4j;
+    // never blocks or breaks the primary decision response.
+    if (args.include_citations !== false && this.citationGraphService?.isEnabled() && row.doc_id != null) {
+      try {
+        const summary = await this.citationGraphService.getDecisionCitationSummary(row.doc_id);
+        if (summary.citedCount > 0) {
+          payload.citation_graph = {
+            backend: 'neo4j',
+            cited_count: summary.citedCount,
+            top_cited_articles: summary.topCitedArticles.map((a) => ({
+              law: a.law,
+              article: a.article,
+              citation_type: a.citationType || undefined,
+              popularity: a.popularity || undefined,
+            })),
+          };
+        }
+      } catch (error: any) {
+        logger.warn('[get_court_decision] citation-graph enrichment failed (non-fatal)', {
+          docId: row.doc_id,
+          error: error?.message,
+        });
+      }
+    }
 
     return this.wrapResponse(payload);
   }

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -116,7 +116,8 @@ export function createToolServices(
     coreServices.embeddingService,
     coreServices.patternStore,
     coreServices.db,
-    edsrFtsService
+    edsrFtsService,
+    coreServices.citationGraphService
   ));
   // EDRSR vectorizer (BGE-M3 + qdrant edrsr_serving HNSW) — shared by ProceduralTools
   // (find_similar_fact_pattern_cases) and EdsrUnifiedSearchTool below.

--- a/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
+++ b/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
@@ -96,6 +96,38 @@ describe('CitationGraphService', () => {
     });
   });
 
+  describe('getDecisionCitationSummary', () => {
+    it('returns top cited articles (with popularity) and total count', async () => {
+      mockRun
+        .mockResolvedValueOnce({
+          records: [
+            rec({ law: 'Кримінальний кодекс України', article: '185', ct: 'codex_article', pop: neoInt(3308876) }),
+            rec({ law: 'КУпАП', article: '130', ct: 'codex_article', pop: neoInt(2965804) }),
+          ],
+        })
+        .mockResolvedValueOnce({ records: [rec({ c: neoInt(7) })] });
+
+      const out = await new CitationGraphService().getDecisionCitationSummary('125502043');
+      expect(out.citedCount).toBe(7);
+      expect(out.topCitedArticles).toEqual([
+        { law: 'Кримінальний кодекс України', article: '185', citationType: 'codex_article', popularity: 3308876 },
+        { law: 'КУпАП', article: '130', citationType: 'codex_article', popularity: 2965804 },
+      ]);
+      // docId coerced to string; runs the list + count queries
+      expect(mockRun.mock.calls[0][1]).toMatchObject({ docId: '125502043' });
+      expect(mockRun).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns zero count and empty list when the decision has no citations', async () => {
+      mockRun
+        .mockResolvedValueOnce({ records: [] })
+        .mockResolvedValueOnce({ records: [rec({ c: neoInt(0) })] });
+
+      const out = await new CitationGraphService().getDecisionCitationSummary('999');
+      expect(out).toEqual({ citedCount: 0, topCitedArticles: [] });
+    });
+  });
+
   describe('getArticleCitedBy', () => {
     it('returns decisions and total count from two queries', async () => {
       mockRun

--- a/mcp_backend/src/services/citation-graph-service.ts
+++ b/mcp_backend/src/services/citation-graph-service.ts
@@ -39,6 +39,21 @@ export interface CitedArticleStat {
   uniqueDecisions: number;
 }
 
+export interface CitedArticleRef {
+  law: string;
+  article: string;
+  citationType?: string | null;
+  /** How often this cited article is referenced corpus-wide (node stat) — a cheap authority signal. */
+  popularity: number;
+}
+
+export interface DecisionCitationSummary {
+  /** Total CITES_ARTICLE edges out of this decision. */
+  citedCount: number;
+  /** Top cited articles, ordered by corpus-wide popularity (most authoritative first). */
+  topCitedArticles: CitedArticleRef[];
+}
+
 export interface CitationGraphNode {
   id: string;
   type: 'decision' | 'article' | 'law';
@@ -157,6 +172,38 @@ export class CitationGraphService {
         context: r.get('ctx'),
       })
     );
+  }
+
+  /**
+   * Compact citation summary for a single decision — what articles it cites, with a
+   * corpus-wide popularity (authority) signal, plus the total citation count.
+   * Intended as inline enrichment for get_court_decision (Decision->Article path only,
+   * which is fully loaded today; decision<->decision is a future layer).
+   */
+  async getDecisionCitationSummary(docId: string | number, limit = 20): Promise<DecisionCitationSummary> {
+    const id = String(docId);
+    const [articles, countRows] = await Promise.all([
+      this.run(
+        `MATCH (d:Decision {doc_id: $docId})-[c:CITES_ARTICLE]->(a:Article)
+         RETURN a.law_number AS law, a.law_article AS article,
+                c.citation_type AS ct, a.total_citations AS pop
+         ORDER BY coalesce(a.total_citations, 0) DESC
+         LIMIT $limit`,
+        { docId: id, limit: neo4j.int(limit) },
+        (r) => ({
+          law: r.get('law'),
+          article: r.get('article'),
+          citationType: r.get('ct'),
+          popularity: toNum(r.get('pop')),
+        })
+      ),
+      this.run(
+        `MATCH (:Decision {doc_id: $docId})-[c:CITES_ARTICLE]->() RETURN count(c) AS c`,
+        { docId: id },
+        (r) => toNum(r.get('c'))
+      ),
+    ]);
+    return { citedCount: countRows[0] ?? 0, topCitedArticles: articles };
   }
 
   /** Decisions that cite a given article (Article <- Decision), plus total count. */


### PR DESCRIPTION
## What

Prototype enriching `get_court_decision` with a citation summary from the Neo4j citation graph (decision→article layer), per the per-tool DB-access review (LEXAI-1770 follow-up).

## Changes
- **`CitationGraphService.getDecisionCitationSummary(docId, limit=20)`** — returns `{ citedCount, topCitedArticles[] }`: the articles a decision cites, each with a corpus-wide `popularity` (`Article.total_citations`) as a cheap authority signal, ordered most-authoritative-first, plus the total `CITES_ARTICLE` out-degree. Single round-trip pair (list + count).
- **`get_court_decision`** attaches a `citation_graph` block to its response:
  ```json
  "citation_graph": { "backend": "neo4j", "cited_count": 30,
    "top_cited_articles": [ { "law": "...", "article": "185", "citation_type": "codex_article", "popularity": 3308876 } ] }
  ```
  - Gated by `CITATION_BACKEND=neo4j` (new `include_citations` input flag, default `true`); a no-op when the flag is off.
  - **Best-effort & non-fatal**: any Neo4j error is logged (`warn`) and the decision response is returned unchanged. Omitted when the decision has no graph citations.
- Wired `citationGraphService` into `CourtDecisionTools` via the core-services factory.
- +2 unit tests (neo4j-driver mocked); full suite 13/13 green.

## Scope / non-goals
- Uses only the **Decision→CITES_ARTICLE→Article** layer, which is fully loaded today (391M edges).
- Inbound "how often this decision is cited" and precedent-chain (decision↔decision) are a **future layer** — blocked on `case_citation_edges` case-number→doc_id resolution.

## Verification
- `npm test` (citation-graph-service): 13/13 pass.
- `tsc --noEmit`: no new errors (3 pre-existing `@secondlayer/core` overlay errors only, mounted in CI).
- Behavior unchanged unless `CITATION_BACKEND=neo4j` (already live in prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Neo4j-powered citation summary to `get_court_decision`, showing top cited articles and total citation count. Aligns with LEXAI-1770’s per-tool DB-access plan and is gated by `CITATION_BACKEND=neo4j`.

- **New Features**
  - Added `CitationGraphService.getDecisionCitationSummary(docId, limit=20)` returning `{ citedCount, topCitedArticles[] }` with article `popularity` (from corpus-wide `total_citations`), ordered most-authoritative first.
  - `get_court_decision` now includes a `citation_graph` block when enabled; best-effort, non-fatal, and omitted if no citations.
  - Introduced `include_citations` (default `true`); active only when `CITATION_BACKEND=neo4j`.
  - Wired the service into `CourtDecisionTools`; added unit tests (Neo4j driver mocked).

- **Migration**
  - Set `CITATION_BACKEND=neo4j` to enable enrichment. Use `include_citations=false` to opt out per call.

<sup>Written for commit a24134e257eaafbaf262de3c90f1d21636076fac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

