### PR TITLE
fix(opendata): correct securities owners column mapping

### DIFF
--- a/mcp_backend/src/scripts/import-securities-owners-datagov.ts
+++ b/mcp_backend/src/scripts/import-securities-owners-datagov.ts
@@ -6,7 +6,9 @@
  * semicolon-delimited, 15 positional columns:
  *   0 report_date  1 issuer_edrpou  2 issuer_name  3 isin  4 owner_edrpou
  *   5 owner surname / entity name  6 owner first name  7 owner patronymic
- *   8 country_code  9 -  10 code  11 share_percent  12 nominal_per_share  13 nominal_value  14 -
+ *   8 depositor_type_code  9 owner_reg_id  10 security_type  11 nominal_value_per_share
+ *   12 share_percent (частка в статутному капіталі)  13 share_count (кількість акцій)
+ *   14 country_code (країна реєстрації власника)
  *
  * The full raw row is preserved in raw_data; upsert matches the existing unique index.
  *
@@ -91,10 +93,10 @@ function mapRow(c: string[], reportDateFallback: string | null): any | null {
     owner_name: ownerName,
     owner_name_alt: null,
     owner_type: ownerEdrpou ? 'legal' : 'individual',
-    share_percent: numFit(toNum(c[11]), 1e6),   // numeric(10,4) → |x| < 1e6
-    nominal_value: numFit(toNum(c[13]), 1e16),   // numeric(18,2) → |x| < 1e16
-    share_count: null as number | null,
-    country_code: toInt(c[8]),
+    share_percent: numFit(toNum(c[12]), 1e6),   // col12 частка, numeric(10,4) → |x| < 1e6
+    nominal_value: numFit(toNum(c[11]), 1e16),   // col11 номінальна вартість, numeric(18,2)
+    share_count: (v => (v == null ? null : Math.round(v)))(toNum(c[13])),  // col13 кількість акцій (bigint)
+    country_code: toInt(c[14]),                  // col14 країна реєстрації
     raw_data: c,
   };
 }
@@ -126,7 +128,8 @@ async function insertBatch(rows: any[]): Promise<number> {
     DO UPDATE SET
       issuer_name = EXCLUDED.issuer_name, isin_code = EXCLUDED.isin_code,
       owner_type = EXCLUDED.owner_type, share_percent = EXCLUDED.share_percent,
-      nominal_value = EXCLUDED.nominal_value, country_code = EXCLUDED.country_code,
+      nominal_value = EXCLUDED.nominal_value, share_count = EXCLUDED.share_count,
+      country_code = EXCLUDED.country_code,
       raw_data = EXCLUDED.raw_data, imported_at = NOW()
   `;
   const res = await pool.query(sql, values);


### PR DESCRIPTION
The nssmc-001 importer mis-indexed columns: share_percent read col11 (nominal value per share) and country_code read col8 (depositor-type code) — producing bogus values (e.g. 300000% share). Per the CSV header the layout is col11 nominal, col12 частка(%), col13 кількість акцій, col14 країна. Corrected indices + populate share_count. Re-run corrects all rows in place via ON CONFLICT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect column mapping in the NSSMC securities owners importer. Restores accurate share_percent and country_code and adds share_count; re-running updates existing rows in place.

- **Bug Fixes**
  - Map per CSV header: col11 nominal_value_per_share, col12 share_percent, col13 share_count, col14 country_code.
  - Populate share_count and include it in the ON CONFLICT update to correct existing records on re-import.

<sup>Written for commit c477b49b855359d6e2c6bba7759d4ed941790722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

