### PR TITLE
fix(redis): raise REDIS_OP_TIMEOUT_MS 1000->2500 (stop spurious cache timeouts)

### DIFF
--- a/mcp_backend/src/infrastructure/adapters/cache-adapter.ts
+++ b/mcp_backend/src/infrastructure/adapters/cache-adapter.ts
@@ -14,7 +14,13 @@ type RedisClient = ReturnType<typeof createClient>;
 // request. Bound each op so a hung Redis fails fast and callers degrade (rate limiter → memory)
 // instead of holding the request open. The underlying command stays queued and runs on
 // reconnect, which is harmless for our cache/counter usage.
-const REDIS_OP_TIMEOUT_MS = Number(process.env.REDIS_OP_TIMEOUT_MS || 1000);
+//
+// Redis itself replies in ~0.1ms, so this budget is NOT about Redis latency — it absorbs
+// command-queue + event-loop lag on the single shared connection during heavy work (e.g. the
+// chat agentic loop parsing large tool results). At 1000ms that lag produced spurious
+// "Redis GET timed out" warnings on the hot path (LEXAI-1795); 2500ms clears them while still
+// failing fast on a genuinely dead socket (which keepAlive/pingInterval also detect ~30s).
+const REDIS_OP_TIMEOUT_MS = Number(process.env.REDIS_OP_TIMEOUT_MS || 2500);
 
 export class CacheAdapter implements ICachePort {
   private client: RedisClient;


### PR DESCRIPTION
## Problem (LEXAI-1795, mitigates LEXAI-1794)
Prod `/api/chat` logs frequently show `[ChatSearchCache] Redis GET timed out after 1000ms`.

Diagnosis on prod:
- Redis is fast — `redis-cli` latency ~0.1ms, `PING`→`PONG` instant, DB not saturated.
- The client (`redis-client.ts`) already has `keepAlive` + `pingInterval(30s)` + `reconnectStrategy`, so dead sockets are detected — this is **not** a dead-socket case.
- Root cause: the 1000ms budget is a `Promise.race` in `CacheAdapter.withTimeout`. It bounds command-queue + **event-loop lag** on the single shared node-redis connection (rate limiter on every route + all services + the deep agentic loop parsing large tool results). Under that load a GET's promise resolves >1000ms after issue even though Redis replied in microseconds.

## Fix
Raise the default op timeout `1000 → 2500ms` (still env-overridable via `REDIS_OP_TIMEOUT_MS`). Clears the false timeouts on the hot path; still fails fast on a genuinely hung socket (also covered by keepAlive/pingInterval).

## Relation to LEXAI-1794
These cascading 1s stalls inflated cache-backed tool latency (e.g. `search_legislation`), contributing to a heavy single tool call tripping the 300s MCP idle timeout. The `/api/chat` path already emits a 15s SSE heartbeat (`chat-inline-routes.ts:161`), so it was never at risk — only the MCP `/api/v2/mcp` single-tool path was, and this reduces that latency.

## Verification
`tsc` clean (only pre-existing core-loader stubs). Post-deploy: confirm the warning disappears from logs and `search_legislation` via MCP returns well under the idle timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the Redis op timeout from 1000ms to 2500ms to stop false cache timeouts under event‑loop lag. This improves chat/MCP reliability and reduces worst‑case latency. Addresses LEXAI-1795 and mitigates LEXAI-1794.

- **Bug Fixes**
  - Bump default `REDIS_OP_TIMEOUT_MS` to 2500ms (still env‑overridable).
  - Resolves spurious "[ChatSearchCache] Redis GET timed out" caused by command‑queue/event‑loop lag on the shared connection, not Redis latency.
  - Cuts cascading stalls in MCP tool calls (helps LEXAI-1794) while still failing fast on real socket issues.

<sup>Written for commit eaf5a28bb36bafa3b2622a40dba619c40613c1ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

