### PR TITLE
feat(registry): expose M&A/antitrust/sanctions sources in search_registry

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -528,4 +528,85 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'state', description: 'State (2-letter code)', match: 'exact', columns: ['state'], transform: 'uppercase' },
     ],
   },
+
+  // ── M&A / antitrust / sanctions demo sources (migration 169) ──────
+
+  drs_sanctions: {
+    title: 'Держреєстр санкцій (РНБО)',
+    description: "Пошук у Державному реєстрі санкцій України (РНБО). 24K суб'єктів: фізособи, юрособи, судна. Пошук за іменем/назвою, ідентифікатором (ЄДРПОУ/ІПН/паспорт), типом, статусом, громадянством.",
+    table: 'opendata_drs_sanctions',
+    selectColumns: 'subject_id, subject_type, subject_status, name, birth_date, identifiers, citizenships',
+    orderBy: 'name ASC NULLS LAST',
+    emptyMessage: "Суб'єктів санкцій не знайдено",
+    fields: [
+      { name: 'name', description: "Ім'я / назва суб'єкта (укр)", match: 'ilike', columns: ['name'] },
+      { name: 'identifier', description: 'Ідентифікатор: ЄДРПОУ / ІПН / номер паспорта', match: 'ilike_cast', columns: ['identifiers'] },
+      { name: 'alias', description: 'Псевдонім / транслітерація / рос. написання', match: 'ilike_cast', columns: ['aliases'] },
+      { name: 'subject_type', description: 'Тип: individual (фізособа), legal (юрособа), vessel (судно)', match: 'exact', columns: ['subject_type'] },
+      { name: 'subject_status', description: 'Статус: active, expired, excluded', match: 'exact', columns: ['subject_status'] },
+      { name: 'citizenship', description: 'Громадянство / країна', match: 'ilike_cast', columns: ['citizenships'] },
+    ],
+  },
+
+  nazk_war_sanctions: {
+    title: 'Війна і санкції (ГУР)',
+    description: "Пошук на порталі «Війна і санкції» (war-sanctions.gur.gov.ua). 18K записів у 14 категоріях: санкційні фізособи/юрособи, судна, тіньовий флот, rostec, виробники БПЛА, пропагандисти тощо. Пошук за іменем, категорією, ІПН, юрисдикцією санкцій.",
+    table: 'opendata_nazk_war_sanctions',
+    selectColumns: 'category, source_id, url, page_title, name_uk, tin, sanction_jurisdictions',
+    orderBy: 'category ASC, source_id ASC',
+    emptyMessage: 'Записів не знайдено',
+    fields: [
+      { name: 'name', description: "Ім'я / назва (укр або англ)", match: 'ilike_multi', columns: ['name_uk', 'page_title'] },
+      { name: 'category', description: 'Категорія: sanctions_persons, sanctions_companies, transport_ships, transport_shadow-fleet, rostec, uav_companies, propaganda_persons тощо', match: 'exact', columns: ['category'] },
+      { name: 'tin', description: 'ІПН / податковий номер', match: 'exact', columns: ['tin'] },
+      { name: 'jurisdiction', description: 'Юрисдикція санкцій (USA, EU, UK, Canada, Switzerland, Australia, Japan, NZ)', match: 'ilike_cast', columns: ['sanction_jurisdictions'] },
+    ],
+  },
+
+  amcu_bid_rigging: {
+    title: 'АМКУ — спотворення торгів (антиконкурентні узгоджені дії)',
+    description: 'Пошук у зведених відомостях АМКУ про спотворення результатів торгів (тендерів). 458K рядків. Пошук за назвою порушника, ЄДРПОУ, датою рішення.',
+    table: 'opendata_amcu_bid_rigging',
+    selectColumns: 'source_file, decision_date, entity_name, entity_edrpou, row_data',
+    orderBy: 'decision_date DESC NULLS LAST',
+    emptyMessage: 'Порушень не знайдено',
+    fields: [
+      { name: 'entity_name', description: 'Назва суб’єкта господарювання, який вчинив порушення', match: 'fts_simple', columns: ['entity_name'] },
+      { name: 'edrpou', description: 'ЄДРПОУ / РНОКПП порушника', match: 'exact', columns: ['entity_edrpou'] },
+      { name: 'date_from', description: 'Дата рішення від (YYYY-MM-DD)', match: 'gte', columns: ['decision_date'] },
+      { name: 'date_to', description: 'Дата рішення до (YYYY-MM-DD)', match: 'lte', columns: ['decision_date'] },
+    ],
+  },
+
+  amcu_decisions: {
+    title: 'АМКУ — рішення та рекомендації',
+    description: 'Пошук у рішеннях і рекомендаціях АМКУ (антимонопольна практика, концентрації, узгоджені дії). 6K документів; повнотекстовий пошук доступний для витягнутих текстів (docx). Пошук за текстом, номером рішення, типом, датою.',
+    table: 'opendata_amcu_decisions',
+    selectColumns: 'archive_file, doc_file, doc_kind, decision_no, decision_date, extracted, left(body_text, 600) AS snippet',
+    orderBy: 'decision_date DESC NULLS LAST',
+    emptyMessage: 'Рішень АМКУ не знайдено',
+    fields: [
+      { name: 'text', description: 'Ключові слова у тексті рішення', match: 'fts_simple', columns: ['body_text'] },
+      { name: 'doc_kind', description: 'Тип: rishennia (рішення), rekomendatsii (рекомендації), list (списки)', match: 'exact', columns: ['doc_kind'] },
+      { name: 'decision_no', description: 'Номер рішення', match: 'ilike', columns: ['decision_no'] },
+      { name: 'date_from', description: 'Дата від (YYYY-MM-DD)', match: 'gte', columns: ['decision_date'] },
+      { name: 'date_to', description: 'Дата до (YYYY-MM-DD)', match: 'lte', columns: ['decision_date'] },
+    ],
+  },
+
+  rada_stenograms: {
+    title: 'ВРУ — стенограми пленарних засідань',
+    description: 'Повнотекстовий пошук у стенограмах пленарних засідань Верховної Ради (намір законодавця). 6.8K документів усіх скликань. Пошук за текстом, скликанням, датою засідання, типом.',
+    table: 'opendata_rada_stenograms',
+    selectColumns: 'convocation, sitting_date, doc_kind, source_file, left(body_text, 600) AS snippet',
+    orderBy: 'sitting_date DESC NULLS LAST',
+    emptyMessage: 'Стенограм не знайдено',
+    fields: [
+      { name: 'text', description: 'Ключові слова у тексті стенограми', match: 'fts_simple', columns: ['body_text'] },
+      { name: 'convocation', description: 'Номер скликання (1-9)', match: 'exact', columns: ['convocation'], type: 'number' },
+      { name: 'doc_kind', description: 'Тип: stenogram (стенограма), agenda (порядок денний), stenpog (погоджувальна рада)', match: 'exact', columns: ['doc_kind'] },
+      { name: 'date_from', description: 'Дата засідання від (YYYY-MM-DD)', match: 'gte', columns: ['sitting_date'] },
+      { name: 'date_to', description: 'Дата засідання до (YYYY-MM-DD)', match: 'lte', columns: ['sitting_date'] },
+    ],
+  },
 };

--- a/mcp_backend/src/migrations/170_align_opendata_fts_indexes.sql
+++ b/mcp_backend/src/migrations/170_align_opendata_fts_indexes.sql
@@ -1,0 +1,15 @@
+-- Migration 170: align the full-text GIN indexes on the M&A/antitrust demo tables
+-- with the expression emitted by the registry search builder (query-ir 'fts_simple':
+--   to_tsvector('simple', <col>)  — WITHOUT coalesce).
+-- Migration 169 created them as to_tsvector('simple', coalesce(<col>,'')), which the
+-- planner cannot match to the fts_simple predicate, so search_registry would seq-scan.
+-- Recreate them in the matching form. (to_tsvector on NULL yields NULL → simply not indexed.)
+
+DROP INDEX IF EXISTS idx_amcu_bid_name;
+CREATE INDEX IF NOT EXISTS idx_amcu_bid_name ON opendata_amcu_bid_rigging USING gin(to_tsvector('simple', entity_name));
+
+DROP INDEX IF EXISTS idx_amcu_dec_body;
+CREATE INDEX IF NOT EXISTS idx_amcu_dec_body ON opendata_amcu_decisions USING gin(to_tsvector('simple', body_text));
+
+DROP INDEX IF EXISTS idx_stenogram_body;
+CREATE INDEX IF NOT EXISTS idx_stenogram_body ON opendata_rada_stenograms USING gin(to_tsvector('simple', body_text));


### PR DESCRIPTION
## What

Makes the 5 tables imported in #2102 (migration 169) **searchable via the `search_registry` MCP tool** by registering them in `registry-catalog.ts`.

| Registry key | Table | Searchable fields |
|---|---|---|
| `drs_sanctions` | `opendata_drs_sanctions` (24K) | name, identifier (ЄДРПОУ/ІПН/паспорт), alias, type, status, citizenship |
| `nazk_war_sanctions` | `opendata_nazk_war_sanctions` (18K) | name, category, tin, jurisdiction |
| `amcu_bid_rigging` | `opendata_amcu_bid_rigging` (458K) | entity_name (FTS), edrpou, date range |
| `amcu_decisions` | `opendata_amcu_decisions` (6K) | text (FTS), kind, decision_no, date range |
| `rada_stenograms` | `opendata_rada_stenograms` (6.8K) | text (FTS), convocation, kind, date range |

## Why a second PR

#2102 loaded the data into Postgres but `search_registry` only searches a hardcoded catalog (`Object.keys(REGISTRY_CATALOG)`), so the new tables were invisible to the tool until registered here.

## Notes

- **Migration 170** realigns the 3 FTS GIN indexes to `to_tsvector('simple', col)` — the exact expression the `fts_simple` query-ir match emits. #169 created them with `coalesce()`, which the planner can't match to the predicate (→ seq-scan on the 458K bid-rigging table).
- JSONB fields (DRS `identifiers`, NAZK `sanction_jurisdictions`) searched via `ilike_cast`.

## Verification

- `tsc`: 0 new errors (3 pre-existing `core-loader.ts` overlay errors on `main`).
- `registry-search-tool.test.ts`: **25/25 pass** (enum test is dynamic).
- Query shapes run against **prod data**: `name ILIKE 'путін'`→6, `identifiers::text ILIKE`→1, `sanction_jurisdictions::text ILIKE 'USA'`→13,789, `fts_simple(entity_name,'Укрсушка')`→191, `fts_simple(body_text,'податок')`→2,098.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose five M&A/antitrust/sanctions datasets to the `search_registry` MCP tool and align FTS indexes to match `fts_simple` for faster queries.

- **New Features**
  - `drs_sanctions` (DRS sanctions): name, identifier, alias, type, status, citizenship.
  - `nazk_war_sanctions` (War sanctions): name, category, TIN, jurisdiction.
  - `amcu_bid_rigging` (AMCU bid-rigging): entity name FTS, EDRPOU, date range.
  - `amcu_decisions` (AMCU decisions): body text FTS, kind, decision no, date range.
  - `rada_stenograms` (Rada stenograms): body text FTS, convocation, kind, date range.

- **Migration**
  - Migration 170 recreates GIN indexes to `to_tsvector('simple', col)` on:
    - `opendata_amcu_bid_rigging.entity_name`
    - `opendata_amcu_decisions.body_text`
    - `opendata_rada_stenograms.body_text`
  - Removes `coalesce` so the planner uses indexes with `fts_simple`.

<sup>Written for commit f3ae4a2f2172894eb92319f1d78f551de5947094. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

