### PR TITLE
fix(opendata-sync): point OPENREYESTR_URL at stable service alias

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -1673,7 +1673,7 @@ services:
       NODE_ENV: production
       BACKEND_URL: http://app-prod:3000
       BACKEND_API_KEY: ${SECONDARY_LAYER_KEYS:-}
-      OPENREYESTR_URL: http://openreyestr-app-prod:3005
+      OPENREYESTR_URL: http://app-openreyestr-prod:3005
       OPENREYESTR_API_KEY: ${OPENREYESTR_API_KEYS:-}
       HEALTH_PORT: "3010"
       TZ: Europe/Kiev


### PR DESCRIPTION
## Problem
`opendata-sync-prod` fails every НАІС import with:
```
[SYNC] FAIL: НАІС — … — Помилка з'єднання з openreyestr: getaddrinfo EAI_AGAIN openreyestr-app-prod
```
Its env was `OPENREYESTR_URL=http://openreyestr-app-prod:3005` — the **blue** `container_name`. Only the **green** color is active (`openreyestr-app-prod-green`), whose network alias is `app-openreyestr-prod`, so `openreyestr-app-prod` does not resolve. (НАЗК imports are fine — they go via `BACKEND_URL=http://app-prod:3000`.)

## Fix
Point `OPENREYESTR_URL` at the compose **service name** `app-openreyestr-prod:3005`, which is a color-stable alias (matches `depends_on: app-openreyestr-prod` and the `app-prod` convention). Resolves regardless of active blue/green color.

## Apply
Config-only change; takes effect when `opendata-sync-prod` is recreated by the deploy pipeline. Container is currently stopped (was stopped manually during investigation) — restart tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched `opendata-sync-prod` to use the stable service alias for OpenReyestr. Set `OPENREYESTR_URL` to `http://app-openreyestr-prod:3005` so DNS resolves across blue/green deploys and НАІС imports succeed.

<sup>Written for commit 0ca55e252107a25d78a3041c58e23f2fb02dd608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

