### PR TITLE
feat(citation-graph): precedent-weight signal for check_precedent_status (decision↔case)

### DIFF
--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -28,7 +28,8 @@ import { HallucinationGuard } from '../services/hallucination-guard.js';
 import { logger } from '../utils/logger.js';
 import { LegislationTools } from './legislation-tools.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from './base-tool-handler.js';
-import { extractSourceStrings } from './tool-utils.js';
+import { extractSourceStrings, generateCaseNumberVariations } from './tool-utils.js';
+import type { CitationGraphService } from '../services/citation-graph-service.js';
 
 export type StreamEventCallback = (event: {
   type: string;
@@ -45,7 +46,8 @@ export class MCPQueryAPI extends BaseToolHandler {
     private patternStore: LegalPatternStore,
     private citationValidator: CitationValidator,
     private hallucinationGuard: HallucinationGuard,
-    private legislationTools: LegislationTools
+    private legislationTools: LegislationTools,
+    private citationGraphService?: CitationGraphService
   ) {
     super();
   }
@@ -231,11 +233,35 @@ export class MCPQueryAPI extends BaseToolHandler {
 
     const status = await this.citationValidator.validatePrecedentStatus(caseId, caseNumber || undefined);
 
+    // Best-effort precedent-weight signal from the decision↔case graph (Neo4j,
+    // LEXAI-1777): how many decisions cite this case. Gated by CITATION_BACKEND=neo4j;
+    // non-fatal. The PG shepardization above remains the authoritative validity check.
+    let citationGraph: any = undefined;
+    if (this.citationGraphService?.isEnabled() && caseNumber) {
+      try {
+        const variations = generateCaseNumberVariations(caseNumber);
+        const stat = await this.citationGraphService.getCaseStats(variations);
+        if (stat && stat.citingDecisions > 0) {
+          citationGraph = {
+            backend: 'neo4j',
+            cited_by_decisions: stat.citingDecisions,
+            documents_in_case: stat.memberCount || undefined,
+            latest_doc_id: stat.latestDocId || undefined,
+          };
+        }
+      } catch (error: any) {
+        logger.warn('[check_precedent_status] citation-graph enrichment failed (non-fatal)', {
+          caseNumber,
+          error: error?.message,
+        });
+      }
+    }
+
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify({ status }, null, 2),
+          text: JSON.stringify({ status, ...(citationGraph ? { citation_graph: citationGraph } : {}) }, null, 2),
         },
       ],
     };

--- a/mcp_backend/src/factories/core-services.ts
+++ b/mcp_backend/src/factories/core-services.ts
@@ -72,7 +72,8 @@ export function createBackendCoreServices(): BackendCoreServices {
     patternStore,
     citationValidator,
     hallucinationGuard,
-    legislationTools
+    legislationTools,
+    citationGraphService
   );
 
   return {


### PR DESCRIPTION
## What
Second half of **LEXAI-1778**: augments `check_precedent_status` with a Neo4j precedent-weight signal from the decision↔case layer (LEXAI-1777).

## Changes
- `MCPQueryAPI.checkPrecedentStatus` now, in addition to the Postgres shepardization validity check (`CitationValidator.validatePrecedentStatus`, unchanged + authoritative), attaches:
  ```json
  "citation_graph": { "backend":"neo4j", "cited_by_decisions": N,
    "documents_in_case": M, "latest_doc_id": "…" }
  ```
  via `CitationGraphService.getCaseStats(generateCaseNumberVariations(case_number))`.
- Gated by `CITATION_BACKEND=neo4j`, best-effort/non-fatal (Neo4j error → logged, PG result returned unchanged). Only runs when `case_number` is present.
- Wired `citationGraphService` into `MCPQueryAPI` via the core-services factory (optional last param).

## Verification
- `tsc --noEmit`: no new errors (3 pre-existing `@secondlayer/core` overlay only).
- CitationGraphService.getCaseStats covered by unit tests in the prior PR (#2017); live Cypher validated against prod Neo4j.

## Notes
- The tool handler is in the monorepo (`MCPQueryAPI`) — no `@secondlayer/core` change needed.
- Temporal overrule/departure (was the precedent overruled) needs an outcome/relation type not yet in `CITES_CASE` — future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Neo4j-based precedent-weight signal to `check_precedent_status`, showing how many decisions cite a case plus basic case doc stats. Completes LEXAI-1778 using the decision↔case graph from LEXAI-1777; Postgres shepardization remains the source of truth.

- **New Features**
  - Enriches response with `citation_graph` when `CITATION_BACKEND=neo4j` and `case_number` is present: `backend`, `cited_by_decisions`, `documents_in_case`, `latest_doc_id`.
  - Fetches stats via `CitationGraphService.getCaseStats(generateCaseNumberVariations(case_number))`.
  - Best-effort: Neo4j failures are logged and do not affect the Postgres result.
  - Wires `citationGraphService` into `MCPQueryAPI` through the core-services factory.

<sup>Written for commit 1c07693c5a9a248a012465a4e0ae992ca57e384c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

