### PR TITLE
chore(citation-graph): transitional-layer Neo4j load artifacts (LEXAI-1817)

### DIFF
--- a/scripts/citation-graph/export-transitional-provisions.sql
+++ b/scripts/citation-graph/export-transitional-provisions.sql
@@ -1,0 +1,28 @@
+-- LEXAI-1817 — export the transitional-provision citation layer for Neo4j (additive load).
+-- Run: docker exec -i secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod < export-transitional-provisions.sql
+-- Then: docker cp the two CSVs out and relay them to qdrant.lex:/home/ubuntu/neo4j/import/
+-- Load with: load-transitional-layer.cypher
+--
+-- Dash-origin exclusion (LEXAI-1818): the extractor normalises dash-points
+-- («п. 16-1 підрозділу 10» → '16.1'), which COLLIDES with the main-body point numbering —
+-- the resolver then binds ст.16 п.16.1 («обов'язки платника») instead of the військовий
+-- збір point. A row is dash-origin when its lcc citation_context still shows the dash form;
+-- such rows are excluded here and marked resolved=false / 'dash_point_collision' in lcl.
+\timing on
+SET statement_timeout='1200s';
+CREATE TEMP TABLE tp AS
+  SELECT l.doc_id, l.article_id, l.resolved, l.law_article_raw,
+         (c.citation_context LIKE '%' || replace(l.law_article_raw, '.', '-') || '%') AS dash_origin
+  FROM legislation_citation_links l
+  JOIN law_court_citations c ON c.id = l.src_citation_id
+  WHERE l.citation_type='transitional_provision';
+SELECT resolved, dash_origin, count(*) FROM tp GROUP BY 1,2 ORDER BY 3 DESC;
+\copy (SELECT t.article_id, 641 AS legislation_id, la.article_number, replace(coalesce(la.title,''), E'\n', ' ') AS title, count(*) AS total_citations, count(DISTINCT t.doc_id) AS unique_decisions FROM tp t JOIN legislation_articles la ON la.id = t.article_id WHERE t.resolved AND NOT t.dash_origin GROUP BY 1,2,3,4) TO '/tmp/transitional_articles.csv' CSV
+\copy (SELECT DISTINCT t.doc_id, t.article_id FROM tp t WHERE t.resolved AND NOT t.dash_origin) TO '/tmp/transitional_cites.csv' CSV
+SELECT 'clean articles', count(DISTINCT article_id) FROM tp WHERE resolved AND NOT dash_origin;
+
+-- One-off mitigation applied 2026-07-03 (documented for reproducibility; idempotent):
+-- UPDATE legislation_citation_links l SET resolved=false, unresolved_reason='dash_point_collision'
+-- FROM law_court_citations c
+-- WHERE c.id = l.src_citation_id AND l.citation_type='transitional_provision' AND l.resolved
+--   AND c.citation_context LIKE '%' || replace(l.law_article_raw, '.', '-') || '%';

--- a/scripts/citation-graph/load-transitional-layer.cypher
+++ b/scripts/citation-graph/load-transitional-layer.cypher
@@ -1,0 +1,35 @@
+// LEXAI-1817 — additive load of the ПКУ transitional-provision layer into the LIVE graph
+// (NEVER neo4j-admin import here — it would wipe the 300M+ CITES_ARTICLE graph).
+// Input CSVs from export-transitional-provisions.sql, placed in the server /import dir
+// (host path /home/ubuntu/neo4j/import/ on qdrant.lex).
+// Run each statement separately via cypher-shell -c "..." (5.26 --file rejects :auto;
+// -c runs an implicit transaction, required by CALL {} IN TRANSACTIONS).
+//
+// ⚠️ Decision.doc_id is a STRING in this graph (CitationGraphService binds String(docId)).
+// A MERGE with toInteger() creates DUPLICATE Decision nodes that the service never reads
+// (this exact mistake produced 11,989 orphan nodes on first load — since cleaned up).
+
+// 1. Article nodes (resolved id-keyed: art_id = legislation_articles.id as string).
+LOAD CSV FROM 'file:///transitional_articles.csv' AS row
+MERGE (a:Article {art_id: row[0]})
+ON CREATE SET a.legislation_id = toInteger(row[1]), a.article_number = row[2], a.title = row[3],
+              a.total_citations = toInteger(row[4]), a.unique_decisions = toInteger(row[5]);
+
+// 2. OF_LAW to the ПКУ Law node (NB: Law.legislation_id is a STRING property).
+MATCH (a:Article) WHERE a.article_number STARTS WITH 'п.'
+WITH a MATCH (l:Law {legislation_id: '641'})
+MERGE (a)-[:OF_LAW]->(l);
+
+// 3. CITES_ARTICLE edges — Decision keyed by STRING doc_id.
+LOAD CSV FROM 'file:///transitional_cites.csv' AS row
+CALL { WITH row
+  MERGE (d:Decision {doc_id: row[0]})
+  MERGE (a:Article {art_id: row[1]})
+  MERGE (d)-[r:CITES_ARTICLE]->(a)
+  ON CREATE SET r.citation_type = 'transitional_provision'
+} IN TRANSACTIONS OF 5000 ROWS;
+
+// 4. Acceptance.
+MATCH (d:Decision)-[:CITES_ARTICLE]->(a:Article {article_number: 'п.38.6'})
+RETURN count(d) AS docs_citing_386,
+       count(CASE WHEN d.doc_id = '107631753' THEN 1 END) AS has_280_5185_19;


### PR DESCRIPTION
Reproducibility artifacts for the LEXAI-1817 data load executed 2026-07-03 (already live: 74 Article nodes + 16,486 CITES_ARTICLE edges on qdrant.lex; acceptance п.38.6 ← 18 decisions incl. 280/5185/19).

- `export-transitional-provisions.sql` — prod export with the **dash-origin exclusion** (LEXAI-1818 defect: «п. 16-1 підрозділу 10» normalised to '16.1' binds ст.16 п.16.1 of the main body; 4,629 lcl rows marked `dash_point_collision`, one-off mitigation documented inline).
- `load-transitional-layer.cypher` — additive LOAD CSV (never neo4j-admin import on the live graph) + the **Decision.doc_id is STRING** gotcha that produced 11,989 duplicate nodes on first attempt.

Scripts only — no service code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reproducible export/load scripts for the ПКУ transitional-provision citation layer into the live Neo4j graph (LEXAI-1817). The load produces 74 Article nodes and 16,486 CITES_ARTICLE edges and includes an acceptance query for п.38.6 (18 decisions incl. 280/5185/19).

- **New Features**
  - SQL export that outputs two CSVs and excludes dash-origin rows to avoid the LEXAI-1818 dash-point collision; mitigation is documented inline.
  - Cypher script for additive LOAD CSV: merges `Article` by `art_id`, links to `Law` 641, and creates `CITES_ARTICLE` edges with `citation_type='transitional_provision'`; includes an acceptance query.

- **Migration**
  - Run the SQL in prod, copy the two CSVs to the Neo4j `/import` dir, then run each Cypher statement separately via `cypher-shell -c "..."`
  - Keep `Decision.doc_id` as STRING (do not cast); casting created duplicate nodes in earlier attempts.

<sup>Written for commit 126a250ecc66544d1cbf52dbb58bbf5f9d892231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

