### PR TITLE
fix(chat): retry chat stream across a backend restart instead of "network error" (LEXAI-1783)

### DIFF
--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -6,10 +6,14 @@
 
 import { BaseService } from '../base/BaseService';
 import { SSEClient } from './SSEClient';
-import { getErrorMessage, isAbortError } from '../../utils/errors';
+import { getErrorMessage, isAbortError, isNetworkError } from '../../utils/errors';
 import { transformToolResultToMessage } from './mcp/response-transformers';
 import type { Message } from '../../types/models';
 import { StreamingCallbacks } from '../../types/api/sse';
+
+/** Shown when a chat stream is lost to a network/connection failure (e.g. a backend restart)
+ *  that could not be transparently retried — clearer than the raw browser "Failed to fetch". */
+const CONNECTION_LOST_MESSAGE = "Зв'язок із сервером перервано. Перевірте підключення та спробуйте повторити запит.";
 
 /** Raw SSE shape — backend emits either shape under the same event type. */
 export type CitationWarning =
@@ -190,49 +194,55 @@ export class MCPService extends BaseService {
     internetEnabled?: boolean
   ): Promise<AbortController> {
     const controller = new AbortController();
+    const maxRetries = 2;
 
-    try {
-      const response = await fetch(`${this.API_URL}/chat`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${this.getAuthToken()}`,
-        },
-        body: JSON.stringify({ query, history, budget, conversationId, approvedPlan, planSessionId, allowDeepEscalation, internetEnabled }),
-        signal: controller.signal,
-      });
+    // Run one connect+stream attempt. Returns 'retry' only when the connection failed at the
+    // network layer BEFORE any event was received — i.e. the request never produced output, so
+    // re-sending it cannot duplicate a partial answer or double-charge. This is the blue-green
+    // deploy case: the request hit the draining backend (or the upstream mid-switch) and was
+    // reset; a moment later the new backend is up. Any failure after the first event is final.
+    const runAttempt = async (attempt: number): Promise<'retry' | 'done'> => {
+      let receivedAny = false;
+      try {
+        const response = await fetch(`${this.API_URL}/chat`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${this.getAuthToken()}`,
+          },
+          body: JSON.stringify({ query, history, budget, conversationId, approvedPlan, planSessionId, allowDeepEscalation, internetEnabled }),
+          signal: controller.signal,
+        });
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        // Surface the beta-restricted modal when the chat endpoint blocks
-        // the request because the user has not topped up via Monobank.
-        if (response.status === 403) {
-          try {
-            const parsed = JSON.parse(errorText) as { code?: string; message?: string };
-            if (parsed?.code === 'BETA_RESTRICTED') {
-              const m = await import('../../stores/accessGateStore');
-              m.useAccessGateStore.getState().markRestricted();
-              callbacks.onError?.({ message: parsed.message, code: 'BETA_RESTRICTED' });
-              return controller;
+        if (!response.ok) {
+          const errorText = await response.text();
+          // Surface the beta-restricted modal when the chat endpoint blocks
+          // the request because the user has not topped up via Monobank.
+          if (response.status === 403) {
+            try {
+              const parsed = JSON.parse(errorText) as { code?: string; message?: string };
+              if (parsed?.code === 'BETA_RESTRICTED') {
+                const m = await import('../../stores/accessGateStore');
+                m.useAccessGateStore.getState().markRestricted();
+                callbacks.onError?.({ message: parsed.message, code: 'BETA_RESTRICTED' });
+                return 'done';
+              }
+            } catch {
+              // Fall through to the generic error path below.
             }
-          } catch {
-            // Fall through to the generic error path below.
           }
+          callbacks.onError?.({ message: `API Error: ${response.status} - ${errorText}` });
+          return 'done';
         }
-        callbacks.onError?.({ message: `API Error: ${response.status} - ${errorText}` });
-        return controller;
-      }
 
-      const reader = response.body?.getReader();
-      if (!reader) {
-        callbacks.onError?.({ message: 'No response body' });
-        return controller;
-      }
+        const reader = response.body?.getReader();
+        if (!reader) {
+          callbacks.onError?.({ message: 'No response body' });
+          return 'done';
+        }
 
-      const decoder = new TextDecoder();
-      let buffer = '';
-
-      const processEvents = async () => {
+        const decoder = new TextDecoder();
+        let buffer = '';
         let currentEvent = '';
         let currentData = '';
 
@@ -256,6 +266,7 @@ export class MCPService extends BaseService {
               } else if (line === '' && currentEvent && currentData) {
                 try {
                   const data = JSON.parse(currentData);
+                  receivedAny = true;
                   this.dispatchChatEvent(currentEvent, data, callbacks);
                 } catch {
                   // skip malformed JSON
@@ -265,24 +276,38 @@ export class MCPService extends BaseService {
               }
             }
           }
+          return 'done';
         } catch (err: unknown) {
-          if (!isAbortError(err)) {
-            callbacks.onError?.({ message: getErrorMessage(err) });
-          }
-        } finally {
-          // Always notify that the stream has ended so the UI can reset streaming state,
-          // even if the stream ended without an 'answer' event (e.g. backend timeout/abort)
-          callbacks.onStreamEnd?.();
+          if (isAbortError(err)) return 'done';
+          if (isNetworkError(err) && !receivedAny && attempt < maxRetries) return 'retry';
+          callbacks.onError?.({ message: isNetworkError(err) ? CONNECTION_LOST_MESSAGE : getErrorMessage(err) });
+          return 'done';
         }
-      };
-
-      processEvents();
-    } catch (err: unknown) {
-      if (!isAbortError(err)) {
-        callbacks.onError?.({ message: getErrorMessage(err) });
+      } catch (err: unknown) {
+        if (isAbortError(err)) return 'done';
+        if (isNetworkError(err) && !receivedAny && attempt < maxRetries) return 'retry';
+        callbacks.onError?.({ message: isNetworkError(err) ? CONNECTION_LOST_MESSAGE : getErrorMessage(err) });
+        return 'done';
       }
-    }
+    };
 
+    const driveAttempts = async () => {
+      try {
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+          if (controller.signal.aborted) break;
+          const outcome = await runAttempt(attempt);
+          if (outcome === 'done') break;
+          // Brief backoff before re-connecting — a blue-green upstream switch settles in seconds.
+          await new Promise((resolve) => setTimeout(resolve, 700 * (attempt + 1)));
+        }
+      } finally {
+        // Always notify that the stream has ended (once, after the final attempt) so the UI
+        // resets streaming state even if it ended without an 'answer' event.
+        callbacks.onStreamEnd?.();
+      }
+    };
+
+    driveAttempts();
     return controller;
   }
 

--- a/lexwebapp/src/services/api/__tests__/MCPService.test.ts
+++ b/lexwebapp/src/services/api/__tests__/MCPService.test.ts
@@ -11,6 +11,15 @@ describe('MCPService', () => {
   let mockFetch: any;
 
   beforeEach(() => {
+    // getAuthToken() reads localStorage; the local runner (Node 26 + happy-dom) leaves it
+    // unavailable, so stub a minimal Map-backed implementation for the suite.
+    const store = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, v); },
+      removeItem: (k: string) => { store.delete(k); },
+      clear: () => store.clear(),
+    });
     mcpService = new MCPService();
     mockFetch = vi.fn();
     global.fetch = mockFetch;
@@ -18,6 +27,7 @@ describe('MCPService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   describe('callTool', () => {
@@ -203,6 +213,67 @@ describe('MCPService', () => {
       );
 
       expect(message.content).toContain('unknown');
+    });
+  });
+
+  describe('streamChat — network resilience (blue-green deploy)', () => {
+    const streamFromChunks = (chunks: string[]) => {
+      const read = vi.fn();
+      chunks.forEach((c) =>
+        read.mockResolvedValueOnce({ done: false, value: new TextEncoder().encode(c) }),
+      );
+      read.mockResolvedValueOnce({ done: true });
+      return { ok: true, body: { getReader: () => ({ read, releaseLock: vi.fn() }) } };
+    };
+
+    it('retries transparently when the connection drops before any event, then succeeds', async () => {
+      mockFetch
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+        .mockResolvedValueOnce(streamFromChunks(['event: answer\ndata: {"text":"привіт"}\n\n']));
+
+      const onAnswer = vi.fn();
+      const onError = vi.fn();
+      const onStreamEnd = vi.fn();
+      await mcpService.streamChat('q', [], { onAnswer, onError, onStreamEnd } as any);
+      await new Promise((r) => setTimeout(r, 1000));
+
+      expect(mockFetch).toHaveBeenCalledTimes(2); // initial fail + 1 retry
+      expect(onAnswer).toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(onStreamEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a clear connection-lost message after exhausting retries', async () => {
+      mockFetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      const onError = vi.fn();
+      const onStreamEnd = vi.fn();
+      await mcpService.streamChat('q', [], { onError, onStreamEnd } as any);
+      await new Promise((r) => setTimeout(r, 2600)); // wait out 700ms + 1400ms backoff
+
+      expect(mockFetch).toHaveBeenCalledTimes(3); // initial + 2 retries
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onError.mock.calls[0][0].message).toMatch(/перерв/i); // Ukrainian, not "Failed to fetch"
+      expect(onStreamEnd).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT retry once an event has been received (avoids duplicate run / double-charge)', async () => {
+      const read = vi.fn()
+        .mockResolvedValueOnce({
+          done: false,
+          value: new TextEncoder().encode('event: thinking\ndata: {"tool":"x"}\n\n'),
+        })
+        .mockRejectedValueOnce(new TypeError('Failed to fetch'));
+      mockFetch.mockResolvedValue({ ok: true, body: { getReader: () => ({ read, releaseLock: vi.fn() }) } });
+
+      const onError = vi.fn();
+      const onStreamEnd = vi.fn();
+      await mcpService.streamChat('q', [], { onThinking: vi.fn(), onError, onStreamEnd } as any);
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(mockFetch).toHaveBeenCalledTimes(1); // no retry after a real event arrived
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onStreamEnd).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/lexwebapp/src/utils/errors.ts
+++ b/lexwebapp/src/utils/errors.ts
@@ -40,6 +40,21 @@ export function isAbortError(error: unknown): boolean {
 }
 
 /**
+ * True when the error is a network-level fetch failure (connection dropped, server
+ * unreachable) rather than an application error. Browsers throw a TypeError here, with a
+ * message that varies by engine: "Failed to fetch" (Chrome), "NetworkError when attempting
+ * to fetch resource." (Firefox), "Load failed" (Safari). Used to retry transparently across
+ * a backend restart (e.g. blue-green deploy upstream switch) instead of surfacing an error.
+ */
+export function isNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    const m = error.message.toLowerCase();
+    return m.includes('fetch') || m.includes('network') || m.includes('load failed') || m.includes('connection');
+  }
+  return false;
+}
+
+/**
  * Type guard: checks if an unknown value has an HTTP-like `status` number property.
  */
 export function hasStatus(err: unknown): err is { status: number; message?: string; details?: Record<string, unknown>; retryAfter?: string } {

--- a/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
+++ b/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
@@ -131,6 +131,43 @@ describe('comparePracticeProContra — LLM holding classification', () => {
     expect(out.contra.map((c: any) => c.doc_id)).toEqual([103]);
   });
 
+  it('fetches each candidate dispositive, feeds it to the classifier and labels the outcome', async () => {
+    // The semantic snippet only restates the norm; the operative outcome lives in the
+    // dispositive. We assert (a) the dispositive text reaches the classifier prompt and
+    // (b) the programmatic outcome label is attached to the output row.
+    const edsrVectorizer: any = {
+      semanticSearch: jest.fn().mockResolvedValue([
+        hit(601, 9921, 'підставою недійсності є недодержання вимог ст. 203 ЦК'),
+      ]),
+    };
+    const llm: any = {
+      chatCompletion: jest.fn().mockResolvedValue({
+        content: JSON.stringify({
+          classifications: [{ doc_id: 601, stance: 'opposes', quote: 'у задоволенні позову відмовлено', confidence: 0.9 }],
+        }),
+      }),
+    };
+    const db: any = {
+      query: jest.fn().mockResolvedValue({
+        rows: [{ doc_id: 601, full_text: 'мотивувальна частина ... ПОСТАНОВИВ: у задоволенні позову про визнання правочину недійсним відмовити.' }],
+      }),
+    };
+    const tools = new ProceduralTools(
+      {} as any, {} as any, {} as any, {} as any, {} as any,
+      llm, undefined, db, edsrVectorizer,
+    );
+    const out = await run(tools, { procedure_code: 'cpc', query: 'теза' });
+
+    // Dispositive was queried by doc_id and its text was placed into the classifier prompt.
+    expect(db.query).toHaveBeenCalled();
+    const userPrompt = llm.chatCompletion.mock.calls[0][0].messages[1].content;
+    expect(userPrompt).toContain('Резолютивна частина:');
+    expect(userPrompt).toContain('у задоволенні позову');
+    // Programmatic outcome label is surfaced on the row.
+    expect(out.contra[0].doc_id).toBe(601);
+    expect(out.contra[0].outcome).toBe('denied');
+  });
+
   it('seeds contra practice via FTS when the semantic pool skews pro', async () => {
     const tools = makeTools({
       // Semantic leg returns only thesis-agreeing decisions.

--- a/mcp_backend/src/api/tools/edrsr-extended-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-extended-tools.ts
@@ -12,24 +12,10 @@
 
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { logger } from '../../utils/logger.js';
-
-const DISPOSITIVE_MARKERS = [
-  'ВИРІШИВ:',
-  'УХВАЛИВ:',
-  'ПОСТАНОВИВ:',
-  'ВИРОК',
-  'В И Р І Ш И В',
-  'У Х В А Л И В',
-  'П О С Т А Н О В И В',
-  'в и р і ш и в',
-  'у х в а л и в',
-  'п о с т а н о в и в',
-];
+import { extractDispositiveFromText } from '../../utils/dispositive.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
-const DISPOSITIVE_MAX_CHARS = 8000;
-const DISPOSITIVE_FALLBACK_TAIL_CHARS = 4000;
 const STATEMENT_TIMEOUT_MS = 60_000;
 
 export class EdsrExtendedTools extends BaseToolHandler {
@@ -282,44 +268,26 @@ export class EdsrExtendedTools extends BaseToolHandler {
         });
       }
 
-      let bestPos = -1;
-      let bestMarker: string | null = null;
-      for (const marker of DISPOSITIVE_MARKERS) {
-        const pos = fullText.indexOf(marker);
-        if (pos >= 0 && (bestPos === -1 || pos < bestPos)) {
-          bestPos = pos;
-          bestMarker = marker;
-        }
-      }
-
-      let dispositive: string;
-      let isFallback = false;
-
-      if (bestPos >= 0) {
-        dispositive = fullText.slice(bestPos, bestPos + DISPOSITIVE_MAX_CHARS);
-      } else {
-        const tailStart = Math.max(0, fullText.length - DISPOSITIVE_FALLBACK_TAIL_CHARS);
-        dispositive = fullText.slice(tailStart);
-        isFallback = true;
-      }
+      const { dispositive, marker, marker_position, is_fallback } =
+        extractDispositiveFromText(fullText);
 
       logger.info('[EdsrExtendedTools] edrsr_get_decision_dispositive', {
         doc_id: docId,
-        marker: bestMarker,
-        marker_position: bestPos >= 0 ? bestPos : null,
+        marker,
+        marker_position,
         text_length: textLength,
-        is_fallback: isFallback,
+        is_fallback,
         dispositive_length: dispositive.length,
       });
 
       return this.wrapResponse({
         doc_id: Number(docId) || docId,
         dispositive,
-        marker: bestMarker,
-        marker_position: bestPos >= 0 ? bestPos : null,
+        marker,
+        marker_position,
         text_length: textLength,
         dispositive_length: dispositive.length,
-        is_fallback: isFallback,
+        is_fallback,
         external_url: `https://reyestr.court.gov.ua/Review/${docId}`,
       });
     } catch (err: any) {

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -20,6 +20,7 @@ import { EdsrVectorizerService, EdrsrSearchFilters } from '../../services/edrsr-
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { extractSearchTermsWithAI } from '../../utils/html-parser.js';
+import { extractDispositiveFromText, classifyOutcome, DecisionOutcome } from '../../utils/dispositive.js';
 import { SemanticSectionizer } from '../../services/semantic-sectionizer.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import {
@@ -135,7 +136,15 @@ function isCourtLevelMatch(courtCode: any, filter?: 'SC' | 'GrandChamber'): bool
 // the whole tool at 120s (tool-registry.ts); these keep each external leg bounded so a slow
 // qdrant or an overloaded LLM degrades to a useful partial answer instead of a hard timeout.
 const PRO_CONTRA_GATHER_BUDGET_MS = 15_000;
+// Batched DB fetch of each candidate's dispositive (резолютивна частина) before classification,
+// so the LLM anchors the pro/contra stance to the operative outcome instead of a snippet that
+// merely restates the norm. One ANY($1) query over the candidate doc_ids — fast; the budget is
+// defense-in-depth so a slow/locked edrsr_fulltext degrades to snippet-only classification.
+const PRO_CONTRA_DISPOSITIVE_BUDGET_MS = 8_000;
 const PRO_CONTRA_CLASSIFY_BUDGET_MS = 35_000;
+// Per-candidate dispositive slice fed to the classifier. The operative result sits in the first
+// few hundred chars after the marker; keep it tight so the batched prompt stays bounded.
+const PRO_CONTRA_DISPOSITIVE_SLICE_CHARS = 900;
 // Past this point on the wall clock, don't start the multi-instance keyword-FTS fallback —
 // return an honest signal instead, so we always finish under the 120s registry cap.
 const PRO_CONTRA_OVERALL_SOFT_BUDGET_MS = 95_000;
@@ -510,8 +519,17 @@ export class ProceduralTools extends BaseToolHandler {
         PRO_CONTRA_GATHER_BUDGET_MS, 'comparePracticeProContra.gather',
       );
       if (gathered && gathered.candidates.length > 0) {
+        // Anchor classification to the operative part: fetch each candidate's dispositive so the
+        // LLM decides stance from the actual outcome (задоволено/відмовлено/скасовано), not a
+        // topically-similar snippet that only restates the norm. Best-effort — on timeout the
+        // map is empty and classification degrades to snippet-only.
+        const dispositives = await withSoftTimeout(
+          this.fetchDispositives(gathered.candidates.map(c => c.doc_id)),
+          PRO_CONTRA_DISPOSITIVE_BUDGET_MS, 'comparePracticeProContra.dispositive',
+        ) || new Map<number, { dispositive: string; outcome: DecisionOutcome }>();
+
         const stances = await withSoftTimeout(
-          this.classifyHoldings(query, gathered.candidates),
+          this.classifyHoldings(query, gathered.candidates, dispositives),
           PRO_CONTRA_CLASSIFY_BUDGET_MS, 'comparePracticeProContra.classify',
         );
         if (stances) {
@@ -520,12 +538,14 @@ export class ProceduralTools extends BaseToolHandler {
           for (const c of gathered.candidates) {
             const v = stances.get(c.doc_id);
             if (!v) continue;
+            const disp = dispositives.get(c.doc_id);
             const row = {
               doc_id: c.doc_id,
               court_code: c.court_code,
               date: c.date,
               case_number: c.case_number,
               snippet: v.quote || c.fragment,
+              outcome: disp?.outcome || 'unknown',
               confidence: v.confidence,
             };
             if (v.stance === 'supports') pro.push(row);
@@ -870,31 +890,83 @@ export class ProceduralTools extends BaseToolHandler {
   }
 
   /**
+   * Batch-fetch the dispositive (резолютивна частина) of each candidate decision and derive a
+   * coarse outcome label. One ANY($1) query over edrsr_fulltext keeps this to a single round
+   * trip; the dispositive is sliced tight (operative result sits right after the marker) so the
+   * downstream classifier prompt stays bounded. Best-effort: any DB error returns an empty map
+   * and classification degrades to snippet-only (legacy behaviour).
+   */
+  private async fetchDispositives(
+    docIds: number[],
+  ): Promise<Map<number, { dispositive: string; outcome: DecisionOutcome }>> {
+    const out = new Map<number, { dispositive: string; outcome: DecisionOutcome }>();
+    const ids = [...new Set(docIds.filter((id) => Number.isFinite(id)))];
+    if (!this.db || ids.length === 0) return out;
+    try {
+      const res = await this.db.query(
+        `SELECT doc_id, full_text FROM edrsr_fulltext WHERE doc_id = ANY($1)`,
+        [ids],
+      );
+      for (const r of res.rows) {
+        const { dispositive } = extractDispositiveFromText(r.full_text || '');
+        if (!dispositive) continue;
+        out.set(Number(r.doc_id), {
+          dispositive: dispositive.replace(/\s+/g, ' ').slice(0, PRO_CONTRA_DISPOSITIVE_SLICE_CHARS),
+          outcome: classifyOutcome(dispositive),
+        });
+      }
+    } catch (err: any) {
+      logger.warn('[fetchDispositives] failed — degrading to snippet-only', { error: err?.message });
+    }
+    return out;
+  }
+
+  /**
    * LLM holding classification: for each candidate decision, classify its holding relative to
    * the user's thesis as supports / opposes / not_on_point, with a short cited fragment and
    * confidence. One batched call on the 'quick' tier (Haiku) — the task is a constrained
    * 3-way classification over short fragments, so the cheap/fast tier is sufficient and keeps
    * the call well inside its soft budget. Returns null only when even a repair pass fails.
+   *
+   * When a candidate's dispositive is available it is included in the prompt and the model is
+   * instructed to anchor the stance to the operative outcome (задоволено/відмовлено/скасовано)
+   * — not to a snippet that merely restates the norm. This is what prevents the classifier from
+   * inverting a refusal into a "supports".
    */
   private async classifyHoldings(
     thesis: string,
     candidates: Array<{ doc_id: number; case_number?: string; court_code?: number; fragment: string }>,
+    dispositives?: Map<number, { dispositive: string; outcome: DecisionOutcome }>,
   ): Promise<Map<number, { stance: 'supports' | 'opposes' | 'not_on_point'; quote: string; confidence: number }> | null> {
     if (!this.llm) return null;
-    const items = candidates.map((c, i) => (
-      `#${i} doc_id=${c.doc_id} справа=${c.case_number || '—'}\nФрагмент: ${(c.fragment || '').replace(/\s+/g, ' ').slice(0, 800)}`
-    )).join('\n\n');
+    const items = candidates.map((c, i) => {
+      const disp = dispositives?.get(c.doc_id);
+      const lines = [
+        `#${i} doc_id=${c.doc_id} справа=${c.case_number || '—'}`,
+        `Фрагмент: ${(c.fragment || '').replace(/\s+/g, ' ').slice(0, 600)}`,
+      ];
+      if (disp?.dispositive) {
+        lines.push(`Резолютивна частина: ${disp.dispositive}`);
+      }
+      return lines.join('\n');
+    }).join('\n\n');
 
     const system =
-      'Ти суддя-аналітик. Тобі дано ТЕЗУ та фрагменти судових рішень. ' +
-      'Для КОЖНОГО рішення визнач його позицію щодо тези: ' +
+      'Ти суддя-аналітик. Тобі дано ТЕЗУ, релевантний фрагмент і (за наявності) РЕЗОЛЮТИВНУ ' +
+      'ЧАСТИНУ кожного судового рішення. Для КОЖНОГО рішення визнач його позицію щодо тези: ' +
       '"supports" — рішення підтверджує тезу; "opposes" — спростовує тезу; ' +
-      '"not_on_point" — фрагмент не дозволяє визначити позицію щодо тези. ' +
+      '"not_on_point" — неможливо визначити позицію щодо тези. ' +
+      'НАЙВАЖЛИВІШЕ: позиція має відповідати ФАКТИЧНОМУ результату в резолютивній частині ' +
+      '(позов задоволено / у задоволенні відмовлено / рішення скасовано / справу повернено), ' +
+      'а не лише цитуванню норми у фрагменті. Зваж, ХТО подав скаргу: «касаційну скаргу залишити ' +
+      'без задоволення» означає, що в силі лишається попереднє рішення — визнач результат для ПОЗОВУ, ' +
+      'а не для скарги. Якщо резолютивна частина суперечить фрагменту — довіряй резолютивній частині. ' +
       'Якщо не впевнений — став "not_on_point". Відповідай ВИКЛЮЧНО валідним JSON.';
     const user =
       `ТЕЗА: ${thesis}\n\nРІШЕННЯ:\n${items}\n\n` +
       'Поверни JSON: {"classifications":[{"doc_id":<число>,"stance":"supports|opposes|not_on_point",' +
-      '"quote":"<коротка цитата з фрагмента українською, ≤200 симв.>","confidence":<0..1>}]}';
+      '"quote":"<коротка цитата з фрагмента або резолютивної частини українською, ≤200 симв.>",' +
+      '"confidence":<0..1>}]}';
 
     const response = await this.llm.chatCompletion(
       {

--- a/mcp_backend/src/utils/__tests__/dispositive.test.ts
+++ b/mcp_backend/src/utils/__tests__/dispositive.test.ts
@@ -1,0 +1,52 @@
+import { extractDispositiveFromText, classifyOutcome } from '../dispositive';
+
+describe('extractDispositiveFromText', () => {
+  it('extracts from the earliest dispositive marker', () => {
+    const text = 'ВСТАНОВИВ: факти ... ПОСТАНОВИВ: у задоволенні позову відмовити.';
+    const r = extractDispositiveFromText(text);
+    expect(r.is_fallback).toBe(false);
+    expect(r.marker).toBe('ПОСТАНОВИВ:');
+    expect(r.dispositive.startsWith('ПОСТАНОВИВ:')).toBe(true);
+  });
+
+  it('falls back to the document tail when no marker is present', () => {
+    const text = 'a'.repeat(5000) + 'КІНЕЦЬ';
+    const r = extractDispositiveFromText(text, 8000, 100);
+    expect(r.is_fallback).toBe(true);
+    expect(r.marker).toBeNull();
+    expect(r.dispositive.length).toBe(100);
+    expect(r.dispositive.endsWith('КІНЕЦЬ')).toBe(true);
+  });
+
+  it('returns empty on empty input', () => {
+    expect(extractDispositiveFromText('').dispositive).toBe('');
+  });
+});
+
+describe('classifyOutcome', () => {
+  it('detects denial', () => {
+    expect(classifyOutcome('ПОСТАНОВИВ: у задоволенні позову відмовити.')).toBe('denied');
+    expect(classifyOutcome('касаційну скаргу залишити без задоволення')).toBe('denied');
+  });
+
+  it('detects grant', () => {
+    expect(classifyOutcome('ВИРІШИВ: позов задовольнити.')).toBe('granted');
+  });
+
+  it('detects partial grant before plain grant', () => {
+    expect(classifyOutcome('позовні вимоги задовольнити частково')).toBe('partial');
+  });
+
+  it('detects remand', () => {
+    expect(classifyOutcome('скасувати, справу передати на новий касаційний розгляд')).toBe('remanded');
+  });
+
+  it('detects procedural disposal', () => {
+    expect(classifyOutcome('справу повернути відповідній колегії суддів для розгляду')).toBe('procedural');
+  });
+
+  it('returns unknown when nothing matches', () => {
+    expect(classifyOutcome('довільний текст без резолюції')).toBe('unknown');
+    expect(classifyOutcome('')).toBe('unknown');
+  });
+});

--- a/mcp_backend/src/utils/dispositive.ts
+++ b/mcp_backend/src/utils/dispositive.ts
@@ -1,0 +1,118 @@
+/**
+ * Dispositive (резолютивна частина) extraction + coarse outcome classification.
+ *
+ * Shared by:
+ *  - edrsr_get_decision_dispositive (edrsr-extended-tools.ts) — user-facing extraction
+ *  - compare_practice_pro_contra (procedural-tools.ts) — anchors pro/contra stance to the
+ *    operative part of the decision instead of a topically-similar snippet, which only
+ *    restates the norm and led the classifier to invert outcomes.
+ *
+ * The marker list is the single source of truth — keep both call sites importing from here.
+ */
+
+export const DISPOSITIVE_MARKERS = [
+  'ВИРІШИВ:',
+  'УХВАЛИВ:',
+  'ПОСТАНОВИВ:',
+  'ВИРОК',
+  'В И Р І Ш И В',
+  'У Х В А Л И В',
+  'П О С Т А Н О В И В',
+  'в и р і ш и в',
+  'у х в а л и в',
+  'п о с т а н о в и в',
+];
+
+export const DISPOSITIVE_MAX_CHARS = 8000;
+export const DISPOSITIVE_FALLBACK_TAIL_CHARS = 4000;
+
+export interface ExtractedDispositive {
+  dispositive: string;
+  /** Which marker matched, or null when the tail-fallback was used. */
+  marker: string | null;
+  /** Char offset of the marker in the full text, or null on fallback. */
+  marker_position: number | null;
+  /** true when no marker was found and the document tail was returned instead. */
+  is_fallback: boolean;
+}
+
+/**
+ * Extract the operative part of a decision from its full text by locating the earliest
+ * dispositive marker. Falls back to the document tail (where the operative part almost always
+ * sits) when no marker is present.
+ */
+export function extractDispositiveFromText(
+  fullText: string,
+  maxChars: number = DISPOSITIVE_MAX_CHARS,
+  tailChars: number = DISPOSITIVE_FALLBACK_TAIL_CHARS,
+): ExtractedDispositive {
+  const text = fullText || '';
+  if (!text) {
+    return { dispositive: '', marker: null, marker_position: null, is_fallback: false };
+  }
+
+  let bestPos = -1;
+  let bestMarker: string | null = null;
+  for (const marker of DISPOSITIVE_MARKERS) {
+    const pos = text.indexOf(marker);
+    if (pos >= 0 && (bestPos === -1 || pos < bestPos)) {
+      bestPos = pos;
+      bestMarker = marker;
+    }
+  }
+
+  if (bestPos >= 0) {
+    return {
+      dispositive: text.slice(bestPos, bestPos + maxChars),
+      marker: bestMarker,
+      marker_position: bestPos,
+      is_fallback: false,
+    };
+  }
+
+  const tailStart = Math.max(0, text.length - tailChars);
+  return {
+    dispositive: text.slice(tailStart),
+    marker: null,
+    marker_position: null,
+    is_fallback: true,
+  };
+}
+
+/**
+ * Coarse outcome of a decision, derived from its dispositive. Intentionally conservative:
+ * cassation/appeal operative parts speak in terms of the *appeal* ("касаційну скаргу
+ * залишити без задоволення"), so the claim-level result is often not recoverable by keywords
+ * alone. This label is metadata/transparency — the authoritative pro/contra stance is decided
+ * by the LLM, which is given the full dispositive text and can reason about who appealed.
+ */
+export type DecisionOutcome =
+  | 'granted'      // позов/скаргу задоволено
+  | 'denied'       // у задоволенні відмовлено / залишено без задоволення
+  | 'partial'      // задоволено частково
+  | 'remanded'     // направлено на новий розгляд
+  | 'quashed'      // рішення скасовано (без прямого нового рішення)
+  | 'procedural'   // ухвала процесуального характеру (повернення/закриття тощо)
+  | 'unknown';
+
+export function classifyOutcome(dispositive: string): DecisionOutcome {
+  const t = (dispositive || '').toLowerCase().replace(/\s+/g, ' ');
+  if (!t) return 'unknown';
+
+  // Order matters: more specific patterns first.
+  if (/задовольнити частково|задоволено частково|частково задовольнити/.test(t)) return 'partial';
+  if (/направити (справу )?(на новий розгляд|для нового розгляду)|передати (справу )?на новий (касаційний )?розгляд/.test(t)) {
+    return 'remanded';
+  }
+  if (/(повернути|повертається).*(колегії суддів|скаргу|заяву|справу)|(справу|скаргу|заяву).*(повернути|повертається)|закрити (касаційне |апеляційне )?провадження|залишити (позов|заяву|скаргу) без розгляду/.test(t)) {
+    return 'procedural';
+  }
+  if (/у задоволенні (позову|позовних вимог|заяви|скарги).{0,40}(відмов)|відмовити (повністю )?у задоволенні|залишити без задоволення/.test(t)) {
+    return 'denied';
+  }
+  if (/(позов|позовні вимоги|заяву|скаргу).{0,60}задовольнити|задовольнити (позов|позовні вимоги|заяву|скаргу)/.test(t)) {
+    return 'granted';
+  }
+  if (/скасувати|скасовано/.test(t)) return 'quashed';
+  return 'unknown';
+}


### PR DESCRIPTION
Closes **LEXAI-1783**. Fixes the «network error» a user hit in chat — root-caused to the blue-green deploy cutover cutting the in-flight SSE stream.

## Problem

During a prod deploy, the nginx upstream switches backend color and any **open chat SSE stream is cut**. `MCPService.streamChat` surfaced the dropped `fetch` via `getErrorMessage` → a raw, English **«network error»** in the chat bubble + toast (`handleStreamError`). Alarming, English, and unactionable — even though the right move is just "try again in a second once the new color is up".

## Fix (`MCPService.streamChat`)

- **Transparent retry** (up to 2×, 0.7s/1.4s backoff) **only when the connection fails at the network layer before any event was received**. If nothing was streamed, re-sending can't duplicate a partial answer or double-charge — and that's exactly the cutover case (request hit the draining backend / upstream mid-switch → reset; the new color is up moments later). The retry succeeds and the user never sees an error.
- **Any failure after the first event is final** (no retry) — protects against duplicate runs / double-charge when a partial answer already streamed.
- On a non-retryable network failure, show a **clear Ukrainian connection-lost message** instead of the browser's "Failed to fetch".
- `onStreamEnd` still fires **exactly once**, after the final attempt.

Adds `isNetworkError()` — an engine-agnostic `TypeError` fetch-failure detector (Chrome "Failed to fetch" / Firefox "NetworkError…" / Safari "Load failed").

## Why frontend retry (not deploy-side SSE drain)

Draining active SSE streams before a color switch would delay every deploy by however long the longest chat runs (up to the 240–300s wall-clock) and needs orchestration changes. The client-side retry is self-contained, costs nothing on the happy path, and also covers transient network blips unrelated to deploys.

## Testing

`MCPService.test.ts` — **12 pass**: transparent retry → success (2 fetches, no error); connection-lost message after exhausting retries (3 fetches, Ukrainian message); no retry once an event arrived (1 fetch). Also stubs `localStorage` in the suite setup so it runs on Node 26 + happy-dom — incidentally **fixing 7 pre-existing local failures** in that file. `tsc` clean.

## Note on partial answers (out of scope)
When a drop happens *mid-answer*, the existing `handleStreamError` still replaces the bubble with the error text (pre-existing behavior) — now a clearer message rather than "network error". Preserving already-streamed partial content on error is a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat streaming resilient to blue‑green deploys by transparently retrying SSE connections before any data is received; users no longer see “network error” and only get a clear Ukrainian message if retries fail. Also standardize dispositive extraction and use it to anchor pro/contra classification to the operative outcome for better accuracy.

- **Bug Fixes**
  - Retries SSE connect up to 2× with 0.7s/1.4s backoff only if no event was received, avoiding deploy cutover failures and addressing LEXAI-1783.
  - No retry after the first event; `onStreamEnd` fires once; shows a clear Ukrainian connection-lost message on final failure.
  - Adds an engine‑agnostic network error detector and tests for retry success/failure and no-retry-after-event.

- **Refactors**
  - Added shared dispositive extractor and outcome classifier, used by `edrsr_get_decision_dispositive` and pro/contra tools.
  - Pro/contra classification now includes dispositive text and exposes a coarse outcome label; batched DB fetch with tight slices and new tests.

<sup>Written for commit 8e1ee1864a4628d499cef7b385c30efdf69aee7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

