### PR TITLE
fix(db): guard transaction() against idle-in-transaction crash (25P03)

### DIFF
--- a/packages/shared/src/database/base-database.ts
+++ b/packages/shared/src/database/base-database.ts
@@ -87,16 +87,40 @@ export class BaseDatabase {
 
   async transaction<T>(callback: (client: PoolClient) => Promise<T>): Promise<T> {
     const client = await this.pool.connect();
+
+    // A checked-out client can emit an asynchronous 'error' while the callback
+    // awaits non-DB work (e.g. an LLM/HTTP call) and no query is in flight to
+    // reject — most commonly Postgres terminating an idle-in-transaction
+    // session (SQLSTATE 25P03). Without a listener, node-pg re-throws it as an
+    // unhandled 'error' event, which crashes the whole process. Capture it here
+    // so it surfaces as a normal rejection and the broken connection is
+    // discarded on release instead of being returned to the pool poisoned.
+    let connectionError: Error | undefined;
+    const onClientError = (err: Error) => {
+      connectionError = err;
+      logger.error('Database client error during transaction (connection terminated):', err);
+    };
+    client.on('error', onClientError);
+
     try {
       await client.query('BEGIN');
       const result = await callback(client);
       await client.query('COMMIT');
       return result;
     } catch (error) {
-      await client.query('ROLLBACK');
-      throw error;
+      // The connection may already be dead (e.g. after 25P03); a failed
+      // ROLLBACK must not mask the original error or throw on its own.
+      try {
+        await client.query('ROLLBACK');
+      } catch (rollbackError) {
+        logger.warn('Transaction ROLLBACK failed (connection likely already terminated):', rollbackError);
+      }
+      throw connectionError ?? error;
     } finally {
-      client.release();
+      client.removeListener('error', onClientError);
+      // Passing the error destroys the client instead of returning it to the
+      // pool; a connection killed mid-transaction must not be reused.
+      client.release(connectionError);
     }
   }
 

--- a/packages/shared/tests/base-database.test.ts
+++ b/packages/shared/tests/base-database.test.ts
@@ -3,12 +3,18 @@
  * pool stats, metrics collector, close, schema sanitization, and createDatabaseFromEnv.
  */
 
+import { EventEmitter } from 'events';
+
 const mockQuery = jest.fn();
 const mockRelease = jest.fn();
-const mockConnect = jest.fn().mockResolvedValue({
+// Real EventEmitter so the checked-out client supports on()/removeListener()/emit()
+// — the transaction helper attaches an 'error' listener to it, and the
+// idle-in-transaction regression test emits a real 'error' event.
+const mockClient: any = Object.assign(new EventEmitter(), {
   query: mockQuery,
   release: mockRelease,
 });
+const mockConnect = jest.fn().mockResolvedValue(mockClient);
 const mockPoolQuery = jest.fn();
 const mockEnd = jest.fn().mockResolvedValue(undefined);
 const mockOn = jest.fn();
@@ -186,6 +192,42 @@ describe('BaseDatabase', () => {
       await expect(db.transaction(callback)).rejects.toThrow();
 
       expect(mockRelease).toHaveBeenCalled();
+    });
+
+    it('captures an async client error (idle-in-transaction) instead of crashing the process', async () => {
+      const db = new BaseDatabase(defaultConfig);
+      const fatal = new Error('terminating connection due to idle-in-transaction timeout');
+      mockQuery
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockRejectedValueOnce(fatal)        // COMMIT fails on the dead connection
+        .mockRejectedValueOnce(fatal);       // ROLLBACK also fails
+
+      // Postgres kills the idle-in-transaction session; pg emits 'error' on the
+      // checked-out client. Without the helper's listener this throws
+      // synchronously and crashes the process.
+      let emitThrew = false;
+      const callback = jest.fn().mockImplementation(async () => {
+        try {
+          mockClient.emit('error', fatal);
+        } catch {
+          emitThrew = true;
+        }
+      });
+
+      await expect(db.transaction(callback)).rejects.toBe(fatal);
+      expect(emitThrew).toBe(false);
+      // The poisoned connection is destroyed (released WITH the error), not
+      // returned to the pool.
+      expect(mockRelease).toHaveBeenCalledWith(fatal);
+    });
+
+    it('releases the client without an error on a clean commit', async () => {
+      const db = new BaseDatabase(defaultConfig);
+      const callback = jest.fn().mockResolvedValue('ok');
+
+      await db.transaction(callback);
+
+      expect(mockRelease).toHaveBeenCalledWith(undefined);
     });
   });
 


### PR DESCRIPTION
## Problem

A checked-out `pg` client can emit an asynchronous `'error'` while a transaction callback `await`s **non-DB work** (e.g. an LLM/Bedrock or HTTP call) with no query in flight to reject. The most common trigger is Postgres terminating an **idle-in-transaction** session (`SQLSTATE 25P03`; prod has `idle_in_transaction_session_timeout = 1min`). node-pg re-throws that as an **unhandled `'error'` event**, which crashes the entire backend process and drops every in-flight SSE chat.

### Observed on prod (2026-06-29)
One stalled transaction killed the active backend (`RestartCount=1`), surfacing to a user mid-stream as **«Зв'язок із сервером перервано»**. The crash stack was pure pg (`Client._handleErrorEvent`, `code: '25P03'`, `routine: 'ProcessInterrupts'`) with **no EDRSR/Qdrant frames** — i.e. unrelated to the qdrant-readonly cutover; a pre-existing latent bug that any transaction held open across slow work can trip.

`BaseDatabase.transaction()` is the crash vector: it `pool.connect()` → `BEGIN` → `await callback(client)`. The pool already has an `'error'` handler, but that only covers **idle** clients — a **checked-out** client mid-transaction has no listener.

## Fix

In `transaction()`:
- Attach an `'error'` listener to the checked-out client so a killed connection surfaces as a normal rejection instead of an unhandled event.
- Guard `ROLLBACK` so a dead-connection rollback can't throw or mask the original error.
- `client.release(connectionError)` — release **with** the error so the poisoned connection is destroyed, not returned to the pool.

Fully backward compatible (public signature unchanged; clean-commit path still releases normally).

### Not changed
`edrsr-fts-service.ts`'s `queryWithTimeout` uses the same connect/BEGIN pattern but is **safe** — every `await` there is an in-flight `client.query` (errors reject the await) and it's bounded by `SET LOCAL statement_timeout`, so it never sits idle-in-transaction without a listener.

## Tests

`packages/shared/tests/base-database.test.ts` — upgraded the mock client to a real `EventEmitter` and added regression tests:
- emitting `'error'` mid-transaction does **not** throw/crash, the transaction rejects with the connection error, and the client is released **with** the error (destroyed).
- clean commit releases the client with no error.

All 26 tests pass; `tsc` build clean.

## Follow-up (separate, in secondlayer-core)
Root cause is a transaction held open across LLM streaming. This PR stops the **crash**; narrowing that transaction so it doesn't sit idle >60s is a separate change in the proprietary chat/billing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents backend crashes when a checked-out `pg` client emits an async 'error' during a transaction (idle-in-transaction, SQLSTATE 25P03). The transaction now rejects cleanly and the killed connection is discarded instead of returned to the pool.

- **Bug Fixes**
  - Add a temporary `'error'` listener to the checked-out client for the transaction scope.
  - Safeguard `ROLLBACK` so a dead connection doesn’t mask the original error; release the client with the error to destroy it.
  - Add regression tests with an `EventEmitter`-backed mock client to cover mid-transaction error and clean commit.

<sup>Written for commit f9e585cd22f4aa432022e16ac6219b81c31aede1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

