### PR TITLE
fix(edrsr-fts): LLM-reformulate query in fulltext mode (v1-style term rewrite)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -469,9 +469,20 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       const partyName = typeof args.party_name === 'string' ? args.party_name.trim() : undefined;
       const partyRole = args.party_role as EdsrFtsFilters['party_role'] | undefined;
 
+      // LLM term-rewrite (v1-style): a verbose natural-language question split on whitespace
+      // becomes a long all-AND tsquery that the stemless 'simple' config can't satisfy → 0 hits.
+      // Reuse QueryReformulator.fts (already used by the hybrid/semantic legs) to distil the
+      // question into key legal terms BEFORE relaxation, so the AND probe starts from real
+      // anchors, not function words. originalQuery is kept for the headline and hybrid fallback.
+      // Fail-safe: reformulator off/erroring → originalQuery (no regression).
+      const reformulated = this.queryReformulator
+        ? await this.queryReformulator.reformulate(originalQuery).catch(() => null)
+        : null;
+      const ftsQuery = reformulated?.fts || originalQuery;
+
       // Term-budget search: cap to the leading tokens and relax downward on an empty hit.
       let fts = await this.ftsWithRelaxation(
-        originalQuery,
+        ftsQuery,
         { ...baseFilters, party_name: partyName || undefined, party_role: partyRole },
         args.limit || 20, args.offset || 0,
       );
@@ -487,7 +498,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
           party_name: partyName, party_role: partyRole,
         });
         fts = await this.ftsWithRelaxation(
-          originalQuery, { ...baseFilters, party_name: partyName },
+          ftsQuery, { ...baseFilters, party_name: partyName },
           args.limit || 20, args.offset || 0,
         );
         result = fts.result;
@@ -522,6 +533,7 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
         ...(fts.usedTokens < fts.startTokens ? { query_truncated: { from_tokens: fts.startTokens, used: fts.usedQuery } } : {}),
         ...(fts.relaxedFromTokens ? { term_relaxed: { from_tokens: fts.relaxedFromTokens, to_tokens: fts.usedTokens } } : {}),
         ...(partyRoleRelaxed ? { party_role_relaxed: true } : {}),
+        ...(reformulated && ftsQuery !== originalQuery ? { reformulated: { fts: reformulated.fts } } : {}),
         results: output.filtered,
         ...(output.original_count !== output.filtered_count
           ? { relevance_filter: { from: output.original_count, to: output.filtered_count } }


### PR DESCRIPTION
## Проблема

v3 `mode=fulltext` ничего не находит на verbose-вопросах. Причина: в `searchFulltext` сырой вопрос пользователя уходил прямо в `ftsWithRelaxation`, где он бьётся по пробелам в длинный all-AND `to_tsquery`. Stemless 'simple'-конфиг такой конъюнкцию из словоформ + служебных слов удовлетворить не может → 0 результатов, и релаксация (срез хвоста) не спасает.

## Решение (подход из secondlayer-core v1)

Переиспользуем уже существующий `QueryReformulator.fts` — LLM-перевод вопроса в ключевые юридические термины. Он **уже** подключён в hybrid и semantic путях, но не в чистом fulltext. Теперь:

- перед релаксацией прогоняем `originalQuery` через reformulator → `ftsQuery = reformulated.fts || originalQuery`;
- AND-проба стартует с реальных анкоров, а не со служебных слов;
- `originalQuery` сохраняется для headline и hybrid-fallback;
- fail-safe: reformulator выключен/упал → `originalQuery` (без регрессии);
- зеркалит hybrid-leg один-в-один; в ответ добавлен `reformulated.fts` для наблюдаемости.

Это связка идеи v1 (LLM пишет термины) с текущим IDF/stem-snap конвейером: LLM даёт чистые термины → `selectFtsTerms`/`snapTokensToStems` ранжируют и снапят их к корпусным стемам.

## Проверка
- `tsc`: затронутый файл чист (3 ошибки `core-loader` — предсуществующие, из проприетарного secondlayer-core, не в этом чекауте).
- `edrsr-fts-term-selection.test.ts`: 22/22 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-result full-text searches on verbose questions by rewriting the query into key legal terms before relaxation. Mirrors the hybrid/semantic path and falls back to the original query if reformulation fails.

- **Bug Fixes**
  - Run `originalQuery` through `QueryReformulator.fts` and use it for `ftsWithRelaxation` (including the party-role relaxation pass).
  - Keep `originalQuery` for headlines and hybrid fallback; fail-safe to it if reformulation errors or is disabled.
  - Include `reformulated.fts` in the response when used for observability.

<sup>Written for commit 71a290329a78e1ac63900c797b0d114e7eed89eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

