### PR TITLE
feat(auth): Google Sign-In for iOS app

### DIFF
--- a/mcp_backend/.env.example
+++ b/mcp_backend/.env.example
@@ -61,6 +61,10 @@ SECONDARY_LAYER_KEYS=your-api-key-1,your-api-key-2
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
+# Extra client ids accepted by POST /auth/google/mobile (comma-separated).
+# Use for native iOS/Android OAuth clients whose idToken audience differs from
+# the web GOOGLE_CLIENT_ID. Additive — does not affect the web login flow.
+GOOGLE_MOBILE_CLIENT_IDS=
 
 # =============================================================================
 # WebAuthn / Passkeys (optional)

--- a/mcp_backend/src/controllers/auth-google.ts
+++ b/mcp_backend/src/controllers/auth-google.ts
@@ -84,11 +84,21 @@ export async function googleMobileAuth(req: Request, res: Response): Promise<Res
       return res.status(501).json({ error: 'Google OAuth is not configured on server' });
     }
 
+    // Accept the primary web client id plus any additional mobile client ids
+    // (comma-separated in GOOGLE_MOBILE_CLIENT_IDS) — e.g. a native iOS/Android
+    // OAuth client whose issued idToken carries a different audience. This is
+    // additive: the web (passport) login keeps using GOOGLE_CLIENT_ID only.
+    const extraMobileIds = (process.env.GOOGLE_MOBILE_CLIENT_IDS || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const allowedAudiences = [clientId, ...extraMobileIds];
+
     // Verify the idToken with Google
     const client = new OAuth2Client(clientId);
     const ticket = await client.verifyIdToken({
       idToken,
-      audience: clientId,
+      audience: allowedAudiences,
     });
     const payload = ticket.getPayload();
 

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,2 +1,6 @@
 API_URL=https://stage.legal.org.ua
 FLAVOR=stage
+# Google Sign-In: WEB OAuth client id (serverClientId). Must match the
+# backend's accepted audience for POST /auth/google/mobile.
+# The iOS client id is configured separately in ios/Runner/Info.plist (GIDClientID).
+GOOGLE_CLIENT_ID=

--- a/mobile/ios/Runner/Info.plist
+++ b/mobile/ios/Runner/Info.plist
@@ -26,6 +26,19 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>GIDClientID</key>
+	<string>144958755023-hffsik0une6mcnpeb6cj86jfslkuqgbl.apps.googleusercontent.com</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.144958755023-hffsik0une6mcnpeb6cj86jfslkuqgbl</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Додаток використовує камеру, щоб сфотографувати документи для аналізу.</string>
 	<key>NSDocumentsFolderUsageDescription</key>


### PR DESCRIPTION
## Summary
Enables Google login from the iOS app. The native `google_sign_in` flow obtains an idToken whose audience is the **secondlayer-gpu** OAuth client, and the backend's mobile endpoint is widened (additively) to accept it.

## Changes
- **Backend** (`auth-google.ts`): `POST /auth/google/mobile` verifies the idToken against `GOOGLE_CLIENT_ID` **plus** optional comma-separated `GOOGLE_MOBILE_CLIENT_IDS`. Additive — the web (passport) login is untouched and still uses `GOOGLE_CLIENT_ID` only.
- **iOS** (`Info.plist`): `GIDClientID` + `CFBundleURLTypes` reversed-client URL scheme for the iOS OAuth client.
- **Docs**: `GOOGLE_MOBILE_CLIENT_IDS` (backend) and `GOOGLE_CLIENT_ID` / serverClientId (mobile) added to `.env.example`.

## Deploy steps (after merge)
1. On prod, add to backend env: `GOOGLE_MOBILE_CLIENT_IDS=144958755023-18kfh59ocaklp4j9jjqfvkson6lam4q7.apps.googleusercontent.com` (the secondlayer-gpu web client used as the app's serverClientId).
2. secondlayer-gpu OAuth consent screen: add the tester's Google account as a Test user (or publish), scopes `email`/`profile`.
3. Rebuild & reinstall the iOS app (its `.env` sets `GOOGLE_CLIENT_ID` to the same web client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Google Sign-In on iOS using the native `google_sign_in` flow. The backend now accepts idTokens for the web client plus optional mobile client IDs; web login remains unchanged.

- New Features
  - Backend: `POST /auth/google/mobile` validates idToken audience against `GOOGLE_CLIENT_ID` and optional comma-separated `GOOGLE_MOBILE_CLIENT_IDS`.
  - iOS: Added `GIDClientID` and the reversed-client URL scheme in `ios/Runner/Info.plist`.
  - Docs: Updated `.env.example` for backend and mobile with Google Sign-In variables and notes (serverClientId).

- Migration
  - Set `GOOGLE_MOBILE_CLIENT_IDS=144958755023-18kfh59ocaklp4j9jjqfvkson6lam4q7.apps.googleusercontent.com` on the backend.
  - In the OAuth consent screen, add test users (or publish). Scopes: email, profile.
  - Rebuild and reinstall the iOS app. Ensure mobile `.env` `GOOGLE_CLIENT_ID` matches the backend’s accepted audience.

<sup>Written for commit fd0fc465ed2e922ea18cc753c3924bd56ea03f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

