### PR TITLE
fix(security): resolve CodeQL + Dependabot high-severity alerts

### DIFF
--- a/lexwebapp/package-lock.json
+++ b/lexwebapp/package-lock.json
@@ -7949,9 +7949,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/lexwebapp/package.json
+++ b/lexwebapp/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "overrides": {
+    "ws": "^8.21.0"
+  },
   "scripts": {
     "dev": "npx vite",
     "build": "tsc --noEmit && npx vite build",

--- a/mcp_backend/package.json
+++ b/mcp_backend/package.json
@@ -70,7 +70,7 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/passport": "^1.0.17",
     "@types/passport-google-oauth20": "^2.0.17",
-    "adm-zip": "^0.5.16",
+    "adm-zip": "^0.6.0",
     "axios": "^1.15.0",
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.70.4",

--- a/mcp_backend/src/adapters/rada-legislation-adapter.ts
+++ b/mcp_backend/src/adapters/rada-legislation-adapter.ts
@@ -84,6 +84,20 @@ export class RadaLegislationAdapter {
   // cut the main scan at 53%, and a «Про споживче кредитування» reference cut ПКУ
   // at 2% — nearly the whole main body went through the transitional extractor,
   // producing thousands of bogus 'п.*' rows).
+  /**
+   * Strip HTML/XML tags to plain text, looping until stable so overlapping
+   * constructs (e.g. `<<a>script>`) cannot reconstitute a tag after one pass.
+   */
+  private static stripTags(input: string): string {
+    let out = input;
+    let prev: string;
+    do {
+      prev = out;
+      out = out.replace(/<[^>]+>/g, '');
+    } while (out !== prev);
+    return out;
+  }
+
   private static readonly TRANSITIONAL_HEADER_PATTERNS = [
     /<span\s+class=["']?rvts(?:15|23)["']?>[^<]{0,120}?ПРИКІНЦЕВІ\s+ТА\s+ПЕРЕХІДНІ\s+ПОЛОЖЕННЯ/i,
     /<span\s+class=["']?rvts(?:15|23)["']?>[^<]{0,120}?ПЕРЕХІДНІ\s+ТА\s+ПРИКІНЦЕВІ\s+ПОЛОЖЕННЯ/i,
@@ -522,7 +536,7 @@ export class RadaLegislationAdapter {
       const m = pat.exec(bodyHtml);
       if (m) {
         sectionStart = m.index;
-        sectionTitle = m[0].replace(/<[^>]*>/g, '').trim();
+        sectionTitle = RadaLegislationAdapter.stripTags(m[0]).trim();
         break;
       }
     }

--- a/mcp_backend/src/scripts/import-amcu-decisions.ts
+++ b/mcp_backend/src/scripts/import-amcu-decisions.ts
@@ -135,11 +135,18 @@ async function extractOdt(buf: Buffer): Promise<string | null> {
     const entry = new AdmZip(buf).getEntry('content.xml');
     if (!entry) return null;
     const xml = entry.getData().toString('utf8');
-    const text = xml
+    let stripped = xml
       .replace(/<\/text:(?:p|h)>/g, '\n')     // paragraph/heading breaks
       .replace(/<text:tab\/?>/g, '\t')
-      .replace(/<text:line-break\/?>/g, '\n')
-      .replace(/<[^>]+>/g, '')                 // drop remaining tags
+      .replace(/<text:line-break\/?>/g, '\n');
+    // Drop remaining tags, looping until stable so overlapping constructs
+    // (e.g. `<<a>a>`) cannot reconstitute a tag after a single pass.
+    let prev: string;
+    do {
+      prev = stripped;
+      stripped = stripped.replace(/<[^>]+>/g, '');
+    } while (stripped !== prev);
+    const text = stripped
       .replace(/&apos;/g, "'").replace(/&quot;/g, '"')
       .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&')
       .replace(/[ \t]+\n/g, '\n')


### PR DESCRIPTION
Closes all 4 open security alerts (2 CodeQL code-scanning + 2 Dependabot), all high severity.

## CodeQL — `js/incomplete-multi-character-sanitization`
Both sites stripped HTML/XML tags with a single-pass `replace(/<[^>]+>/g, '')`, which CodeQL flags because overlapping input (e.g. `<<a>script>`) can reconstitute a tag after one pass.

- **#337** `mcp_backend/src/adapters/rada-legislation-adapter.ts:525` — section-title cleanup now uses a new `stripTags()` helper that loops until the string is stable.
- **#338** `mcp_backend/src/scripts/import-amcu-decisions.ts:142` — ODT text extractor now strips remaining tags in a loop-until-stable pass.

Both are plain-text extraction paths (not HTML output), so behavior for real inputs is unchanged; the loop only closes the theoretical reconstitution case.

## Dependabot
- **#249** `adm-zip` `^0.5.16` → `^0.6.0` (mcp_backend) — crafted ZIP triggering 4GB memory allocation. API used (`new AdmZip(buf).getEntry().getData()`) is unchanged in 0.6.0.
- **#233** `ws` `8.20.0` → `8.21.1` (lexwebapp, transitive via `happy-dom`) — memory-exhaustion DoS. Pinned with an `overrides` entry; `npm ci` verified in sync.

## Verification
- `mcp_backend` tsc: both edited files compile clean (pre-existing unrelated missing-module errors in `core-loader.ts` are untouched and present on `main`).
- `lexwebapp` `npm ci --dry-run` passes with the patched lockfile; resolved `ws@8.21.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all high-severity security alerts by hardening tag stripping against overlapping inputs and updating vulnerable dependencies (2 CodeQL + 2 Dependabot).

- **Bug Fixes**
  - Implemented loop-until-stable tag stripping to satisfy CodeQL `js/incomplete-multi-character-sanitization`: added `stripTags()` and used it in `rada-legislation-adapter`; applied the same stable loop in the ODT extractor.

- **Dependencies**
  - Bumped `adm-zip` to `^0.6.0`.
  - Pinned `ws` via `overrides` to `^8.21.0` (lockfile resolved to `8.21.1`).

<sup>Written for commit 069fbceecaa0232bd92fe7da3b3c2f1ececce864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

