### PR TITLE
fix(legislation): merge split dash-article headers (КК shape) (LEXAI-1821)

### DIFF
--- a/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-superscript.test.ts
+++ b/mcp_backend/src/adapters/__tests__/rada-legislation-adapter-superscript.test.ts
@@ -92,3 +92,56 @@ describe('RadaLegislationAdapter — superscript dash-index units (LEXAI-1821)',
     expect(art297_1.full_text).not.toContain('rvts37');
   });
 });
+
+describe('RadaLegislationAdapter — split dash-article headers (КК shape, LEXAI-1821)', () => {
+  // Verbatim from the stored HTML of КК (2341-14): the header of a dash article is
+  // SPLIT across three spans — the number span closes BEFORE the superscript index:
+  //   <span class=rvts9>Стаття 111</span><sup-markup>-2</sup-markup><span class=rvts9>.</span> Пособництво…
+  // so the article regex captured «111» and the «-2. …» tail fell into the body.
+  const supRaw = (n: string) => `<span class="rvts44"><span style="font-size:0px">-</span>${n}</span>`;
+
+  const KK_PRINT_HTML = `
+<!DOCTYPE html><html><head><title>Кримінальний кодекс України</title></head><body>
+<span class=rvts15>Розділ I </span><br><span class=rvts15>ЗЛОЧИНИ ПРОТИ ОСНОВ НАЦІОНАЛЬНОЇ БЕЗПЕКИ</span>
+<span class=rvts9>Стаття 109. Дії, спрямовані на насильницьку зміну ладу</span> Текст статті сто дев'ять достатньої довжини для фільтра.
+<span class=rvts9>Стаття 110. Посягання на територіальну цілісність</span> Текст статті сто десять достатньої довжини для фільтра.
+<span class=rvts9>Стаття 111.</span> Державна зрада
+<p class="rvps2"><a name="n722"></a> 1. Державна зрада, тобто діяння, умисно вчинене громадянином України на шкоду суверенітетові держави.</p>
+<span class=rvts9>Стаття 111</span>${supRaw('1')}<span class="rvts9">.</span> Колабораційна діяльність
+<p class="rvps2"><a name="n3900"></a> 1. Публічне заперечення громадянином України здійснення збройної агресії проти України є колабораційною діяльністю.</p>
+<span class=rvts9>Стаття 111</span>${supRaw('2')}<span class="rvts9">.</span> Пособництво державі-агресору
+<p class="rvps2"><a name="n3932"></a> 1. Умисні дії, спрямовані на допомогу державі-агресору (пособництво), вчинені з метою завдання шкоди Україні.</p>
+<span class=rvts9>Стаття 112. Посягання на життя державного діяча</span> Текст статті сто дванадцять достатньої довжини для фільтра.
+<span class=rvts9>Стаття 113. Диверсія</span> Текст статті сто тринадцять достатньої довжини для фільтра.
+</body></html>
+`;
+
+  let adapter: RadaLegislationAdapter;
+  let mockAxiosInstance: any;
+
+  beforeEach(() => {
+    mockAxiosInstance = { get: jest.fn() };
+    mockedAxios.create = jest.fn().mockReturnValue(mockAxiosInstance);
+    adapter = new RadaLegislationAdapter({} as any);
+    mockAxiosInstance.get.mockResolvedValue({ data: KK_PRINT_HTML });
+  });
+
+  test('split-header dash articles are extracted with their own numbers', async () => {
+    const { articles } = await adapter.fetchLegislation('2341-14');
+    const numbers = articles.map(a => a.article_number);
+
+    expect(numbers).toContain('111');
+    expect(numbers).toContain('111-1');
+    expect(numbers).toContain('111-2');
+
+    const zrada = articles.find(a => a.article_number === '111')!;
+    expect(zrada.full_text).toContain('Державна зрада');
+    expect(zrada.full_text).not.toContain('Колабораційна');
+
+    const collab = articles.find(a => a.article_number === '111-1')!;
+    expect(collab.full_text).toContain('колабораційною діяльністю');
+
+    const posobn = articles.find(a => a.article_number === '111-2')!;
+    expect(posobn.full_text).toContain('Пособництво');
+  });
+});

--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -197,10 +197,20 @@ export class RadaLegislationAdapter {
    * parsing so every downstream regex sees plain «297-1» / «16-1».
    */
   static normalizeSuperscriptIndexes(html: string): string {
-    return html.replace(
-      /<span[^>]*>\s*<span[^>]*font-size:\s*0(?:px)?[^>]*>\s*-\s*<\/span>\s*(\d+)\s*<\/span>/gi,
-      '-$1',
-    );
+    return html
+      .replace(
+        /<span[^>]*>\s*<span[^>]*font-size:\s*0(?:px)?[^>]*>\s*-\s*<\/span>\s*(\d+)\s*<\/span>/gi,
+        '-$1',
+      )
+      // Second pass (КК shape): the dash-article HEADER is split across spans — the
+      // number span closes BEFORE the superscript index, and the trailing dot (with or
+      // without the title) sits in its own span:
+      //   <span class=rvts9>Стаття 111</span>-1<span class=rvts9>. Title?</span>
+      // Merge it back into the single-span shape the article regex expects.
+      .replace(
+        /(Стаття\s+\d+)<\/span>(-\d+)<span[^>]*>\s*\.\s*([^<]*)<\/span>/gi,
+        '$1$2. $3</span>',
+      );
   }
 
   private extractArticles($: cheerio.CheerioAPI, radaId: string): LegislationArticle[] {


### PR DESCRIPTION
Second superscript shape (КК, verbatim from stored HTML): dash-article headers are split across three spans — number span closes before the `<sup>` index, dot/title in their own span. First-pass normalization flattened the index but the article regex still needed a single-span header; a second pass merges it back. Unlocks КК 111-1/111-2, КУпАП 173-2, ПКУ 297-1. TDD, adapter suites 68/68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of split dash-article headers in the Rada adapter (КК shape) so articles like 111-1 and 111-2 extract with correct titles and bodies. Adds a second normalization pass to merge the split spans (LEXAI-1821).

- **Bug Fixes**
  - Added a second pass in `normalizeSuperscriptIndexes` to merge split headers into a single span the article regex expects.
  - Unlocks extraction for: КК 111-1/111-2, КУпАП 173-2, ПКУ 297-1.
  - Added a KK-shaped HTML fixture and tests; adapter suites pass (68/68).

<sup>Written for commit 116e158bf59882194fd23fa22528671a44f507f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

