### PR TITLE
fix(legislation): stop parser swallowing transitional tail into mega-record (LEXAI-1809)

### DIFF
--- a/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-mega-record.test.ts
+++ b/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-mega-record.test.ts
@@ -1,0 +1,86 @@
+/**
+ * LEXAI-1809: the /print and edition parsers must not let the last "Стаття N."
+ * swallow the "Прикінцеві та перехідні положення" tail into one mega-record
+ * (ПКУ ст. 346 was ~1M chars). These tests build synthetic RADA markup where a
+ * huge transitional block follows the last article and assert the bound holds.
+ */
+
+import axios from 'axios';
+import { RadaLegislationAdapter } from '../rada-legislation-adapter.js';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Distinctive sentence that lives ONLY in transitional point 38.6 — must never
+// end up inside the ст. 346 body.
+const TRANSITIONAL_MARKER =
+  'не є об’єктом оподаткування податком на нерухоме майно на тимчасово окупованій території';
+
+// A large filler so that, pre-fix, ст. 346 would balloon (it used to swallow the
+// entire transitional tail). Sized to keep the individual point realistic (<400K).
+const BIG_FILLER = ('додатковий текст перехідних положень підрозділу 10 розділу XX. ').repeat(3000);
+
+const PKU_PRINT_HTML = `
+<!DOCTYPE html><html><head><title>Податковий кодекс України</title></head><body>
+<span class=rvts15>Розділ I </span><br><span class=rvts15>ЗАГАЛЬНІ ПОЛОЖЕННЯ</span>
+<span class=rvts9>Стаття 1. Сфера дії</span> Текст першої статті достатньої довжини для проходження фільтра парсера.
+<span class=rvts9>Стаття 2. Визначення</span> Текст другої статті також достатньої довжини щоб пройти фільтр.
+<span class=rvts9>Стаття 3. Принципи</span> Текст третьої статті достатньої довжини для проходження.
+<span class=rvts9>Стаття 4. Засади</span> Текст четвертої статті достатньої довжини для проходження.
+<span class=rvts9>Стаття 5. Співвідношення</span> Текст пʼятої статті достатньої довжини для проходження.
+<span class=rvts15>Розділ XVIII-2 </span><br><span class=rvts15>ОСОБЛИВОСТІ ОПОДАТКУВАННЯ</span>
+<span class=rvts9>Стаття 346. Оплата праці працівників контролюючого органу</span> Держава забезпечує достатній рівень оплати праці державних службовців контролюючого органу.
+ПРИКІНЦЕВІ ТА ПЕРЕХІДНІ ПОЛОЖЕННЯ
+<span class=rvts15>Підрозділ 10 </span><br><span class=rvts15>Інші перехідні положення</span>
+<a name="n386"></a> 38.6. Об’єкти житлової та нежитлової нерухомості, розташовані на тимчасово окупованій території, ${TRANSITIONAL_MARKER}. ${BIG_FILLER}
+<a name="n6922"></a> 69.22. Тимчасово, на період дії воєнного стану, положення статті 266 застосовуються з особливостями.
+</body></html>
+`;
+
+describe('RadaLegislationAdapter — mega-record prevention (LEXAI-1809)', () => {
+  let adapter: RadaLegislationAdapter;
+  let mockAxiosInstance: any;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockAxiosInstance = { get: jest.fn() };
+    mockedAxios.create = jest.fn().mockReturnValue(mockAxiosInstance);
+    adapter = new RadaLegislationAdapter({} as any);
+  });
+
+  test('the last article does not swallow the transitional tail', async () => {
+    mockAxiosInstance.get.mockResolvedValue({ data: PKU_PRINT_HTML });
+
+    const { articles } = await adapter.fetchLegislation('2755-17');
+
+    const art346 = articles.find(a => a.article_number === '346');
+    expect(art346).toBeDefined();
+    // ст. 346 keeps only its own body — none of the transitional block.
+    expect(art346!.full_text).toContain('оплати праці');
+    expect(art346!.full_text).not.toContain(TRANSITIONAL_MARKER);
+    // And it is nowhere near the old ~1M-char size.
+    expect(art346!.full_text.length).toBeLessThan(5000);
+  });
+
+  test('transitional points are still extracted as separate п. records', async () => {
+    mockAxiosInstance.get.mockResolvedValue({ data: PKU_PRINT_HTML });
+
+    const { articles } = await adapter.fetchLegislation('2755-17');
+    const numbers = articles.map(a => a.article_number);
+
+    expect(numbers).toContain('п.38.6');
+    expect(numbers).toContain('п.69.22');
+    const p386 = articles.find(a => a.article_number === 'п.38.6');
+    expect(p386!.full_text).toContain(TRANSITIONAL_MARKER);
+    expect(p386!.metadata?.is_transitional).toBe(true);
+  });
+
+  test('no article exceeds the mega-parse guard threshold', async () => {
+    mockAxiosInstance.get.mockResolvedValue({ data: PKU_PRINT_HTML });
+
+    const { articles } = await adapter.fetchLegislation('2755-17');
+    for (const a of articles) {
+      expect(a.full_text.length).toBeLessThan(400_000);
+    }
+  });
+});

--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -66,7 +66,38 @@ export class RadaLegislationAdapter {
   private readonly BASE_URL = 'https://zakon.rada.gov.ua';
   private readonly CHUNK_SIZE = 500; // characters per chunk for vector search
   private readonly CHUNK_OVERLAP = 100; // overlap between chunks
+  /**
+   * full_text length above which a parsed article is almost certainly a broken parse
+   * (the last "Стаття N." swallowing the document tail — LEXAI-1809). The largest legit
+   * article observed is ПКУ ст. 14 «визначення понять» ≈ 216K chars, so 400K is a safe
+   * alarm threshold. We keep the record but log an error so the anomaly is visible.
+   */
+  private readonly MEGA_ARTICLE_WARN_CHARS = 400_000;
+  /**
+   * Headings that begin the "Прикінцеві та перехідні положення" block. Article bodies
+   * must stop here — the block is extracted separately by extractTransitionalProvisions,
+   * and letting the last article run past it produces the ст. 346 mega-record.
+   */
+  private static readonly TRANSITIONAL_HEADER_PATTERNS = [
+    /ПРИКІНЦЕВІ\s+ТА\s+ПЕРЕХІДНІ\s+ПОЛОЖЕННЯ/i,
+    /ПЕРЕХІДНІ\s+ТА\s+ПРИКІНЦЕВІ\s+ПОЛОЖЕННЯ/i,
+    /ПЕРЕХІДНІ\s+ПОЛОЖЕННЯ/i,
+    /ПРИКІНЦЕВІ\s+ПОЛОЖЕННЯ/i,
+  ];
   private externalApiMetrics: ((service: string, status: string, durationSec: number) => void) | null = null;
+
+  /**
+   * Index of the earliest "Прикінцеві та перехідні положення" heading in the HTML, or -1.
+   * Used to bound the main-article scan so the last article can't swallow the tail.
+   */
+  private findTransitionalSectionStart(html: string): number {
+    let earliest = -1;
+    for (const pat of RadaLegislationAdapter.TRANSITIONAL_HEADER_PATTERNS) {
+      const m = pat.exec(html);
+      if (m && (earliest < 0 || m.index < earliest)) earliest = m.index;
+    }
+    return earliest;
+  }
 
   constructor(db: IDatabase) {
     this.db = db;
@@ -161,11 +192,20 @@ export class RadaLegislationAdapter {
     // Chapters: <span class=rvts15>Глава 1 </span><br><span class=rvts15>TITLE</span>
     const structureMap = this.extractStructureMap(bodyHtml);
 
-    // Parse articles: handles both <span class=rvts9>Стаття N. Title</span> and <span class=rvts9>Стаття N.</span>
-    const articleRegex = /<span\s+class=["']?rvts9["']?>Стаття\s+(\d+(?:-\d+)?)\.?\s*([^<]*)<\/span>\s*(.*?)(?=<span\s+class=["']?rvts9["']?>Стаття\s+\d|$)/gs;
+    // Bound the article scan at the "Прикінцеві та перехідні положення" heading: that block
+    // is parsed separately (extractTransitionalProvisions), and without this bound the last
+    // "Стаття N." greedily absorbs the entire tail (the ст. 346 ≈1M-char mega-record, LEXAI-1809).
+    // Slicing only the tail keeps match.index aligned with structureMap (built on full bodyHtml).
+    const transitionalStart = this.findTransitionalSectionStart(bodyHtml);
+    const scanHtml = transitionalStart >= 0 ? bodyHtml.slice(0, transitionalStart) : bodyHtml;
+
+    // Parse articles: handles both <span class=rvts9>Стаття N. Title</span> and <span class=rvts9>Стаття N.</span>.
+    // A body also terminates at the next structural header (Розділ/Підрозділ/Глава/Книга) so an article
+    // never swallows a following section that has no "Стаття N." of its own.
+    const articleRegex = /<span\s+class=["']?rvts9["']?>Стаття\s+(\d+(?:-\d+)?)\.?\s*([^<]*)<\/span>\s*(.*?)(?=<span\s+class=["']?rvts9["']?>Стаття\s+\d|<span\s+class=["']?rvts15["']?>\s*(?:Розділ|Підрозділ|Глава|Книга)\b|$)/gs;
 
     let match;
-    while ((match = articleRegex.exec(bodyHtml)) !== null) {
+    while ((match = articleRegex.exec(scanHtml)) !== null) {
       const articleNumber = match[1];
       const inlineTitle = match[2]?.trim(); // Title text inside the <span> tag
       const articleHtml = match[3];
@@ -204,6 +244,15 @@ export class RadaLegislationAdapter {
         : bodyText;
 
       if (fullText.length < 10) continue;
+
+      // Alarm on a likely broken parse (a body that swallowed the tail). Kept, not dropped,
+      // but logged so the anomaly surfaces instead of silently polluting search (LEXAI-1809).
+      if (fullText.length > this.MEGA_ARTICLE_WARN_CHARS) {
+        logger.error(
+          `[legislation] Suspiciously large article ${radaId} ст.${articleNumber}: ${fullText.length} chars ` +
+          `(> ${this.MEGA_ARTICLE_WARN_CHARS}) — probable parser tail-swallow, please re-check`
+        );
+      }
 
       // Use inline title from span if available, otherwise extract from body text
       let title: string | undefined;
@@ -421,17 +470,10 @@ export class RadaLegislationAdapter {
   private extractTransitionalProvisions(bodyHtml: string, radaId: string): LegislationArticle[] {
     const articles: LegislationArticle[] = [];
 
-    // Find the transitional provisions section header
-    const headerPatterns = [
-      /ПРИКІНЦЕВІ\s+ТА\s+ПЕРЕХІДНІ\s+ПОЛОЖЕННЯ/i,
-      /ПЕРЕХІДНІ\s+ТА\s+ПРИКІНЦЕВІ\s+ПОЛОЖЕННЯ/i,
-      /ПЕРЕХІДНІ\s+ПОЛОЖЕННЯ/i,
-      /ПРИКІНЦЕВІ\s+ПОЛОЖЕННЯ/i,
-    ];
-
+    // Find the transitional provisions section header (shared with the article-scan bound).
     let sectionStart = -1;
     let sectionTitle = '';
-    for (const pat of headerPatterns) {
+    for (const pat of RadaLegislationAdapter.TRANSITIONAL_HEADER_PATTERNS) {
       const m = pat.exec(bodyHtml);
       if (m) {
         sectionStart = m.index;
@@ -1027,12 +1069,16 @@ export class RadaLegislationAdapter {
 
   private extractArticlesPreBold(html: string): LegislationArticle[] {
     const articles: LegislationArticle[] = [];
+    // Bound the scan at the transitional block so the last <b>Стаття N.</b> can't swallow
+    // the document tail (same mega-record defect as the /print parser — LEXAI-1809).
+    const transitionalStart = this.findTransitionalSectionStart(html);
+    const scanHtml = transitionalStart >= 0 ? html.slice(0, transitionalStart) : html;
     // Edition pages wrap text in <pre> blocks with <b>Стаття N.</b> headers
     const articleRegex = /<b>Стаття\s+(\d+(?:-\d+)?)\.?<\/b>\s*(.*?)(?=<b>Стаття\s+\d|<\/pre>\s*$|$)/gs;
 
     const seen = new Set<string>();
     let match;
-    while ((match = articleRegex.exec(html)) !== null) {
+    while ((match = articleRegex.exec(scanHtml)) !== null) {
       const articleNumber = match[1].trim();
       if (seen.has(articleNumber)) continue;
       seen.add(articleNumber);
@@ -1053,6 +1099,13 @@ export class RadaLegislationAdapter {
       body = body.trim();
 
       if (body.length < 5) continue;
+
+      if (body.length > this.MEGA_ARTICLE_WARN_CHARS) {
+        logger.error(
+          `[legislation] Suspiciously large edition article ст.${articleNumber}: ${body.length} chars ` +
+          `(> ${this.MEGA_ARTICLE_WARN_CHARS}) — probable parser tail-swallow, please re-check`
+        );
+      }
 
       const firstLine = body.split('\n')[0].trim();
       const title = firstLine.length < 200 ? firstLine : undefined;


### PR DESCRIPTION
## Problem (LEXAI-1809)

The article parsers terminated each body only at the next `Стаття N.` header or end-of-document, so the **last `Стаття` before «Прикінцеві та перехідні положення» absorbed the entire tail** — the transitional block + trailing `Розділ …` provisions. This produced the broken **~1M-char ПКУ ст. 346 mega-record** surfaced in LEXAI-1806, which (a) makes exact fetch of ст. 346 return garbage and (b) floods Qdrant `legal_sections` with ~2000 mis-tagged chunks.

## Fix

- Bound the main-article scan (`extractArticles`) at the transitional-provisions heading — that block is already parsed separately by `extractTransitionalProvisions`. Shared via `findTransitionalSectionStart` + `TRANSITIONAL_HEADER_PATTERNS`.
- Also terminate an article body at the next **structural header** (`Розділ/Підрозділ/Глава/Книга`), so it can't swallow a headerless following section.
- Same bound applied to the edition parser (`extractArticlesPreBold`).
- Slicing only the tail keeps `match.index` aligned with the structure map (positions unaffected).
- **Mega-parse guard**: log an error when any parsed article exceeds 400K chars (largest legit article, ПКУ ст. 14, ≈216K) so future breakage is visible instead of silent.

Prevents recurrence on any future import/re-import.

> **Existing polluted data** (the ст. 346 row already in the DB + its stale `legal_sections` chunks) is remediated as a separate data op after this deploys — re-import ПКУ (UPDATEs the row in place) + delete the stale Qdrant chunks + audit other codes.

## Testing

Synthetic RADA `/print` markup with a large transitional block after the last article:
- ст. 346 keeps only its own body (not the transitional marker), length < 5K.
- Transitional points still extracted as `п.38.6` / `п.69.22` (`is_transitional: true`).
- No article exceeds the 400K guard threshold.

Full adapter + legislation suites green (130 tests); `tsc` clean for touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the last “Стаття” from absorbing the “Прикінцеві та перехідні положення” tail, fixing the ПКУ ст. 346 mega-record and blocking repeats (LEXAI-1809). Applies the same bounds to both `/print` and edition parsers and adds a size guard with logging.

- **Bug Fixes**
  - Bound the main article scan at the transitional heading using `findTransitionalSectionStart` + `TRANSITIONAL_HEADER_PATTERNS`; the transitional block is parsed separately.
  - Also stop an article at the next structural header (`Розділ`/`Підрозділ`/`Глава`/`Книга`).
  - Applied the same bound to the edition parser `extractArticlesPreBold`.
  - Added a size guard: log an error when `full_text` > 400K chars.
  - Added tests: ст. 346 stays small, transitional points (`п.38.6`, `п.69.22`) are extracted, and no article exceeds the threshold.

<sup>Written for commit ce7b4cdefc8403970196731553299006e5cb29d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

