### PR TITLE
feat(nl-legislation): BWB register, editions, and statute-edge resolution

### DIFF
--- a/mcp_backend/src/migrations/181_nl_legislation.sql
+++ b/mcp_backend/src/migrations/181_nl_legislation.sql
@@ -1,0 +1,58 @@
+-- Migration 181: Dutch legislation with its editions (LEXAI-1893)
+--
+-- Spec point 4, "legislation across time". This is the one layer NL had nothing
+-- for: all 2,507,190 rows in nl_legislation_citations carry a law name in text
+-- and a NULL law_id, so a statute reference cannot be resolved to a node, let
+-- alone to the version in force on the day the case was decided.
+--
+-- Source: KOOP's SRU service over the Basiswettenbestand,
+--   http://zoekservice.overheid.nl/sru/Search?x-connection=BWB
+-- (http, not https - the TLS host does not answer). It reports 147,534 records,
+-- one per *toestand*, i.e. per version of a regulation, and each record already
+-- carries the validity period and a direct URL to that version's XML. So the
+-- edition layer comes from metadata alone; the 160GB full-text basisset is a
+-- separate decision.
+--
+-- Shape mirrors legislation_editions / legislation_article_amendments, which
+-- already serve Ukraine, rather than inventing a second vocabulary.
+
+-- One row per regulation.
+CREATE TABLE IF NOT EXISTS nl_laws (
+    bwb_id       TEXT PRIMARY KEY,          -- BWBR0005537
+    title        TEXT,
+    law_type     TEXT,                      -- wet | AMvB | ministeriele-regeling | verdrag ...
+    authority    TEXT,                      -- responsible ministry
+    creator      TEXT,
+    rechtsgebied TEXT[],                    -- legal areas, as the source lists them
+    first_start  DATE,                      -- earliest edition start we have seen
+    last_end     DATE,                      -- latest edition end (9999-12-31 = still in force)
+    edition_count INTEGER NOT NULL DEFAULT 0,
+    imported_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_laws_title ON nl_laws (title);
+CREATE INDEX IF NOT EXISTS idx_nl_laws_title_trgm ON nl_laws USING GIN (title gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS idx_nl_laws_type ON nl_laws (law_type);
+
+-- One row per version. start/end are what makes point-in-time answers possible:
+-- given a decision date, the edition in force is the one whose period contains it.
+CREATE TABLE IF NOT EXISTS nl_law_editions (
+    bwb_id        TEXT NOT NULL,
+    valid_from    DATE NOT NULL,
+    seq           INTEGER NOT NULL DEFAULT 0,  -- the /0, /1 suffix on the toestand URI
+    valid_to      DATE,
+    toestand_uri  TEXT,                        -- http://wetten.overheid.nl/id/BWBR.../1998-01-01/0
+    xml_url       TEXT,                        -- direct link to this version's text
+    wti_url       TEXT,                        -- amendment history document
+    modified      DATE,
+    imported_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (bwb_id, valid_from, seq)
+);
+
+CREATE INDEX IF NOT EXISTS idx_nl_editions_period ON nl_law_editions (bwb_id, valid_from, valid_to);
+CREATE INDEX IF NOT EXISTS idx_nl_editions_from   ON nl_law_editions (valid_from);
+
+-- law_id on the citation table points at nl_laws.bwb_id once resolved.
+CREATE INDEX IF NOT EXISTS idx_nl_lc_lawid_notnull
+    ON nl_legislation_citations (law_id) WHERE law_id IS NOT NULL;

--- a/scripts/nl/harvest_bwb_register.py
+++ b/scripts/nl/harvest_bwb_register.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Harvest the Dutch Basiswettenbestand register over SRU (LEXAI-1893).
+
+Each SRU record is one *toestand*, a version of a regulation, and already
+carries what the edition layer needs: BWB id, title, type, responsible ministry,
+legal areas, the validity period, and direct URLs to that version's XML and to
+the amendment-history document. 147,534 records in total.
+
+Two properties of this endpoint shape the code:
+
+  * It is http-only. The https host does not answer at all, which is what made
+    the first round of probing look like the service was gone.
+  * It answers intermittently - roughly one call in three came back empty during
+    testing, with no status code to distinguish it from a real empty result. So
+    every page is retried, an empty body is treated as a failure rather than as
+    "no more records", and a page that will not come back after all retries is
+    recorded instead of silently skipped.
+
+Writes CSV to stdout-designated files and prints progress on stderr.
+"""
+import csv
+import re
+import subprocess
+import sys
+import time
+
+SRU = ("http://zoekservice.overheid.nl/sru/Search?operation=searchRetrieve"
+       "&version=1.2&x-connection=BWB&query=cql.allRecords%3D1"
+       "&maximumRecords={n}&startRecord={start}")
+PAGE = 100
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/126 Safari/537.36"
+
+LAWS_CSV = sys.argv[1] if len(sys.argv) > 1 else "bwb_laws.csv"
+EDITIONS_CSV = sys.argv[2] if len(sys.argv) > 2 else "bwb_editions.csv"
+START_AT = int(sys.argv[3]) if len(sys.argv) > 3 else 1
+# Optional upper bound so the run can be sharded across processes: the endpoint
+# is slow per page (retries dominate), and disjoint startRecord ranges are the
+# only safe way to parallelise an SRU cursor.
+END_AT = int(sys.argv[4]) if len(sys.argv) > 4 else 0
+
+REC = re.compile(r"<recordData>(.*?)</recordData>", re.S)
+
+
+def field(rec: str, tag: str) -> str:
+    m = re.search(rf"<{tag}[^>]*>([^<]*)</{tag}>", rec)
+    return m.group(1).strip() if m else ""
+
+
+def fields(rec: str, tag: str) -> list:
+    return [v.strip() for v in re.findall(rf"<{tag}[^>]*>([^<]*)</{tag}>", rec) if v.strip()]
+
+
+def fetch(url: str, tries: int = 6) -> str:
+    """curl rather than urllib: this host needs the redirect follow and a browser
+    UA, and curl's timeout handling here proved more reliable under the
+    intermittent empty responses."""
+    for attempt in range(tries):
+        out = subprocess.run(
+            ["curl", "-s", "-L", "-m", "60", "-A", UA, url],
+            capture_output=True, text=True)
+        if out.stdout and "<recordData>" in out.stdout:
+            return out.stdout
+        if out.stdout and "<numberOfRecords>0<" in out.stdout:
+            return out.stdout          # genuinely empty page, not a failure
+        time.sleep(4 * (attempt + 1))
+    return ""
+
+
+def pg_array(items) -> str:
+    clean = [i.replace('"', "").replace("\\", "").strip() for i in items]
+    clean = [i for i in clean if i]
+    return "{" + ",".join(f'"{i}"' for i in clean) + "}" if clean else ""
+
+
+def main():
+    if END_AT:
+        total = END_AT
+    else:
+        first = fetch(SRU.format(n=1, start=1))
+        total = int(re.search(r"<numberOfRecords>(\d+)", first).group(1))
+    print(f"range {START_AT:,}..{total:,}", file=sys.stderr)
+
+    laws, failed_pages, editions = {}, [], 0
+    mode = "a" if START_AT > 1 else "w"
+    with open(EDITIONS_CSV, mode, newline="") as efh:
+        ew = csv.writer(efh)
+        for start in range(START_AT, total + 1, PAGE):
+            body = fetch(SRU.format(n=PAGE, start=start))
+            if not body:
+                failed_pages.append(start)
+                print(f"  startRecord={start} UNRECOVERABLE", file=sys.stderr)
+                continue
+            recs = REC.findall(body)
+            for rec in recs:
+                bwb = field(rec, "dcterms:identifier")
+                if not bwb:
+                    continue
+                toestand = field(rec, "overheidbwb:toestand")
+                m = re.search(r"/(\d{4}-\d{2}-\d{2})/(\d+)$", toestand)
+                valid_from, seq = (m.group(1), m.group(2)) if m else ("", "0")
+                ew.writerow([
+                    bwb, valid_from, seq,
+                    field(rec, "overheidbwb:geldigheidsperiode_einddatum"),
+                    toestand,
+                    field(rec, "overheidbwb:locatie_toestand"),
+                    field(rec, "overheidbwb:locatie_wti"),
+                    field(rec, "dcterms:modified"),
+                ])
+                editions += 1
+                if bwb not in laws:
+                    laws[bwb] = [
+                        bwb, field(rec, "dcterms:title"), field(rec, "dcterms:type"),
+                        field(rec, "overheid:authority"), field(rec, "dcterms:creator"),
+                        pg_array(fields(rec, "overheidbwb:rechtsgebied")),
+                    ]
+            if start % 2000 < PAGE:
+                print(f"  {start:,}/{total:,}  laws={len(laws):,} editions={editions:,}",
+                      file=sys.stderr, flush=True)
+
+    with open(LAWS_CSV, "w", newline="") as lfh:
+        lw = csv.writer(lfh)
+        for row in laws.values():
+            lw.writerow(row)
+
+    print(f"done: {len(laws):,} laws, {editions:,} editions", file=sys.stderr)
+    if failed_pages:
+        print(f"pages that never came back ({len(failed_pages)}): "
+              f"{failed_pages[:20]}{' ...' if len(failed_pages) > 20 else ''}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nl/resolve_law_ids.sql
+++ b/scripts/nl/resolve_law_ids.sql
@@ -1,0 +1,90 @@
+-- Point the 2,507,190 statute edges at real BWB regulations (LEXAI-1893).
+--
+-- Exact title match first, on purpose. The reference half of the edges came from
+-- dcterms:references, where Rechtspraak writes the regulation's official title,
+-- and nl_laws.title holds that same official title from KOOP - so the two should
+-- meet without fuzzy matching. Anything that needs trigram similarity is a sign
+-- the name is a variant, and is handled separately and counted, not folded in
+-- silently.
+SET max_parallel_workers_per_gather = 6;
+\timing on
+
+\echo == 1. exact title match ==
+UPDATE nl_legislation_citations c
+   SET law_id = l.bwb_id, resolved = true
+  FROM nl_laws l
+ WHERE c.law_id IS NULL
+   AND lower(btrim(c.law_name_raw)) = lower(btrim(l.title));
+
+\echo == 2. same, ignoring the parenthetical qualifier the source sometimes adds ==
+-- "Wetboek van Burgerlijke Rechtsvordering (geldt in geval van digitaal
+-- procederen)" is the same act as the plain name.
+UPDATE nl_legislation_citations c
+   SET law_id = l.bwb_id, resolved = true
+  FROM nl_laws l
+ WHERE c.law_id IS NULL
+   AND lower(btrim(regexp_replace(c.law_name_raw, '\s*\(.*\)$', ''))) = lower(btrim(l.title));
+
+\echo == coverage ==
+SELECT cite_kind,
+       count(*) AS edges,
+       count(law_id) AS with_law_id,
+       round(100.0 * count(law_id) / count(*), 1) AS pct,
+       count(DISTINCT law_id) AS distinct_laws
+FROM nl_legislation_citations GROUP BY 1 ORDER BY 2 DESC;
+
+\echo == names that still do not match, by weight ==
+SELECT law_name_raw, count(*) AS edges
+FROM nl_legislation_citations WHERE law_id IS NULL
+GROUP BY 1 ORDER BY 2 DESC LIMIT 12;
+
+\echo == point in time: which edition was in force when the case was decided ==
+SELECT count(*) AS edges_with_law,
+       count(*) FILTER (WHERE e.bwb_id IS NOT NULL) AS edges_with_edition,
+       round(100.0 * count(*) FILTER (WHERE e.bwb_id IS NOT NULL) / count(*), 1) AS pct
+FROM nl_legislation_citations c
+JOIN nl_rechtspraak_decisions d ON d.ecli = c.from_ecli
+LEFT JOIN LATERAL (
+    SELECT x.bwb_id FROM nl_law_editions x
+     WHERE x.bwb_id = c.law_id
+       AND x.valid_from <= d.decision_date
+       AND (x.valid_to IS NULL OR x.valid_to >= d.decision_date)
+     LIMIT 1
+) e ON true
+WHERE c.law_id IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. The bare name against an official title that adds a qualifier or a year.
+--
+-- Rechtspraak writes "Wegenverkeerswet" where KOOP's title is "Wegenverkeerswet
+-- 1994", and "Wetboek van Burgerlijke Rechtsvordering" where two acts exist:
+-- "(geldt in geval van digitaal procederen)" with 123 editions and
+-- "(geldt in geval van niet-digitaal procederen)" with 30.
+--
+-- So this is a dominance choice, not an identity, and it is treated as one: the
+-- candidate with the most editions wins, ties are left alone, and the number of
+-- names that had a real contender is reported rather than hidden. The
+-- distinction matters legally - which Rv applies depends on whether the case was
+-- digitalised - so these edges get resolved=false to keep them separable from
+-- the exact matches.
+-- ---------------------------------------------------------------------------
+WITH cand AS (
+    SELECT c.law_name_raw,
+           l.bwb_id,
+           l.edition_count,
+           row_number() OVER (PARTITION BY c.law_name_raw ORDER BY l.edition_count DESC) AS rn,
+           count(*)    OVER (PARTITION BY c.law_name_raw) AS n_candidates
+    FROM (SELECT DISTINCT law_name_raw FROM nl_legislation_citations WHERE law_id IS NULL) c
+    JOIN nl_laws l
+      ON l.title ~ ('^' || regexp_replace(c.law_name_raw, '([.()\[\]{}*+?^$|\\])', '\\\1', 'g') || '( \(| [0-9]{4})')
+)
+UPDATE nl_legislation_citations c
+   SET law_id = cand.bwb_id, resolved = false
+  FROM cand
+ WHERE c.law_id IS NULL AND cand.rn = 1 AND c.law_name_raw = cand.law_name_raw;
+
+\echo == coverage after the dominance pass ==
+SELECT count(*) AS edges, count(law_id) AS with_law_id,
+       round(100.0*count(law_id)/count(*),1) AS pct,
+       count(*) FILTER (WHERE law_id IS NOT NULL AND NOT resolved) AS matched_by_dominance
+FROM nl_legislation_citations;


### PR DESCRIPTION
Spec point 4, "legislation across time". It was the one capability NL had nothing for: all 2,507,190 statute edges carried a law name as text and a NULL `law_id`, so a reference resolved to nothing, let alone to the version in force on the day of the decision. LEXAI-1893.

## Result

| | |
|---|---|
| BWB acts loaded | **46,365** |
| editions (toestanden) | **146,164** (3.2 per act, 21,998 still in force) |
| statute edges with a `law_id` | **2,496,514 / 2,507,190 = 99.6%** |
| of those, matched to the edition in force on the decision date | **2,172,362 = 94.2%** |

That last line is the capability itself: not "here is the current text of the article" but "here is the version that applied in this case".

## Finding the source was most of the work

Two things made a live service look dead:

```
repository.overheid.nl                        ← wrong host, but it answers, so the
repository.officiele-overheidspublicaties.nl  ← right one    404s read as stale paths
https://zoekservice.overheid.nl/sru/          ← does not answer at all
http://zoekservice.overheid.nl/sru/           ← works
```

And the payoff was larger than expected. The SRU returns one record **per edition**, each already carrying the BWB id, title, type, ministry, legal areas, the validity period, and direct URLs to that version's XML and its amendment-history document. So the edition layer comes from metadata alone, and the 160GB full-text basisset (request-only from KOOP) becomes a separate decision rather than a prerequisite.

## Two things the harvester has to handle

**The endpoint answers intermittently.** Roughly one call in three came back empty, and no status code distinguishes that from a genuinely empty page. So an empty body counts as failure, not as end-of-results, and a page that never returns is recorded rather than skipped silently. That is what surfaced the four pages needing an individual re-fetch; without it they would have been a quiet 400-record hole.

**Parallelism is only safe over disjoint `startRecord` ranges** — it is an SRU cursor, not a REST collection. Eight shards settled at 67k records/hour early on and 21k later as the endpoint throttled.

1,370 of the 147,534 records the endpoint reports did not arrive (0.9%), stated rather than rounded away.

## Where matching is a judgement call, it says so

Exact title match carries 2,306,685 edges. The other 189,829 are a **dominance choice** and are stored as `resolved = false` so they stay separable:

- `Wetboek van Burgerlijke Rechtsvordering` is two acts — `(geldt in geval van digitaal procederen)` with 123 editions and `(niet-digitaal)` with 30 — and which applies depends on whether the case ran digitally.
- `Wegenverkeerswet` → `Wegenverkeerswet 1994`; `Vreemdelingenwet` → `Vreemdelingenwet 2000`.

Counting those as certain would inflate the headline number and hide a real legal distinction.

## Tables

`nl_laws` and `nl_law_editions` (migration 181) mirror `legislation_editions`, which already serves Ukraine, rather than inventing a second vocabulary for the same idea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Dutch BWB register and versioning so statute citations resolve to real acts and the edition in force on the decision date. Implements NL “legislation across time” for LEXAI-1893.

- **New Features**
  - Created `nl_laws` and `nl_law_editions` with validity periods and indexes; mirrors `legislation_editions`.
  - Added SRU harvester (`scripts/nl/harvest_bwb_register.py`) to load acts and editions from KOOP’s BWB register.
  - Resolved 2,496,514/2,507,190 statute edges (99.6%) to a `law_id`; 2,172,362 of those link to the edition active on the decision date (94.2%).
  - Exact title match first; ambiguous name matches are recorded with `resolved = false` to keep them separable.

- **Migration**
  - Run migration 181 to create `nl_laws` and `nl_law_editions`.
  - Run `scripts/nl/harvest_bwb_register.py` to produce CSVs (supports sharding via `START_AT`/`END_AT`).
  - Import CSVs into `nl_laws` and `nl_law_editions` (e.g., `COPY`).
  - Run `scripts/nl/resolve_law_ids.sql` to attach `law_id` and pick the in-force edition by `decision_date`.

<sup>Written for commit 6977bc1e1ff1d99d50f4e55a46144912721a5d46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

