### PR TITLE
fix(edrsr-search): honour instance/court_level filter on the vector leg

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -104,6 +104,27 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
     this.queryReformulator = reformulator;
   }
 
+  // instance_code → court_code[] (cached; instances are static). The vector leg can only filter
+  // by court_code (no instance_code in the Qdrant payload), so an instance/court_level filter is
+  // translated to its set of court_codes before being pushed to the vector leg. Fail-safe: on a
+  // DB error returns [] so the caller skips the vector court filter (no crash, just unfiltered).
+  private readonly instanceCourtCodeCache = new Map<number, number[]>();
+  private async resolveInstanceCourtCodes(instanceCode: number): Promise<number[]> {
+    const cached = this.instanceCourtCodeCache.get(instanceCode);
+    if (cached) return cached;
+    try {
+      const res = await this.db.query(
+        `SELECT court_code FROM edrsr_courts WHERE instance_code = $1`, [instanceCode],
+      );
+      const codes = res.rows.map((r: any) => Number(r.court_code)).filter((n: number) => Number.isFinite(n));
+      if (codes.length > 0) this.instanceCourtCodeCache.set(instanceCode, codes);
+      return codes;
+    } catch (err: any) {
+      logger.warn('[EdsrUnifiedSearch] resolveInstanceCourtCodes failed', { instanceCode, error: err.message });
+      return [];
+    }
+  }
+
   getToolDefinitions(): ToolDefinition[] {
     return [{
       name: 'search_court_decisions',
@@ -609,6 +630,15 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       date_to: args.date_to,
     };
 
+    // Translate an instance/court_level filter to a court_code set the vector leg CAN enforce
+    // (instance_code is not in the Qdrant payload). Without this the vector candidates all fail
+    // the post-fusion instance re-check and instance-filtered hybrid searches collapse to the
+    // FTS leg alone. Only when the model didn't pin a single court_code.
+    if (instanceCode && !args.court_code) {
+      const instanceCourtCodes = await this.resolveInstanceCourtCodes(instanceCode);
+      if (instanceCourtCodes.length > 0) vectorFilters.court_codes = instanceCourtCodes;
+    }
+
     const vectorPromise = (this.vectorizer && hasVectors)
       ? this.vectorizer.semanticSearch(semanticQuery, vectorFilters, candidateLimit)
           .catch((err: any) => { logger.warn('[EdsrUnifiedSearch] Qdrant leg failed', { error: err.message }); return null; })
@@ -720,6 +750,14 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
         court_code: args.court_code, justice_kind: justiceKind,
         judge: args.judge, date_from: args.date_from, date_to: args.date_to,
       };
+      // Push an instance/court_level filter onto the vector leg as a court_code set (see
+      // searchHybrid / resolveInstanceCourtCodes): instance_code is not in the Qdrant payload,
+      // so otherwise every semantic hit is dropped by the post-fusion instance re-check.
+      const semInstanceCode = args.instance_code ? Number(args.instance_code) : undefined;
+      if (semInstanceCode && !args.court_code) {
+        const instanceCourtCodes = await this.resolveInstanceCourtCodes(semInstanceCode);
+        if (instanceCourtCodes.length > 0) filters.court_codes = instanceCourtCodes;
+      }
 
       const reformulated = this.queryReformulator
         ? await this.queryReformulator.reformulate(args.query).catch(() => null)

--- a/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-vectorizer-service.test.ts
@@ -199,5 +199,21 @@ describe('EdsrVectorizerService', () => {
       await service.semanticSearch('тест');
       expect(filterMust().find((c) => c.key === 'justice_kind')).toBeUndefined();
     });
+
+    it('pushes court_codes as a match-any on court_code (instance/court_level → vector leg)', async () => {
+      const service = new EdsrVectorizerService();
+      await service.semanticSearch('тест', { court_codes: [9901, 9911, '9921' as unknown as number] });
+      const cc = filterMust().find((c) => c.key === 'court_code');
+      expect(cc).toBeDefined();
+      expect(cc.match.any).toEqual([9901, 9911, 9921]); // coerced to integers for the index
+    });
+
+    it('prefers a single court_code over court_codes when both are set', async () => {
+      const service = new EdsrVectorizerService();
+      await service.semanticSearch('тест', { court_code: 9931, court_codes: [9901, 9911] });
+      const cc = filterMust().find((c) => c.key === 'court_code');
+      expect(cc.match.value).toBe(9931);
+      expect(cc.match.any).toBeUndefined();
+    });
   });
 });

--- a/mcp_backend/src/services/edrsr-vectorizer-service.ts
+++ b/mcp_backend/src/services/edrsr-vectorizer-service.ts
@@ -81,6 +81,12 @@ export interface EdrsrSearchResult {
 
 export interface EdrsrSearchFilters {
   court_code?: number;
+  // Multi-court constraint (match-any on the court_code payload index). Used to push an
+  // instance/court_level filter onto the vector leg: instance_code is NOT in the Qdrant payload,
+  // but court_code is — so an instance filter is translated to its set of court_codes. Without
+  // this the vector leg can't honour a court/instance filter and every vector candidate is
+  // dropped by the post-fusion instance re-check, collapsing instance-filtered searches.
+  court_codes?: number[];
   justice_kind?: number;
   date_from?: string;
   date_to?: string;
@@ -396,6 +402,10 @@ export class EdsrVectorizerService {
     // though the code exists. Coerce to Number so the integer index actually matches.
     if (filters?.court_code) {
       must.push({ key: 'court_code', match: { value: Number(filters.court_code) } });
+    } else if (filters?.court_codes?.length) {
+      // match-any over the court_code integer index (e.g. all cassation courts for an
+      // instance/court_level filter). Single court_code wins if both are somehow set.
+      must.push({ key: 'court_code', match: { any: filters.court_codes.map(Number) } });
     }
 
     if (filters?.justice_kind) {


### PR DESCRIPTION
## Проблема (выявлена при оценке PR #70)

Фильтр по инстанции/`court_level` (напр. `court_level=SC` → `instance_code=1`) **схлопывал** hybrid/semantic-поиск. Eval на 10 разных ВС-запросах: civil3% **8→1**, property **6→2**, limitation 7→3 — при том, что у ВС по теме сотни решений (civil3%: пул ≥500).

## Root cause

`instance_code` **нет в Qdrant payload** → вектор-лега не может по нему фильтровать → **все** вектор-кандидаты отсекаются post-fusion instance-проверкой (semantic+SC: 60 кандидатов → 0 выживает). Hybrid вырождается в **FTS-only**, а FTS-лега недовыбирает (all-AND) — компенсировать некому.

## Фикс (общий, не под кейс)

`court_code` **в payload есть**, инстанция = фиксированное множество court_code. Транслируем instance-фильтр в `court_code match-any` для вектор-леги:
- `EdrsrSearchFilters.court_codes?: number[]` → Qdrant `match:{any:[...]}` (court_code уже индексирован).
- Тул резолвит `instance_code → court_code[]` (кэш, fail-safe) и ставит на вектор-фильтры в **hybrid** и **semantic**, если модель не зафиксировала единичный court_code.

## Проверка

- На живом Qdrant: фильтр `court_code ∈ ВС` для civil3% возвращает **190 ВС-документов** в топ-200 (против 0, выживавших раньше). Механизм topic-agnostic.
- tsc чисто; `edrsr-vectorizer-service` тесты **19/19** (вкл. 2 новых).

## Связь

Общий фикс recall для instance-фильтрованного вектор-поиска. Убирает схлопывание, блокировавшее планировщик-фикс `court_level=SC` (secondlayer-core PR #70) — после него PR #70 можно безопасно мержить. С перф-фиксом #2031 (cap-before-rank) складывается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
