### PR TITLE
fix(edrsr-fts): demote sub-floor junk tokens so FTS keeps real anchors (Cause-A)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -389,9 +389,14 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     // instead of the positional tail. Empty idf map → original order (no regression).
     // noIdf is the A/B baseline arm (P1.eval) — bypass the df lookup to reproduce the old
     // positional behaviour for a controlled before/after.
-    const idf = (this.ftsService && !noIdf) ? await this.ftsService.lexemeDf(rawTokens, this.db) : new Map<string, number>();
-    const tokens = selectFtsTerms(rawTokens, idf);
-    const idfRanked = idf.size > 0;
+    // LEXAI Cause-A: fetch idf + raw df + sample size, so selectFtsTerms can demote
+    // sub-floor junk tokens (сумування/дррп/typos) to the tail instead of letting them
+    // survive IDF-only relaxation and starve the all-AND probe of real anchors.
+    const stats = (this.ftsService && !noIdf)
+      ? await this.ftsService.lexemeStats(rawTokens, this.db)
+      : { idf: new Map<string, number>(), df: new Map<string, number>(), sampleDocs: 0 };
+    const tokens = selectFtsTerms(rawTokens, stats.idf, { df: stats.df, sampleDocs: stats.sampleDocs });
+    const idfRanked = stats.idf.size > 0;
     const startTokens = tokens.length;
     let n = Math.min(startTokens, FULLTEXT_MAX_TOKENS) || 1;
     const cappedFrom = n; // token count at the first (capped) probe

--- a/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
@@ -39,6 +39,43 @@ describe('selectFtsTerms (CORE-21 P1.5a)', () => {
   });
 });
 
+describe('selectFtsTerms — anchor-floor demotion (LEXAI Cause-A)', () => {
+  // sample 3.0M → floor = 3.0M * 1e-4 = 300 docs. "сумування"/"дррп" sub-floor (junk);
+  // "окупована"/"нерухоме" well above. Junk has HIGH idf (rare) yet must NOT lead.
+  const sampleDocs = 3_000_000;
+  const idf = new Map<string, number>([
+    ['окупована', Math.log(sampleDocs / 41321)],
+    ['нерухоме', Math.log(sampleDocs / 193320)],
+    ['сумування', Math.log(sampleDocs / 80)],   // rarest → highest idf
+    ['дррп', Math.log(sampleDocs / 526)],        // just above floor
+  ]);
+  const df = new Map<string, number>([
+    ['окупована', 41321], ['нерухоме', 193320], ['сумування', 80], ['дррп', 526],
+  ]);
+  const tokens = ['сумування', 'окупована', 'дррп', 'нерухоме'];
+
+  it('demotes sub-floor junk to the tail even though it has the highest idf', () => {
+    const out = selectFtsTerms(tokens, idf, { df, sampleDocs });
+    // anchors (df ≥ 300) first, ordered by idf desc: окупована (rarer) before нерухоме;
+    // дррп (526) is an anchor too. сумування (80 < 300) is demoted to LAST.
+    expect(out[out.length - 1]).toBe('сумування');
+    expect(out.indexOf('окупована')).toBeLessThan(out.indexOf('сумування'));
+    expect(out.indexOf('нерухоме')).toBeLessThan(out.indexOf('сумування'));
+  });
+
+  it('keeps idf-only behaviour (junk leads) when df is NOT supplied — proves the regression', () => {
+    const out = selectFtsTerms(tokens, idf);            // no df → old behaviour
+    expect(out[0]).toBe('сумування');                   // rarest leads → this is the bug
+  });
+
+  it('never empties an all-junk query — returns least-rare junk first', () => {
+    const jIdf = new Map([['сумування', 5.0], ['ввп', 6.0]]);
+    const jDf = new Map([['сумування', 80], ['ввп', 20]]);
+    const out = selectFtsTerms(['ввп', 'сумування'], jIdf, { df: jDf, sampleDocs });
+    expect(out).toEqual(['сумування', 'ввп']);          // both weak → df desc (80 before 20)
+  });
+});
+
 describe('EdsrFtsService.lexemeDf (CORE-21 P1.5a)', () => {
   const svc = new EdsrFtsService();
 
@@ -76,5 +113,26 @@ describe('EdsrFtsService.lexemeDf (CORE-21 P1.5a)', () => {
     const db = dbReturning([{ lexeme: 'донецьк', df: 10, sample_docs: 1000 }]);
     const m = await svc.lexemeDf(['Донецьк'], db);
     expect(m.get('донецьк')!).toBeCloseTo(Math.log(1000 / 10));
+  });
+
+  it('lexemeStats returns raw df (0 for absent) and the sample size (LEXAI Cause-A)', async () => {
+    const db = dbReturning([
+      { lexeme: 'окупована', df: 41321, sample_docs: 3_000_000 },
+      { lexeme: 'сумування', df: 80, sample_docs: 3_000_000 },
+    ]);
+    const s = await svc.lexemeStats(['Окупована', 'сумування', 'абракадабра'], db);
+    expect(s.sampleDocs).toBe(3_000_000);
+    expect(s.df.get('окупована')).toBe(41321);
+    expect(s.df.get('сумування')).toBe(80);
+    expect(s.df.get('абракадабра')).toBe(0);                 // absent → 0, the junk signal
+    expect(s.idf.get('окупована')!).toBeCloseTo(Math.log(3_000_000 / 41321));
+  });
+
+  it('lexemeStats degrades to empty maps + 0 sample on db error', async () => {
+    const db = { query: jest.fn().mockRejectedValue(new Error('relation does not exist')) };
+    const s = await svc.lexemeStats(['x'], db);
+    expect(s.idf.size).toBe(0);
+    expect(s.df.size).toBe(0);
+    expect(s.sampleDocs).toBe(0);
   });
 });

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -127,20 +127,57 @@ export interface EdsrIndexProgress {
   percentComplete: number;
 }
 
+// Anchor-vocabulary floor (LEXAI Cause-A fix). A token must occur in at least this many
+// sampled documents to be trusted as an FTS anchor. Below it (or absent from the corpus),
+// the token is a WEAK term — a colloquial abbreviation / OCR / typo (e.g. "сумування",
+// "дррп") that the LLM reformulator baked into the fts string. Such tokens pollute an
+// all-AND plainto_tsquery (→ 0 results) AND, fatally, survive IDF-only relaxation because
+// "rare == high idf == kept first". The floor is relative to the sample with an absolute
+// minimum, and is applied ONLY when document frequencies are supplied.
+export const ANCHOR_DF_FRACTION = 1e-4;  // 3.0M-doc sample → ~300-doc floor
+export const ANCHOR_DF_MIN_ABS = 8;
+
+export interface SelectFtsTermsOpts {
+  // Per-(lowercased)-token document frequency from edrsr_lexeme_df. When present, tokens
+  // below the anchor floor are demoted to the tail so relaxation drops THEM first.
+  df?: Map<string, number>;
+  sampleDocs?: number;  // total sampled docs → relative floor = sampleDocs * ANCHOR_DF_FRACTION
+}
+
 /**
- * IDF-weighted ordering of FTS keyword tokens (CORE-21 P1.5a). Returns the tokens
- * most-discriminative first so the caller probes the rarest terms and relaxation drops
- * the commonest. `idfByToken` is keyed by lowercased token (see EdsrFtsService.lexemeDf).
+ * IDF-weighted ordering of FTS keyword tokens (CORE-21 P1.5a + LEXAI Cause-A).
  *
- * Zero-risk fallback: an EMPTY idf map (df table unpopulated / lookup failed) preserves
- * the original token order — i.e. the previous positional behaviour. Stable sort: equal
- * idf (and the fallback) keep input order via the original index.
+ * Returns discriminative-but-REAL terms first, so the caller probes them and relaxation
+ * drops the commonest (low idf) and the junk (sub-floor df) first. Two-tier order:
+ *   1. anchors (df ≥ floor, or df unknown) — by idf desc (rarest real term first)
+ *   2. weak terms (df < floor: ultra-rare / absent → likely colloquial/typo) — by df desc,
+ *      kept only as a last resort so a fully-colloquial query still searches *something*.
+ *
+ * Zero-risk fallbacks: an EMPTY idf map (df table unpopulated / lookup failed) preserves the
+ * original positional order; with no `opts.df` the behaviour is exactly the previous pure-idf
+ * ordering. Stable on ties via the original index.
  */
-export function selectFtsTerms(tokens: string[], idfByToken: Map<string, number>): string[] {
+export function selectFtsTerms(
+  tokens: string[],
+  idfByToken: Map<string, number>,
+  opts?: SelectFtsTermsOpts,
+): string[] {
   if (idfByToken.size === 0) return [...tokens];
+  const df = opts?.df;
+  const floor = df
+    ? Math.max(ANCHOR_DF_MIN_ABS, Math.round((opts?.sampleDocs ?? 0) * ANCHOR_DF_FRACTION))
+    : 0;
   return tokens
-    .map((tok, i) => ({ tok, i, idf: idfByToken.get(tok.toLowerCase()) ?? 0 }))
-    .sort((a, b) => (b.idf - a.idf) || (a.i - b.i))
+    .map((tok, i) => {
+      const lc = tok.toLowerCase();
+      const d = df ? (df.get(lc) ?? 0) : undefined;
+      return { tok, i, idf: idfByToken.get(lc) ?? 0, d: d ?? 0, weak: df ? (d! < floor) : false };
+    })
+    .sort((a, b) =>
+      (a.weak === b.weak)
+        ? (a.weak ? (b.d - a.d) || (a.i - b.i)   // weak tail: least-rare junk first
+                  : (b.idf - a.idf) || (a.i - b.i)) // anchors: discriminative first
+        : (a.weak ? 1 : -1))                        // anchors before weak
     .map(x => x.tok);
 }
 
@@ -159,9 +196,24 @@ export class EdsrFtsService {
    * callers then keep positional ordering (no regression before the table is built).
    */
   async lexemeDf(tokens: string[], dbPool: any): Promise<Map<string, number>> {
-    const out = new Map<string, number>();
+    return (await this.lexemeStats(tokens, dbPool)).idf;
+  }
+
+  /**
+   * Like lexemeDf but also returns the raw per-token document frequency and the sample size,
+   * so callers can apply the anchor-floor in selectFtsTerms (LEXAI Cause-A). `df` carries 0
+   * for tokens absent from the sampled corpus — the signal that separates a rare-but-real
+   * legal term from colloquial junk/typos. Same fail-safe contract as lexemeDf: an
+   * empty/missing/unreadable table yields empty maps + sampleDocs 0 (positional fallback).
+   */
+  async lexemeStats(
+    tokens: string[],
+    dbPool: any,
+  ): Promise<{ idf: Map<string, number>; df: Map<string, number>; sampleDocs: number }> {
+    const idf = new Map<string, number>();
+    const df = new Map<string, number>();
     const lexemes = [...new Set(tokens.map(t => t.toLowerCase()).filter(Boolean))];
-    if (lexemes.length === 0) return out;
+    if (lexemes.length === 0) return { idf, df, sampleDocs: 0 };
     try {
       const res = await dbPool.query(
         `SELECT lexeme, df, sample_docs FROM edrsr_lexeme_df WHERE lexeme = ANY($1::text[])`,
@@ -174,18 +226,19 @@ export class EdsrFtsService {
         const probe = await dbPool.query(`SELECT sample_docs FROM edrsr_lexeme_df LIMIT 1`);
         sampleDocs = Number(probe.rows[0]?.sample_docs) || 0;
       }
-      if (!sampleDocs) return out;
+      if (!sampleDocs) return { idf, df, sampleDocs: 0 };
       const maxIdf = Math.log(sampleDocs);
       const dfByLex = new Map<string, number>();
       for (const r of res.rows) dfByLex.set(r.lexeme, Number(r.df));
       for (const lex of lexemes) {
-        const df = dfByLex.get(lex);
-        out.set(lex, df && df > 0 ? Math.log(sampleDocs / df) : maxIdf);
+        const d = dfByLex.get(lex);
+        idf.set(lex, d && d > 0 ? Math.log(sampleDocs / d) : maxIdf);
+        df.set(lex, d && d > 0 ? d : 0);
       }
-      return out;
+      return { idf, df, sampleDocs };
     } catch (err: any) {
-      logger.warn('[EdsrFtsService] lexemeDf lookup failed; positional FTS fallback', { error: err.message });
-      return new Map();
+      logger.warn('[EdsrFtsService] lexemeStats lookup failed; positional FTS fallback', { error: err.message });
+      return { idf: new Map(), df: new Map(), sampleDocs: 0 };
     }
   }
 

--- a/scripts/edrsr/build-lexeme-df-parallel.sh
+++ b/scripts/edrsr/build-lexeme-df-parallel.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# build-lexeme-df-parallel.sh — parallel rebuild of edrsr_lexeme_df on the LOCAL
+# EDRSR proxy (edrsr_all), sharded by year-partition.
+#
+# WHY: the single-pass build (scripts/edrsr/build-lexeme-df.sql) runs ts_stat in
+# ONE backend — CPU-bound on to_tsvector, ~40-70 min for a 3% sample of ~101M
+# rows while 3 of 4 cores idle. ts_stat / TABLESAMPLE do not use native parallel
+# query, so we parallelise BY HAND: one worker per year-partition (capped at
+# $WORKERS concurrent), each computing a partial lexeme document-frequency over a
+# SYSTEM(pct) sample of its partition into a staging table; then a single merge
+# sums df per lexeme and sums the per-shard sample sizes.
+#
+# Correctness: document frequency is additive over disjoint partitions, and the
+# total sample size is the sum of per-shard sampled-doc counts. IDF is computed
+# at read time as ln(sample_docs / df) (see EdsrFtsService.lexemeDf), so storing
+# summed df + summed sample_docs is exact. Sharding by partition also yields a
+# YEAR-STRATIFIED sample (more representative than block-SYSTEM on the parent).
+#
+# Local note: edrsr_all.edrsr_fulltext has NO tsv column (tsv lives only on prod),
+# so we tokenise with to_tsvector('simple', full_text) on the fly — the expensive
+# step this script parallelises. On prod (where tsv exists) prefer the single-pass
+# build over the precomputed tsv, which needs no tokenisation.
+#
+# Floor semantics: per-shard floor keeps lexemes with ndoc >= $SHARD_FLOOR (drops
+# per-shard hapax/OCR); the merge then applies the GLOBAL floor sum(df) >= $DF_MIN
+# to match the single-pass `ndoc >= 3`. A term with 1 occurrence in each of three
+# shards (global df=3) is the only edge dropped vs the single-pass build — a
+# negligible difference for an IDF table.
+#
+# Usage (on the workstation / local proxy):
+#   scripts/edrsr/build-lexeme-df-parallel.sh
+#   PCT=5 WORKERS=4 scripts/edrsr/build-lexeme-df-parallel.sh
+#
+# Env:
+#   DB           target database          (default: edrsr_all)
+#   PCT          TABLESAMPLE SYSTEM pct   (default: 3)
+#   SEED         REPEATABLE seed          (default: 42)
+#   WORKERS      max concurrent shards    (default: nproc-1, min 1)
+#   SHARD_FLOOR  per-shard ndoc floor     (default: 2)
+#   DF_MIN       global df floor at merge (default: 3)
+#   PSQL         psql command             (default: "sudo -n -u postgres psql")
+#   LOGDIR       per-shard log dir        (default: /tmp/lexeme_build)
+
+set -euo pipefail
+
+export DB="${DB:-edrsr_all}"
+export PCT="${PCT:-3}"
+export SEED="${SEED:-42}"
+WORKERS="${WORKERS:-$(( $(nproc) > 1 ? $(nproc) - 1 : 1 ))}"
+export SHARD_FLOOR="${SHARD_FLOOR:-2}"
+DF_MIN="${DF_MIN:-3}"
+export PSQL="${PSQL:-sudo -n -u postgres psql}"
+export LOGDIR="${LOGDIR:-/tmp/lexeme_build}"
+
+mkdir -p "$LOGDIR"
+
+echo "[build] DB=$DB PCT=$PCT SEED=$SEED WORKERS=$WORKERS SHARD_FLOOR=$SHARD_FLOOR DF_MIN=$DF_MIN"
+echo "[build] started $(date -Is)"
+
+# ---------------------------------------------------------------------------
+# 0. Staging tables (UNLOGGED — transient, faster, crash-discardable)
+# ---------------------------------------------------------------------------
+$PSQL -d "$DB" -v ON_ERROR_STOP=1 -q <<SQL
+CREATE TABLE IF NOT EXISTS edrsr_lexeme_df (
+  lexeme TEXT PRIMARY KEY, df BIGINT NOT NULL,
+  sample_docs BIGINT NOT NULL, updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+DROP TABLE IF EXISTS edrsr_lexeme_df_stage;
+DROP TABLE IF EXISTS edrsr_lexeme_df_shardmeta;
+CREATE UNLOGGED TABLE edrsr_lexeme_df_stage     (part TEXT, lexeme TEXT, df BIGINT);
+CREATE UNLOGGED TABLE edrsr_lexeme_df_shardmeta (part TEXT PRIMARY KEY, sample_docs BIGINT);
+SQL
+
+# ---------------------------------------------------------------------------
+# 1. Discover non-empty year partitions of edrsr_fulltext (biggest first →
+#    better job-pool packing)
+# ---------------------------------------------------------------------------
+mapfile -t PARTS < <($PSQL -d "$DB" -v ON_ERROR_STOP=1 -tAc "
+  SELECT c.relname
+  FROM pg_inherits i
+  JOIN pg_class c ON c.oid = i.inhrelid
+  JOIN pg_class p ON p.oid = i.inhparent
+  WHERE p.relname = 'edrsr_fulltext' AND c.reltuples > 0
+  ORDER BY c.reltuples DESC")
+
+if [ "${#PARTS[@]}" -eq 0 ]; then echo "[build] no partitions found" >&2; exit 1; fi
+echo "[build] ${#PARTS[@]} partitions: ${PARTS[*]}"
+
+# ---------------------------------------------------------------------------
+# 2. Per-shard worker — partial DF + sample size for ONE partition.
+#    Exported for the xargs subshells. Reads config from the environment;
+#    $part is a discovered relname (never user input) → safe to inline.
+# ---------------------------------------------------------------------------
+shard() {
+  local part="$1" log="$LOGDIR/$1.log"
+  {
+    echo "[$part] start $(date -Is)"
+    $PSQL -d "$DB" -v ON_ERROR_STOP=1 -q <<SQL
+SET client_min_messages = error;   -- silence "word too long" NOTICEs
+INSERT INTO edrsr_lexeme_df_shardmeta(part, sample_docs)
+SELECT '$part', count(*)::bigint
+  FROM $part TABLESAMPLE SYSTEM ($PCT) REPEATABLE ($SEED);
+INSERT INTO edrsr_lexeme_df_stage(part, lexeme, df)
+SELECT '$part', s.word, s.ndoc
+FROM ts_stat(\$\$SELECT to_tsvector('simple', full_text)
+               FROM $part TABLESAMPLE SYSTEM ($PCT) REPEATABLE ($SEED)\$\$)
+     AS s(word, ndoc, nentry)
+WHERE s.ndoc >= $SHARD_FLOOR;
+SQL
+    echo "[$part] done  $(date -Is)"
+  } >"$log" 2>&1
+}
+export -f shard
+
+# ---------------------------------------------------------------------------
+# 3. Run shards with a bounded job pool ($WORKERS concurrent)
+# ---------------------------------------------------------------------------
+printf '%s\n' "${PARTS[@]}" | xargs -d '\n' -P "$WORKERS" -I{} bash -c 'shard "$@"' _ {}
+echo "[build] all shards done $(date -Is)"
+
+# ---------------------------------------------------------------------------
+# 4. Merge — sum df per lexeme, sum per-shard sample sizes
+# ---------------------------------------------------------------------------
+$PSQL -d "$DB" -v ON_ERROR_STOP=1 -q <<SQL
+SET statement_timeout = '30min';
+BEGIN;
+TRUNCATE edrsr_lexeme_df;
+INSERT INTO edrsr_lexeme_df (lexeme, df, sample_docs, updated_at)
+SELECT st.lexeme, sum(st.df)::bigint,
+       (SELECT coalesce(sum(sample_docs),0) FROM edrsr_lexeme_df_shardmeta),
+       NOW()
+FROM edrsr_lexeme_df_stage st
+GROUP BY st.lexeme
+HAVING sum(st.df) >= $DF_MIN;
+COMMIT;
+ANALYZE edrsr_lexeme_df;
+DROP TABLE IF EXISTS edrsr_lexeme_df_stage;
+DROP TABLE IF EXISTS edrsr_lexeme_df_shardmeta;
+SQL
+
+# ---------------------------------------------------------------------------
+# 5. Summary + sanity (domain anchors must outrank colloquial junk)
+# ---------------------------------------------------------------------------
+$PSQL -d "$DB" -v ON_ERROR_STOP=1 -tAc \
+  "SELECT 'lexemes='||count(*)||' sample_docs='||max(sample_docs) FROM edrsr_lexeme_df;"
+$PSQL -d "$DB" -v ON_ERROR_STOP=1 -tAc "
+  SELECT k||' df='||coalesce((SELECT sum(df) FROM edrsr_lexeme_df WHERE lexeme LIKE k||'%'),0)
+  FROM (VALUES ('окупован'),('нерухом'),('оподаткув'),('зіткнен'),('сумуван'),('дррп')) v(k);"
+echo "[build] finished $(date -Is)"

--- a/scripts/edrsr/build-lexeme-df.sql
+++ b/scripts/edrsr/build-lexeme-df.sql
@@ -4,10 +4,13 @@
 -- OFF-PEAK on the local DB-proxy, then export the table to prod (local->prod
 -- pattern). Idempotent — safe to re-run; refreshed by the EDRSR cron.
 --
--- Sample size: 0.3% of ~296M rows ~= 900k docs — enough to rank "податок"
--- (almost everywhere) below "донецьк" (rare). REPEATABLE makes the count and
--- the ts_stat see the SAME sample, so sample_docs matches the df corpus.
--- If ts_stat runs too long, drop the sample to SYSTEM (0.1).
+-- Sample size: 3% of ~99.5M rows ~= 3.0M docs. Raised from 0.3% (~298k) so the
+-- table reliably resolves terms down to ~300-1000 corpus-docs — closing the
+-- "unknown lexeme" gap that let colloquial junk (ВПО/ДРРП/сумувати, df≈0) sit
+-- next to real-but-rare legal terms when building/relaxing the FTS query.
+-- "податок" (almost everywhere) still ranks below "донецьк" (rare). REPEATABLE
+-- makes the count and the ts_stat see the SAME sample, so sample_docs matches
+-- the df corpus. If ts_stat runs too long / OOMs, drop the sample to SYSTEM (1).
 --
 -- Usage:
 --   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f scripts/edrsr/build-lexeme-df.sql
@@ -23,10 +26,10 @@ SELECT
   s.word,
   s.ndoc,
   (SELECT count(*)::bigint
-     FROM edrsr_fulltext TABLESAMPLE SYSTEM (0.3) REPEATABLE (42)),
+     FROM edrsr_fulltext TABLESAMPLE SYSTEM (3) REPEATABLE (42)),
   NOW()
 FROM ts_stat(
-  $$SELECT tsv FROM edrsr_fulltext TABLESAMPLE SYSTEM (0.3) REPEATABLE (42)$$
+  $$SELECT tsv FROM edrsr_fulltext TABLESAMPLE SYSTEM (3) REPEATABLE (42)$$
 ) AS s(word, ndoc, nentry)
 WHERE s.ndoc >= 3;   -- drop hapax/OCR noise
 


### PR DESCRIPTION
## Проблема (Cause-A retrieval-промаха чата v3)
Чат v3 не находил эталонную постанову ВС **280/5185/19** по вопросу «податок на нерухомість на ТОТ»: вместо неё выдавал нерелевантные дела и ложный вывод «позиции ВС нет».

Из логов прода (`chat-32f60a4d…`): FTS к суду уходил как `сумування ДРРП переміщені окупована…` → **0 результатов**, релаксация ужималась до `сумування ДРРП` → снова 0.

**Корень в коде:** `lexemeDf` присваивал отсутствующим/ультра-редким токенам **max IDF**, а `ftsWithRelaxation` держит токены с наибольшим IDF первыми (`slice(0,n)`). Разговорный мусор (ВПО/ДРРП/сумувати), который реформулятор-LLM зашивает в `fts`, оказывался «самым ценным» → выживал релаксацию и вытеснял доменные якоря (окупован/нерухом).

## Фикс
- **`selectFtsTerms`**: опциональные `df`/`sampleDocs`; токены ниже якорного порога `max(8, sampleDocs*1e-4)` уводятся в хвост → релаксация отбрасывает их первыми. Обратносовместимо: без `df` — прежний pure-IDF порядок.
- **`EdsrFtsService.lexemeStats`**: возвращает `idf + raw df + sampleDocs` (`lexemeDf` теперь обёртка); `df=0` = токен отсутствует в корпусе (сигнал мусора).
- **`ftsWithRelaxation`**: берёт `lexemeStats`, передаёт `df`/`sampleDocs`.
- **`edrsr_lexeme_df` пересобран 3%** (~3.0M док, 988k лексем) — надёжный словарь-порог. `build-lexeme-df.sql` → `SYSTEM(3)`; добавлен параллельный шардовый билдер `build-lexeme-df-parallel.sh` (×3-4 на 4 vCPU).

## Данные словаря (3M sample)
| токен | df | роль |
|---|---|---|
| нерухом\* | 193320 | якорь |
| окупован\* | 41321 | якорь |
| оподаткув\* | 28538 | якорь |
| дррп\* | 526 | якорь (>порог 300) |
| сумуван\* | 80 | мусор (<порог) → в хвост |

## Тесты
`edrsr-fts-term-selection.test.ts` — 14/14 (демоция мусора при наличии df; сохранение старого поведения без df как доказательство регрессии; `lexemeStats` df/sampleDocs + degrade на ошибке БД).

## Деплой
Словарь `edrsr_lexeme_df` уже залит на прод (local→prod). Этот PR — только код отбора токенов.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix FTS term selection so real anchors outrank junk from reformulations. We now demote ultra-rare/absent tokens by document frequency, so relaxation drops them first and relevant cases surface (e.g., 280/5185/19).

- **Bug Fixes**
  - `selectFtsTerms`: uses optional `df` + `sampleDocs` and an anchor floor `max(8, sampleDocs*1e-4)` to push sub-floor tokens to the tail; falls back to pure-IDF/positional order when `df` is missing.
  - `EdsrFtsService.lexemeStats`: returns `idf`, raw `df`, and `sampleDocs`; `lexemeDf` now delegates. `df=0` marks corpus-absent tokens. FTS tool now passes these to `selectFtsTerms`.
  - Tests cover junk demotion, legacy behavior without `df`, and DB-error fallback.

- **New Features**
  - Rebuilt `edrsr_lexeme_df` at 3% (~3.0M docs) for a stable vocabulary floor.
  - Added `scripts/edrsr/build-lexeme-df-parallel.sh` (partition-sharded local builder); bumped `scripts/edrsr/build-lexeme-df.sql` to `SYSTEM(3)`.

<sup>Written for commit 9114c9e1ee2a863f3a6f41bfe05f2001a9caddd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

