### PR TITLE
feat(opendata): extract АМКУ decision .7z archives via system 7z

### DIFF
--- a/mcp_backend/src/scripts/import-amcu-decisions.ts
+++ b/mcp_backend/src/scripts/import-amcu-decisions.ts
@@ -5,8 +5,10 @@
  * loose doc/docx, and annual index XLSX. One row per document file.
  *   - .docx  → text extracted via mammoth
  *   - .doc   → legacy binary; metadata only (extracted=false)
- *   - .7z    → skipped (adm-zip cannot read 7z); logged
+ *   - .7z    → extracted via the system `7z` binary, then doc/docx processed
  *   - .xlsx  → annual list; recorded as doc_kind='list', no text
+ *
+ * Requires the `7z` CLI on PATH (p7zip) for .7z archives; if absent, they are skipped.
  *
  * Usage:
  *   npx tsx src/scripts/import-amcu-decisions.ts [dir]
@@ -15,7 +17,9 @@
 
 import { Pool } from 'pg';
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
+import { execFileSync } from 'child_process';
 import AdmZip from 'adm-zip';
 import mammoth from 'mammoth';
 
@@ -54,6 +58,24 @@ function decisionNoOf(name: string): string | null {
   m = name.match(/(\d+)[-_](rk|р[кп])/i);
   if (m) return m[1];
   return null;
+}
+
+function walkDocs(dir: string): string[] {
+  const out: string[] = [];
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...walkDocs(p));
+    else if (/\.docx?$/i.test(e.name)) out.push(p);
+  }
+  return out;
+}
+
+let sevenZipAvailable: boolean | null = null;
+function has7z(): boolean {
+  if (sevenZipAvailable !== null) return sevenZipAvailable;
+  try { execFileSync('7z', ['i'], { stdio: 'ignore' }); sevenZipAvailable = true; }
+  catch { sevenZipAvailable = false; }
+  return sevenZipAvailable;
 }
 
 async function extractDocx(buf: Buffer): Promise<string | null> {
@@ -111,7 +133,30 @@ async function main(): Promise<void> {
     const full = path.join(dir, f);
     const ext = path.extname(f).toLowerCase();
 
-    if (ext === '.7z') { sevenZip++; continue; }
+    if (ext === '.7z') {
+      if (!has7z()) { sevenZip++; continue; }
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'amcu7z-'));
+      try {
+        execFileSync('7z', ['x', '-y', '-bd', `-o${tmp}`, full], { stdio: 'ignore' });
+        for (const docPath of walkDocs(tmp)) {
+          const rel = path.relative(tmp, docPath);
+          const e2 = path.extname(rel).toLowerCase();
+          let body: string | null = null, extracted = false;
+          if (e2 === '.docx') { body = await extractDocx(fs.readFileSync(docPath)); extracted = body != null; if (extracted) docxOk++; else docLegacy++; }
+          else docLegacy++;
+          await push({
+            archive_file: f, doc_file: `${f}!${rel}`, doc_kind: kindOf(rel),
+            decision_no: decisionNoOf(rel), decision_date: dateOf(rel), body_text: body, extracted,
+          });
+        }
+        sevenZip++;
+      } catch (e: any) {
+        console.warn(`   ⚠️ 7z ${f}: ${e.message}`);
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+      continue;
+    }
 
     if (ext === '.zip') {
       let entries: any[];
@@ -149,7 +194,8 @@ async function main(): Promise<void> {
   }
   if (batch.length) total += await insertBatch(batch);
 
-  console.log(`✅ АМКУ decisions: ${total} rows (docx text ${docxOk}, legacy/no-text ${docLegacy}); ${sevenZip} .7z archives skipped (need 7z extraction)`);
+  const zMsg = has7z() ? `${sevenZip} .7z archives extracted` : `${sevenZip} .7z archives skipped (7z binary not found)`;
+  console.log(`✅ АМКУ decisions: ${total} rows (docx text ${docxOk}, legacy/no-text ${docLegacy}); ${zMsg}`);
   await pool.end();
 }
 


### PR DESCRIPTION
## What

Completes the АМКУ decisions import (#2102) by processing the **43 `.7z` archives** that `import-amcu-decisions.ts` previously skipped (adm-zip can't read 7z).

Now extracts each `.7z` via the system `7z` binary (p7zip) into a temp dir, walks `.doc`/`.docx`, and processes them like zip entries. Falls back to skipping if the `7z` binary is unavailable.

## Impact

Adds **~514 documents** to `opendata_amcu_decisions`: 498 legacy `.doc` (metadata-only) + 16 `.docx` (text extracted via mammoth). Idempotent (`ON CONFLICT (doc_file)`), so re-running the importer only inserts the new 7z-sourced rows.

## Verification

- `tsc`: 0 new errors (3 pre-existing `core-loader.ts` overlay errors on `main`).
- On prod: all **43/43** archives extract cleanly (498 .doc + 16 .docx); `7z x` + mammoth path confirmed working.

## Note

No migration — table schema unchanged. Backfill runs post-merge:
`npx tsx src/scripts/import-amcu-decisions.ts` (re-processes the dir; only the 43 .7z add rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts АМКУ decision .7z archives using the system `7z` CLI, importing files that were previously skipped. Adds ~514 documents to `opendata_amcu_decisions` (498 `.doc` metadata-only, 16 `.docx` with text), and gracefully skips when `7z` is missing.

- **New Features**
  - Use `7z x` to extract `.7z` into a temp dir; process `.doc`/`.docx` like zip entries.
  - `.docx` text via `mammoth`; `.doc` stored as metadata-only. Inserts are idempotent on `doc_file`.
  - Logs report `.7z` archives extracted or skipped based on `7z` availability.

- **Migration**
  - No schema changes. Requires `7z` on PATH for `.7z` support.
  - Backfill: `npx tsx src/scripts/import-amcu-decisions.ts` (reprocesses; only `.7z` add rows).

<sup>Written for commit 754022d5ca2811dd0014fbf029b5a61f8767ca16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

