### PR TITLE
feat(stage): wire EDRSR citation graph to Brev neo4j

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -611,6 +611,12 @@ services:
       QDRANT_EDRSR_SKIP_INIT: ${QDRANT_EDRSR_SKIP_INIT:-true}
       QDRANT_EDRSR_MAX_CONCURRENCY: ${QDRANT_EDRSR_MAX_CONCURRENCY:-6}
       QDRANT_EDRSR_TIMEOUT_MS: ${QDRANT_EDRSR_TIMEOUT_MS:-20000}
+      # EDRSR citation graph — Brev neo4j-citation, reached over WG (same URI
+      # prod uses). Read-only queries from the citation-graph tools.
+      NEO4J_URI: ${NEO4J_URI:-}
+      NEO4J_USER: ${NEO4J_USER:-neo4j}
+      NEO4J_PASSWORD: ${NEO4J_PASSWORD:-}
+      NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
     # host.docker.internal -> host gateway, so the container can reach the
     # edrsr-pg-relay socat listener bound on the host.
     extra_hosts:


### PR DESCRIPTION
Follow-up to #2166/#2167. Maps `NEO4J_URI/USER/PASSWORD/DATABASE` into `app-stage` so citation-graph tools work on the Brev stage.

- `NEO4J_URI=bolt://10.88.0.3:7687` — the same Brev `neo4j-citation` instance prod uses (over WG), read-only.
- Values in `/home/nvidia/stage-secrets/.env.stage`.
- The tools resolve `case_id` via the Postgres `documents` table; stage's was populated from a prod data-only copy (226,306 rows).

Verified: `get_citation_graph` returns real graph nodes (no "not imported" error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable EDRSR citation graph tools on stage by wiring `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, and `NEO4J_DATABASE` into `app-stage` and pointing them to the Brev `neo4j-citation` instance. Tools like `get_citation_graph`, `search_legal_precedents`, and `get_similar_reasoning` now run read-only against the same Neo4j as prod, using the prod-seeded `documents` table to resolve `case_id`.

<sup>Written for commit e240b48dcd0dcabad34dd310e7972241b281e153. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

