### PR TITLE
fix(deploy): pass GOOGLE_MOBILE_CLIENT_IDS to prod backend

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -622,6 +622,7 @@ services:
 
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      GOOGLE_MOBILE_CLIENT_IDS: ${GOOGLE_MOBILE_CLIENT_IDS:-}
       GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
       # Diia (Дія) Auth
       DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2.diia.gov.ua}
@@ -1056,6 +1057,7 @@ services:
       WEBAUTHN_ORIGIN: ${WEBAUTHN_ORIGIN:-https://legal.org.ua}
       GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
       GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      GOOGLE_MOBILE_CLIENT_IDS: ${GOOGLE_MOBILE_CLIENT_IDS:-}
       GOOGLE_CALLBACK_URL: https://legal.org.ua/auth/google/callback
       DIIA_BASE_URL: ${DIIA_BASE_URL:-https://api2.diia.gov.ua}
       DIIA_ACQUIRER_TOKEN: ${DIIA_ACQUIRER_TOKEN:-}


### PR DESCRIPTION
Adds `GOOGLE_MOBILE_CLIENT_IDS` to the backend env block (blue + green) in `docker-compose.prod.yml`. Without it, the value set in `.env.prod` never reached the container, so the iOS Google-login audience widening from #2058 had no effect. Follow-up to #2058.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes GOOGLE_MOBILE_CLIENT_IDS to the prod backend (blue + green) so iOS Google Sign-In uses the full mobile client ID list instead of falling back to GOOGLE_CLIENT_ID.

- Bug Fixes
  - Added GOOGLE_MOBILE_CLIENT_IDS to env for app-prod and app-prod-green in deployment/docker-compose.prod.yml.
  - Ensures the value from .env.prod reaches the container and is used by the Google login audience check.

<sup>Written for commit df2e865387a2ac88f392d04bc3e35bfd551195a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

