### PR TITLE
feat(scale): RUN_SCHEDULER flag to gate crons + background workers

### DIFF
--- a/mcp_backend/src/factories/app-services.ts
+++ b/mcp_backend/src/factories/app-services.ts
@@ -163,8 +163,14 @@ export function createAppServices(
     coreServices.db,
     coreServices.documentService
   );
-  uploadQueueService.startWorker();
-  logger.info('BullMQ upload queue service initialized');
+  // Consume the (Redis/BullMQ) upload queue on the scheduler instance only; web replicas
+  // still enqueue jobs but don't process them (heavy OCR/doc work stays off web) (LEXAI-1802).
+  if (process.env.RUN_SCHEDULER !== 'false') {
+    uploadQueueService.startWorker();
+    logger.info('BullMQ upload queue worker started (scheduler instance)');
+  } else {
+    logger.info('BullMQ upload queue service initialized (worker disabled: RUN_SCHEDULER=false)');
+  }
 
   // Prometheus metrics service + wiring
   const metricsService = new MetricsService();

--- a/mcp_backend/src/factories/billing-services.ts
+++ b/mcp_backend/src/factories/billing-services.ts
@@ -60,13 +60,17 @@ export function createBillingServices(db: Database, embeddingService: EmbeddingS
     logger.warn('[BillingServices] Initial NBU rate fetch failed', { error: (err as Error).message });
   });
 
-  // Schedule daily NBU rate refresh at 6:00 AM Kyiv time
-  cron.schedule('0 6 * * *', () => {
-    logger.info('[BillingServices] Running scheduled NBU rate refresh');
-    currencyService.refreshRate().catch(err => {
-      logger.error('[BillingServices] Scheduled NBU rate refresh failed', { error: (err as Error).message });
-    });
-  }, { timezone: 'Europe/Kyiv' });
+  // Schedule daily NBU rate refresh at 6:00 AM Kyiv time — scheduler instance only
+  // (RUN_SCHEDULER!=false) so N web replicas don't each refresh (LEXAI-1802). The initial
+  // fetch above stays on every instance (idempotent, warms the rate locally).
+  if (process.env.RUN_SCHEDULER !== 'false') {
+    cron.schedule('0 6 * * *', () => {
+      logger.info('[BillingServices] Running scheduled NBU rate refresh');
+      currencyService.refreshRate().catch(err => {
+        logger.error('[BillingServices] Scheduled NBU rate refresh failed', { error: (err as Error).message });
+      });
+    }, { timezone: 'Europe/Kyiv' });
+  }
 
   const pricingService = new PricingService(db);
   const subscriptionService = new SubscriptionService(db);

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -118,6 +118,11 @@ class HTTPMCPServer {
     this.setupMiddleware();
     this.setupRoutes();
 
+    // Scheduler role: these crons must run on exactly ONE instance. Web replicas set
+    // RUN_SCHEDULER=false so escrow release / payout / Monobank reconciliation / cleanup
+    // jobs are not multiplied across workers. Default (unset) = enabled, so a single
+    // container keeps current behaviour (LEXAI-1802).
+    if (process.env.RUN_SCHEDULER !== 'false') {
     // Cron: auto-release stale escrow payments daily at 07:00 Kyiv time
     cron.schedule('0 7 * * *', () => {
       logger.info('[Cron] Running auto-release stale escrow payments');
@@ -180,6 +185,9 @@ class HTTPMCPServer {
         logger.error('[Cron] OAuth cleanup failed', { error: (err as Error).message });
       }
     }, { timezone: 'Europe/Kyiv' });
+    } else {
+      logger.info('[Cron] RUN_SCHEDULER=false — crons disabled on this instance (web replica)');
+    }
   }
 
   private setupMiddleware() {
@@ -1055,13 +1063,17 @@ class HTTPMCPServer {
         });
       }, 5 * 60 * 1000);
       // Run once on startup too
-      this.tools.uploadService.cleanupStale(30).catch((err) => {
-        logger.error('Upload stale cleanup on startup failed', { error: err.message });
-      });
+      // Upload maintenance (stale cleanup + recovery loop) — scheduler instance only, so N
+      // web replicas don't each run recovery/cleanup (LEXAI-1802).
+      if (process.env.RUN_SCHEDULER !== 'false') {
+        this.tools.uploadService.cleanupStale(30).catch((err) => {
+          logger.error('Upload stale cleanup on startup failed', { error: err.message });
+        });
 
-      // Start upload recovery service (30s delay, then every 5 min)
-      this.app_.uploadRecoveryService.start();
-      logger.info('Upload recovery service started');
+        // Start upload recovery service (30s delay, then every 5 min)
+        this.app_.uploadRecoveryService.start();
+        logger.info('Upload recovery service started');
+      }
 
       (this as any)._initialized = true;
       logger.info('HTTP MCP Server services initialized');


### PR DESCRIPTION
## Context (LEXAI-1802, umbrella LEXAI-1796)
Prereq for running >1 backend replica. The LEXAI-1799 audit found the backend registers crons + background workers **in-process**, so N identical copies would run them N times — including money paths (escrow auto-release, Monobank reconciliation, payout alerts).

## Change
Gate all crons + background-worker startup behind `RUN_SCHEDULER`. **Default ON** (unset → enabled), so the current single container is unchanged; web replicas will set `RUN_SCHEDULER=false`.

Gated:
- `http-server.ts` crons: escrow auto-release `0 7`, Monobank reconciliation `*/30`, stuck/failed-payout alerts `0 8`, legislation-change detection `0 6`, expired-session cleanup `0 */6`, soft-delete purge `0 3`, OAuth cleanup `0 4`.
- `billing-services.ts`: daily NBU rate refresh cron (the initial startup fetch stays on every instance — idempotent).
- `app-services.ts`: BullMQ upload-queue worker — web replicas still **enqueue**, but consumption (heavy OCR/doc work) runs on the scheduler instance only. Upload queue is Redis/BullMQ, so this is safe.
- `http-server.ts`: upload stale-cleanup + recovery loop.

`edrsr-pre-vectorizer` has no active `start()` call in the current flow — nothing to gate.

## Safety
Default-on = zero behavior change for the current single prod container (crons keep running). Verified `tsc` clean (only pre-existing core-loader stubs).

## Next (separate PR, with LEXAI-1798)
docker-compose split: one `worker` service (RUN_SCHEDULER unset) + N `web` services (RUN_SCHEDULER=false), nginx sticky/LB for MCP/SSE sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a RUN_SCHEDULER env flag to run crons and background workers on a single “scheduler” instance. Prevents duplicate jobs when scaling beyond one backend replica (LEXAI-1802, under LEXAI-1796).

- **New Features**
  - Gate server crons behind RUN_SCHEDULER (escrow auto-release, Monobank reconciliation, payout alerts, legislation checks, session/OAuth cleanup, soft-delete purge).
  - Gate daily NBU rate refresh in billing; the initial startup fetch still runs on all instances (idempotent).
  - Run the upload queue worker and upload maintenance only when RUN_SCHEDULER != 'false'; web replicas only enqueue.

- **Migration**
  - No change for a single container (default is enabled).
  - For multiple replicas: set RUN_SCHEDULER=false on web replicas and leave it unset/true on one scheduler instance.

<sup>Written for commit b7bb5ba77656d359f18afdae04af53b7f686b0f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

