### PR TITLE
fix(deploy): point QDRANT_URL default at live Brev Qdrant (wg mesh)

### DIFF
--- a/deployment/docker-compose.prod.yml
+++ b/deployment/docker-compose.prod.yml
@@ -505,7 +505,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
-      QDRANT_URL: ${QDRANT_URL:-http://qdrant-prod:6333}
+      QDRANT_URL: ${QDRANT_URL:-http://10.88.0.3:6333}
       LEGISLATION_VECTOR_BACKEND: ${LEGISLATION_VECTOR_BACKEND:-}
       LEG_BGE_COLLECTION: ${LEG_BGE_COLLECTION:-legal_sections_bge}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
@@ -713,7 +713,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
-      QDRANT_URL: ${QDRANT_URL:-http://qdrant-prod:6333}
+      QDRANT_URL: ${QDRANT_URL:-http://10.88.0.3:6333}
       LEGISLATION_VECTOR_BACKEND: ${LEGISLATION_VECTOR_BACKEND:-}
       LEG_BGE_COLLECTION: ${LEG_BGE_COLLECTION:-legal_sections_bge}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
@@ -953,7 +953,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
-      QDRANT_URL: ${QDRANT_URL:-http://qdrant-prod:6333}
+      QDRANT_URL: ${QDRANT_URL:-http://10.88.0.3:6333}
       LEGISLATION_VECTOR_BACKEND: ${LEGISLATION_VECTOR_BACKEND:-}
       LEG_BGE_COLLECTION: ${LEG_BGE_COLLECTION:-legal_sections_bge}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}
@@ -1230,7 +1230,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-secondlayer}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-secondlayer_prod}
-      QDRANT_URL: ${QDRANT_URL:-http://qdrant-prod:6333}
+      QDRANT_URL: ${QDRANT_URL:-http://10.88.0.3:6333}
       LEGISLATION_VECTOR_BACKEND: ${LEGISLATION_VECTOR_BACKEND:-}
       LEG_BGE_COLLECTION: ${LEG_BGE_COLLECTION:-legal_sections_bge}
       QDRANT_API_KEY: ${QDRANT_API_KEY:-}


### PR DESCRIPTION
## Problem
Prod backend `QDRANT_URL` resolved to the decommissioned AWS Qdrant `172.31.25.243:6333` (private IP no longer exists — host unreachable). Embedding service failed to init → semantic/hybrid legislation search broken; chat surfaced "Помилка мережі". The compose fallback was the dead `qdrant-prod:6333` alias.

## Fix
Serving Qdrant now runs on **Brev**, reachable over the `wg-sync` mesh:
- `10.88.0.3:6333` — legislation (`legislation_full_bge`) → `QDRANT_URL`
- `10.88.0.3:6343` — EDRSR (`edrsr_decisions`) → `QDRANT_EDRSR_URL` (already correct)

Change compose fallback `${QDRANT_URL:-http://qdrant-prod:6333}` → `${QDRANT_URL:-http://10.88.0.3:6333}` (4 blue/green service blocks) so a redeploy no longer defaults to the dead alias.

## Note
Prod `deployment/.env.prod` (gitignored) still sets the old value and overrides the compose default — fixed manually on prod alongside this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production Qdrant connection by pointing the default `QDRANT_URL` to the live Brev instance at http://10.88.0.3:6333. Restores embeddings init and legislation semantic/hybrid search and prevents deploys from falling back to the dead alias.

- **Bug Fixes**
  - Updated `deployment/docker-compose.prod.yml`: set fallback `QDRANT_URL` to http://10.88.0.3:6333 in four services.
  - `QDRANT_EDRSR_URL` already targets http://10.88.0.3:6343; no change.

- **Migration**
  - If an env file overrides `QDRANT_URL`, update it to http://10.88.0.3:6333.

<sup>Written for commit 6df7b882652bcb4347a01c1140d59b2203b7c718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

