### PR TITLE
fix(opendata-ip): human-readable patent status; share color→status helper (LEXAI-1832)

### DIFF
--- a/mcp_backend/src/migrations/173_fix_patent_status_human_readable.sql
+++ b/mcp_backend/src/migrations/173_fix_patent_status_human_readable.sql
@@ -1,0 +1,29 @@
+-- 173_fix_patent_status_human_readable.sql
+-- Backfill opendata_patents.status to the human-readable form the corrected extractor
+-- now produces, matching opendata_trademarks (see migration 172).
+--
+-- Patents previously stored the raw NIPO colour flag ("red"/"green"/"yellow") in status,
+-- while trademarks store human-readable text. This harmonises the two tables:
+--   green  → active   (in force)
+--   red    → inactive (not in force)
+--   yellow → pending  (registered but awaiting an action, e.g. an annual fee)
+--
+-- Idempotent: only rows whose status actually differs are touched.
+
+SET statement_timeout = '10min';
+
+UPDATE opendata_patents
+SET status = CASE raw_data->>'registration_status_color'
+               WHEN 'green'  THEN 'active'
+               WHEN 'red'    THEN 'inactive'
+               WHEN 'yellow' THEN 'pending'
+               ELSE status
+             END
+WHERE status IS DISTINCT FROM (
+        CASE raw_data->>'registration_status_color'
+          WHEN 'green'  THEN 'active'
+          WHEN 'red'    THEN 'inactive'
+          WHEN 'yellow' THEN 'pending'
+          ELSE status
+        END
+      );

--- a/mcp_backend/src/scripts/import-uipv-ip.ts
+++ b/mcp_backend/src/scripts/import-uipv-ip.ts
@@ -86,6 +86,19 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+// NIPO exposes the authoritative live/dead flag as a colour: green = in force,
+// red = not in force, yellow = registered but pending (e.g. awaiting an annual fee).
+// Map it to a human-readable status shared by both trademarks and patents so the
+// registry-catalog text filters work and the two tables stay consistent.
+function statusFromColor(color: any, fallback: string | null = null): string | null {
+  switch (color) {
+    case 'green': return 'active';
+    case 'red': return 'inactive';
+    case 'yellow': return 'pending';
+    default: return fallback;
+  }
+}
+
 // ── Extract trademark fields ────────────────────────────────────────────────
 function extractTrademark(record: any): any[] {
   const data = record.data || {};
@@ -138,15 +151,12 @@ function extractTrademark(record: any): any[] {
   // 2016 while it was actually renewed to 2026).
   const expiryDate = data.ProlonagationExpiryDate || data.ExpiryDate || null;
 
-  // Status — `registration_status_color` (green=in force, red=not) is the authoritative
-  // live/dead flag, same source patents use. `application_status` is unreliable: ~127K
-  // marks are stamped "active" while their color is red (expired/terminated), so the raw
-  // `TerminationDate` never surfaced. Map color → human-readable status the registry
-  // catalog filters on by text ("зареєстровано, припинено тощо").
-  const color = data.registration_status_color;
-  const status = color === 'green' ? 'active'
-    : color === 'red' ? 'inactive'
-    : (data.application_status || null);
+  // Status — `registration_status_color` is the authoritative live/dead flag, same
+  // source patents use. `application_status` is unreliable: ~127K marks are stamped
+  // "active" while their color is red (expired/terminated), so the raw `TerminationDate`
+  // never surfaced. Map color → human-readable status the registry catalog filters on
+  // by text ("зареєстровано, припинено тощо"), falling back to application_status.
+  const status = statusFromColor(data.registration_status_color, data.application_status || null);
 
   return [
     record.app_number,
@@ -206,7 +216,9 @@ function extractPatent(record: any, objType: number): any[] {
     inventorNames = inventors.map((i: any) => i['I_72.N.U'] || i['I_72.N.R'] || '').filter(Boolean);
   }
 
-  const status = data.registration_status_color || null;
+  // Human-readable status from the NIPO colour flag (green→active, red→inactive,
+  // yellow→pending), consistent with trademarks. Previously stored the raw colour.
+  const status = statusFromColor(data.registration_status_color);
 
   return [
     objType,


### PR DESCRIPTION
Follow-up to #2154. `opendata_patents` stored the raw NIPO colour flag (`red`/`green`/`yellow`) in `status`, while `opendata_trademarks` now stores human-readable text — an inconsistency across the two IP tables.

## Change

- Extract a shared `statusFromColor()` helper and use it in both `extractTrademark` and `extractPatent`:
  - `green → active`, `red → inactive`, `yellow → pending`
- `yellow` (24,504 patents — e.g. registered utility models awaiting an annual fee) maps to `pending`; trademarks never carry yellow.
- Backfill migration `173_fix_patent_status_human_readable.sql` harmonises the existing **347,297** patent rows (idempotent, only changed rows touched).

## Prod colour distribution (patents)

| color | → status | count |
|-------|----------|-------|
| red | inactive | 290,274 |
| green | active | 32,519 |
| yellow | pending | 24,504 |

## Verification

Dry-run on prod: patent **67482** (both Винаходи + Корисні моделі) `red → inactive` ✅. Patents have no `status` text filter in `registry-catalog`, so this changes returned display only, not query behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `opendata_patents.status` human-readable and consistent with trademarks by mapping NIPO color flags to text via a shared `statusFromColor()` helper (LEXAI-1832). Adds an idempotent migration to backfill existing rows.

- **Bug Fixes**
  - Share `statusFromColor()` in trademark/patent extractors: green→active, red→inactive, yellow→pending; patents now store text status for consistent catalog display.

- **Migration**
  - Add `173_fix_patent_status_human_readable.sql` to update ~347k `opendata_patents` rows only when the mapped value differs.

<sup>Written for commit 1465d756461a9f4926f87ed0d0c7bad8403a7871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

