### PR TITLE
feat(opendata): RATE_LIMIT_MS env override for NIPO importer pacing

### DIFF
--- a/mcp_backend/src/scripts/import-uipv-ip.ts
+++ b/mcp_backend/src/scripts/import-uipv-ip.ts
@@ -18,7 +18,10 @@ import * as https from 'https';
 
 // ── Config ──────────────────────────────────────────────────────────────────
 const API_BASE = 'https://sis.nipo.gov.ua/api/v1/open-data/';
-const RATE_LIMIT_MS = 1100; // 1 req/sec + margin
+// 1 req/sec API limit; the sleep runs BEFORE each fetch, so effective period =
+// RATE_LIMIT_MS + fetch latency (~0.6s). Override via env to pace closer to the
+// real limit (429s are retried with a 5s backoff anyway).
+const RATE_LIMIT_MS = parseInt(process.env.RATE_LIMIT_MS || '1100');
 const BATCH_INSERT_SIZE = 50;
 const CHECKPOINT_DIR = '/tmp/uipv-import-checkpoints';
 const CONCURRENCY = parseInt(process.env.CONCURRENCY || '1'); // stay at 1 for rate limit


### PR DESCRIPTION
The fixed 1100ms sleep runs BEFORE each fetch, so the effective request
period is 1100ms + fetch latency (~600ms) ≈ 0.55 req/s — half the API's
1 req/s allowance. Allow overriding via RATE_LIMIT_MS (e.g. 500 → ~0.9
req/s); occasional 429s are already retried with a 5s backoff.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the NIPO open-data importer pacing configurable via `RATE_LIMIT_MS` to run closer to the 1 req/s API limit and improve throughput. The pre-fetch sleep plus ~0.6s latency previously capped at ~0.55 req/s; lowering `RATE_LIMIT_MS` (e.g., 500ms) targets ~0.9 req/s, while the default stays 1100ms and 429s keep a 5s retry backoff.

<sup>Written for commit 67de89ddca355b54485816ebdf7df176cbaa36f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

