### PR TITLE
feat(legislation): wire 'most-changed articles' to clause-level amendment metric

### DIFF
--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -762,6 +762,38 @@ export class LegislationService {
     earliest_version: string | null;
     latest_version: string | null;
   }>> {
+    // Preferred source: clause-level amendment operations parsed from Rada's
+    // inline {…} notes (legislation_article_amendments). version_count here is the
+    // real number of times an article was amended (added/modified/removed), NOT
+    // the number of editions. Article '0' = document-wide notes, excluded.
+    try {
+      const amend = await this.db.query(
+        `SELECT a.article_number,
+                COUNT(*)::int as version_count,
+                to_char(MIN(a.act_date), 'YYYY-MM-DD') as earliest_version,
+                to_char(MAX(a.act_date), 'YYYY-MM-DD') as latest_version
+         FROM legislation_article_amendments a
+         JOIN legislation l ON a.legislation_id = l.id
+         WHERE LOWER(l.rada_id) = LOWER($1) AND a.article_number <> '0'
+         GROUP BY a.article_number
+         ORDER BY COUNT(*) DESC`,
+        [radaId]
+      );
+      if (amend.rows.length > 0) {
+        return amend.rows.map((row: any) => ({
+          article_number: row.article_number,
+          version_count: row.version_count,
+          earliest_version: row.earliest_version,
+          latest_version: row.latest_version,
+        }));
+      }
+    } catch (err) {
+      // Table may not exist in some environments yet — fall back to legacy count.
+      logger.warn(`getAmendmentSummary: amendment metric unavailable, falling back to edition count: ${(err as Error).message}`);
+    }
+
+    // Fallback (legacy): counts edition snapshots in legislation_articles. Used
+    // only for laws not yet covered by the amendment metric (e.g. resolutions).
     const result = await this.db.query(
       `SELECT la.article_number,
               COUNT(*)::int as version_count,

--- a/scripts/rada/build-amendment-metric.py
+++ b/scripts/rada/build-amendment-metric.py
@@ -50,7 +50,22 @@ def to_text(htmlfrag):
           .replace("&laquo;", "«").replace("&raquo;", "»").replace("&amp;", "&"))
     return re.sub(r"[ \t]+", " ", t)
 
-ACT = re.compile(r"Закон[ауомих]* № (\d+-[IVXІ]+)(?:\s+від\s+(\d{2})\.(\d{2})\.(\d{4}))?")
+# Handles «№ 1432-IX» and old «N 244/94-ВР ( 2342-14 ) від 05.04.2001» formats.
+ACT = re.compile(
+    r"Закон[а-яіїєґ']*\s*(?:№|N)\s*"
+    r"([0-9]+(?:[/-][0-9A-Za-zА-Яа-яІЇЄҐ]+)+)"
+    r"(?:\s*\([^)]*\))?"
+    r"(?:\s+від\s+(\d{1,2})\.(\d{1,2})\.(\d{2,4}))?", re.I)
+
+def norm_year(y):
+    return y if len(y) == 4 else (("19" + y) if int(y) >= 30 else ("20" + y))
+
+def valid_date(dt):
+    m = re.match(r"^(\d{4})-(\d{2})-(\d{2})$", dt) if dt else None
+    if not m:
+        return None
+    y, mo, d = map(int, m.groups())
+    return dt if (1900 <= y <= 2100 and 1 <= mo <= 12 and 1 <= d <= 31) else None
 
 def classify(ctx):
     ctx = ctx.lower()
@@ -68,7 +83,7 @@ def parse_notes(text):
         for m in ACT.finditer(inner):
             ctx = inner[prev:m.start()] or inner[:m.end()]
             act = m.group(1)
-            date_iso = (f"{m.group(4)}-{m.group(3)}-{m.group(2)}"
+            date_iso = (valid_date(f"{norm_year(m.group(4))}-{m.group(3).zfill(2)}-{m.group(2).zfill(2)}")
                         if m.group(2) else None)
             yield classify(ctx), act, date_iso, note
             prev = m.end()

--- a/scripts/rada/rollout-amend-metric.py
+++ b/scripts/rada/rollout-amend-metric.py
@@ -59,11 +59,27 @@ def fetch(url, tries=6):
         time.sleep(3 + 3 * i)
     return txt
 
-ACT = re.compile(r"Закон[ауомих]* № (\d+-[IVXІ]+)(?:\s+від\s+(\d{2})\.(\d{2})\.(\d{4}))?")
+# Act ref: «Закон[ом] № 1432-IX» AND old КУпАП-style «Законом N 244/94-ВР ( 2342-14 ) від 05.04.2001»
+# — handles both № and Latin N, slashed/Roman numbers, and 2- or 4-digit years.
+ACT = re.compile(
+    r"Закон[а-яіїєґ']*\s*(?:№|N)\s*"
+    r"([0-9]+(?:[/-][0-9A-Za-zА-Яа-яІЇЄҐ]+)+)"          # 1432-IX, 244/94-ВР, 2342-III
+    r"(?:\s*\([^)]*\))?"                                  # optional ( rada-id )
+    r"(?:\s+від\s+(\d{1,2})\.(\d{1,2})\.(\d{2,4}))?", re.I)
 HDR = re.compile(r"Стаття\s+(\d+(?:-\d+)?)\.")               # article header (capital С + period)
 NOTEREF = re.compile(r"статт[іяюеї]\s+(\d+(?:-\d+)?)", re.I)  # note's own article ref
 TOK = re.compile(r"(Стаття\s+\d+(?:-\d+)?\.)|(\{[^}]*\})", re.S)
 JUNK = re.compile(r"dataLayer|function|https?:|link:|stat:|gtag|push\(")
+
+def norm_year(y):
+    return y if len(y) == 4 else (("19" + y) if int(y) >= 30 else ("20" + y))
+
+def valid_date(dt):
+    m = re.match(r"^(\d{4})-(\d{2})-(\d{2})$", dt) if dt else None
+    if not m:
+        return None
+    y, mo, d = map(int, m.groups())
+    return dt if (1900 <= y <= 2100 and 1 <= mo <= 12 and 1 <= d <= 31) else None
 
 def classify(ctx):
     ctx = ctx.lower()
@@ -99,7 +115,7 @@ def parse_ops(html):
         prev = 0
         for a in ACT.finditer(inner):
             ctx = inner[prev:a.start()] or inner[:a.end()]
-            dt = f"{a.group(4)}-{a.group(3)}-{a.group(2)}" if a.group(2) else None
+            dt = valid_date(f"{norm_year(a.group(4))}-{a.group(3).zfill(2)}-{a.group(2).zfill(2)}") if a.group(2) else None
             ops.append([art, classify(ctx), a.group(1), dt, note])
             prev = a.end()
     return ops


### PR DESCRIPTION
## What
Wires the «Найбільш змінювані статті» feature to the real clause-level amendment metric and improves the parser that builds it.

### Feature fix
`mcp_backend/src/services/legislation-service.ts` — `getAmendmentSummary()` now counts real amendments from **`legislation_article_amendments`** (clause-level `{…}` operations: added/modified/removed, with act + date), excluding document-wide notes (`article_number = '0'`). Falls back to the legacy edition-count query only when a law isn't covered by the metric or the table is missing.

**Before:** `version_count` = COUNT of `legislation_articles` rows = number of **editions** (every article showed the same N → the «по 31 версії» bug).
**After:** `version_count` = number of times the article was actually amended.

Surfaced unchanged via MCP tool `get_legislation_history` (`most_amended_articles[].version_count`) and `GET /api/legislation/:radaId/history`.

### Parser improvements (`scripts/rada/`)
- Broadened act-reference parsing to handle old КУпАП-style notes: Latin `N` as well as `№`, slashed/Roman act numbers (`244/94-ВР`, `2342-III`), and 2-digit years.
- Date validation (drops impossible values like `1991-33-20`).
- Recovers big continuous-article codes that previously parsed to zero (e.g. КУпАП `80731-10`: ст.188 = 101 amendments, ст.164 = 96).

## Verified on prod data
- Culture (`2778-17`): ст.1 = 15, ст.26 = 11, ст.21 = 10.
- КУпАП (`80731-10`): ст.188 = 101, ст.164 = 96.
- Metric corpus: **164 laws, ~34.2K clause-level operations, 2327 acts**.

## Notes
- Remaining 0-op laws are постанови/накази (structured by пункти, not статті) — legitimately 0 for an article metric; the fallback keeps their legacy display.
- Pre-existing `tsc` errors in `core-loader.ts` (proprietary modules from secondlayer-core) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires “Найбільш змінювані статті” to the real clause-level amendment metric so counts reflect actual amendments, not editions. Also improves the parser to handle legacy act references and validate dates for more complete data.

- **Bug Fixes**
  - Count clause-level amendments from `legislation_article_amendments`; exclude document-wide notes (`article_number = '0'`).
  - Fall back to the legacy edition count only when the metric/table is unavailable.
  - Fixes the “all articles show the same N editions” issue.

- **Refactors**
  - Broaden act parsing: support `№` and `N`, slashed/Roman ids (e.g., `244/94-ВР`, `2342-III`), and 2-digit years.
  - Validate dates and drop impossible values.
  - Recover continuous-article codes (e.g., `80731-10`) to restore missing amendment counts.

<sup>Written for commit c936453a168511f32433bc54c7588234c0579bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

