### PR TITLE
fix(opendata): rate-limit nl_rechtspraak importer, opt-in court scope filter

### DIFF
--- a/services/opendata-importers/importers/nl_rechtspraak.py
+++ b/services/opendata-importers/importers/nl_rechtspraak.py
@@ -26,6 +26,21 @@ from shared.prod_writer import _ssh_cmd  # noqa: E402
 
 ATOM_NS = {"a": "http://www.w3.org/2005/Atom"}
 
+# Court scope filter: comma-separated ECLI court-code segments (e.g.
+# "HR,GHAMS,GHARL,GHDHA,GHSHE" for Hoge Raad + the 4 Gerechtshoven), or unset/"ALL"
+# to disable filtering — default is unset so existing full-coverage behavior is
+# unchanged; this is strictly opt-in for a narrower pilot/test run.
+# ECLI shape is ECLI:NL:<court-code>:<year>:<ordinal>.
+_PILOT_COURTS_ENV = os.environ.get("PILOT_COURTS", "ALL")
+_PILOT_COURTS = None if _PILOT_COURTS_ENV.strip().upper() == "ALL" else set(
+    _PILOT_COURTS_ENV.split(","))
+_ECLI_COURT_RE = re.compile(r"^ECLI:NL:([A-Z]+):")
+
+
+def _ecli_court(ecli: str) -> str | None:
+    m = _ECLI_COURT_RE.match(ecli)
+    return m.group(1) if m else None
+
 
 class NLRechtspraakImporter(BaseImporter):
     SERVICE_NAME = "nl_rechtspraak"
@@ -36,6 +51,9 @@ class NLRechtspraakImporter(BaseImporter):
     PK_COLUMNS = ["ecli"]
     ON_CONFLICT = "do_nothing"
     BATCH_SIZE = 500
+    # data.rechtspraak.nl documents a 10 req/sec fair-use cap; stay under it with margin
+    # (measured: 4 workers alone already hit 11.7 req/s on this fast API).
+    RATE_LIMIT_PER_SEC = 8.0
 
     SEARCH_URL = "https://data.rechtspraak.nl/uitspraken/zoeken"
     CONTENT_URL = "https://data.rechtspraak.nl/uitspraken/content"
@@ -135,12 +153,17 @@ class NLRechtspraakImporter(BaseImporter):
         }
 
     async def import_dataset(self, pool: MultiIPSessionPool):
-        max_date_str = self._get_max_date_on_prod()
-        self.log.info(f"Max decision_date on prod: {max_date_str}")
-        try:
-            start_day = date.fromisoformat(max_date_str)
-        except ValueError:
-            start_day = date(2000, 1, 1)
+        start_date_override = os.environ.get("START_DATE")
+        if start_date_override:
+            start_day = date.fromisoformat(start_date_override)
+            self.log.info(f"START_DATE override: starting from {start_day}")
+        else:
+            max_date_str = self._get_max_date_on_prod()
+            self.log.info(f"Max decision_date on prod: {max_date_str}")
+            try:
+                start_day = date.fromisoformat(max_date_str)
+            except ValueError:
+                start_day = date(2000, 1, 1)
 
         days_to_walk = int(os.environ.get("WALK_DAYS", "30"))
         end_day = start_day + timedelta(days=days_to_walk)
@@ -166,6 +189,12 @@ class NLRechtspraakImporter(BaseImporter):
             for sub in results:
                 eclis.extend(sub)
             self.log.info(f"  listed {chunk_start+len(chunk)}/{len(days)} days, {len(eclis)} ECLIs found so far")
+
+        if _PILOT_COURTS is not None:
+            eclis = [e for e in eclis if _ecli_court(e) in _PILOT_COURTS]
+            self.log.info(f"Pilot filter ({sorted(_PILOT_COURTS)}): {len(eclis)} ECLIs remain")
+        else:
+            self.log.info(f"PILOT_COURTS=ALL — no court filter, {len(eclis)} ECLIs")
 
         seen = self.ckpt.done_set
         new_eclis = [e for e in eclis if e not in seen]

--- a/services/opendata-importers/shared/base.py
+++ b/services/opendata-importers/shared/base.py
@@ -47,6 +47,7 @@ class BaseImporter(ABC):
     ON_CONFLICT = "do_nothing"       # or "do_update"
     BATCH_SIZE = 500                 # rows per COPY batch
     USER_AGENT: str | None = None    # override to bypass Cloudflare/UA filters
+    RATE_LIMIT_PER_SEC: float | None = None  # override: hard cap, source-documented
 
     def __init__(self):
         self.log = logging.getLogger(self.SERVICE_NAME)
@@ -96,6 +97,8 @@ class BaseImporter(ABC):
         pool_kwargs = {}
         if self.USER_AGENT:
             pool_kwargs["user_agent"] = self.USER_AGENT
+        if self.RATE_LIMIT_PER_SEC:
+            pool_kwargs["rate_limit_per_sec"] = self.RATE_LIMIT_PER_SEC
         async with MultiIPSessionPool(ips, self.workers_per_ip, **pool_kwargs) as pool:
             self.log.info(f"Total concurrent workers: {pool.total_workers}")
             self.log.info(f"Target: {self.ssh_host}/{self.container}/{self.dbname}/{self.TARGET_TABLE}")

--- a/services/opendata-importers/shared/http_client.py
+++ b/services/opendata-importers/shared/http_client.py
@@ -1,6 +1,8 @@
 """Multi-IP aiohttp connector pool with round-robin scheduling."""
 import asyncio
 import logging
+import time
+from collections import deque
 
 import aiohttp
 
@@ -10,11 +12,38 @@ log = logging.getLogger(__name__)
 DEFAULT_UA = "SecondLayer-Legal-Platform/2.0 (legal.org.ua; opendata-importer)"
 
 
+class RateLimiter:
+    """Sliding-window limiter: at most `max_per_sec` acquire()s complete per rolling
+    second, enforced across ALL callers regardless of how many workers/IPs share it.
+
+    Use this instead of guessing a "safe" worker count — low per-request latency can
+    push a fixed-concurrency pool's real throughput above a documented limit even when
+    the worker count looks conservative.
+    """
+
+    def __init__(self, max_per_sec: float):
+        self.max_per_sec = max_per_sec
+        self._times: deque[float] = deque()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self):
+        async with self._lock:
+            while True:
+                now = time.monotonic()
+                while self._times and now - self._times[0] > 1.0:
+                    self._times.popleft()
+                if len(self._times) < self.max_per_sec:
+                    self._times.append(now)
+                    return
+                sleep_for = 1.0 - (now - self._times[0])
+                await asyncio.sleep(max(sleep_for, 0.01))
+
+
 class MultiIPSessionPool:
     """One aiohttp session per source IP, round-robin handed out by index."""
 
     def __init__(self, ips: list[str], workers_per_ip: int, user_agent: str = DEFAULT_UA,
-                 timeout_total: int = 120):
+                 timeout_total: int = 120, rate_limit_per_sec: float | None = None):
         if not ips:
             ips = [""]  # empty string = system default routing
         self.ips = ips
@@ -23,6 +52,7 @@ class MultiIPSessionPool:
         self._sessions: list[aiohttp.ClientSession] = []
         self._semaphores: list[asyncio.Semaphore] = []
         self._workers_per_ip = workers_per_ip
+        self._rate_limiter = RateLimiter(rate_limit_per_sec) if rate_limit_per_sec else None
 
     async def __aenter__(self):
         for ip in self.ips:
@@ -57,6 +87,8 @@ class MultiIPSessionPool:
         last_exc = None
         async with sem:
             for attempt in range(retries):
+                if self._rate_limiter:
+                    await self._rate_limiter.acquire()
                 try:
                     async with session.get(url, **kwargs) as r:
                         return r.status, await r.text()
@@ -72,6 +104,8 @@ class MultiIPSessionPool:
         last_exc = None
         async with sem:
             for attempt in range(retries):
+                if self._rate_limiter:
+                    await self._rate_limiter.acquire()
                 try:
                     async with session.get(url, **kwargs) as r:
                         return r.status, await r.read()


### PR DESCRIPTION
## Summary
- Adds a real sliding-window rate limiter (`shared/http_client.py`) shared across all workers/IPs in a `MultiIPSessionPool`, wired in via an opt-in `RATE_LIMIT_PER_SEC` on `BaseImporter`.
- Enables it for `nl_rechtspraak` at 8 req/sec — `data.rechtspraak.nl` documents a 10 req/sec fair-use cap, and a plain 4-worker concurrency setting was measured hitting 11.7 req/s during pilot testing (worker count alone doesn't guarantee staying under a documented limit when per-request latency is low).
- Adds an optional ECLI-court-code scope filter (`PILOT_COURTS` env var, default `ALL` — **no behavior change** for existing deployments) for narrowing a run to specific courts (e.g. `HR,GHAMS,GHARL,GHDHA,GHSHE` for Hoge Raad + Gerechtshoven only).
- Adds a `START_DATE` override for `import_dataset()` — useful for a cold-start historical backfill where the existing "resume from `MAX(decision_date)` on target" logic would otherwise start from the year-2000 fallback sentinel.

All three additions are opt-in via env var / class attribute with defaults that preserve current behavior — no change to `docker-compose.opendata.yml` or any deployed target configuration.

## Test plan
- [x] `python3 -m py_compile` on all three changed files
- [x] Ran the importer directly (venv, not via compose) against a scratch Postgres instance with `PILOT_COURTS` set to a 5-court subset and to `ALL`, confirmed the filter includes/excludes correctly
- [x] Confirmed the rate limiter holds steady at the configured cap (measured 7.5-7.7 req/s against an 8/sec limit) across a multi-hour real run against `data.rechtspraak.nl`
- [ ] Not yet verified inside the actual `opendata-importers` Docker image / compose stack (only tested via direct `python3 -m importers.nl_rechtspraak` execution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared sliding-window rate limiter and enables it at 8 req/sec for the `nl_rechtspraak` importer to stay under the 10 req/sec fair-use cap. Also adds opt-in court scoping and a start-date override for targeted pilots and backfills; defaults keep current behavior.

- **New Features**
  - Global RateLimiter in `shared/http_client.py` that caps requests per rolling second across all workers/IPs in `MultiIPSessionPool`.
  - `BaseImporter` now accepts `RATE_LIMIT_PER_SEC`; `nl_rechtspraak` sets it to 8.0.
  - Optional court scope filter via `PILOT_COURTS` (comma-separated ECLI court codes; `ALL` or unset disables filtering).
  - Optional `START_DATE` to start historical runs from a specific day instead of `MAX(decision_date)` fallback.
  - No changes needed to existing configs; all additions are opt-in.

<sup>Written for commit 0ce455baf3228251f0ee6d4c090aa2ef56b6255d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

