### PR TITLE
fix(opendata): bound securities share_percent to 0-100

### DIFF
--- a/mcp_backend/src/scripts/import-securities-owners-datagov.ts
+++ b/mcp_backend/src/scripts/import-securities-owners-datagov.ts
@@ -93,7 +93,7 @@ function mapRow(c: string[], reportDateFallback: string | null): any | null {
     owner_name: ownerName,
     owner_name_alt: null,
     owner_type: ownerEdrpou ? 'legal' : 'individual',
-    share_percent: numFit(toNum(c[12]), 1e6),   // col12 частка, numeric(10,4) → |x| < 1e6
+    share_percent: (v => (v != null && v >= 0 && v <= 100 ? v : null))(toNum(c[12])),  // col12 частка; a share % >100 signals a malformed/column-shifted source row → null
     nominal_value: numFit(toNum(c[11]), 1e16),   // col11 номінальна вартість, numeric(18,2)
     share_count: (v => (v == null ? null : Math.round(v)))(toNum(c[13])),  // col13 кількість акцій (bigint)
     country_code: toInt(c[14]),                  // col14 країна реєстрації


### PR DESCRIPTION
~0.23% of nssmc-001 rows are column-shifted (malformed source quoting), landing bogus values in the частка column (e.g. 987920%) that dominate min_share_percent search results. A share of capital can't exceed 100% — null out share_percent outside [0,100]; row still imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp securities owners share_percent to 0–100 during nssmc-001 import. Invalid percentages are set to null so malformed rows stop skewing min_share_percent results.

- **Bug Fixes**
  - Replace loose numeric fit with explicit [0,100] check; values outside range become null while the row still imports.

<sup>Written for commit 41aad827a35ca686324a3eea067b07f643ad7d3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

