### PR TITLE
fix(registry): ip_objects dates as text + certificate/number aliases

### DIFF
--- a/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
@@ -192,6 +192,37 @@ describe('RegistrySearchTool', () => {
       expect(calls[0].sql).toContain('founders::text ILIKE');
     });
 
+    it('trademarks: certificate / certificate_number alias resolve to registration_number', async () => {
+      for (const key of ['certificate', 'certificate_number']) {
+        calls = [];
+        db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+        tool = new RegistrySearchTool(db);
+
+        await tool.executeTool('search_registry', {
+          registry: 'trademarks',
+          filters: { [key]: '67482' },
+        });
+
+        expect(calls[0].sql).toContain('registration_number = $');
+        expect(calls[0].params).toContain('67482');
+      }
+    });
+
+    it('trademarks: date columns are selected as ::text (avoids DATE off-by-one)', async () => {
+      db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+      tool = new RegistrySearchTool(db);
+
+      await tool.executeTool('search_registry', {
+        registry: 'trademarks',
+        filters: { registration_number: '67482' },
+      });
+
+      const sql = calls[0].sql;
+      expect(sql).toContain('app_date::text AS app_date');
+      expect(sql).toContain('registration_date::text AS registration_date');
+      expect(sql).toContain('expiry_date::text AS expiry_date');
+    });
+
     it('ilike_multi: uses ILIKE with OR across columns', async () => {
       db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
       tool = new RegistrySearchTool(db);

--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -204,7 +204,11 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     description: 'Пошук торговельних марок — свідоцтв на знаки для товарів і послуг (реєстр НІПО/УІПВ ip_objects: заявки + зареєстровані, живий синк).\n\nПошук за текстом марки, власником, ЄДРПОУ, класом МКТП/NICE, статусом, номером свідоцтва/заявки.',
     table: 'ip_objects',
     baseWhere: 'obj_type = 4',
-    selectColumns: 'obj_type_name, obj_state, app_number, app_date, registration_number, registration_date, expiry_date, title_ua AS mark_text, status, owner_name AS holder_name, owner_edrpou AS holder_edrpou, owner_country AS holder_country, classes AS nice_classes',
+    // Dates are ::text so node-postgres does not round-trip DATE columns through a
+    // local-midnight JS Date (which JSON-serializes as the prior day in UTC —
+    // an off-by-one that corrupts legal term calculations). ISO YYYY-MM-DD sorts
+    // chronologically, so the text-aliased columns keep ORDER BY correct.
+    selectColumns: 'obj_type_name, obj_state, app_number, app_date::text AS app_date, registration_number, registration_date::text AS registration_date, expiry_date::text AS expiry_date, title_ua AS mark_text, status, owner_name AS holder_name, owner_edrpou AS holder_edrpou, owner_country AS holder_country, classes AS nice_classes',
     orderBy: 'COALESCE(registration_date, app_date) DESC NULLS LAST',
     emptyMessage: 'Торговельних марок не знайдено',
     fields: [
@@ -214,6 +218,9 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'nice_class', description: 'Клас МКТП/NICE (1-45), напр. "34"', match: 'array_contains_text', columns: ['classes'] },
       { name: 'status', description: 'Статус марки — точне значення: "active" (чинна) або "stopped" (припинена: сплив строк / достроково припинена)', match: 'exact_ci', columns: ['status'] },
       { name: 'registration_number', description: 'Номер свідоцтва / реєстрації', match: 'exact', columns: ['registration_number'] },
+      // Synonyms the model reaches for on "перевір свідоцтво №N" — map to registration_number.
+      { name: 'certificate', description: 'Номер свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
+      { name: 'certificate_number', description: 'Номер свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
       { name: 'app_number', description: 'Номер заявки (напр. m202420274)', match: 'exact', columns: ['app_number'] },
     ],
   },
@@ -223,7 +230,8 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     description: 'Пошук патентів на винаходи, корисних моделей та промислових зразків (реєстр НІПО/УІПВ ip_objects: заявки + охоронні документи, живий синк).\n\nПошук за назвою, власником, кодом МПК/Локарно, номером заявки/патенту.',
     table: 'ip_objects',
     baseWhere: 'obj_type IN (1, 2, 6)',
-    selectColumns: 'obj_type_name, obj_state, app_number, app_date, registration_number, registration_date, title_ua, title_en, abstract_ua, classes AS ipc_codes, owner_name, owner_country, status',
+    // Dates ::text — see trademarks note (avoids node-postgres DATE off-by-one).
+    selectColumns: 'obj_type_name, obj_state, app_number, app_date::text AS app_date, registration_number, registration_date::text AS registration_date, title_ua, title_en, abstract_ua, classes AS ipc_codes, owner_name, owner_country, status',
     orderBy: 'COALESCE(registration_date, app_date) DESC NULLS LAST',
     emptyMessage: 'Патентів не знайдено',
     fields: [
@@ -231,7 +239,10 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'owner_name', description: "Ім'я або назва патентовласника", match: 'ilike', columns: ['owner_name'] },
       { name: 'ipc_code', description: 'Код МПК/Локарно (наприклад, A61K)', match: 'array_contains_text', columns: ['classes'] },
       { name: 'app_number', description: 'Номер заявки', match: 'exact', columns: ['app_number'] },
-      { name: 'registration_number', description: 'Номер патенту', match: 'exact', columns: ['registration_number'] },
+      { name: 'registration_number', description: 'Номер патенту / свідоцтва', match: 'exact', columns: ['registration_number'] },
+      // Synonyms the model reaches for — map to registration_number.
+      { name: 'certificate', description: 'Номер патенту/свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
+      { name: 'certificate_number', description: 'Номер патенту/свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
       { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 6=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
     ],
   },


### PR DESCRIPTION
## Контекст

Розбір прод-чату `chat-1bed5d5b-8582-4ff0-87fc-e342b2db0d26` («Сделай аналіз торговельної марки №67482»). Відповідь по суті правильна (Fix B #2183 працює — марку знайдено), але виявились два дефекти в роботі `search_registry` над `ip_objects`.

## 1. Зсув дат на −1 день (критично для юридичних розрахунків)

Колонки `app_date/registration_date/expiry_date` в `ip_objects` мають тип `DATE`. node-postgres парсить `DATE` у JS `Date` на **локальну** північ (Europe/Kyiv), що при JSON-серіалізації дає попередній день у UTC (`...T22:00:00Z`). Модель чесно прочитала те, що отримала → **усі дати у відповіді на день раніше**:

| Поле | Було у відповіді | Реально |
|---|---|---|
| 67482 реєстрація | 14.09.2006 | 15.09.2006 |
| 67482 сплив строку | 03.04.2016 | 04.04.2016 |
| Dell 381898 сплив | 23.11.2031 | 24.11.2031 |

**Фікс:** вибираємо DATE-колонки як `::text` → чистий `YYYY-MM-DD` без Date-раунд-тріпу. ISO-рядки сортуються хронологічно, тому `ORDER BY COALESCE(registration_date, app_date)` лишається коректним (перевірено на проді, вкл. мультирядкове сортування + NULLS LAST). Застосовано до trademarks і patents.

## 2. Втрачений перший виклик тула

Модель інстинктивно фільтрує за `certificate`/`certificate_number` на «перевір свідоцтво №N» (у КОЖНОМУ IP-чаті: c7771a3e, 70ca1664, 1bed5d5b) → строга валідація каталогу відхиляє («Невідомі поля фільтра») → змарнований LLM-хід перед ретраєм з `registration_number`. **Фікс:** додано `certificate` та `certificate_number` як синоніми → `registration_number` (trademarks + patents).

## Перевірка
- 27/27 юніт-тестів `registry-search-tool.test.ts` (нові: cert-аліаси, date::text).
- Згенерований SQL перевірено на проді: №67482 повертає 2006-04-04 / 2006-09-15 / 2016-04-04.
- tsc по змінених файлах чистий (overlay-резолвинг shared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes off-by-one date serialization and missing certificate filters in registry search. Dates from `ip_objects` now return as plain `YYYY-MM-DD` strings, and `certificate`/`certificate_number` are accepted as aliases for `registration_number`.

- **Bug Fixes**
  - Dates: select `app_date`, `registration_date`, `expiry_date` as `::text` to avoid `node-postgres` local-midnight shifts; `ORDER BY COALESCE(registration_date, app_date)` remains correct.
  - Aliases: add `certificate` and `certificate_number` → `registration_number` for trademarks and patents to avoid rejected filters on first tool call.

<sup>Written for commit acf51e8b9fc1f5e2343e5d7f45a2e5d0476fa4d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

