### PR TITLE
fix(metrics): align chat_tool_calls_per_request buckets with caps (25/30)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {

--- a/mcp_backend/src/services/metrics-service.ts
+++ b/mcp_backend/src/services/metrics-service.ts
@@ -237,7 +237,7 @@ export class MetricsService {
       name: 'chat_tool_calls_per_request',
       help: 'Total tool calls executed per chat request',
       labelNames: ['query_type'] as const,
-      buckets: [0, 1, 2, 3, 5, 8, 12, 20],
+      buckets: [0, 1, 2, 3, 5, 8, 12, 20, 25, 30],
       registers: [this.registry],
     });
     this.chatToolRepeatMax = new Histogram({


### PR DESCRIPTION
Top finite histogram bucket was 20 while `TOTAL_TOOL_CALL_CAP=25` — requests with 21–25 calls landed in `+Inf`. Add `25` and `30` buckets for clean viz up to/over the cap. Bump 1.0.12. (CORE-55 follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align `chat_tool_calls_per_request` histogram buckets with the tool-call cap so 21–25 no longer fall into +Inf.
Added 25 and 30 buckets and bumped `secondlayer-mcp` to 1.0.12 (CORE-55 follow-up).

<sup>Written for commit 0e427fcd8a922860134ea0bac172bfc58e2a4f77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

