### PR TITLE
fix(opendata): refresh DB connection before me-gov download/import writes

### DIFF
--- a/scripts/opendata/me-gov-ua/me_datagov_pipeline.py
+++ b/scripts/opendata/me-gov-ua/me_datagov_pipeline.py
@@ -155,6 +155,22 @@ def connect():
     return conn
 
 
+def ensure_conn(conn):
+    """Return a live connection. The download stage holds a connection idle for
+    minutes while files stream, and Postgres/a gateway can drop it before the
+    final status commit — ping and reconnect if it died."""
+    try:
+        with conn.cursor() as c:
+            c.execute("SELECT 1")
+        return conn
+    except Exception:
+        try:
+            conn.close()
+        except Exception:
+            pass
+        return connect()
+
+
 def _ts(value):
     """Parse a CKAN ISO timestamp to a tz-aware datetime, or None."""
     if not value:
@@ -406,6 +422,7 @@ def download(conn, limit: int | None):
     asyncio.run(run())
 
     ok = err = 0
+    conn = ensure_conn(conn)  # the long download may have dropped the connection
     with conn.cursor() as cur:
         for rid, r in results.items():
             if r["status"] == "downloaded":
@@ -576,6 +593,7 @@ def import_records(conn, reimport: bool):
             continue
 
         rows = rows[:MAX_ROWS_PER_RESOURCE]
+        conn = ensure_conn(conn)  # a large parse may have idled the connection
         with conn.cursor() as cur:
             cur.execute("DELETE FROM me_records WHERE resource_id=%s", (res["id"],))
             if rows:


### PR DESCRIPTION
The download stage held one psycopg2 connection idle for the minutes it took to stream 300+ resources; Postgres dropped it and the final status-update commit failed (`server closed the connection unexpectedly`) — files landed on disk but no `import_status` advanced. Adds `ensure_conn()` (ping + reconnect) before the download status write and each import write. Verified by re-running the bulk on prod (data-proxy box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the Postgres connection before status and import writes in the ME Gov pipeline to prevent failures after long idle downloads. Fixes dropped-connection errors so import status and record writes complete reliably.

- **Bug Fixes**
  - Added ensure_conn() to ping the connection (`SELECT 1`) and reconnect via connect() if dead.
  - Call ensure_conn before the download status update in ip_worker and before each import write in import_records to handle long idle periods with `psycopg2`.

<sup>Written for commit f73b64fee223b54dd7de6e89c6b949805a1420ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

