### PR TITLE
fix(chat): raise deep wall-clock backstop 300s → 360s

### DIFF
--- a/mcp_backend/src/routes/__tests__/chat-inline-routes.test.ts
+++ b/mcp_backend/src/routes/__tests__/chat-inline-routes.test.ts
@@ -7,14 +7,14 @@ describe('resolveChatTimeoutMs', () => {
   // auto-escalated to deep (plan >= 8 steps) was aborted mid-VERIFY at 240s.
 
   it('gives the deep timeout when no maxBudget caps escalation', () => {
-    expect(resolveChatTimeoutMs('standard', undefined)).toBe(300_000);
-    expect(resolveChatTimeoutMs('quick', undefined)).toBe(300_000);
-    expect(resolveChatTimeoutMs(undefined, undefined)).toBe(300_000);
-    expect(resolveChatTimeoutMs('deep', undefined)).toBe(300_000);
+    expect(resolveChatTimeoutMs('standard', undefined)).toBe(360_000);
+    expect(resolveChatTimeoutMs('quick', undefined)).toBe(360_000);
+    expect(resolveChatTimeoutMs(undefined, undefined)).toBe(360_000);
+    expect(resolveChatTimeoutMs('deep', undefined)).toBe(360_000);
   });
 
   it('gives the deep timeout when maxBudget is deep', () => {
-    expect(resolveChatTimeoutMs('standard', 'deep')).toBe(300_000);
+    expect(resolveChatTimeoutMs('standard', 'deep')).toBe(360_000);
   });
 
   it('gives the standard timeout when maxBudget caps escalation below deep', () => {

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -24,7 +24,10 @@ import { runWithABUser } from '../infrastructure/adapters/llm-adapter.js';
  */
 export function resolveChatTimeoutMs(budget?: string, maxBudget?: string): number {
   const escalationCeiling = maxBudget || 'deep';
-  return escalationCeiling === 'deep' ? 300_000 : 240_000;
+  // 360s: heavy composite runs vary — chat-a79fffe7 spent 260s in EXECUTE alone
+  // (22 tool calls), leaving VERIFY + LLM repair no room inside 300s. This is a
+  // runaway backstop, not QoS: SSE heartbeats keep proxies alive either way.
+  return escalationCeiling === 'deep' ? 360_000 : 240_000;
 }
 
 export function createChatInlineRoutes(deps: {


### PR DESCRIPTION
Follow-up to #2092. Heavy composite demo runs vary: chat-a79fffe7 (2026-07-03) spent **260s in EXECUTE alone** (22 tool calls, slow get_case_documents_chain), so VERIFY + P0.2 + LLM repair could not fit in the remaining 40s of the 300s cap — the answer and citation warnings streamed fine, then the timer aborted before persistence. Earlier today a 236s run passed with only 64s margin.

The wall-clock timer is a runaway backstop, not a QoS knob — SSE heartbeats keep proxies alive either way. 360s gives escalated runs the same relative headroom the 240s cap gave standard ones.

Tests updated (3/3). VERIFY-phase cost of the new CORE-109 gate measured at 43ms — not a factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the deep chat wall-clock backstop from 300s to 360s to prevent heavy runs from aborting during VERIFY/repair. Updated `resolveChatTimeoutMs` and tests; standard budgets remain at 240s when escalation is capped.

<sup>Written for commit 2a45895c3ecb7150d51eb456ad18aa67f7b3d159. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

