### PR TITLE
feat(coliee): BC diagnostics and the Reachability Gain measure

### DIFF
--- a/scripts/coliee/bc_diagnostics.py
+++ b/scripts/coliee/bc_diagnostics.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Tier-0 diagnostics for the Sekiguchi/Yoshioka/Kwan (ICTIR '26) bibliographic-
+coupling evaluation framework.
+
+Three questions, all answerable on the data already in data/coliee/task1/:
+
+  D1  Popularity floor. Yoshioka (email 2026-07-25) suggests that in a densely
+      coupled corpus "simply checking the highly cited cases may be sufficient".
+      We test it literally: rank the pool by in-pool in-degree, ignoring the
+      query entirely, and score that query-independent list under Extended
+      Precision and Coverage. Whatever a constant list scores is the floor the
+      metric hands out for free.
+
+  D2  Head vs tail. Yoshioka's second point: what matters for recall/coverage is
+      reaching the *infrequently* cited cases. We decompose Coverage@k by the
+      citation frequency (in-pool in-degree) of each gold case, so the metric
+      stops averaging the head and the tail together.
+
+  D3  How the BC (Silver) layer grows with pool size. Their §6 limitation is that
+      the analysis is on a 1,870-case subset and that problems "become even more
+      pronounced ... with large-scale databases". We hold queries and gold fixed
+      and sweep the number of distractors, measuring how much of the pool becomes
+      BC-eligible for an average query.
+
+Retrieval side uses BM25 (CPU, no GPU, no model download) so the diagnostics are
+reproducible anywhere; BM25 is already one of the three systems in the
+cross-jurisdictional draft.
+
+Usage:
+    python scripts/coliee/bc_diagnostics.py --corpus ua
+    python scripts/coliee/bc_diagnostics.py --corpus ca
+"""
+
+import argparse
+import json
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from retrieval_experiment import bm25_sims, load_cases  # noqa: E402
+
+DATA = "data/coliee/task1"
+
+CORPORA = {
+    "ua": {
+        "zip": f"{DATA}/ua_case_retrieval.zip",
+        "years_json": f"{DATA}/ua_years.json",
+        "citations_json": f"{DATA}/ua_citations.json",
+    },
+    "ca": {
+        "zip": f"{DATA}/task1_train_files_2026.zip",
+        "years_json": None,
+        "citations_json": None,  # COLIEE: noticed list IS the citation list
+    },
+}
+
+K_VALUES = [1, 3, 5, 10]
+
+
+# ----------------------------------------------------------------- metrics ---
+def ext_p_and_cov(topk, gold, citations):
+    """Sekiguchi et al. Extended Precision and Coverage for one query."""
+    k = len(topk)
+    hit = sum(1 for d in topk if d in gold or gold.intersection(citations.get(d, ())))
+    tset = set(topk)
+    covered = [g for g in gold
+               if g in tset or any(g in citations.get(d, ()) for d in topk)]
+    return hit / k, len(covered) / len(gold), set(covered)
+
+
+def score_ranking(query_ids, ranked, labels, citations, k_values):
+    out = {}
+    for k in k_values:
+        f1s = eps = covs = 0.0
+        n = 0
+        for q in query_ids:
+            gold = set(labels.get(q, []))
+            if not gold:
+                continue
+            topk = ranked[q][:k]
+            hit = sum(1 for c in topk if c in gold)
+            p, r = hit / k, hit / len(gold)
+            f1s += 2 * p * r / (p + r) if (p + r) else 0.0
+            e, c, _ = ext_p_and_cov(topk, gold, citations)
+            eps += e
+            covs += c
+            n += 1
+        out[f"k={k}"] = {"F1": round(f1s / n, 4), "ExtP": round(eps / n, 4),
+                         "Cov": round(covs / n, 4), "queries": n}
+    return out
+
+
+# ------------------------------------------------------------------ D1 ------
+def indegree(case_ids, citations):
+    """In-pool in-degree: how many pool documents cite each case."""
+    pool = set(case_ids)
+    deg = {c: 0 for c in case_ids}
+    for d, cited in citations.items():
+        if d not in pool:
+            continue
+        for g in cited:
+            if g in deg:
+                deg[g] += 1
+    return deg
+
+
+def d1_popularity_floor(case_ids, query_ids, labels, citations, bm25_ranked, seed=42):
+    deg = indegree(case_ids, citations)
+    pop_order = sorted(case_ids, key=lambda c: (-deg[c], c))
+    rng = random.Random(seed)
+    rnd_order = case_ids[:]
+    rng.shuffle(rnd_order)
+
+    def constant_ranking(order):
+        maxk = max(K_VALUES) + 1
+        head = order[:maxk + 1]
+        return {q: [c for c in head if c != q][:maxk] for q in query_ids}
+
+    res = {
+        "popularity_only": score_ranking(query_ids, constant_ranking(pop_order),
+                                         labels, citations, K_VALUES),
+        "random": score_ranking(query_ids, constant_ranking(rnd_order),
+                                labels, citations, K_VALUES),
+        "bm25": score_ranking(query_ids, bm25_ranked, labels, citations, K_VALUES),
+    }
+    res["_indegree"] = {
+        "max": max(deg.values()),
+        "mean": round(sum(deg.values()) / len(deg), 4),
+        "cited_at_least_once": sum(1 for v in deg.values() if v),
+        "pool": len(case_ids),
+        "top10": [(c, deg[c]) for c in pop_order[:10]],
+    }
+    return res
+
+
+# ------------------------------------------------------------------ D2 ------
+BUCKETS = [(0, 0), (1, 1), (2, 3), (4, 9), (10, 10 ** 9)]
+BUCKET_NAMES = ["df=0", "df=1", "df=2-3", "df=4-9", "df>=10"]
+
+
+def bucket_of(df):
+    for i, (lo, hi) in enumerate(BUCKETS):
+        if lo <= df <= hi:
+            return i
+    return len(BUCKETS) - 1
+
+
+def d2_head_vs_tail(case_ids, query_ids, labels, citations, rankings, k=5):
+    """Per-gold reachability at k, bucketed by the gold case's in-pool df."""
+    deg = indegree(case_ids, citations)
+    out = {}
+    for name, ranked in rankings.items():
+        tot = [0] * len(BUCKETS)
+        direct = [0] * len(BUCKETS)
+        viabc = [0] * len(BUCKETS)
+        for q in query_ids:
+            gold = set(labels.get(q, []))
+            if not gold:
+                continue
+            topk = ranked[q][:k]
+            tset = set(topk)
+            for g in gold:
+                b = bucket_of(deg.get(g, 0))
+                tot[b] += 1
+                if g in tset:
+                    direct[b] += 1
+                elif any(g in citations.get(d, ()) for d in topk):
+                    viabc[b] += 1
+        out[name] = [
+            {"bucket": BUCKET_NAMES[i], "gold_instances": tot[i],
+             "share_of_gold": round(tot[i] / max(1, sum(tot)), 4),
+             "direct_rate": round(direct[i] / tot[i], 4) if tot[i] else None,
+             "bc_rate": round(viabc[i] / tot[i], 4) if tot[i] else None,
+             "cov_rate": round((direct[i] + viabc[i]) / tot[i], 4) if tot[i] else None}
+            for i in range(len(BUCKETS))
+        ]
+    return out
+
+
+# ------------------------------------------------------------------ D3 ------
+def d3_bc_layer_growth(case_ids, query_ids, labels, citations, fractions, seed=42):
+    """How the Silver (BC) layer grows with the number of documents whose
+    citation list is known.
+
+    Adding *distractors* to the pool cannot create BC cases: a BC case is by
+    definition a document with a known outgoing citation into the query's gold
+    set. So the quantity that actually governs BC availability is |{d: Cite(d)
+    known}|, which is exactly what COLIEE bounds (Cite(d) exists only for the
+    labelled query cases). We subsample the citing-document set and measure how
+    much of the BC layer becomes visible."""
+    pool = set(case_ids)
+    citing_docs = sorted(d for d in citations if d in pool and citations[d])
+    rng = random.Random(seed)
+    order = citing_docs[:]
+    rng.shuffle(order)
+
+    rows = []
+    for frac in fractions:
+        n_cite = max(1, int(round(frac * len(citing_docs))))
+        visible = set(order[:n_cite])
+        citers = {}
+        for d in visible:
+            for g in citations[d]:
+                citers.setdefault(g, set()).add(d)
+        bc_counts = []
+        q_with_bc = 0
+        for q in query_ids:
+            gold = set(labels.get(q, [])) & pool
+            if not gold:
+                continue
+            bc = set()
+            for g in gold:
+                bc |= citers.get(g, set())
+            bc -= gold
+            bc.discard(q)
+            bc_counts.append(len(bc))
+            q_with_bc += len(bc) > 0
+        n = len(bc_counts)
+        rows.append({
+            "citing_docs_known": n_cite,
+            "pct_of_pool_with_known_cite": round(100 * n_cite / len(pool), 2),
+            "queries_scored": n,
+            "queries_with_bc_pct": round(100 * q_with_bc / n, 2) if n else None,
+            "mean_bc_per_query": round(sum(bc_counts) / n, 3) if n else None,
+        })
+    return rows
+
+
+# ----------------------------------------------------------------- driver ---
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", choices=list(CORPORA), required=True)
+    ap.add_argument("--max-chars", type=int, default=4000)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    cfg = CORPORA[args.corpus]
+    case_ids, texts, years, labels = load_cases(
+        cfg["zip"], None, args.max_chars, cfg["years_json"])
+    query_ids = [q for q in labels if q in texts]
+    if cfg["citations_json"]:
+        citations = {k: set(v) for k, v in json.load(open(cfg["citations_json"])).items()}
+    else:
+        citations = {k: set(v) for k, v in labels.items()}
+    print(f"[{args.corpus}] pool={len(case_ids)} queries={len(query_ids)} "
+          f"citing-docs={len(citations)}", flush=True)
+
+    # BM25 rankings (shared by D1 and D2)
+    print("running BM25 ...", flush=True)
+    import numpy as np
+    sims = bm25_sims(case_ids, texts, query_ids)
+    idx = {c: i for i, c in enumerate(case_ids)}
+    maxk = max(K_VALUES)
+    for i, q in enumerate(query_ids):
+        sims[i, idx[q]] = -1e9
+    part = np.argpartition(-sims, maxk, axis=1)[:, :maxk]
+    order = np.argsort(-np.take_along_axis(sims, part, axis=1), axis=1)
+    top = np.take_along_axis(part, order, axis=1)
+    bm25_ranked = {query_ids[i]: [case_ids[j] for j in top[i]]
+                   for i in range(len(query_ids))}
+    del sims
+
+    deg = indegree(case_ids, citations)
+    pop_order = sorted(case_ids, key=lambda c: (-deg[c], c))
+    pop_ranked = {q: [c for c in pop_order[:maxk + 1] if c != q][:maxk]
+                  for q in query_ids}
+
+    out = {
+        "corpus": args.corpus,
+        "pool": len(case_ids),
+        "queries": len(query_ids),
+        "D1_popularity_floor": d1_popularity_floor(
+            case_ids, query_ids, labels, citations, bm25_ranked),
+        "D2_head_vs_tail_at5": d2_head_vs_tail(
+            case_ids, query_ids, labels, citations,
+            {"bm25": bm25_ranked, "popularity_only": pop_ranked}, k=5),
+        "D3_bc_layer_growth": d3_bc_layer_growth(
+            case_ids, query_ids, labels, citations,
+            fractions=[0.05, 0.1, 0.25, 0.5, 0.75, 1.0]),
+    }
+
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(out, fh, indent=2, ensure_ascii=False)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/bootstrap_ci.py
+++ b/scripts/coliee/bootstrap_ci.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Bootstrap 95% CIs for the retrieval metrics and a UA vs CA significance test,
+from the per-query dumps of retrieval_experiment.py (--per-query-json).
+Stdlib only. Usage: bootstrap_ci.py ca_perq.json ua_perq.json [out.json]"""
+import json
+import random
+import sys
+
+random.seed(42)
+B = 5000
+METRICS = ["f1", "extp", "cov"]
+MODELS = ["bm25", "e5", "bge-m3"]
+
+
+def boot_ci(vals):
+    n = len(vals)
+    ms = sorted(sum(vals[random.randrange(n)] for _ in range(n)) / n for _ in range(B))
+    return sum(vals) / n, ms[int(0.025 * B)], ms[int(0.975 * B)]
+
+
+def boot_diff(a, b):  # mean(a) - mean(b), 95% CI
+    na, nb = len(a), len(b)
+    ds = sorted((sum(a[random.randrange(na)] for _ in range(na)) / na
+                 - sum(b[random.randrange(nb)] for _ in range(nb)) / nb)
+                for _ in range(B))
+    return sum(a) / na - sum(b) / nb, ds[int(0.025 * B)], ds[int(0.975 * B)]
+
+
+ca = json.load(open(sys.argv[1]))["per_query"]
+ua = json.load(open(sys.argv[2]))["per_query"]
+k = json.load(open(sys.argv[1])).get("k", 5)
+out = {"k": k, "ci": {}, "ua_vs_ca": {}}
+
+print(f"=== 95% bootstrap CIs (metric@{k}, B={B}) ===")
+for corpus, data in (("CA", ca), ("UA", ua)):
+    for model in MODELS:
+        if model not in data:
+            continue
+        recs = data[model]
+        for m in METRICS:
+            vals = [r[m] for r in recs if m in r]
+            if not vals:
+                continue
+            mean, lo, hi = boot_ci(vals)
+            out["ci"][f"{corpus}.{model}.{m}"] = [round(mean, 4), round(lo, 4), round(hi, 4)]
+            print(f"  {corpus:2s} {model:7s} {m:4s}@{k}: {mean:.4f}  [{lo:.4f}, {hi:.4f}]")
+
+print(f"\n=== UA vs CA difference of means (metric@{k}, 95% CI; sig = CI excludes 0) ===")
+for model in MODELS:
+    if model not in ua or model not in ca:
+        continue
+    for m in METRICS:
+        a = [r[m] for r in ua[model] if m in r]
+        b = [r[m] for r in ca[model] if m in r]
+        if not a or not b:
+            continue
+        d, lo, hi = boot_diff(a, b)
+        sig = (lo > 0) or (hi < 0)
+        out["ua_vs_ca"][f"{model}.{m}"] = [round(d, 4), round(lo, 4), round(hi, 4), sig]
+        print(f"  {model:7s} {m:4s}: UA-CA = {d:+.4f}  [{lo:+.4f}, {hi:+.4f}]  "
+              f"{'SIGNIFICANT' if sig else 'n.s.'}")
+
+if len(sys.argv) > 3:
+    json.dump(out, open(sys.argv[3], "w"), indent=2)
+    print(f"\nwrote {sys.argv[3]}")

--- a/scripts/coliee/build_canada_citation_graph.py
+++ b/scripts/coliee/build_canada_citation_graph.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+Canadian-side pilot for extending arXiv:2605.17639
+("Temporal Decay of Co-Citation Predictability") to a second jurisdiction
+using the COLIEE 2026 Task 1 (Legal Case Retrieval) corpus.
+
+Given the Task 1 train zip (Canadian Federal Court decisions + a labels JSON
+mapping each query case -> its "noticed"/cited cases), this builds a dated
+case->case citation graph and computes, with the standard library only:
+
+  1. decision-date parsing + coverage
+  2. graph size / out-degree (citations per case)
+  3. citation-age distribution (citing_year - cited_year)
+  4. bibliographic coupling (query cases sharing noticed cases)
+     and co-citation (cases noticed together by a common query)
+  5. a Mann-Kendall trend test on mean citation age per citing-year
+     (the temporal-decay signal the paper measures on the Ukrainian graph)
+
+Dense retrieval (E5 / BGE-M3) + exp recency-weighting is intentionally left
+as a follow-up step (needs GPU + the retrieval eval harness); this script
+produces the graph statistics you can bring to the call.
+
+Usage:
+    python scripts/coliee/build_canada_citation_graph.py \
+        --zip data/coliee/task1/task1_train_files_2026.zip \
+        [--labels task1_train_files_2026/clean_task1_train_labels_2026.json] \
+        [--out data/coliee/task1/ca_graph_stats.json]
+
+No third-party dependencies.
+"""
+
+import argparse
+import json
+import math
+import re
+import statistics
+import sys
+import zipfile
+from collections import Counter, defaultdict
+
+MONTHS = {
+    "january": 1, "february": 2, "march": 3, "april": 4, "may": 5, "june": 6,
+    "july": 7, "august": 8, "september": 9, "october": 10, "november": 11,
+    "december": 12,
+}
+_DATE_RE = re.compile(
+    r"\b(" + "|".join(MONTHS) + r")\s+(\d{1,2}),?\s+((?:19|20)\d{2})\b",
+    re.IGNORECASE,
+)
+_YEAR_RE = re.compile(r"\b((?:19|20)\d{2})\b")
+
+# The Federal Court of Canada was established in 1971; the Task 1 corpus is
+# Federal Court decisions, so any parsed "decision year" before that is a
+# mis-parse (a reviewed-tribunal date, a footnote/statute year, an OCR blob).
+FC_MIN_YEAR = 1971
+
+
+def parse_year(text: str, max_year: int = 2026):
+    """Best-effort decision year from a case text.
+
+    The judgment date is the *latest* real event in the header: a decision
+    cannot post-date itself, and the header often also carries an *earlier*
+    date (the reviewed-tribunal decision, e.g. "the March 2, 2005 decision
+    of the Board"). So among the plausible 'Month DD, YYYY' dates in the
+    header block we take the **maximum** year, clamped to [FC_MIN_YEAR,
+    max_year]. Fall back to the max plausible bare year token.
+    """
+    head = text[:2500]
+    cand = [
+        int(m.group(3)) for m in _DATE_RE.finditer(head)
+        if FC_MIN_YEAR <= int(m.group(3)) <= max_year
+    ]
+    if cand:
+        return max(cand)
+    yrs = [
+        int(y) for y in _YEAR_RE.findall(head)
+        if FC_MIN_YEAR <= int(y) <= max_year
+    ]
+    if yrs:
+        return max(yrs)
+    return None
+
+
+def load_corpus(zip_path: str, labels_arcname: str | None):
+    """Return (years: {case_id -> year}, labels: {query_id -> [noticed_id...]}).
+
+    case_id is the bare file name (e.g. '000378.txt') to match the labels JSON.
+    """
+    years: dict[str, int] = {}
+    labels: dict[str, list[str]] = {}
+
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+
+        # locate the labels JSON if not given explicitly
+        if labels_arcname is None:
+            cand = [n for n in names if n.endswith(".json") and "label" in n.lower()]
+            if not cand:
+                sys.exit("No labels JSON found in the zip; pass --labels explicitly.")
+            labels_arcname = sorted(cand, key=len)[0]
+        with zf.open(labels_arcname) as fh:
+            labels = json.load(fh)
+        print(f"labels file: {labels_arcname}  ({len(labels)} query cases)")
+
+        case_members = [n for n in names if "/cases/" in n and n.endswith(".txt")]
+        for n in case_members:
+            case_id = n.rsplit("/", 1)[-1]
+            with zf.open(n) as fh:
+                text = fh.read().decode("utf-8", errors="replace")
+            y = parse_year(text)
+            if y is not None:
+                years[case_id] = y
+
+        print(f"case files: {len(case_members)}  |  dated: {len(years)} "
+              f"({100.0 * len(years) / max(1, len(case_members)):.1f}%)")
+
+    return years, labels
+
+
+def mann_kendall(series: list[float]):
+    """Two-sided Mann-Kendall trend test (normal approximation with tie
+    correction). Returns dict with S, tau, z, p, trend."""
+    n = len(series)
+    if n < 3:
+        return {"n": n, "trend": "insufficient-data"}
+    s = 0
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            s += (series[j] > series[i]) - (series[j] < series[i])
+
+    # variance with ties
+    ties = Counter(series)
+    tie_term = sum(t * (t - 1) * (2 * t + 5) for t in ties.values())
+    var_s = (n * (n - 1) * (2 * n + 5) - tie_term) / 18.0
+
+    if s > 0:
+        z = (s - 1) / math.sqrt(var_s) if var_s > 0 else 0.0
+    elif s < 0:
+        z = (s + 1) / math.sqrt(var_s) if var_s > 0 else 0.0
+    else:
+        z = 0.0
+
+    p = 2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(z) / math.sqrt(2.0))))
+    denom = 0.5 * n * (n - 1)
+    tau = s / denom if denom else 0.0
+    trend = "no-trend"
+    if p < 0.05:
+        trend = "increasing" if s > 0 else "decreasing"
+    return {"n": n, "S": s, "tau": round(tau, 4), "z": round(z, 3),
+            "p": round(p, 5), "trend": trend}
+
+
+def analyze(years, labels, top_n=15, min_year_n=10):
+    stats: dict = {}
+
+    # ---- graph size + out-degree ----
+    edges = []  # (query_id, noticed_id)
+    out_deg = {}
+    for q, noticed in labels.items():
+        out_deg[q] = len(noticed)
+        for n in noticed:
+            edges.append((q, n))
+    stats["query_cases"] = len(labels)
+    stats["edges"] = len(edges)
+    stats["mean_citations_per_query"] = round(statistics.mean(out_deg.values()), 2) if out_deg else 0
+    stats["median_citations_per_query"] = statistics.median(out_deg.values()) if out_deg else 0
+    stats["max_citations_per_query"] = max(out_deg.values()) if out_deg else 0
+
+    # ---- citation-age distribution (needs both endpoints dated) ----
+    # A valid citation cannot point to a future case, so age >= 0. We keep the
+    # negative fraction only as a residual date-quality flag and compute the
+    # actual age stats on valid (non-negative) edges.
+    ages_all = []
+    for q, n in edges:
+        if q in years and n in years:
+            ages_all.append(years[q] - years[n])
+    ages = [a for a in ages_all if a >= 0]
+    stats["edges_both_dated"] = len(ages_all)
+    stats["edges_valid_age"] = len(ages)
+    if ages_all:
+        stats["citation_age_negative_frac"] = round(
+            sum(a < 0 for a in ages_all) / len(ages_all), 4)  # residual QC flag
+    if ages:
+        stats["citation_age_mean"] = round(statistics.mean(ages), 2)
+        stats["citation_age_median"] = statistics.median(ages)
+        stats["citation_age_p90"] = sorted(ages)[int(0.9 * (len(ages) - 1))]
+        stats["citation_age_hist"] = [
+            {"age": a, "count": c} for a, c in sorted(Counter(ages).items())]
+
+    # ---- bibliographic coupling: query pairs sharing noticed cases ----
+    cited_by = defaultdict(list)  # noticed_id -> [query ...]
+    for q, n in edges:
+        cited_by[n].append(q)
+    coupling = Counter()  # frozenset({q1,q2}) -> shared noticed count
+    for n, qs in cited_by.items():
+        uq = sorted(set(qs))
+        for i in range(len(uq)):
+            for j in range(i + 1, len(uq)):
+                coupling[(uq[i], uq[j])] += 1
+    stats["coupling_pairs"] = len(coupling)
+    if coupling:
+        cvals = list(coupling.values())
+        stats["coupling_strength_mean"] = round(statistics.mean(cvals), 3)
+        stats["coupling_strength_max"] = max(cvals)
+        stats["coupling_strength_hist"] = [
+            {"strength": s, "count": c} for s, c in sorted(Counter(cvals).items())]
+        stats["coupling_top"] = [
+            {"pair": list(p), "shared": s}
+            for p, s in coupling.most_common(top_n)
+        ]
+
+    # ---- co-citation: cases noticed together by a common query ----
+    cocit = Counter()
+    for q, noticed in labels.items():
+        un = sorted(set(noticed))
+        for i in range(len(un)):
+            for j in range(i + 1, len(un)):
+                cocit[(un[i], un[j])] += 1
+    stats["cocitation_pairs"] = len(cocit)
+    if cocit:
+        stats["cocitation_strength_mean"] = round(statistics.mean(cocit.values()), 3)
+        stats["cocitation_strength_max"] = max(cocit.values())
+
+    # ---- most-cited (in-degree) ----
+    indeg = Counter({n: len(qs) for n, qs in cited_by.items()})
+    stats["most_cited"] = [{"case": c, "in_degree": d} for c, d in indeg.most_common(top_n)]
+
+    # ---- temporal-decay signal: mean citation age per citing-year ----
+    # Only valid (age >= 0) edges; only citing-years with >= min_year_n edges
+    # enter the trend series, so the Mann-Kendall test is not driven by
+    # 1-3-sample early years.
+    per_year_ages = defaultdict(list)
+    for q, n in edges:
+        if q in years and n in years and years[q] - years[n] >= 0:
+            per_year_ages[years[q]].append(years[q] - years[n])
+    yearly = sorted(
+        (y, statistics.mean(a), len(a))
+        for y, a in per_year_ages.items() if len(a) >= min_year_n
+    )
+    stats["min_year_n"] = min_year_n
+    stats["mean_age_by_citing_year"] = [
+        {"year": y, "mean_age": round(a, 2), "n": nn} for y, a, nn in yearly
+    ]
+    stats["mann_kendall_mean_age_trend"] = mann_kendall([a for _, a, _ in yearly])
+
+    return stats
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--zip", required=True, help="Task 1 train zip path")
+    ap.add_argument("--labels", default=None,
+                    help="labels arcname inside the zip (auto-detected if omitted)")
+    ap.add_argument("--out", default=None, help="write full stats JSON here")
+    ap.add_argument("--top", type=int, default=15, help="top-N lists to keep")
+    ap.add_argument("--min-year-n", type=int, default=10,
+                    help="min edges in a citing-year for it to enter the trend test")
+    args = ap.parse_args()
+
+    years, labels = load_corpus(args.zip, args.labels)
+    stats = analyze(years, labels, top_n=args.top, min_year_n=args.min_year_n)
+
+    # console summary
+    print("\n===== Canadian citation-graph pilot (COLIEE Task 1) =====")
+    for k in ("query_cases", "edges", "edges_both_dated", "edges_valid_age",
+              "mean_citations_per_query", "median_citations_per_query",
+              "max_citations_per_query", "citation_age_mean", "citation_age_median",
+              "citation_age_p90", "citation_age_negative_frac",
+              "coupling_pairs", "coupling_strength_mean", "coupling_strength_max",
+              "cocitation_pairs", "cocitation_strength_mean", "cocitation_strength_max"):
+        if k in stats:
+            print(f"  {k:32s}: {stats[k]}")
+    mk = stats.get("mann_kendall_mean_age_trend", {})
+    print(f"  {'MK mean-age trend':32s}: {mk}")
+    print("\n  mean citation age by citing-year:")
+    for row in stats.get("mean_age_by_citing_year", []):
+        print(f"    {row['year']}: age={row['mean_age']:5.2f}  (n={row['n']})")
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(stats, fh, indent=2)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/build_ua_case_retrieval_package.py
+++ b/scripts/coliee/build_ua_case_retrieval_package.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+Build a COLIEE-Task-1-format case-retrieval package for the Ukrainian corpus,
+so the SAME dense-retrieval + recency-weighting experiment can be run on UA and
+compared apples-to-apples with the Canadian result.
+
+Gold = non-self, resolved precedent edges from case_citation_links
+(from_doc_id cites the case whose representative decision is latest_doc_id).
+Texts/dates from edrsr_fulltext. Sized to mirror the Canadian corpus
+(~2000 queries, ~7700-decision pool) so GPU cost matches the CA run.
+
+The server is UTF8 but a tiny fraction of full_text rows contain invalid byte
+sequences; text fetches batch-and-bisect so a single bad row is skipped rather
+than aborting the whole pull.
+
+Runs ON prod. Emits, under OUTDIR:
+  ua_case_retrieval.zip   (ua_cases/cases/<doc_id>.txt + clean_ua_case_labels.json)
+  ua_years.json           ({<doc_id>.txt: year})
+
+Usage (on prod):
+    UA_QUERIES=2000 UA_POOL=7708 OUTDIR=/tmp/ua_case_pkg \
+        python3 build_ua_case_retrieval_package.py
+"""
+import json
+import os
+import zipfile
+from collections import defaultdict
+
+import psycopg2
+
+N_QUERIES = int(os.environ.get("UA_QUERIES", "2000"))
+POOL = int(os.environ.get("UA_POOL", "7708"))
+SEED = int(os.environ.get("UA_SEED", "42"))
+MAXCHARS = int(os.environ.get("UA_MAXCHARS", "6000"))
+OUTDIR = os.environ.get("OUTDIR", "/tmp/ua_case_pkg")
+os.makedirs(OUTDIR, exist_ok=True)
+
+conn = psycopg2.connect(host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+                        user=os.environ["POSTGRES_USER"],
+                        password=os.environ["POSTGRES_PASSWORD"],
+                        dbname=os.environ["POSTGRES_DB"])
+cur = conn.cursor()
+cur.execute("SET statement_timeout = '300000'")
+
+
+def fetch_docs(ids):
+    """Return {doc_id: (text, year)} for ids that have text+year, skipping the
+    rare rows with invalid UTF-8 via batch bisection."""
+    out = {}
+
+    def run(batch):
+        cur.execute(
+            "SELECT doc_id, left(full_text, %s), adj_year FROM edrsr_fulltext "
+            "WHERE doc_id = ANY(%s) AND adj_year IS NOT NULL AND full_text IS NOT NULL",
+            (MAXCHARS, batch))
+        for did, txt, yr in cur.fetchall():
+            if txt and txt.strip():
+                out[did] = (txt, int(yr))
+
+    def attempt(batch):
+        if not batch:
+            return
+        try:
+            run(batch)
+        except psycopg2.Error:
+            conn.rollback()
+            if len(batch) == 1:
+                return  # skip the single bad row
+            m = len(batch) // 2
+            attempt(batch[:m])
+            attempt(batch[m:])
+
+    ids = list(ids)
+    for i in range(0, len(ids), 1000):
+        attempt(ids[i:i + 1000])
+    return out
+
+
+# 1. oversample query decisions with >=1 non-self resolved precedent
+cur.execute("""
+    SELECT DISTINCT from_doc_id
+    FROM case_citation_links TABLESAMPLE SYSTEM (0.2) REPEATABLE (%s)
+    WHERE resolved AND NOT is_self_citation AND latest_doc_id IS NOT NULL
+    LIMIT %s
+""", (SEED, N_QUERIES * 3))
+q_cand = [r[0] for r in cur.fetchall()]
+print(f"query candidates sampled: {len(q_cand)}", flush=True)
+
+# 2. gold precedent targets for those queries
+cur.execute("""
+    SELECT from_doc_id, latest_doc_id
+    FROM case_citation_links
+    WHERE from_doc_id = ANY(%s)
+      AND resolved AND NOT is_self_citation AND latest_doc_id IS NOT NULL
+""", (q_cand,))
+gold = defaultdict(set)
+for frm, tgt in cur.fetchall():
+    if tgt != frm:
+        gold[frm].add(tgt)
+
+# 3. texts+years for queries + gold (resilient)
+need = set(gold) | {t for s in gold.values() for t in s}
+docs = fetch_docs(need)
+print(f"docs with text/year (queries+gold): {len(docs)}", flush=True)
+
+# 4. keep queries whose gold survives; trim to N_QUERIES
+queries = {}
+for q, tgts in gold.items():
+    if q not in docs:
+        continue
+    kept = [t for t in tgts if t in docs]
+    if kept:
+        queries[q] = kept
+    if len(queries) >= N_QUERIES:
+        break
+print(f"usable queries: {len(queries)}", flush=True)
+
+pool = set(queries) | {t for ts in queries.values() for t in ts}
+print(f"pool before distractors: {len(pool)}", flush=True)
+
+# 5. distractors: sample candidate ids, then resilient text fetch
+if len(pool) < POOL:
+    cur.execute("""
+        SELECT doc_id
+        FROM edrsr_fulltext TABLESAMPLE SYSTEM (0.02) REPEATABLE (%s)
+        WHERE adj_year IS NOT NULL AND full_text IS NOT NULL
+        LIMIT %s
+    """, (SEED + 1, (POOL - len(pool)) * 4))
+    cand = [r[0] for r in cur.fetchall() if r[0] not in pool]
+    extra = fetch_docs(cand)
+    for did, (txt, yr) in extra.items():
+        if did in pool:
+            continue
+        docs[did] = (txt, yr)
+        pool.add(did)
+        if len(pool) >= POOL:
+            break
+conn.close()
+print(f"final pool: {len(pool)} | queries: {len(queries)}", flush=True)
+
+# 6. write COLIEE-format zip + years json
+labels = {f"{q}.txt": [f"{t}.txt" for t in ts] for q, ts in queries.items()}
+years_out = {f"{d}.txt": docs[d][1] for d in pool}
+
+zpath = os.path.join(OUTDIR, "ua_case_retrieval.zip")
+with zipfile.ZipFile(zpath, "w", zipfile.ZIP_DEFLATED) as zf:
+    for d in pool:
+        zf.writestr(f"ua_cases/cases/{d}.txt", docs[d][0])
+    zf.writestr("ua_cases/clean_ua_case_labels.json", json.dumps(labels))
+with open(os.path.join(OUTDIR, "ua_years.json"), "w") as fh:
+    json.dump(years_out, fh)
+
+print(f"wrote {zpath} ({os.path.getsize(zpath)//1024//1024} MB) + ua_years.json")

--- a/scripts/coliee/build_ua_citations.py
+++ b/scripts/coliee/build_ua_citations.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Build Cite(d) for the UA case-retrieval pool: {doc_id.txt: [cited
+latest_doc_id.txt, ...]} from case_citation_links (non-self, resolved
+precedent). Needed for the Yoshioka Extended-Precision/Coverage metrics.
+Runs ON prod; reads pool ids from a file, writes ua_citations.json."""
+import json
+import os
+from collections import defaultdict
+
+import psycopg2
+
+IDS = os.environ.get("IDS_FILE", "/tmp/ua_pool_ids.txt")
+OUT = os.environ.get("OUT", "/tmp/ua_citations.json")
+
+pool = [int(x) for x in open(IDS).read().split()]
+conn = psycopg2.connect(host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+                        user=os.environ["POSTGRES_USER"],
+                        password=os.environ["POSTGRES_PASSWORD"],
+                        dbname=os.environ["POSTGRES_DB"])
+cur = conn.cursor()
+cur.execute("SET statement_timeout = '180000'")
+cur.execute("""
+    SELECT from_doc_id, latest_doc_id
+    FROM case_citation_links
+    WHERE from_doc_id = ANY(%s)
+      AND resolved AND NOT is_self_citation AND latest_doc_id IS NOT NULL
+""", (pool,))
+cites = defaultdict(set)
+for frm, tgt in cur.fetchall():
+    if tgt != frm:
+        cites[frm].add(tgt)
+conn.close()
+
+out = {f"{d}.txt": sorted(f"{t}.txt" for t in ts) for d, ts in cites.items()}
+json.dump(out, open(OUT, "w"))
+print(f"citations for {len(out)}/{len(pool)} pool cases -> {OUT}")

--- a/scripts/coliee/build_ua_coupling_sample.py
+++ b/scripts/coliee/build_ua_coupling_sample.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Ukrainian-side bibliographic coupling / co-citation on the article-level
+citation graph, matched to the Canadian (COLIEE) computation for the
+cross-jurisdictional coupling paper.
+
+Roles are mirrored from the Canadian graph:
+  citing document  = court decision      (Canadian: query case)
+  cited target     = legislation article (Canadian: noticed case)
+  bibliographic coupling B = M M^T  -> decision pairs sharing cited articles
+  co-citation        C = M^T M      -> article pairs co-cited by a decision
+
+Full-scale decision coupling (100M nodes) is intractable and hub-dominated, so
+we sample N decisions (default 2000, matched to the Canadian 2001 query cases)
+via TABLESAMPLE with a fixed seed, fetch their complete article-edge sets, and
+compute the matched statistics. Runs ON the prod host (reads prod Postgres
+locally); prints a JSON stats blob to stdout (no bulk data egress).
+
+Usage (on prod):
+    UA_N=2000 python3 build_ua_coupling_sample.py
+"""
+import json
+import os
+import statistics
+import sys
+from collections import Counter, defaultdict
+
+import psycopg2
+
+N = int(os.environ.get("UA_N", "2000"))
+SEED = int(os.environ.get("UA_SEED", "42"))
+# optional justice_kind filter (4 = administrative = COLIEE-comparable domain)
+JK = os.environ.get("JUSTICE_KIND")
+JK = int(JK) if JK else None
+# article-level citation types only (exclude supreme_court_ruling = case cites,
+# and law_by_number = no article granularity)
+ARTICLE_TYPES = ("codex_article", "law_article", "constitution",
+                 "transitional_provision")
+
+
+def main():
+    conn = psycopg2.connect(
+        host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+        user=os.environ["POSTGRES_USER"], password=os.environ["POSTGRES_PASSWORD"],
+        dbname=os.environ["POSTGRES_DB"])
+    cur = conn.cursor()
+    cur.execute("SET statement_timeout = '180000'")
+
+    jk_sql = " AND justice_kind = %s" if JK is not None else ""
+    jk_arg = (JK,) if JK is not None else ()
+
+    # 1. sample decisions (reproducible via REPEATABLE seed)
+    cur.execute(
+        f"""
+        SELECT DISTINCT court_case_id
+        FROM law_court_citations TABLESAMPLE SYSTEM (0.1) REPEATABLE (%s)
+        WHERE citation_type = ANY(%s){jk_sql}
+        LIMIT %s
+        """,
+        (SEED, list(ARTICLE_TYPES)) + jk_arg + (N,))
+    decisions = [r[0] for r in cur.fetchall()]
+
+    # 2. complete article-edge sets for the sampled decisions
+    cur.execute(
+        """
+        SELECT court_case_id, citation_type, law_number, law_article
+        FROM law_court_citations
+        WHERE court_case_id = ANY(%s) AND citation_type = ANY(%s)
+        """,
+        (decisions, list(ARTICLE_TYPES)))
+    dec_articles = defaultdict(set)
+    for cid, ctype, lnum, lart in cur.fetchall():
+        dec_articles[cid].add(f"{ctype}|{lnum}|{lart}")
+    conn.close()
+
+    dec_articles = {d: a for d, a in dec_articles.items() if a}
+    stats = {"sample_decisions": len(dec_articles), "seed": SEED,
+             "article_types": list(ARTICLE_TYPES)}
+
+    # out-degree (articles per decision) -- mirrors CA citations-per-query
+    degs = [len(a) for a in dec_articles.values()]
+    stats["mean_articles_per_decision"] = round(statistics.mean(degs), 2)
+    stats["median_articles_per_decision"] = statistics.median(degs)
+    stats["max_articles_per_decision"] = max(degs)
+
+    # bibliographic coupling: decision pairs sharing >= 1 article
+    cited_by = defaultdict(list)          # article -> [decision ...]
+    for d, arts in dec_articles.items():
+        for a in arts:
+            cited_by[a].append(d)
+    coupling = Counter()
+    for a, ds in cited_by.items():
+        u = sorted(set(ds))
+        for i in range(len(u)):
+            for j in range(i + 1, len(u)):
+                coupling[(u[i], u[j])] += 1
+    stats["distinct_articles"] = len(cited_by)
+    stats["coupling_pairs"] = len(coupling)
+    if coupling:
+        cv = list(coupling.values())
+        stats["coupling_strength_mean"] = round(statistics.mean(cv), 3)
+        stats["coupling_strength_max"] = max(cv)
+        stats["coupling_strength_hist"] = [
+            {"strength": s, "count": c} for s, c in sorted(Counter(cv).items())][:40]
+    # coupling density among sampled decisions
+    n = len(dec_articles)
+    stats["coupling_density"] = round(len(coupling) / (n * (n - 1) / 2), 5) if n > 1 else 0
+
+    # co-citation: article pairs co-cited by a common decision
+    cocit = Counter()
+    for d, arts in dec_articles.items():
+        u = sorted(arts)
+        for i in range(len(u)):
+            for j in range(i + 1, len(u)):
+                cocit[(u[i], u[j])] += 1
+    stats["cocitation_pairs"] = len(cocit)
+    if cocit:
+        cc = list(cocit.values())
+        stats["cocitation_strength_mean"] = round(statistics.mean(cc), 3)
+        stats["cocitation_strength_max"] = max(cc)
+
+    json.dump(stats, sys.stdout, indent=2)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/build_ua_temporal.py
+++ b/scripts/coliee/build_ua_temporal.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Full Ukrainian case->case citation-age temporal analysis, symmetric with the
+Canadian fig1 (mean age by citing year + Mann-Kendall) and fig2 (age
+distribution). Runs over ALL non-self resolved precedent edges in
+case_citation_links (not a sample). Server-side aggregation by
+(citing_year, cited_year) keeps it cheap. Runs ON prod; prints JSON to stdout.
+"""
+import json
+import math
+import os
+import sys
+from collections import Counter, defaultdict
+
+import psycopg2
+
+conn = psycopg2.connect(host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+                        user=os.environ["POSTGRES_USER"],
+                        password=os.environ["POSTGRES_PASSWORD"],
+                        dbname=os.environ["POSTGRES_DB"])
+cur = conn.cursor()
+cur.execute("SET statement_timeout = '600000'")
+MIN_YEAR_N = int(os.environ.get("MIN_YEAR_N", "10"))
+
+
+def mann_kendall(series):
+    n = len(series)
+    if n < 3:
+        return {"n": n, "trend": "insufficient-data"}
+    s = 0
+    for i in range(n - 1):
+        for j in range(i + 1, n):
+            s += (series[j] > series[i]) - (series[j] < series[i])
+    ties = Counter(series)
+    tie = sum(t * (t - 1) * (2 * t + 5) for t in ties.values())
+    var = (n * (n - 1) * (2 * n + 5) - tie) / 18.0
+    z = (s - 1) / math.sqrt(var) if s > 0 and var > 0 else \
+        ((s + 1) / math.sqrt(var) if s < 0 and var > 0 else 0.0)
+    p = 2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(z) / math.sqrt(2.0))))
+    tau = s / (0.5 * n * (n - 1))
+    trend = "no-trend" if p >= 0.05 else ("increasing" if s > 0 else "decreasing")
+    return {"n": n, "S": s, "tau": round(tau, 4), "z": round(z, 3),
+            "p": round(p, 6), "trend": trend}
+
+
+# sanity: is case_citation_links.adj_year the citing (from_doc) year?
+cur.execute("""
+    SELECT c.adj_year, f.adj_year
+    FROM case_citation_links c JOIN edrsr_fulltext f ON f.doc_id = c.from_doc_id
+    WHERE c.adj_year IS NOT NULL AND f.adj_year IS NOT NULL LIMIT 200""")
+same = [1 for a, b in cur.fetchall() if a == b]
+print(f"# adj_year==from_doc year on sample: {len(same)}/200", file=sys.stderr)
+
+# full aggregation: citing_year x cited_year counts
+cur.execute("""
+    SELECT c.adj_year AS citing_year, t.adj_year AS cited_year, count(*)
+    FROM case_citation_links c
+    JOIN edrsr_fulltext t ON t.doc_id = c.latest_doc_id
+    WHERE c.resolved AND NOT c.is_self_citation
+      AND c.adj_year IS NOT NULL AND t.adj_year IS NOT NULL
+    GROUP BY 1, 2""")
+rows = cur.fetchall()
+conn.close()
+
+per_year = defaultdict(lambda: [0, 0])   # citing_year -> [sum_age, n]
+age_hist = Counter()
+total = neg = 0
+for cy, ty, cnt in rows:
+    total += cnt
+    age = cy - ty
+    if age < 0:
+        neg += cnt
+        continue
+    per_year[cy][0] += age * cnt
+    per_year[cy][1] += cnt
+    age_hist[age] += cnt
+
+yearly = sorted((y, sa / n, n) for y, (sa, n) in per_year.items() if n >= MIN_YEAR_N)
+stats = {
+    "edges_with_both_years": total,
+    "citation_age_negative_frac": round(neg / total, 4) if total else 0,
+    "min_year_n": MIN_YEAR_N,
+    "mean_age_by_citing_year": [
+        {"year": y, "mean_age": round(a, 2), "n": n} for y, a, n in yearly],
+    "citation_age_hist": [{"age": a, "count": c} for a, c in sorted(age_hist.items())],
+    "mann_kendall_mean_age_trend": mann_kendall([a for _, a, _ in yearly]),
+}
+# overall mean/median age
+flat_total = sum(age_hist.values())
+cum, med = 0, None
+for a, c in sorted(age_hist.items()):
+    cum += c
+    if med is None and cum >= flat_total / 2:
+        med = a
+stats["citation_age_mean"] = round(
+    sum(a * c for a, c in age_hist.items()) / flat_total, 2) if flat_total else None
+stats["citation_age_median"] = med
+
+json.dump(stats, sys.stdout, indent=2)
+print()

--- a/scripts/coliee/dump_rankings.py
+++ b/scripts/coliee/dump_rankings.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Dump top-k ranked lists for the dense encoders, so that rank-aware measures
+(Reachability Gain) can be scored on more than the BM25 baseline.
+
+The July runs reported aggregate metrics only and did not keep the rankings,
+so RG could not be recomputed from them. This script writes them out.
+Settings match the paper exactly: max_chars 4000, E5 at 512 tokens with the
+query:/passage: prefixes, BGE-M3 at 1024 tokens.
+
+CPU-only by default (no GPU on this host); ~1.5-4 h per model per corpus.
+
+    python scripts/coliee/dump_rankings.py --corpus ua --models e5 bge-m3
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from retrieval_experiment import MODELS, load_cases  # noqa: E402
+
+DATA = "data/coliee/task1"
+CORPORA = {
+    "ua": {"zip": f"{DATA}/ua_case_retrieval.zip",
+           "years_json": f"{DATA}/ua_years.json"},
+    "ca": {"zip": f"{DATA}/task1_train_files_2026.zip", "years_json": None},
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", choices=list(CORPORA), required=True)
+    ap.add_argument("--models", nargs="+", default=["e5", "bge-m3"])
+    ap.add_argument("--depth", type=int, default=10)
+    ap.add_argument("--max-chars", type=int, default=4000)
+    ap.add_argument("--batch-size", type=int, default=8)
+    ap.add_argument("--threads", type=int, default=0,
+                    help="torch CPU threads (0 = leave default)")
+    args = ap.parse_args()
+
+    import numpy as np
+    import torch
+    if args.threads:
+        torch.set_num_threads(args.threads)
+    from sentence_transformers import SentenceTransformer
+
+    cfg = CORPORA[args.corpus]
+    case_ids, texts, _, labels = load_cases(
+        cfg["zip"], None, args.max_chars, cfg["years_json"])
+    query_ids = [q for q in labels if q in texts]
+    idx = {c: i for i, c in enumerate(case_ids)}
+    print(f"[{args.corpus}] pool={len(case_ids)} queries={len(query_ids)}",
+          flush=True)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    for key in args.models:
+        mc = MODELS[key]
+        out = f"{DATA}/rankings_{args.corpus}_{key.replace('-', '')}.json"
+        if os.path.exists(out):
+            print(f"  {key}: {out} exists, skipping", flush=True)
+            continue
+        t0 = time.time()
+        model = SentenceTransformer(mc["hf"], device=device)
+        model.max_seq_length = mc["max_seq_length"]
+        pool_emb = model.encode([mc["passage_prefix"] + texts[c] for c in case_ids],
+                                batch_size=args.batch_size,
+                                normalize_embeddings=True, show_progress_bar=False)
+        print(f"  {key}: pool encoded in {(time.time()-t0)/60:.1f} min", flush=True)
+        q_emb = model.encode([mc["query_prefix"] + texts[q] for q in query_ids],
+                             batch_size=args.batch_size,
+                             normalize_embeddings=True, show_progress_bar=False)
+        sims = np.asarray(q_emb, dtype="float32") @ np.asarray(pool_emb, dtype="float32").T
+        for i, q in enumerate(query_ids):
+            sims[i, idx[q]] = -1e9
+        part = np.argpartition(-sims, args.depth, axis=1)[:, :args.depth]
+        order = np.argsort(-np.take_along_axis(sims, part, axis=1), axis=1)
+        top = np.take_along_axis(part, order, axis=1)
+        ranked = {query_ids[i]: [case_ids[j] for j in top[i]]
+                  for i in range(len(query_ids))}
+        with open(out, "w") as fh:
+            json.dump({"corpus": args.corpus, "model": key,
+                       "max_chars": args.max_chars,
+                       "max_seq_length": mc["max_seq_length"],
+                       "depth": args.depth, "rankings": ranked}, fh)
+        print(f"  {key}: wrote {out} in {(time.time()-t0)/60:.1f} min total",
+              flush=True)
+        del model, pool_emb, q_emb, sims
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/probe_ua_case_retrieval.py
+++ b/scripts/coliee/probe_ua_case_retrieval.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Read-only scoping probe for the UA case-retrieval experiment. Determines
+whether case_citation_links + text/date sources support a COLIEE-style
+case->case retrieval task, and sizes the sample so we do not over-compute.
+Runs ON prod. Prints findings only."""
+import os
+import psycopg2
+
+conn = psycopg2.connect(host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+                        user=os.environ["POSTGRES_USER"],
+                        password=os.environ["POSTGRES_PASSWORD"],
+                        dbname=os.environ["POSTGRES_DB"])
+cur = conn.cursor()
+cur.execute("SET statement_timeout = '120000'")
+
+
+def cols(t):
+    cur.execute("""SELECT column_name, data_type FROM information_schema.columns
+                   WHERE table_name=%s AND table_schema='public'
+                   ORDER BY ordinal_position""", (t,))
+    return cur.fetchall()
+
+
+for t in ("case_citation_links", "edrsr_case_index", "edrsr_documents"):
+    print(f"\n=== {t} columns ===")
+    for c, d in cols(t):
+        print(f"  {c}: {d}")
+
+# fulltext columns (partitioned parent)
+print("\n=== edrsr_fulltext columns ===")
+for c, d in cols("edrsr_fulltext"):
+    print(f"  {c}: {d}")
+
+print("\n=== distinct query-capable decisions (non-self resolved precedent) ===")
+cur.execute("""SELECT count(DISTINCT from_doc_id) FROM case_citation_links
+               WHERE resolved AND NOT is_self_citation""")
+print("  distinct from_doc_id:", cur.fetchone()[0])
+
+print("\n=== out-degree distribution (non-self resolved precedent per decision) ===")
+cur.execute("""
+  WITH d AS (
+    SELECT from_doc_id, count(*) AS k
+    FROM case_citation_links
+    WHERE resolved AND NOT is_self_citation
+    GROUP BY from_doc_id)
+  SELECT round(avg(k),2), percentile_cont(0.5) WITHIN GROUP (ORDER BY k),
+         percentile_cont(0.9) WITHIN GROUP (ORDER BY k), max(k),
+         count(*) FILTER (WHERE k>=1), count(*) FILTER (WHERE k>=3)
+  FROM d""")
+avg, p50, p90, mx, ge1, ge3 = cur.fetchone()
+print(f"  mean {avg} median {p50} p90 {p90} max {mx}")
+print(f"  decisions with >=1 precedent: {ge1} | >=3: {ge3}")
+
+conn.close()

--- a/scripts/coliee/reachability_gain.py
+++ b/scripts/coliee/reachability_gain.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+Reachability Gain (RG@k): one measure that contains the Sekiguchi/Yoshioka/Kwan
+(ICTIR '26) Extended Precision and Coverage as corner cases.
+
+Motivation. Yoshioka (email, 2026-07-25) asks for "a single evaluation measure
+for considering the BC case". Their own §6 lists what such a measure must add:
+context-based weighting, rank-awareness, and a penalty for redundant boilerplate
+cases dominating the top. All three are standard machinery in the two literatures
+their paper already cites (nugget-based evaluation and result diversification),
+so the proposal is to assemble rather than invent.
+
+Construction. Each gold case is a nugget. A retrieved document covers a nugget
+either by being it (direct) or by citing it (one BC hop, the "one-click" pathway).
+
+  credit    c_i(g) = 1                     if d_i = g
+                   = beta * rho(d_i) * tau(dt)  if g in Cite(d_i)
+                   = 0                     otherwise
+  redundancy r_i(g) = |{ j < i : c_j(g) > 0 }|
+  gain      gain_i = sum_g u(g) * c_i(g) * (1-alpha)^{r_i(g)}
+  RG@k             = sum_{i<=k} gain_i / log2(1+i)   / ideal(k)
+
+  u(g)    nugget weight, default IDF: log(N / df(g)), normalized to sum 1 over G_q.
+          Rare gold is worth more than boilerplate gold. This is the single knob
+          that fixes both the over-crediting of hub gold and the invisibility of
+          the tail.
+  beta    how much a one-click pathway is worth relative to the document itself.
+          Not a free constant: it should be measured (LLM/expert audit of BC
+          pairs), see the accompanying proposal.
+  rho     citation-role factor (holding vs dissent vs overruled/rejected). Hook is
+          implemented; on the 7.7K COLIEE-matched pool only 30 pool documents carry
+          an instance-status label, so it is not exercisable here and needs a
+          national-scale run.
+  tau     temporal factor from the measured coupling-decay curve. Off by default.
+  alpha   redundancy discount, the diversification dial.
+
+The corner cases (verified numerically by --verify):
+
+  Coverage       = alpha=1, beta=1, u=1/|G_q|, no rank discount, no normalization
+  Ext. Precision = alpha=0, beta=1, document-level saturation, divide by k
+
+So their two metrics are the two ends of one redundancy dial: Coverage counts a
+nugget once however many times it is reachable (alpha=1), Extended Precision
+credits every pathway in full however redundant (alpha=0). The interesting
+operating point is in between.
+
+Usage:
+    python scripts/coliee/reachability_gain.py --corpus ua --verify
+    python scripts/coliee/reachability_gain.py --corpus ca
+"""
+
+import argparse
+import csv
+import gzip
+import json
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from retrieval_experiment import bm25_sims, load_cases  # noqa: E402
+
+DATA = "data/coliee/task1"
+# Optional EDRSR instance-status export (edrsr_overruled.csv.gz,
+# edrsr_dissent.csv.gz) used for the citation-role factor rho. Point
+# ISL_EXPORT_DIR at it to enable; without it every pathway is treated as
+# role "holding", which is what the published figures use.
+ISL = os.environ.get("ISL_EXPORT_DIR", "")
+
+CORPORA = {
+    "ua": {"zip": f"{DATA}/ua_case_retrieval.zip",
+           "years_json": f"{DATA}/ua_years.json",
+           "citations_json": f"{DATA}/ua_citations.json"},
+    "ca": {"zip": f"{DATA}/task1_train_files_2026.zip",
+           "years_json": None, "citations_json": None},
+}
+
+
+# ------------------------------------------------------------ the measure ---
+class RG:
+    def __init__(self, citations, df, n_pool, alpha=0.5, beta=0.5,
+                 weight="idf", discount=True, normalize="ideal",
+                 saturate_doc=False, roles=None, rho=None,
+                 years=None, tau=None):
+        self.cit = citations
+        self.df = df
+        self.N = n_pool
+        self.alpha = alpha
+        self.beta = beta
+        self.weight = weight
+        self.discount = discount
+        self.normalize = normalize
+        self.saturate_doc = saturate_doc
+        self.roles = roles or {}
+        self.rho = rho or {}
+        self.years = years or {}
+        self.tau = tau          # {gap: factor}, empirical coupling-decay curve
+        self._q = None          # current query, for the temporal factor
+
+    def _u(self, gold):
+        if self.weight == "uniform":
+            return {g: 1.0 / len(gold) for g in gold}
+        w = {g: math.log(self.N / max(1, self.df.get(g, 0) or 1)) for g in gold}
+        s = sum(w.values()) or 1.0
+        return {g: v / s for g, v in w.items()}
+
+    def _credit(self, d, g):
+        """Credit document d gives to nugget g."""
+        if d == g:
+            return 1.0
+        if g in self.cit.get(d, ()):
+            c = self.beta * self.rho.get(self.roles.get(d, "holding"), 1.0)
+            if self.tau is not None and self._q is not None:
+                yq, yd = self.years.get(self._q), self.years.get(d)
+                if yq is not None and yd is not None:
+                    gap = abs(int(yq) - int(yd))
+                    c *= self.tau.get(gap, self.tau[max(self.tau)])
+            return c
+        return 0.0
+
+    def _dcg(self, ranked, gold, u, k):
+        seen = {g: 0 for g in gold}
+        total = 0.0
+        for i, d in enumerate(ranked[:k], start=1):
+            if self.saturate_doc:
+                gain = 1.0 if any(self._credit(d, g) > 0 for g in gold) else 0.0
+            else:
+                gain = 0.0
+                for g in gold:
+                    c = self._credit(d, g)
+                    if c > 0:
+                        gain += u[g] * c * (1.0 - self.alpha) ** seen[g]
+            for g in gold:
+                if self._credit(d, g) > 0:
+                    seen[g] += 1
+            total += gain / math.log2(1 + i) if self.discount else gain
+        return total
+
+    def _ideal(self, gold, u, k, candidates):
+        """Greedy ideal ranking over the documents that can cover anything."""
+        seen = {g: 0 for g in gold}
+        chosen, total = [], 0.0
+        pool = list(candidates)
+        for i in range(1, k + 1):
+            best, best_gain = None, -1.0
+            for d in pool:
+                if d in chosen:
+                    continue
+                if self.saturate_doc:
+                    gain = 1.0 if any(self._credit(d, g) > 0 for g in gold) else 0.0
+                else:
+                    gain = sum(u[g] * self._credit(d, g) * (1 - self.alpha) ** seen[g]
+                               for g in gold if self._credit(d, g) > 0)
+                if gain > best_gain:
+                    best, best_gain = d, gain
+            if best is None or best_gain <= 0:
+                break
+            chosen.append(best)
+            for g in gold:
+                if self._credit(best, g) > 0:
+                    seen[g] += 1
+            total += best_gain / math.log2(1 + i) if self.discount else best_gain
+        return total
+
+    def score(self, query_ids, ranked, labels, k, candidates_of=None):
+        vals = []
+        for q in query_ids:
+            gold = set(labels.get(q, []))
+            if not gold:
+                continue
+            self._q = q
+            u = self._u(gold)
+            v = self._dcg(ranked[q], gold, u, k)
+            if self.normalize == "k":
+                v /= k
+            elif self.normalize == "ideal":
+                cand = candidates_of(q) if candidates_of else set()
+                ideal = self._ideal(gold, u, k, cand)
+                v = v / ideal if ideal > 0 else 0.0
+            vals.append(v)
+        return sum(vals) / len(vals) if vals else None
+
+
+# ------------------------------------------------------------- reference ----
+def ext_p(ranked, gold, cit, k):
+    topk = ranked[:k]
+    return sum(1 for d in topk
+               if d in gold or gold.intersection(cit.get(d, ()))) / k
+
+
+def coverage(ranked, gold, cit, k):
+    topk = ranked[:k]
+    ts = set(topk)
+    return sum(1 for g in gold
+               if g in ts or any(g in cit.get(d, ()) for d in topk)) / len(gold)
+
+
+# ------------------------------------------------------------- rankers ------
+def bm25_ranking(case_ids, texts, query_ids, depth=10):
+    import numpy as np
+    sims = bm25_sims(case_ids, texts, query_ids)
+    idx = {c: i for i, c in enumerate(case_ids)}
+    for i, q in enumerate(query_ids):
+        sims[i, idx[q]] = -1e9
+    part = np.argpartition(-sims, depth, axis=1)[:, :depth]
+    order = np.argsort(-np.take_along_axis(sims, part, axis=1), axis=1)
+    top = np.take_along_axis(part, order, axis=1)
+    return {query_ids[i]: [case_ids[j] for j in top[i]]
+            for i in range(len(query_ids))}
+
+
+def boilerplate_ranking(query_ids, labels, cit, df, citers, pool, k=5):
+    """Adversarial ranker: return k documents that all reach the SAME, most
+    heavily cited gold case. This is the failure mode their §6 names (redundant
+    boilerplate dominating the top) in its purest form."""
+    ranked, full = {}, 0
+    for q in query_ids:
+        gold = set(labels.get(q, []))
+        if not gold:
+            continue
+        g_star = max(sorted(gold), key=lambda g: df.get(g, 0))
+        cands = [d for d in citers.get(g_star, ()) if d != q and d not in gold]
+        cands.sort(key=lambda d: (-df.get(d, 0), d))   # doc id breaks ties -> deterministic
+        lst = cands[:k]
+        if len(lst) >= k:
+            full += 1
+        if len(lst) < k:                       # pad with other BC documents
+            extra = []
+            for g in sorted(gold):
+                extra += sorted((d for d in citers.get(g, ())
+                                 if d != q and d not in gold and d not in lst),
+                                key=lambda d: (-df.get(d, 0), d))
+            lst = (lst + extra)[:k]
+        if len(lst) < k:                       # then with global hubs
+            hubs = sorted(pool, key=lambda d: -df.get(d, 0))
+            lst = (lst + [d for d in hubs if d != q and d not in lst])[:k]
+        ranked[q] = lst
+    return ranked, full
+
+
+# --------------------------------------------------------------- driver -----
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", choices=list(CORPORA), required=True)
+    ap.add_argument("--k", type=int, default=5)
+    ap.add_argument("--alpha", type=float, default=0.5)
+    ap.add_argument("--beta", type=float, default=0.5)
+    ap.add_argument("--verify", action="store_true",
+                    help="assert the corner cases reproduce ExtP and Coverage")
+    ap.add_argument("--max-chars", type=int, default=4000)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    cfg = CORPORA[args.corpus]
+    case_ids, texts, years, labels = load_cases(
+        cfg["zip"], None, args.max_chars, cfg["years_json"])
+    query_ids = [q for q in labels if q in texts]
+    if cfg["citations_json"]:
+        cit = {k: set(v) for k, v in json.load(open(cfg["citations_json"])).items()}
+    else:
+        cit = {k: set(v) for k, v in labels.items()}
+    pool = set(case_ids)
+
+    df, citers = {}, {}
+    for d, cs in cit.items():
+        if d not in pool:
+            continue
+        for g in cs:
+            if g in pool:
+                df[g] = df.get(g, 0) + 1
+                citers.setdefault(g, set()).add(d)
+
+    # roles from the EDRSR instance-status layer (UA only, hook demo)
+    roles = {}
+    if args.corpus == "ua" and os.path.isdir(ISL):
+        with gzip.open(ISL + "edrsr_overruled.csv.gz", "rt") as fh:
+            for r in csv.DictReader(fh):
+                n = r["doc_id"] + ".txt"
+                if n in pool:
+                    roles[n] = "overruled_lower"
+        with gzip.open(ISL + "edrsr_dissent.csv.gz", "rt") as fh:
+            for r in csv.DictReader(fh):
+                n = r["dissent_doc_id"] + ".txt"
+                if n in pool:
+                    roles[n] = "dissent"
+    RHO = {"holding": 1.0, "overruled_lower": 0.0, "dissent": 0.25}
+
+    def candidates_of(q):
+        gold = set(labels.get(q, []))
+        c = set(gold)
+        for g in gold:
+            c |= citers.get(g, set())
+        c.discard(q)
+        return c
+
+    print(f"[{args.corpus}] pool={len(case_ids)} queries={len(query_ids)} "
+          f"k={args.k} | role-labelled pool docs={len(roles)}", flush=True)
+
+    rankings = {"bm25": bm25_ranking(case_ids, texts, query_ids)}
+    pop_order = sorted(case_ids, key=lambda c: (-df.get(c, 0), c))
+    rankings["popularity"] = {q: [c for c in pop_order[:11] if c != q][:10]
+                              for q in query_ids}
+    boiler, full = boilerplate_ranking(query_ids, labels, cit, df, citers,
+                                       case_ids, k=args.k)
+    rankings["boilerplate_attack"] = boiler
+    print(f"boilerplate attack: {full}/{len(query_ids)} queries admit a full "
+          f"{args.k}-document single-gold pathway set", flush=True)
+
+    # ---------------------------------------------------------- verify -----
+    if args.verify:
+        cov_rg = RG(cit, df, len(case_ids), alpha=1.0, beta=1.0, weight="uniform",
+                    discount=False, normalize=None)
+        ext_rg = RG(cit, df, len(case_ids), alpha=0.0, beta=1.0, weight="uniform",
+                    discount=False, normalize="k", saturate_doc=True)
+        for name, ranked in rankings.items():
+            ref_c = sum(coverage(ranked[q], set(labels[q]), cit, args.k)
+                        for q in query_ids if labels.get(q)) / len(query_ids)
+            ref_e = sum(ext_p(ranked[q], set(labels[q]), cit, args.k)
+                        for q in query_ids if labels.get(q)) / len(query_ids)
+            got_c = cov_rg.score(query_ids, ranked, labels, args.k)
+            got_e = ext_rg.score(query_ids, ranked, labels, args.k)
+            assert abs(ref_c - got_c) < 1e-9, (name, "Coverage", ref_c, got_c)
+            assert abs(ref_e - got_e) < 1e-9, (name, "ExtP", ref_e, got_e)
+            print(f"  corner check [{name:20s}] Coverage {ref_c:.6f} == {got_c:.6f}"
+                  f"   ExtP {ref_e:.6f} == {got_e:.6f}   OK")
+
+    # ------------------------------------------------------- main table ----
+    rg = RG(cit, df, len(case_ids), alpha=args.alpha, beta=args.beta,
+            weight="idf", discount=True, normalize="ideal",
+            roles=roles, rho=RHO)
+    rg_norole = RG(cit, df, len(case_ids), alpha=args.alpha, beta=args.beta,
+                   weight="idf", discount=True, normalize="ideal")
+    rows = {}
+    print(f"\n{'ranker':22s} {'F1@k':>8s} {'ExtP@k':>8s} {'Cov@k':>8s} "
+          f"{'RG@k':>8s} {'RG(role)':>9s}")
+    for name, ranked in rankings.items():
+        f1 = 0.0
+        for q in query_ids:
+            gold = set(labels.get(q, []))
+            if not gold:
+                continue
+            hit = sum(1 for c in ranked[q][:args.k] if c in gold)
+            p, r = hit / args.k, hit / len(gold)
+            f1 += 2 * p * r / (p + r) if (p + r) else 0.0
+        f1 /= len(query_ids)
+        e = sum(ext_p(ranked[q], set(labels[q]), cit, args.k)
+                for q in query_ids if labels.get(q)) / len(query_ids)
+        c = sum(coverage(ranked[q], set(labels[q]), cit, args.k)
+                for q in query_ids if labels.get(q)) / len(query_ids)
+        v = rg_norole.score(query_ids, ranked, labels, args.k, candidates_of)
+        vr = rg.score(query_ids, ranked, labels, args.k, candidates_of)
+        rows[name] = {"F1": round(f1, 4), "ExtP": round(e, 4), "Cov": round(c, 4),
+                      "RG": round(v, 4), "RG_role": round(vr, 4)}
+        print(f"{name:22s} {f1:8.4f} {e:8.4f} {c:8.4f} {v:8.4f} {vr:9.4f}")
+
+    # -------------------------------------------------------- sensitivity --
+    print(f"\nsensitivity (BM25 vs boilerplate attack), RG@{args.k}:")
+    print(f"  {'alpha':>6s} {'beta':>6s} {'RG bm25':>9s} {'RG attack':>10s} {'ratio':>7s}")
+    sens = []
+    for alpha in (0.0, 0.25, 0.5, 0.75, 1.0):
+        for beta in (0.25, 0.5, 1.0):
+            m = RG(cit, df, len(case_ids), alpha=alpha, beta=beta, weight="idf",
+                   discount=True, normalize="ideal")
+            a = m.score(query_ids, rankings["bm25"], labels, args.k, candidates_of)
+            b = m.score(query_ids, rankings["boilerplate_attack"], labels,
+                        args.k, candidates_of)
+            sens.append({"alpha": alpha, "beta": beta, "bm25": round(a, 4),
+                         "attack": round(b, 4)})
+            print(f"  {alpha:6.2f} {beta:6.2f} {a:9.4f} {b:10.4f} "
+                  f"{(b / a if a else float('nan')):7.2f}")
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump({"corpus": args.corpus, "k": args.k,
+                       "alpha": args.alpha, "beta": args.beta,
+                       "rankers": rows, "sensitivity": sens,
+                       "role_labelled_pool_docs": len(roles)}, fh, indent=2)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/retrieval_experiment.py
+++ b/scripts/coliee/retrieval_experiment.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""
+Retrieval experiment scaffold for the Canadian side of arXiv:2605.17639
+("Temporal Decay of Co-Citation Predictability"), on the COLIEE 2026 Task 1
+(Legal Case Retrieval) corpus.
+
+Pipeline (mirrors the two dense models used in the paper):
+  1. embed every case with E5 (intfloat/multilingual-e5-large) and BGE-M3
+     (BAAI/bge-m3), first-stage dense retrieval over the whole corpus;
+  2. for each query case, rank all other cases by cosine similarity and
+     score against the gold "noticed" set -> Precision/Recall/F1@K;
+  3. apply the paper's exp recency-weighting rerank
+        score' = cos_sim * exp(-lambda * max(0, citing_year - cand_year))
+     and sweep lambda to see whether the 3-23% gain seen on the Ukrainian
+     graph replicates in Canadian common law.
+
+This is a SCAFFOLD: heavy step (needs `sentence-transformers` + torch, a GPU
+is strongly recommended, and it downloads ~2-2.5GB of model weights). Dates
+are parsed with the same hardened parser as build_canada_citation_graph.py.
+
+Quick smoke test (subset, tiny):
+    python scripts/coliee/retrieval_experiment.py \
+        --zip data/coliee/task1/task1_train_files_2026.zip \
+        --models e5 --limit 50 --max-chars 3000
+
+Full run:
+    python scripts/coliee/retrieval_experiment.py \
+        --zip data/coliee/task1/task1_train_files_2026.zip \
+        --models e5 bge-m3 \
+        --out data/coliee/task1/retrieval_results.json
+"""
+
+import argparse
+import json
+import os
+import sys
+import zipfile
+
+# reuse the hardened date parser from the sibling graph script
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from build_canada_citation_graph import parse_year  # noqa: E402
+
+MODELS = {
+    "e5": {
+        "hf": "intfloat/multilingual-e5-large",
+        "query_prefix": "query: ",
+        "passage_prefix": "passage: ",
+        "max_seq_length": 512,
+    },
+    "bge-m3": {
+        "hf": "BAAI/bge-m3",
+        "query_prefix": "",
+        "passage_prefix": "",
+        "max_seq_length": 1024,  # bge-m3 supports up to 8192; cap for speed
+    },
+    "bm25": {"hf": None},  # sparse lexical baseline (no embedding model)
+}
+
+
+def _tokenize(t):
+    import re
+    return re.findall(r"\w+", t.lower(), re.UNICODE)  # \w is Unicode -> Cyrillic ok
+
+
+def bm25_sims(case_ids, texts, query_ids, k1=1.5, b=0.75):
+    """Dense (Q x N) BM25 score matrix, vectorized as a sparse matmul
+    Q_binary (Q x V) @ DocWeight (V x N). Unicode tokenization -> Ukrainian and
+    English alike. Needs numpy + scipy."""
+    import numpy as np
+    from collections import Counter
+    from scipy import sparse
+    N = len(case_ids)
+    tf = [Counter(_tokenize(texts[c])) for c in case_ids]
+    dl = np.array([sum(c.values()) for c in tf], dtype="float64")
+    avgdl = float(dl.mean()) if N else 1.0
+    vocab = {}
+    for c in tf:
+        for t in c:
+            if t not in vocab:
+                vocab[t] = len(vocab)
+    V = len(vocab)
+    rows, cols, data = [], [], []               # (term, doc, tf)
+    for di, c in enumerate(tf):
+        for t, f in c.items():
+            rows.append(vocab[t]); cols.append(di); data.append(f)
+    rows = np.asarray(rows); cols = np.asarray(cols)
+    data = np.asarray(data, dtype="float64")
+    df = np.zeros(V)
+    np.add.at(df, rows, 1.0)
+    idf = np.log(1 + (N - df + 0.5) / (df + 0.5))
+    denom = data + k1 * (1 - b + b * dl[cols] / avgdl)
+    w = idf[rows] * (data * (k1 + 1)) / denom    # per (term,doc) BM25 weight
+    DW = sparse.csr_matrix((w, (rows, cols)), shape=(V, N))
+    qr, qc = [], []                              # query x term (binary presence)
+    for qi, q in enumerate(query_ids):
+        for t in set(_tokenize(texts[q])):
+            ti = vocab.get(t)
+            if ti is not None:
+                qr.append(qi); qc.append(ti)
+    Q = sparse.csr_matrix((np.ones(len(qr)), (qr, qc)),
+                          shape=(len(query_ids), V))
+    return (Q @ DW).toarray().astype("float32")
+
+
+def per_query_metrics(query_ids, ranked, labels, citations, k):
+    """Per-query F1@k (and Yoshioka ExtP/Cov@k) for bootstrap CIs / significance."""
+    recs = []
+    for q in query_ids:
+        gold = set(labels.get(q, []))
+        if not gold:
+            continue
+        topk = ranked[q][:k]
+        hit = sum(1 for c in topk if c in gold)
+        prec, rec = hit / k, hit / len(gold)
+        r = {"f1": 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0}
+        if citations is not None:
+            h = sum(1 for d in topk
+                    if d in gold or gold.intersection(citations.get(d, ())))
+            tset = set(topk)
+            cov = sum(1 for g in gold if g in tset
+                      or any(g in citations.get(d, ()) for d in topk)) / len(gold)
+            r["extp"], r["cov"] = h / k, cov
+        recs.append(r)
+    return recs
+
+
+def load_cases(zip_path, labels_arcname, max_chars, years_json=None):
+    """Return (case_ids, texts, years, labels).
+
+    texts is truncated to max_chars (dense encoders cap at a few hundred
+    tokens anyway; the head of a Federal Court decision carries the issue,
+    parties, and holding — enough signal for a first-stage pilot).
+
+    Decision years come from parse_year over the text (Canadian format). For
+    corpora whose dates are not parseable that way (e.g. Ukrainian texts),
+    pass years_json = a {case_id: year} mapping and text parsing is skipped."""
+    ext_years = None
+    if years_json:
+        with open(years_json) as fh:
+            ext_years = {k: int(v) for k, v in json.load(fh).items()}
+    texts, years = {}, {}
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        if labels_arcname is None:
+            cand = [n for n in names if n.endswith(".json") and "label" in n.lower()]
+            labels_arcname = sorted(cand, key=len)[0]
+        with zf.open(labels_arcname) as fh:
+            labels = json.load(fh)
+        for n in names:
+            if "/cases/" in n and n.endswith(".txt"):
+                cid = n.rsplit("/", 1)[-1]
+                raw = zf.open(n).read().decode("utf-8", errors="replace")
+                texts[cid] = raw[:max_chars]
+                y = ext_years.get(cid) if ext_years is not None else parse_year(raw)
+                if y is not None:
+                    years[cid] = y
+    case_ids = sorted(texts)
+    return case_ids, texts, years, labels
+
+
+def prf_at_k(ranked_ids, gold, k):
+    """Precision/Recall/F1 for the top-k retrieved ids against gold set."""
+    if not gold:
+        return None
+    topk = ranked_ids[:k]
+    hit = sum(1 for c in topk if c in gold)
+    prec = hit / k
+    rec = hit / len(gold)
+    f1 = 2 * prec * rec / (prec + rec) if (prec + rec) else 0.0
+    return prec, rec, f1
+
+
+def evaluate(query_ids, ranked_by_query, labels, k_values, citations=None):
+    """Macro-averaged P/R/F1 and, when a citations map is given, the
+    Yoshioka et al. (ICTIR 2026) bibliographic-coupling metrics.
+
+    A candidate d is a bibliographic-coupling ("BC" / Silver) case for query q
+    when it shares a gold case with q, i.e. Cite(d) ∩ G_q != {}. Extended
+    Precision = fraction of the top-k that are gold OR BC; Coverage = fraction
+    of gold cases reachable from the top-k directly or via one BC hop.
+    citations maps case_id -> iterable of cited case_ids (Cite(d))."""
+    out = {}
+    for k in k_values:
+        ps = rs = fs = eps = covs = 0.0
+        n = 0
+        for q in query_ids:
+            gold = set(labels.get(q, []))
+            if not gold:
+                continue
+            ranked = ranked_by_query[q]
+            r = prf_at_k(ranked, gold, k)
+            if r is None:
+                continue
+            p, rec, f1 = r
+            ps += p; rs += rec; fs += f1
+            if citations is not None:
+                topk = ranked[:k]
+                hit = sum(1 for d in topk
+                          if d in gold or gold.intersection(citations.get(d, ())))
+                eps += hit / k
+                tset = set(topk)
+                covered = sum(1 for g in gold if g in tset
+                              or any(g in citations.get(d, ()) for d in topk))
+                covs += covered / len(gold)
+            n += 1
+        if n:
+            rec_out = {"P": round(ps / n, 4), "R": round(rs / n, 4),
+                       "F1": round(fs / n, 4), "queries": n}
+            if citations is not None:
+                rec_out["ExtP"] = round(eps / n, 4)   # Yoshioka Extended Precision
+                rec_out["Cov"] = round(covs / n, 4)   # Yoshioka Coverage
+            out[f"k={k}"] = rec_out
+    return out
+
+
+def run_model(model_key, case_ids, texts, years, labels, query_ids,
+              k_values, lambdas, batch_size, devices, citations=None,
+              per_query_k=None):
+    import numpy as np
+
+    cfg = MODELS[model_key]
+    if model_key == "bm25":
+        print(f"\n### bm25 (lexical) on {len(case_ids)} docs", flush=True)
+        sims = bm25_sims(case_ids, texts, query_ids)
+    else:
+        from sentence_transformers import SentenceTransformer
+        print(f"\n### {model_key} ({cfg['hf']}) on {len(devices)} device(s)", flush=True)
+        model = SentenceTransformer(cfg["hf"])
+        model.max_seq_length = cfg["max_seq_length"]
+
+        def encode(texts_list):
+            if len(devices) > 1:
+                pool = model.start_multi_process_pool(target_devices=devices)
+                try:
+                    emb = model.encode_multi_process(
+                        texts_list, pool, batch_size=batch_size,
+                        normalize_embeddings=True)
+                finally:
+                    model.stop_multi_process_pool(pool)
+                return np.asarray(emb, dtype="float32")
+            emb = model.encode(texts_list, batch_size=batch_size,
+                               normalize_embeddings=True, show_progress_bar=False,
+                               device=devices[0])
+            return np.asarray(emb, dtype="float32")
+
+        pool_emb = encode([cfg["passage_prefix"] + texts[c] for c in case_ids])
+        q_emb = encode([cfg["query_prefix"] + texts[q] for q in query_ids])
+        sims = q_emb @ pool_emb.T  # (Q x N) cosine (embeddings normalized)
+
+    idx = {c: i for i, c in enumerate(case_ids)}
+
+    # ---- vectorized recency rerank (no Python per-candidate loop) ----
+    cand_years = np.array([years.get(c, -1) for c in case_ids], dtype="int32")
+    has_year = cand_years >= 0
+    q_year = np.array([years.get(q, -1) for q in query_ids], dtype="int32")
+    self_col = np.array([idx[q] for q in query_ids])
+    rows = np.arange(len(query_ids))
+    maxk = min(max(k_values), len(case_ids) - 1)
+
+    def ranked_for(lam):
+        S = sims.copy()
+        S[rows, self_col] = -1e9  # exclude self
+        if lam > 0:
+            age = q_year[:, None] - cand_years[None, :]           # Q x N
+            w = np.exp(-lam * np.clip(age, 0, None)).astype("float32")
+            Sw = S * w
+            # undated candidate or future candidate = not temporally judgeable
+            invalid = (~has_year[None, :]) | (age < 0)
+            Sw = np.where(invalid, -1e9, Sw)
+            # apply weighting only to queries that have a year; keep baseline
+            # scores for undated queries
+            S = np.where((q_year >= 0)[:, None], Sw, S)
+            S[rows, self_col] = -1e9
+        part = np.argpartition(-S, maxk, axis=1)[:, :maxk]         # top-maxk (unordered)
+        part_scores = np.take_along_axis(S, part, axis=1)
+        order = np.argsort(-part_scores, axis=1)                   # sort those
+        top = np.take_along_axis(part, order, axis=1)
+        return {query_ids[i]: [case_ids[j] for j in top[i]]
+                for i in range(len(query_ids))}
+
+    base_ranked = ranked_for(0.0)
+    results = {"baseline": evaluate(query_ids, base_ranked, labels,
+                                    k_values, citations)}
+    for lam in lambdas:
+        results[f"recency_lambda={lam}"] = evaluate(
+            query_ids, ranked_for(lam), labels, k_values, citations)
+    if per_query_k is not None:
+        results["_perq"] = per_query_metrics(query_ids, base_ranked, labels,
+                                             citations, per_query_k)
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--zip", required=True)
+    ap.add_argument("--labels", default=None)
+    ap.add_argument("--years-json", default=None,
+                    help="external {case_id: year} map (for corpora whose dates "
+                         "the Canadian text parser cannot read, e.g. UA)")
+    ap.add_argument("--citations-json", default=None,
+                    help="{case_id: [cited_case_id,...]} = Cite(d), for the "
+                         "Yoshioka Extended-Precision/Coverage metrics. If omitted, "
+                         "the gold labels are reused as citations (works for COLIEE "
+                         "where each case's noticed list IS its citation list).")
+    ap.add_argument("--models", nargs="+", default=["e5", "bge-m3"],
+                    choices=list(MODELS))
+    ap.add_argument("--max-chars", type=int, default=4000,
+                    help="truncate each case text to this many chars before encoding")
+    ap.add_argument("--k-values", nargs="+", type=int, default=[1, 3, 5, 10])
+    ap.add_argument("--lambdas", nargs="+", type=float,
+                    default=[0.02, 0.05, 0.1, 0.2],
+                    help="recency-decay rates to sweep (score *= exp(-lambda*age))")
+    ap.add_argument("--limit", type=int, default=0,
+                    help="use only the first N query cases (0 = all) for a smoke test")
+    ap.add_argument("--batch-size", type=int, default=32)
+    ap.add_argument("--num-gpus", type=int, default=1,
+                    help="GPUs to fan the encode across (1 = single card, best for "
+                         "this ~9.7K-doc corpus; multi-GPU overhead only pays off at "
+                         "paragraph-level / full-corpus scale; 0 = all visible)")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--per-query-json", default=None,
+                    help="dump per-query baseline metrics (for bootstrap CIs / "
+                         "significance tests) at --perq-k")
+    ap.add_argument("--perq-k", type=int, default=5)
+    args = ap.parse_args()
+
+    devices = ["cpu"]
+    if any(m != "bm25" for m in args.models):  # dense models need torch/GPU
+        try:
+            import sentence_transformers  # noqa: F401
+            import torch
+        except ImportError:
+            sys.exit("Dense models need `pip install sentence-transformers torch`.")
+        n_gpu = torch.cuda.device_count()
+        n_use = args.num_gpus if args.num_gpus > 0 else n_gpu
+        devices = [f"cuda:{i}" for i in range(n_use)] if n_gpu else ["cpu"]
+
+    case_ids, texts, years, labels = load_cases(
+        args.zip, args.labels, args.max_chars, args.years_json)
+    query_ids = [q for q in labels if q in texts]
+    if args.limit:
+        query_ids = query_ids[:args.limit]
+    if args.citations_json:
+        with open(args.citations_json) as fh:
+            citations = {k: set(v) for k, v in json.load(fh).items()}
+    else:
+        citations = {k: set(v) for k, v in labels.items()}  # COLIEE: noticed = citations
+    print(f"pool={len(case_ids)} cases | queries={len(query_ids)} "
+          f"| dated={len(years)} | citing-docs={len(citations)} "
+          f"| max_chars={args.max_chars} | devices={devices}", flush=True)
+
+    per_query_k = args.perq_k if args.per_query_json else None
+    all_results, perq = {}, {}
+    for m in args.models:
+        res = run_model(
+            m, case_ids, texts, years, labels, query_ids,
+            args.k_values, args.lambdas, args.batch_size, devices, citations,
+            per_query_k)
+        if "_perq" in res:
+            perq[m] = res.pop("_perq")
+        all_results[m] = res
+
+    if args.per_query_json:
+        with open(args.per_query_json, "w") as fh:
+            json.dump({"k": args.perq_k, "per_query": perq}, fh)
+        print(f"wrote {args.per_query_json}")
+
+    print("\n===== Retrieval results (macro P/R/F1) =====")
+    for m, res in all_results.items():
+        print(f"\n[{m}]")
+        for variant, byk in res.items():
+            print(f"  {variant}")
+            for k, v in byk.items():
+                extra = (f"  ExtP={v['ExtP']:.4f}  Cov={v['Cov']:.4f}"
+                         if "ExtP" in v else "")
+                print(f"    {k:6s}  P={v['P']:.4f}  R={v['R']:.4f}  "
+                      f"F1={v['F1']:.4f}{extra}")
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump({"config": vars(args), "results": all_results}, fh, indent=2)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/ua_coupling_cocit_correlation.py
+++ b/scripts/coliee/ua_coupling_cocit_correlation.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+UALB-4: correlation between bibliographic coupling and co-citation on the SAME
+case pairs of the Ukrainian case->case precedent graph. For a case pair (a,b):
+  coupling(a,b)   = |Out(a) ∩ Out(b)|  (cases both a and b cite)   [shared OUT]
+  cocitation(a,b) = |In(a)  ∩ In(b)|   (cases citing both a and b)  [shared IN]
+These are duals; the question is whether they rank the same "similar" pairs or
+complementary ones. Runs ON prod over case_citation_links (non-self resolved
+precedent edges). Prints correlation + overlap stats.
+"""
+import math
+import os
+from collections import Counter, defaultdict
+
+import psycopg2
+
+N = int(os.environ.get("N", "6000"))     # sampled cases
+SEED = int(os.environ.get("SEED", "42"))
+CAP = int(os.environ.get("CAP", "150"))  # skip hub groups larger than this
+
+conn = psycopg2.connect(host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+                        user=os.environ["POSTGRES_USER"],
+                        password=os.environ["POSTGRES_PASSWORD"],
+                        dbname=os.environ["POSTGRES_DB"])
+cur = conn.cursor()
+cur.execute("SET statement_timeout = '240000'")
+
+# sample cases that BOTH cite and are cited (so both Out and In can be non-empty)
+cur.execute("""
+    SELECT from_doc_id
+    FROM case_citation_links TABLESAMPLE SYSTEM (0.5) REPEATABLE (%s)
+    WHERE resolved AND NOT is_self_citation AND latest_doc_id IS NOT NULL
+    GROUP BY from_doc_id
+    LIMIT %s
+""", (SEED, N))
+S = set(r[0] for r in cur.fetchall())
+
+# Out(a) for a in S  (edges FROM sampled cases)
+cur.execute("""SELECT from_doc_id, latest_doc_id FROM case_citation_links
+               WHERE from_doc_id = ANY(%s) AND resolved AND NOT is_self_citation
+                 AND latest_doc_id IS NOT NULL""", (list(S),))
+Out = defaultdict(set)
+for a, x in cur.fetchall():
+    if x != a:
+        Out[a].add(x)
+
+# In(a) for a in S  (edges TO sampled cases) -- who cites the sampled cases
+cur.execute("""SELECT from_doc_id, latest_doc_id FROM case_citation_links
+               WHERE latest_doc_id = ANY(%s) AND resolved AND NOT is_self_citation""",
+            (list(S),))
+In = defaultdict(set)
+for y, a in cur.fetchall():
+    if y != a:
+        In[a].add(y)
+conn.close()
+
+# coupling pairs: invert Out over cited target x -> sampled cases citing x
+coupling = Counter()
+inv_out = defaultdict(list)
+for a, xs in Out.items():
+    for x in xs:
+        inv_out[x].append(a)
+for x, lst in inv_out.items():
+    if len(lst) > CAP:
+        continue
+    u = sorted(set(lst))
+    for i in range(len(u)):
+        for j in range(i + 1, len(u)):
+            coupling[(u[i], u[j])] += 1
+
+# co-citation pairs (independent): invert In over citing case y -> sampled
+# cases cited by y (these are pairs co-cited by a common decision)
+cocit = Counter()
+inv_in = defaultdict(list)
+for a, ys_ in In.items():
+    for y in ys_:
+        inv_in[y].append(a)
+for y, lst in inv_in.items():
+    if len(lst) > CAP:
+        continue
+    u = sorted(set(lst))
+    for i in range(len(u)):
+        for j in range(i + 1, len(u)):
+            cocit[(u[i], u[j])] += 1
+
+# For the CORRELATION we evaluate both measures on the SAME pairs (the union of
+# coupled and co-cited pairs), computing co-citation DIRECTLY from the full In
+# sets so it is not restricted to same-sample citers.
+pairs = set(coupling) | set(cocit)
+xs, ys = [], []
+for (a, b) in pairs:
+    xs.append(coupling.get((a, b), 0))
+    ys.append(len(In.get(a, set()) & In.get(b, set())))   # direct co-citation
+n = len(pairs)
+
+
+def pearson(xs, ys):
+    if n < 2:
+        return 0.0
+    mx, my = sum(xs) / n, sum(ys) / n
+    sxy = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    sxx = sum((x - mx) ** 2 for x in xs)
+    syy = sum((y - my) ** 2 for y in ys)
+    return sxy / math.sqrt(sxx * syy) if sxx and syy else 0.0
+
+
+coupled = sum(1 for x in xs if x > 0)
+both = sum(1 for x, y in zip(xs, ys) if x > 0 and y > 0)
+print(f"sampled cases:            {len(S)}")
+print(f"coupled pairs (coupling>0): {len(coupling)}")
+print(f"co-cited pairs (sample):    {len(cocit)}")
+print(f"union pairs evaluated:      {n}")
+print(f"coupled pairs also co-cited (direct In-overlap>0): {both}  "
+      f"({100*both/max(1,coupled):.2f}% of coupled pairs)")
+r = pearson(xs, ys)
+print(f"Pearson r (coupling vs direct co-citation): {r:.4f}")
+
+out = os.environ.get("OUT")
+if out:
+    import json
+    json.dump({"sampled_cases": len(S), "coupled_pairs": len(coupling),
+               "coupled_also_cocited": both,
+               "overlap_pct": round(100 * both / max(1, coupled), 3),
+               "pearson_r": round(r, 4)}, open(out, "w"), indent=2)
+    print("wrote", out)

--- a/scripts/coliee/ua_coupling_temporal_stability.py
+++ b/scripts/coliee/ua_coupling_temporal_stability.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+UALB-5: temporal stability of bibliographic-coupling strength. Is coupling(A,B)
+(decisions sharing cited statute articles) stable over time, or does it decay
+as the time gap between the two decisions grows? If it decays, static coupling
+relevance labels are time-sensitive. Dual of the co-citation-decay result in
+arXiv:2605.17639. Runs ON prod over law_court_citations (decision->article).
+"""
+import math
+import os
+from collections import Counter, defaultdict
+
+import psycopg2
+
+N = int(os.environ.get("N", "5000"))
+SEED = int(os.environ.get("SEED", "42"))
+CAP = int(os.environ.get("CAP", "300"))       # skip article groups larger than this
+MIN_GAP_N = int(os.environ.get("MIN_GAP_N", "50"))
+ARTICLE_TYPES = ("codex_article", "law_article", "constitution", "transitional_provision")
+
+conn = psycopg2.connect(host="127.0.0.1", port=int(os.environ.get("PGPORT", "5438")),
+                        user=os.environ["POSTGRES_USER"],
+                        password=os.environ["POSTGRES_PASSWORD"],
+                        dbname=os.environ["POSTGRES_DB"])
+cur = conn.cursor()
+cur.execute("SET statement_timeout = '240000'")
+
+cur.execute("""
+    SELECT DISTINCT court_case_id
+    FROM law_court_citations TABLESAMPLE SYSTEM (0.05) REPEATABLE (%s)
+    WHERE citation_type = ANY(%s) AND adj_year IS NOT NULL
+    LIMIT %s
+""", (SEED, list(ARTICLE_TYPES), N))
+S = [r[0] for r in cur.fetchall()]
+
+cur.execute("""
+    SELECT court_case_id, citation_type, law_number, law_article, adj_year
+    FROM law_court_citations
+    WHERE court_case_id = ANY(%s) AND citation_type = ANY(%s) AND adj_year IS NOT NULL
+""", (S, list(ARTICLE_TYPES)))
+arts = defaultdict(set)
+year = {}
+for cid, ctype, lnum, lart, yr in cur.fetchall():
+    arts[cid].add(f"{ctype}|{lnum}|{lart}")
+    year[cid] = int(yr)
+conn.close()
+
+# coupling pairs via inverted article index; strength + time gap
+inv = defaultdict(list)
+for d, aset in arts.items():
+    for a in aset:
+        inv[a].append(d)
+gap_strength = defaultdict(lambda: [0, 0])   # gap -> [sum_strength, n_pairs]
+pair_strength = Counter()
+for a, ds in inv.items():
+    if len(ds) > CAP:
+        continue
+    u = sorted(set(ds))
+    for i in range(len(u)):
+        for j in range(i + 1, len(u)):
+            pair_strength[(u[i], u[j])] += 1
+for (a, b), s in pair_strength.items():
+    g = abs(year[a] - year[b])
+    gap_strength[g][0] += s
+    gap_strength[g][1] += 1
+
+
+def mann_kendall(series):
+    n = len(series)
+    if n < 3:
+        return {"n": n, "trend": "insufficient"}
+    S = sum((series[j] > series[i]) - (series[j] < series[i])
+            for i in range(n - 1) for j in range(i + 1, n))
+    ties = Counter(series)
+    var = (n * (n - 1) * (2 * n + 5)
+           - sum(t * (t - 1) * (2 * t + 5) for t in ties.values())) / 18.0
+    z = (S - 1) / math.sqrt(var) if S > 0 and var > 0 else \
+        ((S + 1) / math.sqrt(var) if S < 0 and var > 0 else 0.0)
+    p = 2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(z) / math.sqrt(2.0))))
+    tau = S / (0.5 * n * (n - 1))
+    trend = "no-trend" if p >= 0.05 else ("increasing" if S > 0 else "decreasing")
+    return {"n": n, "tau": round(tau, 4), "z": round(z, 3), "p": round(p, 6),
+            "trend": trend}
+
+
+rows = sorted((g, sa / n, n) for g, (sa, n) in gap_strength.items() if n >= MIN_GAP_N)
+mk = mann_kendall([m for _, m, _ in rows])
+print(f"sampled decisions: {len(S)} | coupled pairs: {sum(v[1] for v in gap_strength.values())}")
+print("gap(yrs)  mean_coupling_strength  n_pairs")
+for g, mean_s, n in rows:
+    print(f"  {g:3d}      {mean_s:6.3f}                {n}")
+print("Mann-Kendall (mean coupling strength vs time gap):", mk)
+
+out = os.environ.get("OUT")
+if out:
+    import json
+    json.dump({"sampled_decisions": len(S),
+               "coupled_pairs": sum(v[1] for v in gap_strength.values()),
+               "gap_series": [{"gap": g, "mean_strength": round(m, 3), "n": n}
+                              for g, m, n in rows],
+               "mann_kendall": mk}, open(out, "w"), indent=2)
+    print("wrote", out)


### PR DESCRIPTION
## What

Tracks the COLIEE / cross-jurisdictional coupling tooling, which had been running out of the working tree and was never committed. The July scripts come along because the new ones import `retrieval_experiment.py`.

## New scripts

| Script | Purpose |
|---|---|
| `bc_diagnostics.py` | Popularity floor plus a greedy oracle constant list (bounds every constant list, since coverage at fixed k is monotone submodular); Coverage decomposed by how often each gold case is cited; growth of the BC layer with citation knowledge |
| `reachability_gain.py` | Reachability Gain, a nugget/diversity formulation of coupling-aware evaluation. `--verify` asserts that its corner cases reproduce Extended Precision and Coverage (difference 0 on three rankers, two corpora) |
| `dump_rankings.py` | Dump dense-encoder top-k lists; the July runs kept aggregates only, so rank-aware measures could not be recomputed |

## Two fixes worth flagging

- **Non-determinism.** Candidate ordering in the boilerplate ranker came from set iteration, so results moved with `PYTHONHASHSEED` (third decimal). Now tie-broken on document id and verified identical across seeds.
- **Hardcoded path.** The EDRSR instance-status export is read from `ISL_EXPORT_DIR` instead of an absolute scratch path, and is optional.

## Context

Answers Prof. Yoshioka's request for a single BC-aware evaluation measure (ICTIR '26, doi:10.1145/3805713.3820412). Paper and note go through overthelex/secondlayer-papers#59; released artifacts are already updated on HF (`overthelex/crossjur-citation-coupling`).

No production code touched: new files under `scripts/coliee/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bibliographic-coupling diagnostics and a new Reachability Gain (RG) metric that unifies Extended Precision and Coverage for COLIEE evaluation. Also adds retrieval scaffolding and CA/UA data tools to run, dump, and analyze experiments.

- **New Features**
  - Reachability Gain (rank-aware, diversity-weighted) with `--verify` proving it reduces to Extended Precision and Coverage; includes a deterministic “boilerplate” adversarial ranker.
  - Diagnostics: popularity floor, head-vs-tail coverage breakdown, and BC-layer growth vs. known citations.
  - Retrieval tooling: BM25/E5/BGE‑M3 harness with recency re‑ranking, top‑k ranking dumps, and bootstrap CIs for per‑query metrics.
  - CA/UA data scripts: Canadian citation-graph stats; UA case-retrieval package and citation map; UA coupling/cocitation correlation, temporal stability, and full case→case temporal analysis.

- **Bug Fixes**
  - Deterministic candidate ordering in the boilerplate ranker (tie-break on document id).
  - Instance-status export path is configurable via ISL_EXPORT_DIR and optional.

<sup>Written for commit 1c02ec5c7015c0014561ced42ad9843108b276b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

