### PR TITLE
fix(registry): surface IP validity (prolongation/termination) + derived legal_status

### DIFF
--- a/mcp_backend/src/api/tools/ip-objects-tools.ts
+++ b/mcp_backend/src/api/tools/ip-objects-tools.ts
@@ -370,10 +370,18 @@ export class IpObjectsTools extends BaseToolHandler {
 
   private deriveLegalStatus(obj: any, events: any[]): string {
     const kinds = new Set(events.map(e => e.event_kind));
+    // Prefer the SIS dossier fields in raw_data over classified events: event classification is
+    // incomplete for older records (e.g. reg. №67482 has only the 3 original 2006 docs, so the
+    // termination/prolongation live ONLY in raw_data). Without this, a terminated mark reads as
+    // "чинний" (obj_state=2) or, off the stale expiry_date alone, wrongly as "строк дії сплив".
+    const raw = obj.raw_data || {};
     if (kinds.has('invalidation')) return 'визнано недійсним';
-    if (kinds.has('termination')) return 'дію припинено';
+    if (kinds.has('termination') || raw.TerminationDate) return 'дію припинено';
+    if (String(raw.registration_status_color || '').toLowerCase() === 'red') return 'не чинний';
     if (Number(obj.obj_state) === 1) return 'заявка на розгляді';
-    if (obj.expiry_date && new Date(obj.expiry_date) < new Date()) return 'строк дії сплив';
+    // Effective term end = renewed expiry (ProlonagationExpiryDate) if present, else original.
+    const effectiveExpiry = raw.ProlonagationExpiryDate || obj.expiry_date;
+    if (effectiveExpiry && new Date(effectiveExpiry) < new Date()) return 'строк дії сплив';
     if (Number(obj.obj_state) === 2) return 'чинний';
     return obj.status || 'невідомо';
   }

--- a/mcp_backend/src/api/tools/registry-catalog.ts
+++ b/mcp_backend/src/api/tools/registry-catalog.ts
@@ -201,14 +201,24 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
   // (mark_text/holder_*/nice_classes/ipc_codes) via aliases for a stable shape.
   trademarks: {
     title: 'Торговельні марки (НІПО/УІПВ)',
-    description: 'Пошук торговельних марок — свідоцтв на знаки для товарів і послуг (реєстр НІПО/УІПВ ip_objects: заявки + зареєстровані, живий синк).\n\nПошук за текстом марки, власником, ЄДРПОУ, класом МКТП/NICE, статусом, номером свідоцтва/заявки.',
+    description: 'Пошук торговельних марок — свідоцтв на знаки для товарів і послуг (реєстр НІПО/УІПВ ip_objects: заявки + зареєстровані, живий синк).\n\nПошук за текстом марки, власником, ЄДРПОУ, класом МКТП/NICE, статусом, номером свідоцтва/заявки.\n\nЧинність визначайте за legal_status / effective_expiry_date / termination_date, а НЕ за сирим полем status (воно з реєстру і буває стале). effective_expiry_date враховує поновлення; termination_date — дострокове припинення.',
     table: 'ip_objects',
     baseWhere: 'obj_type = 4',
     // Dates are ::text so node-postgres does not round-trip DATE columns through a
     // local-midnight JS Date (which JSON-serializes as the prior day in UTC —
     // an off-by-one that corrupts legal term calculations). ISO YYYY-MM-DD sorts
     // chronologically, so the text-aliased columns keep ORDER BY correct.
-    selectColumns: 'obj_type_name, obj_state, app_number, app_date::text AS app_date, registration_number, registration_date::text AS registration_date, expiry_date::text AS expiry_date, title_ua AS mark_text, status, owner_name AS holder_name, owner_edrpou AS holder_edrpou, owner_country AS holder_country, classes AS nice_classes',
+    //
+    // The raw `status` column is unreliable (e.g. reg. №67482 reads "active" while the mark was
+    // terminated 2025-07-22). Authoritative validity lives only in raw_data — surface it:
+    //   effective_expiry_date = renewed term end (ProlonagationExpiryDate) or the original expiry;
+    //   termination_date      = early termination (TerminationDate);
+    //   status_color          = registry colour ('red' = not in force);
+    //   legal_status          = derived headline the model should quote.
+    // All via raw_data->> (null-safe: a row without these keys falls through to obj_state).
+    // Date comparisons use ISO text (YYYY-MM-DD sorts chronologically) — no ::date casts, so a
+    // malformed value can never throw and break the whole search.
+    selectColumns: `obj_type_name, obj_state, app_number, app_date::text AS app_date, registration_number, registration_date::text AS registration_date, expiry_date::text AS expiry_date, COALESCE(NULLIF(raw_data->>'ProlonagationExpiryDate',''), expiry_date::text) AS effective_expiry_date, NULLIF(raw_data->>'ProlongationDate','') AS prolongation_date, NULLIF(raw_data->>'TerminationDate','') AS termination_date, NULLIF(raw_data->>'registration_status_color','') AS status_color, CASE WHEN NULLIF(raw_data->>'TerminationDate','') IS NOT NULL THEN 'дію припинено (достроково)' WHEN lower(COALESCE(raw_data->>'registration_status_color','')) = 'red' THEN 'не чинна' WHEN COALESCE(NULLIF(raw_data->>'ProlonagationExpiryDate',''), expiry_date::text) < CURRENT_DATE::text THEN 'строк дії сплив' WHEN obj_state = 2 THEN 'чинна' WHEN obj_state = 1 THEN 'заявка на розгляді' ELSE COALESCE(status, 'невідомо') END AS legal_status, title_ua AS mark_text, status, owner_name AS holder_name, owner_edrpou AS holder_edrpou, owner_country AS holder_country, classes AS nice_classes`,
     orderBy: 'COALESCE(registration_date, app_date) DESC NULLS LAST',
     emptyMessage: 'Торговельних марок не знайдено',
     fields: [
@@ -216,7 +226,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'holder_name', description: "Назва або ім'я власника / заявника", match: 'ilike', columns: ['owner_name'] },
       { name: 'holder_edrpou', description: 'ЄДРПОУ власника', match: 'exact', columns: ['owner_edrpou'] },
       { name: 'nice_class', description: 'Клас МКТП/NICE (1-45), напр. "34"', match: 'array_contains_text', columns: ['classes'] },
-      { name: 'status', description: 'Статус марки — точне значення: "active" (чинна) або "stopped" (припинена: сплив строк / достроково припинена)', match: 'exact_ci', columns: ['status'] },
+      { name: 'status', description: 'Сирий статус марки з реєстру для фільтрації: "active" / "stopped". УВАГА: буває стале — фактичну чинність дивіться у legal_status/termination_date/effective_expiry_date у результатах, а не тут.', match: 'exact_ci', columns: ['status'] },
       { name: 'registration_number', description: 'Номер свідоцтва / реєстрації', match: 'exact', columns: ['registration_number'] },
       // Synonyms the model reaches for on "перевір свідоцтво №N" — map to registration_number.
       { name: 'certificate', description: 'Номер свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
@@ -227,11 +237,13 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
 
   patents: {
     title: 'Патенти, корисні моделі, промзразки (НІПО/УІПВ)',
-    description: 'Пошук патентів на винаходи, корисних моделей та промислових зразків (реєстр НІПО/УІПВ ip_objects: заявки + охоронні документи, живий синк).\n\nПошук за назвою, власником, кодом МПК/Локарно, номером заявки/патенту.',
+    description: 'Пошук патентів на винаходи, корисних моделей та промислових зразків (реєстр НІПО/УІПВ ip_objects: заявки + охоронні документи, живий синк).\n\nПошук за назвою, власником, кодом МПК/Локарно, номером заявки/патенту.\n\nЧинність визначайте за legal_status / effective_expiry_date / termination_date, а НЕ за сирим полем status.',
     table: 'ip_objects',
     baseWhere: 'obj_type IN (1, 2, 6)',
     // Dates ::text — see trademarks note (avoids node-postgres DATE off-by-one).
-    selectColumns: 'obj_type_name, obj_state, app_number, app_date::text AS app_date, registration_number, registration_date::text AS registration_date, title_ua, title_en, abstract_ua, classes AS ipc_codes, owner_name, owner_country, status',
+    // Validity (legal_status/effective_expiry_date/termination_date/status_color) surfaced from
+    // raw_data the same way as trademarks — see the trademarks selectColumns note. Null-safe.
+    selectColumns: `obj_type_name, obj_state, app_number, app_date::text AS app_date, registration_number, registration_date::text AS registration_date, expiry_date::text AS expiry_date, COALESCE(NULLIF(raw_data->>'ProlonagationExpiryDate',''), expiry_date::text) AS effective_expiry_date, NULLIF(raw_data->>'TerminationDate','') AS termination_date, NULLIF(raw_data->>'registration_status_color','') AS status_color, CASE WHEN NULLIF(raw_data->>'TerminationDate','') IS NOT NULL THEN 'дію припинено (достроково)' WHEN lower(COALESCE(raw_data->>'registration_status_color','')) = 'red' THEN 'не чинний' WHEN COALESCE(NULLIF(raw_data->>'ProlonagationExpiryDate',''), expiry_date::text) < CURRENT_DATE::text THEN 'строк дії сплив' WHEN obj_state = 2 THEN 'чинний' WHEN obj_state = 1 THEN 'заявка на розгляді' ELSE COALESCE(status, 'невідомо') END AS legal_status, title_ua, title_en, abstract_ua, classes AS ipc_codes, owner_name, owner_country, status`,
     orderBy: 'COALESCE(registration_date, app_date) DESC NULLS LAST',
     emptyMessage: 'Патентів не знайдено',
     fields: [
@@ -244,6 +256,7 @@ export const REGISTRY_CATALOG: Record<string, RegistryDef> = {
       { name: 'certificate', description: 'Номер патенту/свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
       { name: 'certificate_number', description: 'Номер патенту/свідоцтва (синонім registration_number)', match: 'exact', columns: ['registration_number'] },
       { name: 'obj_type', description: 'Тип: 1=винахід, 2=корисна модель, 6=промисл. зразок', match: 'exact', columns: ['obj_type'], type: 'number' },
+      { name: 'status', description: 'Сирий статус з реєстру для фільтрації. УВАГА: буває стале — фактичну чинність дивіться у legal_status/termination_date у результатах.', match: 'exact_ci', columns: ['status'] },
     ],
   },
 


### PR DESCRIPTION
## Проблема

Прод-чат `chat-bef2c5b4` — «дата окончания действия ТМ 67482» відповів **«04.04.2016, статус active»**. Насправді №67482 було поновлено до **04.04.2026**, а потім достроково припинено **22.07.2025** (`status_color=red`).

Причина: `search_registry(trademarks)` повертав лише первинний `expiry_date` (2016) і **стале** поле `status` ('active'). Авторитетні поля чинності лежать тільки в `ip_objects.raw_data` (`ProlonagationExpiryDate`, `TerminationDate`, `registration_status_color`) і **ніде не виставлялися**. Модель фізично не мала даних про поновлення/припинення.

`get_ip_object` теж не рятував: його `deriveLegalStatus` бере події з `ip_object_events`, а там для №67482 лише 3 ранні документи 2006 р.

## Фікс (points 2+3 — «лагодимо той tool, який модель уперто кличе», як #2183)

**`registry-catalog.ts`** — `trademarks` + `patents` `selectColumns` тепер виставляють з `raw_data` (null-safe, порівняння ISO-текстом, **без `::date`-кастів**, які могли б кинути помилку й зламати весь пошук):
- `effective_expiry_date` — строк після поновлення або первинний;
- `prolongation_date`, `termination_date`, `status_color`;
- похідний **`legal_status`**: `дію припинено (достроково)` / `не чинна` / `строк дії сплив` / `чинна` / `заявка на розгляді`.

Сире `status` лишили тільки для фільтрації; описи оновлено — попередження, що воно стале, і вказівка дивитись `legal_status`/`termination_date`/`effective_expiry_date`.

**`ip-objects-tools.ts`** — `deriveLegalStatus` тепер читає ті самі поля з `raw_data`, а не лише неповні `ip_object_events`.

## Перевірка (на реальних прод-даних `ip_objects`)

| Об'єкт | legal_status | effective_expiry | termination |
|---|---|---|---|
| №67482 | **дію припинено (достроково)** | 2026-04-04 | 2025-07-22 |
| №312507, №381898 (Dell, чинні) | чинна | 2029/2031 | — |
| заявки (obj_state=1) | заявка на розгляді | — | — |

TS: обидва змінені файли компілюються без помилок зі свіжим `@secondlayer/shared` (локальні залишкові помилки — від застарілого `node_modules` в оффлайн-перевірці, у не пов'язаних файлах; CI зі свіжими залежностями чистий).

## Поза скоупом (follow-up)
Durable-варіант: промотувати `raw_data`-поля в реальні колонки `ip_objects` (міграція + імпортер) і класифікувати `prolongation`/`termination` у `ip_object_events`. Тут — мінімальний фікс через `raw_data->>`, що дає коректну відповідь уже зараз без міграції.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced true IP validity in registry search and added a reliable `legal_status` so renewed or terminated marks/patents return correct dates and status. Uses `ip_objects.raw_data` and avoids fragile date casts.

- **Bug Fixes**
  - Expose from `raw_data`: `effective_expiry_date` (renewed or original), `prolongation_date`, `termination_date`, `status_color`, and a derived `legal_status`.
  - Update `deriveLegalStatus` to prefer `raw_data` over incomplete events; handles termination, red status, renewals, expiry, and applications.
  - Keep raw `status` only for filtering; field help now points to `legal_status`/`effective_expiry_date`/`termination_date`.
  - Null-safe JSON access and ISO text date comparisons; no `::date` casts.

<sup>Written for commit 220c747c9cd6a2f15ab9bb69800b541f8bc5efc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

