### PR TITLE
feat(stage): postgres_fdw for EDRSR direct-DB tools

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -18,6 +18,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_stage}
       TZ: Europe/Kiev
+    # host.docker.internal -> host gateway, so postgres_fdw can reach the
+    # edrsr-pg-relay socat listener (:6432) that fronts the Brev host
+    # edrsr_local DB (foreign tables in the edrsr_fdw schema).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
     - "127.0.0.1:5434:5432"
     volumes:


### PR DESCRIPTION
The court-decision tools (`get_case_documents_chain`, `get_court_decision`, `extract_document_sections`, `get_decision_cited_norms`, `load_full_texts`) read `edrsr_documents`/`edrsr_fulltext` via the **main** pool (`this.db`), which is empty on stage — so they returned 0 results even though the case exists in `edrsr_local`.

Fix: **postgres_fdw** on `secondlayer_stage` → foreign tables (in `public`) proxy `edrsr_documents/edrsr_fulltext/edrsr_courts/...` to the Brev host `edrsr_local` (2.9 TB). Only compose change is `extra_hosts: host.docker.internal` on `postgres-stage` (so FDW reaches the `edrsr-pg-relay` socat at :6432). FDW objects are created in the DB (host-side script).

Verified: `get_case_documents_chain('346/7200/23')` → 2 docs; `get_court_decision` returns full metadata (judge/court/date). migrate still passes (default search_path; edrsr migrations already in ledger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable `postgres_fdw` on stage to read EDRSR data from the host `edrsr_local` DB, so court-decision tools return real results instead of empty sets. Adds `extra_hosts: "host.docker.internal:host-gateway"` to `postgres-stage` so FDW can reach the `edrsr-pg-relay` on port 6432.

- **Migration**
  - Pull the updated `deployment/docker-compose.stage.yml` and restart `postgres-stage`.
  - Ensure the host `edrsr-pg-relay` is running on :6432 and reachable via `host.docker.internal`.
  - FDW foreign tables in `public` map to EDRSR (documents/fulltext/courts); existing tools using the main pool now read the full corpus.

<sup>Written for commit 9f500112e508848a175f7098057612e647d3d816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

