### PR TITLE
feat(reranker): FlagEmbedding converter + bge-reranker-v2-m3 finetune (CORE-64)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -19,7 +19,7 @@ import type { SearchResultFilter } from '../../services/search-result-filter.js'
 import { STRICT_MIN_SCORE } from '../../services/search-result-filter.js';
 import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsSearchResponse } from '../../services/edrsr-fts-service.js';
-import { selectFtsTerms } from '../../services/edrsr-fts-service.js';
+import { selectFtsTerms, sanitizeFtsToken, buildPrefixTsquery } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
 
 const DEFAULT_RRF_K = 60;
@@ -397,12 +397,32 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       : { idf: new Map<string, number>(), df: new Map<string, number>(), sampleDocs: 0 };
     const tokens = selectFtsTerms(rawTokens, stats.idf, { df: stats.df, sampleDocs: stats.sampleDocs });
     const idfRanked = stats.idf.size > 0;
-    const startTokens = tokens.length;
-    let n = Math.min(startTokens, FULLTEXT_MAX_TOKENS) || 1;
-    const cappedFrom = n; // token count at the first (capped) probe
-    let usedQuery = tokens.slice(0, n).join(' ') || String(topicalQuery).trim();
 
-    let result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
+    // LEXAI Cause-A.2: snap ranked tokens to corpus STEMS (edrsr_lexeme_df) and probe with a
+    // declension-tolerant prefix tsquery (окупован:* …). Fixes the stemless-'simple' recall
+    // hole (query "окупована" missed doc form "окупованій") AND drops junk that has no corpus
+    // stem. Empty stem map (snap off / table empty) → fall back to the plainto token string.
+    const stemMap = (this.ftsService && !noIdf)
+      ? await this.ftsService.snapTokensToStems(rawTokens, this.db)
+      : new Map<string, string>();
+    const stems = [...new Set(
+      tokens.map(t => stemMap.get(sanitizeFtsToken(t))).filter((s): s is string => !!s),
+    )];
+    const usePrefix = stems.length > 0;
+    const units = usePrefix ? stems : tokens;   // what we cap & relax over
+    const startTokens = units.length;
+    let n = Math.min(startTokens, FULLTEXT_MAX_TOKENS) || 1;
+    const cappedFrom = n; // unit count at the first (capped) probe
+
+    const probe = (k: number) => {
+      const slice = units.slice(0, k);
+      const usedQuery = slice.join(' ') || String(topicalQuery).trim();
+      const topicalTsquery = usePrefix ? (buildPrefixTsquery(slice) ?? undefined) : undefined;
+      return { usedQuery, topicalTsquery };
+    };
+
+    let { usedQuery, topicalTsquery } = probe(n);
+    let result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset, undefined, topicalTsquery);
 
     let steps = 0;
     // Relax while near-empty (not just hard 0): dropping the LEAST discriminative AND-term
@@ -410,11 +430,12 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     // clears the floor or we hit the bounds.
     while (result.total < FTS_RELAX_MIN_RESULTS && n > FTS_MIN_TOKENS && steps < FTS_MAX_RELAX_STEPS) {
       n -= 1; steps += 1;
-      usedQuery = tokens.slice(0, n).join(' ');
+      ({ usedQuery, topicalTsquery } = probe(n));
       logger.info('[EdsrUnifiedSearch] FTS relax-on-near-empty', {
-        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: usedQuery, idf_ranked: idfRanked,
+        from_tokens: n + 1, to_tokens: n, prev_total: result.total, query: topicalTsquery || usedQuery,
+        idf_ranked: idfRanked, prefix: usePrefix,
       });
-      result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset);
+      result = await this.ftsService!.searchFulltext(usedQuery, this.db, filters, limit, offset, undefined, topicalTsquery);
     }
 
     return {

--- a/mcp_backend/src/migrations/166_edrsr_lexeme_df_prefix_idx.sql
+++ b/mcp_backend/src/migrations/166_edrsr_lexeme_df_prefix_idx.sql
@@ -1,0 +1,11 @@
+-- Prefix index on edrsr_lexeme_df.lexeme for fast `lexeme LIKE 'stem%'` prefix-DF
+-- lookups (LEXAI Cause-A.2 / token→vocabulary snap). The default PK btree uses the
+-- database collation, which does NOT accelerate LIKE prefix scans; text_pattern_ops
+-- gives byte-ordered ranges so the snap (longest corpus stem with df ≥ floor) is an
+-- index range scan instead of a 988k-row seq scan per candidate prefix.
+--
+-- Small table (~1M rows) → plain CREATE INDEX (brief lock) is fine; the migration
+-- runner wraps statements in a txn, so CONCURRENTLY is intentionally NOT used.
+
+CREATE INDEX IF NOT EXISTS edrsr_lexeme_df_lexeme_prefix
+  ON edrsr_lexeme_df (lexeme text_pattern_ops);

--- a/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
@@ -2,7 +2,7 @@
  * CORE-21 P1.5a — IDF-weighted FTS term selection.
  * selectFtsTerms (pure ordering) + EdsrFtsService.lexemeDf (df → idf, db-backed).
  */
-import { selectFtsTerms, EdsrFtsService } from '../edrsr-fts-service';
+import { selectFtsTerms, EdsrFtsService, sanitizeFtsToken, buildPrefixTsquery } from '../edrsr-fts-service';
 
 describe('selectFtsTerms (CORE-21 P1.5a)', () => {
   // Mimics lexemeDf output: common terms low idf, discriminative terms high.
@@ -134,5 +134,64 @@ describe('EdsrFtsService.lexemeDf (CORE-21 P1.5a)', () => {
     expect(s.idf.size).toBe(0);
     expect(s.df.size).toBe(0);
     expect(s.sampleDocs).toBe(0);
+  });
+});
+
+describe('prefix tsquery helpers (LEXAI Cause-A.2)', () => {
+  it('sanitizeFtsToken lowercases and strips tsquery metacharacters', () => {
+    expect(sanitizeFtsToken('Окупована:*')).toBe('окупована');
+    expect(sanitizeFtsToken('60-кв.м')).toBe('60квм');
+    expect(sanitizeFtsToken('a&b|c!')).toBe('abc');
+  });
+
+  it('buildPrefixTsquery ANDs stems with :* prefix', () => {
+    expect(buildPrefixTsquery(['окупован', 'нерухом'])).toBe('окупован:* & нерухом:*');
+  });
+
+  it('buildPrefixTsquery returns null when nothing usable', () => {
+    expect(buildPrefixTsquery([])).toBeNull();
+    expect(buildPrefixTsquery(['', '  '])).toBeNull();
+  });
+});
+
+describe('EdsrFtsService.snapTokensToStems (LEXAI Cause-A.2)', () => {
+  const svc = new EdsrFtsService();
+  // floor at sampleDocs 3.0M = max(8, 3.0M*1e-4) = 300.
+  function db(prefixDf: Record<string, number>, sampleDocs = 3_000_000) {
+    return {
+      query: jest.fn().mockImplementation((sql: string) => {
+        if (/LIMIT 1/.test(sql)) return Promise.resolve({ rows: [{ sample_docs: sampleDocs }] });
+        // unnest candidates query → return df for known prefixes, 0 otherwise
+        return Promise.resolve({ rows: Object.entries(prefixDf).map(([cand, d]) => ({ cand, df: d })) });
+      }),
+    };
+  }
+
+  it('snaps a declined token to the SHORTEST above-floor stem (inflection-tolerant)', async () => {
+    // shortest valid prefix wins so the :* query catches all declensions. "нерух" (≥floor)
+    // is chosen over the longer "нерухом"/"нерухомість".
+    const m = await svc.snapTokensToStems(['нерухомість'], db({ 'нерух': 193320, 'нерухом': 193000, 'нерухомість': 5000 }));
+    expect(m.get('нерухомість')).toBe('нерух');
+  });
+
+  it('skips below-floor short prefixes and snaps to the first above-floor one', async () => {
+    // "окуп"/"окупо" sub-floor here; "окупов" clears it → snapped (not the full form).
+    const m = await svc.snapTokensToStems(['окупована'], db({ 'окупо': 50, 'окупов': 41321, 'окупован': 41000 }));
+    expect(m.get('окупована')).toBe('окупов');
+  });
+
+  it('drops junk with no above-floor corpus stem', async () => {
+    const m = await svc.snapTokensToStems(['сумування'], db({ 'сумування': 80, 'сумуван': 80, 'сумув': 90 }));
+    expect(m.has('сумування')).toBe(false);
+  });
+
+  it('returns empty map when the df table is empty (plainto fallback)', async () => {
+    const m = await svc.snapTokensToStems(['окупована'], db({}, 0));
+    expect(m.size).toBe(0);
+  });
+
+  it('never throws — empty map on db error', async () => {
+    const errDb = { query: jest.fn().mockRejectedValue(new Error('boom')) };
+    expect((await svc.snapTokensToStems(['окупована'], errDb)).size).toBe(0);
   });
 });

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -181,6 +181,28 @@ export function selectFtsTerms(
     .map(x => x.tok);
 }
 
+// Token sanitisation for prefix tsquery construction. The 'simple' config keeps Cyrillic
+// and Latin letters + digits; everything else (punctuation, tsquery metachars & | ! ( ) : *)
+// is stripped so the token can never break to_tsquery or inject operators.
+const MIN_STEM_LEN = 5;       // shortest prefix we will snap to (4-grams over-match in uk)
+const MAX_STEM_LEN = 12;      // longest candidate prefix considered
+
+export function sanitizeFtsToken(token: string): string {
+  return (token || '').toLowerCase().replace(/[^\p{L}\p{Nd}]+/gu, '');
+}
+
+/**
+ * Build a declension-tolerant prefix tsquery string from already-snapped stems:
+ *   ['окупован', 'нерухом'] → "окупован:* & нерухом:*"
+ * Stems are sanitised corpus prefixes (no user metacharacters), so they are safe to embed.
+ * Returns null when there is nothing usable (caller falls back to plainto_tsquery).
+ */
+export function buildPrefixTsquery(stems: string[]): string | null {
+  const parts = stems.map(s => sanitizeFtsToken(s)).filter(s => s.length >= 1);
+  if (parts.length === 0) return null;
+  return parts.map(s => `${s}:*`).join(' & ');
+}
+
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
@@ -243,6 +265,65 @@ export class EdsrFtsService {
   }
 
   /**
+   * Snap each query token to the LONGEST corpus stem present in edrsr_lexeme_df with
+   * prefix-df ≥ floor (LEXAI Cause-A.2). This is the data-driven fix for two coupled
+   * failures: (1) the 'simple' config has no Ukrainian stemmer, so an exact-form match
+   * ("окупована") misses the declined forms a decision actually uses ("окупованій",
+   * "нерухомості"); snapping to the stem ("окупован") + a `:*` prefix query restores
+   * recall. (2) colloquial junk / typos that have no corpus stem (or only a sub-floor
+   * one) snap to nothing and are dropped — choosing terms FROM the existing key list.
+   *
+   * Returns Map<sanitized-token, stem>. Tokens with no qualifying stem are absent (dropped).
+   * Floor mirrors the anchor floor: max(ANCHOR_DF_MIN_ABS, sampleDocs * ANCHOR_DF_FRACTION).
+   * Fail-safe: any error → empty map (caller keeps the plainto_tsquery path).
+   */
+  async snapTokensToStems(tokens: string[], dbPool: any): Promise<Map<string, string>> {
+    const out = new Map<string, string>();
+    const clean = [...new Set(tokens.map(sanitizeFtsToken).filter(t => t.length >= MIN_STEM_LEN))];
+    if (clean.length === 0) return out;
+    // Candidate prefixes per token: longest → shortest (we pick the longest that clears the
+    // floor). Bounded by [MIN_STEM_LEN, MAX_STEM_LEN] so very long words stay cheap.
+    const candidates: string[] = [];
+    for (const tok of clean) {
+      const top = Math.min(tok.length, MAX_STEM_LEN);
+      for (let len = top; len >= MIN_STEM_LEN; len--) candidates.push(tok.slice(0, len));
+    }
+    const uniqCandidates = [...new Set(candidates)];
+    try {
+      // Prefix-df for every candidate in one round-trip. The text_pattern_ops index
+      // (migration 166) turns each `lexeme LIKE cand||'%'` into an index range scan.
+      const res = await dbPool.query(
+        `SELECT u.cand AS cand,
+                (SELECT COALESCE(sum(df), 0) FROM edrsr_lexeme_df WHERE lexeme LIKE u.cand || '%') AS df
+         FROM unnest($1::text[]) AS u(cand)`,
+        [uniqCandidates],
+      );
+      let sampleDocs = 0;
+      const probe = await dbPool.query(`SELECT sample_docs FROM edrsr_lexeme_df LIMIT 1`);
+      sampleDocs = Number(probe.rows[0]?.sample_docs) || 0;
+      if (!sampleDocs) return out;  // table empty → no snap signal → plainto fallback
+      const floor = Math.max(ANCHOR_DF_MIN_ABS, Math.round(sampleDocs * ANCHOR_DF_FRACTION));
+      const dfByCand = new Map<string, number>();
+      for (const r of res.rows) dfByCand.set(r.cand, Number(r.df));
+      for (const tok of clean) {
+        const top = Math.min(tok.length, MAX_STEM_LEN);
+        // SHORTEST valid prefix wins: it is the most inflection-tolerant stem (e.g. "нерух"
+        // matches нерухоме/нерухомості/нерухомість), whereas the longest above-floor prefix
+        // ("нерухомість") would again miss other declensions. The floor blocks meaningless
+        // short n-grams that don't actually occur in the corpus.
+        for (let len = MIN_STEM_LEN; len <= top; len++) {
+          const cand = tok.slice(0, len);
+          if ((dfByCand.get(cand) ?? 0) >= floor) { out.set(tok, cand); break; }
+        }
+      }
+      return out;
+    } catch (err: any) {
+      logger.warn('[EdsrFtsService] snapTokensToStems failed; plainto fallback', { error: err.message });
+      return new Map();
+    }
+  }
+
+  /**
    * Full text search over edrsr_fulltext with optional metadata filters from edrsr_documents.
    *
    * Uses ts_rank_cd for relevance scoring and ts_headline for snippet generation.
@@ -255,15 +336,25 @@ export class EdsrFtsService {
     limit: number = 20,
     offset: number = 0,
     headlineQuery?: string,
+    topicalTsquery?: string,
   ): Promise<EdsrFtsSearchResponse> {
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const safeOffset = Math.max(offset, 0);
 
+    // LEXAI Cause-A.2: when the caller supplies a prebuilt prefix tsquery (vocabulary-snapped
+    // stems like "окупован:* & нерухом:*"), match/rank/highlight with to_tsquery so declined
+    // Ukrainian forms are caught. Without it, behaviour is the original plainto_tsquery path.
+    const useTsq = !!(topicalTsquery && topicalTsquery.trim());
+    const topicalArg = useTsq ? topicalTsquery!.trim() : query;
+    const topicalExpr = useTsq ? `to_tsquery('simple', $1)` : `plainto_tsquery('simple', $1)`;
+    // Distinct cache key per actual tsquery so prefix and plainto results never collide.
+    const cacheKey = useTsq ? `tsq:${topicalArg}` : query;
+
     // Check cache first
     if (this.edsrCache) {
-      const cached = await this.edsrCache.getCachedFtsResults(query, filters, safeLimit, safeOffset);
+      const cached = await this.edsrCache.getCachedFtsResults(cacheKey, filters, safeLimit, safeOffset);
       if (cached) {
-        logger.debug('[EdsrFtsService] Cache hit for FTS query', { query });
+        logger.debug('[EdsrFtsService] Cache hit for FTS query', { query: cacheKey });
         return cached;
       }
     }
@@ -278,8 +369,8 @@ export class EdsrFtsService {
     //   - party_name → phraseto_tsquery (contiguous phrase, declension-tolerant for
     //     quoted proper names which courts keep in nominative)
     //   - party_role → to_tsquery of enumerated role-noun case forms
-    const tsqueryParts: string[] = [`plainto_tsquery('simple', $${paramIdx})`];
-    params.push(query);
+    const tsqueryParts: string[] = [topicalExpr];   // $1 — plainto OR to_tsquery (see useTsq)
+    params.push(topicalArg);
     paramIdx++;
 
     const partyName = filters.party_name?.trim();
@@ -375,20 +466,28 @@ export class EdsrFtsService {
       ? `edrsr_fulltext f INNER JOIN edrsr_documents d ON d.doc_id = f.doc_id`
       : `edrsr_fulltext f`;
 
+    // Headline tsquery: a caller-supplied bare headlineQuery is plain text (plainto); otherwise
+    // it reuses $1, which is a prefix tsquery when useTsq → highlight via to_tsquery so the
+    // snippet centres on the same declined matches the search found.
+    const explicitHeadline = !!(headlineQuery && headlineQuery !== query);
+    const headlineFn = (useTsq && !explicitHeadline)
+      ? `to_tsquery('simple', $${headlineParamIdx})`
+      : `plainto_tsquery('simple', $${headlineParamIdx})`;
+
     const buildSelectFields = (withHeadline: boolean) => {
       const headlineExpr = withHeadline
-        ? `safe_ts_headline('simple'::regconfig, f.full_text, plainto_tsquery('simple', $${headlineParamIdx}),
+        ? `safe_ts_headline('simple'::regconfig, f.full_text, ${headlineFn},
            'MaxWords=${FTS_HEADLINE_MAX_WORDS}, MinWords=${FTS_HEADLINE_MIN_WORDS}, StartSel=**, StopSel=**') AS headline`
         : `NULL AS headline`;
 
       return hasMetadataFilter
         ? `f.doc_id,
-           ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
+           ts_rank_cd(f.tsv, ${topicalExpr}) AS rank,
            ${headlineExpr},
            d.adjudication_date, d.cause_num, d.judge, d.court_code,
            d.justice_kind, d.judgment_code`
         : `f.doc_id,
-           ts_rank_cd(f.tsv, plainto_tsquery('simple', $1)) AS rank,
+           ts_rank_cd(f.tsv, ${topicalExpr}) AS rank,
            ${headlineExpr}`;
     };
 
@@ -453,9 +552,9 @@ export class EdsrFtsService {
         })),
       };
 
-      // Cache the result
+      // Cache the result (keyed by the actual tsquery so prefix/plainto never collide)
       if (this.edsrCache) {
-        this.edsrCache.setCachedFtsResults(query, filters, safeLimit, safeOffset, response).catch(() => {});
+        this.edsrCache.setCachedFtsResults(cacheKey, filters, safeLimit, safeOffset, response).catch(() => {});
       }
 
       return response;

--- a/scripts/citation-graph/19_reranker_to_flagembedding.py
+++ b/scripts/citation-graph/19_reranker_to_flagembedding.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Convert the CORE-63 reranker triples into FlagEmbedding reranker-finetune format
+(CORE-64).
+
+Input  (reranker/ from 18_build_reranker_dataset.py):
+  corpus.jsonl                 {doc_id, text}
+  train.jsonl / dev.jsonl      {qid, doc_id, grade, label, source}
+
+Output (--out-dir):
+  ft_train.jsonl / ft_dev.jsonl   {query, pos: [text...], neg: [text...]}
+
+FlagEmbedding builds train groups of `train_group_size` passages (1 sampled pos
++ rest negs) per line, so each line needs >= 1 pos and enough negs. We cap pos
+per query (--max-pos) for balanced, bounded line sizes and keep all negatives
+(hard bge-m3 mistakes + random). Queries lacking a pos or a neg are dropped.
+
+Usage:
+  python3 19_reranker_to_flagembedding.py \
+      --in-dir output/eval500k/reranker --out-dir /data/reranker-train
+"""
+
+import argparse
+import json
+import logging
+import random
+from collections import defaultdict
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s [%(levelname)s] %(message)s", datefmt="%H:%M:%S")
+log = logging.getLogger("ft-convert")
+SEED = 42
+
+
+def load_corpus(path):
+    corpus = {}
+    with open(path) as f:
+        for line in f:
+            r = json.loads(line)
+            corpus[r["doc_id"]] = r["text"]
+    log.info("corpus: %d docs", len(corpus))
+    return corpus
+
+
+def convert(split_path, corpus, out_path, max_pos, max_neg, rng):
+    groups = defaultdict(lambda: {"pos": [], "neg": []})
+    with open(split_path) as f:
+        for line in f:
+            r = json.loads(line)
+            groups[r["qid"]]["pos" if r["label"] == 1 else "neg"].append(r["doc_id"])
+    kept, drop_nopos, drop_noneg, miss = 0, 0, 0, 0
+    with open(out_path, "w") as out:
+        for qid, g in groups.items():
+            if qid not in corpus:
+                miss += 1
+                continue
+            pos_ids, neg_ids = g["pos"], g["neg"]
+            if not pos_ids:
+                drop_nopos += 1
+                continue
+            if not neg_ids:
+                drop_noneg += 1
+                continue
+            rng.shuffle(pos_ids)
+            pos = [corpus[d] for d in pos_ids[:max_pos] if d in corpus]
+            neg = [corpus[d] for d in neg_ids[:max_neg] if d in corpus]
+            if not pos or not neg:
+                continue
+            out.write(json.dumps({"query": corpus[qid], "pos": pos, "neg": neg},
+                                 ensure_ascii=False) + "\n")
+            kept += 1
+    log.info("%s -> %s: kept=%d (drop no-pos=%d no-neg=%d miss-query=%d)",
+             split_path.name, out_path.name, kept, drop_nopos, drop_noneg, miss)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--in-dir", default="output/eval500k/reranker")
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--max-pos", type=int, default=15)
+    ap.add_argument("--max-neg", type=int, default=50)
+    args = ap.parse_args()
+
+    in_dir, out_dir = Path(args.in_dir), Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(SEED)
+    corpus = load_corpus(in_dir / "corpus.jsonl")
+    for split, out in (("train", "ft_train.jsonl"), ("dev", "ft_dev.jsonl")):
+        convert(in_dir / f"{split}.jsonl", corpus, out_dir / out,
+                args.max_pos, args.max_neg, rng)
+    log.info("DONE -> %s", out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/20_finetune_reranker.sh
+++ b/scripts/citation-graph/20_finetune_reranker.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Finetune bge-reranker-v2-m3 on the EVAL-500K citation-graph reranker set (CORE-64).
+# Cross-encoder over (query decision, candidate decision); trains on Brev H100s,
+# avoiding GPUs 0,1 (qdrant-gpu). Run inside tmux.
+#
+#   bash 20_finetune_reranker.sh
+set -euo pipefail
+
+DATA_DIR=${DATA_DIR:-/data/reranker-train}
+OUT_DIR=${OUT_DIR:-$DATA_DIR/bge-reranker-v2-m3-ua-ft}
+BASE=${BASE:-BAAI/bge-reranker-v2-m3}
+GPUS=${GPUS:-2,3,4,5,6,7}
+NPROC=$(echo "$GPUS" | tr ',' '\n' | wc -l)
+
+# MLflow (workstation.lex); falls back to no reporting if unreachable.
+export MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI:-http://workstation.lex:5000}
+export MLFLOW_EXPERIMENT_NAME=${MLFLOW_EXPERIMENT_NAME:-reranker-finetune}
+REPORT_TO=${REPORT_TO:-mlflow}
+
+export CUDA_VISIBLE_DEVICES=$GPUS
+export TOKENIZERS_PARALLELISM=false
+
+echo "[$(date '+%F %T')] base=$BASE gpus=$GPUS nproc=$NPROC out=$OUT_DIR report=$REPORT_TO"
+
+python3 -m torch.distributed.run --nproc_per_node "$NPROC" \
+  -m FlagEmbedding.finetune.reranker.encoder_only.base \
+  --model_name_or_path "$BASE" \
+  --train_data "$DATA_DIR/ft_train.jsonl" \
+  --output_dir "$OUT_DIR" \
+  --overwrite_output_dir \
+  --train_group_size 8 \
+  --query_max_len 512 \
+  --passage_max_len 1024 \
+  --knowledge_distillation False \
+  --learning_rate 6e-5 \
+  --num_train_epochs ${EPOCHS:-5} \
+  --per_device_train_batch_size 4 \
+  --gradient_accumulation_steps ${GRAD_ACCUM:-1} \
+  --dataloader_drop_last True \
+  --warmup_ratio 0.1 \
+  --lr_scheduler_type cosine \
+  --bf16 \
+  --logging_steps 20 \
+  --save_steps ${SAVE_STEPS:-200} \
+  --save_total_limit 3 \
+  --report_to "$REPORT_TO" \
+  --project reranker-finetune
+
+echo "[$(date '+%F %T')] TRAINING DONE -> $OUT_DIR"


### PR DESCRIPTION
## CORE-64 — finetune the domain cross-encoder reranker

- `19_reranker_to_flagembedding.py` — converts CORE-63 triples + corpus into FlagEmbedding `{query, pos, neg}` (2399 train / 299 dev queries, 0 dropped).
- `20_finetune_reranker.sh` — finetunes `bge-reranker-v2-m3` on Brev H100 (GPUs 2-7, bf16 DDP, group_size 8, query≤512/passage≤1024, 5 epochs, lr 6e-5 cosine), MLflow → workstation.lex, experiment `reranker-finetune`.

Base = bge-reranker-v2-m3 (same XLM-R family as the prod bge-m3 bi-encoder). Trains the reranker to sink the grade-0 hard negatives that bge-m3 currently ranks high.

Next: CORE-65 offline eval (nDCG@10/MRR on the held-out test split) vs the bge-m3 baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a finetuning pipeline for the `bge-reranker-v2-m3` cross-encoder to improve re-ranking on our domain (CORE-64). Also fixes FTS recall for Ukrainian declensions by snapping tokens to corpus stems and using a prefix tsquery.

- New Features
  - Converter to `FlagEmbedding` format from CORE‑63 triples (`{query, pos, neg}`) with train/dev outputs.
  - Training launcher to finetune `bge-reranker-v2-m3` (bf16 DDP, group size 8, H100s, optional MLflow reporting) on the citation-graph set.

- Bug Fixes
  - FTS: sanitize tokens, snap to corpus stems (`edrsr_lexeme_df`), and search/rank/headline via prefix `to_tsquery`; automatic fallback to `plainto_tsquery`.
  - Distinct cache keys for prefix vs plainto queries; relaxation probes operate on stems.
  - Migration: add `edrsr_lexeme_df_lexeme_prefix` index (`text_pattern_ops`) for fast prefix-DF lookups; tests cover sanitization, tsquery build, snapping, and fail-safes.

<sup>Written for commit 546140300fa6234355f02d5d6d09d1b29b161a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

