### PR TITLE
fix(opendata): parse ISO dates + _YYYY_qN filenames in securities owners

### DIFF
--- a/mcp_backend/src/scripts/import-securities-owners-datagov.ts
+++ b/mcp_backend/src/scripts/import-securities-owners-datagov.ts
@@ -53,9 +53,11 @@ function parseLine(line: string): string[] {
 }
 
 function toDate(v: string): string | null {
-  const m = v.match(/(\d{1,2})\.(\d{1,2})\.(\d{4})/); // d.m.yyyy
-  if (!m) return null;
-  return `${m[3]}-${m[2].padStart(2, '0')}-${m[1].padStart(2, '0')}`;
+  let m = v.match(/(\d{4})-(\d{2})-(\d{2})/); // ISO yyyy-mm-dd (2018–2021 files)
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  m = v.match(/(\d{1,2})\.(\d{1,2})\.(\d{4})/); // d.m.yyyy (2022+ files)
+  if (m) return `${m[3]}-${m[2].padStart(2, '0')}-${m[1].padStart(2, '0')}`;
+  return null;
 }
 function toNum(v: string): number | null {
   if (!v) return null;
@@ -132,10 +134,12 @@ async function insertBatch(rows: any[]): Promise<number> {
 }
 
 function reportDateFromName(f: string): string | null {
-  // e.g. "1-qv-2024.csv", "data-4-qv-2025.csv" → last day of the quarter
-  const m = f.match(/(\d)-qv-(\d{4})/);
-  if (!m) return null;
-  const q = parseInt(m[1]), y = m[2];
+  // "1-qv-2024.csv", "data-4-qv-2025.csv", "owners_2020_q3.csv" → last day of the quarter
+  let m = f.match(/(\d)-qv-(\d{4})/);
+  let q: number, y: string;
+  if (m) { q = parseInt(m[1]); y = m[2]; }
+  else if ((m = f.match(/_(\d{4})_q(\d)/))) { y = m[1]; q = parseInt(m[2]); }
+  else return null;
   const ends = ['03-31', '06-30', '09-30', '12-31'];
   return q >= 1 && q <= 4 ? `${y}-${ends[q - 1]}` : null;
 }


### PR DESCRIPTION
Follow-up to #2114: the 2018-2021 owner dumps use ISO dates (2020-09-30) and a header row; every data row was skipped (0 rows imported for those quarters). Accept ISO + d.m.yyyy dates, and derive a quarter-end date from the _YYYY_qN filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes skipped rows in securities owners imports by parsing ISO dates and recognizing `_YYYY_qN` filenames. 2018–2021 dumps now import correctly.

- **Bug Fixes**
  - `toDate` now accepts ISO `yyyy-mm-dd` in addition to `d.m.yyyy`.
  - `reportDateFromName` derives quarter-end dates from `_YYYY_qN` filenames (e.g., `owners_2020_q3.csv`) and still supports `-qv-` patterns.

<sup>Written for commit 4eb7582eebbec8bd34da90bacb164f89793f57b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

