### PR TITLE
fix(opendata): bound securities country_code to int4 range

### DIFF
--- a/mcp_backend/src/scripts/import-securities-owners-datagov.ts
+++ b/mcp_backend/src/scripts/import-securities-owners-datagov.ts
@@ -68,7 +68,8 @@ function numFit(n: number | null, maxInteger: number): number | null {
 }
 function toInt(v: string): number | null {
   if (!v || !/^\d+$/.test(v)) return null;
-  return parseInt(v);
+  const n = parseInt(v);
+  return n <= 2147483647 ? n : null; // int4 range (country_code); out-of-range → null
 }
 
 function mapRow(c: string[], reportDateFallback: string | null): any | null {


### PR DESCRIPTION
Follow-up to #2113: another overflow (pg_strtoint32) — country_code gets a >2^31 value in column-shifted rows. Return null for out-of-int4 values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds parsed `country_code` values to int4 in the securities owners import; `toInt` now returns null for values > 2,147,483,647. This prevents Postgres insert errors from column‑shifted `nssmc-001` rows while preserving the raw row.

<sup>Written for commit f5bfaa0da25e443f2a785af9af46b11f9fb028f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

