### PR TITLE
fix(substrate): stop truncating snippets with SQL left()

### DIFF
--- a/mcp_backend/src/routes/substrate-routes.ts
+++ b/mcp_backend/src/routes/substrate-routes.ts
@@ -176,7 +176,7 @@ export function createSubstrateRoutes(db: IDatabase): Router {
       params.push(limit);
       const rows = await db.query(
         `SELECT d.ecli, d.court_name, d.decision_date, d.decision_type, d.procedure_type,
-                d.subject_areas, left(d.summary, 400) AS summary,
+                d.subject_areas, d.summary,
                 ts_rank(to_tsvector('${j.ftsConfig}', coalesce(d.summary,'') || ' ' || coalesce(d.full_text,'')),
                         plainto_tsquery('${j.ftsConfig}', $1)) AS rank,
                 coalesce(p.cited_by_count, 0) AS cited_by_count, p.status AS precedent_status
@@ -197,7 +197,11 @@ export function createSubstrateRoutes(db: IDatabase): Router {
           type: r.decision_type,
           procedure: r.procedure_type,
           subjects: r.subject_areas,
-          summary: r.summary,
+          // truncated in JS, not with SQL left(): that function raises
+          // "invalid byte sequence for encoding UTF8" on some rows at some
+          // offsets even when the stored value is valid, and a search endpoint
+          // that 500s on a legitimate row is worse than a longer snippet
+          summary: r.summary ? String(r.summary).slice(0, 400) : null,
           cited_by_count: Number(r.cited_by_count),
           precedent_status: r.precedent_status,
           redistribution: classifyEcli(r.ecli).redistribution,
@@ -416,7 +420,7 @@ export function createSubstrateRoutes(db: IDatabase): Router {
 
       const rows = await db.query(
         `SELECT DISTINCT ON (d.ecli) d.ecli, d.court_name, d.decision_date, c.article,
-                left(d.summary, 300) AS summary, coalesce(p.cited_by_count,0) AS cited_by_count
+                d.summary, coalesce(p.cited_by_count,0) AS cited_by_count
            FROM ${j.statuteEdgesTable} c
            JOIN ${j.decisionsTable} d ON d.ecli = c.from_ecli
            LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
@@ -429,7 +433,9 @@ export function createSubstrateRoutes(db: IDatabase): Router {
         article: req.query.article ?? null, count: rows.rows.length,
         decisions: rows.rows.map((r: any) => ({
           ecli: r.ecli, court: r.court_name, date: r.decision_date,
-          article: r.article, summary: r.summary, cited_by_count: Number(r.cited_by_count),
+          article: r.article,
+          summary: r.summary ? String(r.summary).slice(0, 300) : null,
+          cited_by_count: Number(r.cited_by_count),
         })),
       });
     } catch (err) {


### PR DESCRIPTION
Search returned 500 on prod:

```
[Substrate] search failed
error: invalid byte sequence for encoding "UTF8": 0xe2
```

This is not corrupt data. Postgres `left()` raises that on some rows at some cut offsets even when the stored value is valid UTF-8 — the same behaviour that earlier in this corpus made a detector report 1,614 broken rows when only 116 were real, and where `left(x, 300)` failed on a row that `left(x, 299)` and `left(x, 301)` both handled.

The snippet is now cut in JavaScript, where slicing a string cannot raise. The query returns the summary column whole; summaries are capped at 5,000 characters at ingest, so nothing is paid for it.

The same call sat in the case-law endpoint, which happened to pass on the rows the smoke test hit. Removed there too rather than waiting for it to fire in front of a customer.

Found by smoke-testing all ten endpoints against the deployed service. Eight were already green; this and the `/catalog` routing fix (#2231) were the two that were not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop truncating summaries in SQL. Slice snippets in JS to avoid UTF‑8 boundary errors that caused 500s in search; same fix applied to case-law.

- **Bug Fixes**
  - Removed SQL `left()` on `summary`; select full `summary` instead.
  - Truncate in JS: `slice(0, 400)` in search and `slice(0, 300)` in case-law, null-safe.
  - Eliminates Postgres “invalid byte sequence for encoding UTF8” errors; summaries are capped at 5,000 chars, so query cost is unchanged.

<sup>Written for commit 044a9b5fc80baecf48ee012d76f2fc51272edc04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

