### PR TITLE
feat(precedent): surface instance-status overrules in check_precedent_status

### DIFF
--- a/mcp_backend/src/api/mcp-query-api.ts
+++ b/mcp_backend/src/api/mcp-query-api.ts
@@ -230,6 +230,8 @@ export class MCPQueryAPI extends BaseToolHandler {
   private async checkPrecedentStatus(args: any) {
     const caseId = args.case_id || args.doc_id || '';
     const caseNumber = args.case_number || '';
+    // A ЄДРСР doc_id is all-digits; case numbers contain slashes (e.g. 922/989/18).
+    const docId = args.doc_id || (/^\d+$/.test(String(caseId)) ? String(caseId) : '');
 
     const status = await this.citationValidator.validatePrecedentStatus(caseId, caseNumber || undefined);
 
@@ -266,6 +268,39 @@ export class MCPQueryAPI extends BaseToolHandler {
       }
     }
 
+    // Instance-status layer (LEXAI-1861): if a specific doc_id was overruled/modified by a
+    // higher court (SUPERSEDED_BY) or is a dissent, surface it. Gated by CITATION_BACKEND=neo4j;
+    // non-fatal. This is the direct answer to "чи не скасовано вищою інстанцією".
+    let supersession: any = undefined;
+    if (this.citationGraphService?.isEnabled() && docId) {
+      try {
+        const sup = await this.citationGraphService.getDecisionSupersession(docId);
+        if (sup && (sup.status || sup.supersededBy)) {
+          supersession = sup;
+          citationGraph = citationGraph || { backend: 'neo4j' };
+          if (sup.supersededBy) {
+            citationGraph.superseded_by = {
+              by_decision: sup.supersededBy.docId,
+              disposition: sup.supersededBy.disposition, // reversed | modified
+              on: sup.supersededBy.on || undefined,
+              note:
+                sup.supersededBy.disposition === 'modified'
+                  ? 'Це рішення змінено вищою інстанцією — застосовувати з урахуванням внесених змін.'
+                  : 'Це рішення скасовано вищою інстанцією — не є чинним прецедентом.',
+            };
+          }
+          if (sup.status === 'dissent') {
+            citationGraph.is_dissent = true;
+          }
+        }
+      } catch (error: any) {
+        logger.warn('[check_precedent_status] supersession enrichment failed (non-fatal)', {
+          docId,
+          error: error?.message,
+        });
+      }
+    }
+
     // If the Grand Chamber formally departed from this case's legal position (Neo4j
     // DEPARTS_FROM), the precedent is no longer fully good law — downgrade an otherwise
     // valid/unknown status to "limited" so the top-level status reflects it.
@@ -279,6 +314,20 @@ export class MCPQueryAPI extends BaseToolHandler {
         status: 'limited',
         departed_note:
           'Правову позицію у цій справі відступлено Великою Палатою ВС — прецедент обмежено чинний (див. citation_graph.position_departed_from).',
+      };
+    }
+
+    // A SUPERSEDED_BY reversal/modification is a hard fact (higher court overturned this
+    // decision). Override an otherwise valid/limited/unknown status: reversed → explicitly
+    // overruled, modified → limited. Never weakens an already explicitly_overruled status.
+    if (supersession?.status === 'overruled' && effectiveStatus?.status !== 'explicitly_overruled') {
+      const modified = supersession.supersededBy?.disposition === 'modified';
+      effectiveStatus = {
+        ...effectiveStatus,
+        status: modified ? 'limited' : 'explicitly_overruled',
+        superseded_note: modified
+          ? 'Рішення змінено вищою інстанцією (див. citation_graph.superseded_by).'
+          : 'Рішення скасовано вищою інстанцією (див. citation_graph.superseded_by).',
       };
     }
 
@@ -348,7 +397,7 @@ export class MCPQueryAPI extends BaseToolHandler {
       {
         name: 'check_precedent_status',
         annotations: { title: 'Статус прецеденту', readOnlyHint: true, idempotentHint: true },
-        description: `Перевіряє актуальність судового рішення: чи не скасовано вищою інстанцією. Реконструює ланцюг інстанцій з локального реєстру ЄДРСР (перша → апеляція → касація → ВП) і визначає статус: valid, explicitly_overruled, limited, unknown. Додатково враховує відступ від правової позиції Великою Палатою (граф цитувань Neo4j).
+        description: `Перевіряє актуальність судового рішення: чи не скасовано вищою інстанцією. Реконструює ланцюг інстанцій з локального реєстру ЄДРСР (перша → апеляція → касація → ВП) і визначає статус: valid, explicitly_overruled, limited, unknown. Для конкретного doc_id перевіряє граф інстанцій (SUPERSEDED_BY): чи скасовано/змінено це рішення вищою інстанцією та яким рішенням. Додатково враховує відступ від правової позиції Великою Палатою (граф цитувань Neo4j).
 
 Приймає: case_number (номер справи, наприклад 922/989/18) або doc_id (ЄДРСР doc_id).
 

--- a/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
+++ b/mcp_backend/src/services/__tests__/citation-graph-service.test.ts
@@ -192,6 +192,45 @@ describe('CitationGraphService', () => {
     });
   });
 
+  describe('getDecisionSupersession (instance-status layer, LEXAI-1861)', () => {
+    it('reports an overruled decision with its superseding decision', async () => {
+      mockRun.mockResolvedValueOnce({
+        records: [
+          rec({ status: 'overruled', sup: { docId: '137945904', disposition: 'reversed', on: '2025-06-01' } }),
+        ],
+      });
+      const out = await new CitationGraphService().getDecisionSupersession('131667638');
+      expect(out).toEqual({
+        status: 'overruled',
+        supersededBy: { docId: '137945904', disposition: 'reversed', on: '2025-06-01' },
+      });
+      // doc_id is coerced to string for the Decision key lookup
+      expect(mockRun.mock.calls[0][1]).toMatchObject({ docId: '131667638' });
+      // matches the loaded graph schema: Decision.doc_id + SUPERSEDED_BY + Decision.status
+      const q = mockRun.mock.calls[0][0] as string;
+      expect(q).toContain('Decision {doc_id: $docId}');
+      expect(q).toContain('[r:SUPERSEDED_BY]->');
+      expect(q).toContain('d.status AS status');
+    });
+
+    it('returns null marks for a decision that exists but is good law', async () => {
+      mockRun.mockResolvedValueOnce({ records: [rec({ status: null, sup: null })] });
+      const out = await new CitationGraphService().getDecisionSupersession('999');
+      expect(out).toEqual({ status: null, supersededBy: null });
+    });
+
+    it('flags a dissent (окрема думка) with no supersession', async () => {
+      mockRun.mockResolvedValueOnce({ records: [rec({ status: 'dissent', sup: null })] });
+      const out = await new CitationGraphService().getDecisionSupersession('42');
+      expect(out).toEqual({ status: 'dissent', supersededBy: null });
+    });
+
+    it('returns null when the doc_id is not a node in the graph', async () => {
+      mockRun.mockResolvedValueOnce({ records: [] });
+      expect(await new CitationGraphService().getDecisionSupersession('0')).toBeNull();
+    });
+  });
+
   describe('healthCheck', () => {
     it('returns ok with node-label counts', async () => {
       mockRun.mockResolvedValueOnce({

--- a/mcp_backend/src/services/citation-graph-service.ts
+++ b/mcp_backend/src/services/citation-graph-service.ts
@@ -82,6 +82,17 @@ export interface CaseStat {
   departedOn: string | null;
 }
 
+/**
+ * Instance-status layer (LEXAI-1861): whether a specific decision was overruled/modified
+ * by a higher court, or is a dissent (окрема думка).
+ */
+export interface DecisionSupersession {
+  /** Decision.status: 'overruled' | 'dissent' | null (null = no mark = good law / not covered). */
+  status: string | null;
+  /** The higher-court decision that reversed/modified it, via SUPERSEDED_BY; null if none. */
+  supersededBy: { docId: string; disposition: string | null; on: string | null } | null;
+}
+
 /** A case cited by a decision (precedent outbound). */
 export interface CitedCaseRef {
   causeNum: string;
@@ -315,6 +326,36 @@ export class CitationGraphService {
         departedByDecision: r.get('depBy') != null ? String(r.get('depBy')) : null,
         departedOn: r.get('depOn') != null ? String(r.get('depOn')) : null,
       })
+    );
+    return rows[0] ?? null;
+  }
+
+  /**
+   * Instance-status (LEXAI-1861): whether a specific decision was overruled/modified by a
+   * higher court (SUPERSEDED_BY) or is a dissent. Returns null when the doc_id is not a
+   * node in the graph; {status:null, supersededBy:null} when it exists but carries no mark.
+   */
+  async getDecisionSupersession(docId: string | number): Promise<DecisionSupersession | null> {
+    const rows = await this.run(
+      `MATCH (d:Decision {doc_id: $docId})
+       OPTIONAL MATCH (d)-[r:SUPERSEDED_BY]->(s:Decision)
+       RETURN d.status AS status,
+              head(collect(CASE WHEN s IS NULL THEN null
+                ELSE {docId: s.doc_id, disposition: r.disposition, on: r.reversed_date} END)) AS sup`,
+      { docId: String(docId) },
+      (r) => {
+        const sup = r.get('sup');
+        return {
+          status: r.get('status') != null ? String(r.get('status')) : null,
+          supersededBy: sup
+            ? {
+                docId: String(sup.docId),
+                disposition: sup.disposition != null ? String(sup.disposition) : null,
+                on: sup.on != null ? String(sup.on) : null,
+              }
+            : null,
+        };
+      }
     );
     return rows[0] ?? null;
   }


### PR DESCRIPTION
## What

Wires the new **instance-status layer** (`SUPERSEDED_BY` + `Decision.status`, LEXAI-1861, already live in prod `neo4j-citation`) into the existing `check_precedent_status` tool. For a `doc_id`, the tool now reports whether that specific decision was **overruled/modified by a higher court** and by which decision, and downgrades the top-level status:
- reversed → `explicitly_overruled`
- modified → `limited`
- dissent (окрема думка) → surfaced as `citation_graph.is_dissent`

This is the direct answer to *"чи не скасовано це рішення вищою інстанцією"* for a concrete decision.

## Scope: monorepo-only

- `CitationGraphService` is fully in the monorepo (not proprietary) — added `getDecisionSupersession(docId)`.
- `check_precedent_status` is **already** in secondlayer-core's `FIXED_V2_TOOLS`, so **V2 chat picks this up with no core change**.
- Enrichment is best-effort / non-fatal, gated by `CITATION_BACKEND=neo4j`. The PG shepardization (core) remains the authoritative validity check; the graph override only fires on the hard SUPERSEDED_BY fact.

## Changes

- `mcp_backend/src/services/citation-graph-service.ts` — `getDecisionSupersession()` + `DecisionSupersession` interface (matches `Decision {doc_id}` string key + `SUPERSEDED_BY` + `Decision.status`).
- `mcp_backend/src/api/mcp-query-api.ts` — doc_id detection, `citation_graph.superseded_by` enrichment, top-level status downgrade.
- Tests: +4 unit tests (27 pass, neo4j-driver mocked).

## Verification

- `npx jest citation-graph-service.test.ts` → 27/27 pass.
- Post-deploy: `check_precedent_status {doc_id:"131667638"}` should return `explicitly_overruled` + `superseded_by.by_decision:"137945904"` (known overruled node).

Tracked in LEXAI-1861.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the instance-status graph layer (SUPERSEDED_BY + Decision.status) into `check_precedent_status` to show if a specific `doc_id` was reversed/modified and by which decision. Fulfills LEXAI-1861 and downgrades the top-level status accordingly; also flags dissents.

- **New Features**
  - Added `CitationGraphService.getDecisionSupersession(docId)` returning `status` and `supersededBy { docId, disposition, on }`.
  - Enriched `citation_graph.superseded_by` and `citation_graph.is_dissent` when `CITATION_BACKEND=neo4j`.
  - Adjusted effective status: reversed → `explicitly_overruled`, modified → `limited` (does not weaken an existing `explicitly_overruled`).
  - Auto-detects numeric `doc_id` from `case_id`; +4 unit tests (Neo4j mocked).

- **Migration**
  - No changes required in core. Available when `CITATION_BACKEND=neo4j` is enabled; the tool is already in `FIXED_V2_TOOLS`.

<sup>Written for commit 9e192943bc338baea32596d8e508b9b19045be70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

