### PR TITLE
feat(observability): richer chat thrashing panels + alert rules

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -352,12 +352,138 @@
         "uid": "Prometheus"
       },
       "type": "timeseries",
-      "title": "Tool repeat-max p95 (thrashing)",
+      "title": "Tool repeat-max p50/p95/p99 (thrashing)",
+      "description": "Max calls to a single tool in one request. Threshold line = repeat safety cap. Rising lines = model looping on one tool.",
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "C",
+          "legendFormat": "p99"
+        }
+      ],
+      "id": 8
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "heatmap",
+      "title": "Tool repeat-max distribution (heatmap)",
+      "description": "Full distribution of per-tool repeats. A bright band at the top bucket = requests slamming into the repeat cap (thrashing).",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "yAxis": {
+          "unit": "short"
+        },
+        "tooltip": {
+          "mode": "single",
+          "yHistogram": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_tool_repeat_max_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "refId": "A",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "id": 10
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Tool repeat-max p95 by query_type",
+      "description": "Which query types thrash most. topk surfaces the worst-offending intents.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
       },
       "fieldConfig": {
         "defaults": {
@@ -385,12 +511,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "expr": "topk(5, histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le, query_type)))",
           "refId": "A",
-          "legendFormat": "p95"
+          "legendFormat": "{{query_type}}"
         }
       ],
-      "id": 8
+      "id": 11
     },
     {
       "datasource": {
@@ -401,7 +527,7 @@
       "title": "Safety-cap hits / min by kind (CORE-55)",
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 33
       },
@@ -437,6 +563,112 @@
         }
       ],
       "id": 9
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "stat",
+      "title": "Cap-hits per request (1h)",
+      "description": "Safety-cap hits (repeat + total) divided by chat requests. Thrashing intensity: 0 = healthy, >0.2 = many requests truncated mid-loop.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_cap_hits_total[1h])) / sum(rate(chat_tool_calls_per_request_count[1h]))",
+          "refId": "A"
+        }
+      ],
+      "id": 12
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "heatmap",
+      "title": "Tool calls / request distribution (heatmap)",
+      "description": "Full distribution of tool-calls per request. A bright band at the 25/30 buckets = requests hitting the total-call cap.",
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 41
+      },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "yAxis": {
+          "unit": "short"
+        },
+        "tooltip": {
+          "mode": "single",
+          "yHistogram": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_tool_calls_per_request_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "refId": "A",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "id": 13
     }
   ]
 }

--- a/deployment/prometheus/rules/alert-rules.yml
+++ b/deployment/prometheus/rules/alert-rules.yml
@@ -138,3 +138,42 @@ groups:
         annotations:
           summary: "Node.js heap usage > 90% on {{ $labels.job }}"
           description: "Heap utilization is {{ $value | humanizePercentage }}. Possible memory leak."
+
+  - name: chat_quality_alerts
+    rules:
+      - alert: ChatToolThrashingHigh
+        expr: histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[10m])) by (le)) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat tool thrashing (repeat-max p95 > 5)"
+          description: "P95 max-repeats-on-a-single-tool is {{ $value }} for 10+ minutes. Model is looping on one tool; check tool-loop stop logic / safety caps."
+
+      - alert: ChatCapHitsHigh
+        expr: >
+          sum(rate(chat_cap_hits_total[10m])) / sum(rate(chat_tool_calls_per_request_count[10m])) > 0.2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat safety-cap hits > 0.2 per request"
+          description: "Safety caps (repeat/total) are firing at {{ $value }} hits/request for 10+ minutes. Many requests are being truncated mid-loop."
+
+      - alert: ChatAgenticIterationsHigh
+        expr: histogram_quantile(0.95, sum(rate(chat_agentic_iterations_bucket[10m])) by (le)) > 16
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat agentic iterations p95 > 16"
+          description: "P95 agentic-loop iterations is {{ $value }} for 10+ minutes. Possible runaway / non-converging reasoning loops."
+
+      - alert: ChatGroundingScoreLow
+        expr: histogram_quantile(0.5, sum(rate(chat_grounding_score_bucket[10m])) by (le)) < 70
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat grounding score p50 < 70"
+          description: "Median grounding score is {{ $value }} (target >= 85) for 15+ minutes. More fabricated/ungrounded citations than usual."


### PR DESCRIPTION
## What

Improves the **Chat Quality (V3)** Grafana dashboard's thrashing section and adds Prometheus alerting for chat-loop health. All built on metrics that already ship (`chat_tool_repeat_max`, `chat_cap_hits_total`, `chat_tool_calls_per_request`, `chat_agentic_iterations`, `chat_grounding_score`).

### Dashboard (`07-chat-quality.json`)
- **Tool repeat-max**: now p50/p95/**p99** with a **repeat-cap threshold line (5)** — the tail matters more than the median for thrashing.
- **Repeat-max distribution heatmap** — a bright band at the top bucket = requests slamming the per-tool repeat cap.
- **Repeat-max p95 by `query_type`** (`topk(5,…)`) — surfaces which intents loop most.
- **Cap-hits per request** stat — thrashing intensity, colored (green <0.05 / yellow / red >0.2).
- **Tool-calls/request distribution heatmap** — visualizes the "wall" at the 25/30 total-call cap (buckets aligned in #2016).

### Alerts (`alert-rules.yml`, new `chat_quality_alerts` group)
- `ChatToolThrashingHigh` — repeat-max p95 > 5 (10m)
- `ChatCapHitsHigh` — cap hits > 0.2/request (10m)
- `ChatAgenticIterationsHigh` — iterations p95 > 16 (10m)
- `ChatGroundingScoreLow` — grounding p50 < 70 (15m)

## Note / follow-up
`chat_cap_hits_total` counts the *number* of cap firings (can be >1 per request), so "cap-hits per request" is an **intensity** signal, not strictly "% of requests truncated". A true per-request percentage would need a separate counter incremented once per request on first cap hit — happy to add that to `metrics-service.ts` + `app-services.ts` in a follow-up if wanted.

## Validation
- Dashboard JSON parses ✅
- Alert-rules YAML parses ✅
- `promtool` not installed locally; PromQL validated by Prometheus on load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Chat Quality (V3) Grafana dashboard to better surface chat thrashing and adds Prometheus alerts to detect looping and grounding issues using existing metrics.

- **New Features**
  - Dashboard: added p50/p95/p99 lines with a repeat-cap threshold; repeat-max distribution heatmap; repeat-max p95 by `query_type`; “cap-hits per request” stat with color thresholds; tool-calls/request distribution heatmap aligned to the 25/30 cap.
  - Alerts: ChatToolThrashingHigh (p95 > 5, 10m), ChatCapHitsHigh (>0.2 hits/request, 10m), ChatAgenticIterationsHigh (p95 > 16, 10m), ChatGroundingScoreLow (p50 < 70, 15m).
  - Note: “Cap-hits per request” is an intensity measure, not a % of requests capped.

<sup>Written for commit 9c2f8131553ef0ee5b0c26e41c3d60ff59ff6492. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

