### PR TITLE
feat(citation-graph): extract ПКУ transitional-provision points + targeted backfill mode (LEXAI-1817)

### DIFF
--- a/scripts/citation-graph/extract-citations.py
+++ b/scripts/citation-graph/extract-citations.py
@@ -69,6 +69,22 @@ PATTERNS = {
         r'(?:\s+України)?',
         re.IGNORECASE | re.UNICODE
     ),
+    # Transitional provisions of the Tax Code (LEXAI-1817): «підпункту 38.6 пункту 38
+    # підрозділу 10 розділу ХХ «Перехідні положення» ПК України», «п.п. 69.22 п. 69
+    # підрозд. 10 розд. XX ПКУ», «пункту 38.6. Підрозділу «Інших Перехідних положень»
+    # Податкового Кодексу України». Anchored on «підрозділ» + (розділ XX | «Перехідн…»)
+    # so ordinary article sub-points (пп. 14.1.235 … статті 14) never match. NB розділ
+    # number appears both as Latin XX and Cyrillic ХХ in EDRSR texts.
+    "transitional_provision": re.compile(
+        r'(?:підпункт[а-яїіє]{0,3}|пункт[а-яїіє]{0,3}|п\.\s?п\.|пп\.|п\.)\s*'
+        r'(\d{1,3}(?:[.\-]\d{1,3}){1,2})\.?'                       # dotted point: 38.6 / 69.22 / 38.6.1
+        r'(?:\s+(?:пункт[а-яїіє]{0,3}|п\.)\s*\d{1,3})?'            # optional parent «пункту 38»
+        r'\s+підрозд(?:іл[а-яїіє]{0,3}|\.)'
+        r'(?:\s*(\d{1,2}))?'                                        # optional підрозділ number
+        r'(?:\s+розд(?:іл[а-яїіє]{0,3}|\.)\s*[XХxх]{2}(?![XХxх])'  # anchor A: розділ XX (Latin/Cyrillic)
+        r'|[^.\n]{0,40}?Перехідн)',                                 # anchor B: named «…Перехідн…» subdivision
+        re.IGNORECASE | re.UNICODE
+    ),
     # Constitution: "стаття 124 Конституції України"
     "constitution": re.compile(
         r'(?:стат(?:т[іея]|ей)|ст\.)\s*'
@@ -218,8 +234,8 @@ MAX_TEXT_LEN = 10_000
 
 def extract_citations_from_text(doc_id: int, text: str) -> list[Citation]:
     citations = []
-    if len(text) > MAX_TEXT_LEN:
-        text = text[:MAX_TEXT_LEN]
+    if len(text) > _MAX_TEXT_LEN:
+        text = text[:_MAX_TEXT_LEN]
 
     for m in PATTERNS["law_article"].finditer(text):
         articles_raw = m.group(1)
@@ -238,6 +254,14 @@ def extract_citations_from_text(doc_id: int, text: str) -> list[Citation]:
         articles_raw = m.group(1)
         for art in parse_article_numbers(articles_raw):
             citations.append(Citation(doc_id, "constitution", "Конституція України", art, m.group(0)[:200]))
+
+    # Transitional provisions (LEXAI-1817): dotted point numbers must NOT go through
+    # parse_article_numbers (it drops non-integer tokens and range-expands dashes);
+    # keep the captured point as-is, normalising '-' to the official dotted form.
+    for m in PATTERNS["transitional_provision"].finditer(text):
+        point = m.group(1).rstrip(".").replace("-", ".")
+        citations.append(Citation(
+            doc_id, "transitional_provision", "Податковий кодекс України", point, m.group(0)[:200]))
 
     for m in PATTERNS["case_reference"].finditer(text):
         citations.append(Citation(doc_id, "case_reference", m.group(1), "", m.group(0)[:200]))
@@ -264,9 +288,15 @@ _CASE_TABLE = "case_citation_edges"
 _BULK_LOAD = False
 # Skip the per-year justice_kind enrich UPDATE (defer it to a single end-of-run pass).
 _NO_ENRICH = False
+# Targeted mode (LEXAI-1817): restrict scanned rows to tsv @@ to_tsquery('simple', _TSQUERY).
+# Lets a backfill touch only candidate docs (e.g. '38.6 | 69.22') instead of the whole corpus.
+_TSQUERY = None
+# Effective per-doc scan window; --max-text-len can raise it for targeted backfills
+# where the citation may sit deep in a long decision.
+_MAX_TEXT_LEN = MAX_TEXT_LEN
 
 # case_reference is routed to the separate decision->case edge table, not the statute table
-_STATUTE_TYPES = {"law_article", "codex_article", "constitution", "law_by_number", "supreme_court_ruling"}
+_STATUTE_TYPES = {"law_article", "codex_article", "constitution", "law_by_number", "supreme_court_ruling", "transitional_provision"}
 
 def _check_partitions():
     global _USE_PARTITIONS
@@ -294,18 +324,25 @@ def process_chunk(args: tuple) -> dict:
     # Partitions carry justice_kind per row, so filter/select directly off the partition (no join needed).
     if _check_partitions():
         table = f"edrsr_fulltext_p_{year}"
-        where = "WHERE justice_kind = %s " if _JUSTICE_KIND_FILTER is not None else ""
-        params = ([_JUSTICE_KIND_FILTER] if _JUSTICE_KIND_FILTER is not None else []) + [offset, chunk_size]
+        conds, params = [], []
+        if _JUSTICE_KIND_FILTER is not None:
+            conds.append("justice_kind = %s"); params.append(_JUSTICE_KIND_FILTER)
+        if _TSQUERY is not None:
+            conds.append("tsv @@ to_tsquery('simple', %s)"); params.append(_TSQUERY)
+        where = f"WHERE {' AND '.join(conds)} " if conds else ""
         cur.execute(
             f"SELECT doc_id, full_text, justice_kind FROM {table} {where}OFFSET %s LIMIT %s",
-            tuple(params),
+            tuple(params + [offset, chunk_size]),
         )
     else:
-        where = "AND justice_kind = %s " if _JUSTICE_KIND_FILTER is not None else ""
-        params = [year] + ([_JUSTICE_KIND_FILTER] if _JUSTICE_KIND_FILTER is not None else []) + [offset, chunk_size]
+        conds, params = ["adj_year = %s"], [year]
+        if _JUSTICE_KIND_FILTER is not None:
+            conds.append("justice_kind = %s"); params.append(_JUSTICE_KIND_FILTER)
+        if _TSQUERY is not None:
+            conds.append("tsv @@ to_tsquery('simple', %s)"); params.append(_TSQUERY)
         cur.execute(
-            f"SELECT doc_id, full_text, justice_kind FROM edrsr_fulltext WHERE adj_year = %s {where}OFFSET %s LIMIT %s",
-            tuple(params),
+            f"SELECT doc_id, full_text, justice_kind FROM edrsr_fulltext WHERE {' AND '.join(conds)} OFFSET %s LIMIT %s",
+            tuple(params + [offset, chunk_size]),
         )
 
     statute_data = []   # (doc_id, citation_type, law_ref, article_ref, raw_match, justice_kind)
@@ -409,15 +446,20 @@ def process_year(year: int, workers: int, dry_run: bool, chunk_size: int = 50000
     cur = conn.cursor()
     if _check_partitions():
         table = f"edrsr_fulltext_p_{year}"
+        conds, params = [], []
         if _JUSTICE_KIND_FILTER is not None:
-            cur.execute(f"SELECT COUNT(*) FROM {table} WHERE justice_kind = %s", (_JUSTICE_KIND_FILTER,))
-        else:
-            cur.execute(f"SELECT COUNT(*) FROM {table}")
+            conds.append("justice_kind = %s"); params.append(_JUSTICE_KIND_FILTER)
+        if _TSQUERY is not None:
+            conds.append("tsv @@ to_tsquery('simple', %s)"); params.append(_TSQUERY)
+        where = f" WHERE {' AND '.join(conds)}" if conds else ""
+        cur.execute(f"SELECT COUNT(*) FROM {table}{where}", tuple(params))
     else:
+        conds, params = ["adj_year = %s"], [year]
         if _JUSTICE_KIND_FILTER is not None:
-            cur.execute("SELECT COUNT(*) FROM edrsr_fulltext WHERE adj_year = %s AND justice_kind = %s", (year, _JUSTICE_KIND_FILTER))
-        else:
-            cur.execute("SELECT COUNT(*) FROM edrsr_fulltext WHERE adj_year = %s", (year,))
+            conds.append("justice_kind = %s"); params.append(_JUSTICE_KIND_FILTER)
+        if _TSQUERY is not None:
+            conds.append("tsv @@ to_tsquery('simple', %s)"); params.append(_TSQUERY)
+        cur.execute(f"SELECT COUNT(*) FROM edrsr_fulltext WHERE {' AND '.join(conds)}", tuple(params))
     total = cur.fetchone()[0]
     cur.close()
     conn.close()
@@ -491,17 +533,21 @@ def main():
     parser.add_argument("--limit", type=int, default=None, help="Cap rows processed per year (for piloting)")
     parser.add_argument("--bulk-load", action="store_true", help="Plain INSERT, no ON CONFLICT (deferred index: target tables must have NO unique index; dedup+index built afterwards)")
     parser.add_argument("--no-enrich", action="store_true", help="Skip per-year justice_kind enrich UPDATE (defer to a single end-of-run pass)")
+    parser.add_argument("--tsquery", type=str, default=None, help="Targeted mode: only rows matching to_tsquery('simple', TSQUERY), e.g. '38.6 | 69.22' (LEXAI-1817)")
+    parser.add_argument("--max-text-len", type=int, default=MAX_TEXT_LEN, help=f"Per-doc scan window in chars (default {MAX_TEXT_LEN}); raise for targeted backfills")
     args = parser.parse_args()
 
     if not args.year and not args.all:
         parser.error("Specify --year YYYY or --all")
 
-    global _JUSTICE_KIND_FILTER, _TARGET_TABLE, _CASE_TABLE, _BULK_LOAD, _NO_ENRICH
+    global _JUSTICE_KIND_FILTER, _TARGET_TABLE, _CASE_TABLE, _BULK_LOAD, _NO_ENRICH, _TSQUERY, _MAX_TEXT_LEN
     _JUSTICE_KIND_FILTER = args.justice_kind
     _TARGET_TABLE = args.target_table
     _CASE_TABLE = args.case_table
     _BULK_LOAD = args.bulk_load
     _NO_ENRICH = args.no_enrich
+    _TSQUERY = args.tsquery
+    _MAX_TEXT_LEN = args.max_text_len
 
     years = list(range(args.years_from, args.years_to + 1)) if args.all else [args.year]
 

--- a/scripts/citation-graph/test_transitional_extraction.py
+++ b/scripts/citation-graph/test_transitional_extraction.py
@@ -1,0 +1,98 @@
+"""LEXAI-1817 — transitional-provision citation extraction (пункти перехідних положень ПКУ).
+
+The extractor parsed only «ст. N» constructions: across all 331M law_court_citations
+rows there was not a single dotted law_article, so norms like пп. 38.6 / 69.22
+підрозд. 10 розд. XX ПКУ (the whole ATO/martial-law tax wave) were invisible to the
+citation graph. Fixtures below are verbatim from prod decision 107631753 (280/5185/19).
+
+Run: python3 -m unittest scripts/citation-graph/test_transitional_extraction.py -v
+(or from this directory: python3 -m unittest test_transitional_extraction -v)
+"""
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+# extract-citations.py imports psycopg2 at module level; the parser under test is
+# pure-regex, so stub the DB driver when it isn't installed locally.
+if "psycopg2" not in sys.modules:
+    try:
+        import psycopg2  # noqa: F401
+    except ImportError:
+        stub = types.ModuleType("psycopg2")
+        stub.extras = types.ModuleType("psycopg2.extras")
+        stub.extras.execute_values = lambda *a, **k: None
+        sys.modules["psycopg2"] = stub
+        sys.modules["psycopg2.extras"] = stub.extras
+
+_SPEC = importlib.util.spec_from_file_location(
+    "extract_citations", Path(__file__).with_name("extract-citations.py"))
+ec = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(ec)
+
+
+def transitional(text: str):
+    return [
+        (c.law_ref, c.article_ref)
+        for c in ec.extract_citations_from_text(1, text)
+        if c.citation_type == "transitional_provision"
+    ]
+
+
+class TransitionalProvisionExtraction(unittest.TestCase):
+    def test_canonical_form_cyrillic_xx(self):
+        # Verbatim from doc 107631753 (280/5185/19) — NB розділ «ХХ» is CYRILLIC here.
+        text = ("розташована на тимчасово окупованій території та/або території населених "
+                "пунктів на лінії зіткнення, а тому, в силу положень підпункту 38.6 пункту 38 "
+                "підрозділу 10 розділу ХХ «Перехідні положення» ПК України, не є об`єктом "
+                "оподаткування податком на нерухоме майно")
+        self.assertIn(("Податковий кодекс України", "38.6"), transitional(text))
+
+    def test_loose_form_named_pidrozdil(self):
+        # Verbatim from the same decision: no розділ number, subdivision named in words.
+        text = ("Позивач уважає, що у відповідно до пункту 38.6. Підрозділу «Інших "
+                "Перехідних положень» Податкового Кодексу України він звільнений від сплати податку")
+        self.assertIn(("Податковий кодекс України", "38.6"), transitional(text))
+
+    def test_martial_law_6922_abbreviated_latin_xx(self):
+        text = ("відповідно до п.п. 69.22 п. 69 підрозд. 10 розд. XX ПКУ податок на нерухоме "
+                "майно не нараховується та не сплачується")
+        self.assertIn(("Податковий кодекс України", "69.22"), transitional(text))
+
+    def test_punkt_form_without_parent(self):
+        text = "згідно з пунктом 69.22 підрозділу 10 розділу XX Податкового кодексу України"
+        self.assertIn(("Податковий кодекс України", "69.22"), transitional(text))
+
+    def test_article_subpoint_is_not_transitional(self):
+        # Sub-points of ordinary articles must NOT be captured (no підрозділ anchor).
+        text = "у розумінні підпункту 14.1.235 пункту 14.1 статті 14 ПКУ позивач є резидентом"
+        self.assertEqual(transitional(text), [])
+
+    def test_final_provisions_of_a_law_are_not_captured(self):
+        text = ("відповідно до пункту 5 розділу II «Прикінцеві положення» Закону України "
+                "від 06.06.2012 № 4915-VI")
+        self.assertEqual(transitional(text), [])
+
+    def test_codex_article_extraction_unaffected(self):
+        text = "не є об`єктом оподаткування відповідно до статті 266 ПК України"
+        cites = ec.extract_citations_from_text(1, text)
+        self.assertTrue(any(
+            c.citation_type == "codex_article"
+            and c.law_ref == "Податковий кодекс України"
+            and c.article_ref == "266"
+            for c in cites))
+
+    def test_statute_types_route_to_statute_table(self):
+        self.assertIn("transitional_provision", ec._STATUTE_TYPES)
+
+    def test_trailing_dot_stripped_from_point_number(self):
+        text = "відповідно до пункту 69.22. підрозділу 10 розділу XX ПКУ"
+        arts = [a for (_l, a) in transitional(text)]
+        self.assertIn("69.22", arts)
+        self.assertNotIn("69.22.", arts)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The citation extractor parsed only «ст. N» constructions — across all 331M `law_court_citations` rows there was **not a single dotted law_article**. The ATO (пп. 38.x, from 2014) and martial-law (пп. 69.x, from 2022) tax norms of підрозд. 10 розд. XX ПКУ were invisible to the citation graph: the gold-eval profile decision 280/5185/19 had only ПКУ ст. 266 + КАС ст. 328 while its actual legal base is пп. 38.6.

## Changes

1. **New `citation_type=transitional_provision`** — anchored on «підрозділ» + (розділ XX | «Перехідн…»), so ordinary article sub-points (пп. 14.1.235 … ст. 14) never match. Handles Latin and **Cyrillic** «XX/ХХ», abbreviations (п.п./підрозд./розд.), and the named form «Підрозділу «Інших Перехідних положень»». Fixtures verbatim from prod doc 107631753.
2. Dotted points bypass `parse_article_numbers` (it silently drops non-integer tokens and range-expands dashes).
3. **`--tsquery`** — targeted backfill mode: scans only `tsv @@ to_tsquery('simple', …)` candidates via GIN. Gotcha: bare float lexemes (`38.2`, `69.1`) match areas/amounts corpus-wide — AND the query with `підрозділу` word forms (53-key bare OR timed out; AND-narrowed runs in ~1s/partition, ~5K docs/year).
4. **`--max-text-len`** — raise the 10K per-doc scan window for targeted backfills.

## Verification

- 9 unit tests (`test_transitional_extraction.py`, psycopg2 stubbed, `python3 -m unittest`) — TDD, watched fail first.
- Prod dry-run on p_2023: **12,948 transitional citations from 4,998 candidate docs**.
- Full targeted backfill 2014-2026 running on prod (idempotent, ON CONFLICT DO NOTHING).

Resolver mapping confirmed: `legislation_articles` stores these as `article_number = 'п.38.6' / 'п.69.22'` (legislation_id 641, section «Прикінцеві та перехідні положення», is_current) — `legislation_citation_links` backfill follows as data-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds extraction for ПКУ transitional-provision points (e.g., пп. 38.6/69.22 підрозд. 10 розд. XX) and a targeted backfill mode to quickly populate missing citations. Addresses LEXAI-1817 by surfacing ATO and martial-law tax norms that were previously invisible in the citation graph.

- **New Features**
  - New citation_type=transitional_provision anchored on “підрозділ” + (розділ XX/«Перехідн…»); handles Cyrillic/Latin «XX/ХХ», abbreviations, and named subdivision form.
  - Dotted points (e.g., 38.6, 69.22) are captured as-is and normalized (dash → dot); bypasses parse_article_numbers to avoid token loss.
  - --tsquery to scan only tsv @@ to_tsquery('simple', …) candidates; works with partitioned and non-partitioned paths and combines with justice_kind filters.
  - --max-text-len to raise the per-doc scan window for targeted runs; internal _MAX_TEXT_LEN respected in extraction.
  - Tests added for Cyrillic/Latin forms, abbreviations, non-matching article sub-points, and routing to statute types.

<sup>Written for commit 92afff533b941decc9d93486d322d487b15b8bbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

