### PR TITLE
fix(edrsr-fts): guard statement-timeout client for wrapper pools (regression from #2031)

### DIFF
--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -82,6 +82,19 @@ describe('EdsrFtsService.searchFulltext party filters', () => {
     expect(rx).toContain('за[[:space:]]+позов'); // anchored on the claimant slot
   });
 
+  it('falls back to pool.query when connect() yields no usable client (wrapper pool regression)', async () => {
+    // Regression: compare_practice_pro_contra passes a wrapper pool whose connect() exists but
+    // returns undefined; the statement-timeout path did `client.release()` and crashed with
+    // "Cannot read properties of undefined (reading 'release')". Must fall back, not throw.
+    const svc = new EdsrFtsService();
+    const db = makeDb() as any;
+    db.connect = jest.fn(() => Promise.resolve(undefined)); // connect present but yields nothing
+
+    await expect(svc.searchFulltext('поновлення строку', db)).resolves.toBeDefined();
+    expect(db.query).toHaveBeenCalled();           // fell back to the plain pooled query
+    expect(db.calls[0].sql).toContain('cand AS MATERIALIZED'); // still runs cap-before-rank
+  });
+
   it('treats party_role "any" as no role constraint', async () => {
     const svc = new EdsrFtsService();
     const db = makeDb();

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -510,10 +510,19 @@ export class EdsrFtsService {
     // so use a dedicated client when the pool exposes connect(); otherwise fall back to a
     // plain pooled query (timeout-less) so non-pg pool wrappers still work.
     const queryWithTimeout = async (sql: string, args: any[]) => {
-      if (typeof dbPool.connect !== 'function') {
+      // A pooled client lets us scope SET LOCAL statement_timeout to one transaction. Only the
+      // raw pg Pool yields a client with query()/release(); sharded/wrapper pools may expose a
+      // connect() that returns undefined or a non-pg object (this broke compare_practice_pro_contra,
+      // which passes such a wrapper). Probe the client and fall back to a plain pooled query —
+      // which still runs the cap-before-rank SQL, just without the per-statement timeout.
+      let client: any;
+      if (typeof dbPool.connect === 'function') {
+        try { client = await dbPool.connect(); } catch { client = undefined; }
+      }
+      if (!client || typeof client.query !== 'function' || typeof client.release !== 'function') {
+        if (client && typeof client.release === 'function') client.release();
         return dbPool.query(sql, args);
       }
-      const client = await dbPool.connect();
       try {
         await client.query('BEGIN');
         await client.query(`SET LOCAL statement_timeout = ${FTS_STATEMENT_TIMEOUT_MS}`);


### PR DESCRIPTION
## Регрессия от #2031, найдена smoke-тестом V3-набора

Прогнал smoke по 15 инструментам чата V3 — **14 pass / 1 fail**. Фейл: `compare_practice_pro_contra` → `FTS search failed: Cannot read properties of undefined (reading 'release')`.

## Причина

Statement-timeout guard из #2031 (cap-before-rank):
```js
const client = await dbPool.connect();
try {...} finally { client.release(); }
```
гейтился только на `typeof dbPool.connect === 'function'`. `search_court_decisions` передаёт настоящий pg Pool (ок), а `compare_practice_pro_contra` — **обёртку-пул**, чей `connect()` существует, но возвращает `undefined` → `client.release()` падает.

## Фикс

После `connect()` проверяю клиента: если его нет или нет `query()/release()` — освобождаю (если можно) и **fallback на `dbPool.query`** (который всё равно выполняет cap-before-rank SQL, просто без per-statement timeout). `connect()`, бросающий исключение, тоже перехвачен.

## Проверка
- tsc чист; `edrsr-fts-service` тесты **13/13** (вкл. новый регресс-тест: `connect()→undefined` не падает, идёт fallback, cap-before-rank сохраняется).
- Остальные 12 инструментов V3-набора прошли smoke (+ search_court_decisions/get_citation_graph проверены ранее) → после этого фикса **15/15**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression in FTS where wrapper pools with `connect()` returning `undefined` caused a crash. We now validate the client and fall back to `dbPool.query`, restoring stable searches for tools like `compare_practice_pro_contra`.

- **Bug Fixes**
  - After `connect()`, check for a client with `query`/`release`; otherwise (or on error) fall back to `dbPool.query`.
  - Release the client if possible before falling back.
  - Keep cap-before-rank SQL; apply per-statement timeout only with a real pg client.
  - Added a regression test for `connect() => undefined` to ensure fallback and no crash.

<sup>Written for commit 94cd984983fe6a85a40bdd1dd807fd3b24290c3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

