### PR TITLE
feat(registry): aggregate mode in search_registry (LEXAI-1820)

### DIFF
--- a/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
@@ -104,9 +104,11 @@ describe('RegistrySearchTool', () => {
         filters: { last_name: 'Іваненко' },
       });
 
-      expect(calls).toHaveLength(1);
+      // Data query + parallel COUNT(*) query share the same WHERE
+      expect(calls).toHaveLength(2);
       expect(calls[0].sql).toContain('ILIKE');
       expect(calls[0].params).toContain('%Іваненко%');
+      expect(calls[1].sql).toContain('COUNT(*)');
     });
 
     it('exact: uses = operator without wrapping', async () => {
@@ -264,9 +266,12 @@ describe('RegistrySearchTool', () => {
     });
 
     it('strips _total_count from results', async () => {
-      db = makeDb(() => ({
-        rows: [{ name: 'Test Corp', schema: 'Company', _total_count: 42 }],
-      }));
+      // The COUNT(*) companion query supplies the total; data rows carry it as _total_count
+      db = makeDb((sql: string) =>
+        sql.includes('COUNT(*)')
+          ? { rows: [{ total: '42' }] }
+          : { rows: [{ name: 'Test Corp', schema: 'Company', _total_count: 42 }] }
+      );
       tool = new RegistrySearchTool(db);
 
       const result = await tool.executeTool('search_registry', {
@@ -295,5 +300,108 @@ describe('RegistrySearchTool', () => {
       expect(result?.isError).toBe(true);
       expect(result?.content[0].text).toContain('connection refused');
     });
+  });
+});
+
+// LEXAI-1820: aggregate mode — GROUP BY a catalog field with optional distinct-count,
+// so the chat can answer "which identical marks are held by multiple owners" without
+// pulling 26K rows through the LLM context.
+describe('aggregate mode (LEXAI-1820)', () => {
+  let db: any;
+  let calls: QueryCall[];
+  let tool: RegistrySearchTool;
+
+  const makeDb = (responder: (sql: string, params?: any[]) => any) => ({
+    query: jest.fn((sql: string, params?: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve(responder(sql, params));
+    }),
+  });
+
+  beforeEach(() => {
+    calls = [];
+  });
+
+  it('builds GROUP BY + HAVING count(DISTINCT …) query for the TM-collision case', async () => {
+    db = makeDb(() => ({
+      rows: [{ group_value: 'marengo', distinct_count: '5', row_count: '9', samples: ['ТОВ А', 'ТОВ Б'] }],
+    }));
+    tool = new RegistrySearchTool(db);
+
+    const result = await tool.executeTool('search_registry', {
+      registry: 'trademarks',
+      filters: { nice_class: 33 },
+      aggregate: { group_by: 'mark_text', count_distinct: 'holder_name', min_count: 2, min_length: 4 },
+      limit: 10,
+    });
+
+    expect(calls).toHaveLength(1);
+    const sql = calls[0].sql;
+    expect(sql).toContain('GROUP BY');
+    expect(sql).toContain('COUNT(DISTINCT holder_name)');
+    expect(sql).toContain('HAVING');
+    expect(sql).toContain('length(mark_text) >= 4');
+    expect(sql).toContain('= ANY(nice_classes)');
+    const text = (result as any).content[0].text;
+    expect(text).toContain('marengo');
+  });
+
+  it('aggregates without count_distinct as plain frequency count', async () => {
+    db = makeDb(() => ({ rows: [{ group_value: 'нфіл', distinct_count: null, row_count: '12' }] }));
+    tool = new RegistrySearchTool(db);
+
+    await tool.executeTool('search_registry', {
+      registry: 'trademarks',
+      filters: { nice_class: 33 },
+      aggregate: { group_by: 'holder_name' },
+    });
+
+    const sql = calls[0].sql;
+    expect(sql).toContain('GROUP BY');
+    expect(sql).not.toContain('HAVING');
+  });
+
+  it('rejects group_by field not present in the catalog', async () => {
+    db = makeDb(() => ({ rows: [] }));
+    tool = new RegistrySearchTool(db);
+
+    const result = await tool.executeTool('search_registry', {
+      registry: 'trademarks',
+      filters: { nice_class: 33 },
+      aggregate: { group_by: 'drop_table' },
+    });
+
+    const text = (result as any).content[0].text;
+    expect(text).toContain('group_by');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('rejects aggregation on array fields (nice_class)', async () => {
+    db = makeDb(() => ({ rows: [] }));
+    tool = new RegistrySearchTool(db);
+
+    const result = await tool.executeTool('search_registry', {
+      registry: 'trademarks',
+      filters: { mark_text: 'nemiroff' },
+      aggregate: { group_by: 'nice_class' },
+    });
+
+    const text = (result as any).content[0].text;
+    expect(text).toContain('group_by');
+    expect(calls).toHaveLength(0);
+  });
+
+  it('still requires at least one filter in aggregate mode', async () => {
+    db = makeDb(() => ({ rows: [] }));
+    tool = new RegistrySearchTool(db);
+
+    const result = await tool.executeTool('search_registry', {
+      registry: 'trademarks',
+      aggregate: { group_by: 'mark_text', count_distinct: 'holder_name' },
+    });
+
+    const text = (result as any).content[0].text;
+    expect(text).toContain('фільтр');
+    expect(calls).toHaveLength(0);
   });
 });

--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -48,6 +48,18 @@ ${registryDescriptions}
             type: 'object',
             description: 'Фільтри пошуку (набір полів залежить від реєстру). Передайте registry без filters щоб побачити доступні поля.',
           },
+          aggregate: {
+            type: 'object',
+            description: `Режим агрегації замість переліку рядків: group_by (поле з фільтрів реєстру), count_distinct (рахувати унікальні значення цього поля в групі), min_count (залишити групи з count_distinct ≥ N), min_length (мін. довжина значення group_by, відсікає шум). Повертає топ груп за спаданням.
+Приклад (тотожні ТМ на кількох власників у класі 33): registry="trademarks", filters={"nice_class": 33}, aggregate={"group_by": "mark_text", "count_distinct": "holder_name", "min_count": 2, "min_length": 4}`,
+            properties: {
+              group_by: { type: 'string', description: 'Поле групування (з переліку фільтрів реєстру)' },
+              count_distinct: { type: 'string', description: 'Поле, унікальні значення якого рахуються в групі' },
+              min_count: { type: 'number', description: 'Мін. кількість унікальних значень count_distinct у групі (за замовч. 2, якщо задано count_distinct)' },
+              min_length: { type: 'number', description: 'Мін. довжина значення group_by у символах' },
+            },
+            required: ['group_by'],
+          },
           limit: {
             type: 'number',
             description: 'Макс. результатів (за замовч. 50, макс. 100)',
@@ -61,7 +73,7 @@ ${registryDescriptions}
   async executeTool(name: string, args: any): Promise<ToolResult | null> {
     if (name !== 'search_registry') return null;
 
-    const { registry, filters = {}, limit } = args;
+    const { registry, filters = {}, limit, aggregate } = args;
     const def = REGISTRY_CATALOG[registry];
     if (!def) {
       return this.wrapError(`Невідомий реєстр "${registry}". Доступні: ${REGISTRY_KEYS.join(', ')}`);
@@ -86,6 +98,10 @@ ${registryDescriptions}
     const defaultLimit = def.defaultLimit ?? 50;
     const lim = Math.max(1, Math.min(Number(limit) || defaultLimit, maxLimit));
 
+    if (aggregate) {
+      return this.executeAggregate(registry, def, aggregate, whereClause, values, paramIndex, lim);
+    }
+
     const countValues = [...values];
     values.push(lim);
 
@@ -109,6 +125,86 @@ ${registryDescriptions}
     } catch (error: any) {
       logger.error(`search_registry[${registry}] error`, { error: error.message });
       return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  /**
+   * Aggregate mode (LEXAI-1820): GROUP BY a catalog field with an optional
+   * distinct-count, so multi-thousand-row questions («тотожні марки на кількох
+   * власників») come back as a ranked top instead of raw rows the LLM cannot
+   * aggregate. All identifiers are resolved through the catalog — user input
+   * never reaches SQL as an identifier.
+   */
+  private async executeAggregate(
+    registry: string,
+    def: RegistryDef,
+    aggregate: any,
+    whereClause: string,
+    values: any[],
+    paramIndex: number,
+    lim: number
+  ): Promise<ToolResult> {
+    const resolveColumn = (fieldName: string, role: string): string | null => {
+      const field = def.fields.find(f => f.name === fieldName);
+      if (!field) return null;
+      // Array-typed columns (match: array_contains) cannot be grouped/counted directly.
+      if (field.match === 'array_contains') return null;
+      return field.columns[0];
+    };
+
+    const groupCol = aggregate.group_by ? resolveColumn(String(aggregate.group_by), 'group_by') : null;
+    if (!groupCol) {
+      const usable = def.fields.filter(f => f.match !== 'array_contains').map(f => f.name).join(', ');
+      return this.wrapResponse(`Невірне поле group_by. Доступні для агрегації: ${usable}`);
+    }
+
+    let distinctCol: string | null = null;
+    if (aggregate.count_distinct) {
+      distinctCol = resolveColumn(String(aggregate.count_distinct), 'count_distinct');
+      if (!distinctCol) {
+        const usable = def.fields.filter(f => f.match !== 'array_contains').map(f => f.name).join(', ');
+        return this.wrapResponse(`Невірне поле count_distinct. Доступні для агрегації: ${usable}`);
+      }
+    }
+
+    const conditions = [whereClause, `${groupCol} IS NOT NULL`];
+    const minLength = Number(aggregate.min_length) || 0;
+    if (minLength > 0) conditions.push(`length(${groupCol}) >= ${Math.floor(minLength)}`);
+
+    const minCount = Math.max(1, Number(aggregate.min_count) || (distinctCol ? 2 : 1));
+    const having = distinctCol && minCount > 1 ? ` HAVING COUNT(DISTINCT ${distinctCol}) >= ${Math.floor(minCount)}` : '';
+
+    const distinctSelect = distinctCol
+      ? `COUNT(DISTINCT ${distinctCol}) AS distinct_count, (array_agg(DISTINCT ${distinctCol}))[1:5] AS samples,`
+      : '';
+    const orderBy = distinctCol ? 'distinct_count DESC, row_count DESC' : 'row_count DESC';
+
+    const sql = `SELECT lower(${groupCol}::text) AS group_value,
+        ${distinctSelect}
+        COUNT(*) AS row_count
+      FROM ${def.table}
+      WHERE ${conditions.join(' AND ')}
+      GROUP BY 1${having}
+      ORDER BY ${orderBy}
+      LIMIT $${paramIndex}`;
+
+    try {
+      const result = await this.db.query(sql, [...values, lim]);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('Агрегація не знайшла жодної групи за заданими умовами.');
+      }
+      return this.wrapResponse({
+        aggregate: {
+          registry,
+          group_by: aggregate.group_by,
+          ...(aggregate.count_distinct ? { count_distinct: aggregate.count_distinct, min_count: minCount } : {}),
+        },
+        groups: result.rows,
+        total_groups: result.rows.length,
+      });
+    } catch (error: any) {
+      logger.error(`search_registry[${registry}] aggregate error`, { error: error.message });
+      return this.wrapError(`Помилка агрегації: ${error.message}`);
     }
   }
 


### PR DESCRIPTION
## Problem (MSP demo rehearsal, 2026-07-03)

Part 2 of the NEMIROFF demo query asks for «топ тотожних позначень (від 4 символів), зареєстрованих одночасно на кількох різних власників у класі 33». `search_registry` can only return rows — 3 of 26,174 class-33 records fit the LLM context — so the chat either honestly reported the gap (rehearsal-q1) or substituted random single-owner marks (chat-ae921608).

## Change

Optional `aggregate` parameter on `search_registry`:

```json
{ "registry": "trademarks", "filters": {"nice_class": 33},
  "aggregate": {"group_by": "mark_text", "count_distinct": "holder_name", "min_count": 2, "min_length": 4} }
```

→ `GROUP BY lower(col) HAVING COUNT(DISTINCT holder) >= 2 ORDER BY distinct_count DESC` with up to 5 sample values per group. Column identifiers resolve exclusively through the registry catalog (unknown fields and array-typed fields like `nice_class` are rejected with a helpful message); the `filters` object keeps working as the WHERE. At least one filter is still required. Demo example included in the tool description so the LLM maps the question to the call.

Also fixed two stale tests that predate the COUNT(*) companion-query change (they expected 1 DB call and a shared responder for both queries).

## Validation

- 25/25 unit tests (5 new aggregate cases: SQL shape, frequency-only mode, unknown/array field rejection, filter requirement)
- tsc clean (pre-existing core-loader errors unchanged)
- Prod data: class 33 → MARENGO (5 holders/9 marks), KOBLEVO (4/14), OREANDA (4/11) — matches the validated report sent to MSP

Plane: LEXAI-1820

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds aggregate mode to `search_registry` to return grouped results (e.g., identical marks held by multiple owners) instead of raw rows, solving MSP demo need in LEXAI-1820 and keeping answers within context limits.

- **New Features**
  - Optional `aggregate` param: `group_by`, `count_distinct`, `min_count`, `min_length` → builds `GROUP BY` with optional `HAVING COUNT(DISTINCT …)` and orders by distinct count.
  - Fields resolve via the registry catalog; unknown and array fields (e.g., `nice_class`) are rejected with a clear message. At least one filter is still required and used as `WHERE`.
  - Returns grouped payload with `group_value` (lowercased), `distinct_count`, `row_count`, and up to 5 `samples`. Demo example added to the tool description.

<sup>Written for commit 68441c3044c6bb60f7ad54682e5a05b9d1101946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

