### PR TITLE
fix(edrsr-fts): vocabulary-snap tokens to corpus stems + prefix tsquery (Cause-A.2)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -19,7 +19,7 @@ import type { SearchResultFilter } from '../../services/search-result-filter.js'
 import { STRICT_MIN_SCORE } from '../../services/search-result-filter.js';
 import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsSearchResponse } from '../../services/edrsr-fts-service.js';
-import { selectFtsTerms } from '../../services/edrsr-fts-service.js';
+import { selectFtsTerms, sanitizeFtsToken, buildPrefixTsquery } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
 
 const DEFAULT_RRF_K = 60;
@@ -397,12 +397,32 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       : { idf: new Map<string, number>(), df: new Map<string, number>(), sampleDocs: 0 };
     const tokens = selectFtsTerms(rawTokens, stats.idf, { df: stats.df, sampleDocs: stats.sampleDocs });
     const idfRanked = stats.idf.size > 0;
-    const startTokens = tokens.length;
-    let n = Math.min(startTokens, FULLTEXT_MAX_TOKENS) || 1;
-    const cappedFrom = n; // token count at the first (capped) probe
-    let usedQuery = tokens.slice(0, n).join(' ') || String(topicalQuery).trim();
 
-    let result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
+    // LEXAI Cause-A.2: snap ranked tokens to corpus STEMS (edrsr_lexeme_df) and probe with a
+    // declension-tolerant prefix tsquery (окупован:* …). Fixes the stemless-'simple' recall
+    // hole (query "окупована" missed doc form "окупованій") AND drops junk that has no corpus
+    // stem. Empty stem map (snap off / table empty) → fall back to the plainto token string.
+    const stemMap = (this.ftsService && !noIdf)
+      ? await this.ftsService.snapTokensToStems(rawTokens, this.db)
+      : new Map<string, string>();
+    const stems = [...new Set(
+      tokens.map(t => stemMap.get(sanitizeFtsToken(t))).filter((s): s is string => !!s),
+    )];
+    const usePrefix = stems.length > 0;
+    const units = usePrefix ? stems : tokens;   // what we cap & relax over
+    const startTokens = units.length;
+    let n = Math.min(startTokens, FULLTEXT_MAX_TOKENS) || 1;
+    const cappedFrom = n; // unit count at the first (capped) probe
+
+    const probe = (k: number) => {
+      const slice = units.slice(0, k);
+      const usedQuery = slice.join(' ') || String(topicalQuery).trim();
+      const topicalTsquery = usePrefix ? (buildPrefixTsquery(slice) ?? undefined) : undefined;
+      return { usedQuery, topicalTsquery };
+    };
+
+    let { usedQuery, topicalTsquery } = probe(n);
+    let result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset, undefined, topicalTsquery);
 
     let steps = 0;
     // Relax while near-empty (not just hard 0): dropping the LEAST discriminative AND-term
@@ -410,11 +430,12 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     // clears the floor or we hit the bounds.
     while (result.total < FTS_RELAX_MIN_RESULTS && n > FTS_MIN_TOKENS && steps < FTS_MAX_RELAX_STEPS) {
       n -= 1; steps += 1;
-      usedQuery = tokens.slice(0, n).join(' ');
+      ({ usedQuery, topicalTsquery } = probe(n));
       logger.info('[EdsrUnifiedSearch] FTS relax-on-near-empty', {
-        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: usedQuery, idf_ranked: idfRanked,
+        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: topicalTsquery || usedQuery,
+        idf_ranked: idfRanked, prefix: usePrefix,
       });
-      result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
+      result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset, undefined, topicalTsquery);
     }
 
     return {

--- a/mcp_backend/src/migrations/166_edrsr_lexeme_df_prefix_idx.sql
+++ b/mcp_backend/src/migrations/166_edrsr_lexeme_df_prefix_idx.sql
@@ -1,0 +1,11 @@
+-- Prefix index on edrsr_lexeme_df.lexeme for fast `lexeme LIKE 'stem%'` prefix-DF
+-- lookups (LEXAI Cause-A.2 / token→vocabulary snap). The default PK btree uses the
+-- database collation, which does NOT accelerate LIKE prefix scans; text_pattern_ops
+-- gives byte-ordered ranges so the snap (longest corpus stem with df ≥ floor) is an
+-- index range scan instead of a 988k-row seq scan per candidate prefix.
+--
+-- Small table (~1M rows) → plain CREATE INDEX (brief lock) is fine; the migration
+-- runner wraps statements in a txn, so CONCURRENTLY is intentionally NOT used.
+
+CREATE INDEX IF NOT EXISTS edrsr_lexeme_df_lexeme_prefix
+  ON edrsr_lexeme_df (lexeme text_pattern_ops);

--- a/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
@@ -2,7 +2,7 @@
  * CORE-21 P1.5a — IDF-weighted FTS term selection.
  * selectFtsTerms (pure ordering) + EdsrFtsService.lexemeDf (df → idf, db-backed).
  */
-import { selectFtsTerms, EdsrFtsService } from '../edrsr-fts-service';
+import { selectFtsTerms, EdsrFtsService, sanitizeFtsToken, buildPrefixTsquery } from '../edrsr-fts-service';
 
 describe('selectFtsTerms (CORE-21 P1.5a)', () => {
   // Mimics lexemeDf output: common terms low idf, discriminative terms high.
@@ -134,5 +134,64 @@ describe('EdsrFtsService.lexemeDf (CORE-21 P1.5a)', () => {
     expect(s.idf.size).toBe(0);
     expect(s.df.size).toBe(0);
     expect(s.sampleDocs).toBe(0);
+  });
+});
+
+describe('prefix tsquery helpers (LEXAI Cause-A.2)', () => {
+  it('sanitizeFtsToken lowercases and strips tsquery metacharacters', () => {
+    expect(sanitizeFtsToken('Окупована:*')).toBe('окупована');
+    expect(sanitizeFtsToken('60-кв.м')).toBe('60квм');
+    expect(sanitizeFtsToken('a&b|c!')).toBe('abc');
+  });
+
+  it('buildPrefixTsquery ANDs stems with :* prefix', () => {
+    expect(buildPrefixTsquery(['окупован', 'нерухом'])).toBe('окупован:* & нерухом:*');
+  });
+
+  it('buildPrefixTsquery returns null when nothing usable', () => {
+    expect(buildPrefixTsquery([])).toBeNull();
+    expect(buildPrefixTsquery(['', '  '])).toBeNull();
+  });
+});
+
+describe('EdsrFtsService.snapTokensToStems (LEXAI Cause-A.2)', () => {
+  const svc = new EdsrFtsService();
+  // floor at sampleDocs 3.0M = max(8, 3.0M*1e-4) = 300.
+  function db(prefixDf: Record<string, number>, sampleDocs = 3_000_000) {
+    return {
+      query: jest.fn().mockImplementation((sql: string) => {
+        if (/LIMIT 1/.test(sql)) return Promise.resolve({ rows: [{ sample_docs: sampleDocs }] });
+        // unnest candidates query → return df for known prefixes, 0 otherwise
+        return Promise.resolve({ rows: Object.entries(prefixDf).map(([cand, d]) => ({ cand, df: d })) });
+      }),
+    };
+  }
+
+  it('snaps a declined token to the SHORTEST above-floor stem (inflection-tolerant)', async () => {
+    // shortest valid prefix wins so the :* query catches all declensions. "нерух" (≥floor)
+    // is chosen over the longer "нерухом"/"нерухомість".
+    const m = await svc.snapTokensToStems(['нерухомість'], db({ 'нерух': 193320, 'нерухом': 193000, 'нерухомість': 5000 }));
+    expect(m.get('нерухомість')).toBe('нерух');
+  });
+
+  it('skips below-floor short prefixes and snaps to the first above-floor one', async () => {
+    // "окуп"/"окупо" sub-floor here; "окупов" clears it → snapped (not the full form).
+    const m = await svc.snapTokensToStems(['окупована'], db({ 'окупо': 50, 'окупов': 41321, 'окупован': 41000 }));
+    expect(m.get('окупована')).toBe('окупов');
+  });
+
+  it('drops junk with no above-floor corpus stem', async () => {
+    const m = await svc.snapTokensToStems(['сумування'], db({ 'сумування': 80, 'сумуван': 80, 'сумув': 90 }));
+    expect(m.has('сумування')).toBe(false);
+  });
+
+  it('returns empty map when the df table is empty (plainto fallback)', async () => {
+    const m = await svc.snapTokensToStems(['окупована'], db({}, 0));
+    expect(m.size).toBe(0);
+  });
+
+  it('never throws — empty map on db error', async () => {
+    const errDb = { query: jest.fn().mockRejectedValue(new Error('boom')) };
+    expect((await svc.snapTokensToStems(['окупована'], errDb)).size).toBe(0);
   });
 });

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -181,6 +181,28 @@ export function selectFtsTerms(
     .map(x => x.tok);
 }
 
+// Token sanitisation for prefix tsquery construction. The 'simple' config keeps Cyrillic
+// and Latin letters + digits; everything else (punctuation, tsquery metachars & | ! ( ) : *)
+// is stripped so the token can never break to_tsquery or inject operators.
+const MIN_STEM_LEN = 5;       // shortest prefix we will snap to (4-grams over-match in uk)
+const MAX_STEM_LEN = 12;      // longest candidate prefix considered
+
+export function sanitizeFtsToken(token: string): string {
+  return (token || '').toLowerCase().replace(/[^\p{L}\p{Nd}]+/gu, '');
+}
+
+/**
+ * Build a declension-tolerant prefix tsquery string from already-snapped stems:
+ *   ['окупован', 'нерухом'] → "окупован:* & нерухом:*"
+ * Stems are sanitised corpus prefixes (no user metacharacters), so they are safe to embed.
+ * Returns null when there is nothing usable (caller falls back to plainto_tsquery).
+ */
+export function buildPrefixTsquery(stems: string[]): string | null {
+  const parts = stems.map(s => sanitizeFtsToken(s)).filter(s => s.length >= 1);
+  if (parts.length === 0) return null;
+  return parts.map(s => `${s}:*`).join(' & ');
+}
+
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
@@ -243,6 +265,65 @@ export class EdsrFtsService {
   }
 
   /**
+   * Snap each query token to the LONGEST corpus stem present in edrsr_lexeme_df with
+   * prefix-df ≥ floor (LEXAI Cause-A.2). This is the data-driven fix for two coupled
+   * failures: (1) the 'simple' config has no Ukrainian stemmer, so an exact-form match
+   * ("окупована") misses the declined forms a decision actually uses ("окупованій",
+   * "нерухомості"); snapping to the stem ("окупован") + a `:*` prefix query restores
+   * recall. (2) colloquial junk / typos that have no corpus stem (or only a sub-floor
+   * one) snap to nothing and are dropped — choosing terms FROM the existing key list.
+   *
+   * Returns Map<sanitized-token, stem>. Tokens with no qualifying stem are absent (dropped).
+   * Floor mirrors the anchor floor: max(ANCHOR_DF_MIN_ABS, sampleDocs * ANCHOR_DF_FRACTION).
+   * Fail-safe: any error → empty map (caller keeps the plainto_tsquery path).
+   */
+  async snapTokensToStems(tokens: string[], dbPool: any): Promise<Map<string, string>> {
+    const out = new Map<string, string>();
+    const clean = [...new Set(tokens.map(sanitizeFtsToken).filter(t => t.length >= MIN_STEM_LEN))];
+    if (clean.length === 0) return out;
+    // Candidate prefixes per token: longest → shortest (we pick the longest that clears the
+    // floor). Bounded by [MIN_STEM_LEN, MAX_STEM_LEN] so very long words stay cheap.
+    const candidates: string[] = [];
+    for (const tok of clean) {
+      const top = Math.min(tok.length, MAX_STEM_LEN);
+      for (let len = top; len >= MIN_STEM_LEN; len--) candidates.push(tok.slice(0, len));
+    }
+    const uniqCandidates = [...new Set(candidates)];
+    try {
+      // Prefix-df for every candidate in one round-trip. The text_pattern_ops index
+      // (migration 166) turns each `lexeme LIKE cand||'%'` into an index range scan.
+      const res = await dbPool.query(
+        `SELECT u.cand AS cand,
+                (SELECT COALESCE(sum(df), 0) FROM edrsr_lexeme_df WHERE lexeme LIKE u.cand || '%') AS df
+         FROM unnest($1::text[]) AS u(cand)`,
+        [uniqCandidates],
+      );
+      let sampleDocs = 0;
+      const probe = await dbPool.query(`SELECT sample_docs FROM edrsr_lexeme_df LIMIT 1`);
+      sampleDocs = Number(probe.rows[0]?.sample_docs) || 0;
+      if (!sampleDocs) return out;  // table empty → no snap signal → plainto fallback
+      const floor = Math.max(ANCHOR_DF_MIN_ABS, Math.round(sampleDocs * ANCHOR_DF_FRACTION));
+      const dfByCand = new Map<string, number>();
+      for (const r of res.rows) dfByCand.set(r.cand, Number(r.df));
+      for (const tok of clean) {
+        const top = Math.min(tok.length, MAX_STEM_LEN);
+        // SHORTEST valid prefix wins: it is the most inflection-tolerant stem (e.g. "нерух"
+        // matches нерухоме/нерухомості/нерухомість), whereas the longest above-floor prefix
+        // ("нерухомість") would again miss other declensions. The floor blocks meaningless
+        // short n-grams that don't actually occur in the corpus.
+        for (let len = MIN_STEM_LEN; len <= top; len++) {
+          const cand = tok.slice(0, len);
+          if ((dfByCand.get(cand) ?? 0) >= floor) { out.set(tok, cand); break; }
+        }
+      }
+      return out;
+    } catch (err: any) {
+      logger.warn('[EdsrFtsService] snapTokensToStems failed; plainto fallback', { error: err.message });
+      return new Map();
+    }
+  }
+
+  /**
    * Full text search over edrsr_fulltext with optional metadata filters from edrsr_documents.
    *
    * Uses ts_rank_cd for relevance scoring and ts_headline for snippet generation.
@@ -255,15 +336,25 @@ export class EdsrFtsService {
     limit: number = 20,
     offset: number = 0,
     headlineQuery?: string,
+    topicalTsquery?: string,
   ): Promise<EdsrFtsSearchResponse> {
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const safeOffset = Math.max(offset, 0);
 
+    // LEXAI Cause-A.2: when the caller supplies a prebuilt prefix tsquery (vocabulary-snapped
+    // stems like "окупован:* & нерухом:*"), match/rank/highlight with to_tsquery so declined
+    // Ukrainian forms are caught. Without it, behaviour is the original plainto_tsquery path.
+    const useTsq = !!(topicalTsquery && topicalTsquery.trim());
+    const topicalArg = useTsq ? topicalTsquery!.trim() : query;
+    const topicalExpr = useTsq ? `to_tsquery('simple', $1)` : `plainto_tsquery('simple', $1)`;
+    // Distinct cache key per actual tsquery so prefix and plainto results never collide.
+    const cacheKey = useTsq ? `tsq:${topicalArg}` : query;
+
     // Check cache first
     if (this.edsrCache) {
-      const cached = await this.edsrCache.getCachedFtsResults(query, filters, safeLimit, safeOffset);
+      const cached = await this.edsrCache.getCachedFtsResults(cacheKey, filters, safeLimit, safeOffset);
       if (cached) {
-        logger.debug('[EdsrFtsService] Cache hit for FTS query', { query });
+        logger.debug('[EdsrFtsService] Cache hit for FTS query', { query: cacheKey });
         return cached;
       }
     }
@@ -278,8 +369,8 @@ export class EdsrFtsService {
     //   - party_name → phraseto_tsquery (contiguous phrase, declension-tolerant for
     //     quoted proper names which courts keep in nominative)
     //   - party_role → to_tsquery of enumerated role-noun case forms
-    const tsqueryParts: string[] = [`plainto_tsquery('simple', $${paramIdx})`];
-    params.push(query);
+    const tsqueryParts: string[] = [topicalExpr];   // $1 — plainto OR to_tsquery (see useTsq)
+    params.push(topicalArg);
     paramIdx++;
 
     const partyName = filters.party_name?.trim();
@@ -375,20 +466,28 @@ export class EdsrFtsService {
       ? `edrsr_fulltext f INNER JOIN edrsr_documents d ON d.doc_id = f.doc_id`
       : `edrsr_fulltext f`;
 
+    // Headline tsquery: a caller-supplied bare headlineQuery is plain text (plainto); otherwise
+    // it reuses $1, which is a prefix tsquery when useTsq → highlight via to_tsquery so the
+    // snippet centres on the same declined matches the search found.
+    const explicitHeadline = !!(headlineQuery && headlineQuery !== query);
+    const headlineFn = (useTsq && !explicitHeadline)
+      ? `to_tsquery('simple', $${headlineParamIdx})`
+      : `plainto_tsquery('simple', $${headlineParamIdx})`;
+
     const buildSelectFields = (withHeadline: boolean) => {
       const headlineExpr = withHeadline
-        ? `safe_ts_headline('simple'::regconfig, f.full_text, plainto_tsquery('simple', $${headlineParamIdx}),
+        ? `safe_ts_headline('simple'::regconfig, f.full_text, ${headlineFn},
            'MaxWords=${FTS_HEADLINE_MAX_WORDS}, MinWords=${FTS_HEADLINE_MIN_WORDS}, StartSel=**, StopSel=**') AS headline`
         : `NULL AS headline`;
 
       return hasMetadataFilter
         ? `f.doc_id,
-           ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
+           ts_rank_cd(f.tsv, ${topicalExpr}) AS rank,
            ${headlineExpr},
            d.adjudication_date, d.cause_num, d.judge, d.court_code,
            d.justice_kind, d.judgment_code`
         : `f.doc_id,
-           ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
+           ts_rank_cd(f.tsv, ${topicalExpr}) AS rank,
            ${headlineExpr}`;
     };
 
@@ -453,9 +552,9 @@ export class EdsrFtsService {
         })),
       };
 
-      // Cache the result
+      // Cache the result (keyed by the actual tsquery so prefix/plainto never collide)
       if (this.edsrCache) {
-        this.edsrCache.setCachedFtsResults(query, filters, safeLimit, safeOffset, response).catch(() => {});
+        this.edsrCache.setCachedFtsResults(cacheKey, filters, safeLimit, safeOffset, response).catch(() => {});
       }
 
       return response;


### PR DESCRIPTION
## Корень (глубже, чем junk-токены из #2025)
Конфиг tsv — **`'simple'` без украинского стеммера**, а `searchFulltext` использовал `plainto_tsquery` → матч **только по точной словоформе**. Запрос «окупована нерухоме майно» не находил эталон **280/5185/19**, где в тексте формы «окупованій»/«нерухомості». FTS возвращал 0 на реальных юр-запросах; выживали только случайные совпадения форм или мусор («переміщені ВПО»).

Доказательство на проде:
| запрос | матч эталона |
|---|---|
| `plainto_tsquery('окупована нерухоме майно')` | ❌ |
| `to_tsquery('окупо:* & нерух:* & опода:*')` | ✅ |

## Фикс — «выбирать из списка ключей» (`edrsr_lexeme_df`)
- **`snapTokensToStems`**: токен → **самый короткий** корпус-префикс (len ≥ 5) с prefix-df ≥ якорного порога. `нерухомість→нерух`, `окупована→окупо`; мусор без надпорогового стема (`впо`, `сумування`) отбрасывается. Короткий стем = толерантность ко всем склонениям через `:*`.
- **`buildPrefixTsquery`/`sanitizeFtsToken`**: строит `окупо:* & нерух:* & опода:*` (санитизация, без метасимволов tsquery).
- **`searchFulltext`**: опциональный `topicalTsquery` → match/rank/headline через `to_tsquery` вместо `plainto`; отдельный кэш-ключ. Без аргумента — прежнее поведение (обратносовместимо).
- **`ftsWithRelaxation`**: снапит ранжированные токены, пробует/релаксит по стемам префиксным tsquery; fallback на plainto при пустом снапе.
- **Миграция 166**: `text_pattern_ops` индекс на `edrsr_lexeme_df.lexeme` — prefix-df падает с **5.4с** (seq scan) до index range scan.

## Проверка на проде
Префиксный tsquery из стемов ранжирует по КАС ВС адм:
```
#1 805/3601/16-а   (п.38.6)
#2 280/5185/19     ← ЭТАЛОН
#3 200/3904/21
```
Все профильные дела про ТОТ — в топе, **без семантики**.

## Тесты
22/22 в `edrsr-fts-term-selection.test.ts`: shortest-stem снап, отбрасывание мусора, санитизация, сборка prefix tsquery, fail-safe (пустая таблица / ошибка БД → plainto fallback).

## Связь
Продолжение #2025 (Cause-A.1 — демоция junk). Этот PR закрывает доминирующую причину (склонения + AND). `edrsr_lexeme_df` уже пересобран 3% и на проде.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes low FTS recall for Ukrainian by snapping query tokens to corpus stems and searching with a prefix tsquery. Matches now cover declensions (e.g., “окупована” → finds “окупованій”) while dropping junk that has no stem signal.

- **Bug Fixes**
  - Snap each token to the shortest above-floor stem from `edrsr_lexeme_df` (len ≥ 5); drop tokens with no qualifying stem.
  - Build a declension‑tolerant prefix tsquery (`stem:* & …`) from snapped stems; tokens are sanitized to avoid tsquery metacharacters.
  - `searchFulltext` accepts an optional prefix tsquery and uses `to_tsquery` for match/rank/headline; separate cache key; safe fallback to `plainto_tsquery` when no stems.
  - Unified search now probes and relaxes over stems; falls back to plainto when the snap map is empty.

- **Migration**
  - Add `text_pattern_ops` index on `edrsr_lexeme_df.lexeme` to speed prefix-DF lookups (turns LIKE scans into index range scans).

<sup>Written for commit 9db285449a99f5011925567869aad6c050d9ba65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

