### PR TITLE
feat(citation-graph): EDRSR Neo4j rebuild pipeline on Brev (full 135M corpus)

### DIFF
--- a/scripts/citation-graph/brev-departs-01-extract-windows.py
+++ b/scripts/citation-graph/brev-departs-01-extract-windows.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# =====================================================================
+# brev-departs-01-extract-windows.py   (runs ON brev, as postgres)
+# DEPARTS_FROM layer, step 1: extract Grand Chamber (Велика Палата ВС,
+# court_code=9951) "відступ" windows for LLM classification.
+#
+# Scope is tiny (~27K GC decisions), so we pull their fulltext by doc_id
+# (indexed) instead of scanning the 133M edrsr_fulltext. For each decision
+# whose text contains departure language, emit one JSONL record per
+# 'відступ' hit: a ±130/700 char window + a regex-guessed target case №.
+# The Bedrock Haiku pass (departs-02-classify.py, on prod) decides which
+# windows are real formal departures and pins the departed-from case.
+#
+#   sudo -u postgres python3 brev-departs-01-extract-windows.py \
+#       > /home/nvidia/citation-rebuild/gc_departs_windows.jsonl
+# =====================================================================
+import json, re, sys, psycopg2
+
+DSN = "dbname=edrsr_local"
+GC_COURT = "9951"
+PRE, POST = 130, 700
+
+# departure language: "відступ..." followed (nearby) by "висновк|правов"
+DEPART_RE = re.compile(r"відступ\w*", re.IGNORECASE)
+DEPART_CTX_RE = re.compile(r"відступ\w*[\s\S]{0,60}?(висновк|правов)", re.IGNORECASE)
+# obvious negatives: "не вбачає/відсутні підстав ... відступ"
+NEG_RE = re.compile(r"(не\s+вбача\w+|відсутн\w+\s+підстав\w*)[\s\S]{0,80}?відступ", re.IGNORECASE)
+# candidate departed-from case number: "№ 826/3858/18" / "справі № 580/6246/23"
+CASE_RE = re.compile(r"(?:№|справі\s+№)\s*(\d+/\d+/\d+(?:-[а-яіїєґA-Za-z0-9]+)?)", re.IGNORECASE)
+
+
+def main():
+    conn = psycopg2.connect(DSN)
+    conn.set_session(readonly=True)
+    cur = conn.cursor("gc_docs")          # server-side cursor
+    cur.itersize = 2000
+    # GC decisions + own case number + date, join fulltext by doc_id
+    cur.execute(f"""
+        SELECT d.doc_id, d.cause_num, d.adjudication_date, f.full_text
+        FROM edrsr_documents d
+        JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+        WHERE d.court_code = %s
+    """, (GC_COURT,))
+
+    n_docs = n_windows = 0
+    for doc_id, cause_num, adj_date, text in cur:
+        if not text or "відступ" not in text.lower():
+            continue
+        n_docs += 1
+        low = text
+        for m in DEPART_RE.finditer(low):
+            i = m.start()
+            window = text[max(0, i - PRE): i + POST]
+            if not DEPART_CTX_RE.search(window):
+                continue
+            neg = bool(NEG_RE.search(window))
+            cand = CASE_RE.search(window)
+            candidate = cand.group(1) if cand else None
+            # skip self-reference (departing from own case is meaningless)
+            if candidate and cause_num and candidate == cause_num:
+                continue
+            rec = {
+                "doc_id": doc_id,
+                "cause_num": cause_num,
+                "adj_date": adj_date.isoformat() if adj_date else None,
+                "candidate_case": candidate,
+                "likely_negative": neg,
+                "window": window,
+            }
+            print(json.dumps(rec, ensure_ascii=False))
+            n_windows += 1
+    sys.stderr.write(f"GC decisions with departure text: {n_docs}; windows emitted: {n_windows}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/citation-graph/brev-departs-03-load.sh
+++ b/scripts/citation-graph/brev-departs-03-load.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# =====================================================================
+# brev-departs-03-load.sh   (runs ON brev)
+# DEPARTS_FROM layer, step 3: load the LLM-confirmed Grand Chamber
+# departure edges (gc_departs.csv from departs-02-classify.py) into the
+# neo4j-citation graph as (:Decision)-[:DEPARTS_FROM {departed_on}]->(:Case).
+#
+# Prereqs: main graph already imported (Decision + Case nodes exist),
+# and gc_departs.csv (header: doc_id,departed_case,departed_on) copied to
+# /data/neo4j/import/gc_departs.csv.
+#
+#   bash brev-departs-03-load.sh
+#
+# doc_id and cause_num are STRING keys in the graph (CitationGraphService
+# binds String(docId)); MATCH both — never toInteger() (would spawn dup
+# nodes). Departures to a case not in the corpus are skipped (no Case node).
+# =====================================================================
+set -euo pipefail
+NEOPW="${NEOPW:-lexCitationBrev7j2026}"
+CONTAINER=neo4j-citation
+CSV=/data/neo4j/import/gc_departs.csv
+
+[ -f "$CSV" ] || { echo "missing $CSV — run departs-01/02 + relay first"; exit 1; }
+echo "rows in csv: $(( $(wc -l < "$CSV") - 1 ))"
+
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" <<'CYPHER'
+LOAD CSV WITH HEADERS FROM 'file:///gc_departs.csv' AS row
+CALL {
+  WITH row
+  MATCH (d:Decision {doc_id: row.doc_id})
+  MATCH (c:Case {cause_num: row.departed_case})
+  MERGE (d)-[r:DEPARTS_FROM]->(c)
+  SET r.departed_on = row.departed_on
+} IN TRANSACTIONS OF 2000 ROWS;
+CYPHER
+
+echo "=== DEPARTS_FROM count ==="
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" \
+  "MATCH ()-[r:DEPARTS_FROM]->() RETURN count(r) AS departs_from, count(DISTINCT endNode(r)) AS distinct_cases;"

--- a/scripts/citation-graph/brev-neo4j-01-build.sql
+++ b/scripts/citation-graph/brev-neo4j-01-build.sql
@@ -1,0 +1,111 @@
+-- =====================================================================
+-- brev-neo4j-01-build.sql   (runs ON brev host Postgres, db edrsr_local)
+-- Build the derived node/edge source tables for the RAW EDRSR citation
+-- graph, from the finalized lcc_final / cce_final staging (see
+-- local-rebuild-03-finalize.sql) + edrsr_documents.
+--
+-- RAW model (art_id = md5(law_number|law_article)) — matches the 391.9M
+-- CITES_ARTICLE graph that lived on bigbox/qdrant.lex. No legislation
+-- registry needed on brev.
+--
+-- Run (as postgres, peer auth):
+--   sudo -u postgres psql -d edrsr_local -v ON_ERROR_STOP=1 \
+--        -v min_dec=5 -f brev-neo4j-01-build.sql
+-- min_dec = noise filter: keep only articles cited by >= N distinct
+-- decisions (5 drops the ~18.7M junk "laws" + singleton tail; proven).
+-- =====================================================================
+
+\set ON_ERROR_STOP on
+\if :{?min_dec}
+\else
+  \set min_dec 5
+\endif
+
+SET work_mem = '4GB';
+SET maintenance_work_mem = '8GB';
+
+-- ---------------------------------------------------------------------
+-- 1. Article aggregate (RAW text keys). One row per (law_number, law_article).
+-- ---------------------------------------------------------------------
+DROP TABLE IF EXISTS nb_article;
+CREATE UNLOGGED TABLE nb_article AS
+SELECT md5(law_number || '|' || law_article)      AS art_id,
+       law_number,
+       law_article,
+       count(*)::bigint                            AS total_citations,
+       count(DISTINCT court_case_id)::bigint       AS unique_decisions
+FROM lcc_final
+GROUP BY law_number, law_article;
+
+CREATE UNIQUE INDEX uq_nb_article    ON nb_article (art_id);
+CREATE INDEX        idx_nb_article_kv ON nb_article (law_number, law_article);
+ANALYZE nb_article;
+
+-- Kept set: noise filter on unique_decisions.
+DROP TABLE IF EXISTS nb_article_kept;
+CREATE UNLOGGED TABLE nb_article_kept AS
+SELECT * FROM nb_article WHERE unique_decisions >= :min_dec;
+CREATE UNIQUE INDEX uq_nb_article_kept    ON nb_article_kept (art_id);
+CREATE INDEX        idx_nb_article_kept_kv ON nb_article_kept (law_number, law_article);
+ANALYZE nb_article_kept;
+
+-- ---------------------------------------------------------------------
+-- 2. Law nodes = distinct law_number among kept articles.
+-- ---------------------------------------------------------------------
+DROP TABLE IF EXISTS nb_law;
+CREATE UNLOGGED TABLE nb_law AS
+SELECT DISTINCT law_number FROM nb_article_kept;
+CREATE UNIQUE INDEX uq_nb_law ON nb_law (law_number);
+ANALYZE nb_law;
+
+-- ---------------------------------------------------------------------
+-- 3. edrsr_case_index — the Case dimension (cause_num) from edrsr_documents.
+--    latest_doc_id via ordered array_agg; member_count for the chain tool.
+-- ---------------------------------------------------------------------
+DROP TABLE IF EXISTS edrsr_case_index;
+CREATE UNLOGGED TABLE edrsr_case_index AS
+SELECT cause_num,
+       count(*)::int AS member_count,
+       (array_agg(doc_id ORDER BY adjudication_date DESC NULLS LAST, doc_id DESC))[1] AS latest_doc_id,
+       min(adjudication_date) AS first_date,
+       max(adjudication_date) AS last_date
+FROM edrsr_documents
+WHERE cause_num IS NOT NULL AND cause_num <> ''
+GROUP BY cause_num;
+CREATE UNIQUE INDEX uq_eci ON edrsr_case_index (cause_num);
+ANALYZE edrsr_case_index;
+
+-- ---------------------------------------------------------------------
+-- 4. case_citation_links — resolve cce_final.to_case_number -> cause_num.
+--    is_self_citation: cited case number == citing decision's own cause_num.
+--    (get_case_documents_chain / check_precedent_status source; Neo4j CITES_CASE
+--     loads only the resolved, non-self subset.)
+-- ---------------------------------------------------------------------
+DROP TABLE IF EXISTS case_citation_links;
+CREATE UNLOGGED TABLE case_citation_links AS
+SELECT c.from_case_id,
+       c.to_case_number,
+       (ci.cause_num IS NOT NULL)              AS resolved,
+       ci.latest_doc_id,
+       ci.member_count,
+       (fd.cause_num = c.to_case_number)       AS is_self_citation
+FROM cce_final c
+LEFT JOIN edrsr_case_index ci ON ci.cause_num = c.to_case_number
+LEFT JOIN edrsr_documents  fd ON fd.doc_id   = c.from_case_id;
+CREATE INDEX idx_ccl_from ON case_citation_links (from_case_id);
+CREATE INDEX idx_ccl_to   ON case_citation_links (to_case_number);
+ANALYZE case_citation_links;
+
+-- ---------------------------------------------------------------------
+-- Report: node/edge cardinalities for the neo4j-admin import.
+-- ---------------------------------------------------------------------
+SELECT 'Decision nodes (all edrsr_documents)' AS layer, count(*) AS n FROM edrsr_documents
+UNION ALL SELECT 'Article nodes (kept)',   count(*) FROM nb_article_kept
+UNION ALL SELECT 'Article nodes (raw, pre-filter)', count(*) FROM nb_article
+UNION ALL SELECT 'Law nodes',              count(*) FROM nb_law
+UNION ALL SELECT 'Case nodes',             count(*) FROM edrsr_case_index
+UNION ALL SELECT 'CITES_ARTICLE (kept)',   count(*) FROM lcc_final l JOIN nb_article_kept a USING (law_number, law_article)
+UNION ALL SELECT 'IN_CASE (all decisions with cause_num)', count(*) FROM edrsr_documents WHERE cause_num IS NOT NULL AND cause_num <> ''
+UNION ALL SELECT 'CITES_CASE (resolved, non-self)', count(*) FROM case_citation_links WHERE resolved AND NOT is_self_citation
+UNION ALL SELECT 'CITES_CASE self-cites (excluded)', count(*) FROM case_citation_links WHERE resolved AND is_self_citation
+UNION ALL SELECT 'case edges unresolved (case_not_in_corpus)', count(*) FROM case_citation_links WHERE NOT resolved;

--- a/scripts/citation-graph/brev-neo4j-02-export.sh
+++ b/scripts/citation-graph/brev-neo4j-02-export.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# =====================================================================
+# brev-neo4j-02-export.sh   (runs ON brev, as postgres via peer)
+# Export the RAW citation-graph node/edge tables built by
+# brev-neo4j-01-build.sql into neo4j-admin `import full` CSVs (header in
+# each file, gzip). Written into the Neo4j container import dir so
+# neo4j-admin can read them directly.
+#
+#   sudo -u postgres bash brev-neo4j-02-export.sh
+#
+# Notes:
+# - Header lines carry the neo4j-admin typing (:ID(space) / :START_ID / :END_ID
+#   / :long) so `import full` needs no per-column flags beyond --nodes/--relationships.
+# - PGOPTIONS disables mergejoin: on the big CITES_ARTICLE join, the planner
+#   otherwise picks a doomed ~400M external merge sort (memory gotcha). psql -q
+#   keeps "SET"/tag noise out of the CSV.
+# - COPY ... CSV quotes + escapes citation_context (OCR newlines) -> pair with
+#   neo4j-admin --multiline-fields=true on import.
+# =====================================================================
+set -euo pipefail
+
+DB=edrsr_local
+OUT=/data/neo4j/import                      # bind-mounted to the container's /import
+sudo mkdir -p "$OUT"; sudo chown postgres "$OUT" 2>/dev/null || true
+PG="psql -q -d $DB -v ON_ERROR_STOP=1"
+export PGOPTIONS='-c enable_mergejoin=off -c work_mem=4GB'
+
+emit () {  # emit <outfile.gz> <header> <copy-select-sql>
+  local f="$1" hdr="$2" sql="$3"
+  echo "  → $f"
+  { printf '%s\n' "$hdr"; $PG -c "COPY ($sql) TO STDOUT WITH (FORMAT csv)"; } | gzip -1 > "$OUT/$f"
+}
+
+echo "=== node exports ==="
+emit nodes_decision.csv.gz \
+  'doc_id:ID(Decision)' \
+  'SELECT doc_id FROM edrsr_documents'
+
+emit nodes_article.csv.gz \
+  'art_id:ID(Article),law_number,law_article,total_citations:long,unique_decisions:long' \
+  'SELECT art_id, law_number, law_article, total_citations, unique_decisions FROM nb_article_kept'
+
+emit nodes_law.csv.gz \
+  'law_number:ID(Law)' \
+  'SELECT law_number FROM nb_law'
+
+emit nodes_case.csv.gz \
+  'cause_num:ID(Case),member_count:long,latest_doc_id' \
+  'SELECT cause_num, member_count, latest_doc_id FROM edrsr_case_index'
+
+echo "=== relationship exports ==="
+emit rels_cites_article.csv.gz \
+  ':START_ID(Decision),:END_ID(Article),citation_type,citation_context' \
+  'SELECT l.court_case_id, a.art_id, l.citation_type, l.citation_context
+     FROM lcc_final l JOIN nb_article_kept a USING (law_number, law_article)'
+
+emit rels_of_law.csv.gz \
+  ':START_ID(Article),:END_ID(Law)' \
+  'SELECT art_id, law_number FROM nb_article_kept'
+
+emit rels_in_case.csv.gz \
+  ':START_ID(Decision),:END_ID(Case)' \
+  "SELECT doc_id, cause_num FROM edrsr_documents WHERE cause_num IS NOT NULL AND cause_num <> ''"
+
+emit rels_cites_case.csv.gz \
+  ':START_ID(Decision),:END_ID(Case),weight:long' \
+  'SELECT from_case_id, to_case_number, 1 FROM case_citation_links WHERE resolved AND NOT is_self_citation'
+
+echo "=== sizes ==="
+ls -lh "$OUT"/*.csv.gz

--- a/scripts/citation-graph/brev-neo4j-03-import.sh
+++ b/scripts/citation-graph/brev-neo4j-03-import.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# =====================================================================
+# brev-neo4j-03-import.sh   (runs ON brev)
+# Bulk-load the exported CSVs into the neo4j-citation graph via
+# `neo4j-admin database import full` (offline, ~minutes at this scale),
+# then restart the server and apply schema constraints/indexes.
+#
+#   bash brev-neo4j-03-import.sh
+#
+# neo4j-admin needs the DB stopped -> we stop the live container, run the
+# import in a throwaway container sharing the same data/import volumes,
+# then start the live container back up. --overwrite-destination wipes any
+# prior graph (fresh full rebuild).
+# =====================================================================
+set -euo pipefail
+
+NEOPW="${NEOPW:-lexCitationBrev7j2026}"
+DATADIR=/data/neo4j
+CONTAINER=neo4j-citation
+
+echo "=== stop live neo4j ==="
+docker stop "$CONTAINER"
+
+echo "=== neo4j-admin database import full (throwaway container) ==="
+docker run --rm \
+  -v $DATADIR/data:/data -v $DATADIR/import:/import -v $DATADIR/logs:/logs \
+  neo4j:5 \
+  neo4j-admin database import full \
+    --overwrite-destination \
+    --multiline-fields=true \
+    --skip-bad-relationships=true \
+    --skip-duplicate-nodes=true \
+    --bad-tolerance=5000000 \
+    --high-parallel-io=on \
+    --threads="$(nproc)" \
+    --nodes=Decision=/import/nodes_decision.csv.gz \
+    --nodes=Article=/import/nodes_article.csv.gz \
+    --nodes=Law=/import/nodes_law.csv.gz \
+    --nodes=Case=/import/nodes_case.csv.gz \
+    --relationships=CITES_ARTICLE=/import/rels_cites_article.csv.gz \
+    --relationships=OF_LAW=/import/rels_of_law.csv.gz \
+    --relationships=IN_CASE=/import/rels_in_case.csv.gz \
+    --relationships=CITES_CASE=/import/rels_cites_case.csv.gz \
+    neo4j
+
+echo "=== start live neo4j ==="
+docker start "$CONTAINER"
+
+echo "=== wait for boot ==="
+for i in $(seq 1 30); do
+  if docker exec "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" "RETURN 1;" >/dev/null 2>&1; then
+    echo "up after ${i}0s"; break; fi
+  sleep 10
+done
+
+echo "=== apply schema (constraints + indexes) ==="
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" <<'CYPHER'
+CREATE CONSTRAINT decision_doc_id IF NOT EXISTS FOR (d:Decision) REQUIRE d.doc_id IS UNIQUE;
+CREATE CONSTRAINT article_art_id  IF NOT EXISTS FOR (a:Article)  REQUIRE a.art_id IS UNIQUE;
+CREATE CONSTRAINT law_law_number  IF NOT EXISTS FOR (l:Law)      REQUIRE l.law_number IS UNIQUE;
+CREATE CONSTRAINT case_cause_num  IF NOT EXISTS FOR (c:Case)     REQUIRE c.cause_num IS UNIQUE;
+CREATE INDEX article_law_number   IF NOT EXISTS FOR (a:Article)  ON (a.law_number, a.law_article);
+CREATE INDEX cites_article_type   IF NOT EXISTS FOR ()-[r:CITES_ARTICLE]-() ON (r.citation_type);
+CYPHER
+
+echo "=== graph counts ==="
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" <<'CYPHER'
+MATCH (d:Decision) RETURN 'Decision' AS label, count(d) AS n
+UNION ALL MATCH (a:Article) RETURN 'Article', count(a)
+UNION ALL MATCH (l:Law) RETURN 'Law', count(l)
+UNION ALL MATCH (c:Case) RETURN 'Case', count(c);
+CYPHER
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" \
+  "MATCH ()-[r:CITES_ARTICLE]->() RETURN count(r) AS cites_article;"
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" \
+  "MATCH ()-[r:IN_CASE]->() RETURN count(r) AS in_case;"
+docker exec -i "$CONTAINER" cypher-shell -u neo4j -p "$NEOPW" \
+  "MATCH ()-[r:CITES_CASE]->() RETURN count(r) AS cites_case;"

--- a/scripts/citation-graph/departs-02-classify.py
+++ b/scripts/citation-graph/departs-02-classify.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# =====================================================================
+# departs-02-classify.py   (runs ON prod HOST — boto3 1.43.x present there;
+# Bedrock IAM keys live in ~/SecondLayer/deployment/.env.prod, region
+# eu-central-1). DEPARTS_FROM layer, step 2: LLM-classify GC "відступ"
+# windows produced by brev-departs-01-extract-windows.py.
+#
+# For each window, Claude Haiku 4.5 decides whether the Grand Chamber
+# FORMALLY departed (відступити від правового висновку) from a prior
+# position, and which case number it departed from. Real departures with
+# a case number are written to CSV for the Neo4j DEPARTS_FROM load.
+#
+#   set -a; eval "$(grep -E '^(AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|AWS_REGION|BEDROCK_MODEL_QUICK)=' ~/SecondLayer/deployment/.env.prod)"; set +a
+#   python3 departs-02-classify.py < gc_departs_windows.jsonl > gc_departs_edges.csv
+# =====================================================================
+import os, sys, json, csv, re
+from concurrent.futures import ThreadPoolExecutor
+import boto3
+
+MODEL = os.environ.get("BEDROCK_MODEL_QUICK", "eu.anthropic.claude-haiku-4-5-20251001-v1:0")
+REGION = os.environ.get("AWS_REGION", "eu-central-1")
+WORKERS = 6
+CASE_RE = re.compile(r"\d+/\d+/\d+(?:-[а-яіїєґA-Za-z0-9]+)?")
+
+bedrock = boto3.client("bedrock-runtime", region_name=REGION)
+
+PROMPT = """Ти аналізуєш уривок з постанови Великої Палати Верховного Суду України.
+Питання: чи Велика Палата у цьому уривку ФОРМАЛЬНО ВІДСТУПАЄ від раніше висловленого правового висновку (відступає від правової позиції) в іншій справі?
+
+Це НЕ відступ, якщо суд: не вбачає підстав для відступу, відмовляє у відступі, лише згадує/цитує відступ в іншому контексті, або посилається на висновок без відступу від нього.
+
+Поверни СТРОГО JSON без пояснень:
+{"is_departure": true|false, "departed_case": "номер справи від якої відступають, напр. 826/3858/18, або null"}
+
+Уривок:
+---
+%s
+---"""
+
+
+def classify(rec):
+    body = {
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 120,
+        "messages": [{"role": "user", "content": PROMPT % rec["window"][:1600]}],
+    }
+    try:
+        resp = bedrock.invoke_model(modelId=MODEL, body=json.dumps(body))
+        payload = json.loads(resp["body"].read())
+        txt = payload["content"][0]["text"]
+        j = json.loads(txt[txt.find("{"): txt.rfind("}") + 1])
+    except Exception as e:
+        sys.stderr.write(f"err doc {rec['doc_id']}: {e}\n")
+        return None
+    if not j.get("is_departure"):
+        return None
+    dep = j.get("departed_case") or rec.get("candidate_case")
+    if not dep or not CASE_RE.fullmatch(str(dep).strip()):
+        return None
+    return {"doc_id": rec["doc_id"], "departed_case": str(dep).strip(),
+            "departed_on": rec.get("adj_date")}
+
+
+def main():
+    recs = [json.loads(l) for l in sys.stdin if l.strip()]
+    sys.stderr.write(f"windows: {len(recs)}\n")
+    out = csv.writer(sys.stdout)
+    out.writerow(["doc_id", "departed_case", "departed_on"])
+    seen, n = set(), 0
+    with ThreadPoolExecutor(max_workers=WORKERS) as ex:
+        for r in ex.map(classify, recs):
+            if not r:
+                continue
+            key = (r["doc_id"], r["departed_case"])
+            if key in seen:
+                continue
+            seen.add(key)
+            out.writerow([r["doc_id"], r["departed_case"], r["departed_on"] or ""])
+            n += 1
+    sys.stderr.write(f"real departures: {n}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Rebuild the EDRSR citation graph on **Brev** after the prod Neo4j host (bigbox/qdrant.lex, r6i.8xlarge) was **terminated 2026-07-05** with all volumes — instance lost, no backup.

## Why rebuild vs reload
The extracted edges survive in prod Postgres, but they were extracted from the ~101M corpus. Brev `edrsr_local` is the fuller/cleaned corpus: **135.2M docs / 133.5M fulltext** (+34M). So we re-extract fresh over the full base.

## What's here (scripts staged + running on Brev)
- `brev-neo4j-01-build.sql` — Article aggregate (RAW `art_id=md5(law_number|law_article)`, filter `unique_decisions>=5`), `edrsr_case_index`, `case_citation_links`.
- `brev-neo4j-02-export.sh` — neo4j-admin CSVs (ID spaces, gzip, `enable_mergejoin=off`).
- `brev-neo4j-03-import.sh` — `neo4j-admin database import full` + constraints/indexes.
- `brev-departs-01-extract-windows.py` / `departs-02-classify.py` (Bedrock Haiku, ~\$2-3) / `brev-departs-03-load.sh` — DEPARTS_FROM (Велика Палата ВС, court 9951).

## Scope / safety
- **Prod untouched** — `CITATION_BACKEND` stays on postgres fallback; cutover is a separate decision.
- Neo4j runs on Brev internal-only (localhost + WG). GPU workloads (revectorization) untouched — this is CPU/Postgres only.
- Tracked in **LEXAI-1831** (follows LEXAI-1770 pilot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilds the EDRSR citation graph on Brev from the full 135.2M-doc `edrsr_local` corpus and adds a small pipeline for Grand Chamber DEPARTS_FROM edges. No prod cutover; current traffic stays on Postgres while we prepare a clean, larger Neo4j graph (LEXAI-1831).

- **New Features**
  - Build RAW sources in Postgres: article aggregates (`art_id=md5(law_number|law_article)`, keep `unique_decisions>=5`), `edrsr_case_index`, and resolved `case_citation_links` with self-cite flag.
  - Export typed, gz CSVs for `neo4j-admin import` (multiline-safe; merge-join disabled to avoid large sorts).
  - Offline full import into Neo4j (Decision/Article/Law/Case + CITES_ARTICLE/OF_LAW/IN_CASE/CITES_CASE), then apply constraints/indexes and report counts.
  - DEPARTS_FROM (Grand Chamber, court 9951): extract “відступ” windows on Brev, classify on prod via Bedrock Haiku, then load confirmed Decision→Case edges with `departed_on`.
  - Scope: Brev-only; `CITATION_BACKEND` remains Postgres. Aligns with LEXAI-1831 and expands beyond the prior ~101M base.

<sup>Written for commit 382c1619dd4b4f06cf342d53c134632046594aa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

