### PR TITLE
fix(substrate): search timed out on ts_rank, make ordering an explicit choice

### DIFF
--- a/docs/proposals/substrate-api-contract.md
+++ b/docs/proposals/substrate-api-contract.md
@@ -52,7 +52,7 @@ default of "good law".
 
 | # | Endpoint | Answers |
 |---|---|---|
-| 1 | `GET /{j}/search?q=&court=&date_from=&date_to=&subject=` | find decisions |
+| 1 | `GET /{j}/search?q=&court=&date_from=&date_to=&subject=&order=` | find decisions |
 | 2 | `GET /{j}/decisions/{ecli}` | one decision with every reference resolved |
 | 3 | `GET /{j}/decisions/{ecli}/status` | is it still good law, and what changed it |
 | 4 | `GET /{j}/decisions/{ecli}/citing` | who cites it |
@@ -81,6 +81,14 @@ answer under-resolves.
 outcome of each appeal attached. Worth stating that this does not need a graph
 store: Dutch ladders are at most four deep and the query is a few milliseconds.
 Reach for Neo4j when the graph is EDRSR-sized (135M edges), not at 1M.
+
+**1, search, and why ordering is a parameter.** Ranking with `ts_rank` over the
+full text costs **42 seconds** on this corpus: Postgres recomputes the tsvector
+for every matching row before `LIMIT` can apply. Ranking over the summary alone
+is 603ms and still textual; ordering by authority is 73ms. Rather than pick one
+silently, `order` is `relevance` (default), `authority` or `date`, and the
+response says which signal was used. When vectors land, `relevance` changes
+meaning and the contract does not.
 
 **10, changes.** Returns `next_since`, which is the caller's cursor for the next
 poll: polling from it never re-delivers and never skips. This is the RegTech

--- a/mcp_backend/src/routes/substrate-routes.ts
+++ b/mcp_backend/src/routes/substrate-routes.ts
@@ -131,7 +131,7 @@ export function createSubstrateRoutes(db: IDatabase): Router {
         point_in_time: 'statute endpoints accept as_of=YYYY-MM-DD and answer for that date',
       },
       endpoints: [
-        { path: '/{j}/search', q: 'full-text query', filters: 'court, date_from, date_to, subject, has_text' },
+        { path: '/{j}/search', q: 'full-text query', filters: 'court, date_from, date_to, subject', order: 'relevance | authority | date' },
         { path: '/{j}/decisions/{ecli}', returns: 'decision with resolved citations' },
         { path: '/{j}/decisions/{ecli}/status', returns: 'precedent status and what changed it' },
         { path: '/{j}/decisions/{ecli}/citing', returns: 'inbound citations' },
@@ -173,22 +173,40 @@ export function createSubstrateRoutes(db: IDatabase): Router {
       if (req.query.date_to) { params.push(req.query.date_to); where.push(`decision_date <= $${params.length}`); }
       if (req.query.subject) { params.push([req.query.subject]); where.push(`subject_areas && $${params.length}`); }
 
+      // Ordering is a measured tradeoff, so it is a parameter rather than a
+      // hidden choice. Ranking with ts_rank over the full text costs 42s on this
+      // corpus: it recomputes the tsvector for every match before LIMIT applies.
+      // Over the summary alone it is 603ms and still textual; by authority it is
+      // 73ms. Measured on "huurovereenkomst ontbinding", 20 rows.
+      const order = String(req.query.order || 'relevance');
+      const orderSql = order === 'authority'
+        ? 'coalesce(p.cited_by_count,0) DESC, d.decision_date DESC'
+        : order === 'date'
+          ? 'd.decision_date DESC'
+          : `ts_rank(to_tsvector('${j.ftsConfig}', coalesce(d.summary,'')),
+                     plainto_tsquery('${j.ftsConfig}', $1)) DESC,
+             coalesce(p.cited_by_count,0) DESC`;
+
       params.push(limit);
       const rows = await db.query(
         `SELECT d.ecli, d.court_name, d.decision_date, d.decision_type, d.procedure_type,
                 d.subject_areas, d.summary,
-                ts_rank(to_tsvector('${j.ftsConfig}', coalesce(d.summary,'') || ' ' || coalesce(d.full_text,'')),
-                        plainto_tsquery('${j.ftsConfig}', $1)) AS rank,
                 coalesce(p.cited_by_count, 0) AS cited_by_count, p.status AS precedent_status
            FROM ${j.decisionsTable} d
            LEFT JOIN ${j.precedentTable} p ON p.ecli = d.ecli
           WHERE ${where.join(' AND ')}
-          ORDER BY rank DESC
+          ORDER BY ${orderSql}
           LIMIT $${params.length}`, params);
 
       res.json({
         jurisdiction: j.code,
         query: q,
+        // say what the ranking actually is: the match is over the whole text,
+        // the ordering signal is the court's own abstract until vectors land
+        order: order,
+        order_note: order === 'relevance'
+          ? 'matched on full text, ranked on the summary; vector ranking is not wired yet'
+          : `matched on full text, ordered by ${order}`,
         count: rows.rows.length,
         results: rows.rows.map((r: any) => ({
           ecli: r.ecli,


### PR DESCRIPTION
The search endpoint hung and returned nothing. Measured on prod, `"huurovereenkomst ontbinding"`, 20 rows:

| ordering | time |
|---|---|
| filter only, no ordering | **9.9 ms** |
| `ts_rank` over summary + full text | **41,919 ms** |
| `ts_rank` over summary only | 603 ms |
| authority, then date | 73 ms |

`ts_rank` recomputes `to_tsvector` for every matching row before `LIMIT` can apply, so a query matching thousands of documents detoasts and re-parses all of them. The GIN index finds the rows in 10ms; the ranking costs four thousand times that.

Rather than pick one tradeoff and bury it, `order` is now a parameter — `relevance` (default), `authority`, `date` — and the response states which signal was used:

```json
{"order": "relevance",
 "order_note": "matched on full text, ranked on the summary; vector ranking is not wired yet"}
```

Relevance ranks on the court's own abstract while still matching on the whole text. That is honest about what the signal is today, and when vectors land (LEXAI-1887..1890) `relevance` changes meaning while the contract stays put.

Third and last fix from smoke-testing all ten endpoints against the deployed service, after `/catalog` routing (#2231) and SQL `left()` (#2232). The other seven were green on the first pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the search endpoint hanging and makes result ordering an explicit choice. Adds an `order` param with a fast default and tells clients how results were ranked.

- **Bug Fixes**
  - Avoid `ts_rank` over full text; relevance now ranks on the summary while still matching on full text.
  - Removes the pre-LIMIT tsvector recompute that caused long timeouts.

- **New Features**
  - Adds `order` query param: `relevance` (default), `authority`, or `date`.
  - Response returns `order` and `order_note` to explain the ranking signal (notes vectors are not wired yet for relevance).
  - Updates API docs to include `order` and removes the unsupported `has_text` filter from the route description.

<sup>Written for commit 3922aed5be6cb4f1f475263a8b528b037fbabda9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

