### PR TITLE
fix(auth): allow local.legal.org.ua OAuth callback + force https for legal.org.ua hosts

### DIFF
--- a/mcp_backend/src/routes/auth.ts
+++ b/mcp_backend/src/routes/auth.ts
@@ -74,20 +74,27 @@ const ALLOWED_CALLBACK_HOSTS = new Set([
   'platform.legal.org.ua',
   'mcp.legal.org.ua',
   'preview.legal.org.ua',
+  'local.legal.org.ua',
 ]);
 
+// legal.org.ua and its subdomains are always served over HTTPS (TLS is terminated
+// at the edge / Cloudflare Tunnel, so the internal proxy hop may be plain http).
+// Force https for those hosts so the http hop never leaks into OAuth redirect URIs.
+function resolveProtocol(req: any, host: string): string {
+  if (host.endsWith('legal.org.ua')) return 'https';
+  return req.headers['x-forwarded-proto'] || req.protocol || 'https';
+}
+
 function getCallbackURL(req: any): string {
-  const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
   const rawHost = (req.headers['x-forwarded-host'] || req.headers.host || '').split(':')[0];
   const host = ALLOWED_CALLBACK_HOSTS.has(rawHost) ? rawHost : 'legal.org.ua';
-  return `${protocol}://${host}/auth/google/callback`;
+  return `${resolveProtocol(req, host)}://${host}/auth/google/callback`;
 }
 
 function getSafeFrontendUrl(req: any): string {
-  const protocol = req.headers['x-forwarded-proto'] || req.protocol || 'https';
   const rawHost = (req.headers['x-forwarded-host'] || req.headers.host || '').split(':')[0];
   const host = ALLOWED_CALLBACK_HOSTS.has(rawHost) ? rawHost : 'legal.org.ua';
-  return `${protocol}://${host}`;
+  return `${resolveProtocol(req, host)}://${host}`;
 }
 
 /**


### PR DESCRIPTION
## Why
`https://local.legal.org.ua` (the prod-copy on local.lex, served via a Cloudflare Tunnel over the WireGuard mesh) fails Google login with **`Error 400: redirect_uri_mismatch`**.

Root cause: `getCallbackURL()` in `mcp_backend/src/routes/auth.ts` builds the redirect URI from the request host **only if it is in `ALLOWED_CALLBACK_HOSTS`**, else it falls back to `legal.org.ua`. `local.legal.org.ua` was not in the set, and the proxy hop (CF Tunnel → nginx :80) made the protocol resolve to `http`, so the app sent `http://legal.org.ua/auth/google/callback` — which is not a registered redirect URI.

## Change
- Add `local.legal.org.ua` to `ALLOWED_CALLBACK_HOSTS`.
- Force `https` for any `*.legal.org.ua` host (TLS is terminated at the edge; the internal hop may be http). **Prod is unaffected** — it already resolves to https.

## Follow-up (manual, not in this PR)
The redirect URI `https://local.legal.org.ua/auth/google/callback` must be added to the Google OAuth client `323273425312-…` in Google Cloud Console for the flow to complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google login on https://local.legal.org.ua by allowing its OAuth callback and forcing https for all legal.org.ua hosts behind proxies. This ensures correct Google redirect URIs and prevents redirect_uri_mismatch errors.

- **Bug Fixes**
  - Added local.legal.org.ua to the allowed callback hosts.
  - Forced https for any *.legal.org.ua when building OAuth callback and frontend URLs.

- **Migration**
  - Add https://local.legal.org.ua/auth/google/callback to the Google OAuth client’s authorized redirect URIs.

<sup>Written for commit c933b55e9ded1bbd9e347f86fca1002c18ee1959. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

