### PR TITLE
fix(nl): key law articles by document order, not by label

### DIFF
--- a/mcp_backend/src/migrations/182_nl_law_texts.sql
+++ b/mcp_backend/src/migrations/182_nl_law_texts.sql
@@ -18,8 +18,12 @@
 -- found no <artikel> at all (mostly pre-1900 royal decrees), so the text of a
 -- provision is never held twice.
 
--- One row per article per edition. The primary key is deliberately the citation
--- coordinates, so a lookup from nl_legislation_citations is a direct hit.
+-- One row per article per edition. The key is (edition, document order) rather
+-- than (edition, article_label), because a label is not unique inside an act:
+-- annexes restart numbering, so the Awb alone carries two "Artikel 1" and two
+-- "Artikel 2". Keying on the label would have rejected the whole insert batch.
+-- The label lookup is served by the non-unique index below, and a query for an
+-- ambiguous label honestly returns both rows instead of one silently chosen.
 CREATE TABLE IF NOT EXISTS nl_law_articles (
     bwb_id        TEXT NOT NULL,
     valid_from    DATE NOT NULL,
@@ -31,7 +35,7 @@ CREATE TABLE IF NOT EXISTS nl_law_articles (
     text          TEXT NOT NULL,
     n_chars       INTEGER NOT NULL DEFAULT 0,
     ord           INTEGER NOT NULL DEFAULT 0,   -- document order within edition
-    PRIMARY KEY (bwb_id, valid_from, seq, article_label)
+    PRIMARY KEY (bwb_id, valid_from, seq, ord)
 );
 
 -- The lookup that matters: "what did article X of act Y say on date D".


### PR DESCRIPTION
Follow-up to #2236, caught before the harvest hit it.

Verified the parser against the Awb (`BWBR0005537`, 2026-07-01 edition, 2.6 MB): 584 articles, and the labels match what `nl_legislation_citations` actually stores — `8:75`, `3:2`, `6:19`, `7:1` all present, none missing. So the join will work.

But 584 articles carry only 582 distinct labels. Annexes restart numbering, so the act has two `Artikel 1` and two `Artikel 2`. With `article_label` in the primary key, the COPY for that batch would have been rejected — and because the worklist is "editions with no row in `nl_law_edition_texts` yet", nothing would have been recorded, so the next batch would fetch the same editions and fail the same way. A silent infinite loop, not a crash.

Key is now `(bwb_id, valid_from, seq, ord)`. The label lookup keeps its non-unique index, and an ambiguous label returns both rows instead of one silently chosen, matching how the substrate API already handles ambiguous journal citations.

Applied on prod; harvest restarted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Key Dutch law articles by document order instead of label to handle duplicate labels in annexes and stop harvest retry loops. Aligns ambiguous label lookups with the API; addresses LEXAI-1895.

- **Bug Fixes**
  - Changed `nl_law_articles` primary key to `(bwb_id, valid_from, seq, ord)` to avoid insert conflicts when labels repeat.
  - Kept non-unique index on `article_label`; ambiguous label queries return both rows, and joins from `nl_legislation_citations` still work.

<sup>Written for commit 35ead1c342a5b54913484d790f4681ce88e67a6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/overthelex/secondlayer/pull/2237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

