### PR TITLE
fix(monitoring): widen qdrant_edrsr scrape timeout (296M-vector /metrics)

### DIFF
--- a/deployment/prometheus/prometheus-prod.yml
+++ b/deployment/prometheus/prometheus-prod.yml
@@ -85,7 +85,10 @@ scrape_configs:
   # qdrant_edrsr.key, ignored by *.key in .gitignore; the rules loader only reads
   # *.yml so a .key file there is harmless).
   - job_name: qdrant_edrsr
-    scrape_interval: 30s
+    # /metrics generation for the ~296M-vector edrsr_serving collection takes
+    # ~8-12s, so give it a long timeout and a slower interval to avoid flapping.
+    scrape_interval: 60s
+    scrape_timeout: 30s
     metrics_path: /metrics
     authorization:
       type: Bearer


### PR DESCRIPTION
`/metrics` for `edrsr_serving` (~296M vectors) takes ~8-12s to generate. The initial job used the default 10s `scrape_timeout` (observed a 7.56s scrape) — too little headroom, would flap under load and produce false "down"/gaps on the very dashboard meant to watch errors.

Change: `scrape_interval: 60s`, `scrape_timeout: 30s`.

Already applied+reloaded on prod via the monitoring path; target is `up`, metrics flowing (296,556,635 vectors, RSS 161.7 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase Prometheus scrape timeout and interval for `qdrant_edrsr` to stop flapping on the 296M‑vector `edrsr_serving` `/metrics` endpoint. Set `scrape_timeout: 30s` and `scrape_interval: 60s` to give the 8–12s generation time enough headroom and keep dashboards stable.

- **Bug Fixes**
  - Prevents false "down" alerts and gaps under load.
  - Reduces scrape pressure on the service.

<sup>Written for commit ec8aa8c23f9ee3797a112d7bf7d79fda20c428e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

