### PR TITLE
fix(legislation): search_legislation unscoped fallback for ungrounded AI + honor limit

### DIFF
--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -382,15 +382,24 @@ export class LegislationTools extends BaseToolHandler {
 
         if (!trusted) {
           try {
-            const supplemental = await this.service.findRelevantArticles(
-              args.query,
-              resolvedRadaId,
-              limit
-            );
+            // Very low grounding means the AI guess — possibly the LAW itself — may be wrong,
+            // so also search UNSCOPED across all legislation, not only within the guessed act
+            // (a scoped-only fallback returns nothing when the wrong law was picked, leaving a
+            // single wrong answer). When the law is suspect, prefer globally-relevant hits.
+            const lawMayBeWrong = grounding < ARTICLE_GROUNDING_MIN_RATIO;
+            const [scoped, unscoped] = await Promise.all([
+              this.service.findRelevantArticles(args.query, resolvedRadaId, limit),
+              lawMayBeWrong
+                ? this.service.findRelevantArticles(args.query, undefined, limit)
+                : Promise.resolve([] as any[]),
+            ]);
+            const supplemental = lawMayBeWrong ? [...unscoped, ...scoped] : [...scoped, ...unscoped];
+
             const seen = new Set<string>([
               `${resolvedArticle.rada_id}:${resolvedArticle.article_number}`,
             ]);
             for (const a of supplemental) {
+              if (response.articles.length >= limit) break; // honor the caller's limit
               const key = `${a.rada_id}:${a.article_number}`;
               if (seen.has(key)) continue;
               seen.add(key);
@@ -418,6 +427,7 @@ export class LegislationTools extends BaseToolHandler {
               ai_article: directRef.articleNumber,
               confidence: directRef.confidence,
               grounding_ratio: Number(grounding.toFixed(2)),
+              law_may_be_wrong: lawMayBeWrong,
               supplemental_count: response.articles.length - 1,
             });
           } catch (err: any) {

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -1273,8 +1273,8 @@ export class LegislationService {
         }
       }
 
-      // Return all rows above MIN_SCORE threshold, capped at 15 to avoid maxToolCalls exhaustion
-      const result = { rows: allRows.slice(0, 15) };
+      // Return rows above MIN_SCORE, capped at the caller's limit (hard max 15 for safety).
+      const result = { rows: allRows.slice(0, Math.max(1, Math.min(limit, 15))) };
 
       return result.rows.map((row: any) => ({
         rada_id: row.rada_id,


### PR DESCRIPTION
## Problem (LEXAI-1791)
1. **Ungrounded AI → single wrong article.** When the AI reference resolver returned an ungrounded guess (`grounding_ratio: 0`), the low-grounding supplement searched **only within the AI's guessed `rada_id`**. If the AI picked the wrong law (or one with no vectors), the scoped fallback found nothing and a single wrong article was returned (e.g. "поновлення пропущеного процесуального строку" → ЦПК ст.252, which is about staying proceedings).
2. **`limit` ignored.** `findRelevantArticles` hard-capped at 15 and the supplement loop never capped, so `limit:10` returned ~15.

## Fix
- When grounding is below the trusted ratio, also run an **unscoped** semantic search across all legislation and prefer those globally-relevant hits. `findRelevantArticles` text-falls-back across all acts when vectors miss, so this helps even for un-vectorized codes.
- `findRelevantArticles` now slices to `min(limit, 15)`; the supplement loop breaks once `response.articles` reaches `limit`.

## Coverage note
`legislation_chunks` (semantic corpus) covers ~68 acts (ПКУ, ЦК, ГПК, ЗК, …); ЦПК (1618-15) and several codes are **not vectorized** — expanding that is a separate backfill task. The unscoped fallback still surfaces relevant analogues from covered codes via the text fallback instead of one wrong answer.

## Verification
`tsc` clean. Will verify live post-deploy (limit honored; ungrounded query supplemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an unscoped semantic search fallback when the reference resolver has low grounding, preventing single wrong-article results. Enforces the caller `limit` with a safety cap of 15; addresses LEXAI-1791.

- **Bug Fixes**
  - When grounding is below the trusted ratio, run an unscoped search across all acts alongside the scoped search and prefer globally relevant hits; helps when the guessed `rada_id` is wrong or unvectorized.
  - Results now honor `limit`: `findRelevantArticles` slices to `min(limit, 15)` and supplementation stops once `response.articles` reaches `limit`.

<sup>Written for commit 10ceacd10530a866f3c57f6b672418d71641f986. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

