### PR TITLE
feat(citation-graph): decision↔decision Case layer (LEXAI-1777)

### DIFF
--- a/scripts/citation-graph/RUNBOOK-decision-citation-layer.md
+++ b/scripts/citation-graph/RUNBOOK-decision-citation-layer.md
@@ -1,0 +1,61 @@
+# Decision↔decision citation layer (LEXAI-1777)
+
+Resolves `case_citation_edges.to_case_number` → `edrsr_documents.cause_num` and builds the
+precedent (decision↔decision) layer on top of the existing legislation citation graph.
+
+## Background (Step-1 probe, 2026-06-26)
+
+- `case_citation_edges` (prod) = 73.46M raw `from_doc_id → to_case_number` edges (from #1773).
+- Resolution = **exact join** on `cause_num`. ~64% of distinct case numbers resolve; that is the
+  ceiling — year-normalization is net-negative, and the ~36% unresolved are cited cases genuinely
+  absent from the EDRSR corpus (pre-2013 / unpublished / other registry).
+- Cardinality: 38.35M distinct cases / 101M decisions → avg **2.635 decisions/case**.
+- **Model = Case node** (not decision→decision fan-out, which would be ~150-250M noisy edges):
+  `(:Decision)-[:CITES_CASE]->(:Case)`, decision↔decision via 2-hop. `get_case_documents_chain`
+  and `check_precedent_status` are served from Postgres (`edrsr_case_index` / `case_citation_links`);
+  Neo4j adds graph traversal.
+
+## Pipeline
+
+### 1. Build the Postgres resolution layer (on PROD)
+```bash
+docker exec -i secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod \
+  -v ON_ERROR_STOP=1 -f - < build-case-citation-links.sql
+```
+Creates (additive; rollback = `DROP TABLE`):
+- `edrsr_case_index` — Case dimension (cause_num PK, member_count, latest_doc_id, first/last_date).
+- `case_citation_links` — resolved `CITES_CASE` edges + unresolved tail (match_method, reason,
+  `is_self_citation`). Indexes on from_doc_id / to_case_number / resolved.
+
+Serves directly, no graph:
+- `get_case_documents_chain(case)` = `SELECT doc_id FROM edrsr_documents WHERE cause_num = $case`.
+- `check_precedent_status(case)` = `SELECT … FROM case_citation_links WHERE to_case_number = $case
+   AND resolved` (inbound citations).
+
+### 2. Export the Case layer (on PROD)
+```bash
+bash export-case-layer.sh        # -> /tmp/case-layer/{cases,cites_case}.csv.gz
+```
+
+### 3. Transfer prod → qdrant.lex import dir
+prod→qdrant direct ssh is key-blocked; relay through the orchestrator (macbook):
+```bash
+for f in cases cites_case; do
+  ssh prod "cat /tmp/case-layer/$f.csv.gz" | \
+    ssh qdrant.lex "cat > /home/ubuntu/neo4j/import/$f.csv.gz && gunzip -f /home/ubuntu/neo4j/import/$f.csv.gz"
+done
+```
+
+### 4. Online additive load into Neo4j (on qdrant.lex, NO wipe)
+```bash
+ssh qdrant.lex 'docker exec -i neo4j cypher-shell -u neo4j -p <pw> --file /import/load-case-layer.cypher'
+```
+Adds `(:Case)` (38.3M) + `(:Decision)-[:CITES_CASE]->(:Case)` (resolved, non-self) to the live graph.
+Existing article graph (391.9M `CITES_ARTICLE`) is untouched. Idempotent (MERGE) — safe to re-run.
+
+### 5. Verify
+Top-cited precedent cases (inbound `CITES_CASE`) printed by the cypher; cross-check a known case.
+
+## Next (separate ticket)
+Wire `CitationGraphService` (`CITATION_BACKEND=neo4j`) inbound/precedent methods + the
+`check_precedent_status` / `get_case_documents_chain` tool handlers to this layer.

--- a/scripts/citation-graph/build-case-citation-links.sql
+++ b/scripts/citation-graph/build-case-citation-links.sql
@@ -1,0 +1,100 @@
+-- build-case-citation-links.sql  (LEXAI-1777, decision<->decision layer)
+--
+-- Resolves case_citation_edges.to_case_number  ->  edrsr_documents.cause_num (EXACT join).
+-- Step-1 probe (2026-06-26) established: ~64% exact-match IS the ceiling (year-normalization
+-- is net-negative; the ~36% unresolved = cited case genuinely absent from the EDRSR corpus).
+-- So the resolver is a plain exact join -- no heuristics.
+--
+-- Builds two additive tables (no existing data touched; rollback = DROP TABLE):
+--   1. edrsr_case_index  -- the Case dimension: one row per distinct cause_num.
+--                           Doubles as the Neo4j (:Case) node source.
+--   2. case_citation_links -- resolved (:Decision)-[:CITES_CASE]->(:Case) edges + unresolved tail.
+--
+-- Run on PROD (both source tables live there; cce exists only on prod). Mirrors how
+-- legislation_citation_links (331M) was built directly on prod with tuned work_mem.
+--   docker exec -i secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod -f -
+
+\timing on
+SET statement_timeout = 0;          -- reproducible from source; no per-statement cap
+SET work_mem = '16GB';              -- one backend on the 61GB box; legislation resolver needed
+                                    -- this to avoid a 219GB temp spill on the context-carrying sort.
+
+-- 1. Case dimension -----------------------------------------------------------
+--    One row per litigation (cause_num). member_count drives fan-out decisions;
+--    latest_doc_id is the representative decision; first/last_date bound the case
+--    timeline (used later for temporal precedent filtering).
+DROP TABLE IF EXISTS edrsr_case_index;
+CREATE TABLE edrsr_case_index AS
+SELECT cause_num,
+       count(*)::int                                                    AS member_count,
+       min(adjudication_date)                                           AS first_date,
+       max(adjudication_date)                                           AS last_date,
+       (array_agg(doc_id ORDER BY adjudication_date DESC NULLS LAST))[1] AS latest_doc_id
+FROM edrsr_documents
+WHERE cause_num IS NOT NULL AND cause_num <> ''
+GROUP BY cause_num;
+ALTER TABLE edrsr_case_index ADD PRIMARY KEY (cause_num);
+
+-- 2. Resolution / edge table --------------------------------------------------
+DROP TABLE IF EXISTS case_citation_links;
+CREATE TABLE case_citation_links (
+  id                bigserial PRIMARY KEY,
+  from_doc_id       bigint  NOT NULL,        -- citing decision (doc_id)
+  to_case_number    text    NOT NULL,        -- cited case number (raw)
+  resolved          boolean NOT NULL,        -- to_case_number found in edrsr_case_index
+  member_count      int     NOT NULL DEFAULT 0,  -- # decisions in the cited case
+  latest_doc_id     bigint,                  -- representative cited decision (latest)
+  is_self_citation  boolean NOT NULL DEFAULT false, -- citing decision belongs to the cited case
+  match_method      text,                    -- 'exact' | NULL
+  unresolved_reason text,                    -- 'case_not_in_corpus' | 'malformed' | NULL
+  citation_context  text,
+  adj_year          smallint,
+  src_edge_id       bigint,
+  created_at        timestamptz DEFAULT now()
+);
+
+INSERT INTO case_citation_links
+  (from_doc_id, to_case_number, resolved, member_count, latest_doc_id,
+   is_self_citation, match_method, unresolved_reason, citation_context, adj_year, src_edge_id)
+SELECT cce.from_case_id,
+       cce.to_case_number,
+       (ci.cause_num IS NOT NULL),
+       COALESCE(ci.member_count, 0),
+       ci.latest_doc_id,
+       COALESCE(fd.cause_num = cce.to_case_number, false),
+       CASE WHEN ci.cause_num IS NOT NULL THEN 'exact' END,
+       CASE WHEN ci.cause_num IS NULL THEN
+            CASE WHEN cce.to_case_number ~ '^[0-9]{1,4}/[0-9]{1,10}/[0-9]{2,4}$'
+                 THEN 'case_not_in_corpus' ELSE 'malformed' END
+       END,
+       cce.citation_context,
+       cce.adj_year,
+       cce.id
+FROM case_citation_edges cce
+LEFT JOIN edrsr_case_index ci ON ci.cause_num = cce.to_case_number
+LEFT JOIN edrsr_documents  fd ON fd.doc_id    = cce.from_case_id;
+
+CREATE INDEX idx_ccl_from     ON case_citation_links(from_doc_id);
+CREATE INDEX idx_ccl_tocase   ON case_citation_links(to_case_number);
+CREATE INDEX idx_ccl_resolved ON case_citation_links(resolved);
+
+ANALYZE edrsr_case_index;
+ANALYZE case_citation_links;
+
+\echo '=== edrsr_case_index ==='
+SELECT count(*) AS distinct_cases, sum(member_count) AS member_decisions,
+       round(avg(member_count),3) AS avg_members FROM edrsr_case_index;
+
+\echo '=== case_citation_links COVERAGE ==='
+SELECT count(*) AS total,
+       count(*) FILTER (WHERE resolved) AS resolved,
+       round(100.0*count(*) FILTER (WHERE resolved)/count(*),2) AS pct_resolved,
+       count(*) FILTER (WHERE resolved AND NOT is_self_citation) AS resolved_precedent,
+       count(*) FILTER (WHERE resolved AND is_self_citation)     AS resolved_self,
+       count(DISTINCT from_doc_id)                                AS citing_decisions,
+       count(DISTINCT to_case_number) FILTER (WHERE resolved)     AS distinct_cited_cases
+FROM case_citation_links;
+
+\echo '=== unresolved reasons ==='
+SELECT unresolved_reason, count(*) FROM case_citation_links
+WHERE NOT resolved GROUP BY 1 ORDER BY 2 DESC;

--- a/scripts/citation-graph/export-case-layer.sh
+++ b/scripts/citation-graph/export-case-layer.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# export-case-layer.sh  (LEXAI-1777)
+#
+# Exports the decision<->decision Case layer from PROD Postgres into CSVs for an
+# ONLINE additive load into the live Neo4j graph on qdrant.lex (LOAD CSV, no wipe).
+# Source tables built by build-case-citation-links.sql (edrsr_case_index + case_citation_links).
+#
+# Output (gzipped, ~0.8G total): cases.csv.gz + cites_case.csv.gz
+#   cases.csv       : cause_num, member_count, latest_doc_id        -> (:Case) nodes
+#   cites_case.csv  : from_doc_id, cause_num                        -> (:Decision)-[:CITES_CASE]->(:Case)
+#                     (resolved precedent edges only; self-citations excluded as noise)
+#
+# Run ON PROD:  bash export-case-layer.sh   ->  /tmp/case-layer/*.csv.gz
+set -euo pipefail
+OUT=/tmp/case-layer
+mkdir -p "$OUT"
+PSQL="docker exec -i secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod -v ON_ERROR_STOP=1 -q"
+
+echo "=== cases.csv (Case nodes from edrsr_case_index) ==="
+$PSQL -c "\copy (
+  SELECT cause_num, member_count, latest_doc_id
+  FROM edrsr_case_index
+) TO STDOUT WITH (FORMAT csv, HEADER true, FORCE_QUOTE (cause_num))" | gzip > "$OUT/cases.csv.gz"
+
+echo "=== cites_case.csv (CITES_CASE precedent edges; resolved, non-self) ==="
+$PSQL -c "\copy (
+  SELECT from_doc_id, to_case_number AS cause_num
+  FROM case_citation_links
+  WHERE resolved AND NOT is_self_citation
+) TO STDOUT WITH (FORMAT csv, HEADER true, FORCE_QUOTE (cause_num))" | gzip > "$OUT/cites_case.csv.gz"
+
+echo "=== sizes ==="
+ls -lh "$OUT"/*.csv.gz
+echo "DONE. Transfer to qdrant.lex:/home/ubuntu/neo4j/import/ then run load-case-layer.cypher"

--- a/scripts/citation-graph/export-case-layer.sh
+++ b/scripts/citation-graph/export-case-layer.sh
@@ -16,10 +16,16 @@ OUT=/tmp/case-layer
 mkdir -p "$OUT"
 PSQL="docker exec -i secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod -v ON_ERROR_STOP=1 -q"
 
-echo "=== cases.csv (Case nodes from edrsr_case_index) ==="
+echo "=== cases.csv (Case nodes: precedent-target cases only) ==="
+# Only cases actually cited as precedent (inbound non-self CITES_CASE) become Neo4j
+# nodes -- ~85% of resolved case refs are self-citations (a decision restating its own
+# case number), so the precedent graph touches far fewer than the 38.9M total cases.
 $PSQL -c "\copy (
-  SELECT cause_num, member_count, latest_doc_id
-  FROM edrsr_case_index
+  SELECT ci.cause_num, ci.member_count, ci.latest_doc_id
+  FROM edrsr_case_index ci
+  WHERE EXISTS (
+    SELECT 1 FROM case_citation_links l
+    WHERE l.to_case_number = ci.cause_num AND l.resolved AND NOT l.is_self_citation)
 ) TO STDOUT WITH (FORMAT csv, HEADER true, FORCE_QUOTE (cause_num))" | gzip > "$OUT/cases.csv.gz"
 
 echo "=== cites_case.csv (CITES_CASE precedent edges; resolved, non-self) ==="

--- a/scripts/citation-graph/load-case-layer.cypher
+++ b/scripts/citation-graph/load-case-layer.cypher
@@ -15,7 +15,11 @@
 // 1. Case key uniqueness (also index-backs the MERGEs below).
 CREATE CONSTRAINT case_cause_num IF NOT EXISTS FOR (c:Case) REQUIRE c.cause_num IS UNIQUE;
 
-// 2. Case nodes (38.3M). MERGE is idempotent / re-runnable.
+// 2. Case nodes. MERGE is idempotent / re-runnable.
+//    NOTE: run each LOAD CSV ... IN TRANSACTIONS statement on its OWN via
+//    `cypher-shell -c "<statement>"` (5.x auto-uses an implicit txn). Do NOT use a
+//    multi-statement --file: cypher-shell wraps that in an explicit txn and
+//    CALL {} IN TRANSACTIONS then fails ("not allowed in an open transaction").
 LOAD CSV WITH HEADERS FROM 'file:///cases.csv' AS row
 CALL { WITH row
   MERGE (c:Case {cause_num: row.cause_num})

--- a/scripts/citation-graph/load-case-layer.cypher
+++ b/scripts/citation-graph/load-case-layer.cypher
@@ -1,0 +1,42 @@
+// load-case-layer.cypher  (LEXAI-1777)
+//
+// ONLINE additive load of the decision<->decision Case layer into the LIVE Neo4j
+// graph on qdrant.lex. Does NOT wipe the existing article graph (no neo4j-admin import).
+// Adds:  (:Case) nodes  +  (:Decision)-[:CITES_CASE]->(:Case) precedent edges.
+// Pre-req: cases.csv + cites_case.csv (gunzipped) in /home/ubuntu/neo4j/import/.
+//   cat ... | cypher-shell -u neo4j -p <pw> --file load-case-layer.cypher
+//
+// decision<->decision is then a 2-hop traversal:
+//   (d1:Decision)-[:CITES_CASE]->(c:Case)   // d1 relies on case c
+//   inbound to a Case = "who cites this case" = check_precedent_status.
+// Member decisions of a case stay in Postgres (edrsr_case_index / edrsr_documents);
+// get_case_documents_chain is a cause_num lookup, no graph needed.
+
+// 1. Case key uniqueness (also index-backs the MERGEs below).
+CREATE CONSTRAINT case_cause_num IF NOT EXISTS FOR (c:Case) REQUIRE c.cause_num IS UNIQUE;
+
+// 2. Case nodes (38.3M). MERGE is idempotent / re-runnable.
+LOAD CSV WITH HEADERS FROM 'file:///cases.csv' AS row
+CALL { WITH row
+  MERGE (c:Case {cause_num: row.cause_num})
+  SET c.member_count  = toInteger(row.member_count),
+      c.latest_doc_id = row.latest_doc_id
+} IN TRANSACTIONS OF 20000 ROWS;
+
+// 3. CITES_CASE precedent edges. Decision nodes are MERGE'd in case a citing
+//    decision is not already a node (some cite cases but no articles). The
+//    decision_doc_id + case_cause_num constraints make both lookups index seeks.
+LOAD CSV WITH HEADERS FROM 'file:///cites_case.csv' AS row
+CALL { WITH row
+  MATCH (c:Case {cause_num: row.cause_num})
+  MERGE (d:Decision {doc_id: row.from_doc_id})
+  MERGE (d)-[:CITES_CASE]->(c)
+} IN TRANSACTIONS OF 10000 ROWS;
+
+// 4. Sanity checks.
+MATCH (c:Case) RETURN count(c) AS case_nodes;
+MATCH ()-[r:CITES_CASE]->() RETURN count(r) AS cites_case_edges;
+// Top-cited precedent cases (inbound CITES_CASE):
+MATCH (d:Decision)-[:CITES_CASE]->(c:Case)
+RETURN c.cause_num AS cause_num, c.member_count AS members, count(d) AS cited_by
+ORDER BY cited_by DESC LIMIT 15;


### PR DESCRIPTION
## Decision↔decision citation layer (LEXAI-1777)

Builds the precedent (decision↔decision) layer on top of the legislation citation graph by resolving `case_citation_edges.to_case_number` → `edrsr_documents.cause_num`. Natural successor to LEXAI-1773 (which produced `case_citation_edges`).

### Step 1 — resolution probe
- **~64% exact-match is the ceiling**: year-normalization is net-negative; the ~36% unresolved are cited cases genuinely absent from the EDRSR corpus (pre-2013 / unpublished / other registry). Resolver = plain exact join, no heuristics.
- Cardinality: 38.9M distinct cases / 102.6M decisions, avg **2.635 docs/case**.
- **Model = Case node** (not decision→decision fan-out, which would be ~150-250M noisy edges).

### Step 3 — built & loaded (LIVE)
**Postgres (prod):**
- `edrsr_case_index` — Case dimension, **38,895,061** cases (cause_num PK, member_count, latest_doc_id, first/last_date).
- `case_citation_links` — **73,459,213** edges, resolved **46,410,162 = 63.18%**; unresolved all `case_not_in_corpus` (0 malformed).
- **Self-citation finding:** 85.5% of resolved edges are self-references (a decision restating its own case number). True precedent = **6,720,797 edges / 1,542,348 cited cases** — flagged via `is_self_citation`.
- Serves `get_case_documents_chain` (cause_num lookup) and `check_precedent_status` (inbound `case_citation_links`) directly from Postgres.

**Neo4j (qdrant.lex, online additive — no wipe):**
- `(:Case)` **1,542,348** + `(:Decision)-[:CITES_CASE]->(:Case)` **6,720,797** (non-self precedent).
- Existing article graph intact (`CITES_ARTICLE` = 391,883,896). Qdrant stayed healthy (readyz 200) throughout.
- Top-cited precedent verified (e.g. `826/3858/18` cited by 184,018 decisions).

### Artifacts
- `build-case-citation-links.sql` — Postgres resolver (run on prod).
- `export-case-layer.sh` + `load-case-layer.cypher` — online additive Neo4j ETL.
- `RUNBOOK-decision-citation-layer.md`.

### Next (separate ticket)
Wire `CitationGraphService` (`CITATION_BACKEND=neo4j`) inbound/precedent methods + the `check_precedent_status` / `get_case_documents_chain` tool handlers to this layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the decision↔decision precedent layer by resolving cited case numbers to EDRSR cases and exporting them to Neo4j as (:Case) nodes with CITES_CASE edges. Implements LEXAI-1777 and enables inbound precedent checks and case document chains without touching the article graph.

- **New Features**
  - Postgres resolver: creates edrsr_case_index and case_citation_links via exact join, flags self-citations, and adds indexes.
  - Export + Neo4j ETL: ships only resolved, non‑self citations as (:Case) and (:Decision)-[:CITES_CASE]->(:Case) into the live graph (additive, no wipe) with a runbook.

- **Migration**
  - On prod: run build-case-citation-links.sql; run export-case-layer.sh; transfer CSVs to qdrant.lex and run load-case-layer.cypher.
  - No app changes yet; wiring inbound/precedent methods to Neo4j (via `CITATION_BACKEND=neo4j`) will follow in a separate ticket.

<sup>Written for commit c9d9745ba04eeee03d292df8ff95748d3bc4381b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

