### PR TITLE
fix(openreyestr): repair empty enforcement_proceedings (int4 sequence overflow)

### DIFF
--- a/mcp_openreyestr/src/migrations/017_widen_huge_registry_ids_to_bigint.sql
+++ b/mcp_openreyestr/src/migrations/017_widen_huge_registry_ids_to_bigint.sql
@@ -1,0 +1,36 @@
+-- 017: Widen id to BIGINT on TRUNCATE+INSERT ("huge") registries.
+--
+-- enforcement_proceedings and debtors are reimported daily via TRUNCATE + plain
+-- INSERT. TRUNCATE without RESTART IDENTITY leaves the sequence untouched, so
+-- every run permanently burned ~N sequence values for N rows. After ~70 runs
+-- enforcement_proceedings_id_seq hit the int4 ceiling (2147483647): TRUNCATE
+-- still emptied the table, then every INSERT failed on nextval, leaving 0 rows.
+-- debtors_id_seq was at 876869376 (40.8%) and on the same trajectory.
+--
+-- The importer now issues TRUNCATE ... RESTART IDENTITY, which bounds sequence
+-- growth to one run. BIGINT is the backstop so a missed reset degrades to
+-- wasted values instead of a silently empty table.
+
+-- enforcement_proceedings
+ALTER TABLE enforcement_proceedings ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE enforcement_proceedings_id_seq AS BIGINT MAXVALUE 9223372036854775807;
+
+-- debtors
+ALTER TABLE debtors ALTER COLUMN id TYPE BIGINT;
+ALTER SEQUENCE debtors_id_seq AS BIGINT MAXVALUE 9223372036854775807;
+
+-- Rewind each sequence to just past the highest live id. Not RESTART WITH 1:
+-- debtors holds ~10.4M rows with ids up to ~876M, and restarting at 1 would
+-- collide on the primary key for any insert before the next truncate.
+-- Empty tables rewind to 1.
+SELECT setval(
+  'enforcement_proceedings_id_seq',
+  GREATEST(COALESCE((SELECT max(id) FROM enforcement_proceedings), 0), 1),
+  (SELECT count(*) > 0 FROM enforcement_proceedings)
+);
+
+SELECT setval(
+  'debtors_id_seq',
+  GREATEST(COALESCE((SELECT max(id) FROM debtors), 0), 1),
+  (SELECT count(*) > 0 FROM debtors)
+);

--- a/mcp_openreyestr/src/services/csv-importer.ts
+++ b/mcp_openreyestr/src/services/csv-importer.ts
@@ -118,7 +118,10 @@ export async function importCsv(
   let savedIndexes: IndexDef[] = [];
   if (isHuge) {
     console.log(`  TRUNCATE ${config.tableName}...`);
-    await pool.query(`TRUNCATE ${config.tableName}`);
+    // RESTART IDENTITY bounds sequence growth to a single run. Without it each
+    // daily reimport permanently consumed ~N sequence values and the id
+    // sequence eventually overflowed its type (see migration 017).
+    await pool.query(`TRUNCATE ${config.tableName} RESTART IDENTITY`);
     savedIndexes = await dropIndexes(pool, config.tableName);
 
     // Disable autovacuum during bulk load
@@ -253,6 +256,16 @@ export async function importCsv(
 
   const elapsed = (Date.now() - start) / 1000;
   console.log(`\n  CSV import complete: ${totalRows} rows, ${totalImported} imported, ${totalErrors} errors (${elapsed.toFixed(1)}s)`);
+
+  // Batch failures are swallowed per-batch so one bad batch can't abort the run.
+  // But a huge import that read rows and inserted none has already TRUNCATEd the
+  // table, so "success" here would leave the registry empty and report OK.
+  if (isHuge && totalRows > 0 && totalImported === 0) {
+    throw new Error(
+      `${config.name}: read ${totalRows} rows but imported 0 (${totalErrors} errors) — ` +
+      `table was truncated and is now empty. Refusing to report success.`
+    );
+  }
 
   return { registry: config.name, imported: totalImported, errors: totalErrors, elapsed, totalRows };
 }


### PR DESCRIPTION
## Problem

`enforcement_proceedings` is **empty on prod (0 rows)** and the live MCP tool `openreyestr_search_enforcement_proceedings` returns "не знайдено" for every query.

## Root cause

The "huge" CSV import path (`enforcement_proceedings`, `debtors`) reimports daily via `TRUNCATE` + plain `INSERT`. `TRUNCATE` **without** `RESTART IDENTITY` leaves the sequence untouched, so each run permanently burned ~N sequence values for N rows. After ~70 runs the `SERIAL` (int4) sequence hit its 2147483647 ceiling. Every run since then has TRUNCATEd the table and then failed every insert:

```
Batch INSERT failed: nextval: reached maximum value of sequence
"enforcement_proceedings_id_seq" (2147483647)
```

The table isn't just un-populated — it is emptied and re-emptied daily.

**Why it went unnoticed:** batch errors are swallowed per-batch so the import reported success, and `opendata-sync` only ever saw the fire-and-forget `202` (`NAIS sync OK ... (5ms)`).

**`debtors` is the same bug, not yet fired:** its sequence was at `876869376` — 40.8% of int4 and climbing every day.

## Fix

- **Migration 017** — `id` → `BIGINT` and sequence → `BIGINT` on both tables. Sequences rewound to `max(id)`, *not* `RESTART WITH 1`: `debtors` holds ~10.4M live rows with ids up to ~876M and restarting at 1 would collide on the primary key.
- **Importer** — `TRUNCATE ... RESTART IDENTITY` bounds sequence growth to a single run (the actual recurrence fix; BIGINT is the backstop).
- **Importer** — a huge import that reads rows but imports none now throws rather than reporting success over a table it just truncated.

## Verification

Reproduced the exact failure on a scratch DB seeded to prod's state (exhausted seq + 100 debtor rows), then applied 017:

| check | result |
|---|---|
| repro before fix | insert blocked by exhausted int4 seq |
| enforcement insert after fix | ✅ id=1 |
| debtors insert after fix | ✅ id=101, no PK collision |
| both `id` columns | ✅ `bigint` |
| `TRUNCATE ... RESTART IDENTITY` | ✅ resets to 1 |

`npx tsc --noEmit` passes. Scratch DB dropped.

## Deploy notes

- Migration rewrites `debtors` (~10.4M rows) under an `ACCESS EXCLUSIVE` lock — expect a brief lock, best off-peak. `enforcement_proceedings` is empty so its rewrite is instant.
- Data repopulates on the next daily NAIS cron (04:30 Kyiv), or trigger `POST /api/admin/sync-registry {"registry":"enforcement_proceedings"}` after deploy.

## Note on the memo

The investment memo's claims don't survive contact with prod: `enforcement_proceedings` is 0, and `debtors` is **10.48M**, not 29M. "NAIS 11/11 complete" is not true for this registry. Worth correcting there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty `enforcement_proceedings` on prod by widening IDs to BIGINT and resetting sequences during bulk imports. Prevents future int4 sequence overflows and makes failed huge imports fail loudly.

- **Bug Fixes**
  - Use TRUNCATE ... RESTART IDENTITY for "huge" CSV imports to reset sequences each run.
  - Throw if a huge import reads rows but inserts 0 after truncation, to avoid silent empties.

- **Migration**
  - 017 widens `id` and sequences to BIGINT for `enforcement_proceedings` and `debtors`.
  - Sequences rewound to max(id) to prevent PK collisions; empty tables reset to 1.
  - Deploy note: `debtors` rewrite takes an ACCESS EXCLUSIVE lock; data repopulates on the next daily NAIS run or via `POST /api/admin/sync-registry` for `enforcement_proceedings`.

<sup>Written for commit 4452c53c1bf565df50ec0a60e749d7351b01fd76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

