### PR TITLE
perf(citation-graph): materialize Case.cited_by_count instead of counting at query time

### DIFF
--- a/deployment/neo4j-citation-run.sh
+++ b/deployment/neo4j-citation-run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# neo4j-citation-run.sh
+#
+# (Re)creates the neo4j-citation container on PROD. This container is NOT in any
+# compose file: the store is a 168G bind mount migrated from Brev on 2026-07-20
+# (see /home/ubuntu/neo4j-migrate.sh), so it is deliberately outside the blue-green
+# deploy. It was previously started by an ad-hoc `docker run` that existed nowhere,
+# which is how NEO4J_db_transaction_timeout=5s ended up as undocumented prod state.
+# Recreate it ONLY through this script so the config stays reviewable.
+#
+# Recreating is safe for the data: /data is a bind mount, the container is disposable.
+# Impact: the citation graph is down for the restart. Backend callers degrade to
+# logger.warn; get_citation_graph returns a user-facing error for that window.
+#
+# Usage (on prod):
+#   bash neo4j-citation-run.sh                 # normal serving config
+#   TX_TIMEOUT=600s bash neo4j-citation-run.sh # maintenance window for a backfill
+#
+# TX_TIMEOUT is a backstop against runaway queries, NOT a latency fix. The serving
+# path must be fast on its own: precedent in-degree is read from the materialized
+# Case.cited_by_count, never counted at query time (LEXAI-1777).
+# The case-layer backfill/maintenance statement scans every CITES_CASE edge in one
+# transaction and needs TX_TIMEOUT=600s -- see
+# scripts/citation-graph/backfill-case-cited-by-count.cypher.
+set -euo pipefail
+
+NAME=neo4j-citation
+IMAGE=neo4j@sha256:4bae36aff76271e27fd6a6ed0835413f86a284cd179cfb1cb7d188f5f7533aca  # neo4j 5.26.28 community
+DATA=/home/ubuntu/neo4j-citation/data
+NETWORK=deployment_secondlayer-prod-network
+TX_TIMEOUT="${TX_TIMEOUT:-30s}"
+
+if [ ! -d "$DATA/databases/neo4j" ]; then
+  echo "FATAL: $DATA/databases/neo4j missing -- refusing to start on an empty store." >&2
+  exit 1
+fi
+
+echo "=== recreating $NAME (db.transaction.timeout=$TX_TIMEOUT) ==="
+docker rm -f "$NAME" >/dev/null 2>&1 || true
+
+docker run -d \
+  --name "$NAME" \
+  --restart unless-stopped \
+  --network "$NETWORK" \
+  --memory 26g \
+  -p 127.0.0.1:7474:7474 \
+  -p 127.0.0.1:7687:7687 \
+  -v "$DATA":/data \
+  -e NEO4J_server_default__listen__address=0.0.0.0 \
+  -e NEO4J_server_memory_heap_initial__size=8g \
+  -e NEO4J_server_memory_heap_max__size=8g \
+  -e NEO4J_server_memory_pagecache_size=12g \
+  -e NEO4J_db_transaction_timeout="$TX_TIMEOUT" \
+  "$IMAGE"
+
+echo "=== waiting for bolt ==="
+for i in $(seq 1 60); do
+  if docker exec -i "$NAME" cypher-shell -u neo4j -p "${NEOPW:?set NEOPW}" \
+       --format plain "RETURN 1;" >/dev/null 2>&1; then
+    echo "up after ${i}s"
+    docker exec -i "$NAME" cypher-shell -u neo4j -p "$NEOPW" --format plain \
+      "SHOW SETTINGS YIELD name, value WHERE name = 'db.transaction.timeout' RETURN name, value;"
+    exit 0
+  fi
+  sleep 1
+done
+echo "FATAL: bolt did not come up within 60s" >&2
+docker logs --tail 40 "$NAME" >&2
+exit 1

--- a/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
+++ b/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
@@ -287,6 +287,18 @@ describe('CitationGraphService', () => {
       expect(q).toContain('[:OF_LAW]->(l:Law)');
     });
 
+    it('reads the materialized Case.cited_by_count instead of counting edges', async () => {
+      mockRun.mockResolvedValue({ records: [] });
+      await new CitationGraphService().getCaseStats(['910/123/20']);
+
+      const q = cypherOf(0);
+      expect(q).toContain('coalesce(c.cited_by_count, 0) AS citing');
+      // A live in-degree count here is the 97s prod regression: 168G store, 12G page
+      // cache, so counting inbound CITES_CASE on a hot case hits disk tens of
+      // thousands of times. The count is materialized by the case-layer loader.
+      expect(q).not.toMatch(/COUNT\s*\{[^}]*CITES_CASE/i);
+    });
+
     it('keys the article lookup by law_number/law_article', async () => {
       mockRun.mockResolvedValue({ records: [] });
       await new CitationGraphService().getArticleCitedBy('ЦПК України', '175');

--- a/mcp_backend/src/services/citation-graph-service.ts
+++ b/mcp_backend/src/services/citation-graph-service.ts
@@ -7,6 +7,11 @@
  * Schema as actually loaded by the Brev rebuild:
  *   (:Decision {doc_id})-[:CITES_ARTICLE {citation_type, citation_context}]->(:Article)
  *   (:Article {art_id, law_number, law_article, total_citations, unique_decisions})-[:OF_LAW]->(:Law {law_number})
+ *   (:Decision)-[:CITES_CASE]->(:Case {cause_num, member_count, latest_doc_id, cited_by_count})
+ * Case.cited_by_count is the materialized inbound CITES_CASE degree, written by the
+ * loader (scripts/citation-graph/backfill-case-cited-by-count.cypher) and only present
+ * on cases with at least one inbound edge — read it via coalesce(..., 0), never by
+ * counting the edges at query time.
  * The human-readable law name comes from (:Law).law_number, reached via the OF_LAW hop.
  * That property is overloaded: usually a title ("Господарський процесуальний кодекс
  * України"), sometimes a bare date or a "№1961 від 01.07.2004" form — so it is a
@@ -281,12 +286,21 @@ export class CitationGraphService {
    * Precedent stats for a case (decision↔case layer, LEXAI-1777). Accepts the
    * case-number variations and picks the most-cited matching Case node. Returns
    * how many decisions cite the case + how many documents the case spans.
+   *
+   * `citing` reads the materialized Case.cited_by_count, it does NOT count the
+   * inbound edges at query time. The store is ~168G against a 12G page cache, so
+   * a live `COUNT { (c)<-[:CITES_CASE]-() }` on a hot case degenerates into tens
+   * of thousands of random disk reads (measured up to 97s). The property is
+   * maintained by the case-layer loader; see
+   * scripts/citation-graph/backfill-case-cited-by-count.cypher.
+   * coalesce() because the loader only writes the property on cases that have at
+   * least one inbound precedent edge — an absent property means zero.
    */
   async getCaseStats(causeNums: string[]): Promise<CaseStat | null> {
     if (!causeNums || causeNums.length === 0) return null;
     const rows = await this.run(
       `MATCH (c:Case) WHERE c.cause_num IN $cns
-       WITH c, COUNT { (c)<-[:CITES_CASE]-(:Decision) } AS citing
+       WITH c, coalesce(c.cited_by_count, 0) AS citing
        ORDER BY citing DESC LIMIT 1
        OPTIONAL MATCH (c)<-[df:DEPARTS_FROM]-(gc:Decision)
        WITH c, citing, gc, df ORDER BY df.departed_on DESC

--- a/scripts/citation-graph/backfill-case-cited-by-count.cypher
+++ b/scripts/citation-graph/backfill-case-cited-by-count.cypher
@@ -1,0 +1,34 @@
+// backfill-case-cited-by-count.cypher
+//
+// Materializes the inbound precedent degree onto (:Case).cited_by_count.
+//
+// WHY: getCaseStats used to compute `COUNT { (c)<-[:CITES_CASE]-(:Decision) }` per
+// request. The prod store is ~168G against a 12G page cache, so the in-degree of a
+// hot case is tens of thousands of random disk reads -- measured up to 97s. A 5s
+// db.transaction.timeout was set on the container, which does not make the query
+// fast, it just turns a slow answer into no answer: the callers swallow the error
+// (logger.warn) and check_precedent_status silently drops precedent weight.
+// Reading a property instead makes it an index seek + one property load.
+//
+// This statement is BOTH the one-time backfill and the maintenance step run by
+// load-case-layer.cypher after every additive load, so the two can never drift.
+//
+// Idempotent: it recomputes from the edges, so re-running is always safe.
+// Only cases with >=1 inbound edge get the property; readers must coalesce(...,0).
+// That is sound only because the loader is additive (MERGE, never deletes edges) --
+// a count can never need to drop back to zero. If edge deletion is ever introduced,
+// this must also reset cases that no longer have inbound edges.
+//
+// PRE-REQ: db.transaction.timeout must be >= ~10min (or 0). The outer aggregation
+// scans every CITES_CASE edge in one transaction, so the 5s prod default kills it.
+// Verified 2026-07-21: the 5s timeout blocks this very backfill.
+//
+// RUN (statement must be its own implicit txn -- `-c`, NOT `--file`, same gotcha as
+// load-case-layer.cypher):
+//   docker exec -i neo4j-citation cypher-shell -u neo4j -p "$NEOPW" -c "$(sed '/^\/\//d' backfill-case-cited-by-count.cypher)"
+
+MATCH (:Decision)-[r:CITES_CASE]->(c:Case)
+WITH c, count(r) AS n
+CALL { WITH c, n
+  SET c.cited_by_count = n
+} IN TRANSACTIONS OF 10000 ROWS;

--- a/scripts/citation-graph/load-case-layer.cypher
+++ b/scripts/citation-graph/load-case-layer.cypher
@@ -37,10 +37,23 @@ CALL { WITH row
   MERGE (d)-[:CITES_CASE]->(c)
 } IN TRANSACTIONS OF 10000 ROWS;
 
-// 4. Sanity checks.
+// 4. Materialize the inbound precedent degree onto the Case nodes. REQUIRED: the
+//    serving path (CitationGraphService.getCaseStats) reads c.cited_by_count and
+//    never counts these edges at query time -- skipping this step leaves precedent
+//    weight silently stuck at its previous value. Canonical statement lives in
+//    backfill-case-cited-by-count.cypher; keep the two identical.
+//    Needs db.transaction.timeout >= ~10min: the aggregation scans every CITES_CASE.
+MATCH (:Decision)-[r:CITES_CASE]->(c:Case)
+WITH c, count(r) AS n
+CALL { WITH c, n
+  SET c.cited_by_count = n
+} IN TRANSACTIONS OF 10000 ROWS;
+
+// 5. Sanity checks.
 MATCH (c:Case) RETURN count(c) AS case_nodes;
 MATCH ()-[r:CITES_CASE]->() RETURN count(r) AS cites_case_edges;
-// Top-cited precedent cases (inbound CITES_CASE):
-MATCH (d:Decision)-[:CITES_CASE]->(c:Case)
-RETURN c.cause_num AS cause_num, c.member_count AS members, count(d) AS cited_by
+// Top-cited precedent cases, read off the materialized property (step 4). Also
+// doubles as the check that step 4 actually ran -- an empty result means it did not.
+MATCH (c:Case) WHERE c.cited_by_count IS NOT NULL
+RETURN c.cause_num AS cause_num, c.member_count AS members, c.cited_by_count AS cited_by
 ORDER BY cited_by DESC LIMIT 15;


### PR DESCRIPTION
## Проблема

`getCaseStats` рахував `COUNT { (c)<-[:CITES_CASE]-(:Decision) }` на кожен запит. Стор на проді ~168G проти 12G page cache, тож in-degree популярної справи — це десятки тисяч випадкових читань з диска (заміряно до 97s).

Розгорнутим пом'якшенням був `NEO4J_db_transaction_timeout=5s` на контейнері. Він не робить запит швидким, а перетворює повільну відповідь на **відсутність** відповіді: викликач глушить помилку в `logger.warn` (`mcp-query-api.ts:261`), і `check_precedent_status` тихо віддає вагу прецеденту, якої ніколи не рахував.

Таймаут ще й захищав сам себе — він убивав саме той бекфіл, що це лагодить (перевірено: `The transaction has been terminated`).

## Що зроблено

- `getCaseStats` читає `coalesce(c.cited_by_count, 0)` — index seek плюс читання властивості.
- Завантажувач слою матеріалізує властивість після кожного additive-завантаження.
- `backfill-case-cited-by-count.cypher` тримає канонічний statement, щоб бекфіл і крок підтримки не розійшлися.
- Тест падає при поверненні до `COUNT {}`.
- `deployment/neo4j-citation-run.sh` фіксує конфіг контейнера, який досі існував лише як ad-hoc `docker run` на проді — саме так 5s і стали незадокументованим станом.

Властивість пишеться тільки на справи з >=1 вхідним ребром, звідси `coalesce(..., 0)` на читанні. Це коректно, бо завантажувач additive (MERGE, ніколи не видаляє), тож лічильник не може впасти назад у нуль.

## Заміри на проді

Бекфіл: 9м35с, оброблено 10.96M ребер CITES_CASE.

Найцитованіша справа `826/3858/18` (293 676 вхідних цитувань), `PROFILE`:

| | обращений к БД |
|---|---|
| було (live `COUNT {}`) | 587 358 |
| стало (властивість) | **3** |

Замір wall-clock одразу після бекфілу дав 2.3s в обох варіантах, але він недостовірний: бекфіл щойно прогрів кеш, а самі 2.3s — це переважно старт JVM у `cypher-shell`. Кількість звернень до БД від стану кешу не залежить, тому наведено її.

Таймаут повернуто на 30s — тепер це справжня страховка від runaway-запитів, а не несуча конструкція.

## Семантика збережена

`ORDER BY citing DESC LIMIT 1` (максимум по варіаціях номера справи) лишився як був. У графі `0430/1311/12` і `0430/1311/2012` — різні вузли, і RUNBOOK фіксує, що нормалізацію року свідомо відхилили. Заміна max на sum була б тихою зміною поведінки і має вирішуватись окремо.

## Суміжна знахідка

Під час роботи виявилось, що prod-PG розійшовся з графом: `edrsr_case_index` / `case_citation_links` застаріли (граф відповідає сьогоднішньому `edrsr_documents`, PG — ні). Через це лічильники рахувались у самому графі: бекфіл з PG зрізав би вагу прецеденту приблизно на 40%. Заведено окремий тікет **LEXAI-1860**.

## Перевірка

- `npx jest src/services/__tests__/citation-graph-service.test.ts` — 23 passed
- tsc чистий по змінених файлах
- Після рестарту прод віддає 293676 / 138100 / 113530 для трьох топових справ, у логах бекенду помилок citation немає

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Materializes Case.cited_by_count and switches getCaseStats to read it (coalesce to 0) instead of counting inbound edges. This removes the 97s prod regression and makes precedent weight reliable again (LEXAI-1777).

- **Performance**
  - Read coalesce(c.cited_by_count, 0) in getCaseStats (index seek + property load).
  - Materialize cited_by_count after each additive load; canonical Cypher in scripts/citation-graph/backfill-case-cited-by-count.cypher and reused in scripts/citation-graph/load-case-layer.cypher.
  - Test ensures no live COUNT of CITES_CASE at query time.

- **Migration**
  - Backfill cited_by_count by running scripts/citation-graph/backfill-case-cited-by-count.cypher (scans all CITES_CASE; requires TX_TIMEOUT≈600s).
  - Recreate the `neo4j-citation` container via deployment/neo4j-citation-run.sh; default db.transaction.timeout=30s (override with TX_TIMEOUT=600s for backfill).
  - No schema changes; property exists only when ≥1 inbound edge, so readers use coalesce(..., 0).

<sup>Written for commit f4811a91d8e7b69d7dbdcbbc28ac52513acddf75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

