### PR TITLE
fix(opendata): parse EU FSF per-entity (avoid fast-xml-parser entity limit)

### DIFF
--- a/mcp_backend/src/scripts/import-eu-sanctions.ts
+++ b/mcp_backend/src/scripts/import-eu-sanctions.ts
@@ -117,15 +117,18 @@ async function main(): Promise<void> {
   await pool.query('SELECT 1');
 
   const xml = fs.readFileSync(path, 'utf8');
+  // Parse each <sanctionEntity> block on its own: the full 25MB document trips
+  // fast-xml-parser's entity-expansion guard, but a single entity is tiny.
   const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '@_', parseAttributeValue: false, parseTagValue: false });
-  const doc = parser.parse(xml);
-  const entities = asArray(doc.export?.sanctionEntity);
-  console.log(`   entities: ${entities.length}`);
+  const blocks = xml.match(/<sanctionEntity\b[\s\S]*?<\/sanctionEntity>/g) || [];
+  console.log(`   entities: ${blocks.length}`);
 
   let imported = 0, skipped = 0;
   let batch: any[][] = [];
-  for (const e of entities) {
-    const row = mapEntity(e);
+  for (const block of blocks) {
+    let e: any;
+    try { e = parser.parse(block).sanctionEntity; } catch { skipped++; continue; }
+    const row = e ? mapEntity(e) : null;
     if (!row) { skipped++; continue; }
     batch.push(row);
     if (batch.length >= BATCH_SIZE) { imported += await insertBatch(batch); batch = []; }


### PR DESCRIPTION
The EU refresh importer (#2111) failed with `Entity expansion limit exceeded: 1002 > 1000` — fast-xml-parser's DoS guard trips on the whole 25MB FSF document. Fix: split into per-`<sanctionEntity>` blocks via regex and parse each individually (tiny, well under the limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the EU FSF importer by parsing each <sanctionEntity> block individually instead of the full 25MB XML. This avoids the `fast-xml-parser` entity-expansion limit and makes imports reliable and more memory-friendly.

- **Bug Fixes**
  - Split XML into `<sanctionEntity>` blocks via regex and parse each with `fast-xml-parser`.
  - Skip malformed blocks with try/catch; continue batching and insertion without aborting.

<sup>Written for commit a7abe17f8881d99633e0e9dbff8b94e15bbe008b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

