### PR TITLE
fix(chat): deliver answer, chat id and cost when a run hits the timeout

### DIFF
--- a/lexwebapp/src/hooks/chat/useAIChatStream.ts
+++ b/lexwebapp/src/hooks/chat/useAIChatStream.ts
@@ -92,6 +92,17 @@ export function useAIChatStream(options: UseAIChatStreamOptions = {}) {
           responseIdRef.current = data.response_id;
         },
 
+        onConversation: (data) => {
+          // Adopt the id as soon as the backend creates the conversation. Waiting for
+          // `complete` meant a run that timed out left the chat unreachable from the
+          // sidebar even though the backend had saved it.
+          if (data.conversationId && !useChatStore.getState().conversationId) {
+            const store = useChatStore.getState();
+            useChatStore.setState({ conversationId: data.conversationId });
+            store.loadConversations();
+          }
+        },
+
         onPlan: (data) => {
           // Plan implies tool calls will follow — any preamble buffered so far is discarded
           if (preambleTimerRef.current) {

--- a/lexwebapp/src/services/api/MCPService.ts
+++ b/lexwebapp/src/services/api/MCPService.ts
@@ -69,6 +69,8 @@ export interface EvidenceEnvelope {
 
 export interface ChatStreamCallbacks {
   onResponseId?: (data: { response_id: string }) => void;
+  /** Conversation id, emitted up front — do not wait for `complete` to learn it. */
+  onConversation?: (data: { conversationId: string; requestId?: string }) => void;
   onPlan?: (data: { goal: string; steps: Array<{ id: number; tool: string; params: Record<string, unknown>; purpose: string; depends_on?: number[] }>; expected_iterations: number }) => void;
   onThinking?: (data: { step: number; tool: string; params: Record<string, unknown>; description?: string; cost_usd?: number }) => void;
   onToolResult?: (data: { tool: string; result: unknown; evidence?: EvidenceEnvelope; cost_usd?: number }) => void;
@@ -313,6 +315,7 @@ export class MCPService extends BaseService {
   private dispatchChatEvent(event: string, data: Record<string, any>, callbacks: ChatStreamCallbacks) {
     switch (event) {
       case 'response_id': callbacks.onResponseId?.(data as { response_id: string }); break;
+      case 'conversation': callbacks.onConversation?.(data as { conversationId: string; requestId?: string }); break;
       case 'plan': callbacks.onPlan?.(data as Parameters<NonNullable<ChatStreamCallbacks['onPlan']>>[0]); break;
       case 'thinking': callbacks.onThinking?.(data as Parameters<NonNullable<ChatStreamCallbacks['onThinking']>>[0]); break;
       case 'tool_result': callbacks.onToolResult?.(data as Parameters<NonNullable<ChatStreamCallbacks['onToolResult']>>[0]); break;

--- a/mcp_backend/src/routes/__tests__/chat-inline-routes.test.ts
+++ b/mcp_backend/src/routes/__tests__/chat-inline-routes.test.ts
@@ -1,4 +1,5 @@
-import { resolveChatTimeoutMs } from '../chat-inline-routes';
+import { EventEmitter } from 'events';
+import { resolveChatTimeoutMs, createChatInlineRoutes } from '../chat-inline-routes';
 
 describe('resolveChatTimeoutMs', () => {
   // ChatService auto-escalates effectiveBudget up to maxBudget (default: deep),
@@ -20,5 +21,130 @@ describe('resolveChatTimeoutMs', () => {
   it('gives the standard timeout when maxBudget caps escalation below deep', () => {
     expect(resolveChatTimeoutMs('standard', 'standard')).toBe(240_000);
     expect(resolveChatTimeoutMs('quick', 'quick')).toBe(240_000);
+  });
+});
+
+/**
+ * The SSE consumer must never break out of the for-await while the pipeline is
+ * still winding down: `break` calls generator.return(), which skips the
+ * persistence + cost-record closure that ChatService does on its way out.
+ * Repro: chat-e26df847 (2026-07-20) — answer streamed to the user, then the
+ * 360s backstop aborted the run mid citation-repair. The turn was never saved
+ * (conversation had 0 messages), cost_tracking stayed `pending`, and the client
+ * got neither `complete` nor `cost_summary`, so the UI showed no chat id and no
+ * cost and the chat was unreachable from the sidebar.
+ */
+describe('chat SSE consumption on abort', () => {
+  type Harness = {
+    handler: (req: any, res: any) => Promise<void>;
+    events: Array<{ type: string; data: any }>;
+    finalized: () => boolean;
+    req: any;
+  };
+
+  function makeHarness(opts: { onIteration?: (i: number, req: any) => void } = {}): Harness {
+    let didFinalize = false;
+    const written: string[] = [];
+
+    // Stands in for ChatService.chat(): streams a few events, then does its
+    // persistence in a `finally` — exactly like the real pipeline.
+    async function* fakeChat(request: any) {
+      try {
+        yield { type: 'conversation', data: { conversationId: 'conv-1' } };
+        yield { type: 'answer_delta', data: { text: 'частина відповіді' } };
+        opts.onIteration?.(1, request);
+        yield { type: 'answer', data: { text: 'повна відповідь' } };
+        yield { type: 'complete', data: { iterations: 3, elapsed_ms: 10, total_cost_usd: 1.44 } };
+      } finally {
+        didFinalize = true;
+      }
+    }
+
+    const router = createChatInlineRoutes({
+      chatService: { chat: fakeChat } as any,
+      billingService: {
+        getOrCreateUserBilling: async () => ({ billing_enabled: false }),
+        getBillingSummary: async () => ({ balance_usd: 10 }),
+      } as any,
+      costTracker: { estimateCost: async () => ({ total_estimated_cost_usd: 0 }) } as any,
+      db: { query: async () => ({ rows: [{ total_cost_usd: '1.60', markup_percentage: 10 }] }) } as any,
+    });
+
+    const layer = (router as any).stack.find(
+      (l: any) => l.route?.path === '/' && l.route?.methods?.post
+    );
+    const handler = layer.route.stack[layer.route.stack.length - 1].handle;
+
+    const req: any = new EventEmitter();
+    req.body = { query: 'позов до ТЦК', budget: 'standard' };
+    req.user = { id: 'user-1' };
+
+    const res: any = {
+      writableEnded: false,
+      setHeader: () => {},
+      write: (chunk: string) => { written.push(chunk); return true; },
+      end: () => { res.writableEnded = true; },
+      status: () => res,
+      json: () => res,
+      headersSent: true,
+    };
+
+    const events = {
+      get list() {
+        const out: Array<{ type: string; data: any }> = [];
+        for (let i = 0; i < written.length; i++) {
+          const m = /^event: (.+)\n$/.exec(written[i]);
+          if (m) {
+            const d = /^data: (.*)\n\n$/s.exec(written[i + 1] || '');
+            out.push({ type: m[1], data: d ? JSON.parse(d[1]) : null });
+          }
+        }
+        return out;
+      },
+    };
+
+    return {
+      handler: () => handler(req, res),
+      get events() { return events.list; },
+      finalized: () => didFinalize,
+      req,
+    } as any;
+  }
+
+  it('lets the pipeline finalize and still reports chat id, complete and cost when the client stays connected', async () => {
+    const h = makeHarness();
+    await h.handler(h.req, null);
+
+    const types = h.events.map(e => e.type);
+    expect(h.finalized()).toBe(true);
+    expect(types).toContain('conversation');
+    expect(types).toContain('complete');
+    expect(types).toContain('cost_summary');
+    expect(h.events.find(e => e.type === 'conversation')?.data.conversationId).toBe('conv-1');
+    expect(h.events.find(e => e.type === 'cost_summary')?.data.charged_usd).toBe(1.6);
+  });
+
+  it('emits the conversation id before the answer, so a run that dies late is still reachable', async () => {
+    const h = makeHarness();
+    await h.handler(h.req, null);
+
+    const types = h.events.map(e => e.type);
+    expect(types.indexOf('conversation')).toBeLessThan(types.indexOf('answer'));
+    // response_id is the very first event — traceability before anything else.
+    expect(types[0]).toBe('response_id');
+  });
+
+  it('drains the generator to completion after the client disconnects, but stops writing', async () => {
+    // Disconnect mid-stream, from inside the generator — by then the route has
+    // registered its 'close' listener, so the ordering is deterministic.
+    const h = makeHarness({ onIteration: () => { h.req.emit('close'); } });
+    await h.handler(h.req, null);
+
+    // The pipeline must still have reached its `finally` — that is where the turn
+    // is persisted and the billing record closed.
+    expect(h.finalized()).toBe(true);
+    // Nothing written past the disconnect.
+    const types = h.events.map(e => e.type);
+    expect(types).not.toContain('cost_summary');
   });
 });

--- a/mcp_backend/src/routes/chat-inline-routes.ts
+++ b/mcp_backend/src/routes/chat-inline-routes.ts
@@ -30,6 +30,15 @@ export function resolveChatTimeoutMs(budget?: string, maxBudget?: string): numbe
   return escalationCeiling === 'deep' ? 360_000 : 240_000;
 }
 
+/**
+ * After the wall-clock timeout fires (or the client disconnects) the pipeline gets
+ * this long to wind down: emit the verified answer, `complete` and `cost_summary`,
+ * persist the turn, close the cost record. Sized for the slowest tail stage — an
+ * unsupported-citation repair took 96s in chat-e26df847 (2026-07-20). Past it the
+ * generator is dropped, which is a leak backstop, not a normal path.
+ */
+export const FINALIZE_GRACE_MS = 150_000;
+
 export function createChatInlineRoutes(deps: {
   chatService: ChatService;
   billingService: BillingService;
@@ -165,11 +174,25 @@ export function createChatInlineRoutes(deps: {
       // Abort controller for cancellation propagation
       const abortController = new AbortController();
 
+      // Timing out is not the same as the client going away: on timeout the socket
+      // is still open, so the run must be allowed to wind down (verify → citation
+      // repair → `complete` → cost_summary) and the user must still get the answer,
+      // the chat id and the cost. Only a real disconnect stops us writing.
+      let clientGone = false;
+      let hardStop = false;
+      let hardStopTimer: NodeJS.Timeout | undefined;
+
       // Absolute wall-clock timeout to prevent runaway agentic loops
       const timeoutMs = resolveChatTimeoutMs(budget, maxBudget);
       const requestTimeout = setTimeout(() => {
-        logger.warn('[ChatService] Request timed out', { requestId, timeoutMs, budget });
+        logger.warn('[ChatService] Request timed out — winding down', { requestId, timeoutMs, budget });
+        // The signal stops the agentic loop from starting new work; the pipeline is
+        // then given FINALIZE_GRACE_MS to finish what it already has in hand.
         abortController.abort();
+        hardStopTimer = setTimeout(() => {
+          logger.warn('[ChatService] Finalization grace expired — dropping stream', { requestId });
+          hardStop = true;
+        }, FINALIZE_GRACE_MS);
       }, timeoutMs);
 
       // SSE heartbeat to prevent proxy timeouts during long tool calls
@@ -178,9 +201,14 @@ export function createChatInlineRoutes(deps: {
       }, 15000);
 
       req.on('close', () => {
-        clearTimeout(requestTimeout);
+        clientGone = true;
         clearInterval(heartbeat);
         abortController.abort();
+        // Do NOT stop iterating here — the generator persists the turn and closes
+        // the billing record on its way out, and only gets there if it is drained.
+        if (!hardStopTimer) {
+          hardStopTimer = setTimeout(() => { hardStop = true; }, FINALIZE_GRACE_MS);
+        }
       });
 
       let chatCompleted = false;
@@ -218,7 +246,10 @@ export function createChatInlineRoutes(deps: {
       try {
         await runWithABUser(userId || '', async () => {
           for await (const event of deps.chatService.chat(chatRequest)) {
-            if (abortController.signal.aborted) break;
+            // Only a hard stop breaks the loop. Breaking calls generator.return(),
+            // which skips the pipeline's persistence + cost-record closure — that is
+            // how chat-e26df847 lost its answer and stayed `pending` forever.
+            if (hardStop) break;
 
             if (event.type === 'thinking') {
               tallySearch(event.data?.tool, event.data?.params?.mode);
@@ -234,25 +265,33 @@ export function createChatInlineRoutes(deps: {
               if (chatRequest.conversationId && chatRequest.conversationId !== conversationId) {
                 event.data.conversationId = chatRequest.conversationId;
               }
+              if (abortController.signal.aborted) {
+                // Answer is real but the run was cut short — let the UI say so.
+                event.data.truncated = true;
+              }
             }
+
+            // Client hung up: keep draining so the generator finalizes, just stop writing.
+            if (clientGone || res.writableEnded) continue;
 
             res.write(`event: ${event.type}\n`);
             res.write(`data: ${JSON.stringify(event.data)}\n\n`);
           }
         });
 
-        if (abortController.signal.aborted && !chatCompleted && !res.writableEnded) {
+        if (abortController.signal.aborted && !chatCompleted && !clientGone && !res.writableEnded) {
           logger.warn('[ChatService] Sending timeout error to client', { requestId });
           res.write(`event: error\n`);
           res.write(`data: ${JSON.stringify({ message: 'Час очікування вичерпано. Спробуйте уточнити запит.' })}\n\n`);
         }
       } finally {
         clearTimeout(requestTimeout);
+        if (hardStopTimer) clearTimeout(hardStopTimer);
         clearInterval(heartbeat);
       }
 
       // Emit cost_summary SSE event — billing was already handled by CostTracker.onTrackingComplete()
-      if (chatCompleted && userId && chatTotalCostUsd > 0 && !res.writableEnded) {
+      if (chatCompleted && userId && chatTotalCostUsd > 0 && !clientGone && !res.writableEnded) {
         try {
           const [summary, trackingRow] = await Promise.all([
             deps.billingService.getBillingSummary(userId),
@@ -282,7 +321,10 @@ export function createChatInlineRoutes(deps: {
           // Persist charged_usd + search_stats back to conversation_messages so reload
           // shows correct cost and the FTS/Qdrant breakdown. Merge into the existing
           // cost_summary JSONB so already-saved fields (e.g. tools_used) are preserved.
-          if (conversationId) {
+          // Use the effective id — ChatService fills chatRequest.conversationId in
+          // when it auto-creates the conversation, and those turns need the cost too.
+          const effectiveConversationId = chatRequest.conversationId || conversationId;
+          if (effectiveConversationId) {
             deps.db.query(
               `UPDATE conversation_messages
                SET cost_summary = COALESCE(cost_summary, '{}'::jsonb) || $1::jsonb
@@ -291,7 +333,7 @@ export function createChatInlineRoutes(deps: {
                  WHERE conversation_id = $2 AND role = 'assistant'
                  ORDER BY created_at DESC LIMIT 1
                )`,
-              [JSON.stringify(costSummaryFull), conversationId]
+              [JSON.stringify(costSummaryFull), effectiveConversationId]
             ).catch(e => logger.warn('[ChatService] Failed to persist charged_usd', { error: e.message }));
           }
         } catch (e: any) {


### PR DESCRIPTION
## Problem

`chat-e26df847` (2026-07-20): user read the answer, but the UI showed **no chat id and no cost**, and the chat could not be opened from the left sidebar. Backend: conversation with **0 messages**, `cost_tracking.status = pending` (so no charge either).

The run hit the 360s backstop while the citation-repair tail stage was still running (that stage took 96s). The SSE consumer treated a timeout exactly like a client disconnect — `break` on abort — which:

1. calls `generator.return()`, skipping ChatService's persistence + cost-record closure, and
2. drops `complete` and `cost_summary` even though the socket is still open.

The client only learns an auto-created `conversationId` from `complete`, so it never registered the chat in the sidebar.

## Fix

**Route** (`chat-inline-routes.ts`):
- only a hard stop breaks the loop. On timeout the pipeline gets `FINALIZE_GRACE_MS` (150s, sized for the observed 96s repair tail) to wind down; the user still receives `complete` + `cost_summary`, with `truncated: true` on complete
- on a real disconnect, keep draining the generator so it finalizes — just stop writing
- persist `charged_usd` against the *effective* conversation id, so auto-created conversations get their cost persisted too

**Frontend**: adopt the conversation id from the new `conversation` event rather than waiting for `complete`, and refresh the sidebar there.

Pairs with secondlayer-core#101, which moves persistence + `completeTrackingRecord()` into a `finally`.

## Testing

- `npx jest src/routes/__tests__/chat-inline-routes.test.ts` — 6/6 pass, including new tests that a disconnected client still lets the generator reach its `finally`, and that `conversation` precedes `answer`
- `tsc --noEmit` on mcp_backend with the core overlay: clean (one pre-existing error in `session-replay-service.ts` from unrelated WIP on another branch)
- `tsc --noEmit` on lexwebapp: clean; `vitest run src/services/api`: 24/24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures timed-out chats still deliver the answer, a conversation id, and the cost. The SSE loop now lets the run finalize on timeout instead of dropping `complete` and billing.

- Bug Fixes
  - Backend (`mcp_backend`): only a hard stop breaks the loop; on timeout, abort new work but allow FINALIZE_GRACE_MS (150s) to finish and emit `complete` + `cost_summary` with `truncated: true`.
  - Backend (`mcp_backend`): on real disconnect, keep draining the generator to finalize persistence and billing, but stop writing to the socket.
  - Backend (`mcp_backend`): emit a `conversation` event early; persist `charged_usd` against the effective conversation id (covers auto-created chats).
  - Frontend (`lexwebapp`): adopt the conversation id from the `conversation` event and refresh the sidebar; wire `onConversation` in `MCPService`.

<sup>Written for commit 1d392f1d821d6835500c16141f622d3e4a8f21bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

