### PR TITLE
feat(coliee): dense ranking dump on SageMaker and the multi-ranker RG table

### DIFF
--- a/scripts/coliee/launch_rankings_sagemaker.py
+++ b/scripts/coliee/launch_rankings_sagemaker.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Launch the dense ranking dump for the COLIEE / Ukrainian case-retrieval
+corpora on SageMaker.
+
+One job covers both corpora and both encoders: the GPU work is only a few
+minutes, so paying instance start-up four times would cost more than it saves.
+This is a data dump, not an experiment, so the one-job-one-model rule for
+training runs does not apply.
+
+Cost: ml.g5.xlarge on-demand in us-west-2 is about $1.41/h; the job is expected
+to bill 20-30 minutes including start-up and model download, so well under $1.
+
+    python scripts/coliee/launch_rankings_sagemaker.py --upload
+    python scripts/coliee/launch_rankings_sagemaker.py --wait
+"""
+
+import argparse
+import os
+import tarfile
+import time
+from pathlib import Path
+
+import boto3
+
+REGION = "us-west-2"
+ROLE = "arn:aws:iam::272594900302:role/SageMakerDPOExecutionRole"
+BUCKET = "secondlayer-ml-data-usw2"
+IMAGE_URI = ("763104351884.dkr.ecr.us-west-2.amazonaws.com/"
+             "pytorch-training:2.8.0-gpu-py312-cu129-ubuntu22.04-sagemaker")
+PREFIX = "coliee-rankings"
+LOCAL = Path("data/coliee/task1")
+CORPUS_FILES = ["ua_case_retrieval.zip", "task1_train_files_2026.zip"]
+
+
+def upload_corpus(s3):
+    for name in CORPUS_FILES:
+        key = f"{PREFIX}/corpus/{name}"
+        try:
+            s3.head_object(Bucket=BUCKET, Key=key)
+            print(f"  {name}: already in s3")
+            continue
+        except s3.exceptions.ClientError:
+            pass
+        size = (LOCAL / name).stat().st_size / 1e6
+        print(f"  {name}: uploading {size:.0f} MB", flush=True)
+        s3.upload_file(str(LOCAL / name), BUCKET, key)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--instance-type", default="ml.g5.xlarge")
+    ap.add_argument("--models", default="e5,bge-m3")
+    ap.add_argument("--corpora", default="ua,ca")
+    ap.add_argument("--batch-size", type=int, default=64)
+    ap.add_argument("--upload", action="store_true", help="push corpora to S3 first")
+    ap.add_argument("--wait", action="store_true", help="poll until the job ends")
+    ap.add_argument("--max-runtime-hours", type=float, default=2)
+    args = ap.parse_args()
+
+    s3 = boto3.client("s3", region_name=REGION)
+    if args.upload:
+        upload_corpus(s3)
+
+    ts = int(time.time())
+    job = f"coliee-rankings-{ts}"
+    here = Path(__file__).parent
+    code_key = f"{PREFIX}/code/{job}/sourcedir.tar.gz"
+    tar_path = f"/tmp/{job}-source.tar.gz"
+    with tarfile.open(tar_path, "w:gz") as tar:
+        tar.add(here / "sm_rankings_entry.py", arcname="sm_rankings_entry.py")
+        req = Path(tar_path).with_name(f"{job}-requirements.txt")
+        req.write_text("sentence-transformers>=3.0\n")
+        tar.add(req, arcname="requirements.txt")
+        req.unlink()
+    s3.upload_file(tar_path, BUCKET, code_key)
+    os.remove(tar_path)
+
+    sm = boto3.client("sagemaker", region_name=REGION)
+    sm.create_training_job(
+        TrainingJobName=job,
+        RoleArn=ROLE,
+        AlgorithmSpecification={"TrainingImage": IMAGE_URI,
+                                "TrainingInputMode": "File"},
+        HyperParameters={
+            "models": args.models,
+            "corpora": args.corpora,
+            "batch_size": str(args.batch_size),
+            "sagemaker_program": "sm_rankings_entry.py",
+            "sagemaker_submit_directory": f"s3://{BUCKET}/{code_key}",
+            "sagemaker_region": REGION,
+        },
+        InputDataConfig=[{
+            "ChannelName": "corpus",
+            "DataSource": {"S3DataSource": {
+                "S3DataType": "S3Prefix",
+                "S3Uri": f"s3://{BUCKET}/{PREFIX}/corpus/",
+                "S3DataDistributionType": "FullyReplicated",
+            }},
+        }],
+        OutputDataConfig={"S3OutputPath": f"s3://{BUCKET}/{PREFIX}/output/"},
+        ResourceConfig={"InstanceType": args.instance_type,
+                        "InstanceCount": 1, "VolumeSizeInGB": 60},
+        StoppingCondition={
+            "MaxRuntimeInSeconds": int(args.max_runtime_hours * 3600)},
+        Tags=[{"Key": "project", "Value": "secondlayer"},
+              {"Key": "experiment", "Value": "coliee-coupling"},
+              {"Key": "workload", "Value": "ml-embedding"}],
+    )
+    print(f"launched {job} on {args.instance_type}")
+    print(f"output: s3://{BUCKET}/{PREFIX}/output/{job}/output/model.tar.gz")
+
+    if args.wait:
+        while True:
+            d = sm.describe_training_job(TrainingJobName=job)
+            st = d["TrainingJobStatus"]
+            sec = d.get("SecondaryStatus")
+            print(f"  {st} / {sec}", flush=True)
+            if st in ("Completed", "Failed", "Stopped"):
+                if st != "Completed":
+                    print(d.get("FailureReason", ""))
+                bs = d.get("BillableTimeInSeconds")
+                if bs:
+                    print(f"  billable {bs}s (~${bs/3600*1.408:.2f} at "
+                          f"$1.408/h on-demand)")
+                break
+            time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/rg_table.py
+++ b/scripts/coliee/rg_table.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Recompute the coupling-metric table across every available ranker.
+
+Until now RG was reported for BM25 only, because the July dense runs kept
+aggregate metrics and not the ranked lists. With rankings_*.json present
+(see dump_rankings.py / launch_rankings_sagemaker.py) the whole table can be
+scored on the same footing: BM25, E5, BGE-M3, plus the two reference rankers
+(query-independent popularity and the boilerplate ranker) that bound what the
+metrics can be driven to.
+
+    python scripts/coliee/rg_table.py --corpus ua --corpus ca
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+_spec = importlib.util.spec_from_file_location(
+    "rgm", os.path.join(HERE, "reachability_gain.py"))
+rgm = importlib.util.module_from_spec(_spec)
+sys.modules["rgm"] = rgm
+_spec.loader.exec_module(rgm)
+from retrieval_experiment import load_cases  # noqa: E402
+
+DATA = "data/coliee/task1"
+DENSE = [("e5", "e5"), ("bge-m3", "bgem3")]
+
+
+def f1_at(ranked, gold, k):
+    hit = sum(1 for x in ranked[:k] if x in gold)
+    p, r = hit / k, hit / len(gold)
+    return 2 * p * r / (p + r) if (p + r) else 0.0
+
+
+def build(corpus, k):
+    cfg = rgm.CORPORA[corpus]
+    ids, texts, _, labels = load_cases(cfg["zip"], None, 4000, cfg["years_json"])
+    qs = [q for q in labels if q in texts]
+    cit = ({x: set(v) for x, v in json.load(open(cfg["citations_json"])).items()}
+           if cfg["citations_json"] else {x: set(v) for x, v in labels.items()})
+    pool = set(ids)
+    df, citers = {}, {}
+    for d, cs in cit.items():
+        if d not in pool:
+            continue
+        for g in cs:
+            if g in pool:
+                df[g] = df.get(g, 0) + 1
+                citers.setdefault(g, set()).add(d)
+
+    rankers = {"BM25": rgm.bm25_ranking(ids, texts, qs)}
+    for name, slug in DENSE:
+        path = f"{DATA}/rankings_{corpus}_{slug}.json"
+        if os.path.exists(path):
+            rankers[name.upper()] = json.load(open(path))["rankings"]
+        else:
+            print(f"  (missing {path}, skipping {name})", file=sys.stderr)
+    pop = sorted(ids, key=lambda c: (-df.get(c, 0), c))
+    rankers["popularity"] = {q: [c for c in pop[:k + 1] if c != q][:k] for q in qs}
+    att, full = rgm.boilerplate_ranking(qs, labels, cit, df, citers, ids, k=k)
+    rankers["boilerplate"] = att
+
+    def cand(q):
+        g = set(labels.get(q, []))
+        c = set(g)
+        for x in g:
+            c |= citers.get(x, set())
+        c.discard(q)
+        return c
+
+    return ids, qs, labels, cit, df, rankers, cand, full
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", action="append", default=None)
+    ap.add_argument("--k", type=int, default=5)
+    ap.add_argument("--alpha", type=float, default=0.5)
+    ap.add_argument("--beta", type=float, default=0.25)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+    corpora = args.corpus or ["ua", "ca"]
+
+    report = {}
+    for corpus in corpora:
+        ids, qs, labels, cit, df, rankers, cand, full = build(corpus, args.k)
+        rg = rgm.RG(cit, df, len(ids), alpha=args.alpha, beta=args.beta,
+                    weight="idf", discount=True, normalize="ideal")
+        print(f"\n{corpus.upper()}  pool={len(ids)}  queries={len(qs)}  "
+              f"k={args.k}  (RG: alpha={args.alpha}, beta={args.beta}, IDF)")
+        print(f"  {'ranker':14s} {'F1':>8s} {'Ext.P':>8s} {'Cov':>8s} {'RG':>8s}")
+        rows = {}
+        for name, R in rankers.items():
+            n = len(qs)
+            f1 = sum(f1_at(R[q][:args.k], set(labels[q]), args.k) for q in qs) / n
+            e = sum(rgm.ext_p(R[q], set(labels[q]), cit, args.k) for q in qs) / n
+            c = sum(rgm.coverage(R[q], set(labels[q]), cit, args.k) for q in qs) / n
+            v = rg.score(qs, R, labels, args.k, cand)
+            rows[name] = {"F1": round(f1, 4), "ExtP": round(e, 4),
+                          "Cov": round(c, 4), "RG": round(v, 4)}
+            print(f"  {name:14s} {f1:8.4f} {e:8.4f} {c:8.4f} {v:8.4f}")
+        report[corpus] = {"queries": len(qs), "pool": len(ids),
+                          "attackable_queries": full, "rankers": rows}
+
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump({"k": args.k, "alpha": args.alpha, "beta": args.beta,
+                       "corpora": report}, fh, indent=2)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/coliee/sm_rankings_entry.py
+++ b/scripts/coliee/sm_rankings_entry.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""SageMaker entry point: dump dense top-k ranked lists for the COLIEE and the
+matched Ukrainian case-retrieval corpora.
+
+Reads the corpus zips from the `corpus` channel, encodes pool and queries with
+each requested model, and writes one rankings JSON per (corpus, model) into
+/opt/ml/model, which SageMaker packs to the job's S3 output.
+
+Settings mirror the paper: texts truncated to 4000 chars, E5 at 512 tokens with
+the query:/passage: prefixes, BGE-M3 at 1024.
+"""
+
+import argparse
+import json
+import os
+import time
+import zipfile
+
+import numpy as np
+import torch
+from sentence_transformers import SentenceTransformer
+
+CORPUS_DIR = os.environ.get("SM_CHANNEL_CORPUS", "/opt/ml/input/data/corpus")
+OUT_DIR = os.environ.get("SM_MODEL_DIR", "/opt/ml/model")
+
+CORPORA = {
+    "ua": "ua_case_retrieval.zip",
+    "ca": "task1_train_files_2026.zip",
+}
+MODELS = {
+    "e5": {"hf": "intfloat/multilingual-e5-large", "q": "query: ",
+           "p": "passage: ", "max_len": 512},
+    "bge-m3": {"hf": "BAAI/bge-m3", "q": "", "p": "", "max_len": 1024},
+}
+
+
+def load_corpus(zip_path, max_chars):
+    with zipfile.ZipFile(zip_path) as zf:
+        names = zf.namelist()
+        label_name = sorted(
+            [n for n in names if n.endswith(".json") and "label" in n.lower()],
+            key=len)[0]
+        labels = json.load(zf.open(label_name))
+        texts = {}
+        for n in names:
+            if "/cases/" in n and n.endswith(".txt"):
+                cid = n.rsplit("/", 1)[-1]
+                texts[cid] = zf.open(n).read().decode("utf-8", "replace")[:max_chars]
+    case_ids = sorted(texts)
+    query_ids = [q for q in labels if q in texts]
+    return case_ids, texts, query_ids
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--models", default="e5,bge-m3")
+    ap.add_argument("--corpora", default="ua,ca")
+    ap.add_argument("--depth", type=int, default=10)
+    ap.add_argument("--max-chars", type=int, default=4000)
+    ap.add_argument("--batch-size", type=int, default=64)
+    args, _ = ap.parse_known_args()
+
+    dev = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"device={dev} "
+          f"gpu={torch.cuda.get_device_name(0) if dev == 'cuda' else 'n/a'}",
+          flush=True)
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    loaded = {}
+    for corpus in args.corpora.split(","):
+        path = os.path.join(CORPUS_DIR, CORPORA[corpus])
+        loaded[corpus] = load_corpus(path, args.max_chars)
+        ids, _, qs = loaded[corpus]
+        print(f"[{corpus}] pool={len(ids)} queries={len(qs)}", flush=True)
+
+    for key in args.models.split(","):
+        cfg = MODELS[key]
+        t0 = time.time()
+        model = SentenceTransformer(cfg["hf"], device=dev)
+        model.max_seq_length = cfg["max_len"]
+        for corpus in args.corpora.split(","):
+            case_ids, texts, query_ids = loaded[corpus]
+            idx = {c: i for i, c in enumerate(case_ids)}
+            pool = model.encode([cfg["p"] + texts[c] for c in case_ids],
+                                batch_size=args.batch_size,
+                                normalize_embeddings=True, show_progress_bar=False)
+            qemb = model.encode([cfg["q"] + texts[q] for q in query_ids],
+                                batch_size=args.batch_size,
+                                normalize_embeddings=True, show_progress_bar=False)
+            sims = np.asarray(qemb, "float32") @ np.asarray(pool, "float32").T
+            for i, q in enumerate(query_ids):
+                sims[i, idx[q]] = -1e9
+            part = np.argpartition(-sims, args.depth, axis=1)[:, :args.depth]
+            order = np.argsort(-np.take_along_axis(sims, part, axis=1), axis=1)
+            top = np.take_along_axis(part, order, axis=1)
+            out = os.path.join(
+                OUT_DIR, f"rankings_{corpus}_{key.replace('-', '')}.json")
+            with open(out, "w") as fh:
+                json.dump({"corpus": corpus, "model": key,
+                           "max_chars": args.max_chars,
+                           "max_seq_length": cfg["max_len"],
+                           "depth": args.depth,
+                           "rankings": {query_ids[i]: [case_ids[j] for j in top[i]]
+                                        for i in range(len(query_ids))}}, fh)
+            print(f"  wrote {out} ({(time.time()-t0)/60:.1f} min into {key})",
+                  flush=True)
+        del model
+        if dev == "cuda":
+            torch.cuda.empty_cache()
+    print("done", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
RG was reported for BM25 only, because the July dense runs kept aggregate metrics and not the ranked lists. These scripts close that.

| Script | Purpose |
|---|---|
| `sm_rankings_entry.py` + `launch_rankings_sagemaker.py` | Dump E5 and BGE-M3 top-k lists for both corpora in one SageMaker job |
| `rg_table.py` | Score every ranker on the same footing: BM25, E5, BGE-M3, popularity, boilerplate |

**Cost, measured:** `ml.g5.xlarge` us-west-2, billable 1936 s ≈ **$0.76**. A10G throughput ~41 texts/s (E5) and ~18 (BGE-M3): 27 min of training against ~9 h for the same work on this host's CPU. One job covers all four model-corpus combinations — the GPU work is minutes, so four instance start-ups would cost more than the work itself. It is a data dump rather than an experiment, so the one-job-one-model rule for training runs does not apply.

**Validation:** the rerun reproduces the July results to three decimals on different hardware two months later.

**What it changed:** the pathway discount at which Reachability Gain stops rewarding the boilerplate ranker is per-system, not global — 0.304 (BM25), 0.241 (BGE-M3), **0.184 (E5)** — and at β = 0.25 that ranker already outscores both dense encoders while retrieving no gold case at all. Written up in overthelex/secondlayer-papers#60 and sent to the ICTIR authors.

Also: `reachability_gain.py` picks the boilerplate target from a sorted set, so the choice no longer depends on set iteration order.

New files under `scripts/coliee/` only; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dump dense top‑k rankings for COLIEE and the Ukrainian corpora on SageMaker and add a script to rebuild the multi‑ranker RG table. This lets us compare BM25 and dense models on the same ranked lists with a single, low‑cost GPU run.

- **New Features**
  - One SageMaker job dumps E5 and BGE‑M3 rankings for both corpora: `scripts/coliee/launch_rankings_sagemaker.py` + `scripts/coliee/sm_rankings_entry.py` (writes rankings JSONs to S3).
  - Rebuilds the coupling table across rankers (F1@k, Ext.P, Coverage, RG) for BM25, E5, BGE‑M3, popularity, and boilerplate: `scripts/coliee/rg_table.py`.
  - Measured on `ml.g5.xlarge`: ~1936s billable (~$0.76); one job covers all model–corpus combos.
  - Scripts live under `scripts/coliee/`; no production code changed.

- **Dependencies**
  - SageMaker job bundles `sentence-transformers>=3.0` and uses the AWS DLC image `pytorch-training:2.8.0-gpu-py312-cu129-ubuntu22.04-sagemaker`.

<sup>Written for commit 1df0d0cb5288e385f2b9db5749588cfaf66f8e5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

