### PR TITLE
fix(opendata): clamp securities numeric values to column precision

### DIFF
--- a/mcp_backend/src/scripts/import-securities-owners-datagov.ts
+++ b/mcp_backend/src/scripts/import-securities-owners-datagov.ts
@@ -62,6 +62,10 @@ function toNum(v: string): number | null {
   const n = parseFloat(v.replace(/\s/g, '').replace(',', '.'));
   return Number.isFinite(n) ? n : null;
 }
+/** Clamp to a NUMERIC(precision, scale) column; out-of-range → null (raw kept in raw_data). */
+function numFit(n: number | null, maxInteger: number): number | null {
+  return n != null && Math.abs(n) < maxInteger ? n : null;
+}
 function toInt(v: string): number | null {
   if (!v || !/^\d+$/.test(v)) return null;
   return parseInt(v);
@@ -84,8 +88,8 @@ function mapRow(c: string[], reportDateFallback: string | null): any | null {
     owner_name: ownerName,
     owner_name_alt: null,
     owner_type: ownerEdrpou ? 'legal' : 'individual',
-    share_percent: toNum(c[11]),
-    nominal_value: toNum(c[13]),
+    share_percent: numFit(toNum(c[11]), 1e6),   // numeric(10,4) → |x| < 1e6
+    nominal_value: numFit(toNum(c[13]), 1e16),   // numeric(18,2) → |x| < 1e16
     share_count: null as number | null,
     country_code: toInt(c[8]),
     raw_data: c,


### PR DESCRIPTION
The securities-owners refresh (#2111) hit a Postgres numeric overflow (`apply_typmod`, numeric.c) on rows whose share_percent/nominal_value exceed numeric(10,4)/numeric(18,2). Clamp out-of-range values to null; raw row stays in raw_data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp out-of-range values for share_percent and nominal_value during the securities owners import to match column precision and prevent Postgres numeric overflow. Values exceeding numeric(10,4) or numeric(18,2) are set to null; the original row stays in raw_data.

<sup>Written for commit 5c92bd6d9471e8d3e517d2c0e9c39dc7ea8baa94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

