### PR TITLE
feat(billing): reprice V2 chat tools vs ZakonOnline benchmark

### DIFF
--- a/mcp_backend/src/migrations/176_v2_chat_pricing_correction_zakononline.sql
+++ b/mcp_backend/src/migrations/176_v2_chat_pricing_correction_zakononline.sql
@@ -1,0 +1,34 @@
+-- Migration 176: correct V2 chat tool prices against competitor (ZakonOnline) benchmark.
+--
+-- ZakonOnline API (договір, 09.01.2025) = flat per-request access to a legal-info base
+-- (court decisions + legislation): 0.29 UAH/req at low volume, 0.10 UAH/req >50k/mo,
+-- 3000 UAH/mo floor (=0.30 UAH/req at 10k). No business-registry product.
+--
+-- Strategy "premium but competitive" (rate assumption: 1 USD = 42 UAH):
+--   * search/retrieval tools  -> ~1.4x ZO low-volume  => $0.010 (0.42 UAH)
+--   * LLM-analysis tools       -> 4-6x ZO (value ZO cannot deliver)
+--   * legislation lookups      -> lifted off the near-zero floor to $0.001 (still ~0.15x ZO)
+-- Registry (openreyestr_*) tools have no ZO equivalent and are left unchanged.
+--
+-- See LEXAI-1836. Idempotent: re-running sets the same target values.
+
+UPDATE tool_pricing AS tp
+SET base_cost_usd = v.price,
+    updated_by = 'migration_176_zakononline_benchmark',
+    updated_at = NOW()
+FROM (VALUES
+  -- Search / retrieval: 3x ZO -> ~1.4x ZO
+  ('search_court_decisions',          0.01000000::numeric),
+  ('get_court_decision',              0.01000000),
+  ('search_legislation',              0.01000000),
+  -- LLM-analysis: trim extreme premiums to 4-6x ZO
+  ('find_similar_fact_pattern_cases', 0.03000000),
+  ('compare_practice_pro_contra',     0.04000000),
+  -- Legislation lookups: lift off the $0.0001-0.0002 floor
+  ('get_legislation_section',         0.00100000),
+  ('get_legislation_articles',        0.00100000),
+  ('get_legislation_structure',       0.00100000),
+  ('get_legislation_history',         0.00100000),
+  ('list_legislation_editions',       0.00100000)
+) AS v(tool_name, price)
+WHERE tp.tool_name = v.tool_name;


### PR DESCRIPTION
## Контекст

Коррекция цен V2-чата относительно конкурента **ЗаконОнлайн** (договір API, 09.01.2025).

ЗаконОнлайн = плоская цена за запит до бази правової інформації (суд. рішення + законодавство):

| Обсяг/міс | Тариф | USD @42₴ |
|---|---|---|
| ≤10 000 | 3 000₴ фікс (0.30₴/req) | $0.0071 |
| ≤50 000 | 0.27–0.29₴/req | ~$0.0067 |
| >50 000 | 0.10₴/req | $0.0024 |

Наши поисковые инструменты стояли ~3× их тарифа, LLM-аналитика 9–15×. Стратегия: **премиум, но конкурентно** (курс 1 USD = 42₴).

## Изменения (migration 176)

| Инструмент | Было | Стало | ×ЗО |
|---|---|---|---|
| `search_court_decisions` | $0.020 | **$0.010** | 1.4× |
| `get_court_decision` | $0.025 | **$0.010** | 1.4× |
| `search_legislation` | $0.020 | **$0.010** | 1.4× |
| `find_similar_fact_pattern_cases` | $0.065 | **$0.030** | 4.3× |
| `compare_practice_pro_contra` | $0.100 | **$0.040** | 5.8× |
| `get_legislation_section/articles/structure/history/editions` | $0.0001–0.0002 | **$0.001** | 0.15× |

Реестры (`openreyestr_*`) — у ЗО нет аналога, без изменений. Прочие суд-инструменты уже в целевом диапазоне.

Idempotent `UPDATE` (повторный прогон ставит те же значения).

Plane: LEXAI-1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repriced V2 chat tool costs to be premium but competitive with ZakonOnline. Search tools now $0.010, LLM-analysis $0.030–$0.040, and legislation lookups $0.001; registry tools unchanged; applied via idempotent migration 176 (LEXAI-1836).

<sup>Written for commit 660a168051c1db258acefbecae5b3a95f7e0f28a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

