### PR TITLE
fix(edrsr-fts): cap candidates before ranking + statement-timeout guard

### DIFF
--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -203,6 +203,21 @@ export function buildPrefixTsquery(stems: string[]): string | null {
   return parts.map(s => `${s}:*`).join(' & ');
 }
 
+// Cap-before-rank (LEXAI FTS perf). `ORDER BY ts_rank_cd(...) DESC` forces Postgres to
+// compute the rank of EVERY matching row before it can take the top N. For broad topical
+// prefix queries (податок:* & нерухом:* …) the match set is millions of rows across the
+// year partitions, so ranking alone runs >40s and the tool hits its 120s ceiling. Instead
+// we cap the candidate set with a cheap GIN-only scan (WHERE tsv @@ q LIMIT N), then rank
+// only those — measured 412ms vs >35s on prod. Narrow queries (party/metadata, < cap
+// matches) are unaffected: ranking the full match set and ranking the capped set are
+// identical when the match set already fits under the cap.
+const FTS_CANDIDATE_CAP = 2000;
+// Belt-and-suspenders: even the capped rank could be pathological. A per-statement timeout
+// caps the worst case; on timeout we return EMPTY so the caller's relax/hybrid fallback
+// takes over instead of surfacing an error (the FTS leg returning 0 → hybrid is an
+// already-supported path). Must comfortably clear the capped query (sub-second on prod).
+const FTS_STATEMENT_TIMEOUT_MS = 8000;
+
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
@@ -491,18 +506,57 @@ export class EdsrFtsService {
            ${headlineExpr}`;
     };
 
+    // Run the data query under a per-statement timeout (B). SET LOCAL needs a transaction,
+    // so use a dedicated client when the pool exposes connect(); otherwise fall back to a
+    // plain pooled query (timeout-less) so non-pg pool wrappers still work.
+    const queryWithTimeout = async (sql: string, args: any[]) => {
+      if (typeof dbPool.connect !== 'function') {
+        return dbPool.query(sql, args);
+      }
+      const client = await dbPool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query(`SET LOCAL statement_timeout = ${FTS_STATEMENT_TIMEOUT_MS}`);
+        const res = await client.query(sql, args);
+        await client.query('COMMIT');
+        return res;
+      } catch (e) {
+        try { await client.query('ROLLBACK'); } catch { /* ignore rollback failure */ }
+        throw e;
+      } finally {
+        client.release();
+      }
+    };
+
     const executeQuery = async (withHeadline: boolean) => {
       const selectFields = buildSelectFields(withHeadline);
 
+      // Cap-before-rank (A): a MATERIALIZED CTE pins a bounded candidate set via a cheap
+      // GIN-only scan (WHERE tsv @@ q LIMIT cap, no rank/headline), then rank/highlight only
+      // those. AS MATERIALIZED stops the planner from inlining the cap back into the ranked
+      // scan. The metadata JOIN (when present) lives in the CTE so its filters bound the
+      // candidates; the outer JOIN re-fetches d.* for the returned rows only.
+      const outerFrom = hasMetadataFilter
+        ? `edrsr_fulltext f
+           JOIN cand ON cand.doc_id = f.doc_id
+           JOIN edrsr_documents d ON d.doc_id = f.doc_id`
+        : `edrsr_fulltext f
+           JOIN cand ON cand.doc_id = f.doc_id`;
+
       // Skip expensive COUNT(*) — use LIMIT+1 to detect has_more instead
       const dataSql = `
+        WITH cand AS MATERIALIZED (
+          SELECT f.doc_id
+          FROM ${fromClause}${extraJoin}
+          WHERE ${whereClause}
+          LIMIT ${FTS_CANDIDATE_CAP}
+        )
         SELECT ${selectFields}
-        FROM ${fromClause}${extraJoin}
-        WHERE ${whereClause}
+        FROM ${outerFrom}
         ORDER BY ${EDRSR_FTS_SEARCH_ORDER}
         LIMIT $${paramIdx} OFFSET $${paramIdx + 1}`;
 
-      const dataResult = await dbPool.query(dataSql, [...params, safeLimit + 1, safeOffset]);
+      const dataResult = await queryWithTimeout(dataSql, [...params, safeLimit + 1, safeOffset]);
       const total = dataResult.rows.length > safeLimit ? safeLimit * 10 : dataResult.rows.length;
       if (dataResult.rows.length > safeLimit) {
         dataResult.rows = dataResult.rows.slice(0, safeLimit);
@@ -521,6 +575,15 @@ export class EdsrFtsService {
         if (headlineErr.code === '22021') {
           logger.warn('[EdsrFtsService] Retrying without ts_headline due to encoding error', { query });
           ({ total, dataResult } = await executeQuery(false));
+        } else if (headlineErr.code === '57014') {
+          // Statement timeout (B): even the candidate-capped rank blew the budget. Return
+          // empty so the caller's relax/hybrid fallback (FTS-0 → hybrid) takes over instead
+          // of erroring out to the user.
+          logger.warn('[EdsrFtsService] FTS statement timeout; returning empty for fallback', {
+            query: cacheKey, timeoutMs: FTS_STATEMENT_TIMEOUT_MS,
+          });
+          total = 0;
+          dataResult = { rows: [] };
         } else {
           throw headlineErr;
         }


### PR DESCRIPTION
## Проблема (реальный прод-инцидент)

Запрос в чате (податок на нерухомість на окупованій території + ВПО + ДРРП + позиція ВС) → **`Час очікування вичерпано`**.

Трассировка логов прода (`chat-881e8f45`): chat-пайплайн веером шлёт несколько `search_court_decisions` параллельными парами; каждый упирается в свой потолок **120с**; бюджет чата 240с исчерпывается за ~2 раунда → `ChatService Request timed out`.

## Root cause

`EDRSR_FTS_SEARCH_ORDER = 'rank DESC'` → запрос `... ORDER BY ts_rank_cd(tsv, q) DESC LIMIT 10`. Чтобы отсортировать, Postgres обязан вычислить `ts_rank_cd` для **каждой** совпавшей строки. Для широких prefix-терминов (`податок:*`, `територ:*`, `окупован:*` — каждый матчит миллионы рішень по year-партициям) ранжирование всего match-set'а идёт **>40с** (подтверждено: `EXPLAIN ANALYZE` не уложился в 40с). Relaxation-цикл при разреженных результатах ещё и расширяет запрос → match-set больше → медленнее.

Сам матч по GIN — быстрый; медленное именно ранжирование.

## Фикс

**A. Cap-before-rank** — `WITH cand AS MATERIALIZED (SELECT doc_id … WHERE tsv @@ q LIMIT 2000)`, затем `ts_rank_cd`/`ts_headline` только по кандидатам. Замер на проде: **>35с → 412мс**. Узкие запросы (party/metadata, < cap совпадений) не затронуты — ранжирование полного и capped-набора идентично, когда match-set и так меньше cap.

**B. Statement-timeout-гард** — data-запрос под `SET LOCAL statement_timeout = 8s` на выделенном клиенте; на `57014` сервис возвращает **пусто**, и срабатывает уже существующий фолбэк (FTS-0 → hybrid), а не ошибка пользователю. Пулы без `connect()` падают на обычный `dbPool.query` (без регрессии).

## Трейд-офф (заложен честно)

Топ-10 берётся из первых ~2000 кандидатов (порядок выдачи GIN, не глобальный rank). Для широких запросов это норм; точную релевантность в hybrid даёт вектор-лега. cap=2000 при необходимости легко поднять.

## Проверка
- `tsc`: затронутый файл чист (3 ошибки `core-loader` — предсуществующие, проприетарный core не в чекауте).
- `edrsr-fts-service.test.ts` + `edrsr-fts-term-selection.test.ts`: **34/34 passed**.
- Форма capped-запроса валидирована на проде через `EXPLAIN ANALYZE` (412мс).

Не меняем индексы: «общий GIN» проблему не решает (узкое место — ранжирование, не индексный поиск; partitioned table = GIN на партицию by design). RUM-индекс мог бы ранжировать из индекса, но это многочасовая сборка на 100M строк при том, что cap-before-rank уже даёт 412мс при нулевой инфра-цене.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented chat timeouts from broad EDRSR FTS queries by capping candidates before ranking and adding a per-statement timeout. Broad queries drop from >35s to ~412ms; narrow queries are unchanged.

- **Bug Fixes**
  - Cap-before-rank: use a MATERIALIZED CTE to LIMIT candidates to 2000 via GIN, then run `ts_rank_cd`/`ts_headline` only on those; measured ~412ms on prod for wide prefix queries.
  - Statement-timeout guard: run the data query under `SET LOCAL statement_timeout = 8s`; on `57014` return empty so the existing relax/hybrid fallback kicks in; falls back to plain pooled query if `connect()` isn’t available.
  - Trade-off: top results come from the first ~2000 GIN-ordered candidates; acceptable for broad queries and adjustable via the cap.

<sup>Written for commit 86a7a187cb90391d2bf23d1a618d7da5c29696a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

