### PR TITLE
fix(prod): green SECONDLAYER_URL -> app-prod (resolve fix)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1166,7 +1166,7 @@ services:
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-task-aware}
-      SECONDLAYER_URL: http://app-prod-green:3000
+      SECONDLAYER_URL: http://app-prod:3000
       SECONDLAYER_API_KEY: ${SECONDARY_LAYER_KEYS:-}
       RADA_API_KEYS: ${RADA_API_KEYS:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
@@ -1213,7 +1213,7 @@ services:
       OPENAI_MODEL_QUICK: ${OPENAI_MODEL_QUICK:-gpt-5-nano}
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
-      SECONDLAYER_URL: http://app-prod-green:3000
+      SECONDLAYER_URL: http://app-prod:3000
       SECONDLAYER_API_KEY: ${SECONDARY_LAYER_KEYS:-}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       NODE_OPTIONS: --max-old-space-size=1536


### PR DESCRIPTION
Green rada/openreyestr services used `http://app-prod-green:3000` for SECONDLAYER_URL, but only the color-stable alias `app-prod` resolves to the active backend (set by the blue-green switch). `app-prod-green` resolves to nothing → backend cross-calls fail. Blue services already use `app-prod`; align green.

Discovered during LEXAI-1807 bigbox cutover verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `SECONDLAYER_URL` in green `rada` and `openreyestr` services from `http://app-prod-green:3000` to the color-stable `http://app-prod:3000` to restore backend cross-calls. Aligns with blue services and fixes the NameResolutionError observed during LEXAI-1807 cutover verification.

<sup>Written for commit f51ebce84c8a37244f029bb7e03051326b5c816d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

