### PR TITLE
feat(citation-graph): surface Grand Chamber departures in precedent status (DEPARTS_FROM)

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -352,12 +352,138 @@
         "uid": "Prometheus"
       },
       "type": "timeseries",
-      "title": "Tool repeat-max p95 (thrashing)",
+      "title": "Tool repeat-max p50/p95/p99 (thrashing)",
+      "description": "Max calls to a single tool in one request. Threshold line = repeat safety cap. Rising lines = model looping on one tool.",
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 25
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 2,
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "A",
+          "legendFormat": "p50"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "B",
+          "legendFormat": "p95"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "refId": "C",
+          "legendFormat": "p99"
+        }
+      ],
+      "id": 8
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "heatmap",
+      "title": "Tool repeat-max distribution (heatmap)",
+      "description": "Full distribution of per-tool repeats. A bright band at the top bucket = requests slamming into the repeat cap (thrashing).",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 25
+      },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "yAxis": {
+          "unit": "short"
+        },
+        "tooltip": {
+          "mode": "single",
+          "yHistogram": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_tool_repeat_max_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "refId": "A",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "id": 10
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "timeseries",
+      "title": "Tool repeat-max p95 by query_type",
+      "description": "Which query types thrash most. topk surfaces the worst-offending intents.",
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 33
       },
       "fieldConfig": {
         "defaults": {
@@ -385,12 +511,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le))",
+          "expr": "topk(5, histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[1h])) by (le, query_type)))",
           "refId": "A",
-          "legendFormat": "p95"
+          "legendFormat": "{{query_type}}"
         }
       ],
-      "id": 8
+      "id": 11
     },
     {
       "datasource": {
@@ -401,7 +527,7 @@
       "title": "Safety-cap hits / min by kind (CORE-55)",
       "gridPos": {
         "h": 8,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 33
       },
@@ -437,6 +563,112 @@
         }
       ],
       "id": 9
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "stat",
+      "title": "Cap-hits per request (1h)",
+      "description": "Safety-cap hits (repeat + total) divided by chat requests. Thrashing intensity: 0 = healthy, >0.2 = many requests truncated mid-loop.",
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 41
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 3,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        },
+        "colorMode": "value",
+        "graphMode": "area"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_cap_hits_total[1h])) / sum(rate(chat_tool_calls_per_request_count[1h]))",
+          "refId": "A"
+        }
+      ],
+      "id": 12
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "type": "heatmap",
+      "title": "Tool calls / request distribution (heatmap)",
+      "description": "Full distribution of tool-calls per request. A bright band at the 25/30 buckets = requests hitting the total-call cap.",
+      "gridPos": {
+        "h": 8,
+        "w": 18,
+        "x": 6,
+        "y": 41
+      },
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "mode": "scheme",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "yAxis": {
+          "unit": "short"
+        },
+        "tooltip": {
+          "mode": "single",
+          "yHistogram": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "Prometheus"
+          },
+          "expr": "sum(rate(chat_tool_calls_per_request_bucket[5m])) by (le)",
+          "format": "heatmap",
+          "refId": "A",
+          "legendFormat": "{{le}}"
+        }
+      ],
+      "id": 13
     }
   ]
 }

--- a/deployment/prometheus/rules/alert-rules.yml
+++ b/deployment/prometheus/rules/alert-rules.yml
@@ -138,3 +138,42 @@ groups:
         annotations:
           summary: "Node.js heap usage > 90% on {{ $labels.job }}"
           description: "Heap utilization is {{ $value | humanizePercentage }}. Possible memory leak."
+
+  - name: chat_quality_alerts
+    rules:
+      - alert: ChatToolThrashingHigh
+        expr: histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[10m])) by (le)) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat tool thrashing (repeat-max p95 > 5)"
+          description: "P95 max-repeats-on-a-single-tool is {{ $value }} for 10+ minutes. Model is looping on one tool; check tool-loop stop logic / safety caps."
+
+      - alert: ChatCapHitsHigh
+        expr: >
+          sum(rate(chat_cap_hits_total[10m])) / sum(rate(chat_tool_calls_per_request_count[10m])) > 0.2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat safety-cap hits > 0.2 per request"
+          description: "Safety caps (repeat/total) are firing at {{ $value }} hits/request for 10+ minutes. Many requests are being truncated mid-loop."
+
+      - alert: ChatAgenticIterationsHigh
+        expr: histogram_quantile(0.95, sum(rate(chat_agentic_iterations_bucket[10m])) by (le)) > 16
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat agentic iterations p95 > 16"
+          description: "P95 agentic-loop iterations is {{ $value }} for 10+ minutes. Possible runaway / non-converging reasoning loops."
+
+      - alert: ChatGroundingScoreLow
+        expr: histogram_quantile(0.5, sum(rate(chat_grounding_score_bucket[10m])) by (le)) < 70
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Chat grounding score p50 < 70"
+          description: "Median grounding score is {{ $value }} (target >= 85) for 15+ minutes. More fabricated/ungrounded citations than usual."

--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -241,12 +241,21 @@ export class MCPQueryAPI extends BaseToolHandler {
       try {
         const variations = generateCaseNumberVariations(caseNumber);
         const stat = await this.citationGraphService.getCaseStats(variations);
-        if (stat && stat.citingDecisions > 0) {
+        if (stat && (stat.citingDecisions > 0 || stat.departedByDecision)) {
           citationGraph = {
             backend: 'neo4j',
             cited_by_decisions: stat.citingDecisions,
             documents_in_case: stat.memberCount || undefined,
             latest_doc_id: stat.latestDocId || undefined,
+            ...(stat.departedByDecision
+              ? {
+                  position_departed_from: {
+                    by_grand_chamber_decision: stat.departedByDecision,
+                    on: stat.departedOn || undefined,
+                    note: 'Правову позицію у цій справі відступлено Великою Палатою ВС — прецедент може бути нечинним.',
+                  },
+                }
+              : {}),
           };
         }
       } catch (error: any) {

--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -616,7 +616,7 @@ export class CourtDecisionTools extends BaseToolHandler {
     if (this.citationGraphService?.isEnabled()) {
       try {
         const stat = await this.citationGraphService.getCaseStats(caseVariations);
-        if (stat && stat.citingDecisions > 0) {
+        if (stat && (stat.citingDecisions > 0 || stat.departedByDecision)) {
           const sampleCiting = await this.citationGraphService.getCaseCitedBy(stat.causeNum, 20);
           payload.citation_graph = {
             backend: 'neo4j',
@@ -624,6 +624,15 @@ export class CourtDecisionTools extends BaseToolHandler {
             documents_in_case: stat.memberCount || undefined,
             latest_doc_id: stat.latestDocId || undefined,
             sample_citing_decisions: sampleCiting,
+            ...(stat.departedByDecision
+              ? {
+                  position_departed_from: {
+                    by_grand_chamber_decision: stat.departedByDecision,
+                    on: stat.departedOn || undefined,
+                    note: 'Правову позицію у цій справі відступлено Великою Палатою ВС — прецедент може бути нечинним.',
+                  },
+                }
+              : {}),
           };
         }
       } catch (error: any) {

--- a/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
+++ b/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
@@ -146,8 +146,23 @@ describe('CitationGraphService', () => {
         records: [rec({ cn: '826/3858/18', mc: neoInt(18), ld: neoInt(86270655), citing: neoInt(184018) })],
       });
       const out = await new CitationGraphService().getCaseStats(['826/3858/18', '826/3858/2018']);
-      expect(out).toEqual({ causeNum: '826/3858/18', citingDecisions: 184018, memberCount: 18, latestDocId: '86270655' });
+      expect(out).toEqual({
+        causeNum: '826/3858/18',
+        citingDecisions: 184018,
+        memberCount: 18,
+        latestDocId: '86270655',
+        departedByDecision: null,
+        departedOn: null,
+      });
       expect(mockRun.mock.calls[0][1]).toMatchObject({ cns: ['826/3858/18', '826/3858/2018'] });
+    });
+
+    it('surfaces a Grand Chamber departure (DEPARTS_FROM) when present', async () => {
+      mockRun.mockResolvedValueOnce({
+        records: [rec({ cn: '761/15791/15-ц', mc: neoInt(4), ld: neoInt(72150984), citing: neoInt(0), depBy: '72150984', depOn: '2018-01-29' })],
+      });
+      const out = await new CitationGraphService().getCaseStats(['761/15791/15-ц']);
+      expect(out).toMatchObject({ departedByDecision: '72150984', departedOn: '2018-01-29' });
     });
 
     it('returns null for empty input without querying', async () => {

--- a/mcp_backend/src/services/citation-graph-service.ts
+++ b/mcp_backend/src/services/citation-graph-service.ts
@@ -63,6 +63,13 @@ export interface CaseStat {
   memberCount: number;
   /** Most recent document of the case (Case.latest_doc_id); null if unknown. */
   latestDocId: string | null;
+  /**
+   * If the legal position of this case was formally departed from by the Grand
+   * Chamber (DEPARTS_FROM edge, LEXAI-1779) — doc_id of the latest departing
+   * decision and its date. null when the position has not been departed from.
+   */
+  departedByDecision: string | null;
+  departedOn: string | null;
 }
 
 /** A case cited by a decision (precedent outbound). */
@@ -274,15 +281,20 @@ export class CitationGraphService {
     if (!causeNums || causeNums.length === 0) return null;
     const rows = await this.run(
       `MATCH (c:Case) WHERE c.cause_num IN $cns
-       RETURN c.cause_num AS cn, c.member_count AS mc, c.latest_doc_id AS ld,
-              COUNT { (c)<-[:CITES_CASE]-(:Decision) } AS citing
-       ORDER BY citing DESC LIMIT 1`,
+       WITH c, COUNT { (c)<-[:CITES_CASE]-(:Decision) } AS citing
+       ORDER BY citing DESC LIMIT 1
+       OPTIONAL MATCH (c)<-[df:DEPARTS_FROM]-(gc:Decision)
+       WITH c, citing, gc, df ORDER BY df.departed_on DESC
+       RETURN c.cause_num AS cn, c.member_count AS mc, c.latest_doc_id AS ld, citing,
+              head(collect(gc.doc_id)) AS depBy, head(collect(df.departed_on)) AS depOn`,
       { cns: causeNums },
       (r) => ({
         causeNum: r.get('cn'),
         citingDecisions: toNum(r.get('citing')),
         memberCount: toNum(r.get('mc')),
         latestDocId: r.get('ld') != null ? String(toNum(r.get('ld'))) : null,
+        departedByDecision: r.get('depBy') != null ? String(r.get('depBy')) : null,
+        departedOn: r.get('depOn') != null ? String(r.get('depOn')) : null,
       })
     );
     return rows[0] ?? null;


### PR DESCRIPTION
## What
Outcome-typed precedent layer (**LEXAI-1779**): tells whether a case's legal position was formally **departed from by the Grand Chamber** — the actual precedent-validity question that `cited_by_decisions` alone can't answer.

## Data (built on cthulhu → loaded into prod Neo4j)
- Велика Палата ВС (court_code 9951): 26,058 decisions, 2,406 with departure language.
- Cleaned (dropped "no grounds to depart" etc.) → **759 `(:Decision)-[:DEPARTS_FROM {departed_on}]->(:Case)`** edges, 460 distinct departed-from cases. Departed-from case parsed from the departure context (`відступити від висновку … у справі № X`).
- Loaded online via LOAD CSV (MERGE); existing graph intact (CITES_ARTICLE 391.9M / CITES_CASE 6.72M unchanged), Qdrant readyz 200.

## Code
- `CitationGraphService.getCaseStats` now also returns `departedByDecision` + `departedOn` (latest DEPARTS_FROM, via OPTIONAL MATCH).
- `check_precedent_status` and `get_case_documents_chain` add a `position_departed_from` block when present:
  ```json
  "position_departed_from": { "by_grand_chamber_decision": "134833410",
    "on": "2026-03-10",
    "note": "Правову позицію у цій справі відступлено Великою Палатою ВС — прецедент може бути нечинним." }
  ```
- Gated by `CITATION_BACKEND=neo4j`, best-effort/non-fatal. +1 unit test (19/19).

## Verification
- `npm test`: 19/19. `tsc`: no new errors (3 pre-existing core-overlay).
- Live Cypher: case 580/6246/23 → departed by GC decision 134833410 on 2026-03-10.

## Scope / next
- v1 uses a regex/heuristic clean of the departure context; an LLM pass (Bedrock) to recover the ~470 departures without a regex-matched target and to catch non-`відступ`-phrased departures is a noted follow-up.
- Broad affirm/follow/distinguish classification (mostly noisy) remains deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces Grand Chamber departures in precedent status so users can see when a case’s legal position was formally departed from. Also adds dashboards and alerts to monitor chat tool thrashing and grounding quality.

- New Features
  - Precedent status (LEXAI-1779): Neo4j `DEPARTS_FROM` exposed via `getCaseStats` as `departedByDecision` and `departedOn`; `mcp-query-api` and `court-decision-tools` include a `position_departed_from` block (by_grand_chamber_decision, on, note). Gated by `CITATION_BACKEND=neo4j`. +1 unit test.
  - Observability: Grafana updates (repeat-max p50/p95/p99 with cap threshold, distribution heatmaps, topk by `query_type`, cap-hits per request stat). Prometheus `chat_quality_alerts`: thrashing (repeat-max p95 > 5), cap hits (>0.2/request), agentic iterations (p95 > 16), and low grounding (p50 < 70).

<sup>Written for commit 1c90af13a7dccade530be34e07bec1f759de910d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

