### PR TITLE
feat(citation-graph): EDRSR instance-status layer (overruled/dissent)

### DIFF
--- a/scripts/citation-graph/README-instance-status.md
+++ b/scripts/citation-graph/README-instance-status.md
@@ -1,0 +1,57 @@
+# EDRSR instance-status layer (overruled / dissent)
+
+Builds the Ukrainian analogue of a "which passage is losing law" signal for the citation
+graph, shaped for EDRSR. Finnish courts pack overruled reasoning + dissents into **one**
+decision document; EDRSR stores **one document per instance**, so the trap is cross-document:
+retrieval pulls a first/appeal-instance decision that a higher court later *скасував*. This
+pipeline marks those lower decisions `overruled` and attaches окремі думки as `dissent`,
+as a lighter layer over the existing `neo4j-citation` graph.
+
+Feeds the role-aware citation judge (LEXAI-1842 / LEXAI-1850): a citation landing on an
+overruled or dissent decision becomes a same-case hard negative.
+
+## Pipeline
+
+| Stage | Script | Where | Output |
+|---|---|---|---|
+| 0 | `instance-status-00-probe.sql` | Brev `edrsr_local` | sizing (instances, chains, judgment_code, reversal-rate sample) |
+| 1 | `instance-status-01-prep.sql` | Brev `edrsr_local` | `isl_multi_cases`, `isl_chain` |
+| 2 | `instance-status-02-extract-disposition.py` | Brev (14 workers) | `edrsr_instance_disposition` |
+| 3 | `instance-status-03-overruled-dissent.sql` | Brev | `edrsr_overruled`, `edrsr_dissent` |
+| 4 | `instance-status-neo4j-load.cypher` via `instance-status-neo4j-chunk-load.sh` | prod host | graph SUPERSEDED_BY / HAS_DISSENT + Decision.status |
+| 5 (opt) | `instance-status-04a-export-other.py` → `04b-infer-qwen.py` → `04c-merge-llm.sql` | Brev GPU | recover reversals from the regex "other" bucket, produce `edrsr_overruled_delta` |
+
+The classifier (stage 2) anchors on the operative part (slice after the last
+«ПОСТАНОВИВ / ВИРІШИВ / УХВАЛИВ», spaced-letter tolerant) and matches the disposition verb
+with a decision-noun co-presence guard (so "скасувати арешт" ≠ overrule). Stage 5 sends the
+`other` bucket to Qwen2.5-72B-Instruct on Brev to recover reversals phrased outside the regex.
+
+## Results (full corpus, 135.2M docs, 2026-07-22)
+
+- `edrsr_instance_disposition`: 3,041,803 (affirmed 1.69M / reversed 976K / modified 50K / other 303K).
+- `edrsr_overruled`: ~693,729 (first-instance 589,829 + appeal 103,900). LLM stage recovered
+  +10,942 clean additions (from 18,663 recovered reversers). NB the count is fuzzy in the
+  679K–705K band: same-date lower-doc ties make the "which lower doc" pick ambiguous.
+- `edrsr_dissent`: 9,736 окрема-думка docs → 14,614 parent decisions.
+- Prod `neo4j-citation`: **SUPERSEDED_BY = 704,671** (693,729 regex + 10,942 llm, `r.method`),
+  **HAS_DISSENT = 17,542**, `Decision.status ∈ {overruled, dissent}`.
+
+## Gotchas
+
+- Decision nodes key on `doc_id` as a **STRING** (index `decision_doc_id`), not `id`, not int.
+- prod graph is Neo4j **Community** with `db.transaction.timeout=5s`; it cannot be raised at
+  runtime (no `dbms.setConfigValue`, no APOC) and the prod container must not be restarted →
+  bulk loads are chunked into sub-5s pieces (`instance-status-neo4j-chunk-load.sh`).
+- this cypher-shell takes the query **positionally** (no `-c`); call it via `docker exec`
+  directly (a `bash -lc` wrapper loses it from PATH).
+- Brev vLLM (0.11.2) needs `VLLM_ATTENTION_BACKEND=FLASH_ATTN` + `FLASHINFER_DISABLE_VERSION_CHECK=1`
+  + `enforce_eager=True`, and `HF_HOME=/data/hf_cache HF_HUB_OFFLINE=1`.
+- `DISTINCT ON` on same-date ties is non-deterministic; stage 3 adds a `low.doc_id DESC`
+  tiebreak for stable rebuilds, and stage 5 filters the graph delta to `by_method='llm_qwen'`
+  to exclude tie-churn.
+
+## Instance codes (edrsr_instances)
+
+`1 = Касаційна (cassation)`, `2 = Апеляційна (appeal)`, `3 = Перша (first)`. Next-lower
+instance for a higher decision at instance I is `I + 1`. `judgment_code`: 2=постанова,
+3=рішення, 1=вирок, 5=ухвала (procedural), **10=окрема думка (dissent)**.

--- a/scripts/citation-graph/instance-status-00-probe.sql
+++ b/scripts/citation-graph/instance-status-00-probe.sql
@@ -1,0 +1,62 @@
+\timing on
+\set ON_ERROR_STOP off
+SET statement_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET work_mem = '8GB';
+
+\echo '===== Q1: total docs ====='
+SELECT count(*) AS total_docs FROM edrsr_documents;
+
+\echo '===== Q2: instance x judgment_code crosstab (join to courts) ====='
+SELECT c.instance_code, c.name AS instance_name, d.judgment_code, count(*) AS n
+FROM edrsr_documents d
+LEFT JOIN edrsr_courts c ON d.court_code = c.court_code
+GROUP BY 1,2,3
+ORDER BY 1,3;
+
+\echo '===== Q3: identify judgment_code for OKREMA DUMKA (sample text per code) ====='
+-- for each judgment_code take one doc, check if full_text contains ОКРЕМА ДУМКА header
+SELECT jc.judgment_code,
+       (SELECT left(f.full_text, 120)
+          FROM edrsr_documents d2
+          JOIN edrsr_fulltext f ON f.doc_id = d2.doc_id
+         WHERE d2.judgment_code = jc.judgment_code
+         LIMIT 1) AS sample_head
+FROM (SELECT DISTINCT judgment_code FROM edrsr_documents) jc
+ORDER BY 1;
+
+\echo '===== Q4: multi-instance case distribution (HEAVY: group by cause_num over full corpus) ====='
+SELECT instances_per_case, count(*) AS n_cases
+FROM (
+  SELECT d.cause_num, count(DISTINCT c.instance_code) AS instances_per_case
+  FROM edrsr_documents d
+  JOIN edrsr_courts c ON d.court_code = c.court_code
+  WHERE d.cause_num IS NOT NULL AND d.cause_num <> ''
+  GROUP BY d.cause_num
+) t
+GROUP BY 1
+ORDER BY 1;
+
+\echo '===== Q5: disposition-marker sample on 2023 appeal+cassation (reversal-rate estimate) ====='
+-- tail-slice regex; APPROXIMATE (real extraction anchors on operative-part marker)
+WITH samp AS (
+  SELECT right(f.full_text, 2500) AS tail
+  FROM edrsr_fulltext f
+  JOIN edrsr_documents d ON d.doc_id = f.doc_id
+  JOIN edrsr_courts c ON d.court_code = c.court_code
+  WHERE f.adj_year = 2023 AND c.instance_code IN (1,2)
+  LIMIT 100000
+)
+SELECT
+  count(*) AS sampled,
+  count(*) FILTER (WHERE tail ~* 'залишити' AND tail ~* 'без змін') AS affirmed,
+  count(*) FILTER (WHERE tail ~* 'скасувати')                        AS has_skasuvaty,
+  count(*) FILTER (WHERE tail ~* 'змінити')                          AS has_zminyty
+FROM samp;
+
+\echo '===== Q6: okrema dumka count via judgment_code candidates (text-verified) ====='
+-- count docs whose full_text starts with ОКРЕМА ДУМКА, sampled per year is expensive;
+-- instead count by judgment_code once Q3 identifies the code (reported in Q2 already).
+\echo 'see Q2/Q3 for okrema dumka code + count'
+
+\echo '===== DONE ====='

--- a/scripts/citation-graph/instance-status-01-prep.sql
+++ b/scripts/citation-graph/instance-status-01-prep.sql
@@ -1,0 +1,37 @@
+\timing on
+SET statement_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET work_mem = '8GB';
+SET max_parallel_workers_per_gather = 8;
+
+\echo '===== 1) multi-instance cause_num set (>=2 distinct instances) ====='
+DROP TABLE IF EXISTS isl_multi_cases;
+CREATE UNLOGGED TABLE isl_multi_cases AS
+SELECT d.cause_num
+FROM edrsr_documents d
+JOIN edrsr_courts c ON c.court_code = d.court_code
+WHERE d.cause_num IS NOT NULL AND d.cause_num <> ''
+GROUP BY d.cause_num
+HAVING count(DISTINCT c.instance_code) >= 2;
+ALTER TABLE isl_multi_cases ADD PRIMARY KEY (cause_num);
+SELECT count(*) AS multi_cases FROM isl_multi_cases;
+
+\echo '===== 2) chain: all docs of those cases with instance + form ====='
+DROP TABLE IF EXISTS isl_chain;
+CREATE UNLOGGED TABLE isl_chain AS
+SELECT d.doc_id, d.cause_num, c.instance_code, d.judgment_code,
+       d.adjudication_date
+FROM edrsr_documents d
+JOIN edrsr_courts c ON c.court_code = d.court_code
+JOIN isl_multi_cases m ON m.cause_num = d.cause_num;
+CREATE INDEX idx_isl_chain_cause ON isl_chain (cause_num);
+CREATE INDEX idx_isl_chain_doc   ON isl_chain (doc_id);
+SELECT count(*) AS chain_docs FROM isl_chain;
+
+\echo '===== 3) shape of the classification target: instance x form in chains ====='
+SELECT instance_code, judgment_code, count(*) AS n
+FROM isl_chain
+GROUP BY 1,2
+ORDER BY 1,2;
+
+\echo '===== DONE_PREP ====='

--- a/scripts/citation-graph/instance-status-02-extract-disposition.py
+++ b/scripts/citation-graph/instance-status-02-extract-disposition.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+EDRSR instance-status Phase 1: classify the disposition of higher-instance
+merits decisions (appeal/cassation postanova/rishennia) in multi-instance
+case chains, by parsing the operative part.
+
+Reads:  isl_chain (staging) JOIN edrsr_fulltext
+Writes: edrsr_instance_disposition (doc_id, cause_num, instance_code,
+        adjudication_date, disposition, method, oper_len)
+
+disposition in {reversed, modified, affirmed, dismissed, other}
+"""
+import argparse, re, sys
+import psycopg2
+from psycopg2.extras import execute_values
+from concurrent.futures import ProcessPoolExecutor, as_completed
+
+DSN = "dbname=edrsr_local"
+
+# operative-part markers (allow spaced-out letters: "П О С Т А Н О В И В")
+def _spaced(word):
+    return r'\s*'.join(list(word))
+
+OPER_RE = re.compile(
+    '(' + '|'.join(_spaced(w) for w in [
+        'ПОСТАНОВИВ', 'ПОСТАНОВИЛ',
+        'ВИРІШИВ', 'ВИРІШИЛ',
+        'УХВАЛИВ', 'УХВАЛИЛ',
+    ]) + ')',
+    re.IGNORECASE)
+
+def operative_slice(text):
+    """Return text after the LAST operative marker, else last 1500 chars."""
+    if not text:
+        return ''
+    last = None
+    for m in OPER_RE.finditer(text):
+        last = m
+    if last:
+        return text[last.end():last.end()+2500]
+    return text[-1500:]
+
+# disposition classification on the operative slice
+_SKASUV = re.compile(r'скасув', re.IGNORECASE)
+_ZMINY  = re.compile(r'змін(ити|ено|ивши|и)', re.IGNORECASE)
+_BEZ_ZMIN = re.compile(r'без\s+змін', re.IGNORECASE)
+_ZALYSH_BEZ_ZMIN = re.compile(r'залиш\w+\s+без\s+змін', re.IGNORECASE)
+_NEW_DECISION = re.compile(r'ухвалити\s+нов\w+\s+(рішенн|постанов)', re.IGNORECASE)
+_CLOSE_PROC = re.compile(r'закрити\s+(апеляційн\w+|касаційн\w+)?\s*провадженн', re.IGNORECASE)
+_LEAVE_UNCHANGED_ANY = re.compile(r'без\s+задоволенн', re.IGNORECASE)
+
+# a reversal/modification must act on a court DECISION, not on a seizure/measure
+_DECISION_NOUN = re.compile(r'(рішенн|постанов|ухвал|вирок|судов\w+\s+наказ|заочн\w+\s+рішенн)', re.IGNORECASE)
+# "скасув ... <decision noun>" or "<decision noun> ... скасув" within a short window
+_SKASUV_DEC = re.compile(
+    r'(скасув\w*[^.]{0,60}(рішенн|постанов|ухвал|вирок|наказ))'
+    r'|((рішенн|постанов|ухвал|вирок|наказ)\w*[^.]{0,60}скасув)', re.IGNORECASE)
+_ZMINY_DEC = re.compile(
+    r'(змін(ити|ено|ивши)[^.]{0,60}(рішенн|постанов|ухвал|вирок|наказ))'
+    r'|((рішенн|постанов|ухвал|вирок|наказ)\w*[^.]{0,60}змін(ити|ено|ивши))', re.IGNORECASE)
+
+def classify(text):
+    op = operative_slice(text)
+    s = re.sub(r'\s+', ' ', op)
+    has_skasuv = bool(_SKASUV.search(s))
+    has_dec_noun = bool(_DECISION_NOUN.search(s))
+    has_skasuv_dec = has_skasuv and has_dec_noun
+    has_zminy_dec  = bool(_ZMINY.search(s)) and has_dec_noun
+    has_bez_zmin = bool(_BEZ_ZMIN.search(s))
+    if _CLOSE_PROC.search(s) and not has_skasuv and not has_zminy_dec and not has_bez_zmin:
+        return 'dismissed', len(op)
+    # reversal dominates (full or partial skasuvannia of the reviewed decision)
+    if has_skasuv_dec:
+        return 'reversed', len(op)
+    if has_zminy_dec and not has_bez_zmin:
+        return 'modified', len(op)
+    if has_bez_zmin:
+        return 'affirmed', len(op)
+    # skasuv present but NOT on a decision (e.g. "скасувати арешт") -> not an overrule
+    return 'other', len(op)
+
+# ---- DB paths ----
+
+def fetch_smoke(limit, year):
+    q = """
+      SELECT ic.doc_id, ic.instance_code, ic.judgment_code, f.full_text
+      FROM isl_chain ic
+      JOIN edrsr_fulltext f ON f.doc_id = ic.doc_id
+      WHERE ic.instance_code IN (1,2) AND ic.judgment_code IN (2,3)
+        AND f.adj_year = %s
+      LIMIT %s
+    """
+    with psycopg2.connect(DSN) as c, c.cursor() as cur:
+        cur.execute(q, (year, limit))
+        return cur.fetchall()
+
+def run_smoke(limit, year):
+    rows = fetch_smoke(limit, year)
+    counts = {}
+    print(f"# smoke: {len(rows)} higher-instance merits docs, year {year}\n")
+    for doc_id, inst, jc, txt in rows:
+        disp, olen = classify(txt)
+        counts[disp] = counts.get(disp, 0) + 1
+    print("## label distribution:")
+    for k in ('reversed','modified','affirmed','dismissed','other'):
+        print(f"  {k:10s} {counts.get(k,0)}")
+    print("\n## samples (operative snippet):")
+    shown = {}
+    for doc_id, inst, jc, txt in rows:
+        disp, olen = classify(txt)
+        if shown.get(disp,0) >= 4:
+            continue
+        shown[disp] = shown.get(disp,0)+1
+        op = re.sub(r'\s+',' ', operative_slice(txt))[:240]
+        print(f"[{disp}] doc={doc_id} inst={inst} jc={jc} olen={olen}\n    {op}\n")
+
+# ---- full extraction by partition ----
+
+def _relax(conn):
+    with conn.cursor() as cc:
+        cc.execute("SET idle_in_transaction_session_timeout=0")
+        cc.execute("SET statement_timeout=0")
+    conn.commit()
+
+def process_year(year):
+    with psycopg2.connect(DSN) as c:
+        c.autocommit = False
+        _relax(c)
+        with c.cursor(name=f'cur_{year}') as cur:
+            cur.itersize = 5000
+            cur.execute("""
+              SELECT ic.doc_id, ic.cause_num, ic.instance_code, ic.adjudication_date, f.full_text
+              FROM isl_chain ic
+              JOIN edrsr_fulltext f ON f.doc_id = ic.doc_id
+              WHERE ic.instance_code IN (1,2) AND ic.judgment_code IN (2,3)
+                AND f.adj_year = %s
+            """, (year,))
+            batch = []
+            n = 0
+            wc = psycopg2.connect(DSN); _relax(wc); wcur = wc.cursor()
+            for doc_id, cause_num, inst, adate, txt in cur:
+                disp, olen = classify(txt)
+                batch.append((doc_id, cause_num, inst, adate, disp, 'regex_operative', olen))
+                if len(batch) >= 5000:
+                    execute_values(wcur,
+                      "INSERT INTO edrsr_instance_disposition "
+                      "(doc_id, cause_num, instance_code, adjudication_date, disposition, method, oper_len) "
+                      "VALUES %s ON CONFLICT (doc_id) DO NOTHING", batch)
+                    wc.commit(); n += len(batch); batch = []
+            if batch:
+                execute_values(wcur,
+                  "INSERT INTO edrsr_instance_disposition "
+                  "(doc_id, cause_num, instance_code, adjudication_date, disposition, method, oper_len) "
+                  "VALUES %s ON CONFLICT (doc_id) DO NOTHING", batch)
+                wc.commit(); n += len(batch)
+            wcur.close(); wc.close()
+    return (year, n)
+
+def run_full(years, workers):
+    print(f"# full extraction, years {years[0]}-{years[-1]}, {workers} workers", flush=True)
+    with ProcessPoolExecutor(max_workers=workers) as ex:
+        futs = {ex.submit(process_year, y): y for y in years}
+        total = 0
+        for fut in as_completed(futs):
+            y, n = fut.result()
+            total += n
+            print(f"  year {y}: {n} classified (running total {total})", flush=True)
+    print(f"# DONE total={total}", flush=True)
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--smoke', action='store_true')
+    ap.add_argument('--limit', type=int, default=400)
+    ap.add_argument('--year', type=int, default=2023)
+    ap.add_argument('--full', action='store_true')
+    ap.add_argument('--from', dest='yfrom', type=int, default=2005)
+    ap.add_argument('--to', dest='yto', type=int, default=2026)
+    ap.add_argument('--workers', type=int, default=14)
+    a = ap.parse_args()
+    if a.smoke:
+        run_smoke(a.limit, a.year)
+    elif a.full:
+        run_full(list(range(a.yfrom, a.yto+1)), a.workers)
+    else:
+        ap.error("choose --smoke or --full")

--- a/scripts/citation-graph/instance-status-03-overruled-dissent.sql
+++ b/scripts/citation-graph/instance-status-03-overruled-dissent.sql
@@ -1,0 +1,57 @@
+-- Phase 2: chain resolution -> overruled lower decisions + dissents.
+-- Depends on: instance-status-01-prep.sql (isl_chain) and
+--             instance-status-02-extract-disposition.py (edrsr_instance_disposition).
+-- Instance codes (edrsr_instances): 1=cassation, 2=appeal, 3=first. Next-lower = instance_code+1.
+\timing on
+SET statement_timeout = 0;
+SET work_mem = '8GB';
+
+-- 1) overruled: each reversed/modified higher decision overrules the merits decision
+--    one instance below, in the same case, that predates it (the decision under review).
+--    Deterministic tiebreak (low.doc_id DESC) so rebuilds are stable on same-date ties.
+DROP TABLE IF EXISTS edrsr_overruled;
+CREATE TABLE edrsr_overruled AS
+WITH rev AS (
+  SELECT DISTINCT ON (d.doc_id)
+    low.doc_id           AS doc_id,
+    low.instance_code    AS instance_code,
+    d.doc_id             AS overruled_by,
+    d.instance_code      AS by_instance,
+    d.cause_num          AS cause_num,
+    d.disposition        AS disposition,
+    d.method             AS by_method,
+    d.adjudication_date  AS reversed_date
+  FROM edrsr_instance_disposition d
+  JOIN isl_chain low
+    ON low.cause_num     = d.cause_num
+   AND low.instance_code = d.instance_code + 1
+   AND low.judgment_code IN (1,2,3)                 -- lower merits forms (vyrok/postanova/rishennia)
+   AND low.adjudication_date <= d.adjudication_date
+  WHERE d.disposition IN ('reversed','modified')
+  ORDER BY d.doc_id, low.adjudication_date DESC, low.doc_id DESC
+)
+SELECT DISTINCT ON (doc_id)
+  doc_id, instance_code, overruled_by, by_instance, cause_num, disposition, by_method, reversed_date
+FROM rev
+ORDER BY doc_id, reversed_date, overruled_by;
+ALTER TABLE edrsr_overruled ADD PRIMARY KEY (doc_id);
+CREATE INDEX idx_overruled_cause ON edrsr_overruled (cause_num);
+
+-- 2) dissents (okrema dumka = judgment_code 10) attached to same-case same-instance panel merits.
+DROP TABLE IF EXISTS edrsr_dissent;
+CREATE TABLE edrsr_dissent AS
+SELECT DISTINCT dis.doc_id AS dissent_doc_id, dis.cause_num, dis.instance_code,
+       m.doc_id AS parent_doc_id
+FROM isl_chain dis
+JOIN isl_chain m
+  ON m.cause_num = dis.cause_num
+ AND m.instance_code = dis.instance_code
+ AND m.judgment_code IN (2,3)
+ AND m.doc_id <> dis.doc_id
+WHERE dis.judgment_code = 10;
+CREATE INDEX idx_dissent_parent ON edrsr_dissent (parent_doc_id);
+
+SELECT (SELECT count(*) FROM edrsr_overruled) AS overruled_docs,
+       (SELECT count(*) FROM edrsr_overruled WHERE disposition='reversed') AS by_reversed,
+       (SELECT count(*) FROM edrsr_overruled WHERE disposition='modified') AS by_modified,
+       (SELECT count(DISTINCT dissent_doc_id) FROM edrsr_dissent) AS dissent_docs;

--- a/scripts/citation-graph/instance-status-04a-export-other.py
+++ b/scripts/citation-graph/instance-status-04a-export-other.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Phase 4 export (run as postgres): dump {doc_id, oper} JSONL for the regex 'other' bucket."""
+import argparse, re, json, psycopg2
+DSN = "dbname=edrsr_local"
+def _spaced(w): return r'\s*'.join(list(w))
+OPER_RE = re.compile('(' + '|'.join(_spaced(w) for w in
+    ['ПОСТАНОВИВ','ПОСТАНОВИЛ','ВИРІШИВ','ВИРІШИЛ','УХВАЛИВ','УХВАЛИЛ']) + ')', re.IGNORECASE)
+def operative_slice(text):
+    if not text: return ''
+    last=None
+    for m in OPER_RE.finditer(text): last=m
+    return (text[last.end():last.end()+2200] if last else text[-1400:]).strip()
+def main():
+    ap=argparse.ArgumentParser(); ap.add_argument('--limit',type=int,default=0); ap.add_argument('--out',required=True)
+    a=ap.parse_args()
+    q="SELECT d.doc_id, f.full_text FROM edrsr_instance_disposition d JOIN edrsr_fulltext f ON f.doc_id=d.doc_id WHERE d.disposition='other'"
+    if a.limit: q+=f" LIMIT {int(a.limit)}"
+    n=0
+    with psycopg2.connect(DSN) as c, c.cursor(name='c_o') as cur, open(a.out,'w') as w:
+        cur.itersize=4000; cur.execute(q)
+        for doc_id, txt in cur:
+            w.write(json.dumps({"doc_id":doc_id,"oper":operative_slice(txt)[:6000]}, ensure_ascii=False)+"\n"); n+=1
+    print(f"wrote {n} -> {a.out}")
+if __name__=='__main__': main()

--- a/scripts/citation-graph/instance-status-04b-infer-qwen.py
+++ b/scripts/citation-graph/instance-status-04b-infer-qwen.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Phase 4 infer (run as nvidia, GPUs 4-7): Qwen2.5-72B-Instruct classifies 'other' operative parts."""
+import argparse, re, json
+PROMPT = (
+ "Ти класифікуєш резолютивну частину постанови апеляційного або касаційного суду. "
+ "Визнач, що суд зробив із рішенням суду нижчої інстанції, яке переглядав:\n"
+ "- reversed: скасував (повністю або частково)\n"
+ "- modified: змінив\n"
+ "- affirmed: залишив без змін / скаргу без задоволення\n"
+ "- procedural: суто процесуальне (виправлення описки, повернення/залишення скарги без розгляду, "
+ "направлення за підсудністю, закриття провадження, поновлення строку тощо), по суті не переглядав\n"
+ "Відповідай РІВНО одним словом англійською: reversed, modified, affirmed або procedural.\n\n"
+ "Резолютивна частина:\n\"\"\"\n{oper}\n\"\"\"\n\nВідповідь:")
+LABELS={'reversed','modified','affirmed','procedural'}
+def parse(o):
+    for t in re.findall(r'[a-z]+', o.lower()):
+        if t in LABELS: return t
+    return 'unknown'
+def main():
+    ap=argparse.ArgumentParser(); ap.add_argument('--inp',required=True); ap.add_argument('--out',required=True)
+    ap.add_argument('--tp',type=int,default=8); ap.add_argument('--gpu-mem',type=float,default=0.80)
+    a=ap.parse_args()
+    rows=[json.loads(l) for l in open(a.inp)]
+    print(f"# {len(rows)} docs, tp={a.tp} gpu_mem={a.gpu_mem}", flush=True)
+    from vllm import LLM, SamplingParams
+    llm=LLM(model="Qwen/Qwen2.5-72B-Instruct", tensor_parallel_size=a.tp,
+            gpu_memory_utilization=a.gpu_mem, max_model_len=4096, dtype="bfloat16",
+            enforce_eager=True)
+    tok=llm.get_tokenizer()
+    sp=SamplingParams(temperature=0.0, max_tokens=4)
+    prompts=[tok.apply_chat_template([{"role":"user","content":PROMPT.format(oper=r["oper"])}],
+             tokenize=False, add_generation_prompt=True) for r in rows]
+    outs=llm.generate(prompts, sp)
+    dist={};
+    with open(a.out,'w') as w:
+        for r,o in zip(rows,outs):
+            lab=parse(o.outputs[0].text); dist[lab]=dist.get(lab,0)+1
+            w.write(json.dumps({"doc_id":r["doc_id"],"disposition":lab})+"\n")
+    print("## LLM label distribution:")
+    for k in ('reversed','modified','affirmed','procedural','unknown'):
+        print(f"  {k:11s} {dist.get(k,0)}")
+    shown=0
+    for r,o in zip(rows,outs):
+        lab=parse(o.outputs[0].text)
+        if lab in ('reversed','modified') and shown<6:
+            shown+=1; print(f"[{lab}] doc={r['doc_id']}\n    {re.sub(chr(92)+'s+',' ',r['oper'])[:220]}\n")
+if __name__=='__main__': main()

--- a/scripts/citation-graph/instance-status-04c-merge-llm.sql
+++ b/scripts/citation-graph/instance-status-04c-merge-llm.sql
@@ -1,0 +1,36 @@
+\timing on
+SET statement_timeout=0; SET work_mem='8GB';
+
+\echo '===== rebuild overruled v2 DETERMINISTIC (tiebreak low.doc_id) + carry reverser method ====='
+DROP TABLE IF EXISTS edrsr_overruled_v2;
+CREATE TABLE edrsr_overruled_v2 AS
+WITH rev AS (
+  SELECT DISTINCT ON (d.doc_id)
+    low.doc_id AS doc_id, low.instance_code AS instance_code,
+    d.doc_id AS overruled_by, d.instance_code AS by_instance,
+    d.cause_num, d.disposition, d.method AS by_method,
+    d.adjudication_date AS reversed_date
+  FROM edrsr_instance_disposition d
+  JOIN isl_chain low ON low.cause_num=d.cause_num AND low.instance_code=d.instance_code+1
+    AND low.judgment_code IN (1,2,3) AND low.adjudication_date<=d.adjudication_date
+  WHERE d.disposition IN ('reversed','modified')
+  ORDER BY d.doc_id, low.adjudication_date DESC, low.doc_id DESC
+)
+SELECT DISTINCT ON (doc_id) doc_id,instance_code,overruled_by,by_instance,cause_num,disposition,by_method,reversed_date
+FROM rev ORDER BY doc_id, reversed_date, overruled_by;
+ALTER TABLE edrsr_overruled_v2 ADD PRIMARY KEY(doc_id);
+
+\echo '===== clean delta = newly overruled (not in graph v1) AND reverser is LLM-recovered ====='
+DROP TABLE IF EXISTS edrsr_overruled_delta;
+CREATE TABLE edrsr_overruled_delta AS
+SELECT v2.doc_id, v2.instance_code, v2.overruled_by, v2.by_instance,
+       v2.cause_num, v2.disposition, v2.reversed_date
+FROM edrsr_overruled_v2 v2
+LEFT JOIN edrsr_overruled v1 ON v1.doc_id=v2.doc_id
+WHERE v1.doc_id IS NULL AND v2.by_method='llm_qwen';
+
+SELECT (SELECT count(*) FROM edrsr_overruled)        AS v1_in_graph,
+       (SELECT count(*) FROM edrsr_overruled_v2)     AS v2_total,
+       (SELECT count(*) FROM edrsr_overruled_delta)  AS delta_llm_new,
+       (SELECT count(*) FROM edrsr_instance_disposition WHERE method='llm_qwen' AND disposition IN ('reversed','modified')) AS llm_reversers;
+\echo '===== DONE_MERGE2 ====='

--- a/scripts/citation-graph/instance-status-neo4j-chunk-load.sh
+++ b/scripts/citation-graph/instance-status-neo4j-chunk-load.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Phase 3 loader: chunk an overruled CSV into sub-5s pieces and MERGE each into the
+# neo4j-citation graph (works around Neo4j Community + db.transaction.timeout=5s, which
+# cannot be raised at runtime). MERGE is idempotent, so re-runs are safe.
+#
+# Usage: instance-status-neo4j-chunk-load.sh <csv_on_host> [chunk_rows] [rel_method]
+#   <csv_on_host>  host path to an edrsr_overruled(_delta).csv (header: doc_id,instance_code,
+#                  overruled_by,by_instance,cause_num,disposition,reversed_date)
+#   [chunk_rows]   rows per chunk (default 2500)
+#   [rel_method]   optional value written to r.method (e.g. llm_qwen) for delta loads
+# Env: NEO4J_PASS (required), NEO4J_CONTAINER (default neo4j-citation)
+set -euo pipefail
+CSV="${1:?usage: <csv_on_host> [chunk_rows] [rel_method]}"
+ROWS="${2:-2500}"
+METHOD="${3:-}"
+CONT="${NEO4J_CONTAINER:-neo4j-citation}"
+P="${NEO4J_PASS:?set NEO4J_PASS}"
+NAME="$(basename "$CSV" .csv)"
+WORK="/tmp/${NAME}_chunks"
+
+rm -rf "$WORK" && mkdir -p "$WORK"
+HDR="$(head -1 "$CSV")"
+tail -n +2 "$CSV" | split -l "$ROWS" - "$WORK/part_"
+for f in "$WORK"/part_*; do (echo "$HDR"; cat "$f") > "$f.csv"; rm "$f"; done
+echo "chunks: $(ls "$WORK" | wc -l)"
+
+docker exec "$CONT" rm -rf "/var/lib/neo4j/import/$NAME"
+docker cp "$WORK" "$CONT:/var/lib/neo4j/import/$NAME"
+docker exec "$CONT" chown -R neo4j:neo4j "/var/lib/neo4j/import/$NAME"
+
+SETM=""
+[ -n "$METHOD" ] && SETM=", r.method='$METHOD'"
+ERR="/tmp/${NAME}.err"; : > "$ERR"
+for f in $(docker exec "$CONT" bash -c "ls /var/lib/neo4j/import/$NAME/"); do
+  docker exec "$CONT" cypher-shell -u neo4j -p "$P" \
+    "LOAD CSV WITH HEADERS FROM 'file:///$NAME/$f' AS row \
+     MATCH (low:Decision {doc_id: row.doc_id}) MATCH (high:Decision {doc_id: row.overruled_by}) \
+     SET low.status='overruled' MERGE (low)-[r:SUPERSEDED_BY]->(high) \
+     SET r.disposition=row.disposition, r.reversed_date=row.reversed_date$SETM;" \
+    >/dev/null 2>>"$ERR" || echo "FAIL $f" >>"$ERR"
+done
+echo "fails: $(grep -c FAIL "$ERR" || true)"
+docker exec "$CONT" cypher-shell -u neo4j -p "$P" --format plain \
+  "MATCH ()-[r:SUPERSEDED_BY]->() RETURN count(r) AS superseded_by_total;"

--- a/scripts/citation-graph/instance-status-neo4j-load.cypher
+++ b/scripts/citation-graph/instance-status-neo4j-load.cypher
@@ -1,0 +1,29 @@
+// Phase 3: additive load of the instance-status layer into the neo4j-citation graph.
+// Decision nodes key on doc_id as a STRING (index decision_doc_id). Additive: adds
+// Decision.status + (:Decision)-[:SUPERSEDED_BY]->(:Decision) and -[:HAS_DISSENT]->.
+//
+// IMPORTANT (prod = Neo4j Community + db.transaction.timeout=5s): a single LOAD CSV over
+// the full 693K rows exceeds the 5s cap and cannot be raised at runtime (no dbms.setConfigValue,
+// no APOC). Do NOT run these whole; drive them via instance-status-neo4j-chunk-load.sh which
+// splits the CSV into sub-5s chunks. Kept here as the canonical per-row cypher.
+
+// --- overruled: SUPERSEDED_BY + status ---
+LOAD CSV WITH HEADERS FROM 'file:///edrsr_overruled.csv' AS row
+CALL {
+  WITH row
+  MATCH (low:Decision  {doc_id: row.doc_id})
+  MATCH (high:Decision {doc_id: row.overruled_by})
+  SET low.status = 'overruled'
+  MERGE (low)-[r:SUPERSEDED_BY]->(high)
+  SET r.disposition = row.disposition, r.reversed_date = row.reversed_date
+} IN TRANSACTIONS OF 500 ROWS;
+
+// --- dissents: HAS_DISSENT + status ---
+LOAD CSV WITH HEADERS FROM 'file:///edrsr_dissent.csv' AS row
+CALL {
+  WITH row
+  MATCH (p:Decision   {doc_id: row.parent_doc_id})
+  MATCH (dis:Decision {doc_id: row.dissent_doc_id})
+  SET dis.status = 'dissent'
+  MERGE (p)-[:HAS_DISSENT]->(dis)
+} IN TRANSACTIONS OF 500 ROWS;


### PR DESCRIPTION
## What

Adds the EDRSR **instance-status layer** to `scripts/citation-graph/`: a pipeline that marks lower-instance court decisions as `overruled` when a higher court reversed/modified them, and attaches окремі думки (dissents) — an additive layer over the existing `neo4j-citation` graph. This is the data-build behind the role-aware citation judge (LEXAI-1842 / LEXAI-1850): a citation landing on an overruled or dissent decision becomes a same-case hard negative.

Ukraine stores one document per instance (unlike Finland's single-doc overruled/dissent sections), so the trap is cross-document: retrieval pulls a first/appeal decision a higher court later *скасував*.

## Scripts

- `instance-status-00-probe.sql` — corpus sizing
- `instance-status-01-prep.sql` — `isl_multi_cases` / `isl_chain` (3.85M multi-instance cases)
- `instance-status-02-extract-disposition.py` — operative-part classifier (14 workers)
- `instance-status-03-overruled-dissent.sql` — `edrsr_overruled` + `edrsr_dissent`
- `instance-status-04a/b/c` — optional Qwen2.5-72B tail over the regex "other" bucket (Brev 8×H100)
- `instance-status-neo4j-load.cypher` + `instance-status-neo4j-chunk-load.sh` — additive graph load
- `README-instance-status.md`

## Results (live on prod `neo4j-citation`, 2026-07-22)

- `edrsr_instance_disposition`: 3,041,803 classified
- `SUPERSEDED_BY = 704,671` (693,729 regex + 10,942 Qwen-recovered, tagged `r.method`)
- `HAS_DISSENT = 17,542`; `Decision.status ∈ {overruled, dissent}`

Scripts only — no application code paths touched. Data already loaded to prod out-of-band; this commits the reproducible pipeline. Tracked in LEXAI-1861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the EDRSR instance-status layer that marks lower-instance decisions as overruled when a higher court reversed/modified them, and links dissents in `neo4j-citation`. Supports the role-aware citation judge requirements (LEXAI-1842, LEXAI-1850) and is tracked in LEXAI-1861.

- **New Features**
  - Pipeline scripts to probe corpus, build chains, classify dispositions, resolve overruled/dissent, and load to the graph; optional Qwen2.5-72B pass for the “other” bucket.
  - Classifier reads the operative part and requires a decision noun to mark `reversed`/`modified` vs procedural text.
  - Graph load sets `Decision.status` and adds `SUPERSEDED_BY` and `HAS_DISSENT`; chunked to avoid Neo4j Community 5s transaction cap.
  - Results: 3,041,803 classified; 704,671 `SUPERSEDED_BY`; 17,542 `HAS_DISSENT` on prod.

<sup>Written for commit 9ce9eeff58a8c6a1536e2b4f2013818883acd680. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

