### PR TITLE
fix(opendata): dedupe NIPO import batches by conflict key

### DIFF
--- a/mcp_backend/src/scripts/import-uipv-ip.ts
+++ b/mcp_backend/src/scripts/import-uipv-ip.ts
@@ -209,7 +209,19 @@ function extractPatent(record: any, objType: number): any[] {
 }
 
 // ── Batch insert ────────────────────────────────────────────────────────────
-async function insertTrademarks(rows: any[][]): Promise<number> {
+/**
+ * NIPO pages occasionally contain the same app_number twice; a duplicate inside one
+ * multi-row INSERT makes Postgres abort with "ON CONFLICT DO UPDATE command cannot
+ * affect row a second time" (SQLSTATE 21000). Keep the LAST occurrence per key.
+ */
+function dedupeByKey(rows: any[][], keyOf: (r: any[]) => string): any[][] {
+  const map = new Map<string, any[]>();
+  for (const r of rows) map.set(keyOf(r), r);
+  return Array.from(map.values());
+}
+
+async function insertTrademarks(inputRows: any[][]): Promise<number> {
+  const rows = dedupeByKey(inputRows, r => String(r[0])); // key: app_number
   if (rows.length === 0) return 0;
 
   const values: any[] = [];
@@ -248,7 +260,8 @@ async function insertTrademarks(rows: any[][]): Promise<number> {
   return res.rowCount || 0;
 }
 
-async function insertPatents(rows: any[][]): Promise<number> {
+async function insertPatents(inputRows: any[][]): Promise<number> {
+  const rows = dedupeByKey(inputRows, r => `${r[2]}::${r[0]}`); // key: (app_number, obj_type)
   if (rows.length === 0) return 0;
 
   const values: any[] = [];


### PR DESCRIPTION
## Problem

The NIPO/UIPV importer (`import-uipv-ip.ts`) crashed mid-resync on prod (2026-07-02, trademarks page 34,200/38,929):

```
error: ON CONFLICT DO UPDATE command cannot affect row a second time (SQLSTATE 21000)
```

Cause: NIPO API pages occasionally contain the same `app_number` twice, and the importer inserts a whole page as one multi-row `INSERT ... ON CONFLICT DO UPDATE` — Postgres forbids two rows with the same constrained key in a single such command.

## Fix

Dedupe each batch before insert (keep the last occurrence per key): `app_number` for `opendata_trademarks`, `(app_number, obj_type)` for `opendata_patents`.

The equivalent patch was applied surgically to the prod host's `dist/scripts/import-uipv-ip.js` to resume the running resync; this PR makes it durable for the next build.

## Testing

- `tsc --noEmit` (project config): clean apart from pre-existing core-loader stub errors.
- The patched dist on prod resumed from checkpoint page 34,000 and passed the previously-fatal page 34,200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes each NIPO/UIPV import batch to prevent Postgres from aborting multi-row upserts when a page repeats the same application. Keeps the last occurrence per key to avoid SQLSTATE 21000: trademarks by `app_number`, patents by `(app_number, obj_type)`.

- **Bug Fixes**
  - Added `dedupeByKey` and used it in `insertTrademarks` and `insertPatents` to filter duplicate keys within a batch.

<sup>Written for commit 611bd17d7203b54431a17dfc4cf43725b35dd3c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

