### PR TITLE
fix(monitoring): honor exporter service labels in aws_cost scrape job

### DIFF
--- a/deployment/prometheus/prometheus-prod.yml
+++ b/deployment/prometheus/prometheus-prod.yml
@@ -102,7 +102,11 @@ scrape_configs:
   # AWS costs (Cost Explorer) + API activity (CloudTrail) via aws-cost-exporter
   # sidecar. The exporter refreshes AWS APIs on slow background loops (CE hourly -
   # paid API, CloudTrail 15m) and serves last-good data, so scraping is cheap.
+  # honor_labels: the exporter's own service="<AWS service name>" label must win
+  # over the target's service label, otherwise per-service costs all collapse to
+  # service="aws_cost" (real names shoved into exported_service).
   - job_name: aws_cost
+    honor_labels: true
     scrape_interval: 60s
     scrape_timeout: 10s
     static_configs:


### PR DESCRIPTION
Лейбл `service: aws_cost` из static_configs перетирал собственный лейбл `service="<название AWS-сервиса>"` экспортера - в легендах дашборда везде было "aws_cost", а реальные названия уезжали в `exported_service`. `honor_labels: true` отдаёт приоритет лейблам экспортера; метрики без своего service-лейбла (тоталы, кредиты) по-прежнему получают service=aws_cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prometheus now honors the exporter `service` labels in the `aws_cost` scrape job, so per-service cost series show correct AWS service names in dashboards. Metrics without their own `service` label (totals, credits) continue to use `service=aws_cost`.

- **Bug Fixes**
  - Set `honor_labels: true` on the `aws_cost` job to let exporter labels win over `static_configs`’ `service: aws_cost`.

<sup>Written for commit f33367d668c9a79dd7aab3630f05e1b9ca5a3ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

