### PR TITLE
fix(nazk): fill name_uk for non-person sanctions categories via key fallback

### DIFF
--- a/mcp_backend/src/scripts/import-nazk-war-sanctions.ts
+++ b/mcp_backend/src/scripts/import-nazk-war-sanctions.ts
@@ -32,10 +32,42 @@ const pool = new Pool({
   max: 5,
 });
 
+/**
+ * Extract a display name from a record's `fields`. The key differs by category:
+ *  - persons (7 cats)      → `Name` (array [uk, ru, en] or string)
+ *  - legal entities        → `Full name of legal entity`, else `Abbreviated name of the legal entity`
+ *  - vessels               → `Vessel name`
+ *  - stolen objects        → `Name:` (trailing colon)
+ * Values may be arrays or strings; we take the first non-empty entry.
+ */
+function pickString(v: any): string | null {
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      const s = pickString(item);
+      if (s) return s;
+    }
+    return null;
+  }
+  if (typeof v === 'string') {
+    const t = v.trim();
+    return t.length ? t : null;
+  }
+  return null;
+}
+
 function firstName(fields: any): string | null {
-  const n = fields?.Name;
-  if (Array.isArray(n)) return n[0] || null;
-  if (typeof n === 'string') return n;
+  if (!fields) return null;
+  const keys = [
+    'Name',
+    'Full name of legal entity',
+    'Vessel name',
+    'Name:',
+    'Abbreviated name of the legal entity',
+  ];
+  for (const k of keys) {
+    const s = pickString(fields[k]);
+    if (s) return s;
+  }
   return null;
 }
 


### PR DESCRIPTION
## Problem
`import-nazk-war-sanctions.ts` `firstName()` read only `fields.Name`. Persons use `Name`, but the other 7 of 14 categories store the name under different keys, so **12,628 of 18,376** records (companies, vessels, stolen objects) had an empty `name_uk` and were invisible to `search_registry` name lookups. No data was lost — everything is in the `fields` jsonb.

## Fix
Extend name extraction with a fallback chain over the actual per-category keys (first non-empty):
`Name` -> `Full name of legal entity` -> `Vessel name` -> `Name:` -> `Abbreviated name of the legal entity`, handling array-or-string values.

Verified key names against the live jsonl for all 14 categories.

## Reimport
Idempotent: upsert on `(category, source_id)` refreshes `name_uk` from `fields`. Prod reimport run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes name extraction in the NAZK sanctions importer by adding a fallback over category-specific keys, restoring `name_uk` for non-person records and making 12,628 entries searchable again.

- **Bug Fixes**
  - Added fallback keys for name extraction: `Name` -> `Full name of legal entity` -> `Vessel name` -> `Name:` -> `Abbreviated name of the legal entity`.
  - Handle array or string values by picking the first non-empty value.
  - Populates `name_uk` for companies, vessels, and stolen objects so they appear in `search_registry`.

- **Migration**
  - Idempotent reimport: upsert on `(category, source_id)` refreshes `name_uk` from `fields`.
  - Run `import-nazk-war-sanctions.ts` in production to backfill.

<sup>Written for commit d29419158deb72916600a6994311e0ce9f434170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

