### PR TITLE
fix(registry): search_registry trademarks/patents → live ip_objects

### DIFF
--- a/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
@@ -165,7 +165,7 @@ describe('RegistrySearchTool', () => {
       expect(calls[0].sql).toContain('<= $');
     });
 
-    it('array_contains: uses ANY() syntax', async () => {
+    it('array_contains_text: uses ::text = ANY() and casts value', async () => {
       db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
       tool = new RegistrySearchTool(db);
 
@@ -174,8 +174,10 @@ describe('RegistrySearchTool', () => {
         filters: { nice_class: 25 },
       });
 
-      expect(calls[0].sql).toContain('ANY(nice_classes)');
-      expect(calls[0].params).toContain(25);
+      // trademarks is backed by the unified ip_objects table (classes text[])
+      expect(calls[0].sql).toContain('::text = ANY(classes)');
+      expect(calls[0].sql).toContain('obj_type = 4'); // baseWhere applied
+      expect(calls[0].params).toContain('25'); // numeric slot cast to text
     });
 
     it('ilike_cast: casts column to text', async () => {
@@ -190,19 +192,20 @@ describe('RegistrySearchTool', () => {
       expect(calls[0].sql).toContain('founders::text ILIKE');
     });
 
-    it('exact_multi: uses = with OR across columns', async () => {
+    it('ilike_multi: uses ILIKE with OR across columns', async () => {
       db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
       tool = new RegistrySearchTool(db);
 
       await tool.executeTool('search_registry', {
-        registry: 'trademarks',
-        filters: { holder_edrpou: '12345678' },
+        registry: 'patents',
+        filters: { title: 'двигун' },
       });
 
       const sql = calls[0].sql;
-      expect(sql).toContain('holder_edrpou = $');
-      expect(sql).toContain('applicant_edrpou = $');
+      expect(sql).toContain('title_ua ILIKE $');
+      expect(sql).toContain('title_en ILIKE $');
       expect(sql).toContain(' OR ');
+      expect(sql).toContain('obj_type IN (1, 2, 6)'); // baseWhere applied
     });
   });
 
@@ -337,11 +340,14 @@ describe('aggregate mode (LEXAI-1820)', () => {
 
     expect(calls).toHaveLength(1);
     const sql = calls[0].sql;
+    // trademarks is backed by ip_objects: catalog fields resolve to its columns
+    // (mark_text→title_ua, holder_name→owner_name, nice_class→classes).
     expect(sql).toContain('GROUP BY');
-    expect(sql).toContain('COUNT(DISTINCT holder_name)');
+    expect(sql).toContain('COUNT(DISTINCT owner_name)');
     expect(sql).toContain('HAVING');
-    expect(sql).toContain('length(mark_text) >= 4');
-    expect(sql).toContain('= ANY(nice_classes)');
+    expect(sql).toContain('length(title_ua) >= 4');
+    expect(sql).toContain('::text = ANY(classes)');
+    expect(sql).toContain('obj_type = 4'); // baseWhere applied in aggregate mode
     const text = (result as any).content[0].text;
     expect(text).toContain('marengo');
   });

--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -25,6 +25,13 @@ export interface RegistryDef {
   defaultLimit?: number;
   maxLimit?: number;
   requiredFields?: string[];
+  /**
+   * Constant SQL predicate ANDed into every query for this registry (no bind
+   * params). Used when one physical table backs several logical registries —
+   * e.g. the unified `ip_objects` table serves both `trademarks` (obj_type=4)
+   * and `patents` (obj_type IN (1,2,6)).
+   */
+  baseWhere?: string;
 }
 
 export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
@@ -186,38 +193,46 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     ],
   },
 
+  // Backed by the unified `ip_objects` table (НІПО/УІПВ SIS harvest — the live,
+  // continuously-synced IP registry, 788K rows incl. applications + all types).
+  // The legacy `opendata_trademarks`/`opendata_patents` tables are a bulk
+  // snapshot that misses recent registrations (e.g. reg. №389137), so
+  // search_registry now reads ip_objects. Result columns keep the old names
+  // (mark_text/holder_*/nice_classes/ipc_codes) via aliases for a stable shape.
   trademarks: {
-    title: 'Торговельні марки (Укрпатент)',
-    description: 'Пошук торговельних марок (UIPV — Укрпатент)\n\n389K записів (повний реєстр, синхронізовано 2026-07). Пошук за текстом марки, власником, ЄДРПОУ, класом NICE, статусом.',
-    table: 'opendata_trademarks',
-    selectColumns: 'app_number, app_date, registration_number, registration_date, expiry_date, mark_text, holder_name, holder_edrpou, holder_country, nice_classes, status',
-    orderBy: 'registration_date DESC NULLS LAST',
+    title: 'Торговельні марки (НІПО/УІПВ)',
+    description: 'Пошук торговельних марок — свідоцтв на знаки для товарів і послуг (реєстр НІПО/УІПВ ip_objects: заявки + зареєстровані, живий синк).\n\nПошук за текстом марки, власником, ЄДРПОУ, класом МКТП/NICE, статусом, номером свідоцтва/заявки.',
+    table: 'ip_objects',
+    baseWhere: 'obj_type = 4',
+    selectColumns: 'obj_type_name, obj_state, app_number, app_date, registration_number, registration_date, expiry_date, title_ua AS mark_text, status, owner_name AS holder_name, owner_edrpou AS holder_edrpou, owner_country AS holder_country, classes AS nice_classes',
+    orderBy: 'COALESCE(registration_date, app_date) DESC NULLS LAST',
     emptyMessage: 'Торговельних марок не знайдено',
     fields: [
-      { name: 'mark_text', description: 'Текст торговельної марки', match: 'ilike', columns: ['mark_text'] },
-      { name: 'holder_name', description: "Назва або ім'я власника", match: 'ilike_multi', columns: ['holder_name', 'applicant_name'] },
-      { name: 'holder_edrpou', description: 'ЄДРПОУ власника', match: 'exact_multi', columns: ['holder_edrpou', 'applicant_edrpou'] },
-      { name: 'nice_class', description: 'Клас NICE (1-45)', match: 'array_contains', columns: ['nice_classes'], type: 'number' },
-      { name: 'status', description: 'Статус марки — вкажіть точне значення "active" (чинна/діюча) або "inactive" (нечинна: сплив строк або достроково припинена)', match: 'exact_ci', columns: ['status'] },
-      { name: 'registration_number', description: 'Номер реєстрації', match: 'exact', columns: ['registration_number'] },
+      { name: 'mark_text', description: 'Текст (словесна частина) торговельної марки', match: 'ilike', columns: ['title_ua'] },
+      { name: 'holder_name', description: "Назва або ім'я власника / заявника", match: 'ilike', columns: ['owner_name'] },
+      { name: 'holder_edrpou', description: 'ЄДРПОУ власника', match: 'exact', columns: ['owner_edrpou'] },
+      { name: 'nice_class', description: 'Клас МКТП/NICE (1-45), напр. "34"', match: 'array_contains_text', columns: ['classes'] },
+      { name: 'status', description: 'Статус марки — точне значення: "active" (чинна) або "stopped" (припинена: сплив строк / достроково припинена)', match: 'exact_ci', columns: ['status'] },
+      { name: 'registration_number', description: 'Номер свідоцтва / реєстрації', match: 'exact', columns: ['registration_number'] },
+      { name: 'app_number', description: 'Номер заявки (напр. m202420274)', match: 'exact', columns: ['app_number'] },
     ],
   },
 
   patents: {
-    title: 'Патенти (Укрпатент)',
-    description: 'Пошук патентів, корисних моделей та промислових зразків (UIPV — Укрпатент)\n\n347K записів (винаходи, корисні моделі, промзразки; синхронізовано 2026-07). Пошук за назвою, власником, кодом МПК, номером заявки, статусом.',
-    table: 'opendata_patents',
-    selectColumns: 'app_number, app_date, registration_number, registration_date, obj_type_name, title_ua, title_en, abstract_ua, ipc_codes, owner_name, owner_country, status',
-    orderBy: 'registration_date DESC NULLS LAST',
+    title: 'Патенти, корисні моделі, промзразки (НІПО/УІПВ)',
+    description: 'Пошук патентів на винаходи, корисних моделей та промислових зразків (реєстр НІПО/УІПВ ip_objects: заявки + охоронні документи, живий синк).\n\nПошук за назвою, власником, кодом МПК/Локарно, номером заявки/патенту.',
+    table: 'ip_objects',
+    baseWhere: 'obj_type IN (1, 2, 6)',
+    selectColumns: 'obj_type_name, obj_state, app_number, app_date, registration_number, registration_date, title_ua, title_en, abstract_ua, classes AS ipc_codes, owner_name, owner_country, status',
+    orderBy: 'COALESCE(registration_date, app_date) DESC NULLS LAST',
     emptyMessage: 'Патентів не знайдено',
     fields: [
       { name: 'title', description: 'Назва винаходу / корисної моделі', match: 'ilike_multi', columns: ['title_ua', 'title_en'] },
       { name: 'owner_name', description: "Ім'я або назва патентовласника", match: 'ilike', columns: ['owner_name'] },
-      { name: 'ipc_code', description: 'Код МПК (наприклад, A61K)', match: 'array_contains', columns: ['ipc_codes'] },
+      { name: 'ipc_code', description: 'Код МПК/Локарно (наприклад, A61K)', match: 'array_contains_text', columns: ['classes'] },
       { name: 'app_number', description: 'Номер заявки', match: 'exact', columns: ['app_number'] },
       { name: 'registration_number', description: 'Номер патенту', match: 'exact', columns: ['registration_number'] },
       { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 6=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
-      { name: 'status', description: 'Статус патенту — вкажіть точне значення "active" (чинний), "inactive" (нечинний) або "pending" (зареєстрований, очікує дії — напр. сплати збору)', match: 'exact_ci', columns: ['status'] },
     ],
   },
 

--- a/mcp_backend/src/api/tools/registry-search-tool.ts
+++ b/mcp_backend/src/api/tools/registry-search-tool.ts
@@ -12,6 +12,11 @@ import { logger } from '../../utils/logger.js';
 
 const REGISTRY_KEYS = Object.keys(REGISTRY_CATALOG);
 
+// Array-column match types (val tested against ANY(col)). Such columns cannot
+// be used as a GROUP BY / COUNT(DISTINCT) target in aggregate mode.
+const isArrayMatch = (m: FieldDef['match']): boolean =>
+  m === 'array_contains' || m === 'array_contains_text';
+
 export class RegistrySearchTool extends BaseToolHandler {
   constructor(private db: any) {
     super();
@@ -107,8 +112,12 @@ ${registryDescriptions}
     const defaultLimit = def.defaultLimit ?? 50;
     const lim = Math.max(1, Math.min(Number(limit) || defaultLimit, maxLimit));
 
+    // A constant registry-level predicate (no bind params) ANDed in when one
+    // physical table backs several logical registries (e.g. ip_objects).
+    const fullWhere = def.baseWhere ? `(${def.baseWhere}) AND (${whereClause})` : whereClause;
+
     if (aggregate) {
-      return this.executeAggregate(registry, def, aggregate, whereClause, values, paramIndex, lim);
+      return this.executeAggregate(registry, def, aggregate, fullWhere, values, paramIndex, lim);
     }
 
     const countValues = [...values];
@@ -116,11 +125,11 @@ ${registryDescriptions}
 
     const dataSql = `SELECT ${def.selectColumns}
       FROM ${def.table}
-      WHERE ${whereClause}
+      WHERE ${fullWhere}
       ORDER BY ${def.orderBy}
       LIMIT $${paramIndex}`;
 
-    const countSql = `SELECT COUNT(*) AS total FROM ${def.table} WHERE ${whereClause}`;
+    const countSql = `SELECT COUNT(*) AS total FROM ${def.table} WHERE ${fullWhere}`;
 
     try {
       const [dataResult, countResult] = await Promise.all([
@@ -156,14 +165,15 @@ ${registryDescriptions}
     const resolveColumn = (fieldName: string, role: string): string | null => {
       const field = def.fields.find(f => f.name === fieldName);
       if (!field) return null;
-      // Array-typed columns (match: array_contains) cannot be grouped/counted directly.
-      if (field.match === 'array_contains') return null;
+      // Array-typed columns (array_contains / array_contains_text) cannot be
+      // grouped/counted directly.
+      if (isArrayMatch(field.match)) return null;
       return field.columns[0];
     };
 
     const groupCol = aggregate.group_by ? resolveColumn(String(aggregate.group_by), 'group_by') : null;
     if (!groupCol) {
-      const usable = def.fields.filter(f => f.match !== 'array_contains').map(f => f.name).join(', ');
+      const usable = def.fields.filter(f => !isArrayMatch(f.match)).map(f => f.name).join(', ');
       return this.wrapResponse(`Невірне поле group_by. Доступні для агрегації: ${usable}`);
     }
 
@@ -171,7 +181,7 @@ ${registryDescriptions}
     if (aggregate.count_distinct) {
       distinctCol = resolveColumn(String(aggregate.count_distinct), 'count_distinct');
       if (!distinctCol) {
-        const usable = def.fields.filter(f => f.match !== 'array_contains').map(f => f.name).join(', ');
+        const usable = def.fields.filter(f => !isArrayMatch(f.match)).map(f => f.name).join(', ');
         return this.wrapResponse(`Невірне поле count_distinct. Доступні для агрегації: ${usable}`);
       }
     }

--- a/packages/shared/src/query-ir/build-where.ts
+++ b/packages/shared/src/query-ir/build-where.ts
@@ -99,6 +99,15 @@ export function buildWhere(
         pi++;
         break;
 
+      case 'array_contains_text':
+        // text[] array column; cast the bind param so a numeric slot value
+        // (e.g. NICE class 25) compares against text elements without a
+        // "operator does not exist: integer = text" error.
+        conditions.push(`$${pi}::text = ANY(${field.columns[0]})`);
+        values.push(String(val));
+        pi++;
+        break;
+
       case 'eq_any':
         conditions.push(`${field.columns[0]} = ANY($${pi})`);
         values.push(val);

--- a/packages/shared/src/query-ir/field-def.ts
+++ b/packages/shared/src/query-ir/field-def.ts
@@ -16,6 +16,7 @@ export type MatchType =
   | 'gte'            // col >= $N
   | 'lte'            // col <= $N
   | 'array_contains' // $N = ANY(col)         — col is an array column, val is scalar
+  | 'array_contains_text' // $N::text = ANY(col) — text[] array column, val cast to text (LLM may send a number)
   | 'eq_any'         // col = ANY($N)          — col is scalar, val is an array of allowed values
   | 'ilike_cast'     // col::text ILIKE $N  (%val%)
   | 'fts'            // to_tsvector('english', col) @@ plainto_tsquery('english', $N)


### PR DESCRIPTION
## Проблема

Прод-чат на «проверь свидетельство 389137» стабільно відповідає «не знайдено», хоча ТМ №389137 («metalista», ТОВ «ВАРМХАУС ГРУП», заявка m202420274) **чинна** в `ip_objects`.

Діагностика (див. core #95, #96): модель **вперто** обирає `search_registry(registry=trademarks)` для запитів «перевір свідоцтво №N» — це не вдалося перебити ні класифікатором (форс-домен registry), ні системним промптом (пряма вказівка на ip_objects-тули): дедиковані тули ще й випадають за межу 20 інструментів у наборі для legal_consultation. А `search_registry` читав **застарілий** знімок `opendata_trademarks`/`opendata_patents`, де свіжих реєстрацій (389137) немає.

## Фікс

Перенаправив реєстри `trademarks`/`patents` на єдину живу таблицю `ip_objects` (788K, заявки + усі 4 типи, безперервний SIS-синк):
- `RegistryDef.baseWhere` — константний предикат без параметрів, ANDиться у data/count/aggregate запити → одна таблиця обслуговує обидва реєстри (trademarks: `obj_type=4`; patents: `obj_type IN (1,2,6)`);
- вихідні колонки зберігають старі імена через аліаси (`title_ua AS mark_text`, `owner_name AS holder_name`, `classes AS nice_classes/ipc_codes`) → форма відповіді стабільна;
- новий `MatchType 'array_contains_text'` (`$N::text = ANY(col)`) — числовий клас МКТП фільтрує `ip_objects.classes` (text[]) без помилки `integer = text`; в aggregate-режимі відхиляється як GROUP BY, як і `array_contains`;
- опис `status` оновлено під словник ip_objects (active/stopped).

**Компроміс:** `ip_objects.status` (ТМ: active/stopped/green/red; патенти: red/green/yellow) відрізняється від кураторського active/inactive/pending у `opendata_*`. Це впливає лише на фільтр за статусом; пошук за номером/назвою/власником/класом — головний кейс — точний і повніший. Bulk-знімок `opendata_*` лишається в БД (не видаляю), лише search_registry більше на нього не дивиться.

## Перевірка
- Згенерований SQL повертає №389137 проти прод `ip_objects` (з правильними аліасами).
- 25/25 юніт-тестів `registry-search-tool.test.ts` зелені; tsc по змінених файлах чистий (overlay-резолвинг shared).

Repro: `chat-70ca1664-fa43-4404-a78e-e56005864d61`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale results by pointing `search_registry` for `trademarks` and `patents` to the live `ip_objects` table. Results now include current registrations while keeping the response shape unchanged.

- **Bug Fixes**
  - Redirected both registries to `ip_objects`; added `baseWhere` to split types (`obj_type = 4` for `trademarks`, `obj_type IN (1,2,6)` for `patents`).
  - Preserved field names via aliases (`title_ua AS mark_text`, `owner_name AS holder_name`, `classes AS nice_classes/ipc_codes`).
  - Added `array_contains_text` to match numeric NICE classes against `text[]` columns; excluded from aggregate group/count.
  - Applied `baseWhere` in data, count, and aggregate queries; updated sort to `COALESCE(registration_date, app_date) DESC`.
  - Updated status docs to `ip_objects` vocabulary and adjusted tests to the new SQL.

<sup>Written for commit 1a240b05305798baeb54a925e67d751b1e45b7c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

