### PR TITLE
fix(citation-graph): preserve dash-numbered transitional points as written (LEXAI-1818)

### DIFF
--- a/scripts/citation-graph/extract-citations.py
+++ b/scripts/citation-graph/extract-citations.py
@@ -256,10 +256,14 @@ def extract_citations_from_text(doc_id: int, text: str) -> list[Citation]:
             citations.append(Citation(doc_id, "constitution", "Конституція України", art, m.group(0)[:200]))
 
     # Transitional provisions (LEXAI-1817): dotted point numbers must NOT go through
-    # parse_article_numbers (it drops non-integer tokens and range-expands dashes);
-    # keep the captured point as-is, normalising '-' to the official dotted form.
+    # parse_article_numbers (it drops non-integer tokens and range-expands dashes).
+    # LEXAI-1818: keep the point EXACTLY as written — dash-numbered пункти (16-1
+    # військовий збір, 52-1 covid) are a DIFFERENT numbering space from dotted
+    # subpoints (38.6); normalising '-' to '.' collided with main-body point numbering
+    # (16.1 = ст.16 п.16.1) and bound the wrong article. Disambiguation of sloppy court
+    # renderings is the RESOLVER's job (dash→dotted fallback when no dash target exists).
     for m in PATTERNS["transitional_provision"].finditer(text):
-        point = m.group(1).rstrip(".").replace("-", ".")
+        point = m.group(1).rstrip(".")
         citations.append(Citation(
             doc_id, "transitional_provision", "Податковий кодекс України", point, m.group(0)[:200]))
 

--- a/scripts/citation-graph/repair-dash-points.sql
+++ b/scripts/citation-graph/repair-dash-points.sql
@@ -1,0 +1,36 @@
+-- LEXAI-1818 — repair dash-origin transitional rows to their truthful dash form.
+-- A row is dash-origin when its lcc citation_context still shows the dash rendering
+-- (e.g. law_article='16.1' with context «п. 16-1 підрозділу 10»).
+\timing on
+SET statement_timeout='1200s';
+BEGIN;
+
+-- 1. Collect the affected pairs once (lcc context is the source of truth).
+CREATE TEMP TABLE dash_rows AS
+  SELECT c.id AS lcc_id, l.id AS lcl_id, c.law_article AS old_article,
+         replace(c.law_article, '.', '-') AS new_article
+  FROM law_court_citations c
+  JOIN legislation_citation_links l ON l.src_citation_id = c.id
+  WHERE c.citation_type = 'transitional_provision'
+    AND c.citation_context LIKE '%' || replace(c.law_article, '.', '-') || '%';
+SELECT old_article, new_article, count(*) FROM dash_rows GROUP BY 1,2 ORDER BY 3 DESC LIMIT 10;
+
+-- 2. lcc: truthful dash form (no collision possible: no dash rows exist yet, and the
+--    unique key holds one row per (doc, type, law, article)).
+UPDATE law_court_citations c SET law_article = d.new_article
+FROM dash_rows d WHERE c.id = d.lcc_id;
+
+-- 3. lcl: truthful raw form; drop the WRONG binding entirely (article_id pointed at the
+--    main-body article); honest unresolved state until the sectionizer ticket imports
+--    the dash-point rows — a resolver re-run then binds 'п.'||law_article_raw exactly.
+UPDATE legislation_citation_links l
+SET law_article_raw = d.new_article,
+    article_id = NULL, article_number = NULL,
+    resolved = false, unresolved_reason = 'article_not_found'
+FROM dash_rows d WHERE l.id = d.lcl_id;
+
+SELECT 'lcc dash forms', law_article, count(*) FROM law_court_citations
+WHERE citation_type='transitional_provision' AND law_article LIKE '%-%' GROUP BY 1,2 ORDER BY 3 DESC LIMIT 8;
+SELECT 'lcl leftover collisions', count(*) FROM legislation_citation_links
+WHERE citation_type='transitional_provision' AND unresolved_reason='dash_point_collision';
+COMMIT;

--- a/scripts/citation-graph/test_transitional_extraction.py
+++ b/scripts/citation-graph/test_transitional_extraction.py
@@ -96,3 +96,28 @@ class TransitionalProvisionExtraction(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDashPointPreservation(unittest.TestCase):
+    """LEXAI-1818 — dash-numbered пункти підрозділів (16-1 військовий збір, 52-1 covid)
+    are a DIFFERENT numbering space from dotted subpoints (38.6): normalising '-' to '.'
+    made «п. 16-1 підрозділу 10» collide with ст.16 п.16.1 of the main body and bind the
+    wrong article. The extractor must preserve the form as written; disambiguation of
+    sloppy court renderings belongs to the resolver (dash→dotted fallback when the dash
+    target does not exist)."""
+
+    def test_dash_point_military_levy_preserved(self):
+        text = "відповідно до пункту 16-1 підрозділу 10 розділу XX Податкового кодексу України"
+        self.assertIn(("Податковий кодекс України", "16-1"), transitional(text))
+
+    def test_dash_point_covid_moratorium_preserved(self):
+        text = "згідно з п. 52-1 підрозд. 10 розд. ХХ ПК України мораторій на проведення перевірок"
+        self.assertIn(("Податковий кодекс України", "52-1"), transitional(text))
+
+    def test_dotted_subpoint_still_dotted(self):
+        text = "підпункту 38.6 пункту 38 підрозділу 10 розділу XX Податкового кодексу України"
+        self.assertIn(("Податковий кодекс України", "38.6"), transitional(text))
+
+    def test_trailing_dot_still_stripped(self):
+        text = "пункту 69.22 підрозділу 10 розділу XX. Податкового кодексу України"
+        self.assertIn(("Податковий кодекс України", "69.22"), transitional(text))


### PR DESCRIPTION
## Problem

Dash-numbered пункти підрозділів («п. 16-1» військовий збір, «п. 52-1/52-2» covid moratorium) are a different numbering space from dotted subpoints (38.6). PR #2091's extractor normalised `'-'→'.'`, colliding with main-body point numbering: the resolver bound **ст.16 п.16.1 («обов'язки платника»)** instead of the military-levy point — **4,629 wrong bindings** (52-1×2,984, 52-2×803, 16-1×660, 32-2×120…), mitigated earlier by marking them `dash_point_collision`.

## Fix

1. **Extractor preserves the form as written** (`rstrip('.')` only). Resolver-side dash→dotted fallback (when no dash target exists) is where sloppy renderings get disambiguated — safe direction, no collisions.
2. **Data repair applied to prod** (script committed for the record): 4,869 lcc/lcl rows → truthful dash forms, wrong `article_id` bindings dropped, honest `unresolved_reason='article_not_found'`, 0 leftover `dash_point_collision`.
3. TDD: 4 dash-preservation tests, suite 13/13.

## Out of scope (follow-up ticket)

`legislation_articles` has **no dash-point rows at all** — the current-edition sectionizer stores п.16-1's subpoints as bare `'п.1.11'` and glues dash ARTICLES (ст.297-1) into the parent row (`297` starts with «-1. Особливості…»). Corpus-wide class (КК 111-1, КУпАП 173-2). Until that lands, dash-point citations stay honestly unresolved; a resolver re-run then binds them exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves dash-numbered transitional points (e.g., 16-1, 52-1) as written to avoid collisions with dotted subpoints, per LEXAI-1818. Prevents 4,629 wrong bindings caused by normalizing 16-1 → 16.1.

- **Bug Fixes**
  - Extractor keeps the point exactly as written (only strips a trailing dot); resolver will fallback dash→dotted only when no dash target exists.
  - Ran `scripts/citation-graph/repair-dash-points.sql` to restore dash forms, drop wrong `article_id` links, and mark unresolved with `article_not_found` where needed.
  - Added 4 tests for dash preservation; dotted subpoint behavior unchanged.

- **Migration**
  - No local action. Prod data repaired; script is committed for reference.
  - Until `legislation_articles` includes dash-point rows, these citations remain unresolved; rerun the resolver after that import.

<sup>Written for commit 88319273f81ba2d1d3943894ae9295c20bb89930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

