### PR TITLE
fix(chat): key request timeout to budget escalation ceiling (240s kill of escalated deep runs)

### DIFF
--- a/mcp_backend/src/routes/__tests__/chat-inline-routes.test.ts
+++ b/mcp_backend/src/routes/__tests__/chat-inline-routes.test.ts
@@ -1,0 +1,24 @@
+import { resolveChatTimeoutMs } from '../chat-inline-routes';
+
+describe('resolveChatTimeoutMs', () => {
+  // ChatService auto-escalates effectiveBudget up to maxBudget (default: deep),
+  // so the wall-clock backstop must cover the escalation ceiling, not the
+  // requested budget. Repro: chat-f6e736b9 (2026-07-03) — standard request
+  // auto-escalated to deep (plan >= 8 steps) was aborted mid-VERIFY at 240s.
+
+  it('gives the deep timeout when no maxBudget caps escalation', () => {
+    expect(resolveChatTimeoutMs('standard', undefined)).toBe(300_000);
+    expect(resolveChatTimeoutMs('quick', undefined)).toBe(300_000);
+    expect(resolveChatTimeoutMs(undefined, undefined)).toBe(300_000);
+    expect(resolveChatTimeoutMs('deep', undefined)).toBe(300_000);
+  });
+
+  it('gives the deep timeout when maxBudget is deep', () => {
+    expect(resolveChatTimeoutMs('standard', 'deep')).toBe(300_000);
+  });
+
+  it('gives the standard timeout when maxBudget caps escalation below deep', () => {
+    expect(resolveChatTimeoutMs('standard', 'standard')).toBe(240_000);
+    expect(resolveChatTimeoutMs('quick', 'quick')).toBe(240_000);
+  });
+});

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -15,6 +15,18 @@ import { v4 as uuidv4 } from 'uuid';
 import { requestContext } from '../utils/openai-client.js';
 import { runWithABUser } from '../infrastructure/adapters/llm-adapter.js';
 
+/**
+ * Wall-clock timeout for a chat request. ChatService auto-escalates
+ * effectiveBudget up to maxBudget (default: deep) — e.g. plan >= 8 steps or a
+ * queryType budget floor — so the backstop must cover the escalation ceiling,
+ * not the requested budget. Keying it on the requested budget aborted
+ * escalated runs mid-VERIFY at 240s (chat-f6e736b9, 2026-07-03).
+ */
+export function resolveChatTimeoutMs(budget?: string, maxBudget?: string): number {
+  const escalationCeiling = maxBudget || 'deep';
+  return escalationCeiling === 'deep' ? 300_000 : 240_000;
+}
+
 export function createChatInlineRoutes(deps: {
   chatService: ChatService;
   billingService: BillingService;
@@ -151,7 +163,7 @@ export function createChatInlineRoutes(deps: {
       const abortController = new AbortController();
 
       // Absolute wall-clock timeout to prevent runaway agentic loops
-      const timeoutMs = (budget === 'deep') ? 300_000 : 240_000;
+      const timeoutMs = resolveChatTimeoutMs(budget, maxBudget);
       const requestTimeout = setTimeout(() => {
         logger.warn('[ChatService] Request timed out', { requestId, timeoutMs, budget });
         abortController.abort();


### PR DESCRIPTION
## Problem (repro chat-f6e736b9, 2026-07-03)

Composite MSP-demo query (NEMIROFF: registry + class-33 collisions + court practice) died with «Час очікування вичерпано» in the web app.

Prod log timeline:
- 10:28:16 — agentic loop starts, **effectiveBudget auto-escalated to deep** (plan ≥ 8 steps), maxToolCalls=25
- 10:31:56 — EXECUTE phase completed successfully (10 LLM turns, 25 tool calls)
- 10:32:16 — `Request timed out {budget:"standard", timeoutMs:240000}` — abort mid-VERIFY

Root cause: `chat-inline-routes.ts` armed the wall-clock backstop from the **requested** budget (frontend sends none → standard → 240s), while ChatService legally escalates the run to deep. The escalated pipeline is structurally longer than 240s, so the answer was killed during verification after all the work was done.

## Fix

`resolveChatTimeoutMs(budget, maxBudget)` — timeout now covers the **escalation ceiling**: `maxBudget || 'deep'` → 300s by default; an explicit `maxBudget` below deep keeps 240s.

## Tests

- New `chat-inline-routes.test.ts` (TDD, 3 cases): no-cap → 300s, maxBudget=deep → 300s, maxBudget=standard/quick → 240s
- `tsc --noEmit`: 3 pre-existing core-overlay errors, unchanged by this PR (verified via stash diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes chat requests that timed out during verification by basing the wall-clock timeout on the escalation ceiling (`maxBudget`) instead of the requested budget. Default deep runs now get 300s, preventing mid-VERIFY kills on auto-escalated flows.

- **Bug Fixes**
  - Added `resolveChatTimeoutMs(budget, maxBudget)` with tests; wired into `chat-inline-routes.ts`.
  - Requests capped below deep keep 240s, avoiding premature aborts on escalated runs.

<sup>Written for commit 18db063f3649fb116847df537f9877135f14abb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

