### PR TITLE
feat(nl-rechtspraak): explicit date windows, full field parsing, day checkpoints

### DIFF
--- a/services/opendata-importers/importers/nl_rechtspraak.py
+++ b/services/opendata-importers/importers/nl_rechtspraak.py
@@ -1,13 +1,29 @@
 """NL Rechtspraak incremental ECLI sync — top up nl_rechtspraak_decisions.
 
 Strategy:
-1. Query the prod table for the most recent decision_date / max imported_at
-2. Use data.rechtspraak.nl Atom feed (zoeken endpoint) to walk forward from there
-3. For each new ECLI, fetch the full XML, parse fields, batch insert
+1. Pick the date window (START_DATE/END_DATE, else walk forward from prod's max)
+2. Use data.rechtspraak.nl Atom feed (zoeken endpoint) to list ECLIs per day
+3. For each ECLI, fetch the full XML, parse fields, batch upsert
 
 The feed endpoint accepts ?date=YYYY-MM-DD&max=N pagination.
+
+Note on coverage: Rechtspraak publishes most decisions as metadata only. Probing
+420 text-less rows across 2013-2026 found a body for 1% of them, so a NULL
+full_text is normally the source's own state, not a parse failure. The one real
+recovery case is decisions published within roughly the last 90 days, where the
+body lands days after the metadata (30% for 2026-04 rows fetched same-day) — that
+is what nl_rechtspraak_enrich.py re-checks.
+
+Progress is checkpointed per day. Days within SETTLE_DAYS of today are always
+re-walked, because a decision's body is published days after its metadata.
+
+Env:
+  START_DATE / END_DATE   explicit window (YYYY-MM-DD), skips the max-date probe
+  WALK_DAYS               days to walk forward when START_DATE is unset (default 30)
+  SETTLE_DAYS             how recent a day must be to be re-walked (default 45)
 """
 import asyncio
+import json
 import logging
 import os
 import re
@@ -26,19 +42,129 @@ from shared.prod_writer import _ssh_cmd  # noqa: E402
 
 ATOM_NS = {"a": "http://www.w3.org/2005/Atom"}
 
+RDF_NS = {
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "dcterms": "http://purl.org/dc/terms/",
+    "psi": "http://psi.rechtspraak.nl/",
+    "ecli": "https://e-justice.europa.eu/ecli",
+    "rs": "http://www.rechtspraak.nl/schema/rechtspraak-1.0",
+}
+
+# dcterms/psi fields worth keeping verbatim in metadata_json
+META_FIELDS = ("identifier", "format", "accessRights", "modified", "issued",
+               "publisher", "language", "creator", "date", "type", "coverage",
+               "spatial", "subject", "references", "title", "zaaknummer",
+               "procedure", "hasVersion")
+
+_WS = re.compile(r"\s+")
+
+
+def _norm(text: str) -> str:
+    """Collapse whitespace. Matches the flattened form of the rows already on prod."""
+    return _WS.sub(" ", text).strip()
+
+
+def _pg_array(items: list[str]) -> str | None:
+    """Render a text[] literal for COPY. Quotes/backslashes are dropped rather
+    than escaped: these are rechtsgebied labels, never contain them."""
+    clean = []
+    for item in items:
+        item = item.replace('"', "").replace("\\", "").strip()
+        if item and item not in clean:
+            clean.append(item)
+    if not clean:
+        return None
+    return "{" + ",".join(f'"{i}"' for i in clean) + "}"
+
+
+def parse_document(body: str, ecli: str) -> dict | None:
+    """Parse one data.rechtspraak.nl content document into a row dict.
+
+    Returns None when the XML will not parse at all. A document with no
+    <uitspraak>/<conclusie> body is still returned, with full_text=None: that is
+    the normal shape for a metadata-only publication.
+    """
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError:
+        return None
+
+    texts: dict[str, list[str]] = {}
+    full_text = None
+    summary = None
+
+    for el in root.iter():
+        tag = el.tag.split("}", 1)[-1]
+        if tag in ("uitspraak", "conclusie"):
+            if full_text is None:
+                candidate = _norm("".join(el.itertext()))
+                if candidate:
+                    full_text = candidate
+        elif tag == "inhoudsindicatie":
+            if summary is None:
+                candidate = _norm("".join(el.itertext()))
+                if candidate:
+                    summary = candidate
+        elif tag in META_FIELDS:
+            value = _norm("".join(el.itertext()))
+            if value:
+                texts.setdefault(tag, []).append(value)
+
+    def first(tag: str) -> str | None:
+        vals = texts.get(tag)
+        return vals[0] if vals else None
+
+    if summary is None:
+        summary = first("abstract")
+
+    decision_date = first("date")
+    if decision_date and len(decision_date) >= 10:
+        decision_date = decision_date[:10]
+    else:
+        decision_date = None
+
+    # dcterms:subject arrives either as repeated elements or one "A; B" string
+    subjects: list[str] = []
+    for raw in texts.get("subject", []):
+        subjects.extend(part.strip() for part in raw.split(";"))
+
+    court = first("creator")
+
+    return {
+        "ecli": ecli,
+        "case_number": first("zaaknummer"),
+        "court_code": court,
+        "court_name": court,
+        "decision_date": decision_date,
+        "decision_type": first("type"),
+        "procedure_type": first("procedure"),
+        "subject_areas": _pg_array(subjects),
+        "summary": summary[:5000] if summary else None,
+        "full_text": full_text[:1_000_000] if full_text else None,
+        "full_text_xml": body,
+        "metadata_json": json.dumps(
+            {k: (v[0] if len(v) == 1 else v) for k, v in texts.items()},
+            ensure_ascii=False),
+    }
+
 
 class NLRechtspraakImporter(BaseImporter):
     SERVICE_NAME = "nl_rechtspraak"
     TARGET_TABLE = "nl_rechtspraak_decisions"
     COLUMNS = ["ecli", "case_number", "court_code", "court_name",
                "decision_date", "decision_type", "procedure_type",
-               "subject_areas", "parties", "summary", "full_text", "metadata_json"]
+               "subject_areas", "summary", "full_text", "full_text_xml",
+               "metadata_json"]
     PK_COLUMNS = ["ecli"]
-    ON_CONFLICT = "do_nothing"
+    # Enrich rather than skip: a row may already exist from an earlier run that
+    # only had metadata. The source is authoritative, so a freshly parsed value
+    # replaces the stored one; stored values survive where the source has none.
+    ON_CONFLICT = "do_update_prefer_new"
     BATCH_SIZE = 500
 
     SEARCH_URL = "https://data.rechtspraak.nl/uitspraken/zoeken"
     CONTENT_URL = "https://data.rechtspraak.nl/uitspraken/content"
+    FEED_PAGE_SIZE = 1000
 
     def _get_max_date_on_prod(self) -> str:
         cmd = _ssh_cmd(self.ssh_host) + [
@@ -50,147 +176,155 @@ class NLRechtspraakImporter(BaseImporter):
             return "2000-01-01"
         return proc.stdout.strip() or "2000-01-01"
 
+    def _window(self) -> tuple[date, date]:
+        """Resolve the date window to walk.
+
+        START_DATE exists because resuming from MAX(decision_date) silently skips
+        holes: anything loaded out of band (e.g. the 2026-07-25 pilot merge, which
+        pushed the max to 2026-07-03 while leaving 2026-05-23..07-03 nearly empty)
+        moves the cursor past days that were never harvested.
+        """
+        today = date.today()
+        start_env = os.environ.get("START_DATE", "").strip()
+        end_env = os.environ.get("END_DATE", "").strip()
+
+        if start_env:
+            start_day = date.fromisoformat(start_env)
+            end_day = date.fromisoformat(end_env) if end_env else today
+            self.log.info(f"Explicit window from env: {start_day}..{end_day}")
+        else:
+            max_date_str = self._get_max_date_on_prod()
+            self.log.info(f"Max decision_date on prod: {max_date_str}")
+            try:
+                start_day = date.fromisoformat(max_date_str)
+            except ValueError:
+                start_day = date(2000, 1, 1)
+            end_day = start_day + timedelta(days=int(os.environ.get("WALK_DAYS", "30")))
+
+        return start_day, min(end_day, today)
+
     async def _list_eclis_for_date(self, pool, idx: int, day: date) -> list[str]:
-        url = f"{self.SEARCH_URL}?date={day.isoformat()}&max=1000"
-        try:
-            status, body = await pool.fetch(idx, url)
-        except Exception as e:
-            self.log.warning(f"feed fetch failed for {day}: {e}")
-            return []
-        if status != 200:
-            return []
-        try:
-            root = ET.fromstring(body)
-        except ET.ParseError:
-            return []
-        return [e.text for e in root.findall(".//a:entry/a:id", ATOM_NS) if e.text]
+        """List every ECLI for one decision date, following the feed's paging.
+
+        Busy days exceed a single page (2026-05-20 has 955), so stopping at the
+        first response would silently drop decisions. The feed reports the true
+        total in <subtitle> ("Aantal gevonden ECLI's: N"), which is what we page
+        against.
+        """
+        found: list[str] = []
+        offset = 0
+        total = None
+        while True:
+            url = (f"{self.SEARCH_URL}?date={day.isoformat()}"
+                   f"&max={self.FEED_PAGE_SIZE}&from={offset}")
+            try:
+                status, body = await pool.fetch(idx, url)
+            except Exception as e:
+                self.log.warning(f"feed fetch failed for {day} at offset {offset}: {e}")
+                break
+            if status != 200:
+                self.log.warning(f"feed HTTP {status} for {day} at offset {offset}")
+                break
+            try:
+                root = ET.fromstring(body)
+            except ET.ParseError:
+                self.log.warning(f"feed XML parse failed for {day} at offset {offset}")
+                break
+
+            page = [e.text for e in root.findall(".//a:entry/a:id", ATOM_NS) if e.text]
+            if total is None:
+                total = self._feed_total(root)
+            found.extend(page)
+            offset += len(page)
+            if not page or (total is not None and offset >= total):
+                break
+
+        if total is not None and len(found) < total:
+            self.log.warning(f"{day}: feed reports {total} ECLIs but only {len(found)} "
+                             f"were listed — that day is incomplete")
+        return found
+
+    @staticmethod
+    def _feed_total(root) -> int | None:
+        subtitle = root.find("a:subtitle", ATOM_NS)
+        if subtitle is None or not subtitle.text:
+            return None
+        digits = re.search(r"(\d+)", subtitle.text)
+        return int(digits.group(1)) if digits else None
 
     async def _fetch_one(self, pool, idx: int, ecli: str) -> dict | None:
         url = f"{self.CONTENT_URL}?id={ecli}"
         try:
             status, body = await pool.fetch(idx, url)
-        except Exception as e:
+        except Exception:
             self.stats.failed += 1
             return None
         if status != 200 or len(body) < 200:
             self.stats.skipped += 1
             return None
 
-        try:
-            root = ET.fromstring(body)
-        except ET.ParseError:
+        rec = parse_document(body, ecli)
+        if rec is None:
             self.stats.failed += 1
             return None
-
-        # Extract via namespaces — open data uses RDF + dcterms
-        def _text(xpath: str) -> str:
-            ns = {
-                "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-                "dcterms": "http://purl.org/dc/terms/",
-                "psi": "http://psi.rechtspraak.nl/",
-                "ecli": "https://e-justice.europa.eu/ecli",
-                "ucitsi": "http://www.rechtspraak.nl/schema/rechtspraak-1.0",
-            }
-            try:
-                el = root.find(xpath, ns)
-                if el is not None:
-                    return (el.text or "").strip()
-            except Exception:
-                pass
-            return ""
-
-        full_text = ""
-        for el in root.iter():
-            tag = el.tag.split("}", 1)[-1]
-            if tag in ("uitspraak", "conclusie") and el.text:
-                full_text = "".join(el.itertext()).strip()
-                break
-
-        decision_date = _text(".//dcterms:date") or _text(".//{http://purl.org/dc/terms/}date")
-        if decision_date and len(decision_date) >= 10:
-            decision_date = decision_date[:10]
-        else:
-            decision_date = None
-
-        court_code = _text(".//dcterms:creator")
-        decision_type = _text(".//dcterms:type")
-        procedure_type = _text(".//psi:procedure")
-        case_number = _text(".//psi:zaaknummer")
-        summary = _text(".//dcterms:abstract")[:5000]
-
         self.stats.downloaded += 1
-        return {
-            "ecli": ecli,
-            "case_number": case_number,
-            "court_code": court_code,
-            "court_name": court_code,
-            "decision_date": decision_date,
-            "decision_type": decision_type,
-            "procedure_type": procedure_type,
-            "subject_areas": None,
-            "parties": None,
-            "summary": summary,
-            "full_text": full_text[:1_000_000] if full_text else None,
-            "metadata_json": "{}",
-        }
+        return rec
+
+    async def _fetch_many(self, pool, eclis: list[str], offset: int) -> list[dict]:
+        """Fetch a chunk concurrently. The session pool's per-IP semaphores cap
+        real parallelism, so handing it the whole chunk is safe."""
+        results = await asyncio.gather(
+            *[self._fetch_one(pool, offset + i, e) for i, e in enumerate(eclis)])
+        return [r for r in results if r]
 
     async def import_dataset(self, pool: MultiIPSessionPool):
-        max_date_str = self._get_max_date_on_prod()
-        self.log.info(f"Max decision_date on prod: {max_date_str}")
-        try:
-            start_day = date.fromisoformat(max_date_str)
-        except ValueError:
-            start_day = date(2000, 1, 1)
-
-        days_to_walk = int(os.environ.get("WALK_DAYS", "30"))
-        end_day = start_day + timedelta(days=days_to_walk)
-        today = date.today()
-        if end_day > today:
-            end_day = today
-
-        days = [start_day + timedelta(days=i) for i in range((end_day - start_day).days + 1)]
-        self.log.info(f"Walking {len(days)} days from {start_day} to {end_day}")
-
-        # Stage 1: list ECLIs per day in parallel
-        eclis = []
-        sem_idx = [0]
-
-        async def list_one(day):
-            sem_idx[0] += 1
-            ecli_list = await self._list_eclis_for_date(pool, sem_idx[0], day)
-            return ecli_list
-
-        for chunk_start in range(0, len(days), 30):
-            chunk = days[chunk_start:chunk_start+30]
-            results = await asyncio.gather(*[list_one(d) for d in chunk])
-            for sub in results:
-                eclis.extend(sub)
-            self.log.info(f"  listed {chunk_start+len(chunk)}/{len(days)} days, {len(eclis)} ECLIs found so far")
-
-        seen = self.ckpt.done_set
-        new_eclis = [e for e in eclis if e not in seen]
-        self.log.info(f"Total {len(eclis)} ECLIs from feed; {len(new_eclis)} new (not in checkpoint)")
-
-        if not new_eclis:
-            self.log.info("Nothing to fetch — all caught up")
+        start_day, end_day = self._window()
+        if end_day < start_day:
+            self.log.warning(f"Empty window {start_day}..{end_day}, nothing to do")
             return
 
-        # Stage 2: fetch full XML in parallel
-        batch = []
-        for i, ecli in enumerate(new_eclis):
-            rec = await self._fetch_one(pool, i, ecli)
-            if rec:
-                batch.append(tuple(rec[c] for c in self.COLUMNS))
-                self.ckpt.add_done(ecli)
-            if len(batch) >= self.BATCH_SIZE:
-                self.write_batch(batch)
-                self.ckpt.flush()
-                batch = []
-            if (i + 1) % 200 == 0:
-                self.log.info(f"  fetched {i+1}/{len(new_eclis)}")
-        if batch:
-            self.write_batch(batch)
-            self.ckpt.flush()
+        # Progress is tracked per day, not per ECLI: a full-history walk covers
+        # 1.7M+ ECLIs and rewriting that list into the JSON checkpoint after every
+        # batch would cost more I/O than the harvest itself.
+        self.ckpt.delete("done")
+        days_done = set(self.ckpt.get("days_done", []))
+
+        # Recent days are always re-walked. Rechtspraak publishes the body days
+        # after the metadata, so a day is only final once it has settled.
+        settle_days = int(os.environ.get("SETTLE_DAYS", "45"))
+        settled_before = date.today() - timedelta(days=settle_days)
+
+        days = [start_day + timedelta(days=i) for i in range((end_day - start_day).days + 1)]
+        todo = [d for d in days
+                if not (d.isoformat() in days_done and d < settled_before)]
+        self.log.info(f"Window {start_day}..{end_day}: {len(days)} days, "
+                      f"{len(days) - len(todo)} already settled, {len(todo)} to walk "
+                      f"(SETTLE_DAYS={settle_days})")
+
+        for n, day in enumerate(todo, start=1):
+            eclis = list(dict.fromkeys(await self._list_eclis_for_date(pool, n, day)))
+            if not eclis:
+                self._mark_day_done(day)
+                continue
+
+            with_text = 0
+            for start in range(0, len(eclis), self.BATCH_SIZE):
+                chunk = eclis[start:start + self.BATCH_SIZE]
+                records = await self._fetch_many(pool, chunk, start)
+                if records:
+                    with_text += sum(1 for r in records if r["full_text"])
+                    self.write_batch([tuple(r[c] for c in self.COLUMNS) for r in records])
+
+            self._mark_day_done(day)
+            self.log.info(f"  [{n}/{len(todo)}] {day}: {len(eclis)} ECLIs, "
+                          f"{with_text} with text | {self.stats.report()}")
+
+    def _mark_day_done(self, day: date):
+        days_done = self.ckpt.get("days_done", [])
+        iso = day.isoformat()
+        if iso not in days_done:
+            days_done.append(iso)
+        self.ckpt.set("days_done", days_done)
 
 
 if __name__ == "__main__":

--- a/services/opendata-importers/importers/nl_rechtspraak_enrich.py
+++ b/services/opendata-importers/importers/nl_rechtspraak_enrich.py
@@ -1,0 +1,148 @@
+"""NL Rechtspraak enrichment pass — fill holes in rows that already exist on prod.
+
+Unlike nl_rechtspraak.py (which walks the Atom feed forward to discover new
+decisions), this reads its worklist from prod and re-fetches those ECLIs so every
+row ends up parsed by one parser. Writes go through ON CONFLICT DO UPDATE in
+prefer-new mode: a value parsed from the source replaces the stored one, and
+stored values survive only where the source has nothing. jsonb metadata is merged
+key-wise, so load markers survive.
+
+Why it exists: as of 2026-07-25 the table had been filled by three different
+loaders and showed it. Of 1,470,895 rows, 553,250 had no subject_areas and 553,280
+no summary; 617,623 of the rows that did have text carried the document's RDF
+header inside full_text (mime types, publisher, deeplink URL) because one loader
+flattened the whole XML; and 1,614 rows held bytes that are not valid UTF-8, which
+makes any full-table query using string functions abort. Re-fetching and
+re-parsing fixes all three at once.
+
+What it cannot fix: missing full_text. Probing 420 text-less rows across
+2013-2026 found a body for 1% of them — Rechtspraak publishes most decisions as
+metadata only. The exception is recent decisions, where the body lands days after
+the metadata (30% of 2026-04 rows that were fetched same-day now have one), which
+is what MODE=recent_text re-checks.
+
+Modes (MODE env):
+  metadata     rows never enriched from source RDF (default)
+  recent_text  rows with no full_text whose decision_date is within RECHECK_DAYS
+
+Env:
+  MODE, RECHECK_DAYS (default 90), WORKLIST_LIMIT (0 = no limit, for smoke tests)
+"""
+import asyncio
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from importers.nl_rechtspraak import parse_document  # noqa: E402
+from shared.base import BaseImporter, setup_logging  # noqa: E402
+from shared.http_client import MultiIPSessionPool  # noqa: E402
+from shared.prod_writer import _ssh_cmd  # noqa: E402
+
+
+# A row counts as enriched once its metadata_json carries the source's own
+# dcterms:identifier. That makes the worklist self-draining: rows whose source
+# genuinely has no subject_areas still drop out after one pass instead of being
+# re-fetched forever.
+WORKLISTS = {
+    "metadata": (
+        "SELECT ecli FROM nl_rechtspraak_decisions "
+        "WHERE NOT (COALESCE(metadata_json, '{}'::jsonb) ? 'identifier') "
+        "ORDER BY decision_date DESC NULLS LAST, ecli"
+    ),
+    "recent_text": (
+        "SELECT ecli FROM nl_rechtspraak_decisions "
+        "WHERE full_text IS NULL "
+        "AND decision_date >= current_date - INTERVAL '{recheck_days} days' "
+        "ORDER BY decision_date DESC"
+    ),
+}
+
+
+class NLRechtspraakEnricher(BaseImporter):
+    SERVICE_NAME = "nl_rechtspraak_enrich"
+    TARGET_TABLE = "nl_rechtspraak_decisions"
+    COLUMNS = ["ecli", "case_number", "court_code", "court_name",
+               "decision_date", "decision_type", "procedure_type",
+               "subject_areas", "summary", "full_text", "full_text_xml",
+               "metadata_json"]
+    PK_COLUMNS = ["ecli"]
+    ON_CONFLICT = "do_update_prefer_new"
+    BATCH_SIZE = 500
+
+    CONTENT_URL = "https://data.rechtspraak.nl/uitspraken/content"
+
+    def __init__(self):
+        super().__init__()
+        self.mode = os.environ.get("MODE", "metadata")
+        if self.mode not in WORKLISTS:
+            raise SystemExit(f"MODE must be one of {sorted(WORKLISTS)}, got {self.mode!r}")
+        self.recheck_days = int(os.environ.get("RECHECK_DAYS", "90"))
+        self.worklist_limit = int(os.environ.get("WORKLIST_LIMIT", "0"))
+
+    def _worklist(self) -> list[str]:
+        """Pull the ECLIs to re-fetch from prod.
+
+        No ECLI checkpoint here on purpose: the query is self-draining, so a
+        re-run after a crash simply returns what is still missing. Keeping
+        hundreds of thousands of ECLIs in the JSON checkpoint would rewrite a
+        multi-megabyte file on every batch.
+        """
+        # str.replace, not str.format: the metadata query contains '{}'::jsonb
+        sql = WORKLISTS[self.mode].replace("{recheck_days}", str(self.recheck_days))
+        if self.worklist_limit:
+            sql += f" LIMIT {self.worklist_limit}"
+        cmd = _ssh_cmd(self.ssh_host) + [
+            f"docker exec {self.container} psql -U {self.dbuser} -d {self.dbname} "
+            f"-tA -c \"{sql}\""]
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=1800)
+        if proc.returncode != 0:
+            raise RuntimeError(f"worklist query failed: {proc.stderr[-2000:]}")
+        return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+    async def _fetch_one(self, pool, idx: int, ecli: str) -> dict | None:
+        try:
+            status, body = await pool.fetch(idx, f"{self.CONTENT_URL}?id={ecli}")
+        except Exception:
+            self.stats.failed += 1
+            return None
+        if status != 200 or len(body) < 200:
+            self.stats.skipped += 1
+            return None
+        rec = parse_document(body, ecli)
+        if rec is None:
+            self.stats.failed += 1
+            return None
+        self.stats.downloaded += 1
+        return rec
+
+    async def import_dataset(self, pool: MultiIPSessionPool):
+        eclis = self._worklist()
+        self.log.info(f"mode={self.mode} worklist={len(eclis)} ECLIs"
+                      + (f" (RECHECK_DAYS={self.recheck_days})"
+                         if self.mode == "recent_text" else ""))
+        if not eclis:
+            self.log.info("Nothing to enrich")
+            return
+
+        filled_text = 0
+        for start in range(0, len(eclis), self.BATCH_SIZE):
+            chunk = eclis[start:start + self.BATCH_SIZE]
+            records = await asyncio.gather(
+                *[self._fetch_one(pool, start + i, e) for i, e in enumerate(chunk)])
+            records = [r for r in records if r]
+            if records:
+                filled_text += sum(1 for r in records if r["full_text"])
+                self.write_batch([tuple(r[c] for c in self.COLUMNS) for r in records])
+            done = min(start + self.BATCH_SIZE, len(eclis))
+            self.log.info(f"  {done}/{len(eclis)} | bodies found so far: {filled_text}"
+                          f" | {self.stats.report()}")
+
+        self.log.info(f"Enrichment done: {filled_text} of {len(eclis)} documents "
+                      f"carried a body at source")
+
+
+if __name__ == "__main__":
+    setup_logging("nl_rechtspraak_enrich")
+    NLRechtspraakEnricher().run()

--- a/services/opendata-importers/shared/checkpoint.py
+++ b/services/opendata-importers/shared/checkpoint.py
@@ -40,6 +40,13 @@ class Checkpoint:
         if item not in done:
             done.append(item)
 
+    def delete(self, key: str):
+        """Drop a key entirely. Used when an importer migrates to a different
+        progress unit and the old one would keep bloating the file."""
+        if key in self._state:
+            del self._state[key]
+            self.flush()
+
     def is_done(self, item: str) -> bool:
         return item in self._state.get("done", [])
 

--- a/services/opendata-importers/shared/prod_writer.py
+++ b/services/opendata-importers/shared/prod_writer.py
@@ -90,6 +90,12 @@ def copy_into(table: str, columns: list[str], rows: Iterable[tuple],
 
     The temp table mirrors the target's column types so PostgreSQL casts
     text-format COPY inputs into DATE / JSONB / etc. natively.
+
+    on_conflict:
+      do_nothing            skip rows whose key already exists
+      do_update             overwrite every non-key column, NULLs included
+      do_update_prefer_new  incoming value wins, stored value kept where the
+                            incoming one is NULL; jsonb columns merged key-wise
     Returns the number of rows inserted (0 if all conflicted with DO NOTHING).
     Raises subprocess.CalledProcessError on psql failure.
     """
@@ -110,6 +116,25 @@ def copy_into(table: str, columns: list[str], rows: Iterable[tuple],
         elif on_conflict == "do_update":
             updates = ", ".join(f"{c}=EXCLUDED.{c}" for c in columns if c not in pk_columns)
             conflict_clause = f"ON CONFLICT ({', '.join(pk_columns)}) DO UPDATE SET {updates}"
+        elif on_conflict == "do_update_prefer_new":
+            # The incoming value wins; a stored value survives only where the new
+            # row has NULL. Use this for re-fetch passes where the source is the
+            # authority and the stored copy may be stale or badly parsed.
+            # jsonb columns are merged key-wise instead, so a re-fetch can add
+            # source fields without dropping markers a previous load left.
+            setters = []
+            for c in columns:
+                if c in pk_columns:
+                    continue
+                if types.get(c, "").lower() == "jsonb":
+                    setters.append(f"{c}=COALESCE({table}.{c}, '{{}}'::jsonb) "
+                                   f"|| COALESCE(EXCLUDED.{c}, '{{}}'::jsonb)")
+                else:
+                    setters.append(f"{c}=COALESCE(EXCLUDED.{c}, {table}.{c})")
+            if "updated_at" in types and "updated_at" not in columns:
+                setters.append("updated_at=now()")
+            conflict_clause = (f"ON CONFLICT ({', '.join(pk_columns)}) "
+                               f"DO UPDATE SET {', '.join(setters)}")
 
     sql = f"""
 BEGIN;

--- a/services/opendata-importers/tools/README.md
+++ b/services/opendata-importers/tools/README.md
@@ -1,0 +1,30 @@
+# Diagnostic tools
+
+Read-only probes used to size a gap before writing an importer or a backfill.
+Both talk to the source API only; neither writes to a database.
+
+## coverage_scan.py
+
+Per-day comparison of "how many documents the source lists" against "how many
+rows we hold", rolled up by month. This is what showed the NL corpus was at 53.9%
+of the Rechtspraak feed for 2015-2026 (938,704 of 1,741,852) rather than the
+near-complete state the row count suggested.
+
+```bash
+ssh prod "docker exec secondlayer-postgres-prod psql -U secondlayer -d secondlayer_prod -tAc \
+  \"SELECT to_char(decision_date,'YYYY-MM-DD')||','||count(*) FROM nl_rechtspraak_decisions \
+    GROUP BY decision_date ORDER BY decision_date\"" > prod_daily.csv
+python3 tools/coverage_scan.py prod_daily.csv 2015-01-01 2026-07-24 coverage_by_day.csv
+```
+
+## probe_fields.py
+
+Takes "ecli,bucket" lines and reports, per bucket, which fields the source
+actually exposes for those documents. Use it before launching a backfill to find
+out whether the data you are missing exists at all: for NL it showed a body is
+available for only 1% of text-less rows, while dcterms:subject is available for
+96%, which turned a "harvest 549K missing texts" plan into a metadata backfill.
+
+```bash
+python3 tools/probe_fields.py < eclis_with_year.csv
+```

--- a/services/opendata-importers/tools/coverage_scan.py
+++ b/services/opendata-importers/tools/coverage_scan.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Scan feed-vs-prod coverage for every day in a range and roll it up by month.
+
+Usage: coverage_scan.py <prod_counts.csv> <from YYYY-MM-DD> <to YYYY-MM-DD> [out.csv]
+
+prod_counts.csv is "YYYY-MM-DD,count" exported from prod. Writes the per-day
+comparison to out.csv (default coverage_by_day.csv) and prints a monthly rollup.
+"""
+import asyncio
+import sys
+from collections import defaultdict
+from datetime import date, timedelta
+from xml.etree import ElementTree as ET
+
+import aiohttp
+
+UA = "SecondLayer-Legal-Platform/2.0 (legal.org.ua; opendata-importer)"
+SEARCH = "https://data.rechtspraak.nl/uitspraken/zoeken"
+ATOM = {"a": "http://www.w3.org/2005/Atom"}
+CONCURRENCY = 12
+
+
+async def feed_total(session, sem, day):
+    async with sem:
+        for attempt in range(4):
+            try:
+                async with session.get(f"{SEARCH}?date={day}&max=1") as r:
+                    if r.status != 200:
+                        raise RuntimeError(f"http {r.status}")
+                    root = ET.fromstring(await r.text())
+                    sub = root.find("a:subtitle", ATOM)
+                    text = sub.text if sub is not None else ""
+                    return day, int("".join(c for c in text if c.isdigit()) or 0)
+            except Exception:
+                if attempt == 3:
+                    return day, None
+                await asyncio.sleep(2 * (attempt + 1))
+
+
+async def main():
+    prod_file, start_s, end_s = sys.argv[1], sys.argv[2], sys.argv[3]
+    out_path = sys.argv[4] if len(sys.argv) > 4 else "coverage_by_day.csv"
+
+    prod = {}
+    for line in open(prod_file):
+        line = line.strip()
+        if line and "," in line:
+            d, c = line.rsplit(",", 1)
+            prod[d.strip()] = int(c)
+
+    start, end = date.fromisoformat(start_s), date.fromisoformat(end_s)
+    days = [(start + timedelta(days=i)).isoformat()
+            for i in range((end - start).days + 1)]
+    print(f"scanning {len(days)} days {start}..{end}", file=sys.stderr)
+
+    sem = asyncio.Semaphore(CONCURRENCY)
+    async with aiohttp.ClientSession(headers={"User-Agent": UA},
+                                     timeout=aiohttp.ClientTimeout(total=120)) as s:
+        results = []
+        for i in range(0, len(days), 200):
+            batch = days[i:i + 200]
+            results.extend(await asyncio.gather(
+                *[feed_total(s, sem, d) for d in batch]))
+            print(f"  {min(i + 200, len(days))}/{len(days)}", file=sys.stderr)
+
+    per_month = defaultdict(lambda: [0, 0, 0])  # feed, prod, error_days
+    with open(out_path, "w") as fh:
+        fh.write("date,feed,prod,missing\n")
+        for day, total in sorted(results):
+            have = prod.get(day, 0)
+            month = day[:7]
+            if total is None:
+                per_month[month][2] += 1
+                continue
+            per_month[month][0] += total
+            per_month[month][1] += have
+            fh.write(f"{day},{total},{have},{max(0, total - have)}\n")
+
+    print(f"{'month':9} {'feed':>8} {'prod':>8} {'missing':>9} {'coverage':>9} {'errs':>5}")
+    tf = tp = 0
+    for month in sorted(per_month):
+        feed, have, errs = per_month[month]
+        tf += feed
+        tp += have
+        cov = f"{100 * have / feed:.0f}%" if feed else "-"
+        print(f"{month:9} {feed:8} {have:8} {max(0, feed - have):9} {cov:>9} {errs:5}")
+    print(f"{'TOTAL':9} {tf:8} {tp:8} {max(0, tf - tp):9} "
+          f"{(100 * tp / tf if tf else 0):8.1f}%")
+    print(f"per-day detail written to {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/opendata-importers/tools/probe_fields.py
+++ b/services/opendata-importers/tools/probe_fields.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Measure which RDF fields are recoverable for NL rows that currently lack full_text.
+
+Input on stdin: "ecli,bucket" per line (bucket is any grouping label, e.g. year or YYYY-MM).
+Reports per bucket how many documents expose a body, dcterms:subject, dcterms:abstract
+(inhoudsindicatie), psi:procedure and dcterms:type.
+"""
+import asyncio
+import sys
+from collections import defaultdict
+from xml.etree import ElementTree as ET
+
+import aiohttp
+
+UA = "SecondLayer-Legal-Platform/2.0 (legal.org.ua; opendata-importer)"
+CONTENT_URL = "https://data.rechtspraak.nl/uitspraken/content?id="
+CONCURRENCY = 16
+FIELDS = ("body", "subject", "abstract", "procedure", "type", "zaaknummer")
+
+
+def parse(body: str) -> dict:
+    got = {}
+    try:
+        root = ET.fromstring(body)
+    except ET.ParseError:
+        return {"parse_fail": True}
+    for el in root.iter():
+        tag = el.tag.split("}", 1)[-1]
+        if tag in ("uitspraak", "conclusie"):
+            if len("".join(el.itertext()).strip()) > 200:
+                got["body"] = True
+        elif tag in ("subject", "abstract", "inhoudsindicatie", "procedure", "type", "zaaknummer"):
+            txt = "".join(el.itertext()).strip()
+            if txt:
+                got["abstract" if tag == "inhoudsindicatie" else tag] = True
+    return got
+
+
+async def one(session, sem, ecli, bucket, out):
+    async with sem:
+        for attempt in range(3):
+            try:
+                async with session.get(CONTENT_URL + ecli) as r:
+                    if r.status != 200:
+                        out.append((bucket, {"http_error": True}))
+                        return
+                    out.append((bucket, parse(await r.text())))
+                    return
+            except Exception:
+                if attempt == 2:
+                    out.append((bucket, {"fetch_fail": True}))
+                await asyncio.sleep(1 + attempt)
+
+
+async def main():
+    rows = []
+    for line in sys.stdin:
+        line = line.strip()
+        if line and "," in line:
+            ecli, bucket = line.rsplit(",", 1)
+            rows.append((ecli.strip(), bucket.strip()))
+    print(f"probing {len(rows)} ECLIs", file=sys.stderr)
+
+    out = []
+    sem = asyncio.Semaphore(CONCURRENCY)
+    async with aiohttp.ClientSession(headers={"User-Agent": UA},
+                                     timeout=aiohttp.ClientTimeout(total=60)) as s:
+        await asyncio.gather(*[one(s, sem, e, b, out) for e, b in rows])
+
+    per = defaultdict(lambda: defaultdict(int))
+    for bucket, got in out:
+        per[bucket]["n"] += 1
+        for k in got:
+            per[bucket][k] += 1
+
+    hdr = f"{'bucket':9} {'n':>5}" + "".join(f"{f:>11}" for f in FIELDS) + f"{'errors':>8}"
+    print(hdr)
+    tot = defaultdict(int)
+    for bucket in sorted(per):
+        d = per[bucket]
+        n = d["n"]
+        line = f"{bucket:9} {n:5}"
+        for f in FIELDS:
+            line += f"{d[f]:7} {100*d[f]//n:>3}%"
+        line += f"{d['http_error']+d['fetch_fail']+d['parse_fail']:8}"
+        print(line)
+        for k, v in d.items():
+            tot[k] += v
+    n = tot["n"]
+    line = f"{'TOTAL':9} {n:5}"
+    for f in FIELDS:
+        line += f"{tot[f]:7} {100*tot[f]//n:>3}%"
+    print(line)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Why

The NL corpus looked nearly complete by row count but held **53.9% of what the Rechtspraak feed lists** for 2015-2026: 938,704 rows against 1,741,852 documents. Three different loaders had written the table and each left a different shape behind.

Measured per day against the source (`tools/coverage_scan.py`):

| period | feed | prod | coverage |
|---|---|---|---|
| 2015-01 .. 2017-06 | 372,846 | 372,332 | ~100% |
| 2017-07 .. 2024-12 | 1,088,357 | 372,404 | 24-49% |
| 2025-01 .. 2025-09 | 128,630 | 60,966 | 45-49% |
| 2025-10 .. 2026-02 | 76,130 | 70,064 | 69-99% |
| 2026-03 .. 2026-07 | 77,199 | 31,946 | 2-85% |

Sampling 50 of the missing documents found a body for 0 of them: the shortfall is metadata-only publications, so the missing content is the index, not the text. Separately, probing 420 text-less rows we already hold found a body available for 1% while `dcterms:subject` was available for 96%.

## What changed

**`importers/nl_rechtspraak.py`**

- `START_DATE`/`END_DATE` for an explicit window. Resuming from `MAX(decision_date)` silently skips holes: the 2026-07-25 pilot merge pushed the max to 2026-07-03 while leaving 2026-05-23..07-03 nearly empty, so the next run would have stepped over six weeks.
- Follow the feed's paging. Busy days exceed one page (2026-05-20 lists 955), so stopping at the first response dropped decisions with no error. The true total comes from the feed's own `<subtitle>`, and a short read is logged.
- Parse every field the source exposes: `subject_areas`, `summary`, `procedure_type`, `full_text_xml`, and the RDF block into `metadata_json`. `full_text` comes from `<uitspraak>`/`<conclusie>` only, never the whole document, which is how 617,623 rows ended up with the RDF header (mime types, publisher, deeplink URL) sitting inside their text.
- Fetch each day's documents concurrently instead of one `await` at a time.
- Checkpoint per day rather than per ECLI. A full-history walk covers 1.7M+ ECLIs and rewriting that list into the JSON checkpoint after every batch costs more I/O than the harvest itself. Days within `SETTLE_DAYS` (45) are always re-walked, because Rechtspraak publishes a decision's body days after its metadata: 30% of 2026-04 rows that were fetched same-day now have one.

**`importers/nl_rechtspraak_enrich.py`** (new) re-fetches rows that already exist so every row ends up parsed by one parser. Its worklist comes from prod (`metadata_json` without the source's own `identifier`), which makes it self-draining and needs no ECLI checkpoint. `MODE=recent_text` re-checks recent rows for late-published bodies.

**`shared/prod_writer.py`** gains `on_conflict="do_update_prefer_new"`: the incoming value wins, a stored value survives only where the source has none, and jsonb columns are merged key-wise so markers left by a previous load are not dropped.

**`shared/checkpoint.py`** gains `delete(key)` so an importer can drop a superseded progress key instead of carrying it forever.

**`tools/`** adds the two read-only probes this was sized with, plus a README on when to reach for them.

## Verification

- Parser checked against three documents covering all shapes (body + abstract, metadata-only, recent). For `ECLI:NL:CBB:2013:10` it produces 29,098 characters, byte-identical in length to an independent extraction of the same document, and with none of the RDF header the stored copy carries.
- 200-row enrichment against prod: `subject_areas` 0 → 199, `summary` 0 → 116, `full_text_xml` 0 → 200, `full_text` 116 → 116 (nothing lost), pilot load marker preserved on all 200, row count unchanged.
- Window walk 2026-03-01..2026-07-24 against prod: 77,199 documents, 0 failures, +45,249 rows, matching the shortfall the coverage scan predicted for those months.
- Day-checkpoint resume verified on a 3-day window; `days_done` written as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the NL Rechtspraak importer to close feed coverage gaps and fix field parsing. Adds a self‑draining enrichment pass, per‑day checkpoints, and a safer upsert mode to keep rows clean and complete.

- **New Features**
  - Explicit date windows via `START_DATE`/`END_DATE`; per‑day checkpoints with recent days re‑walked (`SETTLE_DAYS`).
  - Feed paging now follows the total in `<subtitle>`; 1000/page; logs short reads.
  - Full field parsing: subject areas, summary, procedure type, decision type; body only from `<uitspraak>`/`<conclusie>`; raw XML stored in `full_text_xml`; RDF merged into `metadata_json`.
  - Concurrent per‑day fetch and batched upserts using `on_conflict="do_update_prefer_new"` (JSONB merged key‑wise).
  - New `nl_rechtspraak_enrich.py` to re‑fetch existing rows; modes `metadata` and `recent_text`; worklist from prod; no ECLI checkpoint.
  - `checkpoint.delete()` to drop old progress keys; new diagnostics `tools/coverage_scan.py` and `tools/probe_fields.py`.

- **Migration**
  - For backfills, set `START_DATE`/`END_DATE`; otherwise use `WALK_DAYS` for forward walks; keep `SETTLE_DAYS` (default 45).
  - After deploy, run `nl_rechtspraak_enrich.py` with `MODE=metadata`, then `MODE=recent_text` (tune `RECHECK_DAYS` if needed).

<sup>Written for commit 38c4b00436a38ef5a096477bb00ac0f4e4d7a413. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

