### PR TITLE
feat(stage): wire EDRSR full-text search to Brev edrsr_local

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -595,6 +595,15 @@ services:
 
       LOG_LEVEL: ${LOG_LEVEL:-info}
       TZ: Europe/Kiev
+      # EDRSR full-text search: when set, EdsrFtsService opens a dedicated pool
+      # to the Brev host edrsr_local DB, reached via a host-network socat relay
+      # (:6432 -> 127.0.0.1:5432). Empty = fall back to the main stage DB.
+      EDRSR_DATABASE_URL: ${EDRSR_DATABASE_URL:-}
+      EDRSR_POOL_MAX: ${EDRSR_POOL_MAX:-10}
+    # host.docker.internal -> host gateway, so the container can reach the
+    # edrsr-pg-relay socat listener bound on the host.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
     - "127.0.0.1:3004:3000"
     depends_on:


### PR DESCRIPTION
Connects the Brev **stage** app to the host's `edrsr_local` (2.9 TB EDRSR corpus) for court-decision search.

## Changes
- `docker-compose.stage.yml`: map `EDRSR_DATABASE_URL` + `EDRSR_POOL_MAX` into `app-stage`, and add `extra_hosts: host.docker.internal:host-gateway`. When `EDRSR_DATABASE_URL` is set, `EdsrFtsService` opens a dedicated pool to it; empty = falls back to the stage DB (default, so this is safe for other envs).

## Host-side prerequisites on Brev (already applied, not in repo)
- **socat relay** `edrsr-pg-relay` (host-net, `:6432 -> 127.0.0.1:5432`, restart unless-stopped) — `edrsr_local` binds localhost-only.
- `EDRSR_DATABASE_URL=postgresql://secondlayer:***@host.docker.internal:6432/edrsr_local` in `/home/nvidia/stage-secrets/.env.stage`.
- `safe_ts_headline()` function added to `edrsr_local` (migration 099; the raw refurbish DB lacks the app's FTS helpers).

## Verified
`search_court_decisions mode=fulltext` on stage returns real registry results with headlines + ranks from `edrsr_local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects the stage app’s EDRSR full-text search to the Brev host `edrsr_local` DB via a dedicated pool, enabling real court-decision search on the 2.9 TB corpus. Adds `EDRSR_DATABASE_URL` and `EDRSR_POOL_MAX` to `app-stage` and maps `host.docker.internal` to the host gateway; if the URL is unset, it falls back to the stage DB.

- **Migration**
  - Set `EDRSR_DATABASE_URL` in stage secrets and run a host `socat` relay `:6432 -> 127.0.0.1:5432` so the container can reach `edrsr_local`.
  - Ensure `safe_ts_headline()` exists in `edrsr_local`.

<sup>Written for commit a2a1b4d4fb2ea2587b552eca380552a097afa4c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

