### PR TITLE
chore(stage): drop postgres_fdw extra_hosts from postgres-stage

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -18,11 +18,6 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_stage}
       TZ: Europe/Kiev
-    # host.docker.internal -> host gateway, so postgres_fdw can reach the
-    # edrsr-pg-relay socat listener (:6432) that fronts the Brev host
-    # edrsr_local DB (foreign tables in the edrsr_fdw schema).
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     ports:
     - "127.0.0.1:5434:5432"
     volumes:


### PR DESCRIPTION
Follow-up to #2173. EDRSR direct-DB tools now use the dedicated EDRSR pool (not a postgres_fdw bridge), so `postgres-stage` no longer needs `host.docker.internal`. The FDW server/foreign tables were dropped from the stage DB; this removes the vestigial `extra_hosts`. `app-stage` keeps its `extra_hosts` (still needs the relay for the EDRSR pool + qdrant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `host.docker.internal` `extra_hosts` from `postgres-stage` since `postgres_fdw` is no longer used and EDRSR tools now connect via the dedicated pool. `app-stage` keeps its `extra_hosts` for the relay to the EDRSR pool and Qdrant.

<sup>Written for commit 2ca8a202c32b2abf48f8dc07e987b780add1491b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

