### PR TITLE
fix(opendata): key EU sanctions by logicalId (dedupe refresh)

### DIFF
--- a/mcp_backend/src/scripts/import-eu-sanctions.ts
+++ b/mcp_backend/src/scripts/import-eu-sanctions.ts
@@ -34,7 +34,9 @@ const at = (o: any, name: string): string | null => {
 const firstNonNull = (arr: (string | null)[]): string | null => arr.find(x => x) ?? null;
 
 function mapEntity(e: any): any[] | null {
-  const entityId = at(e, 'euReferenceNumber') || at(e, 'logicalId');
+  // Key by logicalId to match the existing rows (the original loader used logicalId,
+  // e.g. "1003"); fall back to euReferenceNumber only when logicalId is absent.
+  const entityId = at(e, 'logicalId') || at(e, 'euReferenceNumber');
   if (!entityId) return null;
 
   const subjectType = asArray(e.subjectType)[0];


### PR DESCRIPTION
The EU refresh (#2111/#2112) keyed by euReferenceNumber while existing rows use logicalId, so it doubled the table (5,864 old + 5,994 new dupes). Key by logicalId to update in place. The EU.%-keyed dupes are deleted before re-running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix EU sanctions import to key records by `logicalId` (with fallback to `euReferenceNumber`) so existing rows update in place instead of creating duplicates. This addresses the duplicate rows from the recent EU refresh; `EU.%`-keyed dupes will be removed before re-running the import.

<sup>Written for commit 3413e11cb93d547c94ac927c343515d7bc53a870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

