### PR TITLE
fix(search): demote party-status vocabulary from FTS anchors + promote geo tokens (CORE-106)

### DIFF
--- a/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
+++ b/mcp_backend/src/api/tools/edrsr-unified-search-tool.ts
@@ -19,7 +19,7 @@ import type { SearchResultFilter } from '../../services/search-result-filter.js'
 import { STRICT_MIN_SCORE } from '../../services/search-result-filter.js';
 import type { QueryReformulator } from '../../services/query-reformulator.js';
 import type { EdsrFtsService, EdsrFtsFilters, EdsrFtsSearchResponse } from '../../services/edrsr-fts-service.js';
-import { selectFtsTerms, sanitizeFtsToken, buildPrefixTsquery } from '../../services/edrsr-fts-service.js';
+import { selectFtsTerms, sanitizeFtsToken, buildPrefixTsquery, isStatusVocabToken } from '../../services/edrsr-fts-service.js';
 import type { EdsrVectorizerService, EdrsrSearchFilters, EdrsrSearchResult } from '../../services/edrsr-vectorizer-service.js';
 
 const DEFAULT_RRF_K = 60;
@@ -418,6 +418,17 @@ export class EdsrUnifiedSearchTool extends BaseToolHandler {
       : { idf: new Map<string, number>(), df: new Map<string, number>(), sampleDocs: 0 };
     const tokens = selectFtsTerms(rawTokens, stats.idf, { df: stats.df, sampleDocs: stats.sampleDocs });
     const idfRanked = stats.idf.size > 0;
+
+    // CORE-106 telemetry: party-status vocabulary in the search query is the marker of
+    // query drift (repro chat-98f8472e/chat-5340fe5c — «ВПО/внутрішньо переміщені» stole
+    // cap slots from operative anchors). selectFtsTerms now demotes it to the tail; log
+    // the occurrence so drift stays visible in metrics, not only in gold-eval runs.
+    const statusTokens = rawTokens.filter(isStatusVocabToken);
+    if (statusTokens.length > 0 && idfRanked) {
+      logger.info('[EdsrUnifiedSearch] status vocabulary in query — demoted from FTS anchors (CORE-106)', {
+        status_tokens: statusTokens, query: String(topicalQuery).slice(0, 160),
+      });
+    }
 
     // LEXAI Cause-A.2: snap ranked tokens to corpus STEMS (edrsr_lexeme_df) and probe with a
     // declension-tolerant prefix tsquery (окупован:* …). Fixes the stemless-'simple' recall

--- a/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
+++ b/mcp_backend/src/services/__tests__/edrsr-fts-term-selection.test.ts
@@ -195,3 +195,83 @@ describe('EdsrFtsService.snapTokensToStems (LEXAI Cause-A.2)', () => {
     expect((await svc.snapTokensToStems(['окупована'], errDb)).size).toBe(0);
   });
 });
+
+describe('selectFtsTerms — status-vocabulary demotion + geo promotion (CORE-106)', () => {
+  // Repro chat-98f8472e / chat-5340fe5c: «внутрішньо переміщені» (df 1095, corpus-rare →
+  // top idf) won cap slots over «донецьк»/«площа», producing a satisfiable-but-wrong
+  // AND-query the target decision can never match. Party-status vocabulary describes the
+  // person, not the legal issue — it must not enter the capped AND-set while operative
+  // anchors exist. The semantic leg still sees the full query, so no meaning is lost.
+  const idf = new Map<string, number>([
+    ['податок', 0.2], ['нерухомість', 1.0], ['окупована', 4.0], ['територія', 2.0],
+    ['площа', 1.5], ['донецьк', 3.0],
+    ['внутрішньо', 6.0], ['переміщені', 6.5],   // rarest of all — old logic put them FIRST
+  ]);
+  const df = new Map<string, number>([
+    ['податок', 2_000_000], ['нерухомість', 400_000], ['окупована', 30_000],
+    ['територія', 900_000], ['площа', 600_000], ['донецьк', 120_000],
+    ['внутрішньо', 1_095], ['переміщені', 1_095],   // healthy df → NOT weak-tier
+  ]);
+  const opts = { df, sampleDocs: 3_000_000 };
+  const reproTokens = ['податок', 'нерухомість', 'окупована', 'територія', 'внутрішньо', 'переміщені', 'Донецьк', 'площа'];
+
+  it('demotes status terms below every operative anchor (repro: they left the top-6 cap)', () => {
+    const out = selectFtsTerms(reproTokens, idf, opts);
+    const top6 = out.slice(0, 6);
+    expect(top6).not.toContain('внутрішньо');
+    expect(top6).not.toContain('переміщені');
+    expect(top6).toEqual(expect.arrayContaining(['Донецьк', 'окупована', 'площа', 'податок']));
+  });
+
+  it('demotes status terms below the weak tier (relaxation drops status FIRST)', () => {
+    // Weak junk produces 0 results → relaxation recovers; a satisfiable-but-wrong status
+    // conjunct never triggers relaxation — so status must sit further in the tail.
+    const withJunk = [...reproTokens, 'сумування'];
+    const dfJunk = new Map(df); dfJunk.set('сумування', 3);   // sub-floor → weak
+    const idfJunk = new Map(idf); idfJunk.set('сумування', 9.0);
+    const out = selectFtsTerms(withJunk, idfJunk, { df: dfJunk, sampleDocs: 3_000_000 });
+    expect(out.indexOf('переміщені')).toBeGreaterThan(out.indexOf('сумування'));
+  });
+
+  it('keeps status terms in place when the query is genuinely status-centric (<3 anchors)', () => {
+    const tokens = ['переселенців', 'пільги'];
+    const idf2 = new Map([['переселенців', 5.0], ['пільги', 1.0]]);
+    const out = selectFtsTerms(tokens, idf2, opts);
+    expect(out[0]).toBe('переселенців');   // no demotion — status IS the subject
+  });
+
+  it('promotes a geo anchor into the head even when rarer legal terms outrank it by idf', () => {
+    const tokens = ['стягнення', 'апеляційний', 'провадження', 'касаційний', 'зобов’язання', 'оскарження', 'Донецьк'];
+    const idf3 = new Map<string, number>([
+      ['стягнення', 7.0], ['апеляційний', 6.8], ['провадження', 6.5], ['касаційний', 6.2],
+      ['зобов’язання', 6.0], ['оскарження', 5.8], ['донецьк', 3.0],
+    ]);
+    const df3 = new Map<string, number>([
+      ['стягнення', 5_000], ['апеляційний', 6_000], ['провадження', 7_000], ['касаційний', 8_000],
+      ['зобов’язання', 9_000], ['оскарження', 10_000], ['донецьк', 120_000],
+    ]);
+    const out = selectFtsTerms(tokens, idf3, { df: df3, sampleDocs: 3_000_000 });
+    expect(out.slice(0, 6)).toContain('Донецьк');   // survives the 6-cap despite lowest idf
+  });
+
+  it('handles declined forms via prefix matching (Донецьку, переміщених)', () => {
+    const tokens = ['податок', 'нерухомість', 'окупована', 'переміщених', 'Донецьку'];
+    const idf4 = new Map<string, number>([
+      ['податок', 0.2], ['нерухомість', 1.0], ['окупована', 4.0],
+      ['переміщених', 6.5], ['донецьку', 3.0],
+    ]);
+    const df4 = new Map<string, number>([
+      ['податок', 2_000_000], ['нерухомість', 400_000], ['окупована', 30_000],
+      ['переміщених', 1_095], ['донецьку', 120_000],
+    ]);
+    const out = selectFtsTerms(tokens, idf4, { df: df4, sampleDocs: 3_000_000 });
+    expect(out[0]).toBe('Донецьку');
+    expect(out[out.length - 1]).toBe('переміщених');
+  });
+
+  it('does not change behaviour for queries without status/geo vocabulary', () => {
+    const tokens = ['податок', 'нерухомість', 'окупована', 'територія'];
+    const out = selectFtsTerms(tokens, idf, opts);
+    expect(out).toEqual(['окупована', 'територія', 'нерухомість', 'податок']);
+  });
+});

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -149,6 +149,48 @@ export interface SelectFtsTermsOpts {
   sampleDocs?: number;  // total sampled docs → relative floor = sampleDocs * ANCHOR_DF_FRACTION
 }
 
+// ── Status-vocabulary demotion + geo promotion (CORE-106) ─────────────────────
+// Repro chat-98f8472e/chat-5340fe5c (gold-eval FAILs): the LLM echoes the user's
+// party-status wording («ВПО» → «внутрішньо переміщені особи») into the search query.
+// Those tokens are corpus-RARE (переміщ df≈1095), so IDF-first ordering puts them at the
+// head of the capped AND-set — where they poison it: the query stays satisfiable (IDP
+// cases exist in droves, so term-relaxation never fires) but the target decision, which
+// exempts objects BY TERRITORY and never mentions the owner's status, can no longer match.
+// Party status describes the person, not the legal issue — it must never outrank operative
+// anchors. Conversely a locality token («Донецьк») is the single most discriminative
+// operative fact and must survive the cap even at a modest idf.
+// Prefix stems (lowercased, matched via startsWith over the sanitized token) so declined
+// forms match without morphology.
+
+/** Party-status vocabulary — demoted to the very tail (below weak junk: weak terms yield
+ *  0 results and relaxation recovers, a satisfiable-but-wrong status conjunct does not). */
+export const STATUS_VOCAB_STEMS: readonly string[] = [
+  'впо', 'переміщен', 'переселен', 'внутрішньо', 'пенсіонер', 'інвалід',
+  'ветеран', 'чорнобил', 'багатодіт', 'малозабезпечен', 'біженц', 'безробітн',
+];
+
+/** Occupied/frontline localities + oblast stems — promoted to the head of the anchor tier. */
+export const GEO_ANCHOR_STEMS: readonly string[] = [
+  'донецьк', 'донецк', 'луганськ', 'маріупол', 'крим', 'севастопол', 'херсон',
+  'запоріз', 'запоріж', 'харків', 'миколаїв', 'бахмут', 'авдіївк', 'лисичанськ',
+  'сєвєродонецьк', 'словянськ', 'краматорськ', 'горлівк', 'макіївк', 'мелітопол',
+  'бердянськ', 'енергодар', 'токмак', 'волноваха',
+];
+
+/** Minimum count of non-status anchors for status demotion to apply: with fewer, the
+ *  query is genuinely ABOUT the status (e.g. «пільги переселенців») and stays untouched. */
+const STATUS_DEMOTE_MIN_ANCHORS = 3;
+
+function matchesStemList(tokenLc: string, stems: readonly string[]): boolean {
+  const t = sanitizeFtsToken(tokenLc);
+  return t.length > 0 && stems.some(s => t.startsWith(s));
+}
+
+/** Telemetry helper (CORE-106): does the token belong to the party-status vocabulary? */
+export function isStatusVocabToken(token: string): boolean {
+  return matchesStemList((token || '').toLowerCase(), STATUS_VOCAB_STEMS);
+}
+
 /**
  * IDF-weighted ordering of FTS keyword tokens (CORE-21 P1.5a + LEXAI Cause-A).
  *
@@ -172,17 +214,36 @@ export function selectFtsTerms(
   const floor = df
     ? Math.max(ANCHOR_DF_MIN_ABS, Math.round((opts?.sampleDocs ?? 0) * ANCHOR_DF_FRACTION))
     : 0;
-  return tokens
-    .map((tok, i) => {
-      const lc = tok.toLowerCase();
-      const d = df ? (df.get(lc) ?? 0) : undefined;
-      return { tok, i, idf: idfByToken.get(lc) ?? 0, d: d ?? 0, weak: df ? (d! < floor) : false };
+  const scored = tokens.map((tok, i) => {
+    const lc = tok.toLowerCase();
+    const d = df ? (df.get(lc) ?? 0) : undefined;
+    return {
+      tok, i,
+      idf: idfByToken.get(lc) ?? 0,
+      d: d ?? 0,
+      weak: df ? (d! < floor) : false,
+      geo: matchesStemList(lc, GEO_ANCHOR_STEMS),
+      status: matchesStemList(lc, STATUS_VOCAB_STEMS),
+    };
+  });
+  // CORE-106: demote status vocabulary only while enough operative anchors remain —
+  // a status-centric query (e.g. «пільги переселенців») keeps its subject untouched.
+  const anchorCount = scored.filter(x => !x.weak && !x.status).length;
+  const demoteStatus = anchorCount >= STATUS_DEMOTE_MIN_ANCHORS;
+  // Tier order (cap takes the head, relaxation pops the tail):
+  //   0 geo anchors · 1 anchors · 2 weak junk · 3 demoted status
+  const tier = (x: typeof scored[number]): number => {
+    if (demoteStatus && x.status) return 3;
+    if (x.weak) return 2;
+    return x.geo ? 0 : 1;
+  };
+  return scored
+    .sort((a, b) => {
+      const ta = tier(a), tb = tier(b);
+      if (ta !== tb) return ta - tb;
+      return ta === 2 ? (b.d - a.d) || (a.i - b.i)     // weak tail: least-rare junk first
+                      : (b.idf - a.idf) || (a.i - b.i); // others: discriminative first
     })
-    .sort((a, b) =>
-      (a.weak === b.weak)
-        ? (a.weak ? (b.d - a.d) || (a.i - b.i)   // weak tail: least-rare junk first
-                  : (b.idf - a.idf) || (a.i - b.i)) // anchors: discriminative first
-        : (a.weak ? 1 : -1))                        // anchors before weak
     .map(x => x.tok);
 }
 


### PR DESCRIPTION
## Problem

Gold-eval runs chat-98f8472e (#5) and chat-5340fe5c (#8) lost the profile decision 280/5185/19 because the first search query drifted into party-status vocabulary. Mechanism (full causal chain in CORE-106):

1. The user's question contains «впо»; the planner echoes it (run #5 expanded it to «внутрішньо переміщені особи»).
2. Status tokens are corpus-rare (переміщ df≈1095) → IDF-first ordering puts them at the **head** of the capped 6-term AND-set, evicting «донецьк»/«площа».
3. The poisoned query is satisfiable-but-wrong (thousands of IDP cases) → `FTS_RELAX_MIN_RESULTS=3` relaxation never fires → target can never match by construction.
4. Lab pair: runs #7 vs #8 issued identical first queries ± «Донецьк» — fts rank 1 vs complete miss.

## Fix (enforce in code, per project convention)

`selectFtsTerms` tier order: **geo anchors → anchors → weak junk → demoted status**. Cap takes the head, relaxation pops the tail.

- `STATUS_VOCAB_STEMS` demoted to the very tail — below weak junk (weak → 0 results → relaxation recovers; satisfiable-but-wrong never does). Applies only while ≥3 operative anchors remain: «пільги переселенців» keeps its subject.
- `GEO_ANCHOR_STEMS` (occupied/frontline localities) promoted to the anchor head — the locality is the most discriminative operative fact.
- Prefix-stem matching over sanitized tokens → declined forms covered.
- Telemetry: status-token occurrences logged in `[EdsrUnifiedSearch]`.
- Semantic leg unchanged (full query text) — hybrid keeps status meaning.

## Tests

6 new repro-shaped cases (TDD, watched fail), FTS suites **43/43**, tsc clean apart from the 3 known core-overlay pre-existing errors.

Prompt-level guidance for the planner (first-query anchoring) is deliberately left to a follow-up — this change removes the failure mechanism deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents FTS query drift by demoting party-status vocabulary and promoting geo tokens, so locality anchors survive the 6-term cap and results stay on-topic. Addresses CORE-106 by removing the failure mode where status terms out-ranked geo anchors and blocked relaxation.

- **Bug Fixes**
  - Updated `selectFtsTerms` tier order: geo anchors → anchors → weak → demoted status (cap keeps the head; relaxation drops the tail).
  - Demoted status stems (e.g., впо/переміщен/переселен) to the very tail, below weak, when ≥3 non-status anchors are present; prefix-stem matching covers declined forms.
  - Promoted geo stems (e.g., донецьк/маріупол/херсон) to the head of the anchor tier so locality survives the cap even with lower IDF.
  - Added telemetry to log status tokens in `[EdsrUnifiedSearch]`, plus 6 repro-shaped tests; semantic leg still uses the full query text.

<sup>Written for commit b4f9e06998681fa7887e4bdfa9cba723f2b1427c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

