### PR TITLE
fix(legislation): get_legislation_history returns real amendments + deduped versions

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -867,22 +867,33 @@ export class LegislationTools extends BaseToolHandler {
     const articleFilter = args.article_number?.trim() || null;
     logger.info('[MCP Tool] get_legislation_history started', { rada_id: radaId, article_number: articleFilter });
 
-    const structure = await this.service.getLegislationStructure(radaId);
+    const structure = await this.service.getLegislationStructure(radaId, undefined, false);
 
     if (articleFilter) {
-      // Detailed history for a specific article
-      const history = await this.service.getAmendmentHistory(radaId);
-      const filtered = history.filter(h => h.article_number === articleFilter);
+      // Detailed history for a specific article:
+      // 1) real clause-level amendments (dated, from legislation_article_amendments), and
+      // 2) distinct text versions deduped by full_text (many editions carry identical text,
+      //    so raw per-edition rows over-report). Reads the real version_date column.
+      const [amendments, versionsResult] = await Promise.all([
+        this.service.getArticleAmendments(radaId, articleFilter),
+        this.service.getArticleVersions(radaId, articleFilter, 50),
+      ]);
+      const changed = amendments.length > 0 || versionsResult.total > 1;
       return {
         rada_id: radaId,
         title: structure?.title || null,
         article_number: articleFilter,
         url: `https://zakon.rada.gov.ua/laws/show/${radaId}`,
-        total_versions: filtered.length,
-        versions: filtered,
-        note: filtered.length === 0
-          ? `Попередні редакції статті ${articleFilter} не знайдені в базі`
-          : undefined,
+        amendments_count: amendments.length,
+        amendments,
+        distinct_versions: versionsResult.total,
+        versions: versionsResult.versions,
+        versions_truncated: versionsResult.total > versionsResult.versions.length || undefined,
+        note: !changed
+          ? `Стаття ${articleFilter}: зафіксованих змін немає — поточна редакція єдина.`
+          : amendments.length === 0
+            ? `Деталізованих операцій зміни немає; показано ${versionsResult.versions.length} відмінних редакцій тексту (з ${versionsResult.total}).`
+            : undefined,
       };
     }
 
@@ -919,7 +930,7 @@ export class LegislationTools extends BaseToolHandler {
     if (!args.rada_id) throw new Error('rada_id is required');
     const radaId = normalizeRadaId(args.rada_id);
     const editions = await this.service.getEditionDates(radaId);
-    const structure = await this.service.getLegislationStructure(radaId);
+    const structure = await this.service.getLegislationStructure(radaId, undefined, false);
     return {
       rada_id: radaId,
       title: structure?.title || null,

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -814,6 +814,82 @@ export class LegislationService {
     }));
   }
 
+  /**
+   * Real clause-level amendment events for a single article, parsed from Rada's inline
+   * {…} notes (legislation_article_amendments): each row is an actual change (added/
+   * modified/removed) with the act date and the enacting law — not an edition snapshot.
+   */
+  async getArticleAmendments(radaId: string, articleNumber: string): Promise<Array<{
+    act_date: string | null;
+    change_type: string | null;
+    basis_act: string | null;
+    note_text: string | null;
+    source_edition: string | null;
+  }>> {
+    const result = await this.db.query(
+      `SELECT to_char(a.act_date, 'YYYY-MM-DD') AS act_date, a.change_type,
+              a.basis_act, a.note_text, a.source_edition
+       FROM legislation_article_amendments a
+       JOIN legislation l ON a.legislation_id = l.id
+       WHERE LOWER(l.rada_id) = LOWER($1) AND a.article_number = $2
+       ORDER BY a.act_date DESC NULLS LAST, a.id DESC`,
+      [radaId, articleNumber]
+    );
+    return result.rows.map((row: any) => ({
+      act_date: row.act_date,
+      change_type: row.change_type,
+      basis_act: row.basis_act,
+      note_text: row.note_text,
+      source_edition: row.source_edition,
+    }));
+  }
+
+  /**
+   * Distinct text versions of a single article, deduped by full_text (many editions
+   * carry an identical article, so raw per-edition rows over-report). Reads the real
+   * version_date COLUMN (not metadata->>'version_date', which is empty). Returns the
+   * effective date range each distinct text was in force, most recent first.
+   */
+  async getArticleVersions(
+    radaId: string,
+    articleNumber: string,
+    limit = 50
+  ): Promise<{
+    total: number;
+    versions: Array<{ effective_from: string | null; last_seen: string | null; title: string | null; byte_size: number | null }>;
+  }> {
+    const countResult = await this.db.query(
+      `SELECT COUNT(DISTINCT md5(la.full_text))::int AS n
+       FROM legislation_articles la
+       JOIN legislation l ON la.legislation_id = l.id
+       WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.full_text IS NOT NULL`,
+      [radaId, articleNumber]
+    );
+    const total = countResult.rows[0]?.n || 0;
+
+    const result = await this.db.query(
+      `SELECT to_char(MIN(la.version_date), 'YYYY-MM-DD') AS effective_from,
+              to_char(MAX(la.version_date), 'YYYY-MM-DD') AS last_seen,
+              MAX(la.title) AS title, MAX(la.byte_size) AS byte_size
+       FROM legislation_articles la
+       JOIN legislation l ON la.legislation_id = l.id
+       WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.full_text IS NOT NULL
+       GROUP BY md5(la.full_text)
+       ORDER BY MIN(la.version_date) DESC NULLS LAST
+       LIMIT $3`,
+      [radaId, articleNumber, limit]
+    );
+    return {
+      total,
+      versions: result.rows.map((row: any) => ({
+        effective_from: row.effective_from,
+        last_seen: row.last_seen,
+        title: row.title,
+        byte_size: row.byte_size,
+      })),
+    };
+  }
+
   async searchLegislation(query: string, radaId?: string, limit: number = 10): Promise<LegislationSearchResult[]> {
     if (radaId) {
       await this.ensureLegislationExists(radaId);


### PR DESCRIPTION
## Problem (LEXAI-1789)
`get_legislation_history(rada_id, article_number)` returned **one row per edition snapshot** — e.g. 178 "versions" for ЦК art 625 — each with `version_date: null`.

Two bugs, confirmed against prod:
1. It read `la.metadata->>'version_date'` (empty JSON field) instead of the `la.version_date` **column** (fully populated — 0 nulls across 233k ЦК article rows) → every version was undated.
2. It never deduped → identical per-edition snapshots were all listed. Art 625 has 178 snapshots but only **2 distinct texts** (it changed once, not 178 times).

`legislation_article_amendments` actually has ЦК data (762 rows; art 1308 = 28 real dated amendments) but the detailed path ignored it.

## Fix — detailed path now returns
- **`amendments`**: real clause-level changes from `legislation_article_amendments` — `act_date` + `change_type` (added/modified/removed) + `basis_act` (enacting law) + `note_text` (the inline {…} note).
- **`versions`**: distinct text versions deduped by `md5(full_text)`, dated from the real `version_date` column (`effective_from`/`last_seen`), most-recent first, capped at 50 with `distinct_versions` total + `versions_truncated`.
- An article that never changed now says so (`note`) instead of listing 178 undated dupes.

Summary mode (no `article_number`) already used the amendment metric and is unchanged. Also switched the internal title-only structure fetch in history/editions to the headings-only TOC (avoids materializing the full article list — ties in with #2062).

## Verification
`tsc` clean (only pre-existing `core-loader.ts` stubs). Ground truth: art 625 → 0 amendments + 2 distinct versions (changed once); art 1308 → 28 dated amendments. Will verify live post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LEXAI-1789: get_legislation_history now returns real, dated amendments and deduped article text versions instead of hundreds of undated edition snapshots. Article history is accurate and readable.

- **Bug Fixes**
  - Read `la.version_date` column instead of `metadata->>'version_date'`.
  - Dedup versions by `md5(full_text)`; return `effective_from`/`last_seen`, `distinct_versions`, cap to 50 with `versions_truncated`.
  - Return clause-level amendments from `legislation_article_amendments` (`act_date`, `change_type`, `basis_act`, `note_text`) plus `amendments_count`; add a clear “no changes” note when applicable.
  - Fetch structure via headings-only TOC in history/editions to avoid materializing full article lists.

<sup>Written for commit 34d266760f3ee66fa8736a72739cf3d24d83d95e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

