### PR TITLE
feat(metrics): per-request cap-hit counter for true truncation rate

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -570,8 +570,8 @@
         "uid": "Prometheus"
       },
       "type": "stat",
-      "title": "Cap-hits per request (1h)",
-      "description": "Safety-cap hits (repeat + total) divided by chat requests. Thrashing intensity: 0 = healthy, >0.2 = many requests truncated mid-loop.",
+      "title": "Truncated requests (% hitting any cap, 1h)",
+      "description": "Share of chat requests that hit at least one safety cap (counted once per request via chat_cap_hit_requests_total{kind=\"any\"}). 0% = healthy, >20% = many requests truncated mid-loop.",
       "gridPos": {
         "h": 8,
         "w": 6,
@@ -580,8 +580,8 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "none",
-          "decimals": 3,
+          "unit": "percentunit",
+          "decimals": 1,
           "color": {
             "mode": "thresholds"
           },
@@ -620,7 +620,7 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum(rate(chat_cap_hits_total[1h])) / sum(rate(chat_tool_calls_per_request_count[1h]))",
+          "expr": "sum(rate(chat_cap_hit_requests_total{kind=\"any\"}[1h])) / sum(rate(chat_tool_calls_per_request_count[1h]))",
           "refId": "A"
         }
       ],

--- a/deployment/prometheus/rules/alert-rules.yml
+++ b/deployment/prometheus/rules/alert-rules.yml
@@ -152,13 +152,13 @@ groups:
 
       - alert: ChatCapHitsHigh
         expr: >
-          sum(rate(chat_cap_hits_total[10m])) / sum(rate(chat_tool_calls_per_request_count[10m])) > 0.2
+          sum(rate(chat_cap_hit_requests_total{kind="any"}[10m])) / sum(rate(chat_tool_calls_per_request_count[10m])) > 0.2
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "Chat safety-cap hits > 0.2 per request"
-          description: "Safety caps (repeat/total) are firing at {{ $value }} hits/request for 10+ minutes. Many requests are being truncated mid-loop."
+          summary: "Chat truncated requests > 20%"
+          description: "{{ $value | humanizePercentage }} of chat requests hit a safety cap (repeat/total) for 10+ minutes. Many requests are being truncated mid-loop."
 
       - alert: ChatAgenticIterationsHigh
         expr: histogram_quantile(0.95, sum(rate(chat_agentic_iterations_bucket[10m])) by (le)) > 16

--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -210,8 +210,14 @@ export function createAppServices(
     for (const [k, v] of Object.entries(t.signals)) {
       if (v > 0) metricsService.chatGroundingSignals.inc({ signal_type: k }, v);
     }
-    if (t.capHits?.repeat > 0) metricsService.chatCapHits.inc({ kind: 'repeat' }, t.capHits.repeat);
-    if (t.capHits?.total > 0) metricsService.chatCapHits.inc({ kind: 'total' }, t.capHits.total);
+    const repeatHits = t.capHits?.repeat ?? 0;
+    const totalHits = t.capHits?.total ?? 0;
+    if (repeatHits > 0) metricsService.chatCapHits.inc({ kind: 'repeat' }, repeatHits);
+    if (totalHits > 0) metricsService.chatCapHits.inc({ kind: 'total' }, totalHits);
+    // Once-per-request cap-hit flags → true share of truncated requests.
+    if (repeatHits > 0) metricsService.chatCapHitRequests.inc({ kind: 'repeat' });
+    if (totalHits > 0) metricsService.chatCapHitRequests.inc({ kind: 'total' });
+    if (repeatHits > 0 || totalHits > 0) metricsService.chatCapHitRequests.inc({ kind: 'any' });
   });
 
   logger.info('Prometheus metrics service initialized');

--- a/mcp_backend/src/services/metrics-service.ts
+++ b/mcp_backend/src/services/metrics-service.ts
@@ -57,6 +57,7 @@ export class MetricsService {
   readonly chatToolCallsPerRequest: Histogram;
   readonly chatToolRepeatMax: Histogram;
   readonly chatCapHits: Counter;
+  readonly chatCapHitRequests: Counter;
 
   constructor() {
     this.registry = new Registry();
@@ -253,11 +254,25 @@ export class MetricsService {
       labelNames: ['kind'] as const,
       registers: [this.registry],
     });
+    this.chatCapHitRequests = new Counter({
+      name: 'chat_cap_hit_requests_total',
+      help: 'Requests that hit at least one safety cap, counted once per request (kind: repeat, total, any). Divide by chat_tool_calls_per_request_count for the share of truncated requests.',
+      labelNames: ['kind'] as const,
+      registers: [this.registry],
+    });
 
     // Pre-initialize external API counters so Prometheus always has these series
     // (counters don't appear until first .inc() otherwise)
     for (const svc of ['openai', 'anthropic', 'rada', 'diia']) {
       this.externalApiCallsTotal.inc({ service: svc, status: 'success' }, 0);
+    }
+    // Pre-initialize cap-hit counters so the "share of truncated requests"
+    // ratio resolves to 0 (not "no data") before the first cap fires.
+    for (const kind of ['repeat', 'total']) {
+      this.chatCapHits.inc({ kind }, 0);
+    }
+    for (const kind of ['repeat', 'total', 'any']) {
+      this.chatCapHitRequests.inc({ kind }, 0);
     }
 
     logger.info('[Metrics] MetricsService initialized');


### PR DESCRIPTION
## What

Follow-up to #2019. `chat_cap_hits_total` counts the *number* of cap firings (can be >1 per request), so it measures **intensity**, not the **share of truncated requests**. This adds a once-per-request counter so we can report a true percentage.

### Backend
- `metrics-service.ts`: new `chat_cap_hit_requests_total{kind=repeat|total|any}` counter, incremented **once per request**. Pre-initialized at 0 (along with `chat_cap_hits_total`) so the ratio renders `0%` instead of "no data" before the first cap fires.
- `app-services.ts`: V3 telemetry callback now sets the `repeat` / `total` / `any` flags per request (in addition to the existing intensity counter).

### Dashboard (`07-chat-quality.json`)
- Stat panel repurposed: **"Truncated requests (% hitting any cap, 1h)"** = `chat_cap_hit_requests_total{kind="any"} / chat_tool_calls_per_request_count`, unit `percentunit`, thresholds green / yellow 5% / red 20%.

### Alert (`alert-rules.yml`)
- `ChatCapHitsHigh` now fires on **>20% of requests truncated** (true share) instead of hits-per-request intensity.

## Validation
- `tsc --noEmit`: no errors in changed files. (Pre-existing `core-loader.ts` errors are core-overlay modules injected from the private `secondlayer-core` repo at CI build time — not in this repo, unrelated.)
- Dashboard JSON + alert YAML parse ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-request safety-cap hit counter to measure the true percent of truncated chat requests. Updates the Grafana panel and alert to use this metric instead of intensity.

- New Features
  - New Prometheus counter chat_cap_hit_requests_total{kind="repeat"|"total"|"any"}, counted once per request and pre-initialized to 0 (along with chat_cap_hits_total).
  - Telemetry callback now increments per-request flags (repeat/total/any) in addition to the existing intensity counter.
  - Grafana: stat now shows “Truncated requests (% hitting any cap, 1h)” using sum(rate(chat_cap_hit_requests_total{kind="any"}[1h])) / sum(rate(chat_tool_calls_per_request_count[1h])), displayed as percent.
  - Alert: ChatCapHitsHigh now fires on >20% truncated requests for 10m, with updated summary and description.

<sup>Written for commit d52e6ccfa19bd123732e406d4059a12b2867f53d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

