### PR TITLE
fix(registry): select all DATE columns as ::text (node-pg off-by-one sweep)

### DIFF
--- a/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
+++ b/mcp_backend/src/api/__tests__/registry-search-tool.test.ts
@@ -223,6 +223,22 @@ describe('RegistrySearchTool', () => {
       expect(sql).toContain('expiry_date::text AS expiry_date');
     });
 
+    it('non-IP registries with DATE columns also select them as ::text', async () => {
+      // Same node-postgres DATE off-by-one applies to any `date`-typed column.
+      const cases: Array<[string, Record<string, unknown>, string]> = [
+        ['public_organizations', { name: 'Фонд' }, 'date_reg::text AS date_reg'],
+        ['securities_owners', { owner_name: 'Іван' }, 'report_date::text AS report_date'],
+        ['us_fda_enforcement', { firm: 'Acme' }, 'recall_initiation_date::text AS recall_initiation_date'],
+      ];
+      for (const [registry, filters, expected] of cases) {
+        calls = [];
+        db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
+        tool = new RegistrySearchTool(db);
+        await tool.executeTool('search_registry', { registry, filters });
+        expect(calls[0].sql).toContain(expected);
+      }
+    });
+
     it('ilike_multi: uses ILIKE with OR across columns', async () => {
       db = makeDb(() => ({ rows: [{ _total_count: 1 }] }));
       tool = new RegistrySearchTool(db);

--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -42,7 +42,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'Реєстр громадських формувань',
     description: 'Пошук у реєстрі громадських формувань (ГО, партії, профспілки, релігійні організації тощо)\n\n1.08M записів. Пошук за назвою, ЄДРПОУ, типом реєстру, статусом, засновниками.',
     table: 'opendata_public_organizations',
-    selectColumns: 'registry_type, reg_num, date_reg, name, edrpou, state, address, phone, founders, governing_body, kved, territory, obj_status',
+    selectColumns: 'registry_type, reg_num, date_reg::text AS date_reg, name, edrpou, state, address, phone, founders, governing_body, kved, territory, obj_status',
     orderBy: 'date_reg DESC NULLS LAST',
     emptyMessage: 'Громадських формувань не знайдено',
     fields: [
@@ -59,7 +59,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'Розподіл судових справ',
     description: 'Пошук у протоколах автоматичного розподілу судових справ (ДСАУ)\n\n71K записів. Пошук за номером справи, суддею, судом, учасниками, категорією справи.',
     table: 'dsa_case_distribution',
-    selectColumns: 'cause_number, court_name, case_category, case_complexity, case_essence, presiding_judge, panel_judges, participants, distribution_basis, distribution_start, distribution_end, excluded_judges, source_date',
+    selectColumns: 'cause_number, court_name, case_category, case_complexity, case_essence, presiding_judge, panel_judges, participants, distribution_basis, distribution_start, distribution_end, excluded_judges, source_date::text AS source_date',
     orderBy: 'distribution_start DESC NULLS LAST',
     emptyMessage: 'Протоколів розподілу не знайдено',
     fields: [
@@ -94,7 +94,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'Власники цінних паперів',
     description: 'Пошук власників істотної участі у цінних паперах (НКЦПФР)\n\n128K записів. Пошук за емітентом, власником, ЄДРПОУ, ISIN-кодом, часткою.',
     table: 'opendata_securities_owners',
-    selectColumns: 'report_date, issuer_edrpou, issuer_name, isin_code, owner_edrpou, owner_name, owner_name_alt, owner_type, share_percent, nominal_value, share_count, country_code',
+    selectColumns: 'report_date::text AS report_date, issuer_edrpou, issuer_name, isin_code, owner_edrpou, owner_name, owner_name_alt, owner_type, share_percent, nominal_value, share_count, country_code',
     orderBy: 'share_percent DESC NULLS LAST',
     emptyMessage: 'Власників цінних паперів не знайдено',
     fields: [
@@ -345,7 +345,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'Реєстрація транспорту',
     description: 'Пошук у реєстрі транспортних засобів та їх власників (МВС)\n\n19.5M записів з 2013 року. Дані: VIN, держномер, марка, модель, рік, колір, тип, реєстраційні операції.',
     table: 'opendata_vehicle_registrations',
-    selectColumns: 'person_type, d_reg, oper_name, brand, model, vin, make_year, color, kind, body, purpose, fuel, capacity, n_reg_new, dep',
+    selectColumns: 'person_type, d_reg::text AS d_reg, oper_name, brand, model, vin, make_year, color, kind, body, purpose, fuel, capacity, n_reg_new, dep',
     orderBy: 'd_reg DESC NULLS LAST',
     emptyMessage: 'Транспортних засобів не знайдено',
     fields: [
@@ -473,7 +473,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'US Political Contributions (58M donations)',
     description: 'Search individual political contributions reported to the FEC.\n\n58M records from 2000–2024 election cycles. Contributions over $200 by individuals to federal candidates, PACs, party committees.\n\nFind who donated to whom, how much, employer/occupation of donors.',
     table: 'us_fec_contributions',
-    selectColumns: 'contributor_name, city, state, zip_code, employer, occupation, transaction_date, transaction_amount, committee_id, memo_text',
+    selectColumns: 'contributor_name, city, state, zip_code, employer, occupation, transaction_date::text AS transaction_date, transaction_amount, committee_id, memo_text',
     orderBy: 'transaction_amount DESC NULLS LAST',
     emptyMessage: 'No FEC contributions found matching criteria',
     defaultLimit: 50,
@@ -493,7 +493,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'OSHA Workplace Enforcement (377K employers)',
     description: 'Search OSHA enforcement history by employer.\n\n377K employers with citation counts, penalties, violation types (willful, repeat, serious).\nDate range: 2009–2026. Useful for vendor safety screening and due diligence.',
     table: 'us_osha_enforcement',
-    selectColumns: 'employer_id, employer_name, city, state, naics_code, naics_description, parent_name, citation_count, inspection_count, penalties_current_total, willful_count, repeat_count, serious_count, earliest_citation, latest_citation',
+    selectColumns: 'employer_id, employer_name, city, state, naics_code, naics_description, parent_name, citation_count, inspection_count, penalties_current_total, willful_count, repeat_count, serious_count, earliest_citation::text AS earliest_citation, latest_citation::text AS latest_citation',
     orderBy: 'penalties_current_total DESC NULLS LAST',
     emptyMessage: 'No OSHA enforcement records found for this employer',
     fields: [
@@ -527,7 +527,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'CFPB Consumer Complaints (15M complaints)',
     description: 'Search consumer financial complaints from the CFPB database.\n\n15M complaints since 2011. Search by company, product, state, issue.\nUse for financial partner screening, complaint pattern analysis.',
     table: 'us_cfpb_complaints',
-    selectColumns: 'complaint_id, date_received, product_normalized as product, issue, company, state, company_response, timely_response, consumer_complaint_narrative',
+    selectColumns: 'complaint_id, date_received::text AS date_received, product_normalized as product, issue, company, state, company_response, timely_response, consumer_complaint_narrative',
     orderBy: 'date_received DESC NULLS LAST',
     emptyMessage: 'No CFPB complaints found matching criteria',
     defaultLimit: 30,
@@ -544,7 +544,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
     title: 'FDA Enforcement & Recalls (17.6K actions)',
     description: 'Search FDA drug and food enforcement actions (recalls).\n\n17.6K enforcement actions since 2011. Includes product description, reason for recall, classification (Class I/II/III), recalling firm.',
     table: 'us_fda_enforcement',
-    selectColumns: 'recall_number, status, classification, product_type, recalling_firm, city, state, recall_initiation_date, reason_for_recall, product_description, distribution_pattern',
+    selectColumns: 'recall_number, status, classification, product_type, recalling_firm, city, state, recall_initiation_date::text AS recall_initiation_date, reason_for_recall, product_description, distribution_pattern',
     orderBy: 'recall_initiation_date DESC NULLS LAST',
     emptyMessage: 'No FDA enforcement actions found',
     fields: [


### PR DESCRIPTION
## Контекст

Продовження #2186. Той PR виправив зсув дат лише для trademarks/patents. Корінь — загальний: node-postgres парсить колонку типу `DATE` у JS `Date` на **локальну** північ (Europe/Kyiv), що при JSON-серіалізації дає попередній день у UTC (`...T22:00:00Z`). **Будь-який** реєстр `search_registry`, що віддає `date`-колонку в `selectColumns`, показує моделі дату на день раніше.

## Аудит

Звірив усі реєстри проти `information_schema`. Ще **8 реєстрів** повертають DATE-колонку моделі — обгорнув кожну в `col::text AS col` (чистий `YYYY-MM-DD`):

| Реєстр | Колонка(и) |
|---|---|
| public_organizations | date_reg |
| case_distribution | source_date |
| securities_owners | report_date |
| vehicle_registrations | d_reg |
| us_fec_contributions | transaction_date |
| us_osha_enforcement | earliest_citation, latest_citation |
| us_cfpb_complaints | date_received |
| us_fda_enforcement | recall_initiation_date |

## Коректність

- **ORDER BY** по цих колонках лишається правильним: ISO `YYYY-MM-DD` сортується хронологічно (перевірено на проді для public_organizations та us_fda — DESC-порядок збережено).
- Реєстри, де DATE-колонка НЕ в selectColumns (state_aid.decision_date, us_epa_facilities.\*), не чіпав.
- `timestamp`/`timestamptz` колонки не зачеплені (це реальні моменти часу, серіалізуються коректно).

## Перевірка
- 28/28 юніт-тестів (додано ::text-асерт для не-IP реєстру).
- Наживо: `public_organizations.date_reg` було `2022-11-06` (баг) → `2022-11-07` (вірно).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes off-by-one dates in registry search results by casting all `DATE` columns to text (`YYYY-MM-DD`) in SQL. Prevents `node-postgres` local-midnight conversion from shifting dates to the previous day in UTC.

- **Bug Fixes**
  - Root cause: `node-postgres` converts `DATE` to a local-midnight JS `Date`, which serializes as the prior UTC day.
  - Change: cast `DATE` fields in `selectColumns` as `col::text AS col`.
  - Affected:
    - `public_organizations.date_reg`; `case_distribution.source_date`; `securities_owners.report_date`; `vehicle_registrations.d_reg`; `us_fec_contributions.transaction_date`; `us_osha_enforcement.earliest_citation`, `latest_citation`; `us_cfpb_complaints.date_received`; `us_fda_enforcement.recall_initiation_date`.
  - Ordering: `ORDER BY` stays correct; ISO `YYYY-MM-DD` sorts chronologically.
  - Tests: added a non-IP `::text` assertion; all tests pass.

<sup>Written for commit 0185ceb4c855e02c16bed5c9ff77b1ada89cfc7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

