### PR TITLE
feat(pro-contra): balanced retrieval — seek both sides + ВС/ВП preference (LEXAI-1782)

### DIFF
--- a/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
+++ b/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
@@ -9,6 +9,7 @@ import { ProceduralTools } from '../tools/procedural-tools';
 function makeTools(opts: {
   hits: any[];
   classifications: any[];
+  ftsResults?: any[]; // when set, also stub the FTS service (enables the contra-seed leg)
 }): ProceduralTools {
   const edsrVectorizer: any = {
     semanticSearch: jest.fn().mockResolvedValue(opts.hits),
@@ -18,11 +19,19 @@ function makeTools(opts: {
       content: JSON.stringify({ classifications: opts.classifications }),
     }),
   };
+  const ftsService: any = opts.ftsResults
+    ? { searchFulltext: jest.fn().mockResolvedValue({ results: opts.ftsResults }) }
+    : undefined;
+  const db: any = opts.ftsResults ? {} : undefined;
   // Required ctor args are unused on this path — stub them.
   return new ProceduralTools(
     {} as any, {} as any, {} as any, {} as any, {} as any,
-    llm, undefined, undefined, edsrVectorizer,
+    llm, ftsService, db, edsrVectorizer,
   );
+}
+
+function ftsRow(doc_id: number, court_code: number, headline: string) {
+  return { doc_id, court_code, adjudication_date: '2025-02-02', cause_num: `c/${doc_id}`, headline };
 }
 
 function hit(doc_id: number, court_code: number, text: string) {
@@ -100,5 +109,47 @@ describe('comparePracticeProContra — LLM holding classification', () => {
     expect(out.relevant_practice.map((c: any) => c.doc_id)).toEqual([301, 302]);
     // Repair retry was attempted (2 calls: initial + repair).
     expect(llm.chatCompletion).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies court_level=SC filter — non-99* candidates never reach classification', async () => {
+    const tools = makeTools({
+      // 9921 and 9901 are Supreme Court (99*); 1370 is a first-instance court.
+      hits: [hit(101, 9921, 'frag A'), hit(102, 1370, 'frag B'), hit(103, 9901, 'frag C')],
+      classifications: [
+        { doc_id: 101, stance: 'supports', quote: 'ВС за', confidence: 0.9 },
+        { doc_id: 102, stance: 'opposes', quote: 'перша інстанція проти', confidence: 0.8 },
+        { doc_id: 103, stance: 'opposes', quote: 'ВП проти', confidence: 0.8 },
+      ],
+    });
+    const out = await run(tools, { procedure_code: 'cac', query: 'теза', court_level: 'SC' });
+
+    expect(out.court_level_filter).toBe('SC');
+    // 102 (court 1370) is filtered out before classification — it cannot appear on either side.
+    const allDocs = [...out.pro, ...out.contra].map((c: any) => c.doc_id);
+    expect(allDocs).not.toContain(102);
+    expect(out.pro.map((c: any) => c.doc_id)).toEqual([101]);
+    expect(out.contra.map((c: any) => c.doc_id)).toEqual([103]);
+  });
+
+  it('seeds contra practice via FTS when the semantic pool skews pro', async () => {
+    const tools = makeTools({
+      // Semantic leg returns only thesis-agreeing decisions.
+      hits: [hit(401, 9921, 'за тезу A'), hit(402, 9921, 'за тезу B')],
+      // FTS contra-seed surfaces a refusal decision the semantic leg missed.
+      ftsResults: [ftsRow(501, 9921, 'суд відмовив у задоволенні позову')],
+      classifications: [
+        { doc_id: 401, stance: 'supports', quote: 'за', confidence: 0.9 },
+        { doc_id: 402, stance: 'supports', quote: 'теж за', confidence: 0.8 },
+        { doc_id: 501, stance: 'opposes', quote: 'відмовлено', confidence: 0.85 },
+      ],
+    });
+    const out = await run(tools, { procedure_code: 'cac', query: 'теза' });
+
+    expect(out.search_method).toBe('llm_holding_semantic_hnsw+contra_seed');
+    expect(out.pro.map((c: any) => c.doc_id).sort()).toEqual([401, 402]);
+    expect(out.contra.map((c: any) => c.doc_id)).toEqual([501]);
+    expect(out.total_contra).toBe(1);
+    // No longer a one-sided insufficient_practice result.
+    expect(out.insufficient_practice).toBeUndefined();
   });
 });

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -120,6 +120,17 @@ function parseClassifications(content: string | undefined | null): any[] {
   return list || [];
 }
 
+/**
+ * True when a court_code belongs to the requested instance level. Supreme Court cassation
+ * courts are numbered 99*, the Grand Chamber is 9901. No filter → always true.
+ */
+function isCourtLevelMatch(courtCode: any, filter?: 'SC' | 'GrandChamber'): boolean {
+  if (!filter) return true;
+  const code = String(courtCode ?? '');
+  if (!code.startsWith('99')) return false;
+  return filter === 'GrandChamber' ? code === '9901' : true;
+}
+
 // Per-step soft budgets for the pro/contra holding-classification path. The registry caps
 // the whole tool at 120s (tool-registry.ts); these keep each external leg bounded so a slow
 // qdrant or an overloaded LLM degrades to a useful partial answer instead of a hard timeout.
@@ -196,6 +207,11 @@ export class ProceduralTools extends BaseToolHandler {
           properties: {
             procedure_code: { type: 'string', enum: ['cpc', 'gpc', 'cac', 'crpc'], description: 'Вид судочинства: cpc (цивільне), gpc (господарське), cac (адміністративне), crpc (кримінальне)' },
             query: { type: 'string', description: 'Правова теза для аналізу (наприклад: "поновлення строку апеляційного оскарження через несвоєчасне отримання повного тексту")' },
+            court_level: {
+              type: 'string',
+              enum: ['SC', 'GrandChamber'],
+              description: 'Обмежити практику інстанцією: SC — лише Верховний Суд (касаційні суди, код суду 99*), GrandChamber — лише Велика Палата ВС (9901). Використовуйте, коли потрібне саме цитування ВС. За замовчуванням — усі інстанції.',
+            },
             time_range: {
               oneOf: [
                 { type: 'string' },
@@ -467,20 +483,29 @@ export class ProceduralTools extends BaseToolHandler {
     if (!procedureCode) throw new Error('procedure_code must be one of: cpc, gpc, cac, crpc');
     if (!query) throw new Error('query parameter is required');
 
+    // Optional instance filter — prefer Supreme Court / Grand Chamber practice when the user
+    // wants "цитування ВС" (mirrors find_similar_fact_pattern_cases).
+    const courtLevelFilter: 'SC' | 'GrandChamber' | undefined =
+      args.court_level === 'SC' || args.court_level === 'GrandChamber' ? args.court_level : undefined;
+
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
     const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);
     const startedAt = Date.now();
+    // Widen the candidate pool well past `limit`: BGE-M3 retrieves topically-similar chunks
+    // regardless of stance, so a deeper net surfaces opposing holdings on the same point for
+    // the LLM to classify — countering the structural bias toward "pro" when the pool is small.
+    const candidateTarget = Math.min(28, Math.max(14, limit * 3));
 
-    // Primary path: retrieve candidates once (no pro/contra keyword suffix) and let the LLM
-    // classify each decision's holding relative to the user's thesis (supports / opposes /
-    // not-on-point) with a cited fragment. The legacy keyword suffix (задовольнити/відмовити)
-    // is non-discriminative and cannot separate opposing holdings — kept only as a fallback
-    // when the LLM or vectorizer is unavailable. Each external leg runs under a soft deadline
-    // so a slow qdrant/LLM degrades to a partial answer instead of hitting the 120s hard cap.
+    // Primary path: retrieve candidates (both sides — see gatherProContraCandidates) and let
+    // the LLM classify each decision's holding relative to the user's thesis (supports /
+    // opposes / not-on-point) with a cited fragment. The legacy keyword suffix
+    // (задовольнити/відмовити) is non-discriminative for classification — used only as a
+    // retrieval seed / fallback. Each external leg runs under a soft deadline so a slow
+    // qdrant/LLM degrades to a partial answer instead of hitting the 120s hard cap.
     if (this.llm) {
       const gathered = await withSoftTimeout(
         this.gatherProContraCandidates(
-          query, justiceKind, timeRangeParsed, Math.min(12, Math.max(6, limit * 2)),
+          query, justiceKind, timeRangeParsed, candidateTarget, courtLevelFilter,
         ),
         PRO_CONTRA_GATHER_BUDGET_MS, 'comparePracticeProContra.gather',
       );
@@ -517,7 +542,9 @@ export class ProceduralTools extends BaseToolHandler {
             procedure_code: procedureCode,
             query,
             time_range: args.time_range,
+            court_level_filter: courtLevelFilter || undefined,
             search_method: `llm_holding_${gathered.method}`,
+            candidates_considered: gathered.candidates.length,
             pro: proCases,
             contra: contraCases,
             total_pro: proCases.length,
@@ -707,8 +734,20 @@ export class ProceduralTools extends BaseToolHandler {
     justiceKind: number | null,
     timeRangeParsed: { date_from?: string; date_to?: string },
     maxN: number,
+    courtLevelFilter?: 'SC' | 'GrandChamber',
   ): Promise<{ candidates: Array<{ doc_id: number; court_code?: number; date?: string; case_number?: string; fragment: string }>; method: string }> {
-    // Semantic (preferred)
+    type Candidate = { doc_id: number; court_code?: number; date?: string; case_number?: string; fragment: string };
+    const byDoc = new Map<number, Candidate>();
+    const methods: string[] = [];
+    // Reserve part of the pool for the contra seed (below) so a flood of thesis-similar "pro"
+    // decisions can't crowd out refusal practice. Only meaningful when FTS is available.
+    const canSeed = !!(this.ftsService && this.db);
+    const seedReserve = canSeed ? Math.min(8, Math.floor(maxN / 3)) : 0;
+
+    // Leg A — semantic on the thesis. BGE-M3 retrieves topically-similar chunks regardless of
+    // stance, so a wide net surfaces opposing holdings on the same point. When a court level
+    // is requested, over-fetch much wider and post-filter (SC is a minority of the corpus).
+    let semanticHits: Candidate[] = [];
     if (this.edsrVectorizer) {
       try {
         const semFilters: EdrsrSearchFilters = {
@@ -716,45 +755,103 @@ export class ProceduralTools extends BaseToolHandler {
           ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
           ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
         };
-        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, maxN * 3);
+        const overfetch = courtLevelFilter ? Math.max(maxN * 8, 200) : maxN * 3;
+        const hits = await this.edsrVectorizer.semanticSearch(query, semFilters, overfetch);
         const seen = new Set<number>();
-        const out: any[] = [];
         for (const h of hits) {
           if (seen.has(h.doc_id)) continue;
+          if (!isCourtLevelMatch(h.metadata.court_code, courtLevelFilter)) continue;
           seen.add(h.doc_id);
-          out.push({
+          semanticHits.push({
             doc_id: h.doc_id,
             court_code: h.metadata.court_code,
             date: h.metadata.adjudication_date,
             case_number: h.metadata.cause_num,
             fragment: (h.text || '').slice(0, 900),
           });
-          if (out.length >= maxN) break;
         }
-        if (out.length > 0) return { candidates: out, method: 'semantic_hnsw' };
+        // Fill up to (maxN - seedReserve) now; the remainder of semanticHits is used to top
+        // up after the seed, so reserving space never costs us candidates.
+        const semCap = Math.max(1, maxN - seedReserve);
+        for (const c of semanticHits) {
+          if (byDoc.size >= semCap) break;
+          byDoc.set(c.doc_id, c);
+        }
+        if (byDoc.size > 0) methods.push('semantic_hnsw');
       } catch (err: any) {
-        logger.warn('[gatherProContraCandidates] semantic search failed, falling back to FTS', { error: err?.message });
+        logger.warn('[gatherProContraCandidates] semantic search failed', { error: err?.message });
       }
     }
 
-    // FTS fallback (headline as fragment)
+    // Leg B — contra seed. The thesis-similarity leg under-samples decisions that REFUSE the
+    // claim (courts phrase a refusal differently), biasing the pool toward "pro". Seed a few
+    // refusal decisions via the keyword discriminator so the LLM has both sides to classify.
+    // The suffix is used ONLY for retrieval diversity here — never for the pro/contra decision,
+    // which is the LLM's job. Best-effort; the outer gather soft-timeout bounds it.
+    if (canSeed && seedReserve > 0 && byDoc.size < maxN) {
+      try {
+        const seedFilters: EdsrFtsFilters = {
+          ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
+          ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
+          ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
+        };
+        const bareQuery = trimFtsQuery(query, 3);
+        const instances = courtLevelFilter ? [1] : [1, 2, 3];
+        let seeded = 0;
+        for (const code of instances) {
+          if (seeded >= seedReserve || byDoc.size >= maxN) break;
+          const resp = await this.ftsService!.searchFulltext(
+            `${bareQuery} відмовити у задоволенні позову`, this.db,
+            { ...seedFilters, instance_code: code }, seedReserve, 0, bareQuery,
+          );
+          for (const d of resp.results) {
+            if (byDoc.has(d.doc_id)) continue;
+            if (!isCourtLevelMatch(d.court_code, courtLevelFilter)) continue;
+            byDoc.set(d.doc_id, {
+              doc_id: d.doc_id,
+              court_code: d.court_code,
+              date: d.adjudication_date,
+              case_number: d.cause_num,
+              fragment: d.headline || '',
+            });
+            seeded++;
+            if (seeded >= seedReserve || byDoc.size >= maxN) break;
+          }
+        }
+        if (seeded > 0) methods.push('contra_seed');
+      } catch (err: any) {
+        logger.warn('[gatherProContraCandidates] contra-seed FTS failed', { error: err?.message });
+      }
+    }
+
+    // Top up any remaining room from the semantic overflow (decisions reserved-out above).
+    for (const c of semanticHits) {
+      if (byDoc.size >= maxN) break;
+      if (!byDoc.has(c.doc_id)) byDoc.set(c.doc_id, c);
+    }
+
+    if (byDoc.size > 0) {
+      return { candidates: [...byDoc.values()], method: methods.join('+') || 'semantic_hnsw' };
+    }
+
+    // Pure FTS fallback (semantic unavailable/empty) — court-level aware, headline as fragment.
     if (this.ftsService && this.db) {
       const baseFilters: EdsrFtsFilters = {
         ...(justiceKind !== null ? { justice_kind: justiceKind } : {}),
         ...(timeRangeParsed.date_from ? { date_from: timeRangeParsed.date_from } : {}),
         ...(timeRangeParsed.date_to ? { date_to: timeRangeParsed.date_to } : {}),
       };
-      for (const inst of [
-        { code: 1 }, { code: 2 }, { code: 3 },
-      ] as const) {
+      const instances = courtLevelFilter ? [{ code: 1 }] : [{ code: 1 }, { code: 2 }, { code: 3 }];
+      for (const inst of instances) {
         const resp = await this.ftsService.searchFulltext(
           trimFtsQuery(query), this.db, { ...baseFilters, instance_code: inst.code }, maxN,
         );
         if (resp.results.length > 0) {
           const seen = new Set<number>();
-          const out: any[] = [];
+          const out: Candidate[] = [];
           for (const d of resp.results) {
             if (seen.has(d.doc_id)) continue;
+            if (!isCourtLevelMatch(d.court_code, courtLevelFilter)) continue;
             seen.add(d.doc_id);
             out.push({
               doc_id: d.doc_id,
@@ -873,12 +970,7 @@ export class ProceduralTools extends BaseToolHandler {
     // dominate pure cosine ranking.
     const courtLevelFilter: 'SC' | 'GrandChamber' | undefined =
       args.court_level === 'SC' || args.court_level === 'GrandChamber' ? args.court_level : undefined;
-    const matchesCourtLevel = (courtCode: any): boolean => {
-      if (!courtLevelFilter) return true;
-      const code = String(courtCode ?? '');
-      if (!code.startsWith('99')) return false;
-      return courtLevelFilter === 'GrandChamber' ? code === '9901' : true;
-    };
+    const matchesCourtLevel = (courtCode: any): boolean => isCourtLevelMatch(courtCode, courtLevelFilter);
 
     const timeRangeParsed = parseTimeRangeToDates(args.time_range);
     const justiceKind = mapProcedureCodeToJusticeKind(procedureCode);


### PR DESCRIPTION
**P1 follow-up to #2037** (soft-budgets + Haiku classification, already in prod). Plane: **LEXAI-1782**.

## Problem

`compare_practice_pro_contra` retrieved **≤12** candidates from a *single* semantic ranking of the thesis. BGE-M3 ranks by topical similarity to the thesis wording, which **under-samples decisions that refuse the claim** (courts phrase a refusal differently) → the pool skews **pro**, yielding frequent `insufficient_practice` / one-sided results. There was also no way to prefer Supreme Court practice for "цитування ВС".

## Changes (`gatherProContraCandidates` + schema)

- **Widen the pool** ≤12 → **≤28** (`limit*3`, floor 14). A deeper net surfaces opposing holdings on the same point for the LLM to classify.
- **Explicitly seek both sides** — reserve part of the pool (≤8) for a **contra seed**: a bounded keyword-discriminator FTS leg (`відмовити у задоволенні позову`) that pulls in refusal decisions the similarity leg misses. The suffix is used **only for retrieval diversity**, never for the pro/contra decision (that stays the LLM's job). Reserved space is topped back up from semantic overflow, so seeding never costs candidates.
- **`court_level` (SC | GrandChamber)** arg, mirroring `find_similar_fact_pattern_cases`: prefer Supreme Court / Grand Chamber. Over-fetches wide and post-filters on `court_code` (99* / 9901); FTS legs restrict to the cassation instance.
- Shared **`isCourtLevelMatch()`** helper (deduped `find_similar`'s inline closure).
- Pure-FTS fallback is now court-level aware; payload surfaces `court_level_filter` and `candidates_considered`.

Stays within the #2037 soft budgets (gather ≤15s, classify ≤35s, 120s cap); the contra-seed leg is best-effort and bounded by the gather soft-timeout.

## Testing
`pro-contra-holding.test.ts` — **5 pass** (3 existing + 2 new): `court_level=SC` filtering drops non-99* candidates before classification; FTS contra-seed turns a one-sided pro pool into a pro/contra split. `tsc` clean for the changed file.

## Out of scope (deliberately not done)
**Dispositive-section fragments** (mentioned in LEXAI-1782): for a legal *thesis* the most-similar chunk is already the court's reasoning, so the operative ruling ("позов задовольнити/відмовити") adds little to stance classification. Left for an eval-driven decision rather than a speculative change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Balanced the pro/contra retrieval by widening the pool and explicitly seeding opposing holdings, and added a Supreme Court/Grand Chamber preference to support “цитування ВС”. This addresses LEXAI-1782 by reducing one‑sided results and improving citation control.

- **New Features**
  - Increased candidate pool to ≤28 (limit*3, floor 14); reserve ≤8 for a contra seed and top up from semantic overflow.
  - Added contra seed via FTS (“відмовити у задоволенні позову”) to surface refusal decisions; used only for retrieval diversity and bounded by the gather timeout.
  - Introduced `court_level` (`SC` | `GrandChamber`) to prefer ВС/ВП practice; over-fetch and post-filter by `court_code` (99* / 9901), applied across semantic, seed, and pure-FTS paths; response now includes `court_level_filter`, `search_method`, and `candidates_considered`. Added shared `isCourtLevelMatch()` helper.

<sup>Written for commit caa46ff062198aad0a1054b140659cc780324ab3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

