### PR TITLE
fix(deploy): regenerate qdrant_edrsr Prometheus key on every prod deploy

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -470,6 +470,11 @@ jobs:
           # Pull latest code and tags
           $SSH_CMD "git -C ${REMOTE_REPO} fetch origin main --tags && git -C ${REMOTE_REPO} reset --hard origin/main"
 
+          # Materialize the (gitignored) Prometheus bearer-token file for the
+          # bigbox EDRSR Qdrant scrape from .env.prod, so prometheus-prod always
+          # starts cleanly — a missing credentials_file aborts its startup.
+          $SSH_CMD "chmod +x ${REMOTE_REPO}/deployment/prometheus/ensure-qdrant-edrsr-key.sh && ${REMOTE_REPO}/deployment/prometheus/ensure-qdrant-edrsr-key.sh"
+
           # Write VERSION file with both versions
           $SSH_CMD "printf 'BACKEND_VERSION=%s\nFRONTEND_VERSION=%s\n' '${BACKEND_VERSION}' '${FRONTEND_VERSION}' > ${REMOTE_REPO}/VERSION"
 

--- a/deployment/prometheus/ensure-qdrant-edrsr-key.sh
+++ b/deployment/prometheus/ensure-qdrant-edrsr-key.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Materialize the Prometheus bearer-token file for the bigbox EDRSR Qdrant
+# scrape (job `qdrant_edrsr` in prometheus-prod.yml) from QDRANT_EDRSR_API_KEY
+# in deployment/.env.prod.
+#
+# Why this exists: the key file is a secret and is gitignored (*.key), so it is
+# NOT in the repo. Prometheus fails to START if a referenced credentials_file is
+# missing — so on a from-scratch prometheus-prod rebuild the whole monitoring
+# stack would be down. Running this on every deploy guarantees the file exists
+# and is readable by the in-container prometheus user (nobody) → mode 0644, to
+# match the sibling rule files.
+#
+# Idempotent and safe to run unconditionally. Never fails the deploy: if the env
+# var is absent it warns and exits 0 (an existing key file, if any, is left
+# untouched).
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+env_file="${here}/../.env.prod"
+key_file="${here}/rules/qdrant_edrsr.key"
+
+if [ ! -f "$env_file" ]; then
+  echo "::warning::${env_file} not found — leaving qdrant_edrsr.key untouched" >&2
+  exit 0
+fi
+
+# Extract the value and strip an optional single pair of surrounding quotes.
+key="$(grep -hE '^QDRANT_EDRSR_API_KEY=' "$env_file" | head -1 | cut -d= -f2- || true)"
+key="${key%\"}"; key="${key#\"}"
+key="${key%\'}"; key="${key#\'}"
+
+if [ -z "$key" ]; then
+  echo "::warning::QDRANT_EDRSR_API_KEY empty/missing in .env.prod — leaving qdrant_edrsr.key untouched" >&2
+  exit 0
+fi
+
+mkdir -p "${here}/rules"
+printf '%s' "$key" > "$key_file"
+chmod 644 "$key_file"
+echo "Wrote ${key_file} (${#key} bytes)"


### PR DESCRIPTION
## Problem
The Prometheus bearer-token file for the bigbox EDRSR Qdrant scrape (`job: qdrant_edrsr`) is a secret → gitignored (`*.key`) → lives only on prod, placed by hand. **Prometheus refuses to start if a referenced `credentials_file` is missing**, so a from-scratch `prometheus-prod` rebuild would bring down the entire monitoring stack (all dashboards, all alerts).

## Fix
- New `deployment/prometheus/ensure-qdrant-edrsr-key.sh` — materializes `prometheus/rules/qdrant_edrsr.key` from `QDRANT_EDRSR_API_KEY` in `.env.prod`, mode `0644` (readable by the in-container `nobody` user, matching sibling rule files). Idempotent; never fails the deploy (warns + exits 0 if the var/file is absent, leaving any existing key untouched).
- `deploy-prod.yml` calls it right after the `git reset --hard` in Deploy Preview, before any container starts.

## Verified
Script unit-tested for: unquoted value, double-quoted value (quotes stripped), missing var (safe no-op), missing `.env.prod` (safe no-op). Writes with no trailing newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures Prometheus always starts in prod by regenerating the `qdrant_edrsr` bearer-token file on each deploy. Prevents monitoring downtime when the gitignored credentials file is missing.

- **Bug Fixes**
  - Added `deployment/prometheus/ensure-qdrant-edrsr-key.sh` to write `prometheus/rules/qdrant_edrsr.key` from `QDRANT_EDRSR_API_KEY` in `.env.prod` (0644, idempotent, safe no-op if missing).
  - Invoked the script in `deploy-prod.yml` right after the `git reset` and before containers start.

<sup>Written for commit 212445011a3d30a276f3520f9adbcf3f7e5aafe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

