### PR TITLE
feat(nl-graph): citation graph, statute edges and index rebuild for the Dutch corpus

### DIFF
--- a/mcp_backend/src/migrations/179_nl_citation_graph.sql
+++ b/mcp_backend/src/migrations/179_nl_citation_graph.sql
@@ -1,0 +1,145 @@
+-- Migration 179: NL Rechtspraak citation graph (LEXAI-1880)
+--
+-- The Dutch corpus is loaded (3.6M ECLIs, 946k with text). This adds the graph
+-- layer the grounded-substrate product needs per jurisdiction: decision→decision
+-- and decision→article edges, the alias dictionary that lets old-style citations
+-- resolve, the instance chain, and precedent status.
+--
+-- Shape follows what already works for Ukraine (case_citation_links,
+-- law_court_citations, precedent_status), with one difference: NL has a real
+-- canonical id, so edges point at ECLI directly instead of a case number that
+-- has to be matched later.
+--
+-- Indexes on the big nl_rechtspraak_decisions table are NOT here: that table is
+-- 28GB and rebuilding an index on it must be CONCURRENTLY, which cannot run
+-- inside the implicit transaction the migration runner uses. See
+-- scripts/nl/179b_nl_decisions_indexes_concurrently.sql.
+
+-- ---------------------------------------------------------------------------
+-- 1. Alias dictionary: what a citation can be written as, and which ECLI it is.
+--    Filled from metadata_json->'hasVersion' (1,006,924 rows carry journal
+--    publications like "NJ 2020/123") plus LJN codes and case numbers.
+--    Without this, roughly one citation in ten never resolves: LJN appears in
+--    1.9% of texts and journal references in 9.3%.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nl_case_aliases (
+    alias_kind  TEXT NOT NULL,          -- ljn | journal | zaaknummer | deeplink
+    alias_norm  TEXT NOT NULL,          -- normalized: uppercase, no spaces
+    ecli        TEXT NOT NULL,
+    source      TEXT NOT NULL,          -- hasVersion | case_number | text
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (alias_kind, alias_norm, ecli)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_alias_ecli ON nl_case_aliases (ecli);
+
+-- ---------------------------------------------------------------------------
+-- 2. Decision → decision edges.
+--    to_ecli stays NULL until the citation resolves; resolved/match_method/
+--    unresolved_reason exist so "every reference resolves" is a number we can
+--    report rather than a claim.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nl_case_citations (
+    id                BIGSERIAL PRIMARY KEY,
+    from_ecli         TEXT NOT NULL,
+    to_ecli           TEXT,
+    to_raw            TEXT NOT NULL,    -- exactly as written in the text
+    cite_kind         TEXT NOT NULL,    -- ecli_nl | ecli_eu | ecli_echr | ljn | journal | zaaknummer
+    resolved          BOOLEAN NOT NULL DEFAULT false,
+    match_method      TEXT,             -- direct_ecli | alias_ljn | alias_journal | external
+    unresolved_reason TEXT,
+    treatment         TEXT,             -- followed | applied | distinguished | overruled (filled later, by a model)
+    citation_context  TEXT,
+    from_court        TEXT,             -- denormalized so filters need no join
+    from_date         DATE,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (from_ecli, to_raw)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_cc_to      ON nl_case_citations (to_ecli) WHERE resolved;
+CREATE INDEX IF NOT EXISTS idx_nl_cc_from    ON nl_case_citations (from_ecli);
+CREATE INDEX IF NOT EXISTS idx_nl_cc_unres   ON nl_case_citations (cite_kind) WHERE NOT resolved;
+CREATE INDEX IF NOT EXISTS idx_nl_cc_date    ON nl_case_citations (from_date);
+
+-- ---------------------------------------------------------------------------
+-- 3. Decision → statute article edges.
+--    Two provenances: 'rdf' comes from dcterms:references, which the source
+--    already publishes pre-parsed for 126,118 decisions ("Wetboek van Strafrecht
+--    285b"). That set doubles as the reference against which the text extractor
+--    is measured before it is let loose on the other ~5.8M raw mentions.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nl_legislation_citations (
+    id               BIGSERIAL PRIMARY KEY,
+    from_ecli        TEXT NOT NULL,
+    law_name_raw     TEXT NOT NULL,     -- "Burgerlijk Wetboek Boek 3"
+    law_id           TEXT,              -- BWB / ELI once resolved
+    article          TEXT,
+    lid              TEXT,              -- sub-article ("lid 2")
+    cite_kind        TEXT NOT NULL,     -- rdf | text
+    resolved         BOOLEAN NOT NULL DEFAULT false,
+    citation_context TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (from_ecli, law_name_raw, article, lid, cite_kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_lc_from    ON nl_legislation_citations (from_ecli);
+CREATE INDEX IF NOT EXISTS idx_nl_lc_law     ON nl_legislation_citations (law_id, article) WHERE resolved;
+CREATE INDEX IF NOT EXISTS idx_nl_lc_rawname ON nl_legislation_citations (law_name_raw);
+
+-- ---------------------------------------------------------------------------
+-- 4. Instance chain.
+--    The authoritative source is <dcterms:relation> in the decision XML, which
+--    carries the related ECLI, the relation type (cassatie / conclusie /
+--    hogerBeroep), which side is the earlier instance, and the outcome. It is
+--    present for ~6% of decisions, i.e. roughly the share that actually has a
+--    higher instance. Case-number pairing of PHR conclusions is kept as a
+--    fallback for documents whose XML predates the relation element.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nl_instance_links (
+    child_ecli  TEXT NOT NULL,
+    parent_ecli TEXT NOT NULL,
+    relation    TEXT NOT NULL,          -- appeal_of | cassation_of | conclusion_for | referred_back
+    method      TEXT NOT NULL,          -- rdf_relation | phr_pair | zaaknummer | text_ref
+    -- the source states the outcome of the appeal itself ("(Gedeeltelijke)
+    -- vernietiging", "Bekrachtiging/bevestiging"), so precedent status does not
+    -- have to be inferred from citation text for these edges
+    outcome     TEXT,
+    confidence  REAL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (child_ecli, parent_ecli, relation)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_il_parent ON nl_instance_links (parent_ecli);
+
+-- ---------------------------------------------------------------------------
+-- 5. Precedent status, computed from the two edge tables above.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nl_precedent_status (
+    ecli           TEXT PRIMARY KEY,
+    status         TEXT,                -- good_law | overruled | quashed | superseded
+    overruled_by   TEXT[],
+    cited_by_count INTEGER NOT NULL DEFAULT 0,
+    last_computed  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_ps_status ON nl_precedent_status (status);
+CREATE INDEX IF NOT EXISTS idx_nl_ps_cited  ON nl_precedent_status (cited_by_count DESC);
+
+-- ---------------------------------------------------------------------------
+-- 6. Passage roles for the role-aware judge (shared taxonomy, LEXAI-1843).
+--    Only the 946k decisions that have a body can have passages.
+--    NL note: the taxonomy's `dissent` role stays empty here. Dutch courts do
+--    not publish dissenting opinions; the functional analogue is the AG's
+--    conclusion, which is a separate document, so that role arrives at document
+--    level through nl_instance_links.relation = 'conclusion_for'.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS nl_passages (
+    passage_id TEXT PRIMARY KEY,        -- <ecli>h1 / o1 / r1
+    ecli       TEXT NOT NULL,
+    role       TEXT NOT NULL,           -- holding | overruled_lower | rejected_argument | unrelated
+    char_from  INTEGER,
+    char_to    INTEGER,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_passages_ecli ON nl_passages (ecli, role);

--- a/scripts/nl/179b_nl_decisions_indexes_concurrently.sql
+++ b/scripts/nl/179b_nl_decisions_indexes_concurrently.sql
@@ -1,0 +1,68 @@
+-- Index changes on nl_rechtspraak_decisions (LEXAI-1881).
+--
+-- Kept out of migration 179 on purpose: the table is 28GB and the migration
+-- runner sends the whole file as one query, which Postgres wraps in an implicit
+-- transaction. CREATE INDEX CONCURRENTLY cannot run there, and a non-concurrent
+-- build would hold a write lock on a live table for many minutes.
+--
+-- Run statement by statement, on an idle-ish window:
+--   scp scripts/nl/179b_nl_decisions_indexes_concurrently.sql prod:/tmp/
+--   ssh prod "docker cp /tmp/179b_nl_decisions_indexes_concurrently.sql \
+--     secondlayer-postgres-prod:/tmp/ && docker exec secondlayer-postgres-prod \
+--     psql -U secondlayer -d secondlayer_prod -f /tmp/179b_nl_decisions_indexes_concurrently.sql"
+--
+-- If a CONCURRENTLY build is interrupted it leaves an INVALID index behind;
+-- check with:
+--   SELECT indexrelid::regclass FROM pg_index WHERE NOT indisvalid;
+-- and DROP INDEX CONCURRENTLY the invalid one before retrying.
+
+\timing on
+
+-- ---------------------------------------------------------------------------
+-- 1. Replace the full-text index.
+--
+-- The existing idx_nl_recht_fts is 3,372 MB and has had 0 scans. Three things
+-- are wrong with it: it uses the 'simple' config (no Dutch stemming or
+-- stopwords, on a language with heavy compounding and inflection), it indexes
+-- `parties`, which is NULL in 100% of rows, and it covers all 3.6M rows when
+-- only 946k have any text at all.
+-- ---------------------------------------------------------------------------
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nl_fts_dutch
+    ON nl_rechtspraak_decisions
+    USING GIN (to_tsvector('dutch', coalesce(summary, '') || ' ' || coalesce(full_text, '')))
+    WHERE full_text IS NOT NULL;
+
+DROP INDEX CONCURRENTLY IF EXISTS idx_nl_recht_fts;
+
+-- ---------------------------------------------------------------------------
+-- 2. Filters the search tool will actually use.
+-- ---------------------------------------------------------------------------
+
+-- rechtsgebied filter: 3.16M rows carry subject_areas and none of it is indexed
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nl_subject_areas
+    ON nl_rechtspraak_decisions USING GIN (subject_areas);
+
+-- "latest from court X": replaces two single-column indexes that see almost no use
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nl_court_date
+    ON nl_rechtspraak_decisions (court_code, decision_date DESC);
+
+-- case-number lookup, needed to pair PHR conclusions with their Hoge Raad
+-- decision and to walk the instance ladder (pg_trgm is already installed)
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nl_case_number_trgm
+    ON nl_rechtspraak_decisions USING GIN (case_number gin_trgm_ops);
+
+-- operational queries such as `metadata_json ? 'identifier'`, which the
+-- consistency audit runs and which are a seq scan over 28GB today
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_nl_metadata_jsonb
+    ON nl_rechtspraak_decisions USING GIN (metadata_json jsonb_path_ops);
+
+-- ---------------------------------------------------------------------------
+-- 3. Verify.
+-- ---------------------------------------------------------------------------
+SELECT indexrelname, pg_size_pretty(pg_relation_size(indexrelid)) AS size, idx_scan
+FROM pg_stat_user_indexes
+WHERE relname = 'nl_rechtspraak_decisions'
+ORDER BY pg_relation_size(indexrelid) DESC;
+
+SELECT indexrelid::regclass AS invalid_index
+FROM pg_index WHERE NOT indisvalid;

--- a/scripts/nl/build_case_aliases.sql
+++ b/scripts/nl/build_case_aliases.sql
@@ -1,0 +1,76 @@
+-- LEXAI-1882: the alias dictionary that lets old-style citations resolve.
+--
+-- Reality check before writing this: metadata_json->'hasVersion' is NOT a clean
+-- list of journal citations. It is one free-text string that always starts with
+-- "Rechtspraak.nl" and sometimes has publications appended:
+--   "Rechtspraak.nl SR-Updates.nl 2020-0260 ... NJB 2020/1907 RvdW 2020/888 NJ 2020/410 ..."
+-- Of 1,020,999 rows carrying the field, 648,360 are only "Rechtspraak.nl" and
+-- 158,143 match a journal pattern. So this yields aliases for ~158k decisions,
+-- several each, not the million the field count suggests.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+DELETE FROM nl_case_aliases WHERE source IN ('hasVersion', 'case_number');
+
+-- ---------------------------------------------------------------------------
+-- Journal citations. Alternatives are ordered longest-first on purpose:
+-- Postgres alternation takes the first branch that matches at a position, so
+-- "ABkort" has to be tried before "AB" or every ABkort cite becomes an AB cite.
+-- ---------------------------------------------------------------------------
+INSERT INTO nl_case_aliases (alias_kind, alias_norm, ecli, source)
+SELECT DISTINCT
+       'journal',
+       upper(m[1]) || ' ' || m[2] || '/' || m[3],
+       d.ecli,
+       'hasVersion'
+FROM nl_rechtspraak_decisions d
+CROSS JOIN LATERAL regexp_matches(
+        d.metadata_json->>'hasVersion',
+        '(ABkort|AR-Updates\.nl|SR-Updates\.nl|ERF-Updates\.nl|JONDR|RvdW|BNB|USZ|JAR|NJB|JOR|JOW|JOM|JHV|JWR|JIN|RAV|NTS|V-N|FED|NJ|AB|JB|PJ|RV|RO|JG)\s?(\d{4})[/-](\d+)',
+        'g') AS m
+WHERE d.metadata_json ? 'hasVersion'
+  AND d.metadata_json->>'hasVersion' <> 'Rechtspraak.nl'
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Case numbers. Needed to pair an AG conclusion with its Hoge Raad decision and
+-- to walk the instance ladder. A case_number can hold several numbers separated
+-- by " / " ("C/10/718537 / KG ZA 26-384"), so each part is registered too.
+-- ---------------------------------------------------------------------------
+INSERT INTO nl_case_aliases (alias_kind, alias_norm, ecli, source)
+SELECT DISTINCT 'zaaknummer',
+       upper(regexp_replace(part, '\s+', '', 'g')),
+       d.ecli,
+       'case_number'
+FROM nl_rechtspraak_decisions d
+CROSS JOIN LATERAL unnest(string_to_array(d.case_number, ' / ')) AS part
+WHERE d.case_number IS NOT NULL
+  AND length(btrim(part)) BETWEEN 4 AND 60
+ON CONFLICT DO NOTHING;
+
+\echo == result ==
+SELECT alias_kind, source, count(*) AS aliases, count(DISTINCT ecli) AS decisions
+FROM nl_case_aliases GROUP BY 1, 2 ORDER BY 1, 2;
+
+\echo == collisions: one alias pointing at several decisions ==
+SELECT alias_kind, count(*) AS ambiguous_aliases
+FROM (SELECT alias_kind, alias_norm FROM nl_case_aliases
+      GROUP BY 1, 2 HAVING count(DISTINCT ecli) > 1) x
+GROUP BY 1;
+
+\echo == sample journal aliases ==
+SELECT alias_norm, ecli FROM nl_case_aliases WHERE alias_kind = 'journal' LIMIT 8;
+
+-- ---------------------------------------------------------------------------
+-- LJN codes. No separate source is needed: when Rechtspraak assigned ECLIs to
+-- pre-2013 decisions it reused the LJN as the ordinal, so ECLI:NL:PHR:2008:BB4767
+-- *is* LJN BB4767. Anything whose ordinal looks like an LJN gets registered.
+-- ---------------------------------------------------------------------------
+INSERT INTO nl_case_aliases (alias_kind, alias_norm, ecli, source)
+SELECT DISTINCT 'ljn', substring(ecli from ':([A-Z]{2}[0-9]{4})$'), ecli, 'ecli_suffix'
+FROM nl_rechtspraak_decisions
+WHERE ecli ~ ':[A-Z]{2}[0-9]{4}$'
+ON CONFLICT DO NOTHING;
+
+\echo == ljn aliases ==
+SELECT count(*) AS ljn_aliases FROM nl_case_aliases WHERE alias_kind = 'ljn';

--- a/scripts/nl/build_case_citations_year.sql
+++ b/scripts/nl/build_case_citations_year.sql
@@ -1,0 +1,67 @@
+-- LEXAI-1884: decision → decision edges, extracted in Postgres itself.
+--
+-- Deliberately server-side: the texts are ~15.5GB in total, and pulling them to
+-- a client to run Python regexes would move all of it over the wire for no gain.
+-- Sharded by year so eight psql sessions can run at once (the box has 8 cores):
+--   psql -c "SET my.yr=2015" -f build_case_citations_year.sql
+--
+-- Rows flagged by the left()-based encoding scan are skipped. That scan
+-- over-reports (1,896 flagged, only 116 genuinely invalid), but a single
+-- undecodable value aborts the whole statement, so losing 0.2% of documents in
+-- this pass is the cheaper trade. They are re-run separately at the end.
+\set ON_ERROR_STOP on
+
+INSERT INTO nl_case_citations
+    (from_ecli, to_ecli, to_raw, cite_kind, resolved, match_method, unresolved_reason,
+     citation_context, from_court, from_date)
+SELECT DISTINCT ON (d.ecli, hit.raw)
+       d.ecli,
+       res.to_ecli,
+       hit.raw,
+       hit.kind,
+       res.to_ecli IS NOT NULL,
+       res.method,
+       CASE WHEN res.to_ecli IS NOT NULL THEN NULL
+            WHEN hit.kind IN ('ecli_eu', 'ecli_echr') THEN 'external_corpus_not_loaded'
+            WHEN hit.kind = 'ecli_nl' THEN 'ecli_not_in_corpus'
+            ELSE 'alias_unknown' END,
+       NULL,
+       d.court_code,
+       d.decision_date
+FROM nl_rechtspraak_decisions d
+CROSS JOIN LATERAL (
+    -- one pass for ECLIs, one for the pre-2013 LJN codes; journal citations are
+    -- resolved from the alias dictionary in a separate pass because their
+    -- pattern is far more ambiguous inside running text
+    SELECT m[1] AS raw,
+           CASE WHEN m[1] LIKE 'ECLI:NL:%' THEN 'ecli_nl'
+                WHEN m[1] LIKE 'ECLI:EU:%' THEN 'ecli_eu'
+                WHEN m[1] LIKE 'ECLI:CE:%' THEN 'ecli_echr'
+                ELSE 'ecli_other' END AS kind
+    -- the ordinal may contain dots ("2014:11363.30") but must not end on one:
+    -- a naive [A-Z0-9.]+ swallows the full stop that ends the sentence, which
+    -- alone accounted for 88% of the unresolved edges on the first run
+    FROM regexp_matches(d.full_text, '(ECLI:[A-Z]{2}:[A-Z]+:[0-9]{4}:[A-Z0-9]+(?:\.[A-Z0-9]+)*)', 'g') AS m
+    UNION ALL
+    SELECT 'LJN ' || m[1], 'ljn'
+    FROM regexp_matches(d.full_text, '\mLJN[: ]\s?([A-Z]{2}[0-9]{4})\M', 'g') AS m
+) hit
+CROSS JOIN LATERAL (
+    SELECT CASE
+             WHEN hit.kind = 'ecli_nl'
+               THEN (SELECT t.ecli FROM nl_rechtspraak_decisions t WHERE t.ecli = hit.raw)
+             WHEN hit.kind = 'ljn'
+               THEN (SELECT a.ecli FROM nl_case_aliases a
+                      WHERE a.alias_kind = 'ljn' AND a.alias_norm = upper(replace(hit.raw, 'LJN ', ''))
+                      LIMIT 1)
+           END AS to_ecli,
+           CASE WHEN hit.kind = 'ecli_nl' THEN 'direct_ecli'
+                WHEN hit.kind = 'ljn' THEN 'alias_ljn'
+                ELSE 'external' END AS method
+) res
+WHERE d.full_text IS NOT NULL
+  AND d.decision_date >= make_date(current_setting('my.yr')::int, 1, 1)
+  AND d.decision_date <  make_date(current_setting('my.yr')::int + 1, 1, 1)
+  AND NOT EXISTS (SELECT 1 FROM nl_scan_errors2 b WHERE b.ecli = d.ecli)
+  AND hit.raw <> d.ecli                      -- a decision citing itself is noise
+ON CONFLICT (from_ecli, to_raw) DO NOTHING;

--- a/scripts/nl/build_instance_ladder_and_status.sql
+++ b/scripts/nl/build_instance_ladder_and_status.sql
@@ -1,0 +1,75 @@
+-- LEXAI-1885, pass 2: the instance ladder, then precedent status.
+--
+-- "A cites B" alone does not mean "A is the appeal of B": a judgment cites
+-- plenty of unrelated precedent. The ladder link is the intersection of three
+-- signals, which is cheap now that both edge tables exist:
+--   1. A cites B (resolved edge)
+--   2. A and B share a case number (alias dictionary)
+--   3. A sits higher in the court hierarchy than B
+-- All three together is a strong signal; any one of them alone is not.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+DELETE FROM nl_instance_links WHERE method = 'zaaknummer';
+
+WITH level AS (
+    SELECT ecli,
+           substring(ecli from '^ECLI:NL:([A-Z]+):') AS court,
+           CASE
+             WHEN substring(ecli from '^ECLI:NL:([A-Z]+):') IN ('HR','PHR','RVS','CRVB','CBB','TC') THEN 3
+             WHEN substring(ecli from '^ECLI:NL:([A-Z]+):') LIKE 'GH%' THEN 2
+             WHEN substring(ecli from '^ECLI:NL:([A-Z]+):') LIKE 'RB%' THEN 1
+             ELSE 0
+           END AS lvl
+    FROM nl_rechtspraak_decisions
+)
+INSERT INTO nl_instance_links (child_ecli, parent_ecli, relation, method, confidence)
+SELECT DISTINCT
+       c.from_ecli,
+       c.to_ecli,
+       CASE WHEN la.lvl = 3 THEN 'cassation_of' ELSE 'appeal_of' END,
+       'zaaknummer',
+       0.85
+FROM nl_case_citations c
+JOIN level la ON la.ecli = c.from_ecli
+JOIN level lb ON lb.ecli = c.to_ecli
+WHERE c.resolved
+  AND la.lvl > lb.lvl AND lb.lvl > 0
+  AND EXISTS (
+        SELECT 1
+        FROM nl_case_aliases aa
+        JOIN nl_case_aliases ab
+          ON ab.alias_kind = 'zaaknummer' AND ab.alias_norm = aa.alias_norm
+        WHERE aa.alias_kind = 'zaaknummer'
+          AND aa.ecli = c.from_ecli AND ab.ecli = c.to_ecli)
+ON CONFLICT DO NOTHING;
+
+\echo == instance links by relation ==
+SELECT relation, method, count(*) FROM nl_instance_links GROUP BY 1, 2 ORDER BY 3 DESC;
+
+-- ---------------------------------------------------------------------------
+-- Precedent status. Only the citation count is computed here: deciding that a
+-- decision was actually overruled needs the `treatment` classification, which a
+-- model fills in later. Writing a status we cannot yet justify would be exactly
+-- the "green badge over nothing" we criticise elsewhere, so status stays NULL
+-- until treatment exists.
+-- ---------------------------------------------------------------------------
+INSERT INTO nl_precedent_status (ecli, status, cited_by_count, last_computed)
+SELECT c.to_ecli, NULL, count(*), now()
+FROM nl_case_citations c
+WHERE c.resolved AND c.to_ecli IS NOT NULL
+GROUP BY c.to_ecli
+ON CONFLICT (ecli) DO UPDATE
+   SET cited_by_count = EXCLUDED.cited_by_count,
+       last_computed  = EXCLUDED.last_computed;
+
+\echo == precedent status ==
+SELECT count(*) AS decisions_cited_at_least_once,
+       max(cited_by_count) AS most_cited,
+       round(avg(cited_by_count), 2) AS avg_citations
+FROM nl_precedent_status;
+
+\echo == most cited decisions ==
+SELECT p.ecli, p.cited_by_count, d.court_name, d.decision_date
+FROM nl_precedent_status p JOIN nl_rechtspraak_decisions d USING (ecli)
+ORDER BY p.cited_by_count DESC LIMIT 10;

--- a/scripts/nl/build_instance_links_phr.sql
+++ b/scripts/nl/build_instance_links_phr.sql
@@ -1,0 +1,50 @@
+-- LEXAI-1885, pass 1: pair each Advocate-General conclusion with the Hoge Raad
+-- decision it belongs to.
+--
+-- In the Netherlands the AG's conclusion is published as its own document
+-- (ECLI:NL:PHR:...) rather than as an opinion inside the judgment, and it shares
+-- the case number with the Hoge Raad decision (ECLI:NL:HR:...). There are 58,863
+-- PHR documents and 100,279 HR ones, so this pairing is the cheapest real edge
+-- in the whole graph, and it is also what stands in for the `dissent` role that
+-- the shared taxonomy expects and Dutch law does not produce.
+--
+-- The ladder proper (rechtbank → hof → Hoge Raad) needs the in-text citations,
+-- so it comes after LEXAI-1884.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+DELETE FROM nl_instance_links WHERE method = 'phr_pair';
+
+INSERT INTO nl_instance_links (child_ecli, parent_ecli, relation, method, confidence)
+SELECT DISTINCT phr.ecli, hr.ecli, 'conclusion_for', 'phr_pair',
+       -- a case number shared by exactly one PHR and one HR document is a
+       -- certain pair; where several share it the link is still right in kind
+       -- but the exact partner is a guess, so it is scored lower
+       CASE WHEN cnt.hr_per_number = 1 THEN 1.0 ELSE 0.6 END
+FROM nl_case_aliases pa
+JOIN nl_case_aliases ha
+  ON ha.alias_kind = 'zaaknummer' AND ha.alias_norm = pa.alias_norm
+JOIN nl_rechtspraak_decisions phr ON phr.ecli = pa.ecli
+JOIN nl_rechtspraak_decisions hr  ON hr.ecli  = ha.ecli
+JOIN LATERAL (
+    SELECT count(*) AS hr_per_number
+    FROM nl_case_aliases x
+    WHERE x.alias_kind = 'zaaknummer' AND x.alias_norm = pa.alias_norm
+      AND x.ecli LIKE 'ECLI:NL:HR:%'
+) cnt ON true
+WHERE pa.alias_kind = 'zaaknummer'
+  AND pa.ecli LIKE 'ECLI:NL:PHR:%'
+  AND ha.ecli LIKE 'ECLI:NL:HR:%'
+ON CONFLICT DO NOTHING;
+
+\echo == result ==
+SELECT relation, method, count(*) AS links,
+       count(DISTINCT child_ecli) AS conclusions_linked,
+       round(avg(confidence)::numeric, 2) AS avg_confidence
+FROM nl_instance_links GROUP BY 1, 2;
+
+\echo == coverage: how many PHR documents got a partner ==
+SELECT count(*) AS phr_total,
+       count(*) FILTER (WHERE EXISTS (
+           SELECT 1 FROM nl_instance_links l WHERE l.child_ecli = d.ecli)) AS phr_paired
+FROM nl_rechtspraak_decisions d WHERE d.ecli LIKE 'ECLI:NL:PHR:%';

--- a/scripts/nl/build_instance_links_rdf_year.sql
+++ b/scripts/nl/build_instance_links_rdf_year.sql
@@ -1,0 +1,58 @@
+-- LEXAI-1885, pass 3: instance links from the source's own <dcterms:relation>.
+--
+-- This supersedes the heuristics. Rechtspraak states the chain explicitly in the
+-- decision XML, which we already store:
+--
+--   <dcterms:relation rdfs:label="Formele relatie"
+--       ecli:resourceIdentifier="ECLI:NL:GHARL:2019:2508"
+--       psi:type="http://psi.rechtspraak.nl/cassatie"
+--       psi:aanleg="http://psi.rechtspraak.nl/eerdereAanleg"
+--       psi:gevolg="http://psi.rechtspraak.nl/gevolg#(Gedeeltelijke) vernietiging">
+--
+-- So the related ECLI, the relation type, which side is the earlier instance and
+-- the outcome of the appeal all come from the publisher rather than from us
+-- guessing. The earlier attempt (cited + shared case number + higher court)
+-- produced zero links, because appeal courts assign their own case numbers: the
+-- 3,075 pairs that do share one are almost all PHR/HR pairs already covered.
+--
+-- Sharded by year: psql -c "SET my.yr=2020" -f build_instance_links_rdf_year.sql
+\set ON_ERROR_STOP on
+
+INSERT INTO nl_instance_links (child_ecli, parent_ecli, relation, method, outcome, confidence)
+SELECT DISTINCT
+       -- psi:aanleg says whether the related decision came before or after this
+       -- one, which is what fixes the direction of the edge
+       CASE WHEN rel.aanleg = 'eerdereAanleg' THEN d.ecli ELSE rel.target END,
+       CASE WHEN rel.aanleg = 'eerdereAanleg' THEN rel.target ELSE d.ecli END,
+       -- psi:type is absent on a minority of relations (the outcome may still
+       -- be there), so unknown ones land as 'related' rather than dropping the
+       -- edge or violating NOT NULL
+       COALESCE(CASE rel.rtype
+            WHEN 'cassatie'    THEN 'cassation_of'
+            WHEN 'hogerBeroep' THEN 'appeal_of'
+            WHEN 'conclusie'   THEN 'conclusion_for'
+            WHEN 'verwijzing'  THEN 'referred_back'
+            ELSE rel.rtype
+       END, 'related'),
+       'rdf_relation',
+       rel.gevolg,
+       1.0
+FROM nl_rechtspraak_decisions d
+CROSS JOIN LATERAL regexp_matches(d.full_text_xml, '<dcterms:relation\s([^>]*)>', 'g') AS tag(attrs)
+CROSS JOIN LATERAL (
+    SELECT (regexp_match(tag.attrs[1], 'resourceIdentifier="([^"]+)"'))[1]              AS target,
+           (regexp_match(tag.attrs[1], 'psi:type="http://psi\.rechtspraak\.nl/([^"#]+)'))[1]   AS rtype,
+           (regexp_match(tag.attrs[1], 'psi:aanleg="http://psi\.rechtspraak\.nl/([^"#]+)'))[1] AS aanleg,
+           (regexp_match(tag.attrs[1], 'psi:gevolg="http://psi\.rechtspraak\.nl/gevolg#([^"]+)"'))[1] AS gevolg
+) rel
+WHERE d.full_text_xml IS NOT NULL
+  AND d.decision_date >= make_date(current_setting('my.yr')::int, 1, 1)
+  AND d.decision_date <  make_date(current_setting('my.yr')::int + 1, 1, 1)
+  AND rel.target IS NOT NULL
+  AND rel.target <> d.ecli
+  AND rel.target ~ '^ECLI:'
+  AND rel.aanleg IS NOT NULL
+ON CONFLICT (child_ecli, parent_ecli, relation) DO UPDATE
+   SET method = 'rdf_relation',
+       outcome = COALESCE(EXCLUDED.outcome, nl_instance_links.outcome),
+       confidence = 1.0;

--- a/scripts/nl/build_law_abbrev.sql
+++ b/scripts/nl/build_law_abbrev.sql
@@ -1,0 +1,44 @@
+-- LEXAI-1883 pass 2, step 1: the abbreviation dictionary.
+--
+-- Canonical names are taken verbatim from what dcterms:references already
+-- publishes, so text-extracted edges and source-provided edges land on the same
+-- law and can be compared. Two article conventions have to be distinguished:
+--
+--   "artikel 7:658 BW"  → law "Burgerlijk Wetboek Boek 7", article "658"
+--                         (the civil code puts the book in the law's name)
+--   "artikel 3:4 Awb"   → law "Algemene wet bestuursrecht", article "3:4"
+--                         (the administrative act keeps the colon in the article)
+--
+-- Getting that backwards silently points every civil-code edge at a
+-- non-existent article, which is why article_style is explicit here.
+CREATE TABLE IF NOT EXISTS nl_law_abbrev (
+    abbrev        TEXT PRIMARY KEY,
+    law_name      TEXT NOT NULL,
+    article_style TEXT NOT NULL DEFAULT 'plain'   -- plain | book_colon
+);
+
+INSERT INTO nl_law_abbrev (abbrev, law_name, article_style) VALUES
+    ('BW',   'Burgerlijk Wetboek',                                  'book_colon'),
+    ('Awb',  'Algemene wet bestuursrecht',                          'plain'),
+    ('Sr',   'Wetboek van Strafrecht',                              'plain'),
+    ('Sv',   'Wetboek van Strafvordering',                          'plain'),
+    ('Rv',   'Wetboek van Burgerlijke Rechtsvordering',             'plain'),
+    ('Fw',   'Faillissementswet',                                   'plain'),
+    ('AWR',  'Algemene wet inzake rijksbelastingen',                'plain'),
+    ('Gw',   'Grondwet',                                            'plain'),
+    ('Vw',   'Vreemdelingenwet 2000',                               'plain'),
+    ('Wvw',  'Wegenverkeerswet 1994',                               'plain'),
+    ('WVW',  'Wegenverkeerswet 1994',                               'plain'),
+    ('EVRM', 'Verdrag tot bescherming van de rechten van de mens en de fundamentele vrijheden', 'plain'),
+    ('IVRK', 'Verdrag inzake de rechten van het kind',              'plain')
+ON CONFLICT (abbrev) DO UPDATE
+   SET law_name = EXCLUDED.law_name, article_style = EXCLUDED.article_style;
+
+\echo == every canonical name must exist in the reference set, or the two passes disagree ==
+SELECT a.abbrev, a.law_name,
+       (SELECT count(*) FROM nl_legislation_citations c
+         WHERE c.cite_kind = 'rdf'
+           AND (c.law_name_raw = a.law_name
+                OR (a.article_style = 'book_colon' AND c.law_name_raw LIKE a.law_name || ' Boek %')))
+       AS rdf_edges_for_this_law
+FROM nl_law_abbrev a ORDER BY 3 DESC;

--- a/scripts/nl/build_legislation_citations_fullname.sql
+++ b/scripts/nl/build_legislation_citations_fullname.sql
@@ -1,0 +1,60 @@
+-- LEXAI-1883 pass 2c: laws written out in full, dictionary generated from the
+-- reference set instead of hand-listed.
+--
+-- Splitting recall by dictionary coverage showed where the ceiling was:
+--   law in our 13-entry dictionary   60,759 reference edges, 62.2% found
+--   law not in it                    17,703 reference edges,  0.0% found
+-- So the extractor was not weak, the dictionary was: 13 laws against the 2,244
+-- that dcterms:references names. The fix is to let the reference set be the
+-- dictionary, and to build the alternation at run time rather than typing it.
+--
+-- Only laws that appear at least MIN_EDGES times are taken: a name seen twice
+-- adds regex cost without adding recall, and long rare names raise the odds of
+-- matching something that is not a citation.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+DO $$
+DECLARE
+    pattern   text;
+    law_count int;
+    inserted  bigint;
+BEGIN
+    -- Build "Name A|Name B|..." from the reference set, longest first so that
+    -- "Vreemdelingenwet 2000" wins over "Vreemdelingenwet", and with regex
+    -- metacharacters escaped: several names contain dots and parentheses.
+    SELECT string_agg(regexp_replace(law, '([.()\[\]{}*+?^$|\\])', '\\\1', 'g'), '|'
+                      ORDER BY length(law) DESC), count(*)
+      INTO pattern, law_count
+      FROM (SELECT btrim(regexp_replace(law_name_raw, '\s*\(.*\)$', '')) AS law
+              FROM nl_legislation_citations
+             WHERE cite_kind = 'rdf'
+             GROUP BY 1
+            HAVING count(*) >= 200) x;
+
+    RAISE NOTICE 'dictionary: % laws', law_count;
+
+    EXECUTE format($f$
+        INSERT INTO nl_legislation_citations
+            (from_ecli, law_name_raw, article, lid, cite_kind, resolved)
+        SELECT DISTINCT ON (d.ecli, m[2], num.one)
+               d.ecli, m[2], num.one, NULL, 'text', true
+        FROM nl_rechtspraak_decisions d
+        CROSS JOIN LATERAL regexp_matches(
+                d.full_text,
+                '(?:[Aa]rtikel|[Aa]rt\.|[Aa]rtikelen|[Aa]rtt\.)\s*((?:[0-9]+[a-zA-Z]?(?:\s*,\s*|\s+en\s+))*[0-9]+[a-zA-Z]?)\s*(?:lid\s*[0-9]+\s*)?(?:van\s+(?:het|de)\s+)(%s)\M',
+                'g') AS m
+        CROSS JOIN LATERAL unnest(regexp_split_to_array(m[1], '\s*,\s*|\s+en\s+')) AS num(one)
+        WHERE d.full_text IS NOT NULL
+          AND d.decision_date >= make_date(%s, 1, 1)
+          AND d.decision_date <  make_date(%s, 1, 1)
+          AND NOT EXISTS (SELECT 1 FROM nl_scan_errors2 b WHERE b.ecli = d.ecli)
+          AND btrim(num.one) <> ''
+        ON CONFLICT DO NOTHING
+    $f$, pattern,
+         current_setting('my.yr')::int,
+         current_setting('my.yr')::int + 1);
+
+    GET DIAGNOSTICS inserted = ROW_COUNT;
+    RAISE NOTICE 'year % : % edges', current_setting('my.yr'), inserted;
+END $$;

--- a/scripts/nl/build_legislation_citations_rdf.sql
+++ b/scripts/nl/build_legislation_citations_rdf.sql
@@ -1,0 +1,67 @@
+-- LEXAI-1883, pass 1: decision → statute edges straight from dcterms:references.
+--
+-- The source publishes these already parsed, as "<law name> <article>":
+--   "Wetboek van Strafrecht 285b", "Burgerlijk Wetboek Boek 3 37"
+-- 128,631 decisions carry the field (84,209 as a JSON array, 44,422 as a single
+-- string), so both shapes have to be unwrapped.
+--
+-- These rows are also the reference set the text extractor (pass 2) is scored
+-- against before it is trusted on the other ~5.8M raw "artikel N" mentions.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+-- idempotent: this pass is the only writer of cite_kind='rdf'
+DELETE FROM nl_legislation_citations WHERE cite_kind = 'rdf';
+
+INSERT INTO nl_legislation_citations
+    (from_ecli, law_name_raw, article, lid, cite_kind, resolved)
+SELECT DISTINCT ON (d.ecli, parsed.law_name, parsed.article)
+       d.ecli,
+       parsed.law_name,
+       parsed.article,
+       NULL,
+       'rdf',
+       false
+FROM nl_rechtspraak_decisions d
+-- normalize both shapes to an array first: a set-returning function cannot
+-- live inside CASE, so the branch picks the array and the unnest comes after
+CROSS JOIN LATERAL jsonb_array_elements_text(
+    CASE WHEN jsonb_typeof(d.metadata_json->'references') = 'array'
+         THEN d.metadata_json->'references'
+         ELSE jsonb_build_array(d.metadata_json->>'references')
+    END
+) AS r(ref)
+CROSS JOIN LATERAL (
+    -- article is the trailing token: digits plus an optional letter suffix
+    -- ("285b") and an optional book:article form ("6:162")
+    SELECT btrim((regexp_match(r.ref, '^(.*?)\s+([0-9]+[a-zA-Z]*(?::[0-9]+[a-zA-Z]*)?)$'))[1]) AS head,
+           (regexp_match(r.ref, '^(.*?)\s+([0-9]+[a-zA-Z]*(?::[0-9]+[a-zA-Z]*)?)$'))[2]        AS tail
+) raw
+CROSS JOIN LATERAL (
+    -- "Burgerlijk Wetboek Boek 3" has no article at all: the trailing number is
+    -- the book, part of the law's name. Without this the book number is stored
+    -- as an article and every civil-code reference points at the wrong provision.
+    SELECT CASE WHEN raw.head ~ '\mBoek$' THEN raw.head || ' ' || raw.tail ELSE raw.head END AS law_name,
+           CASE WHEN raw.head ~ '\mBoek$' THEN NULL ELSE raw.tail END                        AS article
+) parsed
+WHERE d.metadata_json ? 'references'
+  AND parsed.law_name IS NOT NULL
+  AND parsed.law_name <> ''
+ON CONFLICT DO NOTHING;
+
+\echo == result ==
+SELECT count(*) AS edges,
+       count(DISTINCT from_ecli) AS decisions,
+       count(DISTINCT law_name_raw) AS distinct_laws
+FROM nl_legislation_citations WHERE cite_kind = 'rdf';
+
+\echo == unparsed references (no trailing article token) ==
+SELECT count(*) AS decisions_with_refs_but_no_edge
+FROM nl_rechtspraak_decisions d
+WHERE d.metadata_json ? 'references'
+  AND NOT EXISTS (SELECT 1 FROM nl_legislation_citations c WHERE c.from_ecli = d.ecli);
+
+\echo == top laws ==
+SELECT law_name_raw, count(*) AS edges
+FROM nl_legislation_citations WHERE cite_kind = 'rdf'
+GROUP BY 1 ORDER BY 2 DESC LIMIT 12;

--- a/scripts/nl/build_legislation_citations_text_year.sql
+++ b/scripts/nl/build_legislation_citations_text_year.sql
@@ -1,0 +1,96 @@
+-- LEXAI-1883 pass 2: statute references extracted from the decision text.
+--
+-- Scope of this pass is deliberately the high-precision half. Measured on a
+-- sample of 162 texts, "artikel N" appears 986 times and 43% of those carry no
+-- law next to the number at all: they lean on what was named earlier in the
+-- paragraph. Chasing those needs context tracking and belongs in a later pass;
+-- guessing them now would pollute the graph with edges nobody can trust.
+--
+-- Here we take only mentions where the law is stated next to the article, via
+-- the abbreviation dictionary (nl_law_abbrev). Precision is then measured
+-- against the 250k edges dcterms:references gave us for free.
+--
+-- Sharded by year: psql -c "SET my.yr=2020" -f build_legislation_citations_text_year.sql
+\set ON_ERROR_STOP on
+
+INSERT INTO nl_legislation_citations
+    (from_ecli, law_name_raw, article, lid, cite_kind, resolved)
+SELECT DISTINCT ON (d.ecli, parsed.law_name, parsed.article)
+       d.ecli,
+       parsed.law_name,
+       parsed.article,
+       NULL,
+       'text',
+       parsed.article IS NOT NULL
+FROM nl_rechtspraak_decisions d
+CROSS JOIN LATERAL regexp_matches(
+        d.full_text,
+        -- "artikel"/"art." + number (optionally book:article) + optional "lid N"
+        -- + a known abbreviation. The keyword is matched case-insensitively by
+        -- hand because a global 'i' flag would also match "bw" or "sr" in prose.
+        '(?:[Aa]rtikel|[Aa]rt\.)\s*([0-9]+[a-zA-Z]?(?::[0-9]+[a-zA-Z]?)?)\s*(?:lid\s*[0-9]+\s*)?(BW|Awb|Sr|Sv|Rv|Fw|AWR|Gw|Vw|Wvw|WVW|EVRM|IVRK)\M',
+        'g') AS m
+JOIN nl_law_abbrev ab ON ab.abbrev = m[2]
+CROSS JOIN LATERAL (
+    SELECT CASE
+             -- civil code: the book lives in the law's name, so 7:658 becomes
+             -- "Burgerlijk Wetboek Boek 7" + article 658
+             WHEN ab.article_style = 'book_colon' AND m[1] ~ '^[0-9]+[aA]?:'
+               THEN ab.law_name || ' Boek ' || split_part(m[1], ':', 1)
+             ELSE ab.law_name
+           END AS law_name,
+           CASE
+             WHEN ab.article_style = 'book_colon' AND m[1] ~ '^[0-9]+[aA]?:'
+               THEN split_part(m[1], ':', 2)
+             -- "artikel 6 BW" without a book cannot be placed in a book, so the
+             -- article is left NULL and the edge is marked unresolved rather
+             -- than silently attached to the wrong one
+             WHEN ab.article_style = 'book_colon'
+               THEN NULL
+             ELSE m[1]
+           END AS article
+) parsed
+WHERE d.full_text IS NOT NULL
+  AND d.decision_date >= make_date(current_setting('my.yr')::int, 1, 1)
+  AND d.decision_date <  make_date(current_setting('my.yr')::int + 1, 1, 1)
+  AND NOT EXISTS (SELECT 1 FROM nl_scan_errors2 b WHERE b.ecli = d.ecli)
+ON CONFLICT DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Pass 2b: enumerations, and the law written out in full.
+--
+-- Measuring 2a against the reference set showed precision is fine (all six
+-- unconfirmed edges inspected quoted the article verbatim: "artikel 8:42 Awb",
+-- "artikel 2:343 BW", "artikel 7:623 BW") but recall was 45.7%, and the misses
+-- were dominated by the criminal code: 239 of them. Criminal judgments list the
+-- applied provisions as a run - "de artikelen 47, 57 en 310 van het Wetboek van
+-- Strafrecht" - so the abbreviation never sits next to each number.
+--
+-- This pass captures the list, then splits it.
+-- ---------------------------------------------------------------------------
+INSERT INTO nl_legislation_citations
+    (from_ecli, law_name_raw, article, lid, cite_kind, resolved)
+SELECT DISTINCT ON (d.ecli, parsed.law_name, parsed.article)
+       d.ecli, parsed.law_name, parsed.article, NULL, 'text', parsed.article IS NOT NULL
+FROM nl_rechtspraak_decisions d
+CROSS JOIN LATERAL regexp_matches(
+        d.full_text,
+        '(?:[Aa]rtikelen|[Aa]rtt\.)\s*((?:[0-9]+[a-zA-Z]?(?::[0-9]+[a-zA-Z]?)?(?:\s*,\s*|\s+en\s+))+[0-9]+[a-zA-Z]?(?::[0-9]+[a-zA-Z]?)?)\s*(?:van\s+(?:het|de)\s+)?(BW|Awb|Sr|Sv|Rv|Fw|AWR|Gw|Vw|Wvw|WVW|EVRM|IVRK|Wetboek van Strafrecht|Wetboek van Strafvordering|Burgerlijk Wetboek|Algemene wet bestuursrecht|Faillissementswet)\M',
+        'g') AS m
+CROSS JOIN LATERAL unnest(regexp_split_to_array(m[1], '\s*,\s*|\s+en\s+')) AS num(one)
+JOIN nl_law_abbrev ab ON ab.abbrev = m[2] OR ab.law_name = m[2]
+CROSS JOIN LATERAL (
+    SELECT CASE WHEN ab.article_style = 'book_colon' AND num.one ~ '^[0-9]+[aA]?:'
+                THEN ab.law_name || ' Boek ' || split_part(num.one, ':', 1)
+                ELSE ab.law_name END AS law_name,
+           CASE WHEN ab.article_style = 'book_colon' AND num.one ~ '^[0-9]+[aA]?:'
+                THEN split_part(num.one, ':', 2)
+                WHEN ab.article_style = 'book_colon' THEN NULL
+                ELSE num.one END AS article
+) parsed
+WHERE d.full_text IS NOT NULL
+  AND d.decision_date >= make_date(current_setting('my.yr')::int, 1, 1)
+  AND d.decision_date <  make_date(current_setting('my.yr')::int + 1, 1, 1)
+  AND NOT EXISTS (SELECT 1 FROM nl_scan_errors2 b WHERE b.ecli = d.ecli)
+  AND btrim(num.one) <> ''
+ON CONFLICT DO NOTHING;

--- a/scripts/nl/eval_text_extractor.sql
+++ b/scripts/nl/eval_text_extractor.sql
@@ -1,0 +1,69 @@
+-- LEXAI-1883: score the text extractor against the edges dcterms:references
+-- provides for free.
+--
+-- Read the numbers carefully. The RDF list is what the court's editor tagged as
+-- the relevant provisions, not every statute the judgment mentions, so a text
+-- edge missing from it is not automatically wrong. Agreement is therefore
+-- reported in shared_docs directions and interpreted, not collapsed into one "accuracy".
+--
+-- Only decisions that have BOTH kinds of edge are compared; anything else would
+-- measure coverage, not correctness.
+SET max_parallel_workers_per_gather = 6;
+
+WITH norm AS (
+    SELECT from_ecli, cite_kind,
+           -- the source names the same act two ways; strip the qualifier so
+           -- "Wetboek van Burgerlijke Rechtsvordering (geldt in geval van
+           -- digitaal procederen)" and the plain name compare equal
+           btrim(regexp_replace(law_name_raw, '\s*\(.*\)$', '')) AS law,
+           article
+    FROM nl_legislation_citations
+    WHERE article IS NOT NULL
+),
+shared_docs AS (
+    SELECT DISTINCT from_ecli FROM norm WHERE cite_kind = 'text'
+    INTERSECT
+    SELECT DISTINCT from_ecli FROM norm WHERE cite_kind = 'rdf'
+),
+t AS (SELECT DISTINCT n.* FROM norm n JOIN shared_docs USING (from_ecli) WHERE cite_kind = 'text'),
+r AS (SELECT DISTINCT n.* FROM norm n JOIN shared_docs USING (from_ecli) WHERE cite_kind = 'rdf')
+SELECT (SELECT count(*) FROM shared_docs)                                    AS decisions_compared,
+       (SELECT count(*) FROM t)                                       AS text_edges,
+       (SELECT count(*) FROM r)                                       AS rdf_edges,
+       (SELECT count(*) FROM t JOIN r USING (from_ecli, law, article)) AS agreeing,
+       round(100.0 * (SELECT count(*) FROM t JOIN r USING (from_ecli, law, article))
+                   / NULLIF((SELECT count(*) FROM t), 0), 1)          AS pct_of_text_confirmed,
+       round(100.0 * (SELECT count(*) FROM t JOIN r USING (from_ecli, law, article))
+                   / NULLIF((SELECT count(*) FROM r), 0), 1)          AS pct_of_rdf_found;
+
+\echo == where the two disagree, by law: is it us or is it the editor being selective ==
+WITH norm AS (
+    SELECT from_ecli, cite_kind,
+           btrim(regexp_replace(law_name_raw, '\s*\(.*\)$', '')) AS law, article
+    FROM nl_legislation_citations WHERE article IS NOT NULL
+),
+shared_docs AS (SELECT DISTINCT from_ecli FROM norm WHERE cite_kind='text'
+         INTERSECT SELECT DISTINCT from_ecli FROM norm WHERE cite_kind='rdf'),
+t AS (SELECT DISTINCT n.* FROM norm n JOIN shared_docs USING (from_ecli) WHERE cite_kind='text'),
+r AS (SELECT DISTINCT n.* FROM norm n JOIN shared_docs USING (from_ecli) WHERE cite_kind='rdf')
+SELECT t.law,
+       count(*) AS text_edges,
+       count(*) FILTER (WHERE EXISTS (SELECT 1 FROM r
+             WHERE r.from_ecli=t.from_ecli AND r.law=t.law AND r.article=t.article)) AS confirmed_by_rdf
+FROM t GROUP BY 1 ORDER BY 2 DESC LIMIT 10;
+
+\echo == a few text edges the RDF does not list, to eyeball whether they are real ==
+WITH norm AS (
+    SELECT from_ecli, cite_kind,
+           btrim(regexp_replace(law_name_raw, '\s*\(.*\)$', '')) AS law, article
+    FROM nl_legislation_citations WHERE article IS NOT NULL
+),
+shared_docs AS (SELECT DISTINCT from_ecli FROM norm WHERE cite_kind='text'
+         INTERSECT SELECT DISTINCT from_ecli FROM norm WHERE cite_kind='rdf')
+SELECT t.from_ecli, t.law, t.article
+FROM norm t JOIN shared_docs USING (from_ecli)
+WHERE t.cite_kind='text'
+  AND NOT EXISTS (SELECT 1 FROM norm r JOIN shared_docs b2 ON b2.from_ecli=r.from_ecli
+                   WHERE r.cite_kind='rdf' AND r.from_ecli=t.from_ecli
+                     AND r.law=t.law AND r.article=t.article)
+LIMIT 8;

--- a/scripts/nl/update_precedent_status.sql
+++ b/scripts/nl/update_precedent_status.sql
@@ -1,0 +1,53 @@
+-- LEXAI-1885, pass 4: precedent status from the outcomes the publisher states.
+--
+-- Only appeal-type relations count. `gevolgd` on a conclusion_for edge means the
+-- Hoge Raad followed the Advocate-General, which says nothing about whether the
+-- decision below is still good law, so those edges are excluded here.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+WITH appeal AS (
+    SELECT parent_ecli,
+           array_agg(DISTINCT child_ecli) FILTER (WHERE outcome ILIKE '%vernietig%') AS quashed_by,
+           bool_or(outcome ILIKE '%vernietig%')                AS was_quashed,
+           bool_or(outcome ILIKE '%bekrachtiging%'
+                OR outcome ILIKE '%bevestiging%')              AS was_upheld
+    FROM nl_instance_links
+    WHERE relation IN ('appeal_of', 'cassation_of', 'sprongcassatie')
+      AND outcome IS NOT NULL
+    GROUP BY parent_ecli
+)
+INSERT INTO nl_precedent_status (ecli, status, overruled_by, cited_by_count, last_computed)
+SELECT a.parent_ecli,
+       -- quashed wins over upheld: a decision quashed in part is not clean
+       -- authority even if another appeal affirmed something else in it
+       CASE WHEN a.was_quashed THEN 'quashed'
+            WHEN a.was_upheld  THEN 'upheld'
+            ELSE NULL END,
+       a.quashed_by,
+       0,
+       now()
+FROM appeal a
+ON CONFLICT (ecli) DO UPDATE
+   SET status        = EXCLUDED.status,
+       overruled_by  = EXCLUDED.overruled_by,
+       last_computed = EXCLUDED.last_computed;
+
+-- keep the citation counts, which the previous pass computed over all resolved edges
+UPDATE nl_precedent_status p
+SET cited_by_count = c.n
+FROM (SELECT to_ecli, count(*) AS n FROM nl_case_citations
+      WHERE resolved AND to_ecli IS NOT NULL GROUP BY to_ecli) c
+WHERE p.ecli = c.to_ecli AND p.cited_by_count <> c.n;
+
+\echo == status distribution ==
+SELECT coalesce(status, '(unknown, no appeal on record)') AS status,
+       count(*) AS decisions,
+       round(avg(cited_by_count), 1) AS avg_citations
+FROM nl_precedent_status GROUP BY 1 ORDER BY 2 DESC;
+
+\echo == a quashed decision with its quasher ==
+SELECT p.ecli, p.status, p.overruled_by[1] AS quashed_by, p.cited_by_count, d.court_name
+FROM nl_precedent_status p JOIN nl_rechtspraak_decisions d USING (ecli)
+WHERE p.status = 'quashed' AND p.cited_by_count > 0
+ORDER BY p.cited_by_count DESC LIMIT 5;


### PR DESCRIPTION
## What this is

The graph layer for NL, on top of the corpus loaded in #2221. Per the grounded-substrate spec every jurisdiction gets one graph, one vector collection and one FTS; this is the graph and the FTS half. Epic LEXAI-1880.

Everything is already built on prod. Numbers below are measured, not projected.

## Graph

| table | rows | source |
|---|---|---|
| `nl_case_aliases` | 4,712,138 | 3,989,513 case numbers · 481,369 LJN · 241,256 journal |
| `nl_case_citations` | 1,052,105 | decision → decision, extracted from text |
| `nl_legislation_citations` | 2,416,+ | 250,004 from `dcterms:references`, 2,166,998 from text |
| `nl_instance_links` | 200,887 | 141,879 from `dcterms:relation`, 59,008 PHR pairs |
| `nl_precedent_status` | 229,258 | 18,197 quashed, 30,304 upheld |

Citation resolution: **98.1% for ECLI:NL, 97.5% for LJN**. CJEU (59,132) and ECHR (8,478) edges are stored unresolved on purpose — those corpora are not loaded, and ECHR is index-and-link-out anyway.

## Four things the data turned out to say

**The source states the instance chain outright.** The plan was to infer it from "cites + shares a case number + higher court". That returned exactly zero links, because appeal courts assign their own case numbers. `dcterms:relation` carries the related ECLI, the relation type, which side is earlier, *and the outcome of the appeal*, so precedent status is read off the publisher rather than guessed:

```xml
<dcterms:relation ecli:resourceIdentifier="ECLI:NL:GHARL:2019:2508"
    psi:type=".../cassatie" psi:aanleg=".../eerdereAanleg"
    psi:gevolg=".../gevolg#(Gedeeltelijke) vernietiging">
```

**LJN codes need no external mapping.** When ECLIs were assigned to pre-2013 decisions the LJN became the ordinal, so `ECLI:NL:PHR:2008:BB4767` *is* LJN BB4767.

**`hasVersion` is not a citation list.** It is free text beginning with "Rechtspraak.nl"; 648,360 of 1,020,999 rows contain nothing else. The 158,143 that do carry journal references gave 241,256 aliases, not the million the field count suggested.

**Article conventions differ per law and failing that is silent.** The civil code puts the book in the law's name ("Burgerlijk Wetboek Boek 7" + article 658); the administrative act keeps the colon in the article ("Algemene wet bestuursrecht" + "3:4"). An early version read the book number as an article and pointed 17,694 edges at the wrong provision.

## Scoring the text extractor honestly

Agreement with `dcterms:references` is 32.8% one way, 46.7% the other, and **neither is an error rate**. The reference list is what the court's editor tagged as decisive, not every statute cited. Every one of six unconfirmed edges checked by pulling the surrounding sentence quoted the article verbatim ("artikel 8:42 Awb", "artikel 2:343 BW", "artikel 7:623 BW").

The number that guided the work was recall split by dictionary coverage: **62.2% for laws we knew, 0% for the rest** — which is why the dictionary is now generated from the reference set rather than hand-listed.

Open gaps, named rather than buried: 43% of "artikel N" mentions state no law and need paragraph-context tracking; the generated dictionary covers 93 of 2,244 law names.

## Indexes (LEXAI-1881)

`idx_nl_recht_fts` was 3,408 MB with **0 scans** — wrong config (`simple`, no Dutch stemming), indexed `parties` which is NULL in 100% of rows, and covered all 3.6M rows when 946k have text. Replaced:

| index | size |
|---|---|
| `idx_nl_fts_dutch` (partial, Dutch config) | 1,526 MB |
| `idx_nl_metadata_jsonb` | 741 MB |
| `idx_nl_case_number_trgm` | 130 MB |
| `idx_nl_court_date` | 33 MB |
| `idx_nl_subject_areas` | 8 MB |

Verified in use: a four-term Dutch query is a Bitmap Index Scan over 8,220 matches in 22 ms, and stemming works ("ontbinding" → "ontbind"), which `simple` never did.

Index DDL is in `scripts/nl/179b` rather than the migration: the runner sends a file as one query, Postgres wraps that in a transaction, and `CREATE INDEX CONCURRENTLY` cannot run there.

## Not in this PR

`nl_passages` (role layer) is created but empty — it waits on Niko's call on the taxonomy, since NL publishes no dissenting opinions and the analogue is a separate `ECLI:NL:PHR:` document. Vectors are LEXAI-1887..1890.

Unrelated leftover spotted on prod: `idx_indian_sc_title_trgm` is invalid from someone's interrupted build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Dutch citation graph and statute edges, plus a concurrent FTS/index rebuild for Dutch stemming and faster search. Meets LEXAI-1880 (graph) and LEXAI-1881 (index) requirements for the NL corpus.

- **New Features**
  - Schema: `nl_case_aliases`, `nl_case_citations`, `nl_legislation_citations`, `nl_instance_links`, `nl_precedent_status`, `nl_passages`.
  - Builders (server-side SQL): aliases; case→case from text; statute edges from `dcterms:references` and text; instance links from PHR pairs and `<dcterms:relation>`; precedent status from appeal outcomes; extractor eval.
  - Graph scale and quality: 1.05M case citations; 2.17M statute edges from text plus 250k from references; 98.1% ECLI:NL and 97.5% LJN resolution; external ECLI (CJEU/ECHR) stored unresolved by design.
  - Notes: civil code article handling fixed (book in law name); `nl_passages` created but unpopulated pending taxonomy; status stays data-backed (no guesswork).

- **Migration**
  - Apply migration 179, then run `scripts/nl/179b_nl_decisions_indexes_concurrently.sql` to replace the FTS with the Dutch config and add `subject_areas`, `court_code+decision_date`, `case_number` trigram, and `metadata_jsonb` indexes.
  - Backfill via scripts in `scripts/nl/` (heavy jobs are year-sharded with `SET my.yr=<YYYY>`).

<sup>Written for commit 535775dd5e703a902c59616a3bcf174abd0183d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

