### PR TITLE
fix(ci): keep nginx certs dir runner-owned to unblock deploy checkout

### DIFF
--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -518,7 +518,11 @@ ensure_letsencrypt_certs() {
         # Ensure latest certs are copied
         sudo cp "$le_dir/fullchain.pem" "$certs_dir/fullchain.pem"
         sudo cp "$le_dir/privkey.pem" "$certs_dir/privkey.pem"
-        sudo chown $(id -u):$(id -g) "$certs_dir/fullchain.pem" "$certs_dir/privkey.pem"
+        # Keep the whole certs dir owned by the runner user. On the self-hosted
+        # CI runner this dir lives inside the Actions workspace; if it (or any
+        # file in it) stays root-owned, the next `actions/checkout` git-clean
+        # fails with EACCES and blocks every subsequent deploy.
+        sudo chown -R $(id -u):$(id -g) "$certs_dir"
         return 0
     fi
 
@@ -539,7 +543,9 @@ ensure_letsencrypt_certs() {
         print_msg "$GREEN" "Certificate obtained successfully"
         sudo cp "$le_dir/fullchain.pem" "$certs_dir/fullchain.pem"
         sudo cp "$le_dir/privkey.pem" "$certs_dir/privkey.pem"
-        sudo chown $(id -u):$(id -g) "$certs_dir/fullchain.pem" "$certs_dir/privkey.pem"
+        # Keep the whole certs dir runner-owned (see note above) so the next
+        # CI checkout can git-clean the workspace without EACCES.
+        sudo chown -R $(id -u):$(id -g) "$certs_dir"
     else
         print_msg "$YELLOW" "Let's Encrypt failed -- falling back to existing certs"
     fi


### PR DESCRIPTION
## Problem

Every **Deploy to Production** run was failing (and earlier-stage jobs failing fast in 10–19s) at the `actions/checkout` step on the self-hosted `local` runner:

```
EACCES: permission denied, unlink '.../deployment/nginx/certs/aidog.sneakypiper.com-key.pem'
```

`actions/checkout` runs `git clean -ffdx`, which removes ignored files too (`deployment/nginx/certs/` is gitignored). The certs dir on the runner had become `root:root` (dir + files), so the runner user couldn't clean it → checkout aborted → pipeline blocked. Note: the actual deploy (`Promote to Production`) succeeded; only the workspace checkout for `Detect Changes` / `Pre-Deploy Tests` / `Create Release` failed.

## Root cause

`ensure_letsencrypt_certs()` in `manage-gateway.sh` `sudo cp`s certs into `deployment/nginx/certs/` but only `chown`s `fullchain.pem`/`privkey.pem` back to the runner user. The dir itself (and other certs placed there) stayed root-owned. Since the runner doesn't own the dir, it can't delete *any* file inside it during git-clean.

## Fix

`chown -R` the whole certs dir to the runner user after copying, in both the valid-cert and freshly-obtained-cert paths. Keeps the Actions workspace cleanable.

## Immediate remediation already applied

Chowned the certs dir back to the runner user on the `local` host and re-ran the latest failed deploy — now fully green (Create Release ✓, Promote to Production ✓). This PR prevents recurrence on the next cert renewal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI deploy checkout failures on the self-hosted runner by making the entire `deployment/nginx/certs` directory runner-owned, so `actions/checkout` can `git clean` without permission errors.

- **Bug Fixes**
  - Update `ensure_letsencrypt_certs()` to `sudo chown -R $(id -u):$(id -g) "$certs_dir"` after copying certs, in both valid-cert and new-cert paths.

<sup>Written for commit dffc17a803a07c173067e1242ec186255c5a2fc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

