### PR TITLE
fix(mcp): serve curated tool whitelist on /sse (unbreaks ChatGPT court lookups)

### DIFF
--- a/mcp_backend/src/api/__tests__/mcp-sse-tools-whitelist.test.ts
+++ b/mcp_backend/src/api/__tests__/mcp-sse-tools-whitelist.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression test for the /sse tools/list curated whitelist.
+ *
+ * Bug: MCPSSEServer.handleToolsList used a blind `allTools.slice(0, 15)`, which kept only
+ * the first 15 tools by registration order and silently dropped the court-decision / ЄДРСР
+ * tools (registered later in tool-services.ts). ChatGPT — which connects via /sse — therefore
+ * could not look up court cases by number.
+ *
+ * Fix: advertise the curated V2_TOOL_NAMES whitelist instead. This test drives the real
+ * constructor (ToolRegistry-based) and asserts the court tools survive and non-curated tools
+ * are filtered out.
+ */
+
+import { MCPSSEServer } from '../mcp-sse-server.js';
+import { V2_TOOL_NAMES } from '../curated-mcp-tools.js';
+import { MockSSEResponse } from '../../__tests__/helpers/mock-sse-response.js';
+import { Request } from 'express';
+
+jest.mock('../../utils/logger.js', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+describe('MCPSSEServer tools/list curated whitelist', () => {
+  // A registry that returns a realistic mix: curated tools (incl. court) registered AFTER
+  // several non-curated ones — exactly the ordering that the old slice(0,15) mishandled.
+  const localToolDefs = [
+    // non-curated, registered first (these used to crowd out the court tools)
+    { name: 'parse_document', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    { name: 'summarize_document', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    { name: 'risk_scoring', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    { name: 'classify_intent', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    // curated legislation
+    { name: 'search_legislation', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    // curated court / ЄДРСР (registered late — the ones the bug dropped)
+    { name: 'search_court_decisions', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    { name: 'get_case_documents_chain', description: 'x', inputSchema: { type: 'object', properties: {} } },
+    { name: 'get_court_decision', description: 'x', inputSchema: { type: 'object', properties: {} } },
+  ];
+
+  const fakeRegistry = {
+    getLocalToolDefinitions: jest.fn().mockReturnValue(localToolDefs),
+    getAllToolDefinitions: jest.fn().mockResolvedValue(localToolDefs),
+    executeTool: jest.fn(),
+  };
+  const fakeCostTracker = {
+    createTrackingRecord: jest.fn(),
+    completeTrackingRecord: jest.fn(),
+  };
+
+  let server: MCPSSEServer;
+  let mockRes: MockSSEResponse;
+  let mockReq: Partial<Request>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    server = new MCPSSEServer(fakeRegistry as any, fakeCostTracker as any);
+    mockRes = new MockSSEResponse();
+    mockReq = {
+      ip: '127.0.0.1',
+      headers: { 'user-agent': 'ChatGPT/1.0' },
+      body: { jsonrpc: '2.0', id: 2, method: 'tools/list' },
+      on: jest.fn(),
+    };
+  });
+
+  it('advertises curated court tools and filters out non-curated tools', async () => {
+    await server.handleSSEConnection(mockReq as Request, mockRes as any, 'user-123');
+    await new Promise((r) => setTimeout(r, 50));
+
+    const events = mockRes.parseEvents();
+    const listEvent = events.find((e) => e.data?.result?.tools);
+    expect(listEvent).toBeDefined();
+
+    const names: string[] = listEvent!.data.result.tools.map((t: any) => t.name);
+
+    // Court tools (the ones the slice(0,15) bug dropped) must now be present.
+    expect(names).toContain('search_court_decisions');
+    expect(names).toContain('get_case_documents_chain');
+    expect(names).toContain('get_court_decision');
+
+    // Non-curated tools must be filtered out.
+    expect(names).not.toContain('parse_document');
+    expect(names).not.toContain('summarize_document');
+    expect(names).not.toContain('risk_scoring');
+
+    // Every advertised tool is in the curated whitelist.
+    for (const n of names) {
+      expect(V2_TOOL_NAMES.has(n)).toBe(true);
+    }
+  });
+});

--- a/mcp_backend/src/api/curated-mcp-tools.ts
+++ b/mcp_backend/src/api/curated-mcp-tools.ts
@@ -1,0 +1,36 @@
+/**
+ * Curated MCP tool set (v2)
+ *
+ * The single source of truth for the small, focused tool list exposed to external
+ * MCP clients (ChatGPT connector, Claude Desktop/Code). Instead of surfacing the
+ * ~100+ low-level tools registered in the ToolRegistry — which makes tool selection
+ * intractable for the model and can exceed client-side tool-count limits — both
+ * transports advertise only this curated subset:
+ *
+ *   • /api/v2/mcp  (Streamable HTTP, buildMcpServerV2)
+ *   • /sse         (legacy SSE transport, MCPSSEServer)
+ *
+ * IMPORTANT: keep this in sync with the actual handler names registered in
+ * factories/tool-services.ts. Every name here must resolve to a LOCAL handler so
+ * it appears in ToolRegistry.getLocalToolDefinitions() (the SSE transport only
+ * lists local tools).
+ */
+export const V2_TOOL_NAMES = new Set<string>([
+  // Legislation (6)
+  'search_legislation',
+  'get_legislation_section',
+  'get_legislation_articles',
+  'get_legislation_structure',
+  'get_legislation_history',
+  'list_legislation_editions',
+  // Court decisions — ЄДРСР (9)
+  'search_court_decisions',
+  'get_court_decision',
+  'get_case_documents_chain',
+  'load_full_texts',
+  'find_similar_fact_pattern_cases',
+  'compare_practice_pro_contra',
+  'count_cases_by_party',
+  'check_precedent_status',
+  'get_citation_graph',
+]);

--- a/mcp_backend/src/api/mcp-sse-server.ts
+++ b/mcp_backend/src/api/mcp-sse-server.ts
@@ -16,6 +16,7 @@ import { ToolRegistry } from './tool-registry.js';
 import { CostTracker } from '../services/cost-tracker.js';
 import { CreditService } from '../services/credit-service.js';
 import { requestContext } from '../utils/openai-client.js';
+import { V2_TOOL_NAMES } from './curated-mcp-tools.js';
 
 export interface MCPToolDefinition {
   name: string;
@@ -319,9 +320,17 @@ export class MCPSSEServer {
   private async handleToolsList(res: Response, request: MCPRequest): Promise<void> {
     const allTools = this.getAllTools();
 
-    // Limit tools for ChatGPT compatibility — large tool lists may fail to register
-    const MAX_TOOLS = 15;
-    const tools = allTools.slice(0, MAX_TOOLS);
+    // Advertise the curated v2 tool set — same whitelist as /api/v2/mcp — instead of
+    // a blind slice(0, N). The previous slice kept only the first 15 tools by registration
+    // order, which silently dropped the court-decision / ЄДРСР tools (registered later in
+    // tool-services.ts) and made this endpoint unusable for case lookups. Filtering by an
+    // explicit whitelist keeps the list small for ChatGPT while guaranteeing the right tools.
+    const tools = allTools.filter((t) => V2_TOOL_NAMES.has(t.name));
+
+    const missing = [...V2_TOOL_NAMES].filter((n) => !tools.some((t) => t.name === n));
+    if (missing.length > 0) {
+      logger.warn('[MCP SSE] Curated tools missing from local registry', { missing });
+    }
 
     logger.info('[MCP SSE] Tools list requested', {
       count: tools.length,

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -17,6 +17,7 @@ import { sanitizeId, maskSensitive } from '../utils/sanitize-log.js';
 import { requestContext } from '../utils/openai-client.js';
 import { MCPSSEServer } from '../api/mcp-sse-server.js';
 import { ToolRegistry, ToolDefinition } from '../api/tool-registry.js';
+import { V2_TOOL_NAMES } from '../api/curated-mcp-tools.js';
 import { ChatService } from '../services/chat-service.js';
 import { OAuthService } from '../services/oauth-service.js';
 import { ApiKeyService } from '../services/api-key-service.js';
@@ -275,25 +276,8 @@ export function createMCPSSERoutes(deps: {
   // tool selection tractable for external MCP clients (Claude Code/Desktop) while still
   // letting them call the real handlers directly. Execution, billing and cost-tracking are
   // identical to v1 (buildMcpServer); only the exposed set differs.
-  const V2_TOOL_NAMES = new Set<string>([
-    // Legislation (6)
-    'search_legislation',
-    'get_legislation_section',
-    'get_legislation_articles',
-    'get_legislation_structure',
-    'get_legislation_history',
-    'list_legislation_editions',
-    // Court decisions — ЄДРСР (9)
-    'search_court_decisions',
-    'get_court_decision',
-    'get_case_documents_chain',
-    'load_full_texts',
-    'find_similar_fact_pattern_cases',
-    'compare_practice_pro_contra',
-    'count_cases_by_party',
-    'check_precedent_status',
-    'get_citation_graph',
-  ]);
+  // The whitelist is shared with the legacy /sse transport (MCPSSEServer) — see
+  // curated-mcp-tools.ts — so both endpoints advertise the same curated set.
 
   // Build an MCP Server exposing only the curated v2 subset. Reuses the fully-wired v1
   // builder (tools/list + tools/call with billing) with the whitelist applied.


### PR DESCRIPTION
## Problem

The ChatGPT connector for SecondLayer MCP connects to `https://mcp.legal.org.ua/sse` and reported it has **no tool to fetch court decisions or cases by number** — only legislation + document-analysis tools. Meanwhile Claude Code (which effectively uses `/api/v2/mcp`) returns court tools fine.

### Root cause

`/sse` is served by `MCPSSEServer`, whose `tools/list` handler capped the list with a blind slice:

```ts
// mcp-sse-server.ts (before)
const MAX_TOOLS = 15;
const tools = allTools.slice(0, MAX_TOOLS);
```

`allTools` follows handler **registration order** in `tool-services.ts`. The first 15 are legislation (6) + document-analysis + due-diligence + `classify_intent`. `CourtDecisionTools` (line 112) and `edsrUnifiedSearch` (line 184) register **after** position 15, so every court/ЄДРСР tool was silently truncated away.

Verified live against prod (minted JWT, `tools/list`):
- `/sse` → 15 tools, **0 court** (`search_court_decisions` absent)
- `/api/v2/mcp` → 15 curated tools = 6 legislation + **9 court** ✅

## Fix

- Extract the v2 whitelist into a shared module `curated-mcp-tools.ts` (single source of truth).
- `/sse` now **filters by `V2_TOOL_NAMES`** instead of slicing, advertising the same curated 15 tools (6 legislation + 9 court) as `/api/v2/mcp`.
- Tool execution already routes through `toolRegistry.executeTool`, so the newly advertised court tools run with no further change.
- Logs a warning if any whitelisted tool is missing from the local registry.

## Test

New regression test `mcp-sse-tools-whitelist.test.ts` drives the real constructor and asserts:
- court tools (`search_court_decisions`, `get_case_documents_chain`, `get_court_decision`) are advertised,
- non-curated tools (`parse_document`, `summarize_document`, `risk_scoring`) are filtered out,
- every advertised tool ∈ `V2_TOOL_NAMES`.

```
Tests: 1 passed, 1 total
```

## Notes / out of scope
- `src/factories/core-loader.ts` and `src/api/__tests__/mcp-sse-server.test.ts` are **already broken on `main`** (missing service modules / stale 4-arg constructor) — pre-existing, untouched here.
- After merge+deploy, the existing ChatGPT connection on the old `/sse` URL will start seeing court tools without needing to change the URL. (Immediate workaround without deploy: point the connector at `https://mcp.legal.org.ua/api/v2/mcp`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the curated v2 MCP tool whitelist on `/sse` so ChatGPT can access court decision tools again. Aligns `/sse` with `/api/v2/mcp` (6 legislation + 9 court).

- **Bug Fixes**
  - `/sse` `tools/list` now filters by `V2_TOOL_NAMES` instead of `slice(0, 15)`.
  - Restores court tools (`search_court_decisions`, `get_case_documents_chain`, `get_court_decision`) and logs a warning if any whitelisted tool is missing.

- **Refactors**
  - Extracted the v2 whitelist to `mcp_backend/src/api/curated-mcp-tools.ts` and reused it across both transports.
  - Added `mcp_backend/src/api/__tests__/mcp-sse-tools-whitelist.test.ts` to verify curated tools are exposed and non-curated tools are filtered out.

<sup>Written for commit dcbc42c23d3ef8b0284ea6153de103ceee31fe4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

