### PR TITLE
feat(metrics): chat safety-cap-hit counter + Grafana panel (CORE-55)

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -391,6 +391,52 @@
         }
       ],
       "id": 8
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Safety-cap hits / min by kind (CORE-55)",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_cap_hits_total[5m])) by (kind) * 60",
+          "refId": "A",
+          "legendFormat": "{{kind}}"
+        }
+      ],
+      "id": 9
     }
   ]
 }

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {

--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -210,6 +210,8 @@ export function createAppServices(
     for (const [k, v] of Object.entries(t.signals)) {
       if (v > 0) metricsService.chatGroundingSignals.inc({ signal_type: k }, v);
     }
+    if (t.capHits?.repeat > 0) metricsService.chatCapHits.inc({ kind: 'repeat' }, t.capHits.repeat);
+    if (t.capHits?.total > 0) metricsService.chatCapHits.inc({ kind: 'total' }, t.capHits.total);
   });
 
   logger.info('Prometheus metrics service initialized');

--- a/mcp_backend/src/services/chat-service.ts
+++ b/mcp_backend/src/services/chat-service.ts
@@ -40,6 +40,7 @@ export interface ChatTelemetry {
   iterations: number;
   toolCalls: number;
   toolRepeatMax: number;
+  capHits: { repeat: number; total: number };
 }
 
 export class ChatService {

--- a/mcp_backend/src/services/metrics-service.ts
+++ b/mcp_backend/src/services/metrics-service.ts
@@ -56,6 +56,7 @@ export class MetricsService {
   readonly chatAgenticIterations: Histogram;
   readonly chatToolCallsPerRequest: Histogram;
   readonly chatToolRepeatMax: Histogram;
+  readonly chatCapHits: Counter;
 
   constructor() {
     this.registry = new Registry();
@@ -244,6 +245,12 @@ export class MetricsService {
       help: 'Max calls to a single tool in one request (repeats with varying params = thrashing)',
       labelNames: ['query_type'] as const,
       buckets: [1, 2, 3, 4, 6, 8, 12],
+      registers: [this.registry],
+    });
+    this.chatCapHits = new Counter({
+      name: 'chat_cap_hits_total',
+      help: 'Safety-cap hits per request (kind: repeat = per-tool repeat cap, total = total tool-call cap)',
+      labelNames: ['kind'] as const,
       registers: [this.registry],
     });
 


### PR DESCRIPTION
Backend wiring for the V3 safety caps (core loop merged in secondlayer-core#68).

- **metrics-service.ts**: `chat_cap_hits_total{kind=repeat|total}` counter.
- **app-services.ts**: wire `ChatTelemetry.capHits` → counter.
- **chat-service.ts** stub: `ChatTelemetry.capHits`.
- **07-chat-quality.json**: "Safety-cap hits / min by kind" panel.
- **bump 1.0.11** → rebuild backend, pull core@main (caps).

The cap-hit counter is the validation signal: it should stay ~0 on normal traffic (caps set above p95). CORE-55 / epic CORE-51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Prometheus counter for chat safety-cap hits and a Grafana panel to track cap events by kind, enabling post-cap validation for CORE-55. This helps confirm caps rarely fire under normal traffic.

- **New Features**
  - Added `chat_cap_hits_total` counter with `kind={repeat|total}` in the metrics service.
  - Wired `ChatTelemetry.capHits` to increment the counter.
  - Extended `ChatTelemetry` with `capHits: { repeat; total }`.
  - Added Grafana panel “Safety-cap hits / min by kind” using `sum(rate(chat_cap_hits_total[5m])) by (kind) * 60`.

- **Dependencies**
  - Bumped `secondlayer-mcp` to `1.0.11` to pull core@main with V3 safety caps.

<sup>Written for commit 32b4789000512aa721703d9b04b40b11ddb2b060. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

