### PR TITLE
fix(substrate): serve /catalog instead of unknown_jurisdiction

### DIFF
--- a/mcp_backend/src/routes/substrate-routes.ts
+++ b/mcp_backend/src/routes/substrate-routes.ts
@@ -114,14 +114,9 @@ export function createSubstrateRoutes(db: IDatabase): Router {
 
   router.use(substrateRateLimit as any);
 
-  router.use('/:jurisdiction', (req: any, res: Response, next: any) => {
-    if (!jurisdictionOf(req)) {
-      return fail(res, 404, 'unknown_jurisdiction',
-        `Known: ${Object.keys(JURISDICTIONS).join(', ')}`);
-    }
-    next();
-  });
-
+  // Catalog is registered before the jurisdiction guard on purpose: Express
+  // matches '/catalog' against router.use('/:jurisdiction'), so a guard placed
+  // first answers unknown_jurisdiction for the discovery endpoint itself.
   // ---------------------------------------------------------------- catalog
   router.get('/catalog', (_req: any, res: Response) => {
     res.json({
@@ -148,6 +143,14 @@ export function createSubstrateRoutes(db: IDatabase): Router {
         { path: '/{j}/changes', params: 'since, limit', returns: 'nodes changed since a timestamp' },
       ],
     });
+  });
+
+  router.use('/:jurisdiction', (req: any, res: Response, next: any) => {
+    if (!jurisdictionOf(req)) {
+      return fail(res, 404, 'unknown_jurisdiction',
+        `Known: ${Object.keys(JURISDICTIONS).join(', ')}`);
+    }
+    next();
   });
 
   // -------------------------------------------------------------- 1. search


### PR DESCRIPTION
Express matches `/catalog` against `router.use('/:jurisdiction')`, so the guard answered `unknown_jurisdiction` for the discovery endpoint itself — the one an agent hits first to learn the surface exists.

```
GET /api/v1/substrate/catalog
{"error":"unknown_jurisdiction","detail":"Known: nl"}
```

Registering the catalog handler before the guard fixes it. The comment explains why the order matters so it does not get tidied back into place.

Found by smoke-testing every endpoint against the deployed service rather than only the SQL underneath them. The other two checked in the same pass were already correct:

```
GET /nl/resolve?ref=NJ%202020/410
{"input":"NJ 2020/410","resolved":true,"kind":"journal","ambiguous":false,
 "candidates":[{"ecli":"ECLI:NL:HR:2020:1215","court":"Hoge Raad",...}]}

GET /nl/decisions/ECLI:NL:HR:2016:252/chain
{"chain":[{"from":"ECLI:NL:HR:2016:252","to":"ECLI:NL:GHDHA:2014:2305",
           "relation":"cassation_of","outcome":"(Gedeeltelijke) vernietiging en zelf afgedaan"},
          {"from":"ECLI:NL:GHDHA:2014:2305","to":"ECLI:NL:RBDHA:2013:6106",
           "relation":"appeal_of","outcome":"(Gedeeltelijke) vernietiging en zelf afgedaan"}]}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve the /catalog discovery endpoint correctly by registering it before the jurisdiction guard in the `express` router, preventing it from being matched as /:jurisdiction and returning unknown_jurisdiction. Added a comment explaining why the order matters to avoid future regressions.

<sup>Written for commit ff273f9041e97319610359e27190edac8062a71a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

