### PR TITLE
feat(stage): wire EDRSR semantic/hybrid search (bge-m3 + qdrant)

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -600,6 +600,17 @@ services:
       # (:6432 -> 127.0.0.1:5432). Empty = fall back to the main stage DB.
       EDRSR_DATABASE_URL: ${EDRSR_DATABASE_URL:-}
       EDRSR_POOL_MAX: ${EDRSR_POOL_MAX:-10}
+      # EDRSR semantic/hybrid search: bge-m3 query embedder (Brev tei-bge-leg,
+      # attached to this network) + read-only queries against the Brev
+      # qdrant-revec edrsr_decisions collection. SKIP_INIT=true so stage never
+      # (re)configures that live, actively-indexed collection.
+      BGE_M3_URL: ${BGE_M3_URL:-}
+      QDRANT_EDRSR_URL: ${QDRANT_EDRSR_URL:-}
+      QDRANT_EDRSR_COLLECTION: ${QDRANT_EDRSR_COLLECTION:-}
+      QDRANT_EDRSR_API_KEY: ${QDRANT_EDRSR_API_KEY:-}
+      QDRANT_EDRSR_SKIP_INIT: ${QDRANT_EDRSR_SKIP_INIT:-true}
+      QDRANT_EDRSR_MAX_CONCURRENCY: ${QDRANT_EDRSR_MAX_CONCURRENCY:-6}
+      QDRANT_EDRSR_TIMEOUT_MS: ${QDRANT_EDRSR_TIMEOUT_MS:-20000}
     # host.docker.internal -> host gateway, so the container can reach the
     # edrsr-pg-relay socat listener bound on the host.
     extra_hosts:


### PR DESCRIPTION
Follow-up to #2166 — adds the **vector** path so stage EDRSR search supports `semantic`/`hybrid`, not just `fulltext`.

## Changes
- `docker-compose.stage.yml`: map `BGE_M3_URL` + `QDRANT_EDRSR_{URL,COLLECTION,API_KEY,SKIP_INIT,MAX_CONCURRENCY,TIMEOUT_MS}` into `app-stage`. `QDRANT_EDRSR_SKIP_INIT` defaults **true**.

## Host-side on Brev (already applied, not in repo)
- `tei-bge-leg` (BAAI/bge-m3) attached to the stage docker network → `BGE_M3_URL=http://tei-bge-leg:80`.
- `QDRANT_EDRSR_URL=http://host.docker.internal:6343` (qdrant-revec), `QDRANT_EDRSR_COLLECTION=edrsr_decisions`, `SKIP_INIT=true` — in `/home/nvidia/stage-secrets/.env.stage`.

## Safety
- `edrsr_decisions` is the **live, actively-indexed** re-vec collection. `SKIP_INIT=true` means stage never creates/reconfigures it. The pre-vectorizer write worker (`EdsrPreVectorizerWorker`) is **never instantiated** at HTTP runtime, so stage only reads.

## Verified
`search_court_decisions` `mode=semantic` (cosine ~0.63) and `mode=hybrid` return real `edrsr_decisions` hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables semantic and hybrid search for EDRSR on stage by wiring the `bge-m3` embedder and `qdrant` vector store via new env vars in `docker-compose.stage.yml`. Stage queries the live `edrsr_decisions` collection in read-only mode with `QDRANT_EDRSR_SKIP_INIT=true`.

- New Features
  - Map `BGE_M3_URL`, `QDRANT_EDRSR_URL`, `QDRANT_EDRSR_COLLECTION`, `QDRANT_EDRSR_API_KEY`, `QDRANT_EDRSR_SKIP_INIT` (default true), `QDRANT_EDRSR_MAX_CONCURRENCY` (6), and `QDRANT_EDRSR_TIMEOUT_MS` (20000) into `app-stage`.

<sup>Written for commit 8dacc916145bc1ba264778df0d3913a643e8ef6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

