### PR TITLE
docs(partner): add partner one-pager, noindexed on prod

### DIFF
--- a/docs/proposals/partner-onepager.html
+++ b/docs/proposals/partner-onepager.html
@@ -1,0 +1,826 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>LEX AI — партнерський пакет</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  @page { size: A4; margin: 16mm 14mm; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: #f0f0f2;
+    color: #18181B;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    line-height: 1.6;
+  }
+
+  .page {
+    max-width: 980px;
+    margin: 0 auto;
+    background: #FAFAFA;
+    padding: 64px 72px 80px;
+  }
+
+  /* ---------- header ---------- */
+  .masthead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 28px;
+    border-bottom: 1px solid #E4E4E7;
+    margin-bottom: 48px;
+  }
+
+  .brand { display: flex; align-items: center; gap: 10px; }
+  .brand svg { width: 26px; height: 26px; }
+  .brand span {
+    font-size: 13px; font-weight: 600; color: #52525B;
+    letter-spacing: 1.5px; text-transform: uppercase;
+  }
+  .masthead .meta { font-size: 12px; color: #A1A1AA; text-align: right; }
+
+  /* ---------- typography ---------- */
+  h1 {
+    font-family: 'Crimson Pro', serif;
+    font-size: 46px; font-weight: 700; line-height: 1.1;
+    margin-bottom: 18px;
+  }
+  h1 em { font-style: normal; color: #5C7C9E; }
+
+  h2 {
+    font-family: 'Crimson Pro', serif;
+    font-size: 32px; font-weight: 700; line-height: 1.15;
+    margin-bottom: 8px;
+  }
+
+  h3 {
+    font-family: 'Crimson Pro', serif;
+    font-size: 21px; font-weight: 600;
+    margin-bottom: 8px;
+  }
+
+  .kicker {
+    font-size: 12px; font-weight: 600; color: #A1A1AA;
+    letter-spacing: 1.5px; text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+
+  .lead { font-size: 18px; color: #52525B; line-height: 1.7; max-width: 760px; }
+  .sub  { font-size: 15px; color: #71717A; margin-bottom: 28px; max-width: 760px; }
+  p     { font-size: 15px; color: #71717A; }
+
+  section { margin-bottom: 56px; page-break-inside: avoid; }
+
+  .rule { height: 1px; background: #E4E4E7; margin: 0 0 32px; }
+
+  /* ---------- cards ---------- */
+  .card {
+    background: #FFFFFF;
+    border: 1px solid #E4E4E7;
+    border-radius: 12px;
+    padding: 26px;
+  }
+  .card.dark { background: #18181B; border-color: #18181B; }
+  .card.dark h3, .card.dark .price { color: #FFFFFF; }
+  .card.dark p, .card.dark li { color: #A1A1AA; }
+  .card.dark .tag { background: #27272A; border-color: #3F3F46; color: #A1A1AA; }
+
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+
+  /* ---------- stats ---------- */
+  .stat-row { display: flex; gap: 48px; flex-wrap: wrap; margin-top: 36px; }
+  .stat .val {
+    font-family: 'Crimson Pro', serif;
+    font-size: 40px; font-weight: 700; line-height: 1.1; color: #18181B;
+  }
+  .stat .lbl { font-size: 13px; color: #A1A1AA; font-weight: 500; margin-top: 2px; }
+
+  /* ---------- service blocks ---------- */
+  .svc { display: flex; gap: 22px; padding: 24px 0; border-bottom: 1px solid #E4E4E7; page-break-inside: avoid; }
+  .svc:last-child { border-bottom: none; }
+  .svc .num {
+    font-family: 'Crimson Pro', serif;
+    font-size: 26px; font-weight: 700; color: #D4D4D8;
+    min-width: 42px; line-height: 1.2;
+  }
+  .svc .body { flex: 1; }
+  .svc .head { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+  .svc .summary { font-size: 15px; color: #52525B; margin-bottom: 12px; }
+  .svc ul { list-style: none; }
+  .svc li {
+    font-size: 14px; color: #71717A; padding-left: 16px;
+    position: relative; margin-bottom: 5px; line-height: 1.55;
+  }
+  .svc li::before {
+    content: ''; position: absolute; left: 0; top: 9px;
+    width: 4px; height: 4px; border-radius: 50%; background: #5C7C9E;
+  }
+  .svc li strong { color: #18181B; font-weight: 600; }
+
+  .tag {
+    display: inline-block; padding: 3px 9px; border-radius: 6px;
+    font-size: 11px; font-weight: 600; letter-spacing: .5px; text-transform: uppercase;
+    background: #F4F4F5; border: 1px solid #E4E4E7; color: #52525B;
+    white-space: nowrap;
+  }
+  .tag.live { background: #ECFDF5; border-color: #A7F3D0; color: #047857; }
+  .tag.beta { background: #FFFBEB; border-color: #FDE68A; color: #B45309; }
+
+  /* ---------- ICP ---------- */
+  .icp-card { background:#FFF; border:1px solid #E4E4E7; border-radius:12px; padding:22px; page-break-inside: avoid; }
+  .icp-card .who { font-family:'Crimson Pro',serif; font-size:19px; font-weight:600; margin-bottom:4px; }
+  .icp-card .size { font-size:12px; color:#A1A1AA; font-weight:500; margin-bottom:12px; }
+  .icp-card .pain { font-size:14px; color:#71717A; line-height:1.55; }
+  .icp-card .pitch {
+    font-size:13px; color:#5C7C9E; margin-top:12px; padding-top:12px;
+    border-top:1px dashed #E4E4E7; line-height:1.5;
+  }
+
+  .signal-list { list-style:none; }
+  .signal-list li {
+    font-size:14px; color:#52525B; padding-left:22px; position:relative; margin-bottom:8px; line-height:1.5;
+  }
+  .signal-list li::before {
+    content:'✓'; position:absolute; left:0; top:0; color:#047857; font-weight:700; font-size:13px;
+  }
+  .signal-list.negative li::before { content:'✕'; color:#DC2626; }
+
+  /* ---------- pricing ---------- */
+  .price { font-family:'Crimson Pro',serif; font-size:32px; font-weight:700; color:#18181B; line-height:1.2; }
+  .price span { font-family:'Inter',sans-serif; font-size:14px; font-weight:400; color:#A1A1AA; }
+  .plan-name {
+    font-size:11px; font-weight:600; color:#A1A1AA;
+    text-transform:uppercase; letter-spacing:1px; margin-bottom:10px;
+  }
+  .plan-desc { font-size:13px; color:#71717A; margin-top:8px; line-height:1.5; }
+
+  /* ---------- deal terms ---------- */
+  .terms { list-style:none; counter-reset: t; }
+  .terms li {
+    position:relative; padding-left:38px; margin-bottom:16px;
+    font-size:15px; color:#52525B; line-height:1.6; counter-increment: t;
+  }
+  .terms li::before {
+    content: counter(t); position:absolute; left:0; top:1px;
+    width:24px; height:24px; border-radius:50%;
+    background:#18181B; color:#FFF;
+    font-size:12px; font-weight:600; text-align:center; line-height:24px;
+  }
+  .terms li strong { color:#18181B; font-weight:600; }
+
+  .callout {
+    background:#FFFFFF; border:1px solid #E4E4E7; border-left:3px solid #5C7C9E;
+    border-radius:8px; padding:18px 22px; margin-top:24px;
+  }
+  .callout p { font-size:14px; color:#52525B; line-height:1.6; }
+  .callout strong { color:#18181B; font-weight:600; }
+
+  /* ---------- table ---------- */
+  table { width:100%; border-collapse:collapse; background:#FFF; border:1px solid #E4E4E7; border-radius:12px; overflow:hidden; }
+  th {
+    font-size:11px; font-weight:600; color:#A1A1AA; text-transform:uppercase; letter-spacing:1px;
+    text-align:left; padding:14px 18px; background:#FAFAFA; border-bottom:1px solid #E4E4E7;
+  }
+  td { font-size:14px; color:#52525B; padding:14px 18px; border-bottom:1px solid #F4F4F5; }
+  tr:last-child td { border-bottom:none; }
+  td.hi { color:#18181B; font-weight:600; }
+
+  /* ---------- footer ---------- */
+  .footer {
+    margin-top:64px; padding-top:28px; border-top:1px solid #E4E4E7;
+    display:flex; justify-content:space-between; align-items:flex-end; gap:24px;
+  }
+  .footer .contact { font-size:14px; color:#52525B; line-height:1.7; }
+  .footer .contact strong { color:#18181B; }
+  .footer a { color:#5C7C9E; text-decoration:none; }
+  .footer .note { font-size:11px; color:#A1A1AA; text-align:right; max-width:280px; line-height:1.5; }
+
+  .todo {
+    background:#FFFBEB; border:1px solid #FDE68A; border-radius:8px;
+    padding:14px 18px; margin-top:20px;
+  }
+  .todo p { font-size:13px; color:#B45309; line-height:1.6; }
+  .todo strong { color:#92400E; }
+
+  @media print {
+    body { background:#FFF; }
+    .page { padding:0; max-width:none; background:#FFF; }
+    .todo { display:none; }
+  }
+
+  @media (max-width: 820px) {
+    .page { padding:32px 20px 48px; }
+    h1 { font-size:32px; }
+    h2 { font-size:25px; }
+    .grid-2, .grid-3, .grid-4 { grid-template-columns:1fr; }
+    .masthead { flex-direction:column; align-items:flex-start; gap:12px; }
+    .masthead .meta { text-align:left; }
+    .footer { flex-direction:column; align-items:flex-start; }
+    .footer .note { text-align:left; }
+    .stat-row { gap:28px; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <div class="masthead">
+    <div class="brand">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="24" height="24" rx="5" fill="#18181B"/>
+        <path d="M7 6.5v11h10" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span>LEX AI</span>
+    </div>
+    <div class="meta">
+      Партнерський пакет · липень 2026<br>
+      legal.org.ua
+    </div>
+  </div>
+
+  <!-- ============ HERO ============ -->
+  <section>
+    <div class="kicker">Для партнерів з лідогенерації</div>
+    <h1>Що ми робимо, <em>кому це продавати</em><br>і скільки ви на цьому заробляєте.</h1>
+    <p class="lead">
+      LEX — продакшн AI-платформа, яка перетворює увесь український правовий корпус на структуровані
+      відповіді з посиланнями на джерела. В основі — <strong style="color:#18181B">повний ЄДРСР</strong>,
+      навколо нього — державні реєстри, законодавство та міжнародні джерела. Не прототип: продукт живий
+      на legal.org.ua, з платними клієнтами та зовнішнім security-аудитом.
+    </p>
+
+    <div class="stat-row">
+      <div class="stat">
+        <div class="val">135M</div>
+        <div class="lbl">судових рішень ЄДРСР, з 2006 року</div>
+      </div>
+      <div class="stat">
+        <div class="val">132M</div>
+        <div class="lbl">з них з повним текстом (97%)</div>
+      </div>
+      <div class="stat">
+        <div class="val">189M</div>
+        <div class="lbl">векторів для семантичного пошуку</div>
+      </div>
+      <div class="stat">
+        <div class="val">118</div>
+        <div class="lbl">AI-інструментів (MCP / REST / SSE)</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ SERVICES ============ -->
+  <section>
+    <h2>Список послуг</h2>
+    <p class="sub">
+      Ядро продукту — ЄДРСР. Усе інше побудовано навколо нього: реєстри дають контекст про сторони,
+      законодавство — про норму, міжнародний шар — про cross-border.
+    </p>
+    <div class="rule"></div>
+
+    <div class="svc" style="background:#FFFFFF; border:1px solid #E4E4E7; border-radius:12px; padding:26px; margin-bottom:8px">
+      <div class="num" style="color:#5C7C9E">01</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">ЄДРСР — судова практика</h3>
+          <span class="tag live">Продакшн</span>
+          <span class="tag" style="background:#5C7C9E; border-color:#5C7C9E; color:#FFF">Головний продукт</span>
+        </div>
+        <div class="summary">
+          Повний Єдиний державний реєстр судових рішень з 2006 року, з семантичним пошуком та AI-аналізом.
+          Це те, заради чого клієнт приходить.
+        </div>
+        <ul>
+          <li><strong>135 млн рішень</strong>, з них <strong>132 млн з повним текстом</strong> (97% покриття). Увесь реєстр, усі суди, з 2006 року.</li>
+          <li><strong>Семантичний пошук</strong> по 189 млн векторів — знаходить релевантну практику, навіть коли формулювання інші. Не пошук за ключовими словами.</li>
+          <li><strong>39 млн справ</strong> в індексі: усі документи однієї справи звʼязані в ланцюг — від першої інстанції до касації.</li>
+          <li><strong>Граф цитувань</strong>: 73 млн звʼязків рішення → рішення і 334 млн норма → рішення. Показує, чи є прецедент досі чинним (Shepardization).</li>
+          <li><strong>Аналітика суддів</strong>: 6 390 профілів з відсотком скасувань та обсягом рішень, 5 952 чинних судді, 417 тис. історичних зрізів.</li>
+          <li><strong>30 млн судових засідань</strong> та розклад — 481 тис. записів.</li>
+          <li><strong>AI-генерація стратегій</strong> із документів справи. Реальний кейс: стягнення 11.9 млн грн, справа 11 років — 473 документи, 9 стратегій, 15 хвилин.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">02</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Законодавство</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Ретрів на рівні статті, а не «ось вам весь кодекс, шукайте самі».</div>
+        <ul>
+          <li><strong>1.3 млн статей</strong> законодавства з поартикульним ретрівом та власним векторним індексом (1.5 млн векторів).</li>
+          <li>44 тис. актів ВРУ, 141 тис. карток ЄДРНПА.</li>
+          <li><strong>Історія редакцій</strong> та зміни на рівні статті (41 тис.) з word-level diff — видно, що саме змінилось у нормі.</li>
+          <li>Моніторинг законодавства з нотифікаціями про зміни у відстежуваних актах.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">03</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Державні реєстри та OSINT</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Перевірка контрагента за 2 хвилини замість пів дня по шести порталах. Вбудовано в LEX і доступно через API.</div>
+        <ul>
+          <li>Повний ЄДР: <strong>2 млн юридичних осіб</strong>, 6.9 млн ФОП, 3 млн засновників, <strong>776 тис. кінцевих бенефіціарів</strong>.</li>
+          <li><strong>Єдиний реєстр боржників — 10.5 млн</strong> записів з номерами виконавчих проваджень, органом стягнення та категорією.</li>
+          <li>Санкції та антикорупція: РНБО (24 тис.), декларації НАЗК (323 тис.), активи АРМА (725 тис.), розшук, корупціонери, змови на торгах (458 тис.).</li>
+          <li>Професійні реєстри: адвокати ЄРАУ (73 тис.), нотаріуси (6.2 тис.), судові експерти (23 тис.), юрфірми (10.8 тис.).</li>
+          <li>Відкриті дані: транспорт (19.6 млн), недійсні паспорти (3.1 млн), публічні витрати (10.9 млн), Prozorro (1 млн тендерів), банкрутства (35 тис.).</li>
+          <li><strong>Інтелектуальна власність — 826 тис. обʼєктів</strong> (торгові марки та патенти, 2006–2026) і 2 млн подій по них.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">04</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Міжнародні джерела</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Для клієнтів з cross-border практикою. Той самий інтерфейс, інша юрисдикція.</div>
+        <ul>
+          <li><strong>ЄСПЛ — 209 тис. справ.</strong> Живе на проді просто зараз.</li>
+          <li><strong>20+ юрисдикцій</strong>: Польща (2.9 млн рішень), США (6.9 млн), Індія (17.7 млн), Чехія, Франція, Швейцарія, Іспанія, Німеччина, Балтія, EUR-Lex і CURIA.</li>
+          <li>Міжнародний комплаєнс: OFAC, EU, SECO, <strong>ICIJ Offshore Leaks</strong> (2.9 млн звʼязків), GLEIF LEI (3.3 млн), реєстри компаній Ірландії та інших.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">05</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">MCP Connect — AI-інструменти для будь-якого LLM-клієнта</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Клієнту не треба міняти інструменти: 118 інструментів підключаються прямо в його ChatGPT або Claude.</div>
+        <ul>
+          <li>Нативний MCP-транспорт (HTTP, SSE, stdio) + REST API.</li>
+          <li>Авторизація через OAuth 2.0 — підтримка ChatGPT і Claude.</li>
+          <li>Публічна dev-документація з copy-paste конфігами.</li>
+          <li>Безкоштовно для індивідуальних розробників, metered для enterprise.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">06</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Парламент та маркетплейс</h3>
+          <span class="tag live">Продакшн</span>
+          <span class="tag beta">Бета</span>
+        </div>
+        <div class="summary">Два менші напрямки — рідко головна причина купівлі, але добре закривають окремі запити.</div>
+        <ul>
+          <li><strong>Верховна Рада</strong> (продакшн): 15 тис. законопроєктів, 242 тис. документів, голосування, стенограми, профілі депутатів з партійною лояльністю, трекінг законопроєктів.</li>
+          <li><strong>Маркетплейс консультацій</strong> (бета): клієнти ↔ адвокати з ЄРАУ, E2EE-повідомлення, оплата через Monobank, escrow.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DATABASES ============ -->
+  <section>
+    <h2>Бази даних на проді</h2>
+    <p class="sub">
+      Повний перелік того, що працює просто зараз — станом на 15 липня 2026.
+      Числа звірені безпосередньо з продакшн-базами, а не взяті з презентацій.
+    </p>
+    <div class="rule"></div>
+
+    <h3 style="margin-bottom:12px">Судова система</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">ЄДРСР — метадані рішень</td><td style="text-align:right" class="hi">135 404 664</td></tr>
+        <tr><td class="hi">ЄДРСР — повні тексти</td><td style="text-align:right" class="hi">131 770 360</td></tr>
+        <tr><td class="hi">ЄДРСР — вектори (семантичний пошук)</td><td style="text-align:right" class="hi">188 971 267</td></tr>
+        <tr><td>Граф цитувань: норма → рішення</td><td style="text-align:right">333 555 776</td></tr>
+        <tr><td>Граф цитувань: рішення → рішення</td><td style="text-align:right">73 457 064</td></tr>
+        <tr><td>Індекс справ</td><td style="text-align:right">38 907 348</td></tr>
+        <tr><td>Судові засідання</td><td style="text-align:right">30 456 150</td></tr>
+        <tr><td>Розклад засідань</td><td style="text-align:right">480 669</td></tr>
+        <tr><td>Судді — історичні зрізи / чинні</td><td style="text-align:right">417 412 / 5 952</td></tr>
+        <tr><td>Аналітика суддів</td><td style="text-align:right">6 390</td></tr>
+        <tr><td>Автоматичний розподіл справ (ДСА)</td><td style="text-align:right">70 873</td></tr>
+        <tr><td>Рішення ВРП / ефективність суддів ВККС</td><td style="text-align:right">16 522 / 10 686</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Законодавство</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Статті законодавства (поартикульний ретрів)</td><td style="text-align:right" class="hi">1 314 908</td></tr>
+        <tr><td>Вектори законодавства</td><td style="text-align:right">1 518 262</td></tr>
+        <tr><td>ЄДРНПА — картки / тексти</td><td style="text-align:right">140 930 / 140 886</td></tr>
+        <tr><td>Акти Верховної Ради</td><td style="text-align:right">44 026</td></tr>
+        <tr><td>Зміни на рівні статті</td><td style="text-align:right">41 035</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Бізнес, реєстри та борги</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Єдиний реєстр боржників</td><td style="text-align:right" class="hi">10 482 905</td></tr>
+        <tr><td class="hi">ФОП</td><td style="text-align:right" class="hi">6 854 457</td></tr>
+        <tr><td class="hi">Юридичні особи (ЄДР)</td><td style="text-align:right" class="hi">1 994 486</td></tr>
+        <tr><td>Спецбланки нотаріальних документів</td><td style="text-align:right">3 962 336</td></tr>
+        <tr><td>Засновники / підписанти</td><td style="text-align:right">2 976 663 / 2 780 602</td></tr>
+        <tr><td class="hi">Кінцеві бенефіціари</td><td style="text-align:right" class="hi">775 898</td></tr>
+        <tr><td>Довідник вулиць / адмінодиниці</td><td style="text-align:right">1 519 559 / 950 701</td></tr>
+        <tr><td>Справи про банкрутство / арбітражні керуючі</td><td style="text-align:right">35 436 / 3 420</td></tr>
+        <tr><td>Правонаступники / припинення</td><td style="text-align:right">48 005 / 148 190</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Комплаєнс, санкції, антикорупція</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Недійсні паспорти (внутрішні / закордонні)</td><td style="text-align:right" class="hi">2 887 669 / 195 387</td></tr>
+        <tr><td>Активи АРМА</td><td style="text-align:right">725 001</td></tr>
+        <tr><td>Змови на торгах (АМКУ)</td><td style="text-align:right">457 796</td></tr>
+        <tr><td class="hi">Декларації НАЗК</td><td style="text-align:right" class="hi">322 934</td></tr>
+        <tr><td>Розшук: особи / транспорт</td><td style="text-align:right">71 363 / 73 194</td></tr>
+        <tr><td>Реєстр корупціонерів</td><td style="text-align:right">61 017</td></tr>
+        <tr><td class="hi">Санкції РНБО / ДРС</td><td style="text-align:right" class="hi">24 059 / 24 059</td></tr>
+        <tr><td>Воєнні санкції НАЗК</td><td style="text-align:right">18 376</td></tr>
+        <tr><td>Санкції США (OFAC) / Швейцарія (SECO) / ЄС</td><td style="text-align:right">19 233 / 16 287 / 6 003</td></tr>
+        <tr><td>Адвокати (ЄРАУ) / юрфірми / нотаріуси</td><td style="text-align:right">72 839 / 10 766 / 6 228</td></tr>
+        <tr><td>Судові експерти / методики експертиз</td><td style="text-align:right">22 645 / 1 578</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Публічні фінанси, ІВ, транспорт</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Реєстрації транспортних засобів</td><td style="text-align:right" class="hi">19 572 436</td></tr>
+        <tr><td class="hi">spending.gov.ua — акти / додаткові угоди</td><td style="text-align:right" class="hi">8 839 284 / 2 030 089</td></tr>
+        <tr><td class="hi">Обʼєкти інтелектуальної власності</td><td style="text-align:right" class="hi">825 718</td></tr>
+        <tr><td>Події по обʼєктах ІВ</td><td style="text-align:right">2 007 760</td></tr>
+        <tr><td>Торговельні марки / патенти (open data)</td><td style="text-align:right">387 992 / 347 307</td></tr>
+        <tr><td class="hi">Prozorro — тендери</td><td style="text-align:right" class="hi">1 033 300</td></tr>
+        <tr><td>Власники цінних паперів / рішення АМКУ</td><td style="text-align:right">490 172 / 9 273</td></tr>
+        <tr><td>Безвісти зниклі / перейменування вулиць</td><td style="text-align:right">117 058 / 63 627</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Парламент</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Документи законопроєктів</td><td style="text-align:right" class="hi">241 648</td></tr>
+        <tr><td class="hi">Законопроєкти</td><td style="text-align:right" class="hi">14 961</td></tr>
+        <tr><td>Голосування / стенограми</td><td style="text-align:right">6 799 / 6 786</td></tr>
+        <tr><td>Депутати / помічники</td><td style="text-align:right">463 / 4 397</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Міжнародні джерела</h3>
+    <table style="margin-bottom:20px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">ЄСПЛ (ECHR)</td><td style="text-align:right" class="hi">209 774</td></tr>
+        <tr><td>США — внески у виборчі кампанії (FEC)</td><td style="text-align:right">53 930 464</td></tr>
+        <tr><td>Індія — рішення (повні тексти / вищі суди)</td><td style="text-align:right">17 707 636 / 14 832 603</td></tr>
+        <tr><td>США — скарги CFPB / судові рішення</td><td style="text-align:right">15 188 499 / 6 945 537</td></tr>
+        <tr><td class="hi">GLEIF LEI (глобальний реєстр)</td><td style="text-align:right" class="hi">3 295 082</td></tr>
+        <tr><td class="hi">ICIJ Offshore Leaks (звʼязки / особи / компанії)</td><td style="text-align:right" class="hi">2 902 092 / 771 483 / 813 713</td></tr>
+        <tr><td class="hi">Польща — судові рішення</td><td style="text-align:right" class="hi">2 864 093</td></tr>
+        <tr><td>Чехія / Франція / Швейцарія</td><td style="text-align:right">819 671 / 721 341 / 666 242</td></tr>
+        <tr><td>Ірландія — реєстр компаній CRO</td><td style="text-align:right">812 455</td></tr>
+        <tr><td>Іспанія (BORME, BOE, AEAT, AEPD, КС)</td><td style="text-align:right">~750 000</td></tr>
+        <tr><td>Латвія / Німеччина / Естонія</td><td style="text-align:right">395 500 / 250 185 / 163 422</td></tr>
+        <tr><td>Люксембург — фонди CSSF</td><td style="text-align:right">195 890</td></tr>
+        <tr><td>EUR-Lex / CURIA</td><td style="text-align:right">46 020 / 35 764</td></tr>
+        <tr><td>Швеція / Угорщина / Фінляндія / UK / Литва / Сінгапур</td><td style="text-align:right">79 876 / 79 299 / 72 863 / 53 469 / 51 020 / 10 001</td></tr>
+      </tbody>
+    </table>
+
+    <div class="callout">
+      <p>
+        <strong>Чесно про обмеження — кажіть це самі, не чекайте, поки спитають.</strong>
+        Податкові реєстри (податковий борг, ЄСВ, ПДВ, єдиний податок) — це останній дамп
+        <strong>станом на 23.02.2022</strong>, до вторгнення; свіжіших відкритих даних не існує ні в кого.
+        У джерелі ЄДРСР трапляються сміттєві дати, тому не обіцяйте «строго 2006–2026».
+        Партнер, який називає обмеження першим, викликає більше довіри, ніж той, у кого їх «немає».
+      </p>
+    </div>
+  </section>
+
+  <!-- ============ ICP ============ -->
+  <section>
+    <h2>ICP — кому це продавати</h2>
+    <p class="sub">
+      Спільний знаменник: <strong style="color:#18181B">велика кількість однотипної ручної роботи з українськими правовими даними</strong>.
+      Що більший потік справ або перевірок — то швидше окупається.
+    </p>
+    <div class="rule"></div>
+
+    <div class="grid-2" style="margin-bottom:18px">
+      <div class="icp-card">
+        <div class="who">Юридичні фірми з судовою практикою</div>
+        <div class="size">5–50 юристів · основний ICP</div>
+        <div class="pain">
+          Асистенти вручну гортають ЄДРСР годинами. Потік однотипних спорів. Ніхто не знає статистику судді,
+          до якого потрапила справа.
+        </div>
+        <div class="pitch">Гак: «Скільки годин на тиждень ваші юніори витрачають на пошук практики?»</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">In-house юрдепартаменти</div>
+        <div class="size">Банки, страхові, ритейл, агро, девелопмент</div>
+        <div class="pain">
+          Сотні справ у роботі, потрібна перевірка контрагентів перед кожною угодою,
+          бюджет на інструменти вже закладений.
+        </div>
+        <div class="pitch">Гак: «Перевірка контрагента — 2 хвилини замість пів дня. З бенефіціарами і санкціями.»</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Стягнення та фінансові компанії</div>
+        <div class="size">Колектори, факторинг, лізинг</div>
+        <div class="pain">
+          Тисячі однотипних справ, ручна перевірка боржників по реєстрах виконавчих проваджень.
+          Найшвидший ROI з усіх сегментів.
+        </div>
+        <div class="pitch">Гак: обсяг × ціна ручної години. Рахунок сходиться на першій зустрічі.</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Комплаєнс, AML та безпека</div>
+        <div class="size">KYC-відділи, служби безпеки, due diligence</div>
+        <div class="pain">
+          Скринінг по фрагментованих порталах, ризик пропустити санкційний збіг.
+          Потрібне покриття, а не швидкість.
+        </div>
+        <div class="pitch">Гак: РНБО + НАЗК + боржники + суди одним запитом.</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Консалтинг та Big4</div>
+        <div class="size">M&A, tax, financial advisory</div>
+        <div class="pain">
+          Cross-border українські мандати. Кожна due diligence — ручний обхід шести держпорталів
+          українською мовою.
+        </div>
+        <div class="pitch">Гак: API або white-label під їхнім брендом. Найбільший чек.</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Legal tech та інтегратори</div>
+        <div class="size">Продукти, яким потрібні українські правові дані</div>
+        <div class="pain">
+          Будувати пайплайни до ЄДРСР і реєстрів самим — місяці роботи.
+          Купити API дешевше, ніж будувати.
+        </div>
+        <div class="pitch">Гак: pay-per-query API, тижні до продакшну.</div>
+      </div>
+    </div>
+
+    <div class="grid-2">
+      <div class="card">
+        <h3>Тригери — пишемо</h3>
+        <ul class="signal-list">
+          <li>Скарги на пошук в ЄДРСР або ручну перевірку контрагентів</li>
+          <li>Великий потік однотипних спорів (стягнення, ПДВ, трудові, банкрутство)</li>
+          <li>Вакансії «юрист-аналітик», «paralegal», «AI/legal tech» — є бюджет і біль</li>
+          <li>Публічні заяви про AI, цифровізацію, «інновації в юрбізнесі»</li>
+          <li>Cross-border практика з українськими клієнтами</li>
+          <li>Фірма росте, але не наймає — шукає важіль продуктивності</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Анти-ICP — не палимо час</h3>
+        <ul class="signal-list negative">
+          <li>Соло-адвокати без потоку справ — не окупають підписку, довго вирішують</li>
+          <li>Держоргани — цикл 12+ місяців, тендерні процедури</li>
+          <li>Нотаріуси, реєстратори — інший робочий процес</li>
+          <li>Фірми без судової практики (чистий корпоратив, реєстрації)</li>
+          <li>Ті, хто шукає «ChatGPT для документів» — не наш продукт</li>
+          <li>Компанії поза Україною без українських мандатів</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ PRICING ============ -->
+  <section>
+    <h2>Тарифи</h2>
+    <p class="sub">Free tier — 50 кредитів при реєстрації, без картки. Це найпростіший перший крок для ліда.</p>
+    <div class="rule"></div>
+
+    <div class="grid-4" style="margin-bottom:18px">
+      <div class="card">
+        <div class="plan-name">Окремий юрист</div>
+        <div class="price">$29<span> / міс</span></div>
+        <div class="plan-desc">Повний доступ до пошуку та AI-аналізу</div>
+      </div>
+      <div class="card">
+        <div class="plan-name">Юридична фірма</div>
+        <div class="price">від $99<span> / міс</span></div>
+        <div class="plan-desc">Командний доступ, спільні матерії</div>
+      </div>
+      <div class="card">
+        <div class="plan-name">API</div>
+        <div class="price">$0.05<span> / запит</span></div>
+        <div class="plan-desc">Pay-per-query, без мінімуму</div>
+      </div>
+      <div class="card dark">
+        <div class="plan-name">Enterprise</div>
+        <div class="price">Custom</div>
+        <div class="plan-desc">On-prem / VPC, white-label, SSO, DPA</div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <p>
+        <strong>Де реальні гроші:</strong> $29 — це вхідний тариф для самостійної реєстрації окремого юриста.
+        Партнерський бонус прив’язаний не до тарифу, а до <strong>фактичних витрат клієнта на місяць</strong>:
+        команда від 3–4 юристів або in-house з API вже проходить поріг. Саме тому цільові сегменти —
+        фірма, in-house, стягнення, комплаєнс. Деталі бонусу — нижче.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============ PARTNER TERMS ============ -->
+  <section>
+    <h2>Умови партнерства</h2>
+    <p class="sub">Просто і без юридичної гімнастики.</p>
+    <div class="rule"></div>
+
+    <p style="font-size:15px; color:#52525B; margin-bottom:18px">
+      Бонус залежить від того, скільки клієнт витрачає на платформі щомісяця. Що більший клієнт — то більший ваш бонус.
+    </p>
+
+    <div class="grid-4" style="margin-bottom:18px; align-items:stretch">
+      <div class="card dark" style="display:flex; flex-direction:column; justify-content:center; position:relative">
+        <div class="plan-name">Від $500 / міс</div>
+        <div class="price">$1 000<span> / клієнт</span></div>
+        <div class="plan-desc">Enterprise, API, великі команди. Цільтесь сюди.</div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center">
+        <div class="plan-name">Від $200 / міс</div>
+        <div class="price">$500<span> / клієнт</span></div>
+        <div class="plan-desc">Фірма або in-house середнього розміру.</div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center">
+        <div class="plan-name">Від $100 / міс</div>
+        <div class="price">$200<span> / клієнт</span></div>
+        <div class="plan-desc">Менші команди та невеликі фірми.</div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center; background:#F4F4F5">
+        <div class="plan-name">Менше $100 / міс</div>
+        <div class="price" style="color:#A1A1AA">—</div>
+        <div class="plan-desc">Бонус не виплачується. Мінімальний поріг — $100 / міс.</div>
+      </div>
+    </div>
+
+    <div class="callout" style="margin-top:0; margin-bottom:28px">
+      <p>
+        <strong>Що це означає для вашого таргетингу:</strong> окремий юрист на тарифі $29 / міс —
+        нижче порога, бонусу не буде. Заробіток починається з <strong>команди від 3–4 юристів</strong>,
+        а верхній тир — це enterprise, API-інтеграції та великі команди.
+        Один такий клієнт = п’ять середніх. Саме тому анти-ICP вище — не формальність, а ваша економіка.
+      </p>
+    </div>
+
+    <div class="card" style="margin-bottom:28px">
+      <h3>Що ми даємо зі свого боку</h3>
+      <ul class="signal-list" style="margin-top:10px">
+        <li>Цей пакет + демо-доступ для ваших лідів</li>
+        <li>Ми беремо на себе демо та всі технічні питання</li>
+        <li>Реєстрація ліда за вами — конфліктів не буде</li>
+        <li>Будь-яка додаткова інформація на запит</li>
+      </ul>
+    </div>
+
+    <ol class="terms">
+      <li><strong>Реєстрація ліда.</strong> Ви надсилаєте контакт і компанію до першого дотику. Ми підтверджуємо, що лід новий — і він закріплюється за вами на <strong>60 днів</strong>.</li>
+      <li><strong>Демо і продаж.</strong> Ви робите інтро, далі демо і закриття беремо ми. Ви можете бути присутні на дзвінку.</li>
+      <li><strong>Що вважається клієнтом.</strong> Компанія, яка підписала договір, здійснила першу оплату і витрачає <strong>від $100 / міс</strong>. Не реєстрація, не free tier, не пілот без оплати.</li>
+      <li><strong>Розмір бонусу</strong> визначається за фактичними витратами клієнта на платформі: від $500 / міс — $1 000, від $200 / міс — $500, від $100 / міс — $200.</li>
+      <li><strong>Виплата у два етапи: 50% одразу</strong> після надходження першого платежу від клієнта, <strong>і 50% через місяць</strong> за умови, що клієнт залишився активним. Так ми обидва зацікавлені в клієнтах, які залишаються, а не просто підписуються.</li>
+      <li><strong>Спосіб виплати — на ваш вибір:</strong> криптовалютою, або офіційно на рахунок вашої компанії — гривнею за курсом НБУ на дату виплати, з договором і закривальними документами.</li>
+    </ol>
+  </section>
+
+  <!-- ============ WHY ============ -->
+  <section>
+    <h2>Чому це відповідає ринку</h2>
+    <p class="sub">Чому ми вважаємо, що це має продаватись — і що казати на дзвінку.</p>
+    <div class="rule"></div>
+
+    <table style="margin-bottom:24px">
+      <thead>
+        <tr>
+          <th>Задача</th>
+          <th>Як зараз</th>
+          <th>З LEX</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="hi">Пошук судової практики</td>
+          <td>4–6 годин на запит</td>
+          <td class="hi">10–15 хвилин</td>
+        </tr>
+        <tr>
+          <td class="hi">Перевірка контрагента</td>
+          <td>2–3 години по реєстрах</td>
+          <td class="hi">менше 2 хвилин</td>
+        </tr>
+        <tr>
+          <td class="hi">Санкційний скринінг</td>
+          <td>Фрагментовано, легко пропустити</td>
+          <td class="hi">Один запит, повне покриття</td>
+        </tr>
+        <tr>
+          <td class="hi">Пошук норми</td>
+          <td>Ручна навігація порталами</td>
+          <td class="hi">Рівень статті + судові посилання</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="grid-3">
+      <div class="card">
+        <h3>Готово зараз</h3>
+        <p>Не прототип. Продакшн на legal.org.ua, платні клієнти, зовнішній security-аудит (березень 2026, 10 OWASP-знахідок виправлено).</p>
+      </div>
+      <div class="card">
+        <h3>Наступне покоління</h3>
+        <p>На ринку є ZakonOnline, LIGA:ZAKON, ActiveLex — це бази з пошуком. Ми не замінюємо базу, ми даємо те, чого в базі немає: AI-аналіз, семантику, MCP.</p>
+      </div>
+      <div class="card">
+        <h3>Довіра</h3>
+        <p>Фіналіст Startup World Cup 2026. Партнер Google Cloud for Startups, AWS Activate, NVIDIA Innovation Lab. 7 наукових публікацій на arXiv.</p>
+      </div>
+    </div>
+
+    <div class="callout" style="border-left-color:#B45309">
+      <p style="margin-bottom:10px">
+        <strong>Заперечення №1: «У нас вже є ZakonOnline / LIGA:ZAKON».</strong>
+        Це прозвучить на першому ж дзвінку. Не кажіть «у них нічого немає» — клієнт користується ними
+        роками і знає краще за нас. Це коштує довіри миттєво.
+      </p>
+      <p>
+        Правильна рамка: <strong>вони — база даних, ми — аналітичний шар над даними.</strong>
+        У них пошук за ключовими словами: треба вгадати формулювання. У нас семантичний пошук:
+        знаходить релевантне, навіть коли слова інші. Плюс те, чого в базах немає взагалі —
+        AI-генерація стратегій із документів справи, citation graph (чи чинний прецедент),
+        держреєстри з бенефіціарами та санкціями в тому ж інтерфейсі, і нативний MCP —
+        робота прямо з ChatGPT або Claude клієнта.
+        <strong>Ми не просимо відмовитись від їхньої бази. Ми закриваємо те, що база не вміє.</strong>
+      </p>
+    </div>
+
+    <div class="callout">
+      <p>
+        <strong>Комплаєнс, якщо спитають:</strong> AWS eu-central-1 (Франкфурт), GDPR з повними пайплайнами
+        експорту та видалення, DPA для enterprise, E2EE для документів, WebAuthn/FIDO2, авторизація через Дію.
+        Дані — виключно з офіційних держреєстрів та порталів відкритих даних.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============ FOOTER ============ -->
+  <div class="footer">
+    <div class="contact">
+      <strong>Volodymyr Ovcharov</strong><br>
+      CEO &amp; Founder, LEX AI<br>
+      <a href="mailto:volodymyr@legal.org.ua">volodymyr@legal.org.ua</a> ·
+      <a href="https://legal.org.ua">legal.org.ua</a>
+    </div>
+    <div class="note">
+      Продукт: legal.org.ua/product · Команда: legal.org.ua/about<br>
+      Матеріал для партнерів з лідогенерації.
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/lexwebapp/public/partner-onepager.html
+++ b/lexwebapp/public/partner-onepager.html
@@ -1,0 +1,828 @@
+<!DOCTYPE html>
+<html lang="uk">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow, noarchive, nosnippet">
+<meta name="googlebot" content="noindex, nofollow">
+<title>LEX AI — партнерський пакет</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@400;600;700&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  @page { size: A4; margin: 16mm 14mm; }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: #f0f0f2;
+    color: #18181B;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    line-height: 1.6;
+  }
+
+  .page {
+    max-width: 980px;
+    margin: 0 auto;
+    background: #FAFAFA;
+    padding: 64px 72px 80px;
+  }
+
+  /* ---------- header ---------- */
+  .masthead {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 28px;
+    border-bottom: 1px solid #E4E4E7;
+    margin-bottom: 48px;
+  }
+
+  .brand { display: flex; align-items: center; gap: 10px; }
+  .brand svg { width: 26px; height: 26px; }
+  .brand span {
+    font-size: 13px; font-weight: 600; color: #52525B;
+    letter-spacing: 1.5px; text-transform: uppercase;
+  }
+  .masthead .meta { font-size: 12px; color: #A1A1AA; text-align: right; }
+
+  /* ---------- typography ---------- */
+  h1 {
+    font-family: 'Crimson Pro', serif;
+    font-size: 46px; font-weight: 700; line-height: 1.1;
+    margin-bottom: 18px;
+  }
+  h1 em { font-style: normal; color: #5C7C9E; }
+
+  h2 {
+    font-family: 'Crimson Pro', serif;
+    font-size: 32px; font-weight: 700; line-height: 1.15;
+    margin-bottom: 8px;
+  }
+
+  h3 {
+    font-family: 'Crimson Pro', serif;
+    font-size: 21px; font-weight: 600;
+    margin-bottom: 8px;
+  }
+
+  .kicker {
+    font-size: 12px; font-weight: 600; color: #A1A1AA;
+    letter-spacing: 1.5px; text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+
+  .lead { font-size: 18px; color: #52525B; line-height: 1.7; max-width: 760px; }
+  .sub  { font-size: 15px; color: #71717A; margin-bottom: 28px; max-width: 760px; }
+  p     { font-size: 15px; color: #71717A; }
+
+  section { margin-bottom: 56px; page-break-inside: avoid; }
+
+  .rule { height: 1px; background: #E4E4E7; margin: 0 0 32px; }
+
+  /* ---------- cards ---------- */
+  .card {
+    background: #FFFFFF;
+    border: 1px solid #E4E4E7;
+    border-radius: 12px;
+    padding: 26px;
+  }
+  .card.dark { background: #18181B; border-color: #18181B; }
+  .card.dark h3, .card.dark .price { color: #FFFFFF; }
+  .card.dark p, .card.dark li { color: #A1A1AA; }
+  .card.dark .tag { background: #27272A; border-color: #3F3F46; color: #A1A1AA; }
+
+  .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+  .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+
+  /* ---------- stats ---------- */
+  .stat-row { display: flex; gap: 48px; flex-wrap: wrap; margin-top: 36px; }
+  .stat .val {
+    font-family: 'Crimson Pro', serif;
+    font-size: 40px; font-weight: 700; line-height: 1.1; color: #18181B;
+  }
+  .stat .lbl { font-size: 13px; color: #A1A1AA; font-weight: 500; margin-top: 2px; }
+
+  /* ---------- service blocks ---------- */
+  .svc { display: flex; gap: 22px; padding: 24px 0; border-bottom: 1px solid #E4E4E7; page-break-inside: avoid; }
+  .svc:last-child { border-bottom: none; }
+  .svc .num {
+    font-family: 'Crimson Pro', serif;
+    font-size: 26px; font-weight: 700; color: #D4D4D8;
+    min-width: 42px; line-height: 1.2;
+  }
+  .svc .body { flex: 1; }
+  .svc .head { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
+  .svc .summary { font-size: 15px; color: #52525B; margin-bottom: 12px; }
+  .svc ul { list-style: none; }
+  .svc li {
+    font-size: 14px; color: #71717A; padding-left: 16px;
+    position: relative; margin-bottom: 5px; line-height: 1.55;
+  }
+  .svc li::before {
+    content: ''; position: absolute; left: 0; top: 9px;
+    width: 4px; height: 4px; border-radius: 50%; background: #5C7C9E;
+  }
+  .svc li strong { color: #18181B; font-weight: 600; }
+
+  .tag {
+    display: inline-block; padding: 3px 9px; border-radius: 6px;
+    font-size: 11px; font-weight: 600; letter-spacing: .5px; text-transform: uppercase;
+    background: #F4F4F5; border: 1px solid #E4E4E7; color: #52525B;
+    white-space: nowrap;
+  }
+  .tag.live { background: #ECFDF5; border-color: #A7F3D0; color: #047857; }
+  .tag.beta { background: #FFFBEB; border-color: #FDE68A; color: #B45309; }
+
+  /* ---------- ICP ---------- */
+  .icp-card { background:#FFF; border:1px solid #E4E4E7; border-radius:12px; padding:22px; page-break-inside: avoid; }
+  .icp-card .who { font-family:'Crimson Pro',serif; font-size:19px; font-weight:600; margin-bottom:4px; }
+  .icp-card .size { font-size:12px; color:#A1A1AA; font-weight:500; margin-bottom:12px; }
+  .icp-card .pain { font-size:14px; color:#71717A; line-height:1.55; }
+  .icp-card .pitch {
+    font-size:13px; color:#5C7C9E; margin-top:12px; padding-top:12px;
+    border-top:1px dashed #E4E4E7; line-height:1.5;
+  }
+
+  .signal-list { list-style:none; }
+  .signal-list li {
+    font-size:14px; color:#52525B; padding-left:22px; position:relative; margin-bottom:8px; line-height:1.5;
+  }
+  .signal-list li::before {
+    content:'✓'; position:absolute; left:0; top:0; color:#047857; font-weight:700; font-size:13px;
+  }
+  .signal-list.negative li::before { content:'✕'; color:#DC2626; }
+
+  /* ---------- pricing ---------- */
+  .price { font-family:'Crimson Pro',serif; font-size:32px; font-weight:700; color:#18181B; line-height:1.2; }
+  .price span { font-family:'Inter',sans-serif; font-size:14px; font-weight:400; color:#A1A1AA; }
+  .plan-name {
+    font-size:11px; font-weight:600; color:#A1A1AA;
+    text-transform:uppercase; letter-spacing:1px; margin-bottom:10px;
+  }
+  .plan-desc { font-size:13px; color:#71717A; margin-top:8px; line-height:1.5; }
+
+  /* ---------- deal terms ---------- */
+  .terms { list-style:none; counter-reset: t; }
+  .terms li {
+    position:relative; padding-left:38px; margin-bottom:16px;
+    font-size:15px; color:#52525B; line-height:1.6; counter-increment: t;
+  }
+  .terms li::before {
+    content: counter(t); position:absolute; left:0; top:1px;
+    width:24px; height:24px; border-radius:50%;
+    background:#18181B; color:#FFF;
+    font-size:12px; font-weight:600; text-align:center; line-height:24px;
+  }
+  .terms li strong { color:#18181B; font-weight:600; }
+
+  .callout {
+    background:#FFFFFF; border:1px solid #E4E4E7; border-left:3px solid #5C7C9E;
+    border-radius:8px; padding:18px 22px; margin-top:24px;
+  }
+  .callout p { font-size:14px; color:#52525B; line-height:1.6; }
+  .callout strong { color:#18181B; font-weight:600; }
+
+  /* ---------- table ---------- */
+  table { width:100%; border-collapse:collapse; background:#FFF; border:1px solid #E4E4E7; border-radius:12px; overflow:hidden; }
+  th {
+    font-size:11px; font-weight:600; color:#A1A1AA; text-transform:uppercase; letter-spacing:1px;
+    text-align:left; padding:14px 18px; background:#FAFAFA; border-bottom:1px solid #E4E4E7;
+  }
+  td { font-size:14px; color:#52525B; padding:14px 18px; border-bottom:1px solid #F4F4F5; }
+  tr:last-child td { border-bottom:none; }
+  td.hi { color:#18181B; font-weight:600; }
+
+  /* ---------- footer ---------- */
+  .footer {
+    margin-top:64px; padding-top:28px; border-top:1px solid #E4E4E7;
+    display:flex; justify-content:space-between; align-items:flex-end; gap:24px;
+  }
+  .footer .contact { font-size:14px; color:#52525B; line-height:1.7; }
+  .footer .contact strong { color:#18181B; }
+  .footer a { color:#5C7C9E; text-decoration:none; }
+  .footer .note { font-size:11px; color:#A1A1AA; text-align:right; max-width:280px; line-height:1.5; }
+
+  .todo {
+    background:#FFFBEB; border:1px solid #FDE68A; border-radius:8px;
+    padding:14px 18px; margin-top:20px;
+  }
+  .todo p { font-size:13px; color:#B45309; line-height:1.6; }
+  .todo strong { color:#92400E; }
+
+  @media print {
+    body { background:#FFF; }
+    .page { padding:0; max-width:none; background:#FFF; }
+    .todo { display:none; }
+  }
+
+  @media (max-width: 820px) {
+    .page { padding:32px 20px 48px; }
+    h1 { font-size:32px; }
+    h2 { font-size:25px; }
+    .grid-2, .grid-3, .grid-4 { grid-template-columns:1fr; }
+    .masthead { flex-direction:column; align-items:flex-start; gap:12px; }
+    .masthead .meta { text-align:left; }
+    .footer { flex-direction:column; align-items:flex-start; }
+    .footer .note { text-align:left; }
+    .stat-row { gap:28px; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <div class="masthead">
+    <div class="brand">
+      <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect width="24" height="24" rx="5" fill="#18181B"/>
+        <path d="M7 6.5v11h10" stroke="#FFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span>LEX AI</span>
+    </div>
+    <div class="meta">
+      Партнерський пакет · липень 2026<br>
+      legal.org.ua
+    </div>
+  </div>
+
+  <!-- ============ HERO ============ -->
+  <section>
+    <div class="kicker">Для партнерів з лідогенерації</div>
+    <h1>Що ми робимо, <em>кому це продавати</em><br>і скільки ви на цьому заробляєте.</h1>
+    <p class="lead">
+      LEX — продакшн AI-платформа, яка перетворює увесь український правовий корпус на структуровані
+      відповіді з посиланнями на джерела. В основі — <strong style="color:#18181B">повний ЄДРСР</strong>,
+      навколо нього — державні реєстри, законодавство та міжнародні джерела. Не прототип: продукт живий
+      на legal.org.ua, з платними клієнтами та зовнішнім security-аудитом.
+    </p>
+
+    <div class="stat-row">
+      <div class="stat">
+        <div class="val">135M</div>
+        <div class="lbl">судових рішень ЄДРСР, з 2006 року</div>
+      </div>
+      <div class="stat">
+        <div class="val">132M</div>
+        <div class="lbl">з них з повним текстом (97%)</div>
+      </div>
+      <div class="stat">
+        <div class="val">189M</div>
+        <div class="lbl">векторів для семантичного пошуку</div>
+      </div>
+      <div class="stat">
+        <div class="val">118</div>
+        <div class="lbl">AI-інструментів (MCP / REST / SSE)</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ SERVICES ============ -->
+  <section>
+    <h2>Список послуг</h2>
+    <p class="sub">
+      Ядро продукту — ЄДРСР. Усе інше побудовано навколо нього: реєстри дають контекст про сторони,
+      законодавство — про норму, міжнародний шар — про cross-border.
+    </p>
+    <div class="rule"></div>
+
+    <div class="svc" style="background:#FFFFFF; border:1px solid #E4E4E7; border-radius:12px; padding:26px; margin-bottom:8px">
+      <div class="num" style="color:#5C7C9E">01</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">ЄДРСР — судова практика</h3>
+          <span class="tag live">Продакшн</span>
+          <span class="tag" style="background:#5C7C9E; border-color:#5C7C9E; color:#FFF">Головний продукт</span>
+        </div>
+        <div class="summary">
+          Повний Єдиний державний реєстр судових рішень з 2006 року, з семантичним пошуком та AI-аналізом.
+          Це те, заради чого клієнт приходить.
+        </div>
+        <ul>
+          <li><strong>135 млн рішень</strong>, з них <strong>132 млн з повним текстом</strong> (97% покриття). Увесь реєстр, усі суди, з 2006 року.</li>
+          <li><strong>Семантичний пошук</strong> по 189 млн векторів — знаходить релевантну практику, навіть коли формулювання інші. Не пошук за ключовими словами.</li>
+          <li><strong>39 млн справ</strong> в індексі: усі документи однієї справи звʼязані в ланцюг — від першої інстанції до касації.</li>
+          <li><strong>Граф цитувань</strong>: 73 млн звʼязків рішення → рішення і 334 млн норма → рішення. Показує, чи є прецедент досі чинним (Shepardization).</li>
+          <li><strong>Аналітика суддів</strong>: 6 390 профілів з відсотком скасувань та обсягом рішень, 5 952 чинних судді, 417 тис. історичних зрізів.</li>
+          <li><strong>30 млн судових засідань</strong> та розклад — 481 тис. записів.</li>
+          <li><strong>AI-генерація стратегій</strong> із документів справи. Реальний кейс: стягнення 11.9 млн грн, справа 11 років — 473 документи, 9 стратегій, 15 хвилин.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">02</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Законодавство</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Ретрів на рівні статті, а не «ось вам весь кодекс, шукайте самі».</div>
+        <ul>
+          <li><strong>1.3 млн статей</strong> законодавства з поартикульним ретрівом та власним векторним індексом (1.5 млн векторів).</li>
+          <li>44 тис. актів ВРУ, 141 тис. карток ЄДРНПА.</li>
+          <li><strong>Історія редакцій</strong> та зміни на рівні статті (41 тис.) з word-level diff — видно, що саме змінилось у нормі.</li>
+          <li>Моніторинг законодавства з нотифікаціями про зміни у відстежуваних актах.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">03</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Державні реєстри та OSINT</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Перевірка контрагента за 2 хвилини замість пів дня по шести порталах. Вбудовано в LEX і доступно через API.</div>
+        <ul>
+          <li>Повний ЄДР: <strong>2 млн юридичних осіб</strong>, 6.9 млн ФОП, 3 млн засновників, <strong>776 тис. кінцевих бенефіціарів</strong>.</li>
+          <li><strong>Єдиний реєстр боржників — 10.5 млн</strong> записів з номерами виконавчих проваджень, органом стягнення та категорією.</li>
+          <li>Санкції та антикорупція: РНБО (24 тис.), декларації НАЗК (323 тис.), активи АРМА (725 тис.), розшук, корупціонери, змови на торгах (458 тис.).</li>
+          <li>Професійні реєстри: адвокати ЄРАУ (73 тис.), нотаріуси (6.2 тис.), судові експерти (23 тис.), юрфірми (10.8 тис.).</li>
+          <li>Відкриті дані: транспорт (19.6 млн), недійсні паспорти (3.1 млн), публічні витрати (10.9 млн), Prozorro (1 млн тендерів), банкрутства (35 тис.).</li>
+          <li><strong>Інтелектуальна власність — 826 тис. обʼєктів</strong> (торгові марки та патенти, 2006–2026) і 2 млн подій по них.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">04</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Міжнародні джерела</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Для клієнтів з cross-border практикою. Той самий інтерфейс, інша юрисдикція.</div>
+        <ul>
+          <li><strong>ЄСПЛ — 209 тис. справ.</strong> Живе на проді просто зараз.</li>
+          <li><strong>20+ юрисдикцій</strong>: Польща (2.9 млн рішень), США (6.9 млн), Індія (17.7 млн), Чехія, Франція, Швейцарія, Іспанія, Німеччина, Балтія, EUR-Lex і CURIA.</li>
+          <li>Міжнародний комплаєнс: OFAC, EU, SECO, <strong>ICIJ Offshore Leaks</strong> (2.9 млн звʼязків), GLEIF LEI (3.3 млн), реєстри компаній Ірландії та інших.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">05</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">MCP Connect — AI-інструменти для будь-якого LLM-клієнта</h3>
+          <span class="tag live">Продакшн</span>
+        </div>
+        <div class="summary">Клієнту не треба міняти інструменти: 118 інструментів підключаються прямо в його ChatGPT або Claude.</div>
+        <ul>
+          <li>Нативний MCP-транспорт (HTTP, SSE, stdio) + REST API.</li>
+          <li>Авторизація через OAuth 2.0 — підтримка ChatGPT і Claude.</li>
+          <li>Публічна dev-документація з copy-paste конфігами.</li>
+          <li>Безкоштовно для індивідуальних розробників, metered для enterprise.</li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="svc">
+      <div class="num">06</div>
+      <div class="body">
+        <div class="head">
+          <h3 style="margin:0">Парламент та маркетплейс</h3>
+          <span class="tag live">Продакшн</span>
+          <span class="tag beta">Бета</span>
+        </div>
+        <div class="summary">Два менші напрямки — рідко головна причина купівлі, але добре закривають окремі запити.</div>
+        <ul>
+          <li><strong>Верховна Рада</strong> (продакшн): 15 тис. законопроєктів, 242 тис. документів, голосування, стенограми, профілі депутатів з партійною лояльністю, трекінг законопроєктів.</li>
+          <li><strong>Маркетплейс консультацій</strong> (бета): клієнти ↔ адвокати з ЄРАУ, E2EE-повідомлення, оплата через Monobank, escrow.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DATABASES ============ -->
+  <section>
+    <h2>Бази даних на проді</h2>
+    <p class="sub">
+      Повний перелік того, що працює просто зараз — станом на 15 липня 2026.
+      Числа звірені безпосередньо з продакшн-базами, а не взяті з презентацій.
+    </p>
+    <div class="rule"></div>
+
+    <h3 style="margin-bottom:12px">Судова система</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">ЄДРСР — метадані рішень</td><td style="text-align:right" class="hi">135 404 664</td></tr>
+        <tr><td class="hi">ЄДРСР — повні тексти</td><td style="text-align:right" class="hi">131 770 360</td></tr>
+        <tr><td class="hi">ЄДРСР — вектори (семантичний пошук)</td><td style="text-align:right" class="hi">188 971 267</td></tr>
+        <tr><td>Граф цитувань: норма → рішення</td><td style="text-align:right">333 555 776</td></tr>
+        <tr><td>Граф цитувань: рішення → рішення</td><td style="text-align:right">73 457 064</td></tr>
+        <tr><td>Індекс справ</td><td style="text-align:right">38 907 348</td></tr>
+        <tr><td>Судові засідання</td><td style="text-align:right">30 456 150</td></tr>
+        <tr><td>Розклад засідань</td><td style="text-align:right">480 669</td></tr>
+        <tr><td>Судді — історичні зрізи / чинні</td><td style="text-align:right">417 412 / 5 952</td></tr>
+        <tr><td>Аналітика суддів</td><td style="text-align:right">6 390</td></tr>
+        <tr><td>Автоматичний розподіл справ (ДСА)</td><td style="text-align:right">70 873</td></tr>
+        <tr><td>Рішення ВРП / ефективність суддів ВККС</td><td style="text-align:right">16 522 / 10 686</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Законодавство</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Статті законодавства (поартикульний ретрів)</td><td style="text-align:right" class="hi">1 314 908</td></tr>
+        <tr><td>Вектори законодавства</td><td style="text-align:right">1 518 262</td></tr>
+        <tr><td>ЄДРНПА — картки / тексти</td><td style="text-align:right">140 930 / 140 886</td></tr>
+        <tr><td>Акти Верховної Ради</td><td style="text-align:right">44 026</td></tr>
+        <tr><td>Зміни на рівні статті</td><td style="text-align:right">41 035</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Бізнес, реєстри та борги</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Єдиний реєстр боржників</td><td style="text-align:right" class="hi">10 482 905</td></tr>
+        <tr><td class="hi">ФОП</td><td style="text-align:right" class="hi">6 854 457</td></tr>
+        <tr><td class="hi">Юридичні особи (ЄДР)</td><td style="text-align:right" class="hi">1 994 486</td></tr>
+        <tr><td>Спецбланки нотаріальних документів</td><td style="text-align:right">3 962 336</td></tr>
+        <tr><td>Засновники / підписанти</td><td style="text-align:right">2 976 663 / 2 780 602</td></tr>
+        <tr><td class="hi">Кінцеві бенефіціари</td><td style="text-align:right" class="hi">775 898</td></tr>
+        <tr><td>Довідник вулиць / адмінодиниці</td><td style="text-align:right">1 519 559 / 950 701</td></tr>
+        <tr><td>Справи про банкрутство / арбітражні керуючі</td><td style="text-align:right">35 436 / 3 420</td></tr>
+        <tr><td>Правонаступники / припинення</td><td style="text-align:right">48 005 / 148 190</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Комплаєнс, санкції, антикорупція</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Недійсні паспорти (внутрішні / закордонні)</td><td style="text-align:right" class="hi">2 887 669 / 195 387</td></tr>
+        <tr><td>Активи АРМА</td><td style="text-align:right">725 001</td></tr>
+        <tr><td>Змови на торгах (АМКУ)</td><td style="text-align:right">457 796</td></tr>
+        <tr><td class="hi">Декларації НАЗК</td><td style="text-align:right" class="hi">322 934</td></tr>
+        <tr><td>Розшук: особи / транспорт</td><td style="text-align:right">71 363 / 73 194</td></tr>
+        <tr><td>Реєстр корупціонерів</td><td style="text-align:right">61 017</td></tr>
+        <tr><td class="hi">Санкції РНБО / ДРС</td><td style="text-align:right" class="hi">24 059 / 24 059</td></tr>
+        <tr><td>Воєнні санкції НАЗК</td><td style="text-align:right">18 376</td></tr>
+        <tr><td>Санкції США (OFAC) / Швейцарія (SECO) / ЄС</td><td style="text-align:right">19 233 / 16 287 / 6 003</td></tr>
+        <tr><td>Адвокати (ЄРАУ) / юрфірми / нотаріуси</td><td style="text-align:right">72 839 / 10 766 / 6 228</td></tr>
+        <tr><td>Судові експерти / методики експертиз</td><td style="text-align:right">22 645 / 1 578</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Публічні фінанси, ІВ, транспорт</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Реєстрації транспортних засобів</td><td style="text-align:right" class="hi">19 572 436</td></tr>
+        <tr><td class="hi">spending.gov.ua — акти / додаткові угоди</td><td style="text-align:right" class="hi">8 839 284 / 2 030 089</td></tr>
+        <tr><td class="hi">Обʼєкти інтелектуальної власності</td><td style="text-align:right" class="hi">825 718</td></tr>
+        <tr><td>Події по обʼєктах ІВ</td><td style="text-align:right">2 007 760</td></tr>
+        <tr><td>Торговельні марки / патенти (open data)</td><td style="text-align:right">387 992 / 347 307</td></tr>
+        <tr><td class="hi">Prozorro — тендери</td><td style="text-align:right" class="hi">1 033 300</td></tr>
+        <tr><td>Власники цінних паперів / рішення АМКУ</td><td style="text-align:right">490 172 / 9 273</td></tr>
+        <tr><td>Безвісти зниклі / перейменування вулиць</td><td style="text-align:right">117 058 / 63 627</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Парламент</h3>
+    <table style="margin-bottom:28px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">Документи законопроєктів</td><td style="text-align:right" class="hi">241 648</td></tr>
+        <tr><td class="hi">Законопроєкти</td><td style="text-align:right" class="hi">14 961</td></tr>
+        <tr><td>Голосування / стенограми</td><td style="text-align:right">6 799 / 6 786</td></tr>
+        <tr><td>Депутати / помічники</td><td style="text-align:right">463 / 4 397</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin-bottom:12px">Міжнародні джерела</h3>
+    <table style="margin-bottom:20px">
+      <thead><tr><th>Джерело</th><th style="text-align:right">Записів</th></tr></thead>
+      <tbody>
+        <tr><td class="hi">ЄСПЛ (ECHR)</td><td style="text-align:right" class="hi">209 774</td></tr>
+        <tr><td>США — внески у виборчі кампанії (FEC)</td><td style="text-align:right">53 930 464</td></tr>
+        <tr><td>Індія — рішення (повні тексти / вищі суди)</td><td style="text-align:right">17 707 636 / 14 832 603</td></tr>
+        <tr><td>США — скарги CFPB / судові рішення</td><td style="text-align:right">15 188 499 / 6 945 537</td></tr>
+        <tr><td class="hi">GLEIF LEI (глобальний реєстр)</td><td style="text-align:right" class="hi">3 295 082</td></tr>
+        <tr><td class="hi">ICIJ Offshore Leaks (звʼязки / особи / компанії)</td><td style="text-align:right" class="hi">2 902 092 / 771 483 / 813 713</td></tr>
+        <tr><td class="hi">Польща — судові рішення</td><td style="text-align:right" class="hi">2 864 093</td></tr>
+        <tr><td>Чехія / Франція / Швейцарія</td><td style="text-align:right">819 671 / 721 341 / 666 242</td></tr>
+        <tr><td>Ірландія — реєстр компаній CRO</td><td style="text-align:right">812 455</td></tr>
+        <tr><td>Іспанія (BORME, BOE, AEAT, AEPD, КС)</td><td style="text-align:right">~750 000</td></tr>
+        <tr><td>Латвія / Німеччина / Естонія</td><td style="text-align:right">395 500 / 250 185 / 163 422</td></tr>
+        <tr><td>Люксембург — фонди CSSF</td><td style="text-align:right">195 890</td></tr>
+        <tr><td>EUR-Lex / CURIA</td><td style="text-align:right">46 020 / 35 764</td></tr>
+        <tr><td>Швеція / Угорщина / Фінляндія / UK / Литва / Сінгапур</td><td style="text-align:right">79 876 / 79 299 / 72 863 / 53 469 / 51 020 / 10 001</td></tr>
+      </tbody>
+    </table>
+
+    <div class="callout">
+      <p>
+        <strong>Чесно про обмеження — кажіть це самі, не чекайте, поки спитають.</strong>
+        Податкові реєстри (податковий борг, ЄСВ, ПДВ, єдиний податок) — це останній дамп
+        <strong>станом на 23.02.2022</strong>, до вторгнення; свіжіших відкритих даних не існує ні в кого.
+        У джерелі ЄДРСР трапляються сміттєві дати, тому не обіцяйте «строго 2006–2026».
+        Партнер, який називає обмеження першим, викликає більше довіри, ніж той, у кого їх «немає».
+      </p>
+    </div>
+  </section>
+
+  <!-- ============ ICP ============ -->
+  <section>
+    <h2>ICP — кому це продавати</h2>
+    <p class="sub">
+      Спільний знаменник: <strong style="color:#18181B">велика кількість однотипної ручної роботи з українськими правовими даними</strong>.
+      Що більший потік справ або перевірок — то швидше окупається.
+    </p>
+    <div class="rule"></div>
+
+    <div class="grid-2" style="margin-bottom:18px">
+      <div class="icp-card">
+        <div class="who">Юридичні фірми з судовою практикою</div>
+        <div class="size">5–50 юристів · основний ICP</div>
+        <div class="pain">
+          Асистенти вручну гортають ЄДРСР годинами. Потік однотипних спорів. Ніхто не знає статистику судді,
+          до якого потрапила справа.
+        </div>
+        <div class="pitch">Гак: «Скільки годин на тиждень ваші юніори витрачають на пошук практики?»</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">In-house юрдепартаменти</div>
+        <div class="size">Банки, страхові, ритейл, агро, девелопмент</div>
+        <div class="pain">
+          Сотні справ у роботі, потрібна перевірка контрагентів перед кожною угодою,
+          бюджет на інструменти вже закладений.
+        </div>
+        <div class="pitch">Гак: «Перевірка контрагента — 2 хвилини замість пів дня. З бенефіціарами і санкціями.»</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Стягнення та фінансові компанії</div>
+        <div class="size">Колектори, факторинг, лізинг</div>
+        <div class="pain">
+          Тисячі однотипних справ, ручна перевірка боржників по реєстрах виконавчих проваджень.
+          Найшвидший ROI з усіх сегментів.
+        </div>
+        <div class="pitch">Гак: обсяг × ціна ручної години. Рахунок сходиться на першій зустрічі.</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Комплаєнс, AML та безпека</div>
+        <div class="size">KYC-відділи, служби безпеки, due diligence</div>
+        <div class="pain">
+          Скринінг по фрагментованих порталах, ризик пропустити санкційний збіг.
+          Потрібне покриття, а не швидкість.
+        </div>
+        <div class="pitch">Гак: РНБО + НАЗК + боржники + суди одним запитом.</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Консалтинг та Big4</div>
+        <div class="size">M&A, tax, financial advisory</div>
+        <div class="pain">
+          Cross-border українські мандати. Кожна due diligence — ручний обхід шести держпорталів
+          українською мовою.
+        </div>
+        <div class="pitch">Гак: API або white-label під їхнім брендом. Найбільший чек.</div>
+      </div>
+
+      <div class="icp-card">
+        <div class="who">Legal tech та інтегратори</div>
+        <div class="size">Продукти, яким потрібні українські правові дані</div>
+        <div class="pain">
+          Будувати пайплайни до ЄДРСР і реєстрів самим — місяці роботи.
+          Купити API дешевше, ніж будувати.
+        </div>
+        <div class="pitch">Гак: pay-per-query API, тижні до продакшну.</div>
+      </div>
+    </div>
+
+    <div class="grid-2">
+      <div class="card">
+        <h3>Тригери — пишемо</h3>
+        <ul class="signal-list">
+          <li>Скарги на пошук в ЄДРСР або ручну перевірку контрагентів</li>
+          <li>Великий потік однотипних спорів (стягнення, ПДВ, трудові, банкрутство)</li>
+          <li>Вакансії «юрист-аналітик», «paralegal», «AI/legal tech» — є бюджет і біль</li>
+          <li>Публічні заяви про AI, цифровізацію, «інновації в юрбізнесі»</li>
+          <li>Cross-border практика з українськими клієнтами</li>
+          <li>Фірма росте, але не наймає — шукає важіль продуктивності</li>
+        </ul>
+      </div>
+
+      <div class="card">
+        <h3>Анти-ICP — не палимо час</h3>
+        <ul class="signal-list negative">
+          <li>Соло-адвокати без потоку справ — не окупають підписку, довго вирішують</li>
+          <li>Держоргани — цикл 12+ місяців, тендерні процедури</li>
+          <li>Нотаріуси, реєстратори — інший робочий процес</li>
+          <li>Фірми без судової практики (чистий корпоратив, реєстрації)</li>
+          <li>Ті, хто шукає «ChatGPT для документів» — не наш продукт</li>
+          <li>Компанії поза Україною без українських мандатів</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ PRICING ============ -->
+  <section>
+    <h2>Тарифи</h2>
+    <p class="sub">Free tier — 50 кредитів при реєстрації, без картки. Це найпростіший перший крок для ліда.</p>
+    <div class="rule"></div>
+
+    <div class="grid-4" style="margin-bottom:18px">
+      <div class="card">
+        <div class="plan-name">Окремий юрист</div>
+        <div class="price">$29<span> / міс</span></div>
+        <div class="plan-desc">Повний доступ до пошуку та AI-аналізу</div>
+      </div>
+      <div class="card">
+        <div class="plan-name">Юридична фірма</div>
+        <div class="price">від $99<span> / міс</span></div>
+        <div class="plan-desc">Командний доступ, спільні матерії</div>
+      </div>
+      <div class="card">
+        <div class="plan-name">API</div>
+        <div class="price">$0.05<span> / запит</span></div>
+        <div class="plan-desc">Pay-per-query, без мінімуму</div>
+      </div>
+      <div class="card dark">
+        <div class="plan-name">Enterprise</div>
+        <div class="price">Custom</div>
+        <div class="plan-desc">On-prem / VPC, white-label, SSO, DPA</div>
+      </div>
+    </div>
+
+    <div class="callout">
+      <p>
+        <strong>Де реальні гроші:</strong> $29 — це вхідний тариф для самостійної реєстрації окремого юриста.
+        Партнерський бонус прив’язаний не до тарифу, а до <strong>фактичних витрат клієнта на місяць</strong>:
+        команда від 3–4 юристів або in-house з API вже проходить поріг. Саме тому цільові сегменти —
+        фірма, in-house, стягнення, комплаєнс. Деталі бонусу — нижче.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============ PARTNER TERMS ============ -->
+  <section>
+    <h2>Умови партнерства</h2>
+    <p class="sub">Просто і без юридичної гімнастики.</p>
+    <div class="rule"></div>
+
+    <p style="font-size:15px; color:#52525B; margin-bottom:18px">
+      Бонус залежить від того, скільки клієнт витрачає на платформі щомісяця. Що більший клієнт — то більший ваш бонус.
+    </p>
+
+    <div class="grid-4" style="margin-bottom:18px; align-items:stretch">
+      <div class="card dark" style="display:flex; flex-direction:column; justify-content:center; position:relative">
+        <div class="plan-name">Від $500 / міс</div>
+        <div class="price">$1 000<span> / клієнт</span></div>
+        <div class="plan-desc">Enterprise, API, великі команди. Цільтесь сюди.</div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center">
+        <div class="plan-name">Від $200 / міс</div>
+        <div class="price">$500<span> / клієнт</span></div>
+        <div class="plan-desc">Фірма або in-house середнього розміру.</div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center">
+        <div class="plan-name">Від $100 / міс</div>
+        <div class="price">$200<span> / клієнт</span></div>
+        <div class="plan-desc">Менші команди та невеликі фірми.</div>
+      </div>
+      <div class="card" style="display:flex; flex-direction:column; justify-content:center; background:#F4F4F5">
+        <div class="plan-name">Менше $100 / міс</div>
+        <div class="price" style="color:#A1A1AA">—</div>
+        <div class="plan-desc">Бонус не виплачується. Мінімальний поріг — $100 / міс.</div>
+      </div>
+    </div>
+
+    <div class="callout" style="margin-top:0; margin-bottom:28px">
+      <p>
+        <strong>Що це означає для вашого таргетингу:</strong> окремий юрист на тарифі $29 / міс —
+        нижче порога, бонусу не буде. Заробіток починається з <strong>команди від 3–4 юристів</strong>,
+        а верхній тир — це enterprise, API-інтеграції та великі команди.
+        Один такий клієнт = п’ять середніх. Саме тому анти-ICP вище — не формальність, а ваша економіка.
+      </p>
+    </div>
+
+    <div class="card" style="margin-bottom:28px">
+      <h3>Що ми даємо зі свого боку</h3>
+      <ul class="signal-list" style="margin-top:10px">
+        <li>Цей пакет + демо-доступ для ваших лідів</li>
+        <li>Ми беремо на себе демо та всі технічні питання</li>
+        <li>Реєстрація ліда за вами — конфліктів не буде</li>
+        <li>Будь-яка додаткова інформація на запит</li>
+      </ul>
+    </div>
+
+    <ol class="terms">
+      <li><strong>Реєстрація ліда.</strong> Ви надсилаєте контакт і компанію до першого дотику. Ми підтверджуємо, що лід новий — і він закріплюється за вами на <strong>60 днів</strong>.</li>
+      <li><strong>Демо і продаж.</strong> Ви робите інтро, далі демо і закриття беремо ми. Ви можете бути присутні на дзвінку.</li>
+      <li><strong>Що вважається клієнтом.</strong> Компанія, яка підписала договір, здійснила першу оплату і витрачає <strong>від $100 / міс</strong>. Не реєстрація, не free tier, не пілот без оплати.</li>
+      <li><strong>Розмір бонусу</strong> визначається за фактичними витратами клієнта на платформі: від $500 / міс — $1 000, від $200 / міс — $500, від $100 / міс — $200.</li>
+      <li><strong>Виплата у два етапи: 50% одразу</strong> після надходження першого платежу від клієнта, <strong>і 50% через місяць</strong> за умови, що клієнт залишився активним. Так ми обидва зацікавлені в клієнтах, які залишаються, а не просто підписуються.</li>
+      <li><strong>Спосіб виплати — на ваш вибір:</strong> криптовалютою, або офіційно на рахунок вашої компанії — гривнею за курсом НБУ на дату виплати, з договором і закривальними документами.</li>
+    </ol>
+  </section>
+
+  <!-- ============ WHY ============ -->
+  <section>
+    <h2>Чому це відповідає ринку</h2>
+    <p class="sub">Чому ми вважаємо, що це має продаватись — і що казати на дзвінку.</p>
+    <div class="rule"></div>
+
+    <table style="margin-bottom:24px">
+      <thead>
+        <tr>
+          <th>Задача</th>
+          <th>Як зараз</th>
+          <th>З LEX</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="hi">Пошук судової практики</td>
+          <td>4–6 годин на запит</td>
+          <td class="hi">10–15 хвилин</td>
+        </tr>
+        <tr>
+          <td class="hi">Перевірка контрагента</td>
+          <td>2–3 години по реєстрах</td>
+          <td class="hi">менше 2 хвилин</td>
+        </tr>
+        <tr>
+          <td class="hi">Санкційний скринінг</td>
+          <td>Фрагментовано, легко пропустити</td>
+          <td class="hi">Один запит, повне покриття</td>
+        </tr>
+        <tr>
+          <td class="hi">Пошук норми</td>
+          <td>Ручна навігація порталами</td>
+          <td class="hi">Рівень статті + судові посилання</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="grid-3">
+      <div class="card">
+        <h3>Готово зараз</h3>
+        <p>Не прототип. Продакшн на legal.org.ua, платні клієнти, зовнішній security-аудит (березень 2026, 10 OWASP-знахідок виправлено).</p>
+      </div>
+      <div class="card">
+        <h3>Наступне покоління</h3>
+        <p>На ринку є ZakonOnline, LIGA:ZAKON, ActiveLex — це бази з пошуком. Ми не замінюємо базу, ми даємо те, чого в базі немає: AI-аналіз, семантику, MCP.</p>
+      </div>
+      <div class="card">
+        <h3>Довіра</h3>
+        <p>Фіналіст Startup World Cup 2026. Партнер Google Cloud for Startups, AWS Activate, NVIDIA Innovation Lab. 7 наукових публікацій на arXiv.</p>
+      </div>
+    </div>
+
+    <div class="callout" style="border-left-color:#B45309">
+      <p style="margin-bottom:10px">
+        <strong>Заперечення №1: «У нас вже є ZakonOnline / LIGA:ZAKON».</strong>
+        Це прозвучить на першому ж дзвінку. Не кажіть «у них нічого немає» — клієнт користується ними
+        роками і знає краще за нас. Це коштує довіри миттєво.
+      </p>
+      <p>
+        Правильна рамка: <strong>вони — база даних, ми — аналітичний шар над даними.</strong>
+        У них пошук за ключовими словами: треба вгадати формулювання. У нас семантичний пошук:
+        знаходить релевантне, навіть коли слова інші. Плюс те, чого в базах немає взагалі —
+        AI-генерація стратегій із документів справи, citation graph (чи чинний прецедент),
+        держреєстри з бенефіціарами та санкціями в тому ж інтерфейсі, і нативний MCP —
+        робота прямо з ChatGPT або Claude клієнта.
+        <strong>Ми не просимо відмовитись від їхньої бази. Ми закриваємо те, що база не вміє.</strong>
+      </p>
+    </div>
+
+    <div class="callout">
+      <p>
+        <strong>Комплаєнс, якщо спитають:</strong> AWS eu-central-1 (Франкфурт), GDPR з повними пайплайнами
+        експорту та видалення, DPA для enterprise, E2EE для документів, WebAuthn/FIDO2, авторизація через Дію.
+        Дані — виключно з офіційних держреєстрів та порталів відкритих даних.
+      </p>
+    </div>
+  </section>
+
+  <!-- ============ FOOTER ============ -->
+  <div class="footer">
+    <div class="contact">
+      <strong>Volodymyr Ovcharov</strong><br>
+      CEO &amp; Founder, LEX AI<br>
+      <a href="mailto:volodymyr@legal.org.ua">volodymyr@legal.org.ua</a> ·
+      <a href="https://legal.org.ua">legal.org.ua</a>
+    </div>
+    <div class="note">
+      Продукт: legal.org.ua/product · Команда: legal.org.ua/about<br>
+      Матеріал для партнерів з лідогенерації.
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/lexwebapp/public/robots.txt
+++ b/lexwebapp/public/robots.txt
@@ -56,5 +56,6 @@ Disallow: /legislation/*
 Disallow: /analysis/*
 Disallow: /decisions
 Disallow: /case-analysis
+Disallow: /partner-onepager.html
 
 Sitemap: https://legal.org.ua/sitemap.xml


### PR DESCRIPTION
## What

Adds a self-contained partner one-pager for lead-gen partners, served at `/partner-onepager.html`.

Contents: service list (EDRSR-first), full prod database inventory, ICP/anti-ICP, pricing, and partner commission tiers.

## Not indexed — on purpose

The page carries partner commission terms and competitive positioning, so it is link-only:

- `<meta name="robots" content="noindex, nofollow, noarchive, nosnippet">`
- `Disallow: /partner-onepager.html` in `robots.txt`

It is still technically public to anyone with the URL — that is the accepted tradeoff, not an oversight.

## Numbers were verified against prod, not copied from decks

Several figures in existing materials turned out to be stale. This page uses values read directly from the production databases:

| Claim | Existing materials | Actual on prod |
|---|---|---|
| EDRSR decisions | 120M+ / 115M / 8.8M | **135,404,664** |
| Judge analytics profiles | 12,000+ | **6,390** |
| Enforcement proceedings | 29M, "NAIS 11/11 complete" | **0 — table empty** |
| Public spending records | 12.6M | **10.9M** |
| IP objects | 295K | **825,718** |
| ECHR cases | "coming soon" | **209,774 live** |

Enforcement proceedings are therefore sold via the debtors register (10.5M), which carries proceeding numbers and enforcement bodies.

## Follow-ups (not in this PR)

- `DataSourcesPage.tsx` still marks ECHR as "coming soon" while 209,774 cases are live on prod.
- `docs/investment-memo-uk.md` claims "NAIS 11/11 complete" with 29M enforcement proceedings against an empty table, and lists ZakonOnline as having no developer API — we consumed that API ourselves.

## Test plan

- [ ] After deploy, `https://legal.org.ua/partner-onepager.html` renders
- [ ] `https://legal.org.ua/robots.txt` contains the Disallow line
- [ ] Page prints cleanly to A4 (Ctrl+P)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a link-only partner one-pager at /partner-onepager.html with verified product stats, pricing, ICP/anti-ICP, and partner commission tiers. The page is excluded from search indexing via meta robots and robots.txt.

- **New Features**
  - Self-contained HTML page at /partner-onepager.html; print-friendly for A4.
  - Content includes: service list (EDRSR-first), full prod database inventory (numbers pulled from prod), ICP/anti-ICP, pricing, and partner commission tiers.
  - Noindex: adds <meta name="robots" noindex,nofollow> and Disallow in robots.txt.
  - Reference copy added at docs/proposals/partner-onepager.html.

<sup>Written for commit 9bd3a304e2fbbbda3a6e2ddb38789c362c6b5a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

