### PR TITLE
fix(edrsr-search): hybrid fallback when relevance gate empties FTS hits (Cause-C)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -505,6 +505,18 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       const enriched = await this.enrichResults(result.results);
       const output = await this.maybeFilter(enriched, fts.usedQuery);
 
+      // LEXAI Cause-C: FTS matched lexically (result.total > 0) but the relevance gate
+      // dropped EVERYTHING — the AND of the model's keywords landed in a topically-wrong
+      // cluster (e.g. "переміщені/внутрішньо" → IDP cases instead of the real-estate-tax
+      // line). Lexical co-occurrence can't recover here; fall back to the semantic-bearing
+      // hybrid leg, which ranks by meaning. Guard against re-entry via _fallback_from.
+      if (output.filtered.length === 0 && result.total > 0 && this.vectorizer && !args._fallback_from) {
+        logger.info('[EdsrUnifiedSearch] fulltext gate emptied results, falling back to hybrid', {
+          query: originalQuery, fts_total: result.total, fts_query: fts.usedQuery,
+        });
+        return this.searchHybrid({ ...args, query: originalQuery, _fallback_from: 'fulltext_gate' });
+      }
+
       return this.wrapResponse({
         mode: 'fulltext', ...result,
         ...(fts.usedTokens < fts.startTokens ? { query_truncated: { from_tokens: fts.startTokens, used: fts.usedQuery } } : {}),


### PR DESCRIPTION
## Проблема
`searchFulltext` падал на hybrid только при `result.total === 0`. Но когда AND-ключи LLM матчатся лексически, но попадают в **топически-чужой кластер** (`переміщені/внутрішньо` → дела про ВПО/пенсии вместо линии «податок на нерухомість на ТОТ»), FTS возвращает N>0 строк, которые **relevance-gate затем обнуляет** — а фолбэка нет. Чат не получал дел и **выдумывал цитаты** (160/23621/21, 200/1185/21).

Подтверждено прогоном после PR #2025+#2027: норма (38.6) и правовой вывод стали верными, но грунтовка делами — всё ещё ложная (эталон 280/5185/19 не извлекался).

## Фикс
Пост-gate фолбэк: если gate обнулил непустой FTS-результат (`output.filtered.length === 0 && result.total > 0`) и есть vectorizer → retry через `searchHybrid`. Семантическая нога (BGE-M3) ранжирует по смыслу и достаёт нужные прецеденты (280/5185/19 — rank 1 при ручной проверке) независимо от выбора слов LLM. Защита от повторного входа через `_fallback_from`.

## Тесты
`edrsr-unified-search-tool.test.ts` имеет **15 предсуществующих падений на main** (устаревшие моки; идентичны до и после правки — проверено git stash). Не трогаю в этом PR (вне скоупа). Логика хелперов покрыта `edrsr-fts-term-selection.test.ts` (22/22).

## Связь
Завершает серию Cause-A.1 (#2025, junk demotion) → Cause-A.2 (#2027, prefix-stem snap, чинит склонения/норму) → **Cause-C (этот, чинит грунтовку делами)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a semantic-hybrid fallback when the relevance gate drops all items from a non-empty full‑text search. This prevents empty results and fake citations when keywords match lexically but land in the wrong topical cluster.

- **Bug Fixes**
  - If `output.filtered.length === 0 && result.total > 0` and a vectorizer exists, retry via `searchHybrid` with the original query.
  - Guard re-entry with `_fallback_from` to avoid loops.

<sup>Written for commit 5364e1721c24fab656aaf05a7448758a5f9b1cc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

