### PR TITLE
feat(edrsr): EDRSR_DATABASE_URL — dedicated DB pool for EdsrFtsService

### DIFF
--- a/mcp_backend/.env.example
+++ b/mcp_backend/.env.example
@@ -14,6 +14,12 @@ POSTGRES_DB=secondlayer
 POSTGRES_SUPERUSER=postgres
 POSTGRES_SUPERUSER_PASSWORD=your_superuser_password
 
+# Optional: dedicated database for EDRSR court-decision data (EdsrFtsService).
+# When set, all EDRSR FTS queries go to this DB instead of the main one — e.g. a dev
+# instance reading EDRSR from prod with a readonly user while writing app data locally.
+# EDRSR_DATABASE_URL=postgresql://readonly_user:password@10.88.0.1:5439/secondlayer_prod
+# EDRSR_POOL_MAX=20
+
 # =============================================================================
 # Application
 # =============================================================================

--- a/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-service.test.ts
@@ -195,3 +195,21 @@ describe('EdsrFtsService.countByParty', () => {
     expect(res.sample![0].doc_id).toBe(5);
   });
 });
+
+describe('EdsrFtsService dedicated EDRSR pool', () => {
+  it('routes queries to the dedicated pool instead of the caller-passed one', async () => {
+    const dedicated = makeDb();
+    const passed = makeDb();
+    const svc = new EdsrFtsService(dedicated as any);
+    await svc.searchFulltext('оренда землі', passed);
+    expect(dedicated.query).toHaveBeenCalled();
+    expect(passed.query).not.toHaveBeenCalled();
+  });
+
+  it('uses the caller-passed pool when no dedicated pool is configured', async () => {
+    const passed = makeDb();
+    const svc = new EdsrFtsService();
+    await svc.searchFulltext('оренда землі', passed);
+    expect(passed.query).toHaveBeenCalled();
+  });
+});

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -11,8 +11,13 @@
  *
  * Data is sharded across 4 databases; this service operates on whichever pool it receives.
  * edrsr_documents (metadata) lives only in the main DB.
+ *
+ * EDRSR_DATABASE_URL (optional): when set, the service opens its own pool to that database
+ * and uses it for ALL its queries, ignoring caller-passed pools — so a dev deployment can
+ * read EDRSR data from prod (readonly user) while the rest of the app stays on its own DB.
  */
 
+import { Pool } from 'pg';
 import { logger } from '../utils/logger.js';
 import type { PartyRole } from '@secondlayer/shared';
 import type { EdsrCacheService } from './edrsr-cache-service.js';
@@ -221,6 +226,36 @@ const FTS_STATEMENT_TIMEOUT_MS = 8000;
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
+  // EDRSR data can live in a different database than the app's main one (e.g. a dev instance
+  // reading EDRSR from prod under a readonly user while writing sessions/costs to its own DB).
+  // When EDRSR_DATABASE_URL is set, this dedicated pool overrides whatever pool callers pass;
+  // unset → the caller-passed pool is used unchanged (prod behaviour).
+  private readonly dedicatedPool: Pool | null;
+
+  constructor(dedicatedPool?: Pool) {
+    if (dedicatedPool) {
+      this.dedicatedPool = dedicatedPool;
+    } else {
+      const url = (process.env.EDRSR_DATABASE_URL || '').trim();
+      this.dedicatedPool = url
+        ? new Pool({
+            connectionString: url,
+            max: parseInt(process.env.EDRSR_POOL_MAX || '20', 10),
+          })
+        : null;
+      if (this.dedicatedPool) {
+        let host = 'unparseable-url';
+        try { host = new URL(url).host; } catch { /* keep placeholder, never log creds */ }
+        logger.info('[EdsrFtsService] EDRSR_DATABASE_URL set — using dedicated EDRSR pool', { host });
+      }
+    }
+  }
+
+  /** Dedicated EDRSR pool when configured, otherwise the pool the caller passed. */
+  private resolvePool(dbPool: any): any {
+    return this.dedicatedPool ?? dbPool;
+  }
+
   // LEXAI-1760: years whose plaintiff/defendant spans have been extracted into edrsr_parties
   // (read from edrsr_parties_coverage). When a count's date range falls entirely inside these
   // years, countByParty serves it from the indexed parties table instead of the full-text
@@ -373,6 +408,7 @@ export class EdsrFtsService {
     tokens: string[],
     dbPool: any,
   ): Promise<{ idf: Map<string, number>; df: Map<string, number>; sampleDocs: number }> {
+    dbPool = this.resolvePool(dbPool);
     const idf = new Map<string, number>();
     const df = new Map<string, number>();
     const lexemes = [...new Set(tokens.map(t => t.toLowerCase()).filter(Boolean))];
@@ -419,6 +455,7 @@ export class EdsrFtsService {
    * Fail-safe: any error → empty map (caller keeps the plainto_tsquery path).
    */
   async snapTokensToStems(tokens: string[], dbPool: any): Promise<Map<string, string>> {
+    dbPool = this.resolvePool(dbPool);
     const out = new Map<string, string>();
     const clean = [...new Set(tokens.map(sanitizeFtsToken).filter(t => t.length >= MIN_STEM_LEN))];
     if (clean.length === 0) return out;
@@ -479,6 +516,7 @@ export class EdsrFtsService {
     headlineQuery?: string,
     topicalTsquery?: string,
   ): Promise<EdsrFtsSearchResponse> {
+    dbPool = this.resolvePool(dbPool);
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const safeOffset = Math.max(offset, 0);
 
@@ -779,6 +817,7 @@ export class EdsrFtsService {
     filters: { date_from?: string; date_to?: string; justice_kind?: number } = {},
     sampleLimit: number = 0,
   ): Promise<PartyCaseCount> {
+    dbPool = this.resolvePool(dbPool);
     // LEXAI-1760: when the requested year span is fully covered by the structured parties
     // table, answer from its indexes (fast, exact) instead of regex-scanning 125M full texts.
     // Returns null when not applicable / on error → fall through to the legacy FTS path below.
@@ -868,6 +907,7 @@ export class EdsrFtsService {
     constraints: { party_name?: string; party_role?: PartyRole; instance_code?: number },
     dbPool: any,
   ): Promise<Set<number>> {
+    dbPool = this.resolvePool(dbPool);
     const matched = new Set<number>();
     if (docIds.length === 0) return matched;
 
@@ -944,6 +984,7 @@ export class EdsrFtsService {
    * @returns Number of rows indexed in this batch
    */
   async indexBatch(batchSize: number = 1000, dbPool: any): Promise<number> {
+    dbPool = this.resolvePool(dbPool);
     const safeBatch = Math.min(Math.max(batchSize, 1), 10000);
 
     try {
@@ -979,6 +1020,7 @@ export class EdsrFtsService {
    * Report indexing progress for the given database pool.
    */
   async getIndexProgress(dbPool: any): Promise<EdsrIndexProgress> {
+    dbPool = this.resolvePool(dbPool);
     try {
       const result = await dbPool.query(`
         SELECT


### PR DESCRIPTION
## Що зроблено

Додано опційну змінну `EDRSR_DATABASE_URL`: коли вона задана, `EdsrFtsService` відкриває власний pg Pool до вказаної бази і направляє туди **всі** свої запити (FTS-пошук, party counts, lexeme stats, tsv-індексація), ігноруючи пул, який передають виклики. Коли змінна не задана (прод) — поведінка не змінюється: використовується пул від викликача.

## Навіщо

Dev-інстанс (GCP) має читати EDRSR-дані з проду (readonly-користувач через WG-тунель), але основний `DATABASE_URL` застосунку повинен лишатися на локальній базі — інакше dev писатиме сесії/cost tracking/консультації в prod БД.

```bash
# dev .env
EDRSR_DATABASE_URL=postgresql://igor_readonly:...@10.88.0.1:5439/secondlayer_prod
EDRSR_POOL_MAX=20   # опційно, дефолт 20
```

## Деталі

- Пул створюється в конструкторі `EdsrFtsService`; конструктор також приймає пул напряму (для тестів)
- `resolvePool()` на вході кожного публічного методу: `lexemeStats`, `snapTokensToStems`, `searchFulltext`, `countByParty`, `filterDocIdsByConstraints`, `indexBatch`, `getIndexProgress` (`lexemeDf` делегує в `lexemeStats`)
- У лог пишеться тільки host з URL, без кредів
- `indexBatch` під readonly-користувачем очікувано впаде на write — це коректно: dev не повинен індексувати прод
- `.env.example` доповнено

## Тести

- 2 нові тести: dedicated pool перехоплює запити / без нього використовується переданий пул
- `npx jest edrsr-fts-service.test.ts` — 15/15 passed
- `tsc --noEmit` — без нових помилок (3 наявні помилки core-loader це відсутній core-оверлей, є й на main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional dedicated DB pool for EDRSR. When `EDRSR_DATABASE_URL` is set, `EdsrFtsService` uses its own `pg` pool for all EDRSR queries; unset keeps current behavior.

- **New Features**
  - Opens a dedicated `pg` Pool via `EDRSR_DATABASE_URL` and optional `EDRSR_POOL_MAX` (default 20).
  - Overrides caller-passed pools for all EDRSR operations (FTS search, party counts, lexeme stats, indexing).
  - Logs only the URL host; `.env.example` updated.

- **Migration**
  - Dev: set `EDRSR_DATABASE_URL` (and `EDRSR_POOL_MAX` if needed); keep main `DATABASE_URL` local.
  - Prod: leave `EDRSR_DATABASE_URL` unset.
  - `indexBatch` will fail under a read-only user; this is expected.

<sup>Written for commit e22430af2a108e81a8e9c7d29142b84c99fceb3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

