### PR TITLE
fix(opendata): parse UA gov me.gov.ua CSVs as semicolon-delimited

### DIFF
--- a/scripts/opendata/me-gov-ua/me_datagov_pipeline.py
+++ b/scripts/opendata/me-gov-ua/me_datagov_pipeline.py
@@ -450,12 +450,15 @@ def _rows_from_csv(path: Path) -> list[dict]:
     import csv
 
     text = _read_text(path)
-    sample = text[:8192]
-    try:
-        dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
-    except csv.Error:
-        dialect = csv.excel
-    reader = csv.DictReader(text.splitlines(), dialect=dialect)
+    lines = text.splitlines()
+    header = lines[0] if lines else ""
+    # UA gov CSVs are overwhelmingly ';'-delimited (',' is the decimal
+    # separator), which fools csv.Sniffer. Pick the delimiter that occurs most
+    # in the header row; break ties in favour of ';'.
+    delim = max((";", "\t", "|", ","), key=lambda d: (header.count(d), d == ";"))
+    if header.count(delim) == 0:
+        delim = ","
+    reader = csv.DictReader(lines, delimiter=delim)
     return [dict(row) for row in reader]
 
 


### PR DESCRIPTION
Restores the semicolon-CSV delimiter fix for the me.gov.ua open-data pipeline.

## Why
main already has the me-gov mirror (migration 015 + Cyrillic `detect_format`) — it arrived via #2154/#2155 (LEXAI-1832 branched off the feat branch). But the `_rows_from_csv` fix was reverted by a linter before those merged, so main shipped the old `csv.Sniffer` version.

data.gov.ua CSVs are `;`-delimited (`,` is the decimal separator); Sniffer mis-picks `,` and splits prices like `53 875,00`. This picks the delimiter by header-row frequency (tie → `;`). Verified on the Ministry-of-Economy vehicle-valuation CSVs.

Supersedes the CSV-fix portion of #2153 (which now conflicts because its other files already reached main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore semicolon-delimited CSV parsing for me.gov.ua datasets to stop splitting values like "53 875,00" into extra columns. Use a header-based heuristic to pick the most frequent delimiter (ties favor ';', fallback ',') instead of relying on Sniffer.

<sup>Written for commit 3671b5a357656dd0f9e19a43447a29b3fe371354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

