### PR TITLE
fix(observability): align chat thrashing thresholds with real safety caps

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -353,7 +353,7 @@
       },
       "type": "timeseries",
       "title": "Tool repeat-max p50/p95/p99 (thrashing)",
-      "description": "Max calls to a single tool in one request. Threshold line = repeat safety cap. Rising lines = model looping on one tool.",
+      "description": "Max executed calls to a single tool in one request. Repeat safety cap (TOOL_REPEAT_CAP) = 15; legitimate deep analysis runs at p95 ~11-12, so yellow at 13 = approaching cap, red at 15 = cap firing (capHits.repeat increments). Below 13 is normal.",
       "gridPos": {
         "h": 8,
         "w": 12,
@@ -379,8 +379,12 @@
                 "value": null
               },
               {
+                "color": "yellow",
+                "value": 13
+              },
+              {
                 "color": "red",
-                "value": 5
+                "value": 15
               }
             ]
           }

--- a/deployment/prometheus/rules/alert-rules.yml
+++ b/deployment/prometheus/rules/alert-rules.yml
@@ -142,13 +142,13 @@ groups:
   - name: chat_quality_alerts
     rules:
       - alert: ChatToolThrashingHigh
-        expr: histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[10m])) by (le)) > 5
+        expr: histogram_quantile(0.95, sum(rate(chat_tool_repeat_max_bucket[10m])) by (le)) > 14
         for: 10m
         labels:
           severity: warning
         annotations:
-          summary: "Chat tool thrashing (repeat-max p95 > 5)"
-          description: "P95 max-repeats-on-a-single-tool is {{ $value }} for 10+ minutes. Model is looping on one tool; check tool-loop stop logic / safety caps."
+          summary: "Chat tool thrashing (repeat-max p95 approaching cap)"
+          description: "P95 max-repeats-on-a-single-tool is {{ $value }} for 10+ minutes (TOOL_REPEAT_CAP=15). Normal deep analysis runs ~11-12; sustained >14 means requests are about to be clipped by the repeat cap — check for runaway tool loops."
 
       - alert: ChatCapHitsHigh
         expr: >


### PR DESCRIPTION
## What

Follow-up to #2019/#2021. The thrashing thresholds I added were guessed (5) and made **normal traffic look alarming**. Verified against `secondlayer-core` (`chat-execution-loop.ts`, CORE-55 #69):

```js
const TOOL_REPEAT_CAP = 15;      // capHits.repeat increments only at >= 15
const TOTAL_TOOL_CALL_CAP = 30;  // capHits.total  increments only at >= 30
```

Code comment (verbatim intent): the caps were **raised from 12/25 to 15/30** because legitimate deep analysis reaches **repeat-max p95 ≈ 11.5 and 24-25 tool calls with grounding ~96** — the old caps were clipping good requests.

So `repeat-max` of 10-12 on the live dashboard is **normal**, and `capHits ≈ 0` is **correct** (caps intentionally sit above normal traffic). Not an observability bug — just my thresholds were wrong.

## Changes
- **Dashboard "Tool repeat-max"**: threshold `red @ 5` → `yellow @ 13` (approaching cap) + `red @ 15` (cap actually firing). Below 13 = normal. Description now states the real cap.
- **Alert `ChatToolThrashingHigh`**: `p95 > 5` → `p95 > 14` (was firing on every normal request). Description references `TOOL_REPEAT_CAP=15`.

Untouched (already correct): `ChatCapHitsHigh` (>20% truncated), cap-hit panels, "Truncated requests %".

## Validation
- Dashboard JSON + alert YAML parse ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns chat thrashing thresholds with real safety caps to remove false alarms and reflect normal traffic. Uses `TOOL_REPEAT_CAP=15` from `secondlayer-core` (normal p95 is ~11–12).

- **Bug Fixes**
  - Dashboard “Tool repeat-max”: yellow at 13 (approaching), red at 15 (cap firing); description updated to state the cap.
  - Alert `ChatToolThrashingHigh`: trigger moved to p95 > 14 for 10m; annotations reference the 15 cap and expected normal range.

<sup>Written for commit 7635524bb09f725452ebddbab72ed0738161366a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

