### PR TITLE
fix(legislation): parse dash-numbered units hidden in RADA superscript markup (LEXAI-1821)

### DIFF
--- a/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-superscript.test.ts
+++ b/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-superscript.test.ts
@@ -1,0 +1,94 @@
+/**
+ * LEXAI-1821: RADA renders the надрядковий індекс of dash-numbered units
+ * (ст. 297-1, транзитний п. 16-1) as a superscript span whose dash is hidden with
+ * font-size:0 — verbatim from the stored HTML of ПКУ (legislation_id 641):
+ *
+ *   297<span class="rvts37"><span style="font-size:0px">-</span>1</span>.1. Платники…
+ *
+ * cheerio .text() flattens it to «297-1», but the PARSERS ran on raw HTML where
+ * `[^<]*` capture stops at the inner span: «Стаття 297-1» was captured as «297»
+ * (and ON CONFLICT then overwrote the REAL ст.297 with 297-1's text), while the
+ * transitional point «16-1.» did not match the dotted-only point regex at all —
+ * its sub-points were stored as bare 'п.1.11' orphans. The whole dash class
+ * (КК 111-1, КУпАП 173-2, ПКУ 16-1/52-1…) was invisible.
+ */
+
+import axios from 'axios';
+import { RadaLegislationAdapter } from '../rada-legislation-adapter.js';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+/** Verbatim RADA superscript-index markup. */
+const sup = (n: string) => `<span class="rvts37"><span style="font-size:0px">-</span>${n}</span>`;
+
+const PKU_PRINT_HTML = `
+<!DOCTYPE html><html><head><title>Податковий кодекс України</title></head><body>
+<span class=rvts15>Розділ I </span><br><span class=rvts15>ЗАГАЛЬНІ ПОЛОЖЕННЯ</span>
+<span class=rvts9>Стаття 1. Сфера дії</span> Текст першої статті достатньої довжини для проходження фільтра парсера.
+<span class=rvts9>Стаття 2. Визначення</span> Текст другої статті також достатньої довжини щоб пройти фільтр.
+<span class=rvts9>Стаття 3. Принципи</span> Текст третьої статті достатньої довжини для проходження.
+<span class=rvts9>Стаття 4. Засади</span> Текст четвертої статті достатньої довжини для проходження.
+<span class=rvts9>Стаття 5. Співвідношення</span> Текст п'ятої статті достатньої довжини для проходження.
+<span class=rvts15>Розділ XIV </span><br><span class=rvts15>СПЕЦІАЛЬНІ ПОДАТКОВІ РЕЖИМИ</span>
+<span class=rvts9>Стаття 297. Особливості нарахування, сплати та подання звітності з окремих податків і зборів</span> Платники єдиного податку звільняються від обов'язку нарахування, сплати та подання податкової звітності з таких податків і зборів.
+<span class=rvts9>Стаття 297${sup('1')}. Особливості визначення загального мінімального податкового зобов'язання платників єдиного податку</span> Платники єдиного податку - власники, орендарі, користувачі земельних ділянок, віднесених до сільськогосподарських угідь, зобов'язані подавати додаток з розрахунком загального мінімального податкового зобов'язання.
+<span class=rvts9>Стаття 298. Порядок обрання або переходу на спрощену систему оподаткування</span> Порядок обрання або переходу на спрощену систему оподаткування здійснюється відповідно до цього Кодексу.
+ПРИКІНЦЕВІ ТА ПЕРЕХІДНІ ПОЛОЖЕННЯ
+<span class=rvts15>Підрозділ 10 </span><br><span class=rvts15>Інші перехідні положення</span>
+<p class="rvps2"><a name="n8990"></a> 16${sup('1')}. Тимчасово, до набрання чинності рішенням Верховної Ради України про завершення реформи Збройних Сил України, встановлюється військовий збір.</p>
+<p class="rvps2"><span class="rvts0">Додатковий контекст пункту для реалістичної довжини розмітки.</span></p>
+<p class="rvps2"><a name="n8991"></a> 1.1. Платниками збору є особи, визначені пунктом 162.1 статті 162 цього Кодексу та особливості справляння збору. Додатковий текст підпункту для реалістичної довжини.</p>
+<p class="rvps2"><a name="n9000"></a> 38.6. Об'єкти житлової та нежитлової нерухомості, розташовані на тимчасово окупованій території, не є об'єктом оподаткування. Додатковий текст пункту для реалістичної довжини розмітки.</p>
+<p class="rvps2"><a name="n9100"></a> 52${sup('1')}. На період з 1 березня 2020 року по останній календарний день місяця, в якому завершується дія карантину, зупиняється перебіг строків давності.</p>
+</body></html>
+`;
+
+describe('RadaLegislationAdapter — superscript dash-index units (LEXAI-1821)', () => {
+  let adapter: RadaLegislationAdapter;
+  let mockAxiosInstance: any;
+
+  beforeEach(() => {
+    mockAxiosInstance = { get: jest.fn() };
+    mockedAxios.create = jest.fn().mockReturnValue(mockAxiosInstance);
+    adapter = new RadaLegislationAdapter({} as any);
+    mockAxiosInstance.get.mockResolvedValue({ data: PKU_PRINT_HTML });
+  });
+
+  test('a dash article gets its own record and does not clobber the parent number', async () => {
+    const { articles } = await adapter.fetchLegislation('2755-17');
+    const numbers = articles.map(a => a.article_number);
+
+    expect(numbers).toContain('297');
+    expect(numbers).toContain('297-1');
+
+    const art297 = articles.find(a => a.article_number === '297')!;
+    expect(art297.full_text).toContain('звільняються від обов\'язку');
+    expect(art297.full_text).not.toContain('мінімального податкового зобов\'язання');
+
+    const art297_1 = articles.find(a => a.article_number === '297-1')!;
+    expect(art297_1.full_text).toContain('мінімального податкового зобов\'язання');
+    expect(art297_1.title).toContain('Особливості визначення');
+  });
+
+  test('dash transitional points are extracted with their dash number preserved', async () => {
+    const { articles } = await adapter.fetchLegislation('2755-17');
+    const numbers = articles.map(a => a.article_number);
+
+    expect(numbers).toContain('п.16-1');   // військовий збір
+    expect(numbers).toContain('п.52-1');   // covid-мораторій
+    expect(numbers).toContain('п.38.6');   // dotted points unaffected
+
+    const p161 = articles.find(a => a.article_number === 'п.16-1')!;
+    expect(p161.full_text).toContain('військовий збір');
+    expect(p161.metadata?.is_transitional).toBe(true);
+  });
+
+  test('flattened text carries the literal dash form for downstream consumers', async () => {
+    const { articles } = await adapter.fetchLegislation('2755-17');
+    const art297_1 = articles.find(a => a.article_number === '297-1')!;
+    // The hidden-dash span must not leak markup or lose the dash in full_text.
+    expect(art297_1.full_text).not.toContain('font-size');
+    expect(art297_1.full_text).not.toContain('rvts37');
+  });
+});

--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -131,7 +131,7 @@ export class RadaLegislationAdapter {
       const callDuration = (Date.now() - callStart) / 1000;
       this.externalApiMetrics?.('zakon_rada', 'success', callDuration);
 
-      const html = response.data;
+      const html = RadaLegislationAdapter.normalizeSuperscriptIndexes(String(response.data));
       const $ = cheerio.load(html);
 
       const metadata = this.extractMetadata($, radaId, url);
@@ -181,6 +181,26 @@ export class RadaLegislationAdapter {
       effective_date: this.parseDate(effectiveDateText),
       status: 'active',
     };
+  }
+
+  /**
+   * LEXAI-1821: RADA renders the надрядковий індекс of dash-numbered units
+   * (ст. 297-1, транзитний п. 16-1) as a superscript span whose dash is hidden with
+   * font-size:0 (visually «297¹», copy-paste «297-1»):
+   *
+   *   297<span class="rvts37"><span style="font-size:0px">-</span>1</span>.
+   *
+   * The HTML-level parsers stop `[^<]*` capture at the inner span, so «Стаття 297-1»
+   * was captured as «297» (and ON CONFLICT overwrote the REAL ст.297 with 297-1's
+   * text), while transitional «16-1.» matched nothing — its sub-points were stored as
+   * bare 'п.1.11' orphans. Flatten the markup to the literal dash form BEFORE any
+   * parsing so every downstream regex sees plain «297-1» / «16-1».
+   */
+  static normalizeSuperscriptIndexes(html: string): string {
+    return html.replace(
+      /<span[^>]*>\s*<span[^>]*font-size:\s*0(?:px)?[^>]*>\s*-\s*<\/span>\s*(\d+)\s*<\/span>/gi,
+      '-$1',
+    );
   }
 
   private extractArticles($: cheerio.CheerioAPI, radaId: string): LegislationArticle[] {
@@ -505,8 +525,10 @@ export class RadaLegislationAdapter {
     }
 
     // Extract numbered points: <a name="nNNNN"></a>\s*N. or N.N. or N.N.N. text...
-    // Matches: "38.6.", "69.14.", "1.", "41.2.5." etc.
-    const pointRegex = /<a\s+name="n(\d+)">\s*<\/a>\s*(\d+(?:\.\d+)*)\.\s*/g;
+    // Matches: "38.6.", "69.14.", "1.", "41.2.5." — and dash-indexed points «16-1.»,
+    // «52-1.» (LEXAI-1821; the superscript markup is flattened to a literal dash
+    // by normalizeSuperscriptIndexes before parsing).
+    const pointRegex = /<a\s+name="n(\d+)">\s*<\/a>\s*(\d+(?:-\d+)?(?:\.\d+)*)\.\s*/g;
     const points: Array<{ anchor: string; num: string; startPos: number }> = [];
     let pMatch;
     while ((pMatch = pointRegex.exec(sectionHtml)) !== null) {
@@ -1034,7 +1056,7 @@ export class RadaLegislationAdapter {
       const callDuration = (Date.now() - callStart) / 1000;
       this.externalApiMetrics?.('zakon_rada', 'success', callDuration);
 
-      const html = response.data as string;
+      const html = RadaLegislationAdapter.normalizeSuperscriptIndexes(String(response.data));
       const $ = cheerio.load(html);
       const metadata = this.extractMetadata($, radaId, url);
 


### PR DESCRIPTION
## Problem

RADA hides the dash of надрядковий індекс units inside superscript markup (`297<span class="rvts37"><span style="font-size:0px">-</span>1</span>`). The HTML-level parsers stopped capture at the inner span:

- **Dash articles were lost or glued**: «Стаття 297-1» captured as «297» → `ON CONFLICT (…article_number, version_date)` overwrote the real ст.297 with 297-1's text. Corpus-wide: ПКУ current edition has **zero** dash article_numbers; КК 111-1 (колабораціонізм) and КУпАП 173-2 (домашнє насильство) are affected classes.
- **Dash transitional points invisible**: «16-1.» (військовий збір) / «52-1.» (covid moratorium) matched nothing; their sub-points landed as bare `'п.1.11'` orphans; `get_legislation_section('16-1', ПКУ)` → not found; 4,869 dash citations in the graph stay honestly unresolved (LEXAI-1818).

## Fix

1. `normalizeSuperscriptIndexes()` — flattens the superscript markup to the literal dash form **before** `cheerio.load` on both fetch paths (current + ed-dated editions). Every downstream regex then sees plain «297-1»/«16-1»; the existing article pattern already supports dashes.
2. Transitional `pointRegex` accepts the dash index: `(\d+(?:-\d+)?(?:\.\d+)*)`.

## Tests

TDD with the **verbatim prod markup** (from stored `full_text_html` of ПКУ). Gotcha encoded in the fixture: it must contain ≥5 plain articles so the REAL print parser runs — the text-based fallback (which flattens `<sup>` and masked the bug) kicks in below that. Adapter suites **67/67**, tsc clean.

## Next (data phase, after deploy)

Re-import affected current editions (ПКУ, КК, КУпАП-1) → resolver re-run for the 4,869 dash citations → Neo4j top-up via the committed LEXAI-1817/1818 artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of dash-numbered units hidden in RADA superscript HTML so articles like 297-1 and transitional points like 16-1 are captured correctly and no longer overwrite base articles. Addresses LEXAI-1821 and unblocks resolution of dash citations noted in LEXAI-1818.

- **Bug Fixes**
  - Added `normalizeSuperscriptIndexes()` to flatten hidden-dash superscripts to literal dashes before `cheerio.load` on both fetch paths.
  - Extended transitional point regex to allow dashes: `(\d+(?:-\d+)?(?:\.\d+)*)`.
  - Added tests with verbatim ПКУ HTML to verify proper extraction of 297-1, п.16-1, and п.52-1 without clobbering 297.

- **Migration**
  - Re-import affected current editions (ПКУ, КК, КУпАП).
  - Rerun the resolver to backfill dash citations and update Neo4j (per LEXAI-1818 artifacts).

<sup>Written for commit 249205115943fc8926065dbf8c3e32bc61f6256e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

