### PR TITLE
fix(mcp): avoid excess-property check on ChatRequest in v2 legal_chat

### DIFF
--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -319,14 +319,18 @@ export function createMCPSSERoutes(deps: {
 
         let answer = '';
         let totalCostUsd = 0;
+        // Build the request as a variable (not an inline literal) so excess-property
+        // checks don't fire against the proprietary ChatRequest type — same pattern as
+        // chat-inline-routes.ts, which forwards `internetEnabled` the same way.
+        const chatRequest = {
+          query,
+          budget,
+          userId,
+          requestId,
+          internetEnabled: args.internetEnabled !== false,
+        };
         await runWithABUser(userId || '', async () => {
-          for await (const event of deps.chatService.chat({
-            query,
-            budget,
-            userId,
-            requestId,
-            internetEnabled: args.internetEnabled !== false,
-          })) {
+          for await (const event of deps.chatService.chat(chatRequest)) {
             if (event.type === 'complete') {
               answer = event.data?.answer || answer;
               totalCostUsd = event.data?.total_cost_usd || totalCostUsd;


### PR DESCRIPTION
## Why

The local CI build for #2051 failed **after the proprietary overlay step**:

```
Object literal may only specify known properties, and 'internetEnabled'
does not exist in type 'ChatRequest'.
```

The real `ChatRequest` (from `@secondlayer/core`, applied by the "Overlay proprietary source" CI step) does not declare `internetEnabled`. The v2 `legal_chat` handler passed an **inline object literal** to `chatService.chat({...})`, which triggers TypeScript's excess-property check. (The repo stub `ChatRequest` does include the field, so it compiled locally — the error only surfaces post-overlay in CI.)

## Fix

Build the request as a `const chatRequest` variable before passing it — exactly the pattern `chat-inline-routes.ts` already uses to forward `internetEnabled`. Variables bypass excess-property checks while remaining structurally assignable; the field is still read at runtime by the pipeline.

This was the **only** type error in the failed build (no missing-required-property errors), so this unblocks the local CI → prod deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TypeScript excess-property error after the proprietary overlay by building the chat request as a variable in `mcp-sse-routes.ts` instead of passing an inline object. This stays compatible with `@secondlayer/core` `ChatRequest` (which doesn’t include `internetEnabled`) while still forwarding the flag at runtime.

<sup>Written for commit 4169eaaff49820b6595e2fd66d0d2d4d7fe33d9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

