### PR TITLE
feat(mcp): expose search_registry + OpenReyestr tools via external MCP (v2)

### DIFF
--- a/mcp_backend/src/api/curated-mcp-tools.ts
+++ b/mcp_backend/src/api/curated-mcp-tools.ts
@@ -33,4 +33,20 @@ export const V2_TOOL_NAMES = new Set<string>([
   'count_cases_by_party',
   'check_precedent_status',
   'get_citation_graph',
+  // Реєстри відкритих даних — local handler (ТМ/патенти, санкції, АМКУ, стенограми, фінзвітність)
+  'search_registry',
+  // Державні реєстри OpenReyestr — remote (proxied via getAllToolDefinitions on /api/v2/mcp).
+  // company/EDRPOU, beneficiaries, debtors, enforcement, bankruptcy, Prozorro, sanctions, ARMA, NAZK, notaries.
+  'openreyestr_get_by_edrpou',
+  'openreyestr_get_entity_details',
+  'openreyestr_search_entities',
+  'openreyestr_search_beneficiaries',
+  'openreyestr_search_debtors',
+  'openreyestr_search_enforcement_proceedings',
+  'openreyestr_search_bankruptcy_cases',
+  'openreyestr_search_prozorro',
+  'openreyestr_search_rnbo_sanctions',
+  'openreyestr_search_arma_seized_assets',
+  'openreyestr_search_nazk_declarations',
+  'openreyestr_search_notaries',
 ]);


### PR DESCRIPTION
The curated V2_TOOL_NAMES (external MCP clients via /api/v2/mcp and /sse) had only court + legislation tools — registry/due-diligence lookups and the new open-data registries were not reachable via the external MCP endpoint.

Adds `search_registry` (local) + 12 OpenReyestr tools (get_by_edrpou, get_entity_details, search_entities, search_beneficiaries, search_debtors, search_enforcement_proceedings, search_bankruptcy_cases, search_prozorro, search_rnbo_sanctions, search_arma_seized_assets, search_nazk_declarations, search_notaries).

OpenReyestr are remote (proxied) → surface on /api/v2/mcp (getAllToolDefinitions includes remote). On legacy /sse (local-only) they log as missing — acceptable. Mirrors the chat FIXED_V2_TOOLS set. tsc clean; whitelist test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `search_registry` and 12 OpenReyestr tools to external MCP v2 so clients can run due‑diligence and open‑data lookups. `search_registry` is local; OpenReyestr tools are remote and available via /api/v2/mcp.

- New Features
  - Added to `V2_TOOL_NAMES`: `search_registry`
  - Added OpenReyestr tools: `openreyestr_get_by_edrpou`, `openreyestr_get_entity_details`, `openreyestr_search_entities`, `openreyestr_search_beneficiaries`, `openreyestr_search_debtors`, `openreyestr_search_enforcement_proceedings`, `openreyestr_search_bankruptcy_cases`, `openreyestr_search_prozorro`, `openreyestr_search_rnbo_sanctions`, `openreyestr_search_arma_seized_assets`, `openreyestr_search_nazk_declarations`, `openreyestr_search_notaries`

<sup>Written for commit b1121d4cefeeefbb3c9c28c451eaa4d844e4c223. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

