### PR TITLE
fix(registry): drop duplicate drs_sanctions + reject unknown filter keys

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -530,23 +530,10 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
   },
 
   // ── M&A / antitrust / sanctions demo sources (migration 169) ──────
-
-  drs_sanctions: {
-    title: 'Держреєстр санкцій (РНБО)',
-    description: "Пошук у Державному реєстрі санкцій України (РНБО). 24K суб'єктів: фізособи, юрособи, судна. Пошук за іменем/назвою, ідентифікатором (ЄДРПОУ/ІПН/паспорт), типом, статусом, громадянством.",
-    table: 'opendata_drs_sanctions',
-    selectColumns: 'subject_id, subject_type, subject_status, name, birth_date, identifiers, citizenships',
-    orderBy: 'name ASC NULLS LAST',
-    emptyMessage: "Суб'єктів санкцій не знайдено",
-    fields: [
-      { name: 'name', description: "Ім'я / назва суб'єкта (укр)", match: 'ilike', columns: ['name'] },
-      { name: 'identifier', description: 'Ідентифікатор: ЄДРПОУ / ІПН / номер паспорта', match: 'ilike_cast', columns: ['identifiers'] },
-      { name: 'alias', description: 'Псевдонім / транслітерація / рос. написання', match: 'ilike_cast', columns: ['aliases'] },
-      { name: 'subject_type', description: 'Тип: individual (фізособа), legal (юрособа), vessel (судно)', match: 'exact', columns: ['subject_type'] },
-      { name: 'subject_status', description: 'Статус: active, expired, excluded', match: 'exact', columns: ['subject_status'] },
-      { name: 'citizenship', description: 'Громадянство / країна', match: 'ilike_cast', columns: ['citizenships'] },
-    ],
-  },
+  // NOTE: РНБО sanctions are intentionally NOT here — that registry (opendata_drs_sanctions,
+  // same official ДРС source) is served by the openreyestr_search_rnbo_sanctions tool, which
+  // is refreshed from the same dump. Exposing a "Держреєстр санкцій (РНБО)" registry here too
+  // made the chat pick search_registry over the intended openreyestr path (duplicate entry).
 
   nazk_war_sanctions: {
     title: 'Війна і санкції (ГУР)',

--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -83,6 +83,15 @@ ${registryDescriptions}
       return this.wrapResponse(this.describeRegistry(registry, def));
     }
 
+    // Reject unknown filter keys with a helpful field list, instead of silently
+    // ignoring them (which returns misleadingly unfiltered results). The model then
+    // self-corrects — e.g. it guessed `company_name` where the field is `entity_name`.
+    const validNames = new Set(def.fields.map(f => f.name));
+    const unknown = Object.keys(filters).filter(k => !validNames.has(k));
+    if (unknown.length > 0) {
+      return this.wrapResponse(`Невідомі поля фільтра: ${unknown.join(', ')}. ${this.describeRegistry(registry, def)}`);
+    }
+
     for (const req of (def.requiredFields ?? [])) {
       if (!filters[req]) {
         return this.wrapResponse(`Обов'язковий параметр: ${req}. ${this.describeRegistry(registry, def)}`);


### PR DESCRIPTION
Follow-up to the prod chat smoke test:

1. **Remove drs_sanctions from search_registry catalog** — it duplicated the official ДРС source that openreyestr_search_rnbo_sanctions already serves (refreshed from the same dump, #2134). The smoke test showed the model picking search_registry(drs_sanctions) for РНБО queries instead of the intended openreyestr path. Table opendata_drs_sanctions stays as raw storage.

2. **Reject unknown filter keys** with a helpful field list instead of silently ignoring them (→ misleadingly unfiltered results). The smoke test showed the model guessing filters.company_name where the field is entity_name; it now self-corrects for any registry.

tsc clean; registry-search-tool.test.ts 25/25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the duplicate RNBO sanctions registry from `search_registry` and added strict filter-key validation to prevent misleading, unfiltered results.

- **Bug Fixes**
  - Dropped `drs_sanctions` from the catalog to avoid duplicate routing; RNBO is served via `openreyestr_search_rnbo_sanctions`. The `opendata_drs_sanctions` table remains as raw storage.
  - Unknown filter keys are now rejected with a message listing valid fields (e.g., fixes `company_name` vs `entity_name`).

<sup>Written for commit 6f93fd714e328a4f6fb4749c1e0a19292aa8d92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

