### PR TITLE
feat(rada): ingest bill documents incl. ГНЕУ conclusions

### DIFF
--- a/mcp_rada/package.json
+++ b/mcp_rada/package.json
@@ -15,6 +15,7 @@
     "sync:deputies": "npm run build && node dist/scripts/sync-deputies.js",
     "sync:laws": "npm run build && node dist/scripts/sync-laws.js",
     "sync:reference": "npm run build && node dist/scripts/sync-reference-data.js",
+    "sync:bill-documents": "npm run build && node --max-old-space-size=4096 dist/scripts/sync-bill-documents.js",
     "cleanup:cache": "npm run build && node dist/scripts/cleanup-cache.js",
     "test": "jest --no-cache --verbose",
     "test:watch": "jest --watch --no-cache --verbose",

--- a/mcp_rada/src/migrations/006_bill_documents.sql
+++ b/mcp_rada/src/migrations/006_bill_documents.sql
@@ -1,0 +1,46 @@
+-- Bill documents (супровідні документи законопроектів)
+-- Source: data.rada.gov.ua/ogd/zpr/sklN/billinfo-sklN.json (full endpoint, ~130 MB, daily)
+-- Covers every workflow/source document per bill, including:
+--   * ГНЕУ conclusions      → kind_id = 100, kind = 'Науково-експертний висновок'
+--   * committee conclusions → 'Висновок Головного комітету' / 'Висновок комітету'
+--   * budget / EU-integration / anti-corruption / linguistic expert reviews
+--   * ГЮУ remarks           → 'Зауваження Головного юридичного управління'
+-- short_review / formal_review carry a machine-readable verdict; docFiles carry the PDF links.
+-- Soft-linked to bills via bill_number / rada_bill_id (no hard FK: the doc source lists a few
+-- hundred bills not present in rada.bills, and we must not drop their documents).
+
+CREATE TABLE IF NOT EXISTS bill_documents (
+  doc_id            BIGINT PRIMARY KEY,                       -- workflow/source item .id (Rada document id)
+  rada_bill_id      BIGINT NOT NULL,                          -- billinfo bill .id (pf3511 id)
+  bill_number       VARCHAR(50),                              -- registrationNumber
+  convocation       SMALLINT,                                 -- скликання (9, 8, ...)
+  doc_group         VARCHAR(20) NOT NULL DEFAULT 'workflow',  -- 'workflow' | 'source'
+  kind_id           INTEGER,                                  -- .kindId (100 = ГНЕУ)
+  kind              TEXT,                                     -- .kind
+  registration_num  VARCHAR(120),
+  registration_date TIMESTAMPTZ,
+  outcoming_num     VARCHAR(120),
+  outcoming_date    TIMESTAMPTZ,
+  publish_date      TIMESTAMPTZ,
+  meeting_date      TIMESTAMPTZ,
+  short_review      TEXT,                                     -- machine-readable verdict summary
+  formal_review     TEXT,
+  main_speaker      TEXT,
+  file_url          TEXT,                                     -- first docFiles[].url (PDF)
+  file_zip_url      TEXT,                                     -- first docFiles[].archiveWithSignsUrl
+  doc_files         JSONB,                                    -- full docFiles array
+  full_text         TEXT,                                     -- nullable; filled from PDF (phase 2)
+  raw               JSONB,                                    -- full source item
+  imported_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_bill_documents_bill_number ON bill_documents(bill_number);
+CREATE INDEX IF NOT EXISTS idx_bill_documents_rada_bill_id ON bill_documents(rada_bill_id);
+CREATE INDEX IF NOT EXISTS idx_bill_documents_kind_id ON bill_documents(kind_id);
+CREATE INDEX IF NOT EXISTS idx_bill_documents_reg_date ON bill_documents(registration_date);
+
+-- Full-text over the verdict summaries + extracted PDF text ('simple' config: Ukrainian, no stemmer)
+CREATE INDEX IF NOT EXISTS idx_bill_documents_review_fts ON bill_documents
+  USING gin(to_tsvector('simple',
+    coalesce(short_review, '') || ' ' || coalesce(formal_review, '') || ' ' || coalesce(full_text, '')));

--- a/mcp_rada/src/scripts/sync-bill-documents.ts
+++ b/mcp_rada/src/scripts/sync-bill-documents.ts
@@ -1,0 +1,190 @@
+/**
+ * Sync bill documents (супровідні документи законопроектів) into rada.bill_documents.
+ *
+ * Pulls the FULL Rada bill-info dataset (with documents + passings) — which our normal
+ * bill sync does NOT fetch — and stores every workflow/source document per bill:
+ * ГНЕУ conclusions (kind_id=100 «Науково-експертний висновок»), committee conclusions,
+ * budget / EU-integration / anti-corruption / linguistic expert reviews, ГЮУ remarks, etc.
+ *
+ * The verdict summary (short_review / formal_review) and the PDF links live directly in the
+ * JSON, so this pass needs NO per-document requests. Extracting PDF full text is a later phase.
+ *
+ * Usage:
+ *   npm run sync:bill-documents            # convocation 9 (default)
+ *   CONVOCATIONS=9,8 npm run sync:bill-documents
+ *   node --max-old-space-size=4096 dist/scripts/sync-bill-documents.js 9
+ *
+ * Env:
+ *   DATABASE_URL or POSTGRES_HOST/PORT/USER/PASSWORD/DB
+ *   CONVOCATIONS   comma-separated skl numbers (overrides argv), default "9"
+ */
+
+import { Pool } from 'pg';
+
+const API_BASE = 'https://data.rada.gov.ua/ogd/zpr';
+const BATCH_SIZE = 200;
+const FETCH_TIMEOUT_MS = 180_000;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'rada_mcp',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  options: '-c search_path=rada',
+  max: 5,
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+function nz(v: any): any {
+  if (v === undefined || v === null) return null;
+  if (typeof v === 'string' && v.trim() === '') return null;
+  return v;
+}
+
+async function fetchBillInfo(conv: number): Promise<any[]> {
+  const url = `${API_BASE}/skl${conv}/billinfo-skl${conv}.json`;
+  console.log(`\n📥 Fetching ${url} …`);
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json', 'User-Agent': 'SecondLayer-Legal-Platform/1.0' },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+  let text = await resp.text();
+  console.log(`   Downloaded ${(text.length / 1_048_576).toFixed(1)} MB, parsing…`);
+  // The Rada feed embeds raw control characters inside string values, which strict
+  // JSON.parse rejects. Escaped sequences (\\n) are two chars and untouched; only raw
+  // bytes 0x00–0x1F get flattened to spaces.
+  text = text.replace(/[\x00-\x1F]/g, ' ');
+  const data = JSON.parse(text);
+  const bills = Array.isArray(data)
+    ? data
+    : (Object.values(data).find((v) => Array.isArray(v)) as any[]) || [];
+  console.log(`   ${bills.length.toLocaleString()} bills in feed`);
+  return bills;
+}
+
+// Map one workflow/source document to a bill_documents row (array in column order).
+function toRow(doc: any, bill: any, conv: number, group: 'workflow' | 'source'): any[] {
+  const files = Array.isArray(doc.docFiles) ? doc.docFiles : [];
+  const f0 = files[0] || {};
+  return [
+    doc.id, // doc_id (PK)
+    bill.id, // rada_bill_id
+    nz(bill.registrationNumber), // bill_number
+    conv, // convocation
+    group, // doc_group
+    nz(doc.kindId), // kind_id
+    nz(doc.kind), // kind
+    nz(doc.registrationNum), // registration_num
+    nz(doc.registrationDate), // registration_date
+    nz(doc.outcomingNum), // outcoming_num
+    nz(doc.outcomingDate), // outcoming_date
+    nz(doc.publishDate), // publish_date
+    nz(doc.meetingDate), // meeting_date
+    nz(doc.short_review), // short_review
+    nz(doc.formal_review), // formal_review
+    nz(doc.mainSpeaker), // main_speaker
+    nz(f0.url), // file_url
+    nz(f0.archiveWithSignsUrl), // file_zip_url
+    files.length ? JSON.stringify(files) : null, // doc_files
+    JSON.stringify(doc), // raw
+  ];
+}
+
+const COLS = [
+  'doc_id', 'rada_bill_id', 'bill_number', 'convocation', 'doc_group', 'kind_id', 'kind',
+  'registration_num', 'registration_date', 'outcoming_num', 'outcoming_date', 'publish_date',
+  'meeting_date', 'short_review', 'formal_review', 'main_speaker', 'file_url', 'file_zip_url',
+  'doc_files', 'raw',
+];
+
+async function upsertBatch(rows: any[][]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const tuples: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    tuples.push(`(${r.map(() => `$${i++}`).join(',')})`);
+    values.push(...r);
+  }
+  const updates = COLS.filter((c) => c !== 'doc_id')
+    .map((c) => `${c} = EXCLUDED.${c}`)
+    .join(', ');
+  const sql = `
+    INSERT INTO rada.bill_documents (${COLS.join(', ')})
+    VALUES ${tuples.join(',')}
+    ON CONFLICT (doc_id) DO UPDATE SET ${updates}, updated_at = now()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function syncConvocation(conv: number): Promise<{ docs: number; gneu: number }> {
+  const bills = await fetchBillInfo(conv);
+
+  let batch: any[][] = [];
+  let total = 0;
+  let gneu = 0;
+  let processedBills = 0;
+
+  for (const bill of bills) {
+    const docs = bill.documents || {};
+    for (const group of ['workflow', 'source'] as const) {
+      const arr = Array.isArray(docs[group]) ? docs[group] : [];
+      for (const doc of arr) {
+        if (doc?.id == null) continue; // PK required
+        if (doc.kindId === 100) gneu++;
+        batch.push(toRow(doc, bill, conv, group));
+        if (batch.length >= BATCH_SIZE) {
+          total += await upsertBatch(batch);
+          batch = [];
+        }
+      }
+    }
+    if (++processedBills % 2000 === 0) {
+      console.log(`   …${processedBills.toLocaleString()}/${bills.length.toLocaleString()} bills, ${total.toLocaleString()} docs upserted`);
+    }
+  }
+  if (batch.length) total += await upsertBatch(batch);
+
+  console.log(`✅ skl${conv}: ${total.toLocaleString()} documents upserted (${gneu.toLocaleString()} ГНЕУ conclusions)`);
+  return { docs: total, gneu };
+}
+
+async function main(): Promise<void> {
+  const convs = (process.env.CONVOCATIONS || process.argv[2] || '9')
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !Number.isNaN(n));
+
+  console.log('═══════════════════════════════════════════════════════════════');
+  console.log('🏛️  Rada Bill Documents Sync (ГНЕУ + супровідні документи)');
+  console.log(`   Convocations: ${convs.join(', ')}`);
+  console.log('═══════════════════════════════════════════════════════════════');
+
+  try {
+    await pool.query('SELECT 1');
+    console.log('✅ Database connected');
+
+    let docs = 0;
+    let gneu = 0;
+    for (const c of convs) {
+      const r = await syncConvocation(c);
+      docs += r.docs;
+      gneu += r.gneu;
+    }
+
+    console.log('\n═══════════════════════════════════════════════════════════════');
+    console.log(`🎉 Done: ${docs.toLocaleString()} documents (${gneu.toLocaleString()} ГНЕУ) across ${convs.length} convocation(s)`);
+    console.log('═══════════════════════════════════════════════════════════════');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('❌ Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

Adds ingestion of **bill supporting documents** into `rada.bill_documents`, most notably **ГНЕУ conclusions** (Головного науково-експертного управління) — which we currently do not have on prod at all.

Recon (2026-07-02): our bill sync only fetches the *light* `billinfo_list-skl9.json` (no documents). The **full** feed `data.rada.gov.ua/ogd/zpr/skl9/billinfo-skl9.json` (~130 MB, daily) carries `documents.{source,workflow}` per bill. In skl9: **6,671 ГНЕУ conclusions** (`kind_id=100`), plus 7.6K committee, 5.8K budget, 4.8K EU-integration, 1.6K ГЮУ, 1.1K anti-corruption, 1.4K linguistic — 35.6K docs total. Each doc has a machine-readable verdict (`short_review`/`formal_review`) + PDF links (`docFiles[].url`), so **no per-document requests needed**.

## Changes

- **`migration 006_bill_documents.sql`** — new table, soft-linked to bills by `bill_number` / `rada_bill_id` (no hard FK: the feed lists a few hundred bills not in `rada.bills`, must not drop their docs). Simple-config FTS GIN over `short_review + formal_review + full_text`.
- **`sync-bill-documents.ts`** — single fetch per convocation, control-char-safe parse (the feed embeds raw control bytes that strict `JSON.parse` rejects), idempotent `ON CONFLICT (doc_id) DO UPDATE` in 200-row batches. `CONVOCATIONS=9,8` env for multi-skl.
- **`npm run sync:bill-documents`** — with raised heap for the 130 MB parse.

## Scope / follow-up

- This pass stores metadata + verdict + PDF URLs. **PDF full-text extraction** (populating `full_text`) is a deliberate later phase.
- After merge+deploy: run `npm run sync:bill-documents` in the rada container to populate.

## Verification

- `tsc --noEmit`: 0 errors.
- Field mapping verified against the live feed (`bill.id`, `registrationNumber`, `doc.kindId`, `short_review`, `docFiles[].url/archiveWithSignsUrl`).

Tracks LEXAI-1792 (recon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds ingestion of bill supporting documents into rada.bill_documents, including ГНЕУ conclusions, by syncing the full Rada bill feed. Addresses LEXAI-1792 by surfacing machine-readable verdicts and PDF links for search and review.

- **New Features**
  - Added `rada.bill_documents` with indexes and simple FTS over `short_review`, `formal_review`, and `full_text`.
  - Added `sync-bill-documents.ts` to pull the full `billinfo-sklN.json`, parse control chars safely, and upsert in 200-row batches; supports multiple convocations via `CONVOCATIONS`.
  - Added `npm run sync:bill-documents` (runs with `--max-old-space-size=4096`).

- **Migration**
  - Apply the migration, then run `npm run sync:bill-documents` (optionally `CONVOCATIONS=9,8`) to populate.
  - Only metadata, verdicts, and PDF URLs are stored now; `full_text` will be filled in a later phase.

<sup>Written for commit e531a72e96ca310795cb3ea4ce79519d9b9a6c3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

