### PR TITLE
feat(legislation): analyze_law_amendments norm-impact tool (CORE-89 Phase A)

### DIFF
--- a/mcp_backend/src/api/__tests__/legislation-analytics-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/legislation-analytics-tools.test.ts
@@ -1,0 +1,190 @@
+/**
+ * LegislationAnalyticsTools unit tests (CORE-89 Phase A)
+ *
+ * Covers:
+ * - Tool definition: single analyze_law_amendments tool
+ * - Required `law` enforcement
+ * - Alias resolution (КК → 2341-14) and rada_id passthrough
+ * - Law-not-found path
+ * - Law-level edition timeline + count
+ * - Article-level version timeline + size growth
+ * - Article-not-found path
+ * - pending intent/court_impact placeholders preserved
+ * - DB-unavailable + DB-error handling
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import { LegislationAnalyticsTools } from '../tools/legislation-analytics-tools.js';
+
+type QueryCall = { sql: string; params?: any[] };
+
+const parse = (res: any) => JSON.parse(res.content[0].text);
+
+describe('LegislationAnalyticsTools', () => {
+  let calls: QueryCall[];
+
+  const makeDb = (responder: (sql: string, params?: any[]) => any) => ({
+    query: jest.fn((sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve(responder(sql, params));
+    }),
+  });
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  describe('tool definition', () => {
+    it('exposes a single analyze_law_amendments tool', () => {
+      const tool = new LegislationAnalyticsTools(makeDb(() => ({ rows: [] })));
+      const defs = tool.getToolDefinitions();
+      expect(defs).toHaveLength(1);
+      expect(defs[0].name).toBe('analyze_law_amendments');
+      expect(defs[0].annotations?.readOnlyHint).toBe(true);
+      expect(defs[0].inputSchema.required).toEqual(['law']);
+    });
+
+    it('returns null for an unknown tool name', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(() => ({ rows: [] })));
+      expect(await tool.executeTool('something_else', {})).toBeNull();
+    });
+  });
+
+  describe('validation', () => {
+    it('errors when law is missing', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(() => ({ rows: [] })));
+      const res = await tool.executeTool('analyze_law_amendments', {});
+      expect(res?.isError).toBe(true);
+    });
+
+    it('reports when DB is unavailable', async () => {
+      const tool = new LegislationAnalyticsTools(undefined);
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК' });
+      expect(parse(res).error).toMatch(/недоступна/);
+    });
+  });
+
+  describe('law resolution', () => {
+    it('resolves the КК alias to rada_id 2341-14', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(() => ({ rows: [] })));
+      await tool.executeTool('analyze_law_amendments', { law: 'КК' });
+      expect(calls[0].params).toEqual(['2341-14']);
+    });
+
+    it('passes through an explicit rada_id', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(() => ({ rows: [] })));
+      await tool.executeTool('analyze_law_amendments', { law: '2778-17' });
+      expect(calls[0].params).toEqual(['2778-17']);
+    });
+
+    it('returns a not-found result with a hint when the law is absent', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(() => ({ rows: [] })));
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК' });
+      const out = parse(res);
+      expect(out.error).toMatch(/не знайдено/);
+      expect(out.resolved_rada_id).toBe('2341-14');
+      expect(out.hint).toBeDefined();
+    });
+  });
+
+  describe('amendment analysis', () => {
+    const lawRow = {
+      id: 7,
+      rada_id: '2341-14',
+      type: 'code',
+      title: 'Кримінальний кодекс України',
+      short_title: 'КК',
+      adoption_date: '2001-04-05',
+      effective_date: '2001-09-01',
+      last_amended_date: '2024-10-06',
+      status: 'active',
+      total_editions: 3,
+      total_articles: 447,
+    };
+
+    const respond = (sql: string) => {
+      if (sql.includes('FROM legislation\n') || sql.includes('FROM legislation ')) {
+        return { rows: [lawRow] };
+      }
+      if (sql.includes('legislation_editions')) {
+        return {
+          rows: [
+            { edition_date: '2001-09-01', edition_key: '20010901', article_count: 440 },
+            { edition_date: '2022-03-15', edition_key: '20220315', article_count: 446 },
+            { edition_date: '2024-10-06', edition_key: '20241006', article_count: 447 },
+          ],
+        };
+      }
+      if (sql.includes('legislation_articles')) {
+        return {
+          rows: [
+            { version_date: '2001-09-01', byte_size: 1000, is_current: false, article_number: 'Стаття 185', title: 'Крадіжка' },
+            { version_date: '2022-03-15', byte_size: 1400, is_current: true, article_number: 'Стаття 185', title: 'Крадіжка' },
+          ],
+        };
+      }
+      return { rows: [] };
+    };
+
+    it('returns law-level edition timeline and count', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(respond));
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК' });
+      const out = parse(res);
+      expect(out.law.rada_id).toBe('2341-14');
+      expect(out.amendments.law_level.editions_count).toBe(3);
+      expect(out.amendments.law_level.editions[0].edition_date).toBe('2001-09-01');
+      expect(out.amendments.article_level).toBeNull();
+    });
+
+    it('keeps intent and court_impact as pending placeholders', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(respond));
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК' });
+      const out = parse(res);
+      expect(out.intent.status).toBe('pending');
+      expect(out.court_impact.status).toBe('pending');
+      expect(out.court_impact.method).toBe('interrupted_time_series');
+    });
+
+    it('analyses a specific article with size growth', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(respond));
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК', article: '185' });
+      const out = parse(res);
+      const a = out.amendments.article_level;
+      expect(a.found).toBe(true);
+      expect(a.versions_count).toBe(2);
+      expect(a.size_bytes_first).toBe(1000);
+      expect(a.size_bytes_last).toBe(1400);
+      expect(a.size_growth_pct).toBe(40);
+    });
+
+    it('matches the article by digits regardless of input format', async () => {
+      const tool = new LegislationAnalyticsTools(makeDb(respond));
+      await tool.executeTool('analyze_law_amendments', { law: 'КК', article: 'ст.185' });
+      const articleCall = calls.find((c) => c.sql.includes('legislation_articles'));
+      expect(articleCall?.params).toEqual([7, '185']);
+    });
+
+    it('reports article-not-found without failing', async () => {
+      const db = makeDb((sql) => {
+        if (sql.includes('FROM legislation\n') || sql.includes('FROM legislation ')) return { rows: [lawRow] };
+        if (sql.includes('legislation_editions')) return { rows: [] };
+        return { rows: [] }; // no article versions
+      });
+      const tool = new LegislationAnalyticsTools(db);
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК', article: '999' });
+      const out = parse(res);
+      expect(out.amendments.article_level.found).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns a graceful error when the query throws', async () => {
+      const db = { query: jest.fn(() => Promise.reject(new Error('boom'))) };
+      const tool = new LegislationAnalyticsTools(db as any);
+      const res = await tool.executeTool('analyze_law_amendments', { law: 'КК' });
+      const out = parse(res);
+      expect(out.error).toMatch(/тимчасово недоступний/);
+      expect(out.detail).toBe('boom');
+    });
+  });
+});

--- a/mcp_backend/src/api/tools/legislation-analytics-tools.ts
+++ b/mcp_backend/src/api/tools/legislation-analytics-tools.ts
@@ -1,0 +1,251 @@
+/**
+ * Legislation Analytics Tools — norm-impact analysis over Ukrainian legislation.
+ *
+ * 1 tool:
+ * - analyze_law_amendments — історія редакцій статті/закону: скільки правок,
+ *   коли, як змінювався обсяг тексту. (CORE-89, Фаза A.)
+ *
+ * Phase A scope (this handler): amendment timeline + counts + size evolution,
+ * read entirely from the backend DB (legislation / legislation_editions /
+ * legislation_articles). The two enrichment layers — amendment *intent* (from
+ * bills.explanatory_note) and *court impact* (ITS over EDRSR) — depend on
+ * CORE-90 (legislation_editions.amending_law_number) and an EDRSR temporal
+ * join; they are returned as structured `pending` placeholders so the response
+ * contract stays stable across phases.
+ *
+ * Additive by design: no existing tool, table, or query is modified.
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+/**
+ * Code aliases → zakon.rada.gov.ua rada_id. Mirrors the subset used by
+ * LegislationService.codeMap; kept local so this handler stays self-contained
+ * and does not couple to (or modify) the legislation-service resolver.
+ */
+const LAW_CODE_ALIASES: Record<string, string> = {
+  'ЦПК': '1618-15',
+  'ГПК': '1798-12',
+  'КАС': '2747-15',
+  'КПК': '4651-17',
+  'ЦК': '435-15',
+  'ГК': '436-15',
+  'ПКУ': '2755-17',
+  'КЗПП': '322-08',
+  'КЗПП ': '322-08',
+  'СК': '2947-14',
+  'ЗК': '2768-14',
+  'КК': '2341-14',
+  'КУ': '254к/96-вр',
+  'КУПАП': '80731-10',
+};
+
+interface DbLike {
+  query: (sql: string, params?: any[]) => Promise<{ rows: any[] }>;
+}
+
+export class LegislationAnalyticsTools extends BaseToolHandler {
+  constructor(private readonly db?: DbLike) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'analyze_law_amendments',
+        annotations: {
+          title: 'Аналіз правок закону',
+          readOnlyHint: true,
+          idempotentHint: true,
+        },
+        description: `Історія редакцій закону або конкретної статті: скільки разів змінювали, коли, як змінювався обсяг тексту.
+
+Приймає law (скорочення на кшталт "КК", "ЦК", "ПКУ" або rada_id напр. "2341-14") та необовʼязковий article (номер статті, напр. "185").
+Повертає: метадані закону, таймлайн редакцій (з датами), кількість правок, еволюцію обсягу статті.
+Намір правок (пояснювальні записки) та вплив на судову практику — наступні фази аналітики.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            law: {
+              type: 'string',
+              description: 'Скорочення кодексу ("КК", "ЦК", "ПКУ"...) або rada_id ("2341-14")',
+            },
+            article: {
+              type: 'string',
+              description: 'Номер статті (напр. "185"). Якщо не вказано — аналіз редакцій усього закону.',
+            },
+          },
+          required: ['law'],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    if (name !== 'analyze_law_amendments') return null;
+    return this.analyzeLawAmendments(args);
+  }
+
+  /** Resolve a user-supplied law identifier to a rada_id. */
+  private resolveRadaId(input: string): string {
+    const trimmed = String(input || '').trim();
+    const upper = trimmed.toUpperCase();
+    return LAW_CODE_ALIASES[upper] || trimmed;
+  }
+
+  private async analyzeLawAmendments(args: any): Promise<ToolResult> {
+    if (!this.db) {
+      return this.wrapResponse({
+        error: 'База даних законодавства недоступна для аналізу редакцій.',
+      });
+    }
+
+    const lawInput = String(args?.law || '').trim();
+    if (!lawInput) {
+      return this.wrapError('Параметр law є обовʼязковим (скорочення кодексу або rada_id).');
+    }
+    const article = args?.article != null ? String(args.article).trim() : '';
+    const radaId = this.resolveRadaId(lawInput);
+
+    try {
+      // 1. Resolve the law
+      const lawRes = await this.db.query(
+        `SELECT id, rada_id, type, title, short_title, adoption_date, effective_date,
+                last_amended_date, status, total_editions, total_articles
+         FROM legislation
+         WHERE rada_id = $1
+         LIMIT 1`,
+        [radaId]
+      );
+
+      if (lawRes.rows.length === 0) {
+        return this.wrapResponse({
+          error: `Закон "${lawInput}" (rada_id: ${radaId}) не знайдено в базі законодавства.`,
+          provided_value: lawInput,
+          resolved_rada_id: radaId,
+          hint: 'Перевірте скорочення або вкажіть rada_id з zakon.rada.gov.ua (напр. "2341-14" для КК).',
+        });
+      }
+
+      const law = lawRes.rows[0];
+
+      // 2. Law-level edition timeline
+      const editionsRes = await this.db.query(
+        `SELECT edition_date, edition_key, article_count
+         FROM legislation_editions
+         WHERE legislation_id = $1
+         ORDER BY edition_date ASC`,
+        [law.id]
+      );
+      const editions = editionsRes.rows.map((r) => ({
+        edition_date: r.edition_date,
+        edition_key: r.edition_key,
+        article_count: r.article_count ?? null,
+      }));
+
+      // 3. Article-level version timeline (optional)
+      let articleAnalysis: any = null;
+      if (article) {
+        const digits = article.replace(/\D/g, '');
+        const versionsRes = await this.db.query(
+          `SELECT version_date, byte_size, is_current, article_number, title
+           FROM legislation_articles
+           WHERE legislation_id = $1
+             AND regexp_replace(article_number, '\\D', '', 'g') = $2
+           ORDER BY version_date ASC`,
+          [law.id, digits]
+        );
+        const versions = versionsRes.rows.map((r) => ({
+          version_date: r.version_date,
+          byte_size: r.byte_size ?? null,
+          is_current: r.is_current,
+        }));
+
+        if (versions.length === 0) {
+          articleAnalysis = {
+            article,
+            found: false,
+            note: `Статтю "${article}" не знайдено у збережених редакціях закону. Можливо, потрібна догрузка історичних редакцій (CORE-90).`,
+          };
+        } else {
+          const first = versions[0];
+          const last = versions[versions.length - 1];
+          const sizeFirst = first.byte_size ?? null;
+          const sizeLast = last.byte_size ?? null;
+          articleAnalysis = {
+            article,
+            found: true,
+            article_label: versionsRes.rows[0].article_number,
+            versions_count: versions.length,
+            first_version: first.version_date,
+            last_version: last.version_date,
+            size_bytes_first: sizeFirst,
+            size_bytes_last: sizeLast,
+            size_growth_pct:
+              sizeFirst && sizeLast ? Math.round(((sizeLast - sizeFirst) / sizeFirst) * 100) : null,
+            versions,
+          };
+        }
+      }
+
+      // 4. Assemble response (pending layers kept as stable placeholders)
+      const result = {
+        law: {
+          rada_id: law.rada_id,
+          title: law.title,
+          short_title: law.short_title ?? null,
+          type: law.type,
+          status: law.status,
+          adoption_date: law.adoption_date,
+          effective_date: law.effective_date,
+          last_amended_date: law.last_amended_date,
+        },
+        amendments: {
+          law_level: {
+            editions_count: editions.length || law.total_editions || 0,
+            editions,
+          },
+          article_level: articleAnalysis,
+        },
+        intent: {
+          status: 'pending',
+          note:
+            'Намір правок (пояснювальні записки законопроєктів) додається після CORE-90: '
+            + 'legislation_editions.amending_law_number → bills.explanatory_note.',
+        },
+        court_impact: {
+          status: 'pending',
+          method: 'interrupted_time_series',
+          note:
+            'Оцінка впливу на судову практику (до/після набрання чинності) додається після '
+            + 'CORE-90 + EDRSR темпорального join. Кореляція, не причинність.',
+        },
+        disclaimer:
+          'Дані редакцій — з legislation_editions / legislation_articles. '
+          + 'Намір та судовий вплив рахуються в наступних фазах (CORE-89 Фаза B / CORE-90).',
+      };
+
+      logger.info('[LegislationAnalytics] analyze_law_amendments', {
+        law: lawInput,
+        radaId,
+        article: article || null,
+        editions: editions.length,
+        articleVersions: articleAnalysis?.versions_count ?? null,
+      });
+
+      return this.wrapResponse(result);
+    } catch (error: any) {
+      logger.error('[LegislationAnalytics] analyze_law_amendments failed', {
+        law: lawInput,
+        radaId,
+        error: error?.message,
+      });
+      return this.wrapResponse({
+        error: 'Аналіз редакцій тимчасово недоступний.',
+        detail: error?.message,
+        provided_value: lawInput,
+      });
+    }
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -33,6 +33,7 @@ import { OpenDataRegistriesTools } from '../api/tools/opendata-registries-tools.
 import { Tier1OpenDataTools } from '../api/tools/tier1-opendata-tools.js';
 import { RegistrySearchTool } from '../api/tools/registry-search-tool.js';
 import { AnalyzeDataTool } from '../api/tools/analyze-data-tool.js';
+import { LegislationAnalyticsTools } from '../api/tools/legislation-analytics-tools.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
 import { DecisionLayerTools } from '../api/tools/decision-layer-tools.js';
 import { ImportTaskTools } from '../api/tools/import-task-tools.js';
@@ -167,6 +168,8 @@ export function createToolServices(
   toolRegistry.registerHandler(new CourtStatusTools(coreServices.db));
   toolRegistry.registerHandler(new RegistrySearchTool(coreServices.db));
   toolRegistry.registerHandler(new AnalyzeDataTool(coreServices.db));
+  // CORE-89 Phase A — norm-impact amendment analytics (additive; not yet in FIXED_V2_TOOLS)
+  toolRegistry.registerHandler(new LegislationAnalyticsTools(coreServices.db));
   // Bespoke tools with non-parametric query patterns
   toolRegistry.registerHandler(new OpenDataTools(coreServices.db));
   toolRegistry.registerHandler(new SpendingTools(coreServices.db));


### PR DESCRIPTION
## What
New read-only MCP tool **`analyze_law_amendments`** — amendment history of a Ukrainian law or a specific article: edition timeline, amendment count, per-article text-size evolution. Read entirely from the backend DB (`legislation` / `legislation_editions` / `legislation_articles`).

Part of **CORE-89** (Norm Impact Analytics), **Phase A**.

## Why
First, fully-additive slice of the Norm Impact product: answer "скільки разів і коли змінювали статтю X, як ріс її обсяг" for any law (e.g. `analyze_law_amendments(law="КК", article="185")`).

## Non-regression (by design)
- **Additive only:** one new handler file + one registration line in `tool-services.ts`. No existing tool/table/query modified.
- **Chat unchanged:** the tool is reachable via HTTP/MCP/tool-registry but is **NOT** added to `FIXED_V2_TOOLS` (that lives in `@secondlayer/core`). Until a separate core PR wires it in (Phase 2), the chat toolset — and chat behaviour — is identical.
- **Stable contract:** `intent` (explanatory notes) and `court_impact` (interrupted time series) are returned as `pending` placeholders; they land with CORE-90 (`amending_law_number`) + an EDRSR temporal join.

## Changes
- `mcp_backend/src/api/tools/legislation-analytics-tools.ts` (new) — handler + `analyze_law_amendments`.
- `mcp_backend/src/factories/tool-services.ts` — register the handler (additive).
- `mcp_backend/src/api/__tests__/legislation-analytics-tools.test.ts` (new) — 13 unit tests.

## Validation
- **Jest:** 13/13 pass (alias resolution КК→2341-14, edition/article timelines, size growth, not-found + error paths).
- **tsc:** no new errors in the changed files. Remaining repo-wide errors are pre-existing (unbuilt `@secondlayer/shared` query-ir exports + core-overlay `TS2307`), resolved in CI — same baseline as recent merged PRs.

## Follow-ups
- Phase 2 (core): add `analyze_law_amendments` to `FIXED_V2_TOOLS` so chat can call it.
- CORE-90: backfill `amending_law_number` + zv'yazky graph → unlocks `intent` and `court_impact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only MCP tool `analyze_law_amendments` to analyze a Ukrainian law’s amendment history or a specific article: edition timeline, amendment counts, and article text-size changes. Part of CORE-89 (Norm Impact Analytics) Phase A; chat behavior is unchanged.

- New Features
  - New handler `mcp_backend/src/api/tools/legislation-analytics-tools.ts` registered in `tool-services.ts` (additive; no existing tools/tables/queries changed).
  - Resolves law aliases (e.g., `КК` → `2341-14`) or accepts `rada_id`; optional `article` matched by digits.
  - Returns law metadata, law-level editions timeline + count, and article-level version timeline with first/last sizes and growth; `intent` and `court_impact` are returned as `pending` placeholders (unblocked by CORE-90).
  - 13 Jest tests cover aliasing, timelines, size growth, and not-found/error paths.

- Migration
  - No action needed. The tool is available via HTTP/MCP but not added to `FIXED_V2_TOOLS` in `@secondlayer/core`, so chat stays the same until a follow-up core PR.

<sup>Written for commit 3071b0f064a3b86a8e69c39d74c2fe6f79be0523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

