### PR TITLE
fix(tool-registry): raise pro/contra + fact-pattern tool timeout to 120s

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -36,6 +36,11 @@ const TOOL_TIMEOUT_OVERRIDES: Record<string, number> = {
   search_court_decisions: 120_000,
   get_case_documents_chain: 120_000,
   edrsr_court_decisions_by_court: 90_000,
+  // Semantic candidate retrieval (qdrant/HNSW) + a "standard" LLM holding-classification
+  // call, with a keyword-FTS fallback. Intermittent qdrant/Bedrock latency can push the
+  // happy path past 60s; matches the other heavy search tools above.
+  compare_practice_pro_contra: 120_000,
+  find_similar_fact_pattern_cases: 120_000,
   edrsr_get_decision_dispositive: 15_000,
   build_legal_decision: 120_000,
   search_public_spending: 120_000,


### PR DESCRIPTION
## Problem

On prod, the chat query *«Практика «за» і «проти» визнання правочину недійсним (ст. 203, 215 ЦК)…»* returned **«Помилка: Час очікування вичерпано. Спробуйте уточнити запит.»**

## Root cause

The orchestrator called `compare_practice_pro_contra`, which:
1. retrieves candidate decisions via semantic search (qdrant/HNSW over `edrsr_serving`), then
2. runs a **"standard" LLM** holding-classification call, with a keyword-FTS fallback.

It was **not** in `TOOL_TIMEOUT_OVERRIDES`, so it used the **60s default**. Prod logs (requestId `b292bf6f…`):

- `06:31:28.250` tool start
- `06:32:28.261` registry abort — `Tool "compare_practice_pro_contra" перевищив ліміт часу 60с`
- `06:32:30.999` LLM classification response finally arrived — **~2.7s after** the deadline

A retry of the **same** tool at `06:35:30` succeeded in **~5s**. So this is **intermittent qdrant/Bedrock latency**, not a logic bug — the 60s cap is just too tight for this tool's worst case. The abort surfaced to the chat layer as the user-facing timeout message.

## Fix

Add both heavy semantic+LLM tools to `TOOL_TIMEOUT_OVERRIDES` at **120s**, matching the existing heavy search tools (`search_court_decisions`, `build_legal_decision`):

- `compare_practice_pro_contra`
- `find_similar_fact_pattern_cases` (same `edsrVectorizer.semanticSearch` + LLM path → identical latent failure)

120s is well within the chat wall-clock budget (240s standard / 300s deep), so this cannot cause a runaway loop.

## Testing

- Change is two numeric entries in a `Record<string, number>`; `tool-registry.ts` typechecks clean.
- (Local full `tsc` reports 3 unrelated errors in `core-loader.ts` for modules that live in the `secondlayer-core` submodule, which isn't checked out locally; CI builds with the submodule present.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase timeouts to 120s for `compare_practice_pro_contra` and `find_similar_fact_pattern_cases` to prevent user-facing timeouts from occasional semantic search and LLM delays. This matches other heavy search tools and stays within the chat budget.

<sup>Written for commit 0b0a93a300292f7114926e6d244dc37d2955f3be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

