### PR TITLE
fix(spain-tools): use safe_ts_headline so one bad row cannot kill the query

### DIFF
--- a/mcp_backend/src/api/tools/spain-legal-tools.ts
+++ b/mcp_backend/src/api/tools/spain-legal-tools.ts
@@ -230,7 +230,7 @@ Util para analizar tendencias en la aplicacion del RGPD en Espana.`,
           estado_consolidacion,
           url_eli,
           url_html,
-          ts_headline('spanish', coalesce(full_text, ''), to_tsquery('spanish', $1),
+          safe_ts_headline('spanish'::regconfig, coalesce(full_text, ''), to_tsquery('spanish', $1),
             'MaxWords=60, MinWords=30, StartSel=<<, StopSel=>>') AS snippet
         FROM spain_boe_legislation
         WHERE ${whereClause}
@@ -378,7 +378,7 @@ Util para analizar tendencias en la aplicacion del RGPD en Espana.`,
           conceptos,
           articulos_infringidos,
           pdf_url,
-          ts_headline('spanish', coalesce(extracto, ''), to_tsquery('spanish', $1),
+          safe_ts_headline('spanish'::regconfig, coalesce(extracto, ''), to_tsquery('spanish', $1),
             'MaxWords=60, MinWords=30, StartSel=<<, StopSel=>>') AS snippet
         FROM spain_aepd_resolutions
         WHERE ${whereClause}


### PR DESCRIPTION
## What

The two Spanish search tools called `ts_headline()` directly. `ts_headline()` raises `22021 character_not_in_repertoire` when the input text contains a byte sequence it cannot render, and that error aborts the whole statement rather than skipping the offending row, so a single bad record turns the entire tool response into an error.

Migration 099 added `safe_ts_headline()` for exactly this case (PL/pgSQL wrapper that returns NULL for the row instead of failing the statement), and the EDRSR search path already uses it. These two call sites were missed.

- `search_spain_legislation` → `spain_boe_legislation.full_text`
- `search_spain_aepd_resolutions` → `spain_aepd_resolutions.extracto`

## Verification

`safe_ts_headline()` is present on prod (`pg_proc`), and both new expressions were run against the full tables on prod before committing:

- `spain_boe_legislation` — 12,228 rows, no error
- `spain_aepd_resolutions` — 46,098 rows, no error

TypeScript compiles clean for the changed file.

## Context

Found during the 24 Jul prod data audit. Worth recording what the audit did **not** find, since it was reported as a wider problem: the claim that `left()` / `substr()` on `full_text` fails with `invalid byte sequence for encoding "UTF8"` across nine tables did **not** reproduce. Full-table scans of `left(full_text, 4000)` completed with zero errors on `nl_rechtspraak_decisions` (1,111,261), `cz_court_decisions` (871,171), `fr_court_decisions` (718,940), `de_court_decisions` (250,855), `uk_court_decisions` (53,469), `hu_court_decisions` (79,300), `sg_court_decisions` (10,690) and `be_court_decisions` (5,681), plus 200,000 rows of `edrsr_fulltext_p_2025`. `convert_from(convert_to(full_text,'UTF8'),'UTF8')` also validated clean on the samples tested, so the stored bytes are valid UTF-8 and no data repair is needed.

What is real is the `ts_headline` failure mode above, which is why this PR is scoped to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `safe_ts_headline` in the Spanish search tools to prevent a single bad row from aborting the query. Now invalid byte sequences yield a NULL snippet and the rest of the results still load.

- **Bug Fixes**
  - Swapped `ts_headline` for `safe_ts_headline` in `search_spain_legislation` (`spain_boe_legislation.full_text`) and `search_spain_aepd_resolutions` (`spain_aepd_resolutions.extracto`).
  - Verified on prod: both full tables scan without errors (12,228 and 46,098 rows).

<sup>Written for commit 9473f56f394ff63c74c2ba1fb34a3742516011a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

