### PR TITLE
fix(redis): fast-fail cache ops + keepAlive so a stale Redis can't hang requests

### DIFF
--- a/mcp_backend/src/infrastructure/adapters/__tests__/cache-adapter.test.ts
+++ b/mcp_backend/src/infrastructure/adapters/__tests__/cache-adapter.test.ts
@@ -1,0 +1,54 @@
+// Set a short op timeout BEFORE the adapter module is evaluated (the constant is read at load).
+process.env.REDIS_OP_TIMEOUT_MS = '80';
+
+import { CacheAdapter } from '../cache-adapter';
+
+/**
+ * Regression: a stale Redis connection used to hang every request because node-redis has no
+ * per-command timeout and this client backs the rate limiter (in front of all /api/ routes).
+ * CacheAdapter now bounds each op so a hung client fails fast and callers can fall back.
+ */
+function makeClient(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    get: jest.fn().mockResolvedValue('5'),
+    set: jest.fn().mockResolvedValue('OK'),
+    setEx: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1),
+    ping: jest.fn().mockResolvedValue('PONG'),
+    multi: jest.fn(() => ({
+      incr: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      exec: jest.fn().mockResolvedValue([6, 1]),
+    })),
+    ...overrides,
+  } as any;
+}
+
+describe('CacheAdapter — fast-fail on a hung Redis client', () => {
+  it('passes through values when Redis responds', async () => {
+    const adapter = new CacheAdapter(makeClient());
+    await expect(adapter.get('k')).resolves.toBe('5');
+    await expect(adapter.increment('k', 60)).resolves.toBe(6);
+    await expect(adapter.ping()).resolves.toBe(true);
+  });
+
+  it('rejects get() instead of hanging when the client never resolves', async () => {
+    const adapter = new CacheAdapter(makeClient({ get: jest.fn(() => new Promise(() => {})) }));
+    await expect(adapter.get('k')).rejects.toThrow(/timed out/i);
+  });
+
+  it('rejects increment() instead of hanging when multi.exec never resolves', async () => {
+    const hangingMulti = {
+      incr: jest.fn().mockReturnThis(),
+      expire: jest.fn().mockReturnThis(),
+      exec: jest.fn(() => new Promise(() => {})),
+    };
+    const adapter = new CacheAdapter(makeClient({ multi: jest.fn(() => hangingMulti) }));
+    await expect(adapter.increment('k', 60)).rejects.toThrow(/timed out/i);
+  });
+
+  it('ping() returns false (not a hang) when the client never resolves', async () => {
+    const adapter = new CacheAdapter(makeClient({ ping: jest.fn(() => new Promise(() => {})) }));
+    await expect(adapter.ping()).resolves.toBe(false);
+  });
+});

--- a/mcp_backend/src/infrastructure/adapters/cache-adapter.ts
+++ b/mcp_backend/src/infrastructure/adapters/cache-adapter.ts
@@ -8,6 +8,14 @@ import type { ICachePort } from '../../domain/ports/index.js';
 
 type RedisClient = ReturnType<typeof createClient>;
 
+// node-redis has no per-command timeout: a stale TCP connection makes commands hang until the
+// OS read timeout fires (tens of seconds). Because this single client backs the rate limiter
+// (in front of every /api/ route) plus many services, one dead socket stalls EVERY in-flight
+// request. Bound each op so a hung Redis fails fast and callers degrade (rate limiter → memory)
+// instead of holding the request open. The underlying command stays queued and runs on
+// reconnect, which is harmless for our cache/counter usage.
+const REDIS_OP_TIMEOUT_MS = Number(process.env.REDIS_OP_TIMEOUT_MS || 1000);
+
 export class CacheAdapter implements ICachePort {
   private client: RedisClient;
 
@@ -15,35 +23,51 @@ export class CacheAdapter implements ICachePort {
     this.client = client;
   }
 
+  private async withTimeout<T>(op: Promise<T>, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        op,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`Redis ${label} timed out after ${REDIS_OP_TIMEOUT_MS}ms`)),
+            REDIS_OP_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+
   async get(key: string): Promise<string | null> {
-    return this.client.get(key);
+    return this.withTimeout(this.client.get(key), 'GET');
   }
 
   async set(key: string, value: string, ttlSeconds?: number): Promise<void> {
     if (ttlSeconds !== undefined) {
-      await this.client.setEx(key, ttlSeconds, value);
+      await this.withTimeout(this.client.setEx(key, ttlSeconds, value), 'SETEX');
     } else {
-      await this.client.set(key, value);
+      await this.withTimeout(this.client.set(key, value), 'SET');
     }
   }
 
   async del(...keys: string[]): Promise<number> {
     if (keys.length === 0) return 0;
-    return this.client.del(keys);
+    return this.withTimeout(this.client.del(keys), 'DEL');
   }
 
   async increment(key: string, ttlSeconds: number): Promise<number> {
-    const results = await this.client
-      .multi()
-      .incr(key)
-      .expire(key, ttlSeconds)
-      .exec();
+    const results = await this.withTimeout(
+      this.client.multi().incr(key).expire(key, ttlSeconds).exec(),
+      'INCR',
+    );
     return (results?.[0] as unknown as number) ?? 0;
   }
 
   async ping(): Promise<boolean> {
     try {
-      const reply = await this.client.ping();
+      const reply = await this.withTimeout(this.client.ping(), 'PING');
       return reply === 'PONG';
     } catch {
       return false;

--- a/mcp_backend/src/utils/__tests__/redis-client.test.ts
+++ b/mcp_backend/src/utils/__tests__/redis-client.test.ts
@@ -58,14 +58,26 @@ describe('redis-client', () => {
     it('should use REDIS_URL env var when set', async () => {
       process.env.REDIS_URL = 'redis://custom-host:6380';
       await getRedisClient();
-      expect(mockCreateClient).toHaveBeenCalledWith({ url: 'redis://custom-host:6380' });
+      expect(mockCreateClient).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'redis://custom-host:6380' }),
+      );
       delete process.env.REDIS_URL;
     });
 
     it('should fall back to redis://localhost:6379 when REDIS_URL is not set', async () => {
       delete process.env.REDIS_URL;
       await getRedisClient();
-      expect(mockCreateClient).toHaveBeenCalledWith({ url: 'redis://localhost:6379' });
+      expect(mockCreateClient).toHaveBeenCalledWith(
+        expect.objectContaining({ url: 'redis://localhost:6379' }),
+      );
+    });
+
+    it('should configure keepAlive + pingInterval so dead connections fail fast', async () => {
+      delete process.env.REDIS_URL;
+      await getRedisClient();
+      const opts = mockCreateClient.mock.calls[0][0];
+      expect(opts.pingInterval).toBeGreaterThan(0);
+      expect(opts.socket?.keepAlive).toBe(true);
     });
 
     it('should return the same singleton on repeated calls', async () => {

--- a/mcp_backend/src/utils/redis-client.ts
+++ b/mcp_backend/src/utils/redis-client.ts
@@ -14,7 +14,19 @@ export async function getRedisClient(): Promise<ReturnType<typeof createClient> 
 
   try {
     const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
-    redisClient = createClient({ url: redisUrl });
+    // keepAlive surfaces a dead TCP connection at the socket layer; pingInterval probes idle
+    // connections from the app so a silently-dropped socket is detected and reconnected before
+    // it stalls a request (see CacheAdapter — these timeouts are the second line of defense).
+    redisClient = createClient({
+      url: redisUrl,
+      socket: {
+        keepAlive: true,
+        keepAliveInitialDelay: 30_000,
+        connectTimeout: 10_000,
+        reconnectStrategy: (retries) => Math.min(retries * 100, 3_000),
+      },
+      pingInterval: 30_000,
+    });
 
     redisClient.on('error', (err) => {
       logger.error('[Redis] Client error:', err);


### PR DESCRIPTION
## Symptom

The **«Завантажити промпт»** modal hung on an infinite spinner on prod (and the user saw it never load). Diagnosis showed the `GET /api/prompts` request reached the backend but never returned.

## Root cause

Backend logs showed a burst of `[RateLimit] Redis error: read ETIMEDOUT` across **every** path at the same instant (`/prompts`, `/conversations`, `/access/status`, `/team/organization`, `/health`, session-replay, …), then recovery:

```
[RateLimit] Redis error, falling back to memory {"error":"read ETIMEDOUT","path":"/prompts"}
```

`node-redis` has **no per-command timeout**, and a single shared client backs the **rate limiter** (mounted in front of every `/api/` route) plus many services. When a TCP connection goes stale, each `await`ed command hangs until the **OS read timeout** fires (tens of seconds) before the rate limiter's `catch` falls back to memory — so one dead socket stalls *every* in-flight request, which the frontend surfaces as a perpetual spinner.

This is the same stale-connection class seen earlier with pgbouncer ETIMEDOUT; this PR fixes the Redis side.

## Fix

- **`CacheAdapter`** bounds each op (`get`/`set`/`del`/`increment`/`ping`) with a `REDIS_OP_TIMEOUT_MS` (default **1000ms**) race. A hung Redis now **rejects fast** and callers degrade immediately (rate limiter → in-memory store) instead of holding the request open. The underlying command stays queued and runs on reconnect — harmless for cache/counter usage. `Promise.race` keeps a handler on the original op, so no unhandled rejection when it later settles.
- **`redis-client`**: enable TCP **keepAlive** + app-level **pingInterval (30s)** and a bounded `reconnectStrategy`, so a silently-dropped socket is detected and reconnected proactively (second line of defense).

## Testing

- `cache-adapter.test.ts` (new): hung `get`/`increment` reject with a timeout (don't hang); `ping` returns `false`; happy path passes through.
- `redis-client.test.ts`: asserts `keepAlive` + `pingInterval` are configured; existing URL assertions relaxed to `objectContaining`.
- **17 pass.** `tsc` clean.

## Notes
- The live blip had already recovered at diagnosis time (0 errors in the trailing 3 min; `/api/prompts` responds in ~3ms), so the modal works again now — this PR prevents the **hang** from recurring on the next stale-connection event.
- Not caused by the pro/contra deploys; independent infra fragility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast on stalled Redis ops and enable keepAlive/pings so a stale Redis connection can’t hang API requests. This prevents the rate limiter from blocking routes and keeps the app responsive.

- **Bug Fixes**
  - Added per-op timeout for `get`/`set`/`del`/`increment`/`ping` (env `REDIS_OP_TIMEOUT_MS`, default 1000ms) so calls fail fast and fall back to in-memory.
  - Configured Redis client with TCP keepAlive, 30s `pingInterval`, and a bounded `reconnectStrategy` to detect and recover silent drops.
  - Tests cover fast-fail behavior and client options; all pass.

<sup>Written for commit 8c635682e2263601c1e9d958f4506a9dce9a6a1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

