### PR TITLE
ci(dev): deploy-dev workflow for GCP dev VM

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,335 @@
+##############################################################################
+# Pipeline: Deploy to Dev (GCP)
+# - Builds and tests changed services
+# - Deploys to GCP dev VM (secondlayer-dev-vm, 34.116.251.221) via SSH
+# - Dev VM uses docker-compose.local.yml + docker-compose.dev-vm.yml override
+#   (reduced resource limits for e2-standard-4; prod Qdrant/Neo4j via WG tunnel)
+# - Triggered on push/merge to dev branch or manually
+##############################################################################
+name: 'Deploy to Dev'
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+    inputs:
+      services:
+        description: 'Services to deploy (comma-separated: backend,rada,openreyestr,frontend). Leave empty to auto-detect.'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-dev
+  cancel-in-progress: false
+
+env:
+  DEV_HOST: 34.116.251.221
+  DEV_USER: igor
+  DEPLOY_DIR: /home/igor/secondlayer
+
+jobs:
+  # ─── Step 1: Detect what changed ─────────────────────────────────────
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      shared: ${{ steps.changes.outputs.shared }}
+      backend: ${{ steps.changes.outputs.backend }}
+      rada: ${{ steps.changes.outputs.rada }}
+      openreyestr: ${{ steps.changes.outputs.openreyestr }}
+      frontend: ${{ steps.changes.outputs.frontend }}
+      deployment: ${{ steps.changes.outputs.deployment }}
+      any_backend: ${{ steps.changes.outputs.any_backend }}
+      services_to_build: ${{ steps.changes.outputs.services_to_build }}
+      has_changes: ${{ steps.check.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        uses: ./.github/actions/detect-changes
+
+      - name: Check if any services need deploy
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.services }}" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Manual deploy requested: ${{ inputs.services }}"
+          else
+            SERVICES='${{ steps.changes.outputs.services_to_build }}'
+            if [ "$SERVICES" = '[]' ]; then
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "No services changed — skipping"
+            else
+              echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+  # ─── Step 2: Build & test ────────────────────────────────────────────
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    env:
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Build shared package
+        run: cd packages/shared && npm install --legacy-peer-deps && npm run build
+
+      - name: Overlay proprietary source
+        if: env.BACKEND_CHANGED == 'true'
+        env:
+          CORE_REPO_SSH_KEY: ${{ secrets.CORE_REPO_SSH_KEY }}
+        run: |
+          CORE_TMP=$(mktemp -d)
+          KEY_FILE=$(mktemp)
+          trap 'shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"; rm -rf "$CORE_TMP"' EXIT
+          printf '%s\n' "$CORE_REPO_SSH_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
+            git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+          test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+            || { echo "::error::core clone incomplete — key files missing in $CORE_TMP"; exit 1; }
+          find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} mcp_backend/src/services/ \;
+          cp -rf "$CORE_TMP"/src/prompts/* mcp_backend/src/prompts/
+          test -s mcp_backend/src/services/chat-execution-loop.ts && test -s mcp_backend/src/prompts/chat-system-prompt.ts \
+            || { echo "::error::core overlay failed — key files missing after copy"; exit 1; }
+
+      - name: Build backend
+        if: env.BACKEND_CHANGED == 'true'
+        run: cd mcp_backend && npm install && npm run build
+
+      - name: Unit test backend
+        if: env.BACKEND_CHANGED == 'true'
+        run: |
+          cd mcp_backend && npx jest --no-cache --forceExit \
+            src/controllers/__tests__/ \
+            src/middleware/__tests__/ \
+            src/adapters/__tests__/ \
+            src/services/__tests__/
+
+      - name: Build RADA
+        if: env.RADA_CHANGED == 'true'
+        run: cd mcp_rada && npm install && npm run build
+
+      - name: Build OpenReyestr
+        if: env.OPENREYESTR_CHANGED == 'true'
+        run: cd mcp_openreyestr && npm install && npm run build
+
+      - name: Install frontend deps
+        if: env.FRONTEND_CHANGED == 'true'
+        run: cd lexwebapp && npm install --legacy-peer-deps
+
+      - name: Build frontend
+        if: env.FRONTEND_CHANGED == 'true'
+        run: cd lexwebapp && npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
+
+  # ─── Step 3: Deploy to dev VM ────────────────────────────────────────
+  deploy-dev:
+    name: Deploy to Dev
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-and-test]
+    if: |
+      always() &&
+      needs.build-and-test.result == 'success'
+    env:
+      BACKEND_CHANGED: ${{ needs.detect-changes.outputs.backend }}
+      RADA_CHANGED: ${{ needs.detect-changes.outputs.rada }}
+      OPENREYESTR_CHANGED: ${{ needs.detect-changes.outputs.openreyestr }}
+      FRONTEND_CHANGED: ${{ needs.detect-changes.outputs.frontend }}
+      SHARED_CHANGED: ${{ needs.detect-changes.outputs.shared }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SSH
+        env:
+          DEV_SSH_KEY: ${{ secrets.DEV_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$DEV_SSH_KEY" > ~/.ssh/dev_key
+          chmod 600 ~/.ssh/dev_key
+          ssh-keyscan -H ${{ env.DEV_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Resolve services to deploy
+        id: services
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.services }}" ]; then
+            echo "list=${{ inputs.services }}" >> "$GITHUB_OUTPUT"
+          else
+            SERVICES=""
+            [ "$BACKEND_CHANGED" = "true" ] && SERVICES="backend"
+            [ "$RADA_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}rada"
+            [ "$OPENREYESTR_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}openreyestr"
+            [ "$FRONTEND_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}frontend"
+            [ "$SHARED_CHANGED" = "true" ] && [ -z "$SERVICES" ] && SERVICES="backend,rada,openreyestr,frontend"
+            echo "list=${SERVICES:-backend,frontend}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Deploy via SSH
+        env:
+          SERVICES: ${{ steps.services.outputs.list }}
+          CORE_REPO_SSH_KEY: ${{ secrets.CORE_REPO_SSH_KEY }}
+        run: |
+          SSH_CMD="ssh -i ~/.ssh/dev_key -o StrictHostKeyChecking=accept-new ${{ env.DEV_USER }}@${{ env.DEV_HOST }}"
+
+          # Sync code to dev VM
+          $SSH_CMD "cd ${{ env.DEPLOY_DIR }} && git fetch origin && git checkout ${GITHUB_SHA} --force"
+
+          # Build TypeScript on dev VM (Dockerfiles require pre-built dist/)
+          $SSH_CMD bash -s -- "$SERVICES" <<'BUILD_EOF'
+            set -euo pipefail
+            SERVICES="$1"
+            cd /home/igor/secondlayer
+            npm --prefix packages/shared install --legacy-peer-deps && npm --prefix packages/shared run build
+            if echo "$SERVICES" | grep -q "backend"; then
+              npm --prefix mcp_backend install
+            fi
+            if echo "$SERVICES" | grep -q "rada"; then
+              npm --prefix mcp_rada install && npm --prefix mcp_rada run build
+            fi
+            if echo "$SERVICES" | grep -q "openreyestr"; then
+              npm --prefix mcp_openreyestr install && npm --prefix mcp_openreyestr run build
+            fi
+          BUILD_EOF
+
+          # Overlay proprietary source if backend is being deployed
+          # (backend build runs AFTER overlay — core modules are required to compile)
+          if echo "$SERVICES" | grep -q "backend"; then
+            KEY_FILE=$(mktemp)
+            trap 'shred -u "$KEY_FILE" 2>/dev/null || rm -f "$KEY_FILE"' EXIT
+            printf '%s\n' "$CORE_REPO_SSH_KEY" > "$KEY_FILE"
+            chmod 600 "$KEY_FILE"
+            scp -i ~/.ssh/dev_key -o StrictHostKeyChecking=accept-new "$KEY_FILE" ${{ env.DEV_USER }}@${{ env.DEV_HOST }}:/tmp/core_key
+            $SSH_CMD bash -s <<'OVERLAY_EOF'
+              set -euo pipefail
+              KEY_FILE=/tmp/core_key
+              chmod 600 "$KEY_FILE"
+              CORE_TMP=$(mktemp -d)
+              trap 'shred -u "$KEY_FILE" 2>/dev/null; rm -rf "$CORE_TMP"' EXIT
+              GIT_SSH_COMMAND="ssh -i $KEY_FILE -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes" \
+                git clone --depth 1 git@github.com:overthelex/secondlayer-core.git "$CORE_TMP"
+              test -s "$CORE_TMP/src/services/chat-execution-loop.ts" && test -s "$CORE_TMP/src/prompts/chat-system-prompt.ts" \
+                || { echo "core clone incomplete — key files missing"; exit 1; }
+              find "$CORE_TMP"/src/services -maxdepth 1 -name '*.ts' -exec cp -f {} /home/igor/secondlayer/mcp_backend/src/services/ \;
+              cp -rf "$CORE_TMP"/src/prompts/* /home/igor/secondlayer/mcp_backend/src/prompts/
+              test -s /home/igor/secondlayer/mcp_backend/src/services/chat-execution-loop.ts \
+                && test -s /home/igor/secondlayer/mcp_backend/src/prompts/chat-system-prompt.ts \
+                || { echo "core overlay failed — key files missing after copy"; exit 1; }
+              cd /home/igor/secondlayer && npm --prefix mcp_backend run build
+          OVERLAY_EOF
+          fi
+
+          # Build and deploy Docker services
+          $SSH_CMD bash -s -- "$SERVICES" <<'DEPLOY_EOF'
+            set -uo pipefail
+            SERVICES="$1"
+            cd /home/igor/secondlayer/deployment
+            DC="docker compose -f docker-compose.local.yml -f docker-compose.dev-vm.yml --env-file .env.local"
+
+            STOP="" BUILD="" START=""
+
+            if echo "$SERVICES" | grep -q "backend"; then
+              STOP="$STOP app-local document-service-local"
+              BUILD="$BUILD app-local document-service-local migrate-local"
+              START="$START app-local document-service-local"
+            fi
+            if echo "$SERVICES" | grep -q "rada"; then
+              STOP="$STOP rada-mcp-app-local"
+              BUILD="$BUILD rada-mcp-app-local rada-db-init-local rada-migrate-local"
+              START="$START rada-mcp-app-local"
+            fi
+            if echo "$SERVICES" | grep -q "openreyestr"; then
+              STOP="$STOP app-openreyestr-local"
+              BUILD="$BUILD app-openreyestr-local migrate-openreyestr-local"
+              START="$START app-openreyestr-local"
+            fi
+            if echo "$SERVICES" | grep -q "frontend"; then
+              STOP="$STOP lexwebapp-local"
+              BUILD="$BUILD lexwebapp-local"
+              START="$START lexwebapp-local"
+            fi
+
+            [ -n "$STOP" ] && $DC stop $STOP 2>/dev/null || true
+            [ -n "$STOP" ] && $DC rm -f $STOP 2>/dev/null || true
+            [ -n "$BUILD" ] && $DC build $BUILD
+
+            # Run migrations (migrate-local may fail on dev — Spain tables absent; non-blocking)
+            if echo "$SERVICES" | grep -q "backend"; then
+              timeout 120 $DC up --abort-on-container-exit migrate-local || true
+            fi
+            if echo "$SERVICES" | grep -q "rada"; then
+              timeout 120 $DC up --abort-on-container-exit rada-db-init-local || true
+              timeout 120 $DC up --abort-on-container-exit rada-migrate-local || true
+            fi
+            if echo "$SERVICES" | grep -q "openreyestr"; then
+              timeout 120 $DC up --abort-on-container-exit migrate-openreyestr-local || true
+            fi
+
+            [ -n "$START" ] && $DC up -d --no-deps $START
+
+            # Always recreate nginx after any deploy
+            $DC up -d --force-recreate --no-deps nginx-local
+
+            docker image prune -f || true
+          DEPLOY_EOF
+
+      - name: Health check
+        run: |
+          SSH_CMD="ssh -i ~/.ssh/dev_key -o StrictHostKeyChecking=accept-new ${{ env.DEV_USER }}@${{ env.DEV_HOST }}"
+
+          FAILED=false
+
+          wait_healthy() {
+            local name=$1 container=$2 max_wait=${3:-120}
+            local elapsed=0
+            echo "Waiting for $name ($container)..."
+            while [ $elapsed -lt $max_wait ]; do
+              status=$($SSH_CMD "docker inspect --format='{{.State.Health.Status}}' $container 2>/dev/null || echo not_found")
+              case "$status" in
+                healthy) echo "✓ $name: healthy (${elapsed}s)"; return 0 ;;
+                unhealthy) echo "✗ $name: unhealthy"; FAILED=true; return 1 ;;
+                *) sleep 10; elapsed=$((elapsed + 10)) ;;
+              esac
+            done
+            echo "✗ $name: timed out"
+            FAILED=true
+          }
+
+          if [ "${{ env.BACKEND_CHANGED }}" = "true" ]; then
+            wait_healthy "Backend" "secondlayer-app-local" 180
+            wait_healthy "Document Service" "document-service-local" 120
+          fi
+          [ "${{ env.RADA_CHANGED }}" = "true" ] && wait_healthy "RADA" "rada-mcp-app-local" 120
+          [ "${{ env.OPENREYESTR_CHANGED }}" = "true" ] && wait_healthy "OpenReyestr" "openreyestr-app-local" 120
+          [ "${{ env.FRONTEND_CHANGED }}" = "true" ] && wait_healthy "Frontend" "lexwebapp-local" 60
+
+          # Verify dev is reachable via HTTP (self-signed cert on 443)
+          for i in 1 2 3 4 5; do
+            curl -skf --max-time 10 "https://${{ env.DEV_HOST }}/health" > /dev/null 2>&1 && {
+              echo "✓ dev VM reachable"
+              break
+            }
+            echo "Attempt $i: dev not reachable yet, retrying..."
+            sleep 10
+          done
+
+          if [ "$FAILED" = "true" ]; then exit 1; fi

--- a/deployment/docker-compose.dev-vm.yml
+++ b/deployment/docker-compose.dev-vm.yml
@@ -1,0 +1,152 @@
+# Dev VM override — снижает resource limits для VM e2-standard-4 (4 CPU / 16 GB)
+# Используется только на secondlayer-dev-vm (34.116.251.221)
+# Запуск: docker compose -f docker-compose.local.yml -f docker-compose.dev-vm.yml --env-file .env.local up -d
+services:
+  postgres-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
+        reservations:
+          cpus: "0.25"
+          memory: 256M
+
+  qdrant-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2G
+        reservations:
+          cpus: "0.25"
+          memory: 512M
+
+  app-local:
+    environment:
+      # Прод-Qdrant (bigbox, 296M векторов) через WireGuard-туннель
+      QDRANT_URL: http://10.88.0.1:6333
+      QDRANT_API_KEY: ${QDRANT_API_KEY}
+      # Neo4j citation graph (bigbox) через WireGuard-туннель
+      NEO4J_URI: bolt://10.88.0.1:7687
+      NEO4J_USER: neo4j
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD}
+      NEO4J_DATABASE: neo4j
+    deploy:
+      resources:
+        limits:
+          cpus: "1.5"
+          memory: 2G
+        reservations:
+          cpus: "0.25"
+          memory: 512M
+
+  rada-mcp-app-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1G
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+
+  document-service-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+
+  app-openreyestr-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+
+  terminal-service-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+
+  minio-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+        reservations:
+          cpus: "0.1"
+          memory: 128M
+
+  lexwebapp-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 1G
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+
+  nginx-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 64M
+        reservations:
+          cpus: "0.05"
+          memory: 32M
+
+  prometheus-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 256M
+        reservations:
+          cpus: "0.05"
+          memory: 64M
+
+  grafana-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+        reservations:
+          cpus: "0.05"
+          memory: 64M
+
+  postgres-hudoc-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 1G
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+
+  redis-exporter-local:
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 32M
+        reservations:
+          cpus: "0.05"
+          memory: 16M


### PR DESCRIPTION
## Summary

- **`.github/workflows/deploy-dev.yml`** — новый workflow деплоя на GCP dev VM (`secondlayer-dev-vm`, 34.116.251.221, проект `secondlayer-dev`), по образцу `deploy-stage.yml`:
  - Триггер: push в ветку `dev` или ручной `workflow_dispatch` (с выбором сервисов)
  - detect-changes → build+test (с core overlay) → SSH-деплой → health checks
  - Деплой в `/home/igor/secondlayer` (git checkout SHA), compose: `docker-compose.local.yml` + `docker-compose.dev-vm.yml`
- **`deployment/docker-compose.dev-vm.yml`** — override для dev VM (e2-standard-4, 4 vCPU/16GB):
  - Снижены resource limits (в local-compose postgres требует 16 CPU/96G — на VM это падает)
  - app-local использует прод-Qdrant (bigbox) и Neo4j через WireGuard-туннель `10.88.0.1`

## Prerequisites (уже настроено)

- ✅ Секрет `DEV_SSH_KEY` добавлен в репо
- ✅ VM подготовлена: Docker, Node 20, git clone, `.env.local`, WG-туннель `wg-mesh`
- ⚠️ Ветку `dev` нужно создать в overthelex/secondlayer (или деплоить вручную через workflow_dispatch)

## Test plan

- [ ] После мержа: запустить workflow вручную (`workflow_dispatch`, services: `backend`)
- [ ] Проверить health: `secondlayer-app-local` healthy, `https://34.116.251.221/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow to deploy changed services to the GCP dev VM and a Compose override tuned for that VM. This automates dev releases on push to `dev` or manual runs, including build, tests, SSH deploy, and health checks.

- **New Features**
  - ` .github/workflows/deploy-dev.yml`: triggers on `dev` pushes or `workflow_dispatch`, detects changed services, builds/tests, overlays `secondlayer-core`, deploys via SSH to `secondlayer-dev-vm` (34.116.251.221) at `/home/igor/secondlayer`, and runs service and HTTPS `/health` checks.
  - Uses `docker-compose.local.yml` + `deployment/docker-compose.dev-vm.yml` for deploys.
  - `deployment/docker-compose.dev-vm.yml`: lowers resource limits for e2-standard-4 (4 vCPU/16GB) and points backend to prod Qdrant/Neo4j via WireGuard `10.88.0.1`.

<sup>Written for commit b2af88df31fd73b7e70f70f99056a28a15fa140d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

