### PR TITLE
fix(stage): set Bedrock model tiers (deep=Sonnet 4.6) to match prod

### DIFF
--- a/deployment/docker-compose.stage.yml
+++ b/deployment/docker-compose.stage.yml
@@ -311,6 +311,11 @@ services:
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
+      # Bedrock model tiers - match prod (deep = Sonnet 4.6, NOT the Opus code
+      # default). Without these stage falls back to opus-4-6 for "deep" -> ~5x cost.
+      BEDROCK_MODEL_QUICK: ${BEDROCK_MODEL_QUICK:-eu.anthropic.claude-haiku-4-5-20251001-v1:0}
+      BEDROCK_MODEL_STANDARD: ${BEDROCK_MODEL_STANDARD:-eu.anthropic.claude-sonnet-4-6}
+      BEDROCK_MODEL_DEEP: ${BEDROCK_MODEL_DEEP:-eu.anthropic.claude-sonnet-4-6}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_REGION: ${AWS_REGION:-eu-central-1}
@@ -520,6 +525,11 @@ services:
       OPENAI_MODEL_STANDARD: ${OPENAI_MODEL_STANDARD:-gpt-5-mini}
       OPENAI_MODEL_DEEP: ${OPENAI_MODEL_DEEP:-gpt-5.1}
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
+      # Bedrock model tiers - match prod (deep = Sonnet 4.6, NOT the Opus code
+      # default). Without these stage falls back to opus-4-6 for "deep" -> ~5x cost.
+      BEDROCK_MODEL_QUICK: ${BEDROCK_MODEL_QUICK:-eu.anthropic.claude-haiku-4-5-20251001-v1:0}
+      BEDROCK_MODEL_STANDARD: ${BEDROCK_MODEL_STANDARD:-eu.anthropic.claude-sonnet-4-6}
+      BEDROCK_MODEL_DEEP: ${BEDROCK_MODEL_DEEP:-eu.anthropic.claude-sonnet-4-6}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_REGION: ${AWS_REGION:-eu-central-1}
@@ -721,6 +731,11 @@ services:
 
       # LLM Provider Strategy (OpenAI-only pipeline)
       LLM_PROVIDER_STRATEGY: ${LLM_PROVIDER_STRATEGY:-openai-first}
+      # Bedrock model tiers - match prod (deep = Sonnet 4.6, NOT the Opus code
+      # default). Without these stage falls back to opus-4-6 for "deep" -> ~5x cost.
+      BEDROCK_MODEL_QUICK: ${BEDROCK_MODEL_QUICK:-eu.anthropic.claude-haiku-4-5-20251001-v1:0}
+      BEDROCK_MODEL_STANDARD: ${BEDROCK_MODEL_STANDARD:-eu.anthropic.claude-sonnet-4-6}
+      BEDROCK_MODEL_DEEP: ${BEDROCK_MODEL_DEEP:-eu.anthropic.claude-sonnet-4-6}
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
       AWS_REGION: ${AWS_REGION:-eu-central-1}


### PR DESCRIPTION
Stage's compose never mapped `BEDROCK_MODEL_*`, so the backend used the code default (`deep = opus-4-6`). Prod maps `deep = sonnet-4-6`. A `deep`-budget chat on stage therefore ran on **Opus 4.6** ($15/$75 per M) vs **Sonnet 4.6** ($3/$15) on prod — **~5x the cost** for a byte-identical pipeline (verified chat-*.js md5 match prod).

Adds `BEDROCK_MODEL_QUICK/STANDARD/DEEP` to app-stage, document-service, rada with prod-matching defaults. Verified on stage: `BEDROCK_MODEL_DEEP=eu.anthropic.claude-sonnet-4-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Bedrock model tiers in stage to match prod so "deep" uses Sonnet 4.6 instead of Opus 4.6, avoiding ~5x higher cost. Adds `BEDROCK_MODEL_QUICK`, `BEDROCK_MODEL_STANDARD`, and `BEDROCK_MODEL_DEEP` mappings in `deployment/docker-compose.stage.yml` for app-stage, document-service, and rada.

- **Bug Fixes**
  - Map `BEDROCK_MODEL_*` for all LLM services in stage.
  - Defaults: quick = eu.anthropic.claude-haiku-4-5-20251001-v1:0, standard/deep = eu.anthropic.claude-sonnet-4-6.

<sup>Written for commit 055da7241fd8ed520c68527036445d3fc72bf109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

