### PR TITLE
chore(citation-graph): LEXAI-1821 dash-article data-phase scripts

### DIFF
--- a/scripts/citation-graph/cleanup-bogus-transitional-points.sql
+++ b/scripts/citation-graph/cleanup-bogus-transitional-points.sql
@@ -1,0 +1,35 @@
+-- LEXAI-1821 cleanup: remove bogus 'п.*' rows produced by the reference-cut transitional
+-- boundary (both tonight's and the ORIGINAL import era — the bug is as old as the page's
+-- «споживче кредитування» reference). The fixed refetch saved each act in ONE transaction,
+-- so every legit row shares that txn timestamp; anything older is stale.
+\timing on
+SET statement_timeout='1800s';
+BEGIN;
+
+CREATE TEMP TABLE fixed_ts AS
+  SELECT legislation_id, max(updated_at) AS ts
+  FROM legislation_articles
+  WHERE legislation_id IN (641, 645, 653)
+  GROUP BY 1;
+SELECT * FROM fixed_ts;
+
+CREATE TEMP TABLE stale AS
+  SELECT la.id, la.legislation_id, la.article_number
+  FROM legislation_articles la
+  JOIN fixed_ts f ON f.legislation_id = la.legislation_id
+  WHERE la.is_current AND la.article_number LIKE 'п.%'
+    AND la.updated_at < f.ts - interval '2 minutes';
+SELECT legislation_id, count(*) AS stale_rows FROM stale GROUP BY 1;
+
+-- lcl rows bound to soon-deleted articles → honest unresolved (re-resolve follows)
+UPDATE legislation_citation_links l
+SET resolved=false, article_id=NULL, article_number=NULL, unresolved_reason='article_not_found'
+WHERE l.article_id IN (SELECT id FROM stale);
+
+DELETE FROM legislation_articles WHERE id IN (SELECT id FROM stale);
+
+SELECT legislation_id, count(*) AS remaining_pt_rows
+FROM legislation_articles
+WHERE legislation_id IN (641, 645, 653) AND is_current AND article_number LIKE 'п.%'
+GROUP BY 1;
+COMMIT;

--- a/scripts/citation-graph/export-statute-dash-layer.sql
+++ b/scripts/citation-graph/export-statute-dash-layer.sql
@@ -1,0 +1,15 @@
+\timing on
+SET statement_timeout='1800s';
+SET work_mem='2GB';
+-- LEXAI-1821 Neo4j top-up: statute dash-article layer (КК 111-1 колабораціонізм,
+-- КУпАП 173-2 домашнє насильство, ПКУ 297-1, …). Resolved id-keyed, matching the
+-- PR #2070 Article schema (art_id = legislation_articles.id as string).
+CREATE TEMP TABLE sd AS
+  SELECT l.doc_id, l.article_id, l.legislation_id, l.article_number
+  FROM legislation_citation_links l
+  WHERE l.resolved AND l.article_id IS NOT NULL
+    AND l.article_number LIKE '%-%' AND l.article_number NOT LIKE 'п.%';
+SELECT count(*) AS edges, count(DISTINCT article_id) AS articles, count(DISTINCT doc_id) AS decisions FROM sd;
+
+\copy (SELECT s.article_id, s.legislation_id, la.article_number, replace(coalesce(la.title,''), E'\n',' ') AS title, count(*) AS total_citations, count(DISTINCT s.doc_id) AS unique_decisions FROM sd s JOIN legislation_articles la ON la.id = s.article_id GROUP BY 1,2,3,4) TO '/tmp/statute_dash_articles.csv' CSV
+\copy (SELECT DISTINCT doc_id, article_id FROM sd) TO '/tmp/statute_dash_cites.csv' CSV

--- a/scripts/citation-graph/resolve-dash-articles.sql
+++ b/scripts/citation-graph/resolve-dash-articles.sql
@@ -1,0 +1,24 @@
+-- LEXAI-1821 — incremental resolve of statute citations to newly imported dash articles
+-- (КК 111-1/111-2/…, КУпАП 173-2/…, ПКУ 19-1/38-1/297-1/…).
+\timing on
+SET statement_timeout='1800s';
+BEGIN;
+CREATE TEMP TABLE best AS
+  SELECT DISTINCT ON (legislation_id, article_number) legislation_id AS lid, article_number, id AS aid
+  FROM legislation_articles
+  WHERE article_number LIKE '%-%' AND article_number NOT LIKE 'п.%'
+  ORDER BY legislation_id, article_number, is_current DESC, version_date DESC NULLS LAST;
+SELECT count(*) AS dash_targets FROM best;
+
+UPDATE legislation_citation_links l
+SET article_id = b.aid, article_number = b.article_number,
+    resolved = true, unresolved_reason = NULL
+FROM best b
+WHERE NOT l.resolved AND l.unresolved_reason = 'article_not_found'
+  AND l.legislation_id = b.lid
+  AND b.article_number = btrim(l.law_article_raw);
+
+SELECT 'newly resolved dash-article citations' AS what, count(*) FROM legislation_citation_links l
+JOIN best b ON b.aid = l.article_id
+WHERE l.resolved AND l.article_number LIKE '%-%' AND l.article_number NOT LIKE 'п.%';
+COMMIT;


### PR DESCRIPTION
Reproducibility record for the prod data operations behind LEXAI-1821 (parser fixes #2107/#2119/#2121/#2123 re-imported dash units; these scripts cleaned the bogus 'п.*' rows, resolved ~4.7M statute dash citations, and exported the Neo4j top-up). Scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SQL scripts to reproduce the LEXAI-1821 data work: clean bogus 'п.*' transitional article rows, resolve dash-numbered statute citations, and export a Neo4j top-up keyed to Article IDs. Supports the parser fix re-imports (2107/2119/2121/2123), resolving ~4.7M citations and exporting 694 dash Article nodes for the live graph.

- **New Features**
  - cleanup-bogus-transitional-points.sql: remove stale 'п.%' rows and mark linked citations as unresolved for re-resolve.
  - resolve-dash-articles.sql: bind citations to current dash-numbered articles (e.g., КК 111-1, КУпАП 173-2, ПКУ 297-1).
  - export-statute-dash-layer.sql: export CSVs for Neo4j top-up (id-keyed to Article schema) with article and cite edges.

<sup>Written for commit 47005950350d40969e9aeac3c184f873158d3823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

