### PR TITLE
docs(substrate): state the export boundary in the API contract

### DIFF
--- a/docs/proposals/substrate-api-contract.md
+++ b/docs/proposals/substrate-api-contract.md
@@ -93,7 +93,57 @@ meaning and the contract does not.
 **10, changes.** Returns `next_since`, which is the caller's cursor for the next
 poll: polling from it never re-delivers and never skips. This is the RegTech
 primitive that turns a purchase into a subscription, so it should exist from day
-one even before webhooks.
+one even before webhooks — and it is also the export risk, see below.
+
+## The export boundary, restated
+
+Niko's rule, from the 24 Jul mail and now in the product description: neither
+seat tier includes a public SPARQL endpoint, because a seat buys answers and an
+endpoint buys the substrate. The rule is right and the artifact it names is too
+narrow. **The property that matters is enumerability, not the query language.**
+This REST layer, built exactly as the product description asks for, reproduces
+the risk it warns about:
+
+- `/changes?since=1990-01-01` plus the `next_since` cursor is a
+  guaranteed-complete enumerator. It was designed that way on purpose for
+  subscriptions. 3.6M decisions at 100 per page is 36,000 requests.
+- `/decisions/{ecli}` then returns the text, and `/cited` plus `/citing` per
+  ECLI rebuild the citation graph.
+- Today there is no per-key quota and no metering on these routes; the only
+  limit is 3,000 requests per minute keyed by IP, not by key.
+
+What is worth protecting is not the corpus. Dutch judgments are open data and
+Rechtspraak gives them away in bulk. The asset is the **derived layer** — the
+resolved graph, precedent status, instance chains, the alias dictionary, the
+edition mapping — and that is precisely what these endpoints hand out one row at
+a time.
+
+Enforcement, in order of leverage; the first is commercial and the strongest:
+
+1. **Sell the bulk snapshot.** Already an Enterprise surface. If the legitimate
+   path is cheaper than 3.6M requests, scraping stops being rational.
+2. **Per-key daily quota, keyed by API key rather than IP.** Rate limits stop
+   bursts; quotas stop patient scrapers. A crawler at 10 req/s under a 3,000/min
+   ceiling looks like an ordinary client.
+3. **Meter the endpoints** into the existing credit system, weighted per
+   endpoint: `/resolve` cheap, `/changes` and `/search` expensive.
+4. **Bound the enumeration primitive.** `/changes` is the only endpoint that
+   guarantees completeness.
+5. **Detect the pattern, not just the count.** Enumeration is distinctive: high
+   unique-entity ratio, near-zero repeats, sequential cursors, breadth without
+   depth.
+
+Not proposed: watermarking the graph with fabricated edges. In a product whose
+pitch is that every reference resolves, seeding false relations to catch thieves
+is self-defeating.
+
+The open commercial question: Niko's tiering says both tiers get the full graph
+and differ only by usage limits, and also puts change-tracking in the Pro seat.
+Once the feed exists those pull apart, because an unbounded cursor over the whole
+corpus from 1990 *is* the substrate. The likely resolution is that Pro gets
+change-tracking over its own monitored set while an unbounded historical cursor
+is a Builder/Enterprise capability — one endpoint name covering two products.
+That is a call for Vlad and Niko, not something to decide in code.
 
 ## What NL currently answers with
 
@@ -133,6 +183,7 @@ Numbers as of 26 Jul 2026, so the FI side has something to compare against.
 - **SPARQL alongside REST.** The spec keeps SPARQL key-gated for the
   infrastructure tier. This REST layer is deliberately the narrow, cacheable
   surface for the per-seat and Builder tiers; it does not replace the endpoint.
+  Both need the same quota rules, or the weaker one becomes the leak.
 - **Whether FI is served from our backend or Niko's**, with this contract as the
   interface either way. That decision is independent of the shape above, which
   is the point of writing the shape down first.


### PR DESCRIPTION
Documentation only. Brings `docs/proposals/substrate-api-contract.md` in line with the Notion page the same text now lives on.

## What changed

A new section, **The export boundary, restated**, plus one line in the open questions.

The contract listed ten endpoints without noting that four of them compose into a complete enumerator:

- `/changes?since=1990-01-01` plus the `next_since` cursor is guaranteed-complete by design (that is the subscription primitive). 3.6M decisions at 100 per page is 36,000 requests.
- `/decisions/{ecli}` then returns the text; `/cited` and `/citing` rebuild the citation graph.
- No per-key quota and no metering on these routes today; the only limit is 3,000 req/min keyed by IP.

Niko's rule in the product description says a seat tier never gets a public SPARQL endpoint. The rule is right, the artifact it names is too narrow: the property that matters is enumerability, not the query language.

What is worth protecting is the derived layer (resolved graph, precedent status, instance chains, alias dictionary, edition mapping), not the corpus, since Rechtspraak gives Dutch judgments away in bulk.

Enforcement is written down in order of leverage (sell the bulk snapshot, per-key quota, metering, bound `/changes`, detect the pattern) and explicitly rejects watermarking with fabricated edges.

## What did not change

No code. Enforcement waits on a tiering decision between Vlad and Niko, because Pro-tier change-tracking scoped to a monitored set and an unbounded historical cursor are the same endpoint serving two different products.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the export boundary in `docs/proposals/substrate-api-contract.md` with a new section on enumerability risk (the `/changes` cursor plus `/decisions/{ecli}`, `/cited`, `/citing`). Adds a brief note on REST/SPARQL quota parity, lists enforcement options, and flags the Pro vs Enterprise cursor decision; no code changes.

<sup>Written for commit 0d2791bb759e593f5f0b156f60032f9c9c3c9ce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

