### PR TITLE
fix(registry-search): exact status filter for TM/patents; add exact_ci match (LEXAI-1832)

### DIFF
--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -198,7 +198,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'holder_name', description: "Назва або ім'я власника", match: 'ilike_multi', columns: ['holder_name', 'applicant_name'] },
       { name: 'holder_edrpou', description: 'ЄДРПОУ власника', match: 'exact_multi', columns: ['holder_edrpou', 'applicant_edrpou'] },
       { name: 'nice_class', description: 'Клас NICE (1-45)', match: 'array_contains', columns: ['nice_classes'], type: 'number' },
-      { name: 'status', description: 'Статус марки: "active" (чинна/діюча) або "inactive" (нечинна: сплив строк або достроково припинена)', match: 'ilike', columns: ['status'] },
+      { name: 'status', description: 'Статус марки — вкажіть точне значення "active" (чинна/діюча) або "inactive" (нечинна: сплив строк або достроково припинена)', match: 'exact_ci', columns: ['status'] },
       { name: 'registration_number', description: 'Номер реєстрації', match: 'exact', columns: ['registration_number'] },
     ],
   },
@@ -217,7 +217,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'app_number', description: 'Номер заявки', match: 'exact', columns: ['app_number'] },
       { name: 'registration_number', description: 'Номер патенту', match: 'exact', columns: ['registration_number'] },
       { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 6=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
-      { name: 'status', description: 'Статус патенту: "active" (чинний), "inactive" (нечинний) або "pending" (зареєстрований, очікує дії — напр. сплати збору)', match: 'ilike', columns: ['status'] },
+      { name: 'status', description: 'Статус патенту — вкажіть точне значення "active" (чинний), "inactive" (нечинний) або "pending" (зареєстрований, очікує дії — напр. сплати збору)', match: 'exact_ci', columns: ['status'] },
     ],
   },
 

--- a/packages/shared/src/query-ir/build-where.ts
+++ b/packages/shared/src/query-ir/build-where.ts
@@ -60,6 +60,15 @@ export function buildWhere(
         pi++;
         break;
 
+      // Case-insensitive exact match for categorical enums. ILIKE with a value
+      // that has no % / _ is a plain case-insensitive equality — avoids the
+      // substring trap of 'ilike' (e.g. status "active" matching "inactive").
+      case 'exact_ci':
+        conditions.push(`${field.columns[0]} ILIKE $${pi}`);
+        values.push(val);
+        pi++;
+        break;
+
       case 'ilike_multi':
         conditions.push(`(${field.columns.map(c => `${c} ILIKE $${pi}`).join(' OR ')})`);
         values.push(`%${val}%`);

--- a/packages/shared/src/query-ir/field-def.ts
+++ b/packages/shared/src/query-ir/field-def.ts
@@ -10,6 +10,7 @@
 export type MatchType =
   | 'ilike'          // col ILIKE $N  (%val%)
   | 'exact'          // col = $N
+  | 'exact_ci'       // col ILIKE $N  (val verbatim, no wildcards) — case-insensitive exact match for categorical enums
   | 'ilike_multi'    // (col1 ILIKE $N OR col2 ILIKE $N ...)  (%val%)
   | 'exact_multi'    // (col1 = $N OR col2 = $N ...)
   | 'gte'            // col >= $N

--- a/packages/shared/tests/query-ir.test.ts
+++ b/packages/shared/tests/query-ir.test.ts
@@ -128,6 +128,7 @@ describe('query-ir / buildWhere', () => {
     { name: 'tags', match: 'array_contains', columns: ['tags'] },
     { name: 'date_from', match: 'gte', columns: ['d.adjudication_date'] },
     { name: 'owner', match: 'ilike_multi', columns: ['owner_a', 'owner_b'] },
+    { name: 'status', match: 'exact_ci', columns: ['status'] },
   ];
 
   it('builds parameterized conditions joined by AND', () => {
@@ -162,6 +163,14 @@ describe('query-ir / buildWhere', () => {
       '$1 = ANY(tags) AND d.adjudication_date >= $2 AND (owner_a ILIKE $3 OR owner_b ILIKE $3)'
     );
     expect(r.values).toEqual(['urgent', '2026-01-01', '%ТОВ%']);
+  });
+
+  it('exact_ci matches case-insensitively WITHOUT substring wildcards (status "active" ≠ "inactive")', () => {
+    const r = buildWhere(FIELDS, { status: 'active' });
+    // ILIKE with the value verbatim (no %) => case-insensitive equality, so
+    // "active" cannot match the stored "inactive".
+    expect(r.whereClause).toBe('status ILIKE $1');
+    expect(r.values).toEqual(['active']);
   });
 
   it('renders eq_any (col = ANY($N)) for array-valued slots', () => {


### PR DESCRIPTION
Follow-up to #2154/#2155/#2157. Verifying the TM status filter **in chat** exposed a real over-matching bug.

## Bug

The `status` field used `match: 'ilike'`, so filtering `status="active"` runs `status ILIKE '%active%'` — which **also matches `"inactive"`** (substring). Confirmed live on prod:

| query | tool result | ground truth |
|-------|-------------|--------------|
| `trademarks, mark_text=NEMIROFF, status=active` | **260** (all) | **120** |
| `..., status=inactive` | 140 | 140 |

An end-to-end chat run ("скільки чинних/нечинних марок NEMIROFF") only got the right split (120/140) because the LLM pivoted to `aggregate group_by status`; a direct status filter was wrong.

## Fix

- Add a query-ir match type **`exact_ci`** = `col ILIKE $N` with the value **verbatim (no `%`)** → a case-insensitive exact match. Case-insensitive so the LLM passing `"Active"`/`"ACTIVE"` still hits the lowercase stored value; no substring trap.
- Switch both IP `status` fields (trademarks, patents) from `ilike` → `exact_ci`; descriptions say "вкажіть точне значення".
- Unit test locks that `exact_ci("active")` renders `status ILIKE $1` with value `active` (never matches `inactive`).

Shared query-ir change is additive (EDRSR uses the same builder; existing match types unchanged). All 32 query-ir tests pass.

## Verify after deploy

`search_registry(trademarks, mark_text=NEMIROFF, status=active)` should return **120** (not 260), `status=inactive` → 140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes over-matching in registry search: `status=active` no longer matches `inactive` by using a case-insensitive exact match. Implements `exact_ci` and updates TM/patent `status` filters to satisfy LEXAI-1832.

- **Bug Fixes**
  - Added `exact_ci` match type (`col ILIKE $N` without wildcards) for categorical enums.
  - Switched `status` fields in trademarks and patents to `exact_ci`; updated help text to require exact values.
  - Added unit test ensuring `exact_ci("active")` renders `status ILIKE $1` with value `active` and avoids substring matches.

<sup>Written for commit 01a1209c869d6bd506e535966df4ae164023224a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

