### PR TITLE
fix(edrsr): strip leftover RTF `\~` from decision text on read

### DIFF
--- a/mcp_backend/src/api/tools/court-decision-tools.ts
+++ b/mcp_backend/src/api/tools/court-decision-tools.ts
@@ -14,6 +14,7 @@
 
 import { EdsrLocalAdapter } from '../../adapters/edrsr-local-adapter.js';
 import type { EdsrFtsService } from '../../services/edrsr-fts-service.js';
+import { cleanEdrsrTextSql } from '../../services/edrsr-fts-service.js';
 import { SemanticSectionizer } from '../../services/semantic-sectionizer.js';
 import type { IEmbeddingPort } from '../../domain/ports/index.js';
 import { LegalPatternStore } from '../../services/legal-pattern-store.js';
@@ -426,7 +427,7 @@ total_resolved_links=0 означає відсутність даних граф
           d.doc_id, d.cause_num, d.judge, d.court_code, d.justice_kind,
           d.judgment_code, d.category_code, d.adjudication_date, d.receipt_date,
           d.doc_url, d.status, d.date_publ,
-          f.full_text
+          ${cleanEdrsrTextSql('f.full_text')} AS full_text
         FROM edrsr_documents d
         LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
         WHERE d.doc_id = $1
@@ -437,7 +438,7 @@ total_resolved_links=0 означає відсутність даних граф
       } else {
         // Try fulltext-only
         const ftResult = await this.edrsrDb().query(
-          `SELECT doc_id, full_text FROM edrsr_fulltext WHERE doc_id = $1`, [docId]
+          `SELECT doc_id, ${cleanEdrsrTextSql('full_text')} AS full_text FROM edrsr_fulltext WHERE doc_id = $1`, [docId]
         );
         if (ftResult.rows.length > 0) {
           row = { doc_id: docId, full_text: ftResult.rows[0].full_text };
@@ -459,7 +460,7 @@ total_resolved_links=0 означає відсутність даних граф
           FROM edrsr_documents d
           WHERE d.cause_num = $1
         )
-        SELECT d.*, f.full_text
+        SELECT d.*, ${cleanEdrsrTextSql('f.full_text')} AS full_text
         FROM docs d
         LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
         ORDER BY d.adjudication_date DESC NULLS LAST
@@ -469,7 +470,7 @@ total_resolved_links=0 означає відсутність даних граф
           d.doc_id, d.cause_num, d.judge, d.court_code, d.justice_kind,
           d.judgment_code, d.category_code, d.adjudication_date, d.receipt_date,
           d.doc_url, d.status, d.date_publ,
-          f.full_text
+          ${cleanEdrsrTextSql('f.full_text')} AS full_text
         FROM edrsr_documents d
         LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
         WHERE d.cause_num = $1
@@ -894,7 +895,7 @@ total_resolved_links=0 означає відсутність даних граф
     if (!this.db || docIds.length === 0) return [];
 
     const rows = (await this.db.query(`
-      SELECT d.doc_id, d.cause_num, d.judge, d.adjudication_date, f.full_text
+      SELECT d.doc_id, d.cause_num, d.judge, d.adjudication_date, ${cleanEdrsrTextSql('f.full_text')} AS full_text
       FROM edrsr_documents d
       LEFT JOIN edrsr_fulltext f ON f.doc_id = d.doc_id
       WHERE d.doc_id = ANY($1)
@@ -905,7 +906,7 @@ total_resolved_links=0 означає відсутність даних граф
     const missing = docIds.filter(id => !byId.has(id));
     if (missing.length > 0) {
       const ftRows = (await this.db.query(
-        `SELECT doc_id, full_text FROM edrsr_fulltext WHERE doc_id = ANY($1)`, [missing]
+        `SELECT doc_id, ${cleanEdrsrTextSql('full_text')} AS full_text FROM edrsr_fulltext WHERE doc_id = ANY($1)`, [missing]
       )).rows;
       for (const r of ftRows) byId.set(Number(r.doc_id), { doc_id: r.doc_id, full_text: r.full_text });
     }

--- a/mcp_backend/src/api/tools/edrsr-extended-tools.ts
+++ b/mcp_backend/src/api/tools/edrsr-extended-tools.ts
@@ -13,6 +13,7 @@
 import { BaseToolHandler, ToolDefinition, ToolResult } from '../base-tool-handler.js';
 import { logger } from '../../utils/logger.js';
 import { extractDispositiveFromText } from '../../utils/dispositive.js';
+import { cleanEdrsrTextSql } from '../../services/edrsr-fts-service.js';
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 100;
@@ -244,7 +245,7 @@ export class EdsrExtendedTools extends BaseToolHandler {
 
     try {
       const result = await this.db.query(
-        `SELECT full_text, text_length FROM edrsr_fulltext WHERE doc_id = $1`,
+        `SELECT ${cleanEdrsrTextSql('full_text')} AS full_text, text_length FROM edrsr_fulltext WHERE doc_id = $1`,
         [docId]
       );
 

--- a/mcp_backend/src/routes/edrsr-routes.ts
+++ b/mcp_backend/src/routes/edrsr-routes.ts
@@ -9,6 +9,7 @@ import { Router, type Response } from 'express';
 import type { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
 import type { IDatabase } from '../domain/ports/index.js';
 import { logger } from '../utils/logger.js';
+import { cleanEdrsrTextSql } from '../services/edrsr-fts-service.js';
 
 export function createEdsrRoutes(db: IDatabase): Router {
   const router = Router();
@@ -40,7 +41,7 @@ export function createEdsrRoutes(db: IDatabase): Router {
 
       // Fetch fulltext
       const textResult = await db.query(
-        `SELECT full_text FROM edrsr_fulltext WHERE doc_id = $1 LIMIT 1`,
+        `SELECT ${cleanEdrsrTextSql('full_text')} AS full_text FROM edrsr_fulltext WHERE doc_id = $1 LIMIT 1`,
         [Number(docId)]
       );
 

--- a/mcp_backend/src/services/edrsr-fts-service.ts
+++ b/mcp_backend/src/services/edrsr-fts-service.ts
@@ -284,6 +284,22 @@ const FTS_CANDIDATE_CAP = 2000;
 // already-supported path). Must comfortably clear the capped query (sub-second on prod).
 const FTS_STATEMENT_TIMEOUT_MS = 8000;
 
+/**
+ * Historical RTF imports (2007-2025) left the RTF control word `\~` (non-breaking
+ * space) in full_text; 2026+ arrives clean, so this is a fixed-size backlog, not a
+ * growing one. Cosmetic only: to_tsvector is byte-identical with and without it, so
+ * the FTS index is unaffected and needs no rebuild.
+ *
+ * Stripping the marker and collapsing the space runs it leaves behind reproduces the
+ * reference (already-cleaned) copy exactly - verified by md5 of both texts with all
+ * whitespace removed.
+ *
+ * Applied on read at the paths whose text a user actually reads. Drop this once the
+ * historical partitions are cleaned in place, after which it is a no-op.
+ */
+export const cleanEdrsrTextSql = (col: string) =>
+  `regexp_replace(replace(${col}, '\\~', ''), '[ ]{2,}', ' ', 'g')`;
+
 export class EdsrFtsService {
   private edsrCache: EdsrCacheService | null = null;
 
@@ -727,7 +743,7 @@ export class EdsrFtsService {
 
     const buildSelectFields = (withHeadline: boolean) => {
       const headlineExpr = withHeadline
-        ? `safe_ts_headline('simple'::regconfig, f.full_text, ${headlineFn},
+        ? `safe_ts_headline('simple'::regconfig, ${cleanEdrsrTextSql('f.full_text')}, ${headlineFn},
            'MaxWords=${FTS_HEADLINE_MAX_WORDS}, MinWords=${FTS_HEADLINE_MIN_WORDS}, StartSel=**, StopSel=**') AS headline`
         : `NULL AS headline`;
 


### PR DESCRIPTION
## What

Historical RTF imports left the RTF control word `\~` (non-breaking space) in `edrsr_fulltext`. This strips it on read at the paths whose text a user actually looks at.

## Scope, measured

Share of documents containing `\~`, sampled across all partitions on prod:

| Years | Affected |
|---|---|
| 2006 | 0% |
| 2007-2013 | 0.1-11% |
| 2014-2017 | 15-40% |
| 2018-2025 | 56-77% |
| **2026** | **0%** |

2026 being clean means the parser is already fixed - this is a fixed-size backlog, not a growing one.

## Cosmetic only - the search index is fine

`to_tsvector` is **byte-identical** with and without the marker (verified directly on prod), so the FTS index needs no rebuild and relevance is unaffected. The only symptom is `\~` showing up in snippets and document bodies.

## The transformation is exact, not approximate

Strip the marker, then collapse the runs of spaces it leaves behind:

```sql
regexp_replace(replace(full_text, '\~', ''), '[ ]{2,}', ' ', 'g')
```

Verified against a reference copy of the same corpus that had already been cleaned:

```
raw      6996 chars
cleaned  6887 chars   <- reference copy is also exactly 6887
md5 of both texts with all whitespace removed:
         06d00435fedf272680ba80219e8abef2   <- identical on both sides
```

So this is a pure local computation - there is no information in the cleaned copy that prod cannot derive itself.

## Where it is applied

FTS headlines (`safe_ts_headline`), `get_court_decision`, `load_full_texts`, and the `/api/edrsr/:docId/fulltext` route.

LLM-facing paths (`legal-advice-tools`, `procedural-tools`, `edrsr-search-tools`, `edrsr-unified-search-tool`) are **deliberately left alone**: wrapping all ~17 call sites would add `regexp_replace` to every query over a 1.6 TB column for a cosmetic gain. The planned in-place cleanup of the historical partitions covers those, after which `cleanEdrsrTextSql` becomes a no-op and can be deleted.

## Note on the build

`npx tsc --noEmit` reports 4 pre-existing errors in `core-loader.ts` and `session-replay-service.ts` from unrelated uncommitted work in the tree. None are in the four files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove leftover `\~` RTF markers from EDRSR decision text at read time to clean up snippets and document bodies. Cosmetic only; search relevance and the FTS index are unchanged.

- **Bug Fixes**
  - Added SQL helper `cleanEdrsrTextSql(...)` to strip `\~` and collapse extra spaces.
  - Applied in FTS headlines and main read paths: court-decision tools, extended tools, and the `/api/edrsr/:docId/fulltext` route.
  - LLM-facing queries are left unchanged to avoid regex on a large column; planned in-place partition cleanup will make this a no-op.

<sup>Written for commit db7948e3d4deeadd566669d0fc8dfdb53ecefd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

