### PR TITLE
ci(stage): don't auto-deploy openreyestr on Brev

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -175,9 +175,12 @@ jobs:
             SERVICES=""
             [ "$BACKEND_CHANGED" = "true" ] && SERVICES="backend"
             [ "$RADA_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}rada"
-            [ "$OPENREYESTR_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}openreyestr"
+            # NOTE: openreyestr is NOT auto-deployed on the Brev stage — its
+            # pre-loaded openreyestr-db image + named-volume/password semantics
+            # need manual handling. Deploy it explicitly via
+            # `workflow_dispatch` with services=openreyestr when needed.
             [ "$FRONTEND_CHANGED" = "true" ] && SERVICES="${SERVICES:+$SERVICES,}frontend"
-            [ "$SHARED_CHANGED" = "true" ] && [ -z "$SERVICES" ] && SERVICES="backend,rada,openreyestr,frontend"
+            [ "$SHARED_CHANGED" = "true" ] && [ -z "$SERVICES" ] && SERVICES="backend,rada,frontend"
             echo "list=${SERVICES:-backend,frontend}" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
Follow-up to #2162. The pre-loaded `openreyestr-db` image + a fresh named volume + empty `OPENREYESTR_POSTGRES_PASSWORD` makes `postgres-openreyestr-stage` crash-loop on the Brev stage, which aborts `docker compose up -d` and fails the deploy. openreyestr is auxiliary and not part of the core stage, so this stops auto-detecting it; deploy it explicitly with `gh workflow run deploy-stage.yml -f services=openreyestr` once its volume/password are sorted.

Core stage (backend, rada, document-service, frontend, nginx) is healthy and `stage.legal.org.ua` is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-deploying `openreyestr` on the Brev stage to prevent `postgres-openreyestr-stage` crash loops that fail the deploy.

- **Bug Fixes**
  - Removed `openreyestr` from the auto-detected service list in `.github/workflows/deploy-stage.yml`.
  - When `SHARED_CHANGED` and no service-specific changes, deploy `backend,rada,frontend` only (no `openreyestr`).
  - Added a note explaining manual handling due to pre-loaded `openreyestr-db`, named volume, and empty `OPENREYESTR_POSTGRES_PASSWORD`.

- **Migration**
  - To deploy `openreyestr` explicitly: `gh workflow run deploy-stage.yml -f services=openreyestr`.

<sup>Written for commit 951a986a60079973e1614b8bcaa0980b9974f1b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

