### PR TITLE
fix(security): bump transformers to >=5.5.0 (CVE-2026-5241)

### DIFF
--- a/scripts/citation-graph/requirements.txt
+++ b/scripts/citation-graph/requirements.txt
@@ -1,3 +1,3 @@
 sentence-transformers>=2.7.0,<4.0.0
-transformers>=4.41.0,<4.51.0
+transformers>=5.5.0  # CVE-2026-5241: patched in 5.5.0 (LightGlue RCE, GHSA-fgcw-684q-jj6r)
 torch>=2.1.0

--- a/scripts/lextreme/sagemaker/td-code/requirements.txt
+++ b/scripts/lextreme/sagemaker/td-code/requirements.txt
@@ -1,5 +1,5 @@
 # Do NOT include torch -- use the version pre-installed in the SageMaker image (CUDA-compatible)
-transformers>=4.36.0,<4.52.0
+transformers>=5.5.0  # CVE-2026-5241: patched in 5.5.0 (LightGlue RCE, GHSA-fgcw-684q-jj6r)
 accelerate>=1.0.0
 datasets>=2.14.0
 numpy>=1.26.0


### PR DESCRIPTION
## Что

Устраняет Dependabot alerts **#247** и **#248** (GitHub security advisory `GHSA-fgcw-684q-jj6r`, **CVE-2026-5241**, high): arbitrary code execution during model initialization в LightGlue model loading path пакета `transformers`.

Vulnerable range: `< 5.5.0` · First patched: **5.5.0**

## Изменения

| Файл | Было | Стало |
|------|------|-------|
| `scripts/lextreme/sagemaker/td-code/requirements.txt` | `transformers>=4.36.0,<4.52.0` | `transformers>=5.5.0` |
| `scripts/citation-graph/requirements.txt` | `transformers>=4.41.0,<4.51.0` | `transformers>=5.5.0` |

Оба пина были целиком ниже патченной версии, поэтому Dependabot и флагнул. Подняли нижнюю границу до первого исправленного релиза.

> Это standalone training-скрипты (SageMaker fine-tune + citation graph), не рантайм бэкенда. Перед следующим запуском стоит прогнать install, т.к. это мажорный bump `transformers` 4.x → 5.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates training script dependencies to use `transformers` >=5.5.0 to patch CVE-2026-5241 (GHSA-fgcw-684q-jj6r) in the LightGlue model loading path. Resolves Dependabot alerts #247 and #248.

- **Dependencies**
  - `scripts/lextreme/sagemaker/td-code/requirements.txt`: `transformers>=5.5.0`
  - `scripts/citation-graph/requirements.txt`: `transformers>=5.5.0`
  - Vulnerable range was `<5.5.0`; first patched release is `5.5.0`.

- **Migration**
  - Reinstall deps for these scripts before the next run (major bump from 4.x to 5.x).

<sup>Written for commit 329f7301f523c3bf06e180be12cfb8749c4f678b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

