### PR TITLE
fix(webapp): correct court-decision rendering in document modal

### DIFF
--- a/lexwebapp/src/components/DocumentViewerModal/MarkdownViewer.tsx
+++ b/lexwebapp/src/components/DocumentViewerModal/MarkdownViewer.tsx
@@ -1,10 +1,29 @@
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 interface MarkdownViewerProps {
   content: string;
 }
 
+/**
+ * Legal source text (court decisions, citations) is plain text, not Markdown.
+ * Two constructs routinely misfire when it is parsed as CommonMark:
+ *  - Ukrainian apostrophes typed as a backtick (зобов`язати, ім`я, комп`ютерів)
+ *    get paired into inline `code` spans (gray monospace). Normalize ` → '.
+ *  - Indented standalone lines (e.g. "ВСТАНОВИВ:") become indented code blocks
+ *    (a solid black `<pre>`). Strip per-line leading whitespace.
+ * Intentional Markdown produced by the app (## headings, --- separators) has no
+ * leading indentation or backticks, so it is unaffected.
+ */
+function normalizeLegalText(content: string): string {
+  return content
+    .replace(/`/g, '’')
+    .replace(/^[ \t]+/gm, '');
+}
+
 export function MarkdownViewer({ content }: MarkdownViewerProps) {
+  const normalized = useMemo(() => normalizeLegalText(content), [content]);
+
   return (
     <div className="
       prose prose-zinc max-w-none
@@ -27,7 +46,7 @@ export function MarkdownViewer({ content }: MarkdownViewerProps) {
       prose-th:font-semibold prose-th:text-zinc-900 prose-th:py-2 prose-th:px-3
       prose-td:py-2 prose-td:px-3 prose-td:text-zinc-600 prose-td:border-b prose-td:border-zinc-100
     ">
-      <ReactMarkdown>{content}</ReactMarkdown>
+      <ReactMarkdown>{normalized}</ReactMarkdown>
     </div>
   );
 }


### PR DESCRIPTION
## Проблема

У модальному вікні перегляду рішення (відкривається з посилання в чаті) текст рішення відображався з двома дефектами форматування:

1. **Чорна плашка «ВСТАНОВИВ:»** — рядок з відступом сприймався як indented code block і малювався суцільною чорною коробкою (`prose-pre:bg-zinc-950`).
2. **Сірі моноширинні виділення посеред абзаців** — український апостроф, набраний як backtick (`` ` ``) у словах `зобов`язати`, `ім`я`, `комп`ютерів`, спарювався react-markdown в inline `code` спани.

## Причина

Сирий текст рішення (звичайний текст) подавався напряму в `react-markdown`, який парсив його як CommonMark.

## Фікс

`MarkdownViewer` нормалізує текст перед парсингом:
- `` ` `` → `'` (виправляє гліф апострофа й прибирає code-спани);
- зняття провідних пробілів/табів у кожному рядку (прибирає indented code blocks).

Справжня розмітка застосунку (`## заголовки`, `---` роздільники з `formatSections`) не містить ні backtick-ів, ні відступів, тож лишається незачепленою.

## Перевірка

- `tsc --noEmit` — без помилок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect formatting of court-decision text in the document modal by normalizing plain text before parsing with `react-markdown`. Removes unintended code blocks and inline code spans.

- **Bug Fixes**
  - Convert backticks to typographic apostrophes to prevent inline code spans in words (зобов’язати, ім’я, комп’ютерів).
  - Strip per-line leading spaces/tabs to avoid indented code blocks (e.g., “ВСТАНОВИВ:”).

<sup>Written for commit 33b11c9a2a5f6cde69d53bee46d67ad559e442a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

