### PR TITLE
fix(nipo): populate trademark mark_text from data.WordMarkSpecification

### DIFF
--- a/mcp_backend/src/scripts/import-uipv-ip.ts
+++ b/mcp_backend/src/scripts/import-uipv-ip.ts
@@ -87,9 +87,11 @@ function sleep(ms: number): Promise<void> {
 function extractTrademark(record: any): any[] {
   const data = record.data || {};
 
-  // Mark text
+  // Mark text — the verbal element is nested under `data`, same as every other
+  // field below (holder/applicant/nice). Reading it off `record` left mark_text
+  // NULL for the entire trademark table.
   let markText = '';
-  const wordMark = record.WordMarkSpecification?.MarkSignificantVerbalElement;
+  const wordMark = data.WordMarkSpecification?.MarkSignificantVerbalElement;
   if (Array.isArray(wordMark)) {
     markText = wordMark.map((w: any) => w['#text'] || '').filter(Boolean).join(' ');
   }


### PR DESCRIPTION
## Problem

`extractTrademark()` in `import-uipv-ip.ts` read the mark's verbal element from `record.WordMarkSpecification`, but the NIPO/УІПВ API nests it under `record.data.WordMarkSpecification` — the same `data` object from which every other field (holder, applicant, NICE classes) is already correctly read.

As a result **`mark_text` was NULL for all ~382K rows** in `opendata_trademarks` on prod. Trademark search-by-name returned nothing, even though the data existed in `raw_data`.

## Fix

One-line change: read the verbal element from `data.WordMarkSpecification`. Future imports now populate `mark_text` via the existing `ON CONFLICT ... DO UPDATE SET mark_text = EXCLUDED.mark_text` path.

## Prod state

Existing rows were already backfilled from `raw_data` on prod (382,413 rows; GIN index `idx_trademarks_mark_text` makes ILIKE fast), so search works today. This patch ensures the next NIPO import does **not** re-null them.

> ⚠️ Follow-up: resume the NIPO top-off resync only **after** this merges — the previous (buggy) build's upsert re-nulls `mark_text`.

## Verification
- `tsc --noEmit`: no errors in `import-uipv-ip.ts` (3 unrelated pre-existing errors in `core-loader.ts` from other WIP, untouched here).
- Verified against live `raw_data`: verbal path is `data.WordMarkSpecification.MarkSignificantVerbalElement[].#text`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes trademark import to read the verbal element from `data.WordMarkSpecification`, ensuring `mark_text` is populated and name search works. Prevents future imports from overwriting `mark_text` with nulls.

- **Migration**
  - Resume the NIPO top-off resync only after this merges to avoid re-nulling `mark_text`.

<sup>Written for commit 3d8eb8a31f27168645c30aec31c4aa5ed605f8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

