### PR TITLE
fix(monitoring): clean qdrant_edrsr dashboard endpoint labels

### DIFF
--- a/deployment/grafana/dashboards/09-qdrant-edrsr.json
+++ b/deployment/grafana/dashboards/09-qdrant-edrsr.json
@@ -548,12 +548,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum by (endpoint) (rate(rest_responses_total{job=\"qdrant_edrsr\"}[5m]))",
-          "legendFormat": "{{endpoint}}",
+          "expr": "label_replace(sum by (endpoint) (rate(rest_responses_total{job=\"qdrant_edrsr\"}[5m])), \"op\", \"$1\", \"endpoint\", \".*/(.+)\")",
+          "legendFormat": "{{op}}",
           "refId": "A"
         }
       ],
-      "description": "REST request rate broken down by endpoint"
+      "description": "REST request rate by operation (search/query/upsert/...)"
     },
     {
       "id": 11,
@@ -642,8 +642,8 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum by (endpoint) (rate(rest_responses_total{job=\"qdrant_edrsr\",endpoint=~\".*points/(search|query)\"}[5m]))",
-          "legendFormat": "{{endpoint}}",
+          "expr": "label_replace(sum by (endpoint) (rate(rest_responses_total{job=\"qdrant_edrsr\",endpoint=~\".*points/(search|query)\"}[5m])), \"op\", \"$1\", \"endpoint\", \".*/(.+)\")",
+          "legendFormat": "{{op}}",
           "refId": "A"
         },
         {
@@ -1040,12 +1040,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "sum by (endpoint,status) (rate(rest_responses_total{job=\"qdrant_edrsr\",status!~\"2..\"}[5m]))",
-          "legendFormat": "{{endpoint}} {{status}}",
+          "expr": "label_replace(sum by (endpoint,status) (rate(rest_responses_total{job=\"qdrant_edrsr\",status!~\"2..\"}[5m])), \"op\", \"$1\", \"endpoint\", \".*/(.+)\")",
+          "legendFormat": "{{op}} {{status}}",
           "refId": "A"
         }
       ],
-      "description": "Errors per second by endpoint and status"
+      "description": "Errors per second by operation and status"
     },
     {
       "id": 17,
@@ -1467,8 +1467,8 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "rest_responses_avg_duration_seconds{job=\"qdrant_edrsr\"}",
-          "legendFormat": "avg {{endpoint}}",
+          "expr": "label_replace(rest_responses_avg_duration_seconds{job=\"qdrant_edrsr\"}, \"op\", \"$1\", \"endpoint\", \".*/(.+)\")",
+          "legendFormat": "avg {{op}}",
           "refId": "A"
         },
         {
@@ -1476,12 +1476,12 @@
             "type": "prometheus",
             "uid": "Prometheus"
           },
-          "expr": "rest_responses_max_duration_seconds{job=\"qdrant_edrsr\",endpoint=~\".*points/(search|query)\"}",
-          "legendFormat": "max {{endpoint}}",
+          "expr": "label_replace(rest_responses_max_duration_seconds{job=\"qdrant_edrsr\",endpoint=~\".*points/(search|query)\"}, \"op\", \"$1\", \"endpoint\", \".*/(.+)\")",
+          "legendFormat": "max {{op}}",
           "refId": "B"
         }
       ],
-      "description": "Average duration per endpoint plus max read-path duration (spikes)"
+      "description": "Average duration per operation plus max read-path duration (spikes)"
     },
     {
       "id": 22,


### PR DESCRIPTION
Legends showed the raw Qdrant path template `/collections/{name}/points/search`. Now uses `label_replace` to show just the operation (`search`/`query`/`scroll`/`count`/`delete`/`upsert`/`index`) via an `{{op}}` legend. Verified against live prod Prometheus — labels resolve cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the Qdrant EDRSR Grafana dashboard legends to show operation names (search/query/scroll/count/delete/upsert/index) instead of full REST paths. Wrapped endpoint-grouped queries with `label_replace` and switched legends to `{{op}}` across request rate, query rate, non-2xx error rate, and avg/max duration panels.

<sup>Written for commit 3a3fbae076ecf9cb260a45e55aaba0cf6f6c7678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

