### PR TITLE
fix(rada): dedupe bill documents by doc_id before upsert

### DIFF
--- a/mcp_rada/src/scripts/sync-bill-documents.ts
+++ b/mcp_rada/src/scripts/sync-bill-documents.ts
@@ -124,30 +124,32 @@ async function upsertBatch(rows: any[][]): Promise<number> {
 async function syncConvocation(conv: number): Promise<{ docs: number; gneu: number }> {
   const bills = await fetchBillInfo(conv);
 
-  let batch: any[][] = [];
-  let total = 0;
+  // A document id can appear more than once in the feed (same doc listed under both
+  // `workflow` and `source`, or attached to more than one bill). Postgres rejects a
+  // duplicate constrained value inside one ON CONFLICT statement, so dedupe by doc_id
+  // up front. `workflow` is iterated first and wins — it carries the review verdict.
+  const byId = new Map<number, any[]>();
   let gneu = 0;
-  let processedBills = 0;
-
   for (const bill of bills) {
     const docs = bill.documents || {};
     for (const group of ['workflow', 'source'] as const) {
       const arr = Array.isArray(docs[group]) ? docs[group] : [];
       for (const doc of arr) {
-        if (doc?.id == null) continue; // PK required
+        if (doc?.id == null || byId.has(doc.id)) continue;
         if (doc.kindId === 100) gneu++;
-        batch.push(toRow(doc, bill, conv, group));
-        if (batch.length >= BATCH_SIZE) {
-          total += await upsertBatch(batch);
-          batch = [];
-        }
+        byId.set(doc.id, toRow(doc, bill, conv, group));
       }
     }
-    if (++processedBills % 2000 === 0) {
-      console.log(`   …${processedBills.toLocaleString()}/${bills.length.toLocaleString()} bills, ${total.toLocaleString()} docs upserted`);
+  }
+
+  const rows = [...byId.values()];
+  let total = 0;
+  for (let i = 0; i < rows.length; i += BATCH_SIZE) {
+    total += await upsertBatch(rows.slice(i, i + BATCH_SIZE));
+    if (i % (BATCH_SIZE * 20) === 0 && i > 0) {
+      console.log(`   …${i.toLocaleString()}/${rows.length.toLocaleString()} docs upserted`);
     }
   }
-  if (batch.length) total += await upsertBatch(batch);
 
   console.log(`✅ skl${conv}: ${total.toLocaleString()} documents upserted (${gneu.toLocaleString()} ГНЕУ conclusions)`);
   return { docs: total, gneu };


### PR DESCRIPTION
## Problem

Follow-up to #2068. The Rada bill-info feed lists the same document `id` more than once (a doc appears under both `documents.workflow` and `documents.source`, or is attached to multiple bills). Batching duplicates into one `INSERT ... ON CONFLICT (doc_id) DO UPDATE` fails:

```
ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
```

## Fix

Collect rows into a `Map` keyed by `doc_id` (workflow iterated first, so the review-bearing copy wins), then upsert the deduped set in batches. No intra- or inter-batch duplicates.

## Verification

Ran the fixed script on prod (skl9): **50,210 documents upserted, 6,667 ГНЕУ conclusions**. Sample check confirms `short_review` verdicts, `file_url` PDF links, and `bill_number` links populated; FTS over review text works (5,364 ГНЕУ conclusions match «зауваж\*»). `tsc --noEmit`: 0 errors.

Tracks LEXAI-1792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Rada bill documents by `doc_id` before upsert to prevent Postgres `ON CONFLICT` errors and keep the review-bearing `workflow` copy. Batches the deduped rows with doc-level progress logs. Addresses LEXAI-1792.

- **Bug Fixes**
  - Collect docs in a Map by `doc_id`; `workflow` is processed first and wins over `source`.
  - Upsert the deduped set in batches to avoid intra/inter-batch duplicates and update progress by docs.

<sup>Written for commit 1a44a0f1f9019b4f26bdc9b08b23308674c64652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

