### PR TITLE
fix(edrsr): correct RTF \uNNNN fallback + control-symbol stripping in fulltext parsers

### DIFF
--- a/scripts/edrsr/download-and-import-2010-2013.py
+++ b/scripts/edrsr/download-and-import-2010-2013.py
@@ -56,6 +56,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -102,7 +104,8 @@ def convert_one_file(filepath_str: str) -> tuple[int, str] | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')

--- a/scripts/edrsr/download-and-import-2018-2019.py
+++ b/scripts/edrsr/download-and-import-2018-2019.py
@@ -43,6 +43,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -81,7 +83,8 @@ def convert_one_file(filepath_str: str) -> tuple[int, str] | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')

--- a/scripts/edrsr/download-and-import-fulltext.py
+++ b/scripts/edrsr/download-and-import-fulltext.py
@@ -36,6 +36,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 def remove_nested_group(text, keyword):
@@ -68,7 +70,8 @@ def rtf_to_text(filepath: Path) -> str | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')

--- a/scripts/edrsr/download-and-import-missing.py
+++ b/scripts/edrsr/download-and-import-missing.py
@@ -32,6 +32,25 @@ CONTAINER = "secondlayer-postgres-local"
 PGUSER = "secondlayer"
 PGDB = "secondlayer_local"
 MAX_RTF_SIZE = 50 * 1024 * 1024
+RTF_MAGIC = b'{\\rtf'
+
+
+def looks_like_rtf(data: bytes) -> bool:
+    """True only if the payload is a real RTF document.
+
+    The court registry frequently answers HTTP 200 with an HTML block/captcha/
+    error page instead of the RTF export. Those must NOT be treated as valid
+    decisions: if written to disk they poison the cache (a non-empty *.rtf that
+    is silently dropped at conversion and never re-downloaded)."""
+    return data[:32].lstrip()[:5] == RTF_MAGIC
+
+
+def file_is_valid_rtf(path: Path) -> bool:
+    try:
+        with open(path, 'rb') as fh:
+            return looks_like_rtf(fh.read(32))
+    except (IOError, OSError):
+        return False
 
 
 def decode_win1251_byte(match):
@@ -46,6 +65,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -88,9 +109,16 @@ def convert_one_file(filepath_str: str) -> tuple[int, str] | None:
     text = re.sub(r'\\par\b', '\n', text)
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
+    # \uN unicode: emit the char AND skip its \ucN fallback (default 1 char: a \'XX hex
+    # or a single plain char). These court RTFs use \uc1 with a letter fallback (always 'F') —
+    # not skipping it interleaves garbage after every Cyrillic char ("ПFОFСFТF").
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    # control SYMBOLS (backslash + non-letter) aren't caught by the control-word strip below:
+    # \~ = non-breaking space, \_ = non-breaking hyphen, \- = optional hyphen.
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
+    text = text.replace('\\\\', '\\').replace('\\{', '{').replace('\\}', '}')
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')
     text = text.replace('\r\n', '\n')
@@ -141,6 +169,7 @@ class Stats:
         self.downloaded = 0
         self.failed = 0
         self.skipped = 0
+        self.poisoned = 0
         self.start = time.time()
         self.lock = asyncio.Lock()
 
@@ -157,7 +186,7 @@ class Stats:
         pct = 100.0 * done / self.total if self.total else 0
         return (
             f"[{done:,}/{self.total:,}] ({pct:.1f}%) "
-            f"ok={self.downloaded:,} fail={self.failed:,} skip={self.skipped:,} | "
+            f"ok={self.downloaded:,} fail={self.failed:,} html={self.poisoned:,} skip={self.skipped:,} | "
             f"{rate:.0f}/s | ETA {eta/60:.0f}m"
         )
 
@@ -165,8 +194,16 @@ class Stats:
 async def download_one(session, doc_id, url, rtf_dir, stats, semaphore):
     outpath = rtf_dir / f"{doc_id}.rtf"
     if outpath.exists() and outpath.stat().st_size > 0:
-        await stats.inc('skipped')
-        return
+        # Only trust an on-disk file if it is a real RTF. A previously cached
+        # HTML error/block page must be discarded and re-downloaded, otherwise
+        # the decision is stuck missing forever.
+        if file_is_valid_rtf(outpath):
+            await stats.inc('skipped')
+            return
+        try:
+            outpath.unlink()
+        except OSError:
+            pass
 
     async with semaphore:
         for attempt in range(3):
@@ -174,9 +211,15 @@ async def download_one(session, doc_id, url, rtf_dir, stats, semaphore):
                 async with session.get(url, timeout=aiohttp.ClientTimeout(total=30)) as resp:
                     if resp.status == 200:
                         data = await resp.read()
-                        if data:
+                        if data and looks_like_rtf(data):
                             outpath.write_bytes(data)
                             await stats.inc('downloaded')
+                            return
+                        if data:
+                            # 200 but not RTF (HTML block/captcha/error). Do NOT
+                            # write it — leaving no file means future runs retry
+                            # instead of caching garbage.
+                            await stats.inc('poisoned')
                             return
                     elif resp.status == 429:
                         await asyncio.sleep(5 * (attempt + 1))
@@ -246,15 +289,25 @@ def process_year(year: int, args):
         print(f"  [{year}] Nothing to do!")
         return
 
-    # Step 2: Filter already on disk
+    # Step 2: Filter already on disk (only trust valid RTF; purge poisoned HTML)
     to_download = []
+    purged = 0
     for doc_id, url in items:
         p = rtf_dir / f"{doc_id}.rtf"
-        if not p.exists() or p.stat().st_size == 0:
-            to_download.append((doc_id, url))
+        if p.exists() and p.stat().st_size > 0 and file_is_valid_rtf(p):
+            continue
+        if p.exists():
+            try:
+                p.unlink()
+                purged += 1
+            except OSError:
+                pass
+        to_download.append((doc_id, url))
     on_disk = len(items) - len(to_download)
     if on_disk:
-        print(f"  [{year}] Already on disk: {on_disk:,}")
+        print(f"  [{year}] Already on disk (valid RTF): {on_disk:,}")
+    if purged:
+        print(f"  [{year}] Purged poisoned/empty files for re-download: {purged:,}")
     print(f"  [{year}] Downloading {len(to_download):,} RTFs ({args.workers} concurrent)...", flush=True)
 
     # Step 3: Download

--- a/scripts/edrsr/download-fulltext-gap-prod.py
+++ b/scripts/edrsr/download-fulltext-gap-prod.py
@@ -60,6 +60,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -133,7 +135,8 @@ def rtf_to_text(filepath: Path) -> str | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')

--- a/scripts/edrsr/import-fulltext-from-hdd.py
+++ b/scripts/edrsr/import-fulltext-from-hdd.py
@@ -41,6 +41,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -89,7 +91,8 @@ def convert_one(doc_id: int) -> tuple[int, str] | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')

--- a/scripts/edrsr/import-fulltext-parallel.py
+++ b/scripts/edrsr/import-fulltext-parallel.py
@@ -38,6 +38,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -75,7 +77,8 @@ def convert_one(doc_id: int) -> tuple[int, str] | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')

--- a/scripts/edrsr/import-rtf-fast.py
+++ b/scripts/edrsr/import-rtf-fast.py
@@ -36,6 +36,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ''
 
 
@@ -82,7 +84,8 @@ def convert_one(filepath: str) -> tuple[int, str] | None:
     text = re.sub(r'\\line\b', '\n', text)
     text = re.sub(r'\\tab\b', '\t', text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r'\\u(\d+)\??', decode_unicode, text)
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    text = text.replace('\\~', ' ').replace('\\_', '-').replace('\\-', '')  # RTF control symbols
     text = re.sub(r'\\[a-zA-Z]+-?\d*\s?', '', text)
     text = text.replace('{', '').replace('}', '')
     text = text.replace('\x00', '')


### PR DESCRIPTION
## Problem

The RTF→text converter shared (copy-pasted) across **all 8 EDRSR fulltext importers** mishandled two RTF constructs. This garbled ~7.3M stored decisions (2006-2012) and left control-symbol noise across the whole corpus (~70-90M rows). Surfaced by inspecting the stored full_text of real cases (doc_id 7695001 / 2010, 31953935 / 2013).

## Root cause

**1. `\uNNNN` unicode fallback not skipped.** RTF `\uN` unicode escapes carry a `\ucN` fallback character for legacy readers. These court RTFs use `\uc1` with a **letter fallback (always `F`)**. The old regex `\\u(\d+)\??` only consumed a `?` fallback, so `F` leaked in after every Cyrillic char:

```
ПFОFСFТFАFНFОFВFАF   (should be ПОСТАНОВА)
```

This also **broke search** — the whole run tokenizes as one lexeme, so `to_tsvector` never matches "постанова".

**2. Control symbols not stripped.** `\~` (nbsp), `\_` (nb-hyphen), `\-` (opt-hyphen) aren't matched by the control-word strip `\\[a-zA-Z]+`, so `\~` litter remained (`...року \~\~\~\~\~\~ м.Дружківка`). Display-only (search unaffected — `\` `~` are tsvector separators), but ugly.

## Fix

- `\u` regex → `\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?` — emit the char, skip its fallback (hex or plain).
- `decode_unicode` now handles signed 16-bit `\uN` (`code += 65536` when negative).
- Explicit `\~`→space, `\_`→`-`, `\-`→`` stripping.

Applied identically to all 8 converters:
`download-and-import-missing`, `download-and-import-fulltext`, `download-and-import-2010-2013`, `download-and-import-2018-2019`, `download-fulltext-gap-prod`, `import-rtf-fast`, `import-fulltext-parallel`, `import-fulltext-from-hdd`.

(`download-and-import-missing.py` also carries an earlier HTML-poison guard: don't cache HTTP-200 HTML block/captcha pages as `.rtf`.)

## Verification

Functionally tested `convert_one_file` on real registry RTFs:
- doc 7695001 → `№ 3-163\10 ПОСТАНОВА ІМЕНЕМ УКРАЇНИ 02 лютого 2010 року…` — `F_corrupt=False, has_backslash_tilde=False`
- doc 31953935 → `Справа № 3/229/60/2013 ПОСТАНОВА ІМЕНЕМ УКРАЇНИ…` — clean

All 8 files pass `py_compile`. Existing stored data on the working DB copy is being repaired/cleaned separately; this PR fixes the parser so **future downloads are clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RTF-to-text parsing across all EDRSR importers to properly decode `\uNNNN` escapes and strip control symbols, producing clean Ukrainian text and restoring search matches. Also prevents caching HTML error pages as `.rtf` and purges previously poisoned files.

- **Bug Fixes**
  - Unicode: skip `\ucN` fallback after `\u` (hex or plain), handle signed 16‑bit, using `\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?` across all 8 converters.
  - Control symbols: map `\~` to space, `\_` to `-`, remove `\-`.
  - Downloader hardening (`download-and-import-missing.py`): validate RTF magic before writing, count `html` in stats, and purge invalid cached files to force re‑download.

<sup>Written for commit 65a36e3d12cde85da5af3b3dc2af5d2bed38b7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

