### PR TITLE
fix(deploy): drop removed qdrant-prod service from deploy-prod + manage-gateway

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -537,9 +537,9 @@ jobs:
 
             # --- 3. Start new-color containers alongside old ones ---
             # Ensure infra services are running WITHOUT recreating them.
-            # Qdrant holds vector indices and may be running long embedding jobs;
-            # recreating it interrupts indexing and takes 10+ min to recover.
-            \$DC up -d --no-recreate qdrant-prod redis-prod pgbouncer-prod
+            # qdrant-prod was removed from the prod compose (LEXAI-1807 Phase B,
+            # PR #2089) — vectors are served from bigbox via QDRANT_URL.
+            \$DC up -d --no-recreate redis-prod pgbouncer-prod
 
             if [ "\$ANY_BACKEND" = "true" ]; then
               if [ "\$NEW_BACKEND" = "green" ]; then

--- a/deployment/manage-gateway.sh
+++ b/deployment/manage-gateway.sh
@@ -204,7 +204,7 @@ start_env() {
             print_msg "$BLUE" "Starting prod services on ${PROD_SERVER}..."
             $ssh_cmd \
                 "cd ${PROD_REMOTE_PATH} && docker compose -f docker-compose.prod.yml --env-file .env.prod up -d \
-                    postgres-prod pgbouncer-prod redis-prod qdrant-prod minio-prod postgres-openreyestr-prod \
+                    postgres-prod pgbouncer-prod redis-prod minio-prod postgres-openreyestr-prod \
                     app-prod rada-mcp-app-prod app-openreyestr-prod document-service-prod lexwebapp-prod \
                     nginx-prod \
                     prometheus-prod grafana-prod cadvisor-prod"
@@ -890,7 +890,7 @@ deploy_to_server() {
                 INFRA_FLAGS="--force-recreate"
             fi
             $DC up -d $INFRA_FLAGS \
-                postgres-prod redis-prod qdrant-prod \
+                postgres-prod redis-prod \
                 postgres-openreyestr-prod minio-prod
             $DC up -d pgbouncer-prod 2>/dev/null || true
 


### PR DESCRIPTION
## Problem

PR #2089 (LEXAI-1807 Phase B) removed the `qdrant-prod` service from `docker-compose.prod.yml`, but `.github/workflows/deploy-prod.yml` Phase 1 still runs:

```
$DC up -d --no-recreate qdrant-prod redis-prod pgbouncer-prod
```

→ every prod deploy now fails with `no such service: qdrant-prod` (first failure: run 28587507852, right after #2089 landed).

## Fix

- `deploy-prod.yml`: start only `redis-prod pgbouncer-prod` in the infra step (comment updated — vectors served from bigbox via `QDRANT_URL`).
- `deployment/manage-gateway.sh`: same stale reference removed from the prod `start` service list and the prod deploy infra step.

No other `qdrant-prod` references remain outside compose env-var defaults (`QDRANT_URL:-http://qdrant-prod:6333`), which are overridden by `.env.prod` and harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale references to the deleted `qdrant-prod` service from the prod deploy workflow and gateway script to stop prod deploy failures. Aligns with LEXAI-1807 Phase B, where vectors moved to bigbox via `QDRANT_URL`.

- **Bug Fixes**
  - `.github/workflows/deploy-prod.yml`: infra step now starts only `redis-prod` and `pgbouncer-prod`; comment updated.
  - `deployment/manage-gateway.sh`: dropped `qdrant-prod` from prod start and infra-up commands.

<sup>Written for commit 777efa1143677ed3cf4df3ab02350350ec4e8bce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

