### PR TITLE
fix(legislation): getArticle п.-prefix fallback accepts dash-indexed points (LEXAI-1821)

### DIFF
--- a/mcp_backend/src/services/__tests__/legislation-service.test.ts
+++ b/mcp_backend/src/services/__tests__/legislation-service.test.ts
@@ -323,6 +323,28 @@ describe('LegislationService', () => {
       expect(result).toBeNull();
     });
 
+    it('falls back to the п.-prefixed row for dash-indexed transitional points (LEXAI-1821)', async () => {
+      // «16-1» (військовий збір, п. 16-1 підрозд. 10 ПКУ) is stored as 'п.16-1';
+      // the old fallback predicate required a dot, so dash forms returned null.
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: 641, rada_id: '2755-17' }],
+        rowCount: 1,
+      });
+      mockAdapter.getArticleByNumber
+        .mockResolvedValueOnce(null)                       // bare '16-1' → no row
+        .mockResolvedValueOnce({
+          article_number: 'п.16-1',
+          title: 'Тимчасово, до набрання чинності... військовий збір',
+          full_text: '16-1. Тимчасово... встановлюється військовий збір.',
+        });
+
+      const result = await service.getArticle('2755-17', '16-1');
+
+      expect(mockAdapter.getArticleByNumber).toHaveBeenCalledWith('2755-17', 'п.16-1', undefined);
+      expect(result?.article_number).toBe('п.16-1');
+      expect(result?.full_text).toContain('військовий збір');
+    });
+
     it('should return actual article_number from DB row (LEXAI-823)', async () => {
       // Simulates the data bug where the adapter returns a row whose article_number
       // differs from the input (e.g. "33-5" stored under article_number "33-5" but

--- a/mcp_backend/src/services/legislation-service.ts
+++ b/mcp_backend/src/services/legislation-service.ts
@@ -544,8 +544,9 @@ export class LegislationService {
     await this.ensureLegislationExists(radaId);
 
     let article = await this.adapter.getArticleByNumber(radaId, articleNumber, asOfDate);
-    // Fallback: transitional provisions stored as "п.38.6" but LLM may request "38.6"
-    if (!article && /^\d+\.\d/.test(articleNumber)) {
+    // Fallback: transitional provisions stored as "п.38.6" / "п.16-1" but the caller may
+    // request the bare point number ("38.6", "16-1" — dash-indexed units, LEXAI-1821).
+    if (!article && /^\d+[.-]\d/.test(articleNumber)) {
       article = await this.adapter.getArticleByNumber(radaId, `п.${articleNumber}`, asOfDate);
     }
     if (!article) {


### PR DESCRIPTION
Companion to #2107: `get_legislation_section('16-1', ПКУ)` must resolve to the stored `п.16-1` row once re-import lands. Old predicate required a dot; now `/^\d+[.-]\d/`. TDD (RED verified by stash-run), suite 40/40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the fallback for transitional provisions so dash-indexed points like "16-1" resolve to stored "п.16-1" rows. Addresses LEXAI-1821 and prevents null results when callers request dash-form numbers.

- **Bug Fixes**
  - Broadened the fallback regex from /^\d+\.\d/ to /^\d+[.-]\d/ to apply the `п.` prefix for both dot- and dash-indexed points.
  - Added a test to verify "16-1" correctly resolves to "п.16-1" for `2755-17`.

<sup>Written for commit 04ca00cd83b456b5a0c68b63fa2c97aa43ddd704. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

