### PR TITLE
chore(prod): remove qdrant-prod service (LEXAI-1807 Phase B)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -147,34 +147,6 @@ services:
         reservations:
           memory: 2G
 
-  qdrant-prod:
-    image: qdrant/qdrant:v1.17.0
-    container_name: secondlayer-qdrant-prod
-    ports:
-    - "127.0.0.1:6339:6333"
-    - "127.0.0.1:6340:6334"
-    volumes:
-    - qdrant_prod_data:/qdrant/storage
-    healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/6333'"]
-      interval: 30s
-      timeout: 5s
-      retries: 10
-      start_period: 1800s
-    restart: unless-stopped
-    networks:
-    - secondlayer-prod-network
-    environment:
-      TZ: Europe/Kiev
-      QDRANT__SERVICE__API_KEY: ${QDRANT_API_KEY:-}
-      QDRANT__STORAGE__OPTIMIZERS__MEMMAP_THRESHOLD_KB: "20480"
-    deploy:
-      resources:
-        limits:
-          memory: 40G
-        reservations:
-          memory: 8G
-
   redis-prod:
     image: redis:7-alpine
     container_name: secondlayer-redis-prod
@@ -686,8 +658,6 @@ services:
     depends_on:
       pgbouncer-prod:
         condition: service_healthy
-      qdrant-prod:
-        condition: service_healthy
       redis-prod:
         condition: service_healthy
       migrate-prod:
@@ -729,8 +699,6 @@ services:
     depends_on:
       pgbouncer-prod:
         condition: service_healthy
-      qdrant-prod:
-        condition: service_started
       redis-prod:
         condition: service_healthy
     environment:
@@ -1107,8 +1075,6 @@ services:
     depends_on:
       pgbouncer-prod:
         condition: service_healthy
-      qdrant-prod:
-        condition: service_healthy
       redis-prod:
         condition: service_healthy
     volumes:
@@ -1250,8 +1216,6 @@ services:
     depends_on:
       pgbouncer-prod:
         condition: service_healthy
-      qdrant-prod:
-        condition: service_started
       redis-prod:
         condition: service_healthy
     environment:
@@ -1696,8 +1660,6 @@ volumes:
   postgres_prod_data:
     driver: local
   postgres_openreyestr_prod_data:
-    driver: local
-  qdrant_prod_data:
     driver: local
   redis_prod_data:
     driver: local


### PR DESCRIPTION
Prod vector search fully consolidated on bigbox (172.31.25.243) and verified e2e. Removes the unused local `qdrant-prod` service + its depends_on (4 backend blocks) + `qdrant_prod_data` volume declaration.

Physical volume data is retained on disk (compose only drops the declaration) as a short rollback net; reclaim later with `docker volume rm`.

Verified before removal: backend QDRANT_URL=bigbox, search_legislation→legal_sections_bge (bigbox-only), search_court_decisions(semantic)→edrsr_serving, stale collections synced (bigbox superset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `qdrant-prod` from production after consolidating vector search to the bigbox Qdrant. Also removed related `depends_on` entries and the `qdrant_prod_data` volume declaration to simplify the stack (LEXAI-1807 Phase B).

- **Refactors**
  - Removed `qdrant-prod` from `deployment/docker-compose.prod.yml`.
  - Dropped `depends_on` on `qdrant-prod` in four backend services.
  - Removed `qdrant_prod_data` volume declaration.
  - Production now uses bigbox via `QDRANT_URL`/`QDRANT_EDRSR_URL` (e2e verified).

- **Migration**
  - No action required if `.env.prod` has `QDRANT_URL`/`QDRANT_EDRSR_URL` pointing to bigbox (172.31.25.243).
  - Rollback: restore `qdrant-prod` and point URLs back; data persists on disk and can be reclaimed later with `docker volume rm`.

<sup>Written for commit 20d7ba1f7c2b1062b78eb2ae191f2eaeee134a51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

