### PR TITLE
fix(ci): bump mobile CI Flutter to 3.44.4

### DIFF
--- a/.github/workflows/ci-mobile-release.yml
+++ b/.github/workflows/ci-mobile-release.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  FLUTTER_VERSION: '3.29.3'
+  FLUTTER_VERSION: '3.44.4'
   JAVA_VERSION: '17'
 
 jobs:


### PR DESCRIPTION
## Problem
Mobile release workflow failed on `flutter pub get`:
> Because secondlayer_mobile requires SDK version ^3.11.1, version solving failed. (current Dart 3.7.2)

`mobile/pubspec.yaml` requires Dart `^3.11.1`, but the workflow pinned **Flutter 3.29.3** (Dart 3.7.2).

## Fix
Bump `FLUTTER_VERSION` → **3.44.4** (Dart 3.12.2), the version the project targets locally. Satisfies `^3.11.1`.

Run: https://github.com/overthelex/secondlayer/actions/runs/28698760291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update mobile release CI to use Flutter 3.44.4 (Dart 3.12.2) to satisfy the project's Dart SDK constraint (^3.11.1) and fix `flutter pub get` version solving failures.

Bump `FLUTTER_VERSION` from 3.29.3 to 3.44.4 in `.github/workflows/ci-mobile-release.yml`.

<sup>Written for commit 6714e9886d8767ba40e201580993b0002477950d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

