### PR TITLE
feat(rada): denormalize bill title/subject + sanitize legacy dates

### DIFF
--- a/mcp_rada/src/migrations/008_bill_documents_bill_denorm.sql
+++ b/mcp_rada/src/migrations/008_bill_documents_bill_denorm.sql
@@ -1,0 +1,11 @@
+-- Denormalize the bill's title/subject onto each document. rada.bills only holds the
+-- current convocation (bill_number is UNIQUE there, and numbers reset each convocation, so
+-- older bills cannot be loaded into it without collisions). Carrying bill_title/bill_subject
+-- on the document makes every document self-describing across all convocations without a
+-- fragile cross-convocation join.
+
+ALTER TABLE bill_documents ADD COLUMN IF NOT EXISTS bill_title   TEXT;
+ALTER TABLE bill_documents ADD COLUMN IF NOT EXISTS bill_subject TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_bill_documents_bill_title_fts ON bill_documents
+  USING gin(to_tsvector('simple', coalesce(bill_title, '')));

--- a/mcp_rada/src/scripts/sync-bill-documents.ts
+++ b/mcp_rada/src/scripts/sync-bill-documents.ts
@@ -43,6 +43,17 @@ function nz(v: any): any {
   return v;
 }
 
+// The legacy feeds contain source-typo dates (year 0006, 3013, …). Drop anything whose
+// year is outside a sane window so they don't pollute registration_date / its index.
+const MAX_DATE_YEAR = new Date().getFullYear() + 2;
+function nzDate(v: any): any {
+  const s = nz(v);
+  if (s === null) return null;
+  const year = parseInt(String(s).slice(0, 4), 10);
+  if (Number.isNaN(year) || year < 1990 || year > MAX_DATE_YEAR) return null;
+  return s;
+}
+
 // Current convocations expose the rich `billinfo-sklN.json` (documents carry kindId,
 // short_review/formal_review verdicts, direct-PDF docFiles). Past convocations only have
 // the legacy `bills-sklN.json`, where each doc is just {date, type, uri} with the doc id in
@@ -92,11 +103,11 @@ function toRow(doc: any, bill: any, conv: number, group: 'workflow' | 'source'):
     nz(doc.kindId), // kind_id
     nz(doc.kind), // kind
     nz(doc.registrationNum), // registration_num
-    nz(doc.registrationDate), // registration_date
+    nzDate(doc.registrationDate), // registration_date
     nz(doc.outcomingNum), // outcoming_num
-    nz(doc.outcomingDate), // outcoming_date
-    nz(doc.publishDate), // publish_date
-    nz(doc.meetingDate), // meeting_date
+    nzDate(doc.outcomingDate), // outcoming_date
+    nzDate(doc.publishDate), // publish_date
+    nzDate(doc.meetingDate), // meeting_date
     nz(doc.short_review), // short_review
     nz(doc.formal_review), // formal_review
     nz(doc.mainSpeaker), // main_speaker
@@ -104,6 +115,8 @@ function toRow(doc: any, bill: any, conv: number, group: 'workflow' | 'source'):
     nz(f0.archiveWithSignsUrl), // file_zip_url
     files.length ? JSON.stringify(files) : null, // doc_files
     JSON.stringify(doc), // raw
+    nz(bill.title || bill.name), // bill_title (modern feed uses `name`)
+    nz(bill.subject), // bill_subject
   ];
 }
 
@@ -119,7 +132,7 @@ function toOldRow(id: number, doc: any, bill: any, conv: number, group: 'workflo
     null, // kind_id (legacy has none)
     nz(doc.type), // kind — the document type name
     null, // registration_num
-    nz(doc.date), // registration_date
+    nzDate(doc.date), // registration_date
     null, // outcoming_num
     null, // outcoming_date
     null, // publish_date
@@ -131,6 +144,8 @@ function toOldRow(id: number, doc: any, bill: any, conv: number, group: 'workflo
     null, // file_zip_url
     null, // doc_files
     JSON.stringify(doc), // raw
+    nz(bill.title || bill.name), // bill_title
+    nz(bill.subject), // bill_subject
   ];
 }
 
@@ -138,7 +153,7 @@ const COLS = [
   'doc_id', 'rada_bill_id', 'bill_number', 'convocation', 'doc_group', 'kind_id', 'kind',
   'registration_num', 'registration_date', 'outcoming_num', 'outcoming_date', 'publish_date',
   'meeting_date', 'short_review', 'formal_review', 'main_speaker', 'file_url', 'file_zip_url',
-  'doc_files', 'raw',
+  'doc_files', 'raw', 'bill_title', 'bill_subject',
 ];
 
 async function upsertBatch(rows: any[][]): Promise<number> {


### PR DESCRIPTION
Follow-up to the bill-documents work (#2068/#2069/#2071), addressing the two tails found in the consistency audit.

## A — bill title/subject on each document (removes the "orphan" gap)

64,810 of 241,648 documents (27%) had no match in `rada.bills` — because `rada.bills` only holds the **current** convocation. It can't hold older bills: `bill_number` is `UNIQUE` there and numbers reset each convocation (skl3 and skl9 both have a bill "2109"), so loading old bills would collide with / overwrite skl9 rows and pollute the existing bill-sync + MCP tools.

Instead, carry the bill's `bill_title` / `bill_subject` on each document (migration 008 + scraper populates from the feed — modern uses `name`, legacy uses `title`). Every document is now self-describing across all convocations with no fragile cross-convocation join. Added a `bill_title` FTS index.

## B — legacy date sanitization

Legacy feeds carry source-typo dates (year `0006`, `3013`, …). `nzDate()` nulls any date whose year is outside `1990..currentYear+2`, keeping `registration_date` and its index clean.

## Verified on prod (re-synced all 7 convocations)

- 241,648 docs; `bill_title` / `bill_subject` **100% populated**
- `registration_date` range now **1996-12-24 .. 2026-07-01** (was `0006` .. `3013`); 249 garbage dates nulled; 0 out-of-range
- `tsc --noEmit`: 0 errors

Tracks LEXAI-1792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Denormalized bill title/subject onto `bill_documents` and sanitized bad legacy dates to make documents self-contained across convocations and keep date indexes clean. Addresses LEXAI-1792.

- New Features
  - Added `bill_title` and `bill_subject` to `bill_documents`.
  - Populated from feeds in `sync-bill-documents.ts` (`name` for modern, `title` for legacy).
  - Added GIN FTS index on `bill_title`.

- Bug Fixes
  - `nzDate()` nulls dates with years outside 1990..currentYear+2 to prevent corrupt `registration_date` values.

<sup>Written for commit afd6fa0d7deff7ea434ce762abd4d6dfd7c2dc5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

