### PR TITLE
fix(ip): dossier filing date → YYYY-MM-DD for as_of_date

### DIFF
--- a/mcp_backend/src/api/tools/ip-objects-tools.ts
+++ b/mcp_backend/src/api/tools/ip-objects-tools.ts
@@ -491,7 +491,11 @@ export class IpObjectsTools extends BaseToolHandler {
         mode: 'fulltext', justice_kind: 3, limit: 5,
         query: `${tm.title_ua} свідоцтво недійсне торговельна марка`,
       });
-      const filingDate = tm.app_date ? String(tm.app_date).slice(0, 10) : null;
+      // app_date comes back as a Date/timestamptz — String(date).slice gives
+      // "Tue Apr 04", not "2006-04-04"; normalise to YYYY-MM-DD for as_of_date.
+      const filingDate = tm.app_date
+        ? (() => { const d = new Date(tm.app_date); return isNaN(d.getTime()) ? String(tm.app_date).slice(0, 10) : d.toISOString().slice(0, 10); })()
+        : null;
       const temporal = filingDate ? {
         filing_date: filingDate,
         article6_as_of_filing: await this.callTool('get_legislation_section', {


### PR DESCRIPTION
One-liner: `get_trademark_dossier` built `as_of_date` from `String(date).slice(0,10)` → 'Tue Apr 04', so the temporal ст.6 lookup returned null. Normalise via `toISOString().slice(0,10)`. Verified live: card/disambiguation/collisions/court-practice already work; this fixes the temporal section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize dossier filing date to YYYY-MM-DD in `get_trademark_dossier` so the temporal Article 6 lookup returns data instead of null. Restores `article6_as_of_filing` in the trademark dossier.

- **Bug Fixes**
  - Build `filingDate` from `tm.app_date` via `new Date(...).toISOString().slice(0,10)` with a safe fallback.
  - Use the normalized date as `as_of_date` for `get_legislation_section`.

<sup>Written for commit 6a2e6fbb0a868588a3b8199f311342f65c5cbe6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

