### PR TITLE
dataset: KAS temporal-drift training helpers

### DIFF
--- a/scripts/lextreme/sagemaker/td-code/fill_large.py
+++ b/scripts/lextreme/sagemaker/td-code/fill_large.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Finish the remaining large-model jobs SINGLE-GPU (no DDP) at 8-way parallel.
+560M fits easily on an 80GB H100, so DDP is pure overhead here. Skips any
+(model,epoch,seed) whose cross_epoch_results.json already exists."""
+import os, sys, time, subprocess
+from pathlib import Path
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+HERE = Path(__file__).parent
+SCRIPT = HERE / "train_temporal.py"
+RESULTS = HERE / "results" / "models"
+MODELS = ["xlm-roberta-large", "legal-xlm-roberta-large"]
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+SEEDS = [42, 123, 456]
+N_GPUS = 8
+
+def done(m, e, s):
+    return (RESULTS / f"{m}_{e}_s{s}" / "cross_epoch_results.json").exists()
+
+def run(slot, m, e, s):
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(slot % N_GPUS)
+    env["MLFLOW_HARDWARE_TAG"] = "h100"
+    env["TOKENIZERS_PARALLELISM"] = "false"
+    cmd = [sys.executable, str(SCRIPT), "--model", m, "--epoch", e, "--seed", str(s)]
+    t0 = time.time()
+    print(f"START [GPU {slot%N_GPUS}] {m}/{e}/s{s}", flush=True)
+    r = subprocess.run(cmd, env=env)
+    dt = time.time() - t0
+    st = "OK" if r.returncode == 0 else "FAIL"
+    print(f"{st} [GPU {slot%N_GPUS}] {m}/{e}/s{s} ({dt:.0f}s)", flush=True)
+    return (m, e, s, st, round(dt))
+
+def main():
+    jobs = [(m, e, s) for m in MODELS for e in EPOCHS for s in SEEDS if not done(m, e, s)]
+    print(f"=== {len(jobs)} remaining large jobs, single-GPU, {N_GPUS} parallel ===", flush=True)
+    # clean incomplete dirs so Trainer doesn't try to resume a stale checkpoint
+    for m, e, s in jobs:
+        d = RESULTS / f"{m}_{e}_s{s}"
+        if d.exists():
+            subprocess.run(["rm", "-rf", str(d)])
+    results = []
+    with ProcessPoolExecutor(max_workers=N_GPUS) as pool:
+        futs = {pool.submit(run, i, *job): job for i, job in enumerate(jobs)}
+        for f in as_completed(futs):
+            results.append(f.result())
+    ok = sum(1 for r in results if r[3] == "OK")
+    print(f"\n=== FILL DONE: {ok} OK / {len(results)} ===", flush=True)
+    for r in results:
+        if r[3] == "FAIL":
+            print("  FAIL", r)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lextreme/sagemaker/td-code/prep_kas_jsonl.py
+++ b/scripts/lextreme/sagemaker/td-code/prep_kas_jsonl.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Materialize ua-temporal-drift-kas into the JSONL layout train_temporal.py expects:
+  output/{pre_war,hybrid_war,full_scale}/{train,validation,test}.jsonl
+with columns {text, label}, remapping KAS labels to the paper's taxonomy so the
+KAS numbers are directly comparable to the civil/commercial matrix:
+  granted -> approved,  denied -> dismissed,  partial -> partial
+Run on the GPU box (pulls the public HF dataset directly)."""
+import os, json
+from datasets import load_dataset
+
+REPO = "overthelex/ua-temporal-drift-kas"
+EPOCHS = ["pre_war", "hybrid_war", "full_scale"]
+SPLITS = {"train": "train", "validation": "validation", "test": "test"}
+REMAP = {"granted": "approved", "denied": "dismissed", "partial": "partial"}
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "output")
+
+def main():
+    for ep in EPOCHS:
+        ds = load_dataset(REPO, ep)
+        for split, hf_split in SPLITS.items():
+            d = os.path.join(OUT, ep)
+            os.makedirs(d, exist_ok=True)
+            n = 0
+            with open(os.path.join(d, f"{split}.jsonl"), "w", encoding="utf-8") as f:
+                for r in ds[hf_split]:
+                    f.write(json.dumps({"text": r["text"], "label": REMAP[r["label"]]},
+                                       ensure_ascii=False) + "\n")
+                    n += 1
+            print(f"{ep}/{split}: {n}")
+    print("done ->", OUT)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reproducibility helpers for the КАС 3×3 matrix (results in secondlayer-papers PR #56).

- `prep_kas_jsonl.py` — materialize `overthelex/ua-temporal-drift-kas` into the `{epoch}/{split}.jsonl` layout `train_temporal.py` expects; remaps labels to the paper taxonomy (granted→approved, denied→dismissed, partial→partial).
- `fill_large.py` — finish large-model jobs single-GPU at 8-way parallel (560M fits one 80GB H100; 2-GPU DDP was pure overhead and the bottleneck on the run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds helpers to reproduce the KAS 3×3 results by preparing epoch-split JSONL data and running large-model jobs efficiently on a single GPU with 8-way parallelism. Reduces DDP overhead and skips already-completed runs.

- **New Features**
  - `prep_kas_jsonl.py`: Converts `overthelex/ua-temporal-drift-kas` to `output/{pre_war,hybrid_war,full_scale}/{train,validation,test}.jsonl` with `{text,label}`; remaps labels: granted→approved, denied→dismissed, partial→partial.
  - `fill_large.py`: Finishes remaining runs for xlm-roberta-large and legal-xlm-roberta-large across epochs and seeds; skips if `cross_epoch_results.json` exists, cleans partial dirs, and runs 8 single-GPU workers via `CUDA_VISIBLE_DEVICES`.

<sup>Written for commit 99359186d94c449cbdafc64d7a740de538cbdfaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

