### PR TITLE
docs(deployment): document QDRANT_EDRSR_* + BGE_M3_URL; repoint prod EDRSR to rebuilt bge-m3 collection

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -84,6 +84,20 @@ REDIS_PORT=6379
 # =============================================================================
 QDRANT_URL=http://qdrant-local:6333
 
+# EDRSR court-decision vector search (EdsrVectorizerService). Falls back to
+# QDRANT_URL / QDRANT_API_KEY when the EDRSR-specific vars are unset.
+# QDRANT_EDRSR_URL points at the qdrant hosting the bge-m3 court-decision vectors
+# (collection default: edrsr_serving). Set QDRANT_EDRSR_SKIP_INIT=true when the
+# collection + payload indexes already exist on a read-only serving node so the
+# app skips collection/index creation on startup.
+QDRANT_EDRSR_URL=http://qdrant-local:6333
+QDRANT_EDRSR_COLLECTION=edrsr_decisions
+QDRANT_EDRSR_API_KEY=
+QDRANT_EDRSR_SKIP_INIT=true
+# bge-m3 embedding endpoint (TEI, OpenAI-compatible) used for BOTH query and doc
+# embeddings — must match the model that produced the collection's vectors.
+BGE_M3_URL=http://tei-bge-m3:80
+
 # =============================================================================
 # Google Cloud Vision API Configuration (for OCR)
 # =============================================================================


### PR DESCRIPTION
## What
Documents the EDRSR court-decision vector-search env vars (`QDRANT_EDRSR_URL`, `QDRANT_EDRSR_COLLECTION`, `QDRANT_EDRSR_API_KEY`, `QDRANT_EDRSR_SKIP_INIT`, `BGE_M3_URL`) in `deployment/.env.example` — they were previously undocumented.

## Why
Prod EDRSR **semantic** search was pointed at a Qdrant host (`172.31.25.243:6333`) that was torn down 2026-07-05, so it had degraded to FTS-only. The court-decision corpus has been **re-vectorized** (court-aware substantive filter, ~34.9M docs → ~189M bge-m3 vectors, 15K-char truncation defect fixed, `instance_code`/`judgment_code` payload for ВС/appellate/admin query-time filtering) into a fresh collection `edrsr_decisions` on the Brev qdrant-gpu, reachable over WG.

Merging this triggers the deploy pipeline, which recreates the backend with the updated host `.env.prod` (the endpoint/collection secrets live there, not in git):
- `QDRANT_EDRSR_URL` → Brev qdrant
- `QDRANT_EDRSR_COLLECTION=edrsr_decisions`
- `QDRANT_EDRSR_SKIP_INIT=true` (collection + payload indexes already exist)

Compatibility verified end-to-end: prod TEI query embedding against the new collection returns correct, well-scored results (identical bge-m3 mean-pool params as the old `edrsr_serving`).

Tracking: LEXAI-1828.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing EDRSR vector-search env vars to `deployment/.env.example` and repoint prod semantic search to the rebuilt bge-m3 collection `edrsr_decisions` on the Brev Qdrant host. Restores semantic results and documents `BGE_M3_URL` for consistent embeddings. Satisfies LEXAI-1828.

- **Migration**
  - Set `QDRANT_EDRSR_URL` to the Brev Qdrant host and `QDRANT_EDRSR_COLLECTION=edrsr_decisions`; set `QDRANT_EDRSR_SKIP_INIT=true` if the collection is prebuilt.
  - Ensure `BGE_M3_URL` points to the bge-m3 TEI endpoint used to create the collection’s vectors.

<sup>Written for commit 8ed0267e905f161e323b93b81a7fcc89d9ac0531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

