### PR TITLE
feat(legislation): article amendment metrics (editions diff + {…} notes)

### DIFF
--- a/docs/superpowers/specs/2026-06-30-mcp-api-v2-15-tools-design.md
+++ b/docs/superpowers/specs/2026-06-30-mcp-api-v2-15-tools-design.md
@@ -1,0 +1,97 @@
+# MCP API v2 — curated 15-tool surface (`/api/v2/mcp`)
+
+**Plane:** LEXAI-1785 · **Supersedes surface of:** LEXAI-1784 (PR #2051/#2052, the single `legal_chat` v2)
+**Date:** 2026-06-30 · **Branch:** `feat/mcp-v2-15-tools`
+
+## Goal
+
+Change the existing `/api/v2/mcp` endpoint so it exposes a **curated set of 15 tools** instead of a single `legal_chat` orchestrating tool. External MCP clients (Claude Code/Desktop, ChatGPT) get the same 15 tools the v3 web-chat uses internally, so they can drive retrieval themselves. v1 (`/api/v1/mcp` + `/v1/sse`, ~112 tools) stays unchanged.
+
+## Background / current state
+
+- `mcp_backend/src/routes/mcp-sse-routes.ts` already has v2 (merged, LEXAI-1784):
+  - `LEGAL_CHAT_TOOL` constant + `buildMcpServerV2()` whose `ListTools` returns `[LEGAL_CHAT_TOOL]` and whose `CallTool` routes everything into `deps.chatService.chat()`.
+  - Routes `POST/GET/DELETE /v2/mcp` (public `/api/v2/mcp`), OAuth (RFC 9728) resource metadata, `Mcp-Session-Id` sessions — all reused as-is.
+- v1 `buildMcpServer()` is fully dynamic: `ListTools` → `toolRegistry.getAllToolDefinitions()`; `CallTool` → credit check → cost-tracking → `toolRegistry.executeTool()` → credit deduction. **v1 keeps no tool list** — the registry is the source of truth and it lets a client call *any* registered tool by name.
+
+## Design
+
+Rework **only** `buildMcpServerV2()`. Transports, routes, auth, OAuth metadata stay untouched.
+
+### 1. The 15-tool set (source of truth)
+
+Add a module-level constant in `mcp-sse-routes.ts` (decision: option A/C — own const in the open repo, not coupled to proprietary `secondlayer-core`):
+
+```ts
+// Mirrors secondlayer-core FIXED_V2_TOOLS (chat-service.ts) as of 2026-06-30.
+// This is the PUBLIC v2 MCP contract — versioned deliberately; sync by hand if the
+// chat toolset changes. Used both to filter tools/list and to allowlist tools/call.
+const MCP_V2_TOOLS = new Set<string>([
+  // Законодавство (6)
+  'search_legislation', 'get_legislation_section', 'get_legislation_articles',
+  'get_legislation_structure', 'list_legislation_editions', 'get_legislation_history',
+  // ЄДРСР / судова практика (9)
+  'search_court_decisions', 'get_court_decision', 'get_case_documents_chain',
+  'load_full_texts', 'find_similar_fact_pattern_cases', 'compare_practice_pro_contra',
+  'count_cases_by_party', 'check_precedent_status', 'get_citation_graph',
+]);
+```
+
+### 2. `ListTools` — filter
+
+```ts
+mcpServer.setRequestHandler(ListToolsRequestSchema, async () => {
+  const all = await deps.toolRegistry.getAllToolDefinitions();
+  const tools = all.filter(t => MCP_V2_TOOLS.has(t.name));
+  const missing = [...MCP_V2_TOOLS].filter(n => !tools.some(t => t.name === n));
+  if (missing.length) logger.warn('[MCP v2] curated tools missing from registry', { missing });
+  return { tools };
+});
+```
+
+Descriptions are reused verbatim from each tool's existing `getToolDefinitions()` (already Ukrainian, already populated — verified for all 15).
+
+### 3. `CallTool` — allowlist + per-tool dispatch (reuse v1 mechanics)
+
+Replace the chat-pipeline `CallTool` with the v1 flow, gated by the allowlist:
+
+1. **Guard:** `if (!MCP_V2_TOOLS.has(toolName)) return isError('tool not exposed by MCP v2')`. This is required — without it a client could call any of the 112 by name even though it is hidden from `tools/list`.
+2. Credit check before (`creditService.calculateCreditsForTool` → `checkBalance`).
+3. `costTracker.createTrackingRecord({ requestId: 'mcp-v2-…', toolName, clientKey, userId, … })`.
+4. `requestContext.run(...)` → `toolRegistry.executeTool(toolName, args)` (with the same VAULT_TOOLS `userId` injection as v1 — though none of the 15 are vault tools, keep the pattern for safety).
+5. `costTracker.completeTrackingRecord` + credit deduction on success; `{ isError }` on failure.
+
+`buildMcpServerV2` no longer needs `deps.chatService` (leave the dep available for v1/other callers; just stop using it here). Drop `LEGAL_CHAT_TOOL`. Keep server `version: '2.0.0'`.
+
+### 4. v1 deprecation header
+
+v1 currently sets `Link: </api/v2/mcp>; rel="successor-version"`. Still valid — keep. (v2 is now a curated tool surface, a clean successor.)
+
+## EDRSR coverage (audit result — informational)
+
+The 15 tools cover EDRSR via:
+- **FTS** — `search_court_decisions` mode=`fulltext` (+ `structured`). ✅
+- **Semantic** (Qdrant HNSW, qdrant-readonly `edrsr_serving` 296.56M, jk 1-5) — mode=`semantic`/`hybrid` + `find_similar_fact_pattern_cases`. ✅
+- **Neo4j graph** — `get_citation_graph`, **partial**: decision→article (CITES_ARTICLE/OF_LAW/co-cited) only. decision↔decision is not exposed and the data is empty on prod (pending LEXAI-1773 full extraction run). ⚠️
+
+## Out of scope
+
+- decision↔decision citation graph / a 16th tool (`find_citing_decisions`) — revisit after LEXAI-1773 lands `case_citation_edges`.
+- Any change to the 15 tools' own implementations.
+- v1 behaviour.
+
+## Cleanup (bundled, low-risk)
+
+- Fix stale comment `edrsr-unified-search-tool.ts:8` ("semantic available only for jk=5") — semantic now covers jk 1-5 (`VECTORIZED_JUSTICE_KINDS = {1..5}`).
+
+## Testing
+
+- Unit test for `buildMcpServerV2`: `tools/list` returns exactly the 15 names; `tools/call` on an in-set tool dispatches to `executeTool`; `tools/call` on an out-of-set tool (e.g. `parse_document`, `rada_*`) returns `isError`.
+- Smoke: `tools/list` over `/api/v2/mcp` (Streamable HTTP) returns 15 with non-empty descriptions; one real call (e.g. `get_legislation_section` "ст. 625 ЦК") succeeds with billing recorded.
+
+## Acceptance criteria
+
+1. `GET/POST /api/v2/mcp` `tools/list` → exactly the 15 tools, each with its description.
+2. `tools/call` works for all 15 with credit check + cost tracking (v1 mechanics).
+3. `tools/call` for any non-listed tool is rejected.
+4. v1 unchanged; build + tests green.

--- a/mcp_backend/src/migrations/167_edrsr_parties.sql
+++ b/mcp_backend/src/migrations/167_edrsr_parties.sql
@@ -1,0 +1,76 @@
+-- 167_edrsr_parties.sql
+-- LEXAI-1760: structured parties table for EDRSR court decisions.
+--
+-- Today party counting (count_cases_by_party / search_court_decisions party_role) is done
+-- entirely at query time by a tsv role-noun prefilter + a POSIX `full_text ~* regex` over the
+-- multi-KB body of every candidate row. For a common company name (e.g. «ПриватБанк» — 193k
+-- rows in the 2023 partition alone) the un-LIMITed exact count blows past the statement
+-- timeout. This table pre-extracts the plaintiff/defendant spans from the standard claim
+-- clause ("за позовом X до Y про …") once, at backfill time, so role counts become a fast
+-- indexed lookup over a small per-party table instead of a regex scan of 125M full texts.
+--
+-- Scope of this migration: schema only (table + partitions + indexes + coverage meta).
+-- The extraction backfill is a separate, resumable, per-year job:
+--   scripts/edrsr/backfill-edrsr-parties.sql  (run per partition, off-peak, in tmux).
+-- Phase 1 covers the civil/commercial/administrative caption (justice_kind 1,3,4) and the
+-- позивач/відповідач roles. EDRPOU normalisation, criminal (обвинувачений) and third-party
+-- roles are deferred to phase 2.
+--
+-- EDRSR tables carry NO foreign keys (source data references codes absent from the reference
+-- tables — same convention as 071_edrsr_metadata.sql). All DDL is idempotent.
+
+-- pg_trgm backs the fuzzy name lookup (name_norm ILIKE '%нова пошта%').
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Parent table, RANGE-partitioned by adjudication year to mirror edrsr_documents /
+-- edrsr_fulltext, so a year backfill only touches its own partition and counts that are
+-- bounded to a year range prune to the matching partitions.
+CREATE TABLE IF NOT EXISTS edrsr_parties (
+  doc_id        BIGINT   NOT NULL,
+  role          SMALLINT NOT NULL,            -- 1 = позивач (plaintiff), 2 = відповідач (defendant); 3+ reserved
+  ord           SMALLINT NOT NULL DEFAULT 1,  -- nth party of that role in the caption (multi-defendant captions)
+  name_raw      TEXT     NOT NULL,            -- party span as extracted from the caption (with legal form / quotes)
+  name_norm     TEXT     NOT NULL,            -- normalised: lower-cased, quotes/punctuation stripped, ws collapsed
+  edrpou        TEXT,                         -- phase 2: matched company code (NULL for now)
+  court_code        INTEGER,                  -- denormalised from edrsr_documents for self-contained by_court breakdown
+  justice_kind      SMALLINT,                 -- denormalised (1 civil, 3 commercial, 4 administrative …)
+  adjudication_date TIMESTAMPTZ,              -- denormalised so day-precision date counts need no join to edrsr_documents
+  adj_year      SMALLINT NOT NULL,            -- partition key (= EXTRACT(YEAR FROM adjudication_date))
+  PRIMARY KEY (doc_id, role, ord, adj_year)
+) PARTITION BY RANGE (adj_year);
+
+-- Pilot partition: 2023. Further years are added by re-running this guarded block with new
+-- bounds (kept here so the schema is self-documenting; backfill populates them).
+DO $mig$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'edrsr_parties_p_2023') THEN
+    CREATE TABLE edrsr_parties_p_2023 PARTITION OF edrsr_parties
+      FOR VALUES FROM (2023) TO (2024);
+  END IF;
+  -- Catch-all so an out-of-range adj_year can never abort an INSERT during backfill.
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = 'edrsr_parties_p_default') THEN
+    CREATE TABLE edrsr_parties_p_default PARTITION OF edrsr_parties DEFAULT;
+  END IF;
+END
+$mig$;
+
+-- Indexes are defined on the parent so they propagate to every (current and future) partition.
+-- Fuzzy company lookup: trigram GIN over the normalised name.
+CREATE INDEX IF NOT EXISTS idx_edrsr_parties_name_trgm
+  ON edrsr_parties USING gin (name_norm gin_trgm_ops);
+-- Role/year pruning for aggregate counts.
+CREATE INDEX IF NOT EXISTS idx_edrsr_parties_role_year
+  ON edrsr_parties (role, adj_year);
+
+-- Coverage meta — which years have been extracted. countByParty consults this to decide
+-- whether the requested date range is fully backed by the parties table (fast path) or must
+-- fall back to the legacy FTS regex scan (uncovered years).
+CREATE TABLE IF NOT EXISTS edrsr_parties_coverage (
+  adj_year     SMALLINT PRIMARY KEY,
+  doc_count    BIGINT,       -- decisions in the partition considered for extraction
+  party_count  BIGINT,       -- party rows extracted for the year
+  built_at     TIMESTAMPTZ DEFAULT now()
+);
+
+COMMENT ON TABLE edrsr_parties IS
+  'LEXAI-1760: structured plaintiff/defendant spans extracted from the EDRSR claim clause. role 1=позивач, 2=відповідач. Populated per-year by scripts/edrsr/backfill-edrsr-parties.sql; see edrsr_parties_coverage for built years.';

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -221,8 +221,134 @@ const FTS_STATEMENT_TIMEOUT_MS = 8000;
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
+  // LEXAI-1760: years whose plaintiff/defendant spans have been extracted into edrsr_parties
+  // (read from edrsr_parties_coverage). When a count's date range falls entirely inside these
+  // years, countByParty serves it from the indexed parties table instead of the full-text
+  // regex scan. Cached briefly; empty set (table absent / not yet built) ⇒ always FTS fallback.
+  private coveredYearsCache: { years: Set<number>; at: number } | null = null;
+  private static readonly COVERAGE_TTL_MS = 60_000;
+
   setEdsrCache(cache: EdsrCacheService): void {
     this.edsrCache = cache;
+  }
+
+  /**
+   * Years served by the structured parties table (edrsr_parties_coverage), cached for
+   * COVERAGE_TTL_MS. Fail-safe: any error / missing table ⇒ empty set ⇒ callers fall back to
+   * the legacy FTS path, so a half-built or absent table can never break counting.
+   */
+  private async coveredPartyYears(dbPool: any): Promise<Set<number>> {
+    const now = Date.now();
+    if (this.coveredYearsCache && now - this.coveredYearsCache.at < EdsrFtsService.COVERAGE_TTL_MS) {
+      return this.coveredYearsCache.years;
+    }
+    let years = new Set<number>();
+    try {
+      const res = await dbPool.query(`SELECT adj_year FROM edrsr_parties_coverage`);
+      years = new Set(res.rows.map((r: any) => Number(r.adj_year)));
+    } catch {
+      years = new Set();
+    }
+    this.coveredYearsCache = { years, at: now };
+    return years;
+  }
+
+  /** Normalise a party name the same way the backfill builds name_norm (lower, strip quotes,
+   *  collapse whitespace), then escape ILIKE wildcards so it is matched literally as a substring. */
+  private normalizePartyName(partyName: string): string {
+    return partyName
+      .toLowerCase()
+      .replace(/[«»"“”']/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/[%_\\]/g, '\\$&');
+  }
+
+  /**
+   * Fast role count from the structured parties table — used by countByParty only when the
+   * whole [date_from, date_to] year span is covered (see coveredPartyYears). Returns null when
+   * the fast path is not applicable (no/partial date range, an uncovered year, or any error),
+   * which signals the caller to fall back to the FTS scan.
+   */
+  private async countByPartyFast(
+    partyName: string,
+    partyRole: PartyRole | undefined,
+    dbPool: any,
+    filters: { date_from?: string; date_to?: string; justice_kind?: number },
+    sampleLimit: number,
+  ): Promise<PartyCaseCount | null> {
+    const { date_from, date_to } = filters;
+    if (!date_from || !date_to) return null;                       // open-ended range — coverage not guaranteed
+    const yFrom = Number(date_from.slice(0, 4));
+    const yTo = Number(date_to.slice(0, 4));
+    if (!Number.isInteger(yFrom) || !Number.isInteger(yTo) || yFrom > yTo) return null;
+
+    const covered = await this.coveredPartyYears(dbPool);
+    if (covered.size === 0) return null;
+    for (let y = yFrom; y <= yTo; y++) {
+      if (!covered.has(y)) return null;                            // any uncovered year ⇒ fall back to FTS
+    }
+
+    const namePattern = `%${this.normalizePartyName(partyName)}%`;
+    const params: any[] = [namePattern, yFrom, yTo];
+    let p = 4;
+    const conditions = [`name_norm ILIKE $1`, `adj_year BETWEEN $2 AND $3`];
+    if (partyRole && partyRole !== 'any') {
+      conditions.push(`role = $${p}`);
+      params.push(partyRole === 'defendant' ? 2 : 1);
+      p++;
+    } else {
+      conditions.push(`role IN (1, 2)`);
+    }
+    // Day-precision bounds inside the boundary years (the year span is coarse): re-check the
+    // exact adjudication_date so e.g. 2023-03-01..2023-09-30 is honoured, not the whole year.
+    conditions.push(`adjudication_date >= $${p}`); params.push(date_from); p++;
+    conditions.push(`adjudication_date <= $${p}`); params.push(date_to); p++;
+    if (filters.justice_kind) { conditions.push(`justice_kind = $${p}`); params.push(filters.justice_kind); p++; }
+    const whereClause = conditions.join(' AND ');
+
+    try {
+      const countSql = `
+        SELECT court_code, count(DISTINCT doc_id)::int AS n
+        FROM edrsr_parties
+        WHERE ${whereClause}
+        GROUP BY court_code
+        ORDER BY n DESC`;
+      const countResult = await dbPool.query(countSql, params);
+      const by_court = countResult.rows
+        .filter((r: any) => r.court_code !== null)
+        .map((r: any) => ({ court_code: r.court_code, count: r.n }));
+      const total = countResult.rows.reduce((s: number, r: any) => s + r.n, 0);
+
+      let sample: PartyCaseCount['sample'];
+      if (sampleLimit > 0) {
+        const safeSample = Math.min(Math.max(sampleLimit, 1), 1000);
+        const sampleSql = `
+          SELECT DISTINCT ON (p.doc_id) p.doc_id, d.cause_num, p.court_code, p.justice_kind, p.adjudication_date
+          FROM edrsr_parties p
+          JOIN edrsr_documents d ON d.doc_id = p.doc_id
+          WHERE ${whereClause.replace(/\bname_norm\b/g, 'p.name_norm')
+                              .replace(/\badj_year\b/g, 'p.adj_year')
+                              .replace(/\brole\b/g, 'p.role')
+                              .replace(/\badjudication_date\b/g, 'p.adjudication_date')
+                              .replace(/\bjustice_kind\b/g, 'p.justice_kind')}
+          ORDER BY p.doc_id, p.adjudication_date DESC NULLS LAST
+          LIMIT ${safeSample}`;
+        const sampleResult = await dbPool.query(sampleSql, params);
+        sample = sampleResult.rows.map((r: any) => ({
+          doc_id: Number(r.doc_id), cause_num: r.cause_num ?? null, court_code: r.court_code ?? null,
+          justice_kind: r.justice_kind ?? null, adjudication_date: r.adjudication_date ?? null,
+        }));
+      }
+
+      logger.info('[EdsrFtsService] countByParty (fast/parties-table)', {
+        party_name: partyName, party_role: partyRole ?? 'any', years: [yFrom, yTo], total, courts: by_court.length,
+      });
+      return { total, by_court, ...(sample ? { sample } : {}) };
+    } catch (err: any) {
+      logger.warn('[EdsrFtsService] countByPartyFast failed; falling back to FTS', { error: err.message, party_name: partyName });
+      return null;
+    }
   }
 
   /**
@@ -653,6 +779,12 @@ export class EdsrFtsService {
     filters: { date_from?: string; date_to?: string; justice_kind?: number } = {},
     sampleLimit: number = 0,
   ): Promise<PartyCaseCount> {
+    // LEXAI-1760: when the requested year span is fully covered by the structured parties
+    // table, answer from its indexes (fast, exact) instead of regex-scanning 125M full texts.
+    // Returns null when not applicable / on error → fall through to the legacy FTS path below.
+    const fast = await this.countByPartyFast(partyName, partyRole, dbPool, filters, sampleLimit);
+    if (fast) return fast;
+
     const params: any[] = [];
     let p = 1;
 

--- a/scripts/edrsr/backfill-edrsr-parties.sql
+++ b/scripts/edrsr/backfill-edrsr-parties.sql
@@ -1,0 +1,99 @@
+-- backfill-edrsr-parties.sql  (LEXAI-1760)
+--
+-- Extract плаінтифф/відповідач spans from the EDRSR claim clause ("за позовом X до Y про …")
+-- for ONE adjudication year into edrsr_parties. In-DB only (no egress), idempotent (rebuilds
+-- the year), and partition-scoped so it can be run per year, off-peak, in tmux.
+--
+-- Usage (run ON the prod DB host — never pull the corpus to local, egress is paid):
+--   ssh prod 'docker exec -i secondlayer-postgres-prod \
+--     psql -U secondlayer -d secondlayer_prod -v year=2023' < scripts/edrsr/backfill-edrsr-parties.sql
+--
+-- The caption is taken from the first 3000 chars (вступна частина) which both bounds the
+-- regex cost and avoids matching a "позовом … до … про" phrase deep in the body. Only
+-- civil/commercial/administrative kinds (justice_kind 1,3,4) carry this caption; criminal /
+-- КУпАП use a different formula and are left for phase 2.
+
+\set ON_ERROR_STOP on
+\timing on
+
+BEGIN;
+-- This is a bulk maintenance job, not a request — let it run to completion.
+SET LOCAL statement_timeout = '0';
+
+-- Idempotent rebuild: drop any rows previously extracted for this year.
+DELETE FROM edrsr_parties WHERE adj_year = :year;
+
+WITH src AS (
+  SELECT
+    f.doc_id,
+    d.court_code,
+    d.justice_kind,
+    d.adjudication_date,
+    regexp_match(
+      left(f.full_text, 3000),
+      -- (optional) "за" + optional qualifier, "позов…", capture PLAINTIFF up to " до ",
+      -- capture DEFENDANT up to " про "/" щодо ".
+      -- NB: POSIX RE_DUP_MAX caps a {m,n} bound at 255 — keep every repetition count ≤ 255.
+      '(?:за\s+)?(?:адміністративн[а-яіїєґ]*\s+|зустрічн[а-яіїєґ]*\s+)?позов(?:ною\s+заявою|ом|у|и|ами|ів)?\s+(.{3,250}?)\s+до\s+(.{3,250}?)\s+(?:про|щодо)\s',
+      'i'
+    ) AS m
+  FROM edrsr_fulltext f
+  JOIN edrsr_documents d ON d.doc_id = f.doc_id
+  WHERE f.adj_year = :year
+    AND d.justice_kind IN (1, 3, 4)
+),
+matched AS (
+  SELECT doc_id, court_code, justice_kind, adjudication_date,
+         m[1] AS plaintiff_raw, m[2] AS defendant_raw
+  FROM src
+  WHERE m IS NOT NULL
+),
+unpiv AS (
+  SELECT doc_id, court_code, justice_kind, adjudication_date, v.role, v.name_raw
+  FROM matched
+  CROSS JOIN LATERAL (VALUES
+    (1::smallint, plaintiff_raw),
+    (2::smallint, defendant_raw)
+  ) AS v(role, name_raw)
+  WHERE v.name_raw IS NOT NULL
+)
+INSERT INTO edrsr_parties (doc_id, role, ord, name_raw, name_norm, court_code, justice_kind, adjudication_date, adj_year)
+SELECT
+  doc_id,
+  role,
+  1,
+  btrim(name_raw),
+  -- normalise: strip quotes, lower-case, collapse whitespace, trim edge punctuation.
+  btrim(
+    regexp_replace(
+      lower(regexp_replace(name_raw, '[«»"“”'']', '', 'g')),
+      '\s+', ' ', 'g'
+    ),
+    ' .,;:-—'
+  ),
+  court_code,
+  justice_kind,
+  adjudication_date,
+  :year
+FROM unpiv
+WHERE length(btrim(name_raw)) BETWEEN 3 AND 400
+ON CONFLICT (doc_id, role, ord, adj_year) DO NOTHING;
+
+-- Record coverage so countByParty knows this year is served by the table.
+INSERT INTO edrsr_parties_coverage (adj_year, doc_count, party_count, built_at)
+SELECT
+  :year,
+  (SELECT count(*) FROM edrsr_fulltext WHERE adj_year = :year),
+  (SELECT count(*) FROM edrsr_parties  WHERE adj_year = :year),
+  now()
+ON CONFLICT (adj_year) DO UPDATE
+  SET doc_count = EXCLUDED.doc_count,
+      party_count = EXCLUDED.party_count,
+      built_at = now();
+
+COMMIT;
+
+-- Quick post-build sanity numbers.
+SELECT adj_year, doc_count, party_count, built_at FROM edrsr_parties_coverage WHERE adj_year = :year;
+SELECT role, count(*) AS rows, count(DISTINCT doc_id) AS docs
+FROM edrsr_parties WHERE adj_year = :year GROUP BY role ORDER BY role;

--- a/scripts/rada/backfill-legislation-changes.sql
+++ b/scripts/rada/backfill-legislation-changes.sql
@@ -1,0 +1,137 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Backfill legislation_changes from per-edition article snapshots
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- WHY:
+--   legislation_changes is empty, so the "most-changed articles" feature falls
+--   back to counting *editions* (every article shows N versions == N editions),
+--   which is wrong. This script reconstructs the real edit history by walking the
+--   per-edition snapshots stored in legislation_articles and emitting one row per
+--   actual added / modified / removed event.
+--
+-- DATA FACTS (verified on prod, 2026-06-29):
+--   * legislation_articles holds exactly 1 row per (legislation_id, article_number,
+--     edition) — no part-splitting.
+--   * Every real article version_date aligns with a legislation_editions.edition_date.
+--   * A synthetic placeholder row (date 2000-01-01, NOT an edition date) exists per
+--     article; it is excluded naturally by joining text to the editions timeline.
+--   * is_current is NOT used for filtering: the importer toggles it onto the latest
+--     real edition (e.g. 2024-10-06), so filtering on it would drop a real edition
+--     and emit phantom 'removed' events. The editions join is the source of truth.
+--
+-- SEMANTICS (matches legislation-monitoring-service.ts):
+--   added    -> old_text NULL,     new_text=current,  diff_html NULL
+--   modified -> old_text=previous,  new_text=current,  diff_html NULL (compute lazily)
+--   removed  -> old_text=previous,  new_text NULL,     diff_html NULL
+--
+--   "Number of amendments to article N" == COUNT(*) WHERE change_type='modified'.
+--   The original adoption of an article is recorded as 'added' (not an amendment).
+--
+-- IDEMPOTENT: a unique natural key + ON CONFLICT DO NOTHING means re-running is
+--   safe and will not duplicate or clobber rows the live monitor inserts later.
+--
+-- RUN (prod, server-side — no data egress):
+--   docker exec -i secondlayer-postgres-prod \
+--     psql -U secondlayer -d secondlayer_prod -v ONLY_LAW=0 \
+--     < scripts/rada/backfill-legislation-changes.sql
+--
+--   Scope to a single law for testing:  -v ONLY_LAW=298
+-- ─────────────────────────────────────────────────────────────────────────────
+
+\set ON_ERROR_STOP on
+\if :{?ONLY_LAW} \else \set ONLY_LAW 0 \endif
+
+BEGIN;
+
+-- Natural key: one event per (law, article, edition, type). Live monitor inserts
+-- (which also carry version_date) dedupe against the backfill via this index.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_leg_changes_event
+  ON legislation_changes (legislation_id, article_number, version_date, change_type);
+
+WITH
+-- Canonical, authoritative edition timeline (1 row per edition).
+ed AS (
+  SELECT legislation_id,
+         edition_date,
+         row_number() OVER (PARTITION BY legislation_id ORDER BY edition_date) AS rn
+  FROM legislation_editions
+  WHERE (:ONLY_LAW = 0 OR legislation_id = :ONLY_LAW)
+),
+-- Article text per (law, article, edition). One row per (law, article, date);
+-- is_current is ignored. The synthetic placeholder date drops out at the editions
+-- join below (its date is not a real edition). DISTINCT ON guards against an edition
+-- date appearing twice (e.g. an is_current=true copy alongside an is_current=false one).
+art AS (
+  SELECT DISTINCT ON (legislation_id, article_number, version_date::date)
+         legislation_id,
+         article_number,
+         version_date::date AS edition_date,
+         full_text          AS raw_text,
+         regexp_replace(coalesce(full_text, ''), '\s+', ' ', 'g') AS norm
+  FROM legislation_articles
+  WHERE article_number IS NOT NULL
+    AND (:ONLY_LAW = 0 OR legislation_id = :ONLY_LAW)
+  ORDER BY legislation_id, article_number, version_date::date, is_current DESC
+),
+-- Full grid: every article crossed with every edition of its law (so gaps where an
+-- article disappears or reappears become visible for removed/added detection).
+grid AS (
+  SELECT al.legislation_id,
+         al.article_number,
+         e.rn,
+         e.edition_date,
+         a.raw_text,
+         a.norm,
+         (a.norm IS NOT NULL) AS present
+  FROM (SELECT DISTINCT legislation_id, article_number FROM art) al
+  JOIN ed  e ON e.legislation_id = al.legislation_id
+  LEFT JOIN art a ON a.legislation_id = al.legislation_id
+                 AND a.article_number = al.article_number
+                 AND a.edition_date   = e.edition_date
+),
+-- Compare each cell to the previous edition of the same article.
+walk AS (
+  SELECT legislation_id, article_number, edition_date, present, raw_text, norm,
+         lag(present)  OVER w AS prev_present,
+         lag(norm)     OVER w AS prev_norm,
+         lag(raw_text) OVER w AS prev_raw
+  FROM grid
+  WINDOW w AS (PARTITION BY legislation_id, article_number ORDER BY rn)
+),
+events AS (
+  SELECT
+    legislation_id, article_number, edition_date,
+    CASE
+      WHEN present AND prev_present IS DISTINCT FROM true       THEN 'added'
+      WHEN present AND prev_present AND norm <> prev_norm        THEN 'modified'
+      WHEN (NOT present) AND prev_present                        THEN 'removed'
+    END AS change_type,
+    CASE
+      WHEN present AND prev_present AND norm <> prev_norm        THEN prev_raw  -- modified
+      WHEN (NOT present) AND prev_present                        THEN prev_raw  -- removed
+    END AS old_text,
+    CASE
+      WHEN present AND prev_present IS DISTINCT FROM true        THEN raw_text  -- added
+      WHEN present AND prev_present AND norm <> prev_norm        THEN raw_text  -- modified
+    END AS new_text
+  FROM walk
+)
+INSERT INTO legislation_changes
+  (legislation_id, rada_id, article_number, change_type,
+   old_text, new_text, diff_html, version_date, detected_at)
+SELECT ev.legislation_id, l.rada_id, ev.article_number, ev.change_type,
+       ev.old_text, ev.new_text, NULL,
+       ev.edition_date::timestamptz, now()
+FROM events ev
+JOIN legislation l ON l.id = ev.legislation_id
+WHERE ev.change_type IS NOT NULL
+ON CONFLICT (legislation_id, article_number, version_date, change_type) DO NOTHING;
+
+-- Report what was produced in this run's scope.
+SELECT change_type, count(*) AS rows
+FROM legislation_changes
+WHERE (:ONLY_LAW = 0 OR legislation_id = :ONLY_LAW)
+GROUP BY change_type
+ORDER BY change_type;
+
+COMMIT;

--- a/scripts/rada/build-amendment-metric.py
+++ b/scripts/rada/build-amendment-metric.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Rebuild the article-amendment metric from Rada's inline `{…}` annotations.
+
+Counts CLAUSE-LEVEL amendment operations per article (what a lawyer sees in the
+text), not editions. Each `{…}` note cites one or more acts; each act-reference
+in a note is one operation, classified by its verb:
+  доповнено  -> added      в редакції -> modified      виключено -> removed
+
+Output: SQL (CREATE TABLE legislation_article_amendments + DELETE + INSERTs) so it
+can be applied to prod, plus a per-article report. Source = the law's CURRENT
+edition print page (the consolidated text that still carries surviving notes).
+
+Usage:
+  python3 scripts/rada/build-amendment-metric.py <rada_id> <legislation_id> [edition_YYYYMMDD]
+  e.g. python3 scripts/rada/build-amendment-metric.py 2778-17 298 20241006
+"""
+import re, sys, subprocess
+from collections import Counter
+
+RADA = sys.argv[1] if len(sys.argv) > 1 else "2778-17"
+LEG_ID = int(sys.argv[2]) if len(sys.argv) > 2 else 298
+EDITION = sys.argv[3] if len(sys.argv) > 3 else "20241006"
+BASE = "https://zakon.rada.gov.ua"
+UA = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+SQL_OUT = "/tmp/amend_metric.sql"
+
+def fetch(url, tries=7):
+    txt = ""
+    for i in range(tries):
+        try:
+            o = subprocess.run(["curl", "-s", "-m", "45", "--compressed",
+                "-A", UA, "-H", "Accept-Language: uk,en;q=0.9", url],
+                capture_output=True, timeout=70)
+            txt = o.stdout.decode("utf-8", "replace")
+            if len(txt) >= 3000:
+                return txt
+        except Exception:
+            pass
+        import time; time.sleep(3 + 4 * i)
+    return txt
+
+RVTS = re.compile(
+    r'<span\s+class=["\']?rvts9["\']?>\s*Стаття\s+(\d+(?:-\d+)?)\.?\s*([^<]*)</span>\s*'
+    r'(.*?)(?=<span\s+class=["\']?rvts9["\']?>\s*Стаття\s+\d|$)', re.S)
+
+def to_text(htmlfrag):
+    t = re.sub(r"<[^>]+>", " ", htmlfrag)
+    t = (t.replace("&nbsp;", " ").replace("&mdash;", "—")
+          .replace("&laquo;", "«").replace("&raquo;", "»").replace("&amp;", "&"))
+    return re.sub(r"[ \t]+", " ", t)
+
+ACT = re.compile(r"Закон[ауомих]* № (\d+-[IVXІ]+)(?:\s+від\s+(\d{2})\.(\d{2})\.(\d{4}))?")
+
+def classify(ctx):
+    ctx = ctx.lower()
+    if "виключ" in ctx:                 return "removed"
+    if "в редакці" in ctx:              return "modified"
+    if "доповн" in ctx:                 return "added"
+    if "замін" in ctx or "змін" in ctx: return "modified"
+    return "modified"
+
+def parse_notes(text):
+    """Yield (change_type, act, act_date_iso|None, note_text) for each act-ref in each {…}."""
+    for note in re.findall(r"\{[^}]*\}", text):
+        inner = note.strip("{}").strip()
+        prev = 0
+        for m in ACT.finditer(inner):
+            ctx = inner[prev:m.start()] or inner[:m.end()]
+            act = m.group(1)
+            date_iso = (f"{m.group(4)}-{m.group(3)}-{m.group(2)}"
+                        if m.group(2) else None)
+            yield classify(ctx), act, date_iso, note
+            prev = m.end()
+
+def sql_str(s):
+    return "'" + (s or "").replace("'", "''") + "'"
+
+# ── Fetch + parse ────────────────────────────────────────────────────────────
+html = fetch(f"{BASE}/laws/show/{RADA}/ed{EDITION}/print")
+rows = []                       # (article, change_type, act, date_iso, note)
+per_article = Counter()
+for m in RVTS.finditer(html):
+    art = m.group(1).strip()
+    body = to_text(m.group(3))
+    for ct, act, dt, note in parse_notes(body):
+        rows.append((art, ct, act, dt, note))
+        per_article[art] += 1
+
+src_iso = f"{EDITION[:4]}-{EDITION[4:6]}-{EDITION[6:8]}"
+
+# ── Emit SQL ─────────────────────────────────────────────────────────────────
+with open(SQL_OUT, "w") as f:
+    f.write("""\\set ON_ERROR_STOP on
+BEGIN;
+CREATE TABLE IF NOT EXISTS legislation_article_amendments (
+  id SERIAL PRIMARY KEY,
+  legislation_id INTEGER NOT NULL REFERENCES legislation(id) ON DELETE CASCADE,
+  rada_id VARCHAR(100) NOT NULL,
+  article_number VARCHAR(50) NOT NULL,
+  change_type VARCHAR(20) NOT NULL CHECK (change_type IN ('added','modified','removed')),
+  basis_act VARCHAR(50),
+  act_date DATE,
+  note_text TEXT,
+  source_edition DATE,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (legislation_id, article_number, change_type, basis_act, note_text)
+);
+CREATE INDEX IF NOT EXISTS idx_law_art_amend
+  ON legislation_article_amendments(legislation_id, article_number);
+""")
+    f.write(f"DELETE FROM legislation_article_amendments WHERE legislation_id={LEG_ID};\n")
+    for art, ct, act, dt, note in rows:
+        dt_sql = sql_str(dt) if dt else "NULL"
+        f.write(
+            "INSERT INTO legislation_article_amendments "
+            "(legislation_id,rada_id,article_number,change_type,basis_act,act_date,note_text,source_edition) VALUES ("
+            f"{LEG_ID},{sql_str(RADA)},{sql_str(art)},{sql_str(ct)},{sql_str(act)},{dt_sql},"
+            f"{sql_str(note)},{sql_str(src_iso)}) ON CONFLICT DO NOTHING;\n")
+    f.write("SELECT article_number, count(*) AS amendments FROM legislation_article_amendments "
+            f"WHERE legislation_id={LEG_ID} GROUP BY article_number ORDER BY amendments DESC, article_number LIMIT 12;\n")
+    f.write("COMMIT;\n")
+
+# ── Report ───────────────────────────────────────────────────────────────────
+print(f"Law {RADA} (id {LEG_ID}), edition {src_iso}")
+print(f"Total clause-level operations parsed: {len(rows)}")
+print(f"Distinct acts: {len(set(r[2] for r in rows))}")
+print(f"\nArticle 1 operations: {per_article.get('1',0)}")
+for art, ct, act, dt, note in rows:
+    if art == "1":
+        print(f"  {ct:9} {act} {dt or ''}")
+print("\nTop articles by clause-level amendments:")
+for art, n in per_article.most_common(10):
+    print(f"  ст.{art}: {n}")
+print(f"\nSQL written to {SQL_OUT}")

--- a/scripts/rada/download-art1-culture.py
+++ b/scripts/rada/download-art1-culture.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Download Article 1 (Стаття 1) of «Про культуру» (2778-17) from every Rada
+edition, save each version, and count the real number of amendments.
+
+Replicates the text extraction of scripts/rada/import-historical-editions.ts
+(rvts9 span format) so results are comparable to the imported DB.
+"""
+import os, re, sys, time, hashlib, subprocess
+
+RADA = "2778-17"
+BASE = "https://zakon.rada.gov.ua"
+OUT = os.path.expanduser("~/rada-culture-art1")
+UA = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+os.makedirs(os.path.join(OUT, "raw"), exist_ok=True)
+
+def fetch(url, tries=7, min_bytes=3000):
+    """Fetch via curl. Treat tiny bodies (<min_bytes) as throttle stubs and retry
+    with growing backoff."""
+    for i in range(tries):
+        try:
+            out = subprocess.run(
+                ["curl", "-s", "-m", "45", "--compressed",
+                 "-A", UA, "-H", "Accept-Language: uk,en;q=0.9", url],
+                capture_output=True, timeout=70)
+            txt = out.stdout.decode("utf-8", "replace")
+            if len(txt) >= min_bytes:
+                return txt
+        except Exception:
+            pass
+        time.sleep(3 + 4 * i)   # 3,7,11,15... seconds — back off through throttling
+    return txt if 'txt' in dir() else ""
+
+# ── 1. Edition discovery ─────────────────────────────────────────────────────
+card4 = fetch(f"{BASE}/laws/show/{RADA}/card4")
+open(os.path.join(OUT, "raw", "card4.html"), "w").write(card4)
+
+hyperlink_dates = sorted(set(re.findall(r"/ed(\d{8})", card4)))
+
+# History table: every row <span class="dat1">DD.MM.YYYY</span> ... whose cell
+# mentions "редакц" is an edition (even without a hyperlink). Also capture the
+# basis act ("підстава ... <number>") in the same row when present.
+rows = re.findall(
+    r'<span class="dat1">(\d{2})\.(\d{2})\.(\d{4})</span>(.*?)(?=<span class="dat1">|</tbody>|$)',
+    card4, re.S)
+table_dates, basis = {}, {}
+for dd, mm, yyyy, rest in rows:
+    if re.search(r"редакц", rest, re.I):
+        key = f"{yyyy}{mm}{dd}"
+        table_dates[key] = True
+        acts = re.findall(r"\b(\d{3,5}-[IVXІ]+)\b", re.sub(r"<[^>]+>", " ", rest))
+        if acts:
+            basis[key] = acts[-1]
+
+all_dates = sorted(set(hyperlink_dates) | set(table_dates.keys()))
+all_dates = [d for d in all_dates if "1900" <= d[:4] <= "2099"]
+
+print(f"hyperlink editions: {len(hyperlink_dates)}")
+print(f"history-table edition rows: {len(table_dates)}")
+print(f"UNION of edition dates: {len(all_dates)}")
+print("dates:", " ".join(all_dates))
+
+# ── 2. Extract Article 1 per edition (importer's rvts9 logic) ─────────────────
+RVTS = re.compile(
+    r'<span\s+class=["\']?rvts9["\']?>\s*Стаття\s+(\d+(?:-\d+)?)\.?\s*([^<]*)</span>\s*'
+    r'(.*?)(?=<span\s+class=["\']?rvts9["\']?>\s*Стаття\s+\d|$)', re.S)
+
+def clean(body):
+    body = re.sub(r"<script.*?</script>|<style.*?</style>", " ", body, flags=re.S)
+    body = re.sub(r"<[^>]+>", " ", body)
+    body = (body.replace("&nbsp;", " ").replace("&mdash;", "—")
+                .replace("&laquo;", "«").replace("&raquo;", "»").replace("&amp;", "&"))
+    body = re.sub(r"\{[^}]*\}", "", body)          # drop {amendment notes}
+    body = re.sub(r"\s+", " ", body).strip()
+    return body
+
+# Historical-edition format: <b>Стаття N.</b> body ... until <b>Стаття N+1</b>
+PREBOLD = re.compile(
+    r'<b>Стаття\s+(\d+(?:-\d+)?)\.?</b>\s*(.*?)(?=<b>Стаття\s+\d|</pre>\s*$|$)', re.S)
+
+def clean_bold(body):
+    body = re.sub(r"<br\s*/?>", "\n", body, flags=re.I)
+    body = re.sub(r"<b>([^<]*)</b>", r"\1", body)
+    return clean(body)
+
+def extract_art1(html):
+    # 1) current rvts9 span format
+    for m in RVTS.finditer(html):
+        if m.group(1).strip() == "1":
+            return clean(m.group(3)), (m.group(2) or "").strip(), "rvts9"
+    # 2) historical <b>Стаття</b> format
+    for m in PREBOLD.finditer(html):
+        if m.group(1).strip() == "1":
+            return clean_bold(m.group(2)), "", "bold"
+    return None, None, None
+
+records = []
+for d in all_dates:
+    iso = f"{d[:4]}-{d[4:6]}-{d[6:8]}"
+    html = fetch(f"{BASE}/laws/show/{RADA}/ed{d}/print")
+    art1, title, fmt = extract_art1(html)
+    if art1 is None:
+        print(f"  {iso}: Стаття 1 NOT FOUND ({len(html)} bytes)")
+        records.append((iso, None, None, basis.get(d, "")))
+        time.sleep(3)
+        continue
+    norm = re.sub(r"\s+", " ", art1).strip()
+    h = hashlib.md5(norm.encode()).hexdigest()[:8]
+    fn = os.path.join(OUT, f"art1_{iso}.txt")
+    open(fn, "w").write(f"# Стаття 1. {title}\n# edition {iso}  basis {basis.get(d,'?')}  hash {h}  len {len(norm)}  fmt {fmt}\n\n{art1}\n")
+    records.append((iso, h, len(norm), basis.get(d, "")))
+    print(f"  {iso}: len={len(norm)} hash={h} fmt={fmt} basis={basis.get(d,'?')}")
+    time.sleep(3)
+
+# ── 3. Count real amendments (text transitions) ──────────────────────────────
+present = [r for r in records if r[1] is not None]
+changes = []
+prev_h = None
+for iso, h, ln, act in present:
+    if prev_h is None:
+        kind = "ORIGINAL"
+    elif h != prev_h:
+        kind = "CHANGED"
+        changes.append((iso, act))
+    else:
+        kind = "same"
+    prev_h = h
+
+lines = []
+lines.append(f"# Стаття 1 ЗУ «Про культуру» ({RADA}) — історія редакцій\n")
+lines.append(f"- Hyperlink editions on card4: {len(hyperlink_dates)}")
+lines.append(f"- History-table edition rows: {len(table_dates)}")
+lines.append(f"- Editions fetched (union): {len(all_dates)}; Стаття 1 present in: {len(present)}")
+lines.append(f"- **Реальних змін тексту Стаття 1: {len(changes)}** (без первинного прийняття)")
+lines.append(f"- Дати змін: {', '.join(c[0] for c in changes)}\n")
+lines.append("| Редакція | Стаття 1 | Підстава |")
+lines.append("|---|---|---|")
+prev_h = None
+for iso, h, ln, act in records:
+    if h is None:
+        st = "НЕ ЗНАЙДЕНО"
+    elif prev_h is None:
+        st = "первинна"
+    elif h != prev_h:
+        st = "ЗМІНЕНО"
+    else:
+        st = "без змін"
+    if h is not None:
+        prev_h = h
+    lines.append(f"| {iso} | {st} | {act or ''} |")
+summary = "\n".join(lines) + "\n"
+open(os.path.join(OUT, "SUMMARY.md"), "w").write(summary)
+print("\n" + summary)
+print(f"Saved to {OUT}/ (art1_*.txt + SUMMARY.md)")

--- a/scripts/rada/rollout-amend-metric.py
+++ b/scripts/rada/rollout-amend-metric.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Roll out the clause-level amendment metric across ALL laws.
+
+For every law it fetches the current-edition print page from Rada, parses inline
+`{…}` amendment notes per article into operations (added/modified/removed + act +
+date), and loads them into legislation_article_amendments.
+
+Multi-threaded with a GLOBAL token-bucket rate limiter (politeness toward Rada)
+and a JSONL checkpoint so it resumes after interruption. Designed to run ON PROD
+(reaches Rada + DB via `docker exec psql`).
+
+Env: WORKERS (default 6), RATE (req/s, default 2.0).
+Inputs: ~/amend-rollout/laws.tsv  (lines: id|rada_id|YYYYMMDD)
+"""
+import re, os, json, time, threading, subprocess
+from concurrent.futures import ThreadPoolExecutor
+
+WORK = os.path.expanduser("~/amend-rollout")
+LAWS = os.path.join(WORK, "laws.tsv")
+DONE = os.path.join(WORK, "done.jsonl")
+PG = ["docker", "exec", "-i", "secondlayer-postgres-prod",
+      "psql", "-U", "secondlayer", "-d", "secondlayer_prod"]
+BASE = "https://zakon.rada.gov.ua"
+UA = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+      "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+WORKERS = int(os.environ.get("WORKERS", "6"))
+RATE = float(os.environ.get("RATE", "2.0"))
+
+# ── global token-bucket rate limiter ─────────────────────────────────────────
+class Rate:
+    def __init__(self, rps):
+        self.rps = rps; self.allow = rps; self.last = time.monotonic()
+        self.lock = threading.Lock()
+    def take(self):
+        while True:
+            with self.lock:
+                now = time.monotonic()
+                self.allow = min(self.rps, self.allow + (now - self.last) * self.rps)
+                self.last = now
+                if self.allow >= 1:
+                    self.allow -= 1; return
+            time.sleep(0.05)
+rate = Rate(RATE)
+wlock = threading.Lock()
+
+def fetch(url, tries=6):
+    txt = ""
+    for i in range(tries):
+        rate.take()
+        try:
+            o = subprocess.run(["curl", "-s", "-m", "45", "--compressed",
+                "-A", UA, "-H", "Accept-Language: uk,en;q=0.9", url],
+                capture_output=True, timeout=70)
+            txt = o.stdout.decode("utf-8", "replace")
+            if len(txt) >= 3000:
+                return txt
+        except Exception:
+            pass
+        time.sleep(3 + 3 * i)
+    return txt
+
+ACT = re.compile(r"Закон[ауомих]* № (\d+-[IVXІ]+)(?:\s+від\s+(\d{2})\.(\d{2})\.(\d{4}))?")
+HDR = re.compile(r"Стаття\s+(\d+(?:-\d+)?)\.")               # article header (capital С + period)
+NOTEREF = re.compile(r"статт[іяюеї]\s+(\d+(?:-\d+)?)", re.I)  # note's own article ref
+TOK = re.compile(r"(Стаття\s+\d+(?:-\d+)?\.)|(\{[^}]*\})", re.S)
+JUNK = re.compile(r"dataLayer|function|https?:|link:|stat:|gtag|push\(")
+
+def classify(ctx):
+    ctx = ctx.lower()
+    if "виключ" in ctx: return "removed"
+    if "в редакці" in ctx: return "modified"
+    if "доповн" in ctx: return "added"
+    if "замін" in ctx or "змін" in ctx: return "modified"
+    return "modified"
+
+def parse_ops(html):
+    """Stream-parse the whole page (format-independent): track the current
+    'Стаття N.' header as context and attribute each {…} note to the article it
+    names ('статті N') or, failing that, the current header. JS blobs filtered.
+    -> list of (article, change_type, act, date_iso|None, note)"""
+    t = re.sub(r"<br\s*/?>", " ", html, flags=re.I)
+    t = re.sub(r"<[^>]+>", " ", t)
+    t = (t.replace("&nbsp;", " ").replace("&mdash;", "—")
+          .replace("&laquo;", "«").replace("&raquo;", "»").replace("&amp;", "&"))
+    t = re.sub(r"[ \t]+", " ", t)
+    ops, cur = [], "0"
+    for m in TOK.finditer(t):
+        if m.group(1):
+            cur = HDR.match(m.group(1)).group(1)
+            continue
+        note = m.group(2)
+        if JUNK.search(note):
+            continue
+        inner = note.strip("{}").strip()
+        if not re.search(r"[А-Яа-яІЇЄҐієїґ]", inner):
+            continue
+        ref = NOTEREF.search(inner)
+        art = ref.group(1) if ref else cur
+        prev = 0
+        for a in ACT.finditer(inner):
+            ctx = inner[prev:a.start()] or inner[:a.end()]
+            dt = f"{a.group(4)}-{a.group(3)}-{a.group(2)}" if a.group(2) else None
+            ops.append([art, classify(ctx), a.group(1), dt, note])
+            prev = a.end()
+    return ops
+
+def process(law):
+    lid, rada, ed = law
+    html = fetch(f"{BASE}/laws/show/{rada}/ed{ed}/print")
+    ops = parse_ops(html)
+    if not ops and "Стаття" not in html:      # fallback to plain current edition
+        html = fetch(f"{BASE}/laws/show/{rada}/print")
+        ops = parse_ops(html)
+    rec = {"id": lid, "rada": rada, "ed": ed, "ops": ops, "bytes": len(html)}
+    with wlock:
+        with open(DONE, "a") as f:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    print(f"  done id={lid} {rada}: {len(ops)} ops ({len(html)}b)", flush=True)
+    return rec
+
+# ── load law list + resume set ───────────────────────────────────────────────
+laws = []
+for ln in open(LAWS):
+    ln = ln.strip()
+    if not ln: continue
+    a = ln.split("|")
+    if len(a) == 3 and a[2]:
+        laws.append((int(a[0]), a[1], a[2]))
+
+done_ids = set()
+if os.path.exists(DONE):
+    for ln in open(DONE):
+        try: done_ids.add(json.loads(ln)["id"])
+        except Exception: pass
+SC = int(os.environ.get("SHARD_COUNT", "1"))
+SI = int(os.environ.get("SHARD_INDEX", "0"))
+todo = [l for l in laws if l[0] % SC == SI and l[0] not in done_ids]
+print(f"laws={len(laws)} shard={SI}/{SC} done={len(done_ids)} todo={len(todo)} workers={WORKERS} rate={RATE}/s", flush=True)
+
+# ── fetch + parse (parallel) ─────────────────────────────────────────────────
+with ThreadPoolExecutor(max_workers=WORKERS) as ex:
+    list(ex.map(process, todo))
+
+if os.environ.get("FETCH_ONLY") == "1":
+    recs = [json.loads(l) for l in open(DONE)]
+    print(f"FETCH_ONLY done: {len(recs)} laws, {sum(len(x['ops']) for x in recs)} ops in {DONE}", flush=True)
+    raise SystemExit(0)
+
+# ── load into DB (single idempotent transaction) ─────────────────────────────
+def sq(s): return "'" + (s or "").replace("'", "''") + "'"
+recs = [json.loads(l) for l in open(DONE)]
+sql = ["""\\set ON_ERROR_STOP on
+BEGIN;
+CREATE TABLE IF NOT EXISTS legislation_article_amendments (
+  id SERIAL PRIMARY KEY,
+  legislation_id INTEGER NOT NULL REFERENCES legislation(id) ON DELETE CASCADE,
+  rada_id VARCHAR(100) NOT NULL,
+  article_number VARCHAR(50) NOT NULL,
+  change_type VARCHAR(20) NOT NULL CHECK (change_type IN ('added','modified','removed')),
+  basis_act VARCHAR(50), act_date DATE, note_text TEXT, source_edition DATE,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (legislation_id, article_number, change_type, basis_act, note_text)
+);
+CREATE INDEX IF NOT EXISTS idx_law_art_amend ON legislation_article_amendments(legislation_id, article_number);
+"""]
+for r in recs:
+    lid = r["id"]; src = f"{r['ed'][:4]}-{r['ed'][4:6]}-{r['ed'][6:8]}"
+    sql.append(f"DELETE FROM legislation_article_amendments WHERE legislation_id={lid};")
+    for art, ct, act, dt, note in r["ops"]:
+        sql.append("INSERT INTO legislation_article_amendments "
+            "(legislation_id,rada_id,article_number,change_type,basis_act,act_date,note_text,source_edition) VALUES ("
+            f"{lid},{sq(r['rada'])},{sq(art)},{sq(ct)},{sq(act)},{sq(dt) if dt else 'NULL'},{sq(note)},{sq(src)}) ON CONFLICT DO NOTHING;")
+sql.append("SELECT count(*) AS total_ops, count(DISTINCT legislation_id) AS laws, count(DISTINCT basis_act) AS acts FROM legislation_article_amendments;")
+sql.append("COMMIT;")
+open(os.path.join(WORK, "load.sql"), "w").write("\n".join(sql))
+print("applying SQL...", flush=True)
+res = subprocess.run(PG, stdin=open(os.path.join(WORK, "load.sql")), capture_output=True, text=True)
+print(res.stdout[-2000:]); print(res.stderr[-1000:])
+print("ROLLOUT COMPLETE", flush=True)


### PR DESCRIPTION
## What

Adds two complementary, Rada-sourced metrics for **"how many times was an article amended"**, plus a verification downloader. Resolves the confusion between *editions where text changed* vs *clause-level amendments* (the «13 vs 6» question for ст.1 ЗУ «Про культуру»).

### Scripts (`scripts/rada/`)
- **`backfill-legislation-changes.sql`** — reconstructs `legislation_changes` (added/modified/removed) by diffing per-edition article snapshots already in the DB. Counts **editions** where an article's text differs. Robust to the importer toggling `is_current` (timeline driven by `legislation_editions`, idempotent via unique key + `ON CONFLICT`).
- **`build-amendment-metric.py`** — single-law: parses Rada's inline `{…}` amendment notes into clause-level operations per article → SQL for `legislation_article_amendments`.
- **`rollout-amend-metric.py`** — corpus rollout: multi-IP **sharded** fetch (`SHARD_INDEX/SHARD_COUNT`, `FETCH_ONLY`), global token-bucket rate limiter, JSONL checkpoint/resume, format-independent stream parser (handles old `<b>Стаття</b>` and current `rvts9` markup), then a single idempotent DB load.
- **`download-art1-culture.py`** — per-edition article downloader/diff used to verify counts against the live site.

## Metrics produced (prod)
- `legislation_changes`: edition-level text changes (e.g. ст.1 «Про культуру» = 6).
- `legislation_article_amendments`: clause-level `{…}` operations — **159 laws, ~31.6K ops, 2146 acts** (e.g. ст.1 = 15; Податковий кодекс ст.346 = 956).

Query: `SELECT count(*) FROM legislation_article_amendments WHERE legislation_id=$1 AND article_number=$2`.

## Notes / follow-ups
- Remaining 0-op laws are mostly постанови/накази/statutes (structured by пункти, not статті) — legitimately 0 for an article-level metric; КУпАП-style continuous-point codes are a known parser gap.
- Wiring the app's «Найбільш змінювані статті» feature to `legislation_article_amendments` (instead of edition count) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two Rada‑sourced article‑amendment metrics (edition diffs and clause‑level “{…}” notes) to power accurate “most changed articles,” and introduces a structured EDRSR parties table with a fast path for party counts. Also includes the MCP v2 curated 15‑tool surface design doc (LEXAI‑1785).

- **New Features**
  - Legislation (amendment metrics)
    - `scripts/rada/backfill-legislation-changes.sql`: reconstructs `legislation_changes` by diffing per‑edition article snapshots (edition‑level add/modify/remove).
    - `scripts/rada/build-amendment-metric.py` + `rollout-amend-metric.py`: parse Rada inline “{…}” notes into clause‑level ops and load `legislation_article_amendments` (act, date, type); sharded, throttled, resumable rollout.
    - `scripts/rada/download-art1-culture.py`: per‑edition downloader/diff to verify counts.
  - EDRSR (LEXAI‑1760)
    - `167_edrsr_parties.sql`: new RANGE‑partitioned `edrsr_parties` + `edrsr_parties_coverage` for fast, indexed party role counts.
    - `scripts/edrsr/backfill-edrsr-parties.sql`: per‑year, idempotent extraction from captions (“за позовом X до Y …”).
    - `edrsr-fts-service.ts`: `countByParty` uses the parties table when the requested year span is fully covered; otherwise falls back to FTS.
  - Docs
    - `docs/superpowers/specs/2026-06-30-mcp-api-v2-15-tools-design.md`: spec for the curated 15‑tool `/api/v2/mcp` surface (LEXAI‑1785).

- **Migration**
  - Apply migration `167_edrsr_parties.sql`.
  - Backfill parties per year: run `scripts/edrsr/backfill-edrsr-parties.sql -v year=<YYYY>`; service auto‑falls back to FTS for uncovered years.
  - Build amendment metrics:
    - Edition‑diffs: run `scripts/rada/backfill-legislation-changes.sql` (optionally scope with `ONLY_LAW`).
    - Clause‑level: run `scripts/rada/rollout-amend-metric.py` (or `build-amendment-metric.py` for a single law). All loads are idempotent.

<sup>Written for commit 5adb72a938348873dd53973dbad5376b148203f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

