### PR TITLE
feat(substrate): REST contract over the grounded graph, NL as reference implementation

### DIFF
--- a/docs/proposals/substrate-api-contract.md
+++ b/docs/proposals/substrate-api-contract.md
@@ -1,0 +1,130 @@
+# Substrate API contract
+
+Working draft for Vlad and Niko, 26 Jul 2026. The Dutch graph is the reference
+implementation; this is the shape the Finnish graph should be served through so
+that one client library, one set of docs and one demo cover both.
+
+Live at `/api/v1/substrate/{jurisdiction}` on the legal.org.ua backend. Adding a
+jurisdiction is one entry in the config map in `substrate-routes.ts`, naming the
+tables; no endpoint code changes.
+
+## Why a fixed contract rather than two APIs
+
+The product sells one thing: references that resolve. A customer who integrates
+against NL and then has to re-integrate for FI has been sold two datasets, not a
+substrate. Everything below is jurisdiction-neutral: ECLI for case law, the
+national act id for legislation (BWB in NL, Finlex in FI), and no response field
+named after a national source.
+
+## Three rules the contract enforces
+
+**1. Every reference carries `resolved`.** When false it carries
+`unresolved_reason` rather than disappearing from the array. A caller can always
+distinguish "we checked and there is nothing" from "we did not check". This is
+the anti-vibecoding guarantee expressed at the API boundary: the confidence a
+client shows is computed over what actually resolved.
+
+```json
+{"as_written": "ECLI:EU:C:2019:218", "ecli": "ECLI:EU:C:2019:218",
+ "kind": "ecli_eu", "resolved": true},
+{"as_written": "NJ 2016/122", "ecli": null, "kind": "journal",
+ "resolved": false, "unresolved_reason": "no alias matches this reference"}
+```
+
+**2. Every node carries `redistribution`.** `full` may be served with text;
+`link_out` returns metadata and `source_url` and never text, whatever the caller
+asks for. This is Niko's index-and-link-out rule made mechanical instead of
+remembered: ECHR nodes cannot leak text through this API even by mistake.
+
+**3. Anything time-dependent takes `as_of`.** A statute answer without a date is
+a guess about which version applied. `GET /legislation/{id}?as_of=2015-06-01`
+returns the edition whose validity period contains that date, or an explicit
+note that no edition covers it.
+
+A fourth, softer rule worth keeping: **absence is stated, not implied**. A Dutch
+decision with no body is `"text_availability": "not_published_by_source"`, not an
+empty string, because the source genuinely publishes most decisions as metadata
+only. A decision with no appeal on record gets `status: null` plus
+`"no appeal on record; absence of an appeal is not a positive finding"`, never a
+default of "good law".
+
+## The ten endpoints
+
+| # | Endpoint | Answers |
+|---|---|---|
+| 1 | `GET /{j}/search?q=&court=&date_from=&date_to=&subject=` | find decisions |
+| 2 | `GET /{j}/decisions/{ecli}` | one decision with every reference resolved |
+| 3 | `GET /{j}/decisions/{ecli}/status` | is it still good law, and what changed it |
+| 4 | `GET /{j}/decisions/{ecli}/citing` | who cites it |
+| 5 | `GET /{j}/decisions/{ecli}/cited` | what it cites, resolved |
+| 6 | `GET /{j}/decisions/{ecli}/chain` | the instance ladder with outcomes |
+| 7 | `GET /{j}/legislation/{lawId}/case-law?article=` | decisions applying a provision |
+| 8 | `GET /{j}/legislation/{lawId}?as_of=` | the act, as in force on a date |
+| 9 | `GET /{j}/resolve?ref=` | any citation string to a canonical node |
+| 10 | `GET /{j}/changes?since=` | what changed, for subscriptions |
+
+`GET /api/v1/substrate/catalog` describes all of it, so an agent discovers the
+surface without reading code.
+
+### Notes on the ones that are easy to get wrong
+
+**9, resolve.** This is the primitive the rest leans on and the hardest to
+retrofit. It takes whatever a lawyer or a model actually wrote — an ECLI, a
+journal citation, a pre-2013 LJN code, a case number — and returns the canonical
+node. It answers `ambiguous: true` with all candidates when one journal
+reference points at several decisions, rather than picking one silently. For NL
+it is backed by 4.7M aliases. Finland will need its own dictionary of whatever
+citation forms Finnish practice uses; building it late means every earlier
+answer under-resolves.
+
+**6, chain.** A recursive walk over an edge table, both directions, with the
+outcome of each appeal attached. Worth stating that this does not need a graph
+store: Dutch ladders are at most four deep and the query is a few milliseconds.
+Reach for Neo4j when the graph is EDRSR-sized (135M edges), not at 1M.
+
+**10, changes.** Returns `next_since`, which is the caller's cursor for the next
+poll: polling from it never re-delivers and never skips. This is the RegTech
+primitive that turns a purchase into a subscription, so it should exist from day
+one even before webhooks.
+
+## What NL currently answers with
+
+Numbers as of 26 Jul 2026, so the FI side has something to compare against.
+
+| | |
+|---|---|
+| decisions | 3,603,085 (946,389 with text; the rest are metadata-only at source) |
+| coverage against the source feed | 100.0% |
+| case-to-case edges | 1,052,105, **98.0% resolved** |
+| statute edges | 2,507,190, **99.6% with a law id** |
+| of those, tied to the edition in force on the decision date | **94.2%** |
+| instance links | 200,887, with the publisher's own appeal outcomes |
+| precedent status | 18,197 quashed, 30,304 upheld |
+| legislation | 46,365 acts, 146,164 editions |
+| cross-border | CJEU 99.4% resolved, ECHR 93.0% (link-out) |
+
+## What Finland needs to supply for the same contract
+
+1. A decisions table with a stable id (ECLI), court, date, subjects, text where
+   redistributable.
+2. A citation edge table with `resolved`, `match_method`, `unresolved_reason`.
+   The three fields together are what make endpoint 2 honest.
+3. An alias dictionary for Finnish citation forms — endpoint 9 is only as good
+   as this.
+4. Instance links with an outcome, if Finnish sources publish one. NL gets this
+   free from `dcterms:relation`; where a source does not state it, the field
+   stays null rather than being inferred.
+5. Acts and editions with validity periods, for endpoint 8.
+6. A `updated_at` on decisions, for endpoint 10.
+
+## Open, for the two of us
+
+- **Auth and metering.** Currently dual-auth (API key or JWT) on the existing
+  credit pool. Builder and Enterprise tiers need quota per key and a rate class,
+  which is billing work, not API work.
+- **SPARQL alongside REST.** The spec keeps SPARQL key-gated for the
+  infrastructure tier. This REST layer is deliberately the narrow, cacheable
+  surface for the per-seat and Builder tiers; it does not replace the endpoint.
+- **Whether FI is served from our backend or Niko's**, with this contract as the
+  interface either way. That decision is independent of the shape above, which
+  is the point of writing the shape down first.

--- a/mcp_backend/src/http-server.ts
+++ b/mcp_backend/src/http-server.ts
@@ -4,6 +4,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import { logger } from './utils/logger.js';
 import { dualAuth, requireJWT, optionalJWT, AuthenticatedRequest as DualAuthRequest } from './middleware/dual-auth.js';
+import { createSubstrateRoutes } from './routes/substrate-routes.js';
 import { createAccessGate } from './middleware/access-gate-middleware.js';
 import { createAccessRoutes } from './routes/access-routes.js';
 import authRouter from './routes/auth.js';
@@ -686,6 +687,12 @@ class HTTPMCPServer {
     // MUST be before the catch-all /api workflow routes
     this.app.use('/api/workers', dualAuth as any, createWorkerHeartbeatRoute());
     logger.info('Worker heartbeat routes registered at /api/workers');
+
+    // Grounded legal substrate — the REST contract customers integrate against
+    // and the shape the Finnish graph is meant to be served through. dualAuth so
+    // an API key works: this surface is sold to builders, not to browser users.
+    this.app.use('/api/v1/substrate', dualAuth as any, createSubstrateRoutes(this.services.db));
+    logger.info('Substrate API registered at /api/v1/substrate');
 
     // Workflow routes - workflow sets, workflow execution, cancellation
     // IMPORTANT: Use specific prefixes, NOT '/api' — a catch-all '/api' prefix with requireJWT

--- a/mcp_backend/src/routes/substrate-routes.ts
+++ b/mcp_backend/src/routes/substrate-routes.ts
@@ -1,0 +1,575 @@
+/**
+ * Grounded legal substrate API — the REST surface a customer integrates against.
+ *
+ * This is the "small REST layer over the ten questions everyone asks" from the
+ * product spec, implemented over the Dutch graph and deliberately written so the
+ * Finnish graph can be served through the same contract: every path is
+ * /api/v1/substrate/:jurisdiction/..., ids are ECLI for case law and the
+ * national act id (BWB for NL, Finlex for FI) for legislation, and the response
+ * shapes never mention Rechtspraak.
+ *
+ * Three rules the contract enforces, because they are what the product sells:
+ *
+ *   1. Every reference carries `resolved`. When false it carries
+ *      `unresolved_reason` instead of quietly disappearing. A caller can always
+ *      tell "we checked and there is nothing" from "we did not check".
+ *   2. Every node carries `redistribution`. `link_out` nodes (ECHR, per the
+ *      index-and-link-out rule) return metadata and a source URL and never text,
+ *      whatever the caller asks for.
+ *   3. Anything time-dependent takes `as_of`. A statute answer without a date is
+ *      a guess about which version applied.
+ *
+ * The ten questions:
+ *   1  GET  /search                        find decisions
+ *   2  GET  /decisions/:ecli               one decision with its resolved refs
+ *   3  GET  /decisions/:ecli/status        is it still good law
+ *   4  GET  /decisions/:ecli/citing        who cites it
+ *   5  GET  /decisions/:ecli/cited         what it cites
+ *   6  GET  /decisions/:ecli/chain         the instance ladder
+ *   7  GET  /legislation/:lawId/case-law   decisions applying an article
+ *   8  GET  /legislation/:lawId            an act, as in force on a date
+ *   9  GET  /resolve                       any citation string to a canonical node
+ *  10  GET  /changes                       what changed since a timestamp
+ *
+ * Plus GET /catalog, which describes all of the above so an agent can discover
+ * the surface without reading this file.
+ */
+
+import { Router, type Response } from 'express';
+import type { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
+import type { IDatabase } from '../domain/ports/index.js';
+import { createRateLimiter } from '../middleware/rate-limit.js';
+import { logger } from '../utils/logger.js';
+
+/** Per-jurisdiction wiring. Adding Finland is adding an entry here. */
+interface JurisdictionConfig {
+  code: string;
+  name: string;
+  decisionsTable: string;
+  citationsTable: string;
+  statuteEdgesTable: string;
+  instanceLinksTable: string;
+  precedentTable: string;
+  aliasTable: string;
+  lawsTable: string;
+  editionsTable: string;
+  ftsConfig: string;
+  /** ECLI prefixes whose text we may serve. Anything else is link-out only. */
+  redistributable: boolean;
+}
+
+const JURISDICTIONS: Record<string, JurisdictionConfig> = {
+  nl: {
+    code: 'NL',
+    name: 'Netherlands (Rechtspraak)',
+    decisionsTable: 'nl_rechtspraak_decisions',
+    citationsTable: 'nl_case_citations',
+    statuteEdgesTable: 'nl_legislation_citations',
+    instanceLinksTable: 'nl_instance_links',
+    precedentTable: 'nl_precedent_status',
+    aliasTable: 'nl_case_aliases',
+    lawsTable: 'nl_laws',
+    editionsTable: 'nl_law_editions',
+    ftsConfig: 'dutch',
+    redistributable: true,
+  },
+};
+
+const MAX_LIMIT = 100;
+
+const substrateRateLimit = createRateLimiter({
+  windowMs: 60 * 1000,
+  maxRequests: 120,
+  keyPrefix: 'substrate_api',
+});
+
+function jurisdictionOf(req: DualAuthRequest): JurisdictionConfig | null {
+  return JURISDICTIONS[String(req.params.jurisdiction || '').toLowerCase()] ?? null;
+}
+
+function clampLimit(raw: unknown, fallback = 20): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(Math.floor(n), MAX_LIMIT);
+}
+
+/**
+ * Which corpus an ECLI belongs to, and whether we may serve its text.
+ * ECHR is indexed but never redistributed, so its nodes come back without text
+ * regardless of the endpoint.
+ */
+function classifyEcli(ecli: string): { corpus: string; redistribution: 'full' | 'link_out' } {
+  if (ecli.startsWith('ECLI:CE:ECHR:')) return { corpus: 'echr', redistribution: 'link_out' };
+  if (ecli.startsWith('ECLI:EU:')) return { corpus: 'cjeu', redistribution: 'full' };
+  if (ecli.startsWith('ECLI:NL:')) return { corpus: 'nl', redistribution: 'full' };
+  return { corpus: 'other', redistribution: 'link_out' };
+}
+
+function fail(res: Response, code: number, error: string, detail?: string) {
+  return res.status(code).json({ error, ...(detail ? { detail } : {}) });
+}
+
+export function createSubstrateRoutes(db: IDatabase): Router {
+  const router = Router({ mergeParams: true });
+
+  router.use(substrateRateLimit as any);
+
+  router.use('/:jurisdiction', (req: any, res: Response, next: any) => {
+    if (!jurisdictionOf(req)) {
+      return fail(res, 404, 'unknown_jurisdiction',
+        `Known: ${Object.keys(JURISDICTIONS).join(', ')}`);
+    }
+    next();
+  });
+
+  // ---------------------------------------------------------------- catalog
+  router.get('/catalog', (_req: any, res: Response) => {
+    res.json({
+      service: 'grounded-legal-substrate',
+      version: '1',
+      jurisdictions: Object.values(JURISDICTIONS).map(j => ({
+        code: j.code, name: j.name, base: `/api/v1/substrate/${j.code.toLowerCase()}`,
+      })),
+      guarantees: {
+        resolved_flag: 'every reference carries resolved; when false, unresolved_reason says why',
+        redistribution: 'link_out nodes never carry text, only metadata and source_url',
+        point_in_time: 'statute endpoints accept as_of=YYYY-MM-DD and answer for that date',
+      },
+      endpoints: [
+        { path: '/{j}/search', q: 'full-text query', filters: 'court, date_from, date_to, subject, has_text' },
+        { path: '/{j}/decisions/{ecli}', returns: 'decision with resolved citations' },
+        { path: '/{j}/decisions/{ecli}/status', returns: 'precedent status and what changed it' },
+        { path: '/{j}/decisions/{ecli}/citing', returns: 'inbound citations' },
+        { path: '/{j}/decisions/{ecli}/cited', returns: 'outbound citations, resolved' },
+        { path: '/{j}/decisions/{ecli}/chain', returns: 'instance ladder with outcomes' },
+        { path: '/{j}/legislation/{lawId}', params: 'as_of', returns: 'act and the edition in force' },
+        { path: '/{j}/legislation/{lawId}/case-law', params: 'article', returns: 'decisions applying it' },
+        { path: '/{j}/resolve', params: 'ref', returns: 'canonical node for any citation string' },
+        { path: '/{j}/changes', params: 'since, limit', returns: 'nodes changed since a timestamp' },
+      ],
+    });
+  });
+
+  // -------------------------------------------------------------- 1. search
+  router.get('/:jurisdiction/search', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const q = String(req.query.q || '').trim();
+      if (!q) return fail(res, 400, 'q_required');
+
+      const limit = clampLimit(req.query.limit);
+      const params: unknown[] = [q];
+      const where: string[] = [
+        `to_tsvector('${j.ftsConfig}', coalesce(summary,'') || ' ' || coalesce(full_text,''))
+           @@ plainto_tsquery('${j.ftsConfig}', $1)`,
+        'full_text IS NOT NULL',   // matches the partial index
+      ];
+
+      if (req.query.court) { params.push(req.query.court); where.push(`court_code = $${params.length}`); }
+      if (req.query.date_from) { params.push(req.query.date_from); where.push(`decision_date >= $${params.length}`); }
+      if (req.query.date_to) { params.push(req.query.date_to); where.push(`decision_date <= $${params.length}`); }
+      if (req.query.subject) { params.push([req.query.subject]); where.push(`subject_areas && $${params.length}`); }
+
+      params.push(limit);
+      const rows = await db.query(
+        `SELECT d.ecli, d.court_name, d.decision_date, d.decision_type, d.procedure_type,
+                d.subject_areas, left(d.summary, 400) AS summary,
+                ts_rank(to_tsvector('${j.ftsConfig}', coalesce(d.summary,'') || ' ' || coalesce(d.full_text,'')),
+                        plainto_tsquery('${j.ftsConfig}', $1)) AS rank,
+                coalesce(p.cited_by_count, 0) AS cited_by_count, p.status AS precedent_status
+           FROM ${j.decisionsTable} d
+           LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
+          WHERE ${where.join(' AND ')}
+          ORDER BY rank DESC
+          LIMIT $${params.length}`, params);
+
+      res.json({
+        jurisdiction: j.code,
+        query: q,
+        count: rows.rows.length,
+        results: rows.rows.map((r: any) => ({
+          ecli: r.ecli,
+          court: r.court_name,
+          date: r.decision_date,
+          type: r.decision_type,
+          procedure: r.procedure_type,
+          subjects: r.subject_areas,
+          summary: r.summary,
+          cited_by_count: Number(r.cited_by_count),
+          precedent_status: r.precedent_status,
+          redistribution: classifyEcli(r.ecli).redistribution,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] search failed', { error: String(err) });
+      fail(res, 500, 'search_failed');
+    }
+  }) as any);
+
+  // ------------------------------------------------------------ 2. decision
+  router.get('/:jurisdiction/decisions/:ecli', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const ecli = String(req.params.ecli);
+      const withText = req.query.text !== 'false';
+
+      const meta = await db.query(
+        `SELECT d.ecli, d.case_number, d.court_name, d.court_code, d.decision_date,
+                d.decision_type, d.procedure_type, d.subject_areas, d.summary,
+                d.full_text IS NOT NULL AS has_text,
+                CASE WHEN $2 THEN d.full_text END AS full_text,
+                p.status AS precedent_status, coalesce(p.cited_by_count,0) AS cited_by_count
+           FROM ${j.decisionsTable} d
+           LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
+          WHERE d.ecli = $1`, [ecli, withText]);
+
+      if (!meta.rows.length) return fail(res, 404, 'not_found', ecli);
+      const d = meta.rows[0];
+
+      const [cases, statutes] = await Promise.all([
+        db.query(
+          `SELECT to_raw, to_ecli, cite_kind, resolved, unresolved_reason
+             FROM ${j.citationsTable} WHERE from_ecli = $1 ORDER BY resolved DESC LIMIT 200`, [ecli]),
+        db.query(
+          `SELECT c.law_name_raw, c.law_id, c.article, c.resolved, l.title AS law_title
+             FROM ${j.statuteEdgesTable} c
+             LEFT JOIN ${j.lawsTable} l ON l.bwb_id = c.law_id
+            WHERE c.from_ecli = $1 ORDER BY c.resolved DESC LIMIT 200`, [ecli]),
+      ]);
+
+      res.json({
+        jurisdiction: j.code,
+        ecli: d.ecli,
+        case_number: d.case_number,
+        court: d.court_name,
+        court_code: d.court_code,
+        date: d.decision_date,
+        type: d.decision_type,
+        procedure: d.procedure_type,
+        subjects: d.subject_areas,
+        summary: d.summary,
+        has_text: d.has_text,
+        // has_text=false is the source's own state for most NL decisions, not a
+        // gap on our side; saying so keeps the caller from re-fetching forever
+        text_availability: d.has_text ? 'available' : 'not_published_by_source',
+        text: d.full_text ?? null,
+        precedent_status: d.precedent_status,
+        cited_by_count: Number(d.cited_by_count),
+        source_url: `https://uitspraken.rechtspraak.nl/details?id=${encodeURIComponent(d.ecli)}`,
+        redistribution: classifyEcli(d.ecli).redistribution,
+        cites: {
+          cases: cases.rows.map((c: any) => ({
+            as_written: c.to_raw, ecli: c.to_ecli, kind: c.cite_kind,
+            resolved: c.resolved, unresolved_reason: c.unresolved_reason,
+            redistribution: c.to_ecli ? classifyEcli(c.to_ecli).redistribution : null,
+          })),
+          legislation: statutes.rows.map((s: any) => ({
+            as_written: s.law_name_raw, law_id: s.law_id, law_title: s.law_title,
+            article: s.article, resolved: s.resolved,
+          })),
+        },
+      });
+    } catch (err) {
+      logger.error('[Substrate] decision failed', { error: String(err) });
+      fail(res, 500, 'decision_failed');
+    }
+  }) as any);
+
+  // -------------------------------------------------------------- 3. status
+  router.get('/:jurisdiction/decisions/:ecli/status', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const ecli = String(req.params.ecli);
+      const [status, affecting] = await Promise.all([
+        db.query(`SELECT status, overruled_by, cited_by_count, last_computed
+                    FROM ${j.precedentTable} WHERE ecli = $1`, [ecli]),
+        db.query(
+          `SELECT l.child_ecli, l.relation, l.outcome, l.method, l.confidence,
+                  d.court_name, d.decision_date
+             FROM ${j.instanceLinksTable} l
+             LEFT JOIN ${j.decisionsTable} d ON d.ecli = l.child_ecli
+            WHERE l.parent_ecli = $1
+            ORDER BY d.decision_date DESC NULLS LAST LIMIT 50`, [ecli]),
+      ]);
+
+      const s = status.rows[0];
+      res.json({
+        jurisdiction: j.code,
+        ecli,
+        // null status means no appeal is on record, which is not the same as
+        // "good law" and is reported as such rather than assumed
+        status: s?.status ?? null,
+        status_meaning: s?.status
+          ? undefined
+          : 'no appeal on record; absence of an appeal is not a positive finding',
+        cited_by_count: Number(s?.cited_by_count ?? 0),
+        overruled_by: s?.overruled_by ?? [],
+        last_computed: s?.last_computed ?? null,
+        affected_by: affecting.rows.map((a: any) => ({
+          ecli: a.child_ecli, relation: a.relation, outcome: a.outcome,
+          court: a.court_name, date: a.decision_date,
+          evidence: a.method, confidence: a.confidence,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] status failed', { error: String(err) });
+      fail(res, 500, 'status_failed');
+    }
+  }) as any);
+
+  // --------------------------------------------------- 4/5. citing & cited
+  router.get('/:jurisdiction/decisions/:ecli/citing', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const rows = await db.query(
+        `SELECT c.from_ecli, c.from_court, c.from_date, c.treatment
+           FROM ${j.citationsTable} c
+          WHERE c.to_ecli = $1 AND c.resolved
+          ORDER BY c.from_date DESC NULLS LAST LIMIT $2`,
+        [String(req.params.ecli), clampLimit(req.query.limit, 50)]);
+      res.json({
+        jurisdiction: j.code, ecli: req.params.ecli, count: rows.rows.length,
+        citing: rows.rows.map((r: any) => ({
+          ecli: r.from_ecli, court: r.from_court, date: r.from_date, treatment: r.treatment,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] citing failed', { error: String(err) });
+      fail(res, 500, 'citing_failed');
+    }
+  }) as any);
+
+  router.get('/:jurisdiction/decisions/:ecli/cited', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const rows = await db.query(
+        `SELECT to_raw, to_ecli, cite_kind, resolved, unresolved_reason
+           FROM ${j.citationsTable} WHERE from_ecli = $1
+          ORDER BY resolved DESC LIMIT $2`,
+        [String(req.params.ecli), clampLimit(req.query.limit, 100)]);
+      const resolved = rows.rows.filter((r: any) => r.resolved).length;
+      res.json({
+        jurisdiction: j.code, ecli: req.params.ecli,
+        count: rows.rows.length, resolved_count: resolved,
+        cited: rows.rows.map((r: any) => ({
+          as_written: r.to_raw, ecli: r.to_ecli, kind: r.cite_kind,
+          resolved: r.resolved, unresolved_reason: r.unresolved_reason,
+          redistribution: r.to_ecli ? classifyEcli(r.to_ecli).redistribution : null,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] cited failed', { error: String(err) });
+      fail(res, 500, 'cited_failed');
+    }
+  }) as any);
+
+  // --------------------------------------------------------------- 6. chain
+  router.get('/:jurisdiction/decisions/:ecli/chain', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const ecli = String(req.params.ecli);
+      // Recursive CTE rather than a graph store: NL ladders are at most four
+      // deep, so a walk over an indexed edge table is the whole requirement.
+      const rows = await db.query(
+        `WITH RECURSIVE up AS (
+             SELECT child_ecli, parent_ecli, relation, outcome, 1 AS depth
+               FROM ${j.instanceLinksTable} WHERE child_ecli = $1
+             UNION ALL
+             SELECT l.child_ecli, l.parent_ecli, l.relation, l.outcome, up.depth + 1
+               FROM ${j.instanceLinksTable} l JOIN up ON l.child_ecli = up.parent_ecli
+              WHERE up.depth < 6
+         ), down AS (
+             SELECT child_ecli, parent_ecli, relation, outcome, 1 AS depth
+               FROM ${j.instanceLinksTable} WHERE parent_ecli = $1
+             UNION ALL
+             SELECT l.child_ecli, l.parent_ecli, l.relation, l.outcome, down.depth + 1
+               FROM ${j.instanceLinksTable} l JOIN down ON l.parent_ecli = down.child_ecli
+              WHERE down.depth < 6
+         )
+         SELECT 'earlier' AS direction, * FROM up
+         UNION ALL SELECT 'later', * FROM down`, [ecli]);
+
+      res.json({
+        jurisdiction: j.code, ecli,
+        chain: rows.rows.map((r: any) => ({
+          direction: r.direction, from: r.child_ecli, to: r.parent_ecli,
+          relation: r.relation, outcome: r.outcome, depth: r.depth,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] chain failed', { error: String(err) });
+      fail(res, 500, 'chain_failed');
+    }
+  }) as any);
+
+  // --------------------------------------------- 7. case law on an article
+  router.get('/:jurisdiction/legislation/:lawId/case-law', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const params: unknown[] = [String(req.params.lawId)];
+      let articleClause = '';
+      if (req.query.article) { params.push(req.query.article); articleClause = `AND c.article = $${params.length}`; }
+      params.push(clampLimit(req.query.limit, 50));
+
+      const rows = await db.query(
+        `SELECT DISTINCT ON (d.ecli) d.ecli, d.court_name, d.decision_date, c.article,
+                left(d.summary, 300) AS summary, coalesce(p.cited_by_count,0) AS cited_by_count
+           FROM ${j.statuteEdgesTable} c
+           JOIN ${j.decisionsTable} d ON d.ecli = c.from_ecli
+           LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
+          WHERE c.law_id = $1 ${articleClause}
+          ORDER BY d.ecli, d.decision_date DESC
+          LIMIT $${params.length}`, params);
+
+      res.json({
+        jurisdiction: j.code, law_id: req.params.lawId,
+        article: req.query.article ?? null, count: rows.rows.length,
+        decisions: rows.rows.map((r: any) => ({
+          ecli: r.ecli, court: r.court_name, date: r.decision_date,
+          article: r.article, summary: r.summary, cited_by_count: Number(r.cited_by_count),
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] case-law failed', { error: String(err) });
+      fail(res, 500, 'case_law_failed');
+    }
+  }) as any);
+
+  // ------------------------------------------ 8. an act, in force on a date
+  router.get('/:jurisdiction/legislation/:lawId', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const lawId = String(req.params.lawId);
+      const asOf = String(req.query.as_of || '') || null;
+
+      const law = await db.query(
+        `SELECT bwb_id, title, law_type, authority, rechtsgebied,
+                first_start, last_end, edition_count
+           FROM ${j.lawsTable} WHERE bwb_id = $1`, [lawId]);
+      if (!law.rows.length) return fail(res, 404, 'not_found', lawId);
+
+      // as_of is the point of this endpoint: without it the caller gets the
+      // current edition and no claim about any other date
+      const edition = await db.query(
+        `SELECT valid_from, valid_to, toestand_uri, xml_url, wti_url
+           FROM ${j.editionsTable}
+          WHERE bwb_id = $1
+            AND ($2::date IS NULL OR (valid_from <= $2::date AND (valid_to IS NULL OR valid_to >= $2::date)))
+          ORDER BY valid_from DESC LIMIT 1`, [lawId, asOf]);
+
+      const l = law.rows[0];
+      res.json({
+        jurisdiction: j.code,
+        law_id: l.bwb_id,
+        title: l.title,
+        type: l.law_type,
+        authority: l.authority,
+        subjects: l.rechtsgebied,
+        editions: { count: l.edition_count, first: l.first_start, last: l.last_end },
+        as_of: asOf,
+        edition_in_force: edition.rows[0]
+          ? {
+              valid_from: edition.rows[0].valid_from,
+              valid_to: edition.rows[0].valid_to,
+              uri: edition.rows[0].toestand_uri,
+              text_url: edition.rows[0].xml_url,
+              amendment_history_url: edition.rows[0].wti_url,
+            }
+          : null,
+        edition_note: edition.rows.length
+          ? undefined
+          : 'no edition covers that date; the act may not have been in force then',
+        source_url: `https://wetten.overheid.nl/${l.bwb_id}${asOf ? '/' + asOf : ''}`,
+      });
+    } catch (err) {
+      logger.error('[Substrate] legislation failed', { error: String(err) });
+      fail(res, 500, 'legislation_failed');
+    }
+  }) as any);
+
+  // ------------------------------------------------------------- 9. resolve
+  router.get('/:jurisdiction/resolve', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const ref = String(req.query.ref || '').trim();
+      if (!ref) return fail(res, 400, 'ref_required');
+
+      // Straight ECLI first, then the alias dictionary, which is what makes
+      // "NJ 2020/410" and "LJN AB1234" resolvable at all.
+      if (/^ECLI:/i.test(ref)) {
+        const hit = await db.query(
+          `SELECT ecli, court_name, decision_date FROM ${j.decisionsTable} WHERE ecli = $1`,
+          [ref.toUpperCase()]);
+        if (hit.rows.length) {
+          return res.json({
+            input: ref, resolved: true, kind: 'ecli', node: hit.rows[0],
+            redistribution: classifyEcli(hit.rows[0].ecli).redistribution,
+          });
+        }
+        return res.json({
+          input: ref, resolved: false, kind: 'ecli',
+          unresolved_reason: 'well-formed ECLI, not present in this corpus',
+        });
+      }
+
+      const norm = ref.toUpperCase().replace(/\s+/g, ' ').trim();
+      const alias = await db.query(
+        `SELECT a.alias_kind, a.ecli, d.court_name, d.decision_date
+           FROM ${j.aliasTable} a
+           LEFT JOIN ${j.decisionsTable} d ON d.ecli = a.ecli
+          WHERE a.alias_norm IN ($1, replace($1,' ',''))
+          LIMIT 5`, [norm]);
+
+      if (!alias.rows.length) {
+        return res.json({
+          input: ref, resolved: false, unresolved_reason: 'no alias matches this reference',
+        });
+      }
+      res.json({
+        input: ref, resolved: true, kind: alias.rows[0].alias_kind,
+        // several decisions can share one journal reference; the caller is told
+        // rather than handed an arbitrary pick
+        ambiguous: alias.rows.length > 1,
+        candidates: alias.rows.map((a: any) => ({
+          ecli: a.ecli, court: a.court_name, date: a.decision_date,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] resolve failed', { error: String(err) });
+      fail(res, 500, 'resolve_failed');
+    }
+  }) as any);
+
+  // ------------------------------------------------------------ 10. changes
+  router.get('/:jurisdiction/changes', (async (req: any, res: Response) => {
+    const j = jurisdictionOf(req)!;
+    try {
+      const since = String(req.query.since || '');
+      if (!since) return fail(res, 400, 'since_required', 'ISO timestamp or date');
+      const limit = clampLimit(req.query.limit, 100);
+
+      const rows = await db.query(
+        `SELECT ecli, court_name, decision_date, updated_at
+           FROM ${j.decisionsTable}
+          WHERE updated_at >= $1::timestamptz
+          ORDER BY updated_at ASC LIMIT $2`, [since, limit]);
+
+      res.json({
+        jurisdiction: j.code, since,
+        count: rows.rows.length,
+        // the cursor is the caller's next `since`; polling from it never
+        // re-delivers and never skips
+        next_since: rows.rows.length ? rows.rows[rows.rows.length - 1].updated_at : since,
+        changes: rows.rows.map((r: any) => ({
+          type: 'decision', ecli: r.ecli, court: r.court_name,
+          date: r.decision_date, changed_at: r.updated_at,
+        })),
+      });
+    } catch (err) {
+      logger.error('[Substrate] changes failed', { error: String(err) });
+      fail(res, 500, 'changes_failed');
+    }
+  }) as any);
+
+  return router;
+}


### PR DESCRIPTION
The spec's "small REST layer over the ten questions everyone asks", served over the Dutch graph and shaped so the Finnish graph goes through the same contract. `docs/proposals/substrate-api-contract.md` is the document for Niko.

Mounted at `/api/v1/substrate/{jurisdiction}` behind dual-auth, so an API key works: this surface is for builders, not browser users. Adding a jurisdiction is one entry in a config map naming its tables — no endpoint code changes.

## The ten endpoints

| # | Endpoint | Answers |
|---|---|---|
| 1 | `GET /{j}/search` | find decisions |
| 2 | `GET /{j}/decisions/{ecli}` | one decision, every reference resolved |
| 3 | `GET /{j}/decisions/{ecli}/status` | is it still good law, and what changed it |
| 4 | `GET /{j}/decisions/{ecli}/citing` | who cites it |
| 5 | `GET /{j}/decisions/{ecli}/cited` | what it cites |
| 6 | `GET /{j}/decisions/{ecli}/chain` | instance ladder with outcomes |
| 7 | `GET /{j}/legislation/{lawId}/case-law` | decisions applying a provision |
| 8 | `GET /{j}/legislation/{lawId}?as_of=` | the act as in force on a date |
| 9 | `GET /{j}/resolve?ref=` | any citation string to a canonical node |
| 10 | `GET /{j}/changes?since=` | what changed, for subscriptions |

`GET /api/v1/substrate/catalog` describes the surface so an agent discovers it without reading code.

## Three rules the contract enforces

**Every reference carries `resolved`**, and when false carries `unresolved_reason` rather than dropping out of the array. A caller can always distinguish "we checked and there is nothing" from "we did not check". That is the confidence-over-citations guarantee expressed at the API boundary.

**Every node carries `redistribution`.** `link_out` nodes return metadata and `source_url` and never text, whatever the caller asks. This makes Niko's index-and-link-out rule mechanical instead of remembered — ECHR text cannot leak through this API by mistake.

**Anything time-dependent takes `as_of`.** A statute answer without a date is a guess about which version applied.

A fourth, softer one: **absence is stated, not implied**. `"text_availability": "not_published_by_source"` rather than an empty string, because that is genuinely the source's state for most Dutch decisions. `status: null` with "absence of an appeal is not a positive finding", never a default of good law.

## Verified before mounting

Every endpoint's query was run against prod data first — a route that 500s in production over a typo is the cheapest bug to catch early:

- chain: `HR:2016:252` → `GHDHA:2014:2305` → `RBDHA:2013:6106`, each step carrying the publisher's own appeal outcome
- resolve: `NJ 2020/410` → `ECLI:NL:HR:2020:1215` via the alias dictionary
- legislation as_of `2015-06-01`: returns the `2015-04-01..2015-06-30` edition of the Awb, with its text URL
- search, decision + refs, citing, cited, case-law-on-article, changes: all return

`tsc --noEmit` clean (remaining output is the known core-overlay false positives).

## What NL answers with today

3,603,085 decisions at 100.0% of the source feed · 1,052,105 case-to-case edges 98.0% resolved · 2,507,190 statute edges 99.6% with a law id, 94.2% tied to the edition in force on the decision date · 200,887 instance links · 46,365 acts with 146,164 editions · CJEU 99.4%, ECHR 93.0% (link-out).

## For Niko

The contract doc lists the six things the Finnish side supplies to serve the same shape. The one worth starting early is the alias dictionary behind endpoint 9: it is the primitive everything else leans on, and building it late means every earlier answer under-resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small REST API at `/api/v1/substrate/{jurisdiction}` over the grounded legal graph, with NL as the reference and the same contract for FI. Implements the ten “common questions” endpoints with explicit resolution and redistribution guarantees.

- **New Features**
  - Mounted at `/api/v1/substrate` with dual auth (API key or JWT) and rate limit (120/min).
  - Jurisdiction added via a config map; no endpoint code changes.
  - Endpoints: search, decision details, status, citing/cited, chain, legislation by date, case-law on an article, resolve, and changes.
  - `GET /api/v1/substrate/catalog` exposes a self-describing surface.
  - Contract rules: every ref has `resolved` (or `unresolved_reason`), all nodes include `redistribution` (link-out nodes never return text), and time-dependent queries take `as_of`.
  - Documented in `docs/proposals/substrate-api-contract.md` with FI requirements.

- **Migration**
  - To add FI: create tables per the contract and add a config entry naming them.
  - Build an alias dictionary to power `GET /{j}/resolve`; other endpoints depend on it.

<sup>Written for commit 9d1c78264b982cd177e22b2983d1326b7ae12c7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

