### PR TITLE
fix(substrate): resolve "LJN BO5087", drop the duplicate rate limiter

### DIFF
--- a/mcp_backend/src/routes/substrate-routes.ts
+++ b/mcp_backend/src/routes/substrate-routes.ts
@@ -38,7 +38,6 @@
 import { Router, type Response } from 'express';
 import type { AuthenticatedRequest as DualAuthRequest } from '../middleware/dual-auth.js';
 import type { IDatabase } from '../domain/ports/index.js';
-import { createRateLimiter } from '../middleware/rate-limit.js';
 import { logger } from '../utils/logger.js';
 
 /** Per-jurisdiction wiring. Adding Finland is adding an entry here. */
@@ -77,12 +76,11 @@ const JURISDICTIONS: Record<string, JurisdictionConfig> = {
 
 const MAX_LIMIT = 100;
 
-const substrateRateLimit = createRateLimiter({
-  windowMs: 60 * 1000,
-  maxRequests: 120,
-  keyPrefix: 'substrate_api',
-});
-
+// No rate limiter here on purpose. '/api' already has the global one, and each
+// limiter costs a Redis GET that currently times out at 2500ms under the known
+// connection-level issue (LEXAI-1795), so a second one doubled every substrate
+// response to ~5s. Per-key quota for the Builder tier belongs in billing, not in
+// a second copy of the same middleware.
 function jurisdictionOf(req: DualAuthRequest): JurisdictionConfig | null {
   return JURISDICTIONS[String(req.params.jurisdiction || '').toLowerCase()] ?? null;
 }
@@ -111,8 +109,6 @@ function fail(res: Response, code: number, error: string, detail?: string) {
 
 export function createSubstrateRoutes(db: IDatabase): Router {
   const router = Router({ mergeParams: true });
-
-  router.use(substrateRateLimit as any);
 
   // Catalog is registered before the jurisdiction guard on purpose: Express
   // matches '/catalog' against router.use('/:jurisdiction'), so a guard placed
@@ -539,7 +535,10 @@ export function createSubstrateRoutes(db: IDatabase): Router {
         });
       }
 
-      const norm = ref.toUpperCase().replace(/\s+/g, ' ').trim();
+      // The alias dictionary stores an LJN by its code alone, because the code is
+      // literally the ECLI ordinal for pre-2013 decisions. A caller writing
+      // "LJN BO5087" must still resolve, so the prefix comes off first.
+      const norm = ref.toUpperCase().replace(/\s+/g, ' ').trim().replace(/^LJN[: ]\s*/, '');
       const alias = await db.query(
         `SELECT a.alias_kind, a.ecli, d.court_name, d.decision_date
            FROM ${j.aliasTable} a


### PR DESCRIPTION
Two things the full ten-endpoint smoke test surfaced.

## resolve missed every LJN

```
GET /nl/resolve?ref=LJN%20BO5087
{"resolved": false, "unresolved_reason": "no alias matches this reference"}
```

481,369 LJN aliases are loaded, but the dictionary stores the **code alone** — the LJN *is* the ECLI ordinal for pre-2013 decisions, which is why no external mapping was needed in the first place. A caller writing the `LJN ` prefix, which is how it appears in judgment text, matched nothing. The prefix now comes off before lookup.

## Every response took exactly ~5 seconds

| endpoint | before |
|---|---|
| catalog | 5.00s |
| chain | 5.01s |
| status | 5.01s |
| search | 5.68s |

Suspiciously uniform, and not the queries: the SQL behind these runs in tens of milliseconds. Two rate limiters were in the path — the global one on `/api` and a second inside this router — and each costs a Redis GET that currently times out at 2500ms under the known connection-level issue (LEXAI-1795, non-fatal, falls back to memory). The duplicate doubled every response for no benefit. Per-key quota for the Builder tier is billing work, not a second copy of the same middleware.

Worth stating plainly since it looks alarming in the numbers above: **the Redis timeout is neither caused by this API nor by Redis**. Prod Redis is up six weeks, 4% CPU, 10MB, background saves succeeding, and `/health` pays the same 2.5s. It is already diagnosed under LEXAI-1795.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LJN resolve failures and removes a duplicate rate limiter in the substrate router to cut ~5s latency. The global `/api` limiter remains.

- **Bug Fixes**
  - Strip the `LJN` prefix (`LJN ` or `LJN:`) during normalization so aliases match the stored code; refs like "LJN BO5087" now resolve.
  - Remove the per-router rate limiter to avoid an extra Redis call that times out (~2.5s; LEXAI-1795), reducing endpoint latency.

<sup>Written for commit 9f076a493101ecc7cdefd750c26f38bf9d400335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

