### PR TITLE
fix(edrsr): allow `exact` mode in EdsrSearchArgs zod validator

### DIFF
--- a/packages/shared/src/query-ir/tool-args.ts
+++ b/packages/shared/src/query-ir/tool-args.ts
@@ -40,7 +40,7 @@ const KUPAP_PRESETS = [
  * values fail too, so the caller can surface a clean error to the model.
  */
 export const EdsrSearchArgs = z.object({
-  mode: z.enum(['structured', 'fulltext', 'hybrid', 'semantic']),
+  mode: z.enum(['structured', 'exact', 'fulltext', 'hybrid', 'semantic']),
   query: z.string().max(2000).optional(),
   party_name: z.string().max(200).optional(),
   party_role: PartyRole.optional(),


### PR DESCRIPTION
Follow-up to #2177. That PR added `mode: exact` to the tool's JSON `inputSchema`, `switch`, and the `searchExact` handler — but the **arg validator** `parseEdsrSearchArgs` (`EdsrSearchArgs` zod schema in `@secondlayer/shared`) still enumerated only `structured|fulltext|hybrid|semantic`.

`executeTool` runs `parseEdsrSearchArgs(args)` **before** the mode switch, so on prod `mode: exact` was rejected with `Invalid option: expected one of "structured"|"fulltext"|"hybrid"|"semantic"` even though the handler shipped. Verified live after #2177 deployed.

Fix: add `exact` to the zod enum. `packages/shared` builds clean (`tsc` exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `mode: exact` in EDSR search by adding it to the `EdsrSearchArgs` zod enum in `@secondlayer/shared`. This fixes a validation error that blocked the existing `searchExact` handler.

<sup>Written for commit 201525c2e79b760085514666ddfa762e7f901876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

