### PR TITLE
fix(opendata-tm): correct trademark expiry_date & status extraction (LEXAI-1832)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-legislation-full-corpus-editions-design.md
+++ b/docs/superpowers/specs/2026-07-08-legislation-full-corpus-editions-design.md
@@ -1,0 +1,126 @@
+# Повний корпус законодавства України з історичними редакціями → bge-m3 → Qdrant
+
+**Дата:** 2026-07-08
+**Гілка:** `feat/legislation-full-corpus-editions`
+**Статус:** дизайн затверджено, реалізація почата
+
+## Мета
+
+Побудувати датасет **усього законодавства України** (нормативно-правові акти з
+zakon.rada.gov.ua) з **усіма історичними редакціями**, векторизувати bge-m3 на
+Brev GPU і додати до колекції векторів прод-пошуку.
+
+Поточний стан до проєкту: на проді лише **654 курованих акти** (7 084 редакції,
+1.29 млн статей), вже векторизовані в `legal_sections_bge` (759 336 точок, bigbox).
+Це ~0.2% реального корпусу.
+
+## Ключові факти розвідки (2026-07-08, перевірено на даних)
+
+### Реальний розмір корпусу (спростовує оцінку «1.3 млн актів»)
+«1.3 млн» = це 1.29 млн **рядків-статей** по 654 актах, а не акти. Реальний
+універсум:
+
+- **293 049 актів** усіх типів (bulk-файл `doc.txt` з Rada open-data).
+- **39 335 актів мають історичні редакції** (події podid 0/6 у `doc-dates.txt`).
+- **407 159 унікальних текстів** до завантаження = 285 235 базових (подія
+  «Прийняття», podid 4) + 122 083 редакції (podid 0 «Редакція» / 6 «Нова редакція»),
+  за вирахуванням збігів дат. Перевірено: КК (nreg `2341-14`) має 242 podid-0 +
+  1 podid-4 = 243 = `edcnt` у card JSON.
+- Типи: тип «Закон» (id 1) = 7 978; Постанова (id 2) = 75 963; та ін. (довідник `typ.txt`, 134 типи).
+- Статуси (довідник `stan.txt`): Чинний (5) = 121 139; Втратив чинність (1) = 45 495; Не визначено (0) = 125 482.
+
+### Санкціоноване bulk + API джерело (без Cloudflare-скрейпу)
+Rada **open-data портал** `data.rada.gov.ua/ogd/zak/laws/` (CC-BY 4.0, hourly,
+статичні файли, БЕЗ Cloudflare-throttle). Доступ до API вимагає заголовок
+`User-Agent: OpenData` (або cookie `OpenData`).
+
+Використовувані файли (win-1251, tab-separated):
+- `data/csv/doc.zip` → `doc.txt` (293 049) — картки: `dokid, nreg, nazva, status, types, …`.
+- `data/csv/ist.zip` → `ist.txt` (293 049) — упакована історія per-документ.
+- `data/csv/doc-dates.zip` → `doc-dates.txt` (663 510 подій) — **плоска таблиця подій**
+  `poddat, nreg, podid, pidstava` → джерело дат редакцій **у bulk, без мережі**.
+- Довідники `data/csv/{podia,stan,typ}.txt`.
+
+API (per-edition текст, потрібна мережа):
+- Картка: `https://data.rada.gov.ua/laws/card/{nreg}.json` → `eds[]`
+  (`{podid, datred, format, pages, pidstava, size}`), `edcnt`.
+- Текст редакції: `https://data.rada.gov.ua/laws/show/{nreg}/ed{YYYYMMDD}` → HTML з
+  шапкою (Стан, Ідентифікатор, «Текст документа від DD.MM.YYYY»).
+
+### Rate (проба 15 послідовних запитів, 2026-07-08)
+15/15 → HTTP 200, **жодного 429/challenge**. ~2.43 с/запит single-stream (латентність
+рендера, домінує на великих кодексах ~0.7–1.5 МБ; середній акт ~13 КБ значно
+швидший). 407K текстів: single-stream ~11 діб; **10–20 паралельних потоків ≈ ~1 добу**.
+Bottleneck — Stage 2, але це санкціоноване API, не Cloudflare-скрейп.
+
+## Архітектура: 5 розв'язаних стадій, кожна з checkpoint/resume
+
+Робоча БД — на **Brev host Postgres 16** (нова БД `rada_npa`; диск `/data` 7.9 ТБ
+вільно; там же GPU і вирішений транспорт prod→brev). Прод скрейпом НЕ навантажуємо.
+
+### Stage 0 — master-перелік
+Завантажити `doc.zip` + довідники → таблиця `rada_docs_master(dokid, nreg, nazva,
+status, types_raw, imported_at)`. Ключ дедупу — `nreg`. ~293K рядків. Мережі майже
+нема (один bulk-файл).
+
+### Stage 1 — перелік редакцій (BULK, без мережі)
+Завантажити `doc-dates.zip` → таблиця `rada_events(nreg, poddat, podid, pidstava)`.
+Вивести `rada_editions(nreg, ed_date, podid, is_current)` фільтром `podid IN (0,4,6)`,
+з валідацією формату дати YYYYMMDD. ~407K рядків. **Опційне збагачення** card JSON
+(`size`, `format`) — можна пропустити або підтягнути лениво в Stage 2.
+
+### Stage 2 — завантаження full-text редакцій (bottleneck)
+Для кожного `(nreg, ed_date)` → GET `/laws/show/{nreg}/ed{date}` з `UA: OpenData` →
+`rada_edition_texts(nreg, ed_date, http_status, raw_html, clean_text, char_len,
+fetched_at)`. Багатопотоково (10–20), **multi-IP за потреби** (техніка prod-EIP +
+WG-хости з `reference_rada_scrape_ips`), throttle + resume per `(nreg,ed_date)`,
+експон. backoff на 429/5xx. Текст-дедуп: сусідні байт-ідентичні редакції
+згортаються (як у bge-міграції). Парсинг HTML → чистий текст (зняти шапку/навігацію).
+
+### Stage 3 — чанкінг (article-aware hybrid)
+Де є структура «Стаття N» — різати по статтях (парсер з
+`scripts/rada/import-historical-editions.ts`), чанки CHUNK_SIZE=500/overlap=100
+(як у поточній колекції); де постанови/накази по пунктах — віконний чанкінг.
+Payload: `{nreg, doc_type, article_number, chunk_index, text, valid_from_ts,
+valid_to_ts, is_current, status, document_type:'legislation'}`. Експорт у JSONL-шарди.
+
+### Stage 4 — bge-m3 embed → Qdrant
+Ембеддинг на Brev 8×H100, перевірений рецепт: `onnxruntime-gpu==1.20.1` **CUDA EP**
+(не TRT), batch, ~1400+ чанків/с. Upsert у **нову колекцію `legislation_full_bge`**
+(1024 Cosine) на serving-Qdrant — поточну `legal_sections_bge` (підключену до проду)
+НЕ чіпаємо до cutover. `vector_id = md5("leg_{nreg}_v_{valid_from}_chunk_{idx}")`
+(ідемпотентно). Валідація self-search → перемикання прод-пошуку на нову колекцію
+флагом `LEG_BGE_COLLECTION` після перевірки.
+
+## Оцінки
+
+| Метрика | Значення |
+|---|---|
+| Акти | 293 049 |
+| Акти з редакціями | 39 335 |
+| Унікальних текстів (Stage 2) | ~407 159 |
+| Символи тексту | ~10–15 млрд (оцінка) |
+| Чанки/вектори | ~20–40 млн (оцінка) |
+| GPU-ембеддинг (Brev) | години |
+| Скрейп Stage 2 (10–20 потоків) | ~1 доба |
+| Raw HTML на диску (Brev) | ~0.3–1 ТБ |
+
+## Рішення (дефолти)
+1. Робоча БД — Brev PG (`rada_npa`), не прод.
+2. Джерело дат редакцій — bulk `doc-dates.txt`, НЕ per-doc скрейп.
+3. Текст — OpenData API `data.rada.gov.ua` (UA=OpenData), не Cloudflare-скрейп zakon.rada.
+4. Нова колекція `legislation_full_bge`, cutover флагом після валідації.
+5. Чанкінг article-aware hybrid — сумісність payload з існуючою колекцією.
+
+## Скрипти (нові, `scripts/legislation/full-corpus/`)
+- `00_fetch_bulk.sh` — завантажити doc/ist/doc-dates/dict з Rada open-data.
+- `01_load_master.py` — parse doc.txt + dict → `rada_docs_master` (Brev PG).
+- `02_load_editions.py` — parse doc-dates.txt → `rada_events` + `rada_editions`.
+- `03_fetch_texts.py` — багатопотоковий завантажувач редакцій (resume, backoff, multi-IP).
+- `04_chunk.py` — article-aware чанкінг → JSONL-шарди.
+- `05_embed_upsert.py` — bge-m3 ORT CUDA → Qdrant `legislation_full_bge` (на Brev).
+
+## Пов'язане
+`project_legislation_editions_backfill`, `project_legislation_bge_migration`,
+`reference_rada_scrape_ips`, `reference_brev_pg`, `reference_brev_wg`,
+`project_edrsr_unified_brev` (рецепт bge-m3 на Brev).

--- a/mcp_backend/src/migrations/172_fix_trademark_expiry_status.sql
+++ b/mcp_backend/src/migrations/172_fix_trademark_expiry_status.sql
@@ -1,0 +1,40 @@
+-- 172_fix_trademark_expiry_status.sql
+-- Backfill opendata_trademarks.expiry_date and status to match the corrected extractor.
+--
+-- Two extraction defects (fixed in import-uipv-ip.ts extractTrademark):
+--   1. expiry_date read the original 10-year `ExpiryDate` and ignored renewals. NIPO keeps
+--      the original date after a prolongation; the effective term end lives in
+--      `ProlonagationExpiryDate` (NIPO's spelling). ~90K renewed marks showed a long-past
+--      expiry (e.g. TM 67482: stored 2016-04-04, actually renewed to 2026-04-04).
+--   2. status came from `application_status` ("active"), which mislabels ~127K expired/
+--      terminated marks as active. `registration_status_color` (green=in force, red=not) is
+--      the authoritative live/dead flag — the same source patents already use.
+--
+-- Idempotent: re-running produces the same rows; only rows that actually change are touched.
+
+SET statement_timeout = '10min';
+
+UPDATE opendata_trademarks t
+SET
+  expiry_date = v.new_expiry,
+  status      = v.new_status
+FROM (
+  SELECT
+    id,
+    COALESCE(
+      NULLIF(LEFT(raw_data->>'ProlonagationExpiryDate', 10), '')::date,
+      NULLIF(LEFT(raw_data->>'ExpiryDate', 10), '')::date,
+      expiry_date
+    ) AS new_expiry,
+    CASE raw_data->>'registration_status_color'
+      WHEN 'green' THEN 'active'
+      WHEN 'red'   THEN 'inactive'
+      ELSE COALESCE(NULLIF(raw_data->>'application_status', ''), status)
+    END AS new_status
+  FROM opendata_trademarks
+) v
+WHERE t.id = v.id
+  AND (
+    t.expiry_date IS DISTINCT FROM v.new_expiry
+    OR t.status   IS DISTINCT FROM v.new_status
+  );

--- a/mcp_backend/src/scripts/import-uipv-ip.ts
+++ b/mcp_backend/src/scripts/import-uipv-ip.ts
@@ -131,12 +131,29 @@ function extractTrademark(record: any): any[] {
     }).join(' | ');
   }
 
+  // Expiry — prefer the prolongation expiry when the mark was renewed. NIPO keeps
+  // the original 10-year `ExpiryDate` even after a prolongation; the effective term
+  // end lives in `ProlonagationExpiryDate` (note NIPO's misspelling). Reading only
+  // `ExpiryDate` reported ~90K renewed marks as long expired (e.g. TM 67482 showed
+  // 2016 while it was actually renewed to 2026).
+  const expiryDate = data.ProlonagationExpiryDate || data.ExpiryDate || null;
+
+  // Status — `registration_status_color` (green=in force, red=not) is the authoritative
+  // live/dead flag, same source patents use. `application_status` is unreliable: ~127K
+  // marks are stamped "active" while their color is red (expired/terminated), so the raw
+  // `TerminationDate` never surfaced. Map color → human-readable status the registry
+  // catalog filters on by text ("зареєстровано, припинено тощо").
+  const color = data.registration_status_color;
+  const status = color === 'green' ? 'active'
+    : color === 'red' ? 'inactive'
+    : (data.application_status || null);
+
   return [
     record.app_number,
     record.app_date ? record.app_date.split('T')[0] : null,
     record.registration_number || null,
     record.registration_date ? record.registration_date.split('T')[0] : null,
-    data.ExpiryDate || null,
+    expiryDate,
     markText || null,
     holderName || null,
     holderEdrpou || null,
@@ -145,7 +162,7 @@ function extractTrademark(record: any): any[] {
     applicantEdrpou || null,
     niceClasses.length > 0 ? niceClasses : null,
     niceDescriptions || null,
-    data.application_status || data.registration_status_color || null,
+    status,
     record.last_update || null,
     JSON.stringify(data),
   ];

--- a/mcp_openreyestr/src/migrations/015_me_gov_datasets_mirror.sql
+++ b/mcp_openreyestr/src/migrations/015_me_gov_datasets_mirror.sql
@@ -1,0 +1,80 @@
+-- 015_me_gov_datasets_mirror.sql
+-- Generic mirror of ALL open datasets published by the Ministry of Economy of Ukraine
+-- (Міністерство економіки України) on data.gov.ua.
+--
+-- Org (CKAN): ministerstvo-ekonomichnoho-rozvytku-i-torhivli-ukrayiny
+--            id c9edbe3d-0a05-4d00-b23b-7c1fe5810ca4  (69 datasets as of 2025-02)
+--
+-- Because the 69 datasets are wildly heterogeneous (IP registers, agri registers,
+-- financials, quotas, trade data, ...) we do NOT model 69 bespoke schemas. Instead
+-- this is a 3-table generic CKAN mirror:
+--   me_datasets   -- one row per CKAN package (dataset metadata)
+--   me_resources  -- one row per file/resource inside a dataset
+--   me_records    -- generic per-row storage for tabular resources (JSONB)
+-- Non-tabular resources (PDF/DOC/ZIP) are mirrored as files (local_path) with no rows.
+--
+-- Populated by scripts/opendata/me-gov-ua/me_datagov_pipeline.py
+--   (discover -> download -> import -> verify), run local -> prod over WG.
+--
+-- Idempotent: safe to re-run (CREATE ... IF NOT EXISTS, ON CONFLICT upserts in loader).
+
+-- ── Datasets (CKAN packages) ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS me_datasets (
+    id                     BIGSERIAL PRIMARY KEY,
+    ckan_id                TEXT UNIQUE NOT NULL,          -- CKAN package id (UUID) or slug
+    slug                   TEXT,                          -- CKAN package "name"
+    title                  TEXT NOT NULL,                 -- CKAN package "title"
+    notes                  TEXT,                          -- description
+    org_id                 TEXT,
+    org_title              TEXT DEFAULT 'Міністерство економіки України',
+    tags                   TEXT[] DEFAULT '{}',
+    num_resources          INTEGER DEFAULT 0,             -- resource count reported by CKAN
+    ckan_metadata_created  TIMESTAMPTZ,
+    ckan_metadata_modified TIMESTAMPTZ,
+    raw                    JSONB,                         -- full package_show result (provenance)
+    mirrored_at            TIMESTAMPTZ DEFAULT NOW(),      -- first time we saw it
+    updated_at             TIMESTAMPTZ DEFAULT NOW()       -- last discover touch
+);
+
+CREATE INDEX IF NOT EXISTS idx_me_datasets_slug ON me_datasets(slug);
+CREATE INDEX IF NOT EXISTS idx_me_datasets_tags ON me_datasets USING gin(tags);
+CREATE INDEX IF NOT EXISTS idx_me_datasets_fts
+    ON me_datasets USING gin(to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(notes, '')));
+
+-- ── Resources (files inside a dataset) ──────────────────────────────────────
+CREATE TABLE IF NOT EXISTS me_resources (
+    id                  BIGSERIAL PRIMARY KEY,
+    dataset_id          BIGINT NOT NULL REFERENCES me_datasets(id) ON DELETE CASCADE,
+    ckan_resource_id    TEXT UNIQUE NOT NULL,             -- CKAN resource id (UUID)
+    name                TEXT,
+    format              TEXT,                             -- CSV / XLSX / XML / JSON / PDF / ...
+    url                 TEXT NOT NULL,                    -- download URL
+    mimetype            TEXT,
+    size_bytes          BIGINT,
+    ckan_created        TIMESTAMPTZ,
+    ckan_last_modified  TIMESTAMPTZ,
+    -- local mirror / import bookkeeping
+    local_path          TEXT,                             -- staging path after download
+    sha256              TEXT,
+    downloaded_at       TIMESTAMPTZ,
+    row_count           INTEGER,                          -- rows imported into me_records
+    import_status       TEXT DEFAULT 'pending',           -- pending|downloaded|imported|skipped|error
+    import_error        TEXT,
+    updated_at          TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_me_resources_dataset  ON me_resources(dataset_id);
+CREATE INDEX IF NOT EXISTS idx_me_resources_format   ON me_resources(format);
+CREATE INDEX IF NOT EXISTS idx_me_resources_status   ON me_resources(import_status);
+
+-- ── Records (generic per-row storage for tabular resources) ─────────────────
+CREATE TABLE IF NOT EXISTS me_records (
+    id           BIGSERIAL PRIMARY KEY,
+    resource_id  BIGINT NOT NULL REFERENCES me_resources(id) ON DELETE CASCADE,
+    row_index    INTEGER NOT NULL,
+    data         JSONB NOT NULL,
+    UNIQUE (resource_id, row_index)
+);
+
+CREATE INDEX IF NOT EXISTS idx_me_records_resource ON me_records(resource_id);
+CREATE INDEX IF NOT EXISTS idx_me_records_data     ON me_records USING gin(data jsonb_path_ops);

--- a/scripts/opendata/me-gov-ua/README.md
+++ b/scripts/opendata/me-gov-ua/README.md
@@ -1,0 +1,88 @@
+# me.gov.ua open-data mirror
+
+Mirrors **all open datasets of the Ministry of Economy of Ukraine** (Міністерство
+економіки України) published on [data.gov.ua](https://data.gov.ua) into the
+**openreyestr** Postgres DB.
+
+- CKAN org: `ministerstvo-ekonomichnoho-rozvytku-i-torhivli-ukrayiny`
+  (`c9edbe3d-0a05-4d00-b23b-7c1fe5810ca4`) — **69 datasets**.
+- Schema: `mcp_openreyestr/src/migrations/015_me_gov_datasets_mirror.sql`
+  (`me_datasets` → `me_resources` → `me_records`).
+
+## Design
+
+The 69 datasets are heterogeneous (IP registers, agri registers, financials,
+quotas, trade data, …), so we use a **generic 3-table CKAN mirror** rather than
+69 bespoke schemas:
+
+| Table | One row per | Notes |
+|-------|-------------|-------|
+| `me_datasets`  | CKAN package | metadata + full `raw` JSONB for provenance |
+| `me_resources` | file inside a dataset | `local_path`, `sha256`, `import_status`, `row_count` |
+| `me_records`   | row of a tabular resource | `data JSONB` (GIN indexed) |
+
+Non-tabular resources (PDF/DOC/ZIP/…) are mirrored as files on disk and marked
+`skipped` (no rows). Tabular formats (CSV/TSV/XLSX/XLS/JSON/XML) are parsed into
+`me_records`.
+
+## Pipeline stages
+
+```
+discover  CKAN package_search  -> upsert me_datasets + me_resources
+download  fetch resource files -> STAGING_DIR, sha256, status='downloaded'
+import    parse tabular files  -> me_records, status='imported'
+                                  non-tabular -> status='skipped'
+verify    counts + reconciliation report (resource gap, error states)
+all       discover -> download -> import -> verify
+```
+
+Every stage is **idempotent and resumable** (upserts + status columns; already
+downloaded files are skipped by sha/size).
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+
+# LOCAL DB (default localhost:5435/openreyestr)
+python3 me_datagov_pipeline.py all
+python3 me_datagov_pipeline.py discover           # metadata only
+python3 me_datagov_pipeline.py download --limit 50
+python3 me_datagov_pipeline.py import --reimport
+python3 me_datagov_pipeline.py verify
+```
+
+### Against prod (openreyestr_prod, WG tunnel)
+
+Prod Postgres are loopback-only, reached over the WG SSH tunnel
+(`openreyestr-postgres-prod` → `127.0.0.1:5440`). Per the local→prod data-proxy
+pattern, download/convert locally, then point `import`/`verify` at prod:
+
+```bash
+POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5440 POSTGRES_DB=openreyestr_prod \
+POSTGRES_USER=openreyestr POSTGRES_PASSWORD="$OPENREYESTR_POSTGRES_PASSWORD" \
+python3 me_datagov_pipeline.py all
+```
+
+## Migration
+
+Applied by the standard openreyestr runner (auto-discovers `*.sql`, tracked in
+`schema_migrations`):
+
+```bash
+cd mcp_openreyestr && npm run migrate            # local
+# prod: run the same migrate against openreyestr_prod (5440) over the WG tunnel,
+#       or apply 015_me_gov_datasets_mirror.sql via psql.
+```
+
+## Env
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `POSTGRES_HOST` | `localhost` | openreyestr DB host |
+| `POSTGRES_PORT` | `5435` | 5435 local / 5440 prod |
+| `POSTGRES_DB`   | `openreyestr` | `openreyestr_prod` on prod |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` | `openreyestr` / … | creds |
+| `DATABASE_URL`  | — | overrides the discrete vars if set |
+| `ME_STAGING_DIR`| `/data/opendata/me_gov_ua` (or `./staging`) | file staging |
+| `ME_MAX_ROWS`   | `500000` | per-resource row cap (safety) |

--- a/scripts/opendata/me-gov-ua/me_datagov_pipeline.py
+++ b/scripts/opendata/me-gov-ua/me_datagov_pipeline.py
@@ -1,0 +1,729 @@
+#!/usr/bin/env python3
+"""
+me.gov.ua (Ministry of Economy) open-data mirror pipeline.
+
+Mirrors ALL open datasets published by the Ministry of Economy of Ukraine on
+data.gov.ua into the openreyestr Postgres DB (tables me_datasets / me_resources /
+me_records — see mcp_openreyestr/src/migrations/015_me_gov_datasets_mirror.sql).
+
+CKAN org: ministerstvo-ekonomichnoho-rozvytku-i-torhivli-ukrayiny
+          id c9edbe3d-0a05-4d00-b23b-7c1fe5810ca4  (69 datasets)
+
+Stages (each is idempotent / resumable):
+    discover  CKAN package_search -> upsert me_datasets + me_resources
+    download  fetch resource files to STAGING_DIR, sha256, mark 'downloaded'
+    import    parse tabular files (CSV/XLSX/JSON/XML) -> me_records, mark 'imported'
+              non-tabular (PDF/DOC/ZIP/...) -> mark 'skipped' (file mirrored only)
+    verify    counts + reconciliation report (also runs a prod-side sanity query)
+    all       discover -> download -> import -> verify
+
+Usage:
+    # local DB (default 5435)
+    python3 me_datagov_pipeline.py all
+    python3 me_datagov_pipeline.py discover
+    python3 me_datagov_pipeline.py download --limit 50
+    python3 me_datagov_pipeline.py import
+    python3 me_datagov_pipeline.py verify
+
+    # prod DB over WG tunnel (openreyestr_prod on 127.0.0.1:5440)
+    POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5440 POSTGRES_DB=openreyestr_prod \\
+    POSTGRES_USER=openreyestr POSTGRES_PASSWORD=... \\
+    python3 me_datagov_pipeline.py verify
+
+Env (same names as mcp_openreyestr):
+    POSTGRES_HOST (localhost)  POSTGRES_PORT (5435)  POSTGRES_DB (openreyestr)
+    POSTGRES_USER (openreyestr)  POSTGRES_PASSWORD (openreyestr_password)
+    DATABASE_URL  (overrides the above if set)
+    ME_STAGING_DIR (default /data/opendata/me_gov_ua on prod host, else ./staging)
+
+Deps: pip install -r requirements.txt
+      (psycopg2-binary requests aiohttp aiofiles openpyxl)
+"""
+
+import argparse
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import requests
+
+try:
+    import aiohttp
+    import aiofiles
+except ImportError:
+    aiohttp = None  # only needed for the download stage
+
+import psycopg2
+import psycopg2.extras
+
+# ── Config ──────────────────────────────────────────────────────────────────
+CKAN_API = "https://data.gov.ua/api/3/action"
+ORG_SLUG = "ministerstvo-ekonomichnoho-rozvytku-i-torhivli-ukrayiny"
+ORG_ID = "c9edbe3d-0a05-4d00-b23b-7c1fe5810ca4"
+USER_AGENT = "SecondLayer-Legal-Platform/1.0 (+https://legal.org.ua)"
+
+# Multi-IP source binding (AWS ENIs on the local data-proxy box). Falls back to
+# the default outbound IP when none of these are bound on the host.
+SOURCE_IPS = [
+    "172.31.29.20",
+    "172.31.21.255",
+    "172.31.31.40",
+    "172.31.22.206",
+    "172.31.28.109",
+]
+THREADS_PER_IP = 5
+
+STAGING_DIR = Path(
+    os.environ.get(
+        "ME_STAGING_DIR",
+        "/data/opendata/me_gov_ua"
+        if Path("/data/opendata").is_dir()
+        else "./staging",
+    )
+)
+
+# Formats we parse into me_records. Everything else is mirrored as a file only.
+TABULAR_FORMATS = {"CSV", "TSV", "XLSX", "XLS", "JSON", "XML"}
+ARCHIVE_FORMATS = {"7Z", "ZIP"}  # mirrored as file; extraction is a later pass
+MAX_ROWS_PER_RESOURCE = int(os.environ.get("ME_MAX_ROWS", "500000"))  # safety cap
+
+# data.gov.ua format labels are hand-entered and frequently use Cyrillic
+# homoglyphs (Х/Р/С/… instead of X/P/C/…), e.g. "ХLSX", "РDF", "СSV". Normalize
+# them so tabular resources aren't misclassified and skipped.
+_CYR2LAT = str.maketrans(
+    {"Х": "X", "Р": "P", "С": "C", "А": "A", "В": "B", "Е": "E", "К": "K",
+     "М": "M", "О": "O", "Т": "T", "Н": "H", "І": "I", "Ѕ": "S", "Ј": "J",
+     "х": "X", "р": "P", "с": "C", "а": "A", "в": "B", "е": "E", "к": "K",
+     "м": "M", "о": "O", "т": "T", "н": "H", "і": "I"}
+)
+_EXT2FMT = {
+    ".xlsx": "XLSX", ".xls": "XLS", ".csv": "CSV", ".tsv": "TSV",
+    ".json": "JSON", ".xml": "XML", ".pdf": "PDF", ".doc": "DOC",
+    ".docx": "DOCX", ".rtf": "RTF", ".7z": "7Z", ".zip": "ZIP",
+}
+
+
+def _norm_fmt(s: str | None) -> str:
+    return (s or "").translate(_CYR2LAT).upper().strip()
+
+
+def detect_format(local_path: str | None, ckan_format: str | None) -> str:
+    """Determine the true resource format from the file extension first
+    (robust against Cyrillic-homoglyph CKAN labels), then the CKAN label.
+    For composite labels like '7Z,XLSX' the archive wins (the file on disk is
+    the .7z), so it is mirrored rather than mis-parsed."""
+    if local_path:
+        ext = Path(local_path).suffix.lower()
+        # a Cyrillic-tainted extension won't match; fall through to the label
+        if ext in _EXT2FMT:
+            return _EXT2FMT[ext]
+    norm = _norm_fmt(ckan_format)
+    tokens = [t for t in re.split(r"[,\s]+", norm) if t]
+    for t in tokens:
+        if t in ARCHIVE_FORMATS:
+            return t
+    return tokens[0] if tokens else ""
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger("me_datagov")
+
+
+# ── DB helpers ──────────────────────────────────────────────────────────────
+def connect():
+    dsn = os.environ.get("DATABASE_URL")
+    if dsn:
+        conn = psycopg2.connect(dsn)
+    else:
+        conn = psycopg2.connect(
+            host=os.environ.get("POSTGRES_HOST", "localhost"),
+            port=int(os.environ.get("POSTGRES_PORT", "5435")),
+            dbname=os.environ.get("POSTGRES_DB", "openreyestr"),
+            user=os.environ.get("POSTGRES_USER", "openreyestr"),
+            password=os.environ.get("POSTGRES_PASSWORD", "openreyestr_password"),
+        )
+    conn.autocommit = False
+    return conn
+
+
+def _ts(value):
+    """Parse a CKAN ISO timestamp to a tz-aware datetime, or None."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+# ── discover ────────────────────────────────────────────────────────────────
+def ckan_get(action: str, **params) -> dict:
+    r = requests.get(
+        f"{CKAN_API}/{action}",
+        params=params,
+        headers={"User-Agent": USER_AGENT},
+        timeout=60,
+    )
+    r.raise_for_status()
+    data = r.json()
+    if not data.get("success"):
+        raise RuntimeError(f"CKAN {action} failed: {data}")
+    return data["result"]
+
+
+def discover(conn):
+    """Enumerate every package of the org and upsert metadata + resources."""
+    log.info("Discovering datasets for org %s ...", ORG_SLUG)
+    packages: list[dict] = []
+    start, rows = 0, 100
+    while True:
+        result = ckan_get(
+            "package_search",
+            fq=f"organization:{ORG_SLUG}",
+            rows=rows,
+            start=start,
+        )
+        batch = result.get("results", [])
+        packages.extend(batch)
+        total = result.get("count", 0)
+        log.info("  fetched %d/%d packages", len(packages), total)
+        start += rows
+        if start >= total or not batch:
+            break
+
+    ds_upserts = res_upserts = 0
+    with conn.cursor() as cur:
+        for pkg in packages:
+            # package_search already returns resources, but fetch package_show to be
+            # authoritative (some CKAN instances trim resources in search results).
+            full = pkg
+            if not full.get("resources"):
+                try:
+                    full = ckan_get("package_show", id=pkg["id"])
+                except Exception as e:  # noqa: BLE001
+                    log.warning("  package_show failed for %s: %s", pkg.get("name"), e)
+
+            tags = [t.get("name") for t in full.get("tags", []) if t.get("name")]
+            cur.execute(
+                """
+                INSERT INTO me_datasets
+                    (ckan_id, slug, title, notes, org_id, tags, num_resources,
+                     ckan_metadata_created, ckan_metadata_modified, raw, updated_at)
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s, NOW())
+                ON CONFLICT (ckan_id) DO UPDATE SET
+                    slug = EXCLUDED.slug,
+                    title = EXCLUDED.title,
+                    notes = EXCLUDED.notes,
+                    org_id = EXCLUDED.org_id,
+                    tags = EXCLUDED.tags,
+                    num_resources = EXCLUDED.num_resources,
+                    ckan_metadata_created = EXCLUDED.ckan_metadata_created,
+                    ckan_metadata_modified = EXCLUDED.ckan_metadata_modified,
+                    raw = EXCLUDED.raw,
+                    updated_at = NOW()
+                RETURNING id
+                """,
+                (
+                    full["id"],
+                    full.get("name"),
+                    full.get("title") or full.get("name") or full["id"],
+                    full.get("notes"),
+                    ORG_ID,
+                    tags,
+                    len(full.get("resources", [])),
+                    _ts(full.get("metadata_created")),
+                    _ts(full.get("metadata_modified")),
+                    json.dumps(full, ensure_ascii=False),
+                ),
+            )
+            dataset_id = cur.fetchone()[0]
+            ds_upserts += 1
+
+            for res in full.get("resources", []):
+                if not res.get("url"):
+                    continue
+                cur.execute(
+                    """
+                    INSERT INTO me_resources
+                        (dataset_id, ckan_resource_id, name, format, url, mimetype,
+                         size_bytes, ckan_created, ckan_last_modified, updated_at)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s, NOW())
+                    ON CONFLICT (ckan_resource_id) DO UPDATE SET
+                        dataset_id = EXCLUDED.dataset_id,
+                        name = EXCLUDED.name,
+                        format = EXCLUDED.format,
+                        url = EXCLUDED.url,
+                        mimetype = EXCLUDED.mimetype,
+                        size_bytes = EXCLUDED.size_bytes,
+                        ckan_created = EXCLUDED.ckan_created,
+                        ckan_last_modified = EXCLUDED.ckan_last_modified,
+                        updated_at = NOW()
+                    """,
+                    (
+                        dataset_id,
+                        res["id"],
+                        res.get("name"),
+                        (res.get("format") or "").upper() or None,
+                        res["url"],
+                        res.get("mimetype"),
+                        int(res["size"]) if str(res.get("size") or "").isdigit() else None,
+                        _ts(res.get("created")),
+                        _ts(res.get("last_modified")) or _ts(res.get("metadata_modified")),
+                    ),
+                )
+                res_upserts += 1
+    conn.commit()
+    log.info("discover done: %d datasets, %d resources upserted", ds_upserts, res_upserts)
+
+
+# ── download ────────────────────────────────────────────────────────────────
+def _available_ips() -> list[str]:
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["ip", "-4", "addr", "show"], capture_output=True, text=True
+        ).stdout
+    except FileNotFoundError:
+        return ["0.0.0.0"]
+    ips = [
+        ln.strip().split()[1].split("/")[0]
+        for ln in out.splitlines()
+        if ln.strip().startswith("inet ")
+    ]
+    bound = [ip for ip in SOURCE_IPS if ip in ips]
+    return bound or ["0.0.0.0"]
+
+
+def _resource_filename(res_id: str, url: str, fmt: str | None) -> str:
+    tail = url.split("?")[0].split("/")[-1]
+    if not tail or tail == "download":
+        ext = (_norm_fmt(fmt).split(",")[0].strip() or "BIN").lower()
+        tail = f"{res_id}.{ext}"
+    return f"{res_id}__{tail}"  # prefix with resource id to guarantee uniqueness
+
+
+def download(conn, limit: int | None):
+    if aiohttp is None:
+        log.error("aiohttp/aiofiles not installed. pip install aiohttp aiofiles")
+        sys.exit(1)
+
+    STAGING_DIR.mkdir(parents=True, exist_ok=True)
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            """
+            SELECT id, ckan_resource_id, url, format, local_path
+            FROM me_resources
+            WHERE import_status IN ('pending', 'error')
+               OR local_path IS NULL
+            ORDER BY id
+            %s
+            """
+            % (f"LIMIT {int(limit)}" if limit else "")
+        )
+        pending = cur.fetchall()
+
+    if not pending:
+        log.info("download: nothing pending")
+        return
+
+    ips = _available_ips()
+    log.info(
+        "download: %d resources, %d source IP(s) × %d threads",
+        len(pending), len(ips), THREADS_PER_IP,
+    )
+
+    results: dict[int, dict] = {}
+
+    async def fetch_one(session, res, sem):
+        fname = _resource_filename(res["ckan_resource_id"], res["url"], res["format"])
+        outpath = STAGING_DIR / fname
+        if outpath.exists() and outpath.stat().st_size > 0:
+            sha = _sha256(outpath)
+            results[res["id"]] = {"local_path": str(outpath), "sha256": sha,
+                                  "status": "downloaded"}
+            return
+        async with sem:
+            for attempt in range(3):
+                try:
+                    to = aiohttp.ClientTimeout(total=600)
+                    async with session.get(res["url"], timeout=to,
+                                           allow_redirects=True) as r:
+                        if r.status == 200:
+                            data = await r.read()
+                            if data:
+                                async with aiofiles.open(outpath, "wb") as f:
+                                    await f.write(data)
+                                results[res["id"]] = {
+                                    "local_path": str(outpath),
+                                    "sha256": hashlib.sha256(data).hexdigest(),
+                                    "status": "downloaded",
+                                }
+                                return
+                        elif r.status == 429:
+                            await asyncio.sleep(10 * (attempt + 1))
+                            continue
+                        elif r.status >= 500:
+                            await asyncio.sleep(5 * (attempt + 1))
+                            continue
+                        else:
+                            log.warning("HTTP %s for %s", r.status, fname)
+                            break
+                except Exception as e:  # noqa: BLE001
+                    log.warning("download error %s: %s (try %d)", fname, e, attempt + 1)
+                    await asyncio.sleep(3 * (attempt + 1))
+            results[res["id"]] = {"status": "error",
+                                  "error": "download failed after 3 attempts"}
+
+    async def run():
+        # round-robin resources across IPs
+        buckets: dict[str, list] = {ip: [] for ip in ips}
+        for i, res in enumerate(pending):
+            buckets[ips[i % len(ips)]].append(res)
+
+        async def ip_worker(ip, items):
+            sem = asyncio.Semaphore(THREADS_PER_IP)
+            conn_kw = {}
+            if ip != "0.0.0.0":
+                conn_kw["local_addr"] = (ip, 0)
+            connector = aiohttp.TCPConnector(limit=THREADS_PER_IP, **conn_kw)
+            async with aiohttp.ClientSession(
+                connector=connector, headers={"User-Agent": USER_AGENT}
+            ) as session:
+                await asyncio.gather(*(fetch_one(session, r, sem) for r in items))
+
+        await asyncio.gather(*(ip_worker(ip, it) for ip, it in buckets.items()))
+
+    asyncio.run(run())
+
+    ok = err = 0
+    with conn.cursor() as cur:
+        for rid, r in results.items():
+            if r["status"] == "downloaded":
+                cur.execute(
+                    """UPDATE me_resources SET local_path=%s, sha256=%s,
+                       downloaded_at=NOW(), import_status='downloaded',
+                       import_error=NULL, updated_at=NOW() WHERE id=%s""",
+                    (r["local_path"], r["sha256"], rid),
+                )
+                ok += 1
+            else:
+                cur.execute(
+                    """UPDATE me_resources SET import_status='error',
+                       import_error=%s, updated_at=NOW() WHERE id=%s""",
+                    (r.get("error"), rid),
+                )
+                err += 1
+    conn.commit()
+    log.info("download done: %d ok, %d error", ok, err)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+# ── import (parse tabular -> me_records) ────────────────────────────────────
+def _read_text(path: Path) -> str:
+    raw = path.read_bytes()
+    for enc in ("utf-8-sig", "utf-8", "cp1251", "windows-1251"):
+        try:
+            return raw.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return raw.decode("utf-8", errors="replace")
+
+
+def _rows_from_csv(path: Path) -> list[dict]:
+    import csv
+
+    text = _read_text(path)
+    sample = text[:8192]
+    try:
+        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+    except csv.Error:
+        dialect = csv.excel
+    reader = csv.DictReader(text.splitlines(), dialect=dialect)
+    return [dict(row) for row in reader]
+
+
+def _rows_from_xlsx(path: Path) -> list[dict]:
+    from openpyxl import load_workbook
+
+    wb = load_workbook(path, read_only=True, data_only=True)
+    rows: list[dict] = []
+    for ws in wb.worksheets:
+        it = ws.iter_rows(values_only=True)
+        try:
+            header = next(it)
+        except StopIteration:
+            continue
+        cols = [str(h) if h is not None else f"col{i}" for i, h in enumerate(header)]
+        for r in it:
+            rows.append(
+                {cols[i]: (v.isoformat() if hasattr(v, "isoformat") else v)
+                 for i, v in enumerate(r) if i < len(cols)}
+            )
+            if len(rows) >= MAX_ROWS_PER_RESOURCE:
+                return rows
+    return rows
+
+
+def _rows_from_json(path: Path) -> list[dict]:
+    data = json.loads(_read_text(path))
+    if isinstance(data, list):
+        return [d if isinstance(d, dict) else {"value": d} for d in data]
+    if isinstance(data, dict):
+        for key in ("data", "records", "result", "items", "rows"):
+            if isinstance(data.get(key), list):
+                return [d if isinstance(d, dict) else {"value": d} for d in data[key]]
+        return [data]
+    return [{"value": data}]
+
+
+def _rows_from_xml(path: Path) -> list[dict]:
+    import xml.etree.ElementTree as ET
+
+    def strip_ns(tag: str) -> str:
+        return tag.split("}", 1)[-1] if "}" in tag else tag
+
+    def elem_to_dict(el):
+        d = {strip_ns(k): v for k, v in el.attrib.items()}
+        for child in el:
+            key = strip_ns(child.tag)
+            val = elem_to_dict(child) if len(child) else (child.text or "").strip()
+            if key in d:
+                if not isinstance(d[key], list):
+                    d[key] = [d[key]]
+                d[key].append(val)
+            else:
+                d[key] = val
+        if not d and (el.text or "").strip():
+            return (el.text or "").strip()
+        return d
+
+    root = ET.parse(path).getroot()
+    children = list(root)
+    # Heuristic: repeating same-tag children = record rows.
+    if children:
+        tags = {strip_ns(c.tag) for c in children}
+        if len(tags) == 1 and len(children) > 1:
+            return [elem_to_dict(c) if isinstance(elem_to_dict(c), dict)
+                    else {"value": elem_to_dict(c)} for c in children]
+    top = elem_to_dict(root)
+    return [top if isinstance(top, dict) else {"value": top}]
+
+
+PARSERS = {
+    "CSV": _rows_from_csv,
+    "TSV": _rows_from_csv,
+    "XLSX": _rows_from_xlsx,
+    "XLS": _rows_from_xlsx,
+    "JSON": _rows_from_json,
+    "XML": _rows_from_xml,
+}
+
+
+def import_records(conn, reimport: bool):
+    statuses = "('downloaded', 'imported', 'error')" if reimport else "('downloaded')"
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute(
+            f"""
+            SELECT id, ckan_resource_id, format, local_path
+            FROM me_resources
+            WHERE local_path IS NOT NULL AND import_status IN {statuses}
+            ORDER BY id
+            """
+        )
+        todo = cur.fetchall()
+
+    log.info("import: %d resources to process", len(todo))
+    imported = skipped = errored = 0
+
+    for res in todo:
+        path = Path(res["local_path"])
+        if not path.exists():
+            _mark(conn, res["id"], "error", err="local file missing")
+            errored += 1
+            continue
+        fmt = detect_format(res["local_path"], res["format"])
+        if fmt not in TABULAR_FORMATS:
+            # non-tabular (PDF/DOC/RTF) or archive (7Z/ZIP) — mirrored as file only
+            _mark(conn, res["id"], "skipped", rows=0)
+            skipped += 1
+            continue
+        try:
+            rows = PARSERS[fmt](path)
+        except Exception as e:  # noqa: BLE001
+            log.warning("parse failed id=%s (%s): %s", res["id"], fmt, e)
+            _mark(conn, res["id"], "error", err=f"parse: {e}")
+            errored += 1
+            continue
+
+        rows = rows[:MAX_ROWS_PER_RESOURCE]
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM me_records WHERE resource_id=%s", (res["id"],))
+            if rows:
+                psycopg2.extras.execute_values(
+                    cur,
+                    """INSERT INTO me_records (resource_id, row_index, data)
+                       VALUES %s
+                       ON CONFLICT (resource_id, row_index) DO UPDATE
+                       SET data = EXCLUDED.data""",
+                    [
+                        (res["id"], i, json.dumps(_jsonable(row), ensure_ascii=False))
+                        for i, row in enumerate(rows)
+                    ],
+                    template="(%s, %s, %s::jsonb)",
+                    page_size=1000,
+                )
+            cur.execute(
+                """UPDATE me_resources SET import_status='imported', row_count=%s,
+                   import_error=NULL, updated_at=NOW() WHERE id=%s""",
+                (len(rows), res["id"]),
+            )
+        conn.commit()
+        imported += 1
+        log.info("  imported id=%s %s rows=%d", res["id"], fmt, len(rows))
+
+    log.info("import done: %d imported, %d skipped(non-tabular), %d error",
+             imported, skipped, errored)
+
+
+def _jsonable(row: dict) -> dict:
+    out = {}
+    for k, v in row.items():
+        key = str(k).strip() if k is not None else "col"
+        if hasattr(v, "isoformat"):
+            v = v.isoformat()
+        elif isinstance(v, bytes):
+            v = v.decode("utf-8", "replace")
+        out[key] = v
+    return out
+
+
+def _mark(conn, res_id: int, status: str, rows: int | None = None, err=None):
+    with conn.cursor() as cur:
+        cur.execute(
+            """UPDATE me_resources SET import_status=%s, row_count=%s,
+               import_error=%s, updated_at=NOW() WHERE id=%s""",
+            (status, rows, err, res_id),
+        )
+    conn.commit()
+
+
+# ── verify ──────────────────────────────────────────────────────────────────
+def verify(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT count(*) FROM me_datasets")
+        n_datasets = cur.fetchone()[0]
+        cur.execute("SELECT count(*), coalesce(sum(num_resources),0) FROM me_datasets")
+        _, expected_res = cur.fetchone()
+        cur.execute("SELECT count(*) FROM me_resources")
+        n_res = cur.fetchone()[0]
+        cur.execute("SELECT count(*) FROM me_records")
+        n_records = cur.fetchone()[0]
+
+        cur.execute(
+            "SELECT import_status, count(*) FROM me_resources GROUP BY 1 ORDER BY 1"
+        )
+        by_status = cur.fetchall()
+        cur.execute(
+            """SELECT coalesce(format,'(none)'), count(*)
+               FROM me_resources GROUP BY 1 ORDER BY 2 DESC"""
+        )
+        by_format = cur.fetchall()
+        cur.execute(
+            """SELECT d.title, count(r.*) AS res, coalesce(sum(r.row_count),0) AS rows
+               FROM me_datasets d LEFT JOIN me_resources r ON r.dataset_id=d.id
+               GROUP BY d.id, d.title ORDER BY rows DESC LIMIT 15"""
+        )
+        top = cur.fetchall()
+        cur.execute(
+            "SELECT count(*) FROM me_resources WHERE import_status='error'"
+        )
+        n_err = cur.fetchone()[0]
+
+    print("\n" + "=" * 64)
+    print("  me.gov.ua open-data mirror — verification")
+    print("=" * 64)
+    print(f"  datasets                : {n_datasets}")
+    print(f"  resources (stored/CKAN) : {n_res} / {expected_res}")
+    print(f"  records (me_records)    : {n_records:,}")
+    print(f"  resources in error      : {n_err}")
+    print("\n  resources by import_status:")
+    for st, c in by_status:
+        print(f"    {st:12s} {c}")
+    print("\n  resources by format:")
+    for f, c in by_format:
+        print(f"    {f:12s} {c}")
+    print("\n  top datasets by imported rows:")
+    for title, res, rows in top:
+        t = (title or "")[:50]
+        print(f"    {rows:>10,}  ({res} res)  {t}")
+    print("=" * 64)
+
+    problems = []
+    if n_datasets == 0:
+        problems.append("no datasets — run discover")
+    if n_res < expected_res:
+        problems.append(f"resource gap: stored {n_res} < CKAN {expected_res}")
+    if n_err:
+        problems.append(f"{n_err} resources in error state")
+    if problems:
+        print("  ⚠ issues:")
+        for p in problems:
+            print(f"    - {p}")
+        return 1
+    print("  ✓ all checks passed")
+    return 0
+
+
+# ── main ────────────────────────────────────────────────────────────────────
+def main():
+    ap = argparse.ArgumentParser(description="me.gov.ua open-data mirror pipeline")
+    ap.add_argument(
+        "stage",
+        choices=["discover", "download", "import", "verify", "all"],
+    )
+    ap.add_argument("--limit", type=int, default=None,
+                    help="download: max resources to fetch this run")
+    ap.add_argument("--reimport", action="store_true",
+                    help="import: re-parse already-imported resources")
+    args = ap.parse_args()
+
+    log.info("target DB: %s:%s/%s (staging=%s)",
+             os.environ.get("POSTGRES_HOST", "localhost"),
+             os.environ.get("POSTGRES_PORT", "5435"),
+             os.environ.get("POSTGRES_DB", "openreyestr"),
+             STAGING_DIR)
+
+    conn = connect()
+    try:
+        if args.stage in ("discover", "all"):
+            discover(conn)
+        if args.stage in ("download", "all"):
+            download(conn, args.limit)
+        if args.stage in ("import", "all"):
+            import_records(conn, args.reimport)
+        if args.stage in ("verify", "all"):
+            rc = verify(conn)
+            sys.exit(rc)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/me-gov-ua/requirements.txt
+++ b/scripts/opendata/me-gov-ua/requirements.txt
@@ -1,0 +1,5 @@
+psycopg2-binary>=2.9
+requests>=2.31
+aiohttp>=3.9
+aiofiles>=23.2
+openpyxl>=3.1


### PR DESCRIPTION
## Problem

`opendata_trademarks` reported wrong term/status. Surfaced while checking TM certificate **№67482** (ALIEN WARE): the table showed `expiry_date=2016-04-04`, `status=active`, while `raw_data` shows the mark was **renewed to 2026-04-04** and **terminated early on 2025-07-22** (`registration_status_color=red`).

## Defects in `extractTrademark` (`mcp_backend/src/scripts/import-uipv-ip.ts`)

1. **expiry_date** used `data.ExpiryDate` (original 10-year term) and ignored renewals. NIPO keeps the original date after a prolongation; the effective end lives in `data.ProlonagationExpiryDate` (NIPO's misspelling). **~89,659** renewed marks showed a long-past expiry.
2. **status** came from `data.application_status` ("active"), which mislabels expired/terminated marks. Prod distribution: **127,558** marks are `application_status=active` but `registration_status_color=red` (not in force). `status_color` is the authoritative live/dead flag — the same field patents already read.

## Fix

- Extractor: `expiry_date = ProlonagationExpiryDate ?? ExpiryDate`; `status` derived from `registration_status_color` (green→`active`, red→`inactive`), fallback to `application_status`. Kept human-readable so the `registry-catalog` text (ilike) filter keeps working.
- Backfill migration `172_fix_trademark_expiry_status.sql` for the existing **388,869** rows (idempotent, only changed rows touched — **~262,565** change).

## Verification (dry-run on prod, read-only)

TM 67482: `expiry 2016-04-04 → 2026-04-04`, `status active → inactive` ✅
Date formats validated: 0 non-ISO `Prolonagation/ExpiryDate` values across the table.

## Follow-up (out of scope)

Patents store the raw color ("red"/"green") in `status` — a pre-existing inconsistency vs the human-readable TM status; harmonize later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes trademark expiry and live/dead status extraction so `opendata_trademarks` reflects renewals and terminations (LEXAI-1832). Adds a generic mirror of all `me.gov.ua` datasets (schema + pipeline), plus the design spec for the full Ukrainian legislation corpus with historical editions.

- **Bug Fixes**
  - Extractor: `expiry_date = ProlonagationExpiryDate ?? ExpiryDate`; `status` from `registration_status_color` (green→active, red→inactive; fallback to `application_status`).
  - Added idempotent backfill `172_fix_trademark_expiry_status.sql` to update existing rows (~262k changed).
  - Verified TM 67482: expiry 2016-04-04 → 2026-04-04; status active → inactive.

- **New Features**
  - Generic CKAN mirror for all `me.gov.ua` datasets into `openreyestr`: `me_datasets`, `me_resources`, `me_records` (migration 015).
  - Resumable pipeline `scripts/opendata/me-gov-ua/me_datagov_pipeline.py` (discover → download → import → verify) with robust format detection and tabular import.
  - Added design spec for the full legislation corpus with historical editions (bge-m3 → Qdrant).

<sup>Written for commit f3d2b68bc703bdc6c6910f2c43ca8815ecf1180b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

