### PR TITLE
feat(cross-jurisdiction): resolve NL citations into CJEU and ECHR

### DIFF
--- a/mcp_backend/src/migrations/180_eu_cjeu_decisions.sql
+++ b/mcp_backend/src/migrations/180_eu_cjeu_decisions.sql
@@ -1,0 +1,32 @@
+-- Migration 180: CJEU decisions as resolvable citation targets (LEXAI-1892)
+--
+-- The NL graph produced 59,132 edges pointing at ECLI:EU:C/T/F decisions and
+-- almost none of them resolve: the existing eu_curia_cases table holds 35,764
+-- rows, but 28,857 are malformed placeholders like
+-- "ECLI:EU:CJ:82005IT0119(02)" with no case number and no case name, leaving
+-- 6,888 usable against the 6,335 distinct decisions our corpus cites.
+--
+-- A separate table rather than a top-up of eu_curia_cases: that table is wired
+-- into other code, and mixing a clean load into a set that is three quarters
+-- placeholders makes both harder to reason about.
+--
+-- Source: CELLAR SPARQL (publications.europa.eu/webapi/rdf/sparql), CC BY under
+-- 2011/833/EU, so unlike ECHR the text may be stored and served.
+
+CREATE TABLE IF NOT EXISTS eu_cjeu_decisions (
+    ecli          TEXT PRIMARY KEY,
+    celex         TEXT,
+    court         TEXT,              -- C (Court of Justice) | T (General Court) | F (Civil Service Tribunal)
+    decision_date DATE,
+    title         TEXT,
+    doc_type      TEXT,              -- judgment | opinion | order, derived from the CELEX sector code
+    full_text     TEXT,              -- left NULL by the metadata pass
+    source_url    TEXT,
+    metadata_json JSONB,
+    imported_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eu_cjeu_celex ON eu_cjeu_decisions (celex);
+CREATE INDEX IF NOT EXISTS idx_eu_cjeu_date  ON eu_cjeu_decisions (decision_date);
+CREATE INDEX IF NOT EXISTS idx_eu_cjeu_court ON eu_cjeu_decisions (court, decision_date DESC);

--- a/scripts/eu/harvest_cjeu_metadata.py
+++ b/scripts/eu/harvest_cjeu_metadata.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Harvest CJEU decision metadata from CELLAR into a CSV for loading (LEXAI-1892).
+
+Why SPARQL and not the REST API: CELLAR's SPARQL endpoint answers without a key
+and returns the ECLI, CELEX, date and title in one pass, which is exactly what a
+citation target needs. Text comes later, per decision, and only where wanted.
+
+Why sharded by court and year rather than LIMIT/OFFSET: deep OFFSET on this
+endpoint degrades badly and silently truncates on timeout, whereas an ECLI
+prefix filter is an index hit. Counted before harvesting:
+    ECLI:EU:C  30,280    ECLI:EU:T  13,122    ECLI:EU:F  1,253
+"""
+import csv
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+from datetime import date
+
+ENDPOINT = "http://publications.europa.eu/webapi/rdf/sparql"
+UA = "SecondLayer-Legal-Platform/2.0 (legal.org.ua; opendata-importer)"
+OUT = sys.argv[1] if len(sys.argv) > 1 else "cjeu_metadata.csv"
+
+COURTS = {"C": (1954, date.today().year), "T": (1989, date.today().year), "F": (2005, 2017)}
+
+QUERY = """
+PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+SELECT DISTINCT ?ecli ?celex ?date ?title WHERE {
+  ?w cdm:case-law_ecli ?ecli ;
+     cdm:work_date_document ?date .
+  OPTIONAL { ?w cdm:resource_legal_id_celex ?celex }
+  OPTIONAL {
+    ?e cdm:expression_belongs_to_work ?w ;
+       cdm:expression_uses_language <http://publications.europa.eu/resource/authority/language/ENG> ;
+       cdm:expression_title ?title
+  }
+  FILTER(STRSTARTS(STR(?ecli), "ECLI:EU:%s:%d"))
+}
+"""
+
+
+def celex_doc_type(celex: str) -> str:
+    """CELEX sector 6 descriptor: CJ judgment, CC opinion of the AG, CO order."""
+    if not celex or len(celex) < 7:
+        return ""
+    code = celex[5:7]
+    return {"CJ": "judgment", "CC": "opinion", "CO": "order",
+            "TJ": "judgment", "TO": "order", "FJ": "judgment", "FO": "order"}.get(code, "")
+
+
+def fetch(court: str, year: int, attempt: int = 0) -> list:
+    body = urllib.parse.urlencode({"query": QUERY % (court, year)}).encode()
+    req = urllib.request.Request(
+        ENDPOINT, data=body,
+        headers={"User-Agent": UA, "Accept": "application/sparql-results+json",
+                 "Content-Type": "application/x-www-form-urlencoded"})
+    try:
+        with urllib.request.urlopen(req, timeout=180) as r:
+            return json.loads(r.read())["results"]["bindings"]
+    except Exception as e:
+        if attempt < 3:
+            time.sleep(5 * (attempt + 1))
+            return fetch(court, year, attempt + 1)
+        print(f"  {court}:{year} FAILED after 4 tries: {e}", file=sys.stderr)
+        return []
+
+
+def main():
+    seen = set()
+    rows = 0
+    with open(OUT, "w", newline="") as fh:
+        w = csv.writer(fh)
+        for court, (lo, hi) in COURTS.items():
+            for year in range(lo, hi + 1):
+                got = fetch(court, year)
+                new = 0
+                for b in got:
+                    ecli = b["ecli"]["value"]
+                    if ecli in seen:
+                        continue
+                    seen.add(ecli)
+                    celex = b.get("celex", {}).get("value", "")
+                    w.writerow([
+                        ecli, celex, court,
+                        b.get("date", {}).get("value", "")[:10],
+                        b.get("title", {}).get("value", "").replace("\n", " ")[:2000],
+                        celex_doc_type(celex),
+                        f"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:{celex}" if celex else "",
+                    ])
+                    new += 1
+                    rows += 1
+                if got:
+                    print(f"  {court}:{year} {len(got):5} rows, {new:5} new (total {rows:,})",
+                          flush=True)
+    print(f"wrote {rows:,} rows to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nl/backfill_echr_ecli.sql
+++ b/scripts/nl/backfill_echr_ecli.sql
@@ -1,0 +1,79 @@
+-- Give the ECtHR corpus its ECLIs, so cross-jurisdiction citations resolve.
+--
+-- 209,774 cases sit on prod, 8,904 of them with an ECLI. The NL graph produced
+-- 8,478 edges pointing at ECLI:CE:ECHR:..., which could match 33 of them.
+--
+-- The identifier is derivable from fields we already hold:
+--   ECLI:CE:ECHR:<yyyy>:<mmdd><TYPE><application no padded to 7><yy>
+--   ECLI:CE:ECHR:2026:0312JUD005270913  ←  2026-03-12, HFJUD, 52709/13
+--
+-- judgment_date is only filled for 11,104 rows, but kp_date carries the date as
+-- ISO text for 198,670, so the two are coalesced.
+--
+-- The rule is not trusted on inspection: it is first required to reproduce all
+-- 8,904 known ECLIs exactly, and the backfill aborts if it does not.
+\timing on
+
+DO $$
+DECLARE
+    checked int;
+    matched int;
+    filled  int;
+BEGIN
+    WITH have AS (
+        SELECT ecli,
+               coalesce(judgment_date, substring(kp_date from 1 for 10)::date) AS dt,
+               doc_type,
+               split_part(split_part(app_no, ';', 1), '/', 1) AS num,
+               split_part(split_part(app_no, ';', 1), '/', 2) AS yy
+        FROM echr_cases
+        WHERE ecli IS NOT NULL AND app_no IS NOT NULL
+          AND coalesce(judgment_date, substring(kp_date from 1 for 10)::date) IS NOT NULL
+    )
+    SELECT count(*),
+           count(*) FILTER (WHERE ecli = 'ECLI:CE:ECHR:' || to_char(dt,'YYYY') || ':' ||
+                to_char(dt,'MMDD') || substring(upper(doc_type) from '(JUD|DEC|REP|ADV|RES|SER)') ||
+                lpad(num,7,'0') || lpad(yy,2,'0'))
+      INTO checked, matched
+      FROM have;
+
+    RAISE NOTICE 'rule check: % of % known ECLIs reproduced', matched, checked;
+    IF checked = 0 OR matched <> checked THEN
+        RAISE EXCEPTION 'rule does not reproduce every known ECLI (% of %), refusing to backfill',
+                        matched, checked;
+    END IF;
+
+    UPDATE echr_cases c
+       SET ecli = 'ECLI:CE:ECHR:' || to_char(d.dt,'YYYY') || ':' || to_char(d.dt,'MMDD') ||
+                  substring(upper(c.doc_type) from '(JUD|DEC|REP|ADV|RES|SER)') ||
+                  lpad(d.num,7,'0') || lpad(d.yy,2,'0')
+      FROM (SELECT id,
+                   coalesce(judgment_date, substring(kp_date from 1 for 10)::date) AS dt,
+                   split_part(split_part(app_no, ';', 1), '/', 1) AS num,
+                   split_part(split_part(app_no, ';', 1), '/', 2) AS yy
+              FROM echr_cases
+             WHERE ecli IS NULL AND app_no IS NOT NULL) d
+     WHERE c.id = d.id
+       AND d.dt IS NOT NULL
+       AND d.num ~ '^[0-9]+$' AND d.yy ~ '^[0-9]+$'
+       AND upper(c.doc_type) ~ '(JUD|DEC|REP|ADV|RES|SER)';
+
+    GET DIAGNOSTICS filled = ROW_COUNT;
+    RAISE NOTICE 'filled % ECLIs', filled;
+END $$;
+
+\echo == coverage after backfill ==
+SELECT count(*) AS cases, count(ecli) AS with_ecli,
+       round(100.0 * count(ecli) / count(*), 1) AS pct
+FROM echr_cases;
+
+\echo == how many NL edges now resolve against it ==
+UPDATE nl_case_citations c
+   SET to_ecli = c.to_raw, resolved = true, match_method = 'external_echr',
+       unresolved_reason = NULL
+  FROM echr_cases h
+ WHERE c.cite_kind = 'ecli_echr' AND NOT c.resolved AND h.ecli = c.to_raw;
+
+SELECT cite_kind, count(*) AS edges, count(*) FILTER (WHERE resolved) AS resolved,
+       round(100.0 * count(*) FILTER (WHERE resolved) / count(*), 1) AS pct
+FROM nl_case_citations WHERE cite_kind = 'ecli_echr' GROUP BY 1;


### PR DESCRIPTION
Spec point 5, "cross-jurisdiction plus supra-national with ELI and ECLI as canonical join keys". The NL graph already produced the edges; this gives them targets. LEXAI-1892.

Citation resolution across the whole NL graph: **91.7% → 98.0%**.

| target | edges | before | after |
|---|---|---|---|
| ECLI:NL | 869,768 | 98.1% | 98.1% |
| LJN | 113,703 | 97.5% | 97.5% |
| **CJEU** | 59,132 | 0% | **99.4%** |
| **ECHR** | 8,478 | 0.4% | **93.0%** |
| other national ECLIs | 1,024 | 0% | 0% (no corpus) |

## ECHR was a resolution problem, not an ingestion one

All 209,774 Strasbourg cases were already on prod. Only 8,904 carried an ECLI, which is why 8,478 edges matched 33 of them.

The identifier is derivable from what we hold: `ECLI:CE:ECHR:<yyyy>:<mmdd><TYPE><application no padded to 7><yy>`. `judgment_date` is filled for 11,104 rows while `kp_date` covers 198,670, so the two are coalesced.

The rule is not trusted on inspection. The backfill first requires it to reproduce **all 8,904 known ECLIs exactly** and raises if it does not:

```
NOTICE:  rule check: 8904 of 8904 known ECLIs reproduced
NOTICE:  filled 168226 ECLIs
```

Corpus ECLI coverage 4.2% → 84.4%.

## CJEU did need a load

`eu_curia_cases` looked like a CJEU corpus at 35,764 rows, but 28,857 of those are placeholders such as `ECLI:EU:CJ:82005IT0119(02)` with no case number and no case name. That left 6,888 usable against the 6,335 distinct decisions our corpus cites, and 321 actually matched.

Harvested 44,655 decisions from CELLAR into a separate clean table:

```
C  30,280   1954-11-10 .. 2026-07-16
T  13,122   1989-12-06 .. 2026-07-22
F   1,253   2006-04-25 .. 2016-08-29
```

A new table rather than a top-up of `eu_curia_cases`: that one is wired into other code, and mixing a clean load into a set that is three quarters placeholders makes both harder to reason about.

The harvester shards by court and year instead of paging with OFFSET. Deep OFFSET on that endpoint degrades and truncates silently on timeout, whereas an ECLI prefix filter is an index hit; the whole corpus came back in under two minutes and matched the count the endpoint itself reports.

Licensing follows Niko's rule: CJEU is CC BY under 2011/833/EU so its text may be stored later, ECHR stays index-and-link-out and only identifiers and metadata are held.

## Not in this PR

Spec point 4, legislation across time, is LEXAI-1893. It is the one point with nothing for NL: all 2,507,190 statute edges have a NULL `law_id`. Probing the Dutch sources did not find a working endpoint yet — `repository.overheid.nl` and `wetten.overheid.nl` answer but the documented paths 404, `zoekservice.overheid.nl` and `linkeddata.overheid.nl/sparql` time out. That needs API discovery rather than URL guessing, so it is written up rather than half-built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve NL cross-jurisdiction citations to CJEU and ECHR by loading clean CJEU metadata and backfilling ECHR ECLIs. Overall NL citation resolution improves from 91.7% to 98.0% (CJEU 99.4%, ECHR 93.0%). Addresses LEXAI-1892 (spec point 5).

- **New Features**
  - Added migration creating a clean `eu_cjeu_decisions` table (ECLI, CELEX, date, title, doc_type).
  - New harvester pulls 44,655 CJEU decisions from CELLAR via SPARQL, sharded by court/year for reliability.
  - ECHR backfill derives ECLIs from date/type/app no.; validates by reproducing 8,904/8,904 known ECLIs before filling ~168k and resolving NL edges.
  - CJEU content is CC BY (2011/833/EU), so text can be stored later; ECHR remains index-and-link-out.

- **Migration**
  - Apply migration 180 to create `eu_cjeu_decisions`.
  - Run `scripts/eu/harvest_cjeu_metadata.py` and load the CSV into `eu_cjeu_decisions`.
  - Run `scripts/nl/backfill_echr_ecli.sql` to fill ECHR ECLIs and update NL citation edges.

<sup>Written for commit 9fbc137bdd57eee3369913bc3e03fc120e48f669. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

