### PR TITLE
fix(monitoring): cache EDRSR Qdrant /metrics via sidecar so scrape stops flapping

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -899,7 +899,10 @@ jobs:
             # Restart monitoring if needed
             if [ "${MONITORING_CHANGED}" = "true" ]; then
               echo "=== Restarting monitoring services ==="
-              \$DC restart grafana-prod prometheus-prod 2>/dev/null || true
+              # Create the EDRSR metrics-cache sidecar if missing, and restart it
+              # so it re-reads the bind-mounted script on config changes.
+              \$DC up -d qdrant-edrsr-metrics-cache 2>/dev/null || true
+              \$DC restart qdrant-edrsr-metrics-cache grafana-prod prometheus-prod 2>/dev/null || true
             fi
 
             docker image prune -f

--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1448,6 +1448,41 @@ services:
           cpus: '0.1'
           memory: 64M
 
+  # Caching /metrics sidecar for the bigbox EDRSR Qdrant (WG 10.88.0.6:6333).
+  # Qdrant's /metrics for the ~296M-vector edrsr_serving collection takes far
+  # longer than any safe scrape timeout to generate (observed >240s), so
+  # Prometheus timed out and the dashboard flapped DOWN / "No data" despite a
+  # healthy Qdrant. This sidecar refreshes /metrics on a slow background loop and
+  # serves the last-good body to Prometheus instantly. Dependency-free Node
+  # stdlib script, bind-mounted — no image build. Holds the bearer key so
+  # Prometheus scrapes it without auth.
+  qdrant-edrsr-metrics-cache:
+    image: node:20-alpine
+    container_name: qdrant-edrsr-metrics-cache-prod
+    command: ['node', '/app/qdrant-edrsr-metrics-cache.js']
+    working_dir: /app
+    volumes:
+      - ./prometheus/qdrant-edrsr-metrics-cache.js:/app/qdrant-edrsr-metrics-cache.js:ro
+    environment:
+      UPSTREAM_URL: "http://10.88.0.6:6333/metrics"
+      QDRANT_EDRSR_API_KEY: "${QDRANT_EDRSR_API_KEY}"
+      REFRESH_INTERVAL_MS: "120000"
+      UPSTREAM_TIMEOUT_MS: "300000"
+      LISTEN_PORT: "9109"
+    networks:
+      - secondlayer-prod-network
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD', 'node', '-e', "require('http').get('http://localhost:9109/healthz',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: 96M
+
   node-exporter:
     image: prom/node-exporter:v1.7.0
     container_name: node-exporter-prod

--- a/deployment/prometheus/prometheus-prod.yml
+++ b/deployment/prometheus/prometheus-prod.yml
@@ -78,23 +78,22 @@ scrape_configs:
           service: qdrant
           environment: production
 
-  # Qdrant EDRSR — dedicated bigbox instance (r6i.8xlarge, WG 10.88.0.6:6333).
-  # Serves the edrsr_serving collection (~296M vectors). Its /metrics endpoint
-  # requires auth; Qdrant accepts "Authorization: Bearer <api-key>". The key lives
-  # in an untracked file mounted via the rules dir (deployment/prometheus/rules/
-  # qdrant_edrsr.key, ignored by *.key in .gitignore; the rules loader only reads
-  # *.yml so a .key file there is harmless).
+  # Qdrant EDRSR — dedicated bigbox instance (r6i.8xlarge, WG 10.88.0.6:6333),
+  # serving the edrsr_serving collection (~296M vectors). We DO NOT scrape Qdrant
+  # directly: its /metrics generation for this collection is I/O-bound over cold
+  # mmap'd segments and takes far longer than any safe scrape timeout (observed
+  # >240s, vs ~8-12s when first tuned) — so direct scrapes timed out and the
+  # dashboard flapped DOWN / "No data" despite a healthy Qdrant. Instead we scrape
+  # the qdrant-edrsr-metrics-cache sidecar, which refreshes /metrics on a slow
+  # background loop and serves the last-good body instantly. The sidecar holds the
+  # bearer key, so no auth is needed here. Freshness is alertable via the appended
+  # qdrant_edrsr_metrics_cache_{up,last_scrape_success,age_seconds} gauges.
   - job_name: qdrant_edrsr
-    # /metrics generation for the ~296M-vector edrsr_serving collection takes
-    # ~8-12s, so give it a long timeout and a slower interval to avoid flapping.
-    scrape_interval: 60s
-    scrape_timeout: 30s
+    scrape_interval: 30s
+    scrape_timeout: 10s
     metrics_path: /metrics
-    authorization:
-      type: Bearer
-      credentials_file: /etc/prometheus/rules/qdrant_edrsr.key
     static_configs:
-      - targets: ['10.88.0.6:6333']
+      - targets: ['qdrant-edrsr-metrics-cache:9109']
         labels:
           service: qdrant_edrsr
           environment: production

--- a/deployment/prometheus/qdrant-edrsr-metrics-cache.js
+++ b/deployment/prometheus/qdrant-edrsr-metrics-cache.js
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Caching /metrics sidecar for the bigbox EDRSR Qdrant instance.
+ *
+ * Why this exists
+ * ---------------
+ * Qdrant's /metrics endpoint for the ~296M-vector `edrsr_serving` collection
+ * takes far longer than any safe Prometheus scrape timeout to generate — it is
+ * I/O-bound scanning cold, mmap'd segments and was observed not completing even
+ * in 240s (vs ~8-12s when the scrape job was first tuned). Prometheus timed out
+ * at 30s on every scrape, marked `up{job=qdrant_edrsr}=0`, and the whole Grafana
+ * dashboard read DOWN / "No data" even though Qdrant itself was healthy and
+ * serving. Bumping the scrape timeout can't fix this: generation time is
+ * unbounded and variable, so the target flaps no matter the timeout.
+ *
+ * What this does
+ * --------------
+ * A tiny, dependency-free (Node stdlib only) HTTP server that:
+ *   - Refreshes the upstream Qdrant /metrics on a slow BACKGROUND loop, holding
+ *     an in-flight lock so at most one expensive fetch runs at a time.
+ *   - Serves the last-good cached body to Prometheus INSTANTLY on every scrape,
+ *     decoupling the (fast) scrape from the (slow) generation. The target stays
+ *     up; freshness is observable via the appended cache metrics below.
+ *
+ * It appends its own gauges so we can alert on staleness:
+ *   qdrant_edrsr_metrics_cache_up                        1 if a cached body exists
+ *   qdrant_edrsr_metrics_cache_last_scrape_success       1 if the last upstream fetch ok
+ *   qdrant_edrsr_metrics_cache_age_seconds               age of the cached body
+ *   qdrant_edrsr_metrics_cache_upstream_duration_seconds duration of last upstream fetch
+ *
+ * Config (env)
+ * ------------
+ *   UPSTREAM_URL           default http://10.88.0.6:6333/metrics
+ *   QDRANT_EDRSR_API_KEY   Bearer token for the upstream (required for real data)
+ *   REFRESH_INTERVAL_MS    default 120000 (2 min) — how often to try a refresh
+ *   UPSTREAM_TIMEOUT_MS    default 300000 (5 min) — hard cap on one upstream fetch
+ *   LISTEN_PORT            default 9109
+ */
+
+const http = require('http');
+const { URL } = require('url');
+
+const UPSTREAM_URL = process.env.UPSTREAM_URL || 'http://10.88.0.6:6333/metrics';
+const API_KEY = process.env.QDRANT_EDRSR_API_KEY || '';
+const REFRESH_INTERVAL_MS = parseInt(process.env.REFRESH_INTERVAL_MS || '120000', 10);
+const UPSTREAM_TIMEOUT_MS = parseInt(process.env.UPSTREAM_TIMEOUT_MS || '300000', 10);
+const LISTEN_PORT = parseInt(process.env.LISTEN_PORT || '9109', 10);
+
+const CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
+
+// Cache state.
+const cache = {
+  body: null,          // last-good upstream body (string)
+  fetchedAt: 0,        // ms epoch of last successful fetch
+  lastSuccess: false,  // whether the most recent fetch attempt succeeded
+  lastDurationMs: 0,   // duration of the most recent fetch attempt
+};
+let refreshing = false;
+
+function log(...args) {
+  console.log(new Date().toISOString(), '[edrsr-metrics-cache]', ...args);
+}
+
+/** Fetch the upstream /metrics once. Resolves with the body string. */
+function fetchUpstream() {
+  return new Promise((resolve, reject) => {
+    const u = new URL(UPSTREAM_URL);
+    const headers = {};
+    if (API_KEY) headers['Authorization'] = 'Bearer ' + API_KEY;
+
+    const req = http.get(
+      {
+        hostname: u.hostname,
+        port: u.port || 6333,
+        path: u.pathname + u.search,
+        headers,
+      },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume(); // drain
+          reject(new Error('upstream HTTP ' + res.statusCode));
+          return;
+        }
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+      }
+    );
+
+    req.setTimeout(UPSTREAM_TIMEOUT_MS, () => {
+      req.destroy(new Error('upstream timeout after ' + UPSTREAM_TIMEOUT_MS + 'ms'));
+    });
+    req.on('error', reject);
+  });
+}
+
+/** Background refresh with an in-flight lock so fetches never overlap. */
+async function refresh() {
+  if (refreshing) {
+    log('skip refresh — previous fetch still in flight');
+    return;
+  }
+  refreshing = true;
+  const started = Date.now();
+  try {
+    const body = await fetchUpstream();
+    cache.body = body;
+    cache.fetchedAt = Date.now();
+    cache.lastSuccess = true;
+    cache.lastDurationMs = Date.now() - started;
+    log('refresh ok:', body.length, 'bytes in', (cache.lastDurationMs / 1000).toFixed(1) + 's');
+  } catch (err) {
+    cache.lastSuccess = false;
+    cache.lastDurationMs = Date.now() - started;
+    log('refresh FAILED after', (cache.lastDurationMs / 1000).toFixed(1) + 's:', err.message,
+      '(serving last-good, age', ageSeconds() + 's)');
+  } finally {
+    refreshing = false;
+  }
+}
+
+function ageSeconds() {
+  return cache.fetchedAt ? Math.round((Date.now() - cache.fetchedAt) / 1000) : -1;
+}
+
+/** Self-metrics appended to every response so staleness is alertable. */
+function selfMetrics() {
+  const up = cache.body ? 1 : 0;
+  const ok = cache.lastSuccess ? 1 : 0;
+  const age = cache.fetchedAt ? Math.round((Date.now() - cache.fetchedAt) / 1000) : 0;
+  const dur = (cache.lastDurationMs / 1000).toFixed(3);
+  return [
+    '# HELP qdrant_edrsr_metrics_cache_up Whether a cached upstream /metrics body is available (1) or not (0).',
+    '# TYPE qdrant_edrsr_metrics_cache_up gauge',
+    'qdrant_edrsr_metrics_cache_up ' + up,
+    '# HELP qdrant_edrsr_metrics_cache_last_scrape_success Whether the most recent upstream fetch succeeded (1) or failed (0).',
+    '# TYPE qdrant_edrsr_metrics_cache_last_scrape_success gauge',
+    'qdrant_edrsr_metrics_cache_last_scrape_success ' + ok,
+    '# HELP qdrant_edrsr_metrics_cache_age_seconds Age of the cached upstream /metrics body in seconds.',
+    '# TYPE qdrant_edrsr_metrics_cache_age_seconds gauge',
+    'qdrant_edrsr_metrics_cache_age_seconds ' + age,
+    '# HELP qdrant_edrsr_metrics_cache_upstream_duration_seconds Duration of the most recent upstream fetch in seconds.',
+    '# TYPE qdrant_edrsr_metrics_cache_upstream_duration_seconds gauge',
+    'qdrant_edrsr_metrics_cache_upstream_duration_seconds ' + dur,
+    '',
+  ].join('\n');
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/healthz' || req.url === '/') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('ok\n');
+    return;
+  }
+  if (req.url.startsWith('/metrics')) {
+    let out = cache.body || '';
+    if (out && !out.endsWith('\n')) out += '\n';
+    out += selfMetrics();
+    res.writeHead(200, { 'Content-Type': CONTENT_TYPE });
+    res.end(out);
+    return;
+  }
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('not found\n');
+});
+
+server.listen(LISTEN_PORT, () => {
+  log('listening on :' + LISTEN_PORT, '| upstream', UPSTREAM_URL,
+    '| refresh', REFRESH_INTERVAL_MS + 'ms', '| timeout', UPSTREAM_TIMEOUT_MS + 'ms',
+    '| key', API_KEY ? 'set' : 'MISSING');
+  refresh(); // warm the cache immediately
+  setInterval(refresh, REFRESH_INTERVAL_MS);
+});


### PR DESCRIPTION
## Problem

The **Qdrant EDRSR — bigbox** Grafana dashboard shows `DOWN` / `No data` for the last several minutes, but **Qdrant itself is healthy** (`/readyz` instant, container up 10 days, serving searches, ~40% CPU, host load ~1.3).

Root cause: the scrape target flaps. `up{job="qdrant_edrsr"}=0`, `lastError: context deadline exceeded`, `scrape_duration` pinned at the 30s timeout. Qdrant's `/metrics` for the ~296M-vector `edrsr_serving` collection is **I/O-bound scanning cold mmap'd segments** (RAM 166/247 GB, ~20M major page faults) and takes **far longer than any safe scrape timeout to generate** — in a direct probe it did **not complete even at 240s**, vs the ~8–12s assumed when #2130 set the 30s timeout. Over the last hour only 15/61 scrapes succeeded.

Since generation time is unbounded and variable, **bumping the timeout can't fix it** (Prometheus also caps `scrape_timeout ≤ scrape_interval`, and overlapping slow scrapes serialize behind Qdrant's metrics path, compounding).

## Fix — caching sidecar

A tiny **dependency-free Node stdlib** sidecar (`qdrant-edrsr-metrics-cache`) that:
- refreshes upstream `/metrics` on a slow **background loop** with an in-flight lock (one expensive fetch at a time), and
- serves the **last-good** body to Prometheus **instantly** on every scrape.

This decouples the fast scrape from the slow generation, so the target stays `up`. Freshness stays observable/alertable via appended gauges: `qdrant_edrsr_metrics_cache_{up,last_scrape_success,age_seconds,upstream_duration_seconds}`.

### Changes
- `deployment/prometheus/qdrant-edrsr-metrics-cache.js` — the exporter. Bind-mounted into `node:20-alpine` (no image build, no CI matrix change). Holds the bearer key via `QDRANT_EDRSR_API_KEY` (already in `.env.prod`).
- `deployment/docker-compose.prod.yml` — new sidecar service on `secondlayer-prod-network` (96M mem, healthcheck).
- `deployment/prometheus/prometheus-prod.yml` — repoint `qdrant_edrsr` job from `10.88.0.6:6333` to `qdrant-edrsr-metrics-cache:9109`, drop `authorization`, tighten to 30s interval / 10s timeout.
- `.github/workflows/deploy-prod.yml` — bring up + restart the sidecar in the monitoring block.

## Verification
Validated locally against a mock slow (1.5s) upstream that fails every 3rd request:
- **Cold:** serves ~4ms, `cache_up=0`.
- **Warm:** serves **~2ms vs 1500ms upstream** → decoupled; body cached, `last_scrape_success=1`.
- **After an upstream failure:** still serves last-good body, `last_scrape_success=0` (alertable).

`node --check` clean; all three edited YAML files parse.

## Notes
- Editing `docker-compose.prod.yml` counts as `deployment/*`, so this triggers a full blue-green infra deploy (safe, one-time). The `qdrant_edrsr` job change also sets `MONITORING_CHANGED`, which now creates+restarts the sidecar and restarts Prometheus.
- The existing `ensure-qdrant-edrsr-key.sh` key materialization is now vestigial (Prometheus no longer reads the `.key` file) but harmless; left in place to minimize blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches Qdrant EDRSR `/metrics` behind a small sidecar so Prometheus scrapes stop timing out and the dashboard stays stable. The sidecar refreshes upstream in the background and serves the last-good body instantly.

- **Bug Fixes**
  - Added `qdrant-edrsr-metrics-cache` (Node stdlib) that fetches upstream with a single in-flight lock and exposes freshness gauges: `qdrant_edrsr_metrics_cache_{up,last_scrape_success,age_seconds,upstream_duration_seconds}`.
  - Pointed the `qdrant_edrsr` job to the sidecar and tightened scrape settings (30s interval, 10s timeout); removed auth from Prometheus since the sidecar holds the bearer key.
  - Added the sidecar to `docker-compose` (healthcheck, env, `secondlayer-prod-network`) and updated the deploy workflow to create/restart it with monitoring changes.

<sup>Written for commit e69b6d5d460fc8878a60ffc714c47cfb39cf60ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

