### PR TITLE
fix(legislation): fix TOC section dedup (17x smaller structure output)

### DIFF
--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -977,6 +977,7 @@ export class LegislationService {
     const toc: any[] = [];
     let currentBook: any = null;
     let currentSection: any = null;
+    let currentSectionKey: string | null = null;
     let currentSubsection: any = null;
     let currentChapter: any = null;
     let currentParagraph: any = null;
@@ -995,13 +996,16 @@ export class LegislationService {
         };
         toc.push(currentBook);
         currentSection = null;
+        currentSectionKey = null;
         currentSubsection = null;
         currentChapter = null;
         currentParagraph = null;
       }
 
-      // Handle section level (section_number may include book prefix like "1.2")
-      if (article.section_number && (!currentSection || currentSection.number !== article.section_number)) {
+      // Handle section level (section_number may include a book prefix like "1.2").
+      // Compare against the FULL section_number — currentSection.number holds the stripped
+      // display number, so comparing to it recreated a section on every article.
+      if (article.section_number && currentSectionKey !== article.section_number) {
         // Extract display number (strip book prefix for display)
         const displayNumber = article.section_number.includes('.')
           ? article.section_number.split('.').pop()
@@ -1013,6 +1017,7 @@ export class LegislationService {
           title: article.section_title || undefined,
           articles: [],
         };
+        currentSectionKey = article.section_number;
 
         if (currentBook) {
           currentBook.children.push(currentSection);


### PR DESCRIPTION
## Context (completes LEXAI-1788)
After #2062 made `get_legislation_structure` headings-only + paginated, the default response for ЦК was still **~864k chars** — because `buildTableOfContents` was generating a bloated tree: **1053 sections / 1075 chapters** where the data actually has **10 / 90**.

## Root cause
The section-dedup compared `currentSection.number` — the **stripped display** number (e.g. `"1"`) — against `article.section_number` — the **full prefixed** value (e.g. `"1.1"`). The two never match, so a new section node was created for **every article**, and each reset the subsection/chapter/paragraph pointers, cascading duplicate containers through the whole tree.

Data is clean and monotonic (verified on prod: 6 books, 6 book-transitions, 10 sections, 90 chapters).

## Fix
Track a separate `currentSectionKey` holding the **full** `section_number` for the comparison; keep the stripped number for display.

## Verification (local replay on real ЦК article metadata)
- Before: `{book:6, section:1053, chapter:1075, subsection:691, paragraph:460}` → 773k chars
- After: `{book:6, section:10, chapter:90, subsection:5, paragraph:44}` → **45.6k chars** (matches DB ground truth)

Also corrects the hierarchy for the leafy (`include_articles` / HTML-nav) path. `tsc` clean. Will confirm live post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes TOC section deduplication in `buildTableOfContents` so sections/chapters aren’t recreated per article, cutting the structure payload by ~17x. Addresses LEXAI-1788; the tree now matches ground truth (6 books, 10 sections, 90 chapters) and the headings-only response drops from ~773k to ~46k chars.

- **Bug Fixes**
  - Compare using a new `currentSectionKey` set to the full `section_number`; keep the stripped number only for display.
  - Reset `currentSectionKey` on book changes to avoid pointer resets and fix the `include_articles`/HTML-nav hierarchy.

<sup>Written for commit 60e55116237cc67fe3d374c1e67d2aeb0fbcb90d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

