### PR TITLE
feat(billing): seed tool_pricing for 5 unpriced V2 chat tools

### DIFF
--- a/mcp_backend/src/migrations/175_v2_chat_missing_tool_pricing.sql
+++ b/mcp_backend/src/migrations/175_v2_chat_missing_tool_pricing.sql
@@ -1,0 +1,20 @@
+-- Migration 175: pricing for V2 chat tools that had no tool_pricing row.
+-- The V2 curated tool set (V2_TOOL_NAMES, curated-mcp-tools.ts) contains 28 tools,
+-- but 5 of them were never seeded into tool_pricing, so on the direct MCP-gateway
+-- billing path they fell through to whatever default the core/billing layer applies.
+-- Prices are set in the post-migration-139 (reduced) scale, matched to sibling tools:
+--   * legislation DB lookups  -> $0.0001 (like get_legislation_section/structure)
+--   * primary semantic search -> $0.0200 (like search_legislation; EDRSR is NOT reduced 10x)
+--   * registry searches       -> $0.0005 (like openreyestr_search_entities/debtors)
+
+INSERT INTO tool_pricing (tool_name, service, display_name, base_cost_usd, notes)
+VALUES
+  ('get_legislation_history',      'backend',     'Історія змін законодавчого акту',   0.00010000, 'DB-lookup, як get_legislation_section/structure'),
+  ('list_legislation_editions',    'backend',     'Список редакцій законодавчого акту', 0.00010000, 'DB-lookup, мінімальна вартість'),
+  ('search_court_decisions',       'backend',     'Пошук судових рішень (ЄДРСР)',       0.02000000, 'Основний семантичний/FTS пошук по ЄДРСР, як search_legislation'),
+  ('search_registry',              'backend',     'Пошук по відкритих реєстрах',        0.00050000, 'Umbrella open-data пошук, як openreyestr_search_entities'),
+  ('openreyestr_search_prozorro',  'openreyestr', 'Пошук закупівель Prozorro',          0.00050000, 'Реєстр закупівель, як openreyestr_search_debtors')
+ON CONFLICT (tool_name) DO UPDATE SET
+  base_cost_usd = EXCLUDED.base_cost_usd,
+  display_name = EXCLUDED.display_name,
+  notes = EXCLUDED.notes;


### PR DESCRIPTION
## Що

V2-набір `V2_TOOL_NAMES` (`mcp_backend/src/api/curated-mcp-tools.ts`) містить 28 інструментів, але 5 з них не мали рядка в `tool_pricing`. На прямому MCP-gateway шляху білінгу вони падали в дефолт core/billing-шару.

Міграція `175_v2_chat_missing_tool_pricing.sql` сідить їх у пост-139 (зменшеному) масштабі, за аналогією із сусідніми інструментами:

| Інструмент | USD/вызов | Аналог |
|---|---|---|
| `get_legislation_history` | $0.0001 | get_legislation_section/structure |
| `list_legislation_editions` | $0.0001 | get_legislation_section |
| `search_court_decisions` | $0.0200 | search_legislation (EDRSR не режеться ×10) |
| `search_registry` | $0.0005 | openreyestr_search_entities |
| `openreyestr_search_prozorro` | $0.0005 | openreyestr_search_debtors |

Idempotent `INSERT ... ON CONFLICT (tool_name) DO UPDATE` — безпечно ганяти повторно.

## Примітка

У самому V2-чаті домінує per-token білінг (`ai_chat`); ці per-tool ціни застосовуються на прямому MCP-gateway шляху.

Plane: LEXAI-1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeded missing `tool_pricing` rows for five V2 chat tools so the direct MCP-gateway path uses correct rates instead of the default. Uses the post-139 reduced scale with an idempotent upsert. (Linear: LEXAI-1836)

- **Migration**
  - Adds `175_v2_chat_missing_tool_pricing.sql` for:
    - `get_legislation_history` $0.0001
    - `list_legislation_editions` $0.0001
    - `search_court_decisions` $0.0200
    - `search_registry` $0.0005
    - `openreyestr_search_prozorro` $0.0005

<sup>Written for commit 75f433a503c86b4be5fb72b6d1d200cb9528ef96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

