### PR TITLE
fix(opendata-ip): document real TM/patent status filter values for chat (LEXAI-1832)

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -198,14 +198,14 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'holder_name', description: "Назва або ім'я власника", match: 'ilike_multi', columns: ['holder_name', 'applicant_name'] },
       { name: 'holder_edrpou', description: 'ЄДРПОУ власника', match: 'exact_multi', columns: ['holder_edrpou', 'applicant_edrpou'] },
       { name: 'nice_class', description: 'Клас NICE (1-45)', match: 'array_contains', columns: ['nice_classes'], type: 'number' },
-      { name: 'status', description: 'Статус (зареєстровано, припинено тощо)', match: 'ilike', columns: ['status'] },
+      { name: 'status', description: 'Статус марки: "active" (чинна/діюча) або "inactive" (нечинна: сплив строк або достроково припинена)', match: 'ilike', columns: ['status'] },
       { name: 'registration_number', description: 'Номер реєстрації', match: 'exact', columns: ['registration_number'] },
     ],
   },
 
   patents: {
     title: 'Патенти (Укрпатент)',
-    description: 'Пошук патентів, корисних моделей та промислових зразків (UIPV — Укрпатент)\n\n347K записів (винаходи, корисні моделі, промзразки; синхронізовано 2026-07). Пошук за назвою, власником, кодом МПК, номером заявки.',
+    description: 'Пошук патентів, корисних моделей та промислових зразків (UIPV — Укрпатент)\n\n347K записів (винаходи, корисні моделі, промзразки; синхронізовано 2026-07). Пошук за назвою, власником, кодом МПК, номером заявки, статусом.',
     table: 'opendata_patents',
     selectColumns: 'app_number, app_date, registration_number, registration_date, obj_type_name, title_ua, title_en, abstract_ua, ipc_codes, owner_name, owner_country, status',
     orderBy: 'registration_date DESC NULLS LAST',
@@ -217,6 +217,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'app_number', description: 'Номер заявки', match: 'exact', columns: ['app_number'] },
       { name: 'registration_number', description: 'Номер патенту', match: 'exact', columns: ['registration_number'] },
       { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 6=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
+      { name: 'status', description: 'Статус патенту: "active" (чинний), "inactive" (нечинний) або "pending" (зареєстрований, очікує дії — напр. сплати збору)', match: 'ilike', columns: ['status'] },
     ],
   },
 


### PR DESCRIPTION
Follow-up to #2154/#2155 found while verifying chat/search shows TM status correctly.

## Finding

`search_registry` **display** of status is correct (returns `active`/`inactive` verbatim — verified live: TM 67482 → `status: inactive`, `expiry_date: 2026-04-04`).

But the **status filter description** was stale. After migrations 172/173 the stored values are `active`/`inactive`/`pending`, while the field still advertised `Статус (зареєстровано, припинено тощо)`. So chat asking "покажи діючі марки NEMIROFF" makes the LLM guess a Ukrainian token → `ilike` no match → `Торговельних марок не знайдено` (silent wrong answer).

Verified live on prod:
| filter | result |
|--------|--------|
| `status=active` | 260 ✅ |
| `status=inactive` | 140 ✅ |
| `status=діюча` | **0** ❌ |
| `status=зареєстровано` | **0** ❌ |

## Fix (registry-catalog.ts, description-only)

- trademarks `status`: `"active" (чинна/діюча)` / `"inactive" (нечинна: сплив строк або достроково припинена)`
- patents: add a `status` filter (was display-only) → `active`/`inactive`/`pending`, and mention it in the registry description.

No data or query-logic change; the LLM now sees the real values it can filter by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated trademark `status` filter description to show the actual values ("active", "inactive") and added a `status` filter for patents with "active"/"inactive"/"pending". This addresses LEXAI-1832 by letting chat/search filter with the real tokens and return correct results; no data or query logic changes.

<sup>Written for commit d92e2c8046fdf59ecff1b7948129620f48fa0770. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

