### PR TITLE
feat(tools): get_decision_cited_norms — citation-graph lookup for norm-attribution check (CORE-103)

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -1,7 +1,7 @@
 /**
  * Court Decision Tools - Handlers for court decision retrieval and analysis
  *
- * 7 tools:
+ * 8 tools:
  * - get_court_decision
  * - get_case_documents_chain
  * - extract_document_sections
@@ -9,6 +9,7 @@
  * - bulk_ingest_court_decisions
  * - analyze_case_pattern
  * - count_cases_by_party
+ * - get_decision_cited_norms
  */
 
 import { EdsrLocalAdapter } from '../../adapters/edrsr-local-adapter.js';
@@ -267,6 +268,22 @@ export class CourtDecisionTools extends BaseToolHandler {
           required: ['party_name'],
         },
       },
+      {
+        name: 'get_decision_cited_norms',
+        annotations: { title: 'Норми, цитовані рішенням', readOnlyHint: true, idempotentHint: true },
+        description: `Перелік норм законодавства, на які фактично посилається судове рішення (граф цитувань legislation_citation_links)
+
+Повертає розв'язані посилання рішення на статті законодавства: rada_id закону/кодексу та базовий номер статті, згруповані з кількістю згадок, плюс загальну кількість таких посилань.
+total_resolved_links=0 означає відсутність даних графа для цього рішення, а НЕ відсутність цитувань у тексті.
+Використовуйте для детермінованої перевірки, чи посилається рішення на конкретну норму («суд застосував ст. X у справі Y»).`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            doc_id: { type: ['string', 'number'], description: 'doc_id рішення в ЄДРСР' },
+          },
+          required: ['doc_id'],
+        },
+      },
     ];
   }
 
@@ -287,8 +304,61 @@ export class CourtDecisionTools extends BaseToolHandler {
         return await this.analyzeCasePattern(args);
       case 'count_cases_by_party':
         return await this.countCasesByParty(args);
+      case 'get_decision_cited_norms':
+        return await this.getDecisionCitedNorms(args);
       default:
         return null;
+    }
+  }
+
+  /**
+   * Deterministic norm-attribution lookup (CORE-103): which legislation articles a
+   * decision actually cites, per the citation graph (legislation_citation_links,
+   * resolved rows only, grouped to base article numbers). The chat verify phase uses
+   * this to catch «суд застосував ст. X у справі Y» claims the decision's own
+   * citation edges do not support. Fail-soft: any failure (missing table on local,
+   * no DB) → total_resolved_links=0, which callers must read as "no graph data",
+   * never as "the decision cites nothing".
+   */
+  private async getDecisionCitedNorms(args: any): Promise<ToolResult> {
+    const docId = Number(args.doc_id);
+    if (!Number.isFinite(docId) || docId <= 0) {
+      return this.wrapResponse({
+        error: `doc_id має бути додатним числом, отримано "${args.doc_id}"`,
+        provided_value: args.doc_id,
+      });
+    }
+    if (!this.db) {
+      return this.wrapResponse({ doc_id: docId, total_resolved_links: 0, norms: [], note: 'database unavailable' });
+    }
+    try {
+      const res = await this.db.query(
+        `SELECT l.rada_id,
+                lcl.legislation_id,
+                split_part(lcl.article_number, '.', 1) AS article_base,
+                count(*)::int AS links
+           FROM legislation_citation_links lcl
+           JOIN legislation l ON l.id = lcl.legislation_id
+          WHERE lcl.doc_id = $1 AND lcl.resolved = true AND lcl.article_number IS NOT NULL
+          GROUP BY l.rada_id, lcl.legislation_id, split_part(lcl.article_number, '.', 1)
+          ORDER BY count(*) DESC
+          LIMIT 300`,
+        [docId]
+      );
+      const norms = res.rows.map((r: any) => ({
+        rada_id: r.rada_id,
+        legislation_id: r.legislation_id,
+        article_base: r.article_base,
+        links: r.links,
+      }));
+      return this.wrapResponse({
+        doc_id: docId,
+        total_resolved_links: norms.reduce((s: number, n: any) => s + n.links, 0),
+        norms,
+      });
+    } catch (error: any) {
+      logger.warn('[get_decision_cited_norms] lookup failed (fail-soft)', { docId, error: error?.message });
+      return this.wrapResponse({ doc_id: docId, total_resolved_links: 0, norms: [], note: error?.message });
     }
   }
 


### PR DESCRIPTION
## Что

Новый read-only тул в `CourtDecisionTools`: `doc_id` → distinct (rada_id, legislation_id, базовый номер статьи, links) из `legislation_citation_links` (resolved-строки, мгновенно по `idx_lcl_doc`) + `total_resolved_links`.

## Зачем

Детерминированная проверка norm-attribution в chat verify-фазе (companion: overthelex/secondlayer-core#87): «суд застосував ст. X у справі Y» сверяется с рёбрами графа цитирований самого решения. Repro chat-98f8472e: «ч. 2 ст. 77 КАС» приписана doc 116616306, у которого по КАС только ст. 341.

## Детали

- Fail-soft: нет таблицы (local) / нет БД / ошибка → `total_resolved_links=0`, caller обязан трактовать как «нет данных графа», не «решение ничего не цитирует».
- Прод-проверка SQL для doc 116616306: возвращает ровно рёбра из тикета (КУ 67, ПКУ 14/42/59/70, КАС 341).
- Overlay-типчек с core-файлами: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only tool `get_decision_cited_norms` to `CourtDecisionTools` that returns the legislation articles a decision actually cites, grouped by base article, with a total count. Supports CORE-103 by enabling deterministic norm-attribution checks in the chat verify phase.

- **New Features**
  - Queries `legislation_citation_links` (resolved rows) by `doc_id` and returns per-article `{rada_id, legislation_id, article_base, links}`.
  - Includes `total_resolved_links`; 0 means no graph data (e.g., DB/table missing), not “no citations”.
  - Validates `doc_id` and fails soft on DB errors, returning an empty `norms` list and a note.

<sup>Written for commit 77e2304019930239f85c46cec00a114b6ffdc288. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

