### PR TITLE
feat(rada): denormalize bill initiators (co-sponsors) onto documents

### DIFF
--- a/mcp_rada/src/migrations/009_bill_documents_initiators.sql
+++ b/mcp_rada/src/migrations/009_bill_documents_initiators.sql
@@ -1,0 +1,12 @@
+-- Denormalize the bill's initiators (co-sponsors) onto each document. The feed carries the
+-- real initiator people (deputy: mp/official.person; body: inner/outter with post/org), while
+-- rada.bills.initiator_names only stored the generic type ("Народний депутат України").
+-- bill_initiators = "; "-joined names; bill_initiator_ids = deputy person ids (link to deputies).
+
+ALTER TABLE bill_documents ADD COLUMN IF NOT EXISTS bill_initiators    TEXT;
+ALTER TABLE bill_documents ADD COLUMN IF NOT EXISTS bill_initiator_ids BIGINT[];
+
+CREATE INDEX IF NOT EXISTS idx_bill_documents_initiators_fts ON bill_documents
+  USING gin(to_tsvector('simple', coalesce(bill_initiators, '')));
+CREATE INDEX IF NOT EXISTS idx_bill_documents_initiator_ids ON bill_documents
+  USING gin(bill_initiator_ids);

--- a/mcp_rada/src/scripts/sync-bill-documents.ts
+++ b/mcp_rada/src/scripts/sync-bill-documents.ts
@@ -90,10 +90,44 @@ async function fetchFeed(conv: number): Promise<{ bills: any[]; modern: boolean 
   throw new Error(`No bill feed found for skl${conv} (billinfo/bills both 404)`);
 }
 
+// Extract the bill's initiators (co-sponsors) as a readable "; "-joined name list plus the
+// deputy person-ids (for linking to rada.deputies). Handles both feeds: modern wraps each
+// initiator in mp/inner/outter, legacy in `official`; all carry person {surname,firstname,
+// patronymic,id}. Bodies (President/Cabinet/committee) without a person fall back to the
+// post/organization/department label.
+function extractInitiators(bill: any): { names: string | null; ids: number[] } {
+  const arr = Array.isArray(bill.initiators)
+    ? bill.initiators
+    : Array.isArray(bill.authors)
+      ? bill.authors
+      : [];
+  const names: string[] = [];
+  const ids: number[] = [];
+  for (const ini of arr) {
+    if (typeof ini === 'string') {
+      const s = ini.trim();
+      if (s) names.push(s);
+      continue;
+    }
+    const slot = ini?.mp || ini?.inner || ini?.outter || ini?.official || ini || {};
+    const p = slot.person || null;
+    let nm = '';
+    if (p) {
+      nm = [p.surname, p.firstname, p.patronymic].filter(Boolean).join(' ').trim();
+      const pid = Number(p.id);
+      if (Number.isFinite(pid) && pid > 0) ids.push(pid);
+    }
+    if (!nm) nm = (slot.post || slot.organization || slot.department || '').trim();
+    if (nm) names.push(nm);
+  }
+  return { names: names.length ? names.join('; ') : null, ids };
+}
+
 // Map one workflow/source document to a bill_documents row (array in column order).
 function toRow(doc: any, bill: any, conv: number, group: 'workflow' | 'source'): any[] {
   const files = Array.isArray(doc.docFiles) ? doc.docFiles : [];
   const f0 = files[0] || {};
+  const bi = extractInitiators(bill);
   return [
     doc.id, // doc_id (PK)
     bill.id, // rada_bill_id
@@ -117,12 +151,15 @@ function toRow(doc: any, bill: any, conv: number, group: 'workflow' | 'source'):
     JSON.stringify(doc), // raw
     nz(bill.title || bill.name), // bill_title (modern feed uses `name`)
     nz(bill.subject), // bill_subject
+    bi.names, // bill_initiators
+    bi.ids.length ? bi.ids : null, // bill_initiator_ids
   ];
 }
 
 // Legacy `bills-sklN.json`: each doc is {date, type, uri}. The document id lives in the
 // uri's pf35401 param; there is no kindId / verdict / direct PDF.
 function toOldRow(id: number, doc: any, bill: any, conv: number, group: 'workflow' | 'source'): any[] {
+  const bi = extractInitiators(bill);
   return [
     id, // doc_id (PK) — pf35401 from uri
     bill.id, // rada_bill_id
@@ -146,6 +183,8 @@ function toOldRow(id: number, doc: any, bill: any, conv: number, group: 'workflo
     JSON.stringify(doc), // raw
     nz(bill.title || bill.name), // bill_title
     nz(bill.subject), // bill_subject
+    bi.names, // bill_initiators
+    bi.ids.length ? bi.ids : null, // bill_initiator_ids
   ];
 }
 
@@ -153,7 +192,7 @@ const COLS = [
   'doc_id', 'rada_bill_id', 'bill_number', 'convocation', 'doc_group', 'kind_id', 'kind',
   'registration_num', 'registration_date', 'outcoming_num', 'outcoming_date', 'publish_date',
   'meeting_date', 'short_review', 'formal_review', 'main_speaker', 'file_url', 'file_zip_url',
-  'doc_files', 'raw', 'bill_title', 'bill_subject',
+  'doc_files', 'raw', 'bill_title', 'bill_subject', 'bill_initiators', 'bill_initiator_ids',
 ];
 
 async function upsertBatch(rows: any[][]): Promise<number> {


### PR DESCRIPTION
Follow-up on LEXAI-1792: `rada.bills.initiator_names` only held the generic **type** ("Народний депутат України"), not the actual initiators. This adds the real initiator info from the same feed we already download.

## Change

Each initiator in the feed is a deputy (`mp` / legacy `official` → `person`: id + surname/firstname/patronymic), a committee (`inner`), or President/Cabinet (`outter` with post/organization). Extracted into two denormalized columns on `bill_documents` (all convocations, consistent with `bill_title`):

- `bill_initiators` TEXT — `"; "`-joined names (body post/org as fallback)
- `bill_initiator_ids` BIGINT[] — deputy person ids (link to `rada.deputies`)

Migration 009 adds the columns + a `bill_initiators` FTS index and a GIN index on `bill_initiator_ids`. Handles both feed shapes plus plain-string items.

## Verified on prod (re-synced all 7 convocations)

- **skl9: 100%** initiator coverage (50,208/50,210)
- Older convocations 34–56% — **source-limited** (those older bills carry no initiator data in the open-data feed; adding string-item handling didn't change it)
- Search works: `bill_initiators @@ 'Тимошенко'` → 3,106 docs / 739 bills
- `tsc --noEmit`: 0 errors

Note: `rada.bills.initiator_names` (used by the existing bill sync / MCP tools) still holds the wrong value — fixing that is a separate `BillService` change; this PR delivers correct initiators on the richer `bill_documents` asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Denormalized bill initiators onto `bill_documents` with real names and deputy person IDs to enable search and linking. Addresses LEXAI-1792 by replacing the previous generic initiator type.

- **New Features**
  - Added `bill_initiators` (TEXT, semicolon‑separated names) and `bill_initiator_ids` (BIGINT[], deputy person IDs) to `bill_documents`.
  - Extracts initiators from modern/legacy feeds; falls back to post/organization for bodies; handles plain-string items.
  - Added GIN FTS index on `bill_initiators` and GIN index on `bill_initiator_ids`.

- **Migration**
  - Run migration 009 to create the new columns and indexes.
  - Re-sync bill documents to backfill values across convocations.
  - Note: `rada.bills.initiator_names` remains unchanged; a separate `BillService` update will fix it.

<sup>Written for commit fb9cd5e9377eb46e977379af0898dd59d0acce0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

