### PR TITLE
fix(pro-contra): anchor stance to dispositive, not snippet

### DIFF
--- a/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
+++ b/mcp_backend/src/api/__tests__/pro-contra-holding.test.ts
@@ -131,6 +131,43 @@ describe('comparePracticeProContra — LLM holding classification', () => {
     expect(out.contra.map((c: any) => c.doc_id)).toEqual([103]);
   });
 
+  it('fetches each candidate dispositive, feeds it to the classifier and labels the outcome', async () => {
+    // The semantic snippet only restates the norm; the operative outcome lives in the
+    // dispositive. We assert (a) the dispositive text reaches the classifier prompt and
+    // (b) the programmatic outcome label is attached to the output row.
+    const edsrVectorizer: any = {
+      semanticSearch: jest.fn().mockResolvedValue([
+        hit(601, 9921, 'підставою недійсності є недодержання вимог ст. 203 ЦК'),
+      ]),
+    };
+    const llm: any = {
+      chatCompletion: jest.fn().mockResolvedValue({
+        content: JSON.stringify({
+          classifications: [{ doc_id: 601, stance: 'opposes', quote: 'у задоволенні позову відмовлено', confidence: 0.9 }],
+        }),
+      }),
+    };
+    const db: any = {
+      query: jest.fn().mockResolvedValue({
+        rows: [{ doc_id: 601, full_text: 'мотивувальна частина ... ПОСТАНОВИВ: у задоволенні позову про визнання правочину недійсним відмовити.' }],
+      }),
+    };
+    const tools = new ProceduralTools(
+      {} as any, {} as any, {} as any, {} as any, {} as any,
+      llm, undefined, db, edsrVectorizer,
+    );
+    const out = await run(tools, { procedure_code: 'cpc', query: 'теза' });
+
+    // Dispositive was queried by doc_id and its text was placed into the classifier prompt.
+    expect(db.query).toHaveBeenCalled();
+    const userPrompt = llm.chatCompletion.mock.calls[0][0].messages[1].content;
+    expect(userPrompt).toContain('Резолютивна частина:');
+    expect(userPrompt).toContain('у задоволенні позову');
+    // Programmatic outcome label is surfaced on the row.
+    expect(out.contra[0].doc_id).toBe(601);
+    expect(out.contra[0].outcome).toBe('denied');
+  });
+
   it('seeds contra practice via FTS when the semantic pool skews pro', async () => {
     const tools = makeTools({
       // Semantic leg returns only thesis-agreeing decisions.

--- a/mcp_backend/src/api/tools/edrsr-extended-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-extended-tools.ts
@@ -12,24 +12,10 @@
 
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { logger } from '../../utils/logger.js';
-
-const DISPOSITIVE_MARKERS = [
-  'ВИРІШИВ:',
-  'УХВАЛИВ:',
-  'ПОСТАНОВИВ:',
-  'ВИРОК',
-  'В И Р І Ш И В',
-  'У Х В А Л И В',
-  'П О С Т А Н О В И В',
-  'в и р і ш и в',
-  'у х в а л и в',
-  'п о с т а н о в и в',
-];
+import { extractDispositiveFromText } from '../../utils/dispositive.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
-const DISPOSITIVE_MAX_CHARS = 8000;
-const DISPOSITIVE_FALLBACK_TAIL_CHARS = 4000;
 const STATEMENT_TIMEOUT_MS = 60_000;
 
 export class EdsrExtendedTools extends BaseToolHandler {
@@ -282,44 +268,26 @@ export class EdsrExtendedTools extends BaseToolHandler {
         });
       }
 
-      let bestPos = -1;
-      let bestMarker: string | null = null;
-      for (const marker of DISPOSITIVE_MARKERS) {
-        const pos = fullText.indexOf(marker);
-        if (pos >= 0 && (bestPos === -1 || pos < bestPos)) {
-          bestPos = pos;
-          bestMarker = marker;
-        }
-      }
-
-      let dispositive: string;
-      let isFallback = false;
-
-      if (bestPos >= 0) {
-        dispositive = fullText.slice(bestPos, bestPos + DISPOSITIVE_MAX_CHARS);
-      } else {
-        const tailStart = Math.max(0, fullText.length - DISPOSITIVE_FALLBACK_TAIL_CHARS);
-        dispositive = fullText.slice(tailStart);
-        isFallback = true;
-      }
+      const { dispositive, marker, marker_position, is_fallback } =
+        extractDispositiveFromText(fullText);
 
       logger.info('[EdsrExtendedTools] edrsr_get_decision_dispositive', {
         doc_id: docId,
-        marker: bestMarker,
-        marker_position: bestPos >= 0 ? bestPos : null,
+        marker,
+        marker_position,
         text_length: textLength,
-        is_fallback: isFallback,
+        is_fallback,
         dispositive_length: dispositive.length,
       });
 
       return this.wrapResponse({
         doc_id: Number(docId) || docId,
         dispositive,
-        marker: bestMarker,
-        marker_position: bestPos >= 0 ? bestPos : null,
+        marker,
+        marker_position,
         text_length: textLength,
         dispositive_length: dispositive.length,
-        is_fallback: isFallback,
+        is_fallback,
         external_url: `https://reyestr.court.gov.ua/Review/${docId}`,
       });
     } catch (err: any) {

--- a/mcp_backend/src/api/tools/procedural-tools.ts
+++ b/mcp_backend/src/api/tools/procedural-tools.ts
@@ -20,6 +20,7 @@ import { EdsrVectorizerService, EdrsrSearchFilters } from '../../services/edrsr-
 import { SectionType } from '../../types/index.js';
 import { logger } from '../../utils/logger.js';
 import { extractSearchTermsWithAI } from '../../utils/html-parser.js';
+import { extractDispositiveFromText, classifyOutcome, DecisionOutcome } from '../../utils/dispositive.js';
 import { SemanticSectionizer } from '../../services/semantic-sectionizer.js';
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import {
@@ -135,7 +136,15 @@ function isCourtLevelMatch(courtCode: any, filter?: 'SC' | 'GrandChamber'): bool
 // the whole tool at 120s (tool-registry.ts); these keep each external leg bounded so a slow
 // qdrant or an overloaded LLM degrades to a useful partial answer instead of a hard timeout.
 const PRO_CONTRA_GATHER_BUDGET_MS = 15_000;
+// Batched DB fetch of each candidate's dispositive (резолютивна частина) before classification,
+// so the LLM anchors the pro/contra stance to the operative outcome instead of a snippet that
+// merely restates the norm. One ANY($1) query over the candidate doc_ids — fast; the budget is
+// defense-in-depth so a slow/locked edrsr_fulltext degrades to snippet-only classification.
+const PRO_CONTRA_DISPOSITIVE_BUDGET_MS = 8_000;
 const PRO_CONTRA_CLASSIFY_BUDGET_MS = 35_000;
+// Per-candidate dispositive slice fed to the classifier. The operative result sits in the first
+// few hundred chars after the marker; keep it tight so the batched prompt stays bounded.
+const PRO_CONTRA_DISPOSITIVE_SLICE_CHARS = 900;
 // Past this point on the wall clock, don't start the multi-instance keyword-FTS fallback —
 // return an honest signal instead, so we always finish under the 120s registry cap.
 const PRO_CONTRA_OVERALL_SOFT_BUDGET_MS = 95_000;
@@ -510,8 +519,17 @@ export class ProceduralTools extends BaseToolHandler {
         PRO_CONTRA_GATHER_BUDGET_MS, 'comparePracticeProContra.gather',
       );
       if (gathered && gathered.candidates.length > 0) {
+        // Anchor classification to the operative part: fetch each candidate's dispositive so the
+        // LLM decides stance from the actual outcome (задоволено/відмовлено/скасовано), not a
+        // topically-similar snippet that only restates the norm. Best-effort — on timeout the
+        // map is empty and classification degrades to snippet-only.
+        const dispositives = await withSoftTimeout(
+          this.fetchDispositives(gathered.candidates.map(c => c.doc_id)),
+          PRO_CONTRA_DISPOSITIVE_BUDGET_MS, 'comparePracticeProContra.dispositive',
+        ) || new Map<number, { dispositive: string; outcome: DecisionOutcome }>();
+
         const stances = await withSoftTimeout(
-          this.classifyHoldings(query, gathered.candidates),
+          this.classifyHoldings(query, gathered.candidates, dispositives),
           PRO_CONTRA_CLASSIFY_BUDGET_MS, 'comparePracticeProContra.classify',
         );
         if (stances) {
@@ -520,12 +538,14 @@ export class ProceduralTools extends BaseToolHandler {
           for (const c of gathered.candidates) {
             const v = stances.get(c.doc_id);
             if (!v) continue;
+            const disp = dispositives.get(c.doc_id);
             const row = {
               doc_id: c.doc_id,
               court_code: c.court_code,
               date: c.date,
               case_number: c.case_number,
               snippet: v.quote || c.fragment,
+              outcome: disp?.outcome || 'unknown',
               confidence: v.confidence,
             };
             if (v.stance === 'supports') pro.push(row);
@@ -870,31 +890,83 @@ export class ProceduralTools extends BaseToolHandler {
   }
 
   /**
+   * Batch-fetch the dispositive (резолютивна частина) of each candidate decision and derive a
+   * coarse outcome label. One ANY($1) query over edrsr_fulltext keeps this to a single round
+   * trip; the dispositive is sliced tight (operative result sits right after the marker) so the
+   * downstream classifier prompt stays bounded. Best-effort: any DB error returns an empty map
+   * and classification degrades to snippet-only (legacy behaviour).
+   */
+  private async fetchDispositives(
+    docIds: number[],
+  ): Promise<Map<number, { dispositive: string; outcome: DecisionOutcome }>> {
+    const out = new Map<number, { dispositive: string; outcome: DecisionOutcome }>();
+    const ids = [...new Set(docIds.filter((id) => Number.isFinite(id)))];
+    if (!this.db || ids.length === 0) return out;
+    try {
+      const res = await this.db.query(
+        `SELECT doc_id, full_text FROM edrsr_fulltext WHERE doc_id = ANY($1)`,
+        [ids],
+      );
+      for (const r of res.rows) {
+        const { dispositive } = extractDispositiveFromText(r.full_text || '');
+        if (!dispositive) continue;
+        out.set(Number(r.doc_id), {
+          dispositive: dispositive.replace(/\s+/g, ' ').slice(0, PRO_CONTRA_DISPOSITIVE_SLICE_CHARS),
+          outcome: classifyOutcome(dispositive),
+        });
+      }
+    } catch (err: any) {
+      logger.warn('[fetchDispositives] failed — degrading to snippet-only', { error: err?.message });
+    }
+    return out;
+  }
+
+  /**
    * LLM holding classification: for each candidate decision, classify its holding relative to
    * the user's thesis as supports / opposes / not_on_point, with a short cited fragment and
    * confidence. One batched call on the 'quick' tier (Haiku) — the task is a constrained
    * 3-way classification over short fragments, so the cheap/fast tier is sufficient and keeps
    * the call well inside its soft budget. Returns null only when even a repair pass fails.
+   *
+   * When a candidate's dispositive is available it is included in the prompt and the model is
+   * instructed to anchor the stance to the operative outcome (задоволено/відмовлено/скасовано)
+   * — not to a snippet that merely restates the norm. This is what prevents the classifier from
+   * inverting a refusal into a "supports".
    */
   private async classifyHoldings(
     thesis: string,
     candidates: Array<{ doc_id: number; case_number?: string; court_code?: number; fragment: string }>,
+    dispositives?: Map<number, { dispositive: string; outcome: DecisionOutcome }>,
   ): Promise<Map<number, { stance: 'supports' | 'opposes' | 'not_on_point'; quote: string; confidence: number }> | null> {
     if (!this.llm) return null;
-    const items = candidates.map((c, i) => (
-      `#${i} doc_id=${c.doc_id} справа=${c.case_number || '—'}\nФрагмент: ${(c.fragment || '').replace(/\s+/g, ' ').slice(0, 800)}`
-    )).join('\n\n');
+    const items = candidates.map((c, i) => {
+      const disp = dispositives?.get(c.doc_id);
+      const lines = [
+        `#${i} doc_id=${c.doc_id} справа=${c.case_number || '—'}`,
+        `Фрагмент: ${(c.fragment || '').replace(/\s+/g, ' ').slice(0, 600)}`,
+      ];
+      if (disp?.dispositive) {
+        lines.push(`Резолютивна частина: ${disp.dispositive}`);
+      }
+      return lines.join('\n');
+    }).join('\n\n');
 
     const system =
-      'Ти суддя-аналітик. Тобі дано ТЕЗУ та фрагменти судових рішень. ' +
-      'Для КОЖНОГО рішення визнач його позицію щодо тези: ' +
+      'Ти суддя-аналітик. Тобі дано ТЕЗУ, релевантний фрагмент і (за наявності) РЕЗОЛЮТИВНУ ' +
+      'ЧАСТИНУ кожного судового рішення. Для КОЖНОГО рішення визнач його позицію щодо тези: ' +
       '"supports" — рішення підтверджує тезу; "opposes" — спростовує тезу; ' +
-      '"not_on_point" — фрагмент не дозволяє визначити позицію щодо тези. ' +
+      '"not_on_point" — неможливо визначити позицію щодо тези. ' +
+      'НАЙВАЖЛИВІШЕ: позиція має відповідати ФАКТИЧНОМУ результату в резолютивній частині ' +
+      '(позов задоволено / у задоволенні відмовлено / рішення скасовано / справу повернено), ' +
+      'а не лише цитуванню норми у фрагменті. Зваж, ХТО подав скаргу: «касаційну скаргу залишити ' +
+      'без задоволення» означає, що в силі лишається попереднє рішення — визнач результат для ПОЗОВУ, ' +
+      'а не для скарги. Якщо резолютивна частина суперечить фрагменту — довіряй резолютивній частині. ' +
       'Якщо не впевнений — став "not_on_point". Відповідай ВИКЛЮЧНО валідним JSON.';
     const user =
       `ТЕЗА: ${thesis}\n\nРІШЕННЯ:\n${items}\n\n` +
       'Поверни JSON: {"classifications":[{"doc_id":<число>,"stance":"supports|opposes|not_on_point",' +
-      '"quote":"<коротка цитата з фрагмента українською, ≤200 симв.>","confidence":<0..1>}]}';
+      '"quote":"<коротка цитата з фрагмента або резолютивної частини українською, ≤200 симв.>",' +
+      '"confidence":<0..1>}]}';
 
     const response = await this.llm.chatCompletion(
       {

--- a/mcp_backend/src/utils/__tests__/dispositive.test.ts
+++ b/mcp_backend/src/utils/__tests__/dispositive.test.ts
@@ -1,0 +1,52 @@
+import { extractDispositiveFromText, classifyOutcome } from '../dispositive';
+
+describe('extractDispositiveFromText', () => {
+  it('extracts from the earliest dispositive marker', () => {
+    const text = 'ВСТАНОВИВ: факти ... ПОСТАНОВИВ: у задоволенні позову відмовити.';
+    const r = extractDispositiveFromText(text);
+    expect(r.is_fallback).toBe(false);
+    expect(r.marker).toBe('ПОСТАНОВИВ:');
+    expect(r.dispositive.startsWith('ПОСТАНОВИВ:')).toBe(true);
+  });
+
+  it('falls back to the document tail when no marker is present', () => {
+    const text = 'a'.repeat(5000) + 'КІНЕЦЬ';
+    const r = extractDispositiveFromText(text, 8000, 100);
+    expect(r.is_fallback).toBe(true);
+    expect(r.marker).toBeNull();
+    expect(r.dispositive.length).toBe(100);
+    expect(r.dispositive.endsWith('КІНЕЦЬ')).toBe(true);
+  });
+
+  it('returns empty on empty input', () => {
+    expect(extractDispositiveFromText('').dispositive).toBe('');
+  });
+});
+
+describe('classifyOutcome', () => {
+  it('detects denial', () => {
+    expect(classifyOutcome('ПОСТАНОВИВ: у задоволенні позову відмовити.')).toBe('denied');
+    expect(classifyOutcome('касаційну скаргу залишити без задоволення')).toBe('denied');
+  });
+
+  it('detects grant', () => {
+    expect(classifyOutcome('ВИРІШИВ: позов задовольнити.')).toBe('granted');
+  });
+
+  it('detects partial grant before plain grant', () => {
+    expect(classifyOutcome('позовні вимоги задовольнити частково')).toBe('partial');
+  });
+
+  it('detects remand', () => {
+    expect(classifyOutcome('скасувати, справу передати на новий касаційний розгляд')).toBe('remanded');
+  });
+
+  it('detects procedural disposal', () => {
+    expect(classifyOutcome('справу повернути відповідній колегії суддів для розгляду')).toBe('procedural');
+  });
+
+  it('returns unknown when nothing matches', () => {
+    expect(classifyOutcome('довільний текст без резолюції')).toBe('unknown');
+    expect(classifyOutcome('')).toBe('unknown');
+  });
+});

--- a/mcp_backend/src/utils/dispositive.ts
+++ b/mcp_backend/src/utils/dispositive.ts
@@ -1,0 +1,118 @@
+/**
+ * Dispositive (резолютивна частина) extraction + coarse outcome classification.
+ *
+ * Shared by:
+ *  - edrsr_get_decision_dispositive (edrsr-extended-tools.ts) — user-facing extraction
+ *  - compare_practice_pro_contra (procedural-tools.ts) — anchors pro/contra stance to the
+ *    operative part of the decision instead of a topically-similar snippet, which only
+ *    restates the norm and led the classifier to invert outcomes.
+ *
+ * The marker list is the single source of truth — keep both call sites importing from here.
+ */
+
+export const DISPOSITIVE_MARKERS = [
+  'ВИРІШИВ:',
+  'УХВАЛИВ:',
+  'ПОСТАНОВИВ:',
+  'ВИРОК',
+  'В И Р І Ш И В',
+  'У Х В А Л И В',
+  'П О С Т А Н О В И В',
+  'в и р і ш и в',
+  'у х в а л и в',
+  'п о с т а н о в и в',
+];
+
+export const DISPOSITIVE_MAX_CHARS = 8000;
+export const DISPOSITIVE_FALLBACK_TAIL_CHARS = 4000;
+
+export interface ExtractedDispositive {
+  dispositive: string;
+  /** Which marker matched, or null when the tail-fallback was used. */
+  marker: string | null;
+  /** Char offset of the marker in the full text, or null on fallback. */
+  marker_position: number | null;
+  /** true when no marker was found and the document tail was returned instead. */
+  is_fallback: boolean;
+}
+
+/**
+ * Extract the operative part of a decision from its full text by locating the earliest
+ * dispositive marker. Falls back to the document tail (where the operative part almost always
+ * sits) when no marker is present.
+ */
+export function extractDispositiveFromText(
+  fullText: string,
+  maxChars: number = DISPOSITIVE_MAX_CHARS,
+  tailChars: number = DISPOSITIVE_FALLBACK_TAIL_CHARS,
+): ExtractedDispositive {
+  const text = fullText || '';
+  if (!text) {
+    return { dispositive: '', marker: null, marker_position: null, is_fallback: false };
+  }
+
+  let bestPos = -1;
+  let bestMarker: string | null = null;
+  for (const marker of DISPOSITIVE_MARKERS) {
+    const pos = text.indexOf(marker);
+    if (pos >= 0 && (bestPos === -1 || pos < bestPos)) {
+      bestPos = pos;
+      bestMarker = marker;
+    }
+  }
+
+  if (bestPos >= 0) {
+    return {
+      dispositive: text.slice(bestPos, bestPos + maxChars),
+      marker: bestMarker,
+      marker_position: bestPos,
+      is_fallback: false,
+    };
+  }
+
+  const tailStart = Math.max(0, text.length - tailChars);
+  return {
+    dispositive: text.slice(tailStart),
+    marker: null,
+    marker_position: null,
+    is_fallback: true,
+  };
+}
+
+/**
+ * Coarse outcome of a decision, derived from its dispositive. Intentionally conservative:
+ * cassation/appeal operative parts speak in terms of the *appeal* ("касаційну скаргу
+ * залишити без задоволення"), so the claim-level result is often not recoverable by keywords
+ * alone. This label is metadata/transparency — the authoritative pro/contra stance is decided
+ * by the LLM, which is given the full dispositive text and can reason about who appealed.
+ */
+export type DecisionOutcome =
+  | 'granted'      // позов/скаргу задоволено
+  | 'denied'       // у задоволенні відмовлено / залишено без задоволення
+  | 'partial'      // задоволено частково
+  | 'remanded'     // направлено на новий розгляд
+  | 'quashed'      // рішення скасовано (без прямого нового рішення)
+  | 'procedural'   // ухвала процесуального характеру (повернення/закриття тощо)
+  | 'unknown';
+
+export function classifyOutcome(dispositive: string): DecisionOutcome {
+  const t = (dispositive || '').toLowerCase().replace(/\s+/g, ' ');
+  if (!t) return 'unknown';
+
+  // Order matters: more specific patterns first.
+  if (/задовольнити частково|задоволено частково|частково задовольнити/.test(t)) return 'partial';
+  if (/направити (справу )?(на новий розгляд|для нового розгляду)|передати (справу )?на новий (касаційний )?розгляд/.test(t)) {
+    return 'remanded';
+  }
+  if (/(повернути|повертається).*(колегії суддів|скаргу|заяву|справу)|(справу|скаргу|заяву).*(повернути|повертається)|закрити (касаційне |апеляційне )?провадження|залишити (позов|заяву|скаргу) без розгляду/.test(t)) {
+    return 'procedural';
+  }
+  if (/у задоволенні (позову|позовних вимог|заяви|скарги).{0,40}(відмов)|відмовити (повністю )?у задоволенні|залишити без задоволення/.test(t)) {
+    return 'denied';
+  }
+  if (/(позов|позовні вимоги|заяву|скаргу).{0,60}задовольнити|задовольнити (позов|позовні вимоги|заяву|скаргу)/.test(t)) {
+    return 'granted';
+  }
+  if (/скасувати|скасовано/.test(t)) return 'quashed';
+  return 'unknown';
+}


### PR DESCRIPTION
## Проблема

`compare_practice_pro_contra` классифицировал линию «за/проти» по семантическому сниппету, который лишь повторяет норму. Модель угадывала исход дела и регулярно его **инвертировала** (отказ в иске попадал в линию «supports»).

Аудит реального чата (`chat-56ce271a`) показал: из 7 процитированных дел все doc_id реальные, но ~50% «pro»-линии — с инвертированным или галлюцинированным исходом:
- `104687086` — процессуальная ухвала о возврате дела, выводов по ст. 215 в документе нет;
- `41384789` — дело про исковую давность, направлено на новое рассмотрение;
- `81171291` — фактически **отказ** в признании недействительным (линия ПРОТИ), отнесено к ЗА.

## Решение

Перед классификацией инструмент батч-подтягивает **резолютивную часть** каждого кандидата (один `SELECT ... WHERE doc_id = ANY($1)` по `edrsr_fulltext`, под soft-budget 8с) и передаёт её классификатору. Новый промпт инструктирует определять позицию по фактическому результату резолютивки и учитывать, кто подал жалобу («касаційну скаргу залишити без задоволення» → результат для ПОЗОВА, не для скарги). При ошибке/таймауте БД — graceful degrade к прежнему snippet-only поведению.

## Изменения
- **new `src/utils/dispositive.ts`** — единый источник истины: список маркеров + `extractDispositiveFromText()` + грубая метка `classifyOutcome()` (`granted/denied/partial/remanded/quashed/procedural/unknown`).
- `edrsr-extended-tools.ts` (`edrsr_get_decision_dispositive`) отрефакторен на эту утилиту — маркеры больше не дублируются.
- В каждую строку pro/contra добавлено поле `outcome` для прозрачности.
- Тесты: unit-тесты утилиты + регрессия на dispositive-anchoring; существующие 5 тестов pro/contra проходят.

## Проверка
- `npx tsc --noEmit` — изменённые файлы чисты.
- `npx jest` dispositive + pro-contra — **15/15 passed**, graceful degradation подтверждён.

## Ограничение
Программный `classifyOutcome` намеренно консервативен (для кассационных резолютивок claim-level исход по ключевым словам не восстанавливается надёжно). Авторитетное решение «за/проти» остаётся за LLM, которой теперь дают полный текст резолютивки; `outcome` — метаданные/прозрачность.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchored pro/contra classification to each decision’s dispositive (operative part) instead of the semantic snippet to stop inverted outcomes, and exposed a coarse `outcome` label for transparency.

- **Bug Fixes**
  - Batch-fetch each candidate’s dispositive via a single `ANY($1)` query (8s soft budget) and pass it to the classifier.
  - Prompt now tells the model to decide by the operative result and consider who appealed.
  - Graceful fallback to snippet-only when the DB times out or errors.
  - Each pro/contra row now includes an `outcome` label.

- **Refactors**
  - Added `src/utils/dispositive.ts` with markers, `extractDispositiveFromText()`, and `classifyOutcome()`.
  - Refactored `edrsr_get_decision_dispositive` to use the shared util (no duplicate markers).
  - Added unit tests for the util and a regression test for dispositive anchoring.

<sup>Written for commit 549e2006fc35099e54ad7c9f36f86007cda5d2d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

