### PR TITLE
fix(amcu): validate/repair dates so malformed source values don't drop whole files

### DIFF
--- a/mcp_backend/src/scripts/import-amcu-bid-rigging.ts
+++ b/mcp_backend/src/scripts/import-amcu-bid-rigging.ts
@@ -48,14 +48,28 @@ function cellText(v: any): string | null {
   return String(v).trim() || null;
 }
 
+/**
+ * Return YYYY-MM-DD only if (y, m, d) is a real calendar date, else null. This guards
+ * the DB insert: some source files carry malformed dates (e.g. "2020-29-05") that would
+ * otherwise fail the whole batch and drop an entire file.
+ */
+function isoIfValid(y: number, m: number, d: number): string | null {
+  if (y < 1900 || y > 2100) return null;
+  const leap = y % 4 === 0 && (y % 100 !== 0 || y % 400 === 0);
+  const dim = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  if (m < 1 || m > 12 || d < 1 || d > dim[m - 1]) return null;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${y}-${pad(m)}-${pad(d)}`;
+}
+
 function toDate(v: any): string | null {
   if (v instanceof Date) return v.toISOString().slice(0, 10);
   const s = cellText(v);
   if (!s) return null;
-  let m = s.match(/(\d{2})[.\/](\d{2})[.\/](\d{4})/); // dd.mm.yyyy
-  if (m) return `${m[3]}-${m[2]}-${m[1]}`;
-  m = s.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  let m = s.match(/(\d{1,2})[.\/](\d{1,2})[.\/](\d{4})/); // d.m.yyyy
+  if (m) return isoIfValid(+m[3], +m[2], +m[1]);
+  m = s.match(/^(\d{4})-(\d{1,2})-(\d{1,2})/); // yyyy-m-d (some files store yyyy-d-m)
+  if (m) return isoIfValid(+m[1], +m[2], +m[3]) ?? isoIfValid(+m[1], +m[3], +m[2]);
   return null;
 }
 


### PR DESCRIPTION
## Problem
Follow-up to #2125. Once the importer reads `DateOfDecision` from PascalCase files, ~10 source files (2021 weeklies + `zvb001-1.xls`) turn out to carry malformed dates such as `2020-29-05` (month = 29; the file actually stores `YYYY-DD-MM`). The old `toDate()` passed these through unchanged, so Postgres rejected the whole 500-row batch and the per-file `try/catch` skipped the **entire file** — leaving ~16,500 rows with NULL `entity_name`.

## Fix
Route every date parse through `isoIfValid(y, m, d)`, which returns a string only for a real calendar date; for ISO-form input it also tries the day/month swap that some АМКУ files use (`YYYY-DD-MM`). Malformed values become NULL instead of crashing the insert, so no file is dropped.

Idempotent re-import (upsert on `(source_file, row_num)`) backfills the previously-dropped files.

## Verification
`tsc --noEmit` in `mcp_backend`: 0 new errors (only the 3 pre-existing `core-loader.ts` errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard the AMCU bid‑rigging importer against malformed dates that previously caused whole-file drops. Dates are validated and repaired; bad values become NULL instead of failing the batch.

- **Bug Fixes**
  - Added `isoIfValid(y, m, d)` to return `YYYY-MM-DD` only for real calendar dates.
  - Routed `toDate()` through `isoIfValid`; supports `d.m.yyyy`, `yyyy-m-d`, and tries day/month swap for `YYYY-DD-MM`.
  - Prevents batch failures and file skips; re-import backfills via upsert on `(source_file, row_num)`.

<sup>Written for commit 4b5abea88413217dc1a7b111bad0ba66b958908a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

