### PR TITLE
fix(legislation): semantic fallback for missing AI-resolved articles + IP laws in classifier

### DIFF
--- a/mcp_backend/src/api/__tests__/legislation-search-fallback.test.ts
+++ b/mcp_backend/src/api/__tests__/legislation-search-fallback.test.ts
@@ -1,0 +1,99 @@
+import { LegislationTools } from '../legislation-tools';
+
+/**
+ * Regression for the MSP IP-demo miss (2026-07-01): the AI classifier hallucinated a
+ * rada_id ("строк чинності патенту на винахід" → 3769-12 замість 3687-12), the guessed
+ * article did not exist, and searchLegislation early-returned "Пункт/стаття не знайдено"
+ * with 0 results — never reaching semantic search, which had the right answer all along.
+ * When the AI-resolved article is missing, the handler must fall back to semantic search
+ * (scoped + unscoped) before giving up.
+ */
+
+const patentArticle = {
+  rada_id: '3687-12',
+  article_number: '6',
+  title: 'Умови надання правової охорони',
+  full_text: 'Строк дії патенту на винахід становить 20 років...',
+  url: 'https://zakon.rada.gov.ua/laws/show/3687-12#n6',
+  npa_title: 'Про охорону прав на винаходи і корисні моделі',
+};
+
+function buildTools(overrides: Partial<Record<string, jest.Mock>> = {}) {
+  const service: any = {
+    parseArticleReferenceWithAI: jest.fn().mockResolvedValue({
+      radaId: '3769-12',
+      articleNumber: '7',
+      source: 'ai',
+      confidence: 0.85,
+    }),
+    getArticle: jest.fn().mockResolvedValue(null),
+    findRelevantArticles: jest.fn().mockResolvedValue([patentArticle]),
+    getLegislationStructure: jest.fn().mockResolvedValue(null),
+    ...overrides,
+  };
+  const renderer: any = { renderArticleHTML: jest.fn(), renderMultipleArticlesHTML: jest.fn() };
+  return { tools: new LegislationTools(service, renderer), service };
+}
+
+describe('search_legislation semantic fallback when AI-resolved article is missing', () => {
+  it('falls back to semantic search instead of terminal "не знайдено"', async () => {
+    const { tools, service } = buildTools();
+
+    const result = await tools.searchLegislation({ query: 'строк чинності патенту на винахід' });
+
+    expect(result.total_found).toBe(1);
+    expect(result.articles[0].rada_id).toBe('3687-12');
+    expect(result.articles[0].article_number).toBe('6');
+    expect(result.resolved_reference.not_found).toBe(true);
+    // Both scoped (guessed act) and unscoped searches must run
+    expect(service.findRelevantArticles).toHaveBeenCalledWith(
+      'строк чинності патенту на винахід', '3769-12', 10
+    );
+    expect(service.findRelevantArticles).toHaveBeenCalledWith(
+      'строк чинності патенту на винахід', undefined, 10
+    );
+  });
+
+  it('dedups scoped/unscoped hits by rada_id:article_number', async () => {
+    const { tools } = buildTools({
+      findRelevantArticles: jest.fn().mockResolvedValue([patentArticle, patentArticle]),
+    });
+
+    const result = await tools.searchLegislation({ query: 'строк чинності патенту' });
+    expect(result.total_found).toBe(1);
+  });
+
+  it('keeps the legacy structure hint when semantic fallback finds nothing', async () => {
+    const { tools } = buildTools({
+      findRelevantArticles: jest.fn().mockResolvedValue([]),
+      getLegislationStructure: jest.fn().mockResolvedValue({
+        title: 'Про введення в дію…',
+        total_articles: 3,
+      }),
+    });
+
+    const result = await tools.searchLegislation({ query: 'строк чинності патенту' });
+    expect(result.total_found).toBe(0);
+    expect(result.legislation_found.rada_id).toBe('3769-12');
+    expect(result.suggestion).toContain('не знайдено');
+  });
+
+  it('still returns the article directly when it exists (no fallback)', async () => {
+    const { tools, service } = buildTools({
+      getArticle: jest.fn().mockResolvedValue({
+        ...patentArticle,
+        rada_id: '3687-12',
+      }),
+      parseArticleReferenceWithAI: jest.fn().mockResolvedValue({
+        radaId: '3687-12',
+        articleNumber: '6',
+        source: 'ai',
+        confidence: 0.95,
+      }),
+    });
+
+    const result = await tools.searchLegislation({ query: 'строк дії патенту на винахід' });
+    expect(result.articles[0].article_number).toBe('6');
+    expect(result.resolved_reference.not_found).toBeUndefined();
+  });
+});

--- a/mcp_backend/src/api/legislation-tools.ts
+++ b/mcp_backend/src/api/legislation-tools.ts
@@ -324,7 +324,63 @@ export class LegislationTools extends BaseToolHandler {
       if (directRef.articleNumber) {
         const article = await this.service.getArticle(resolvedRadaId, directRef.articleNumber);
         if (!article) {
-          // Article not found but legislation exists — return structure
+          // AI-визначена стаття не існує — класифікатор міг вгадати не той закон або номер
+          // (на його боці немає retrieval/grounding). Замість термінального "не знайдено"
+          // пробуємо семантичний пошук: у межах вгаданого акту та по всьому законодавству
+          // (сам факт "стаття відсутня" — сильний сигнал, що і закон може бути не той).
+          try {
+            const [scoped, unscoped] = await Promise.all([
+              this.service.findRelevantArticles(args.query, resolvedRadaId, limit),
+              this.service.findRelevantArticles(args.query, undefined, limit),
+            ]);
+            const seen = new Set<string>();
+            const fallbackArticles: any[] = [];
+            for (const a of [...unscoped, ...scoped]) {
+              if (fallbackArticles.length >= limit) break;
+              const key = `${a.rada_id}:${a.article_number}`;
+              if (seen.has(key)) continue;
+              seen.add(key);
+              fallbackArticles.push({
+                rada_id: a.rada_id,
+                article_number: a.article_number,
+                title: a.title,
+                full_text: capText(a.full_text),
+                url: a.url,
+                npa_title: a.npa_title,
+                section_number: a.section_number,
+                section_title: a.section_title,
+                chapter_number: a.chapter_number,
+                chapter_title: a.chapter_title,
+              });
+            }
+            if (fallbackArticles.length > 0) {
+              logger.info('[MCP Tool] search_legislation: AI-resolved article missing, semantic fallback', {
+                rada_id: resolvedRadaId,
+                ai_article: directRef.articleNumber,
+                confidence: directRef.confidence,
+                fallback_count: fallbackArticles.length,
+              });
+              return {
+                query: args.query,
+                resolved_reference: {
+                  rada_id: resolvedRadaId,
+                  article_number: directRef.articleNumber,
+                  source: directRef.source,
+                  confidence: directRef.confidence,
+                  not_found: true,
+                },
+                total_found: fallbackArticles.length,
+                articles: fallbackArticles,
+                note: `Стаття ${directRef.articleNumber} не знайдена в ${resolvedRadaId} — показано релевантні статті за семантичним пошуком.`,
+              };
+            }
+          } catch (err: any) {
+            logger.warn('[MCP Tool] search_legislation semantic fallback failed', {
+              error: err?.message,
+            });
+          }
+
+          // Семантичний fallback нічого не дав — повертаємо структуру акту, якщо він існує
           const structure = await this.service.getLegislationStructure(resolvedRadaId);
           return {
             query: args.query,

--- a/mcp_backend/src/services/__tests__/legislation-classifier.test.ts
+++ b/mcp_backend/src/services/__tests__/legislation-classifier.test.ts
@@ -1,0 +1,76 @@
+import { LegislationClassifier } from '../legislation-classifier';
+import type { ILLMPort } from '../../domain/ports/index.js';
+
+/**
+ * Regression for the MSP IP-demo miss (2026-07-01): the quick-tier classifier returned
+ * article_number as the literal string "null" ("майнові права автора" → 435-15 / "null"),
+ * which downstream treated as a real article number and terminally failed with
+ * "стаття не знайдена". The classifier must sanitize "null"-like strings to real null.
+ * It also hallucinated rada_ids for the 4 IP laws because they were absent from
+ * CODE_MAPPINGS — they must be present so the prompt grounds the LLM.
+ */
+
+function mockLLM(jsonResponse: object): ILLMPort {
+  return {
+    chatCompletion: jest.fn().mockResolvedValue({ content: JSON.stringify(jsonResponse) }),
+    chatCompletionStream: jest.fn(),
+    isAvailable: jest.fn().mockReturnValue(true),
+    setCostTracker: jest.fn(),
+  } as unknown as ILLMPort;
+}
+
+describe('LegislationClassifier normalization', () => {
+  it('sanitizes literal "null" article_number to real null', async () => {
+    const classifier = new LegislationClassifier(undefined, mockLLM({
+      rada_id: '435-15',
+      article_number: 'null',
+      confidence: 0.75,
+    }));
+
+    const result = await classifier.classify('майнові права автора');
+    expect(result.rada_id).toBe('435-15');
+    expect(result.article_number).toBeNull();
+  });
+
+  it('sanitizes "None"/"undefined"/empty strings in both fields', async () => {
+    for (const bad of ['None', 'undefined', '  ']) {
+      const classifier = new LegislationClassifier(undefined, mockLLM({
+        rada_id: bad,
+        article_number: bad,
+        confidence: 0.8,
+      }));
+      const result = await classifier.classify('запит');
+      expect(result.rada_id).toBeNull();
+      expect(result.article_number).toBeNull();
+    }
+  });
+
+  it('keeps legitimate values untouched', async () => {
+    const classifier = new LegislationClassifier(undefined, mockLLM({
+      rada_id: '3689-12',
+      article_number: '6',
+      confidence: 0.95,
+    }));
+
+    const result = await classifier.classify('підстави відмови в реєстрації торговельної марки');
+    expect(result.rada_id).toBe('3689-12');
+    expect(result.article_number).toBe('6');
+  });
+});
+
+describe('LegislationClassifier CODE_MAPPINGS covers the 4 IP laws', () => {
+  const mappings = (new LegislationClassifier() as any).CODE_MAPPINGS as Record<
+    string,
+    { rada_id: string; full_name: string }
+  >;
+  const radaIds = new Set(Object.values(mappings).map(m => m.rada_id));
+
+  it.each([
+    ['3689-12', 'торговельні марки'],
+    ['3687-12', 'винаходи і корисні моделі'],
+    ['3688-12', 'промислові зразки'],
+    ['2811-20', 'авторське право'],
+  ])('includes %s (%s)', (radaId) => {
+    expect(radaIds.has(radaId)).toBe(true);
+  });
+});

--- a/mcp_backend/src/services/legislation-classifier.ts
+++ b/mcp_backend/src/services/legislation-classifier.ts
@@ -43,6 +43,10 @@ export class LegislationClassifier {
     'ЗУ про статус ветеранів': { rada_id: '3551-12', full_name: 'Закон про статус ветеранів війни' },
     'Дисциплінарний статут': { rada_id: '551-14', full_name: 'Дисциплінарний статут Збройних Сил України' },
     'Статут внутрішньої служби': { rada_id: '548-14', full_name: 'Статут внутрішньої служби Збройних Сил України' },
+    'ЗУ про торговельні марки': { rada_id: '3689-12', full_name: 'Закон про охорону прав на знаки для товарів і послуг (торговельні марки)' },
+    'ЗУ про винаходи': { rada_id: '3687-12', full_name: 'Закон про охорону прав на винаходи і корисні моделі (патенти)' },
+    'ЗУ про промислові зразки': { rada_id: '3688-12', full_name: 'Закон про охорону прав на промислові зразки' },
+    'ЗУ про авторське право': { rada_id: '2811-20', full_name: 'Закон про авторське право і суміжні права' },
   };
 
   constructor(redis?: ICachePort, private readonly llm?: ILLMPort) {
@@ -208,10 +212,19 @@ ${availableCodes}
 
     const result = JSON.parse(content);
 
+    // LLM іноді повертає літеральний рядок "null"/"none" замість JSON null — без
+    // санітизації downstream шукає статтю з номером "null" і термінально фейлиться.
+    const sanitizeField = (value: unknown): string | null => {
+      if (value === null || value === undefined) return null;
+      const s = String(value).trim();
+      if (!s || ['null', 'none', 'undefined'].includes(s.toLowerCase())) return null;
+      return s;
+    };
+
     // Валидация и нормализация результата
     const classification: LegislationClassification = {
-      rada_id: result.rada_id || null,
-      article_number: result.article_number ? String(result.article_number).trim() : null,
+      rada_id: sanitizeField(result.rada_id),
+      article_number: sanitizeField(result.article_number),
       confidence: Math.max(0, Math.min(1, Number(result.confidence) || 0)),
       code_name: result.code_name || undefined,
       reasoning: result.reasoning || undefined,


### PR DESCRIPTION
## Problem

During MSP IP-demo prep (2026-07-01), `search_legislation` returned 0 results for patent/copyright queries even though the vectors for all 4 IP laws were healthy in Qdrant (`legal_sections`, scores 0.65–0.75). The failure chain:

1. `LegislationClassifier.CODE_MAPPINGS` had no IP laws, so the quick-tier LLM hallucinated rada_ids («строк чинності патенту на винахід» → **3769-12** instead of 3687-12) with confidence ≥0.7, and the bad guess was cached in Redis for **7 days**.
2. The classifier sometimes returned `article_number` as the literal string `"null"` («майнові права автора» → 435-15 / `"null"`).
3. When the guessed article didn't exist, `searchLegislation` early-returned «Пункт/стаття не знайдено» with 0 results — never falling back to semantic search, which had the right answer all along.

## Fix

- **legislation-classifier.ts**: added the 4 IP laws to `CODE_MAPPINGS` (3689-12 торговельні марки, 3687-12 винаходи, 3688-12 промислові зразки, 2811-20 авторське право); sanitize literal `"null"`/`"none"`/`"undefined"` strings in `rada_id`/`article_number` to real `null`.
- **legislation-tools.ts**: when the AI-resolved article is missing, fall back to semantic `findRelevantArticles` (scoped to the guessed act **+ unscoped**, deduped, capped at `limit`) before the terminal «не знайдено» response. The structure hint is preserved when the fallback also finds nothing. Response marks `resolved_reference.not_found: true` and adds a note.

## Testing

- New `legislation-classifier.test.ts`: "null"-string sanitization (both fields), legit values untouched, all 4 IP rada_ids present in mappings.
- New `legislation-search-fallback.test.ts`: fallback returns semantic hits with `not_found: true`, scoped+unscoped calls, dedup, legacy structure hint when fallback is empty, no fallback when the article exists.
- `npx jest legislation-classifier legislation-search-fallback legislation-grounding` → 15/15 pass.
- `tsc`: only pre-existing core-loader stub errors (proprietary modules synced in CI); no errors in touched files.

Note: poisoned `leg_classify:` Redis keys on prod were already purged and re-seeded with verified classifications (TTL ~9 Jul); this PR is the durable fix so rephrased queries stop re-hallucinating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-result misses for IP law queries by grounding the classifier with IP codes and adding a semantic fallback when the resolved article doesn’t exist. Users now see relevant articles instead of a terminal not-found response.

- **Bug Fixes**
  - Added 4 IP laws to classifier mappings: 3689-12 (trademarks), 3687-12 (inventions), 3688-12 (industrial designs), 2811-20 (copyright).
  - Sanitized literal "null"/"none"/"undefined" in `rada_id` and `article_number` to real nulls.
  - `search_legislation`: when a direct article isn’t found, run semantic search (scoped to the guessed act + unscoped), dedupe and cap by limit; preserve structure hint when empty; tag response with `resolved_reference.not_found` and add a note.

<sup>Written for commit 513de2f8c54fa02131f59bf81ec975d612c36a10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

