### PR TITLE
fix(observability): pin repeat-max panel Y-axis to 0-16 so cap lines show

### DIFF
--- a/deployment/grafana/dashboards/07-chat-quality.json
+++ b/deployment/grafana/dashboards/07-chat-quality.json
@@ -363,6 +363,8 @@
       "fieldConfig": {
         "defaults": {
           "unit": "short",
+          "min": 0,
+          "max": 16,
           "custom": {
             "drawStyle": "line",
             "fillOpacity": 10,


### PR DESCRIPTION
## What

Polish on #2023. On the live dashboard, the repeat-max panel's Y-axis auto-scaled to ~12.5 (the data max), which hid the red cap line at 15 and pinned the yellow "approaching cap" line (13) to the very top edge — making it hard to read how much headroom remains below `TOOL_REPEAT_CAP=15`.

Pin `min: 0, max: 16` so both threshold lines (yellow @13, red @15) and the visual headroom are always visible.

## Validation
- Dashboard JSON parses ✅
- Verified the issue live in Grafana before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the repeat-max Grafana panel Y-axis to 0–16 so the yellow 13 and red 15 cap lines are always visible and remaining headroom below `TOOL_REPEAT_CAP=15` is clear. This replaces auto-scaling that could cap near the data max and hide the 15 line.

<sup>Written for commit 2693b96c05abb583ed8f93b73696088f94ee0ef4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

