### PR TITLE
feat(mcp): v2 MCP endpoint exposing single legal_chat tool

### DIFF
--- a/deployment/nginx/includes/prod-server-common.conf
+++ b/deployment/nginx/includes/prod-server-common.conf
@@ -189,6 +189,51 @@ location /api/v1/mcp {
     }
 }
 
+# POST/GET/DELETE /api/v2/mcp → Streamable HTTP transport (rewrites to /v2/mcp on backend)
+# Canonical MCP surface: a single `legal_chat` tool wrapping the full chat pipeline.
+location /api/v2/mcp {
+    limit_conn sse_conn_limit 20;
+
+    rewrite ^/api(/v2/mcp.*)$ $1 break;
+    proxy_pass $prod_backend;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $forwarded_proto;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header Connection "";
+
+    # Streaming responses (SSE-over-POST) must not be buffered
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 3600s;
+    proxy_connect_timeout 75s;
+    chunked_transfer_encoding on;
+
+    include /etc/nginx/includes/security-headers.conf;
+    add_header Access-Control-Allow-Origin "$cors_origin" always;
+    add_header Access-Control-Allow-Methods "GET, POST, DELETE, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID" always;
+    add_header Access-Control-Expose-Headers "Mcp-Session-Id" always;
+    add_header Access-Control-Allow-Credentials "true" always;
+    add_header X-Accel-Buffering "no";
+
+    if ($request_method = 'OPTIONS') {
+        add_header Access-Control-Allow-Origin "$cors_origin" always;
+        add_header Access-Control-Allow-Methods "GET, POST, DELETE, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Authorization, Content-Type, Accept, Cache-Control, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID" always;
+        add_header Access-Control-Expose-Headers "Mcp-Session-Id" always;
+        add_header Access-Control-Allow-Credentials "true" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header Content-Length 0;
+        add_header Content-Type text/plain;
+        return 204;
+    }
+}
+
 # ==========================================
 # REST API Routes
 # ==========================================

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -407,6 +407,7 @@ class HTTPMCPServer {
     this.app.use(createMCPSSERoutes({
       mcpSSEServer: this.app_.mcpSSEServer,
       toolRegistry: this.tools.toolRegistry,
+      chatService: this.app_.chatService,
       oauthService: this.app_.oauthService,
       apiKeyService: this.billing.apiKeyService,
       costTracker: this.billing.costTracker,

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -16,7 +16,9 @@ import { logger } from '../utils/logger.js';
 import { sanitizeId, maskSensitive } from '../utils/sanitize-log.js';
 import { requestContext } from '../utils/openai-client.js';
 import { MCPSSEServer } from '../api/mcp-sse-server.js';
-import { ToolRegistry } from '../api/tool-registry.js';
+import { ToolRegistry, ToolDefinition } from '../api/tool-registry.js';
+import { ChatService } from '../services/chat-service.js';
+import { runWithABUser } from '../infrastructure/adapters/llm-adapter.js';
 import { OAuthService } from '../services/oauth-service.js';
 import { ApiKeyService } from '../services/api-key-service.js';
 import { CostTracker } from '../services/cost-tracker.js';
@@ -29,6 +31,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema, isInitializeRequest } fr
 export function createMCPSSERoutes(deps: {
   mcpSSEServer: MCPSSEServer;
   toolRegistry: ToolRegistry;
+  chatService: ChatService;
   oauthService: OAuthService;
   apiKeyService: ApiKeyService;
   costTracker: CostTracker;
@@ -236,6 +239,106 @@ export function createMCPSSERoutes(deps: {
           content: [{ type: 'text', text: `Error: ${error.message}` }],
           isError: true,
         };
+      }
+    });
+
+    return mcpServer;
+  }
+
+  // ========================= MCP v2 (single orchestrating tool) =========================
+  // v2 exposes ONE tool — `legal_chat` — instead of the ~112 low-level tools that v1
+  // surfaces. The tool wraps the full ChatService (v3) pipeline: intent classification →
+  // plan → curated tool execution → grounded synthesis. External MCP clients (Claude
+  // Code/Desktop) ask a natural-language legal question and get a cited answer back,
+  // mirroring what the web chat does, rather than choosing among 112 raw tools.
+
+  const LEGAL_CHAT_TOOL: ToolDefinition = {
+    name: 'legal_chat',
+    description:
+      'Ukrainian legal research assistant. Ask a legal question or describe a task in natural ' +
+      'language (Ukrainian preferred; English accepted). It runs the full SecondLayer pipeline — ' +
+      'planning and executing retrieval over court decisions (ЄДРСР), legislation, parliament and ' +
+      'business registries — and returns a grounded answer with citations. Prefer this single tool ' +
+      'over calling low-level search tools directly.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'The legal question or task, in natural language (uk-UA preferred).',
+        },
+        budget: {
+          type: 'string',
+          enum: ['quick', 'standard', 'deep'],
+          description: 'Depth/cost tradeoff. quick = cheap/fast, deep = exhaustive. Default: standard.',
+        },
+        internetEnabled: {
+          type: 'boolean',
+          description: 'Allow web sources in addition to internal legal data. Default: true.',
+        },
+      },
+      required: ['query'],
+    },
+    annotations: { readOnlyHint: true, openWorldHint: true },
+  };
+
+  // Build an MCP Server that exposes only `legal_chat`. Billing/cost-tracking is handled
+  // inside the ChatService pipeline (keyed by requestId), so — unlike the per-tool v1 path —
+  // we do not create tracking records or deduct credits here.
+  function buildMcpServerV2(userId: string | undefined, _clientKey: string | undefined): Server {
+    const safeUserId = sanitizeId(userId || 'anonymous');
+    const mcpServer = new Server(
+      { name: 'secondlayer-mcp', version: '2.0.0' },
+      { capabilities: { tools: {} } }
+    );
+
+    mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [LEGAL_CHAT_TOOL] }));
+
+    mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const toolName = request.params.name;
+      const args = request.params.arguments || {};
+      const requestId = `mcp-v2-${uuidv4()}`;
+
+      if (toolName !== 'legal_chat') {
+        return {
+          content: [{ type: 'text', text: `Error: unknown tool '${toolName}'. MCP v2 exposes only 'legal_chat'.` }],
+          isError: true,
+        };
+      }
+
+      const query = String(args.query || '').trim();
+      if (!query) {
+        return { content: [{ type: 'text', text: 'Error: "query" is required.' }], isError: true };
+      }
+      const budget = ['quick', 'standard', 'deep'].includes(String(args.budget))
+        ? (String(args.budget) as 'quick' | 'standard' | 'deep')
+        : 'standard';
+
+      try {
+        logger.info('[MCP v2] legal_chat call', { userId: safeUserId, requestId, budget });
+
+        let answer = '';
+        let totalCostUsd = 0;
+        await runWithABUser(userId || '', async () => {
+          for await (const event of deps.chatService.chat({
+            query,
+            budget,
+            userId,
+            requestId,
+            internetEnabled: args.internetEnabled !== false,
+          })) {
+            if (event.type === 'complete') {
+              answer = event.data?.answer || answer;
+              totalCostUsd = event.data?.total_cost_usd || totalCostUsd;
+            }
+          }
+        });
+
+        logger.info('[MCP v2] legal_chat done', { userId: safeUserId, requestId, costUsd: totalCostUsd });
+        return { content: [{ type: 'text', text: answer || 'Не вдалося згенерувати відповідь.' }] };
+      } catch (error: any) {
+        logger.error('[MCP v2] legal_chat error', { requestId, error: error.message });
+        return { content: [{ type: 'text', text: `Error: ${error.message}` }], isError: true };
       }
     });
 
@@ -531,6 +634,11 @@ export function createMCPSSERoutes(deps: {
   // POST /v1/mcp - JSON-RPC requests (initialize + tool calls). Stateful via Mcp-Session-Id.
   router.post('/v1/mcp', (async (req: DualAuthRequest, res: Response) => {
     try {
+      // Deprecated in favour of /api/v2/mcp (single `legal_chat` tool). v1 still serves the
+      // full ~112-tool surface for backward compatibility; advertise the successor to clients.
+      res.setHeader('Deprecation', 'true');
+      res.setHeader('Link', '</api/v2/mcp>; rel="successor-version"');
+
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
       // Reuse an existing session if present
@@ -621,6 +729,97 @@ export function createMCPSSERoutes(deps: {
   router.get('/.well-known/oauth-protected-resource/api/v1/mcp', mcpResourceMetadata);
   router.get('/.well-known/oauth-protected-resource/v1/mcp', mcpResourceMetadata);
 
+  // ========================= /v2/mcp (Streamable HTTP, single tool) =========================
+  // Canonical transport. Same OAuth/session mechanics as /v1/mcp, but the wired MCP server
+  // exposes only `legal_chat` (see buildMcpServerV2). Publicly reached at /api/v2/mcp.
+  const MCP_V2_RESOURCE_METADATA_PATH = '/.well-known/oauth-protected-resource/api/v2/mcp';
+
+  router.post('/v2/mcp', (async (req: DualAuthRequest, res: Response) => {
+    try {
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      if (sessionId && streamableSessions.has(sessionId)) {
+        const transport = streamableSessions.get(sessionId)!;
+        return await transport.handleRequest(req, res, req.body);
+      }
+
+      if (sessionId || !isInitializeRequest(req.body)) {
+        return res.status(400).json({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Bad Request: no valid session ID for non-initialize request' },
+          id: null,
+        });
+      }
+
+      const auth = await authenticateMcpBearer(req, res, '[MCP v2/mcp]', MCP_V2_RESOURCE_METADATA_PATH);
+      if (!auth) return; // response already sent
+
+      const { userId, clientKey } = auth;
+      const mcpServer = buildMcpServerV2(userId, clientKey);
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => uuidv4(),
+        onsessioninitialized: (sid: string) => {
+          streamableSessions.set(sid, transport);
+          logger.info('[MCP v2/mcp] Session initialized', { sessionId: sid });
+        },
+      });
+
+      transport.onclose = () => {
+        if (transport.sessionId) {
+          streamableSessions.delete(transport.sessionId);
+          logger.info('[MCP v2/mcp] Session closed', { sessionId: transport.sessionId });
+        }
+        mcpServer.close();
+      };
+
+      await mcpServer.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error: any) {
+      logger.error('[MCP v2/mcp] POST error:', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error', data: error.message },
+          id: null,
+        });
+      }
+    }
+  }) as any);
+
+  router.get('/v2/mcp', (async (req: DualAuthRequest, res: Response) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !streamableSessions.has(sessionId)) {
+      const baseUrl = getBaseUrl(req);
+      res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${baseUrl}${MCP_V2_RESOURCE_METADATA_PATH}"`);
+      return res.status(400).json({ error: 'Invalid or missing Mcp-Session-Id', code: 'INVALID_SESSION' });
+    }
+    const transport = streamableSessions.get(sessionId)!;
+    await transport.handleRequest(req, res);
+  }) as any);
+
+  router.delete('/v2/mcp', (async (req: DualAuthRequest, res: Response) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !streamableSessions.has(sessionId)) {
+      return res.status(400).json({ error: 'Invalid or missing Mcp-Session-Id', code: 'INVALID_SESSION' });
+    }
+    const transport = streamableSessions.get(sessionId)!;
+    await transport.handleRequest(req, res);
+  }) as any);
+
+  // RFC 9728 protected-resource metadata for the v2 transport.
+  const mcpV2ResourceMetadata = (req: Request, res: Response) => {
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      resource: `${baseUrl}/api/v2/mcp`,
+      authorization_servers: [baseUrl],
+      scopes_supported: ['mcp'],
+      bearer_methods_supported: ['header'],
+    });
+  };
+  router.get('/.well-known/oauth-protected-resource/api/v2/mcp', mcpV2ResourceMetadata);
+  router.get('/.well-known/oauth-protected-resource/v2/mcp', mcpV2ResourceMetadata);
+
   // ========================= /mcp discovery =========================
 
   // GET /mcp - MCP discovery endpoint (public, rate limited)
@@ -645,6 +844,9 @@ export function createMCPSSERoutes(deps: {
         sse: '/sse',
         'sse-standard': '/v1/sse',
         http: '/api/tools',
+        'streamable-http-v1': '/api/v1/mcp',
+        // Canonical: single `legal_chat` tool wrapping the full chat pipeline.
+        'streamable-http-v2': '/api/v2/mcp',
       },
       tools: tools.map(t => ({
         name: t.name,


### PR DESCRIPTION
## Why

`/api/v1/mcp` (Streamable HTTP) advertises **all ~112** registry tools (`getAllToolDefinitions()` — backend + `rada_*` + `openreyestr_*`), while the web chat curates **~15** tools internally through the `@secondlayer/core` `ChatService` pipeline. External MCP clients (Claude Code/Desktop) therefore see a 112-tool surface that diverges from what the chat actually uses — the discrepancy this PR addresses.

## What

A canonical **v2** transport that exposes **one** tool — `legal_chat` — wrapping the full chat pipeline (intent classify → plan → curated tool execution → grounded synthesis). Clients ask a natural-language legal question and get a cited answer back, mirroring the web chat instead of choosing among 112 raw tools.

- `mcp-sse-routes.ts`: `buildMcpServerV2()` + `POST/GET/DELETE /v2/mcp` + RFC 9728 resource metadata. Billing/cost-tracking stays inside the pipeline (keyed by `requestId`), so no per-tool credit logic here.
- **v1 unchanged functionally** (still 112 tools) but **softly deprecated** via `Deprecation: true` + `Link: </api/v2/mcp>; rel="successor-version"` headers — does not break the live `mcp.legal.org.ua` OAuth integration.
- `/mcp` discovery now advertises `streamable-http-v2`.
- `http-server.ts`: wire `chatService` into MCP routes.
- `nginx`: `location /api/v2/mcp` with `rewrite ^/api(/v2/mcp.*)$ → $1` (mirror of the v1 block). `.well-known/oauth-protected-resource/*` already covered by existing prefix `location`.

## Cutover note

Soft deprecation by design — v1 keeps serving 112 tools. To make v1 a true single-tool alias later, swap `buildMcpServer(...)` → `buildMcpServerV2(...)` in the `POST /v1/mcp` handler (one line).

## Verify

- `tsc --noEmit` on the two edited TS files is clean. Remaining repo-wide type errors are pre-existing/environmental (unbuilt `@secondlayer/shared` + `@secondlayer/core` overlay not applied locally; CI applies both).
- nginx change is config-only; deploy via CI/CD (nginx requires `--force-recreate` on upstream/config change per CLAUDE.md — handled by the pipeline, not manual SSH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a v2 MCP endpoint at `/api/v2/mcp` that exposes a single `legal_chat` tool mirroring the web chat pipeline from `@secondlayer/core`. v1 stays functional but is softly deprecated and points clients to v2.

- New Features
  - Single orchestrating tool `legal_chat` wrapping the chat pipeline; accepts `query` with optional `budget` and `internetEnabled`; billing handled inside the pipeline.
  - POST/GET/DELETE `/v2/mcp` with session handling and RFC 9728 protected-resource metadata; discovery advertises `streamable-http-v2`.
  - `http-server.ts` wires `chatService` into MCP routes.
  - Nginx proxies `/api/v2/mcp` to backend with streaming and CORS settings.

- Migration
  - No breaking changes; `/api/v1/mcp` continues to serve all tools.
  - Clients should switch to `/api/v2/mcp`; v1 responses include `Deprecation: true` and a `Link` header pointing to v2.

<sup>Written for commit ef32e2cb35638578452e2844a55a12d1f71ec2fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

