### PR TITLE
fix(edrsr-fulltext-worker): correct RTF \u converter + populate tsv/text_length

### DIFF
--- a/services/edrsr-fulltext-worker/worker.py
+++ b/services/edrsr-fulltext-worker/worker.py
@@ -115,6 +115,8 @@ def decode_win1251_byte(match):
 
 def decode_unicode(match):
     code = int(match.group(1))
+    if code < 0:              # RTF \uN is a signed 16-bit value
+        code += 65536
     return chr(code) if 0 <= code <= 0x10FFFF else ""
 
 
@@ -185,7 +187,13 @@ def rtf_bytes_to_text(raw: bytes) -> str | None:
     text = re.sub(r"\\line\b", "\n", text)
     text = re.sub(r"\\tab\b", "\t", text)
     text = re.sub(r"\\'([0-9a-fA-F]{2})", decode_win1251_byte, text)
-    text = re.sub(r"\\u(\d+)\??", decode_unicode, text)
+    # \uN carries a per-\ucN fallback char (court RTFs use \uc1 with a literal
+    # 'F' fallback). Consume the optional delimiter space + one fallback token,
+    # else the fallback leaks after every Cyrillic char ("ПFОFСFТF").
+    text = re.sub(r"\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?", decode_unicode, text)
+    # RTF control SYMBOLS (backslash + non-letter) — the control-word regex below
+    # only matches \word, so strip these explicitly or they survive as junk.
+    text = text.replace("\\~", " ").replace("\\_", "-").replace("\\-", "")
     text = re.sub(r"\\[a-zA-Z]+-?\d*\s?", "", text)
     text = text.replace("{", "").replace("}", "")
     text = text.replace("\x00", "")
@@ -412,8 +420,11 @@ async def insert_batch(pool: asyncpg.Pool, rows: list[tuple]) -> int:
                     columns=["doc_id", "adj_year", "full_text"],
                 )
                 result = await conn.execute("""
-                    INSERT INTO edrsr_fulltext (doc_id, adj_year, full_text)
-                    SELECT s.doc_id, s.adj_year, s.full_text FROM _ft_stage s
+                    INSERT INTO edrsr_fulltext (doc_id, adj_year, full_text, text_length, tsv)
+                    SELECT s.doc_id, s.adj_year, s.full_text,
+                           length(s.full_text),
+                           to_tsvector(left(s.full_text, 400000))
+                    FROM _ft_stage s
                     WHERE NOT EXISTS (SELECT 1 FROM edrsr_fulltext f WHERE f.doc_id = s.doc_id)
                 """)
                 inserted = int(result.split()[-1])
@@ -426,8 +437,8 @@ async def insert_batch(pool: asyncpg.Pool, rows: list[tuple]) -> int:
             for doc_id, adj_year, text in rows:
                 try:
                     r = await conn.execute(
-                        """INSERT INTO edrsr_fulltext (doc_id, adj_year, full_text)
-                           SELECT $1, $2, $3
+                        """INSERT INTO edrsr_fulltext (doc_id, adj_year, full_text, text_length, tsv)
+                           SELECT $1, $2, $3, length($3), to_tsvector(left($3, 400000))
                            WHERE NOT EXISTS (SELECT 1 FROM edrsr_fulltext WHERE doc_id = $1)""",
                         doc_id, adj_year, text,
                     )


### PR DESCRIPTION
## Problem

`edrsr-fulltext-worker` (prod service that continuously fills `edrsr_fulltext` gaps) had two correctness defects, both verified against live data.

### Bug 1 — RTF converter corrupts `\uNNNN`-format decisions
The converter carried the two bugs already fixed in `scripts/edrsr/*.py` on 2026-07-06 but missed here because the worker lives under `services/`.

- `\\u(\d+)\??` only ate a `?` fallback, so the per-`\ucN` literal fallback char (court RTFs use `\uc1` + `'F'`) leaked after every Cyrillic char → `ПFОFСFТF...`
- `decode_unicode` dropped signed `\uN` values.
- Control **symbols** `\~` (nbsp) / `\_` / `\-` were never stripped (the control-word regex only matches `\word`).

**Verified** on real docs (7695001, 31953935, `\u`-format): F-corruption runs **166 → 0**, backslash-symbol junk **118 → 0**; hex-escape (`\'XX`) docs unchanged.

### Bug 2 — imported rows are invisible to full-text search
`insert_batch` inserted only `(doc_id, adj_year, full_text)`. On prod `edrsr_fulltext.tsv` is a plain column with **no BEFORE trigger**, so every worker-inserted row had `tsv = NULL` / `text_length = NULL` and never matched FTS queries. (Prod currently has **17.2M** rows with `tsv IS NULL`; recent worker-days are 100% NULL.)

## Fix
- Converter: `\\u(-?\d+) ?(?:\\'..|[^\\{} \n])?` + signed handling + strip `\~`/`\_`/`\-` (matches the `scripts/edrsr/*.py` converter).
- Both INSERT paths now set `text_length = length(full_text)` and `tsv = to_tsvector(left(full_text, 400000))` (default config; 400k cap avoids the >1MB tsvector abort).

## Follow-ups (separate, not in this PR)
- Backfill `tsv` for the 17.2M existing `tsv IS NULL` rows on prod.
- Re-convert rows the old worker already inserted from `\u`-format RTF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes RTF-to-text conversion in `edrsr-fulltext-worker` and ensures new rows populate `tsv`/`text_length` so they are searchable via full-text.

- **Bug Fixes**
  - Correct `\uN` parsing: consume the delimiter and one fallback per `\ucN`, handle signed values, and strip control symbols (`\~`, `\_`, `\-`).
  - Updated regex to `\\u(-?\d+) ?(?:\\'[0-9a-fA-F]{2}|[^\\{} \n])?`; keeps `\'XX` decoding via Win-1251.
  - Both insert paths now set `text_length = length(full_text)` and `tsv = to_tsvector(left(full_text, 400000))` to prevent NULLs and avoid oversized tsvectors.

<sup>Written for commit 82e908ef4daccb4ceb5eb65025412df1554620b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

