### PR TITLE
fix(mcp): bill /api/v2/mcp tool calls like chat (usage-based from ₴/$ balance)

### DIFF
--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -420,6 +420,7 @@ class HTTPMCPServer {
       apiKeyService: this.billing.apiKeyService,
       costTracker: this.billing.costTracker,
       creditService: this.billing.creditService,
+      billingService: this.billing.billingService,
       mcpSseSessions: this.mcpSseSessions,
     }));
 

--- a/mcp_backend/src/routes/mcp-sse-routes.ts
+++ b/mcp_backend/src/routes/mcp-sse-routes.ts
@@ -23,6 +23,7 @@ import { OAuthService } from '../services/oauth-service.js';
 import { ApiKeyService } from '../services/api-key-service.js';
 import { CostTracker } from '../services/cost-tracker.js';
 import { CreditService } from '../services/credit-service.js';
+import { BillingService } from '../services/billing-service.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -36,6 +37,7 @@ export function createMCPSSERoutes(deps: {
   apiKeyService: ApiKeyService;
   costTracker: CostTracker;
   creditService: CreditService;
+  billingService: BillingService;
   mcpSseSessions: Map<string, SSEServerTransport>;
 }): Router {
   const router = Router();
@@ -154,7 +156,7 @@ export function createMCPSSERoutes(deps: {
   function buildMcpServer(
     userId: string | undefined,
     clientKey: string | undefined,
-    opts?: { allowedTools?: Set<string>; version?: string }
+    opts?: { allowedTools?: Set<string>; version?: string; usageBilling?: boolean }
   ): Server {
     const safeUserId = sanitizeId(userId || 'anonymous');
     const mcpServer = new Server(
@@ -202,17 +204,46 @@ export function createMCPSSERoutes(deps: {
           };
         }
 
-        // Phase 2 Billing: Check credits BEFORE execution
-        if (userId && deps.creditService) {
-          const creditsRequired = await deps.creditService.calculateCreditsForTool(toolName, userId);
-          if (creditsRequired > 0) {
-            const balance = await deps.creditService.checkBalance(userId, creditsRequired);
-            if (!balance.hasCredits) {
-              logger.warn('[MCP] Insufficient credits', { userId: safeUserId, tool: toolName, creditsRequired });
-              return {
-                content: [{ type: 'text', text: `Error: Insufficient credits. Required: ${creditsRequired}, Current balance: ${balance.currentBalance}` }],
-                isError: true,
-              };
+        // Billing gate BEFORE execution.
+        //  • usageBilling (v2): charge the ₴/$ balance (user_billing) by actual cost + tier
+        //    markup, exactly like the chat pipeline. Pre-flight checks the same balance; the
+        //    charge itself happens in costTracker.completeTrackingRecord → billingService.chargeUser.
+        //  • legacy (v1): flat per-call deduction from the separate user_credits pool.
+        if (userId) {
+          if (opts?.usageBilling && deps.billingService) {
+            try {
+              const billing = await deps.billingService.getOrCreateUserBilling(userId);
+              if (billing.billing_enabled) {
+                const estimate = await deps.costTracker.estimateCost({
+                  toolName,
+                  queryLength: JSON.stringify(args).length,
+                  reasoningBudget: 'quick',
+                });
+                const estimatedCostUsd = estimate.total_estimated_cost_usd;
+                const balance = await deps.billingService.checkBalance(userId, estimatedCostUsd);
+                if (!balance.hasBalance) {
+                  logger.warn('[MCP] Insufficient balance', { userId: safeUserId, tool: toolName, estimatedCostUsd });
+                  return {
+                    content: [{ type: 'text', text: `Error: Insufficient balance. Required: $${estimatedCostUsd.toFixed(2)}, Current balance: $${balance.currentBalance.toFixed(2)}` }],
+                    isError: true,
+                  };
+                }
+              }
+            } catch (billingErr: any) {
+              // Never let a billing-estimate hiccup block a (near-zero-cost) tool call.
+              logger.warn('[MCP] Pre-flight balance check failed, allowing call', { userId: safeUserId, tool: toolName, error: billingErr.message });
+            }
+          } else if (deps.creditService) {
+            const creditsRequired = await deps.creditService.calculateCreditsForTool(toolName, userId);
+            if (creditsRequired > 0) {
+              const balance = await deps.creditService.checkBalance(userId, creditsRequired);
+              if (!balance.hasCredits) {
+                logger.warn('[MCP] Insufficient credits', { userId: safeUserId, tool: toolName, creditsRequired });
+                return {
+                  content: [{ type: 'text', text: `Error: Insufficient credits. Required: ${creditsRequired}, Current balance: ${balance.currentBalance}` }],
+                  isError: true,
+                };
+              }
             }
           }
         }
@@ -243,7 +274,9 @@ export function createMCPSSERoutes(deps: {
         const executionTime = Date.now() - startTime;
         await deps.costTracker.completeTrackingRecord({ requestId, executionTimeMs: executionTime, status: 'completed' });
 
-        if (userId && deps.creditService) {
+        // Legacy flat-credit deduction (v1 only). v2 (usageBilling) is already charged against
+        // the ₴/$ balance by costTracker.completeTrackingRecord → billingService.chargeUser above.
+        if (userId && !opts?.usageBilling && deps.creditService) {
           const creditsRequired = await deps.creditService.calculateCreditsForTool(toolName, userId);
           if (creditsRequired > 0) {
             const deduction = await deps.creditService.deductCredits(userId, creditsRequired, toolName, requestId, `Tool execution: ${toolName}`);
@@ -282,7 +315,7 @@ export function createMCPSSERoutes(deps: {
   // Build an MCP Server exposing only the curated v2 subset. Reuses the fully-wired v1
   // builder (tools/list + tools/call with billing) with the whitelist applied.
   function buildMcpServerV2(userId: string | undefined, clientKey: string | undefined): Server {
-    return buildMcpServer(userId, clientKey, { allowedTools: V2_TOOL_NAMES, version: '2.0.0' });
+    return buildMcpServer(userId, clientKey, { allowedTools: V2_TOOL_NAMES, version: '2.0.0', usageBilling: true });
   }
 
   // ========================= /sse endpoints =========================


### PR DESCRIPTION
## Problem

MCP **v2** (`/api/v2/mcp`) tool calls were gated and charged against the separate `user_credits` pool (flat **1 credit/call**). Top-ups to the ₴/$ `user_billing` balance never fill that pool, so a user with a funded balance still got:

> `Insufficient credits. Required: 1, Current balance: 0.00`

(reported by a paying client with 319.96 ₴ / $7.15 on balance but 0 credits).

## Fix

Switch `buildMcpServerV2` to **usage billing** (new `usageBilling` flag on `buildMcpServer`):

- **Pre-flight**: check the `user_billing` balance (`getOrCreateUserBilling` → `estimateCost` → `checkBalance`) — exactly like the chat pipeline. A billing-estimate hiccup never blocks a (near-zero-cost) tool call.
- **Charge**: handled by the cost tracker's existing `completeTrackingRecord → billingService.chargeUser` (actual API cost + tier markup), same mechanism as `ai_chat`.
- The flat `deductCredits` step is **skipped for v2**.
- **v1** and the legacy `/sse` transport keep the credit-pool behavior unchanged.

Net effect: v2 bills 1:1 like chat, drawing from the ₴/$ balance. Raw tool calls cost their true API cost (e.g. `search_court_decisions` ≈ \$0.005), so a funded balance covers MCP without a separate credit pool.

## Files
- `mcp_backend/src/routes/mcp-sse-routes.ts` — `usageBilling` branch + v2 opt-in
- `mcp_backend/src/http-server.ts` — thread `billingService` into `createMCPSSERoutes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bill `/api/v2/mcp` tool calls from the ₴/$ `user_billing` balance with usage-based pricing (same as chat) to fix “Insufficient credits” errors for funded users. v1 and legacy `/sse` keep flat credit billing.

- **Bug Fixes**
  - Added `usageBilling` option to `buildMcpServer` and enabled it for `buildMcpServerV2`.
  - Pre-flight checks `user_billing` via `billingService.getOrCreateUserBilling` → `costTracker.estimateCost` → `billingService.checkBalance`; hiccups don’t block calls.
  - Charges run on `costTracker.completeTrackingRecord` → `billingService.chargeUser`; skip `creditService.deductCredits` for v2.
  - Wired `billingService` into `createMCPSSERoutes`; preserved credit-pool logic for v1.

<sup>Written for commit ac8205da59f857aed91616a28b22769253439012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

