### PR TITLE
fix(legislation): paginate get_legislation_structure, headings-only TOC by default

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -544,7 +544,9 @@ export class LegislationTools extends BaseToolHandler {
     return response;
   }
 
-  async getLegislationStructure(args: LegislationToolArgs & { force_refresh?: boolean }): Promise<any> {
+  async getLegislationStructure(
+    args: LegislationToolArgs & { force_refresh?: boolean; include_articles?: boolean; offset?: number; limit?: number }
+  ): Promise<any> {
     if (!args.rada_id) {
       throw new Error('rada_id is required');
     }
@@ -565,9 +567,14 @@ export class LegislationTools extends BaseToolHandler {
       }
     }
 
-    logger.info(`Getting structure for ${radaId}`, { force_refresh: args.force_refresh });
+    const includeArticles = args.include_articles === true;
 
-    const structure = await this.service.getLegislationStructure(radaId, args.force_refresh);
+    logger.info(`Getting structure for ${radaId}`, { force_refresh: args.force_refresh, includeArticles });
+
+    // Always build a headings-only TOC — a full act (e.g. ЦК, ~1300 articles) with per-article
+    // leaves otherwise returns ~1.2M chars and overflows the MCP token limit. The flat per-article
+    // list is opt-in + paginated below (structure.articles is always the full flat set).
+    const structure = await this.service.getLegislationStructure(radaId, args.force_refresh, false);
 
     if (!structure) {
       return {
@@ -576,18 +583,41 @@ export class LegislationTools extends BaseToolHandler {
       };
     }
 
-    return {
+    const base = {
       rada_id: structure.rada_id,
       title: structure.title,
       short_title: structure.short_title,
       type: structure.type,
       total_articles: structure.total_articles,
       table_of_contents: structure.table_of_contents,
-      articles_summary: structure.articles.map((a: any) => ({
-        article_number: a.article_number,
-        title: a.title,
-        byte_size: a.byte_size,
-      })),
+    };
+
+    if (!includeArticles) {
+      return {
+        ...base,
+        note:
+          'Зміст (розділи/глави/статті-лічильники) без повного переліку статей. Для переліку статей передайте include_articles:true з offset/limit, або скористайтесь get_legislation_articles для конкретних статей.',
+      };
+    }
+
+    // include_articles=true → paginated flat article list.
+    const all: any[] = structure.articles || [];
+    const offset = Math.max(0, Number(args.offset) || 0);
+    const limit = Math.min(1000, Math.max(1, Number(args.limit) || 300));
+    const page = all.slice(offset, offset + limit).map((a: any) => ({
+      article_number: a.article_number,
+      title: a.title,
+      byte_size: a.byte_size,
+    }));
+
+    return {
+      ...base,
+      articles_total: all.length,
+      offset,
+      limit,
+      returned: page.length,
+      has_more: offset + limit < all.length,
+      articles_summary: page,
     };
   }
 
@@ -736,13 +766,29 @@ export class LegislationTools extends BaseToolHandler {
       {
         name: 'get_legislation_structure',
         annotations: { title: 'Структура закону', readOnlyHint: true, idempotentHint: true },
-        description: 'Отримати структуру законодавчого акту (зміст, розділи, глави, список статей). Корисно для навігації по великому документу.',
+        description:
+          'Отримати структуру законодавчого акту: зміст (розділи, глави, параграфи) з лічильником статей у кожному вузлі. За замовчуванням БЕЗ повного переліку статей (великі кодекси інакше не вміщуються). Для переліку статей передайте include_articles:true з offset/limit; для конкретних статей — get_legislation_articles.',
         inputSchema: {
           type: 'object',
           properties: {
             rada_id: {
               type: 'string',
               description: 'ID законодавчого акту',
+            },
+            include_articles: {
+              type: 'boolean',
+              default: false,
+              description: 'Додати плоский перелік статей (пагінований через offset/limit). За замовчуванням false — повертається лише зміст.',
+            },
+            offset: {
+              type: 'number',
+              default: 0,
+              description: 'Зміщення для переліку статей (лише коли include_articles:true)',
+            },
+            limit: {
+              type: 'number',
+              default: 300,
+              description: 'Макс. статей у переліку (1-1000, лише коли include_articles:true)',
             },
           },
           required: ['rada_id'],

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -842,7 +842,7 @@ export class LegislationService {
     }));
   }
 
-  async getLegislationStructure(radaId: string, forceRefresh?: boolean): Promise<any> {
+  async getLegislationStructure(radaId: string, forceRefresh?: boolean, tocIncludeArticles = true): Promise<any> {
     radaId = normalizeRadaId(radaId);
 
     if (forceRefresh) {
@@ -893,11 +893,11 @@ export class LegislationService {
       total_articles: data.total_articles,
       structure: data.structure_metadata || {},
       articles: data.articles || [],
-      table_of_contents: this.buildTableOfContents(data.articles || []),
+      table_of_contents: this.buildTableOfContents(data.articles || [], tocIncludeArticles),
     };
   }
 
-  private buildTableOfContents(articles: any[]): any[] {
+  private buildTableOfContents(articles: any[], includeArticles = true): any[] {
     const toc: any[] = [];
     let currentBook: any = null;
     let currentSection: any = null;
@@ -1014,25 +1014,27 @@ export class LegislationService {
         }
       }
 
-      const articleEntry = {
-        article_number: article.article_number,
-        title: article.title,
-        byte_size: article.byte_size,
-      };
+      const target =
+        currentParagraph || currentChapter || currentSubsection || currentSection || currentBook || null;
 
-      // Place article in the deepest available container
-      if (currentParagraph) {
-        currentParagraph.articles.push(articleEntry);
-      } else if (currentChapter) {
-        currentChapter.articles.push(articleEntry);
-      } else if (currentSubsection) {
-        currentSubsection.articles.push(articleEntry);
-      } else if (currentSection) {
-        currentSection.articles.push(articleEntry);
-      } else if (currentBook) {
-        currentBook.children.push(articleEntry);
-      } else {
-        toc.push(articleEntry);
+      if (includeArticles) {
+        // Full mode: place each article as a leaf in the deepest container.
+        const articleEntry = {
+          article_number: article.article_number,
+          title: article.title,
+          byte_size: article.byte_size,
+        };
+        if (currentParagraph) currentParagraph.articles.push(articleEntry);
+        else if (currentChapter) currentChapter.articles.push(articleEntry);
+        else if (currentSubsection) currentSubsection.articles.push(articleEntry);
+        else if (currentSection) currentSection.articles.push(articleEntry);
+        else if (currentBook) currentBook.children.push(articleEntry);
+        else toc.push(articleEntry);
+      } else if (target) {
+        // Headings-only mode: just count articles per container + track the number range.
+        target.article_count = (target.article_count || 0) + 1;
+        if (!target.article_range) target.article_range = [article.article_number, article.article_number];
+        else target.article_range[1] = article.article_number;
       }
     }
 


### PR DESCRIPTION
## Problem (LEXAI-1788)
`get_legislation_structure` returned the whole `table_of_contents` **with every article as a leaf** (~455k chars) plus a flat `articles_summary` of all ~1300 articles (~137k chars) — **~1.2M chars pretty-printed for ЦК (435-15)**, which overflows the MCP client token limit. The tool was effectively unusable via external MCP clients on any large code.

Measured on prod (`435-15`): `table_of_contents` 455,407 + `articles_summary` 136,817 (compact); ×2 for pretty-print → 1,181,901 chars total.

## Fix
- **Service** `getLegislationStructure(radaId, forceRefresh, tocIncludeArticles=true)` + `buildTableOfContents(articles, includeArticles=true)`: in headings-only mode, omit per-article leaves and instead attach `article_count` + `article_range` per container node. Default stays `true`, so other service callers (HTML navigation, etc.) are unchanged.
- **Handler**: always requests a **headings-only TOC** (compact). The flat per-article list is now **opt-in** via `include_articles:true` and **paginated** (`offset`/`limit`, default 300, max 1000) with `articles_total`/`has_more`. Default response = TOC (with counts) + a hint pointing to `include_articles` / `get_legislation_articles`.
- Tool schema documents `include_articles`/`offset`/`limit`.

## Verification
`tsc --noEmit` clean (only pre-existing `core-loader.ts` stubs). Will verify the response-size drop live on prod post-deploy (expect default response well under the token limit; `include_articles:true` bounded by `limit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce `get_legislation_structure` response size to avoid MCP token overflows by defaulting to a headings-only TOC and making the article list opt-in + paginated. Addresses LEXAI-1788 for large codes.

- **Bug Fixes**
  - Handler now requests a compact TOC; service adds `getLegislationStructure(radaId, forceRefresh, tocIncludeArticles)` and `buildTableOfContents(articles, includeArticles)`. Headings include `article_count` and `article_range`.
  - Flat article list is opt-in via `include_articles:true` with `offset`/`limit` (default 300, max 1000). Response includes `articles_total`, `returned`, `has_more`, `offset`, `limit`.
  - Tool schema and response note document the new flags and point to `get_legislation_articles`. Other service callers keep prior default (full TOC).

<sup>Written for commit 351f4471c5bd7b3335169e6225fec8f78a41d699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

