### PR TITLE
feat(rada): search_bill_documents MCP tool (ГНЕУ conclusions + bill docs)

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -247,9 +247,10 @@ export class ToolRegistry {
     // Backend tool routes are created dynamically by registerHandler().
     // Only remote (proxy) tools need hardcoded routes.
 
-    // ========== RADA Tools (4 tools) - Prefix 'rada_', HTTP proxy ==========
+    // ========== RADA Tools (5 tools) - Prefix 'rada_', HTTP proxy ==========
     const radaTools = [
       { clientName: 'rada_search_parliament_bills', serviceName: 'search_parliament_bills' },
+      { clientName: 'rada_search_bill_documents', serviceName: 'search_bill_documents' },
       { clientName: 'rada_get_deputy_info', serviceName: 'get_deputy_info' },
       { clientName: 'rada_search_legislation_text', serviceName: 'search_legislation_text' },
       { clientName: 'rada_analyze_voting_record', serviceName: 'analyze_voting_record' },

--- a/mcp_backend/src/migrations/168_add_rada_bill_documents_pricing.sql
+++ b/mcp_backend/src/migrations/168_add_rada_bill_documents_pricing.sql
@@ -1,0 +1,13 @@
+-- Migration 168: Pricing for the new rada_search_bill_documents tool.
+-- Non-LLM DB/FTS lookup (ГНЕУ conclusions + bill supporting documents), priced like
+-- rada_search_parliament_bills at its post-139 reduced base cost. Idempotent.
+
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes)
+VALUES (
+  'rada_search_bill_documents',
+  'rada',
+  'Пошук документів законопроєктів (ГНЕУ, висновки комітетів)',
+  0.00100000,
+  'FTS по вердиктах ГНЕУ/комітетів + назві законопроєкту; DB lookup, без LLM'
+)
+ON CONFLICT (tool_name) DO NOTHING;

--- a/mcp_rada/src/api/__tests__/all-rada-tools-integration.test.ts
+++ b/mcp_rada/src/api/__tests__/all-rada-tools-integration.test.ts
@@ -58,8 +58,8 @@ describe('RADA MCP Tools - Integration Tests', () => {
       const response = await client.get('/api/tools');
       expect(response.status).toBe(200);
       expect(response.data.tools).toBeDefined();
-      expect(response.data.tools.length).toBe(4);
-      expect(response.data.count).toBe(4);
+      expect(response.data.tools.length).toBe(5);
+      expect(response.data.count).toBe(5);
     });
   });
 

--- a/mcp_rada/src/api/__tests__/smoke-test-rada-tools.test.ts
+++ b/mcp_rada/src/api/__tests__/smoke-test-rada-tools.test.ts
@@ -34,12 +34,19 @@ describe('RADA MCP Tools - Smoke Tests', () => {
 
   test('List all tools', async () => {
     const response = await client.get('/api/tools');
-    expect(response.data.tools.length).toBe(4);
+    expect(response.data.tools.length).toBe(5);
   });
 
   test('search_parliament_bills works', async () => {
     const result = await callTool('search_parliament_bills', {
       query: 'бюджет', limit: 3
+    });
+    expect(result.success).toBe(true);
+  }, 30000);
+
+  test('search_bill_documents works', async () => {
+    const result = await callTool('search_bill_documents', {
+      query: 'торговельні марки', doc_kind: 'gneu', limit: 3
     });
     expect(result.success).toBe(true);
   }, 30000);

--- a/mcp_rada/src/api/mcp-rada-api.ts
+++ b/mcp_rada/src/api/mcp-rada-api.ts
@@ -11,6 +11,7 @@ import { CrossReferenceService } from '../services/cross-reference-service';
 import { CostTracker } from '../services/cost-tracker';
 import {
   SearchParliamentBillsArgs,
+  SearchBillDocumentsArgs,
   GetDeputyInfoArgs,
   SearchLegislationTextArgs,
   AnalyzeVotingRecordArgs,
@@ -79,6 +80,54 @@ export class MCPRadaAPI {
             },
           },
           required: ['query'],
+        },
+      },
+      {
+        name: 'search_bill_documents',
+        description: `Пошук супровідних документів законопроєктів: висновки ГНЕУ (Головного науково-експертного управління), висновки комітетів, зауваження Головного юридичного управління тощо.
+
+💰 Примерная стоимость: $0.005-$0.02 USD
+Повнотекстовий пошук по вердиктах експертів (short_review/formal_review) та назві законопроєкту. Дозволяє простежити законодавчий намір і експертну критику норми: від правки закону → до законопроєкту → до висновку ГНЕУ. Кожен результат містить вердикт і посилання на PDF.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: {
+              type: 'string',
+              description: 'Пошуковий запит по тексту вердикту або назві законопроєкту (напр. "торговельні марки", "недійсність свідоцтва")',
+            },
+            bill_number: {
+              type: 'string',
+              description: 'Точний номер законопроєкту (напр. "13110", "11229-1")',
+            },
+            doc_kind: {
+              type: 'string',
+              enum: ['gneu', 'committee', 'legal', 'all'],
+              default: 'all',
+              description: 'Тип документа: gneu — висновок ГНЕУ; committee — висновок комітету; legal — зауваження Головного юридичного управління; all — усі',
+            },
+            convocation: {
+              type: 'number',
+              description: 'Скликання Верховної Ради (9, 8, ... 3)',
+            },
+            initiator: {
+              type: 'string',
+              description: 'Ініціатор законопроєкту (ПІБ депутата, орган) — пошук у списку ініціаторів',
+            },
+            date_from: {
+              type: 'string',
+              description: 'Дата початку періоду реєстрації документа (формат: YYYY-MM-DD)',
+            },
+            date_to: {
+              type: 'string',
+              description: 'Дата кінця періоду реєстрації документа (формат: YYYY-MM-DD)',
+            },
+            limit: {
+              type: 'number',
+              default: 20,
+              description: 'Максимальна кількість результатів (1-100)',
+            },
+          },
+          required: [],
         },
       },
       {
@@ -190,6 +239,8 @@ export class MCPRadaAPI {
       switch (name) {
         case 'search_parliament_bills':
           return await this.searchParliamentBills(args);
+        case 'search_bill_documents':
+          return await this.searchBillDocuments(args);
         case 'get_deputy_info':
           return await this.getDeputyInfo(args);
         case 'search_legislation_text':
@@ -258,6 +309,56 @@ export class MCPRadaAPI {
     } catch (error: any) {
       logger.error('Failed to search bills', { error: error.message });
       throw new Error(`Failed to search bills: ${error.message}`);
+    }
+  }
+
+  private async searchBillDocuments(args: SearchBillDocumentsArgs) {
+    logger.info('Searching bill documents', {
+      query: args.query,
+      doc_kind: args.doc_kind,
+      bill_number: args.bill_number,
+    });
+
+    try {
+      const { documents, total } = await this.billService.searchBillDocuments({
+        query: args.query,
+        bill_number: args.bill_number,
+        doc_kind: args.doc_kind,
+        convocation: args.convocation,
+        initiator: args.initiator,
+        date_from: args.date_from,
+        date_to: args.date_to,
+        limit: args.limit || 20,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({
+              query: args.query || null,
+              doc_kind: args.doc_kind || 'all',
+              total_found: total,
+              documents: documents.map((d: any) => ({
+                bill_number: d.bill_number,
+                bill_title: d.bill_title,
+                bill_subject: d.bill_subject,
+                convocation: d.convocation,
+                kind: d.kind,
+                is_gneu: d.kind_id === 100 || /науково-експерт/i.test(d.kind || ''),
+                registration_date: d.registration_date,
+                verdict: d.short_review || d.formal_review || null,
+                initiators: d.bill_initiators,
+                pdf_url: d.file_url,
+                signed_archive_url: d.file_zip_url,
+              })),
+            }, null, 2),
+          },
+        ],
+      };
+    } catch (error: any) {
+      logger.error('Failed to search bill documents', { error: error.message });
+      throw new Error(`Failed to search bill documents: ${error.message}`);
     }
   }
 

--- a/mcp_rada/src/services/bill-service.ts
+++ b/mcp_rada/src/services/bill-service.ts
@@ -194,6 +194,125 @@ export class BillService {
   }
 
   /**
+   * Build a `simple`-config prefix tsquery from free text.
+   * The bill_documents FTS indexes use the 'simple' config (no Ukrainian stemmer),
+   * so we match on word prefixes (`слов:*`) to tolerate inflected forms.
+   * Returns '' when the input has no usable tokens.
+   */
+  private toPrefixTsQuery(input: string): string {
+    const tokens = (input.match(/[\p{L}\p{N}]+/gu) || [])
+      .map(t => t.toLowerCase())
+      .filter(t => t.length > 1);
+    return tokens.map(t => `${t}:*`).join(' & ');
+  }
+
+  /**
+   * Search bill supporting documents (rada.bill_documents): ГНЕУ scientific-expert
+   * conclusions, committee conclusions, legal-office remarks, etc. Full-text over the
+   * verdict summaries (short_review/formal_review/full_text) + bill title, with filters
+   * by document kind, bill number, convocation, initiator and registration date.
+   */
+  async searchBillDocuments(params: {
+    query?: string;
+    bill_number?: string;
+    doc_kind?: 'gneu' | 'committee' | 'legal' | 'all';
+    convocation?: number;
+    initiator?: string;
+    date_from?: string;
+    date_to?: string;
+    limit?: number;
+  }): Promise<{ documents: any[]; total: number }> {
+    if (params.date_from && !this.validateDateFormat(params.date_from)) {
+      throw new Error(
+        `Invalid date_from format: "${params.date_from}". Expected YYYY-MM-DD (e.g., 2024-01-15)`
+      );
+    }
+    if (params.date_to && !this.validateDateFormat(params.date_to)) {
+      throw new Error(
+        `Invalid date_to format: "${params.date_to}". Expected YYYY-MM-DD (e.g., 2024-12-31)`
+      );
+    }
+
+    let sql = `
+      SELECT doc_id, bill_number, convocation, kind, kind_id,
+             registration_date, publish_date,
+             short_review, formal_review,
+             bill_title, bill_subject, bill_initiators,
+             file_url, file_zip_url
+      FROM bill_documents
+      WHERE 1=1`;
+    const queryParams: any[] = [];
+    let i = 1;
+
+    // Full-text over verdict summaries + bill title
+    if (params.query) {
+      const tsq = this.toPrefixTsQuery(params.query);
+      if (tsq) {
+        sql += ` AND (
+          to_tsvector('simple', coalesce(short_review,'') || ' ' || coalesce(formal_review,'') || ' ' || coalesce(full_text,'')) @@ to_tsquery('simple', $${i})
+          OR to_tsvector('simple', coalesce(bill_title,'')) @@ to_tsquery('simple', $${i})
+        )`;
+        queryParams.push(tsq);
+        i++;
+      }
+    }
+
+    if (params.bill_number) {
+      sql += ` AND bill_number = $${i}`;
+      queryParams.push(params.bill_number);
+      i++;
+    }
+
+    // Document kind filter
+    switch (params.doc_kind) {
+      case 'gneu':
+        sql += ` AND (kind_id = 100 OR kind ILIKE '%науково-експерт%')`;
+        break;
+      case 'committee':
+        sql += ` AND kind ILIKE '%комітет%'`;
+        break;
+      case 'legal':
+        sql += ` AND kind ILIKE '%юридичн%'`;
+        break;
+      // 'all' or undefined → no kind filter
+    }
+
+    if (params.convocation) {
+      sql += ` AND convocation = $${i}`;
+      queryParams.push(params.convocation);
+      i++;
+    }
+
+    if (params.initiator) {
+      sql += ` AND bill_initiators ILIKE $${i}`;
+      queryParams.push(`%${params.initiator}%`);
+      i++;
+    }
+
+    if (params.date_from) {
+      sql += ` AND registration_date >= $${i}`;
+      queryParams.push(params.date_from);
+      i++;
+    }
+    if (params.date_to) {
+      sql += ` AND registration_date <= $${i}`;
+      queryParams.push(params.date_to);
+      i++;
+    }
+
+    const limit = Math.min(Math.max(params.limit || 20, 1), 100);
+    sql += ` ORDER BY registration_date DESC NULLS LAST LIMIT ${limit}`;
+
+    const result = await this.db.query(sql, queryParams);
+    logger.info('Bill documents search completed', {
+      query: params.query,
+      doc_kind: params.doc_kind,
+      found: result.rows.length,
+    });
+    return { documents: result.rows, total: result.rows.length };
+  }
+
+  /**
    * Sync recent bills (last 30 days)
    */
   async syncRecentBills(convocation: number = 9): Promise<number> {

--- a/mcp_rada/src/types/rada.ts
+++ b/mcp_rada/src/types/rada.ts
@@ -124,6 +124,17 @@ export interface SearchParliamentBillsArgs {
   limit?: number;
 }
 
+export interface SearchBillDocumentsArgs {
+  query?: string;
+  bill_number?: string;
+  doc_kind?: 'gneu' | 'committee' | 'legal' | 'all';
+  convocation?: number;
+  initiator?: string;
+  date_from?: string;
+  date_to?: string;
+  limit?: number;
+}
+
 export interface GetDeputyInfoArgs {
   name?: string;
   rada_id?: string;


### PR DESCRIPTION
## Що це

Новий MCP-інструмент **`search_bill_documents`** (через gateway — `rada_search_bill_documents`), що віддає таблицю `rada.bill_documents` — **241 648 супровідних документів законопроєктів / 19 339 висновків ГНЕУ** (скликання 9–3).

## Навіщо (демо для MSP / практика ІВ)

Додає до демо шар **«законодавчого наміру»** поверх історичних редакцій норм: від конкретної норми (напр. ст. 6 ЗУ №3689-XII про знаки для товарів) → до закону-поправки → до **науково-експертного висновку ГНЕУ**, що пояснює зміну та експертну критику. На проді є **87 висновків ГНЕУ саме на ІВ-законопроектах** (ТМ, винаходи, промзразки, авторське право).

## Можливості інструмента

Повнотекстовий пошук (`simple`-конфіг, префіксне співставлення під наявні GIN-індекси) по вердиктах експертів (`short_review`/`formal_review`) + назві законопроєкту. Фільтри:
- `query` — вільний текст
- `doc_kind` — `gneu` / `committee` / `legal` / `all`
- `bill_number`, `convocation`, `initiator`, `date_from`/`date_to`, `limit`

Кожен результат містить вердикт, тип документа, ініціаторів і **пряме посилання на PDF**.

## Зміни

- **mcp_rada**: `BillService.searchBillDocuments` (параметризований SQL, збігається з FTS-індексами `bill_documents`), схема інструмента + хендлер + `SearchBillDocumentsArgs`.
- **gateway** (`mcp_backend/tool-registry.ts`): маршрут `rada_search_bill_documents` (4→5 RADA-інструментів).
- **pricing**: міграція 168 — non-LLM DB-lookup, ціна як в інших rada-інструментів (`0.001`).
- **tests**: лічильник інструментів 4→5, smoke-тест на новий інструмент.

## Перевірено

- ✅ `mcp_rada` збірка чиста (`tsc`).
- ✅ SQL інструмента прогнано на проді (`secondlayer_prod.rada`): повертає ГНЕУ по ТМ-законопроектах із вердиктами й PDF.
- ✅ rada-сервіс підключений до `secondlayer_prod` (schema `rada`); `rada_mcp` має `SELECT` на `bill_documents`.
- ℹ️ Прееxистуючі помилки збірки `mcp_backend` у `core-loader.ts` (модулі з `secondlayer-core`) не стосуються цих змін — присутні на `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new MCP tool `search_bill_documents` (gateway `rada_search_bill_documents`) to search supporting bill documents and GNEU conclusions from `rada.bill_documents`. This surfaces legislative intent with verdict summaries and direct PDF links.

- **New Features**
  - Full‑text search over expert verdicts and bill titles (prefix FTS, `simple` config, uses existing GIN indexes).
  - Filters: `doc_kind` (`gneu`/`committee`/`legal`/`all`), `bill_number`, `convocation`, `initiator`, `date_from`/`date_to`, `limit`.
  - Returns verdict summary, kind, initiators, dates, PDF URL (and signed archive when available).
  - API and gateway wired: tool schema + handler in `mcp_rada`; `mcp_backend` registers `rada_search_bill_documents`. Tests updated; tool count 4→5 with a smoke test.

- **Migration**
  - Run `168_add_rada_bill_documents_pricing.sql` to set pricing (`0.001` base cost; non‑LLM DB/FTS lookup).
  - Ensure `mcp_rada` has `SELECT` on `rada.bill_documents`.

<sup>Written for commit 06ffd952dc6b00625341f1252728e894ce5c1b05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

