### PR TITLE
fix(rada): inflection-tolerant FTS in rada_search_bill_documents (LEXAI-1819)

### DIFF
--- a/mcp_rada/src/api/mcp-rada-api.ts
+++ b/mcp_rada/src/api/mcp-rada-api.ts
@@ -320,7 +320,7 @@ export class MCPRadaAPI {
     });
 
     try {
-      const { documents, total } = await this.billService.searchBillDocuments({
+      const { documents, total, relaxed } = await this.billService.searchBillDocuments({
         query: args.query,
         bill_number: args.bill_number,
         doc_kind: args.doc_kind,
@@ -339,6 +339,7 @@ export class MCPRadaAPI {
               query: args.query || null,
               doc_kind: args.doc_kind || 'all',
               total_found: total,
+              ...(relaxed ? { relaxed: true, note: 'Точний збіг усіх слів не знайдено — результати за частковим збігом, відсортовані за релевантністю' } : {}),
               documents: documents.map((d: any) => ({
                 bill_number: d.bill_number,
                 bill_title: d.bill_title,

--- a/mcp_rada/src/services/__tests__/bill-service.test.ts
+++ b/mcp_rada/src/services/__tests__/bill-service.test.ts
@@ -1,0 +1,82 @@
+jest.mock('../../utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+jest.mock('../../adapters/rada-api-adapter', () => ({ RadaAPIAdapter: class {} }));
+jest.mock('uuid', () => ({ v4: () => 'test-uuid' }));
+
+import { BillService } from '../bill-service';
+
+// LEXAI-1819: the bill_documents FTS uses the 'simple' config (no Ukrainian
+// stemmer), so full-word prefixes break on inflection («патентний:*» does not
+// match «патентним») and strict AND makes multi-word natural queries brittle.
+
+describe('BillService.toPrefixTsQuery', () => {
+  it('truncates Cyrillic tokens to inflection-tolerant stems', () => {
+    // «патентним тролінгом» in the bill title must be matched by the
+    // nominative-case query — repro from MSP demo query 2 (2026-07-03)
+    expect(BillService.toPrefixTsQuery('патентний тролінг')).toBe('патентн:* & тролінг:*');
+    expect(BillService.toPrefixTsQuery('торговельні марки промислові зразки')).toBe(
+      'торговельн:* & марк:* & промисл:* & зразк:*'
+    );
+    expect(BillService.toPrefixTsQuery('патентного тролінгу')).toBe('патентн:* & тролінг:*');
+  });
+
+  it('keeps Latin and numeric tokens as-is', () => {
+    expect(BillService.toPrefixTsQuery('NEMIROFF 2258')).toBe('nemiroff:* & 2258:*');
+  });
+
+  it('keeps short tokens whole (no over-truncation below 4-char stems)', () => {
+    expect(BillService.toPrefixTsQuery('для прав дії')).toBe('для:* & прав:* & дії:*');
+  });
+
+  it('drops single-character tokens and returns empty for unusable input', () => {
+    expect(BillService.toPrefixTsQuery('і в')).toBe('');
+    expect(BillService.toPrefixTsQuery('!!!')).toBe('');
+  });
+
+  it('builds an OR query when requested', () => {
+    expect(BillService.toPrefixTsQuery('патентний тролінг', '|')).toBe('патентн:* | тролінг:*');
+  });
+});
+
+describe('BillService.searchBillDocuments OR-relaxation fallback', () => {
+  const makeService = (queryImpl: jest.Mock) =>
+    new BillService({ query: queryImpl } as any, {} as any);
+
+  it('re-runs with OR semantics when the AND pass finds nothing for a multi-word query', async () => {
+    const row = { doc_id: 1, bill_number: '2258' };
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }) // AND pass
+      .mockResolvedValueOnce({ rows: [row] }); // OR pass
+    const service = makeService(query);
+
+    const result = await service.searchBillDocuments({ query: 'патентний тролінг закон' });
+
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(query.mock.calls[0][1][0]).toContain(' & ');
+    expect(query.mock.calls[1][1][0]).toContain(' | ');
+    expect(result.documents).toEqual([row]);
+    expect(result.relaxed).toBe(true);
+  });
+
+  it('does not relax when the AND pass has results', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{ doc_id: 1 }] });
+    const service = makeService(query);
+
+    const result = await service.searchBillDocuments({ query: 'патентний тролінг' });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(result.relaxed).toBeUndefined();
+  });
+
+  it('does not relax single-token queries (OR would change nothing)', async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [] });
+    const service = makeService(query);
+
+    const result = await service.searchBillDocuments({ query: 'тролінг' });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(result.documents).toEqual([]);
+  });
+});

--- a/mcp_rada/src/services/bill-service.ts
+++ b/mcp_rada/src/services/bill-service.ts
@@ -194,16 +194,40 @@ export class BillService {
   }
 
   /**
+   * Ukrainian inflectional endings, longest-first. Full-word prefixes break on
+   * inflection under the 'simple' FTS config («патентний:*» does not match
+   * «патентним»), so Cyrillic tokens are truncated to a stem before `:*`.
+   * One suffix is stripped only when the remaining stem keeps >= 4 chars
+   * (LEXAI-1819).
+   */
+  private static readonly UK_SUFFIXES = [
+    'ього', 'ьому', 'ами', 'ями', 'ові', 'еві', 'ого', 'ому', 'ими', 'іми',
+    'ій', 'ий', 'им', 'ім', 'их', 'іх', 'ої', 'ою', 'ею', 'ах', 'ях',
+    'ам', 'ям', 'ів', 'їв', 'ом', 'ем', 'ей',
+    'и', 'і', 'ї', 'а', 'я', 'о', 'е', 'у', 'ю', 'ь',
+  ];
+
+  private static stemPrefix(token: string): string {
+    if (!/^[а-щьюяіїєґ]+$/.test(token)) return token;
+    for (const suffix of BillService.UK_SUFFIXES) {
+      if (token.length - suffix.length >= 4 && token.endsWith(suffix)) {
+        return token.slice(0, token.length - suffix.length);
+      }
+    }
+    return token;
+  }
+
+  /**
    * Build a `simple`-config prefix tsquery from free text.
    * The bill_documents FTS indexes use the 'simple' config (no Ukrainian stemmer),
-   * so we match on word prefixes (`слов:*`) to tolerate inflected forms.
+   * so we match on stem prefixes (`патентн:*`) to tolerate inflected forms.
    * Returns '' when the input has no usable tokens.
    */
-  private toPrefixTsQuery(input: string): string {
+  static toPrefixTsQuery(input: string, op: '&' | '|' = '&'): string {
     const tokens = (input.match(/[\p{L}\p{N}]+/gu) || [])
       .map(t => t.toLowerCase())
       .filter(t => t.length > 1);
-    return tokens.map(t => `${t}:*`).join(' & ');
+    return tokens.map(t => `${BillService.stemPrefix(t)}:*`).join(` ${op} `);
   }
 
   /**
@@ -221,7 +245,7 @@ export class BillService {
     date_from?: string;
     date_to?: string;
     limit?: number;
-  }): Promise<{ documents: any[]; total: number }> {
+  }): Promise<{ documents: any[]; total: number; relaxed?: boolean }> {
     if (params.date_from && !this.validateDateFormat(params.date_from)) {
       throw new Error(
         `Invalid date_from format: "${params.date_from}". Expected YYYY-MM-DD (e.g., 2024-01-15)`
@@ -245,14 +269,17 @@ export class BillService {
     let i = 1;
 
     // Full-text over verdict summaries + bill title
+    let tsqIndex = 0;
+    let andTsq = '';
     if (params.query) {
-      const tsq = this.toPrefixTsQuery(params.query);
-      if (tsq) {
+      andTsq = BillService.toPrefixTsQuery(params.query);
+      if (andTsq) {
         sql += ` AND (
           to_tsvector('simple', coalesce(short_review,'') || ' ' || coalesce(formal_review,'') || ' ' || coalesce(full_text,'')) @@ to_tsquery('simple', $${i})
           OR to_tsvector('simple', coalesce(bill_title,'')) @@ to_tsquery('simple', $${i})
         )`;
-        queryParams.push(tsq);
+        queryParams.push(andTsq);
+        tsqIndex = i;
         i++;
       }
     }
@@ -301,15 +328,42 @@ export class BillService {
     }
 
     const limit = Math.min(Math.max(params.limit || 20, 1), 100);
-    sql += ` ORDER BY registration_date DESC NULLS LAST LIMIT ${limit}`;
 
-    const result = await this.db.query(sql, queryParams);
+    let result = await this.db.query(
+      sql + ` ORDER BY registration_date DESC NULLS LAST LIMIT ${limit}`,
+      queryParams
+    );
+
+    // Strict AND over all tokens makes multi-word natural queries brittle
+    // (one unmatched word form → 0 rows). Retry with OR semantics, ranked by
+    // relevance so the date ordering doesn't surface loosely-matching noise.
+    let relaxed = false;
+    if (result.rows.length === 0 && tsqIndex > 0 && andTsq.includes(' & ')) {
+      const orParams = [...queryParams];
+      orParams[tsqIndex - 1] = BillService.toPrefixTsQuery(params.query!, '|');
+      result = await this.db.query(
+        sql +
+          ` ORDER BY ts_rank(to_tsvector('simple', coalesce(short_review,'') || ' ' || coalesce(formal_review,'') || ' ' || coalesce(bill_title,'')), to_tsquery('simple', $${tsqIndex})) DESC, registration_date DESC NULLS LAST LIMIT ${limit}`,
+        orParams
+      );
+      relaxed = true;
+      logger.info('Bill documents search relaxed to OR semantics', {
+        query: params.query,
+        found: result.rows.length,
+      });
+    }
+
     logger.info('Bill documents search completed', {
       query: params.query,
       doc_kind: params.doc_kind,
       found: result.rows.length,
+      relaxed,
     });
-    return { documents: result.rows, total: result.rows.length };
+    return {
+      documents: result.rows,
+      total: result.rows.length,
+      ...(relaxed ? { relaxed: true } : {}),
+    };
   }
 
   /**


### PR DESCRIPTION
## Problem (repro: MSP demo query 2, 2026-07-03)

`rada_search_bill_documents` builds `to_tsquery('simple', 'token:* & token:*')` — full-word prefixes with strict AND over the `simple` config (no Ukrainian stemmer). Ukrainian inflection breaks the prefix: the title of bill **2258** says «патентним тролінгом», so the natural query «патентний тролінг» → **0 results** («патентний:*» is not a prefix of «патентним»). During the demo-query run the chat tried 7 natural-language phrasings and every one missed the flagship ГНЕУ conclusion.

Verified against the live tool: «торговельні марки промислові зразки» → finds 2258; «тролінг» → finds; «патентний тролінг» → 0.

## Fix

1. **Stem truncation**: Cyrillic tokens are stripped of one inflectional ending (longest-first list, stem stays ≥ 4 chars) before `:*` — «патентний»/«патентного»/«патентним» all become `патентн:*`. Latin/digits untouched.
2. **OR-relaxation fallback**: when the AND pass returns 0 rows for a multi-word query, re-run with OR semantics ordered by `ts_rank`, and flag the result `relaxed: true` + a Ukrainian note so the LLM knows the match is partial.

## Tests / validation

- 8 unit tests (`bill-service.test.ts`): stemmer cases, Latin/numeric passthrough, no over-truncation of short tokens, OR fallback fires only on 0-row multi-word AND.
- `tsc --noEmit` clean for mcp_rada.
- Prod-data validation via psql: `патентн:* & тролінг:*` (gneu) → bill 2258; ranked OR query → 2258 first.

Plane: LEXAI-1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `rada_search_bill_documents` tolerant to Ukrainian inflection and add an OR-relaxation fallback so natural queries (e.g., «патентний тролінг») find bill 2258. Addresses LEXAI-1819 and fixes the MSP demo miss.

- **Bug Fixes**
  - Truncate Cyrillic tokens to inflection-tolerant stems before `:*` (keep stems ≥4 chars); Latin/digits unchanged.
  - If a multi-word AND query returns 0, retry with OR and rank by `ts_rank`; response includes `relaxed: true` and a Ukrainian note.
  - Expose `relaxed` via the API and add unit tests for stemming and fallback behavior.

<sup>Written for commit 7a35e0b3b60c858fc7549d5755a5203b0ffd5c17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

