### PR TITLE
chore(backend): ship raised V3 safety caps 15/30 (CORE-55)

### DIFF
--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "secondlayer-mcp",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "SecondLayer MCP Backend — semantic legal analysis, court decisions, legislation",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
Bump 1.0.13 → rebuild backend, pull core@main with raised caps (TOOL_REPEAT_CAP=15, TOTAL_TOOL_CALL_CAP=30, core#69). Data-driven from the heavy-query stress run. CORE-55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the backend to ship raised V3 safety caps from `secondlayer-core` (TOOL_REPEAT_CAP=15, TOTAL_TOOL_CALL_CAP=30) to better handle heavy queries. Bumps `secondlayer-mcp` to 1.0.13; aligns with CORE-55.

<sup>Written for commit 611e2a175aaa24355f21d2fef0dd46138c9eeaaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

