### PR TITLE
fix(chat): load_full_texts return_texts — читання ключових секцій одним викликом

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -129,7 +129,10 @@ export class CourtDecisionTools extends BaseToolHandler {
         description: `Завантаження повних текстів судових рішень у базу даних
 
 Завантажує тексти рішень за масивом doc_id, перевіряє наявність у PostgreSQL/Redis кеші перед завантаженням.
-Використовуйте для попереднього завантаження текстів перед масовим аналізом.`,
+Використовуйте для попереднього завантаження текстів перед масовим аналізом.
+
+ВАЖЛИВО: за замовчуванням інструмент лише завантажує тексти в кеш і НЕ повертає їх — для читання кожного документа потрібен окремий get_court_decision, що витрачає бюджет викликів.
+Встановіть return_texts=true, щоб одразу отримати ключові секції (мотивувальна + резолютивна частини + застосовані норми) усіх документів ОДНИМ викликом — це економить бюджет викликів і одразу дає позицію суду та застосовані норми. Саме початок рішення (шапка, історія розгляду) не повертається як малоінформативний.`,
         inputSchema: {
           type: 'object',
           properties: {
@@ -147,6 +150,16 @@ export class CourtDecisionTools extends BaseToolHandler {
               type: 'number',
               default: 100,
               description: 'Розмір батчу для обробки'
+            },
+            return_texts: {
+              type: 'boolean',
+              default: false,
+              description: 'Повернути ключові секції (мотивувальна + резолютивна + застосовані норми) кожного документа одразу, замість окремих get_court_decision. Економить бюджет викликів.'
+            },
+            snippet_chars: {
+              type: 'number',
+              default: 4000,
+              description: 'Макс. символів витягу на документ (лише коли return_texts=true). За замовчуванням 4000.'
             }
           },
           required: ['doc_ids'],
@@ -620,6 +633,8 @@ export class CourtDecisionTools extends BaseToolHandler {
   private async loadFullTexts(args: any): Promise<ToolResult> {
     const docIds: number[] = args.doc_ids || [];
     const maxDocs = args.max_docs || 1000;
+    const returnTexts = args.return_texts === true;
+    const snippetChars = Math.min(20000, Math.max(500, Number(args.snippet_chars || 4000)));
 
     if (!docIds || docIds.length === 0) {
       throw new Error('doc_ids parameter is required and must be a non-empty array');
@@ -660,7 +675,99 @@ export class CourtDecisionTools extends BaseToolHandler {
       result.warning = `Запрошено ${uniqueDocIds.length} уникальных документов, но обработано только ${maxDocs} из-за лимита безопасности`;
     }
 
+    // When requested, return the key sections of each warmed document in a single
+    // response so the model does not need a separate get_court_decision per doc
+    // (which burns the tool-call budget and leaves warmed docs unread).
+    if (returnTexts && this.db) {
+      const processedIds = docs.map(d => d.doc_id);
+      result.documents = await this.buildKeySectionExcerpts(processedIds, snippetChars);
+    }
+
     return this.wrapResponse(result);
+  }
+
+  /**
+   * For each doc_id, fetch metadata + full_text and extract the substantive
+   * sections (застосовані норми + мотивувальна + резолютивна частини), which
+   * carry the holding and the applied norms. The procedural header/facts at the
+   * start of a decision are deliberately dropped as low-signal. Falls back to a
+   * head-truncated full_text only when the sectionizer yields nothing.
+   */
+  private async buildKeySectionExcerpts(docIds: number[], snippetChars: number): Promise<any[]> {
+    if (!this.db || docIds.length === 0) return [];
+
+    const rows = (await this.db.query(`
+      SELECT d.doc_id, d.cause_num, d.judge, d.adjudication_date, f.full_text
+      FROM edrsr_documents d
+      LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
+      WHERE d.doc_id = ANY($1)
+    `, [docIds])).rows;
+
+    // Preserve caller ordering and cover fulltext-only docs missing from edrsr_documents.
+    const byId = new Map<number, any>(rows.map((r: any) => [Number(r.doc_id), r]));
+    const missing = docIds.filter(id => !byId.has(id));
+    if (missing.length > 0) {
+      const ftRows = (await this.db.query(
+        `SELECT doc_id, full_text FROM edrsr_fulltext WHERE doc_id = ANY($1)`, [missing]
+      )).rows;
+      for (const r of ftRows) byId.set(Number(r.doc_id), { doc_id: r.doc_id, full_text: r.full_text });
+    }
+
+    // Priority order: applied norms first, then court reasoning, then the operative part.
+    const KEY_SECTION_ORDER = [
+      SectionType.LAW_REFERENCES,
+      SectionType.MOTIVES,
+      SectionType.COURT_REASONING,
+      SectionType.DECISION,
+    ];
+
+    const out: any[] = [];
+    for (const docId of docIds) {
+      const row = byId.get(docId);
+      if (!row) {
+        out.push({ doc_id: docId, error: 'Текст не знайдено в базі' });
+        continue;
+      }
+      const fullText: string = row.full_text || '';
+      const url = `https://reyestr.court.gov.ua/Review/${row.doc_id}`;
+
+      let excerpt = '';
+      let source: 'sections' | 'truncated' | 'empty' = 'empty';
+
+      if (fullText) {
+        const sections = await this.sectionizer.extractSections(fullText, false);
+        const keyParts: string[] = [];
+        for (const t of KEY_SECTION_ORDER) {
+          for (const s of sections) {
+            if (s && s.type === t && typeof s.text === 'string' && s.text.trim()) {
+              keyParts.push(`[${t}]\n${s.text.trim()}`);
+            }
+          }
+        }
+        if (keyParts.length > 0) {
+          excerpt = keyParts.join('\n\n');
+          source = 'sections';
+        } else {
+          // Fallback: sectionizer produced nothing (short ruling / atypical structure).
+          excerpt = fullText;
+          source = 'truncated';
+        }
+      }
+
+      const truncated = excerpt.length > snippetChars;
+      out.push({
+        doc_id: row.doc_id,
+        case_number: row.cause_num || undefined,
+        judge: row.judge || undefined,
+        adjudication_date: row.adjudication_date || undefined,
+        url,
+        full_text_length: fullText.length,
+        excerpt_source: source,
+        truncated,
+        text: truncated ? excerpt.slice(0, snippetChars) : excerpt,
+      });
+    }
+    return out;
   }
 
   private async bulkIngestCourtDecisions(args: any): Promise<ToolResult> {


### PR DESCRIPTION
## Проблема

У чаті модель прогріває N документів через `load_full_texts` (лише кеш), а потім змушена викликати `get_court_decision` окремо на КОЖЕН документ, щоб прочитати текст. Кожне читання витрачає бюджет `maxToolCalls`, тому на turn'ах із багатьма документами частина прогрітих доків лишається непрочитаною.

Репро — реальний прод-чат `chat-22d5afed-89bb-40a3-b909-54a47fd01632` (питання про податок на нерухомість на ТОТ):
- профільна постанова ВС **280/5185/19** (`doc 107631753`) знайдена пошуком на **позиції 3** і потрапила в `load_full_texts`, але `get_court_decision` по ній так і не викликали → в ответ вона не потрапила;
- модель побудувала висновок на **пп. 69.14** замість правильної норми **п. 38.6 підрозділу 10 розділу ХХ ПКУ**, хоча ця норма була прямо у FTS-headline топ-результату;
- turn упёрся в бюджет вызовів (13 tool-calls).

## Фікс

Додано opt-in параметр **`return_texts`** (default `false`, повністю backward-compatible) до `load_full_texts`. Коли `true`, після прогріву інструмент витягує і повертає **ключові секції кожного документа одним викликом**:

- пріоритет: `LAW_REFERENCES` (застосовані норми) → `MOTIVES` / `COURT_REASONING` (мотивувальна) → `DECISION` (резолютивна);
- малоінформативна процедурна шапка/переказ доводів на початку рішення **не повертається** — саме тому голе усічення по перших N символах відрізало б holding і повторило б помилку з нормою;
- fallback на усічений `full_text`, якщо секціонізатор нічого не виділив (короткі ухвали / нестандартна структура);
- `snippet_chars` обмежує розмір витягу на документ (default 4000).

Це закриває дві причини розходження з еталоном:
1. **бюджет викликів** — усі прогріті доки читаються за 1 виклик замість N;
2. **вибір норми** — модель одразу бачить `LAW_REFERENCES` + мотивувальну, а не процедурну шапку.

## Поза скоупом

Цитування непрочитаних справ 2025/2023 під приводом «ліміт викликів» (причина №3) — це поведінка reasoning, окремо. Опис інструмента вже підштовхує використовувати `return_texts` замість недовантаження.

## Тести / збірка

- Зміна ізольована в `court-decision-tools.ts`; `tsc` по файлу без нових помилок (решта помилок дерева — предіснуючі OSS-стаби `@secondlayer/core`, повна збірка в CI/прод з приватним core).
- Існуючий інтеграційний тест `load_full_texts` лишається валідним (default-поведінка не змінилась).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add opt-in return_texts to load_full_texts to return key sections of warmed documents in one call, eliminating per-doc get_court_decision calls. This reduces tool-call usage and helps the model see applied norms and reasoning up front.

- **New Features**
  - Added return_texts (default false, backward-compatible) to return LAW_REFERENCES → MOTIVES/COURT_REASONING → DECISION for each doc in a single response.
  - Skips low-signal procedural headers; falls back to truncated full_text only if no sections are found.
  - Added snippet_chars to cap per-doc excerpt size (default 4000).

<sup>Written for commit 6d454b5d61893992bc90ddac4badda5b630dfd9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

