### PR TITLE
fix(grounding-eval): normalize case-number suffix to kill false fabricated

### DIFF
--- a/scripts/testing/grounding-eval.ts
+++ b/scripts/testing/grounding-eval.ts
@@ -43,6 +43,16 @@ const PSQL_ARGV: string[] = process.env.GROUNDING_PSQL
 // Ukrainian case-number format: 826/11557/18, 640/329/20, 2-97/2011, 755/15457/14-ц
 const CASE_RE = /\b\d{1,4}-?\d{0,5}\/\d{2,6}(?:\/\d{2})?(?:-[а-яіїєґ]+)?\b/gi;
 
+// Real jurisdiction suffixes present in edrsr_documents.cause_num (proceeding type:
+// -ц цивільне, -к, -п, -а адмін, …). The model frequently drops the suffix in prose
+// while the registry keeps it; we expand cited bases by these to keep the existence
+// match index-free-friendly (pure equality IN). Ordered by registry frequency; the
+// long tail is negligible. Keep in sync with stripSuffix's '-[а-яіїєґ]+$'.
+const CASE_SUFFIXES = [
+  'ц', 'к', 'п', 'а', 'г', 'б', 'ад', 'кп', 'кр', 'цр', 'кс', 'пд', 'нр',
+  'н', 'в', 'й', 'у', 'вх', 'с', 'ск', 'о', 'е', 'ар', 'пн', 'з', 'нм', 'т',
+];
+
 // short stoplist for auto topic-term derivation (function words / boilerplate)
 const STOP = new Set(['яка','який','яке','щодо','після','цьому','такому','разі','коли','якщо','при','для','про','над','під','між','або','осіб','особи','має','мають','наприклад','необхідності','вказує','написала','питання','позиція','верховного','суду']);
 
@@ -54,6 +64,11 @@ function psql(sql: string): string[] {
   return out.split('\n').filter(Boolean);
 }
 const esc = (s: string) => s.replace(/'/g, "''");
+// Court case numbers carry an optional jurisdiction suffix (-а адмін / -ц цивільн /
+// -к etc.). The model often drops it in prose ("802/436/17") while the registry
+// stores it ("802/436/17-а"), so match on the suffix-stripped base to avoid false
+// "fabricated" flags. Mirror this exact strip in the SQL (regexp_replace below).
+const stripSuffix = (c: string) => c.replace(/-[а-яіїєґ]+$/i, '');
 const meta = (r: any) => ({ queryIdx: r.queryIdx, variant: r.variant, label: `q${r.queryIdx ?? '?'}:${r.variant ?? '?'}` });
 
 function deriveTopics(query: string): string[] {
@@ -80,28 +95,43 @@ for (const r of runs) {
   const provided = topicsMap[String(r.queryIdx)];
   const topics = (provided && provided.length) ? provided : deriveTopics(r.query || '');
 
-  // one SQL per answer: existence + per-term presence across the cited cases
-  const inList = cases.map(c => `'${esc(c)}'`).join(',');
+  // one SQL per answer: existence + per-term presence across the cited cases.
+  // Match on the suffix-stripped base (see stripSuffix) so a cited "802/436/17"
+  // still resolves the registry's "802/436/17-а". edrsr_documents has NO index on
+  // cause_num (partitioned → parallel seq scan), so the WHERE must stay pure
+  // equality: a regexp_replace() in WHERE runs over all ~110M rows and times out.
+  // Instead we expand each base into base + every real jurisdiction suffix and
+  // keep an equality IN-list; the regexp_replace base-grouping then runs only over
+  // the handful of matched rows (cheap) in SELECT/GROUP BY.
+  const bases = Array.from(new Set(cases.map(stripSuffix)));
+  const matchValues = Array.from(new Set([
+    ...cases,                                              // as cited (suffix kept)
+    ...bases,                                              // base (registry has no suffix)
+    ...bases.flatMap(b => CASE_SUFFIXES.map(s => `${b}-${s}`)), // base + each real suffix
+  ]));
+  const inList = matchValues.map(c => `'${esc(c)}'`).join(',');
   const termCols = topics.map((t, i) => `BOOL_OR(f.full_text ILIKE '%${esc(t)}%') AS t${i}`).join(', ');
-  const sql = `SELECT d.cause_num, COUNT(DISTINCT d.doc_id) AS docs${termCols ? ', ' + termCols : ''}
+  const sql = `SELECT regexp_replace(d.cause_num, '-[а-яіїєґ]+$', '', 'i') AS base_num,
+      COUNT(DISTINCT d.doc_id) AS docs${termCols ? ', ' + termCols : ''}
     FROM edrsr_documents d LEFT JOIN edrsr_fulltext f USING(doc_id)
-    WHERE d.cause_num IN (${inList}) GROUP BY d.cause_num;`;
+    WHERE d.cause_num IN (${inList}) GROUP BY base_num;`;
 
   let rows: string[] = [];
   try { rows = psql(sql); } catch (e: any) { console.error(`psql failed for ${meta(r).label}: ${e.message}`); }
 
-  // psql -t -A default field separator is '|'
+  // psql -t -A default field separator is '|'; key is the suffix-stripped base_num
   const found = new Map<string, boolean[]>();
   for (const line of rows) {
     const cols = line.split('|');
-    const cause = cols[0];
+    const base = cols[0];
     const terms = topics.map((_, i) => (cols[2 + i] || '').trim() === 't');
-    found.set(cause, terms);
+    found.set(base, terms);
   }
 
   const perCase = cases.map(c => {
-    const exists = found.has(c);
-    const termHits = exists ? found.get(c)!.filter(Boolean).length : 0;
+    const base = stripSuffix(c);
+    const exists = found.has(base);
+    const termHits = exists ? found.get(base)!.filter(Boolean).length : 0;
     const onTopic = exists && termHits >= ON_TOPIC_MIN;
     return { case: c, exists, termHits, onTopic };
   });


### PR DESCRIPTION
## Problem

`scripts/testing/grounding-eval.ts` extracts cited court-case numbers from chat answers and checks each against the EDRSR registry (EXISTS + ON-TOPIC). Ukrainian case numbers carry an optional jurisdiction suffix (`-ц` цивільне, `-к`, `-п`, `-а` адмін, …). The model routinely **drops the suffix in prose** (`802/436/17`) while the registry stores it (`802/436/17-а`), so the exact `cause_num IN (...)` match flagged real, on-topic Supreme Court cases as **fabricated**.

On the canonical occupied-territory ВПО property-tax query this produced `score 0.75 / fabricated 1` when the real grounding is `1.0 / 0` — all 4 cited cases are real КАС ВС (court_code 9921) decisions and all on-topic.

## Fix

Match on the suffix-stripped **base** on both sides:
- `stripSuffix()` drops the trailing `-[а-яіїєґ]+` on the cited side
- registry side groups by `regexp_replace(cause_num, '-[а-яіїєґ]+$', '')`

`edrsr_documents` has **no index** on `cause_num` (partitioned → parallel seq scan), so a `regexp_replace()` in `WHERE` scans all ~110M rows and times out (>3 min). Kept `WHERE` as pure equality `IN` by expanding each base into `base` + every real jurisdiction suffix (`CASE_SUFFIXES`, ordered by registry frequency); the regexp base-grouping then runs only over the matched rows in `SELECT/GROUP BY`. Re-runs in ~2.5s.

## Verification (prod EDRSR)

Re-ran against the occupied-territory property-tax answer (`chat-223be153`):

| | cited | exist | on-topic | off-topic | fabricated | score |
|---|---|---|---|---|---|---|
| before | 4 | 3 | 3 | 0 | 1 | 0.75 |
| after | 4 | 4 | 4 | 0 | 0 | 1.00 |

`802/436/17` now correctly resolves to registry `802/436/17-а` (doc 89928269, КАС ВС, 2020-06-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes grounding eval by normalizing Ukrainian court case-number suffixes when matching against EDRSR, preventing real cases from being marked fabricated and restoring correct scores. Keeps the SQL index-friendly to avoid timeouts.

- **Bug Fixes**
  - Strip suffix on cited cases and group registry rows by base number.
  - Expand `IN` list with base and known suffix variants via `CASE_SUFFIXES` to keep equality lookups.
  - Map existence/on-topic checks by base to eliminate false “fabricated” flags.
  - Verified on prod example: 4/4 exist, 0 fabricated, score 1.00.

<sup>Written for commit 956bd1ff1d2a2af583b499a51b2845c97f102ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

