### PR TITLE
feat(opendata): import tables + loaders for M&A/antitrust/sanctions demo sources

### DIFF
--- a/mcp_backend/src/migrations/169_opendata_ma_antitrust_sources.sql
+++ b/mcp_backend/src/migrations/169_opendata_ma_antitrust_sources.sql
@@ -1,0 +1,115 @@
+-- Migration 169: Open-data tables for the M&A / antitrust / sanctions client demo (03.07.2026)
+-- Sources downloaded to prod /data/opendata/ :
+--   drs/            — Держреєстр санкцій РНБО (official UA sanctions registry)
+--   nazk_sanctions/ — «Війна і санкції» (war-sanctions.gur.gov.ua, GUR) scrape + OpenSanctions bulk
+--   amcu/           — АМКУ: рішення (decisions) + зведені відомості про спотворення торгів (bid-rigging)
+--   rada_stenograms/— ВРУ plenary stenograms (legislative intent)
+--
+-- These sources cannot auto-sync from the prod IP (Cloudflare block / confidential API), so they are
+-- loaded by standalone file importers in src/scripts/import-*.ts reading from /data/opendata/.
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 1. ДРС РНБО — official Ukrainian sanctions registry (drs.nsdc.gov.ua)
+--    ~24k subjects: individuals / legal entities / vessels
+-- ═══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS opendata_drs_sanctions (
+    subject_id      BIGINT PRIMARY KEY,            -- subjectId from the registry
+    subject_type    TEXT,                          -- individual | legal | vessel
+    subject_status  TEXT,                          -- active | expired | excluded
+    name            TEXT,                          -- subjectName (Ukrainian)
+    aliases         JSONB,                          -- subjectAliases[] (translit / ru / other)
+    birth_date      DATE,                          -- subjectBirthDate (individuals)
+    identifiers     JSONB,                          -- subjectIdentifiers {tax, passport, ...}
+    citizenships    JSONB,                          -- subjectCitizenships[]
+    attributes      JSONB,                          -- subjectAttributes
+    raw_data        JSONB NOT NULL,                 -- full record
+    fetched_at      TIMESTAMPTZ,                    -- when the registry snapshot was taken
+    imported_at     TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_drs_type_status ON opendata_drs_sanctions(subject_type, subject_status);
+CREATE INDEX IF NOT EXISTS idx_drs_name ON opendata_drs_sanctions USING gin(to_tsvector('simple', coalesce(name, '')));
+CREATE INDEX IF NOT EXISTS idx_drs_identifiers ON opendata_drs_sanctions USING gin(identifiers);
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 2. НАЗК/ГУР «Війна і санкції» — war-sanctions.gur.gov.ua scrape
+--    14 categories: sanctions_persons/companies, ships, shadow-fleet, rostec,
+--    uav_companies, propaganda, kidnappers, stolen objects/persons, etc.
+-- ═══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS opendata_nazk_war_sanctions (
+    id              BIGSERIAL PRIMARY KEY,
+    category        TEXT NOT NULL,                  -- sanctions_persons, transport_ships, ...
+    source_id       INTEGER,                        -- id on the portal
+    url             TEXT,                           -- canonical portal URL
+    page_title      TEXT,
+    name_uk         TEXT,                           -- primary Ukrainian name (first of fields.Name)
+    tin             TEXT,                           -- ІПН / TIN when present
+    fields          JSONB,                          -- all scraped detail fields
+    sanction_jurisdictions JSONB,                   -- [{jurisdiction, sanctioned, date, document_url}]
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (category, source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nazk_ws_category ON opendata_nazk_war_sanctions(category);
+CREATE INDEX IF NOT EXISTS idx_nazk_ws_name ON opendata_nazk_war_sanctions USING gin(to_tsvector('simple', coalesce(name_uk, '') || ' ' || coalesce(page_title, '')));
+CREATE INDEX IF NOT EXISTS idx_nazk_ws_tin ON opendata_nazk_war_sanctions(tin) WHERE tin IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_nazk_ws_jurisdictions ON opendata_nazk_war_sanctions USING gin(sanction_jurisdictions);
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 3. АМКУ — зведені відомості про спотворення результатів торгів (bid-rigging)
+--    Consolidated data on tender-distortion violations (per-row from XLSX)
+-- ═══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS opendata_amcu_bid_rigging (
+    id              BIGSERIAL PRIMARY KEY,
+    source_file     TEXT NOT NULL,                  -- originating XLSX filename
+    row_num         INTEGER,                        -- row index within the file
+    decision_date   DATE,                           -- parsed from the file (period snapshot)
+    entity_name     TEXT,                           -- violator name if resolvable
+    entity_edrpou   TEXT,                           -- ЄДРПОУ if present
+    row_data        JSONB NOT NULL,                 -- full row keyed by header
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (source_file, row_num)
+);
+
+CREATE INDEX IF NOT EXISTS idx_amcu_bid_edrpou ON opendata_amcu_bid_rigging(entity_edrpou) WHERE entity_edrpou IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_amcu_bid_name ON opendata_amcu_bid_rigging USING gin(to_tsvector('simple', coalesce(entity_name, '')));
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 4. АМКУ — рішення та рекомендації (decisions) : document metadata + text
+--    Archives (zip/7z) of doc/docx + annual index XLSX. One row per document file.
+-- ═══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS opendata_amcu_decisions (
+    id              BIGSERIAL PRIMARY KEY,
+    archive_file    TEXT,                           -- originating archive (relative path)
+    doc_file        TEXT NOT NULL,                  -- document filename inside the archive
+    doc_kind        TEXT,                           -- rishennia | rekomendatsii | list | other
+    decision_no     TEXT,                           -- decision number if parsed
+    decision_date   DATE,                           -- date parsed from filename
+    body_text       TEXT,                           -- extracted text (docx via mammoth; empty for legacy .doc)
+    extracted       BOOLEAN DEFAULT FALSE,          -- whether body_text was successfully extracted
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (doc_file)
+);
+
+CREATE INDEX IF NOT EXISTS idx_amcu_dec_date ON opendata_amcu_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_amcu_dec_kind ON opendata_amcu_decisions(doc_kind);
+CREATE INDEX IF NOT EXISTS idx_amcu_dec_body ON opendata_amcu_decisions USING gin(to_tsvector('simple', coalesce(body_text, '')));
+
+-- ═══════════════════════════════════════════════════════════════════════
+-- 5. ВРУ — стенограми пленарних засідань (legislative intent)
+--    HTM per sitting day (windows-1251), by convocation.
+-- ═══════════════════════════════════════════════════════════════════════
+CREATE TABLE IF NOT EXISTS opendata_rada_stenograms (
+    id              BIGSERIAL PRIMARY KEY,
+    convocation     INTEGER,                        -- skl number (1..9)
+    sitting_date    DATE,                           -- parsed from filename YYYYMMDD
+    doc_kind        TEXT,                           -- stenogram | agenda | stenpog
+    source_file     TEXT NOT NULL,                  -- relative path of the HTM
+    body_text       TEXT,                           -- plain text (win-1251 decoded, HTML stripped)
+    imported_at     TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (source_file)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stenogram_conv_date ON opendata_rada_stenograms(convocation, sitting_date);
+CREATE INDEX IF NOT EXISTS idx_stenogram_kind ON opendata_rada_stenograms(doc_kind);
+CREATE INDEX IF NOT EXISTS idx_stenogram_body ON opendata_rada_stenograms USING gin(to_tsvector('simple', coalesce(body_text, '')));

--- a/mcp_backend/src/scripts/import-amcu-bid-rigging.ts
+++ b/mcp_backend/src/scripts/import-amcu-bid-rigging.ts
@@ -1,0 +1,147 @@
+/**
+ * Import АМКУ «Зведені відомості про спотворення результатів торгів (тендерів)»
+ * (bid-rigging consolidated data) into opendata_amcu_bid_rigging.
+ *
+ * Reads all XLSX files under /data/opendata/amcu/zvedeni-vidomosti-torhy/.
+ * Row 1 = machine headers, row 2 = Ukrainian descriptions (skipped), data from row 3.
+ * Key columns: identifier (ЄДРПОУ), theEntityThatCommittedTheViolation, dateOfDecision.
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-amcu-bid-rigging.ts [dir]
+ *   default dir: /data/opendata/amcu/zvedeni-vidomosti-torhy
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+import ExcelJS from 'exceljs';
+
+const DEFAULT_DIR = '/data/opendata/amcu/zvedeni-vidomosti-torhy';
+const BATCH_SIZE = 500;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+function cellText(v: any): string | null {
+  if (v == null) return null;
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  if (typeof v === 'object') {
+    if (v.text) return String(v.text);
+    if (v.result != null) return String(v.result);
+    if (v.richText) return v.richText.map((t: any) => t.text).join('');
+    return null;
+  }
+  return String(v).trim() || null;
+}
+
+function toDate(v: any): string | null {
+  if (v instanceof Date) return v.toISOString().slice(0, 10);
+  const s = cellText(v);
+  if (!s) return null;
+  let m = s.match(/(\d{2})[.\/](\d{2})[.\/](\d{4})/); // dd.mm.yyyy
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  m = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  return null;
+}
+
+function looksLikeDescriptionRow(rowData: Record<string, any>): boolean {
+  const id = String(rowData['identifier'] ?? '');
+  const dn = String(rowData['decisionNumber'] ?? '');
+  return id.includes('ЄДРПОУ') || dn.includes('за порядком') || dn.includes('рішенн');
+}
+
+async function insertBatch(rows: any[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const placeholders: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    const cols = [r.source_file, r.row_num, r.decision_date, r.entity_name, r.entity_edrpou, JSON.stringify(r.row_data)];
+    placeholders.push(`(${cols.map(() => `$${i++}`).join(',')})`);
+    values.push(...cols);
+  }
+  const sql = `
+    INSERT INTO opendata_amcu_bid_rigging
+      (source_file, row_num, decision_date, entity_name, entity_edrpou, row_data)
+    VALUES ${placeholders.join(',')}
+    ON CONFLICT (source_file, row_num) DO UPDATE SET
+      decision_date = EXCLUDED.decision_date,
+      entity_name = EXCLUDED.entity_name,
+      entity_edrpou = EXCLUDED.entity_edrpou,
+      row_data = EXCLUDED.row_data,
+      imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function importFile(file: string): Promise<number> {
+  const base = path.basename(file);
+  const wb = new ExcelJS.Workbook();
+  await wb.xlsx.readFile(file);
+  const ws = wb.worksheets[0];
+  if (!ws) return 0;
+
+  const headerVals = ws.getRow(1).values as any[];
+  const headers: string[] = [];
+  for (let c = 1; c < headerVals.length; c++) {
+    headers[c] = cellText(headerVals[c]) || `col${c}`;
+  }
+
+  let imported = 0;
+  let batch: any[] = [];
+  for (let rn = 2; rn <= ws.rowCount; rn++) {
+    const rowVals = ws.getRow(rn).values as any[];
+    if (!rowVals || rowVals.length <= 1) continue;
+    const rowData: Record<string, any> = {};
+    let hasContent = false;
+    for (let c = 1; c < headers.length; c++) {
+      const t = cellText(rowVals[c]);
+      if (t != null) hasContent = true;
+      rowData[headers[c]] = t;
+    }
+    if (!hasContent) continue;
+    if (rn === 2 && looksLikeDescriptionRow(rowData)) continue;
+
+    batch.push({
+      source_file: base,
+      row_num: rn,
+      decision_date: toDate(rowData['dateOfDecision']),
+      entity_name: rowData['theEntityThatCommittedTheViolation'] || null,
+      entity_edrpou: (rowData['identifier'] && /^\d{6,10}$/.test(String(rowData['identifier']))) ? String(rowData['identifier']) : null,
+      row_data: rowData,
+    });
+    if (batch.length >= BATCH_SIZE) { imported += await insertBatch(batch); batch = []; }
+  }
+  if (batch.length) imported += await insertBatch(batch);
+  return imported;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] || DEFAULT_DIR;
+  console.log(`📥 АМКУ bid-rigging import from ${dir}`);
+  if (!fs.existsSync(dir)) { console.error(`❌ Dir not found: ${dir}`); process.exit(1); }
+  await pool.query('SELECT 1');
+  const files = fs.readdirSync(dir).filter(f => /\.xlsx?$/i.test(f));
+  let total = 0, done = 0;
+  for (const f of files) {
+    try {
+      total += await importFile(path.join(dir, f));
+    } catch (e: any) {
+      console.warn(`   ⚠️ ${f}: ${e.message}`);
+    }
+    if (++done % 25 === 0) console.log(`   ${done}/${files.length} files, ${total} rows`);
+  }
+  console.log(`✅ АМКУ bid-rigging: ${total} rows from ${files.length} files`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });

--- a/mcp_backend/src/scripts/import-amcu-decisions.ts
+++ b/mcp_backend/src/scripts/import-amcu-decisions.ts
@@ -1,0 +1,156 @@
+/**
+ * Import АМКУ «Рішення та рекомендації» documents into opendata_amcu_decisions.
+ *
+ * Reads /data/opendata/amcu/rishennia-ta-rekomendatsii/ : zip archives of doc/docx,
+ * loose doc/docx, and annual index XLSX. One row per document file.
+ *   - .docx  → text extracted via mammoth
+ *   - .doc   → legacy binary; metadata only (extracted=false)
+ *   - .7z    → skipped (adm-zip cannot read 7z); logged
+ *   - .xlsx  → annual list; recorded as doc_kind='list', no text
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-amcu-decisions.ts [dir]
+ *   default: /data/opendata/amcu/rishennia-ta-rekomendatsii
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+import AdmZip from 'adm-zip';
+import mammoth from 'mammoth';
+
+const DEFAULT_DIR = '/data/opendata/amcu/rishennia-ta-rekomendatsii';
+const BATCH_SIZE = 100;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+function kindOf(name: string): string {
+  const n = name.toLowerCase();
+  if (n.includes('rekomend') || n.includes('recomend')) return 'rekomendatsii';
+  if (n.includes('spisok') || n.includes('list')) return 'list';
+  if (n.includes('rish') || n.includes('rise')) return 'rishennia';
+  return 'other';
+}
+
+function dateOf(name: string): string | null {
+  let m = name.match(/(\d{2})[-.](\d{2})[-.](\d{4})/); // dd-mm-yyyy
+  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
+  m = name.match(/(\d{4})[-.](\d{2})[-.](\d{2})/); // yyyy-mm-dd
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  return null;
+}
+
+function decisionNoOf(name: string): string | null {
+  let m = name.match(/no[-_ ]?(\d+[-_ ]?[a-zа-я]*)/i);
+  if (m) return m[1];
+  m = name.match(/(\d+)[-_](rk|р[кп])/i);
+  if (m) return m[1];
+  return null;
+}
+
+async function extractDocx(buf: Buffer): Promise<string | null> {
+  try {
+    const res = await mammoth.extractRawText({ buffer: buf });
+    return (res.value || '').trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function insertBatch(rows: any[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const placeholders: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    const cols = [r.archive_file, r.doc_file, r.doc_kind, r.decision_no, r.decision_date, r.body_text, r.extracted];
+    placeholders.push(`(${cols.map(() => `$${i++}`).join(',')})`);
+    values.push(...cols);
+  }
+  const sql = `
+    INSERT INTO opendata_amcu_decisions
+      (archive_file, doc_file, doc_kind, decision_no, decision_date, body_text, extracted)
+    VALUES ${placeholders.join(',')}
+    ON CONFLICT (doc_file) DO UPDATE SET
+      archive_file = EXCLUDED.archive_file,
+      doc_kind = EXCLUDED.doc_kind,
+      decision_no = EXCLUDED.decision_no,
+      decision_date = EXCLUDED.decision_date,
+      body_text = COALESCE(EXCLUDED.body_text, opendata_amcu_decisions.body_text),
+      extracted = EXCLUDED.extracted OR opendata_amcu_decisions.extracted,
+      imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] || DEFAULT_DIR;
+  console.log(`📥 АМКУ decisions import from ${dir}`);
+  if (!fs.existsSync(dir)) { console.error(`❌ Dir not found: ${dir}`); process.exit(1); }
+  await pool.query('SELECT 1');
+
+  const files = fs.readdirSync(dir);
+  let total = 0, sevenZip = 0, docxOk = 0, docLegacy = 0;
+  let batch: any[] = [];
+
+  const push = async (row: any) => {
+    batch.push(row);
+    if (batch.length >= BATCH_SIZE) { total += await insertBatch(batch); batch = []; }
+  };
+
+  for (const f of files) {
+    const full = path.join(dir, f);
+    const ext = path.extname(f).toLowerCase();
+
+    if (ext === '.7z') { sevenZip++; continue; }
+
+    if (ext === '.zip') {
+      let entries: any[];
+      try { entries = new AdmZip(full).getEntries(); } catch (e: any) { console.warn(`   ⚠️ ${f}: ${e.message}`); continue; }
+      for (const en of entries) {
+        if (en.isDirectory) continue;
+        const en2 = en.entryName;
+        const e2 = path.extname(en2).toLowerCase();
+        if (e2 !== '.doc' && e2 !== '.docx') continue;
+        let body: string | null = null, extracted = false;
+        if (e2 === '.docx') {
+          body = await extractDocx(en.getData());
+          extracted = body != null;
+          if (extracted) docxOk++; else docLegacy++;
+        } else { docLegacy++; }
+        await push({
+          archive_file: f, doc_file: `${f}!${en2}`, doc_kind: kindOf(en2),
+          decision_no: decisionNoOf(en2), decision_date: dateOf(en2), body_text: body, extracted,
+        });
+      }
+      continue;
+    }
+
+    if (ext === '.docx' || ext === '.doc') {
+      let body: string | null = null, extracted = false;
+      if (ext === '.docx') { body = await extractDocx(fs.readFileSync(full)); extracted = body != null; if (extracted) docxOk++; else docLegacy++; }
+      else docLegacy++;
+      await push({ archive_file: null, doc_file: f, doc_kind: kindOf(f), decision_no: decisionNoOf(f), decision_date: dateOf(f), body_text: body, extracted });
+      continue;
+    }
+
+    if (ext === '.xlsx' || ext === '.xls') {
+      await push({ archive_file: null, doc_file: f, doc_kind: 'list', decision_no: null, decision_date: dateOf(f), body_text: null, extracted: false });
+    }
+  }
+  if (batch.length) total += await insertBatch(batch);
+
+  console.log(`✅ АМКУ decisions: ${total} rows (docx text ${docxOk}, legacy/no-text ${docLegacy}); ${sevenZip} .7z archives skipped (need 7z extraction)`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });

--- a/mcp_backend/src/scripts/import-drs-sanctions.ts
+++ b/mcp_backend/src/scripts/import-drs-sanctions.ts
@@ -1,0 +1,110 @@
+/**
+ * Import the Ukrainian State Register of Sanctions (Держреєстр санкцій РНБО)
+ * into opendata_drs_sanctions.
+ *
+ * Reads the JSON snapshot downloaded to /data/opendata/drs/drs_subjects_full.json
+ * (the public frontend proxy drs.nsdc.gov.ua/registry-api/subjects — no API key).
+ * The prod IP is Cloudflare-blocked on this host, so the file is produced out-of-band
+ * (browser/local) and this importer only loads it.
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-drs-sanctions.ts [path]
+ *   default path: /data/opendata/drs/drs_subjects_full.json
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+
+const DEFAULT_PATH = '/data/opendata/drs/drs_subjects_full.json';
+const BATCH_SIZE = 500;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+/** Normalise a possibly-partial date string to a valid DATE or null. */
+function toDate(v: any): string | null {
+  if (!v || typeof v !== 'string') return null;
+  const m = v.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  if (mo === '00' || d === '00') return null; // partial dates are not storable
+  return `${y}-${mo}-${d}`;
+}
+
+async function insertBatch(items: any[], fetchedAt: string | null): Promise<number> {
+  if (items.length === 0) return 0;
+  const values: any[] = [];
+  const placeholders: string[] = [];
+  let i = 1;
+  for (const s of items) {
+    const fields = [
+      s.subjectId,
+      s.subjectType || null,
+      s.subjectStatus || null,
+      s.subjectName || null,
+      s.subjectAliases ? JSON.stringify(s.subjectAliases) : null,
+      toDate(s.subjectBirthDate),
+      s.subjectIdentifiers ? JSON.stringify(s.subjectIdentifiers) : null,
+      s.subjectCitizenships ? JSON.stringify(s.subjectCitizenships) : null,
+      s.subjectAttributes ? JSON.stringify(s.subjectAttributes) : null,
+      JSON.stringify(s),
+      fetchedAt,
+    ];
+    placeholders.push(`(${fields.map(() => `$${i++}`).join(',')})`);
+    values.push(...fields);
+  }
+  const sql = `
+    INSERT INTO opendata_drs_sanctions
+      (subject_id, subject_type, subject_status, name, aliases, birth_date,
+       identifiers, citizenships, attributes, raw_data, fetched_at)
+    VALUES ${placeholders.join(',')}
+    ON CONFLICT (subject_id) DO UPDATE SET
+      subject_type = EXCLUDED.subject_type,
+      subject_status = EXCLUDED.subject_status,
+      name = EXCLUDED.name,
+      aliases = EXCLUDED.aliases,
+      birth_date = EXCLUDED.birth_date,
+      identifiers = EXCLUDED.identifiers,
+      citizenships = EXCLUDED.citizenships,
+      attributes = EXCLUDED.attributes,
+      raw_data = EXCLUDED.raw_data,
+      fetched_at = EXCLUDED.fetched_at,
+      imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function main(): Promise<void> {
+  const path = process.argv[2] || DEFAULT_PATH;
+  console.log(`📥 ДРС РНБО import from ${path}`);
+  if (!fs.existsSync(path)) {
+    console.error(`❌ File not found: ${path}`);
+    process.exit(1);
+  }
+  const doc = JSON.parse(fs.readFileSync(path, 'utf8'));
+  const items: any[] = doc.items || [];
+  const fetchedAt = doc.fetchedAt || null;
+  console.log(`   total subjects: ${items.length}, snapshot: ${fetchedAt}`);
+
+  await pool.query('SELECT 1');
+  let imported = 0;
+  for (let b = 0; b < items.length; b += BATCH_SIZE) {
+    imported += await insertBatch(items.slice(b, b + BATCH_SIZE), fetchedAt);
+    if (b % (BATCH_SIZE * 10) === 0) console.log(`   ${b}/${items.length}`);
+  }
+  console.log(`✅ ДРС import: ${imported} rows upserted`);
+  await pool.end();
+}
+
+main().catch(err => {
+  console.error('❌ Fatal:', err);
+  process.exit(1);
+});

--- a/mcp_backend/src/scripts/import-nazk-war-sanctions.ts
+++ b/mcp_backend/src/scripts/import-nazk-war-sanctions.ts
@@ -1,0 +1,119 @@
+/**
+ * Import the «Війна і санкції» portal (war-sanctions.gur.gov.ua, GUR МО) scrape
+ * into opendata_nazk_war_sanctions.
+ *
+ * NOTE: the portal formerly lived at sanctions.nazk.gov.ua (now NXDOMAIN); its JSON
+ * API is confidential (GUR-issued token) and the prod IP is Cloudflare-blocked, so the
+ * data is scraped out-of-band and stored as JSONL under /data/opendata/nazk_sanctions/jsonl/.
+ * This importer only loads those files.
+ *
+ * Each JSONL record: { id, category, url, page_title, fields:{Name:[], TIN, ...},
+ *                      sanction_jurisdictions:[{jurisdiction, sanctioned, date, document_url}] }
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-nazk-war-sanctions.ts [jsonlDir]
+ *   default dir: /data/opendata/nazk_sanctions/jsonl
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DEFAULT_DIR = '/data/opendata/nazk_sanctions/jsonl';
+const BATCH_SIZE = 500;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+function firstName(fields: any): string | null {
+  const n = fields?.Name;
+  if (Array.isArray(n)) return n[0] || null;
+  if (typeof n === 'string') return n;
+  return null;
+}
+
+async function insertBatch(rows: any[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const placeholders: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    const fields = r.fields || {};
+    const cols = [
+      r.category,
+      typeof r.id === 'number' ? r.id : (parseInt(r.id) || null),
+      r.url || null,
+      r.page_title || null,
+      firstName(fields),
+      fields.TIN || fields.tin || null,
+      JSON.stringify(fields),
+      r.sanction_jurisdictions ? JSON.stringify(r.sanction_jurisdictions) : null,
+    ];
+    placeholders.push(`(${cols.map(() => `$${i++}`).join(',')})`);
+    values.push(...cols);
+  }
+  const sql = `
+    INSERT INTO opendata_nazk_war_sanctions
+      (category, source_id, url, page_title, name_uk, tin, fields, sanction_jurisdictions)
+    VALUES ${placeholders.join(',')}
+    ON CONFLICT (category, source_id) DO UPDATE SET
+      url = EXCLUDED.url,
+      page_title = EXCLUDED.page_title,
+      name_uk = EXCLUDED.name_uk,
+      tin = EXCLUDED.tin,
+      fields = EXCLUDED.fields,
+      sanction_jurisdictions = EXCLUDED.sanction_jurisdictions,
+      imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function importFile(file: string): Promise<number> {
+  const lines = fs.readFileSync(file, 'utf8').split('\n').filter(l => l.trim());
+  let imported = 0;
+  let batch: any[] = [];
+  for (const line of lines) {
+    let rec: any;
+    try { rec = JSON.parse(line); } catch { continue; }
+    if (rec.source_id == null && rec.id == null) continue;
+    batch.push(rec);
+    if (batch.length >= BATCH_SIZE) {
+      imported += await insertBatch(batch);
+      batch = [];
+    }
+  }
+  if (batch.length) imported += await insertBatch(batch);
+  return imported;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] || DEFAULT_DIR;
+  console.log(`📥 НАЗК/ГУР war-sanctions import from ${dir}`);
+  if (!fs.existsSync(dir)) {
+    console.error(`❌ Dir not found: ${dir}`);
+    process.exit(1);
+  }
+  await pool.query('SELECT 1');
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.jsonl'));
+  let total = 0;
+  for (const f of files) {
+    const n = await importFile(path.join(dir, f));
+    total += n;
+    console.log(`   ${f}: ${n}`);
+  }
+  console.log(`✅ НАЗК import: ${total} rows across ${files.length} categories`);
+  await pool.end();
+}
+
+main().catch(err => {
+  console.error('❌ Fatal:', err);
+  process.exit(1);
+});

--- a/mcp_backend/src/scripts/import-rada-stenograms.ts
+++ b/mcp_backend/src/scripts/import-rada-stenograms.ts
@@ -1,0 +1,133 @@
+/**
+ * Import ВРУ plenary stenograms (and agendas) into opendata_rada_stenograms.
+ *
+ * Reads *_txt.zip archives under /data/opendata/rada_stenograms/ (mirror of data.rada.gov.ua
+ * /ogd/zal/agenda/sklN/{sten,text,spog}/). Each archive holds YYYYMMDD[-N].htm files in
+ * windows-1251. HTML is stripped to plain text (cheerio) and decoded natively via TextDecoder.
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-rada-stenograms.ts [rootDir]
+ *   default: /data/opendata/rada_stenograms
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+import AdmZip from 'adm-zip';
+import * as cheerio from 'cheerio';
+
+const DEFAULT_ROOT = '/data/opendata/rada_stenograms';
+const BATCH_SIZE = 200;
+const win1251 = new TextDecoder('windows-1251');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+function walkZips(dir: string, out: string[]): void {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walkZips(p, out);
+    else if (e.isFile() && /_txt\.zip$/i.test(e.name)) out.push(p);
+  }
+}
+
+function convocationOf(relPath: string): number | null {
+  const m = relPath.match(/skl(\d+)/i);
+  return m ? parseInt(m[1]) : null;
+}
+
+function kindOf(relPath: string): string {
+  if (/\/sten\//i.test(relPath) || /stenogram/i.test(relPath)) return 'stenogram';
+  if (/\/spog\//i.test(relPath) || /stenpog/i.test(relPath)) return 'stenpog';
+  if (/\/text\//i.test(relPath) || /agenda/i.test(relPath)) return 'agenda';
+  return 'other';
+}
+
+function dateOf(fname: string): string | null {
+  const m = fname.match(/(\d{4})(\d{2})(\d{2})/);
+  if (!m) return null;
+  const [, y, mo, d] = m;
+  if (mo < '01' || mo > '12' || d < '01' || d > '31') return null;
+  return `${y}-${mo}-${d}`;
+}
+
+function htmlToText(buf: Buffer): string {
+  const html = win1251.decode(buf);
+  const $ = cheerio.load(html);
+  $('script,style').remove();
+  return $.text().replace(/ /g, ' ').replace(/[ \t]+/g, ' ').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+async function insertBatch(rows: any[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const placeholders: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    const cols = [r.convocation, r.sitting_date, r.doc_kind, r.source_file, r.body_text];
+    placeholders.push(`(${cols.map(() => `$${i++}`).join(',')})`);
+    values.push(...cols);
+  }
+  const sql = `
+    INSERT INTO opendata_rada_stenograms
+      (convocation, sitting_date, doc_kind, source_file, body_text)
+    VALUES ${placeholders.join(',')}
+    ON CONFLICT (source_file) DO UPDATE SET
+      convocation = EXCLUDED.convocation,
+      sitting_date = EXCLUDED.sitting_date,
+      doc_kind = EXCLUDED.doc_kind,
+      body_text = EXCLUDED.body_text,
+      imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function main(): Promise<void> {
+  const root = process.argv[2] || DEFAULT_ROOT;
+  console.log(`📥 ВРУ stenograms import from ${root}`);
+  if (!fs.existsSync(root)) { console.error(`❌ Dir not found: ${root}`); process.exit(1); }
+  await pool.query('SELECT 1');
+
+  const zips: string[] = [];
+  walkZips(root, zips);
+  console.log(`   ${zips.length} *_txt.zip archives`);
+
+  let total = 0;
+  let batch: any[] = [];
+  for (const zp of zips) {
+    const relZip = path.relative(root, zp);
+    const conv = convocationOf(relZip);
+    const kind = kindOf(relZip);
+    let entries: any[];
+    try { entries = new AdmZip(zp).getEntries(); } catch (e: any) { console.warn(`   ⚠️ ${relZip}: ${e.message}`); continue; }
+    for (const en of entries) {
+      if (en.isDirectory || !/\.html?$/i.test(en.entryName)) continue;
+      const source_file = `${relZip}!${en.entryName}`;
+      let body: string;
+      try { body = htmlToText(en.getData()); } catch { continue; }
+      if (!body) continue;
+      batch.push({
+        convocation: conv,
+        sitting_date: dateOf(en.entryName),
+        doc_kind: kind,
+        source_file,
+        body_text: body,
+      });
+      if (batch.length >= BATCH_SIZE) { total += await insertBatch(batch); batch = []; }
+    }
+    console.log(`   ${relZip}: cumulative ${total}`);
+  }
+  if (batch.length) total += await insertBatch(batch);
+  console.log(`✅ ВРУ stenograms: ${total} documents`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });


### PR DESCRIPTION
## What

Adds **migration 169** (5 new tables) and **5 standalone importers** to load the open-data sources downloaded to prod `/data/opendata/` for the client demo (merger control, АМКУ practice, sanctions/export/FDI screening, legislative intent).

| Table | Source | Loader |
|---|---|---|
| `opendata_drs_sanctions` | Держреєстр санкцій РНБО — 24 059 subjects (individuals/legal/vessels) | `import-drs-sanctions.ts` |
| `opendata_nazk_war_sanctions` | «Війна і санкції» (war-sanctions.gur.gov.ua, ГУР) — 18 376 recs, 14 categories | `import-nazk-war-sanctions.ts` |
| `opendata_amcu_bid_rigging` | АМКУ зведені відомості про спотворення торгів (XLSX) | `import-amcu-bid-rigging.ts` |
| `opendata_amcu_decisions` | АМКУ рішення/рекомендації (docx→text via mammoth) | `import-amcu-decisions.ts` |
| `opendata_rada_stenograms` | ВРУ пленарні стенограми (win-1251 HTM → text) | `import-rada-stenograms.ts` |

## Design notes

- **File importers, not auto-sync.** These sources cannot be fetched from the prod IP (Cloudflare block on data.gov.ua/nsdc; the ГУР JSON API is confidential). Data is produced out-of-band (browser/local IP → rsync to prod) and the importers read from `/data/opendata/`. They follow the existing `import-nkcpfr-owners.ts` pattern: batch upsert with `ON CONFLICT`, JSONB raw + extracted columns, GIN text indexes.
- Migration is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`).
- `.doc` (legacy binary) and `.7z` archives in АМКУ decisions are recorded as metadata only (text extraction is a follow-up); `.docx` text is extracted.

## Verification

- `tsc --noEmit`: **0 new errors** (the 3 pre-existing `core-loader.ts` errors are the missing secondlayer-core overlay, present on `main` too).
- АМКУ XLSX parse dry-run on a real sample: dates (dd.mm.yyyy→ISO), ЄДРПОУ/РНОКПП, and entity names extract correctly.

## After merge

Run once on prod (post-deploy, migration applied):
```
cd mcp_backend && npx tsx src/scripts/import-drs-sanctions.ts
npx tsx src/scripts/import-nazk-war-sanctions.ts
npx tsx src/scripts/import-amcu-bid-rigging.ts
npx tsx src/scripts/import-amcu-decisions.ts
npx tsx src/scripts/import-rada-stenograms.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds migration 169 with five open-data tables and file-based importers for sanctions, AMCU bid-rigging/decisions, and Rada stenograms used in the M&A/antitrust/sanctions demo. Importers read from `/data/opendata/`, batch upsert, and add text indexes for search.

- New Features
  - Tables: opendata_drs_sanctions, opendata_nazk_war_sanctions, opendata_amcu_bid_rigging, opendata_amcu_decisions, opendata_rada_stenograms.
  - Importers: import-drs-sanctions.ts, import-nazk-war-sanctions.ts, import-amcu-bid-rigging.ts, import-amcu-decisions.ts, import-rada-stenograms.ts (read JSON/XLSX/ZIP from `/data/opendata/`).
  - Text handling: .docx extracted via `mammoth`; legacy .doc stored as metadata; Rada HTM (win-1251) decoded and stripped to text with `cheerio`.
  - Standalone file loaders (no auto-sync due to blocked/confidential sources), idempotent migration, ON CONFLICT upserts, and GIN text indexes.

- Migration
  - Run once on prod (from mcp_backend):
    - npx tsx src/scripts/import-drs-sanctions.ts
    - npx tsx src/scripts/import-nazk-war-sanctions.ts
    - npx tsx src/scripts/import-amcu-bid-rigging.ts
    - npx tsx src/scripts/import-amcu-decisions.ts
    - npx tsx src/scripts/import-rada-stenograms.ts

<sup>Written for commit 1e512c7efcf5247dbe0d5013803e7cd5d9322133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

