### PR TITLE
feat(legislation): GPU vectorization pipeline (export + ORT bge-m3) — LEXAI-1807

### DIFF
--- a/scripts/legislation/bge-m3-vectorize/embed_legislation_ort_trt.py
+++ b/scripts/legislation/bge-m3-vectorize/embed_legislation_ort_trt.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+STEP 3 (run on Brev, inside NGC TensorRT container): embed pre-chunked legislation
+JSONL shards with bge-m3 via ONNX Runtime + TensorRT FP16, one process per GPU,
+and upsert straight into the big Qdrant (bigbox) collection legal_sections_bge.
+
+Fork of /data/kupap-vectorize/embed_ort_trt_32w.py — but input is ALREADY chunked
+(export_legislation_chunks.py) with final id + payload, so this only embeds and upserts.
+
+Each input line: {"id": <uuid>, "text": <chunk>, "payload": {...legal_sections payload...}}
+
+Launch (from Brev host):
+  docker run -d --name leg-trt --gpus all --network host -v /data:/data \
+    nvcr.io/nvidia/tensorrt:25.05-py3 bash -c \
+    'pip install -q onnxruntime-gpu transformers tokenizers qdrant-client && \
+     python3 /data/legislation-vectorize/embed_legislation_ort_trt.py \
+       --data-dir /data/legislation-vectorize/shards \
+       --qdrant-url http://10.88.0.6:6333 --qdrant-api-key <BIGBOX_KEY> \
+       --collection legal_sections_bge --num-gpus 8 --batch-size 64'
+"""
+import argparse, json, logging, os, time
+from multiprocessing import Process, Value
+from pathlib import Path
+import numpy as np
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [W%(message)s")
+log = logging.getLogger(__name__)
+
+QDRANT_BATCH = 256  # keep request < qdrant 32MB
+EMBED_DIM = 1024
+
+
+def mean_pooling(hidden_state, attention_mask):
+    m = np.expand_dims(attention_mask, -1).astype(np.float32)
+    return np.sum(hidden_state * m, 1) / np.clip(np.sum(m, 1), 1e-9, None)
+
+
+def normalize(e):
+    return e / np.clip(np.linalg.norm(e, axis=1, keepdims=True), 1e-9, None)
+
+
+def worker(gpu_id, jsonl_file, qdrant_url, qdrant_api_key, onnx_path, collection, batch_size, progress):
+    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id % 8)
+    import onnxruntime as ort
+    from transformers import AutoTokenizer
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import PointStruct
+    prefix = f"{gpu_id}] "
+    tok = AutoTokenizer.from_pretrained("BAAI/bge-m3", cache_dir="/data/hf_cache")
+    # CUDA EP only: TensorRT rebuilds an engine per input shape (padding=True => many
+    # shapes) which stalls on a 759K-chunk job. CUDA EP handles dynamic shapes with no
+    # build step and is plenty fast on H100 for this volume. (TRT worth it only at 100M+ scale.)
+    providers = [("CUDAExecutionProvider", {"device_id": 0})]
+    sess = ort.InferenceSession(onnx_path, providers=providers)
+    log.info(f"{prefix}providers={sess.get_providers()}")
+    qc = QdrantClient(url=qdrant_url, api_key=qdrant_api_key or None, timeout=300)
+
+    buf, pending, processed, t0 = [], [], 0, time.time()
+
+    def embed_and_queue():
+        if not buf:
+            return
+        texts = [b["text"] for b in buf]
+        enc = tok(texts, padding=True, truncation=True, max_length=512, return_tensors="np")
+        ids = enc["input_ids"].astype(np.int64); mask = enc["attention_mask"].astype(np.int64)
+        embs = []
+        for i in range(0, len(texts), batch_size):
+            out = sess.run(None, {"input_ids": ids[i:i+batch_size], "attention_mask": mask[i:i+batch_size]})
+            embs.append(normalize(mean_pooling(out[0], mask[i:i+batch_size])))
+        embs = np.concatenate(embs, 0)
+        for b, e in zip(buf, embs):
+            if not np.isfinite(e).all():
+                with open("/data/legislation-vectorize/quarantine_nonfinite.jsonl", "a") as qf:
+                    qf.write(json.dumps({"id": b["id"]}) + "\n")
+                continue
+            pending.append(PointStruct(id=b["id"], vector=e.tolist(), payload=b["payload"]))
+        buf.clear()
+
+    def flush():
+        if not pending:
+            return
+        for bs in range(0, len(pending), QDRANT_BATCH):
+            batch = pending[bs:bs+QDRANT_BATCH]
+            for attempt in range(5):
+                try:
+                    qc.upsert(collection_name=collection, points=batch, wait=False); break
+                except Exception as e:  # noqa: BLE001
+                    if attempt == 4:
+                        with open("/data/legislation-vectorize/failed_upserts.jsonl", "a") as ff:
+                            ff.write(json.dumps({"error": str(e)[:200], "ids": [p.id for p in batch]}) + "\n")
+                    time.sleep(2 ** attempt)
+        pending.clear()
+
+    with open(jsonl_file) as f:
+        for line in f:
+            d = json.loads(line)
+            if not d.get("text") or not d["text"].strip():
+                continue
+            buf.append(d); processed += 1
+            if len(buf) >= 256:
+                embed_and_queue()
+                with progress.get_lock():
+                    progress.value += 256
+                if len(pending) >= 8000:
+                    flush()
+                if processed % 20000 < 256:
+                    g = progress.value; el = time.time() - t0; sp = g/el if el else 0
+                    log.info(f"{prefix}local={processed} global={g} speed={sp:.0f}/s")
+    if buf:
+        embed_and_queue()
+        with progress.get_lock():
+            progress.value += len(buf)
+    flush()
+    log.info(f"{prefix}DONE {processed}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-dir", required=True)
+    ap.add_argument("--qdrant-url", required=True)
+    ap.add_argument("--qdrant-api-key", default="")
+    ap.add_argument("--onnx-path", default="/data/bge-m3-onnx/model.onnx")
+    ap.add_argument("--collection", default="legal_sections_bge")
+    ap.add_argument("--num-gpus", type=int, default=8)
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--recreate-collection", action="store_true")
+    a = ap.parse_args()
+
+    from qdrant_client import QdrantClient
+    from qdrant_client.models import VectorParams, Distance, PayloadSchemaType
+    qc = QdrantClient(url=a.qdrant_url, api_key=a.qdrant_api_key or None, timeout=120)
+    exists = qc.collection_exists(a.collection)
+    if exists and a.recreate_collection:
+        qc.delete_collection(a.collection); exists = False
+    if not exists:
+        qc.create_collection(a.collection, vectors_config=VectorParams(size=EMBED_DIM, distance=Distance.COSINE),
+                             on_disk_payload=True)
+        for fld, sch in [("document_type", PayloadSchemaType.KEYWORD), ("rada_id", PayloadSchemaType.KEYWORD),
+                         ("article_number", PayloadSchemaType.KEYWORD), ("is_current", PayloadSchemaType.BOOL),
+                         ("valid_from_ts", PayloadSchemaType.INTEGER), ("valid_to_ts", PayloadSchemaType.INTEGER)]:
+            try:
+                qc.create_payload_index(a.collection, field_name=fld, field_schema=sch)
+            except Exception:
+                pass
+        log.info(f"created collection {a.collection}")
+
+    shards = sorted(Path(a.data_dir).glob("*.jsonl"))
+    log.info(f"shards={len(shards)} -> {a.collection} @ {a.qdrant_url}")
+    progress = Value("i", 0)
+    procs = []
+    for i, sh in enumerate(shards):
+        p = Process(target=worker, args=(i % a.num_gpus, str(sh), a.qdrant_url, a.qdrant_api_key,
+                                         a.onnx_path, a.collection, a.batch_size, progress))
+        p.start(); procs.append(p)
+    for p in procs:
+        p.join()
+    log.info(f"ALL DONE total={progress.value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/legislation/bge-m3-vectorize/export_legislation_chunks.py
+++ b/scripts/legislation/bge-m3-vectorize/export_legislation_chunks.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+STEP 1 (run on prod, READ-ONLY DB): export legislation article chunks (current +
+historical editions, text-deduped) to balanced JSONL shards for GPU embedding on Brev.
+
+Each JSONL line: {"id": <uuid>, "text": <chunk text>, "payload": {...}}
+- text-dedup: consecutive byte-identical editions collapse into one version.
+- chunk 500/100 (parity with rada-legislation-adapter::createArticleChunks).
+- deterministic versioned id: md5("leg_{rada}_art_{num}_v_{valid_from}_chunk_{idx}").
+- payload = final Qdrant payload (rada_id, article_id, article_number, section/chapter,
+  article_title, chunk_index, text, context_before/after, document_type, is_current,
+  valid_from, valid_to, valid_from_ts, valid_to_ts).
+
+No embedding, no Qdrant here — pure export. Output: <out>/shard_{i}.jsonl (round-robin
+by chunk for balance across GPUs).
+
+  DATABASE_URL=postgresql://...@127.0.0.1:5438/secondlayer_prod \
+  python export_legislation_chunks.py --all --shards 8 --out /home/ubuntu/leg-export
+"""
+import argparse, hashlib, json, os, sys, time, datetime as _dt
+import psycopg2, psycopg2.extras
+
+CHUNK_SIZE, CHUNK_OVERLAP = 500, 100
+TS_SENTINEL = 99991231
+_EPOCH0 = _dt.datetime(1900, 1, 1)
+DEFAULT_EXCLUDE = {"254к/96-ВР", "4651-vi", "5073-VI", "4173-IX"}
+
+
+def log(m): print(f"[{time.strftime('%H:%M:%S')}] {m}", flush=True)
+def det_uuid(s):
+    h = hashlib.md5(s.encode()).hexdigest()
+    return f"{h[0:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+def ts_of(d): return int(d.strftime("%Y%m%d")) if d else 0
+
+
+def make_chunks(text, an, sn, cn, title):
+    text = text or ""
+    if len(text) <= CHUNK_SIZE:
+        return [{"chunk_index": 0, "text": text, "context_before": None, "context_after": None}]
+    out, start, ci = [], 0, 0
+    while start < len(text):
+        end = min(start + CHUNK_SIZE, len(text))
+        out.append({"chunk_index": ci, "text": text[start:end],
+                    "context_before": text[max(0, start - CHUNK_OVERLAP):start] if start > 0 else None,
+                    "context_after": text[end:min(len(text), end + CHUNK_OVERLAP)] if end < len(text) else None})
+        start += CHUNK_SIZE - CHUNK_OVERLAP; ci += 1
+    return out
+
+
+def text_versions(rows):
+    from itertools import groupby
+    rows = sorted(rows, key=lambda r: (str(r["article_number"]), r["version_date"] or _EPOCH0))
+    for _, grp in groupby(rows, key=lambda r: str(r["article_number"])):
+        grp = list(grp)
+        runs, cur, cmd5 = [], [], None
+        for r in grp:
+            m = hashlib.md5((r["full_text"] or "").encode()).hexdigest()
+            if m != cmd5 and cur:
+                runs.append(cur); cur = []
+            cur.append(r); cmd5 = m
+        if cur: runs.append(cur)
+        for i, run in enumerate(runs):
+            rep = next((r for r in run if r["is_current"]), run[0])
+            yield {"article_id": rep["id"], "article_number": rep["article_number"],
+                   "section_number": rep["section_number"], "chapter_number": rep["chapter_number"],
+                   "title": rep["title"], "full_text": rep["full_text"],
+                   "valid_from": run[0]["version_date"],
+                   "valid_to": runs[i + 1][0]["version_date"] if i + 1 < len(runs) else None,
+                   "is_current": any(r["is_current"] for r in run)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--all", action="store_true"); g.add_argument("--rada-id"); g.add_argument("--pilot", action="store_true")
+    ap.add_argument("--shards", type=int, default=8)
+    ap.add_argument("--out", default="/home/ubuntu/leg-export")
+    ap.add_argument("--current-only", action="store_true")
+    ap.add_argument("--exclude", default=",".join(DEFAULT_EXCLUDE))
+    a = ap.parse_args()
+    exclude = {x.strip() for x in a.exclude.split(",") if x.strip()}
+    os.makedirs(a.out, exist_ok=True)
+
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    cur = conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    if a.rada_id:
+        cur.execute("SELECT id, rada_id FROM legislation WHERE lower(rada_id)=lower(%s)", (a.rada_id,))
+    elif a.pilot:
+        cur.execute("SELECT id, rada_id FROM legislation WHERE rada_id=%s", ("254к/96-вр",))
+    else:
+        cur.execute("""SELECT l.id, l.rada_id FROM legislation l WHERE EXISTS
+                       (SELECT 1 FROM legislation_articles la WHERE la.legislation_id=l.id AND length(la.full_text)>0)
+                       ORDER BY l.id""")
+    acts = [r for r in cur.fetchall() if r["rada_id"] not in exclude]
+
+    files = [open(os.path.join(a.out, f"shard_{i}.jsonl"), "w") for i in range(a.shards)]
+    n = 0
+    for act in acts:
+        lid, rada = act["id"], act["rada_id"]
+        cur.execute("""SELECT id, article_number, section_number, chapter_number, title,
+                              full_text, version_date, is_current
+                       FROM legislation_articles WHERE legislation_id=%s AND length(full_text)>0""", (lid,))
+        rows = cur.fetchall()
+        for v in text_versions(rows):
+            if a.current_only and not v["is_current"]:
+                continue
+            for ch in make_chunks(v["full_text"], v["article_number"], v["section_number"],
+                                  v["chapter_number"], v["title"]):
+                vid = det_uuid(f"leg_{rada}_art_{v['article_number']}_v_{v['valid_from']}_chunk_{ch['chunk_index']}")
+                rec = {"id": vid, "text": ch["text"], "payload": {
+                    "rada_id": rada, "article_id": v["article_id"], "article_number": v["article_number"],
+                    "section_number": v["section_number"], "chapter_number": v["chapter_number"],
+                    "article_title": v["title"], "chunk_index": ch["chunk_index"], "text": ch["text"],
+                    "context_before": ch["context_before"], "context_after": ch["context_after"],
+                    "document_type": "legislation", "is_current": v["is_current"],
+                    "valid_from": v["valid_from"].isoformat() if v["valid_from"] else None,
+                    "valid_to": v["valid_to"].isoformat() if v["valid_to"] else None,
+                    "valid_from_ts": ts_of(v["valid_from"]),
+                    "valid_to_ts": ts_of(v["valid_to"]) if v["valid_to"] else TS_SENTINEL,
+                }}
+                files[n % a.shards].write(json.dumps(rec, ensure_ascii=False) + "\n")
+                n += 1
+    for f in files: f.close()
+    log(f"exported {n} chunks across {a.shards} shards from {len(acts)} acts -> {a.out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
GPU vectorization pipeline for the full legislation corpus (current + **historical editions**, text-deduped) with **bge-m3 on Brev 8×H100**, upserting into the big Qdrant (**bigbox**). Avoids CPU-embedding on prod (which caused a load spike). Complements the merged backend PR #2084 (config-gated bge query path).

## Files (`scripts/legislation/bge-m3-vectorize/`)
- **`export_legislation_chunks.py`** — run on prod (READ-ONLY DB). Builds text-deduped editions (consecutive byte-identical collapse), chunks 500/100 (parity with `rada-legislation-adapter::createArticleChunks`), deterministic **versioned** `vector_id` = md5(`leg_{rada}_art_{num}_v_{valid_from}_chunk_{idx}`) + full `legal_sections` payload (`valid_from/valid_to`, `valid_from_ts/valid_to_ts`, `is_current`, `document_type`). Writes balanced JSONL shards.
- **`embed_legislation_ort_trt.py`** — run on Brev inside NGC TensorRT container (`nvcr.io/nvidia/tensorrt:25.05-py3`, `onnxruntime-gpu==1.20.1`, **CUDA EP**). One process per GPU; embeds pre-chunked shards and upserts straight to the target collection (`legal_sections_bge`) + payload indexes (document_type, rada_id, is_current, valid_from_ts, valid_to_ts).

## Result (verified 2026-07-02)
- **759,336 points** into bigbox `legal_sections_bge` (1024 Cosine) in ~10 min (~1400 chunks/s). Self-vector search verified.
- Prod CPU used only for export/chunking (read-only).

## Notes
- TensorRT EP was dropped: it rebuilds an engine per input shape (padding varies) and stalls at this volume; CUDA EP handles dynamic shapes with no build and is plenty fast for 759K on H100.
- Transport: prod→brev direct SSH over WG; brev→bigbox WG was blackholed (bigbox roams) so a temp socat relay on prod was used and removed after.
- Freshness note for later consolidation: bigbox copies of `legal_sections` (−6288) and `vault_documents` (−258) are stale vs prod-local and need a sync before repointing prod `QDRANT_URL`→bigbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GPU vectorization pipeline for the full legislation corpus using `BAAI/bge-m3` with `onnxruntime-gpu` and writes vectors to Qdrant `legal_sections_bge`. Replaces CPU embedding on prod and meets LEXAI-1807 performance and stability goals.

- **New Features**
  - `export_legislation_chunks.py`: read-only export with deduped consecutive identical editions, 500/100 chunking, deterministic versioned `vector_id`, and balanced JSONL shards.
  - `embed_legislation_ort_trt.py`: `onnxruntime-gpu` (CUDA EP) with one process per GPU; embeds shards and upserts to Qdrant `legal_sections_bge` (1024, cosine) and sets payload indexes.
  - Result: 759,336 vectors inserted in ~10 min; prod only does export/chunking.

- **Migration**
  - Run export on prod; run embed on Brev inside `nvcr.io/nvidia/tensorrt:25.05-py3`; set `QDRANT_URL` and API key.
  - Sync bigbox copies of legislation data before repointing prod `QDRANT_URL` to bigbox.

<sup>Written for commit 43df4abfd4a9f3a4804a29df68d3f2447b031f85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

