### PR TITLE
fix(amcu): decode cp866 zip entry names for decision classification

### DIFF
--- a/mcp_backend/src/scripts/import-amcu-decisions.ts
+++ b/mcp_backend/src/scripts/import-amcu-decisions.ts
@@ -50,14 +50,32 @@ const pool = new Pool({
   max: 5,
 });
 
+// adm-zip decodes zip entry names as UTF-8, but legacy Ukrainian archives store
+// them in DOS cp866 when the UTF-8 general-purpose flag (bit 11) is unset, so
+// entryName comes out as mojibake. Re-decode the raw bytes from cp866 in that
+// case — used for CLASSIFICATION ONLY; doc_file keeps the raw entryName so the
+// upsert key stays stable. cp866 drops the Ukrainian і/ї/є/ґ (renders them as a
+// filler char), which is why kindOf matches on the lossy stem (р.?шен) below.
+const cp866 = new TextDecoder('ibm866');
+function displayName(en: any): string {
+  const flags = (en.header && typeof en.header.flags === 'number') ? en.header.flags : 0;
+  if (flags & 0x800) return en.entryName;
+  const raw: Buffer | undefined = en.rawEntryName;
+  if (raw && raw.some((b: number) => b >= 0x80)) {
+    try { return cp866.decode(raw); } catch { /* fall through to entryName */ }
+  }
+  return en.entryName;
+}
+
 function kindOf(name: string): string {
   const n = name.toLowerCase();
   // recommendations (latin translit + cyrillic)
   if (/rekomend|recomend|рекоменд/.test(n)) return 'rekomendatsii';
   // explicit index/list tokens
   if (/спис|перел|spisok|perelik/.test(n)) return 'list';
-  // decisions / orders (latin translit + cyrillic; рішення / розпорядження)
-  if (/рішен|ріше|рiше|розпорядж|розпоряд|rish|rise|rozpor/.test(n)) return 'rishennia';
+  // decisions / orders (latin translit + cyrillic). `р.?шен` tolerates the lossy
+  // і in cp866-decoded «рішення» (comes out as «р_шення»).
+  if (/р.?шен|розпор|rish|rise|rozpor/.test(n)) return 'rishennia';
   // bare latin "list" as a whole token only (avoid "listopad" = November)
   if (/(?:^|[_\-. (])list(?:[_\-. )]|$)/.test(n)) return 'list';
   return 'other';
@@ -293,9 +311,10 @@ async function main(): Promise<void> {
           const extracted = body != null;
           if (extracted) stats.docxOk++; else stats.docLegacy++;
           const df = `${f}!${en2}`;
+          const disp = displayName(en); // cp866-decoded name for classification (doc_file stays raw)
           await push({
-            archive_file: f, doc_file: df, doc_kind: kindOf(df),
-            decision_no: decisionNoOf(path.basename(en2)), decision_date: dateOf(df), body_text: body, extracted,
+            archive_file: f, doc_file: df, doc_kind: kindOf(disp),
+            decision_no: decisionNoOf(path.basename(disp)), decision_date: dateOf(disp), body_text: body, extracted,
           });
         }
       }


### PR DESCRIPTION
Closes the doc_kind='other' residual (505 rows) from the AMCU-decisions audit: in-zip entry names are DOS cp866 (no UTF-8 flag) → adm-zip mojibake → kindOf() never matched. Re-decode raw bytes from cp866 (native TextDecoder 'ibm866', no new dep) for classification only; doc_file keeps the raw name (stable upsert key, in-place update). Loosened рішення pattern to `р.?шен` since cp866 drops Ukrainian і. Verified on prod: ~792 entries reclassified other→rishennia/rekomendatsii.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassification of AMCU decision documents caused by cp866-encoded ZIP entry names without the UTF-8 flag. Decodes names for classification and relaxes the decision pattern, moving ~792 files out of "other" without changing stored filenames.

- **Bug Fixes**
  - Re-decode raw ZIP entry name bytes as cp866 using native TextDecoder ('ibm866') when `adm-zip` lacks the UTF-8 flag.
  - Use the decoded name only for classification/date/number; keep `doc_file` as the raw entry name to preserve the upsert key.
  - Loosen decision match to `р.?шен` to tolerate cp866 dropping the Ukrainian і.

<sup>Written for commit e437c7e1a4548192b9b95de331626bddadf07cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

