### PR TITLE
fix(deps): bump transformers to >=5.3.0 (CVE-2026-4372 RCE)

### DIFF
--- a/scripts/citation-graph/requirements_embed.txt
+++ b/scripts/citation-graph/requirements_embed.txt
@@ -1,7 +1,8 @@
 # torch>=2.6 base image (pytorch-training 2.8.0) lifts the torch.load(.bin)
 # restriction added in transformers>=4.50 (CVE-2025-32434), so bge-m3's
-# pytorch_model.bin loads fine. >=4.53 clears the ReDoS/Trainer advisories.
-transformers>=4.53,<5
+# pytorch_model.bin loads fine. >=5.3.0 clears the config.json RCE
+# (CVE-2026-4372, GHSA-29pf-2h5f-8g72).
+transformers>=5.3.0,<6
 mlflow>=2.10
 pyarrow>=15
 sentencepiece


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #246 (GHSA-29pf-2h5f-8g72 / CVE-2026-4372, high severity)
- `transformers < 5.3.0` allows RCE via a crafted `config.json` `_attn_implementation_internal` field that bypasses `trust_remote_code` and executes arbitrary code on `AutoModelForCausalLM.from_pretrained()`
- Old pin `>=4.53,<5` could never resolve to a patched version; bumped to `>=5.3.0,<6`
- Scope: `scripts/citation-graph/requirements_embed.txt` only (bge-m3 embedding jobs) — no runtime service depends on this file

## Test plan
- [ ] Dependabot alert #246 auto-closes once merged
- [ ] Next embedding job run picks up transformers>=5.3.0 without breaking bge-m3 model loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `transformers` to `>=5.3.0,<6` to patch CVE-2026-4372 (RCE) in model config loading for embedding jobs. Change is limited to `scripts/citation-graph/requirements_embed.txt` (bge-m3) and does not affect runtime services; resolves Dependabot alert #246.

<sup>Written for commit 3241d9294d635e59ea34a2677315cf51b941f3f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

