### PR TITLE
fix(precedent): downgrade status on Grand Chamber departure; drop ZakonOnline wording

### DIFF
--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -266,11 +266,31 @@ export class MCPQueryAPI extends BaseToolHandler {
       }
     }
 
+    // If the Grand Chamber formally departed from this case's legal position (Neo4j
+    // DEPARTS_FROM), the precedent is no longer fully good law — downgrade an otherwise
+    // valid/unknown status to "limited" so the top-level status reflects it.
+    let effectiveStatus: any = status;
+    if (
+      citationGraph?.position_departed_from &&
+      (status?.status === 'valid' || status?.status === 'unknown' || !status?.status)
+    ) {
+      effectiveStatus = {
+        ...status,
+        status: 'limited',
+        departed_note:
+          'Правову позицію у цій справі відступлено Великою Палатою ВС — прецедент обмежено чинний (див. citation_graph.position_departed_from).',
+      };
+    }
+
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify({ status, ...(citationGraph ? { citation_graph: citationGraph } : {}) }, null, 2),
+          text: JSON.stringify(
+            { status: effectiveStatus, ...(citationGraph ? { citation_graph: citationGraph } : {}) },
+            null,
+            2
+          ),
         },
       ],
     };
@@ -328,17 +348,17 @@ export class MCPQueryAPI extends BaseToolHandler {
       {
         name: 'check_precedent_status',
         annotations: { title: 'Статус прецеденту', readOnlyHint: true, idempotentHint: true },
-        description: `Перевіряє актуальність судового рішення: чи не скасовано вищою інстанцією. Шукає ланцюг інстанцій у ZakonOnline, визначає статус: valid, explicitly_overruled, limited, unknown.
+        description: `Перевіряє актуальність судового рішення: чи не скасовано вищою інстанцією. Реконструює ланцюг інстанцій з локального реєстру ЄДРСР (перша → апеляція → касація → ВП) і визначає статус: valid, explicitly_overruled, limited, unknown. Додатково враховує відступ від правової позиції Великою Палатою (граф цитувань Neo4j).
 
-Приймає: case_number (номер справи, наприклад 922/989/18), case_id (UUID документа) або doc_id (zakononline_id).
+Приймає: case_number (номер справи, наприклад 922/989/18) або doc_id (ЄДРСР doc_id).
 
-💰 Вартість: $0.00-$0.02 USD (кешується 24 год у Redis, 7 днів у PostgreSQL)`,
+💰 Вартість: $0.00 USD (локальні БД; кешується 24 год у Redis)`,
         inputSchema: {
           type: 'object',
           properties: {
-            case_id: { type: 'string', description: 'UUID документа з бази даних' },
+            case_id: { type: 'string', description: 'ЄДРСР doc_id або номер справи' },
             case_number: { type: 'string', description: 'Номер справи (наприклад: 922/989/18)' },
-            doc_id: { type: 'string', description: 'ZakonOnline document ID' },
+            doc_id: { type: 'string', description: 'ЄДРСР doc_id' },
           },
         },
       },


### PR DESCRIPTION
## Context (LEXAI-1790)
Companion to **secondlayer-core#72**, which rewrites `ShepardizationService` to reconstruct the instance chain from the local EDRSR registry instead of the deprecated ZakonOnline (the tool previously always returned `unknown`/`zo_api`).

## This PR (main repo — `mcp-query-api.checkPrecedentStatus`)
- When the Neo4j citation graph reports the case's legal position was formally **departed from by the Grand Chamber** (`DEPARTS_FROM` → `citation_graph.position_departed_from`), downgrade an otherwise `valid`/`unknown` status to **`limited`** with a `departed_note`, so the top-level `status` reflects it (not just the buried graph block). Neo4j is only wired here, so this belongs in the handler.
- Update the tool description/params: the chain is now reconstructed from local ЄДРСР, not ZakonOnline; drop `zakononline_id` wording and the per-call cost.

## Deploy order
Merge **core#72 first**, then this — the prod deploy re-clones `secondlayer-core@main`, so both land together on the next backend deploy.

## Verification
`tsc --noEmit`: no new errors (only the pre-existing proprietary `core-loader.ts` stubs). Core status logic validated against prod for case `922/989/18` → `valid` (was `unknown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgrades precedent status to limited when the Neo4j graph shows a Grand Chamber departure, so the top-level result is accurate. Updates `mcp-query-api.checkPrecedentStatus` to use the local ЄДРСР chain (not ZakonOnline), aligning with `secondlayer-core#72` for LEXAI-1790.

- **Bug Fixes**
  - When `citation_graph.position_departed_from` is set (`DEPARTS_FROM`), change `valid`/`unknown` to `limited` and add a `departed_note` at top-level `status`.
  - Refresh tool description and params: reconstruct from local ЄДРСР; use ЄДРСР `doc_id`; remove ZakonOnline wording and per-call cost.

<sup>Written for commit 7e8cdf334247ade01f34a4b801dfcdd9f83a373e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

