### PR TITLE
feat(opendata): NIPO Appeals Chamber decisions scraper + dataset DB

### DIFF
--- a/scripts/opendata/nipo_appeals/Dockerfile
+++ b/scripts/opendata/nipo_appeals/Dockerfile
@@ -1,0 +1,22 @@
+# NIPO Appeals Chamber scraper — runs on the GCP dev VM against the shared
+# Postgres container. Build context = scripts/opendata (see README.md).
+#
+#   docker build -t nipo-appeals -f nipo_appeals/Dockerfile .
+#   docker run --rm --network deployment_default \
+#     -e DATABASE_URL=postgresql://nipo_appeals:***@secondlayer-postgres-local:5432/nipo_appeals \
+#     -v nipo_appeals_data:/data \
+#     nipo-appeals --create-schema --full --workers 6
+
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY nipo_appeals/requirements.txt /app/nipo_appeals/requirements.txt
+RUN pip install --no-cache-dir -r /app/nipo_appeals/requirements.txt
+
+COPY nipo_appeals /app/nipo_appeals
+
+ENV NIPO_APPEALS_DATA_DIR=/data
+VOLUME /data
+
+ENTRYPOINT ["python", "-m", "nipo_appeals.main"]
+CMD []

--- a/scripts/opendata/nipo_appeals/README.md
+++ b/scripts/opendata/nipo_appeals/README.md
@@ -1,0 +1,90 @@
+# NIPO Appeals Chamber decisions dataset (Апеляційна палата НОІВ)
+
+Скрейпер, що будує повний датасет рішень Апеляційної палати НОІВ у **окремій
+базі `nipo_appeals`** (Postgres на GCP dev VM) з інструментом інкрементального
+оновлення.
+
+## Джерела
+
+| Джерело | Роки | Розділи | Обсяг |
+|---|---|---|---|
+| nipo.gov.ua (3 сторінки, без пагінації) | 2024–2026 | ТМ / винаходи-КМ / добре відомі ТМ | ~170 рішень |
+| ukrpatent.org легасі-архів (36 річних сторінок) | 2011–2022 | ті самі | ~1 086 рішень |
+| XLSX-реєстр добре відомих ТМ (хаб nipo.gov.ua) | 1995–2025 | добре відомі ТМ | ~245 записів |
+
+Кожне рішення = пара PDF (наказ + рішення), усі PDF текстові (OCR не потрібен).
+2023 — діра в обох джерелах (палата перезапускалась під НОІВ).
+Раніше 2011 онлайн-архіву нема (окремо — web.archive.org, джерело `ukrpatent` +
+`raw.wayback`).
+
+## Пайплайн
+
+```
+лістинги (HTML) → інкрементальний фільтр (skip відомих decision_pdf_url)
+  → пул процесів (--workers): download наказ+рішення+зображення, pypdf-текст,
+    поля (апелянт, заявник, № заявки, колегія, результат з резолютивки)
+  → ВАЛІДАЦІЯ (errors → data/rejects.ndjson, у БД не потрапляють)
+  → upsert у Postgres (ON CONFLICT decision_pdf_url)
+  → XLSX-реєстр добре відомих ТМ → nipo_well_known_tms (+лінк до рішень)
+```
+
+Схема БД: `db.py` (`--create-schema`), таблиці `nipo_appeal_decisions`
+(з tsvector-колонкою для FTS) і `nipo_well_known_tms`.
+
+## Запуск (dev VM, контейнер)
+
+```bash
+# збірка (контекст = scripts/opendata)
+cd ~/nipo_appeals_build && docker build -t nipo-appeals -f nipo_appeals/Dockerfile .
+
+# перший повний прохід
+source ~/nipo_appeals.env
+docker run --rm --name nipo-appeals-full \
+  --network deployment_secondlayer-local \
+  -e DATABASE_URL="postgresql://nipo_appeals:${NIPO_APPEALS_PASSWORD}@secondlayer-postgres-local:5432/nipo_appeals" \
+  -v nipo_appeals_data:/data \
+  nipo-appeals --create-schema --full --workers 6
+
+# інкрементальне оновлення (дефолтний режим) — тільки нові рішення
+docker run --rm --name nipo-appeals-update \
+  --network deployment_secondlayer-local \
+  -e DATABASE_URL="postgresql://nipo_appeals:${NIPO_APPEALS_PASSWORD}@secondlayer-postgres-local:5432/nipo_appeals" \
+  -v nipo_appeals_data:/data \
+  nipo-appeals
+```
+
+Корисні прапорці: `--dry-run --limit 5` (смоук без БД), `--sources nipo`
+(тільки новий сайт — для регулярних оновлень достатньо), `--sections tm`,
+`--skip-wellknown`. Ненульовий exit code = були відхилені валідацією записи
+(див. `/data/rejects.ndjson`).
+
+PDF/зображення кешуються у volume `nipo_appeals_data` (шляхи — у
+`raw.files` кожного запису); повторні запуски їх не перекачують.
+
+## Оновлення за розкладом
+
+Щотижневий cron на dev VM (нові рішення публікуються лише на nipo.gov.ua):
+
+```cron
+0 3 * * 1 . $HOME/nipo_appeals.env && docker run --rm --network deployment_secondlayer-local -e DATABASE_URL="postgresql://nipo_appeals:${NIPO_APPEALS_PASSWORD}@secondlayer-postgres-local:5432/nipo_appeals" -v nipo_appeals_data:/data nipo-appeals --sources nipo >> $HOME/nipo_appeals_cron.log 2>&1
+```
+
+## Доступ до БД (read-only)
+
+Юзер `vladimir` (SELECT на всі таблиці). Підключення через SSH-тунель до dev VM:
+
+```bash
+ssh -N -L 5439:localhost:5432 <user>@34.116.251.221   # dev VM
+psql "postgresql://vladimir:<password>@localhost:5439/nipo_appeals"
+```
+
+Пароль — у Ігоря (генерується при створенні юзера, див. `~/nipo_appeals.env`
+на dev VM).
+
+## Локальний смоук-тест
+
+```bash
+cd scripts/opendata
+pip install -r nipo_appeals/requirements.txt
+python -m nipo_appeals.main --dry-run --limit 4 --sources nipo --skip-wellknown
+```

--- a/scripts/opendata/nipo_appeals/__init__.py
+++ b/scripts/opendata/nipo_appeals/__init__.py
@@ -1,0 +1,6 @@
+"""NIPO Appeals Chamber (Апеляційна палата НОІВ) decisions scraper.
+
+Sources: nipo.gov.ua (2024+) and the legacy ukrpatent.org archive (2011–2022).
+Pipeline: listings -> PDF download -> text/field extraction (multi-process)
+-> validation -> Postgres upsert (standalone `nipo_appeals` database).
+"""

--- a/scripts/opendata/nipo_appeals/config.py
+++ b/scripts/opendata/nipo_appeals/config.py
@@ -1,0 +1,57 @@
+"""Configuration for the NIPO Appeals Chamber scraper (env-driven, like sibling opendata scripts)."""
+
+import os
+
+USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0 Safari/537.36 SecondLayerBot/1.0"
+)
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "")
+
+# MinIO / S3 (same convention as scripts/opendata/nipo/download_images.py)
+S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "http://127.0.0.1:9000")
+S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", os.environ.get("MINIO_ACCESS_KEY", ""))
+S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY", os.environ.get("MINIO_SECRET_KEY", ""))
+S3_REGION = os.environ.get("S3_REGION", "us-east-1")
+S3_BUCKET = os.environ.get("NIPO_APPEALS_BUCKET", "nipo-appeals")
+
+# Qdrant + BGE-M3 TEI (same stack as the EDRSR vectorizer)
+QDRANT_URL = os.environ.get("QDRANT_URL", "http://127.0.0.1:6333")
+QDRANT_API_KEY = os.environ.get("QDRANT_API_KEY") or None
+QDRANT_COLLECTION = os.environ.get("QDRANT_NIPO_COLLECTION", "nipo_appeals")
+BGE_M3_URL = os.environ.get("BGE_M3_URL", "")
+EMBEDDING_MODEL = "bge-m3"
+EMBEDDING_DIM = 1024
+EMBED_BATCH_SIZE = 64
+MAX_CHUNK_CHARS = 2048
+CHUNK_OVERLAP_WORDS = 50
+
+# Local cache for downloaded PDFs/images (checkpoint: re-runs skip existing files)
+DATA_DIR = os.environ.get("NIPO_APPEALS_DATA_DIR", os.path.join(os.path.dirname(__file__), "data"))
+
+HTTP_TIMEOUT = 60
+DOWNLOAD_RETRIES = 3
+POLITE_DELAY_S = float(os.environ.get("NIPO_APPEALS_DELAY", "0.2"))
+
+# ── Sources ──────────────────────────────────────────────────────────────────
+
+NIPO_BASE = "https://nipo.gov.ua"
+NIPO_HUB_URL = f"{NIPO_BASE}/apeliatsijna-palata-noiv/"
+NIPO_SECTIONS = {
+    "tm": f"{NIPO_BASE}/rishennia-apeliatsiinoi-palaty-tm/",
+    "inventions": f"{NIPO_BASE}/rishennia-apeliatsiinoi-palaty-vynakhody-km/",
+    "well_known": f"{NIPO_BASE}/rishennia-apeliatsiinoi-palaty-dv-tm/",
+}
+
+UKRPATENT_BASE = "https://ukrpatent.org"
+UKRPATENT_YEARS = list(range(2011, 2023))  # 2011–2022; 2023 — палата перезапускалась, архіву нема
+UKRPATENT_SECTIONS = {
+    "tm": "ap-tm",
+    "inventions": "ap-inventions-models",
+    "well_known": "ap-tm-well-known",
+}
+
+
+def ukrpatent_year_url(section_slug: str, year: int) -> str:
+    return f"{UKRPATENT_BASE}/uk/articles/{section_slug}-{year}"

--- a/scripts/opendata/nipo_appeals/db.py
+++ b/scripts/opendata/nipo_appeals/db.py
@@ -1,0 +1,207 @@
+"""Postgres layer for the standalone `nipo_appeals` database.
+
+Schema is owned by this script (like scripts/opendata/nipo/import_ndjson.py):
+run with --create-schema on first use. All writes are idempotent upserts keyed
+on decision_pdf_url, so full and incremental runs are safe to repeat.
+"""
+
+import json
+import logging
+from typing import Dict, Iterable, List, Set
+
+import psycopg2
+from psycopg2.extras import execute_values, Json
+
+from .models import DecisionItem
+
+log = logging.getLogger(__name__)
+
+SCHEMA_SQL = """
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS nipo_appeal_decisions (
+  id                  SERIAL PRIMARY KEY,
+  source              TEXT NOT NULL CHECK (source IN ('nipo', 'ukrpatent')),
+  section             TEXT NOT NULL CHECK (section IN ('tm', 'inventions', 'well_known')),
+  object_type         TEXT,          -- 'tm' | 'invention' | 'utility_model' | 'well_known_tm'
+  object_title        TEXT NOT NULL,
+  result              TEXT CHECK (result IN ('granted', 'refused', 'partial')),
+  result_source       TEXT,          -- 'marker' (listing) | 'pdf' (operative part)
+  order_number        TEXT,
+  order_date          DATE,
+  decision_date       DATE,
+  app_number          TEXT,
+  appellant           TEXT,
+  parties             JSONB,
+  order_pdf_url       TEXT,
+  decision_pdf_url    TEXT UNIQUE NOT NULL,
+  annex_url           TEXT,
+  image_url           TEXT,
+  order_object_key    TEXT,
+  decision_object_key TEXT,
+  image_object_key    TEXT,
+  order_text          TEXT,
+  decision_text       TEXT,
+  raw                 JSONB,
+  scraped_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  tsv tsvector GENERATED ALWAYS AS (
+    to_tsvector('simple',
+      coalesce(object_title, '') || ' ' ||
+      coalesce(appellant, '') || ' ' ||
+      coalesce(app_number, '') || ' ' ||
+      left(coalesce(decision_text, ''), 900000)
+    )
+  ) STORED
+);
+
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_tsv           ON nipo_appeal_decisions USING gin(tsv);
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_section       ON nipo_appeal_decisions(section);
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_result        ON nipo_appeal_decisions(result);
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_decision_date ON nipo_appeal_decisions(decision_date);
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_order_number  ON nipo_appeal_decisions(order_number);
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_app_number    ON nipo_appeal_decisions(app_number);
+CREATE INDEX IF NOT EXISTS idx_nipo_appeals_title_trgm    ON nipo_appeal_decisions USING gin (object_title gin_trgm_ops);
+
+-- Реєстр добре відомих в Україні ТМ (XLSX perelik_dobre_vidomykh_TM_*.xlsx,
+-- 245+ записів із 1995 року) — джерело істини для перевірки статусу знака.
+CREATE TABLE IF NOT EXISTS nipo_well_known_tms (
+  id                SERIAL PRIMARY KEY,
+  tm_name           TEXT NOT NULL,
+  owner             TEXT,
+  applicant         TEXT,
+  app_number        TEXT,
+  app_date          DATE,
+  doc_number        TEXT,
+  recognition_date  DATE,          -- дата охоронного документа = дата, з якої знак добре відомий
+  nice_classes      TEXT,
+  representative    TEXT,
+  publication_441   TEXT,
+  source_file       TEXT,
+  decision_id       INTEGER REFERENCES nipo_appeal_decisions(id) ON DELETE SET NULL,
+  raw               JSONB,
+  imported_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (tm_name, recognition_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nipo_wktm_name_trgm   ON nipo_well_known_tms USING gin (tm_name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_nipo_wktm_recognition ON nipo_well_known_tms(recognition_date);
+"""
+
+UPSERT_COLUMNS = [
+    "source", "section", "object_type", "object_title", "result", "result_source",
+    "order_number", "order_date", "decision_date", "app_number", "appellant", "parties",
+    "order_pdf_url", "decision_pdf_url", "annex_url", "image_url",
+    "order_object_key", "decision_object_key", "image_object_key",
+    "order_text", "decision_text", "raw",
+]
+
+UPSERT_SQL = f"""
+INSERT INTO nipo_appeal_decisions ({', '.join(UPSERT_COLUMNS)})
+VALUES %s
+ON CONFLICT (decision_pdf_url) DO UPDATE SET
+  {', '.join(f'{c} = EXCLUDED.{c}' for c in UPSERT_COLUMNS if c != 'decision_pdf_url')},
+  updated_at = NOW()
+"""
+
+
+def connect(database_url: str):
+    if not database_url:
+        raise SystemExit("DATABASE_URL is required")
+    conn = psycopg2.connect(database_url)
+    conn.autocommit = False
+    return conn
+
+
+def create_schema(conn) -> None:
+    with conn.cursor() as cur:
+        cur.execute(SCHEMA_SQL)
+    conn.commit()
+    log.info("schema ensured")
+
+
+def existing_decision_urls(conn) -> Set[str]:
+    with conn.cursor() as cur:
+        cur.execute("SELECT decision_pdf_url FROM nipo_appeal_decisions")
+        return {r[0] for r in cur.fetchall()}
+
+
+def _no_nul(v):
+    """Strip NUL bytes recursively — Postgres string literals reject 0x00."""
+    if isinstance(v, str):
+        return v.replace("\x00", "")
+    if isinstance(v, dict):
+        return {k: _no_nul(x) for k, x in v.items()}
+    if isinstance(v, list):
+        return [_no_nul(x) for x in v]
+    return v
+
+
+def upsert_decisions(conn, items: Iterable[DecisionItem]) -> int:
+    rows = []
+    for it in items:
+        rows.append(tuple(
+            Json(_no_nul(getattr(it, c))) if c in ("parties", "raw") else _no_nul(getattr(it, c))
+            for c in UPSERT_COLUMNS
+        ))
+    if not rows:
+        return 0
+    with conn.cursor() as cur:
+        execute_values(cur, UPSERT_SQL, rows, page_size=200)
+    conn.commit()
+    return len(rows)
+
+
+def upsert_well_known(conn, rows: List[dict]) -> int:
+    if not rows:
+        return 0
+    # the XLSX contains repeated (tm_name, recognition_date) rows — dedupe inside the
+    # batch (last wins), else ON CONFLICT DO UPDATE raises CardinalityViolation
+    deduped = {(r.get("tm_name"), r.get("recognition_date")): r for r in rows}
+    rows = list(deduped.values())
+    cols = ["tm_name", "owner", "applicant", "app_number", "app_date", "doc_number",
+            "recognition_date", "nice_classes", "representative", "publication_441",
+            "source_file", "raw"]
+    sql = f"""
+    INSERT INTO nipo_well_known_tms ({', '.join(cols)})
+    VALUES %s
+    ON CONFLICT (tm_name, recognition_date) DO UPDATE SET
+      {', '.join(f'{c} = EXCLUDED.{c}' for c in cols if c not in ('tm_name', 'recognition_date'))},
+      updated_at = NOW()
+    """
+    values = [tuple(Json(r[c]) if c == "raw" else r.get(c) for c in cols) for r in rows]
+    with conn.cursor() as cur:
+        execute_values(cur, sql, values, page_size=200)
+    conn.commit()
+    return len(values)
+
+
+def link_well_known_decisions(conn) -> int:
+    """Best-effort link registry rows to Appeals Chamber decisions by TM name."""
+    with conn.cursor() as cur:
+        cur.execute("""
+            UPDATE nipo_well_known_tms w
+            SET decision_id = d.id, updated_at = NOW()
+            FROM nipo_appeal_decisions d
+            WHERE w.decision_id IS NULL
+              AND d.section = 'well_known'
+              AND lower(d.object_title) = lower(w.tm_name)
+        """)
+        n = cur.rowcount
+    conn.commit()
+    return n
+
+
+def stats(conn) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT source || '/' || section, count(*)
+            FROM nipo_appeal_decisions GROUP BY 1 ORDER BY 1
+        """)
+        for k, v in cur.fetchall():
+            out[k] = v
+        cur.execute("SELECT count(*) FROM nipo_well_known_tms")
+        out["well_known_registry"] = cur.fetchone()[0]
+    return out

--- a/scripts/opendata/nipo_appeals/download.py
+++ b/scripts/opendata/nipo_appeals/download.py
@@ -1,0 +1,81 @@
+"""HTTP fetch + file download with retries and a local cache (checkpoint/resume)."""
+
+import hashlib
+import logging
+import os
+import time
+from typing import Optional
+
+import requests
+
+from .config import USER_AGENT, HTTP_TIMEOUT, DOWNLOAD_RETRIES, POLITE_DELAY_S, DATA_DIR
+
+log = logging.getLogger(__name__)
+
+_session: Optional[requests.Session] = None
+
+
+def session() -> requests.Session:
+    global _session
+    if _session is None:
+        _session = requests.Session()
+        _session.headers["User-Agent"] = USER_AGENT
+    return _session
+
+
+def reset_session() -> None:
+    """Drop the cached session. MUST run in every forked worker process:
+    a forked child inherits the parent's keep-alive TLS connections, and several
+    processes reading one SSL socket produce 'record layer failure' errors."""
+    global _session
+    _session = None
+
+
+def fetch_html(url: str) -> str:
+    last_err: Optional[Exception] = None
+    for attempt in range(DOWNLOAD_RETRIES):
+        try:
+            r = session().get(url, timeout=HTTP_TIMEOUT)
+            r.raise_for_status()
+            r.encoding = r.encoding or "utf-8"
+            return r.text
+        except Exception as e:
+            last_err = e
+            wait = 2 ** attempt
+            log.warning("fetch %s failed (%s), retry in %ds", url, e, wait)
+            time.sleep(wait)
+    raise RuntimeError(f"failed to fetch {url}: {last_err}")
+
+
+def cache_path(url: str) -> str:
+    """Deterministic local path for a downloaded file (hash prefix avoids name collisions)."""
+    name = url.rsplit("/", 1)[-1] or "file"
+    name = name.split("?")[0][:150]
+    h = hashlib.sha1(url.encode()).hexdigest()[:10]
+    return os.path.join(DATA_DIR, "files", f"{h}_{name}")
+
+
+def download_file(url: str, force: bool = False) -> str:
+    """Download url to the local cache; returns the path. Skips if already cached."""
+    path = cache_path(url)
+    if not force and os.path.exists(path) and os.path.getsize(path) > 0:
+        return path
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    last_err: Optional[Exception] = None
+    for attempt in range(DOWNLOAD_RETRIES):
+        try:
+            if POLITE_DELAY_S:
+                time.sleep(POLITE_DELAY_S)
+            r = session().get(url, timeout=HTTP_TIMEOUT)
+            r.raise_for_status()
+            tmp = path + ".tmp"
+            with open(tmp, "wb") as f:
+                f.write(r.content)
+            os.replace(tmp, path)  # atomic — a killed run never leaves partial files
+            return path
+        except Exception as e:
+            last_err = e
+            wait = 2 ** attempt
+            log.warning("download %s failed (%s), retry in %ds", url, e, wait)
+            time.sleep(wait)
+    raise RuntimeError(f"failed to download {url}: {last_err}")

--- a/scripts/opendata/nipo_appeals/fetch_nipo.py
+++ b/scripts/opendata/nipo_appeals/fetch_nipo.py
@@ -1,0 +1,134 @@
+"""Parsers for nipo.gov.ua Appeals Chamber listing pages (Elementor, server-rendered, no pagination).
+
+Two layouts:
+  * 'tm' and 'well_known' — 2-column sections: h6 title with ✔︎/✘ marker,
+    Наказ/Рішення links with number+dates, mark image in the right column;
+  * 'inventions' — 3-column: <strong>«TITLE»</strong> + object type line, links in own columns.
+"""
+
+import logging
+import re
+from typing import List, Optional
+
+from .htmlutil import strip_tags, squash_ws, parse_dmy, result_from_marker, clean_title
+from .models import DecisionItem
+
+log = logging.getLogger(__name__)
+
+SECTION_SPLIT = '<section class="elementor-section elementor-top-section'
+LINK_RE = re.compile(r'<a\s+[^>]*href="([^"]+)"[^>]*>(.*?)</a>', re.S | re.I)
+H6_RE = re.compile(r'<h6 class="elementor-heading-title[^"]*">(.*?)</h6>', re.S)
+STRONG_RE = re.compile(r"<strong>(.*?)</strong>", re.S)
+ORDER_NUM_RE = re.compile(r"№\s*([\w\-]+/\d{4})")
+IMG_EXT_RE = re.compile(r"\.(png|jpe?g|gif|webp)(\?|$)", re.I)
+APP_NUM_LISTING_RE = re.compile(r"заявк\w*\s*№?\s*([amus]\s?\d{4}\s?\d{4,6})", re.I)
+
+
+def _links_with_tails(chunk: str) -> List[dict]:
+    """All <a> in a chunk: href, visible text (tags stripped) and tail text.
+
+    Tail = text between </a> and the end of the same <p> (tm/well-known layout:
+    "<a>Наказ</a> №179/2026 від 06.07.2026"). The inventions layout puts the
+    number/date in the NEXT <p> of the same column — fall back to it when the
+    in-paragraph tail is empty.
+    """
+    out = []
+    for m in LINK_RE.finditer(chunk):
+        href, inner = m.group(1), strip_tags(m.group(2))
+        tail_raw = chunk[m.end() : m.end() + 600]
+        tail = squash_ws(strip_tags(tail_raw.split("</p>")[0]))
+        if not tail:
+            next_p = re.search(r"<p[^>]*>(.*?)</p>", tail_raw, re.S)
+            if next_p:
+                tail = squash_ws(strip_tags(next_p.group(1)))
+        out.append({"href": href, "text": squash_ws(inner), "tail": tail})
+    return out
+
+
+def _find_doc_link(links: List[dict], word: str) -> Optional[dict]:
+    for l in links:
+        if word.lower() in l["text"].lower() and l["href"].lower().endswith((".pdf", ".doc", ".docx")):
+            return l
+    return None
+
+
+def _find_image(chunk: str) -> Optional[str]:
+    # Prefer the lightbox <a href> (full-size); thumbs live in src on the dv-tm page.
+    m = re.search(r'<a\s+href="([^"]+)"[^>]*data-elementor-open-lightbox', chunk)
+    if m and IMG_EXT_RE.search(m.group(1)):
+        return m.group(1)
+    for m in re.finditer(r'<img[^>]+src="([^"]+)"', chunk):
+        src = m.group(1)
+        if IMG_EXT_RE.search(src) and "emoji" not in src and "/thumbs/" not in src:
+            return src
+    return None
+
+
+def parse_section_page(html_text: str, section: str) -> List[DecisionItem]:
+    items: List[DecisionItem] = []
+    for chunk in html_text.split(SECTION_SPLIT)[1:]:
+        item = _parse_chunk(chunk, section)
+        if item:
+            items.append(item)
+    log.info("nipo/%s: parsed %d items", section, len(items))
+    return items
+
+
+def _parse_chunk(chunk: str, section: str) -> Optional[DecisionItem]:
+    links = _links_with_tails(chunk)
+    nakaz = _find_doc_link(links, "Наказ")
+    rishennia = _find_doc_link(links, "Рішення")
+    if not rishennia:
+        return None  # header/nav/year-divider section
+
+    if section == "inventions":
+        title_m = STRONG_RE.search(chunk)
+        title_raw = strip_tags(title_m.group(1)) if title_m else ""
+        # object type is the standalone <p> line 'винахід' / 'корисна модель'
+        object_type = None
+        text_lines = [squash_ws(strip_tags(p)) for p in re.findall(r"<p[^>]*>(.*?)</p>", chunk, re.S)]
+        for line in text_lines:
+            low = line.lower()
+            if low == "винахід":
+                object_type = "invention"
+            elif low.replace("’", "'") == "корисна модель":
+                object_type = "utility_model"
+    else:
+        title_m = H6_RE.search(chunk)
+        title_raw = strip_tags(title_m.group(1)) if title_m else ""
+        object_type = "well_known_tm" if section == "well_known" else "tm"
+
+    if not title_raw:
+        return None
+
+    result = result_from_marker(title_raw)
+    order_tail = nakaz["tail"] if nakaz else ""
+    order_num_m = ORDER_NUM_RE.search(order_tail)
+    annex = _find_doc_link(links, "Додаток")
+
+    item = DecisionItem(
+        source="nipo",
+        section=section,
+        decision_pdf_url=rishennia["href"],
+        object_title=clean_title(title_raw),
+        object_type=object_type,
+        result=result,
+        result_source="marker" if result else None,
+        order_number=order_num_m.group(1) if order_num_m else None,
+        order_date=parse_dmy(order_tail),
+        decision_date=parse_dmy(rishennia["tail"]),
+        order_pdf_url=nakaz["href"] if nakaz else None,
+        annex_url=annex["href"] if annex else None,
+        image_url=_find_image(chunk),
+        raw={"listing_title": title_raw, "order_tail": order_tail, "decision_tail": rishennia["tail"]},
+    )
+    return item
+
+
+def find_well_known_xlsx_url(hub_html: str) -> Optional[str]:
+    """Locate the well-known TM registry XLSX on the Appeals Chamber hub page."""
+    m = re.search(r'href="([^"]*perelik[^"]*\.xlsx)"', hub_html, re.I)
+    if m:
+        return m.group(1)
+    m = re.search(r'href="([^"]*dobre[_-]?vidom[^"]*\.xlsx)"', hub_html, re.I)
+    return m.group(1) if m else None

--- a/scripts/opendata/nipo_appeals/fetch_ukrpatent.py
+++ b/scripts/opendata/nipo_appeals/fetch_ukrpatent.py
@@ -1,0 +1,104 @@
+"""Parser for the legacy ukrpatent.org Appeals Chamber archive (2011–2022).
+
+Year pages render a plain HTML table, one decision per <tr>:
+  <tr>
+    <td><img src="/i_upload/blablabus.jpg" ...></td>      -- mark image (may be absent)
+    <td>02.11.2021</td>                                    -- decision date
+    <td><a href="/atachs/BLABLABUS-nakaz-2021.pdf">16.12.2021 № 284-Н/2021</a></td>
+    <td><a href="/atachs/BLABLABUS-res-2021.pdf">PDF</a></td>
+  </tr>
+Listing has no result marker and no textual title — both are backfilled from the
+decision PDF at the parse stage; the slug from the file name is the provisional title.
+"""
+
+import logging
+import re
+from typing import List, Optional
+
+from .config import UKRPATENT_BASE
+from .htmlutil import strip_tags, squash_ws, parse_dmy, absolutize
+from .models import DecisionItem
+
+log = logging.getLogger(__name__)
+
+TR_RE = re.compile(r"<tr[^>]*>(.*?)</tr>", re.S | re.I)
+TD_RE = re.compile(r"<td[^>]*>(.*?)</td>", re.S | re.I)
+ATACH_LINK_RE = re.compile(r'<a\s+[^>]*href="((?:https?://ukrpatent\.org)?/atachs/[^"]+\.pdf)"[^>]*>(.*?)</a>', re.S | re.I)
+IMG_RE = re.compile(r'<img[^>]+src="([^"]+)"', re.I)
+# '№ 284-Н/2021' (2019+), but older years write bare '№ 32' / '№ 42-Н' — year optional
+ORDER_NUM_RE = re.compile(r"№\s*([\w\-]+(?:/\d{4})?)")
+NAKAZ_NAME_RE = re.compile(r"nakaz", re.I)
+
+
+def slug_from_pdf_url(url: str) -> str:
+    name = url.rsplit("/", 1)[-1]
+    name = re.sub(r"\.pdf$", "", name, flags=re.I)
+    name = re.sub(r"[-_](nakaz|res|rish\w*)[-_]?\d{4}$", "", name, flags=re.I)
+    name = re.sub(r"[-_](nakaz|res)[-_]?", " ", name, flags=re.I)
+    return squash_ws(name.replace("-", " ").replace("_", " "))
+
+
+def parse_year_page(html_text: str, section: str, year: int) -> List[DecisionItem]:
+    items: List[DecisionItem] = []
+    seen: set = set()
+    for tr_m in TR_RE.finditer(html_text):
+        row = tr_m.group(1)
+        links = ATACH_LINK_RE.findall(row)
+        if not links:
+            continue
+        nakaz = next(((h, t) for h, t in links if NAKAZ_NAME_RE.search(h)), None)
+        decision = next(((h, t) for h, t in links if not NAKAZ_NAME_RE.search(h)), None)
+        guessed = False
+        if not decision and nakaz:
+            # site glitch: a couple of rows link the наказ twice (or omit the decision).
+            # Derive the conventional -res- URL; the download stage rejects it loudly
+            # if the guess doesn't exist.
+            guess = re.sub(r"nakaz", "res", nakaz[0], flags=re.I)
+            if guess != nakaz[0]:
+                decision = (guess, "PDF")
+                guessed = True
+                log.warning("ukrpatent/%s-%d: no decision link, guessing %s", section, year, guess)
+        if not decision:
+            log.warning("ukrpatent/%s-%d: row without decision pdf, skipped: %s", section, year, links)
+            continue
+
+        decision_url = absolutize(decision[0], UKRPATENT_BASE)
+        if decision_url in seen:
+            continue
+        seen.add(decision_url)
+
+        tds = [squash_ws(strip_tags(td)) for td in TD_RE.findall(row)]
+        # decision date = first standalone date cell that is NOT inside the nakaz link text
+        nakaz_text = squash_ws(strip_tags(nakaz[1])) if nakaz else ""
+        decision_date = None
+        for td in tds:
+            if td and td != nakaz_text and parse_dmy(td) and "№" not in td:
+                decision_date = parse_dmy(td)
+                break
+
+        # order number is usually in the nakaz link text, but some years put it
+        # in a separate cell — fall back to scanning all cells of the row
+        order_num_m = ORDER_NUM_RE.search(nakaz_text) or ORDER_NUM_RE.search(" | ".join(tds))
+        img_m = IMG_RE.search(row)
+        image_url = absolutize(img_m.group(1), UKRPATENT_BASE) if img_m else None
+
+        object_type = {"tm": "tm", "inventions": None, "well_known": "well_known_tm"}[section]
+
+        items.append(
+            DecisionItem(
+                source="ukrpatent",
+                section=section,
+                decision_pdf_url=decision_url,
+                object_title=slug_from_pdf_url(decision_url),  # provisional; replaced from PDF
+                object_type=object_type,
+                order_number=order_num_m.group(1) if order_num_m else None,
+                order_date=parse_dmy(nakaz_text),
+                decision_date=decision_date,
+                order_pdf_url=absolutize(nakaz[0], UKRPATENT_BASE) if nakaz else None,
+                image_url=image_url,
+                raw={"year_page": year, "nakaz_text": nakaz_text, "row_tds": tds[:6],
+                     **({"decision_url_guessed": True} if guessed else {})},
+            )
+        )
+    log.info("ukrpatent/%s-%d: parsed %d items", section, year, len(items))
+    return items

--- a/scripts/opendata/nipo_appeals/htmlutil.py
+++ b/scripts/opendata/nipo_appeals/htmlutil.py
@@ -1,0 +1,67 @@
+"""Small HTML helpers (regex-based; both sites are static server-rendered pages)."""
+
+import html
+import re
+from datetime import datetime
+from typing import Optional
+
+TAG_RE = re.compile(r"<[^>]+>")
+DATE_RE = re.compile(r"(\d{2})\.(\d{2})\.(\d{4})")
+
+GRANTED_MARKS = "✔"  # ✔ (nipo pages use ✔︎ = U+2714 U+FE0E)
+REFUSED_MARKS = "✘✖"  # ✘ and ✖ (both glyphs occur)
+
+
+def strip_tags(fragment: str) -> str:
+    return html.unescape(TAG_RE.sub(" ", fragment)).replace("\xa0", " ").strip()
+
+
+def squash_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def parse_dmy(text: str) -> Optional[str]:
+    """First DD.MM.YYYY in text -> ISO date string, validated."""
+    m = DATE_RE.search(text or "")
+    if not m:
+        return None
+    d, mo, y = m.groups()
+    try:
+        return datetime(int(y), int(mo), int(d)).strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def result_from_marker(title_text: str) -> Optional[str]:
+    has_granted = any(ch in title_text for ch in GRANTED_MARKS)
+    has_refused = any(ch in title_text for ch in REFUSED_MARKS)
+    if has_granted and has_refused:
+        return "partial"
+    if has_granted:
+        return "granted"
+    if has_refused:
+        return "refused"
+    return None
+
+
+def clean_title(title_text: str) -> str:
+    """Drop result markers and surrounding quotes/whitespace from a listing title."""
+    t = title_text
+    for ch in GRANTED_MARKS + REFUSED_MARKS + "︎️":
+        t = t.replace(ch, "")
+    t = t.replace("\xa0", " ").strip()
+    # strip one symmetric layer of quotes: "..." «...» “...”
+    m = re.match(r'^["«“„\'](.*)["»”“\']$', t)
+    if m:
+        t = m.group(1).strip()
+    return t
+
+
+def absolutize(url: str, base: str) -> str:
+    if url.startswith("http://") or url.startswith("https://"):
+        return url
+    if url.startswith("//"):
+        return "https:" + url
+    if not url.startswith("/"):
+        url = "/" + url
+    return base.rstrip("/") + url

--- a/scripts/opendata/nipo_appeals/main.py
+++ b/scripts/opendata/nipo_appeals/main.py
@@ -1,0 +1,249 @@
+"""NIPO Appeals Chamber scraper — CLI orchestrator.
+
+Usage (from scripts/opendata/):
+  python -m nipo_appeals.main --create-schema --full --workers 6   # first full run
+  python -m nipo_appeals.main                                      # incremental update (default)
+  python -m nipo_appeals.main --dry-run --limit 5                  # smoke test, no DB writes
+
+Stages:
+  1. fetch listing pages (nipo.gov.ua: 3 pages; ukrpatent.org: 36 year pages)
+  2. incremental filter — skip decisions already in the DB (unless --full)
+  3. worker pool (--workers processes): download наказ+рішення PDFs, extract text + fields
+  4. validate every record; rejects -> rejects.ndjson, NEVER the DB
+  5. upsert accepted records into Postgres
+  6. well-known TM registry XLSX -> nipo_well_known_tms (+ link to decisions)
+"""
+
+import argparse
+import dataclasses
+import json
+import logging
+import os
+import sys
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from typing import List, Optional
+
+from . import config, db
+from .download import fetch_html, download_file, reset_session
+from .fetch_nipo import parse_section_page, find_well_known_xlsx_url
+from .fetch_ukrpatent import parse_year_page
+from .htmlutil import absolutize
+from .models import DecisionItem
+from .pdf_fields import extract_pdf_text, extract_fields
+from .validate import validate
+from .wellknown import parse_registry_xlsx
+
+log = logging.getLogger("nipo_appeals")
+
+
+# ── Stage 1: listings ────────────────────────────────────────────────────────
+
+def collect_listings(sources: List[str], sections: List[str]) -> List[DecisionItem]:
+    items: List[DecisionItem] = []
+    if "nipo" in sources:
+        for section in sections:
+            url = config.NIPO_SECTIONS[section]
+            items.extend(parse_section_page(fetch_html(url), section))
+    if "ukrpatent" in sources:
+        for section in sections:
+            slug = config.UKRPATENT_SECTIONS[section]
+            for year in config.UKRPATENT_YEARS:
+                url = config.ukrpatent_year_url(slug, year)
+                items.extend(parse_year_page(fetch_html(url), section, year))
+    # dedup by natural key (nipo hub occasionally repeats an item)
+    seen, unique = set(), []
+    for it in items:
+        if it.decision_pdf_url in seen:
+            continue
+        seen.add(it.decision_pdf_url)
+        unique.append(it)
+    return unique
+
+
+# ── Stage 3: per-item worker (runs in a separate process) ────────────────────
+
+def process_item(item_dict: dict) -> dict:
+    """Download PDFs (+image), extract texts and structured fields. Never raises —
+    failures are recorded in raw['processing_error'] and caught by validation."""
+    item = DecisionItem(**item_dict)
+    try:
+        decision_path = download_file(item.decision_pdf_url)
+        item.decision_text = extract_pdf_text(decision_path)
+        files = {"decision_pdf": os.path.relpath(decision_path, config.DATA_DIR)}
+
+        if item.order_pdf_url:
+            try:
+                order_path = download_file(item.order_pdf_url)
+                item.order_text = extract_pdf_text(order_path)
+                files["order_pdf"] = os.path.relpath(order_path, config.DATA_DIR)
+            except Exception as e:
+                item.raw["order_pdf_error"] = str(e)
+
+        if item.image_url:
+            try:
+                img_path = download_file(item.image_url)
+                files["image"] = os.path.relpath(img_path, config.DATA_DIR)
+            except Exception as e:
+                item.raw["image_error"] = str(e)
+
+        item.raw["files"] = files
+
+        fields = extract_fields(item.order_text or "", item.decision_text or "", item.section)
+        item.app_number = fields.get("app_number")
+        item.appellant = fields.get("appellant")
+        item.parties = fields.get("parties") or {}
+
+        # legacy listings carry only a filename slug — the PDF title is authoritative there
+        pdf_title = fields.get("pdf_title")
+        if pdf_title and (item.source == "ukrpatent" or not item.object_title):
+            item.raw["slug_title"] = item.object_title
+            item.object_title = pdf_title
+
+        if item.section == "inventions" and fields.get("object_type") and not item.object_type:
+            item.object_type = fields["object_type"]
+
+        # result: listing marker wins (nipo); otherwise derive from the operative part
+        if not item.result and fields.get("result_pdf"):
+            item.result = fields["result_pdf"]
+            item.result_source = "pdf"
+    except Exception as e:
+        item.raw["processing_error"] = str(e)
+    return dataclasses.asdict(item)
+
+
+# ── Stage 6: well-known registry ─────────────────────────────────────────────
+
+def import_well_known_registry(conn, dry_run: bool) -> None:
+    hub_html = fetch_html(config.NIPO_HUB_URL)
+    xlsx_url = find_well_known_xlsx_url(hub_html)
+    if not xlsx_url:
+        log.warning("well-known registry XLSX not found on hub page %s", config.NIPO_HUB_URL)
+        return
+    xlsx_url = absolutize(xlsx_url, config.NIPO_BASE)
+    path = download_file(xlsx_url)
+    rows = parse_registry_xlsx(path, source_file=xlsx_url.rsplit("/", 1)[-1])
+    if dry_run:
+        log.info("[dry-run] would upsert %d well-known registry rows", len(rows))
+        return
+    n = db.upsert_well_known(conn, rows)
+    linked = db.link_well_known_decisions(conn)
+    log.info("well-known registry: upserted %d rows, linked %d to decisions", n, linked)
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+def run(args: argparse.Namespace) -> int:
+    sources = [s.strip() for s in args.sources.split(",") if s.strip()]
+    sections = [s.strip() for s in args.sections.split(",") if s.strip()]
+    for s in sections:
+        if s not in config.NIPO_SECTIONS:
+            raise SystemExit(f"unknown section: {s}")
+
+    conn = None
+    if not args.dry_run:
+        conn = db.connect(config.DATABASE_URL)
+        if args.create_schema:
+            db.create_schema(conn)
+
+    log.info("collecting listings: sources=%s sections=%s", sources, sections)
+    items = collect_listings(sources, sections)
+    log.info("total listed decisions: %d", len(items))
+
+    if not args.full and conn is not None:
+        known = db.existing_decision_urls(conn)
+        before = len(items)
+        items = [it for it in items if it.decision_pdf_url not in known]
+        log.info("incremental mode: %d known skipped, %d new to process", before - len(items), len(items))
+
+    if args.limit:
+        items = items[: args.limit]
+        log.info("--limit: processing first %d items", len(items))
+
+    if not items:
+        log.info("nothing new to process")
+    processed: List[dict] = []
+    if items:
+        log.info("processing %d items in %d worker processes…", len(items), args.workers)
+        with ProcessPoolExecutor(max_workers=args.workers, initializer=reset_session) as pool:
+            futures = {pool.submit(process_item, dataclasses.asdict(it)): it.decision_pdf_url for it in items}
+            done = 0
+            for fut in as_completed(futures):
+                processed.append(fut.result())
+                done += 1
+                if done % 25 == 0 or done == len(items):
+                    log.info("  …%d/%d", done, len(items))
+
+    # ── validation gate: nothing unvalidated reaches the DB ─────────────────
+    accepted: List[DecisionItem] = []
+    rejected: List[dict] = []
+    for d in processed:
+        item = DecisionItem(**d)
+        errors, warnings = validate(item)
+        if warnings:
+            item.raw["validation_warnings"] = warnings
+        if errors:
+            rejected.append({"errors": errors, "item": dataclasses.asdict(item)})
+        else:
+            accepted.append(item)
+
+    log.info("validation: %d accepted, %d rejected", len(accepted), len(rejected))
+    if rejected:
+        os.makedirs(os.path.dirname(os.path.abspath(args.rejects_file)) or ".", exist_ok=True)
+        with open(args.rejects_file, "a", encoding="utf-8") as f:
+            for r in rejected:
+                # texts are huge and re-derivable from the cached PDFs — keep rejects readable
+                r["item"]["decision_text"] = (r["item"]["decision_text"] or "")[:500]
+                r["item"]["order_text"] = (r["item"]["order_text"] or "")[:500]
+                f.write(json.dumps(r, ensure_ascii=False) + "\n")
+        log.warning("rejected records appended to %s", args.rejects_file)
+        for r in rejected[:10]:
+            log.warning("  REJECT %s: %s", r["item"]["decision_pdf_url"], "; ".join(r["errors"]))
+
+    if args.dry_run:
+        for it in accepted[: args.limit or 5]:
+            preview = {k: v for k, v in dataclasses.asdict(it).items()
+                       if k not in ("decision_text", "order_text", "raw")}
+            log.info("[dry-run] %s", json.dumps(preview, ensure_ascii=False))
+        log.info("[dry-run] would upsert %d decisions", len(accepted))
+    elif accepted:
+        n = db.upsert_decisions(conn, accepted)
+        log.info("upserted %d decisions", n)
+
+    if not args.skip_wellknown and "well_known" in sections and "nipo" in sources:
+        import_well_known_registry(conn, args.dry_run)
+
+    if conn is not None:
+        log.info("DB stats: %s", json.dumps(db.stats(conn), ensure_ascii=False))
+        conn.close()
+
+    # non-zero exit when anything was rejected, so cron surfaces it
+    return 1 if rejected else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="NIPO Appeals Chamber decisions scraper")
+    p.add_argument("--full", action="store_true",
+                   help="reprocess everything (default: incremental — only decisions not in the DB)")
+    p.add_argument("--create-schema", action="store_true", help="create tables if missing before run")
+    p.add_argument("--workers", type=int, default=4, help="worker processes for PDF download+parse (default 4)")
+    p.add_argument("--sources", default="nipo,ukrpatent", help="comma list: nipo,ukrpatent")
+    p.add_argument("--sections", default="tm,inventions,well_known", help="comma list: tm,inventions,well_known")
+    p.add_argument("--limit", type=int, default=0, help="process at most N items (smoke tests)")
+    p.add_argument("--dry-run", action="store_true", help="no DB writes; print parsed records")
+    p.add_argument("--skip-wellknown", action="store_true", help="skip the well-known TM registry XLSX import")
+    p.add_argument("--rejects-file", default=os.path.join(config.DATA_DIR, "rejects.ndjson"))
+    return p
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        stream=sys.stdout,
+    )
+    args = build_parser().parse_args()
+    sys.exit(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opendata/nipo_appeals/models.py
+++ b/scripts/opendata/nipo_appeals/models.py
@@ -1,0 +1,40 @@
+"""Decision record model shared by both source parsers."""
+
+from dataclasses import dataclass, field, asdict
+from typing import Optional
+
+
+@dataclass
+class DecisionItem:
+    """One Appeals Chamber decision — listing metadata + fields parsed from PDFs."""
+
+    source: str  # 'nipo' | 'ukrpatent'
+    section: str  # 'tm' | 'inventions' | 'well_known'
+    decision_pdf_url: str  # natural key
+    object_title: str = ""
+    object_type: Optional[str] = None  # 'tm' | 'invention' | 'utility_model' | 'well_known_tm'
+    result: Optional[str] = None  # 'granted' | 'refused' | 'partial'
+    result_source: Optional[str] = None  # 'marker' | 'pdf'
+    order_number: Optional[str] = None
+    order_date: Optional[str] = None  # ISO YYYY-MM-DD
+    decision_date: Optional[str] = None
+    order_pdf_url: Optional[str] = None
+    annex_url: Optional[str] = None
+    image_url: Optional[str] = None
+
+    # filled by the PDF stage
+    app_number: Optional[str] = None
+    appellant: Optional[str] = None
+    parties: dict = field(default_factory=dict)
+    order_text: Optional[str] = None
+    decision_text: Optional[str] = None
+
+    # filled by the storage stage
+    order_object_key: Optional[str] = None
+    decision_object_key: Optional[str] = None
+    image_object_key: Optional[str] = None
+
+    raw: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return asdict(self)

--- a/scripts/opendata/nipo_appeals/pdf_fields.py
+++ b/scripts/opendata/nipo_appeals/pdf_fields.py
@@ -1,0 +1,162 @@
+"""PDF text extraction + field parsing (runs in worker processes).
+
+All Appeals Chamber PDFs are digitally-born with clean Ukrainian text layers
+(verified on samples from both nipo.gov.ua and ukrpatent.org) — no OCR needed.
+"""
+
+import logging
+import re
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+APP_NUM_RE = re.compile(r"заявк\w*\s*№\s*([amus]\s?\d{4}\s?\d{4,6})", re.I)
+INTL_REG_RE = re.compile(r"міжнародн\w+\s+реєстрац\w+\s*№?\s*(\d{5,9})", re.I)
+TITLE_TM_RE = re.compile(r"торговельн\w+\s+марк\w+\s*[«\"„]([^»\"”]{1,200})[»\"”]")
+TITLE_ZNAK_RE = re.compile(r"знак\w*(?:\s+для\s+товарів\s+і\s+послуг)?\s*[«\"„]([^»\"”]{1,200})[»\"”]")
+TITLE_INV_RE = re.compile(r"(?:винах[іо]д\w*|корисн\w+\s+модел\w+)\s*[«\"„]([^»\"”]{1,300})[»\"”]")
+APPELLANT_DASH_RE = re.compile(r"[Аа]пелянт\w*\s*[–—-]\s*([^\n]{3,200}?)\s*(?:\(далі|,\s*подан|$)", re.M)
+OPPOSITION_RE = re.compile(
+    r"(?:заперечення|заяв[уи])\s+(.{3,160}?)\s+(?:проти\s+рішення|про\s+визнання)", re.S
+)
+APPLICANT_RE = re.compile(r"заявник\w?\s*[–—-]\s*([^\n;]{3,160})", re.I)
+OWNER_RE = re.compile(r"власник\w?\s*(?:свідоцтва|патенту)?\s*[–—-]\s*([^\n;]{3,160})", re.I)
+COLLEGIUM_RE = re.compile(
+    r"у\s+складі\s+головуючого\s+(.{3,80}?)\s+(?:та|і)\s+членів\s+колегії\s+(.{3,250}?)(?:,?\s*за\s+участю|,?\s*розглянул)",
+    re.S,
+)
+REPS_RE = re.compile(r"Представник\w*\s+(апелянта|заявника|власника|УКРНОІВІ|Укрпатенту|заявник[аі]в)\s*[–—-]\s*([^\n]{3,150})")
+OPERATIVE_RE = re.compile(r"(?:В\s*И\s*Р\s*І\s*Ш\s*И\s*Л\s*А|вирішила)\s*:?", re.I)
+
+
+def extract_pdf_text(path: str) -> str:
+    from pypdf import PdfReader  # imported here so worker processes load it lazily
+
+    reader = PdfReader(path)
+    pages = []
+    for p in reader.pages:
+        try:
+            pages.append(p.extract_text() or "")
+        except Exception as e:  # single corrupt page must not kill the document
+            log.warning("page extraction failed in %s: %s", path, e)
+            pages.append("")
+    # pypdf occasionally emits NUL bytes from broken CMaps — Postgres rejects them
+    return "\n".join(pages).replace("\x00", "")
+
+
+def _norm(s: Optional[str]) -> Optional[str]:
+    if not s:
+        return None
+    s = re.sub(r"\s+", " ", s)
+    s = re.sub(r"\s*\(далі.*$", "", s)  # drop '(далі – апелянт)' style tails
+    s = s.strip(" ,;–—-.")
+    return s or None
+
+
+def _search_not_after(pattern: re.Pattern, text: str, forbidden_prefix: str) -> Optional[re.Match]:
+    """First match whose preceding context does NOT contain forbidden_prefix
+    (e.g. skip 'Представник заявника – …' when looking for 'заявник – …')."""
+    for m in pattern.finditer(text):
+        before = text[max(0, m.start() - 25) : m.start()].lower()
+        if forbidden_prefix not in before:
+            return m
+    return None
+
+
+def normalize_app_number(m: Optional[re.Match]) -> Optional[str]:
+    if not m:
+        return None
+    return re.sub(r"\s+", " ", m.group(1).lower()).strip()
+
+
+def extract_fields(order_text: str, decision_text: str, section: str) -> dict:
+    """Pull structured fields out of the наказ + рішення texts."""
+    combined = (order_text or "") + "\n" + (decision_text or "")
+    fields: dict = {}
+
+    app_m = APP_NUM_RE.search(combined)
+    fields["app_number"] = normalize_app_number(app_m)
+    if not fields["app_number"]:
+        intl = INTL_REG_RE.search(combined)
+        fields["app_number"] = f"IR {intl.group(1)}" if intl else None
+
+    # title from the decision text (authoritative for legacy items where the
+    # listing only had a filename slug)
+    title = None
+    if section == "inventions":
+        m = TITLE_INV_RE.search(combined)
+        title = m.group(1) if m else None
+        low = combined.lower()
+        fields["object_type"] = (
+            "utility_model" if "корисн" in low and "модел" in low and "винах" not in low[:2000] else None
+        )
+        if fields["object_type"] is None:
+            fields["object_type"] = "invention" if "винах" in low else None
+    else:
+        m = TITLE_TM_RE.search(decision_text or "") or TITLE_ZNAK_RE.search(decision_text or "")
+        title = m.group(1) if m else None
+    fields["pdf_title"] = _norm(title)
+
+    appellant = None
+    m = _search_not_after(APPELLANT_DASH_RE, decision_text or "", "представник")
+    if m:
+        appellant = m.group(1)
+    else:
+        m = OPPOSITION_RE.search(decision_text or "")
+        if m:
+            appellant = m.group(1)
+    fields["appellant"] = _norm(appellant)
+
+    parties: dict = {}
+    m = _search_not_after(APPLICANT_RE, decision_text or "", "представник")
+    if m:
+        parties["applicant"] = _norm(m.group(1))
+    m = _search_not_after(OWNER_RE, decision_text or "", "представник")
+    if m:
+        parties["owner"] = _norm(m.group(1))
+    m = COLLEGIUM_RE.search(decision_text or "")
+    if m:
+        head = _norm(m.group(1))
+        members = [_norm(x) for x in re.split(r",| та | і ", m.group(2)) if _norm(x)]
+        parties["collegium"] = {"head": head, "members": members}
+    reps = {}
+    for who, name in REPS_RE.findall(decision_text or ""):
+        reps[who.lower()] = _norm(name)
+    if reps:
+        parties["representatives"] = reps
+    fields["parties"] = parties
+
+    fields["result_pdf"] = result_from_operative(decision_text or "")
+    return fields
+
+
+def result_from_operative(decision_text: str) -> Optional[str]:
+    """Derive the outcome from the operative part (after 'ВИРІШИЛА:')."""
+    m = None
+    for m in OPERATIVE_RE.finditer(decision_text):
+        pass  # keep the LAST occurrence — earlier ones may cite other decisions
+    if not m:
+        return None
+    seg = decision_text[m.end() : m.end() + 1500]
+    low = seg.lower()
+    if re.search(r"задовольнити\s+частково|частково\s+задовольнити|задовольнити\s+в\s+частині", low):
+        return "partial"
+    # both word orders occur: "відмовити ... у задоволенні" and "у задоволенні ... відмовити"
+    refused = (
+        re.search(r"відмовити\b.{0,250}?у\s+задоволенн", low, re.S)
+        or re.search(r"у\s+задоволенн\w*.{0,250}?\bвідмовити", low, re.S)
+        or re.search(r"залишити\s+без\s+задоволенн", low)
+    )
+    granted = re.search(r"(?<!не\s)\bзадовольнити\b|визнати\s+.{0,160}?добре\s+відом", low, re.S)
+    if refused and granted:
+        # both verbs in the operative part — usually numbered points like
+        # "1. Заперечення задовольнити ... 2. Відмовити у ..." -> judge by first verb
+        return "granted" if granted.start() < refused.start() else "refused"
+    if refused:
+        return "refused"
+    if granted:
+        return "granted"
+    # upholding the contested decision without the задоволення formula = refusal
+    if re.search(r"рішення\s+.{0,120}?залишити\s+(чинним|в\s+силі)", low, re.S):
+        return "refused"
+    return None

--- a/scripts/opendata/nipo_appeals/requirements.txt
+++ b/scripts/opendata/nipo_appeals/requirements.txt
@@ -1,0 +1,4 @@
+requests>=2.31
+pypdf>=4.0
+psycopg2-binary>=2.9
+openpyxl>=3.1

--- a/scripts/opendata/nipo_appeals/validate.py
+++ b/scripts/opendata/nipo_appeals/validate.py
@@ -1,0 +1,71 @@
+"""Validation stage — every parsed record is checked BEFORE it may touch the database.
+
+Records with errors go to rejects.ndjson and are NOT inserted.
+Warnings are stored in raw.validation_warnings and the record proceeds.
+"""
+
+import re
+from datetime import date
+from typing import List, Tuple
+
+from .models import DecisionItem
+
+MIN_DECISION_TEXT_CHARS = 400
+# '179/2026', '284-Н/2021'; old ukrpatent years write bare '32' / '42-Н'
+ORDER_NUMBER_RE = re.compile(r"^[\w\-]+(?:/\d{4})?$")
+ALLOWED_SECTIONS = {"tm", "inventions", "well_known"}
+ALLOWED_SOURCES = {"nipo", "ukrpatent"}
+ALLOWED_RESULTS = {"granted", "refused", "partial", None}
+
+
+def _plausible_date(iso: str) -> bool:
+    try:
+        y = int(iso[:4])
+    except (TypeError, ValueError):
+        return False
+    return 2000 <= y <= date.today().year + 1
+
+
+def validate(item: DecisionItem) -> Tuple[List[str], List[str]]:
+    """Return (errors, warnings). Any error blocks the DB write."""
+    errors: List[str] = []
+    warnings: List[str] = []
+
+    if item.source not in ALLOWED_SOURCES:
+        errors.append(f"unknown source: {item.source!r}")
+    if item.section not in ALLOWED_SECTIONS:
+        errors.append(f"unknown section: {item.section!r}")
+    if not item.decision_pdf_url or not item.decision_pdf_url.startswith("http"):
+        errors.append(f"bad decision_pdf_url: {item.decision_pdf_url!r}")
+    if not (item.object_title or "").strip():
+        errors.append("empty object_title")
+    if item.result not in ALLOWED_RESULTS:
+        errors.append(f"unknown result: {item.result!r}")
+
+    if not item.decision_text or len(item.decision_text) < MIN_DECISION_TEXT_CHARS:
+        errors.append(
+            f"decision_text too short ({len(item.decision_text or '')} chars) — "
+            "download or text extraction failed"
+        )
+
+    for name, value in (("order_date", item.order_date), ("decision_date", item.decision_date)):
+        if value and not _plausible_date(value):
+            errors.append(f"{name} out of plausible range: {value}")
+
+    # ── warnings (record still accepted) ────────────────────────────────────
+    if not item.decision_date:
+        warnings.append("missing decision_date")
+    if not item.order_pdf_url:
+        warnings.append("missing order pdf")
+    if item.order_number and not ORDER_NUMBER_RE.match(item.order_number):
+        warnings.append(f"odd order_number format: {item.order_number}")
+    if not item.result:
+        warnings.append("result not determined (no marker, operative part unparsed)")
+    if not item.app_number:
+        warnings.append("app_number not found in PDFs")
+    if item.section != "inventions" and not item.appellant:
+        warnings.append("appellant not extracted")
+    if item.order_pdf_url and (not item.order_text or len(item.order_text) < 200):
+        warnings.append("order_text short/empty")
+
+    return errors, warnings

--- a/scripts/opendata/nipo_appeals/wellknown.py
+++ b/scripts/opendata/nipo_appeals/wellknown.py
@@ -1,0 +1,88 @@
+"""Well-known trademarks registry (XLSX from the Appeals Chamber hub page) -> rows."""
+
+import logging
+import re
+from datetime import datetime
+from typing import List, Optional
+
+log = logging.getLogger(__name__)
+
+# Header row (verified on perelik_dobre_vidomykh_TM_30052025.xlsx):
+# A Тип об'єкта | B Стан | C Номер заявки | D Дата подання заявки | E Номер охоронного документа
+# F Дата охоронного документа | G Ключові слова | H Заявник | I Власник | J Винахідник\автор
+# K Представник | L МПК | M МКТП | N МКПЗ | O (441) Дата публікації | P Зображення ТМ
+COLUMN_MAP = {
+    "номер заявки": "app_number",
+    "дата подання заявки": "app_date",
+    "номер охоронного документа": "doc_number",
+    "дата охоронного документа": "recognition_date",
+    "ключові слова": "tm_name",
+    "заявник": "applicant",
+    "власник": "owner",
+    "представник": "representative",
+    "мктп": "nice_classes",
+    "(441)": "publication_441",
+}
+
+DATE_FIELDS = {"app_date", "recognition_date"}
+
+
+def _cell_str(v) -> Optional[str]:
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.strftime("%d.%m.%Y")
+    s = str(v).replace("_x000D_", " ").replace("\r", " ").replace("\n", " ")
+    s = re.sub(r"\s+", " ", s).strip()
+    return s or None
+
+
+def _to_iso_date(v) -> Optional[str]:
+    if v is None:
+        return None
+    if isinstance(v, datetime):
+        return v.strftime("%Y-%m-%d")
+    m = re.search(r"(\d{2})\.(\d{2})\.(\d{4})", str(v))
+    if not m:
+        return None
+    d, mo, y = m.groups()
+    try:
+        return datetime(int(y), int(mo), int(d)).strftime("%Y-%m-%d")
+    except ValueError:
+        return None
+
+
+def parse_registry_xlsx(path: str, source_file: str) -> List[dict]:
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    ws = wb.active
+    rows_iter = ws.iter_rows(values_only=True)
+    header = next(rows_iter)
+
+    field_by_idx = {}
+    for idx, cell in enumerate(header):
+        label = (_cell_str(cell) or "").lower()
+        for key, field in COLUMN_MAP.items():
+            if label.startswith(key):
+                field_by_idx[idx] = field
+                break
+
+    if "tm_name" not in field_by_idx.values():
+        raise RuntimeError(f"registry XLSX header not recognized: {header}")
+
+    out: List[dict] = []
+    for row in rows_iter:
+        rec: dict = {}
+        raw: dict = {}
+        for idx, field in field_by_idx.items():
+            v = row[idx] if idx < len(row) else None
+            raw[field] = _cell_str(v)
+            rec[field] = _to_iso_date(v) if field in DATE_FIELDS else _cell_str(v)
+        if not rec.get("tm_name"):
+            continue
+        rec["source_file"] = source_file
+        rec["raw"] = raw
+        out.append(rec)
+    log.info("well-known registry: parsed %d rows from %s", len(out), source_file)
+    return out


### PR DESCRIPTION
## Що це

Скрейпер повного корпусу рішень **Апеляційної палати НОІВ** → окрема Postgres-база `nipo_appeals` (на GCP dev VM) з інструментом інкрементального оновлення.

## Джерела та обсяг

| Джерело | Роки | Рішень |
|---|---|---|
| nipo.gov.ua (ТМ / винаходи-КМ / добре відомі ТМ) | 2024–2026 | 170 |
| ukrpatent.org легасі-архів (36 річних сторінок) | 2011–2022 | 1 086 |
| XLSX-реєстр добре відомих ТМ | 1991–2025 | 241 запис |

**Уже імпортовано на dev VM: 1 097 рішень (60 MB текстів) + 241 добре відома ТМ.** 159 старих PDF (2011–2013) — скани без текстового шару, відсіяні валідацією у `rejects.ndjson` (OCR-беклог).

## Пайплайн

лістинги → інкрементальний фільтр → пул процесів (download + pypdf + поля: апелянт, заявник, № заявки, колегія, результат із резолютивки) → **валідація перед БД** (rejects.ndjson) → ідемпотентний upsert (`ON CONFLICT decision_pdf_url`) → XLSX-реєстр + лінковка.

## Оновлення

Щотижневий cron на dev VM (`--sources nipo`, понеділок 03:00). Деталі запуску/доступу — у `scripts/opendata/nipo_appeals/README.md`.

## Доступ

Read-only юзер `vladimir` (SELECT), підключення через SSH-тунель до dev VM. Перевірено: SELECT ок, INSERT — denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scraper and standalone Postgres dataset for NIPO Appeals Chamber decisions with incremental updates. Builds a complete corpus from nipo.gov.ua and the legacy ukrpatent.org archive, with strict validation and a weekly cron on the dev VM.

- **New Features**
  - Coverage: TM, inventions/utility models, well-known TMs; sources nipo.gov.ua (2024–) + ukrpatent.org (2011–2022).
  - Multi-process pipeline: download PDFs/images, extract text with `pypdf`, parse app number, appellant, parties/collegium, and result from the operative part.
  - Validation gate: rejects never touch the DB; logged to /data/rejects.ndjson; idempotent upserts by decision_pdf_url.
  - Postgres schema: `nipo_appeal_decisions` (with FTS tsvector) and `nipo_well_known_tms`; XLSX registry import and linking to decisions.
  - Dockerized CLI with cached downloads; default mode = incremental; weekly cron enabled on the GCP dev VM; read-only DB access documented in README.

- **Dependencies**
  - Adds `requests`, `pypdf`, `psycopg2-binary`, `openpyxl`.

<sup>Written for commit f475c5d89c10e2f8eb8024b3a5edc2663fe55d3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

