### PR TITLE
fix(legislation): hybrid FTS+vector retrieval for get_legislation_section query mode (LEXAI-1806)

### DIFF
--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import * as cheerio from 'cheerio';
 import { logger } from '../utils/logger';
 import type { IDatabase } from '../domain/ports/index.js';
+import { buildLegislationTsquery, extractArticleNumberTokens } from '../services/legislation-search-utils';
 
 /**
  * КУпАП (Кодекс України про адміністративні правопорушення) is split in RADA
@@ -890,6 +891,65 @@ export class RadaLegislationAdapter {
 
     sql += ` ORDER BY ts_rank(to_tsvector('simple', la.full_text), plainto_tsquery('simple', $1)) DESC LIMIT $${params.length + 1}`;
     params.push(limit);
+
+    const result = await this.db.query(sql, params);
+    return result.rows;
+  }
+
+  /**
+   * FTS leg for the hybrid legislation retrieval path (LEXAI-1806).
+   *
+   * Unlike `searchArticles` (which AND-joins terms via plainto_tsquery('simple', …) and
+   * is brittle against Ukrainian inflection), this builds an OR-of-prefixes tsquery
+   * ("подат:* | нерух:* | окупова:*") so an article matching more topical stems ranks
+   * higher, and separately matches exact article-number tokens from the query
+   * (e.g. "266" → art. 266, "38.6" → п.38.6). Returns rows ordered by ts_rank, best first.
+   */
+  async searchArticlesHybrid(query: string, radaId?: string, limit: number = 24): Promise<any[]> {
+    const tsq = buildLegislationTsquery(query);
+    // Match both the bare token and its transitional "п."-prefixed form.
+    const numberTokens = extractArticleNumberTokens(query);
+    const articleNumberVariants = [
+      ...numberTokens,
+      ...numberTokens.map((t) => `п.${t}`),
+    ];
+
+    const params: any[] = [];
+    const conditions: string[] = [];
+
+    if (tsq) {
+      params.push(tsq);
+      conditions.push(`to_tsvector('simple', la.full_text) @@ to_tsquery('simple', $${params.length})`);
+    }
+    if (articleNumberVariants.length > 0) {
+      params.push(articleNumberVariants);
+      conditions.push(`la.article_number = ANY($${params.length})`);
+    }
+
+    // No usable terms at all → nothing to search on.
+    if (conditions.length === 0) return [];
+
+    let sql = `
+      SELECT la.*, l.rada_id, l.title as legislation_title, l.short_title
+      FROM legislation_articles la
+      JOIN legislation l ON la.legislation_id = l.id
+      WHERE la.is_current = true
+        AND (${conditions.join(' OR ')})
+    `;
+
+    if (radaId) {
+      params.push(expandKupapRadaIds(radaId.toLowerCase()).map((id) => id.toLowerCase()));
+      sql += ` AND LOWER(l.rada_id) = ANY($${params.length})`;
+    }
+
+    // Rank by lexical relevance when we have a tsquery; otherwise fall back to a stable order.
+    if (tsq) {
+      sql += ` ORDER BY ts_rank(to_tsvector('simple', la.full_text), to_tsquery('simple', $1)) DESC`;
+    } else {
+      sql += ` ORDER BY la.id ASC`;
+    }
+    params.push(limit);
+    sql += ` LIMIT $${params.length}`;
 
     const result = await this.db.query(sql, params);
     return result.rows;

--- a/mcp_backend/src/services/__tests__/legislation-search-utils.test.ts
+++ b/mcp_backend/src/services/__tests__/legislation-search-utils.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the hybrid legislation retrieval helpers (LEXAI-1806).
+ * These cover the ranking math only — no DB / Qdrant needed.
+ */
+
+import {
+  HYBRID_RRF_K,
+  MEGA_RECORD_CHAR_THRESHOLD,
+  ARTICLE_NUMBER_MATCH_BOOST,
+  TRANSITIONAL_BOOST,
+  MEGA_RECORD_PENALTY_FACTOR,
+  legislationKey,
+  bareArticleNumber,
+  extractArticleNumberTokens,
+  buildLegislationTsquery,
+  fuseRankLists,
+  applyLegislationBoosts,
+} from '../legislation-search-utils';
+
+describe('legislationKey', () => {
+  it('lowercases rada_id and keeps article_number verbatim', () => {
+    expect(legislationKey('2755-17', '266')).toBe('2755-17:266');
+    expect(legislationKey('254К/96-ВР', '124')).toBe('254к/96-вр:124');
+    expect(legislationKey('2755-17', 'п.38.6')).toBe('2755-17:п.38.6');
+  });
+});
+
+describe('bareArticleNumber', () => {
+  it('strips transitional prefixes', () => {
+    expect(bareArticleNumber('п.38.6')).toBe('38.6');
+    expect(bareArticleNumber('п. 69.22')).toBe('69.22');
+    expect(bareArticleNumber('ст.266')).toBe('266');
+  });
+  it('leaves bare numbers untouched', () => {
+    expect(bareArticleNumber('266')).toBe('266');
+    expect(bareArticleNumber('354-1')).toBe('354-1');
+  });
+});
+
+describe('extractArticleNumberTokens', () => {
+  it('pulls article and point tokens', () => {
+    expect(extractArticleNumberTokens('пільга за ст 266 та п 38.6 і 69.22')).toEqual(
+      expect.arrayContaining(['266', '38.6', '69.22'])
+    );
+  });
+  it('drops 4-digit years to avoid date noise', () => {
+    const tokens = extractArticleNumberTokens('окупація з 14 квітня 2014 року, стаття 266');
+    expect(tokens).toContain('266');
+    expect(tokens).toContain('14');
+    expect(tokens).not.toContain('2014');
+  });
+  it('dedupes', () => {
+    expect(extractArticleNumberTokens('266 266 266')).toEqual(['266']);
+  });
+  it('returns [] for text with no numbers', () => {
+    expect(extractArticleNumberTokens('податок на нерухоме майно')).toEqual([]);
+  });
+});
+
+describe('buildLegislationTsquery', () => {
+  it('builds OR-of-prefixes from content tokens', () => {
+    const q = buildLegislationTsquery('податок на нерухоме майно окупованій території');
+    expect(q).toContain(':*');
+    expect(q).toContain(' | ');
+    // stems, not full inflected forms — so "нерухомого" / "територія" also match
+    expect(q).toContain('нерух:*');
+    expect(q).toContain('терито:*');
+  });
+  it('drops stopwords and short tokens', () => {
+    const q = buildLegislationTsquery('на про від що як');
+    expect(q).toBe('');
+  });
+  it('drops pure-number tokens (handled by the article_number branch instead)', () => {
+    const q = buildLegislationTsquery('266 нерухоме');
+    expect(q).toContain('нерух:*');
+    expect(q).not.toContain('266');
+  });
+  it('returns empty string for empty input (caller must skip to_tsquery)', () => {
+    expect(buildLegislationTsquery('')).toBe('');
+  });
+});
+
+describe('fuseRankLists (RRF)', () => {
+  it('accumulates score for keys present in both legs', () => {
+    const scores = fuseRankLists(['a', 'b'], ['b', 'c']);
+    // b is rank 2 in vector (1/(k+2)) and rank 1 in fts (1/(k+1))
+    const expectedB = 1 / (HYBRID_RRF_K + 1) + 1 / (HYBRID_RRF_K + 2);
+    expect(scores.get('b')).toBeCloseTo(expectedB, 10);
+    // a only in vector at rank 1, c only in fts at rank 2
+    expect(scores.get('a')).toBeCloseTo(1 / (HYBRID_RRF_K + 1), 10);
+    expect(scores.get('c')).toBeCloseTo(1 / (HYBRID_RRF_K + 2), 10);
+    // b (both legs) outranks single-leg keys
+    expect(scores.get('b')!).toBeGreaterThan(scores.get('a')!);
+    expect(scores.get('b')!).toBeGreaterThan(scores.get('c')!);
+  });
+  it('handles an empty leg', () => {
+    const scores = fuseRankLists([], ['x', 'y']);
+    expect(scores.get('x')).toBeCloseTo(1 / (HYBRID_RRF_K + 1), 10);
+    expect(scores.size).toBe(2);
+  });
+});
+
+describe('applyLegislationBoosts', () => {
+  const base = 0.01;
+  it('boosts an exact article-number token match', () => {
+    const scored = applyLegislationBoosts(
+      base,
+      { article_number: '266', full_text_length: 5000, is_transitional: false },
+      ['266']
+    );
+    expect(scored).toBeCloseTo(base + ARTICLE_NUMBER_MATCH_BOOST, 10);
+  });
+  it('matches a transitional point number after stripping the п. prefix', () => {
+    const scored = applyLegislationBoosts(
+      base,
+      { article_number: 'п.38.6', full_text_length: 2725, is_transitional: true },
+      ['38.6']
+    );
+    expect(scored).toBeCloseTo(base + ARTICLE_NUMBER_MATCH_BOOST + TRANSITIONAL_BOOST, 10);
+  });
+  it('demotes a mega-record even when its number token matches', () => {
+    const megaLen = MEGA_RECORD_CHAR_THRESHOLD + 1;
+    const scored = applyLegislationBoosts(
+      base,
+      { article_number: '346', full_text_length: megaLen, is_transitional: false },
+      ['346']
+    );
+    // penalty is multiplicative and applied last
+    expect(scored).toBeCloseTo((base + ARTICLE_NUMBER_MATCH_BOOST) * MEGA_RECORD_PENALTY_FACTOR, 10);
+  });
+  it('a real transitional provision outranks the demoted mega-record', () => {
+    const mega = applyLegislationBoosts(
+      1 / (HYBRID_RRF_K + 1),
+      { article_number: '346', full_text_length: 997546, is_transitional: false },
+      []
+    );
+    const real = applyLegislationBoosts(
+      1 / (HYBRID_RRF_K + 3),
+      { article_number: 'п.69.22', full_text_length: 13464, is_transitional: true },
+      ['69.22']
+    );
+    expect(real).toBeGreaterThan(mega);
+  });
+  it('leaves score unchanged when nothing applies', () => {
+    const scored = applyLegislationBoosts(
+      base,
+      { article_number: '500', full_text_length: 1000, is_transitional: false },
+      ['266']
+    );
+    expect(scored).toBe(base);
+  });
+});

--- a/mcp_backend/src/services/__tests__/legislation-service.test.ts
+++ b/mcp_backend/src/services/__tests__/legislation-service.test.ts
@@ -38,6 +38,7 @@ const createMockEmbeddingService = () => ({
   generateEmbedding: jest.fn().mockResolvedValue(new Array(1536).fill(0)),
   generateEmbeddings: jest.fn().mockResolvedValue([new Array(1536).fill(0)]),
   searchSimilar: jest.fn().mockResolvedValue([]),
+  searchVectors: jest.fn().mockResolvedValue([]),
   upsertVectors: jest.fn().mockResolvedValue(undefined),
 });
 
@@ -51,6 +52,8 @@ const createMockAdapter = () => ({
   chunkArticles: jest.fn().mockReturnValue([]),
   getLegislationStructure: jest.fn().mockResolvedValue(null),
   searchArticles: jest.fn().mockResolvedValue([]),
+  searchArticlesHybrid: jest.fn().mockResolvedValue([]),
+  createArticleChunks: jest.fn().mockReturnValue([]),
 });
 
 const createMockClassifier = () => ({
@@ -515,6 +518,75 @@ describe('LegislationService', () => {
     it('should delegate to parseLegislationReference', () => {
       const result = service.parseArticleReference('ст. 1 ЦК');
       expect(result).toEqual({ radaId: '435-15', articleNumber: '1' });
+    });
+  });
+
+  describe('findRelevantArticles (hybrid FTS + vector, LEXAI-1806)', () => {
+    it('demotes the broken mega-record below on-point transitional provisions', async () => {
+      // Vector leg surfaces the noisy ~1M-char ст. 346 first (as it does in prod), plus п.69.22.
+      mockEmbedding.searchVectors.mockResolvedValueOnce([
+        { id: 'v1', score: 0.72, payload: { rada_id: '2755-17', article_number: '346', article_id: 1 } },
+        { id: 'v2', score: 0.55, payload: { rada_id: '2755-17', article_number: 'п.69.22', article_id: 2 } },
+      ]);
+      // FTS leg (lexical) finds the actually-relevant transitional provisions.
+      mockAdapter.searchArticlesHybrid.mockResolvedValueOnce([
+        {
+          id: 2, rada_id: '2755-17', article_number: 'п.69.22', title: '69.22',
+          full_text: 'нерухоме майно окуповані території...'.padEnd(13464, 'x'),
+          metadata: { is_transitional: true }, legislation_title: 'ПКУ',
+        },
+        {
+          id: 3, rada_id: '2755-17', article_number: 'п.38.6', title: '38.6',
+          full_text: 'об’єкти нерухомості на тимчасово окупованій території...'.padEnd(2725, 'x'),
+          metadata: { is_transitional: true }, legislation_title: 'ПКУ',
+        },
+      ]);
+      // The vector-only ст. 346 is resolved from DB and is a broken mega-record.
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{
+          id: 1, rada_id: '2755-17', article_number: '346', title: 'Оплата праці ДПС',
+          full_text: 'x'.repeat(997546), metadata: {}, npa_title: 'ПКУ',
+        }],
+        rowCount: 1,
+      });
+
+      const result = await service.findRelevantArticles(
+        'податок на нерухоме майно на тимчасово окупованій території пільга',
+        '2755-17',
+        5
+      );
+
+      const numbers = result.map(r => r.article_number);
+      // The on-point transitional provision ranks first; the mega-record is demoted last.
+      expect(numbers[0]).toBe('п.69.22');
+      expect(numbers).toContain('п.38.6');
+      expect(numbers[numbers.length - 1]).toBe('346');
+      // 346 still present (retrievable), just no longer dominating.
+      expect(numbers).toContain('346');
+    });
+
+    it('boosts an article whose exact number token appears in the query', async () => {
+      mockEmbedding.searchVectors.mockResolvedValueOnce([]);
+      mockAdapter.searchArticlesHybrid.mockResolvedValueOnce([
+        { id: 10, rada_id: '2755-17', article_number: '265', title: '265', full_text: 'склад', metadata: {}, legislation_title: 'ПКУ' },
+        { id: 11, rada_id: '2755-17', article_number: '266', title: '266', full_text: 'нерухоме майно', metadata: {}, legislation_title: 'ПКУ' },
+      ]);
+
+      const result = await service.findRelevantArticles('податок за ст 266', '2755-17', 5);
+      // 265 is FTS rank 1, but 266 is named explicitly → the number-token boost lifts it to the top.
+      expect(result[0].article_number).toBe('266');
+    });
+
+    it('falls back to text search when both legs return nothing', async () => {
+      mockEmbedding.searchVectors.mockResolvedValueOnce([]);
+      mockAdapter.searchArticlesHybrid.mockResolvedValueOnce([]);
+      mockAdapter.searchArticles.mockResolvedValueOnce([
+        { rada_id: '2755-17', legislation_title: 'ПКУ', article_number: '99', title: 'x', full_text: 'y', metadata: {} },
+      ]);
+
+      const result = await service.findRelevantArticles('щось незрозуміле', '2755-17', 5);
+      expect(mockAdapter.searchArticles).toHaveBeenCalled();
+      expect(result[0].article_number).toBe('99');
     });
   });
 

--- a/mcp_backend/src/services/legislation-search-utils.ts
+++ b/mcp_backend/src/services/legislation-search-utils.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure helpers for hybrid (FTS + vector) legislation retrieval — LEXAI-1806.
+ *
+ * `get_legislation_section` query-mode used to run a bare Qdrant cosine search over
+ * `legal_sections`, which (a) let the broken ~1M-char ПКУ ст. 346 mega-record flood
+ * the results and (b) never surfaced the on-point transitional provisions
+ * (підрозділ 10 розд. XX: п.38.6 / п.69.22 / ст. 266) for morphology-heavy queries.
+ *
+ * These functions implement the ranking side of the fix, mirroring the RRF pattern
+ * used by `search_court_decisions` (edrsr-unified-search-tool.ts). They are kept in a
+ * standalone module so both LegislationService and RadaLegislationAdapter can use them
+ * without an import cycle, and so the ranking math stays unit-testable without a DB.
+ */
+
+/** Reciprocal-rank-fusion constant, matching the EDRSR hybrid path (DEFAULT_RRF_K). */
+export const HYBRID_RRF_K = 60;
+
+/**
+ * full_text length above which a record is treated as a broken parser artifact and
+ * demoted in discovery. ПКУ ст. 346 ≈ 1M chars is the known offender; the largest
+ * *legitimate* article (ПКУ ст. 14 "визначення понять" ≈ 216K) stays below this, so
+ * it is never demoted. The record is still fully retrievable by explicit article_number.
+ */
+export const MEGA_RECORD_CHAR_THRESHOLD = 300_000;
+
+/** Additive boost when a bare article-number token from the query matches the candidate. */
+export const ARTICLE_NUMBER_MATCH_BOOST = 0.02;
+
+/** Small additive nudge for transitional/final provisions (перехідні положення). */
+export const TRANSITIONAL_BOOST = 0.003;
+
+/** Multiplicative penalty applied to mega-record candidates. */
+export const MEGA_RECORD_PENALTY_FACTOR = 0.1;
+
+/** Vector-leg cosine floor for hybrid candidate inclusion. Lower than the old pure-vector
+ * 0.6 gate because RRF ranks by position, not score, and on-point transitional provisions
+ * often score ~0.4-0.5 against a paraphrased query. The FTS leg + boosts do the ranking. */
+export const MIN_VECTOR_SCORE_HYBRID = 0.35;
+
+/** Ukrainian function words that carry no retrieval signal — dropped from the FTS tsquery. */
+const UK_STOPWORDS = new Set([
+  'для', 'або', 'від', 'про', 'які', 'яка', 'який', 'яке', 'щодо', 'цього', 'цьому',
+  'якщо', 'при', 'над', 'під', 'між', 'його', 'її', 'їх', 'що', 'як', 'так', 'цей',
+  'той', 'все', 'усі', 'він', 'вона', 'вони', 'має', 'був', 'була', 'було', 'бути',
+  'нею', 'ним', 'них', 'аби', 'був', 'цих', 'them',
+]);
+
+/**
+ * Build a stable dedup/fusion key for an article across the two legs.
+ * FTS rows and vector payloads both carry the same `legislation_articles.article_number`,
+ * so an exact join on (rada_id, article_number) is unambiguous.
+ */
+export function legislationKey(radaId: string, articleNumber: string): string {
+  return `${String(radaId || '').toLowerCase()}:${String(articleNumber ?? '').trim()}`;
+}
+
+/**
+ * Strip the transitional-provision prefix ("п." / "ст.") so a stored article_number
+ * like "п.38.6" can be compared to a bare query token "38.6".
+ */
+export function bareArticleNumber(articleNumber: string): string {
+  return String(articleNumber || '')
+    .replace(/^\s*(?:п|ст|стаття)\.?\s*/i, '')
+    .trim();
+}
+
+/**
+ * Extract numeric article/point tokens from a query — "266", "38.6", "69.22", "354-1".
+ * Used both to boost exact-number matches and to seed the FTS article_number branch.
+ * Plain 4-digit years (1991..2099) are dropped: they are almost always dates, not
+ * article numbers, and would otherwise match unrelated articles.
+ */
+export function extractArticleNumberTokens(query: string): string[] {
+  const raw = String(query || '').match(/\d+(?:[.\-]\d+)*/g) || [];
+  const tokens = raw.filter((t) => !/^(?:19|20)\d{2}$/.test(t));
+  return [...new Set(tokens)];
+}
+
+/** Crude Ukrainian stem: trim the inflectional tail so a prefix tsquery matches відмінки/числа. */
+function stemToPrefix(token: string): string {
+  const clean = token.replace(/[^\p{L}\p{N}]/gu, '');
+  if (!clean) return '';
+  return clean.slice(0, Math.max(4, clean.length - 3));
+}
+
+/**
+ * Build an OR-of-prefixes tsquery ("подат:* | нерух:* | окупова:*") from a free-text query.
+ * OR + prefix matching tolerates Ukrainian morphology far better than the AND-joined
+ * plainto_tsquery('simple', …) used by the legacy searchArticles, so an article that
+ * matches more topical stems ranks higher via ts_rank. Returns '' when the query has no
+ * usable content tokens (caller must then skip the tsquery branch — to_tsquery('') errors).
+ */
+export function buildLegislationTsquery(query: string): string {
+  const tokens = (String(query || '').toLowerCase().match(/[\p{L}\p{N}]+/gu) || [])
+    .filter((t) => t.length >= 3 && !UK_STOPWORDS.has(t) && !/^\d+$/.test(t))
+    .slice(0, 10);
+  const stems = tokens.map(stemToPrefix).filter(Boolean);
+  return [...new Set(stems)].map((s) => `${s}:*`).join(' | ');
+}
+
+/**
+ * Reciprocal-rank fusion of two ranked key lists into a combined score map.
+ * Each list contributes 1/(k + rank) per key; keys present in both legs accumulate.
+ */
+export function fuseRankLists(
+  vectorKeys: string[],
+  ftsKeys: string[],
+  k: number = HYBRID_RRF_K
+): Map<string, number> {
+  const scores = new Map<string, number>();
+  const add = (keys: string[]) => {
+    keys.forEach((key, idx) => {
+      const rank = idx + 1;
+      scores.set(key, (scores.get(key) || 0) + 1 / (k + rank));
+    });
+  };
+  add(ftsKeys);
+  add(vectorKeys);
+  return scores;
+}
+
+export interface LegislationBoostInput {
+  article_number: string;
+  full_text_length: number;
+  is_transitional: boolean;
+}
+
+/**
+ * Adjust a fused base score with the LEXAI-1806 boosts: exact article-number match,
+ * transitional-provision nudge, and mega-record demotion (applied last, so a demoted
+ * record cannot outrank a real one on the strength of a number-token match alone).
+ */
+export function applyLegislationBoosts(
+  baseScore: number,
+  candidate: LegislationBoostInput,
+  queryNumberTokens: string[]
+): number {
+  let score = baseScore;
+  const bare = bareArticleNumber(candidate.article_number);
+  if (bare && queryNumberTokens.includes(bare)) {
+    score += ARTICLE_NUMBER_MATCH_BOOST;
+  }
+  if (candidate.is_transitional) {
+    score += TRANSITIONAL_BOOST;
+  }
+  if (candidate.full_text_length > MEGA_RECORD_CHAR_THRESHOLD) {
+    score *= MEGA_RECORD_PENALTY_FACTOR;
+  }
+  return score;
+}

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -4,6 +4,13 @@ import { logger } from '../utils/logger';
 import { createHash } from 'crypto';
 import { LegislationClassifier } from './legislation-classifier';
 import type { ICachePort, ILLMPort } from '../domain/ports/index.js';
+import {
+  legislationKey,
+  extractArticleNumberTokens,
+  fuseRankLists,
+  applyLegislationBoosts,
+  MIN_VECTOR_SCORE_HYBRID,
+} from './legislation-search-utils';
 
 export interface LegislationReference {
   rada_id: string;
@@ -1198,115 +1205,161 @@ export class LegislationService {
     logger.info(`Indexed ${totalChunks} chunks for ${articles.length} articles in legislation ${radaId}`);
   }
 
+  /**
+   * Hybrid (FTS + vector) discovery of the most relevant articles for a free-text query,
+   * used by get_legislation_section query-mode and search_legislation (LEXAI-1806).
+   *
+   * The legacy implementation ran a bare Qdrant cosine search with a 0.6 floor, which let
+   * the broken ~1M-char ПКУ ст. 346 mega-record dominate and never surfaced the on-point
+   * transitional provisions. This now RRF-fuses two legs (mirroring search_court_decisions):
+   *   1. vector leg — Qdrant cosine over legal_sections, collapsed to best-chunk-per-article;
+   *   2. FTS leg — OR-prefix tsquery + exact article-number match over legislation_articles.
+   * The fused candidates are re-scored with an article-number-token boost, a transitional-
+   * provision nudge, and a mega-record demotion, then the top `limit` are returned.
+   */
   async findRelevantArticles(query: string, radaId?: string, limit: number = 5): Promise<LegislationReference[]> {
+    const toReference = (row: any): LegislationReference => ({
+      rada_id: row.rada_id,
+      article_number: row.article_number,
+      title: row.title,
+      full_text: row.full_text,
+      full_text_html: row.full_text_html,
+      url: `https://zakon.rada.gov.ua/laws/show/${row.rada_id}#n${row.article_number}`,
+      metadata: row.metadata,
+      npa_title: row.npa_title ?? row.legislation_title,
+      section_number: row.section_number,
+      section_title: row.section_title,
+      chapter_number: row.chapter_number,
+      chapter_title: row.chapter_title,
+    });
+
+    const textFallback = async (): Promise<LegislationReference[]> => {
+      const textResults = await this.searchLegislation(query, radaId, limit);
+      return textResults.flatMap(r => r.articles.map((a: any) => toReference({
+        ...a,
+        rada_id: r.rada_id,
+        npa_title: r.legislation_title,
+      })));
+    };
+
     try {
-      const queryEmbedding = await this.embeddingService.generateEmbedding(query);
-      
+      const candidateLimit = Math.max(limit * 4, 24);
       const filter: any = { document_type: 'legislation' };
-      if (radaId) {
-        filter.rada_id = radaId;
-      }
+      if (radaId) filter.rada_id = radaId;
 
-      const MIN_SCORE = 0.6;
-      const allResults = await this.embeddingService.searchVectors(queryEmbedding, Math.max(limit * 3, 20), filter);
-      const searchResults = allResults.filter((r: any) => (r.score || 0) >= MIN_SCORE);
+      // Both legs run concurrently; either may fail/return empty without sinking the other.
+      const [vectorHits, ftsRows] = await Promise.all([
+        (async () => {
+          try {
+            const queryEmbedding = await this.embeddingService.generateEmbedding(query);
+            return await this.embeddingService.searchVectors(queryEmbedding, candidateLimit, filter);
+          } catch (e: any) {
+            logger.warn('[LegislationService] hybrid vector leg failed', { error: e?.message });
+            return [] as any[];
+          }
+        })(),
+        (async () => {
+          try {
+            return await this.adapter.searchArticlesHybrid(query, radaId, candidateLimit);
+          } catch (e: any) {
+            logger.warn('[LegislationService] hybrid FTS leg failed', { error: e?.message });
+            return [] as any[];
+          }
+        })(),
+      ]);
 
-      if (searchResults.length === 0) {
-        logger.warn('[LegislationService] Vector search returned 0 results, falling back to text search', {
-          query: query.substring(0, 50),
-        });
-        const textResults = await this.searchLegislation(query, radaId, limit);
-        return textResults.flatMap(r => r.articles.map((a: any) => ({
-          rada_id: r.rada_id,
-          article_number: a.article_number,
-          title: a.title,
-          full_text: a.full_text,
-          full_text_html: a.full_text_html,
-          url: `https://zakon.rada.gov.ua/laws/show/${r.rada_id}#n${a.article_number}`,
-          metadata: a.metadata,
-          npa_title: r.legislation_title,
-          section_number: a.section_number,
-          section_title: a.section_title,
-          chapter_number: a.chapter_number,
-          chapter_title: a.chapter_title,
-        })));
-      }
-
-      // Resolve vector results to DB records via integer IDs or payload lookup
-      const integerIds: number[] = [];
-      const payloadLookups: Array<{ rada_id: string; article_number: string }> = [];
-
-      for (const r of searchResults) {
-        if (r.payload?.article_id) {
-          integerIds.push(r.payload.article_id);
-        } else if (typeof r.id === 'number') {
-          integerIds.push(r.id);
-        } else if (r.payload?.rada_id && r.payload?.article_number) {
-          payloadLookups.push({ rada_id: r.payload.rada_id, article_number: r.payload.article_number });
+      // Vector leg: collapse chunk hits to the best-scoring chunk per article, keep score order.
+      const vectorBest = new Map<string, { score: number; articleId?: number; radaId: string; articleNumber: string }>();
+      for (const h of vectorHits as any[]) {
+        const rid = h.payload?.rada_id;
+        const an = h.payload?.article_number;
+        if (!rid || an == null) continue;
+        if ((h.score || 0) < MIN_VECTOR_SCORE_HYBRID) continue;
+        const key = legislationKey(rid, an);
+        const prev = vectorBest.get(key);
+        if (!prev || (h.score || 0) > prev.score) {
+          vectorBest.set(key, { score: h.score || 0, articleId: h.payload?.article_id, radaId: rid, articleNumber: an });
         }
       }
+      const vectorKeys = [...vectorBest.entries()].sort((a, b) => b[1].score - a[1].score).map(([k]) => k);
 
-      const queries: Promise<any>[] = [];
-      if (integerIds.length > 0) {
-        queries.push(this.db.query(
+      // FTS leg: rows already ts_rank-ordered; keep first row per article.
+      const ftsRowByKey = new Map<string, any>();
+      const ftsKeys: string[] = [];
+      for (const row of ftsRows as any[]) {
+        const key = legislationKey(row.rada_id, row.article_number);
+        if (!ftsRowByKey.has(key)) { ftsRowByKey.set(key, row); ftsKeys.push(key); }
+      }
+
+      const fused = fuseRankLists(vectorKeys, ftsKeys);
+      if (fused.size === 0) {
+        logger.warn('[LegislationService] hybrid search returned 0 candidates, falling back to text search', {
+          query: query.substring(0, 50),
+        });
+        return await textFallback();
+      }
+
+      // Resolve a generous candidate pool to full DB rows, then re-score with boosts.
+      const pool = [...fused.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, Math.max(limit * 3, 15));
+
+      // Vector-only winners need a DB fetch (payload lacks full_text/hierarchy); fetch by
+      // article_id where the payload carried one, else by (rada_id, article_number).
+      const fetchIds: number[] = [];
+      const fetchPairs: Array<{ rada_id: string; article_number: string }> = [];
+      for (const [key] of pool) {
+        if (ftsRowByKey.has(key)) continue;
+        const v = vectorBest.get(key);
+        if (v?.articleId) fetchIds.push(v.articleId);
+        else if (v) fetchPairs.push({ rada_id: v.radaId, article_number: v.articleNumber });
+      }
+
+      const fetchedByKey = new Map<string, any>();
+      const fetchQueries: Promise<any>[] = [];
+      if (fetchIds.length > 0) {
+        fetchQueries.push(this.db.query(
           `SELECT la.*, l.rada_id, l.title as npa_title
            FROM legislation_articles la JOIN legislation l ON la.legislation_id = l.id
-           WHERE la.id = ANY($1)`, [[...new Set(integerIds)]]
+           WHERE la.id = ANY($1)`, [[...new Set(fetchIds)]]
         ));
       }
-      for (const pl of payloadLookups.slice(0, limit)) {
-        queries.push(this.db.query(
+      for (const p of fetchPairs) {
+        fetchQueries.push(this.db.query(
           `SELECT la.*, l.rada_id, l.title as npa_title
            FROM legislation_articles la JOIN legislation l ON la.legislation_id = l.id
            WHERE LOWER(l.rada_id) = LOWER($1) AND la.article_number = $2 AND la.is_current = true
-           LIMIT 1`, [pl.rada_id, pl.article_number]
+           LIMIT 1`, [p.rada_id, p.article_number]
         ));
       }
-
-      const queryResults = await Promise.all(queries);
-      const seen = new Set<string>();
-      const allRows: any[] = [];
-      for (const qr of queryResults) {
+      for (const qr of await Promise.all(fetchQueries)) {
         for (const row of qr.rows) {
-          const key = `${row.rada_id}:${row.article_number}`;
-          if (!seen.has(key)) { seen.add(key); allRows.push(row); }
+          fetchedByKey.set(legislationKey(row.rada_id, row.article_number), row);
         }
       }
 
-      // Return rows above MIN_SCORE, capped at the caller's limit (hard max 15 for safety).
-      const result = { rows: allRows.slice(0, Math.max(1, Math.min(limit, 15))) };
+      const numberTokens = extractArticleNumberTokens(query);
+      const scored = pool
+        .map(([key, base]) => {
+          const row = ftsRowByKey.get(key) || fetchedByKey.get(key);
+          if (!row) return null;
+          const isTransitional = Boolean(row.metadata?.is_transitional) || /^\s*п\./i.test(row.article_number || '');
+          const score = applyLegislationBoosts(base, {
+            article_number: row.article_number,
+            full_text_length: (row.full_text || '').length,
+            is_transitional: isTransitional,
+          }, numberTokens);
+          return { row, score };
+        })
+        .filter((x): x is { row: any; score: number } => x !== null)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, Math.max(1, Math.min(limit, 15)));
 
-      return result.rows.map((row: any) => ({
-        rada_id: row.rada_id,
-        article_number: row.article_number,
-        title: row.title,
-        full_text: row.full_text,
-        full_text_html: row.full_text_html,
-        url: `https://zakon.rada.gov.ua/laws/show/${row.rada_id}#n${row.article_number}`,
-        metadata: row.metadata,
-        npa_title: row.npa_title,
-        section_number: row.section_number,
-        section_title: row.section_title,
-        chapter_number: row.chapter_number,
-        chapter_title: row.chapter_title,
-      }));
+      if (scored.length === 0) return await textFallback();
+      return scored.map(s => toReference(s.row));
     } catch (error: any) {
-      logger.error('Vector search failed, falling back to text search:', error.message);
-      const results = await this.searchLegislation(query, radaId, limit);
-      return results.flatMap(r => r.articles.map((a: any) => ({
-        rada_id: r.rada_id,
-        article_number: a.article_number,
-        title: a.title,
-        full_text: a.full_text,
-        full_text_html: a.full_text_html,
-        url: `https://zakon.rada.gov.ua/laws/show/${r.rada_id}#n${a.article_number}`,
-        metadata: a.metadata,
-        npa_title: r.legislation_title,
-        section_number: a.section_number,
-        section_title: a.section_title,
-        chapter_number: a.chapter_number,
-        chapter_title: a.chapter_title,
-      })));
+      logger.error('[LegislationService] hybrid search failed, falling back to text search:', error?.message);
+      return await textFallback();
     }
   }
 


### PR DESCRIPTION
## Problem (LEXAI-1806)

`get_legislation_section` in **query mode** (`vector_search`) returned irrelevant articles for pinpoint normative queries. Reproduced on prod with «податок на нерухоме майно на тимчасово окупованій території пільга» (rada_id `2755-17`, ПКУ): top hits were the broken **ст. 346** (ДПС salaries, ~1M chars), **п.26.7**, **п.26.11** — while the on-point **п.38.6 / п.69.22 / ст. 266** never appeared.

Two root causes:
1. `findRelevantArticles` ran a **bare Qdrant cosine** search (0.6 floor, no FTS/RRF). The ~1M-char parser-broken **ст. 346** produces ~2000 chunks all tagged `article_number=346`, flooding the vector leg.
2. No lexical/number signal, so morphology-heavy Ukrainian queries never surfaced the transitional provisions (підрозділ 10 розд. XX).

## Fix

Make `findRelevantArticles` **hybrid**, mirroring `search_court_decisions`:

- **New `RadaLegislationAdapter.searchArticlesHybrid`** — OR-of-prefixes tsquery (`подат:* | нерух:* | окупова:*`) tolerant of Ukrainian inflection (vs the brittle AND-joined `plainto_tsquery` in `searchArticles`), plus exact `article_number` matching (`266` → art 266, `38.6` → `п.38.6`).
- **RRF fusion** of the vector leg (collapsed to best-chunk-per-article) and the FTS leg, keyed on `(rada_id, article_number)`, k=60.
- **Re-scoring**: article-number-token boost, transitional-provision nudge, and a **mega-record demotion** (`full_text > 300K` — the broken parser tail; the largest legitimate article, ПКУ ст. 14 ≈ 216K, stays below the threshold). The mega-record remains fully retrievable via explicit `article_number`.
- Ranking math extracted to `legislation-search-utils.ts` (no import cycle, unit-tested).

Both legs run concurrently and degrade independently; the text-search fallback is preserved for the zero-candidate case. `search_legislation` benefits too (shares `findRelevantArticles`).

> The underlying mega-record data defect (parser swallowing the transitional-provisions tail into ст. 346) is a separate data-quality ticket; this PR mitigates its impact on retrieval ranking.

## Testing

- 18 unit tests for the ranking helpers (RRF, boosts, tsquery builder, token extraction).
- 3 integration tests for the hybrid path: mega-record demotion, number-token boost, empty-legs fallback.
- Hybrid FTS SQL validated against Postgres 15 (tsquery + `= ANY` syntax, ranking).
- Full legislation + adapter suites green (134 tests). `tsc` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches get_legislation_section (query mode) to hybrid FTS + vector retrieval to return the right articles and demote the broken mega-record. Fixes LEXAI-1806 and improves relevance for Ukrainian, including transitional provisions.

- **Bug Fixes**
  - Made `findRelevantArticles` hybrid: RRF-fuses vector hits (best chunk per article) with FTS, keyed by `(rada_id, article_number)`.
  - Added `searchArticlesHybrid`: OR-of-prefixes tsquery tolerant to inflection, plus exact `article_number` matching.
  - Re-scoring adds a number-token boost, a transitional-provisions nudge, and demotes mega-records (`full_text > 300K`). Explicit `article_number` still retrieves them.
  - Both legs run in parallel and degrade independently. Falls back to text search on zero candidates. Also improves `search_legislation`.

- **Refactors**
  - Extracted ranking/math to `legislation-search-utils.ts` (no import cycles) and added unit/integration tests.

<sup>Written for commit 2d8215574edfac9f1e5bc3a696a56a8631be8e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

