### PR TITLE
feat(rada): legacy convocations (skl8/skl7) + composite PK fix

### DIFF
--- a/mcp_rada/src/migrations/007_bill_documents_composite_pk.sql
+++ b/mcp_rada/src/migrations/007_bill_documents_composite_pk.sql
@@ -1,0 +1,12 @@
+-- Document ids are NOT globally unique across convocations: the legacy bills-sklN.json
+-- feeds identify documents by the uri's pf35401 param, whose value space overlaps the
+-- modern itd document ids used by billinfo-skl9.json. With a doc_id-only primary key,
+-- loading an older convocation overwrote same-id rows from a newer one. The key must
+-- therefore include convocation.
+
+DO $$ BEGIN
+  ALTER TABLE bill_documents ALTER COLUMN convocation SET NOT NULL;
+EXCEPTION WHEN others THEN NULL; END $$;
+
+ALTER TABLE bill_documents DROP CONSTRAINT IF EXISTS bill_documents_pkey;
+ALTER TABLE bill_documents ADD CONSTRAINT bill_documents_pkey PRIMARY KEY (doc_id, convocation);

--- a/mcp_rada/src/scripts/sync-bill-documents.ts
+++ b/mcp_rada/src/scripts/sync-bill-documents.ts
@@ -43,26 +43,40 @@ function nz(v: any): any {
   return v;
 }
 
-async function fetchBillInfo(conv: number): Promise<any[]> {
-  const url = `${API_BASE}/skl${conv}/billinfo-skl${conv}.json`;
-  console.log(`\n📥 Fetching ${url} …`);
-  const resp = await fetch(url, {
-    headers: { Accept: 'application/json', 'User-Agent': 'SecondLayer-Legal-Platform/1.0' },
-    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
-  });
-  if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
-  let text = await resp.text();
-  console.log(`   Downloaded ${(text.length / 1_048_576).toFixed(1)} MB, parsing…`);
-  // The Rada feed embeds raw control characters inside string values, which strict
-  // JSON.parse rejects. Escaped sequences (\\n) are two chars and untouched; only raw
-  // bytes 0x00–0x1F get flattened to spaces.
-  text = text.replace(/[\x00-\x1F]/g, ' ');
-  const data = JSON.parse(text);
-  const bills = Array.isArray(data)
-    ? data
-    : (Object.values(data).find((v) => Array.isArray(v)) as any[]) || [];
-  console.log(`   ${bills.length.toLocaleString()} bills in feed`);
-  return bills;
+// Current convocations expose the rich `billinfo-sklN.json` (documents carry kindId,
+// short_review/formal_review verdicts, direct-PDF docFiles). Past convocations only have
+// the legacy `bills-sklN.json`, where each doc is just {date, type, uri} with the doc id in
+// the uri's pf35401 param and no verdict/PDF. We auto-detect and handle both.
+async function fetchFeed(conv: number): Promise<{ bills: any[]; modern: boolean }> {
+  const candidates: [string, boolean][] = [
+    [`${API_BASE}/skl${conv}/billinfo-skl${conv}.json`, true],
+    [`${API_BASE}/skl${conv}/bills-skl${conv}.json`, false],
+  ];
+  for (const [url, modern] of candidates) {
+    console.log(`\n📥 Trying ${url} …`);
+    const resp = await fetch(url, {
+      headers: { Accept: 'application/json', 'User-Agent': 'SecondLayer-Legal-Platform/1.0' },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (resp.status === 404) {
+      console.log('   404 — trying next candidate…');
+      continue;
+    }
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}: ${resp.statusText}`);
+    let text = await resp.text();
+    console.log(`   Downloaded ${(text.length / 1_048_576).toFixed(1)} MB (${modern ? 'modern' : 'legacy'} format), parsing…`);
+    // The Rada feed embeds raw control characters inside string values, which strict
+    // JSON.parse rejects. Escaped sequences (\\n) are two chars and untouched; only raw
+    // bytes 0x00–0x1F get flattened to spaces.
+    text = text.replace(/[\x00-\x1F]/g, ' ');
+    const data = JSON.parse(text);
+    const bills = Array.isArray(data)
+      ? data
+      : (Object.values(data).find((v) => Array.isArray(v)) as any[]) || [];
+    console.log(`   ${bills.length.toLocaleString()} bills in feed`);
+    return { bills, modern };
+  }
+  throw new Error(`No bill feed found for skl${conv} (billinfo/bills both 404)`);
 }
 
 // Map one workflow/source document to a bill_documents row (array in column order).
@@ -93,6 +107,33 @@ function toRow(doc: any, bill: any, conv: number, group: 'workflow' | 'source'):
   ];
 }
 
+// Legacy `bills-sklN.json`: each doc is {date, type, uri}. The document id lives in the
+// uri's pf35401 param; there is no kindId / verdict / direct PDF.
+function toOldRow(id: number, doc: any, bill: any, conv: number, group: 'workflow' | 'source'): any[] {
+  return [
+    id, // doc_id (PK) — pf35401 from uri
+    bill.id, // rada_bill_id
+    nz(bill.number || bill.registrationNumber), // bill_number
+    conv, // convocation
+    group, // doc_group
+    null, // kind_id (legacy has none)
+    nz(doc.type), // kind — the document type name
+    null, // registration_num
+    nz(doc.date), // registration_date
+    null, // outcoming_num
+    null, // outcoming_date
+    null, // publish_date
+    null, // meeting_date
+    null, // short_review (legacy has no verdict summary)
+    null, // formal_review
+    null, // main_speaker
+    nz(doc.uri), // file_url — legacy webproc34 portal link
+    null, // file_zip_url
+    null, // doc_files
+    JSON.stringify(doc), // raw
+  ];
+}
+
 const COLS = [
   'doc_id', 'rada_bill_id', 'bill_number', 'convocation', 'doc_group', 'kind_id', 'kind',
   'registration_num', 'registration_date', 'outcoming_num', 'outcoming_date', 'publish_date',
@@ -115,14 +156,14 @@ async function upsertBatch(rows: any[][]): Promise<number> {
   const sql = `
     INSERT INTO rada.bill_documents (${COLS.join(', ')})
     VALUES ${tuples.join(',')}
-    ON CONFLICT (doc_id) DO UPDATE SET ${updates}, updated_at = now()
+    ON CONFLICT (doc_id, convocation) DO UPDATE SET ${updates}, updated_at = now()
   `;
   const res = await pool.query(sql, values);
   return res.rowCount || 0;
 }
 
 async function syncConvocation(conv: number): Promise<{ docs: number; gneu: number }> {
-  const bills = await fetchBillInfo(conv);
+  const { bills, modern } = await fetchFeed(conv);
 
   // A document id can appear more than once in the feed (same doc listed under both
   // `workflow` and `source`, or attached to more than one bill). Postgres rejects a
@@ -130,17 +171,34 @@ async function syncConvocation(conv: number): Promise<{ docs: number; gneu: numb
   // up front. `workflow` is iterated first and wins — it carries the review verdict.
   const byId = new Map<number, any[]>();
   let gneu = 0;
+  let skipped = 0;
   for (const bill of bills) {
     const docs = bill.documents || {};
     for (const group of ['workflow', 'source'] as const) {
-      const arr = Array.isArray(docs[group]) ? docs[group] : [];
-      for (const doc of arr) {
-        if (doc?.id == null || byId.has(doc.id)) continue;
-        if (doc.kindId === 100) gneu++;
-        byId.set(doc.id, toRow(doc, bill, conv, group));
+      if (modern) {
+        const arr = Array.isArray(docs[group]) ? docs[group] : [];
+        for (const doc of arr) {
+          if (doc?.id == null || byId.has(doc.id)) continue;
+          if (doc.kindId === 100) gneu++;
+          byId.set(doc.id, toRow(doc, bill, conv, group));
+        }
+      } else {
+        // legacy: docs[group] = { document: [{date,type,uri}, …] }
+        const grp = docs[group];
+        const arr = grp && Array.isArray(grp.document) ? grp.document : [];
+        for (const doc of arr) {
+          if (!doc || typeof doc !== 'object') continue;
+          const m = /pf35401=(\d+)/.exec(doc.uri || '');
+          if (!m) { skipped++; continue; } // no stable doc id → skip (procedural docs)
+          const id = parseInt(m[1], 10);
+          if (byId.has(id)) continue;
+          if ((doc.type || '').toLowerCase().includes('науково-експертн')) gneu++;
+          byId.set(id, toOldRow(id, doc, bill, conv, group));
+        }
       }
     }
   }
+  if (skipped) console.log(`   (skipped ${skipped.toLocaleString()} legacy docs without a pf35401 id)`);
 
   const rows = [...byId.values()];
   let total = 0;


### PR DESCRIPTION
## What

Extends `sync-bill-documents` (from #2068/#2069) to load **past convocations** (skl8, skl7, …) and fixes a cross-convocation `doc_id` collision.

## Two changes

**1. Dual-format feed support.** Past convocations have no `billinfo-sklN.json`; only the legacy `bills-sklN.json`, where documents are `{date, type, uri}` — the doc id is in the uri's `pf35401` param, and there is **no** `kindId` / `short_review` verdict / direct-PDF (`file_url` holds the old `webproc34` portal link instead). The scraper now tries `billinfo-` and falls back to `bills-`, extracting both shapes. ГНЕУ in legacy = `type = "Висновок Головного науково-експертного управління"`.

**2. Composite PK (migration 007).** The legacy `pf35401` id space **overlaps** the modern itd document ids, so a `doc_id`-only PK let an older-convocation load silently overwrite newer rows (skl9 dropped 50,210→48,445 when skl8 loaded). PK is now `(doc_id, convocation)`, and the upsert conflicts on that pair.

## Verified on prod

Truncated + reloaded all three convocations cleanly:

| Convocation | Docs | ГНЕУ |
|---|---|---|
| skl9 (modern) | 50,210 | 6,667 |
| skl8 (legacy) | 61,597 | 5,031 |
| skl7 (legacy) | 30,048 | 2,205 |
| **Total** | **141,855** | **13,903** |

0 duplicate keys. `tsc --noEmit`: 0 errors. (~1,300 legacy procedural docs without a pf35401 id are skipped and logged.)

## Caveat

Legacy-convocation rows have no machine-readable verdict (`short_review` null) and no direct PDF — only the doc type + `webproc34` portal link. Modern skl9 keeps the full verdict + pubFile PDF.

Tracks LEXAI-1792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds legacy convocation support (skl8/skl7) to `sync-bill-documents` and prevents cross-convocation `doc_id` collisions with a composite primary key. Enables loading past documents without overwriting skl9; fulfills LEXAI-1792.

- **New Features**
  - Auto-detects bill feed per convocation: tries `billinfo-sklN.json`, falls back to `bills-sklN.json`.
  - Parses legacy docs `{date, type, uri}`; extracts `pf35401` as `doc_id`, flags ГНЕУ by type, and skips docs without `pf35401`.

- **Migration**
  - Adds composite PK `(doc_id, convocation)` and sets `convocation` NOT NULL (migration 007); upsert now conflicts on that pair.
  - Run migration 007 before syncing legacy convocations.

<sup>Written for commit 873451577febb7f80d73353953e925a638874c33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

