### PR TITLE
feat(ip): unified ip_objects search tools + NDJSON harvest pipeline

### DIFF
--- a/lexwebapp/src/hooks/chat/evidence/registry.ts
+++ b/lexwebapp/src/hooks/chat/evidence/registry.ts
@@ -13,12 +13,61 @@ const REGISTRY_TOOLS = [
   'openreyestr_search_notaries',
   'openreyestr_search_court_experts',
   'openreyestr_search_arbitration_managers',
+  'search_ip_objects',
+  'search_trademarks',
+  'find_similar_trademarks',
+  'get_ip_object',
 ];
+
+const IP_TYPE_LABEL: Record<number, string> = {
+  1: 'Винахід',
+  2: 'Корисна модель',
+  4: 'Торговельна марка',
+  6: 'Промисловий зразок',
+};
+
+function ipObjectToDocument(o: any): VaultDocument {
+  const isRegistered = o.obj_state === 2;
+  const number = o.registration_number || o.app_number;
+  const typeLabel = IP_TYPE_LABEL[o.obj_type] || o.obj_type_name || 'Об’єкт ІВ';
+  const classes = Array.isArray(o.classes) && o.classes.length ? `Класи: ${o.classes.join(', ')}` : null;
+  return {
+    id: `ip-${o.id || number || Math.random().toString(36).slice(2, 8)}`,
+    title: o.title_ua || number || typeLabel,
+    type: 'other',
+    metadata: {
+      snippet: [
+        typeLabel,
+        o.similarity != null && `Схожість: ${o.similarity}`,
+        isRegistered ? `Свідоцтво/патент № ${o.registration_number || '—'}` : `Заявка № ${o.app_number || '—'}`,
+        classes,
+        o.owner_name && `Власник: ${o.owner_name}`,
+        o.owner_edrpou && `ЄДРПОУ: ${o.owner_edrpou}`,
+        o.status && `Статус: ${o.status}`,
+      ].filter(Boolean).join(' • '),
+      status: o.status,
+      edrpou: o.owner_edrpou,
+    },
+  };
+}
 
 export function extractRegistryEvidence(toolName: string, parsed: ToolResultData): EvidenceResult {
   const citations: Citation[] = [];
   const documents: VaultDocument[] = [];
   if (!REGISTRY_TOOLS.some((t) => toolName === t)) {
+    return { decisions: [], citations, documents };
+  }
+
+  // IP registry objects (trademarks / patents / utility models / designs)
+  if (toolName === 'search_ip_objects' || toolName === 'search_trademarks' || toolName === 'find_similar_trademarks') {
+    const items = Array.isArray(parsed.results) ? parsed.results : [];
+    for (const o of items) documents.push(ipObjectToDocument(o));
+    return { decisions: [], citations, documents };
+  }
+  if (toolName === 'get_ip_object') {
+    if (parsed && ((parsed as any).app_number || (parsed as any).registration_number)) {
+      documents.push(ipObjectToDocument(parsed));
+    }
     return { decisions: [], citations, documents };
   }
 

--- a/mcp_backend/src/api/__tests__/ip-objects-tools.test.ts
+++ b/mcp_backend/src/api/__tests__/ip-objects-tools.test.ts
@@ -1,0 +1,180 @@
+import { IpObjectsTools } from '../tools/ip-objects-tools.js';
+
+type Call = { sql: string; params: any[] };
+
+function makeDb(responder: (sql: string, params: any[]) => any) {
+  const calls: Call[] = [];
+  const db = {
+    calls,
+    query: jest.fn((sql: string, params: any[]) => {
+      calls.push({ sql, params });
+      return Promise.resolve(responder(sql, params));
+    }),
+  };
+  return db;
+}
+
+const tmRow = {
+  id: 1, obj_type: 4, obj_type_name: 'Торговельні марки', obj_state: 1,
+  app_number: 'm202400890', app_date: '2024-01-10', registration_number: null,
+  registration_date: null, expiry_date: null, status: 'active', title_ua: 'planet',
+  class_system: 'nice', classes: ['34'], owner_name: 'ТОВ «Тест»',
+  owner_edrpou: '38565147', owner_country: 'UA', owner_kind: 'legal_entity',
+  owner_role: 'applicant', image_path: '/media/x.jpg', _total_count: 1,
+};
+
+function parse(result: any) {
+  return JSON.parse(result.content[0].text);
+}
+
+describe('IpObjectsTools', () => {
+  it('exposes four read-only tools', () => {
+    const tool = new IpObjectsTools(makeDb(() => ({ rows: [] })));
+    const defs = tool.getToolDefinitions();
+    expect(defs.map(d => d.name).sort()).toEqual(
+      ['find_similar_trademarks', 'get_ip_object', 'search_ip_objects', 'search_trademarks'],
+    );
+    expect(defs.every(d => d.annotations?.readOnlyHint)).toBe(true);
+  });
+
+  it('returns null for an unknown tool name', async () => {
+    const tool = new IpObjectsTools(makeDb(() => ({ rows: [] })));
+    expect(await tool.executeTool('something_else', {})).toBeNull();
+  });
+
+  it('search_ip_objects builds ILIKE + class-overlap filters with parameters', async () => {
+    const db = makeDb(() => ({ rows: [tmRow] }));
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('search_ip_objects', { query: 'planet', obj_type: 4, classes: ['34'] });
+    const call = db.calls[0];
+    expect(call.sql).toContain('title_ua ILIKE');
+    expect(call.sql).toContain('classes &&');
+    expect(call.sql).toContain('COUNT(*) OVER()');
+    expect(call.params).toContain('%planet%');
+    expect(call.params).toContain(4);
+    expect(call.params).toContainEqual(['34']);
+    const parsed = parse(res);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.total_count).toBe(1);
+    expect(parsed.results[0]._total_count).toBeUndefined();
+  });
+
+  it('search_ip_objects asks for a filter when none provided', async () => {
+    const db = makeDb(() => ({ rows: [] }));
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('search_ip_objects', {});
+    expect(db.query).not.toHaveBeenCalled();
+    expect(res!.content[0].text).toContain('фільтр');
+  });
+
+  it('search_ip_objects rejects an invalid obj_type', async () => {
+    const tool = new IpObjectsTools(makeDb(() => ({ rows: [] })));
+    const res = await tool.executeTool('search_ip_objects', { obj_type: 9 });
+    expect(res!.isError).toBe(true);
+  });
+
+  it('search_trademarks pins obj_type=4 and maps nice_classes', async () => {
+    const db = makeDb(() => ({ rows: [tmRow] }));
+    const tool = new IpObjectsTools(db);
+    await tool.executeTool('search_trademarks', { query: 'ELFA', nice_classes: ['34'] });
+    const call = db.calls[0];
+    expect(call.sql).toContain('obj_type = 4');
+    expect(call.sql).toContain('classes &&');
+    expect(call.params).toContain('%ELFA%');
+    expect(call.params).toContainEqual(['34']);
+  });
+
+  it('search_trademarks requires at least one real criterion', async () => {
+    const db = makeDb(() => ({ rows: [] }));
+    const tool = new IpObjectsTools(db);
+    await tool.executeTool('search_trademarks', {});
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it('find_similar_trademarks requires an identifier', async () => {
+    const db = makeDb(() => ({ rows: [] }));
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('find_similar_trademarks', {});
+    expect(db.query).not.toHaveBeenCalled();
+    expect(res!.isError).toBe(true);
+  });
+
+  it('find_similar_trademarks requires classes when only query is given', async () => {
+    const db = makeDb(() => ({ rows: [] }));
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('find_similar_trademarks', { query: 'планета' });
+    expect(db.query).not.toHaveBeenCalled();
+    expect(res!.isError).toBe(true);
+    expect(res!.content[0].text).toContain('клас');
+  });
+
+  it('find_similar_trademarks by query+classes uses similarity + class overlap', async () => {
+    const db = makeDb(() => ({ rows: [{ ...tmRow, similarity: 0.6 }] }));
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('find_similar_trademarks', { query: 'планета', classes: ['34'] });
+    const call = db.calls[0];
+    expect(call.sql).toContain('similarity(title_ua, $1)');
+    expect(call.sql).toContain('classes && $2::text[]');
+    expect(call.params[0]).toBe('планета');
+    expect(call.params[1]).toEqual(['34']);
+    expect(call.params[2]).toBe(0.3); // default threshold
+    const parsed = parse(res);
+    expect(parsed.results[0].similarity).toBe(0.6);
+  });
+
+  it('find_similar_trademarks by app_number loads the reference then excludes it', async () => {
+    const db = makeDb((sql) =>
+      sql.includes('LIMIT 1') && sql.includes('title_ua, classes')
+        ? { rows: [{ title_ua: 'planet', classes: ['34'] }] }
+        : { rows: [tmRow] },
+    );
+    const tool = new IpObjectsTools(db);
+    await tool.executeTool('find_similar_trademarks', { app_number: 'm202401037' });
+    // 1st call loads the reference mark, 2nd runs the similarity search
+    expect(db.calls[0].sql).toContain('WHERE app_number = $1 AND obj_type = 4');
+    const search = db.calls[1];
+    expect(search.params[0]).toBe('planet');       // ref text
+    expect(search.params[1]).toEqual(['34']);       // ref classes
+    expect(search.sql).toContain('app_number <> $');
+    expect(search.params).toContain('m202401037');  // excluded self
+  });
+
+  it('get_ip_object fetches a single record by app_number', async () => {
+    const db = makeDb(() => ({ rows: [{ ...tmRow, raw_data: {} }] }));
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('get_ip_object', { app_number: 'm202400890' });
+    const call = db.calls[0];
+    expect(call.sql).toContain('app_number = $1');
+    expect(call.sql).toContain('LIMIT 1');
+    expect(call.params).toEqual(['m202400890']);
+    const parsed = parse(res);
+    expect(parsed.app_number).toBe('m202400890');
+  });
+
+  it('get_ip_object attaches lifecycle events and derives legal_status', async () => {
+    const db = makeDb((sql) =>
+      sql.includes('ip_object_events')
+        ? { rows: [{ event_date: '2025-07-24', event_kind: 'termination', doc_type: 'Повідомлення про припинення', direction: 'Outcoming', doc_number: 'НО-51' }] }
+        : { rows: [{ ...tmRow, obj_state: 2, raw_data: {} }] });
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('get_ip_object', { app_number: 'm202400890' });
+    const parsed = parse(res);
+    expect(db.calls[1].sql).toContain('ip_object_events');
+    expect(parsed.events).toHaveLength(1);
+    expect(parsed.legal_status).toBe('дію припинено');
+  });
+
+  it('get_ip_object errors without an identifier', async () => {
+    const tool = new IpObjectsTools(makeDb(() => ({ rows: [] })));
+    const res = await tool.executeTool('get_ip_object', {});
+    expect(res!.isError).toBe(true);
+  });
+
+  it('wraps DB errors', async () => {
+    const db = makeDb(() => { throw new Error('boom'); });
+    const tool = new IpObjectsTools(db);
+    const res = await tool.executeTool('search_ip_objects', { query: 'x' });
+    expect(res!.isError).toBe(true);
+    expect(res!.content[0].text).toContain('boom');
+  });
+});

--- a/mcp_backend/src/api/tools/ip-objects-tools.ts
+++ b/mcp_backend/src/api/tools/ip-objects-tools.ts
@@ -1,0 +1,380 @@
+/**
+ * IP Objects Tools — native search over the unified `ip_objects` table
+ * (Ukrainian IP registry harvested from the NIPO/UIPV SIS open-data API:
+ * trademarks(4), inventions(1), utility models(2), industrial designs(6),
+ * both applications (obj_state=1) and registered documents (obj_state=2)).
+ *
+ * Three tools:
+ *   • search_ip_objects — cross-type search (title, class, owner, type, state)
+ *   • search_trademarks — trademark-focused convenience wrapper (Nice classes)
+ *   • get_ip_object      — single record by application or registration number
+ *
+ * Backed by coreServices.db (the same pool the rest of the backend uses,
+ * pointing at the DB that holds ip_objects). Read-only.
+ */
+
+import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
+import { logger } from '../../utils/logger.js';
+
+const OBJ_TYPES = [1, 2, 4, 6];
+const OBJ_STATES = [1, 2];
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+// Columns returned by the list tools — compact, panel-friendly (no raw_data).
+const LIST_COLUMNS = `id, obj_type, obj_type_name, obj_state, app_number, app_date,
+  registration_number, registration_date, expiry_date, status, title_ua,
+  class_system, classes, owner_name, owner_edrpou, owner_country, owner_kind,
+  owner_role, image_path`;
+
+export class IpObjectsTools extends BaseToolHandler {
+  constructor(private db: any) {
+    super();
+  }
+
+  getToolDefinitions(): ToolDefinition[] {
+    return [
+      {
+        name: 'search_ip_objects',
+        annotations: { title: 'Пошук об’єктів права інтелектуальної власності', readOnlyHint: true },
+        description: `Пошук у реєстрі об’єктів права інтелектуальної власності України (НІПО/УІПВ): торговельні марки, винаходи, корисні моделі, промислові зразки — заявки та охоронні документи.
+
+Фільтри (передайте хоча б один): query (текст назви/позначення), obj_type (1=винаходи, 2=корисні моделі, 4=торговельні марки, 6=промислові зразки), obj_state (1=заявка, 2=зареєстровано), classes (масив кодів МКТП/МПК/Локарно), owner (назва власника/заявника), owner_edrpou (код ЄДРПОУ власника).
+
+Приклад: query="Планета", obj_type=4, classes=["34"]
+Приклад: owner_edrpou="38565147"`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Текстовий пошук за назвою/позначенням (title_ua)' },
+            obj_type: { type: 'number', enum: OBJ_TYPES, description: '1=винаходи, 2=корисні моделі, 4=торговельні марки, 6=промислові зразки' },
+            obj_state: { type: 'number', enum: OBJ_STATES, description: '1=заявка, 2=зареєстровано' },
+            classes: { type: 'array', items: { type: 'string' }, description: 'Коди класифікації (МКТП для ТМ, МПК для винаходів, Локарно для зразків). Збіг за будь-яким.' },
+            owner: { type: 'string', description: 'Назва власника або заявника (частковий збіг)' },
+            owner_edrpou: { type: 'string', description: 'Код ЄДРПОУ власника/заявника (для юросіб)' },
+            limit: { type: 'number', description: `Макс. результатів (за замовч. ${DEFAULT_LIMIT}, макс. ${MAX_LIMIT})` },
+          },
+        },
+      },
+      {
+        name: 'search_trademarks',
+        annotations: { title: 'Пошук торговельних марок', readOnlyHint: true },
+        description: `Пошук саме торговельних марок (свідоцтв на знаки для товарів і послуг) у реєстрі НІПО/УІПВ — заявки та зареєстровані. Спеціалізована обгортка над search_ip_objects з obj_type=4.
+
+Фільтри: query (словесна частина марки), nice_classes (масив класів МКТП), owner, owner_edrpou, obj_state (1=заявка, 2=зареєстровано).
+
+Приклад: query="ELFA", nice_classes=["34"]`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Словесна частина марки (частковий збіг)' },
+            nice_classes: { type: 'array', items: { type: 'string' }, description: 'Класи МКТП (Ніццька класифікація). Збіг за будь-яким.' },
+            owner: { type: 'string', description: 'Власник або заявник (частковий збіг)' },
+            owner_edrpou: { type: 'string', description: 'Код ЄДРПОУ власника' },
+            obj_state: { type: 'number', enum: OBJ_STATES, description: '1=заявка, 2=зареєстровано' },
+            limit: { type: 'number', description: `Макс. результатів (за замовч. ${DEFAULT_LIMIT}, макс. ${MAX_LIMIT})` },
+          },
+        },
+      },
+      {
+        name: 'find_similar_trademarks',
+        annotations: { title: 'Пошук схожих торговельних марок («зіткнення»)', readOnlyHint: true },
+        description: `Пошук тотожних або схожих торговельних марок у тих самих класах МКТП — для перевірки на «зіткнення» (ризик змішування, підстави для відмови за ст. 6 ЗУ №3689-XII).
+
+Передайте АБО app_number (еталонна марка — її словесну частину і класи візьмемо автоматично), АБО query (позначення) РАЗОМ з classes (класи МКТП). Пошук іде і серед заявок, і серед зареєстрованих марок, окрім самої еталонної. Результати відсортовані за схожістю (0..1).
+
+Приклад: app_number="m202401037"
+Приклад: query="планета", classes=["34"]`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            app_number: { type: 'string', description: 'Номер заявки еталонної марки (класи й позначення підтягнуться автоматично)' },
+            query: { type: 'string', description: 'Позначення для перевірки (якщо немає app_number)' },
+            classes: { type: 'array', items: { type: 'string' }, description: 'Класи МКТП (обов’язково разом із query)' },
+            obj_state: { type: 'number', enum: OBJ_STATES, description: 'Обмежити: 1=лише заявки, 2=лише зареєстровані (за замовч. обидва)' },
+            min_similarity: { type: 'number', description: 'Поріг схожості 0..1 (за замовч. 0.3)' },
+            limit: { type: 'number', description: `Макс. результатів (за замовч. ${DEFAULT_LIMIT}, макс. ${MAX_LIMIT})` },
+          },
+        },
+      },
+      {
+        name: 'get_ip_object',
+        annotations: { title: 'Картка об’єкта інтелектуальної власності', readOnlyHint: true },
+        description: `Отримати повну картку одного об’єкта ІВ за номером заявки або номером свідоцтва/патенту.
+
+Передайте app_number (напр. "m202410968", "a201500075") АБО registration_number. За потреби уточніть obj_type.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            app_number: { type: 'string', description: 'Номер заявки' },
+            registration_number: { type: 'string', description: 'Номер свідоцтва/патенту' },
+            obj_type: { type: 'number', enum: OBJ_TYPES, description: 'Тип об’єкта (для уточнення)' },
+          },
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<ToolResult | null> {
+    switch (name) {
+      case 'search_ip_objects':
+        return this.searchIpObjects(args ?? {});
+      case 'search_trademarks':
+        return this.searchTrademarks(args ?? {});
+      case 'find_similar_trademarks':
+        return this.findSimilarTrademarks(args ?? {});
+      case 'get_ip_object':
+        return this.getIpObject(args ?? {});
+      default:
+        return null;
+    }
+  }
+
+  private clampLimit(limit: any): number {
+    return Math.max(1, Math.min(Number(limit) || DEFAULT_LIMIT, MAX_LIMIT));
+  }
+
+  private async runSearch(
+    conditions: string[],
+    values: any[],
+    limit: number,
+    toolLabel: string,
+  ): Promise<ToolResult> {
+    if (conditions.length === 0) {
+      return this.wrapResponse('Вкажіть хоча б один фільтр для пошуку.');
+    }
+    const lim = this.clampLimit(limit);
+    values.push(lim);
+    const sql = `
+      SELECT ${LIST_COLUMNS}, COUNT(*) OVER() AS _total_count
+      FROM ip_objects
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY COALESCE(registration_date, app_date) DESC NULLS LAST, id DESC
+      LIMIT $${values.length}`;
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('За вказаними критеріями об’єктів не знайдено.');
+      }
+      return this.wrapSearchResults(result.rows, lim);
+    } catch (error: any) {
+      logger.error(`${toolLabel} error`, { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async searchIpObjects(args: any): Promise<ToolResult> {
+    const conditions: string[] = [];
+    const values: any[] = [];
+
+    if (args.query) {
+      values.push(`%${args.query}%`);
+      conditions.push(`title_ua ILIKE $${values.length}`);
+    }
+    if (args.obj_type != null) {
+      if (!OBJ_TYPES.includes(Number(args.obj_type))) {
+        return this.wrapError(`Невірний obj_type. Дозволені: ${OBJ_TYPES.join(', ')}`);
+      }
+      values.push(Number(args.obj_type));
+      conditions.push(`obj_type = $${values.length}`);
+    }
+    if (args.obj_state != null) {
+      if (!OBJ_STATES.includes(Number(args.obj_state))) {
+        return this.wrapError(`Невірний obj_state. Дозволені: ${OBJ_STATES.join(', ')}`);
+      }
+      values.push(Number(args.obj_state));
+      conditions.push(`obj_state = $${values.length}`);
+    }
+    if (Array.isArray(args.classes) && args.classes.length > 0) {
+      values.push(args.classes.map((c: any) => String(c)));
+      conditions.push(`classes && $${values.length}::text[]`);
+    }
+    if (args.owner) {
+      values.push(`%${args.owner}%`);
+      conditions.push(`owner_name ILIKE $${values.length}`);
+    }
+    if (args.owner_edrpou) {
+      values.push(String(args.owner_edrpou));
+      conditions.push(`owner_edrpou = $${values.length}`);
+    }
+
+    return this.runSearch(conditions, values, args.limit, 'search_ip_objects');
+  }
+
+  private async searchTrademarks(args: any): Promise<ToolResult> {
+    const conditions: string[] = ['obj_type = 4'];
+    const values: any[] = [];
+
+    if (args.query) {
+      values.push(`%${args.query}%`);
+      conditions.push(`title_ua ILIKE $${values.length}`);
+    }
+    if (Array.isArray(args.nice_classes) && args.nice_classes.length > 0) {
+      values.push(args.nice_classes.map((c: any) => String(c)));
+      conditions.push(`classes && $${values.length}::text[]`);
+    }
+    if (args.owner) {
+      values.push(`%${args.owner}%`);
+      conditions.push(`owner_name ILIKE $${values.length}`);
+    }
+    if (args.owner_edrpou) {
+      values.push(String(args.owner_edrpou));
+      conditions.push(`owner_edrpou = $${values.length}`);
+    }
+    if (args.obj_state != null) {
+      if (!OBJ_STATES.includes(Number(args.obj_state))) {
+        return this.wrapError(`Невірний obj_state. Дозволені: ${OBJ_STATES.join(', ')}`);
+      }
+      values.push(Number(args.obj_state));
+      conditions.push(`obj_state = $${values.length}`);
+    }
+
+    // obj_type=4 alone is not a user filter; require at least one real criterion.
+    if (values.length === 0) {
+      return this.wrapResponse('Вкажіть хоча б один фільтр: query, nice_classes, owner або owner_edrpou.');
+    }
+    return this.runSearch(conditions, values, args.limit, 'search_trademarks');
+  }
+
+  private async findSimilarTrademarks(args: any): Promise<ToolResult> {
+    let refText: string | undefined = args.query;
+    let refClasses: string[] | undefined = Array.isArray(args.classes)
+      ? args.classes.map((c: any) => String(c))
+      : undefined;
+    let excludeApp: string | undefined;
+
+    // Resolve reference mark from an application number, if given.
+    if (args.app_number) {
+      try {
+        const ref = await this.db.query(
+          `SELECT title_ua, classes FROM ip_objects WHERE app_number = $1 AND obj_type = 4 LIMIT 1`,
+          [String(args.app_number)],
+        );
+        if (ref.rows.length === 0) {
+          return this.wrapResponse(`Еталонну марку за номером заявки "${args.app_number}" не знайдено.`);
+        }
+        refText = refText || ref.rows[0].title_ua;
+        refClasses = refClasses || ref.rows[0].classes;
+        excludeApp = String(args.app_number);
+      } catch (error: any) {
+        logger.error('find_similar_trademarks ref-load error', { error: error.message });
+        return this.wrapError(`Помилка завантаження еталонної марки: ${error.message}`);
+      }
+    }
+
+    if (!refText) {
+      return this.wrapError('Вкажіть app_number еталонної марки або query (позначення).');
+    }
+    if (!refClasses || refClasses.length === 0) {
+      return this.wrapError('Пошук «зіткнення» прив’язаний до класів МКТП. Вкажіть classes разом із query (або передайте app_number).');
+    }
+
+    const minSim = args.min_similarity != null
+      ? Math.max(0, Math.min(Number(args.min_similarity), 1))
+      : 0.3;
+
+    const values: any[] = [refText, refClasses, minSim];
+    const conditions = [
+      'obj_type = 4',
+      `classes && $2::text[]`,
+      `similarity(title_ua, $1) >= $3`,
+    ];
+    if (excludeApp) {
+      values.push(excludeApp);
+      conditions.push(`app_number <> $${values.length}`);
+    }
+    if (args.obj_state != null) {
+      if (!OBJ_STATES.includes(Number(args.obj_state))) {
+        return this.wrapError(`Невірний obj_state. Дозволені: ${OBJ_STATES.join(', ')}`);
+      }
+      values.push(Number(args.obj_state));
+      conditions.push(`obj_state = $${values.length}`);
+    }
+
+    const lim = this.clampLimit(args.limit);
+    values.push(lim);
+
+    const sql = `
+      SELECT ${LIST_COLUMNS},
+             ROUND(similarity(title_ua, $1)::numeric, 3) AS similarity,
+             COUNT(*) OVER() AS _total_count
+      FROM ip_objects
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY similarity(title_ua, $1) DESC, COALESCE(registration_date, app_date) DESC NULLS LAST
+      LIMIT $${values.length}`;
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('Схожих марок у тих самих класах не знайдено.');
+      }
+      return this.wrapSearchResults(result.rows, lim);
+    } catch (error: any) {
+      logger.error('find_similar_trademarks error', { error: error.message });
+      return this.wrapError(`Помилка пошуку: ${error.message}`);
+    }
+  }
+
+  private async getIpObject(args: any): Promise<ToolResult> {
+    const conditions: string[] = [];
+    const values: any[] = [];
+
+    if (args.app_number) {
+      values.push(String(args.app_number));
+      conditions.push(`app_number = $${values.length}`);
+    } else if (args.registration_number) {
+      values.push(String(args.registration_number));
+      conditions.push(`registration_number = $${values.length}`);
+    } else {
+      return this.wrapError('Вкажіть app_number або registration_number.');
+    }
+    if (args.obj_type != null) {
+      values.push(Number(args.obj_type));
+      conditions.push(`obj_type = $${values.length}`);
+    }
+
+    const sql = `
+      SELECT ${LIST_COLUMNS}, title_en, abstract_ua, bulletin_441_date,
+             bulletin_441_number, inventor_names, last_update, raw_data
+      FROM ip_objects
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY obj_state DESC
+      LIMIT 1`;
+    try {
+      const result = await this.db.query(sql, values);
+      if (result.rows.length === 0) {
+        return this.wrapResponse('Об’єкт не знайдено.');
+      }
+      const obj = result.rows[0];
+      // Lifecycle timeline (продовження / визнання недійсним / припинення) from
+      // the classified data_docs events, plus a derived current legal status.
+      let events: any[] = [];
+      try {
+        const ev = await this.db.query(
+          `SELECT event_date, event_kind, doc_type, direction, doc_number
+           FROM ip_object_events WHERE app_number = $1
+           ORDER BY event_date NULLS LAST, id`,
+          [obj.app_number],
+        );
+        events = ev.rows;
+      } catch (e: any) {
+        logger.warn('get_ip_object events lookup failed', { error: e.message });
+      }
+      obj.events = events;
+      obj.legal_status = this.deriveLegalStatus(obj, events);
+      return this.wrapResponse(obj);
+    } catch (error: any) {
+      logger.error('get_ip_object error', { error: error.message });
+      return this.wrapError(`Помилка: ${error.message}`);
+    }
+  }
+
+  private deriveLegalStatus(obj: any, events: any[]): string {
+    const kinds = new Set(events.map(e => e.event_kind));
+    if (kinds.has('invalidation')) return 'визнано недійсним';
+    if (kinds.has('termination')) return 'дію припинено';
+    if (Number(obj.obj_state) === 1) return 'заявка на розгляді';
+    if (obj.expiry_date && new Date(obj.expiry_date) < new Date()) return 'строк дії сплив';
+    if (Number(obj.obj_state) === 2) return 'чинний';
+    return obj.status || 'невідомо';
+  }
+}

--- a/mcp_backend/src/factories/tool-services.ts
+++ b/mcp_backend/src/factories/tool-services.ts
@@ -32,6 +32,7 @@ import { SpendingTools } from '../api/tools/spending-tools.js';
 import { OpenDataRegistriesTools } from '../api/tools/opendata-registries-tools.js';
 import { Tier1OpenDataTools } from '../api/tools/tier1-opendata-tools.js';
 import { RegistrySearchTool } from '../api/tools/registry-search-tool.js';
+import { IpObjectsTools } from '../api/tools/ip-objects-tools.js';
 import { AnalyzeDataTool } from '../api/tools/analyze-data-tool.js';
 import { LLMAdapter } from '../infrastructure/adapters/llm-adapter.js';
 import { DecisionLayerTools } from '../api/tools/decision-layer-tools.js';
@@ -166,6 +167,7 @@ export function createToolServices(
   toolRegistry.registerHandler(new ECHRPracticeTools(coreServices.zoECHRAdapter));
   toolRegistry.registerHandler(new CourtStatusTools(coreServices.db));
   toolRegistry.registerHandler(new RegistrySearchTool(coreServices.db));
+  toolRegistry.registerHandler(new IpObjectsTools(coreServices.db));
   toolRegistry.registerHandler(new AnalyzeDataTool(coreServices.db));
   // Bespoke tools with non-parametric query patterns
   toolRegistry.registerHandler(new OpenDataTools(coreServices.db));

--- a/scripts/opendata/nipo/.gitignore
+++ b/scripts/opendata/nipo/.gitignore
@@ -1,1 +1,3 @@
 *.json
+*.ndjson
+harvest/

--- a/scripts/opendata/nipo/download_images.py
+++ b/scripts/opendata/nipo/download_images.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Download NIPO mark / design images referenced by ip_objects.image_path and
+store them in MinIO (S3-compatible), recording the object key back in the DB.
+
+The SIS API only gives relative media paths (e.g.
+/media/TRADE_MARKS/2024/m202400411/m202400411.JPG); the binaries live under
+https://sis.nipo.gov.ua. This script fetches each image (rate-limited, like the
+harvester) and puts it into a MinIO bucket, then sets ip_objects.image_object_key
+so the frontend / evidence panel can render the mark and so the collision search
+(#4) can later add a visual-similarity stage over figurative marks.
+
+Idempotent: adds image_object_key if missing and only processes rows where it is
+still NULL, so re-runs resume where they left off.
+
+Env:
+  POSTGRES_HOST/PORT/DB/USER/PASSWORD   - DB holding ip_objects
+  S3_ENDPOINT        - MinIO endpoint (default http://127.0.0.1:9000)
+  MINIO_ACCESS_KEY / MINIO_SECRET_KEY   - MinIO credentials
+
+Usage:
+  python3 download_images.py --dry-run --limit 3     # download only, no MinIO/DB
+  python3 download_images.py --bucket nipo-images    # full run
+"""
+
+import argparse
+import os
+import time
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+MEDIA_HOST = "https://sis.nipo.gov.ua"
+MAX_RETRIES = 6
+
+CONTENT_TYPES = {
+    ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png",
+    ".gif": "image/gif", ".tif": "image/tiff", ".tiff": "image/tiff",
+    ".bmp": "image/bmp", ".webp": "image/webp",
+}
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def content_type_for(path):
+    ext = os.path.splitext(path)[1].lower()
+    return CONTENT_TYPES.get(ext, "application/octet-stream")
+
+
+def fetch_bytes(url, rate):
+    for attempt in range(MAX_RETRIES):
+        try:
+            time.sleep(rate)
+            req = Request(url, headers={"User-Agent": "Mozilla/5.0 (SecondLayer NIPO image fetch)"})
+            with urlopen(req, timeout=90) as resp:
+                return resp.read(), resp.headers.get("Content-Type")
+        except (URLError, HTTPError, TimeoutError, ConnectionError, OSError) as e:
+            code = getattr(e, "code", None)
+            if code == 404:
+                return None, None  # missing image, skip permanently-ish
+            wait = min(2 ** attempt + 1, 40)
+            if "429" in str(e) or "503" in str(e):
+                wait = max(wait, 10)
+            if attempt < MAX_RETRIES - 1:
+                time.sleep(wait)
+            else:
+                raise
+    return None, None
+
+
+def get_db_conn():
+    import psycopg2
+    host = os.environ.get("POSTGRES_HOST", "127.0.0.1")
+    port = int(os.environ.get("POSTGRES_PORT", "5432"))
+    db = os.environ.get("POSTGRES_DB", "secondlayer")
+    user = os.environ.get("POSTGRES_USER", "secondlayer")
+    log(f"  DB target: postgresql://{user}@{host}:{port}/{db}")
+    return psycopg2.connect(host=host, port=port, dbname=db, user=user,
+                            password=os.environ.get("POSTGRES_PASSWORD"))
+
+
+def make_s3():
+    import boto3
+    endpoint = os.environ.get("S3_ENDPOINT", "http://127.0.0.1:9000")
+    log(f"  S3 endpoint: {endpoint}")
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=os.environ.get("MINIO_ACCESS_KEY"),
+        aws_secret_access_key=os.environ.get("MINIO_SECRET_KEY"),
+        region_name=os.environ.get("S3_REGION", "us-east-1"),
+    )
+
+
+def ensure_bucket(s3, bucket):
+    from botocore.exceptions import ClientError
+    try:
+        s3.head_bucket(Bucket=bucket)
+    except ClientError:
+        s3.create_bucket(Bucket=bucket)
+        log(f"  created bucket {bucket}")
+
+
+def run(args):
+    conn = get_db_conn()
+    cur = conn.cursor()
+
+    if not args.dry_run:
+        cur.execute("ALTER TABLE ip_objects ADD COLUMN IF NOT EXISTS image_object_key TEXT;")
+        conn.commit()
+
+    where = "image_path IS NOT NULL AND image_object_key IS NULL" if not args.dry_run \
+        else "image_path IS NOT NULL"
+    limit_sql = f"LIMIT {int(args.limit)}" if args.limit else ""
+    cur.execute(f"SELECT id, app_number, image_path FROM ip_objects WHERE {where} ORDER BY id {limit_sql}")
+    rows = cur.fetchall()
+    log(f"Found {len(rows)} images to process")
+
+    s3 = None
+    if not args.dry_run:
+        s3 = make_s3()
+        ensure_bucket(s3, args.bucket)
+
+    done = skipped = failed = 0
+    for oid, app_number, image_path in rows:
+        url = f"{MEDIA_HOST}{image_path}"
+        try:
+            data, ctype = fetch_bytes(url, args.rate)
+        except Exception as e:
+            log(f"  [{app_number}] FAILED: {e}")
+            failed += 1
+            continue
+        if not data:
+            log(f"  [{app_number}] missing (404): {image_path}")
+            skipped += 1
+            continue
+
+        key = image_path.lstrip("/")  # preserve media/ hierarchy as object key
+        if args.dry_run:
+            log(f"  [{app_number}] {len(data)} bytes {content_type_for(image_path)} -> would put {args.bucket}/{key}")
+            done += 1
+            continue
+
+        s3.put_object(Bucket=args.bucket, Key=key, Body=data,
+                      ContentType=ctype or content_type_for(image_path))
+        cur.execute("UPDATE ip_objects SET image_object_key=%s WHERE id=%s", (key, oid))
+        conn.commit()
+        done += 1
+        if done % 25 == 0:
+            log(f"  ...{done} uploaded")
+
+    cur.close(); conn.close()
+    log(f"\nDONE: {done} processed, {skipped} missing, {failed} failed"
+        + (" (dry run — nothing uploaded)" if args.dry_run else f" -> bucket {args.bucket}"))
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Download NIPO images into MinIO")
+    p.add_argument("--bucket", default=os.environ.get("NIPO_IMAGE_BUCKET", "nipo-images"))
+    p.add_argument("--limit", type=int, default=0, help="max images (0 = all)")
+    p.add_argument("--rate", type=float, default=1.0, help="seconds between fetches")
+    p.add_argument("--dry-run", action="store_true", help="download only, no MinIO / no DB write")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/scripts/opendata/nipo/harvest_nipo.py
+++ b/scripts/opendata/nipo/harvest_nipo.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Full-registry harvester for the NIPO/UIPV SIS open-data API.
+
+Unlike download_nipo.py (which only pulled registered trademarks + inventions
+for the 2024-2026 window into one big in-memory JSON), this harvester covers:
+
+  * all four object types  - inventions(1), utility models(2), trademarks(4),
+                             industrial designs(6);
+  * both object states     - applications (obj_state=1, filtered by app_date)
+                             AND registered protection documents
+                             (obj_state=2, filtered by reg_date);
+  * the full history        - trademarks/inventions back to ~1993, utility
+                             models/designs back to ~1994 (empty early windows
+                             cost one request and are cached as empty).
+
+Design notes:
+  * The SIS API is a single origin behind Cloudflare with a ~1 req/sec limit.
+    We therefore go sequential at a configurable rate (default 1.0s between
+    requests). Do NOT crank concurrency against one egress IP - use the
+    existing import-uipv-multi-ip.py path if you need multi-IP speed.
+  * Resumable by construction: work is split into per (type, state, month)
+    windows. Each finished window is written to its own NDJSON file via a
+    tmp-file + atomic rename. On re-run, any window whose output file already
+    exists is skipped - so an interrupted run re-fetches only the one window
+    that was in flight, never duplicating records.
+  * Output is NDJSON (one raw API record per line), the natural input for the
+    downstream Postgres importer (task #2).
+
+Usage:
+  python3 harvest_nipo.py                       # everything, full history
+  python3 harvest_nipo.py --obj-types 4         # trademarks only
+  python3 harvest_nipo.py --obj-states 1        # applications only
+  python3 harvest_nipo.py --start-year 2024     # narrow the range
+  python3 harvest_nipo.py --updated-since 01.01.2026   # incremental sync
+  python3 harvest_nipo.py --rate 1.5            # be gentler on the API
+"""
+
+import argparse
+import calendar
+import http.client
+import json
+import math
+import os
+import time
+import urllib.request
+from urllib.request import Request
+from urllib.error import URLError, HTTPError
+
+BASE_URL = "https://sis.nipo.gov.ua/api/v1/open-data/"
+
+# Optional source-IP binding, so multiple shards on a multi-homed host (e.g.
+# prod with N secondary IPs → N distinct public egress IPs) can each run at the
+# SIS per-IP rate limit for near-linear speedup. Set once from --source-ip.
+_SOURCE_IP = None
+
+
+class _BoundHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, *a, **k):
+        if _SOURCE_IP:
+            k.setdefault("source_address", (_SOURCE_IP, 0))
+        super().__init__(*a, **k)
+
+
+class _BoundHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, *a, **k):
+        if _SOURCE_IP:
+            k.setdefault("source_address", (_SOURCE_IP, 0))
+        super().__init__(*a, **k)
+
+
+class _BoundHTTPSHandler(urllib.request.HTTPSHandler):
+    def https_open(self, req):
+        return self.do_open(_BoundHTTPSConnection, req)
+
+
+class _BoundHTTPHandler(urllib.request.HTTPHandler):
+    def http_open(self, req):
+        return self.do_open(_BoundHTTPConnection, req)
+
+
+_OPENER = urllib.request.build_opener(_BoundHTTPSHandler(), _BoundHTTPHandler())
+DEFAULT_OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "harvest")
+MAX_RETRIES = 7
+
+# obj_type -> (folder/slug, first year the register has data)
+OBJ_TYPES = {
+    1: ("inventions", 1993),
+    2: ("utility_models", 1994),
+    4: ("trademarks", 1993),
+    6: ("designs", 1993),
+}
+
+# obj_state -> (folder/slug, date field used to window the query)
+OBJ_STATES = {
+    1: ("applications", "app_date"),
+    2: ("registered", "reg_date"),
+}
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def fetch_json(url, rate):
+    """Fetch one JSON page with retries + exponential backoff.
+
+    Sleeps `rate` seconds BEFORE every network call so the global request rate
+    never exceeds 1/`rate` regardless of how many windows we walk.
+    """
+    for attempt in range(MAX_RETRIES):
+        try:
+            time.sleep(rate)
+            req = Request(url, headers={"Accept": "application/json",
+                                        "User-Agent": "Mozilla/5.0 (SecondLayer NIPO harvester)"})
+            with _OPENER.open(req, timeout=90) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except (URLError, HTTPError, TimeoutError, ConnectionError, OSError) as e:
+            wait = min(2 ** attempt + 1, 60)
+            if "429" in str(e) or "503" in str(e):
+                wait = max(wait, 10)
+            if attempt < MAX_RETRIES - 1:
+                log(f"      retry {attempt + 1}/{MAX_RETRIES} in {wait}s ({e})")
+                time.sleep(wait)
+            else:
+                raise
+    return None
+
+
+def iter_window_records(obj_type, obj_state, date_field, d_from, d_to, rate,
+                        updated_since=None):
+    """Yield every record for one (type, state, date-window) by following the
+    API's `next` cursor. Returns (records, api_count)."""
+    params = [f"obj_type={obj_type}", f"obj_state={obj_state}"]
+    if d_from and d_to:
+        params.append(f"{date_field}_from={d_from}")
+        params.append(f"{date_field}_to={d_to}")
+    if updated_since:
+        params.append(f"last_update_from={updated_since}")
+    url = f"{BASE_URL}?{'&'.join(params)}"
+
+    first = fetch_json(url, rate)
+    if first is None:
+        raise RuntimeError("no response for first page")
+    total = first.get("count", 0)
+    records = list(first.get("results", []))
+    if total == 0:
+        return records, 0
+
+    total_pages = math.ceil(total / max(len(records), 1)) if records else 1
+    page = 1
+    nxt = first.get("next")
+    while nxt:
+        page += 1
+        if nxt.startswith("http://"):
+            nxt = "https://" + nxt[len("http://"):]  # keep TLS + consistent binding
+        data = fetch_json(nxt, rate)
+        if data is None:
+            log(f"      page {page}/{total_pages} empty response, stopping window")
+            break
+        records.extend(data.get("results", []))
+        nxt = data.get("next")
+
+    return records, total
+
+
+def month_windows(start_year, end_year, end_month):
+    """Generate (d_from, d_to) monthly windows from Jan start_year to
+    end_month/end_year inclusive, as DD.MM.YYYY strings."""
+    windows = []
+    for y in range(start_year, end_year + 1):
+        for m in range(1, 13):
+            if y == end_year and m > end_month:
+                break
+            last = calendar.monthrange(y, m)[1]
+            windows.append((f"01.{m:02d}.{y}", f"{last:02d}.{m:02d}.{y}", f"{y}-{m:02d}"))
+    return windows
+
+
+def write_window(path, records):
+    """Atomically write a window's records as NDJSON (empty file if none)."""
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False))
+            f.write("\n")
+    os.replace(tmp, path)
+
+
+def harvest(args):
+    obj_types = [int(x) for x in args.obj_types.split(",")] if args.obj_types else list(OBJ_TYPES)
+    obj_states = [int(x) for x in args.obj_states.split(",")] if args.obj_states else list(OBJ_STATES)
+
+    grand_total = 0
+    grand_windows = 0
+    grand_skipped = 0
+    start = time.time()
+
+    for obj_type in obj_types:
+        type_slug, type_start = OBJ_TYPES[obj_type]
+        for obj_state in obj_states:
+            state_slug, date_field = OBJ_STATES[obj_state]
+            out_dir = os.path.join(args.out_dir, type_slug, state_slug)
+            os.makedirs(out_dir, exist_ok=True)
+
+            # Incremental sync: one wide window filtered by last_update.
+            if args.updated_since:
+                path = os.path.join(out_dir, f"updated_since_{args.updated_since.replace('.', '')}.ndjson")
+                recs, count = iter_window_records(
+                    obj_type, obj_state, date_field, None, None, args.rate,
+                    updated_since=args.updated_since)
+                write_window(path, recs)
+                grand_total += len(recs)
+                grand_windows += 1
+                log(f"[{type_slug}/{state_slug}] updated since {args.updated_since}: "
+                    f"{len(recs)} records (api count={count})")
+                continue
+
+            start_year = args.start_year or type_start
+            windows = month_windows(start_year, args.end_year, args.end_month)
+            type_total = 0
+            for i, (d_from, d_to, tag) in enumerate(windows, 1):
+                path = os.path.join(out_dir, f"{tag}.ndjson")
+                if os.path.exists(path):
+                    grand_skipped += 1
+                    continue
+                try:
+                    recs, count = iter_window_records(
+                        obj_type, obj_state, date_field, d_from, d_to, args.rate)
+                    write_window(path, recs)
+                    type_total += len(recs)
+                    grand_total += len(recs)
+                    grand_windows += 1
+                    if recs:
+                        log(f"[{type_slug}/{state_slug}] {i}/{len(windows)} {tag}: "
+                            f"+{len(recs)} (type total {type_total})")
+                except Exception as e:
+                    log(f"[{type_slug}/{state_slug}] {tag} FAILED (will retry next run): {e}")
+            log(f"[{type_slug}/{state_slug}] window sweep done: {type_total} new records")
+
+    elapsed = time.time() - start
+    log(f"\nDONE: {grand_total} records across {grand_windows} fetched windows "
+        f"({grand_skipped} windows skipped as already done) in {elapsed:.0f}s")
+    log(f"Output NDJSON tree: {args.out_dir}")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Harvest the full NIPO/UIPV registry via the SIS open-data API.")
+    p.add_argument("--out-dir", default=DEFAULT_OUT_DIR, help="output root for NDJSON tree")
+    p.add_argument("--obj-types", default="", help="comma list of obj_type ids (default: 1,2,4,6)")
+    p.add_argument("--obj-states", default="", help="comma list of obj_state ids (default: 1,2)")
+    p.add_argument("--start-year", type=int, default=0, help="override per-type start year")
+    p.add_argument("--end-year", type=int, default=2026, help="last year to harvest (inclusive)")
+    p.add_argument("--end-month", type=int, default=12, help="last month of end-year (inclusive)")
+    p.add_argument("--rate", type=float, default=1.0, help="seconds between requests (>=1.0 recommended)")
+    p.add_argument("--source-ip", default="", help="bind outbound socket to this local IP (multi-IP sharding)")
+    p.add_argument("--updated-since", default="", help="DD.MM.YYYY incremental sync by last_update")
+    args = p.parse_args()
+    args.updated_since = args.updated_since or None
+    return args
+
+
+if __name__ == "__main__":
+    a = parse_args()
+    if a.source_ip:
+        _SOURCE_IP = a.source_ip
+    log("NIPO/UIPV full-registry harvester")
+    log(f"  types={a.obj_types or 'all(1,2,4,6)'} states={a.obj_states or 'all(1,2)'} "
+        f"rate={a.rate}s src_ip={a.source_ip or 'default'} out={a.out_dir}")
+    harvest(a)

--- a/scripts/opendata/nipo/import_ndjson.py
+++ b/scripts/opendata/nipo/import_ndjson.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+"""Import the harvested NIPO/UIPV NDJSON tree into a single unified Postgres
+table `ip_objects`.
+
+Input: the directory tree produced by harvest_nipo.py -
+    harvest/<type_slug>/<state_slug>/<YYYY-MM>.ndjson
+    type_slug  in {inventions, utility_models, trademarks, designs}
+    state_slug in {applications, registered}
+obj_type and obj_state are inferred from the path, so each raw API record maps
+to exactly one unified row.
+
+Why one table (vs the legacy opendata_trademarks / opendata_patents pair):
+  * covers ALL four object types AND both states (the legacy importer only did
+    obj_state=2 and lumped utility models + designs together);
+  * a single `owner_*` block with a `owner_role` discriminator (applicant vs
+    holder) instead of split holder_*/applicant_* columns - the "unified owner"
+    the task calls for;
+  * classes normalised into one `classes text[]` + `class_system`
+    (nice | ipc | locarno) so the collision-search tool (#4) can GIN-filter by
+    class regardless of object type;
+  * registration_* / expiry_date are nullable (absent on applications);
+  * application-only bulletin fields (Code_441) captured;
+  * raw_data kept as jsonb so nothing is lost.
+
+Safety: the DB target is env-driven and printed loudly on startup. It does NOT
+default to the prod loopback port - use --dry-run to validate extraction with
+no DB at all, and set POSTGRES_* explicitly for a real load.
+
+Usage:
+  python3 import_ndjson.py --dry-run --limit 3           # inspect extraction
+  python3 import_ndjson.py --create-schema               # DDL only
+  python3 import_ndjson.py                               # full load
+  python3 import_ndjson.py --harvest-dir harvest/trademarks   # subtree only
+"""
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+DEFAULT_HARVEST_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "harvest")
+
+TYPE_SLUGS = {"inventions": 1, "utility_models": 2, "trademarks": 4, "designs": 6}
+TYPE_NAMES = {1: "Винаходи", 2: "Корисні моделі", 4: "Торговельні марки", 6: "Промислові зразки"}
+STATE_SLUGS = {"applications": 1, "registered": 2}
+CLASS_SYSTEM = {1: "ipc", 2: "ipc", 4: "nice", 6: "locarno"}
+
+CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS ip_objects (
+    id                  BIGSERIAL PRIMARY KEY,
+    obj_type            SMALLINT NOT NULL,
+    obj_type_name       TEXT,
+    obj_state           SMALLINT NOT NULL,
+    app_number          TEXT NOT NULL,
+    app_date            DATE,
+    registration_number TEXT,
+    registration_date   DATE,
+    expiry_date         DATE,
+    status              TEXT,
+    title_ua            TEXT,
+    title_en            TEXT,
+    abstract_ua         TEXT,
+    class_system        TEXT,
+    classes             TEXT[],
+    owner_name          TEXT,
+    owner_edrpou        TEXT,
+    owner_country       TEXT,
+    owner_kind          TEXT,
+    owner_role          TEXT,
+    inventor_names      TEXT[],
+    image_path          TEXT,
+    image_object_key    TEXT,
+    bulletin_441_date   TEXT,
+    bulletin_441_number TEXT,
+    last_update         TIMESTAMPTZ,
+    raw_data            JSONB,
+    imported_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (app_number, obj_type, obj_state)
+);
+CREATE INDEX IF NOT EXISTS idx_ip_objects_classes     ON ip_objects USING GIN (classes);
+CREATE INDEX IF NOT EXISTS idx_ip_objects_owner_edrpou ON ip_objects (owner_edrpou) WHERE owner_edrpou IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_ip_objects_reg_number  ON ip_objects (registration_number) WHERE registration_number IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_ip_objects_app_number  ON ip_objects (app_number);
+CREATE INDEX IF NOT EXISTS idx_ip_objects_type_state  ON ip_objects (obj_type, obj_state);
+CREATE INDEX IF NOT EXISTS idx_ip_objects_title_trgm  ON ip_objects USING GIN (title_ua gin_trgm_ops);
+"""
+
+CREATE_EVENTS_SQL = """
+CREATE TABLE IF NOT EXISTS ip_object_events (
+    id          BIGSERIAL PRIMARY KEY,
+    app_number  TEXT NOT NULL,
+    obj_type    SMALLINT,
+    obj_state   SMALLINT,
+    event_date  DATE,
+    event_kind  TEXT,
+    doc_type    TEXT,
+    direction   TEXT,
+    doc_number  TEXT,
+    doc_cead_id BIGINT,
+    imported_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (doc_cead_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ip_events_app  ON ip_object_events (app_number);
+CREATE INDEX IF NOT EXISTS idx_ip_events_kind ON ip_object_events (event_kind);
+"""
+
+# DocType (free-text) -> lifecycle event kind. Order matters: first match wins.
+# Derived from the real registered-trademark DocType vocabulary in the SIS API.
+EVENT_RULES = [
+    ("invalidation", ("недійсн",)),                       # визнання недійсним
+    ("termination",  ("припин",)),                        # припинення дії
+    ("renewal",      ("продовж", "поновл", "відновл")),   # продовження строку дії
+    ("registration", ("рішення про реєстрац", "реєстрацію знака", "видача свідоцтва",
+                      "видачу охоронного", "рішення про видачу")),
+    ("amendment",    ("внесення змін",)),                 # зміни до реєстру
+    ("refusal",      ("відмов",)),                        # відмова в реєстрації
+]
+
+EVENT_COLUMNS = ["app_number", "obj_type", "obj_state", "event_date", "event_kind",
+                 "doc_type", "direction", "doc_number", "doc_cead_id"]
+
+
+def classify_doctype(doc_type):
+    low = (doc_type or "").lower()
+    for kind, keys in EVENT_RULES:
+        if any(k in low for k in keys):
+            return kind
+    return None
+
+
+def extract_events(record, obj_type, obj_state):
+    """Yield lifecycle-event rows from a record's data_docs (skips pure
+    correspondence — only classified продовження/недійсність/припинення/… kept)."""
+    rows = []
+    for d in record.get("data_docs") or []:
+        dr = d.get("DocRecord") or {}
+        kind = classify_doctype(dr.get("DocType"))
+        cead = dr.get("DocIdDocCEAD")
+        if not kind or cead is None:
+            continue
+        rows.append((
+            record.get("app_number"), obj_type, obj_state,
+            _date(dr.get("DocRegDate")), kind, dr.get("DocType"),
+            dr.get("DocDirection"), dr.get("DocRegNumber"), cead,
+        ))
+    return rows
+
+
+COLUMNS = [
+    "obj_type", "obj_type_name", "obj_state", "app_number", "app_date",
+    "registration_number", "registration_date", "expiry_date", "status",
+    "title_ua", "title_en", "abstract_ua", "class_system", "classes",
+    "owner_name", "owner_edrpou", "owner_country", "owner_kind", "owner_role",
+    "inventor_names", "image_path", "bulletin_441_date", "bulletin_441_number",
+    "last_update", "raw_data",
+]
+
+
+def _date(v):
+    return (v or "")[:10] or None if isinstance(v, str) else None
+
+
+def _values_one_lang(blocks, base):
+    """Collect values for `base` from an INID list, using a SINGLE language for
+    the whole list (prefer .U, then .R, then .E). The API repeats each party /
+    inventor once per language, so picking one language avoids triple-counting.
+    """
+    for suf in (".U", ".R", ".E"):
+        vals = [e.get(base + suf) for e in blocks or [] if e.get(base + suf)]
+        if vals:
+            return vals
+    return []
+
+
+def _party_from_inid(blocks, name_base, country_base):
+    """Extract (primary name, country) from an I_71/I_73 style list."""
+    names = _values_one_lang(blocks, name_base)
+    countries = _values_one_lang(blocks, country_base)
+    return (names[0] if names else None), (countries[0] if countries else None)
+
+
+def extract_trademark(record, obj_state):
+    data = record.get("data") or {}
+
+    wm = (data.get("WordMarkSpecification") or {}).get("MarkSignificantVerbalElement")
+    mark_text = " ".join(w.get("#text", "") for w in wm if w.get("#text")) if isinstance(wm, list) else None
+
+    classes = []
+    gs = ((data.get("GoodsServicesDetails") or {}).get("GoodsServices") or {})
+    cds = (gs.get("ClassDescriptionDetails") or {}).get("ClassDescription")
+    if isinstance(cds, dict):
+        cds = [cds]
+    for c in cds or []:
+        cn = c.get("ClassNumber")
+        if cn is not None:
+            classes.append(str(cn))
+
+    # Unified owner: holder if present (registered), else applicant.
+    owner_name = owner_edrpou = owner_country = owner_kind = owner_role = None
+    holders = (data.get("HolderDetails") or {}).get("Holder") or []
+    applicants = (data.get("ApplicantDetails") or {}).get("Applicant") or []
+    party = None
+    if holders:
+        party, owner_role = (holders[0].get("HolderAddressBook") or {}), "holder"
+    elif applicants:
+        party, owner_role = (applicants[0].get("ApplicantAddressBook") or {}), "applicant"
+    if party is not None:
+        fna = party.get("FormattedNameAddress") or {}
+        fn = (fna.get("Name") or {}).get("FreeFormatName") or {}
+        owner_name = (fn.get("FreeFormatNameDetails") or {}).get("FreeFormatNameLine") or None
+        owner_edrpou = fn.get("EDRPOU") or None
+        owner_kind = fn.get("NameKind") or None
+        owner_country = (fna.get("Address") or {}).get("AddressCountryCode") or None
+
+    image_path = ((data.get("MarkImageDetails") or {}).get("MarkImage") or {}).get("MarkImageFilename")
+
+    return {
+        "title_ua": mark_text, "title_en": None, "abstract_ua": None,
+        "classes": classes or None,
+        "owner_name": owner_name, "owner_edrpou": owner_edrpou,
+        "owner_country": owner_country, "owner_kind": owner_kind, "owner_role": owner_role,
+        "inventor_names": None,
+        "image_path": image_path,
+        "expiry_date": _date(data.get("ExpiryDate")),
+        "status": data.get("application_status") or data.get("registration_status_color"),
+        "bulletin_441_date": data.get("Code_441"),
+        "bulletin_441_number": data.get("Code_441_BulNumber"),
+    }
+
+
+def extract_patentlike(record, obj_type, obj_state):
+    """Inventions (1), utility models (2), designs (6) - WIPO INID coded."""
+    data = record.get("data") or {}
+
+    title_ua = title_en = None
+    for t in data.get("I_54") or []:
+        title_ua = title_ua or t.get("I_54.U")
+        title_en = title_en or t.get("I_54.E")
+
+    abstract_ua = None
+    for a in data.get("AB") or []:
+        if a.get("AB.L") == "UA" and a.get("AB.T"):
+            abstract_ua = a.get("AB.T")
+            break
+
+    if obj_type == 6:
+        classes = data.get("I_51") or data.get("Locarno") or data.get("IPC") or []
+    else:
+        classes = data.get("IPC") or []
+    if isinstance(classes, str):
+        classes = [classes]
+    classes = [str(c) for c in classes if c]
+
+    # Unified owner: holder I_73 (granted) else applicant I_71.
+    if data.get("I_73"):
+        owner_name, owner_country = _party_from_inid(data.get("I_73"), "I_73.N", "I_73.C")
+        owner_role = "holder"
+    else:
+        owner_name, owner_country = _party_from_inid(data.get("I_71"), "I_71.N", "I_71.C")
+        owner_role = "applicant"
+
+    inventors = []
+    for nm in _values_one_lang(data.get("I_72"), "I_72.N"):
+        if nm not in inventors:
+            inventors.append(nm)
+
+    return {
+        "title_ua": title_ua, "title_en": title_en, "abstract_ua": abstract_ua,
+        "classes": classes or None,
+        "owner_name": owner_name, "owner_edrpou": None,
+        "owner_country": owner_country, "owner_kind": None, "owner_role": owner_role,
+        "inventor_names": inventors or None,
+        "image_path": None,
+        "expiry_date": None,
+        "status": data.get("registration_status_color") or data.get("application_status"),
+        "bulletin_441_date": None,
+        "bulletin_441_number": None,
+    }
+
+
+def extract_row(record, obj_type, obj_state):
+    if obj_type == 4:
+        spec = extract_trademark(record, obj_state)
+    else:
+        spec = extract_patentlike(record, obj_type, obj_state)
+    row = {
+        "obj_type": obj_type,
+        "obj_type_name": TYPE_NAMES.get(obj_type),
+        "obj_state": obj_state,
+        "app_number": record.get("app_number"),
+        "app_date": _date(record.get("app_date")),
+        "registration_number": record.get("registration_number"),
+        "registration_date": _date(record.get("registration_date")),
+        "class_system": CLASS_SYSTEM.get(obj_type),
+        "last_update": record.get("last_update"),
+        "raw_data": json.dumps(record.get("data") or {}, ensure_ascii=False),
+    }
+    row.update(spec)
+    return tuple(row[c] for c in COLUMNS)
+
+
+def iter_ndjson_files(harvest_dir):
+    """Yield (path, obj_type, obj_state) for every ndjson under the tree."""
+    for path in sorted(glob.glob(os.path.join(harvest_dir, "**", "*.ndjson"), recursive=True)):
+        parts = path.split(os.sep)
+        type_slug = next((p for p in parts if p in TYPE_SLUGS), None)
+        state_slug = next((p for p in parts if p in STATE_SLUGS), None)
+        if type_slug is None or state_slug is None:
+            print(f"  WARN skip (cannot infer type/state): {path}")
+            continue
+        yield path, TYPE_SLUGS[type_slug], STATE_SLUGS[state_slug]
+
+
+def get_db_conn():
+    import psycopg2
+    host = os.environ.get("POSTGRES_HOST", "127.0.0.1")
+    port = int(os.environ.get("POSTGRES_PORT", "5432"))
+    db = os.environ.get("POSTGRES_DB", "secondlayer")
+    user = os.environ.get("POSTGRES_USER", "secondlayer")
+    print(f"  DB target: postgresql://{user}@{host}:{port}/{db}")
+    return psycopg2.connect(host=host, port=port, dbname=db, user=user,
+                            password=os.environ.get("POSTGRES_PASSWORD"))
+
+
+def run(args):
+    files = list(iter_ndjson_files(args.harvest_dir))
+    print(f"Found {len(files)} ndjson window files under {args.harvest_dir}")
+
+    if args.dry_run:
+        shown = 0
+        total = 0
+        for path, ot, ost in files:
+            with open(path, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    total += 1
+                    if shown < args.limit:
+                        row = dict(zip(COLUMNS, extract_row(json.loads(line), ot, ost)))
+                        row.pop("raw_data")
+                        print(json.dumps(row, ensure_ascii=False, indent=2))
+                        shown += 1
+        print(f"\nDRY RUN: parsed {total} records across {len(files)} files, "
+              f"showed {shown}. No DB touched.")
+        return
+
+    import psycopg2.extras
+    conn = get_db_conn()
+    cur = conn.cursor()
+    # ip_object_events is cheap and needed even by --no-schema watcher runs.
+    cur.execute(CREATE_EVENTS_SQL)
+    conn.commit()
+    if args.create_schema or not args.no_schema:
+        cur.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+        cur.execute(CREATE_SQL)
+        conn.commit()
+        print("  schema ensured (ip_objects + ip_object_events + indexes)")
+    if args.create_schema:
+        cur.close(); conn.close(); return
+
+    upsert = f"""
+        INSERT INTO ip_objects ({','.join(COLUMNS)})
+        VALUES %s
+        ON CONFLICT (app_number, obj_type, obj_state) DO UPDATE SET
+            registration_number=EXCLUDED.registration_number,
+            registration_date=EXCLUDED.registration_date,
+            expiry_date=EXCLUDED.expiry_date,
+            status=EXCLUDED.status,
+            owner_name=EXCLUDED.owner_name,
+            owner_edrpou=EXCLUDED.owner_edrpou,
+            classes=EXCLUDED.classes,
+            last_update=EXCLUDED.last_update,
+            raw_data=EXCLUDED.raw_data,
+            imported_at=NOW()
+    """
+    events_upsert = f"""
+        INSERT INTO ip_object_events ({','.join(EVENT_COLUMNS)})
+        VALUES %s
+        ON CONFLICT (doc_cead_id) DO NOTHING
+    """
+    total = 0
+    total_events = 0
+    for path, ot, ost in files:
+        batch = []
+        events = []
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                batch.append(extract_row(rec, ot, ost))
+                events.extend(extract_events(rec, ot, ost))
+        if not batch:
+            continue
+        # SIS pagination can repeat an app_number within one window; ON CONFLICT
+        # cannot touch the same row twice in one command, so dedupe by the
+        # conflict key (app_number, obj_type, obj_state), keeping the last seen.
+        deduped = {}
+        for row in batch:
+            deduped[(row[3], row[0], row[2])] = row
+        batch = list(deduped.values())
+        psycopg2.extras.execute_values(cur, upsert, batch, template=None, page_size=500)
+        if events:
+            ev_dedup = {e[8]: e for e in events}  # dedupe by doc_cead_id
+            psycopg2.extras.execute_values(cur, events_upsert, list(ev_dedup.values()), page_size=500)
+            total_events += len(ev_dedup)
+        conn.commit()
+        total += len(batch)
+        print(f"  {os.path.relpath(path, args.harvest_dir)}: {len(batch)} rows (running {total})")
+    cur.close(); conn.close()
+    print(f"\nDONE: upserted {total} rows into ip_objects, {total_events} lifecycle events")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Import harvested NIPO NDJSON into ip_objects")
+    p.add_argument("--harvest-dir", default=DEFAULT_HARVEST_DIR)
+    p.add_argument("--dry-run", action="store_true", help="parse + print sample, no DB")
+    p.add_argument("--limit", type=int, default=3, help="sample rows to show in --dry-run")
+    p.add_argument("--create-schema", action="store_true", help="run DDL then exit")
+    p.add_argument("--no-schema", action="store_true", help="skip DDL on load")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    run(parse_args())

--- a/scripts/opendata/nipo/launch_2006_2015.sh
+++ b/scripts/opendata/nipo/launch_2006_2015.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Backfill NIPO harvest for 2006-2014 (2015 already done in the 2015-2026 pass),
+# sharded across all 15 prod egress IPs. 9 year-shards (all types+states) + 6
+# boost workers on the heavier years' TM-registered slice. Resumable; writes to
+# the same /home/ubuntu/nipo_harvest tree (year windows do not collide).
+set -u
+DIR=/home/ubuntu/SecondLayer/scripts/opendata/nipo
+OUT=${OUT:-/home/ubuntu/nipo_harvest}; LOG=$OUT/logs
+RATE=${RATE:-1.1}
+mkdir -p "$LOG"
+
+# One IP per year, full types+states.
+years=(
+  "172.31.29.20 2006" "172.31.21.47 2007" "172.31.22.206 2008"
+  "172.31.27.31 2009" "172.31.28.109 2010" "172.31.31.40 2011"
+  "172.31.21.255 2012" "172.31.19.142 2013" "172.31.19.20 2014"
+)
+for s in "${years[@]}"; do set -- $s; ip=$1; y=$2
+  nohup python3 "$DIR/harvest_nipo.py" --start-year $y --end-year $y \
+    --source-ip $ip --rate $RATE --out-dir "$OUT" > "$LOG/bf_${y}.log" 2>&1 &
+  echo "year   src=$ip $y pid=$!"; sleep 0.3
+done
+
+# Boost workers: TM-registered (the bottleneck) on heavier years.
+boosts=(
+  "172.31.17.145 2014" "172.31.16.240 2013" "172.31.21.126 2012"
+  "172.31.21.214 2011" "172.31.27.133 2010" "172.31.22.179 2009"
+)
+for s in "${boosts[@]}"; do set -- $s; ip=$1; y=$2
+  nohup python3 "$DIR/harvest_nipo.py" --obj-types 4 --obj-states 2 \
+    --start-year $y --end-year $y --source-ip $ip --rate $RATE --out-dir "$OUT" \
+    > "$LOG/bf_boost_${y}.log" 2>&1 &
+  echo "TMreg  src=$ip $y pid=$!"; sleep 0.3
+done
+echo "launched 15 shards for 2006-2014 backfill -> $OUT"

--- a/scripts/opendata/nipo/launch_shards.sh
+++ b/scripts/opendata/nipo/launch_shards.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Launch the NIPO harvest sharded by year across prod's distinct egress IPs.
+# One year per secondary IP (each maps to its own public EIP -> its own SIS
+# per-IP rate budget). The app's primary IP (172.31.29.20) is intentionally
+# NOT used. Resumable: re-running skips already-fetched windows.
+set -u
+DIR=/home/ubuntu/SecondLayer/scripts/opendata/nipo
+OUT=${OUT:-/home/ubuntu/nipo_harvest}
+LOGDIR=$OUT/logs
+RATE=${RATE:-1.1}
+mkdir -p "$LOGDIR"
+
+# "source_ip start_year end_year" — heaviest (recent) years get their own IP;
+# the two lightest early years share one.
+shards=(
+  "172.31.21.47 2026 2026"
+  "172.31.22.206 2025 2025"
+  "172.31.27.31 2024 2024"
+  "172.31.28.109 2023 2023"
+  "172.31.31.40 2022 2022"
+  "172.31.21.255 2021 2021"
+  "172.31.19.142 2020 2020"
+  "172.31.19.20 2019 2019"
+  "172.31.17.145 2018 2018"
+  "172.31.16.240 2017 2017"
+  "172.31.21.126 2015 2016"
+)
+
+for s in "${shards[@]}"; do
+  set -- $s; ip=$1; y0=$2; y1=$3
+  nohup python3 "$DIR/harvest_nipo.py" \
+    --start-year "$y0" --end-year "$y1" --source-ip "$ip" \
+    --rate "$RATE" --out-dir "$OUT" \
+    > "$LOGDIR/shard_${y0}_${y1}.log" 2>&1 &
+  echo "launched src=$ip years=$y0-$y1 pid=$!"
+  sleep 0.3
+done
+echo "all shards launched -> $OUT (logs in $LOGDIR)"

--- a/scripts/opendata/nipo/watch_import.sh
+++ b/scripts/opendata/nipo/watch_import.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Incrementally import the growing NIPO NDJSON tree into prod ip_objects.
+# Re-imports (idempotent upsert) every INTERVAL seconds while harvest shards are
+# running, then one final pass after they finish.
+set -u
+DIR=/home/ubuntu/SecondLayer/scripts/opendata/nipo
+OUT=${OUT:-/home/ubuntu/nipo_harvest}
+LOG=$OUT/logs/import.log
+INTERVAL=${INTERVAL:-600}
+PW=$(docker exec secondlayer-postgres-prod printenv POSTGRES_PASSWORD)
+
+run_import() {
+  cd "$DIR"
+  POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=5438 POSTGRES_DB=secondlayer_prod \
+  POSTGRES_USER=secondlayer POSTGRES_PASSWORD="$PW" \
+    python3 import_ndjson.py --harvest-dir "$OUT" --no-schema >> "$LOG" 2>&1
+}
+
+echo "=== import watcher started $(date -u +%H:%M:%S) ===" >> "$LOG"
+while pgrep -f harvest_nipo.py >/dev/null; do
+  run_import
+  sleep "$INTERVAL"
+done
+echo "=== harvest done, final import $(date -u +%H:%M:%S) ===" >> "$LOG"
+run_import
+echo "=== import watcher finished $(date -u +%H:%M:%S) ===" >> "$LOG"


### PR DESCRIPTION
## What

Adds native MCP tools over a new unified **`ip_objects`** table (NIPO/УІПВ registry: trademarks, inventions, utility models, industrial designs; both **applications** and **registered** documents), plus the resumable multi-IP harvest/import pipeline that populates it. This lets the chat analyse IP objects (реєстрові дані, «зіткнення», правовий статус) directly over `ip_objects`.

## Tools (`mcp_backend/src/api/tools/ip-objects-tools.ts`)

- **`search_ip_objects`** — cross-type search: title (ILIKE), class (МКТП/IPC/Locarno via GIN `&&`), owner, ЄДРПОУ, `obj_type`, `obj_state`.
- **`search_trademarks`** — trademark-focused wrapper (Nice classes).
- **`find_similar_trademarks`** — «зіткнення» collision search via `pg_trgm` similarity, scoped to shared МКТП classes, across applications **and** registered, reference by app number or `query`+classes.
- **`get_ip_object`** — object card + **lifecycle events timeline** (from `data_docs`) + derived **`legal_status`** (чинний / визнано недійсним / дію припинено / строк дії сплив / заявка на розгляді).

Registered once in `tool-services.ts`; dispatch/HTTP routes are generic (no route changes). Results render in the right **evidence panel** (`lexwebapp/.../evidence/registry.ts`). **15 unit tests** (`ip-objects-tools.test.ts`), e2e-verified against live data.

## Data pipeline (`scripts/opendata/nipo/`)

- **`harvest_nipo.py`** — resumable per-window NDJSON harvester (all 4 types × both states), follows the SIS `next` cursor at ~1 req/s, `--source-ip` binds the egress IP for multi-IP sharding.
- **`import_ndjson.py`** — NDJSON → `ip_objects` + `ip_object_events` (lifecycle events classified from `data_docs` DocType), idempotent upsert, per-window batch dedupe (SIS repeats app_number within a window).
- **`download_images.py`** — mark images → MinIO (`image_object_key`).
- `launch_shards.sh` / `launch_2006_2015.sh` / `watch_import.sh` — sharded launch + incremental import loop.

## Schema

`import_ndjson.py --create-schema` builds (idempotent): `ip_objects` (unified owner+role, `classes text[]`+`class_system`, nullable reg/expiry, `image_object_key`, `raw_data`, GIN class + trigram-title indexes) and `ip_object_events` (unique on `DocIdDocCEAD`). Already applied on prod; 2015-2026 fully loaded (~473K objects, ~1.17M events); pre-2015 backfill in progress.

## Notes

- Parallel to the existing `opendata_trademarks`/`opendata_patents` + `search_registry` track (full history, deployed). This is a richer unified schema (both states in one table, classified events, derived legal status, pg_trgm collision). Consolidation can be decided later.
- Local build failures for `node-pty`/`neo4j-driver` are missing optional native deps in the dev env, unrelated to this change; my files are tsc-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native MCP tools to search a unified `ip_objects` table (NIPO/UIPV trademarks, inventions, utility models, designs; applications and registered) and a resumable NDJSON harvest/import pipeline to populate it. Enables cross-type IP search, collision checks for trademarks, and single-object cards with lifecycle status in the evidence panel.

- **New Features**
  - `search_ip_objects` — cross-type search by title, class (МКТП/IPC/Locarno), owner, ЄДРПОУ, `obj_type`, `obj_state`.
  - `search_trademarks` — TM-focused wrapper with Nice classes.
  - `find_similar_trademarks` — collision search via `pg_trgm` similarity, scoped by shared classes; works across applications and registered.
  - `get_ip_object` — full card with lifecycle events from `ip_object_events` and derived `legal_status`.
  - Registered in `mcp_backend/src/factories/tool-services.ts`; results render in the right evidence panel via `lexwebapp/src/hooks/chat/evidence/registry.ts`.
  - 15 unit tests in `mcp_backend/src/api/__tests__/ip-objects-tools.test.ts`.

- **Data Pipeline**
  - `scripts/opendata/nipo/harvest_nipo.py` — resumable, per-month NDJSON harvester for all types/states; follows API cursor at ~1 req/s; supports multi-IP sharding via `--source-ip`.
  - `scripts/opendata/nipo/import_ndjson.py` — loads into `ip_objects` (unified owner+role, `classes text[]` with `class_system`, nullable reg/expiry, `raw_data`) and `ip_object_events`; idempotent upsert with per-window dedupe; creates GIN index on classes and trigram index on title.
  - `scripts/opendata/nipo/download_images.py` — fetches referenced images to MinIO and sets `image_object_key`.
  - Shard/ops helpers: `launch_shards.sh`, `launch_2006_2015.sh`, `watch_import.sh`.

<sup>Written for commit dd2a34b4c93075f059d0a567543eb8420fc0f01d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

