### PR TITLE
fix(opendata): import nested-zip financial archives + widen key with period_month

### DIFF
--- a/mcp_backend/src/migrations/171_finstmt_period_month_key.sql
+++ b/mcp_backend/src/migrations/171_finstmt_period_month_key.sql
@@ -1,0 +1,11 @@
+-- Migration 171: widen the opendata_financial_statements unique key to include period_month.
+--
+-- The prior key (tin, period_year, form_type, c_doc_sub) did not distinguish the reporting
+-- period within a year, so a company's Q1 (month 3), half-year (6), 9-month (9) and annual (12)
+-- filings of the same form collapsed onto a single row. Include period_month so all periods
+-- coexist. Widening a unique key can only reduce collisions, so existing data stays valid.
+-- (New imports default a missing period_month to 0 to keep the key non-null and idempotent.)
+
+DROP INDEX IF EXISTS idx_finzvit_tin_year_form;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_finzvit_tin_year_month_form
+  ON opendata_financial_statements (tin, period_year, period_month, form_type, c_doc_sub);

--- a/mcp_backend/src/scripts/import-financial-statements.ts
+++ b/mcp_backend/src/scripts/import-financial-statements.ts
@@ -60,7 +60,7 @@ function parseFiling(buf: Buffer): any | null {
     c_doc_sub: cDocSub,
     c_doc_ver: tag(head, 'C_DOC_VER'),
     period_year: periodYear,
-    period_month: toInt(tag(head, 'PERIOD_MONTH')),
+    period_month: toInt(tag(head, 'PERIOD_MONTH')) ?? 0, // 0 = unknown; keeps the unique key non-null
     period_type: toInt(tag(head, 'PERIOD_TYPE')),
     c_reg: tag(head, 'C_REG'),
     c_raj: tag(head, 'C_RAJ'),
@@ -69,11 +69,31 @@ function parseFiling(buf: Buffer): any | null {
   };
 }
 
+/**
+ * Yield every XML payload inside a zip, recursing into nested `.zip` entries.
+ * The ДПС dumps come in two shapes: flat (outer zip → XML) and nested
+ * (outer zip → per-form inner zip → XML). The nested archives hold the main
+ * annual річні звіти, so both must be walked.
+ */
+function* collectXmls(zip: AdmZip): Generator<Buffer> {
+  for (const en of zip.getEntries()) {
+    if (en.isDirectory) continue;
+    const name = en.entryName.toLowerCase();
+    if (name.endsWith('.xml')) {
+      yield en.getData();
+    } else if (name.endsWith('.zip')) {
+      let inner: AdmZip;
+      try { inner = new AdmZip(en.getData()); } catch { continue; }
+      yield* collectXmls(inner);
+    }
+  }
+}
+
 async function insertBatch(rows: any[]): Promise<number> {
   if (rows.length === 0) return 0;
   const seen = new Set<string>();
   const deduped = rows.filter(r => {
-    const k = `${r.tin}|${r.period_year}|${r.form_type}|${r.c_doc_sub}`;
+    const k = `${r.tin}|${r.period_year}|${r.period_month}|${r.form_type}|${r.c_doc_sub}`;
     if (seen.has(k)) return false; seen.add(k); return true;
   });
   const values: any[] = [];
@@ -90,7 +110,7 @@ async function insertBatch(rows: any[]): Promise<number> {
       (tin, c_doc, c_doc_sub, c_doc_ver, period_year, period_month, period_type,
        c_reg, c_raj, form_type, raw_xml)
     VALUES ${ph.join(',')}
-    ON CONFLICT (tin, period_year, form_type, c_doc_sub) DO UPDATE SET
+    ON CONFLICT (tin, period_year, period_month, form_type, c_doc_sub) DO UPDATE SET
       c_doc = EXCLUDED.c_doc, c_doc_ver = EXCLUDED.c_doc_ver, period_month = EXCLUDED.period_month,
       period_type = EXCLUDED.period_type, c_reg = EXCLUDED.c_reg, c_raj = EXCLUDED.c_raj,
       raw_xml = EXCLUDED.raw_xml, imported_at = NOW()
@@ -115,12 +135,11 @@ async function main(): Promise<void> {
   let total = 0, parsed = 0, skipped = 0;
   let batch: any[] = [];
   for (const zp of zips) {
-    let entries: any[];
-    try { entries = new AdmZip(zp).getEntries(); } catch (e: any) { console.warn(`   ⚠️ ${path.basename(zp)}: ${e.message}`); continue; }
-    for (const en of entries) {
-      if (en.isDirectory || !/\.xml$/i.test(en.entryName)) continue;
+    let zip: AdmZip;
+    try { zip = new AdmZip(zp); } catch (e: any) { console.warn(`   ⚠️ ${path.basename(zp)}: ${e.message}`); continue; }
+    for (const xmlBuf of collectXmls(zip)) {
       let row: any = null;
-      try { row = parseFiling(en.getData()); } catch { /* skip corrupt */ }
+      try { row = parseFiling(xmlBuf); } catch { /* skip corrupt */ }
       if (!row) { skipped++; continue; }
       parsed++;
       batch.push(row);


### PR DESCRIPTION
## Problem (found by consistency/completeness analysis)

The finrep import captured only **~35% of the source**: 502,611 distinct rows, **2022-2023 only**, missing the main annual reports.

**Root cause:** 21 of 39 finrep archives are *nested* (outer.zip → per-form inner.zip → XML). The importer only read flat top-level `.xml` entries, so it silently skipped **~712,144 filings** — including **all main annual річні звіти 2021-2025** (one 2025 archive alone = 577,986) and every Q1/half-year/9-month.

The misleading `0 skipped` count came from filtering `.zip` entries out *before* the skip counter.

## Fix

- `collectXmls()` recurses into nested `.zip` entries (handles both flat and nested shapes).
- **Migration 171** widens the unique key to `(tin, period_year, period_month, form_type, c_doc_sub)`. The old key omitted the period, so Q1(3)/half(6)/9-month(9)/annual(12) filings of the same form collapsed onto one row. `period_month` defaults to 0.

## Verification

- On prod: the i-kv_26 (Q1 2026) nested archive now yields month=3 filings (3000/3000 parsed) that were previously absent entirely.

## After merge

Re-run `import-financial-statements.ts` (full ~1.43M XML, background) → adds ~712K filings incl. the annual reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the finrep importer to read nested `.zip` archives and adds `period_month` to the unique key to prevent period collisions. Restores ~712k missing filings, including annual reports (2021–2025) and interim periods.

- **Bug Fixes**
  - Recursively read nested `.zip` entries to collect all XMLs (handles flat and nested archives).
  - Include `period_month` in the in-memory dedup key and `ON CONFLICT` clause; default `period_month` to 0 when absent.

- **Migration**
  - Apply Migration 171 to create a unique index on `(tin, period_year, period_month, form_type, c_doc_sub)`.
  - Re-run `import-financial-statements.ts` for a full backfill to ingest the previously skipped filings.

<sup>Written for commit b706f48844528d26d132dcd2f43e601e321146b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

