### PR TITLE
Deprecate get_similar_reasoning (queried empty legal_sections)

### DIFF
--- a/lexwebapp/src/hooks/chat/evidence/court.ts
+++ b/lexwebapp/src/hooks/chat/evidence/court.ts
@@ -43,7 +43,6 @@ const COURT_TOOLS = [
   'check_precedent_status',
   'analyze_case_pattern',
   'analyze_legal_patterns', // backward-compat alias
-  'get_similar_reasoning',
   'get_citation_graph',
   'get_case_text',
   'search_court_decisions',

--- a/lexwebapp/src/hooks/chat/tool-categories.ts
+++ b/lexwebapp/src/hooks/chat/tool-categories.ts
@@ -32,7 +32,6 @@ export const TOOL_CATEGORIES: ToolCategory[] = [
     label: 'Аналіз',
     tools: [
       { name: 'analyze_case_pattern', label: 'Аналіз патерну' },
-      { name: 'get_similar_reasoning', label: 'Схоже обґрунтування' },
       { name: 'get_citation_graph', label: 'Граф цитувань' },
       { name: 'check_precedent_status', label: 'Статус прецеденту' },
     ],

--- a/lexwebapp/src/hooks/chat/tool-labels.ts
+++ b/lexwebapp/src/hooks/chat/tool-labels.ts
@@ -14,7 +14,6 @@ export const TOOL_LABELS: Record<string, string> = {
   count_cases_by_party: 'Справи сторони',
   get_case_text: 'Текст справи',
   analyze_case_pattern: 'Аналіз паттернів',
-  get_similar_reasoning: 'Схоже обґрунтування',
   get_citation_graph: 'Граф цитувань',
   check_precedent_status: 'Статус прецеденту',
   load_full_texts: 'Повні тексти рішень',

--- a/mcp_backend/src/api/__tests__/all-tools-integration.test.ts
+++ b/mcp_backend/src/api/__tests__/all-tools-integration.test.ts
@@ -130,15 +130,6 @@ describe('SecondLayer MCP Tools - Integration Tests', () => {
       expect(result).toBeDefined();
     }, 30000);
 
-    test('get_similar_reasoning - should find similar reasoning', async () => {
-      const result = await callTool('get_similar_reasoning', {
-        query: 'Позивач не довів факт порушення своїх прав',
-        limit: 5,
-      });
-
-      expect(result).toBeDefined();
-    }, 30000);
-
     test('search_supreme_court_practice - should find Supreme Court cases', async () => {
       const result = await callTool('search_supreme_court_practice', {
         procedure_code: 'cpc',

--- a/mcp_backend/src/api/tools/legal-advice-tools.ts
+++ b/mcp_backend/src/api/tools/legal-advice-tools.ts
@@ -1,11 +1,16 @@
 /**
  * Legal Advice Tools - Handlers for precedent search, citation analysis, and answer formatting
  *
- * 4 tools:
+ * 3 tools:
  * - format_answer_pack
  * - search_legal_precedents
- * - get_similar_reasoning
  * - get_citation_graph
+ *
+ * Note: get_similar_reasoning was removed (2026-07). It queried the legacy
+ * Voyage-embedding `legal_sections` collection, which is empty in the current
+ * topology (court data now lives in the BGE-M3 `edrsr_decisions` collection).
+ * Its capability is covered by search_court_decisions (semantic) and
+ * search_legal_precedents.
  */
 
 import { load } from 'cheerio';
@@ -167,33 +172,6 @@ export class LegalAdviceTools extends BaseToolHandler {
         },
       },
       {
-        name: 'get_similar_reasoning',
-        annotations: { title: 'Схожі обґрунтування', readOnlyHint: true },
-        description: `Пошук схожих судових обґрунтувань за векторною подібністю
-
-Векторний пошук по ембедінгах через Qdrant. Знаходить рішення зі схожою аргументацією суду.
-Використовуйте для пошуку рішень, де суд використав аналогічну логіку обґрунтування.
-Підтримує фільтри: дата, суд, палата, категорія спору, результат.`,
-        inputSchema: {
-          type: 'object',
-          properties: {
-            query: { type: 'string' },
-            section_type: { type: 'string', enum: Object.values(SectionType) },
-            date_from: { type: 'string', description: 'YYYY-MM-DD' },
-            date_to: { type: 'string', description: 'YYYY-MM-DD' },
-            court: { type: 'string' },
-            chamber: { type: 'string' },
-            dispute_category: { type: 'string' },
-            outcome: { type: 'string' },
-            deviation_flag: { type: ['boolean', 'null'] },
-            precedent_status: { type: 'string' },
-            case_number: { type: 'string' },
-            limit: { type: 'number', default: 10 },
-          },
-          required: ['query'],
-        },
-      },
-      {
         name: 'get_citation_graph',
         annotations: { title: 'Граф цитувань', readOnlyHint: true, idempotentHint: true },
         description: `Граф цитувань судового рішення: на які НОРМИ/СТАТТІ законодавства воно посилається (decision→article).
@@ -220,8 +198,6 @@ export class LegalAdviceTools extends BaseToolHandler {
       case 'search_legal_precedents':
       case 'search_supreme_court_practice': // backward-compat alias
         return await this.searchLegalPrecedents(args);
-      case 'get_similar_reasoning':
-        return await this.getSimilarReasoning(args);
       case 'get_citation_graph':
         return await this.getCitationGraph(args);
       default:
@@ -239,35 +215,6 @@ export class LegalAdviceTools extends BaseToolHandler {
       risks: args.risks || args.counterarguments_and_risks || null,
       warning: 'format_answer_pack currently performs a structural packaging only.',
     });
-  }
-
-  private async getSimilarReasoning(args: any): Promise<ToolResult> {
-    const defaultDateFrom = (() => {
-      const d = new Date();
-      d.setFullYear(d.getFullYear() - 3);
-      return d.toISOString().slice(0, 10);
-    })();
-    const defaultSupremeCourtChambers = ['ВП ВС', 'КЦС', 'КГС', 'КАС', 'ККС'];
-
-    const queryEmbedding = await this.embeddingService.generateEmbedding(args.query);
-    const similar = await this.embeddingService.searchSimilar(
-      queryEmbedding,
-      {
-        section_type: args.section_type as SectionType,
-        date_from: args.date_from || defaultDateFrom,
-        date_to: args.date_to,
-        court: args.court,
-        chamber: args.chamber || defaultSupremeCourtChambers,
-        dispute_category: args.dispute_category,
-        outcome: args.outcome,
-        deviation_flag: args.deviation_flag,
-        precedent_status: args.precedent_status,
-        case_number: args.case_number,
-      },
-      args.limit || 10
-    );
-
-    return this.wrapResponse({ similar });
   }
 
   /**

--- a/platform/src/utils/tools-data.ts
+++ b/platform/src/utils/tools-data.ts
@@ -83,14 +83,6 @@ export const tools: Tool[] = [
       { name: 'case_ids', type: 'string[]', required: false, description: 'ID справ для аналізу' },
     ],
   },
-  { name: 'get_similar_reasoning', category: 'Analysis', description: 'Подібні судові обґрунтування за векторною схожістю', cost: '$0.01–$0.03',
-    params: [
-      { name: 'query', type: 'string', required: true, description: 'Текст обґрунтування' },
-      { name: 'section_type', type: 'string', required: false, description: 'Тип секції' },
-      { name: 'date_from', type: 'string', required: false, description: 'Дата від' },
-      { name: 'date_to', type: 'string', required: false, description: 'Дата до' },
-    ],
-  },
   { name: 'get_citation_graph', category: 'Analysis', description: 'Граф цитувань між справами', cost: '$0.005–$0.02',
     params: [
       { name: 'case_id', type: 'string', required: true, description: 'ID справи' },


### PR DESCRIPTION
## Summary

`get_similar_reasoning` searched the legacy **Voyage**-embedding `legal_sections` Qdrant collection, which is **empty (0 points)** in the current prod topology — verified on both the EC2 vector node (`172.31.21.244:6333`) and the Brev source. Court reasoning now lives in the **BGE-M3** `edrsr_decisions` collection (a different vector space, so a plain repoint won't work). The tool therefore silently returned nothing on every call.

Its capability is already covered by `search_court_decisions` (semantic mode) + `search_legal_precedents`, so we remove the tool rather than reimplement it.

## Changes
- **mcp_backend**: remove `get_similar_reasoning` tool schema, `executeTool` switch case, `getSimilarReasoning()` handler, and its integration test.
- **lexwebapp**: remove the tool from chat categories, labels, and the court evidence map.
- **platform**: remove the tool from the tools catalog.
- Leaves the generic `EmbeddingService.searchSimilar` port method in place (no live caller now; deliberately out of scope).

## Verification
- Backend `tsc --noEmit`: no new errors (only the 3 known core-overlay false positives in `core-loader.ts`; the `session-replay-service.ts` error is a pre-existing unrelated local change, not part of this PR).
- Grep confirms no remaining code references (only historical blog-article prose left untouched).

## Context
Found during a prod vector-DB evaluation. Related follow-ups: LEXAI-1862 (EDRSR HA/backup), LEXAI-1864 (grey/segment merge, running on Brev), LEXAI-1865 (rescore eval), LEXAI-1866 (doc drift).

Refs LEXAI-1863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `get_similar_reasoning` tool, which queried the empty legacy `legal_sections` collection in prod. The same need is met by `search_court_decisions` (semantic) and `search_legal_precedents`, aligning with LEXAI-1863.

- **Refactors**
  - mcp_backend: removed tool schema, switch case, handler, and its integration test.
  - lexwebapp: removed from chat categories, labels, and court evidence map.
  - platform: removed from tools catalog.
  - Kept `EmbeddingService.searchSimilar` port for future use (no live callers).

<sup>Written for commit bffc33d7b6a8dff3436232252b6101be7dd16800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

