### PR TITLE
fix(legislation): correct article ordering in structure query (regex escape)

### DIFF
--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -947,7 +947,7 @@ export class LegislationService {
              'chapter_title', la.chapter_title,
              'byte_size', la.byte_size,
              'metadata', la.metadata
-           ) ORDER BY (regexp_match(la.article_number, '^\d+'))[1]::integer NULLS LAST, la.article_number
+           ) ORDER BY (regexp_match(la.article_number, '^\\d+'))[1]::integer NULLS LAST, la.article_number
          ) as articles
        FROM legislation l
        LEFT JOIN legislation_articles la ON l.id = la.legislation_id AND la.is_current = true


### PR DESCRIPTION
## Root cause (dominant part of LEXAI-1788)
The structure query ordered articles by `(regexp_match(la.article_number, '^\d+'))[1]::integer` inside a JS template literal. `\d` is an identity escape, so at runtime the SQL string became `'^d+'` — a regex that never matches a numeric article number. `regexp_match` returned NULL for every row, collapsing the sort to a plain TEXT sort (`"1","10","100","1000",...`).

Articles from different books interleaved (Book 1 `1xx` next to Book 5 `10xx`), so `buildTableOfContents` thrashed containers: the live TOC had 214 book nodes alternating 1/5/1/5 and ballooned the response.

Proof: node evaluates the template `^\d+` to `"^d+"`. The DB sorts correctly when actually given `\d+`.

## Fix
Escape the backslash so the runtime SQL regex is `\d+` and articles sort by numeric prefix.

## Composes with the other two LEXAI-1788 fixes
- #2062 headings-only default + paginated article list
- #2064 section dedup (compare full section_number)
- this: correct numeric article ordering

Together: ЦК structure TOC now reflects the real 6 books / 10 sections / 90 chapters (~46k chars) instead of ~1.2M. tsc clean; local replay confirms 6/10/90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes numeric article ordering in the legislation structure query by properly escaping the regex, so the DB matches digits and sorts by numeric prefix. This restores correct TOC hierarchy and reduces payload size.

- **Bug Fixes**
  - Use `'^\\d+'` so SQL receives `\d+` for `regexp_match` in ORDER BY.
  - Prevents text-based sorting and cross-book interleaving; TOC is stable and smaller. Addresses the ordering issue in LEXAI-1788.

<sup>Written for commit 606529b169469f137f8cc7af6a7b25e8d199d4a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

