### PR TITLE
feat(monitoring): WG-mesh dashboard - GPU temp/power + traffic-light summary table

### DIFF
--- a/deployment/grafana/dashboards/08-wg-mesh.json
+++ b/deployment/grafana/dashboards/08-wg-mesh.json
@@ -23,49 +23,147 @@
       "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
       "id": 1,
       "panels": [],
-      "title": "Fleet Overview",
+      "title": "Fleet Summary",
       "type": "row"
     },
     {
       "datasource": { "type": "prometheus", "uid": "Prometheus" },
-      "description": "Per-host node_exporter scrape status over the WireGuard mesh.",
+      "description": "Traffic-light overview of every WG-mesh host. Green/yellow/red cells flag CPU, RAM and disk pressure; Status shows node_exporter reachability.",
       "fieldConfig": {
         "defaults": {
-          "color": { "mode": "thresholds" },
-          "mappings": [
-            { "options": { "0": { "color": "red", "index": 1, "text": "DOWN" } }, "type": "value" },
-            { "options": { "1": { "color": "green", "index": 0, "text": "UP" } }, "type": "value" }
-          ],
-          "thresholds": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] },
-          "unit": "none"
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Status" },
+            "properties": [
+              { "id": "mappings", "value": [ { "type": "value", "options": { "0": { "text": "DOWN", "color": "red", "index": 1 }, "1": { "text": "UP", "color": "green", "index": 0 } } } ] },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "red", "value": null }, { "color": "green", "value": 1 } ] } },
+              { "id": "custom.align", "value": "center" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "CPU %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "max", "value": 100 },
+              { "id": "min", "value": 0 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 90 } ] } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "RAM %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "max", "value": 100 },
+              { "id": "min", "value": 0 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 75 }, { "color": "red", "value": 90 } ] } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Disk %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 1 },
+              { "id": "max", "value": 100 },
+              { "id": "min", "value": 0 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 80 }, { "color": "red", "value": 90 } ] } }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Net RX" },
+            "properties": [ { "id": "unit", "value": "Bps" } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Net TX" },
+            "properties": [ { "id": "unit", "value": "Bps" } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "Disk I/O" },
+            "properties": [ { "id": "unit", "value": "Bps" } ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "GPU max %" },
+            "properties": [
+              { "id": "unit", "value": "percent" },
+              { "id": "decimals", "value": 0 },
+              { "id": "max", "value": 100 },
+              { "id": "min", "value": 0 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background", "mode": "basic" } },
+              { "id": "thresholds", "value": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 70 }, { "color": "red", "value": 95 } ] } }
+            ]
+          }
+        ]
       },
-      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 1 },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 1 },
       "id": 2,
       "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "horizontal",
-        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
-        "textMode": "value_and_name"
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [ { "displayName": "CPU %", "desc": true } ]
       },
       "pluginVersion": "10.0.0",
       "targets": [
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "max by (host) (up{job=\"wg_mesh\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "100 - (avg by (host) (rate(node_cpu_seconds_total{job=\"wg_mesh\",mode=\"idle\"}[5m])) * 100)", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "B" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "100 * (1 - sum by (host) (node_memory_MemAvailable_bytes{job=\"wg_mesh\"}) / sum by (host) (node_memory_MemTotal_bytes{job=\"wg_mesh\"}))", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "C" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "max by (host) (100 - (node_filesystem_avail_bytes{job=\"wg_mesh\",fstype!~\"tmpfs|overlay|squashfs|ramfs|fuse.*\"} * 100 / node_filesystem_size_bytes{job=\"wg_mesh\",fstype!~\"tmpfs|overlay|squashfs|ramfs|fuse.*\"}))", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "D" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "sum by (host) (rate(node_disk_read_bytes_total{job=\"wg_mesh\"}[5m]) + rate(node_disk_written_bytes_total{job=\"wg_mesh\"}[5m]))", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "E" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "sum by (host) (rate(node_network_receive_bytes_total{job=\"wg_mesh\",device!~\"lo|veth.*|docker.*|br-.*|virbr.*|vnet.*|cali.*|cni.*|flannel.*\"}[5m]))", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "F" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "sum by (host) (rate(node_network_transmit_bytes_total{job=\"wg_mesh\",device!~\"lo|veth.*|docker.*|br-.*|virbr.*|vnet.*|cali.*|cni.*|flannel.*\"}[5m]))", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "G" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "max by (host) (DCGM_FI_DEV_GPU_UTIL{job=\"wg_mesh_gpu\"})", "format": "table", "instant": true, "legendFormat": "__auto", "refId": "H" }
+      ],
+      "transformations": [
+        { "id": "merge", "options": {} },
         {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "max by (host) (up{job=\"wg_mesh\"})",
-          "legendFormat": "{{host}}",
-          "refId": "A"
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "job": true, "instance": true },
+            "includeByName": {},
+            "indexByName": {
+              "host": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4,
+              "Value #H": 5,
+              "Value #E": 6,
+              "Value #F": 7,
+              "Value #G": 8
+            },
+            "renameByName": {
+              "host": "Host",
+              "Value #A": "Status",
+              "Value #B": "CPU %",
+              "Value #C": "RAM %",
+              "Value #D": "Disk %",
+              "Value #H": "GPU max %",
+              "Value #E": "Disk I/O",
+              "Value #F": "Net RX",
+              "Value #G": "Net TX"
+            }
+          }
         }
       ],
-      "title": "Host Status (node_exporter)",
-      "type": "stat"
+      "title": "Fleet Summary (traffic light)",
+      "type": "table"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 10 },
       "id": 3,
       "panels": [],
       "title": "CPU / Memory",
@@ -92,7 +190,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 11 },
       "id": 4,
       "options": {
         "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -100,12 +198,7 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "100 - (avg by (host) (rate(node_cpu_seconds_total{job=\"wg_mesh\",mode=\"idle\"}[5m])) * 100)",
-          "legendFormat": "{{host}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "100 - (avg by (host) (rate(node_cpu_seconds_total{job=\"wg_mesh\",mode=\"idle\"}[5m])) * 100)", "legendFormat": "{{host}}", "refId": "A" }
       ],
       "title": "CPU Utilization %",
       "type": "timeseries"
@@ -131,7 +224,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 11 },
       "id": 5,
       "options": {
         "legend": { "calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -139,19 +232,14 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "100 * (1 - (node_memory_MemAvailable_bytes{job=\"wg_mesh\"} / node_memory_MemTotal_bytes{job=\"wg_mesh\"}))",
-          "legendFormat": "{{host}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "100 * (1 - (node_memory_MemAvailable_bytes{job=\"wg_mesh\"} / node_memory_MemTotal_bytes{job=\"wg_mesh\"}))", "legendFormat": "{{host}}", "refId": "A" }
       ],
       "title": "Memory Used %",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 14 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 19 },
       "id": 6,
       "panels": [],
       "title": "Disk / IO",
@@ -178,7 +266,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 15 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
       "id": 7,
       "options": {
         "legend": { "calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -186,12 +274,7 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "max by (host) (100 - (node_filesystem_avail_bytes{job=\"wg_mesh\",fstype!~\"tmpfs|overlay|squashfs|ramfs|fuse.*\"} * 100 / node_filesystem_size_bytes{job=\"wg_mesh\",fstype!~\"tmpfs|overlay|squashfs|ramfs|fuse.*\"}))",
-          "legendFormat": "{{host}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "max by (host) (100 - (node_filesystem_avail_bytes{job=\"wg_mesh\",fstype!~\"tmpfs|overlay|squashfs|ramfs|fuse.*\"} * 100 / node_filesystem_size_bytes{job=\"wg_mesh\",fstype!~\"tmpfs|overlay|squashfs|ramfs|fuse.*\"}))", "legendFormat": "{{host}}", "refId": "A" }
       ],
       "title": "Disk Used % (busiest filesystem)",
       "type": "timeseries"
@@ -216,7 +299,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 15 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
       "id": 8,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -224,19 +307,14 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "sum by (host) (rate(node_disk_read_bytes_total{job=\"wg_mesh\"}[5m]) + rate(node_disk_written_bytes_total{job=\"wg_mesh\"}[5m]))",
-          "legendFormat": "{{host}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "sum by (host) (rate(node_disk_read_bytes_total{job=\"wg_mesh\"}[5m]) + rate(node_disk_written_bytes_total{job=\"wg_mesh\"}[5m]))", "legendFormat": "{{host}}", "refId": "A" }
       ],
       "title": "Disk I/O (read + write)",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 23 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 28 },
       "id": 9,
       "panels": [],
       "title": "Network (sum of all adapters)",
@@ -262,7 +340,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 29 },
       "id": 10,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -270,12 +348,7 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "sum by (host) (rate(node_network_receive_bytes_total{job=\"wg_mesh\",device!~\"lo|veth.*|docker.*|br-.*|virbr.*|vnet.*|cali.*|cni.*|flannel.*\"}[5m]))",
-          "legendFormat": "{{host}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "sum by (host) (rate(node_network_receive_bytes_total{job=\"wg_mesh\",device!~\"lo|veth.*|docker.*|br-.*|virbr.*|vnet.*|cali.*|cni.*|flannel.*\"}[5m]))", "legendFormat": "{{host}}", "refId": "A" }
       ],
       "title": "Network RX (all adapters)",
       "type": "timeseries"
@@ -300,7 +373,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 29 },
       "id": 11,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -308,22 +381,17 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "sum by (host) (rate(node_network_transmit_bytes_total{job=\"wg_mesh\",device!~\"lo|veth.*|docker.*|br-.*|virbr.*|vnet.*|cali.*|cni.*|flannel.*\"}[5m]))",
-          "legendFormat": "{{host}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "sum by (host) (rate(node_network_transmit_bytes_total{job=\"wg_mesh\",device!~\"lo|veth.*|docker.*|br-.*|virbr.*|vnet.*|cali.*|cni.*|flannel.*\"}[5m]))", "legendFormat": "{{host}}", "refId": "A" }
       ],
       "title": "Network TX (all adapters)",
       "type": "timeseries"
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 32 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 37 },
       "id": 12,
       "panels": [],
-      "title": "GPU (brev — 8x H100)",
+      "title": "GPU (brev - 8x H100)",
       "type": "row"
     },
     {
@@ -347,7 +415,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 33 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 38 },
       "id": 13,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -355,12 +423,7 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "DCGM_FI_DEV_GPU_UTIL{job=\"wg_mesh_gpu\"}",
-          "legendFormat": "GPU {{gpu}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "DCGM_FI_DEV_GPU_UTIL{job=\"wg_mesh_gpu\"}", "legendFormat": "GPU {{gpu}}", "refId": "A" }
       ],
       "title": "GPU Utilization %",
       "type": "timeseries"
@@ -385,7 +448,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 33 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 38 },
       "id": 14,
       "options": {
         "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
@@ -393,14 +456,78 @@
       },
       "pluginVersion": "10.0.0",
       "targets": [
-        {
-          "datasource": { "type": "prometheus", "uid": "Prometheus" },
-          "expr": "DCGM_FI_DEV_FB_USED{job=\"wg_mesh_gpu\"}",
-          "legendFormat": "GPU {{gpu}}",
-          "refId": "A"
-        }
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "DCGM_FI_DEV_FB_USED{job=\"wg_mesh_gpu\"}", "legendFormat": "GPU {{gpu}}", "refId": "A" }
       ],
       "title": "GPU Memory Used (MiB)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "description": "Per-GPU temperature (C) on the brev H100 box (DCGM). H100 throttles around 85-87 C.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
+            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false,
+            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "dashed" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "yellow", "value": 75 }, { "color": "red", "value": 85 } ] },
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 46 },
+      "id": 15,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "DCGM_FI_DEV_GPU_TEMP{job=\"wg_mesh_gpu\"}", "legendFormat": "GPU {{gpu}}", "refId": "A" }
+      ],
+      "title": "GPU Temperature (C)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "Prometheus" },
+      "description": "Per-GPU power draw (W) on the brev H100 box (DCGM). H100 SXM TDP is ~700 W.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto",
+            "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "insertNulls": false,
+            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "watt"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 46 },
+      "id": 16,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "DCGM_FI_DEV_POWER_USAGE{job=\"wg_mesh_gpu\"}", "legendFormat": "GPU {{gpu}}", "refId": "A" }
+      ],
+      "title": "GPU Power Draw (W)",
       "type": "timeseries"
     }
   ],
@@ -413,6 +540,6 @@
   "timezone": "browser",
   "title": "WG Mesh - Fleet Resources",
   "uid": "wg-mesh-resources",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
Builds on #2045.

## Adds
- **Fleet Summary (traffic light)** table at the top: one row per mesh host with **Status / CPU % / RAM % / Disk % / GPU max % / Disk I/O / Net RX / Net TX**. CPU/RAM/Disk/GPU cells are colored green→yellow→red by threshold; Status maps to UP/DOWN. Built from instant queries merged on the `host` label.
- **GPU Temperature (°C)** — `DCGM_FI_DEV_GPU_TEMP`, dashed thresholds at 75/85 °C (H100 throttle).
- **GPU Power Draw (W)** — `DCGM_FI_DEV_POWER_USAGE`.

## Verified live on prod
Dashboard auto-provisioned to v2 (16 panels). GPU temp currently 34–62 °C, power 120–614 W across the 8 H100s; all panel queries return data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a traffic-light Fleet Summary table and GPU temperature/power panels to the WG-mesh Grafana dashboard to surface host pressure and GPU health at a glance.
Improves visibility of CPU/RAM/Disk/GPU usage and I/O/network per host.

- **New Features**
  - Fleet Summary table: Status / CPU% / RAM% / Disk% / GPU max% / Disk I/O / Net RX / Net TX with green→yellow→red thresholds; Status shows UP/DOWN. Built from instant queries merged by `host`.
  - GPU Temperature: `DCGM_FI_DEV_GPU_TEMP` with dashed thresholds at 75/85 °C.
  - GPU Power Draw: `DCGM_FI_DEV_POWER_USAGE`.

<sup>Written for commit 886a0017be705213fff804fd635b53d5c54675ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

