### PR TITLE
chore(deploy): bump core overlay to 1f33a4f (relevance-gate identifier terms)

### DIFF
--- a/mcp_backend/CORE_OVERLAY.md
+++ b/mcp_backend/CORE_OVERLAY.md
@@ -11,6 +11,7 @@ a core-only change triggers a backend build + deploy.
 | 2026-06-23 | `17b1b0a` | CORE-21 P0.1 quote-or-drop (#55) + P0.2 claim↔source verifier (#57): warn-only citation-grounding gates (`ungrounded_quote`, `claim_unsupported`). |
 | 2026-06-23 | `3fd3bed` | CORE-21 P0.3 verify-before-stream (#58): high-stakes query types (practice/institutional/comparative_analysis, due_diligence) verify + repair citations before the answer is streamed — final answer renders at once, not token-by-token. |
 | 2026-06-23 | `810155f` | CORE-21 P0.enforce (#59): flip P0.1/P0.2 warn→enforce — unsupported quotes/holdings on real cited cases are now stripped from the answer (repairUnsupportedCitations), not just flagged. |
+| 2026-07-09 | `1f33a4f` | fix(chat) keep alphanumeric identifiers in relevance-gate query terms (#93): `buildQueryTerms` now retains letter+digit tokens (e.g. заявки `m200604929`), so an exact-token lookup no longer flags its own correct result as low-relevance (repro chat-81eb782d). Pairs with EDRSR `exact` search mode. |
 
 > Update this row whenever a core change must reach prod. The overlay always uses
 > core `main` HEAD; keep the recorded commit equal to that HEAD at merge time.


### PR DESCRIPTION
Ships **secondlayer-core #93** to prod.

`deploy-prod.yml` clones core `main` HEAD (`--depth 1`) and overlays it onto `mcp_backend/`; a core-only merge doesn't touch the monorepo, so the overlay row bump under `mcp_backend/` is what triggers the backend build + deploy (detect-changes: `mcp_backend/*` → `BACKEND=true`).

Fixes the false-positive **«Можливо, не стосується запиту»** warning on exact-token lookups (repro `chat-81eb782d`): `buildQueryTerms` now keeps letter+digit identifiers (e.g. заявки `m200604929`) so a case whose text contains the queried token is not flagged low-relevance. Complements EDRSR `exact` search mode (#2177/#2178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploys a core fix that keeps alphanumeric identifiers in relevance-gate query terms, so exact-token lookups (e.g. m200604929) are no longer flagged as low relevance. Bumps the core overlay under `mcp_backend/` to trigger the backend build; complements EDRSR `exact` search mode.

<sup>Written for commit b1f6efff79cdb2c38a317e7e81429944ef2f6709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

