### PR TITLE
fix(migrations): unblock fresh-DB migration run (126/131/150/161 guarded)

### DIFF
--- a/mcp_backend/src/migrations/126_spain_legal_data.sql
+++ b/mcp_backend/src/migrations/126_spain_legal_data.sql
@@ -1,78 +1,105 @@
--- Migration 121: Spanish legal open data — align existing tables + add missing columns/indexes
--- Tables already exist from prior schema; this migration adds missing columns and FTS indexes.
+-- Migration 126: Spanish legal open data — align existing tables + add missing columns/indexes
+-- Tables were created manually on prod (no CREATE migration exists), so every section is
+-- guarded with to_regclass(): on a fresh database (local/dev) the tables are absent and the
+-- section is skipped — otherwise this migration aborts the whole migration run.
 
 -- ═══════════════════════════════════════════════════════════════
 -- 1. BOE — add missing columns (full_text_xml, analysis_json, url_html_consolidada)
 -- Existing schema uses: id (serial), boe_id, title, metadata (jsonb)
 -- ═══════════════════════════════════════════════════════════════
-ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS full_text_xml TEXT;
-ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS analysis_json JSONB;
-ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS url_html_consolidada TEXT;
-ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS diario TEXT;
-ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS diario_numero TEXT;
-ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS fecha_actualizacion TIMESTAMPTZ;
+DO $$ BEGIN
+  IF to_regclass('spain_boe_legislation') IS NOT NULL THEN
+    ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS full_text_xml TEXT;
+    ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS analysis_json JSONB;
+    ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS url_html_consolidada TEXT;
+    ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS diario TEXT;
+    ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS diario_numero TEXT;
+    ALTER TABLE spain_boe_legislation ADD COLUMN IF NOT EXISTS fecha_actualizacion TIMESTAMPTZ;
 
-CREATE INDEX IF NOT EXISTS idx_spain_boe_rango ON spain_boe_legislation(rango);
-CREATE INDEX IF NOT EXISTS idx_spain_boe_fecha_pub ON spain_boe_legislation(fecha_publicacion);
-CREATE INDEX IF NOT EXISTS idx_spain_boe_estado ON spain_boe_legislation(estado_consolidacion);
-CREATE INDEX IF NOT EXISTS idx_spain_boe_ambito ON spain_boe_legislation(ambito);
-CREATE UNIQUE INDEX IF NOT EXISTS idx_spain_boe_boe_id ON spain_boe_legislation(boe_id);
+    CREATE INDEX IF NOT EXISTS idx_spain_boe_rango ON spain_boe_legislation(rango);
+    CREATE INDEX IF NOT EXISTS idx_spain_boe_fecha_pub ON spain_boe_legislation(fecha_publicacion);
+    CREATE INDEX IF NOT EXISTS idx_spain_boe_estado ON spain_boe_legislation(estado_consolidacion);
+    CREATE INDEX IF NOT EXISTS idx_spain_boe_ambito ON spain_boe_legislation(ambito);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_spain_boe_boe_id ON spain_boe_legislation(boe_id);
+
+    CREATE INDEX IF NOT EXISTS idx_spain_boe_fts ON spain_boe_legislation
+        USING gin(to_tsvector('spanish', COALESCE(title, '') || ' ' || COALESCE(full_text, '')));
+  END IF;
+END $$;
 
 -- ═══════════════════════════════════════════════════════════════
 -- 2. EUR-Lex — already matches, ensure indexes
 -- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_eurlex_type ON spain_eurlex_legislation(doc_type);
-CREATE INDEX IF NOT EXISTS idx_spain_eurlex_date ON spain_eurlex_legislation(doc_date);
-CREATE INDEX IF NOT EXISTS idx_spain_eurlex_force ON spain_eurlex_legislation(in_force);
+DO $$ BEGIN
+  IF to_regclass('spain_eurlex_legislation') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_spain_eurlex_type ON spain_eurlex_legislation(doc_type);
+    CREATE INDEX IF NOT EXISTS idx_spain_eurlex_date ON spain_eurlex_legislation(doc_date);
+    CREATE INDEX IF NOT EXISTS idx_spain_eurlex_force ON spain_eurlex_legislation(in_force);
+
+    CREATE INDEX IF NOT EXISTS idx_spain_eurlex_fts ON spain_eurlex_legislation
+        USING gin(to_tsvector('spanish', COALESCE(title, '') || ' ' || COALESCE(full_text, '')));
+  END IF;
+END $$;
 
 -- ═══════════════════════════════════════════════════════════════
 -- 3. Tribunal Constitucional — actual columns are tipo/fecha (not tipo_resolucion/fecha_registro)
 -- Indexes idx_tc_tipo and idx_tc_fecha already exist; create idempotent aliases.
 -- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_tc_tipo ON spain_tribunal_constitucional(tipo);
-CREATE INDEX IF NOT EXISTS idx_spain_tc_fecha ON spain_tribunal_constitucional(fecha);
+DO $$ BEGIN
+  IF to_regclass('spain_tribunal_constitucional') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_spain_tc_tipo ON spain_tribunal_constitucional(tipo);
+    CREATE INDEX IF NOT EXISTS idx_spain_tc_fecha ON spain_tribunal_constitucional(fecha);
+
+    CREATE INDEX IF NOT EXISTS idx_spain_tc_fts ON spain_tribunal_constitucional
+        USING gin(to_tsvector('spanish', COALESCE(full_text, '')));
+  END IF;
+END $$;
 
 -- ═══════════════════════════════════════════════════════════════
 -- 4. BORME Section C — already matches, ensure indexes
 -- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_borme_fecha ON spain_borme_section_c(fecha_publicacion);
-CREATE INDEX IF NOT EXISTS idx_spain_borme_tipo ON spain_borme_section_c(tipo_anuncio);
+DO $$ BEGIN
+  IF to_regclass('spain_borme_section_c') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_spain_borme_fecha ON spain_borme_section_c(fecha_publicacion);
+    CREATE INDEX IF NOT EXISTS idx_spain_borme_tipo ON spain_borme_section_c(tipo_anuncio);
+  END IF;
+END $$;
 
 -- ═══════════════════════════════════════════════════════════════
 -- 5. Consejo de Estado — already matches, ensure indexes
 -- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_ce_fecha ON spain_consejo_estado(fecha_aprobacion);
-CREATE INDEX IF NOT EXISTS idx_spain_ce_procedencia ON spain_consejo_estado(procedencia);
+DO $$ BEGIN
+  IF to_regclass('spain_consejo_estado') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_spain_ce_fecha ON spain_consejo_estado(fecha_aprobacion);
+    CREATE INDEX IF NOT EXISTS idx_spain_ce_procedencia ON spain_consejo_estado(procedencia);
+
+    CREATE INDEX IF NOT EXISTS idx_spain_ce_fts ON spain_consejo_estado
+        USING gin(to_tsvector('spanish', COALESCE(full_text, '')));
+  END IF;
+END $$;
 
 -- ═══════════════════════════════════════════════════════════════
 -- 6. AEAT — already matches, ensure indexes
 -- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_aeat_fecha ON spain_aeat_consultas(fecha);
-CREATE INDEX IF NOT EXISTS idx_spain_aeat_impuesto ON spain_aeat_consultas(impuesto);
+DO $$ BEGIN
+  IF to_regclass('spain_aeat_consultas') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_spain_aeat_fecha ON spain_aeat_consultas(fecha);
+    CREATE INDEX IF NOT EXISTS idx_spain_aeat_impuesto ON spain_aeat_consultas(impuesto);
+
+    CREATE INDEX IF NOT EXISTS idx_spain_aeat_fts ON spain_aeat_consultas
+        USING gin(to_tsvector('spanish', COALESCE(cuestion, '') || ' ' || COALESCE(contestacion, '')));
+  END IF;
+END $$;
 
 -- ═══════════════════════════════════════════════════════════════
 -- 7. Fiscalía — already matches, ensure indexes
 -- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_tipo ON spain_fiscalia(tipo);
-CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_fecha ON spain_fiscalia(fecha);
+DO $$ BEGIN
+  IF to_regclass('spain_fiscalia') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_tipo ON spain_fiscalia(tipo);
+    CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_fecha ON spain_fiscalia(fecha);
 
--- ═══════════════════════════════════════════════════════════════
--- Full-text search indexes (tsvector, Spanish config)
--- ═══════════════════════════════════════════════════════════════
-CREATE INDEX IF NOT EXISTS idx_spain_boe_fts ON spain_boe_legislation
-    USING gin(to_tsvector('spanish', COALESCE(title, '') || ' ' || COALESCE(full_text, '')));
-
-CREATE INDEX IF NOT EXISTS idx_spain_eurlex_fts ON spain_eurlex_legislation
-    USING gin(to_tsvector('spanish', COALESCE(title, '') || ' ' || COALESCE(full_text, '')));
-
-CREATE INDEX IF NOT EXISTS idx_spain_tc_fts ON spain_tribunal_constitucional
-    USING gin(to_tsvector('spanish', COALESCE(full_text, '')));
-
-CREATE INDEX IF NOT EXISTS idx_spain_ce_fts ON spain_consejo_estado
-    USING gin(to_tsvector('spanish', COALESCE(full_text, '')));
-
-CREATE INDEX IF NOT EXISTS idx_spain_aeat_fts ON spain_aeat_consultas
-    USING gin(to_tsvector('spanish', COALESCE(cuestion, '') || ' ' || COALESCE(contestacion, '')));
-
-CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_fts ON spain_fiscalia
-    USING gin(to_tsvector('spanish', COALESCE(titulo, '') || ' ' || COALESCE(full_text, '')));
+    CREATE INDEX IF NOT EXISTS idx_spain_fiscalia_fts ON spain_fiscalia
+        USING gin(to_tsvector('spanish', COALESCE(titulo, '') || ' ' || COALESCE(full_text, '')));
+  END IF;
+END $$;

--- a/mcp_backend/src/migrations/131_json_array_importer_mapping.sql
+++ b/mcp_backend/src/migrations/131_json_array_importer_mapping.sql
@@ -10,14 +10,22 @@
 --   mvs_missing_persons, mvs_wanted_vehicles, nazk_corruption.
 
 -- ── Unique indexes backing ON CONFLICT ──────────────────────────────────
-CREATE UNIQUE INDEX IF NOT EXISTS opendata_missing_persons_source_id_uniq
-  ON opendata_missing_persons(source_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS opendata_wanted_vehicles_natural_uniq
-  ON opendata_wanted_vehicles(vehicle_number, body_number);
-
-CREATE UNIQUE INDEX IF NOT EXISTS opendata_corruption_record_id_uniq
-  ON opendata_corruption(record_id);
+-- Tables opendata_* were created outside migrations (manual/prod-only), so each
+-- index is guarded — on a fresh database the statement is skipped.
+DO $$ BEGIN
+  IF to_regclass('opendata_missing_persons') IS NOT NULL THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS opendata_missing_persons_source_id_uniq
+      ON opendata_missing_persons(source_id);
+  END IF;
+  IF to_regclass('opendata_wanted_vehicles') IS NOT NULL THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS opendata_wanted_vehicles_natural_uniq
+      ON opendata_wanted_vehicles(vehicle_number, body_number);
+  END IF;
+  IF to_regclass('opendata_corruption') IS NOT NULL THEN
+    CREATE UNIQUE INDEX IF NOT EXISTS opendata_corruption_record_id_uniq
+      ON opendata_corruption(record_id);
+  END IF;
+END $$;
 
 -- ── mvs_missing_persons ────────────────────────────────────────────────
 UPDATE import_source_catalog

--- a/mcp_backend/src/migrations/150_us_opendata_quality_fixes.sql
+++ b/mcp_backend/src/migrations/150_us_opendata_quality_fixes.sql
@@ -54,9 +54,16 @@ CREATE INDEX IF NOT EXISTS idx_us_court_opinions_length ON us_court_opinions(tex
 CREATE INDEX IF NOT EXISTS idx_us_court_opinions_reporter ON us_court_opinions(reporter_series);
 
 -- ── Fixes (run after tables exist) ─────────────────────────────────
+-- Tables opensanctions_entities / us_cfpb_complaints / us_fec_candidates were
+-- created outside migrations (importer-managed), so each fix is guarded with
+-- to_regclass() — on a fresh database the block is skipped.
 
 -- 1. OpenSanctions: FTS index on name
-CREATE INDEX IF NOT EXISTS idx_opensanctions_name_fts ON opensanctions_entities USING gin(to_tsvector('simple', name));
+DO $$ BEGIN
+  IF to_regclass('opensanctions_entities') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_opensanctions_name_fts ON opensanctions_entities USING gin(to_tsvector('simple', name));
+  END IF;
+END $$;
 
 -- 2. Court opinions: reporter_series column + populate
 ALTER TABLE us_court_opinions ADD COLUMN IF NOT EXISTS reporter_series TEXT;
@@ -64,28 +71,36 @@ DROP INDEX IF EXISTS idx_us_court_opinions_created;
 UPDATE us_court_opinions SET reporter_series = split_part(id, '/', 1) WHERE reporter_series IS NULL;
 
 -- 3. CFPB: normalized product taxonomy
-ALTER TABLE us_cfpb_complaints ADD COLUMN IF NOT EXISTS product_normalized TEXT;
-UPDATE us_cfpb_complaints SET product_normalized = CASE
-    WHEN product IN ('Credit reporting, credit repair services, or other personal consumer reports',
-                     'Credit reporting or other personal consumer reports')
-        THEN 'Credit reporting'
-    WHEN product IN ('Credit card or prepaid card', 'Credit card', 'Prepaid card')
-        THEN 'Credit card / prepaid'
-    WHEN product IN ('Payday loan, title loan, personal loan, or advance',
-                     'Payday loan, title loan, or personal loan', 'Payday loan')
-        THEN 'Payday / personal loan'
-    WHEN product IN ('Money transfer, virtual currency, or money service',
-                     'Money transfers', 'Virtual currency')
-        THEN 'Money transfer / crypto'
-    WHEN product IN ('Checking or savings account', 'Bank account or service')
-        THEN 'Bank account'
-    ELSE product
-END
-WHERE product_normalized IS NULL;
-CREATE INDEX IF NOT EXISTS idx_us_cfpb_product_norm ON us_cfpb_complaints(product_normalized);
+DO $$ BEGIN
+  IF to_regclass('us_cfpb_complaints') IS NOT NULL THEN
+    ALTER TABLE us_cfpb_complaints ADD COLUMN IF NOT EXISTS product_normalized TEXT;
+    UPDATE us_cfpb_complaints SET product_normalized = CASE
+        WHEN product IN ('Credit reporting, credit repair services, or other personal consumer reports',
+                         'Credit reporting or other personal consumer reports')
+            THEN 'Credit reporting'
+        WHEN product IN ('Credit card or prepaid card', 'Credit card', 'Prepaid card')
+            THEN 'Credit card / prepaid'
+        WHEN product IN ('Payday loan, title loan, personal loan, or advance',
+                         'Payday loan, title loan, or personal loan', 'Payday loan')
+            THEN 'Payday / personal loan'
+        WHEN product IN ('Money transfer, virtual currency, or money service',
+                         'Money transfers', 'Virtual currency')
+            THEN 'Money transfer / crypto'
+        WHEN product IN ('Checking or savings account', 'Bank account or service')
+            THEN 'Bank account'
+        ELSE product
+    END
+    WHERE product_normalized IS NULL;
+    CREATE INDEX IF NOT EXISTS idx_us_cfpb_product_norm ON us_cfpb_complaints(product_normalized);
+  END IF;
+END $$;
 
 -- 4. FEC candidates: fix garbled election years
-UPDATE us_fec_candidates SET election_year = NULL WHERE election_year > 2030;
+DO $$ BEGIN
+  IF to_regclass('us_fec_candidates') IS NOT NULL THEN
+    UPDATE us_fec_candidates SET election_year = NULL WHERE election_year > 2030;
+  END IF;
+END $$;
 
 -- 5. OFAC standalone: deprecate in catalog
 UPDATE import_source_catalog SET enabled = false WHERE name = 'us_ofac_sdn';

--- a/mcp_backend/src/migrations/161_echr_sync_tracking.sql
+++ b/mcp_backend/src/migrations/161_echr_sync_tracking.sql
@@ -18,5 +18,11 @@ CREATE INDEX IF NOT EXISTS idx_echr_sync_log_country ON echr_sync_log(country_co
 CREATE INDEX IF NOT EXISTS idx_echr_sync_log_status ON echr_sync_log(status);
 
 -- 2. Performance indexes on echr_cases
-CREATE INDEX IF NOT EXISTS idx_echr_cases_respondent ON echr_cases(respondent);
-CREATE INDEX IF NOT EXISTS idx_echr_cases_kp_date ON echr_cases(kp_date);
+-- echr_cases lives in the separate hudoc database on some environments — guard
+-- so a fresh main database doesn't abort the migration run.
+DO $$ BEGIN
+  IF to_regclass('echr_cases') IS NOT NULL THEN
+    CREATE INDEX IF NOT EXISTS idx_echr_cases_respondent ON echr_cases(respondent);
+    CREATE INDEX IF NOT EXISTS idx_echr_cases_kp_date ON echr_cases(kp_date);
+  END IF;
+END $$;


### PR DESCRIPTION
## Problem

На свежей базе (dev/local) прогон миграций падал на **126_spain_legal_data.sql** и обрывался — применялась только 121 из 166 миграций (45 не доезжали, включая `164_edrsr_lexeme_df`, из-за чего падал EDRSR FTS).

Причина: миграции 126, 131, 150, 161 ссылаются на таблицы, которые **не создаются ни одной миграцией** (созданы вручную на проде / importer-managed): `spain_*`, `opendata_*`, `opensanctions_entities`, `us_cfpb_complaints`, `us_fec_candidates`, `echr_cases`.

## Fix

Statements обёрнуты в `DO $$ ... END $$` с guard'ом `to_regclass()` — на базе без таблицы блок пропускается, на проде поведение не меняется (таблицы есть → все statements выполняются как раньше).

## Verification

- ✅ Dev VM, свежая БД: все **166/166** миграций применяются
- ✅ Повторный прогон: 0 ошибок (идемпотентно)
- Прод не затронут: guard-блоки на проде выполняют те же statements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unblocks fresh database migrations by guarding 126, 131, 150, and 161 with table-existence checks. All 166 migrations now run end to end; production behavior stays the same.

- **Bug Fixes**
  - Skip statements when prod/importer-only tables are absent: spain_*, opendata_*, opensanctions_entities, us_cfpb_complaints, us_fec_candidates, echr_cases.
  - Wrapped affected statements in DO $$ blocks with to_regclass() guards (indexes, updates, schema tweaks).
  - Verified on a fresh DB: 166/166 applied; reruns are idempotent.

<sup>Written for commit 2aa6fd92fb2f034e3af8b8cd7df11a1ad55b5c3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

