### PR TITLE
infra(stage): always start MinIO + stateful infra on deploy

### DIFF
--- a/.github/workflows/deploy-stage.yml
+++ b/.github/workflows/deploy-stage.yml
@@ -268,6 +268,11 @@ jobs:
             timeout 120 $DC up --abort-on-container-exit migrate-openreyestr-stage || true
           fi
 
+          # Ensure stateful infra services are up (idempotent, no rebuild) so a
+          # partial deploy never leaves them down. minio-stage in particular is
+          # not a depends_on of any app service, so it would otherwise never start.
+          $DC up -d postgres-stage redis-stage qdrant-stage minio-stage 2>/dev/null || true
+
           [ -n "$START" ] && $DC up -d $START
 
           # Always recreate nginx after any deploy (bind-mount staleness)


### PR DESCRIPTION
## What

`minio-stage` is defined in `docker-compose.stage.yml` but is **not a `depends_on`** of any app service, so the Brev deploy job's `START` set never brought it up. On a fresh/partial stage deploy MinIO stayed down.

Consequence: session-replay chunk uploads and user-bucket `ensureBucket` failed with `getaddrinfo EAI_AGAIN minio-stage` → HTTP 500 → the frontend's global error interceptor showed the generic **"Помилка сервера. Спробуйте пізніше."** toast every ~10s on `/chat`.

## Fix

Add an idempotent `docker compose up -d postgres-stage redis-stage qdrant-stage minio-stage` (no rebuild) right before the app `START` in the Brev self-hosted deploy job, so stateful infra is always running regardless of which services changed.

## Note

MinIO is already running on stage now (started manually + `restart: unless-stopped`); this makes it durable across future deploys. Verified after fix: bucket created, chunks upload (`Chunk stored`), zero session-replay 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure stateful infra services (including `minio-stage`) always start on stage deploys to prevent storage-related 500s. Adds an idempotent `docker compose up -d` step before app startup so partial deploys don't leave MinIO down.

- **Bug Fixes**
  - In `.github/workflows/deploy-stage.yml`, run `$DC up -d postgres-stage redis-stage qdrant-stage minio-stage` before starting apps.
  - Fixes session-replay chunk upload failures and user-bucket `ensureBucket` errors that showed recurring 500s on `/chat`.

<sup>Written for commit 70573fdaf46f68b09c45e2e07772ad6d220ca1f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

