### PR TITLE
feat(opendata): refresh importers for OFAC, EU, securities owners, financial statements

### DIFF
--- a/mcp_backend/src/scripts/import-eu-sanctions.ts
+++ b/mcp_backend/src/scripts/import-eu-sanctions.ts
@@ -1,0 +1,138 @@
+/**
+ * Refresh eu_sanctions from the EU Consolidated Financial Sanctions File (FSF XML).
+ *
+ * Reads /data/opendata/intl_sanctions/eu/xmlFullSanctionsList_1_1.xml, parses
+ * <sanctionEntity> elements and upserts by entity_id (euReferenceNumber, or logicalId).
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-eu-sanctions.ts [path]
+ *   default: /data/opendata/intl_sanctions/eu/xmlFullSanctionsList_1_1.xml
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import { XMLParser } from 'fast-xml-parser';
+
+const DEFAULT_PATH = '/data/opendata/intl_sanctions/eu/xmlFullSanctionsList_1_1.xml';
+const BATCH_SIZE = 300;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+const asArray = (v: any): any[] => (v == null ? [] : Array.isArray(v) ? v : [v]);
+const at = (o: any, name: string): string | null => {
+  const v = o?.[`@_${name}`];
+  return v == null || v === '' ? null : String(v);
+};
+const firstNonNull = (arr: (string | null)[]): string | null => arr.find(x => x) ?? null;
+
+function mapEntity(e: any): any[] | null {
+  const entityId = at(e, 'euReferenceNumber') || at(e, 'logicalId');
+  if (!entityId) return null;
+
+  const subjectType = asArray(e.subjectType)[0];
+  const entityType = at(subjectType, 'code'); // person | enterprise
+
+  const nameAliases = asArray(e.nameAlias);
+  const wholeNames = nameAliases.map(n => at(n, 'wholeName')).filter(Boolean) as string[];
+  const strong = nameAliases.find(n => at(n, 'strong') === 'true');
+  const name = at(strong || nameAliases[0], 'wholeName');
+
+  const births = asArray(e.birthdate);
+  const birthDate = firstNonNull(births.map(b => at(b, 'birthdate') || at(b, 'year')));
+  const birthPlace = firstNonNull(births.map(b => [at(b, 'city'), at(b, 'countryDescription')].filter(Boolean).join(', ') || null));
+
+  const citizenship = asArray(e.citizenship).map(c => at(c, 'countryDescription')).filter(Boolean) as string[];
+  const addresses = asArray(e.address).map(a =>
+    [at(a, 'street'), at(a, 'city'), at(a, 'countryDescription')].filter(Boolean).join(', ') || null
+  ).filter(Boolean) as string[];
+  const identifications = asArray(e.identification).map(id => ({
+    type: at(id, 'identificationTypeDescription') || at(id, 'identificationTypeCode'),
+    number: at(id, 'number') || at(id, 'latinNumber'),
+    country: at(id, 'countryDescription'),
+  }));
+
+  const regs = asArray(e.regulation);
+  const reg = regs[0] || {};
+  const regulationBasis = at(reg, 'numberTitle');
+  const programme = firstNonNull(regs.map(r => at(r, 'programme')));
+  const listingDate = firstNonNull(regs.map(r => at(r, 'publicationDate') || at(r, 'entryIntoForceDate')));
+  const remark = asArray(e.remark).map(r => (typeof r === 'string' ? r : r?.['#text'])).filter(Boolean).join('; ') || null;
+
+  return [
+    entityId,
+    entityType,
+    name,
+    wholeNames,
+    birthDate,
+    birthPlace,
+    citizenship,
+    addresses,
+    JSON.stringify(identifications),
+    regulationBasis,
+    listingDate,
+    programme,
+    remark,
+    JSON.stringify(e),
+  ];
+}
+
+async function insertBatch(rows: any[][]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const ph: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    ph.push(`(${r.map(() => `$${i++}`).join(',')})`);
+    values.push(...r);
+  }
+  const sql = `
+    INSERT INTO eu_sanctions
+      (entity_id, entity_type, name, name_aliases, birth_date, birth_place, citizenship,
+       addresses, identifications, regulation_basis, listing_date, programme, remark, metadata_json)
+    VALUES ${ph.join(',')}
+    ON CONFLICT (entity_id) DO UPDATE SET
+      entity_type = EXCLUDED.entity_type, name = EXCLUDED.name, name_aliases = EXCLUDED.name_aliases,
+      birth_date = EXCLUDED.birth_date, birth_place = EXCLUDED.birth_place, citizenship = EXCLUDED.citizenship,
+      addresses = EXCLUDED.addresses, identifications = EXCLUDED.identifications,
+      regulation_basis = EXCLUDED.regulation_basis, listing_date = EXCLUDED.listing_date,
+      programme = EXCLUDED.programme, remark = EXCLUDED.remark, metadata_json = EXCLUDED.metadata_json,
+      updated_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function main(): Promise<void> {
+  const path = process.argv[2] || DEFAULT_PATH;
+  console.log(`📥 EU FSF refresh from ${path}`);
+  if (!fs.existsSync(path)) { console.error(`❌ Not found: ${path}`); process.exit(1); }
+  await pool.query('SELECT 1');
+
+  const xml = fs.readFileSync(path, 'utf8');
+  const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_', parseAttributeValue: false, parseTagValue: false });
+  const doc = parser.parse(xml);
+  const entities = asArray(doc.export?.sanctionEntity);
+  console.log(`   entities: ${entities.length}`);
+
+  let imported = 0, skipped = 0;
+  let batch: any[][] = [];
+  for (const e of entities) {
+    const row = mapEntity(e);
+    if (!row) { skipped++; continue; }
+    batch.push(row);
+    if (batch.length >= BATCH_SIZE) { imported += await insertBatch(batch); batch = []; }
+  }
+  if (batch.length) imported += await insertBatch(batch);
+  console.log(`✅ EU: ${imported} rows upserted${skipped ? `, ${skipped} skipped (no id)` : ''}`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });

--- a/mcp_backend/src/scripts/import-financial-statements.ts
+++ b/mcp_backend/src/scripts/import-financial-statements.ts
@@ -1,0 +1,136 @@
+/**
+ * Refresh opendata_financial_statements from the ДПС «Фінансова звітність підприємств»
+ * dumps (data.gov.ua). Reads the ZIP archives under /data/opendata/finrep/{annual,quarterly}/,
+ * each holding many KEP-signed XML filings. For every filing the <DECLAR> payload is located
+ * inside the signed envelope, its DECLARHEAD fields are extracted, and one row is upserted by
+ * (tin, period_year, form_type, c_doc_sub).
+ *
+ * Heavy: ~713K filings / ~3.7 GB. Run in the background; idempotent (ON CONFLICT).
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-financial-statements.ts [root]
+ *   default: /data/opendata/finrep
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+import AdmZip from 'adm-zip';
+
+const DEFAULT_ROOT = '/data/opendata/finrep';
+const BATCH_SIZE = 500;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+const tag = (xml: string, name: string): string | null => {
+  const m = xml.match(new RegExp(`<${name}>([^<]*)</${name}>`, 'i'));
+  return m ? m[1].trim() || null : null;
+};
+const toInt = (v: string | null): number | null => (v && /^\d+$/.test(v) ? parseInt(v) : null);
+
+function parseFiling(buf: Buffer): any | null {
+  // The signed envelope has binary before the payload; locate the <DECLAR ...>...</DECLAR>.
+  const raw = buf.toString('latin1');
+  const start = raw.indexOf('<DECLAR');
+  const endTag = raw.lastIndexOf('</DECLAR>');
+  if (start < 0 || endTag < 0) return null;
+  // Re-decode just the payload as UTF-8 (the XML declares encoding="UTF-8").
+  const declarXml = buf.slice(Buffer.byteLength(raw.slice(0, start), 'latin1'),
+    Buffer.byteLength(raw.slice(0, endTag), 'latin1') + '</DECLAR>'.length).toString('utf8');
+
+  const head = declarXml.slice(0, declarXml.indexOf('</DECLARHEAD>') + 13 || 4000);
+  const tin = tag(head, 'TIN');
+  const periodYear = toInt(tag(head, 'PERIOD_YEAR'));
+  const cDocSub = tag(head, 'C_DOC_SUB');
+  const fm = declarXml.match(/noNamespaceSchemaLocation="([^"]+?)\.XSD"/i);
+  const formType = fm ? fm[1] : null;
+  if (!tin || periodYear == null || !formType || !cDocSub) return null;
+
+  return {
+    tin,
+    c_doc: tag(head, 'C_DOC'),
+    c_doc_sub: cDocSub,
+    c_doc_ver: tag(head, 'C_DOC_VER'),
+    period_year: periodYear,
+    period_month: toInt(tag(head, 'PERIOD_MONTH')),
+    period_type: toInt(tag(head, 'PERIOD_TYPE')),
+    c_reg: tag(head, 'C_REG'),
+    c_raj: tag(head, 'C_RAJ'),
+    form_type: formType,
+    raw_xml: declarXml,
+  };
+}
+
+async function insertBatch(rows: any[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const seen = new Set<string>();
+  const deduped = rows.filter(r => {
+    const k = `${r.tin}|${r.period_year}|${r.form_type}|${r.c_doc_sub}`;
+    if (seen.has(k)) return false; seen.add(k); return true;
+  });
+  const values: any[] = [];
+  const ph: string[] = [];
+  let i = 1;
+  for (const r of deduped) {
+    const cols = [r.tin, r.c_doc, r.c_doc_sub, r.c_doc_ver, r.period_year, r.period_month,
+      r.period_type, r.c_reg, r.c_raj, r.form_type, r.raw_xml];
+    ph.push(`(${cols.map(() => `$${i++}`).join(',')})`);
+    values.push(...cols);
+  }
+  const sql = `
+    INSERT INTO opendata_financial_statements
+      (tin, c_doc, c_doc_sub, c_doc_ver, period_year, period_month, period_type,
+       c_reg, c_raj, form_type, raw_xml)
+    VALUES ${ph.join(',')}
+    ON CONFLICT (tin, period_year, form_type, c_doc_sub) DO UPDATE SET
+      c_doc = EXCLUDED.c_doc, c_doc_ver = EXCLUDED.c_doc_ver, period_month = EXCLUDED.period_month,
+      period_type = EXCLUDED.period_type, c_reg = EXCLUDED.c_reg, c_raj = EXCLUDED.c_raj,
+      raw_xml = EXCLUDED.raw_xml, imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function main(): Promise<void> {
+  const root = process.argv[2] || DEFAULT_ROOT;
+  console.log(`📥 Financial statements refresh from ${root}`);
+  if (!fs.existsSync(root)) { console.error(`❌ Not found: ${root}`); process.exit(1); }
+  await pool.query('SELECT 1');
+
+  const zips: string[] = [];
+  for (const sub of ['annual', 'quarterly']) {
+    const d = path.join(root, sub);
+    if (fs.existsSync(d)) for (const f of fs.readdirSync(d)) if (f.toLowerCase().endsWith('.zip')) zips.push(path.join(d, f));
+  }
+  console.log(`   ${zips.length} archives`);
+
+  let total = 0, parsed = 0, skipped = 0;
+  let batch: any[] = [];
+  for (const zp of zips) {
+    let entries: any[];
+    try { entries = new AdmZip(zp).getEntries(); } catch (e: any) { console.warn(`   ⚠️ ${path.basename(zp)}: ${e.message}`); continue; }
+    for (const en of entries) {
+      if (en.isDirectory || !/\.xml$/i.test(en.entryName)) continue;
+      let row: any = null;
+      try { row = parseFiling(en.getData()); } catch { /* skip corrupt */ }
+      if (!row) { skipped++; continue; }
+      parsed++;
+      batch.push(row);
+      if (batch.length >= BATCH_SIZE) { total += await insertBatch(batch); batch = []; }
+    }
+    console.log(`   ${path.basename(zp)}: parsed ${parsed}, upserted ${total}, skipped ${skipped}`);
+  }
+  if (batch.length) total += await insertBatch(batch);
+  console.log(`✅ Financial statements: ${total} rows upserted (${parsed} parsed, ${skipped} skipped)`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });

--- a/mcp_backend/src/scripts/import-ofac-sanctions.ts
+++ b/mcp_backend/src/scripts/import-ofac-sanctions.ts
@@ -1,0 +1,121 @@
+/**
+ * Refresh us_ofac_sanctions from the OFAC SDN list (SDN.XML).
+ *
+ * Reads /data/opendata/intl_sanctions/ofac/SDN.XML (downloaded out-of-band; the prod
+ * IP is fine for OFAC but we load the local snapshot for reproducibility). Parses
+ * <sdnEntry> elements and upserts by uid.
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-ofac-sanctions.ts [path]
+ *   default: /data/opendata/intl_sanctions/ofac/SDN.XML
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import { XMLParser } from 'fast-xml-parser';
+
+const DEFAULT_PATH = '/data/opendata/intl_sanctions/ofac/SDN.XML';
+const BATCH_SIZE = 500;
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+const asArray = (v: any): any[] => (v == null ? [] : Array.isArray(v) ? v : [v]);
+const txt = (v: any): string | null => (v == null || v === '' ? null : String(v));
+
+function sdnName(e: any): string | null {
+  const parts = [e.firstName, e.lastName].filter(Boolean);
+  return parts.length ? parts.join(' ') : null;
+}
+
+function mapEntry(e: any): any[] {
+  const programs = asArray(e.programList?.program).map(txt).filter(Boolean);
+  const aliases = asArray(e.akaList?.aka).map((a: any) => ({
+    type: txt(a.type), category: txt(a.category),
+    name: [a.firstName, a.lastName].filter(Boolean).join(' ') || null,
+  }));
+  const addresses = asArray(e.addressList?.address).map((a: any) => ({
+    address1: txt(a.address1), city: txt(a.city), country: txt(a.country),
+    stateOrProvince: txt(a.stateOrProvince), postalCode: txt(a.postalCode),
+  }));
+  const ids = asArray(e.idList?.id).map((i: any) => ({
+    type: txt(i.idType), number: txt(i.idNumber), country: txt(i.idCountry),
+  }));
+  const v = e.vesselInfo || {};
+  return [
+    txt(e.uid),
+    'sdn',
+    sdnName(e),
+    txt(e.sdnType),
+    programs.join('; ') || null,
+    txt(e.title),
+    txt(e.remarks),
+    txt(v.callSign),
+    txt(v.vesselType),
+    txt(v.tonnage),
+    txt(v.grossRegisteredTonnage),
+    txt(v.vesselFlag),
+    txt(v.vesselOwner),
+    JSON.stringify(addresses),
+    JSON.stringify(aliases),
+    JSON.stringify(ids),
+  ];
+}
+
+async function insertBatch(rows: any[][]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const values: any[] = [];
+  const ph: string[] = [];
+  let i = 1;
+  for (const r of rows) {
+    ph.push(`(${r.map(() => `$${i++}`).join(',')})`);
+    values.push(...r);
+  }
+  const sql = `
+    INSERT INTO us_ofac_sanctions
+      (uid, entry_type, sdn_name, sdn_type, program, title, remarks, call_sign,
+       vessel_type, tonnage, grt, vessel_flag, vessel_owner, addresses, aliases, ids)
+    VALUES ${ph.join(',')}
+    ON CONFLICT (uid) DO UPDATE SET
+      sdn_name = EXCLUDED.sdn_name, sdn_type = EXCLUDED.sdn_type, program = EXCLUDED.program,
+      title = EXCLUDED.title, remarks = EXCLUDED.remarks, call_sign = EXCLUDED.call_sign,
+      vessel_type = EXCLUDED.vessel_type, tonnage = EXCLUDED.tonnage, grt = EXCLUDED.grt,
+      vessel_flag = EXCLUDED.vessel_flag, vessel_owner = EXCLUDED.vessel_owner,
+      addresses = EXCLUDED.addresses, aliases = EXCLUDED.aliases, ids = EXCLUDED.ids,
+      imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+async function main(): Promise<void> {
+  const path = process.argv[2] || DEFAULT_PATH;
+  console.log(`📥 OFAC SDN refresh from ${path}`);
+  if (!fs.existsSync(path)) { console.error(`❌ Not found: ${path}`); process.exit(1); }
+  await pool.query('SELECT 1');
+
+  const xml = fs.readFileSync(path, 'utf8');
+  const parser = new XMLParser({ ignoreAttributes: true, parseTagValue: false });
+  const doc = parser.parse(xml);
+  const entries = asArray(doc.sdnList?.sdnEntry);
+  console.log(`   entries: ${entries.length}`);
+
+  let imported = 0;
+  let batch: any[][] = [];
+  for (const e of entries) {
+    batch.push(mapEntry(e));
+    if (batch.length >= BATCH_SIZE) { imported += await insertBatch(batch); batch = []; }
+  }
+  if (batch.length) imported += await insertBatch(batch);
+  console.log(`✅ OFAC: ${imported} rows upserted`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });

--- a/mcp_backend/src/scripts/import-securities-owners-datagov.ts
+++ b/mcp_backend/src/scripts/import-securities-owners-datagov.ts
@@ -1,0 +1,170 @@
+/**
+ * Refresh opendata_securities_owners from the НКЦПФР "власники значних пакетів акцій"
+ * quarterly dumps (data.gov.ua dataset nssmc-001).
+ *
+ * Reads /data/opendata/smida/datagov_nssmc/owners/*.csv — headerless, windows-1251,
+ * semicolon-delimited, 15 positional columns:
+ *   0 report_date  1 issuer_edrpou  2 issuer_name  3 isin  4 owner_edrpou
+ *   5 owner surname / entity name  6 owner first name  7 owner patronymic
+ *   8 country_code  9 -  10 code  11 share_percent  12 nominal_per_share  13 nominal_value  14 -
+ *
+ * The full raw row is preserved in raw_data; upsert matches the existing unique index.
+ *
+ * Usage:
+ *   npx tsx src/scripts/import-securities-owners-datagov.ts [dir]
+ *   default: /data/opendata/smida/datagov_nssmc/owners
+ */
+
+import { Pool } from 'pg';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const DEFAULT_DIR = '/data/opendata/smida/datagov_nssmc/owners';
+const BATCH_SIZE = 500;
+const win1251 = new TextDecoder('windows-1251');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.POSTGRES_HOST || 'localhost',
+  port: parseInt(process.env.POSTGRES_PORT || '5432'),
+  user: process.env.POSTGRES_USER || 'secondlayer',
+  password: process.env.POSTGRES_PASSWORD,
+  database: process.env.POSTGRES_DB || 'secondlayer_prod',
+  max: 5,
+});
+
+/** Parse one semicolon-delimited line honouring "" quotes. */
+function parseLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let inQ = false;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (inQ) {
+      if (c === '"') {
+        if (line[i + 1] === '"') { cur += '"'; i++; } else inQ = false;
+      } else cur += c;
+    } else if (c === '"') inQ = true;
+    else if (c === ';') { out.push(cur); cur = ''; }
+    else cur += c;
+  }
+  out.push(cur);
+  return out.map(s => s.trim());
+}
+
+function toDate(v: string): string | null {
+  const m = v.match(/(\d{1,2})\.(\d{1,2})\.(\d{4})/); // d.m.yyyy
+  if (!m) return null;
+  return `${m[3]}-${m[2].padStart(2, '0')}-${m[1].padStart(2, '0')}`;
+}
+function toNum(v: string): number | null {
+  if (!v) return null;
+  const n = parseFloat(v.replace(/\s/g, '').replace(',', '.'));
+  return Number.isFinite(n) ? n : null;
+}
+function toInt(v: string): number | null {
+  if (!v || !/^\d+$/.test(v)) return null;
+  return parseInt(v);
+}
+
+function mapRow(c: string[], reportDateFallback: string | null): any | null {
+  const reportDate = (c[0] && toDate(c[0])) || reportDateFallback;
+  const issuerEdrpou = c[1] || null;
+  if (!reportDate || !issuerEdrpou) return null;
+  const ownerEdrpou = c[4] || null;
+  const ownerName = ownerEdrpou
+    ? (c[5] || null)                                  // legal entity → name in col5
+    : ([c[5], c[6], c[7]].filter(Boolean).join(' ') || null); // individual → ПІБ
+  return {
+    report_date: reportDate,
+    issuer_edrpou: issuerEdrpou,
+    issuer_name: c[2] || null,
+    isin_code: c[3] || null,
+    owner_edrpou: ownerEdrpou,
+    owner_name: ownerName,
+    owner_name_alt: null,
+    owner_type: ownerEdrpou ? 'legal' : 'individual',
+    share_percent: toNum(c[11]),
+    nominal_value: toNum(c[13]),
+    share_count: null as number | null,
+    country_code: toInt(c[8]),
+    raw_data: c,
+  };
+}
+
+async function insertBatch(rows: any[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  // dedupe within batch on the unique key
+  const seen = new Set<string>();
+  const deduped = rows.filter(r => {
+    const k = `${r.report_date}|${r.issuer_edrpou}|${r.owner_edrpou || ''}|${r.owner_name || ''}`;
+    if (seen.has(k)) return false; seen.add(k); return true;
+  });
+  const values: any[] = [];
+  const ph: string[] = [];
+  let i = 1;
+  for (const r of deduped) {
+    const cols = [r.report_date, r.issuer_edrpou, r.issuer_name, r.isin_code, r.owner_edrpou,
+      r.owner_name, r.owner_name_alt, r.owner_type, r.share_percent, r.nominal_value,
+      r.share_count, r.country_code, JSON.stringify(r.raw_data)];
+    ph.push(`(${cols.map(() => `$${i++}`).join(',')})`);
+    values.push(...cols);
+  }
+  const sql = `
+    INSERT INTO opendata_securities_owners
+      (report_date, issuer_edrpou, issuer_name, isin_code, owner_edrpou, owner_name,
+       owner_name_alt, owner_type, share_percent, nominal_value, share_count, country_code, raw_data)
+    VALUES ${ph.join(',')}
+    ON CONFLICT (report_date, issuer_edrpou, coalesce(owner_edrpou, ''), coalesce(owner_name, ''))
+    DO UPDATE SET
+      issuer_name = EXCLUDED.issuer_name, isin_code = EXCLUDED.isin_code,
+      owner_type = EXCLUDED.owner_type, share_percent = EXCLUDED.share_percent,
+      nominal_value = EXCLUDED.nominal_value, country_code = EXCLUDED.country_code,
+      raw_data = EXCLUDED.raw_data, imported_at = NOW()
+  `;
+  const res = await pool.query(sql, values);
+  return res.rowCount || 0;
+}
+
+function reportDateFromName(f: string): string | null {
+  // e.g. "1-qv-2024.csv", "data-4-qv-2025.csv" → last day of the quarter
+  const m = f.match(/(\d)-qv-(\d{4})/);
+  if (!m) return null;
+  const q = parseInt(m[1]), y = m[2];
+  const ends = ['03-31', '06-30', '09-30', '12-31'];
+  return q >= 1 && q <= 4 ? `${y}-${ends[q - 1]}` : null;
+}
+
+async function importFile(file: string): Promise<number> {
+  const buf = fs.readFileSync(file);
+  const text = win1251.decode(buf);
+  const fallback = reportDateFromName(path.basename(file));
+  let imported = 0, batch: any[] = [];
+  for (const line of text.split('\n')) {
+    if (!line.trim()) continue;
+    const row = mapRow(parseLine(line), fallback);
+    if (!row) continue;
+    batch.push(row);
+    if (batch.length >= BATCH_SIZE) { imported += await insertBatch(batch); batch = []; }
+  }
+  if (batch.length) imported += await insertBatch(batch);
+  return imported;
+}
+
+async function main(): Promise<void> {
+  const dir = process.argv[2] || DEFAULT_DIR;
+  console.log(`📥 НКЦПФР owners refresh from ${dir}`);
+  if (!fs.existsSync(dir)) { console.error(`❌ Not found: ${dir}`); process.exit(1); }
+  await pool.query('SELECT 1');
+  const files = fs.readdirSync(dir).filter(f => f.toLowerCase().endsWith('.csv')).sort();
+  let total = 0;
+  for (const f of files) {
+    const n = await importFile(path.join(dir, f));
+    total += n;
+    console.log(`   ${f}: ${n}`);
+  }
+  console.log(`✅ Securities owners: ${total} rows upserted from ${files.length} files`);
+  await pool.end();
+}
+
+main().catch(err => { console.error('❌ Fatal:', err); process.exit(1); });


### PR DESCRIPTION
## What

Standalone file importers to **refresh the stale opendata pipeline tables** from the fresh snapshots in `/data/opendata/`. The generic `opendata-sync` loader only fetches JSON APIs and can't parse these XML/CSV sources, and no importer existed for them.

| Importer | Table | Source | Upsert key |
|---|---|---|---|
| `import-ofac-sanctions.ts` | `us_ofac_sanctions` | OFAC SDN.XML (19K) | uid |
| `import-eu-sanctions.ts` | `eu_sanctions` | EU FSF XML (~6K) | entity_id |
| `import-securities-owners-datagov.ts` | `opendata_securities_owners` | НКЦПФР nssmc-001 cp1251 CSV (425K) | (report_date, issuer, owner) |
| `import-financial-statements.ts` | `opendata_financial_statements` | ДПС 713K KEP-signed XML | (tin, year, form_type, sub) |

## Notes

- All batch-upsert against the **existing** table schemas / unique keys — idempotent refresh, no migration.
- financial_statements is heavy (713K signed XML / 3.7 GB) → run in background.
- SECO (`ch_seco_sanctions`) intentionally excluded — no Swiss file was downloaded.
- securities CSVs are headerless windows-1251, mapped positionally; full raw row kept in `raw_data`.

## Verification

- `tsc`: 0 errors in the 4 new files.
- On prod data: financial `parseFiling` extracts TIN/form_type(S0103354)/period/raw_xml from the signed envelope; securities cp1251 map handles both individual (ПІБ «Сафонов Сергій Анатолійович») and legal-entity (owner_edrpou + name) owners.

## After merge

Run on prod (host checkout): OFAC/EU/securities immediately; financial in background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four import scripts to refresh stale opendata tables from local XML/CSV snapshots under `/data/opendata`. Performs batch, idempotent upserts for sanctions, securities owners, and financial statements without schema changes.

- **New Features**
  - `import-ofac-sanctions.ts` → `us_ofac_sanctions` from OFAC SDN.XML; upsert by `uid`.
  - `import-eu-sanctions.ts` → `eu_sanctions` from EU FSF XML; upsert by `entity_id`.
  - `import-securities-owners-datagov.ts` → `opendata_securities_owners` from NSSMC cp1251 CSV; upsert by report_date/issuer/owner.
  - `import-financial-statements.ts` → `opendata_financial_statements` from KEP-signed XML; upsert by `(tin, period_year, form_type, c_doc_sub)`.

- **Migration**
  - Run: `npx tsx src/scripts/import-ofac-sanctions.ts`, `import-eu-sanctions.ts`, `import-securities-owners-datagov.ts`.
  - Run financial statements in background: `npx tsx src/scripts/import-financial-statements.ts` (heavy: ~713K filings / ~3.7 GB).
  - Scripts read local snapshots in `/data/opendata/` and parse non-JSON sources the generic sync doesn’t handle.

<sup>Written for commit d1cb3a7eb8be122165739cea7713498c14416be5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

