### PR TITLE
feat(openreyestr): expose me.gov.ua open-data mirror in chat search

### DIFF
--- a/mcp_backend/src/api/tool-registry.ts
+++ b/mcp_backend/src/api/tool-registry.ts
@@ -295,6 +295,8 @@ export class ToolRegistry {
       { clientName: 'openreyestr_search_arma_seized_assets', serviceName: 'search_arma_seized_assets' },
       { clientName: 'openreyestr_search_nazk_declarations', serviceName: 'search_nazk_declarations' },
       { clientName: 'openreyestr_search_exchange_data', serviceName: 'search_exchange_data' },
+      { clientName: 'openreyestr_search_me_datasets', serviceName: 'search_me_datasets' },
+      { clientName: 'openreyestr_search_me_records', serviceName: 'search_me_records' },
     ];
 
     for (const tool of openreyestrTools) {

--- a/mcp_backend/src/migrations/174_me_gov_datasets_tool_pricing.sql
+++ b/mcp_backend/src/migrations/174_me_gov_datasets_tool_pricing.sql
@@ -1,0 +1,12 @@
+-- Migration 174: pricing for me.gov.ua (Ministry of Economy) open-data search tools
+-- Exposed via the openreyestr service (data lives in openreyestr DB: me_datasets/
+-- me_resources/me_records). Non-LLM SQL tools, priced like other openreyestr search tools.
+
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes)
+VALUES
+  ('openreyestr_search_me_datasets', 'openreyestr', 'Датасети Мінекономіки', 0.00100000, '69 наборів відкритих даних Мінекономіки'),
+  ('openreyestr_search_me_records',  'openreyestr', 'Дані Мінекономіки',     0.00100000, '~274K рядків у 150 ресурсах Мінекономіки')
+ON CONFLICT (tool_name) DO UPDATE SET
+  base_cost_usd = EXCLUDED.base_cost_usd,
+  display_name = EXCLUDED.display_name,
+  notes = EXCLUDED.notes;

--- a/mcp_openreyestr/src/api/mcp-openreyestr-api.ts
+++ b/mcp_openreyestr/src/api/mcp-openreyestr-api.ts
@@ -530,6 +530,37 @@ export class MCPOpenReyestrAPI {
           required: ['query'],
         },
       },
+      {
+        name: 'search_me_datasets',
+        description: `Пошук датасетів Міністерства економіки України (Мінекономіки) з відкритих даних
+
+💰 Примерная стоимость: $0.001 USD
+Знайти релевантний набір серед 69 датасетів Мінекономіки (реєстри інтелектуальної власності, ліцензіати, експортно-імпортні квоти, реекспорт, вартість авто, довідник підприємств, фінзвітність держсектору, індустріальні парки тощо). Повертає slug датасету — використайте його у search_me_records для пошуку рядків.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Ключові слова (напр. "ліцензіати", "сорти рослин", "вартість авто", "квоти")' },
+            limit: { type: 'number', default: 30, maximum: 69, minimum: 1, description: 'Максимальна кількість датасетів' },
+          },
+        },
+      },
+      {
+        name: 'search_me_records',
+        description: `Пошук рядків усередині датасету Мінекономіки
+
+💰 Примерная стоимость: $0.001 USD
+Пошук у конкретному датасеті (за slug з search_me_datasets або за resource_id). Дані різнорідні (JSONB), тому датасет вказувати обовʼязково. Приклад: dataset="reiestr-industrialnikh-parkiv" query="Львів".`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            dataset: { type: 'string', description: 'Slug датасету (з search_me_datasets)' },
+            resource_id: { type: 'number', description: 'ID конкретного ресурсу (альтернатива dataset)' },
+            query: { type: 'string', description: 'Пошуковий рядок (шукається по всіх полях рядка)' },
+            limit: { type: 'number', default: 50, maximum: 100, minimum: 1, description: 'Максимальна кількість рядків' },
+            offset: { type: 'number', default: 0, description: 'Зміщення для пагінації' },
+          },
+        },
+      },
     ];
   }
 
@@ -620,6 +651,12 @@ export class MCPOpenReyestrAPI {
           break;
         case 'search_rnbo_sanctions':
           result = await this.tools.searchRnboSanctions(args);
+          break;
+        case 'search_me_datasets':
+          result = await this.tools.searchMeDatasets(args);
+          break;
+        case 'search_me_records':
+          result = await this.tools.searchMeRecords(args);
           break;
         default:
           throw new Error(`Unknown tool: ${name}`);

--- a/mcp_openreyestr/src/api/openreyestr-tools.ts
+++ b/mcp_openreyestr/src/api/openreyestr-tools.ts
@@ -1374,6 +1374,98 @@ export class OpenReyestrTools {
   /**
    * Search RNBO sanctions lists
    */
+  /**
+   * Search datasets of the Ministry of Economy (Мінекономіки) open-data mirror.
+   * Returns dataset slugs so the model can then search rows via searchMeRecords.
+   */
+  async searchMeDatasets(params: { query?: string; limit?: number }): Promise<any[]> {
+    const { query, limit = 30 } = params;
+    const values: any[] = [];
+    let where = '';
+    if (query && query.trim()) {
+      where = `WHERE to_tsvector('simple', coalesce(d.title, '') || ' ' || coalesce(d.notes, '')) @@ plainto_tsquery('simple', $1)
+               OR d.title ILIKE $2 OR d.slug ILIKE $2`;
+      values.push(query.trim(), `%${query.trim()}%`);
+    }
+    values.push(limit);
+
+    const result = await this.pool.query(
+      `SELECT d.slug, d.title, left(d.notes, 300) AS notes, d.num_resources,
+              count(r.*) FILTER (WHERE r.import_status = 'imported') AS imported_resources,
+              coalesce(sum(r.row_count), 0) AS total_rows
+       FROM me_datasets d
+       LEFT JOIN me_resources r ON r.dataset_id = d.id
+       ${where}
+       GROUP BY d.id, d.slug, d.title, d.notes, d.num_resources
+       ORDER BY total_rows DESC
+       LIMIT $${values.length}`,
+      values
+    );
+
+    if (result.rows.length === 0) {
+      return [{ found: false, query, message: 'Датасети Мінекономіки не знайдено' }];
+    }
+    return result.rows;
+  }
+
+  /**
+   * Search rows inside a single Ministry of Economy dataset. The mirrored data
+   * is heterogeneous JSONB, so a dataset scope (slug or resource_id) is required;
+   * the query matches across all fields of a row via data::text ILIKE.
+   */
+  async searchMeRecords(params: { dataset?: string; resource_id?: number; query?: string; limit?: number; offset?: number }): Promise<any> {
+    const { dataset, resource_id, query, limit = 50, offset = 0 } = params;
+    if (!dataset && !resource_id) {
+      return {
+        found: false,
+        message: 'Вкажіть dataset (slug) або resource_id. Спершу знайдіть датасет через search_me_datasets.',
+      };
+    }
+
+    const conditions: string[] = [];
+    const values: any[] = [];
+    let pi = 1;
+    if (resource_id) {
+      conditions.push(`r.resource_id = $${pi++}`);
+      values.push(resource_id);
+    } else {
+      conditions.push(`d.slug = $${pi++}`);
+      values.push(dataset);
+    }
+    if (query && query.trim()) {
+      conditions.push(`rec.data::text ILIKE $${pi++}`);
+      values.push(`%${query.trim()}%`);
+    }
+    const whereClause = `WHERE ${conditions.join(' AND ')}`;
+
+    const countRes = await this.pool.query(
+      `SELECT count(*) FROM me_records rec
+       JOIN me_resources r ON r.id = rec.resource_id
+       JOIN me_datasets d ON d.id = r.dataset_id
+       ${whereClause}`,
+      values
+    );
+    const total = parseInt(countRes.rows[0].count, 10);
+
+    values.push(limit, offset);
+    const result = await this.pool.query(
+      `SELECT d.title AS dataset_title, r.name AS resource_name, r.format,
+              rec.row_index, rec.data
+       FROM me_records rec
+       JOIN me_resources r ON r.id = rec.resource_id
+       JOIN me_datasets d ON d.id = r.dataset_id
+       ${whereClause}
+       ORDER BY rec.resource_id, rec.row_index
+       LIMIT $${pi++} OFFSET $${pi++}`,
+      values
+    );
+
+    if (total === 0) {
+      return { found: false, dataset, resource_id, query, message: 'Рядків не знайдено' };
+    }
+    return { total, count: result.rows.length, rows: result.rows };
+  }
+
   async searchRnboSanctions(params: { query: string; schema_type?: string; country?: string; identifier?: string; limit?: number; offset?: number }): Promise<any[]> {
     const { query, schema_type, country, identifier, limit = 50, offset = 0 } = params;
     const conditions: string[] = [];


### PR DESCRIPTION
Makes the me.gov.ua (Ministry of Economy) open-data mirror searchable from chat.

## Why not backend REGISTRY_CATALOG / search_registry
`search_registry` queries the **backend** DB and has no JSONB match type; the mirror lives in the **openreyestr** DB as heterogeneous `me_records.data` JSONB. So it's implemented via the openreyestr imperative search-tool pattern (exposed through the unified gateway as `openreyestr_*`), which is how every openreyestr registry reaches chat.

## Tools
- **`openreyestr_search_me_datasets`** — FTS over `me_datasets` (title/notes) → returns dataset `slug`, `num_resources`, imported row counts. Lets the model find the right dataset first.
- **`openreyestr_search_me_records`** — searches rows inside one dataset (by `dataset` slug or `resource_id`) via `data::text ILIKE`. Dataset scope required (keys are heterogeneous).

## Wiring
- `mcp_openreyestr/src/api/openreyestr-tools.ts` — two `this.pool` search methods
- `mcp_openreyestr/src/api/mcp-openreyestr-api.ts` — tool schemas + switch cases
- `mcp_backend/src/api/tool-registry.ts` — gateway route entries
- `mcp_backend/src/migrations/174_me_gov_datasets_tool_pricing.sql` — pricing ($0.001, non-LLM)

Both services type-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the me.gov.ua Ministry of Economy open-data mirror searchable from chat via new `openreyestr` tools. Find datasets and query rows inside a selected dataset.

- **New Features**
  - `search_me_datasets`: FTS over titles/notes in `me_datasets`; returns dataset slug plus resource/row counts.
  - `search_me_records`: dataset-scoped search over `me_records.data` (JSONB) via `data::text ILIKE` by dataset slug or `resource_id` (scope required).
  - Exposed via gateway as `openreyestr_search_me_datasets` and `openreyestr_search_me_records`; implemented in `openreyestr` since data is JSONB.

- **Migration**
  - Adds `174_me_gov_datasets_tool_pricing.sql`: sets $0.001 for both tools (non-LLM).

<sup>Written for commit 2a30f8b780ef4b1dcbe0cf165a5da95b3b2707f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

